### PR TITLE
MouseSelection: Use EditorExtension API and ignore drags < 2px

### DIFF
--- a/code/mouseselection/solutions/de.itemis.mps.selection.runtime/models/de/itemis/mps/selection/runtime/mouse.mps
+++ b/code/mouseselection/solutions/de.itemis.mps.selection.runtime/models/de/itemis/mps/selection/runtime/mouse.mps
@@ -2,9 +2,9 @@
 <model ref="r:5c0390a8-12e2-407a-ba93-793107153436(de.itemis.mps.selection.runtime.mouse)">
   <persistence version="9" />
   <languages>
-    <use id="63650c59-16c8-498a-99c8-005c7ee9515d" name="jetbrains.mps.lang.access" version="0" />
-    <use id="c0080a47-7e37-4558-bee9-9ae18e690549" name="jetbrains.mps.lang.extension" version="2" />
-    <use id="774bf8a0-62e5-41e1-af63-f4812e60e48b" name="jetbrains.mps.baseLanguage.checkedDots" version="0" />
+    <use id="63650c59-16c8-498a-99c8-005c7ee9515d" name="jetbrains.mps.lang.access" version="-1" />
+    <use id="c0080a47-7e37-4558-bee9-9ae18e690549" name="jetbrains.mps.lang.extension" version="-1" />
+    <use id="774bf8a0-62e5-41e1-af63-f4812e60e48b" name="jetbrains.mps.baseLanguage.checkedDots" version="-1" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -24,6 +24,7 @@
     <import index="mpcv" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang.ref(JDK/)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
     <import index="z8iw" ref="r:dfdf3542-dbcf-43df-870a-3c3504b3c840(jetbrains.mps.baseLanguage.collections.custom)" implicit="true" />
+    <import index="fbzs" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt.geom(JDK/)" implicit="true" />
     <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" implicit="true" />
   </imports>
   <registry>
@@ -182,6 +183,9 @@
         <child id="1163668922816" name="ifTrue" index="3K4E3e" />
         <child id="1163668934364" name="ifFalse" index="3K4GZi" />
       </concept>
+      <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
+        <child id="8356039341262087992" name="line" index="1aUNEU" />
+      </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
       <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
       <concept id="1146644641414" name="jetbrains.mps.baseLanguage.structure.ProtectedVisibility" flags="nn" index="3Tmbuc" />
@@ -222,6 +226,14 @@
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+    <language id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text">
+      <concept id="155656958578482948" name="jetbrains.mps.lang.text.structure.Word" flags="nn" index="3oM_SD">
+        <property id="155656958578482949" name="value" index="3oM_SC" />
+      </concept>
+      <concept id="2535923850359271782" name="jetbrains.mps.lang.text.structure.Line" flags="nn" index="1PaTwC">
+        <child id="2535923850359271783" name="elements" index="1PaTwD" />
       </concept>
     </language>
     <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
@@ -1402,6 +1414,49 @@
       <node concept="3cqZAl" id="630t2b8eeCv" role="3clF45" />
       <node concept="3Tmbuc" id="630t2b8eeCw" role="1B3o_S" />
       <node concept="3clFbS" id="630t2b8eeCx" role="3clF47">
