### PR TITLE
grammarcell: substitution post-process in wrapper cells

### DIFF
--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/generator/template/main@generator.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/generator/template/main@generator.mps
@@ -9010,6 +9010,7 @@
                                                                 </node>
                                                               </node>
                                                             </node>
+                                                            <node concept="3clFbH" id="OmLGeIOlrv" role="3cqZAp" />
                                                             <node concept="3clFbF" id="7NlRaxBn2iN" role="3cqZAp">
                                                               <node concept="2OqwBi" id="7NlRaxBn2iO" role="3clFbG">
                                                                 <node concept="2ShNRf" id="7NlRaxBn2iP" role="2Oq$k0">
@@ -9024,6 +9025,16 @@
                                                                         <node concept="37vLTG" id="7NlRaxBn2iU" role="3clF46">
                                                                           <property role="TrG5h" value="node" />
                                                                           <node concept="3Tqbb2" id="7NlRaxBn2iV" role="1tU5fm" />
+                                                                        </node>
+                                                                        <node concept="37vLTG" id="Mf8p5h9Xjo" role="3clF46">
+                                                                          <property role="TrG5h" value="editorContext" />
+                                                                          <node concept="3uibUv" id="Mf8p5h9ZKs" role="1tU5fm">
+                                                                            <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+                                                                          </node>
+                                                                        </node>
+                                                                        <node concept="37vLTG" id="OmLGeINNrM" role="3clF46">
+                                                                          <property role="TrG5h" value="parentNode" />
+                                                                          <node concept="3Tqbb2" id="OmLGeINOjc" role="1tU5fm" />
                                                                         </node>
                                                                         <node concept="3cqZAl" id="7NlRaxBn2iW" role="3clF45" />
                                                                         <node concept="3Tm1VV" id="7NlRaxBn2iX" role="1B3o_S" />
@@ -9063,6 +9074,22 @@
                                                                   <ref role="37wK5l" node="7NlRaxBn2iT" resolve="postprocess" />
                                                                   <node concept="37vLTw" id="7NlRaxBn2jc" role="37wK5m">
                                                                     <ref role="3cqZAo" node="7NlRaxBn2ic" resolve="wrapper" />
+                                                                  </node>
+                                                                  <node concept="2OqwBi" id="Mf8p5h9Z2N" role="37wK5m">
+                                                                    <node concept="37vLTw" id="Mf8p5h9YwD" role="2Oq$k0">
+                                                                      <ref role="3cqZAo" node="2mvFNoUxG2A" resolve="_context" />
+                                                                    </node>
+                                                                    <node concept="liA8E" id="Mf8p5h9ZyS" role="2OqNvi">
+                                                                      <ref role="37wK5l" to="78sh:~SubstituteMenuContext.getEditorContext()" resolve="getEditorContext" />
+                                                                    </node>
+                                                                  </node>
+                                                                  <node concept="2OqwBi" id="OmLGeINPTC" role="37wK5m">
+                                                                    <node concept="37vLTw" id="OmLGeINPlE" role="2Oq$k0">
+                                                                      <ref role="3cqZAo" node="2mvFNoUxG2A" resolve="_context" />
+                                                                    </node>
+                                                                    <node concept="liA8E" id="OmLGeINQsJ" role="2OqNvi">
+                                                                      <ref role="37wK5l" to="78sh:~SubstituteMenuContext.getParentNode()" resolve="getParentNode" />
+                                                                    </node>
                                                                   </node>
                                                                 </node>
                                                               </node>
@@ -10063,6 +10090,107 @@
                                                         </node>
                                                         <node concept="37vLTw" id="_I9mxtzdCV" role="37vLTx">
                                                           <ref role="3cqZAo" node="7Bho1IUq1Qu" resolve="literal" />
