### PR TITLE
grammarcells: provide cell context in SplittableCell factory method

### DIFF
--- a/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
+++ b/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
@@ -5633,6 +5633,11 @@
               <ref role="3bR37D" to="ffeo:7YI57w6K0hQ" resolve="jetbrains.mps.lang.actions#1154466409006" />
             </node>
           </node>
+          <node concept="1SiIV0" id="17heSRQmGcw" role="3bR37C">
+            <node concept="3bR9La" id="17heSRQmGcx" role="1SiIV1">
+              <ref role="3bR37D" to="ffeo:2Qa9MYMHrcB" resolve="jetbrains.mps.editorlang.runtime" />
+            </node>
+          </node>
         </node>
       </node>
     </node>

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/com.mbeddr.mpsutil.grammarcells.mpl
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/com.mbeddr.mpsutil.grammarcells.mpl
@@ -30,6 +30,7 @@
         <dependency reexport="false">52733268-be24-4f5f-ab84-a73b7c0c03b0(de.slisson.mps.richtext.customcell)</dependency>
         <dependency reexport="false">b4f35ed8-45af-4efa-abe4-00ac26956e69(com.mbeddr.mpsutil.grammarcells.runtimelang)</dependency>
         <dependency reexport="false">7866978e-a0f0-4cc7-81bc-4d213d9375e1(jetbrains.mps.lang.smodel)</dependency>
+        <dependency reexport="false">2e24a298-44d1-4697-baec-5c424fed3a3b(jetbrains.mps.editorlang.runtime)</dependency>
       </dependencies>
       <languageVersions>
         <language slang="l:9d69e719-78c8-4286-90db-fb19c107d049:com.mbeddr.mpsutil.grammarcells" version="0" />
@@ -76,6 +77,7 @@
         <module reference="fd392034-7849-419d-9071-12563d152375(jetbrains.mps.baseLanguage.closures)" version="0" />
         <module reference="83888646-71ce-4f1c-9c53-c54016f6ad4f(jetbrains.mps.baseLanguage.collections)" version="0" />
         <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
+        <module reference="2e24a298-44d1-4697-baec-5c424fed3a3b(jetbrains.mps.editorlang.runtime)" version="0" />
         <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
         <module reference="aee9cad2-acd4-4608-aef2-0004f6a1cdbd(jetbrains.mps.lang.actions)" version="0" />
         <module reference="018659ff-d3ef-4215-97e0-bcfeeb111145(jetbrains.mps.lang.actions#1154466409006)" version="0" />

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/generator/template/main@generator.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/generator/template/main@generator.mps
@@ -67,10 +67,10 @@
     <import index="5b0" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel.presentation(MPS.Core/)" />
     <import index="tp25" ref="r:00000000-0000-4000-0000-011c89590301(jetbrains.mps.lang.smodel.structure)" />
     <import index="tp27" ref="r:00000000-0000-4000-0000-011c89590303(jetbrains.mps.lang.smodel.generator.baseLanguage.template.main@generator)" />
+    <import index="qvne" ref="r:8ff33705-85bf-4855-805c-06d68fbe233c(jetbrains.mps.editor.runtime.descriptor)" />
     <import index="x4mf" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.menus(MPS.Editor/)" implicit="true" />
     <import index="hox0" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.style(MPS.Editor/)" implicit="true" />
     <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" implicit="true" />
-    <import index="qvne" ref="r:8ff33705-85bf-4855-805c-06d68fbe233c(jetbrains.mps.editor.runtime.descriptor)" implicit="true" />
   </imports>
   <registry>
     <language id="a247e09e-2435-45ba-b8d2-07e93feba96a" name="jetbrains.mps.baseLanguage.tuples">
@@ -295,9 +295,14 @@
       <concept id="1079359253375" name="jetbrains.mps.baseLanguage.structure.ParenthesizedExpression" flags="nn" index="1eOMI4">
         <child id="1079359253376" name="expression" index="1eOMHV" />
       </concept>
+      <concept id="1081506762703" name="jetbrains.mps.baseLanguage.structure.GreaterThanExpression" flags="nn" index="3eOSWO" />
       <concept id="1081506773034" name="jetbrains.mps.baseLanguage.structure.LessThanExpression" flags="nn" index="3eOVzh" />
       <concept id="1081516740877" name="jetbrains.mps.baseLanguage.structure.NotExpression" flags="nn" index="3fqX7Q">
         <child id="1081516765348" name="expression" index="3fr31v" />
+      </concept>
+      <concept id="1154542696413" name="jetbrains.mps.baseLanguage.structure.ArrayCreatorWithInitializer" flags="nn" index="3g6Rrh">
+        <child id="1154542793668" name="componentType" index="3g7fb8" />
+        <child id="1154542803372" name="initValue" index="3g7hyw" />
       </concept>
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
@@ -418,6 +423,9 @@
       <concept id="1167171569011" name="jetbrains.mps.lang.generator.structure.Weaving_MappingRule" flags="lg" index="30QchW">
         <child id="1169570368028" name="ruleConsequence" index="1fOSGc" />
         <child id="1184616230853" name="contextNodeQuery" index="3gCiVm" />
+      </concept>
+      <concept id="1227303129915" name="jetbrains.mps.lang.generator.structure.AbstractMacro" flags="lg" index="30XT8A">
+        <property id="3265704088513289864" name="comment" index="34cw8o" />
       </concept>
       <concept id="1092059087312" name="jetbrains.mps.lang.generator.structure.TemplateDeclaration" flags="ig" index="13MO4I">
         <reference id="1168285871518" name="applicableConcept" index="3gUMe" />
