### PR TITLE
Richtext: Improve pasting over selection

### DIFF
--- a/code/.mps/modules.xml
+++ b/code/.mps/modules.xml
@@ -154,7 +154,7 @@
       <modulePath path="$PROJECT_DIR$/shadowmodels/solutions/test.de.q60.mps.shadowmodels.examples/test.de.q60.mps.shadowmodels.examples.msd" folder="shadowmodels.tests" />
       <modulePath path="$PROJECT_DIR$/shadowmodels/solutions/test.de.q60.mps.shadowmodels.runtime/test.de.q60.mps.shadowmodels.runtime.msd" folder="shadowmodels.tests" />
       <modulePath path="$PROJECT_DIR$/solutions/com.fasterxml.jackson/com.fasterxml.jackson.msd" folder="jackson" />
-        <modulePath path="$PROJECT_DIR$/structurecheck/languages/de.slisson.mps.structurecheck/de.slisson.mps.structurecheck.mpl" folder="structurecheck" />
+      <modulePath path="$PROJECT_DIR$/structurecheck/languages/de.slisson.mps.structurecheck/de.slisson.mps.structurecheck.mpl" folder="structurecheck" />
       <modulePath path="$PROJECT_DIR$/structurecheck/solutions/de.slisson.mps.structurecheck.runtime/de.slisson.mps.structurecheck.runtime.msd" folder="structurecheck" />
       <modulePath path="$PROJECT_DIR$/structurecheck/solutions/de.slisson.mps.structurecheck.sandbox/de.slisson.mps.structurecheck.sandbox.msd" folder="structurecheck" />
       <modulePath path="$PROJECT_DIR$/tables/languages/de.slisson.mps.tables.demolang/de.slisson.mps.tables.demolang.mpl" folder="tables" />

--- a/code/richtext/languages/richtext/languageModels/behavior.mps
+++ b/code/richtext/languages/richtext/languageModels/behavior.mps
@@ -1165,6 +1165,140 @@
         <node concept="10Oyi0" id="4YWDi1U$X5P" role="1tU5fm" />
       </node>
     </node>