+                                                        </node>
+                                                      </node>
+                                                    </node>
+                                                    <node concept="3clFbH" id="OmLGeIOj$S" role="3cqZAp" />
+                                                    <node concept="3clFbF" id="OmLGeINSim" role="3cqZAp">
+                                                      <node concept="2OqwBi" id="OmLGeINSin" role="3clFbG">
+                                                        <node concept="2ShNRf" id="OmLGeINSio" role="2Oq$k0">
+                                                          <node concept="YeOm9" id="OmLGeINSip" role="2ShVmc">
+                                                            <node concept="1Y3b0j" id="OmLGeINSiq" role="YeSDq">
+                                                              <property role="2bfB8j" value="true" />
+                                                              <ref role="1Y3XeK" to="wyt6:~Object" resolve="Object" />
+                                                              <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
+                                                              <node concept="3Tm1VV" id="OmLGeINSir" role="1B3o_S" />
+                                                              <node concept="3clFb_" id="OmLGeINSis" role="jymVt">
+                                                                <property role="TrG5h" value="postProcess" />
+                                                                <node concept="3clFbS" id="OmLGeINSit" role="3clF47">
+                                                                  <node concept="3clFbH" id="OmLGeINSiu" role="3cqZAp">
+                                                                    <node concept="2b32R4" id="OmLGeINSiv" role="lGtFl">
+                                                                      <node concept="3JmXsc" id="OmLGeINSiw" role="2P8S$">
+                                                                        <node concept="3clFbS" id="OmLGeINSix" role="2VODD2">
+                                                                          <node concept="3clFbF" id="OmLGeINSiy" role="3cqZAp">
+                                                                            <node concept="2OqwBi" id="OmLGeINSiz" role="3clFbG">
+                                                                              <node concept="2OqwBi" id="OmLGeINSi$" role="2Oq$k0">
+                                                                                <node concept="2OqwBi" id="OmLGeINSi_" role="2Oq$k0">
+                                                                                  <node concept="30H73N" id="OmLGeINSiA" role="2Oq$k0" />
+                                                                                  <node concept="3TrEf2" id="OmLGeINSiB" role="2OqNvi">
+                                                                                    <ref role="3Tt5mk" to="teg0:1GvnUgo6SDq" resolve="postprocessNodeSubstitute" />
+                                                                                  </node>
+                                                                                </node>
+                                                                                <node concept="3TrEf2" id="OmLGeINSiC" role="2OqNvi">
+                                                                                  <ref role="3Tt5mk" to="tpee:gyVODHa" resolve="body" />
+                                                                                </node>
+                                                                              </node>
+                                                                              <node concept="3Tsc0h" id="OmLGeINSiD" role="2OqNvi">
+                                                                                <ref role="3TtcxE" to="tpee:fzcqZ_x" resolve="statement" />
+                                                                              </node>
+                                                                            </node>
+                                                                          </node>
+                                                                        </node>
+                                                                      </node>
+                                                                    </node>
+                                                                  </node>
+                                                                </node>
+                                                                <node concept="3Tm1VV" id="OmLGeINSiE" role="1B3o_S" />
+                                                                <node concept="3cqZAl" id="OmLGeINSiF" role="3clF45" />
+                                                                <node concept="37vLTG" id="OmLGeINSiG" role="3clF46">
+                                                                  <property role="TrG5h" value="node" />
+                                                                  <node concept="3Tqbb2" id="OmLGeINSiH" role="1tU5fm" />
+                                                                </node>
+                                                                <node concept="37vLTG" id="OmLGeINSiI" role="3clF46">
+                                                                  <property role="TrG5h" value="editorContext" />
+                                                                  <node concept="3uibUv" id="OmLGeINSiJ" role="1tU5fm">
+                                                                    <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+                                                                  </node>
+                                                                </node>
+                                                                <node concept="37vLTG" id="OmLGeINSiK" role="3clF46">
+                                                                  <property role="TrG5h" value="parentNode" />
+                                                                  <node concept="3Tqbb2" id="OmLGeINSiL" role="1tU5fm" />
+                                                                </node>
+                                                              </node>
+                                                            </node>
+                                                          </node>
+                                                        </node>
+                                                        <node concept="liA8E" id="OmLGeINSiM" role="2OqNvi">
+                                                          <ref role="37wK5l" node="OmLGeINSis" resolve="postProcess" />
+                                                          <node concept="37vLTw" id="OmLGeINSiN" role="37wK5m">
+                                                            <ref role="3cqZAo" node="4qdNcH$2c9I" resolve="newNode" />
+                                                          </node>
+                                                          <node concept="2OqwBi" id="OmLGeINSiO" role="37wK5m">
+                                                            <node concept="37vLTw" id="OmLGeINSiP" role="2Oq$k0">
+                                                              <ref role="3cqZAo" node="2mvFNoUxYFZ" resolve="_context" />
+                                                            </node>
+                                                            <node concept="liA8E" id="OmLGeINSiQ" role="2OqNvi">
+                                                              <ref role="37wK5l" to="78sh:~SubstituteMenuContext.getEditorContext()" resolve="getEditorContext" />
+                                                            </node>
+                                                          </node>
+                                                          <node concept="2OqwBi" id="OmLGeINSiR" role="37wK5m">
+                                                            <node concept="37vLTw" id="OmLGeINSiS" role="2Oq$k0">
+                                                              <ref role="3cqZAo" node="2mvFNoUxYFZ" resolve="_context" />
+                                                            </node>
+                                                            <node concept="liA8E" id="OmLGeINSiT" role="2OqNvi">
+                                                              <ref role="37wK5l" to="78sh:~SubstituteMenuContext.getParentNode()" resolve="getParentNode" />
+                                                            </node>
+                                                          </node>
+                                                        </node>
+                                                      </node>
+                                                      <node concept="1W57fq" id="OmLGeIO7Su" role="lGtFl">
+                                                        <node concept="3IZrLx" id="OmLGeIO7Sv" role="3IZSJc">
+                                                          <node concept="3clFbS" id="OmLGeIO7Sw" role="2VODD2">
+                                                            <node concept="3clFbF" id="OmLGeIO8nF" role="3cqZAp">
+                                                              <node concept="2OqwBi" id="OmLGeIO8nG" role="3clFbG">
+                                                                <node concept="2OqwBi" id="OmLGeIO8nH" role="2Oq$k0">
+                                                                  <node concept="30H73N" id="OmLGeIO8nI" role="2Oq$k0" />
+                                                                  <node concept="3TrEf2" id="OmLGeIO8nJ" role="2OqNvi">
+                                                                    <ref role="3Tt5mk" to="teg0:1GvnUgo6SDq" resolve="postprocessNodeSubstitute" />
+                                                                  </node>
+                                                                </node>
+                                                                <node concept="3x8VRR" id="OmLGeIO8nK" role="2OqNvi" />
+                                                              </node>
+                                                            </node>
+                                                          </node>
                                                         </node>
                                                       </node>
                                                     </node>
