### PR TITLE
updated documentation how to build from sources

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -1,5 +1,7 @@
 # Building
-The MPS extensions are built using gradle. In order to build the source code, all you need on the machine is a Java 8 JDK. Of course, if you want to hack on the MPS extensions you need MPS. The MPS version that is currently used, is in our [build.gradle](https://github.com/JetBrains/MPS-extensions/blob/master/build.gradle#L61) file under the value ext.mpsMajor.
+The MPS extensions are built using gradle. In order to build the source code, all you need on the machine is a Java JDK.
+If you want to use the most [current version](https://github.com/JetBrains/MPS-extensions/blob/master/docs/index.md#current-versions) of MPS-extensions (based on MPS 2019.3) JDK 11 is required for older maintenance versions you need JDK 8. 
+Of course, if you want to hack on the MPS extensions you need MPS. The MPS version that is currently used, is in our [build.gradle](https://github.com/JetBrains/MPS-extensions/blob/2ccebf081f214a21431a7c158b064df96ca036fd/build.gradle#L80) file under the value ext.mpsMajor.
 
 In order to build the project, run:
 


### PR DESCRIPTION
Now that we are using MPS 2019.3 the preconditions for building MPS-extensions from sources 
have chaged. Users have to have JDK 11 installed. 

In addtion the link to the current MPS verions in the build.gradle file was updated.