### PR TITLE
updated table of currently maintained MPS versions

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -87,7 +87,8 @@ A version in maintenance will not get actively new features and is only maintain
 
 | MPS Version | State |
 |:--|:--|
-| 2019.2 | active development |
+| 2019.3 | active development |
+| 2019.2 | maintenance |
 | 2019.1 | maintenance |
 | 2018.3 | maintenance |
 | 2018.2 | maintenance |


### PR DESCRIPTION
Now that we migrated to 2019.3 we should keep the docu in sync. This PR just
updates the table with the maintained MPS versions.