+    <node concept="13i0hz" id="2FluRPpNMcC" role="13h7CS">
+      <property role="TrG5h" value="replaceSelection" />
+      <node concept="3Tm1VV" id="2FluRPpNMcD" role="1B3o_S" />
+      <node concept="3cqZAl" id="2FluRPpNML2" role="3clF45" />
+      <node concept="3clFbS" id="2FluRPpNMcF" role="3clF47">
+        <node concept="3cpWs8" id="2FluRPpNPwe" role="3cqZAp">
+          <node concept="3cpWsn" id="2FluRPpNPwf" role="3cpWs9">
+            <property role="TrG5h" value="selection" />
+            <node concept="1LlUBW" id="2FluRPpNPoo" role="1tU5fm">
+              <node concept="10Oyi0" id="2FluRPpNPox" role="1Lm7xW" />
+              <node concept="10Oyi0" id="2FluRPpNPov" role="1Lm7xW" />
+              <node concept="10Oyi0" id="2FluRPpNPow" role="1Lm7xW" />
+            </node>
+            <node concept="BsUDl" id="2FluRPpNPwg" role="33vP2m">
+              <ref role="37wK5l" node="lp3OKvgCxD" resolve="getSelection" />
+              <node concept="37vLTw" id="2FluRPpNPwh" role="37wK5m">
+                <ref role="3cqZAo" node="2FluRPpNNU$" resolve="context" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="2FluRPpNQOg" role="3cqZAp">
+          <node concept="3cpWsn" id="2FluRPpNQOj" role="3cpWs9">
+            <property role="TrG5h" value="start" />
+            <node concept="10Oyi0" id="2FluRPpNQOe" role="1tU5fm" />
+            <node concept="1LFfDK" id="2FluRPpNRrX" role="33vP2m">
+              <node concept="3cmrfG" id="2FluRPpNRsx" role="1LF_Uc">
+                <property role="3cmrfH" value="1" />
+              </node>
+              <node concept="37vLTw" id="2FluRPpNQX3" role="1LFl5Q">
+                <ref role="3cqZAo" node="2FluRPpNPwf" resolve="selection" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="2FluRPpNRAf" role="3cqZAp">
+          <node concept="3cpWsn" id="2FluRPpNRAi" role="3cpWs9">
+            <property role="TrG5h" value="end" />
+            <node concept="10Oyi0" id="2FluRPpNRAd" role="1tU5fm" />
+            <node concept="1LFfDK" id="2FluRPpNS3w" role="33vP2m">
+              <node concept="3cmrfG" id="2FluRPpNS44" role="1LF_Uc">
+                <property role="3cmrfH" value="2" />
+              </node>
+              <node concept="37vLTw" id="2FluRPpNREG" role="1LFl5Q">
+                <ref role="3cqZAo" node="2FluRPpNPwf" resolve="selection" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="2FluRPpNNmH" role="3cqZAp">
+          <node concept="3cpWsn" id="2FluRPpNNmI" role="3cpWs9">
+            <property role="TrG5h" value="myText" />
+            <node concept="17QB3L" id="2FluRPpNNmJ" role="1tU5fm" />
+            <node concept="BsUDl" id="2FluRPpNNmK" role="33vP2m">
+              <ref role="37wK5l" node="ehGfXvI_DB" resolve="getText" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="2FluRPpNNmL" role="3cqZAp">
+          <node concept="3cpWsn" id="2FluRPpNNmM" role="3cpWs9">
+            <property role="TrG5h" value="s1" />
+            <node concept="17QB3L" id="2FluRPpNNmN" role="1tU5fm" />
+            <node concept="2OqwBi" id="2FluRPpNNmO" role="33vP2m">
+              <node concept="37vLTw" id="2FluRPpNNmP" role="2Oq$k0">
+                <ref role="3cqZAo" node="2FluRPpNNmI" resolve="myText" />
+              </node>
+              <node concept="liA8E" id="2FluRPpNNmQ" role="2OqNvi">
+                <ref role="37wK5l" to="wyt6:~String.substring(int,int)" resolve="substring" />
+                <node concept="3cmrfG" id="2FluRPpNNmR" role="37wK5m">
+                  <property role="3cmrfH" value="0" />
+                </node>
+                <node concept="37vLTw" id="2FluRPpNSpY" role="37wK5m">
+                  <ref role="3cqZAo" node="2FluRPpNQOj" resolve="start" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="2FluRPpNNmT" role="3cqZAp">
+          <node concept="3cpWsn" id="2FluRPpNNmU" role="3cpWs9">
+            <property role="TrG5h" value="s2" />
+            <node concept="17QB3L" id="2FluRPpNNmV" role="1tU5fm" />
+            <node concept="2OqwBi" id="2FluRPpNNmW" role="33vP2m">
+              <node concept="37vLTw" id="2FluRPpNNmX" role="2Oq$k0">
+                <ref role="3cqZAo" node="2FluRPpNNmI" resolve="myText" />
+              </node>
+              <node concept="liA8E" id="2FluRPpNNmY" role="2OqNvi">
+                <ref role="37wK5l" to="wyt6:~String.substring(int)" resolve="substring" />
+                <node concept="37vLTw" id="2FluRPpNSxZ" role="37wK5m">
+                  <ref role="3cqZAo" node="2FluRPpNRAi" resolve="end" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="2FluRPpNNn0" role="3cqZAp">
+          <node concept="3cpWsn" id="2FluRPpNNn1" role="3cpWs9">
+            <property role="TrG5h" value="newText" />
+            <node concept="17QB3L" id="2FluRPpNNn2" role="1tU5fm" />
+            <node concept="3cpWs3" id="2FluRPpNNn3" role="33vP2m">
+              <node concept="37vLTw" id="2FluRPpNNn4" role="3uHU7w">
+                <ref role="3cqZAo" node="2FluRPpNNmU" resolve="s2" />
+              </node>
+              <node concept="3cpWs3" id="2FluRPpNNn5" role="3uHU7B">
+                <node concept="37vLTw" id="2FluRPpNNn6" role="3uHU7B">
+                  <ref role="3cqZAo" node="2FluRPpNNmM" resolve="s1" />
+                </node>
+                <node concept="37vLTw" id="2FluRPpNNn7" role="3uHU7w">
+                  <ref role="3cqZAo" node="2FluRPpNMLA" resolve="text" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="2FluRPpNNn8" role="3cqZAp">
+          <node concept="BsUDl" id="2FluRPpNNn9" role="3clFbG">
+            <ref role="37wK5l" node="1JwC6U7zkKz" resolve="setText" />
+            <node concept="37vLTw" id="2FluRPpNNna" role="37wK5m">
+              <ref role="3cqZAo" node="2FluRPpNNn1" resolve="newText" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="2FluRPpNMLA" role="3clF46">
+        <property role="TrG5h" value="text" />
+        <node concept="17QB3L" id="2FluRPpNML_" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="2FluRPpNNU$" role="3clF46">
+        <property role="TrG5h" value="context" />
+        <node concept="3uibUv" id="2FluRPpNO1o" role="1tU5fm">
+          <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+        </node>
+      </node>
+    </node>
     <node concept="13i0hz" id="4WdkpBdiPPZ" role="13h7CS">
       <property role="TrG5h" value="insertNodesAtCaret" />
       <node concept="3Tm1VV" id="4WdkpBdiPQ0" role="1B3o_S" />

