### PR TITLE
build: removed noneffective commandLine (only one per Exec possible)

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -2,7 +2,7 @@
 <project version="4">
   <component name="ProjectModuleManager">
     <modules>
-      <module fileurl="file://$PROJECT_DIR$/MPS-extensions.iml" filepath="$PROJECT_DIR$/MPS-extensions.iml" />
+      <module fileurl="file://$PROJECT_DIR$/MPS-extensions.iml" filepath="$PROJECT_DIR$/MPS-extensions.iml" group="MPS-extensions" />
     </modules>
   </component>
 </project>

--- a/build.gradle
+++ b/build.gradle
@@ -311,7 +311,6 @@ task previewDocs(type: Exec, dependsOn: pipInstall) {
 }
 
 task deployDocs(type: Exec, dependsOn: pipInstall) {
-    commandLine "git", "remote", "add",  "gh-pages", "https://${System.properties["system.github.token"]}@github.com/JetBrains/MPS-extensions.git"
     commandLine "mkdocs", "gh-deploy", "--clean", "-r", "gh-pages", "--force"
 }
 


### PR DESCRIPTION
Required git command is executed as a first build step on the build server.