### PR TITLE
fix language namespace of diagram editor (documentation)

### DIFF
--- a/docs/extensions/diagrams.md
+++ b/docs/extensions/diagrams.md
@@ -1,6 +1,6 @@
 # Diagrams
 
-**Language Namespace :** `de.slisson.mps.editor.diagram`
+**Language Namespace :** `de.itemis.mps.editor.diagram`
 
 If you have downloaded the recent mbeddr master branch, you will have noticed that, for example, component wiring and state machines can now be edited graphically. The screenshots below show examples of these two notations.
 


### PR DESCRIPTION
While reading the [documentation of the diagram language](https://jetbrains.github.io/MPS-extensions/extensions/diagrams/) I noticed that the namespace in the documentation doesn't match the namespace of the code. This pull request adjusts the namespace in the documentation.