### PR TITLE
Tables: Make moving children between rows deterministic

### DIFF
--- a/code/tables/languages/de.slisson.mps.tables/runtime/models/de/slisson/mps/tables/runtime/cells.mps
+++ b/code/tables/languages/de.slisson.mps.tables/runtime/models/de/slisson/mps/tables/runtime/cells.mps
@@ -30988,7 +30988,7 @@
       </node>
       <node concept="2ShNRf" id="1362cT3cSDH" role="33vP2m">
         <node concept="1pGfFk" id="1362cT3cTul" role="2ShVmc">
-          <ref role="37wK5l" to="33ny:~HashSet.&lt;init&gt;()" resolve="HashSet" />
+          <ref role="37wK5l" to="33ny:~LinkedHashSet.&lt;init&gt;()" resolve="LinkedHashSet" />
           <node concept="3uibUv" id="1362cT3cTCy" role="1pMfVU">
             <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
           </node>
@@ -31006,7 +31006,7 @@
       </node>
       <node concept="2ShNRf" id="4MuW45D85Cn" role="33vP2m">
         <node concept="1pGfFk" id="4MuW45D8C6i" role="2ShVmc">
-          <ref role="37wK5l" to="33ny:~HashSet.&lt;init&gt;()" resolve="HashSet" />
+          <ref role="37wK5l" to="33ny:~LinkedHashSet.&lt;init&gt;()" resolve="LinkedHashSet" />
           <node concept="3uibUv" id="4MuW45D8CgH" role="1pMfVU">
             <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
           </node>
@@ -31164,7 +31164,7 @@
         <node concept="3clFbF" id="x$t3A6YEDz" role="3cqZAp">
           <node concept="2ShNRf" id="x$t3A6YEDx" role="3clFbG">
             <node concept="1pGfFk" id="x$t3A6ZfAG" role="2ShVmc">
-              <ref role="37wK5l" to="33ny:~HashSet.&lt;init&gt;(java.util.Collection)" resolve="HashSet" />
+              <ref role="37wK5l" to="33ny:~LinkedHashSet.&lt;init&gt;(java.util.Collection)" resolve="LinkedHashSet" />
               <node concept="3uibUv" id="x$t3A6ZfKF" role="1pMfVU">
                 <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
               </node>
@@ -31190,7 +31190,7 @@
         <node concept="3clFbF" id="4MuW45D96p5" role="3cqZAp">
           <node concept="2ShNRf" id="4MuW45D96p6" role="3clFbG">
             <node concept="1pGfFk" id="4MuW45D96p7" role="2ShVmc">
-              <ref role="37wK5l" to="33ny:~HashSet.&lt;init&gt;(java.util.Collection)" resolve="HashSet" />
+              <ref role="37wK5l" to="33ny:~LinkedHashSet.&lt;init&gt;(java.util.Collection)" resolve="LinkedHashSet" />
               <node concept="3uibUv" id="4MuW45D96p8" role="1pMfVU">
                 <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
               </node>


### PR DESCRIPTION
Given a table editor that contains a collection inside its rows (in my case, a switch statement displayed as a decision table, so each switch case is a row and the second column is the switch case body, which contains a statement list), moving a child of a table cell up- or downwards with Ctrl+Shift+Up/Down is non-deterministic: The child randomly ends up either in one of the other rows above or below, or above/below the table.
Apparently, this is caused by the ChildsTracker utility class using HashSets to remember the table's child EditorCells. I didn't try to fully grasp the implementation, but in any case, replacing the HashSets with LinkedHashSets seems to help.