+        <node concept="3clFbJ" id="2CeCNUceE_Q" role="3cqZAp">
+          <node concept="3clFbS" id="2CeCNUceE_S" role="3clFbx">
+            <node concept="3SKdUt" id="2Gp73YkRR4T" role="3cqZAp">
+              <node concept="1PaTwC" id="2Gp73YkRR4U" role="1aUNEU">
+                <node concept="3oM_SD" id="2Gp73YkRS3y" role="1PaTwD">
+                  <property role="3oM_SC" value="consider" />
+                </node>
+                <node concept="3oM_SD" id="2Gp73YkRS3$" role="1PaTwD">
+                  <property role="3oM_SC" value="such" />
+                </node>
+                <node concept="3oM_SD" id="2Gp73YkRS3K" role="1PaTwD">
+                  <property role="3oM_SC" value="a" />
+                </node>
+                <node concept="3oM_SD" id="2Gp73YkRS3O" role="1PaTwD">
+                  <property role="3oM_SC" value="small" />
+                </node>
+                <node concept="3oM_SD" id="2Gp73YkRS3T" role="1PaTwD">
+                  <property role="3oM_SC" value="drag" />
+                </node>
+                <node concept="3oM_SD" id="2Gp73YkRS3Z" role="1PaTwD">
+                  <property role="3oM_SC" value="accidental" />
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs6" id="2CeCNUceGYw" role="3cqZAp" />
+          </node>
+          <node concept="2dkUwp" id="2CeCNUceGGE" role="3clFbw">
+            <node concept="2OqwBi" id="2CeCNUceF2$" role="3uHU7B">
+              <node concept="37vLTw" id="2CeCNUceEFR" role="2Oq$k0">
+                <ref role="3cqZAo" node="630t2b8eeD1" resolve="from" />
+              </node>
+              <node concept="liA8E" id="2CeCNUceFm_" role="2OqNvi">
+                <ref role="37wK5l" to="fbzs:~Point2D.distance(java.awt.geom.Point2D)" resolve="distance" />
+                <node concept="37vLTw" id="2CeCNUceFsU" role="37wK5m">
+                  <ref role="3cqZAo" node="630t2b8eeD3" resolve="to" />
+                </node>
+              </node>
+            </node>
+            <node concept="3cmrfG" id="2CeCNUceHa6" role="3uHU7w">
+              <property role="3cmrfH" value="2" />
+            </node>
+          </node>
+        </node>
         <node concept="3cpWs8" id="630t2b8eeCy" role="3cqZAp">
           <node concept="3cpWsn" id="630t2b8eeCz" role="3cpWs9">
             <property role="TrG5h" value="startCell" />

--- a/code/mouseselection/solutions/de.itemis.mps.selection.runtime/models/de/itemis/mps/selection/runtime/plugin.mps
+++ b/code/mouseselection/solutions/de.itemis.mps.selection.runtime/models/de/itemis/mps/selection/runtime/plugin.mps
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <model ref="r:b49d7b4c-a97a-4226-a59e-b10183eecf00(de.itemis.mps.selection.runtime.plugin)">
   <persistence version="9" />
+  <attribute name="doNotGenerate" value="false" />
   <languages>
-    <use id="ef7bf5ac-d06c-4342-b11d-e42104eb9343" name="jetbrains.mps.lang.plugin.standalone" version="-1" />
-    <use id="28f9e497-3b42-4291-aeba-0a1039153ab1" name="jetbrains.mps.lang.plugin" version="5" />
-    <use id="443f4c36-fcf5-4eb6-9500-8d06ed259e3e" name="jetbrains.mps.baseLanguage.classifiers" version="-1" />
-    <use id="c0080a47-7e37-4558-bee9-9ae18e690549" name="jetbrains.mps.lang.extension" version="-1" />
-    <use id="774bf8a0-62e5-41e1-af63-f4812e60e48b" name="jetbrains.mps.baseLanguage.checkedDots" version="-1" />
+    <use id="ef7bf5ac-d06c-4342-b11d-e42104eb9343" name="jetbrains.mps.lang.plugin.standalone" version="0" />
+    <use id="28f9e497-3b42-4291-aeba-0a1039153ab1" name="jetbrains.mps.lang.plugin" version="4" />
+    <use id="443f4c36-fcf5-4eb6-9500-8d06ed259e3e" name="jetbrains.mps.baseLanguage.classifiers" version="0" />
+    <use id="c0080a47-7e37-4558-bee9-9ae18e690549" name="jetbrains.mps.lang.extension" version="2" />
+    <use id="774bf8a0-62e5-41e1-af63-f4812e60e48b" name="jetbrains.mps.baseLanguage.checkedDots" version="0" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -22,6 +23,8 @@
     <import index="hceu" ref="r:69b3ca2b-c749-4a2d-9d65-e52a0ef5bb3a(de.itemis.mps.selection.runtime.intentions)" />
     <import index="k3nr" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.ide.editor(MPS.Editor/)" />
     <import index="6tp1" ref="r:5c0390a8-12e2-407a-ba93-793107153436(de.itemis.mps.selection.runtime.mouse)" />
+    <import index="wvnl" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.extensions(MPS.Editor/)" />
+    <import index="cj4x" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor(MPS.Editor/)" />
   </imports>
   <registry>
     <language id="28f9e497-3b42-4291-aeba-0a1039153ab1" name="jetbrains.mps.lang.plugin">
@@ -73,11 +76,8 @@
       <concept id="7520713872864775836" name="jetbrains.mps.lang.plugin.standalone.structure.StandalonePluginDescriptor" flags="ng" index="2DaZZR" />
     </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
