### PR TITLE
mbeddr.mpsutil.blutil.genutil: added can be child constraints

### DIFF
--- a/code/mps-blutil/languages/com.mbeddr.mpsutil.blutil.genutil/com.mbeddr.mpsutil.blutil.genutil.mpl
+++ b/code/mps-blutil/languages/com.mbeddr.mpsutil.blutil.genutil/com.mbeddr.mpsutil.blutil.genutil.mpl
@@ -74,6 +74,7 @@
   <sourcePath />
   <dependencies>
     <dependency reexport="true">6c5bab3e-5035-4a48-b9ea-62747c04e3d6(com.mbeddr.mpsutil.blutil.genutil.rt)</dependency>
+    <dependency reexport="false">b401a680-8325-4110-8fd3-84331ff25bef(jetbrains.mps.lang.generator)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="5" />
@@ -122,6 +123,7 @@
     <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
     <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
     <module reference="a9e4c532-c5f5-4bb7-99ef-42abb73bbb70(jetbrains.mps.lang.descriptor.aspects)" version="0" />
+    <module reference="b401a680-8325-4110-8fd3-84331ff25bef(jetbrains.mps.lang.generator)" version="0" />
     <module reference="d7eb0a2a-bd50-4576-beae-e4a89db35f20(jetbrains.mps.lang.scopes.runtime)" version="0" />
     <module reference="c72da2b9-7cce-4447-8389-f407dc1158b7(jetbrains.mps.lang.structure)" version="0" />
     <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />

--- a/code/mps-blutil/languages/com.mbeddr.mpsutil.blutil.genutil/models/constraints.mps
+++ b/code/mps-blutil/languages/com.mbeddr.mpsutil.blutil.genutil/models/constraints.mps
@@ -5,7 +5,120 @@
     <use id="3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1" name="jetbrains.mps.lang.constraints" version="4" />
     <devkit ref="00000000-0000-4000-0000-5604ebd4f22c(jetbrains.mps.devkit.aspect.constraints)" />
   </languages>