@@ -11139,6 +11267,107 @@
                                                                 </node>
                                                               </node>
                                                             </node>
+                                                          </node>
+                                                        </node>
+                                                      </node>
+                                                    </node>
+                                                  </node>
+                                                </node>
+                                                <node concept="3clFbH" id="OmLGeIOhRt" role="3cqZAp" />
+                                                <node concept="3clFbF" id="Mf8p5h9ycI" role="3cqZAp">
+                                                  <node concept="2OqwBi" id="Mf8p5h9RBH" role="3clFbG">
+                                                    <node concept="2ShNRf" id="Mf8p5h9ycE" role="2Oq$k0">
+                                                      <node concept="YeOm9" id="Mf8p5h9OKq" role="2ShVmc">
+                                                        <node concept="1Y3b0j" id="Mf8p5h9OKt" role="YeSDq">
+                                                          <property role="2bfB8j" value="true" />
+                                                          <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
+                                                          <ref role="1Y3XeK" to="wyt6:~Object" resolve="Object" />
+                                                          <node concept="3Tm1VV" id="Mf8p5h9OKu" role="1B3o_S" />
+                                                          <node concept="3clFb_" id="Mf8p5h9PR2" role="jymVt">
+                                                            <property role="TrG5h" value="postProcess" />
+                                                            <node concept="3clFbS" id="Mf8p5h9PR5" role="3clF47">
+                                                              <node concept="3clFbH" id="Mf8p5h9UFh" role="3cqZAp">
+                                                                <node concept="2b32R4" id="Mf8p5h9UIr" role="lGtFl">
+                                                                  <node concept="3JmXsc" id="Mf8p5h9UIu" role="2P8S$">
+                                                                    <node concept="3clFbS" id="Mf8p5h9UIv" role="2VODD2">
+                                                                      <node concept="3clFbF" id="Mf8p5h9V4q" role="3cqZAp">
+                                                                        <node concept="2OqwBi" id="Mf8p5h9V4r" role="3clFbG">
+                                                                          <node concept="2OqwBi" id="Mf8p5h9V4s" role="2Oq$k0">
+                                                                            <node concept="2OqwBi" id="Mf8p5h9V4t" role="2Oq$k0">
+                                                                              <node concept="30H73N" id="Mf8p5h9V4u" role="2Oq$k0" />
+                                                                              <node concept="3TrEf2" id="Mf8p5h9V4v" role="2OqNvi">
+                                                                                <ref role="3Tt5mk" to="teg0:1GvnUgo6SDq" resolve="postprocessNodeSubstitute" />
+                                                                              </node>
+                                                                            </node>
+                                                                            <node concept="3TrEf2" id="Mf8p5h9V4w" role="2OqNvi">
+                                                                              <ref role="3Tt5mk" to="tpee:gyVODHa" resolve="body" />
+                                                                            </node>
+                                                                          </node>
+                                                                          <node concept="3Tsc0h" id="Mf8p5h9V4x" role="2OqNvi">
+                                                                            <ref role="3TtcxE" to="tpee:fzcqZ_x" resolve="statement" />
+                                                                          </node>
+                                                                        </node>
+                                                                      </node>
+                                                                    </node>
+                                                                  </node>
+                                                                </node>
+                                                              </node>
+                                                            </node>
+                                                            <node concept="3Tm1VV" id="Mf8p5h9PNi" role="1B3o_S" />
+                                                            <node concept="3cqZAl" id="Mf8p5h9PQD" role="3clF45" />
+                                                            <node concept="37vLTG" id="Mf8p5h9SVR" role="3clF46">
+                                                              <property role="TrG5h" value="node" />
+                                                              <node concept="3Tqbb2" id="Mf8p5h9SVQ" role="1tU5fm" />
+                                                            </node>
+                                                            <node concept="37vLTG" id="Mf8p5ha2vP" role="3clF46">
+                                                              <property role="TrG5h" value="editorContext" />
+                                                              <node concept="3uibUv" id="Mf8p5ha3gk" role="1tU5fm">
+                                                                <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+                                                              </node>
+                                                            </node>
+                                                            <node concept="37vLTG" id="Mf8p5h9T_4" role="3clF46">
+                                                              <property role="TrG5h" value="parentNode" />
+                                                              <node concept="3Tqbb2" id="Mf8p5h9THy" role="1tU5fm" />
+                                                            </node>
+                                                          </node>
+                                                        </node>
+                                                      </node>
+                                                    </node>
+                                                    <node concept="liA8E" id="Mf8p5h9RMB" role="2OqNvi">
+                                                      <ref role="37wK5l" node="Mf8p5h9PR2" resolve="postProcess" />
+                                                      <node concept="37vLTw" id="Mf8p5h9U9v" role="37wK5m">
+                                                        <ref role="3cqZAo" node="7NlRaxAWo9$" resolve="newNode" />
+                                                      </node>
+                                                      <node concept="2OqwBi" id="Mf8p5ha4S0" role="37wK5m">
+                                                        <node concept="37vLTw" id="Mf8p5ha4lo" role="2Oq$k0">
+                                                          <ref role="3cqZAo" node="2mvFNoUy03S" resolve="_context" />
+                                                        </node>
+                                                        <node concept="liA8E" id="Mf8p5ha5nu" role="2OqNvi">
+                                                          <ref role="37wK5l" to="78sh:~SubstituteMenuContext.getEditorContext()" resolve="getEditorContext" />
+                                                        </node>
+                                                      </node>
+                                                      <node concept="2OqwBi" id="Mf8p5h9uWN" role="37wK5m">
+                                                        <node concept="37vLTw" id="Mf8p5h9udL" role="2Oq$k0">
+                                                          <ref role="3cqZAo" node="2mvFNoUy03S" resolve="_context" />
+                                                        </node>
+                                                        <node concept="liA8E" id="Mf8p5h9w3L" role="2OqNvi">
+                                                          <ref role="37wK5l" to="78sh:~SubstituteMenuContext.getParentNode()" resolve="getParentNode" />
+                                                        </node>
+                                                      </node>
+                                                    </node>
+                                                  </node>
+                                                  <node concept="1W57fq" id="OmLGeIOfHZ" role="lGtFl">
+                                                    <node concept="3IZrLx" id="OmLGeIOfI0" role="3IZSJc">
+                                                      <node concept="3clFbS" id="OmLGeIOfI1" role="2VODD2">
+                                                        <node concept="3clFbF" id="OmLGeIOfUX" role="3cqZAp">
+                                                          <node concept="2OqwBi" id="OmLGeIOfUY" role="3clFbG">
+                                                            <node concept="2OqwBi" id="OmLGeIOfUZ" role="2Oq$k0">
+                                                              <node concept="30H73N" id="OmLGeIOfV0" role="2Oq$k0" />
+                                                              <node concept="3TrEf2" id="OmLGeIOfV1" role="2OqNvi">
+                                                                <ref role="3Tt5mk" to="teg0:1GvnUgo6SDq" resolve="postprocessNodeSubstitute" />
+                                                              </node>
+                                                            </node>
+                                                            <node concept="3x8VRR" id="OmLGeIOfV2" role="2OqNvi" />
                                                           </node>
                                                         </node>
                                                       </node>

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/models/com/mbeddr/mpsutil/grammarcells/behavior.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/models/com/mbeddr/mpsutil/grammarcells/behavior.mps
@@ -3303,6 +3303,9 @@
               <node concept="35c_gC" id="1L96m4u4nK4" role="HW$Y0">
                 <ref role="35c_gD" to="teg0:2aaSxIgh9is" resolve="Parameter_editorContext" />
               </node>