-      <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
-        <child id="1068498886297" name="rValue" index="37vLTx" />
-        <child id="1068498886295" name="lValue" index="37vLTJ" />
-      </concept>
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
       <concept id="1188207840427" name="jetbrains.mps.baseLanguage.structure.AnnotationInstance" flags="nn" index="2AHcQZ">
         <reference id="1188208074048" name="annotation" index="2AI5Lk" />
       </concept>
@@ -100,39 +100,36 @@
       <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
       </concept>
-      <concept id="1070533707846" name="jetbrains.mps.baseLanguage.structure.StaticFieldReference" flags="nn" index="10M0yZ">
-        <reference id="1144433057691" name="classifier" index="1PxDUh" />
+      <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
+      <concept id="1070534934090" name="jetbrains.mps.baseLanguage.structure.CastExpression" flags="nn" index="10QFUN">
+        <child id="1070534934091" name="type" index="10QFUM" />
+        <child id="1070534934092" name="expression" index="10QFUP" />
       </concept>
-      <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <property id="1176718929932" name="isFinal" index="3TUv4t" />
         <child id="1068431790190" name="initializer" index="33vP2m" />
       </concept>
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
       <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
-      <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
       <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
-        <property id="1181808852946" name="isFinal" index="DiZV1" />
         <child id="1068580123133" name="returnType" index="3clF45" />
         <child id="1068580123134" name="parameter" index="3clF46" />
         <child id="1068580123135" name="body" index="3clF47" />
       </concept>
-      <concept id="1068580123165" name="jetbrains.mps.baseLanguage.structure.InstanceMethodDeclaration" flags="ig" index="3clFb_">
-        <property id="1178608670077" name="isAbstract" index="1EzhhJ" />
-      </concept>
+      <concept id="1068580123165" name="jetbrains.mps.baseLanguage.structure.InstanceMethodDeclaration" flags="ig" index="3clFb_" />
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
-      <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
-        <child id="1068580123160" name="condition" index="3clFbw" />
-        <child id="1068580123161" name="ifTrue" index="3clFbx" />
-      </concept>
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
+        <property id="1068580123138" name="value" index="3clFbU" />
       </concept>
       <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
         <child id="1068581517676" name="expression" index="3cqZAk" />
@@ -142,6 +139,9 @@
       </concept>
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
       <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
+      <concept id="1079359253375" name="jetbrains.mps.baseLanguage.structure.ParenthesizedExpression" flags="nn" index="1eOMI4">
+        <child id="1079359253376" name="expression" index="1eOMHV" />
+      </concept>
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
@@ -153,16 +153,14 @@
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
       </concept>
-      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
-        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
-        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
-      </concept>
-      <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
       <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
       <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
+      <concept id="1116615150612" name="jetbrains.mps.baseLanguage.structure.ClassifierClassExpression" flags="nn" index="3VsKOn">
+        <reference id="1116615189566" name="classifier" index="3VsUkX" />
+      </concept>
       <concept id="1170345865475" name="jetbrains.mps.baseLanguage.structure.AnonymousClass" flags="ig" index="1Y3b0j">
         <reference id="1170346070688" name="classifier" index="1Y3XeK" />
       </concept>
@@ -195,138 +193,41 @@
   <node concept="2DaZZR" id="7CiSlGy$vK7" />
   <node concept="2uRRBy" id="2vJRo8g$$xf">
     <property role="TrG5h" value="MouseListenerPlugin" />
-    <node concept="2BZ0e9" id="2vJRo8g$$xg" role="2uRRBA">
-      <property role="TrG5h" value="myConnection" />
-      <node concept="3Tm6S6" id="2vJRo8g$$xh" role="1B3o_S" />
-      <node concept="3uibUv" id="2vJRo8g$$xi" role="1tU5fm">
-        <ref role="3uigEE" to="4b2m:~MessageBusConnection" resolve="MessageBusConnection" />
-      </node>
-    </node>
     <node concept="2uRRBT" id="2vJRo8g$$xj" role="2uRRB$">
       <node concept="3clFbS" id="2vJRo8g$$xk" role="2VODD2">
-        <node concept="3cpWs8" id="2vJRo8g$$xl" role="3cqZAp">
-          <node concept="3cpWsn" id="2vJRo8g$$xm" role="3cpWs9">
-            <property role="TrG5h" value="ideaProject" />
-            <node concept="3uibUv" id="2vJRo8g$$xn" role="1tU5fm">
-              <ref role="3uigEE" to="4nm9:~Project" resolve="Project" />
+        <node concept="3cpWs8" id="2CeCNUcewVk" role="3cqZAp">
+          <node concept="3cpWsn" id="2CeCNUcewVl" role="3cpWs9">
+            <property role="TrG5h" value="extension" />
+            <node concept="3uibUv" id="2CeCNUcewbR" role="1tU5fm">
+              <ref role="3uigEE" to="wvnl:~EditorExtension" resolve="EditorExtension" />
             </node>