--- a/code/richtext/languages/richtext/models/de/slisson/mps/richtext/runtime/selection.mps
+++ b/code/richtext/languages/richtext/models/de/slisson/mps/richtext/runtime/selection.mps
@@ -41,6 +41,10 @@
       <concept id="1238853782547" name="jetbrains.mps.baseLanguage.tuples.structure.IndexedTupleLiteral" flags="nn" index="1Ls8ON">
         <child id="1238853845806" name="component" index="1Lso8e" />
       </concept>
+      <concept id="1238857743184" name="jetbrains.mps.baseLanguage.tuples.structure.IndexedTupleMemberAccessExpression" flags="nn" index="1LFfDK">
+        <child id="1238857764950" name="tuple" index="1LFl5Q" />
+        <child id="1238857834412" name="index" index="1LF_Uc" />
+      </concept>
     </language>
     <language id="654422bf-e75f-44dc-936d-188890a746ce" name="de.slisson.mps.reflection">
       <concept id="8473566765275063380" name="de.slisson.mps.reflection.structure.ReflectionFieldAccess" flags="ng" index="1PnCL0">
@@ -5550,6 +5554,93 @@
                   </node>
                 </node>
               </node>
+              <node concept="3clFbF" id="2FluRPq2tvz" role="3cqZAp">
+                <node concept="1rXfSq" id="2FluRPq2tvx" role="3clFbG">
+                  <ref role="37wK5l" node="635SBilAZic" resolve="clearSelection" />
+                </node>
+              </node>
+              <node concept="3clFbF" id="2FluRPq4eB$" role="3cqZAp">
+                <node concept="2YIFZM" id="2FluRPq4eB_" role="3clFbG">
+                  <ref role="1Pybhc" to="dxuu:~SwingUtilities" resolve="SwingUtilities" />
+                  <ref role="37wK5l" to="dxuu:~SwingUtilities.invokeLater(java.lang.Runnable)" resolve="invokeLater" />
+                  <node concept="1bVj0M" id="2FluRPq4eBA" role="37wK5m">
+                    <node concept="3clFbS" id="2FluRPq4eBB" role="1bW5cS">
+                      <node concept="3cpWs8" id="2FluRPq4gZ2" role="3cqZAp">
+                        <node concept="3cpWsn" id="2FluRPq4gZ3" role="3cpWs9">
+                          <property role="TrG5h" value="mlCell" />
+                          <node concept="3uibUv" id="2FluRPq4gZ4" role="1tU5fm">
+                            <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+                          </node>
+                          <node concept="2OqwBi" id="2FluRPq4gZ5" role="33vP2m">
+                            <node concept="1rXfSq" id="2FluRPq4gZ6" role="2Oq$k0">
+                              <ref role="37wK5l" to="b8lf:~AbstractSelection.getEditorComponent()" resolve="getEditorComponent" />
+                            </node>
+                            <node concept="liA8E" id="2FluRPq4gZ7" role="2OqNvi">
+                              <ref role="37wK5l" to="cj4x:~EditorComponent.findNodeCell(org.jetbrains.mps.openapi.model.SNode)" resolve="findNodeCell" />
+                              <node concept="2OqwBi" id="2FluRPq4gZ8" role="37wK5m">
+                                <node concept="37vLTw" id="2FluRPq4gZ9" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="4YWDi1UQFdQ" resolve="caretPos" />
+                                </node>
+                                <node concept="2S8uIT" id="2FluRPq4gZa" role="2OqNvi">
+                                  <ref role="2S8YL0" node="7nqK$2JOq_X" resolve="word" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbJ" id="2FluRPq4gZb" role="3cqZAp">
+                        <node concept="3clFbS" id="2FluRPq4gZc" role="3clFbx">
+                          <node concept="3clFbF" id="2FluRPq4gZd" role="3cqZAp">
+                            <node concept="2OqwBi" id="2FluRPq4gZe" role="3clFbG">
+                              <node concept="1eOMI4" id="2FluRPq4gZf" role="2Oq$k0">
+                                <node concept="10QFUN" id="2FluRPq4gZg" role="1eOMHV">
+                                  <node concept="3uibUv" id="2FluRPq4gZh" role="10QFUM">
+                                    <ref role="3uigEE" to="93vl:7cgOZHrhAS_" resolve="EditorCell_Multiline" />
+                                  </node>
+                                  <node concept="37vLTw" id="2FluRPq4gZi" role="10QFUP">
+                                    <ref role="3cqZAo" node="2FluRPq4gZ3" resolve="mlCell" />
+                                  </node>
+                                </node>
+                              </node>
+                              <node concept="liA8E" id="2FluRPq4gZj" role="2OqNvi">
+                                <ref role="37wK5l" to="93vl:16btBGPcV7x" resolve="setCaretPosition" />
+                                <node concept="3cpWs3" id="2FluRPq4gZk" role="37wK5m">
+                                  <node concept="2OqwBi" id="2FluRPq4gZl" role="3uHU7w">
+                                    <node concept="2YIFZM" id="2FluRPq4gZm" role="2Oq$k0">
+                                      <ref role="1Pybhc" to="mywg:4wYmLz_LWxB" resolve="ClipboardUtils" />
+                                      <ref role="37wK5l" to="mywg:4wYmLz_LWxH" resolve="getClipboardText" />
+                                    </node>
+                                    <node concept="liA8E" id="2FluRPq4gZn" role="2OqNvi">
+                                      <ref role="37wK5l" to="wyt6:~String.length()" resolve="length" />
+                                    </node>
+                                  </node>
+                                  <node concept="2OqwBi" id="2FluRPq4gZo" role="3uHU7B">
+                                    <node concept="37vLTw" id="2FluRPq4gZp" role="2Oq$k0">
+                                      <ref role="3cqZAo" node="4YWDi1UQFdQ" resolve="caretPos" />
+                                    </node>
+                                    <node concept="2S8uIT" id="2FluRPq4gZq" role="2OqNvi">
+                                      <ref role="2S8YL0" node="7nqK$2JOqA5" resolve="relativePos" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="2ZW3vV" id="2FluRPq4gZr" role="3clFbw">
+                          <node concept="3uibUv" id="2FluRPq4gZs" role="2ZW6by">
+                            <ref role="3uigEE" to="93vl:7cgOZHrhAS_" resolve="EditorCell_Multiline" />
+                          </node>
+                          <node concept="37vLTw" id="2FluRPq4gZt" role="2ZW6bz">
+                            <ref role="3cqZAo" node="2FluRPq4gZ3" resolve="mlCell" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -9857,22 +9948,33 @@
                   </node>
                 </node>
               </node>