-  <imports />
-  <registry />
+  <imports>
+    <import index="tpf8" ref="r:00000000-0000-4000-0000-011c895902e8(jetbrains.mps.lang.generator.structure)" />
+    <import index="uvrt" ref="r:c266b17e-13c4-40d1-81f3-e76cbf26809a(com.mbeddr.mpsutil.blutil.genutil.structure)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
+        <child id="1137022507850" name="body" index="2VODD2" />
+      </concept>
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+    </language>
+    <language id="3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1" name="jetbrains.mps.lang.constraints">
+      <concept id="6702802731807351367" name="jetbrains.mps.lang.constraints.structure.ConstraintFunction_CanBeAChild" flags="in" index="9S07l" />
+      <concept id="1202989658459" name="jetbrains.mps.lang.constraints.structure.ConstraintFunctionParameter_parentNode" flags="nn" index="nLn13" />
+      <concept id="1213093968558" name="jetbrains.mps.lang.constraints.structure.ConceptConstraints" flags="ng" index="1M2fIO">
+        <reference id="1213093996982" name="concept" index="1M2myG" />
+        <child id="6702802731807737306" name="canBeChild" index="9Vyp8" />
+      </concept>
+    </language>
+    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
+        <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
+      </concept>
+      <concept id="1138411891628" name="jetbrains.mps.lang.smodel.structure.SNodeOperation" flags="nn" index="eCIE_">
+        <child id="1144104376918" name="parameter" index="1xVPHs" />
+      </concept>
+      <concept id="1171407110247" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorOperation" flags="nn" index="2Xjw5R" />
+      <concept id="1172008320231" name="jetbrains.mps.lang.smodel.structure.Node_IsNotNullOperation" flags="nn" index="3x8VRR" />
+      <concept id="1144101972840" name="jetbrains.mps.lang.smodel.structure.OperationParm_Concept" flags="ng" index="1xMEDy">
+        <child id="1207343664468" name="conceptArgument" index="ri$Ld" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="1M2fIO" id="6DNydqPXU3V">
+    <ref role="1M2myG" to="uvrt:3DSLkDUGEYj" resolve="RootMappingExecuteOnceExpression" />
+    <node concept="9S07l" id="6DNydqPXWYK" role="9Vyp8">
+      <node concept="3clFbS" id="6DNydqPXWYL" role="2VODD2">
+        <node concept="3clFbF" id="6DNydqPXX5W" role="3cqZAp">
+          <node concept="2OqwBi" id="6DNydqPY3E4" role="3clFbG">
+            <node concept="2OqwBi" id="6DNydqPY2oX" role="2Oq$k0">
+              <node concept="nLn13" id="6DNydqPXX5V" role="2Oq$k0" />
+              <node concept="2Xjw5R" id="6DNydqPY2H_" role="2OqNvi">
+                <node concept="1xMEDy" id="6DNydqPY2HB" role="1xVPHs">
+                  <node concept="chp4Y" id="6DNydqPY2Uv" role="ri$Ld">
+                    <ref role="cht4Q" to="tpf8:gZlhOrr" resolve="Root_MappingRule" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3x8VRR" id="6DNydqPY3VU" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1M2fIO" id="6DNydqPY4q_">
+    <property role="3GE5qa" value="genUtil" />
+    <ref role="1M2myG" to="uvrt:3DSLkDUvP9k" resolve="RootMappingHasBeenExecutedExpression" />
+    <node concept="9S07l" id="6DNydqPY4yx" role="9Vyp8">
+      <node concept="3clFbS" id="6DNydqPY4yy" role="2VODD2">
+        <node concept="3clFbF" id="6DNydqPY4DE" role="3cqZAp">
+          <node concept="2OqwBi" id="6DNydqPY4DG" role="3clFbG">
+            <node concept="2OqwBi" id="6DNydqPY4DH" role="2Oq$k0">
+              <node concept="nLn13" id="6DNydqPY4DI" role="2Oq$k0" />
+              <node concept="2Xjw5R" id="6DNydqPY4DJ" role="2OqNvi">
+                <node concept="1xMEDy" id="6DNydqPY4DK" role="1xVPHs">
+                  <node concept="chp4Y" id="6DNydqPY4DL" role="ri$Ld">
+                    <ref role="cht4Q" to="tpf8:gZlhOrr" resolve="Root_MappingRule" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3x8VRR" id="6DNydqPY4DM" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1M2fIO" id="6DNydqPY4qZ">
+    <property role="3GE5qa" value="genUtil" />
+    <ref role="1M2myG" to="uvrt:3DSLkDUGEYi" resolve="SetRootMappingHasBeenExecutedExpression" />
+    <node concept="9S07l" id="6DNydqPY4Rn" role="9Vyp8">
+      <node concept="3clFbS" id="6DNydqPY4Ro" role="2VODD2">
+        <node concept="3clFbF" id="6DNydqPY4Yw" role="3cqZAp">
+          <node concept="2OqwBi" id="6DNydqPY4Yy" role="3clFbG">
+            <node concept="2OqwBi" id="6DNydqPY4Yz" role="2Oq$k0">
+              <node concept="nLn13" id="6DNydqPY4Y$" role="2Oq$k0" />
+              <node concept="2Xjw5R" id="6DNydqPY4Y_" role="2OqNvi">
+                <node concept="1xMEDy" id="6DNydqPY4YA" role="1xVPHs">
+                  <node concept="chp4Y" id="6DNydqPY4YB" role="ri$Ld">
+                    <ref role="cht4Q" to="tpf8:gZlhOrr" resolve="Root_MappingRule" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3x8VRR" id="6DNydqPY4YC" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
 </model>
 

--- a/code/mps-build/solutions/de.slisson.mps.all.build/models/de/slisson/mps/all/build.mps
+++ b/code/mps-build/solutions/de.slisson.mps.all.build/models/de/slisson/mps/all/build.mps
@@ -4783,6 +4783,12 @@
         <node concept="1E0d5M" id="2NyZxKpUUgU" role="1E1XAP">
           <ref role="1E0d5P" node="2NyZxKpUQhZ" resolve="com.mbeddr.mpsutil.blutil.genutil.rt" />
         </node>
+        <node concept="1SiIV0" id="6DNydqPYb7m" role="3bR37C">
+          <node concept="3bR9La" id="6DNydqPYb7n" role="1SiIV1">
+            <property role="3bR36h" value="false" />
+            <ref role="3bR37D" to="ffeo:7Kfy9QB6L6C" resolve="jetbrains.mps.lang.generator" />
+          </node>
+        </node>
       </node>
       <node concept="1E1JtA" id="2NyZxKpUL5F" role="2G$12L">
         <property role="BnDLt" value="true" />


### PR DESCRIPTION
The constrains for the newly introduced baselanguage expressions were missing. The new expressions:
`RootMappingExecuteOnceExpression`
`RootMappingHasBeenExecutedExpression`
`SetRootMappingHasBeenExecutedExpression`

should only be usable in `Root_MappingRule`s but in no toher context.

This pullrequest would introduce the missing contraints.