-            <node concept="2YIFZM" id="2vJRo8g$$xo" role="33vP2m">
-              <ref role="1Pybhc" to="alof:~ProjectHelper" resolve="ProjectHelper" />
-              <ref role="37wK5l" to="alof:~ProjectHelper.toIdeaProject(jetbrains.mps.project.Project)" resolve="toIdeaProject" />
-              <node concept="1KvdUw" id="2vJRo8g$$xp" role="37wK5m" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="2vJRo8g$$xq" role="3cqZAp">
-          <node concept="37vLTI" id="2vJRo8g$$xr" role="3clFbG">
-            <node concept="2OqwBi" id="2vJRo8g$$xs" role="37vLTJ">
-              <node concept="2WthIp" id="2vJRo8g$$xt" role="2Oq$k0" />
-              <node concept="2BZ7hE" id="2vJRo8g$$xu" role="2OqNvi">
-                <ref role="2WH_rO" node="2vJRo8g$$xg" resolve="myConnection" />
-              </node>
-            </node>
-            <node concept="2OqwBi" id="2vJRo8g$$xv" role="37vLTx">
-              <node concept="2OqwBi" id="2vJRo8g$$xw" role="2Oq$k0">
-                <node concept="37vLTw" id="2vJRo8g$$xx" role="2Oq$k0">
-                  <ref role="3cqZAo" node="2vJRo8g$$xm" resolve="ideaProject" />
-                </node>
-                <node concept="liA8E" id="2vJRo8g$$xy" role="2OqNvi">
-                  <ref role="37wK5l" to="1m72:~ComponentManager.getMessageBus()" resolve="getMessageBus" />
-                </node>
-              </node>
-              <node concept="liA8E" id="2vJRo8g$$xz" role="2OqNvi">
-                <ref role="37wK5l" to="4b2m:~MessageBus.connect()" resolve="connect" />
+            <node concept="2OqwBi" id="2CeCNUcewVm" role="33vP2m">
+              <node concept="2WthIp" id="2CeCNUcewVn" role="2Oq$k0" />
+              <node concept="2BZ7hE" id="2CeCNUcewVo" role="2OqNvi">
+                <ref role="2WH_rO" node="2CeCNUcedSn" resolve="selectionListener" />
               </node>
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="2vJRo8g$$x$" role="3cqZAp">
-          <node concept="2OqwBi" id="2vJRo8g$$x_" role="3clFbG">
-            <node concept="2OqwBi" id="2vJRo8g$$xA" role="2Oq$k0">
-              <node concept="2WthIp" id="2vJRo8g$$xB" role="2Oq$k0" />
-              <node concept="2BZ7hE" id="2vJRo8g$$xC" role="2OqNvi">
-                <ref role="2WH_rO" node="2vJRo8g$$xg" resolve="myConnection" />
+        <node concept="3clFbF" id="2CeCNUceceF" role="3cqZAp">
+          <node concept="2EnYce" id="2CeCNUcewaa" role="3clFbG">
+            <node concept="2EnYce" id="2CeCNUcevVN" role="2Oq$k0">
+              <node concept="2YIFZM" id="2CeCNUcevpQ" role="2Oq$k0">
+                <ref role="1Pybhc" to="alof:~ProjectHelper" resolve="ProjectHelper" />
+                <ref role="37wK5l" to="alof:~ProjectHelper.toIdeaProject(jetbrains.mps.project.Project)" resolve="toIdeaProject" />
+                <node concept="1KvdUw" id="2CeCNUcevpR" role="37wK5m" />
+              </node>
+              <node concept="liA8E" id="2CeCNUced9W" role="2OqNvi">
+                <ref role="37wK5l" to="1m72:~ComponentManager.getComponent(java.lang.Class)" resolve="getComponent" />
+                <node concept="3VsKOn" id="2CeCNUcedtX" role="37wK5m">
+                  <ref role="3VsUkX" to="wvnl:~EditorExtensionRegistry" resolve="EditorExtensionRegistry" />
+                </node>
               </node>
             </node>
