### PR TITLE
Fix generator warnings when using collapsible cells

### DIFF
--- a/code/widgets/languages/de.itemis.mps.editor.collapsible/generator/template/main@generator.mps
+++ b/code/widgets/languages/de.itemis.mps.editor.collapsible/generator/template/main@generator.mps
@@ -415,8 +415,10 @@
                             </node>
                           </node>
                           <node concept="gft3U" id="5pN$eUp3SMI" role="UU_$l">
-                            <node concept="3cpWs6" id="5pN$eUp3T5O" role="gfFT$">
-                              <node concept="10Nm6u" id="5pN$eUq1bKI" role="3cqZAk" />
+                            <node concept="3clFbS" id="3W4ZQahPhkp" role="gfFT$">
+                              <node concept="3cpWs6" id="3W4ZQahPjiB" role="3cqZAp">
+                                <node concept="10Nm6u" id="3W4ZQahPjnl" role="3cqZAk" />
+                              </node>
                             </node>
                           </node>
                         </node>
@@ -515,7 +517,9 @@
                             </node>
                           </node>
                           <node concept="gft3U" id="5pN$eUpk2gp" role="UU_$l">
-                            <node concept="3cpWs6" id="5pN$eUpk2gq" role="gfFT$" />
+                            <node concept="3clFbS" id="3W4ZQai2zDJ" role="gfFT$">
+                              <node concept="3cpWs6" id="3W4ZQai2zJN" role="3cqZAp" />
+                            </node>
                           </node>
                         </node>
                         <node concept="29HgVG" id="5pN$eUpk2gr" role="lGtFl">
@@ -580,7 +584,9 @@
                             </node>
                           </node>
                           <node concept="gft3U" id="5pN$eUpfaw0" role="UU_$l">
-                            <node concept="3cpWs6" id="5pN$eUpfaN4" role="gfFT$" />
+                            <node concept="3clFbS" id="3W4ZQai2BBw" role="gfFT$">
+                              <node concept="3cpWs6" id="3W4ZQai2BGO" role="3cqZAp" />
+                            </node>
                           </node>
                         </node>
                         <node concept="29HgVG" id="5pN$eUpf0hw" role="lGtFl">
@@ -645,7 +651,9 @@
                             </node>
                           </node>
                           <node concept="gft3U" id="5pN$eUpkdAP" role="UU_$l">
-                            <node concept="3cpWs6" id="5pN$eUpkdAQ" role="gfFT$" />
+                            <node concept="3clFbS" id="3W4ZQahWaV7" role="gfFT$">
+                              <node concept="3cpWs6" id="3W4ZQahWb0O" role="3cqZAp" />
+                            </node>
                           </node>
                         </node>
                         <node concept="29HgVG" id="5pN$eUpkdAR" role="lGtFl">


### PR DESCRIPTION
Several $IF$ macros in the template had a StatementList for "then"
branch but a ReturnStatement for "else". All branches of those $IF$s are
now StatementLists.