+              <node concept="35c_gC" id="Mf8p5ha7fB" role="HW$Y0">
+                <ref role="35c_gD" to="teg0:Mf8p5ha6ow" resolve="Parameter_parentNode" />
+              </node>
             </node>
           </node>
         </node>
@@ -3897,6 +3900,27 @@
     </node>
     <node concept="13hLZK" id="2q0cFwF2bgp" role="13h7CW">
       <node concept="3clFbS" id="2q0cFwF2bgq" role="2VODD2" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="Mf8p5ha6qi">
+    <ref role="13h7C2" to="teg0:Mf8p5ha6ow" resolve="Parameter_parentNode" />
+    <node concept="13hLZK" id="Mf8p5ha6qj" role="13h7CW">
+      <node concept="3clFbS" id="Mf8p5ha6qk" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="Mf8p5ha6qt" role="13h7CS">
+      <property role="TrG5h" value="getType" />
+      <ref role="13i0hy" to="tpek:27DJnJtIQ9C" resolve="getType" />
+      <node concept="3Tm1VV" id="Mf8p5ha6qu" role="1B3o_S" />
+      <node concept="3clFbS" id="Mf8p5ha6qz" role="3clF47">
+        <node concept="3clFbF" id="Mf8p5ha6Bt" role="3cqZAp">
+          <node concept="2c44tf" id="Mf8p5ha6Bv" role="3clFbG">
+            <node concept="3Tqbb2" id="Mf8p5ha79C" role="2c44tc" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tqbb2" id="Mf8p5ha6q$" role="3clF45">
+        <ref role="ehGHo" to="tpee:fz3vP1H" resolve="Type" />
+      </node>
     </node>
   </node>
 </model>

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/models/com/mbeddr/mpsutil/grammarcells/structure.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/models/com/mbeddr/mpsutil/grammarcells/structure.mps
@@ -994,5 +994,11 @@
       <ref role="20lvS9" node="6oKG1kMxv_T" resolve="FlagCell" />
     </node>
   </node>
+  <node concept="1TIwiD" id="Mf8p5ha6ow">
+    <property role="EcuMT" value="904978958140335648" />
+    <property role="TrG5h" value="Parameter_parentNode" />
+    <property role="34LRSv" value="parentNode" />
+    <ref role="1TJDcQ" to="tpee:g76ryKb" resolve="ConceptFunctionParameter" />
+  </node>
 </model>
 


### PR DESCRIPTION
- Adds support for substitution post-process function in WrapperCell for all kinds of supported wrapped cells. 
- Post-process function now also gets the parent node passed as a parameter.