### PR TITLE
show comprehensible error message if not building with java 8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,10 @@ if (project.hasProperty("forceCI")) {
     }
 }
 
+// comprehensible error message if not running java 8
+if(JavaVersion.current() != JavaVersion.VERSION_1_8){
+    throw new GradleException("This build script requires java " + JavaVersion.VERSION_1_8 + ", but you are currently using " + JavaVersion.current())
+}
 // Detect jdk location, required to start ant with tools.jar on classpath otherwise javac and tests will fail
 def java_home = System.properties['java.home']
 def jdk_home = java_home


### PR DESCRIPTION
analogous to [mbeddr.core#1976](https://github.com/mbeddr/mbeddr.core/pull/1976)

# Before
When running `./gradlew` from java 10, I get an error message that doesn't hint me on my mistake:
```
➜  MPS-extensions git:(master) ./gradlew

FAILURE: Build failed with an exception.

* Where:
Build file '/Users/bkruck/MPS-extensions/build.gradle' line: 49

* What went wrong:
A problem occurred evaluating root project 'MPS-extensions'.
> Was not able to locate jdk home folder. Use 'jdk_home' project variable to specify JDK location explicitly. Current JAVA_HOME is: /Library/Java/JavaVirtualMachines/jdk-10.0.1.jdk/Contents/Home

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

```

# After
```
➜  MPS-extensions git:(master) ✗ ./gradlew

FAILURE: Build failed with an exception.

* Where:
Build file '/Users/bkruck/MPS-extensions/build.gradle' line: 44

* What went wrong:
A problem occurred evaluating root project 'MPS-extensions'.
> This build script requires java 1.8, but you are currently using 1.10

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 1s
```