### PR TITLE
langvis: fix #386 - property doubling in uml diagram

### DIFF
--- a/code/langvis/languages/com.dslfoundry.langvis.demolang/models/structure.mps
+++ b/code/langvis/languages/com.dslfoundry.langvis.demolang/models/structure.mps
@@ -12,6 +12,7 @@
       <concept id="1169125787135" name="jetbrains.mps.lang.structure.structure.AbstractConceptDeclaration" flags="ig" index="PkWjJ">
         <property id="6714410169261853888" name="conceptId" index="EcuMT" />
         <child id="1071489727083" name="linkDeclaration" index="1TKVEi" />
+        <child id="1071489727084" name="propertyDeclaration" index="1TKVEl" />
       </concept>
       <concept id="1169127622168" name="jetbrains.mps.lang.structure.structure.InterfaceConceptReference" flags="ig" index="PrWs8">
         <reference id="1169127628841" name="intfc" index="PrY4T" />
@@ -19,6 +20,10 @@
       <concept id="1071489090640" name="jetbrains.mps.lang.structure.structure.ConceptDeclaration" flags="ig" index="1TIwiD">
         <reference id="1071489389519" name="extends" index="1TJDcQ" />
         <child id="1169129564478" name="implements" index="PzmwI" />
+      </concept>
+      <concept id="1071489288299" name="jetbrains.mps.lang.structure.structure.PropertyDeclaration" flags="ig" index="1TJgyi">
+        <property id="241647608299431129" name="propertyId" index="IQ2nx" />
+        <reference id="1082985295845" name="dataType" index="AX2Wp" />
       </concept>
       <concept id="1071489288298" name="jetbrains.mps.lang.structure.structure.LinkDeclaration" flags="ig" index="1TJgyj">
         <property id="1071599776563" name="role" index="20kJfa" />
@@ -48,6 +53,11 @@
       <property role="20lbJX" value="fLJekj5/_0__n" />
       <ref role="20lvS9" node="3QRrWZ6ZVua" resolve="B" />
     </node>
+    <node concept="1TJgyi" id="63uC6nQP4F1" role="1TKVEl">
+      <property role="IQ2nx" value="6980192832264096449" />
+      <property role="TrG5h" value="aproperty" />
+      <ref role="AX2Wp" to="tpck:fKAOsGN" resolve="string" />
+    </node>
   </node>
   <node concept="1TIwiD" id="3QRrWZ6ZVua">
     <property role="EcuMT" value="4447146095239214986" />
@@ -55,6 +65,11 @@
     <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
     <node concept="PrWs8" id="3QRrWZ6ZVub" role="PzmwI">
       <ref role="PrY4T" to="tpck:h0TrEE$" resolve="INamedConcept" />
+    </node>
+    <node concept="1TJgyi" id="63uC6nQP4F3" role="1TKVEl">
+      <property role="IQ2nx" value="6980192832264096451" />
+      <property role="TrG5h" value="bproperty" />
+      <ref role="AX2Wp" to="tpck:fKAQMTA" resolve="integer" />
     </node>
   </node>
 </model>

--- a/code/langvis/solutions/com.dslfoundry.langvis.plugin/models/com.dslfoundry.langvis.plugin.plugin.mps
+++ b/code/langvis/solutions/com.dslfoundry.langvis.plugin/models/com.dslfoundry.langvis.plugin.plugin.mps
@@ -1892,28 +1892,6 @@
                 </node>
               </node>
             </node>
-            <node concept="3clFbH" id="6H8rSFRgiNh" role="3cqZAp" />
-            <node concept="2Gpval" id="4LYtwguVwO" role="3cqZAp">
-              <node concept="2GrKxI" id="4LYtwguVwQ" role="2Gsz3X">
-                <property role="TrG5h" value="concept" />
-              </node>
-              <node concept="37vLTw" id="4LYtwguXSE" role="2GsD0m">
-                <ref role="3cqZAo" node="6H8rSFQVJLL" resolve="elements" />
-              </node>
-              <node concept="3clFbS" id="4LYtwguVwU" role="2LFqv$">
-                <node concept="3clFbF" id="4LYtwgv0YM" role="3cqZAp">
-                  <node concept="1rXfSq" id="4LYtwgv0YL" role="3clFbG">
-                    <ref role="37wK5l" node="4LYtwgslQW" resolve="writeProperties" />
-                    <node concept="37vLTw" id="4LYtwgv3TB" role="37wK5m">
-                      <ref role="3cqZAo" node="6H8rSFQVJLX" resolve="fw" />
-                    </node>
-                    <node concept="2GrUjf" id="4LYtwgv4Fb" role="37wK5m">
-                      <ref role="2Gs0qQ" node="4LYtwguVwQ" resolve="concept" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
             <node concept="3clFbH" id="4LYtwguS_T" role="3cqZAp" />
             <node concept="3clFbJ" id="6H8rSFRkCwW" role="3cqZAp">
               <node concept="3clFbS" id="6H8rSFRkCwZ" role="3clFbx">


### PR DESCRIPTION
This fixes the property doubling occurring for classes rendered in the diagrams created by `langvis/solutions/com.dslfoundry.langvis.plugin`.

The fix eliminates a surplus `for` loop.

The fix also adds a property to the classes `A` and `B` of `langvis/languages/com.dslfoundry.langvis.demolang` to be able to see potential regressions.

The diagrams seem to be correctly rendered now:

<img width="1440" alt="Screenshot 2021-04-25 at 17 32 04" src="https://user-images.githubusercontent.com/5954346/116001188-87dd5f00-a5f3-11eb-8fea-e1aa17e775b2.png">

Thanks for your feedback and consideration!