### PR TITLE
PriorityInfoCell reduction rule generates proper setup block for the editor cell

### DIFF
--- a/code/conditional-editor/languages/de.slisson.mps.conditionalEditor/generator/template/main@generator.mps
+++ b/code/conditional-editor/languages/de.slisson.mps.conditionalEditor/generator/template/main@generator.mps
@@ -1018,6 +1018,9 @@
                 </node>
               </node>
             </node>
+            <node concept="1sPUBX" id="oEOEQjZrbY" role="lGtFl">
+              <ref role="v9R2y" to="tpc3:4AbVKpmvegw" resolve="SetBigCellProperty" />
+            </node>
           </node>
           <node concept="3cpWs6" id="g0oLfbs" role="3cqZAp">
             <node concept="37vLTw" id="3GM_nagTuWL" role="3cqZAk">


### PR DESCRIPTION
The `reduce_CellModel_PriorityInfo` template now makes use of the `SetBigCellProperty` template switch. This makes sure that whenever appropriate, the `setCellContext` method will also be called beyond setting the `big` flag. 