-            <node concept="liA8E" id="2vJRo8g$$xD" role="2OqNvi">
-              <ref role="37wK5l" to="4b2m:~SimpleMessageBusConnection.subscribe(com.intellij.util.messages.Topic,java.lang.Object)" resolve="subscribe" />
-              <node concept="10M0yZ" id="2vJRo8g$$xE" role="37wK5m">
-                <ref role="3cqZAo" to="rlg8:~EditorComponentCreateListener.EDITOR_COMPONENT_CREATION" resolve="EDITOR_COMPONENT_CREATION" />
-                <ref role="1PxDUh" to="rlg8:~EditorComponentCreateListener" resolve="EditorComponentCreateListener" />
-              </node>
-              <node concept="2ShNRf" id="2vJRo8g$$xF" role="37wK5m">
-                <node concept="YeOm9" id="2vJRo8g$$xG" role="2ShVmc">
-                  <node concept="1Y3b0j" id="2vJRo8g$$xH" role="YeSDq">
-                    <property role="2bfB8j" value="true" />
-                    <ref role="1Y3XeK" to="rlg8:~EditorComponentCreateListener" resolve="EditorComponentCreateListener" />
-                    <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
-                    <node concept="3Tm1VV" id="2vJRo8g$$xI" role="1B3o_S" />
-                    <node concept="3clFb_" id="2vJRo8g$$xJ" role="jymVt">
-                      <property role="1EzhhJ" value="false" />
-                      <property role="TrG5h" value="editorComponentCreated" />
-                      <property role="DiZV1" value="false" />
-                      <node concept="3Tm1VV" id="2vJRo8g$$xK" role="1B3o_S" />
-                      <node concept="3cqZAl" id="2vJRo8g$$xL" role="3clF45" />
-                      <node concept="37vLTG" id="2vJRo8g$$xM" role="3clF46">
-                        <property role="TrG5h" value="editorComponent" />
-                        <node concept="3uibUv" id="2vJRo8g$$xN" role="1tU5fm">
-                          <ref role="3uigEE" to="exr9:~EditorComponent" resolve="EditorComponent" />
-                        </node>
-                        <node concept="2AHcQZ" id="2vJRo8g$$xO" role="2AJF6D">
-                          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
-                        </node>
-                      </node>
-                      <node concept="3clFbS" id="2vJRo8g$$xP" role="3clF47">
-                        <node concept="3clFbF" id="80_psBV2bR" role="3cqZAp">
-                          <node concept="2OqwBi" id="80_psBV2kq" role="3clFbG">
-                            <node concept="2YIFZM" id="80_psBV2cZ" role="2Oq$k0">
-                              <ref role="1Pybhc" to="6tp1:630t2b8ee$$" resolve="DragSelectionMouseListener" />
-                              <ref role="37wK5l" to="6tp1:630t2b8ee$K" resolve="getOrCreateInstance" />
-                              <node concept="37vLTw" id="80_psBV2e8" role="37wK5m">
-                                <ref role="3cqZAo" node="2vJRo8g$$xM" resolve="editorComponent" />
-                              </node>
-                            </node>
-                            <node concept="liA8E" id="80_psBV3mD" role="2OqNvi">
-                              <ref role="37wK5l" to="6tp1:630t2b8eeA1" resolve="install" />
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="3clFb_" id="2vJRo8g$$xT" role="jymVt">
-                      <property role="1EzhhJ" value="false" />
-                      <property role="TrG5h" value="editorComponentDisposed" />
-                      <property role="DiZV1" value="false" />
-                      <node concept="3Tm1VV" id="2vJRo8g$$xU" role="1B3o_S" />
-                      <node concept="3cqZAl" id="2vJRo8g$$xV" role="3clF45" />
-                      <node concept="37vLTG" id="2vJRo8g$$xW" role="3clF46">
-                        <property role="TrG5h" value="editorComponent" />
-                        <node concept="3uibUv" id="2vJRo8g$$xX" role="1tU5fm">
-                          <ref role="3uigEE" to="exr9:~EditorComponent" resolve="EditorComponent" />
-                        </node>
-                        <node concept="2AHcQZ" id="2vJRo8g$$xY" role="2AJF6D">
-                          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
-                        </node>
-                      </node>
-                      <node concept="3clFbS" id="2vJRo8g$$xZ" role="3clF47">
-                        <node concept="3clFbF" id="80_psBV3s3" role="3cqZAp">
-                          <node concept="2EnYce" id="6CcfvtYXOj2" role="3clFbG">
-                            <node concept="2YIFZM" id="6CcfvtYXOgx" role="2Oq$k0">
-                              <ref role="37wK5l" to="6tp1:6CcfvtYXLKo" resolve="getInstance" />
-                              <ref role="1Pybhc" to="6tp1:630t2b8ee$$" resolve="DragSelectionMouseListener" />
-                              <node concept="37vLTw" id="6CcfvtYXOgy" role="37wK5m">
-                                <ref role="3cqZAo" node="2vJRo8g$$xW" resolve="editorComponent" />
-                              </node>
-                            </node>
-                            <node concept="liA8E" id="80_psBV3s7" role="2OqNvi">
-                              <ref role="37wK5l" to="6tp1:630t2b8eeAg" resolve="uninstall" />
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
+            <node concept="liA8E" id="2CeCNUcedPZ" role="2OqNvi">
+              <ref role="37wK5l" to="wvnl:~EditorExtensionRegistry.registerExtension(jetbrains.mps.openapi.editor.extensions.EditorExtension)" resolve="registerExtension" />
+              <node concept="37vLTw" id="2CeCNUcewVp" role="37wK5m">
+                <ref role="3cqZAo" node="2CeCNUcewVl" resolve="extension" />
               </node>
             </node>
           </node>
