### PR TITLE
build: register inputs/outputs for all scripts 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,9 +31,6 @@ if (project.hasProperty("forceCI")) {
     }
 }
 
-
-
-
 // Detect jdk location, required to start ant with tools.jar on classpath otherwise javac and tests will fail
 def java_home = System.properties['java.home']
 def jdk_home = java_home
@@ -103,12 +100,12 @@ dependencies {
 }
 
 repositories {
-        mavenLocal()
-        for (repoUrl in project.dependencyRepositories) {
-            maven {
-                url repoUrl
-            }
+    mavenLocal()
+    for (repoUrl in project.dependencyRepositories) {
+        maven {
+            url repoUrl
         }
+    }
 }
 
 task resolveMps(type: Copy) {
@@ -128,26 +125,27 @@ dependencies {
     ant_lib "org.apache.ant:ant-junit:1.10.1"
 }
 
-
 // tools might be needed later for running test scripts
-ext.buildScriptClasspath = project.configurations.ant_lib.fileCollection({ true }) + project.files("$project.jdk_home/lib/tools.jar")
+ext.buildScriptClasspath = project.configurations.ant_lib.fileCollection({
+    true
+}) + project.files("$project.jdk_home/lib/tools.jar")
 
 def artifactsDir = new File(rootDir, 'artifacts')
 
 
-ext.mps_home =  '-Dmps.home=' + resolveMps.destinationDir.getAbsolutePath()
+ext.mps_home = '-Dmps.home=' + resolveMps.destinationDir.getAbsolutePath()
 ext.build_dir = '-Dbuild.dir=' + file(rootProject.projectDir.absolutePath).getAbsolutePath()
 ext.artifacts_dir = '-Dartifacts.root=' + artifactsDir
 ext.pluginVersion = "-Dversion=" + version
 ext.buildDate = "-DbuildDate=" + new Date().toString()
-ext.extensions_home =  '-Dextensions.home=' + rootDir
+ext.extensions_home = '-Dextensions.home=' + rootDir
 
 // ___________________ utilities ___________________
 File scriptFile(String relativePath) {
     new File("$rootDir/build/generated/$relativePath")
 }
 
-def defaultScriptArgs = [mps_home,  build_dir, artifacts_dir, ext.buildDate, ext.pluginVersion]
+def defaultScriptArgs = [mps_home, build_dir, artifacts_dir, ext.buildDate, ext.pluginVersion]
 
 
 
@@ -157,10 +155,10 @@ task build_allScripts(type: BuildLanguages, dependsOn: [resolveMps]){
      scriptClasspath = buildScriptClasspath
 }
 
-task build_languages(type: BuildLanguages, dependsOn: [build_allScripts]){
-     script scriptFile('languages/build.xml')
-     scriptArgs = defaultScriptArgs
-     scriptClasspath = buildScriptClasspath
+task build_languages(type: BuildLanguages, dependsOn: [build_allScripts]) {
+    script scriptFile('languages/build.xml')
+    scriptArgs = defaultScriptArgs
+    scriptClasspath = buildScriptClasspath
 }
 
 task run_tests(type: TestLanguages, dependsOn: build_languages) {

--- a/build.gradle
+++ b/build.gradle
@@ -149,10 +149,15 @@ def defaultScriptArgs = [mps_home, build_dir, artifacts_dir, ext.buildDate, ext.
 
 
 
-task build_allScripts(type: BuildLanguages, dependsOn: [resolveMps]){
-     script scriptFile('allScripts/build.xml')
-     scriptArgs = defaultScriptArgs
-     scriptClasspath = buildScriptClasspath
+task build_allScripts(type: BuildLanguages, dependsOn: [resolveMps]) {
+    script scriptFile('allScripts/build.xml')
+    inputs.file(scriptFile('allScripts/build.xml'))
+    inputs.dir("$rootDir/code/mps-build/solutions/de.slisson.mps.all.build/models")
+    inputs.file("$rootDir/code/mps-build/solutions/de.slisson.mps.all.build/de.slisson.mps.all.build.msd")
+    outputs.dir("$rootDir/build/generated/languages")
+    outputs.dir("$rootDir/build/generated/tests")
+    scriptArgs = defaultScriptArgs
+    scriptClasspath = buildScriptClasspath
 }
 
 task build_languages(type: BuildLanguages, dependsOn: [build_allScripts]) {


### PR DESCRIPTION
Registering the inputs and outputs of the all scripts task enables
gradle to skip build script generation in case the generated files are
uptodate and the outputs have beend produces. This cuts roughly 30 sec
of the over all 2min 30sec build time.

I also reformatted the build.gradle file with intelliJ.