### PR TITLE
dropdowncell: always feed node substitutor with last leaf

### DIFF
--- a/code/widgets/solutions/de.itemis.mps.editor.dropdown.runtime/models/de/itemis/mps/editor/dropdown/runtime.mps
+++ b/code/widgets/solutions/de.itemis.mps.editor.dropdown.runtime/models/de/itemis/mps/editor/dropdown/runtime.mps
@@ -442,8 +442,12 @@
             </node>
             <node concept="liA8E" id="7szUFELGcB1" role="2OqNvi">
               <ref role="37wK5l" to="exr9:~EditorComponent.activateNodeSubstituteChooser(jetbrains.mps.openapi.editor.cells.EditorCell,boolean,boolean):boolean" resolve="activateNodeSubstituteChooser" />
-              <node concept="37vLTw" id="7szUFELGu6Z" role="37wK5m">
-                <ref role="3cqZAo" node="7szUFELGql2" resolve="myLabelCell" />
+              <node concept="2YIFZM" id="7mmXjFojzZk" role="37wK5m">
+                <ref role="37wK5l" to="f4zo:~CellTraversalUtil.getLastLeaf(jetbrains.mps.openapi.editor.cells.EditorCell):jetbrains.mps.openapi.editor.cells.EditorCell" resolve="getLastLeaf" />
+                <ref role="1Pybhc" to="f4zo:~CellTraversalUtil" resolve="CellTraversalUtil" />
+                <node concept="37vLTw" id="7mmXjFoj$bS" role="37wK5m">
+                  <ref role="3cqZAo" node="7szUFELGql2" resolve="myLabelCell" />
+                </node>
               </node>
               <node concept="3clFbT" id="7szUFELGggc" role="37wK5m">
                 <property role="3clFbU" value="true" />

--- a/code/widgets/solutions/de.itemis.mps.editor.dropdown.sandbox/de.itemis.mps.editor.dropdown.sandbox.msd
+++ b/code/widgets/solutions/de.itemis.mps.editor.dropdown.sandbox/de.itemis.mps.editor.dropdown.sandbox.msd
@@ -8,7 +8,9 @@
   <sourcePath />
   <languageVersions>
     <language slang="l:6b5dd191-3c21-47c5-a7d3-c6e1f7c7cbd0:de.itemis.mps.editor.dropdown.demolang" version="0" />
+    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="6" />
     <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="1" />
+    <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
   </languageVersions>
   <dependencyVersions>
     <module reference="dba47e42-d4c1-4eae-bc35-556658c0dc1e(de.itemis.mps.editor.dropdown.sandbox)" version="0" />

--- a/code/widgets/solutions/de.itemis.mps.editor.dropdown.sandbox/models/de/itemis/mps/editor/dropdown/sandbox.mps
+++ b/code/widgets/solutions/de.itemis.mps.editor.dropdown.sandbox/models/de/itemis/mps/editor/dropdown/sandbox.mps
@@ -3,6 +3,7 @@
   <persistence version="9" />
   <languages>
     <use id="6b5dd191-3c21-47c5-a7d3-c6e1f7c7cbd0" name="de.itemis.mps.editor.dropdown.demolang" version="0" />
+    <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="6" />
   </languages>
   <imports />
   <registry>


### PR DESCRIPTION
Currently, if the collection is empty when you click the drop-down button, the completion menu will also be empty. When using the keyboard the completion menu is correctly populated. 

When using the keyboard the editor label cell is used as input to the substitute chooser, while the combo box always uses the editor cell collection. To fix this I always pass into the substitute chooser the last leaf. I am sure if this is a good solution but it seems to work for this particular scenario.

To play around one can just use the existing example in the sandbox:
http://127.0.0.1:63320/node?ref=r%3A33040f6a-f60b-472b-aae3-ed4400e941e2%28de.itemis.mps.editor.dropdown.sandbox%29%2F4141535073103138147&project=mps-extensions