@@ -335,36 +236,171 @@
     </node>
     <node concept="2uRRBN" id="2vJRo8g$$y0" role="2uRRB_">
       <node concept="3clFbS" id="2vJRo8g$$y1" role="2VODD2">
-        <node concept="3clFbJ" id="4X6FKySdTnj" role="3cqZAp">
-          <node concept="3clFbS" id="4X6FKySdTnm" role="3clFbx">
-            <node concept="3clFbF" id="2vJRo8g$$y2" role="3cqZAp">
-              <node concept="2OqwBi" id="2vJRo8g$$y3" role="3clFbG">
-                <node concept="2OqwBi" id="2vJRo8g$$y4" role="2Oq$k0">
-                  <node concept="2WthIp" id="2vJRo8g$$y5" role="2Oq$k0" />
-                  <node concept="2BZ7hE" id="2vJRo8g$$y6" role="2OqNvi">
-                    <ref role="2WH_rO" node="2vJRo8g$$xg" resolve="myConnection" />
-                  </node>
-                </node>
-                <node concept="liA8E" id="13HFeh2d0CP" role="2OqNvi">
-                  <ref role="37wK5l" to="4b2m:~SimpleMessageBusConnection.disconnect()" resolve="disconnect" />
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3y3z36" id="4X6FKySdTHZ" role="3clFbw">
-            <node concept="10Nm6u" id="4X6FKySdTJG" role="3uHU7w" />
-            <node concept="2OqwBi" id="4X6FKySdToG" role="3uHU7B">
-              <node concept="2WthIp" id="4X6FKySdToJ" role="2Oq$k0" />
-              <node concept="2BZ7hE" id="4X6FKySdToL" role="2OqNvi">
-                <ref role="2WH_rO" node="2vJRo8g$$xg" resolve="myConnection" />
-              </node>
-            </node>
-          </node>
-        </node>
         <node concept="3clFbF" id="80_psC71Lu" role="3cqZAp">
           <node concept="2YIFZM" id="80_psC71N1" role="3clFbG">
             <ref role="37wK5l" to="6tp1:630t2b8ee_g" resolve="uninstallAll" />
             <ref role="1Pybhc" to="6tp1:630t2b8ee$$" resolve="DragSelectionMouseListener" />