+              <node concept="3cpWs8" id="2FluRPpN9CE" role="3cqZAp">
+                <node concept="3cpWsn" id="2FluRPpN9CF" role="3cpWs9">
+                  <property role="TrG5h" value="selectionStart" />
+                  <node concept="1LFfDK" id="2FluRPpPunj" role="33vP2m">
+                    <node concept="3cmrfG" id="2FluRPpPusz" role="1LF_Uc">
+                      <property role="3cmrfH" value="1" />
+                    </node>
+                    <node concept="2OqwBi" id="2FluRPpN9CG" role="1LFl5Q">
+                      <node concept="37vLTw" id="2FluRPpN9CH" role="2Oq$k0">
+                        <ref role="3cqZAo" node="4WdkpBdiPPg" resolve="wordNode" />
+                      </node>
+                      <node concept="2qgKlT" id="2FluRPpN9CI" role="2OqNvi">
+                        <ref role="37wK5l" to="tbr6:lp3OKvgCxD" resolve="getSelection" />
+                        <node concept="37vLTw" id="2FluRPpN9CJ" role="37wK5m">
+                          <ref role="3cqZAo" node="4WdkpBdiNJI" resolve="context" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="10Oyi0" id="2FluRPpPv4a" role="1tU5fm" />
+                </node>
+              </node>
               <node concept="3cpWs8" id="4OHf36xN4RF" role="3cqZAp">
                 <node concept="3cpWsn" id="4OHf36xN4RG" role="3cpWs9">
                   <property role="TrG5h" value="caretPos" />
                   <node concept="10Oyi0" id="4OHf36xN4RH" role="1tU5fm" />
                   <node concept="3cpWs3" id="4OHf36xN7PS" role="33vP2m">