@@ -24833,10 +24841,11 @@
       <node concept="1Koe21" id="48TKAW3Vg0D" role="1lVwrX">
         <node concept="9aQIb" id="48TKAW3Vg0E" role="1Koe22">
           <node concept="3clFbS" id="48TKAW3Vg0F" role="9aQI4">
-            <node concept="3clFbH" id="48TKAW3Vg0G" role="3cqZAp">
-              <node concept="raruj" id="48TKAW3Vg0H" role="lGtFl" />
-              <node concept="5jKBG" id="48TKAW3Vg0I" role="lGtFl">
-                <ref role="v9R2y" to="tpc3:g_$xCuf" resolve="reduce_CellModel_WithRole" />
+            <node concept="3clFbH" id="3dIwcSTzdqV" role="3cqZAp">
+              <node concept="raruj" id="3dIwcSTzdrc" role="lGtFl" />
+              <node concept="5jKBG" id="3dIwcSTzdri" role="lGtFl">
+                <property role="34cw8o" value="Replaces original reduce_CellModel_WithRole with some code from reduce_CellModel_Property to properly provide cell context" />
+                <ref role="v9R2y" node="3dIwcSTyQ2Q" resolve="reduce_SplittableCell" />
               </node>
             </node>
             <node concept="3clFbH" id="48TKAW3Vg0J" role="3cqZAp">
@@ -25949,6 +25958,633 @@
             </node>
           </node>
         </node>
