### PR TITLE
build: install pip and run mkdocs from gradle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ test_gen/
 site
 .DS_Store
 .gradletasknamecache
+.idea/encodings.xml

--- a/build.gradle
+++ b/build.gradle
@@ -294,6 +294,19 @@ publishing {
     }
 }
 
+task pipInstall(type: Exec) {
+    inputs.file("requirements.txt")
+    commandLine "pip", "install", "-r", "requirements.txt"
+}
+
+task previewDocs(type: Exec, dependsOn: pipInstall) {
+    commandLine "mkdocs", "serve"
+}
+
+task deployDocs(type: Exec, dependsOn: pipInstall) {
+    commandLine "git", "remote", "add",  "gh-pages", "https://${rootProject.findProperty("system.github.token")}@github.com/JetBrains/MPS-extensions.git"
+    commandLine "mkdocs", "gh-deploy", "--clean", "-r", "gh-pages", "--force"
+}
 
 defaultTasks 'build_languages'
 task test(dependsOn: run_tests)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,7 +9,7 @@ site_url: https://jetbrains.github.io/MPS-extensions/
 
 repo_url: https://github.com/jetbrains/mps-extensions
 
-pages:
+nav:
 - Home: index.md
 - Building: building.md
 - Contributing: contributing.md

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+mkdocs==1.0.4
+mkdocs-cinder==0.16.0


### PR DESCRIPTION
move the logic to generate the documentation into gradle. This allows
us to update and maintain the documentation without depending on the
build server infrastructure.