-                    <node concept="2OqwBi" id="4OHf36xN4Rq" role="3uHU7B">
-                      <node concept="37vLTw" id="4OHf36xN4R3" role="2Oq$k0">
-                        <ref role="3cqZAo" node="4WdkpBdiPPg" resolve="wordNode" />
-                      </node>
-                      <node concept="2qgKlT" id="4OHf36xN4Rw" role="2OqNvi">
-                        <ref role="37wK5l" to="tbr6:13kKwkYC$wf" resolve="getCaretPosition" />
-                        <node concept="37vLTw" id="4OHf36xN4Rx" role="37wK5m">
-                          <ref role="3cqZAo" node="4WdkpBdiNJI" resolve="context" />
-                        </node>
-                      </node>
-                    </node>
                     <node concept="2OqwBi" id="4OHf36xN7PV" role="3uHU7w">
                       <node concept="37vLTw" id="4OHf36xN7PW" role="2Oq$k0">
                         <ref role="3cqZAo" node="4OHf36xN4QX" resolve="text" />
@@ -9880,6 +9982,9 @@
                       <node concept="liA8E" id="4OHf36xN7PX" role="2OqNvi">
                         <ref role="37wK5l" to="wyt6:~String.length()" resolve="length" />
                       </node>
+                    </node>
+                    <node concept="37vLTw" id="2FluRPpPvZD" role="3uHU7B">
+                      <ref role="3cqZAo" node="2FluRPpN9CF" resolve="selectionStart" />
                     </node>
                   </node>
                 </node>
@@ -9890,7 +9995,7 @@
                     <ref role="3cqZAo" node="4WdkpBdiPPg" resolve="wordNode" />
                   </node>
                   <node concept="2qgKlT" id="mbKrkPbnVY" role="2OqNvi">
-                    <ref role="37wK5l" to="tbr6:2dWzqxECJHs" resolve="insertTextAtCaret" />
+                    <ref role="37wK5l" to="tbr6:2FluRPpNMcC" resolve="replaceSelection" />
                     <node concept="37vLTw" id="4OHf36xN53T" role="37wK5m">
                       <ref role="3cqZAo" node="4OHf36xN4QX" resolve="text" />
                     </node>


### PR DESCRIPTION
Pasting in richtext while text is selected behaved differently than intuitively expected  from text editors.
In particular:
- When text withing a single word (i.e. part of a string without spaces, not the Word concept) was selected, pasting did not delete the selected text, but simply insert the clipboard text at the caret position
- When multiple words within a Word were selected, pasting did not deselect that text, and the caret position was not moved to the end of the pasted text

This fixes these problems.