+          </node>
+        </node>
+        <node concept="3cpWs8" id="2CeCNUcex88" role="3cqZAp">
+          <node concept="3cpWsn" id="2CeCNUcex89" role="3cpWs9">
+            <property role="TrG5h" value="extension" />
+            <node concept="3uibUv" id="2CeCNUcex1q" role="1tU5fm">
+              <ref role="3uigEE" to="wvnl:~EditorExtension" resolve="EditorExtension" />
+            </node>
+            <node concept="2OqwBi" id="2CeCNUcex8a" role="33vP2m">
+              <node concept="2WthIp" id="2CeCNUcex8b" role="2Oq$k0" />
+              <node concept="2BZ7hE" id="2CeCNUcex8c" role="2OqNvi">
+                <ref role="2WH_rO" node="2CeCNUcedSn" resolve="selectionListener" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="2CeCNUceexz" role="3cqZAp">
+          <node concept="2EnYce" id="2CeCNUcew0M" role="3clFbG">
+            <node concept="2EnYce" id="2CeCNUcevPU" role="2Oq$k0">
+              <node concept="2YIFZM" id="2CeCNUcevxd" role="2Oq$k0">
+                <ref role="1Pybhc" to="alof:~ProjectHelper" resolve="ProjectHelper" />
+                <ref role="37wK5l" to="alof:~ProjectHelper.toIdeaProject(jetbrains.mps.project.Project)" resolve="toIdeaProject" />
+                <node concept="1KvdUw" id="2CeCNUcevxe" role="37wK5m" />
+              </node>
+              <node concept="liA8E" id="2CeCNUceexB" role="2OqNvi">
+                <ref role="37wK5l" to="1m72:~ComponentManager.getComponent(java.lang.Class)" resolve="getComponent" />
+                <node concept="3VsKOn" id="2CeCNUceexC" role="37wK5m">
+                  <ref role="3VsUkX" to="wvnl:~EditorExtensionRegistry" resolve="EditorExtensionRegistry" />
+                </node>
+              </node>
+            </node>
+            <node concept="liA8E" id="2CeCNUceexD" role="2OqNvi">
+              <ref role="37wK5l" to="wvnl:~EditorExtensionRegistry.unregisterExtension(jetbrains.mps.openapi.editor.extensions.EditorExtension)" resolve="unregisterExtension" />
+              <node concept="37vLTw" id="2CeCNUcex8d" role="37wK5m">
+                <ref role="3cqZAo" node="2CeCNUcex89" resolve="extension" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2BZ0e9" id="2CeCNUcedSn" role="2uRRBA">
+      <property role="TrG5h" value="selectionListener" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="2CeCNUcedSo" role="1B3o_S" />
+      <node concept="3uibUv" id="2CeCNUcee7F" role="1tU5fm">
+        <ref role="3uigEE" to="wvnl:~EditorExtension" resolve="EditorExtension" />
+      </node>
+      <node concept="2ShNRf" id="2CeCNUceeNx" role="33vP2m">
+        <node concept="YeOm9" id="2CeCNUcepr7" role="2ShVmc">
+          <node concept="1Y3b0j" id="2CeCNUcepra" role="YeSDq">
+            <property role="2bfB8j" value="true" />
+            <ref role="1Y3XeK" to="wvnl:~EditorExtension" resolve="EditorExtension" />
+            <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
+            <node concept="3Tm1VV" id="2CeCNUceprb" role="1B3o_S" />
+            <node concept="3clFb_" id="2CeCNUceprg" role="jymVt">
+              <property role="TrG5h" value="isApplicable" />
+              <node concept="3Tm1VV" id="2CeCNUceprh" role="1B3o_S" />
+              <node concept="10P_77" id="2CeCNUceprj" role="3clF45" />
+              <node concept="37vLTG" id="2CeCNUceprk" role="3clF46">
+                <property role="TrG5h" value="p0" />
+                <node concept="3uibUv" id="2CeCNUcerBE" role="1tU5fm">
+                  <ref role="3uigEE" to="cj4x:~EditorComponent" resolve="EditorComponent" />
+                </node>
+                <node concept="2AHcQZ" id="2CeCNUceprm" role="2AJF6D">
+                  <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+                </node>
+              </node>
+              <node concept="3clFbS" id="2CeCNUceprn" role="3clF47">
+                <node concept="3clFbF" id="2CeCNUceq1Y" role="3cqZAp">
+                  <node concept="3clFbT" id="2CeCNUceq1X" role="3clFbG">
+                    <property role="3clFbU" value="true" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2AHcQZ" id="2CeCNUceprp" role="2AJF6D">
+                <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+              </node>
+            </node>
+            <node concept="2tJIrI" id="2CeCNUceprq" role="jymVt" />
+            <node concept="3clFb_" id="2CeCNUceprr" role="jymVt">
+              <property role="TrG5h" value="install" />
+              <node concept="3Tm1VV" id="2CeCNUceprs" role="1B3o_S" />
+              <node concept="3cqZAl" id="2CeCNUcepru" role="3clF45" />
+              <node concept="37vLTG" id="2CeCNUceprv" role="3clF46">
+                <property role="TrG5h" value="editorComponent" />
+                <node concept="3uibUv" id="2CeCNUceri0" role="1tU5fm">
+                  <ref role="3uigEE" to="cj4x:~EditorComponent" resolve="EditorComponent" />
+                </node>
+                <node concept="2AHcQZ" id="2CeCNUceprx" role="2AJF6D">
+                  <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+                </node>
+              </node>
+              <node concept="3clFbS" id="2CeCNUcepry" role="3clF47">
+                <node concept="3clFbF" id="2CeCNUcepGc" role="3cqZAp">
+                  <node concept="2OqwBi" id="2CeCNUcepGd" role="3clFbG">
+                    <node concept="2YIFZM" id="2CeCNUcepGe" role="2Oq$k0">
+                      <ref role="37wK5l" to="6tp1:630t2b8ee$K" resolve="getOrCreateInstance" />
+                      <ref role="1Pybhc" to="6tp1:630t2b8ee$$" resolve="DragSelectionMouseListener" />
+                      <node concept="1eOMI4" id="2CeCNUceuon" role="37wK5m">
+                        <node concept="10QFUN" id="2CeCNUceuok" role="1eOMHV">
+                          <node concept="3uibUv" id="2CeCNUceu$d" role="10QFUM">
+                            <ref role="3uigEE" to="exr9:~EditorComponent" resolve="EditorComponent" />
+                          </node>
+                          <node concept="37vLTw" id="2CeCNUcepGf" role="10QFUP">
+                            <ref role="3cqZAo" node="2CeCNUceprv" resolve="editorComponent" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="2CeCNUcepGg" role="2OqNvi">
+                      <ref role="37wK5l" to="6tp1:630t2b8eeA1" resolve="install" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="2AHcQZ" id="2CeCNUcepr$" role="2AJF6D">
+                <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+              </node>
+            </node>
+            <node concept="2tJIrI" id="2CeCNUcepr_" role="jymVt" />
+            <node concept="3clFb_" id="2CeCNUceprA" role="jymVt">
+              <property role="TrG5h" value="uninstall" />
+              <node concept="3Tm1VV" id="2CeCNUceprB" role="1B3o_S" />
+              <node concept="3cqZAl" id="2CeCNUceprD" role="3clF45" />
+              <node concept="37vLTG" id="2CeCNUceprE" role="3clF46">
+                <property role="TrG5h" value="editorComponent" />
+                <node concept="3uibUv" id="2CeCNUcerst" role="1tU5fm">
+                  <ref role="3uigEE" to="cj4x:~EditorComponent" resolve="EditorComponent" />
+                </node>
+                <node concept="2AHcQZ" id="2CeCNUceprG" role="2AJF6D">
+                  <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+                </node>
+              </node>
+              <node concept="3clFbS" id="2CeCNUceprH" role="3clF47">
+                <node concept="3clFbF" id="2CeCNUcepMo" role="3cqZAp">
+                  <node concept="2EnYce" id="2CeCNUcepMp" role="3clFbG">
+                    <node concept="2YIFZM" id="2CeCNUcepMq" role="2Oq$k0">
+                      <ref role="1Pybhc" to="6tp1:630t2b8ee$$" resolve="DragSelectionMouseListener" />
+                      <ref role="37wK5l" to="6tp1:6CcfvtYXLKo" resolve="getInstance" />
+                      <node concept="1eOMI4" id="2CeCNUceuKm" role="37wK5m">
+                        <node concept="10QFUN" id="2CeCNUceuKl" role="1eOMHV">
+                          <node concept="37vLTw" id="2CeCNUceuKk" role="10QFUP">
+                            <ref role="3cqZAo" node="2CeCNUceprE" resolve="editorComponent" />
+                          </node>
+                          <node concept="3uibUv" id="2CeCNUceuKj" role="10QFUM">
+                            <ref role="3uigEE" to="exr9:~EditorComponent" resolve="EditorComponent" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="2CeCNUcepMs" role="2OqNvi">
+                      <ref role="37wK5l" to="6tp1:630t2b8eeAg" resolve="uninstall" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="2AHcQZ" id="2CeCNUceprJ" role="2AJF6D">
+                <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+              </node>
+            </node>
           </node>
         </node>
       </node>


### PR DESCRIPTION
# What changed

- If the mouseSelection plugin (for some reason) loads after an editor was opened, it didn't get installed into that editor so far. Switching to the EditorExtension API for installing resolved that issue
- when trying to click somewhere to place the cursor, it sometimes happens that we move a few pixels between press and release (by accident). The selection plugin now only considers drags that go further than 2 pixels as the intention to select something

This is the forward port of what we fixed already in `maintenance/mps20193` as part of #408 .

And I built it together with @slisson , so we can consider it reviewed.