+      </node>
+    </node>
+  </node>
+  <node concept="13MO4I" id="3dIwcSTyQ2Q">
+    <property role="TrG5h" value="reduce_SplittableCell" />
+    <ref role="3gUMe" to="teg0:3pFNVizDvwD" resolve="SplittableCell" />
+    <node concept="312cEu" id="3dIwcSTz3Iz" role="13RCb5">
+      <property role="TrG5h" value="_context_class_" />
+      <property role="1sVAO0" value="true" />
+      <node concept="3clFb_" id="3dIwcSTyQ39" role="jymVt">
+        <property role="TrG5h" value="_cell_factory_method_" />
+        <node concept="3clFbS" id="3dIwcSTyQ3c" role="3clF47">
+          <node concept="3SKdUt" id="1pA5V1UG4ak" role="3cqZAp">
+            <node concept="3SKdUq" id="1pA5V1UG4am" role="3SKWNk">
+              <property role="3SKdUp" value="(*): lines added to the factory method from reduce_CellModel_Property (originally used for SplittableCell: reduce_CellModel_WithRole)" />
+            </node>
+          </node>
+          <node concept="3SKdUt" id="1pA5V1UFWie" role="3cqZAp">
+            <node concept="3SKdUq" id="1pA5V1UFWig" role="3SKWNk">
+              <property role="3SKdUp" value="(*) push new cell context to stack" />
+            </node>
+          </node>
+          <node concept="3clFbF" id="1ByWmfQyWQB" role="3cqZAp">
+            <node concept="2OqwBi" id="1ByWmfQyXVh" role="3clFbG">
+              <node concept="1rXfSq" id="1ByWmfQyWQ_" role="2Oq$k0">
+                <ref role="37wK5l" to="qvne:6OQfiPCHBjx" resolve="getCellFactory" />
+              </node>
+              <node concept="liA8E" id="1ByWmfQyY74" role="2OqNvi">
+                <ref role="37wK5l" to="f4zo:~EditorCellFactory.pushCellContext()" resolve="pushCellContext" />
+              </node>
+            </node>
+          </node>
+          <node concept="2GUZhq" id="3dIwcSTAG9J" role="3cqZAp">
+            <node concept="3clFbS" id="3dIwcSTAFmM" role="2GV8ay">
+              <node concept="3SKdUt" id="1pA5V1UG1xZ" role="3cqZAp">
+                <node concept="3SKdUq" id="1pA5V1UG1y1" role="3SKWNk">
+                  <property role="3SKdUp" value="(*) set property info into the cell context" />
+                </node>
+              </node>
+              <node concept="3cpWs8" id="6J9VvZhUtHu" role="3cqZAp">
+                <node concept="3cpWsn" id="6J9VvZhUtHv" role="3cpWs9">
+                  <property role="TrG5h" value="property" />
+                  <node concept="3uibUv" id="6J9VvZhUtHs" role="1tU5fm">
+                    <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
+                  </node>
+                  <node concept="355D3s" id="6J9VvZhUtHw" role="33vP2m">
+                    <ref role="355D3t" to="tpck:gw2VY9q" resolve="BaseConcept" />
+                    <ref role="355D3u" to="tpck:hnGE5uv" resolve="virtualPackage" />
+                    <node concept="1ZhdrF" id="6J9VvZhUtHx" role="lGtFl">
+                      <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/2644386474302386080/2644386474302386081" />
+                      <property role="2qtEX8" value="conceptDeclaration" />
+                      <node concept="3$xsQk" id="6J9VvZhUtHy" role="3$ytzL">
+                        <node concept="3clFbS" id="6J9VvZhUtHz" role="2VODD2">
+                          <node concept="3clFbF" id="6J9VvZhUtH$" role="3cqZAp">
+                            <node concept="2OqwBi" id="6J9VvZhUtH_" role="3clFbG">
+                              <node concept="2OqwBi" id="6J9VvZhUtHA" role="2Oq$k0">
+                                <node concept="30H73N" id="6J9VvZhUtHB" role="2Oq$k0" />
+                                <node concept="3TrEf2" id="6J9VvZhUtHC" role="2OqNvi">
+                                  <ref role="3Tt5mk" to="tpc2:fBF1KQc" resolve="propertyDeclaration" />
+                                </node>
+                              </node>
+                              <node concept="2Xjw5R" id="6J9VvZhUtHD" role="2OqNvi">
+                                <node concept="1xMEDy" id="6J9VvZhUtHE" role="1xVPHs">
+                                  <node concept="chp4Y" id="6J9VvZhUtHF" role="ri$Ld">
+                                    <ref role="cht4Q" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="1ZhdrF" id="6J9VvZhUtHG" role="lGtFl">
+                      <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/2644386474302386080/2644386474302386082" />
+                      <property role="2qtEX8" value="propertyDeclaration" />
+                      <node concept="3$xsQk" id="6J9VvZhUtHH" role="3$ytzL">
+                        <node concept="3clFbS" id="6J9VvZhUtHI" role="2VODD2">
+                          <node concept="3clFbF" id="6J9VvZhUtHJ" role="3cqZAp">
+                            <node concept="2OqwBi" id="6J9VvZhUtHK" role="3clFbG">
+                              <node concept="3TrEf2" id="6J9VvZhUtHL" role="2OqNvi">
+                                <ref role="3Tt5mk" to="tpc2:fBF1KQc" resolve="propertyDeclaration" />
+                              </node>
+                              <node concept="30H73N" id="6J9VvZhUtHM" role="2Oq$k0" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbF" id="1ByWmfQ$5Ra" role="3cqZAp">
+                <node concept="2OqwBi" id="1ByWmfQ$7o3" role="3clFbG">
+                  <node concept="1rXfSq" id="1ByWmfQ$5R8" role="2Oq$k0">
+                    <ref role="37wK5l" to="qvne:6OQfiPCHBjx" resolve="getCellFactory" />
+                  </node>
+                  <node concept="liA8E" id="1ByWmfQ$dRc" role="2OqNvi">
+                    <ref role="37wK5l" to="f4zo:~EditorCellFactory.setPropertyInfo(jetbrains.mps.openapi.editor.menus.transformation.SPropertyInfo)" resolve="setPropertyInfo" />
+                    <node concept="2ShNRf" id="1ByWmfQ$eK5" role="37wK5m">
+                      <node concept="1pGfFk" id="1ByWmfQ$gdP" role="2ShVmc">
+                        <ref role="37wK5l" to="uddc:~SPropertyInfo.&lt;init&gt;(org.jetbrains.mps.openapi.model.SNode,org.jetbrains.mps.openapi.language.SProperty)" resolve="SPropertyInfo" />
+                        <node concept="37vLTw" id="1ByWmfQ$iyx" role="37wK5m">
+                          <ref role="3cqZAo" to="tpc3:7GOmDNDA2zg" resolve="myNode" />
+                        </node>
+                        <node concept="37vLTw" id="1ByWmfQ$iSQ" role="37wK5m">
+                          <ref role="3cqZAo" node="6J9VvZhUtHv" resolve="property" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbH" id="3dIwcSTMUOO" role="3cqZAp" />
+              <node concept="3cpWs8" id="g_Cet48" role="3cqZAp">
+                <node concept="3cpWsn" id="g_Cet49" role="3cpWs9">
+                  <property role="TrG5h" value="provider" />
+                  <node concept="10Nm6u" id="4YnqLFjpfwA" role="33vP2m">
+                    <node concept="1sPUBX" id="4YnqLFjpfwB" role="lGtFl">
+                      <ref role="v9R2y" to="tpc3:55my_QKXKCI" resolve="CellProviderWithRoleInitializer" />
+                      <node concept="2OqwBi" id="4YnqLFjpfwC" role="v9R3O">
+                        <node concept="30H73N" id="4YnqLFjpfwD" role="2Oq$k0" />
+                        <node concept="2qgKlT" id="4YnqLFjpfwE" role="2OqNvi">
+                          <ref role="37wK5l" to="tpcb:4YnqLFjkxyn" resolve="getFeatureForCell" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3uibUv" id="287iZ$rUSBb" role="1tU5fm">
+                    <ref role="3uigEE" to="emqf:~CellProviderWithRole" resolve="CellProviderWithRole" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbF" id="g_Cf8_z" role="3cqZAp">
+                <node concept="1W57fq" id="hF5sZoj" role="lGtFl">
+                  <node concept="3IZrLx" id="hF5sZok" role="3IZSJc">
+                    <node concept="3clFbS" id="hF5sZol" role="2VODD2">
+                      <node concept="3clFbF" id="hF5tdt6" role="3cqZAp">
+                        <node concept="22lmx$" id="hF9uLyR" role="3clFbG">
+                          <node concept="2OqwBi" id="hF9uM$7" role="3uHU7w">
+                            <node concept="30H73N" id="hF9uMg$" role="2Oq$k0" />
+                            <node concept="3TrcHB" id="hF9uMRW" role="2OqNvi">
+                              <ref role="3TsBF5" to="tpc2:hF9s7y1" resolve="emptyNoTargetText" />
+                            </node>
+                          </node>
+                          <node concept="1eOMI4" id="hF9uL65" role="3uHU7B">
+                            <node concept="1Wc70l" id="hF9uL66" role="1eOMHV">
+                              <node concept="3eOSWO" id="hF9uL6c" role="3uHU7w">
+                                <node concept="2OqwBi" id="hF9uL6e" role="3uHU7B">
+                                  <node concept="2OqwBi" id="hF9uL6f" role="2Oq$k0">
+                                    <node concept="30H73N" id="hF9uL6g" role="2Oq$k0" />
+                                    <node concept="3TrcHB" id="hF9uL6h" role="2OqNvi">
+                                      <ref role="3TsBF5" to="tpc2:g_$x2vM" resolve="noTargetText" />
+                                    </node>
+                                  </node>
+                                  <node concept="liA8E" id="hF9uL6i" role="2OqNvi">
+                                    <ref role="37wK5l" to="wyt6:~String.length()" resolve="length" />
+                                  </node>
+                                </node>
+                                <node concept="3cmrfG" id="hF9uL6d" role="3uHU7w">
+                                  <property role="3cmrfH" value="0" />
+                                </node>
+                              </node>
+                              <node concept="3y3z36" id="hF9uL67" role="3uHU7B">
+                                <node concept="10Nm6u" id="hF9uL6b" role="3uHU7w" />
+                                <node concept="2OqwBi" id="hF9uL68" role="3uHU7B">
+                                  <node concept="3TrcHB" id="hF9uL6a" role="2OqNvi">
+                                    <ref role="3TsBF5" to="tpc2:g_$x2vM" resolve="noTargetText" />
+                                  </node>
+                                  <node concept="30H73N" id="hF9uL69" role="2Oq$k0" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="h_XJ9TG" role="3clFbG">
+                  <node concept="37vLTw" id="3GM_nagT_ka" role="2Oq$k0">
+                    <ref role="3cqZAo" node="g_Cet49" resolve="provider" />
+                  </node>
+                  <node concept="liA8E" id="h_XJ9TH" role="2OqNvi">
+                    <ref role="37wK5l" to="emqf:~CellProviderWithRole.setNoTargetText(java.lang.String)" resolve="setNoTargetText" />
+                    <node concept="Xl_RD" id="g_Cf8_A" role="37wK5m">
+                      <property role="Xl_RC" value="noTarget" />
+                      <node concept="17Uvod" id="g_Cf8_B" role="lGtFl">
+                        <property role="2qtEX9" value="value" />
+                        <property role="P4ACc" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1070475926800/1070475926801" />
+                        <node concept="3zFVjK" id="hdOgFyx" role="3zH0cK">
+                          <node concept="3clFbS" id="hdOgFyy" role="2VODD2">
+                            <node concept="3clFbF" id="hdOgGnM" role="3cqZAp">
+                              <node concept="2OqwBi" id="hxx$Gr_" role="3clFbG">
+                                <node concept="30H73N" id="hdOgGnN" role="2Oq$k0" />
+                                <node concept="3TrcHB" id="hdOgHoz" role="2OqNvi">
+                                  <ref role="3TsBF5" to="tpc2:g_$x2vM" resolve="noTargetText" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbF" id="hF5tlF1" role="3cqZAp">
+                <node concept="1W57fq" id="hF5tlFd" role="lGtFl">
+                  <node concept="3IZrLx" id="hF5tlFe" role="3IZSJc">
+                    <node concept="3clFbS" id="hF5tlFf" role="2VODD2">
+                      <node concept="3clFbF" id="hF5tlFg" role="3cqZAp">
+                        <node concept="1Wc70l" id="hF9uGFG" role="3clFbG">
+                          <node concept="3clFbC" id="hF5v89Y" role="3uHU7B">
+                            <node concept="10Nm6u" id="hF5v8v0" role="3uHU7w" />
+                            <node concept="2OqwBi" id="hF5v60F" role="3uHU7B">
+                              <node concept="30H73N" id="hF5v5Mw" role="2Oq$k0" />
+                              <node concept="3TrcHB" id="hF5v6bt" role="2OqNvi">
+                                <ref role="3TsBF5" to="tpc2:g_$x2vM" resolve="noTargetText" />
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="3fqX7Q" id="hF9uHfS" role="3uHU7w">
+                            <node concept="2OqwBi" id="hF9uIg8" role="3fr31v">
+                              <node concept="3TrcHB" id="hF9uIGJ" role="2OqNvi">
+                                <ref role="3TsBF5" to="tpc2:hF9s7y1" resolve="emptyNoTargetText" />
+                              </node>
+                              <node concept="30H73N" id="hF9uI0v" role="2Oq$k0" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="hF5tlF2" role="3clFbG">
+                  <node concept="37vLTw" id="3GM_nagTyCs" role="2Oq$k0">
+                    <ref role="3cqZAo" node="g_Cet49" resolve="provider" />
+                  </node>
+                  <node concept="liA8E" id="hF5tlF4" role="2OqNvi">
+                    <ref role="37wK5l" to="emqf:~CellProviderWithRole.setNoTargetText(java.lang.String)" resolve="setNoTargetText" />
+                    <node concept="Xl_RD" id="hF5tlF5" role="37wK5m">
+                      <property role="Xl_RC" value="noTarget" />
+                      <node concept="17Uvod" id="hF5tlF6" role="lGtFl">
+                        <property role="2qtEX9" value="value" />
+                        <property role="P4ACc" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1070475926800/1070475926801" />
+                        <node concept="3zFVjK" id="hF5tlF7" role="3zH0cK">
+                          <node concept="3clFbS" id="hF5tlF8" role="2VODD2">
+                            <node concept="3clFbF" id="hF5treF" role="3cqZAp">
+                              <node concept="3cpWs3" id="hF5vIaP" role="3clFbG">
+                                <node concept="Xl_RD" id="hF5vVYj" role="3uHU7w">
+                                  <property role="Xl_RC" value="&gt;" />
+                                </node>
+                                <node concept="3cpWs3" id="hF5tttZ" role="3uHU7B">
+                                  <node concept="2OqwBi" id="4YnqLFjl6w1" role="3uHU7w">
+                                    <node concept="2OqwBi" id="hGPN0Z$" role="2Oq$k0">
+                                      <node concept="30H73N" id="hGPN0N_" role="2Oq$k0" />
+                                      <node concept="2qgKlT" id="4YnqLFjl63b" role="2OqNvi">
+                                        <ref role="37wK5l" to="tpcb:4YnqLFjkxyn" resolve="getFeatureForCell" />
+                                      </node>
+                                    </node>
+                                    <node concept="3TrcHB" id="4YnqLFjl6Sc" role="2OqNvi">
+                                      <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                                    </node>
+                                  </node>
+                                  <node concept="Xl_RD" id="hF5ts84" role="3uHU7B">
+                                    <property role="Xl_RC" value="&lt;no " />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbF" id="g_IqQ8v" role="3cqZAp">
+                <node concept="1W57fq" id="6ydIPyw2EoL" role="lGtFl">
+                  <node concept="3IZrLx" id="6ydIPyw2EoM" role="3IZSJc">
+                    <node concept="3clFbS" id="6ydIPyw2EoN" role="2VODD2">
+                      <node concept="3clFbF" id="6ydIPyw2EoO" role="3cqZAp">
+                        <node concept="2OqwBi" id="6ydIPyw2EoP" role="3clFbG">
+                          <node concept="30H73N" id="6ydIPyw2EoQ" role="2Oq$k0" />
+                          <node concept="3TrcHB" id="6ydIPyw2EoR" role="2OqNvi">
+                            <ref role="3TsBF5" to="tpc2:g_IntAF" resolve="readOnly" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="h_XJ8y1" role="3clFbG">
+                  <node concept="liA8E" id="h_XJ8y2" role="2OqNvi">
+                    <ref role="37wK5l" to="emqf:~CellProviderWithRole.setReadOnly(boolean)" resolve="setReadOnly" />
+                    <node concept="3clFbT" id="g_IqT62" role="37wK5m">
+                      <property role="3clFbU" value="true" />
+                    </node>
+                  </node>
+                  <node concept="37vLTw" id="3GM_nagTr_x" role="2Oq$k0">
+                    <ref role="3cqZAo" node="g_Cet49" resolve="provider" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbF" id="g_O9MXy" role="3cqZAp">
+                <node concept="1W57fq" id="6ydIPyw2ETR" role="lGtFl">
+                  <node concept="3IZrLx" id="6ydIPyw2ETS" role="3IZSJc">
+                    <node concept="3clFbS" id="6ydIPyw2ETT" role="2VODD2">
+                      <node concept="3clFbF" id="6ydIPyw2ETU" role="3cqZAp">
+                        <node concept="2OqwBi" id="6ydIPyw2ETV" role="3clFbG">
+                          <node concept="30H73N" id="6ydIPyw2ETW" role="2Oq$k0" />
+                          <node concept="3TrcHB" id="6ydIPyw2ETX" role="2OqNvi">
+                            <ref role="3TsBF5" to="tpc2:g_O74Lt" resolve="allowEmptyText" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="h_XJ785" role="3clFbG">
+                  <node concept="liA8E" id="h_XJ786" role="2OqNvi">
+                    <ref role="37wK5l" to="emqf:~CellProviderWithRole.setAllowsEmptyTarget(boolean)" resolve="setAllowsEmptyTarget" />
+                    <node concept="3clFbT" id="g_O9Vlj" role="37wK5m">
+                      <property role="3clFbU" value="true" />
+                    </node>
+                  </node>
+                  <node concept="37vLTw" id="3GM_nagTti7" role="2Oq$k0">
+                    <ref role="3cqZAo" node="g_Cet49" resolve="provider" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3cpWs8" id="g_CeiMn" role="3cqZAp">
+                <node concept="3cpWsn" id="g_CeiMo" role="3cpWs9">
+                  <property role="TrG5h" value="editorCell" />
+                  <node concept="3uibUv" id="5Hr2i_R1ZQa" role="1tU5fm">
+                    <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbF" id="3dYY$_sKB28" role="3cqZAp">
+                <node concept="37vLTI" id="3dYY$_sKB2a" role="3clFbG">
+                  <node concept="2OqwBi" id="3dYY$_sKB2d" role="37vLTx">
+                    <node concept="liA8E" id="3dYY$_sKB2f" role="2OqNvi">
+                      <ref role="37wK5l" to="exr9:~AbstractCellProvider.createEditorCell(jetbrains.mps.openapi.editor.EditorContext)" resolve="createEditorCell" />
+                      <node concept="1rXfSq" id="7VRiLsftisH" role="37wK5m">
+                        <ref role="37wK5l" to="qvne:6OQfiPCHBdf" resolve="getEditorContext" />
+                      </node>
+                    </node>
+                    <node concept="37vLTw" id="3GM_nagTtE4" role="2Oq$k0">
+                      <ref role="3cqZAo" node="g_Cet49" resolve="provider" />
+                    </node>
+                  </node>
+                  <node concept="37vLTw" id="3GM_nagTudP" role="37vLTJ">
+                    <ref role="3cqZAo" node="g_CeiMo" resolve="editorCell" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3cpWs8" id="3dYY$_sKB13" role="3cqZAp">
+                <node concept="5jKBG" id="za$VMvkNO$" role="lGtFl">
+                  <ref role="v9R2y" to="tpc3:4v1iCryNDHi" resolve="template_cellSetupBlock" />
+                </node>
+                <node concept="3cpWsn" id="3dYY$_sKB14" role="3cpWs9">
+                  <property role="TrG5h" value="i" />
+                  <node concept="10Oyi0" id="3dYY$_sKB15" role="1tU5fm" />
+                </node>
+              </node>
+              <node concept="3clFbF" id="2csR5Duk0Bv" role="3cqZAp">
+                <node concept="2OqwBi" id="2csR5Duk0Bx" role="3clFbG">
+                  <node concept="liA8E" id="2csR5Duk0Ct" role="2OqNvi">
+                    <ref role="37wK5l" to="f4zo:~EditorCell.setSubstituteInfo(jetbrains.mps.openapi.editor.cells.SubstituteInfo)" resolve="setSubstituteInfo" />
+                    <node concept="2ShNRf" id="2csR5Duk0Cw" role="37wK5m">
+                      <node concept="1W57fq" id="2csR5Duk0D7" role="lGtFl">
+                        <node concept="3IZrLx" id="2csR5Duk0D8" role="3IZSJc">
+                          <node concept="3clFbS" id="2csR5Duk0D9" role="2VODD2">
+                            <node concept="3clFbF" id="2csR5Duk0Da" role="3cqZAp">
+                              <node concept="3y3z36" id="2csR5Duk0Db" role="3clFbG">
+                                <node concept="10Nm6u" id="2csR5Duk0Dc" role="3uHU7w" />
+                                <node concept="2OqwBi" id="2csR5Duk0Dd" role="3uHU7B">
+                                  <node concept="30H73N" id="2csR5Duk0De" role="2Oq$k0" />
+                                  <node concept="3TrEf2" id="2csR5Duk0Df" role="2OqNvi">
+                                    <ref role="3Tt5mk" to="tpc2:gWP5bHW" resolve="menuDescriptor" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="gft3U" id="2csR5Duk0Dh" role="UU_$l">
+                          <node concept="2OqwBi" id="2csR5Duk0Dj" role="gfFT$">
+                            <node concept="liA8E" id="2csR5Duk0Dn" role="2OqNvi">
+                              <ref role="37wK5l" to="emqf:~CellProviderWithRole.createDefaultSubstituteInfo()" resolve="createDefaultSubstituteInfo" />
+                            </node>
+                            <node concept="37vLTw" id="3GM_nagTtpS" role="2Oq$k0">
+                              <ref role="3cqZAo" node="g_Cet49" resolve="provider" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="1pGfFk" id="2csR5Duk0Cx" role="2ShVmc">
+                        <ref role="37wK5l" to="6lvu:~CompositeSubstituteInfo.&lt;init&gt;(jetbrains.mps.openapi.editor.EditorContext,jetbrains.mps.nodeEditor.cellMenu.CellContext,jetbrains.mps.nodeEditor.cellMenu.SubstituteInfoPartExt[])" resolve="CompositeSubstituteInfo" />
+                        <node concept="1rXfSq" id="7VRiLsftiK4" role="37wK5m">
+                          <ref role="37wK5l" to="qvne:6OQfiPCHBdf" resolve="getEditorContext" />
+                        </node>
+                        <node concept="2OqwBi" id="2csR5Duk0Cz" role="37wK5m">
+                          <node concept="37vLTw" id="3GM_nagTxpJ" role="2Oq$k0">
+                            <ref role="3cqZAo" node="g_Cet49" resolve="provider" />
+                          </node>
+                          <node concept="liA8E" id="2csR5Duk0C_" role="2OqNvi">
+                            <ref role="37wK5l" to="exr9:~AbstractCellProvider.getCellContext()" resolve="getCellContext" />
+                          </node>
+                        </node>
+                        <node concept="2ShNRf" id="2csR5Duk0CA" role="37wK5m">
+                          <node concept="3g6Rrh" id="2csR5Duk0CB" role="2ShVmc">
+                            <node concept="3uibUv" id="3HEU06eN4Ru" role="3g7fb8">
+                              <ref role="3uigEE" to="6lvu:~SubstituteInfoPartExt" resolve="SubstituteInfoPartExt" />
+                            </node>
+                            <node concept="2ShNRf" id="2csR5Duk0CD" role="3g7hyw">
+                              <node concept="1WS0z7" id="2csR5Duk0CE" role="lGtFl">
+                                <node concept="3JmXsc" id="2csR5Duk0CF" role="3Jn$fo">
+                                  <node concept="3clFbS" id="2csR5Duk0CG" role="2VODD2">
+                                    <node concept="3clFbF" id="2csR5Duk0CH" role="3cqZAp">
+                                      <node concept="2OqwBi" id="2csR5Duk0CI" role="3clFbG">
+                                        <node concept="2OqwBi" id="2csR5Duk0CJ" role="2Oq$k0">
+                                          <node concept="3TrEf2" id="2csR5Duk0CL" role="2OqNvi">
+                                            <ref role="3Tt5mk" to="tpc2:gWP5bHW" resolve="menuDescriptor" />
+                                          </node>
+                                          <node concept="30H73N" id="2csR5Duk0CK" role="2Oq$k0" />
+                                        </node>
+                                        <node concept="3Tsc0h" id="2csR5Duk0CM" role="2OqNvi">
+                                          <ref role="3TtcxE" to="tpc2:gWOY2$g" resolve="cellMenuPart" />
+                                        </node>
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                              <node concept="1pGfFk" id="2csR5Duk0CN" role="2ShVmc">
+                                <ref role="37wK5l" to="tpc3:gWQakdt" resolve="stuff_CellMenuPart" />
+                                <node concept="1ZhdrF" id="2csR5Duk0CO" role="lGtFl">
+                                  <property role="2qtEX8" value="baseMethodDeclaration" />
+                                  <property role="P3scX" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1204053956946/1068499141037" />
+                                  <node concept="3$xsQk" id="2csR5Duk0CP" role="3$ytzL">
+                                    <node concept="3clFbS" id="2csR5Duk0CQ" role="2VODD2">
+                                      <node concept="3cpWs8" id="2csR5Duk0CR" role="3cqZAp">
+                                        <node concept="3cpWsn" id="2csR5Duk0CS" role="3cpWs9">
+                                          <property role="TrG5h" value="generatedClass" />
+                                          <node concept="2OqwBi" id="2csR5Duk0CV" role="33vP2m">
+                                            <node concept="1iwH70" id="2csR5Duk0CX" role="2OqNvi">
+                                              <ref role="1iwH77" to="tpc3:hG00Hig" resolve="generatedClass" />
+                                              <node concept="30H73N" id="2csR5Duk0CY" role="1iwH7V" />
+                                            </node>
+                                            <node concept="1iwH7S" id="2csR5Duk0CW" role="2Oq$k0" />
+                                          </node>
+                                          <node concept="3Tqbb2" id="2csR5Duk0CT" role="1tU5fm">
+                                            <ref role="ehGHo" to="tpee:fz12cDA" resolve="ClassConcept" />
+                                          </node>
+                                        </node>
+                                      </node>
+                                      <node concept="3cpWs6" id="2csR5Duk0CZ" role="3cqZAp">
+                                        <node concept="2OqwBi" id="2csR5Duk0D0" role="3cqZAk">
+                                          <node concept="1uHKPH" id="2csR5Duk0D4" role="2OqNvi" />
+                                          <node concept="2OqwBi" id="2csR5Duk0D1" role="2Oq$k0">
+                                            <node concept="37vLTw" id="3GM_nagTsW9" role="2Oq$k0">
+                                              <ref role="3cqZAo" node="2csR5Duk0CS" resolve="generatedClass" />
+                                            </node>
+                                            <node concept="2qgKlT" id="2oLu0Jc28mW" role="2OqNvi">
+                                              <ref role="37wK5l" to="tpek:4_LVZ3pCvsd" resolve="constructors" />
+                                            </node>
+                                          </node>
+                                        </node>
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="2ShNRf" id="AIV2SdRq3U" role="3g7hyw">
+                              <node concept="1pGfFk" id="AIV2SdRq3V" role="2ShVmc">
+                                <ref role="37wK5l" to="6lvu:~SChildSubstituteInfoPartEx.&lt;init&gt;(jetbrains.mps.openapi.editor.cells.EditorCell)" resolve="SChildSubstituteInfoPartEx" />
+                                <node concept="37vLTw" id="AIV2SdRq3W" role="37wK5m">
+                                  <ref role="3cqZAo" node="g_CeiMo" resolve="editorCell" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="37vLTw" id="3GM_nagTsAw" role="2Oq$k0">
+                    <ref role="3cqZAo" node="g_CeiMo" resolve="editorCell" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbH" id="3dIwcSTMWf2" role="3cqZAp" />
+              <node concept="3SKdUt" id="1pA5V1UG9Fr" role="3cqZAp">
+                <node concept="3SKdUq" id="1pA5V1UG9Ft" role="3SKWNk">
+                  <property role="3SKdUp" value="(*) store cell context for the new cell" />
+                </node>
+              </node>
+              <node concept="3clFbF" id="6dQuMDPfRat" role="3cqZAp">
+                <node concept="1rXfSq" id="6dQuMDPfRar" role="3clFbG">
+                  <ref role="37wK5l" to="tpc3:4gNWjiBdWj$" resolve="setCellContext" />
+                  <node concept="37vLTw" id="3dIwcSTHYu7" role="37wK5m">
+                    <ref role="3cqZAo" node="g_CeiMo" resolve="editorCell" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbH" id="3dIwcSTMX_b" role="3cqZAp" />
+              <node concept="3cpWs8" id="g_CeiMu" role="3cqZAp">
+                <node concept="3cpWsn" id="g_CeiMv" role="3cpWs9">
+                  <property role="TrG5h" value="attributeConcept" />
+                  <node concept="3Tqbb2" id="i2nPODq" role="1tU5fm" />
+                  <node concept="2OqwBi" id="h_XJ9y7" role="33vP2m">
+                    <node concept="37vLTw" id="4KFVuabugEc" role="2Oq$k0">
+                      <ref role="3cqZAo" node="g_Cet49" resolve="provider" />
+                    </node>
+                    <node concept="liA8E" id="h_XJ9y8" role="2OqNvi">
+                      <ref role="37wK5l" to="emqf:~CellProviderWithRole.getRoleAttribute()" resolve="getRoleAttribute" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbJ" id="4KFVuabug8s" role="3cqZAp">
+                <node concept="3cpWs6" id="4KFVuabug8t" role="9aQIa">
+                  <node concept="37vLTw" id="4KFVuabuhB5" role="3cqZAk">
+                    <ref role="3cqZAo" node="g_CeiMo" resolve="editorCell" />
+                  </node>
+                </node>
+                <node concept="3clFbS" id="4KFVuabug8v" role="3clFbx">
+                  <node concept="3cpWs8" id="4KFVuabug8w" role="3cqZAp">
+                    <node concept="3cpWsn" id="4KFVuabug8x" role="3cpWs9">
+                      <property role="TrG5h" value="manager" />
+                      <node concept="3uibUv" id="4KFVuabug8y" role="1tU5fm">
+                        <ref role="3uigEE" to="exr9:~EditorManager" resolve="EditorManager" />
+                      </node>
+                      <node concept="2YIFZM" id="4KFVuabug8z" role="33vP2m">
+                        <ref role="1Pybhc" to="exr9:~EditorManager" resolve="EditorManager" />
+                        <ref role="37wK5l" to="exr9:~EditorManager.getInstanceFromContext(jetbrains.mps.openapi.editor.EditorContext)" resolve="getInstanceFromContext" />
+                        <node concept="1rXfSq" id="7VRiLsftjtD" role="37wK5m">
+                          <ref role="37wK5l" to="qvne:6OQfiPCHBdf" resolve="getEditorContext" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3cpWs6" id="4KFVuabug8_" role="3cqZAp">
+                    <node concept="2OqwBi" id="7JyXXoD3okL" role="3cqZAk">
+                      <node concept="37vLTw" id="7JyXXoD3nlp" role="2Oq$k0">
+                        <ref role="3cqZAo" node="4KFVuabug8x" resolve="manager" />
+                      </node>
+                      <node concept="liA8E" id="7JyXXoD3oTG" role="2OqNvi">
+                        <ref role="37wK5l" to="exr9:~EditorManager.createNodeRoleAttributeCell(org.jetbrains.mps.openapi.model.SNode,jetbrains.mps.openapi.editor.update.AttributeKind,jetbrains.mps.openapi.editor.cells.EditorCell)" resolve="createNodeRoleAttributeCell" />
+                        <node concept="37vLTw" id="7JyXXoD3p5q" role="37wK5m">
+                          <ref role="3cqZAo" node="g_CeiMv" resolve="attributeConcept" />
+                        </node>
+                        <node concept="2OqwBi" id="7JyXXoD3pGG" role="37wK5m">
+                          <node concept="37vLTw" id="7JyXXoD3piI" role="2Oq$k0">
+                            <ref role="3cqZAo" node="g_Cet49" resolve="provider" />
+                          </node>
+                          <node concept="liA8E" id="7JyXXoD3pSe" role="2OqNvi">
+                            <ref role="37wK5l" to="emqf:~CellProviderWithRole.getRoleAttributeKind()" resolve="getRoleAttributeKind" />
+                          </node>
+                        </node>
+                        <node concept="37vLTw" id="7JyXXoD3qg0" role="37wK5m">
+                          <ref role="3cqZAo" node="g_CeiMo" resolve="editorCell" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3y3z36" id="g_CeiM_" role="3clFbw">
+                  <node concept="37vLTw" id="4KFVuabug8G" role="3uHU7B">
+                    <ref role="3cqZAo" node="g_CeiMv" resolve="attributeConcept" />
+                  </node>
+                  <node concept="10Nm6u" id="g_CeiMA" role="3uHU7w" />
+                </node>
+              </node>
+              <node concept="3clFbH" id="3dIwcSTHKoW" role="3cqZAp" />
+            </node>
+            <node concept="3clFbS" id="3dIwcSTAG9M" role="2GVbov">
+              <node concept="3SKdUt" id="1pA5V1UGb0w" role="3cqZAp">
+                <node concept="3SKdUq" id="1pA5V1UGb0y" role="3SKWNk">
+                  <property role="3SKdUp" value="(*) remove cell context from stack" />
+                </node>
+              </node>
+              <node concept="3clFbF" id="1ByWmfQz0li" role="3cqZAp">
+                <node concept="2OqwBi" id="1ByWmfQz0lj" role="3clFbG">
+                  <node concept="1rXfSq" id="1ByWmfQz0lk" role="2Oq$k0">
+                    <ref role="37wK5l" to="qvne:6OQfiPCHBjx" resolve="getCellFactory" />
+                  </node>
+                  <node concept="liA8E" id="1ByWmfQz0ll" role="2OqNvi">
+                    <ref role="37wK5l" to="f4zo:~EditorCellFactory.popCellContext()" resolve="popCellContext" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3uibUv" id="3dIwcSTyQP1" role="3clF45">
+          <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+        </node>
+        <node concept="3Tm6S6" id="3dIwcSTyQ3v" role="1B3o_S" />
+        <node concept="raruj" id="3dIwcSTyR1q" role="lGtFl">
+          <ref role="2sdACS" to="tpc3:2dNBF9rpTiT" resolve="cellFactory.factoryMethod" />
+        </node>
+        <node concept="17Uvod" id="3dIwcSTyR1r" role="lGtFl">
+          <property role="2qtEX9" value="name" />
+          <property role="P4ACc" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c/1169194658468/1169194664001" />
+          <node concept="3zFVjK" id="3dIwcSTyR1s" role="3zH0cK">
+            <node concept="3clFbS" id="3dIwcSTyR1t" role="2VODD2">
+              <node concept="3clFbF" id="3dIwcSTyRmu" role="3cqZAp">
+                <node concept="2OqwBi" id="3dIwcSTyRMe" role="3clFbG">
+                  <node concept="30H73N" id="3dIwcSTyRmt" role="2Oq$k0" />
+                  <node concept="2qgKlT" id="3dIwcSTySGo" role="2OqNvi">
+                    <ref role="37wK5l" to="tpcb:hHfE2BD" resolve="getFactoryMethodName" />
+                    <node concept="1iwH7S" id="3dIwcSTyXe2" role="37wK5m" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="3dIwcSTz3I$" role="1B3o_S" />
+      <node concept="3uibUv" id="3dIwcSTACR6" role="1zkMxy">
+        <ref role="3uigEE" to="tpc3:7GOmDNDyRby" resolve="CellFactoryContextClass" />
       </node>
     </node>
   </node>


### PR DESCRIPTION
When you use an editor with a `SplittableCell` in a generator template (e.g. StringLiteral, NumberLiteral), the usual "Add Property Macro" intention is not available for the property behind the `SplittableCell`. This happens because `SplittableCell` doesn't have propery cell context with property infomation that is checked from the intention precondition (see method j.m.l.generator.helper.EditingUtil#isPropertyMacroApplicable).

In order to fix this I have added custom cell factory method generation template for the SplittableCell that sets cell context exactly how it's done for CellModel_Property. Just using factory method generation template for the CellModel_Property directly is not possible because then `SplittableCell` doesn't work as intended (splitting doesn't work).