### PR TITLE
Grammar cells migration to the transformation menu language

### DIFF
--- a/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
+++ b/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
@@ -5561,9 +5561,9 @@
         </node>
       </node>
       <node concept="3LEwk6" id="5kDpuTS3hez" role="2G$12L">
-        <property role="BnDLt" value="true" />
         <property role="TrG5h" value="de.itemis.mps.editor.diagram.devkit" />
         <property role="3LESm3" value="b1972fb0-9171-4e58-8cee-05866bb91ec2" />
+        <property role="BnDLt" value="true" />
         <node concept="398BVA" id="5kDpuTS3htL" role="3LF7KH">
           <ref role="398BVh" node="2fo8bJE$D4t" resolve="extensions.code" />
           <node concept="2Ry0Ak" id="5kDpuTS3ink" role="iGT6I">
@@ -14217,6 +14217,11 @@
             <node concept="3qWCbU" id="7q24334ZKzD" role="3LXTna">
               <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
             </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="5ycts4SlSD6" role="3bR37C">
+          <node concept="3bR9La" id="5ycts4SlSD7" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:7Kfy9QB6LfQ" resolve="jetbrains.mps.kernel" />
           </node>
         </node>
       </node>

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells.sandboxlang/com.mbeddr.mpsutil.grammarcells.sandboxlang.mpl
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells.sandboxlang/com.mbeddr.mpsutil.grammarcells.sandboxlang.mpl
@@ -47,6 +47,7 @@
     <dependency reexport="false">7ac49bcb-77fb-4f0f-9036-e31b86b854b2(com.mbeddr.mpsutil.grammarcells.runtime)</dependency>
     <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
     <dependency reexport="false">1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)</dependency>
+    <dependency reexport="false">2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:9d69e719-78c8-4286-90db-fb19c107d049:com.mbeddr.mpsutil.grammarcells" version="1" />
@@ -98,6 +99,7 @@
     <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
     <module reference="7ac49bcb-77fb-4f0f-9036-e31b86b854b2(com.mbeddr.mpsutil.grammarcells.runtime)" version="0" />
     <module reference="a257f68c-93a3-47b0-838b-6905dd9c20f6(com.mbeddr.mpsutil.grammarcells.sandboxlang)" version="0" />
+    <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
     <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
     <module reference="a9e4c532-c5f5-4bb7-99ef-42abb73bbb70(jetbrains.mps.lang.descriptor.aspects)" version="0" />
   </dependencyVersions>

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells.sandboxlang/models/com/mbeddr/mpsutil/grammarcells/sandboxlang/constraints.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells.sandboxlang/models/com/mbeddr/mpsutil/grammarcells/sandboxlang/constraints.mps
@@ -2,9 +2,11 @@
 <model ref="r:916e3eb0-f4e8-4708-a417-7408e906a8c8(com.mbeddr.mpsutil.grammarcells.sandboxlang.constraints)">
   <persistence version="9" />
   <languages>
+    <use id="3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1" name="jetbrains.mps.lang.constraints" version="6" />
     <devkit ref="00000000-0000-4000-0000-5604ebd4f22c(jetbrains.mps.devkit.aspect.constraints)" />
   </languages>
   <imports>
+    <import index="o8zo" ref="r:314576fc-3aee-4386-a0a5-a38348ac317d(jetbrains.mps.scope)" />
     <import index="ibwz" ref="r:ad27d4b4-fc2c-4b6d-9e22-455eb0ccf354(com.mbeddr.mpsutil.grammarcells.sandboxlang.structure)" implicit="true" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
@@ -21,6 +23,9 @@
       </concept>
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
       </concept>
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
       <concept id="1068580123152" name="jetbrains.mps.baseLanguage.structure.EqualsExpression" flags="nn" index="3clFbC" />
@@ -53,16 +58,42 @@
       </concept>
     </language>
     <language id="3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1" name="jetbrains.mps.lang.constraints">
+      <concept id="8966504967485224688" name="jetbrains.mps.lang.constraints.structure.ConstraintFunctionParameter_contextNode" flags="nn" index="2rP1CM" />
       <concept id="1147467115080" name="jetbrains.mps.lang.constraints.structure.NodePropertyConstraint" flags="ng" index="EnEH3">
         <reference id="1147467295099" name="applicableProperty" index="EomxK" />
         <child id="1212097481299" name="propertyValidator" index="QCWH9" />
       </concept>
       <concept id="1212096972063" name="jetbrains.mps.lang.constraints.structure.ConstraintFunction_PropertyValidator" flags="in" index="QB0g5" />
+      <concept id="5564765827938091039" name="jetbrains.mps.lang.constraints.structure.ConstraintFunction_ReferentSearchScope_Scope" flags="ig" index="3dgokm" />
       <concept id="1213093968558" name="jetbrains.mps.lang.constraints.structure.ConceptConstraints" flags="ng" index="1M2fIO">
         <reference id="1213093996982" name="concept" index="1M2myG" />
         <child id="1213098023997" name="property" index="1MhHOB" />
+        <child id="1213100494875" name="referent" index="1Mr941" />
+      </concept>
+      <concept id="1148687176410" name="jetbrains.mps.lang.constraints.structure.NodeReferentConstraint" flags="ng" index="1N5Pfh">
+        <reference id="1148687202698" name="applicableLink" index="1N5Vy1" />
+        <child id="1148687345559" name="searchScopeFactory" index="1N6uqs" />
       </concept>
       <concept id="1153138554286" name="jetbrains.mps.lang.constraints.structure.ConstraintsFunctionParameter_propertyValue" flags="nn" index="1Wqviy" />
+    </language>
+    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
+        <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
+      </concept>
+      <concept id="1138411891628" name="jetbrains.mps.lang.smodel.structure.SNodeOperation" flags="nn" index="eCIE_">
+        <child id="1144104376918" name="parameter" index="1xVPHs" />
+      </concept>
+      <concept id="4693937538533521280" name="jetbrains.mps.lang.smodel.structure.OfConceptOperation" flags="ng" index="v3k3i">
+        <child id="4693937538533538124" name="requestedConcept" index="v3oSu" />
+      </concept>
+      <concept id="1171407110247" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorOperation" flags="nn" index="2Xjw5R" />
+      <concept id="1144100932627" name="jetbrains.mps.lang.smodel.structure.OperationParm_Inclusion" flags="ng" index="1xIGOp" />
+      <concept id="1144101972840" name="jetbrains.mps.lang.smodel.structure.OperationParm_Concept" flags="ng" index="1xMEDy">
+        <child id="1207343664468" name="conceptArgument" index="ri$Ld" />
+      </concept>
+      <concept id="1138056282393" name="jetbrains.mps.lang.smodel.structure.SLinkListAccess" flags="nn" index="3Tsc0h">
+        <reference id="1138056546658" name="link" index="3TtcxE" />
+      </concept>
     </language>
   </registry>
   <node concept="1M2fIO" id="6oKG1kMxtAs">
@@ -116,6 +147,45 @@
                   <ref role="37wK5l" to="wyt6:~String.contains(java.lang.CharSequence)" resolve="contains" />
                   <node concept="Xl_RD" id="3pFNVizHonA" role="37wK5m">
                     <property role="Xl_RC" value="\&quot;" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1M2fIO" id="5ycts4SloHX">
+    <ref role="1M2myG" to="ibwz:5ycts4Sb$rO" resolve="TEST_OptionalWithoutText_Reference" />
+    <node concept="1N5Pfh" id="5ycts4SloHY" role="1Mr941">
+      <ref role="1N5Vy1" to="ibwz:5ycts4Sb$rR" resolve="refTarget" />
+      <node concept="3dgokm" id="5ycts4SloJC" role="1N6uqs">
+        <node concept="3clFbS" id="5ycts4SloJD" role="2VODD2">
+          <node concept="3clFbF" id="5ycts4Slp9T" role="3cqZAp">
+            <node concept="2YIFZM" id="5ycts4SlplP" role="3clFbG">
+              <ref role="37wK5l" to="o8zo:4IP40Bi3eAf" resolve="forNamedElements" />
+              <ref role="1Pybhc" to="o8zo:4IP40Bi3e_R" resolve="ListScope" />
+              <node concept="2OqwBi" id="5ycts4SlrAg" role="37wK5m">
+                <node concept="2OqwBi" id="5ycts4Slq74" role="2Oq$k0">
+                  <node concept="2OqwBi" id="5ycts4Slp$T" role="2Oq$k0">
+                    <node concept="2rP1CM" id="5ycts4Slpq9" role="2Oq$k0" />
+                    <node concept="2Xjw5R" id="5ycts4SlpMd" role="2OqNvi">
+                      <node concept="1xMEDy" id="5ycts4SlpMf" role="1xVPHs">
+                        <node concept="chp4Y" id="5ycts4SlpRW" role="ri$Ld">
+                          <ref role="cht4Q" to="ibwz:1x69AmkdY_M" resolve="Module" />
+                        </node>
+                      </node>
+                      <node concept="1xIGOp" id="5ycts4SlpXa" role="1xVPHs" />
+                    </node>
+                  </node>
+                  <node concept="3Tsc0h" id="5ycts4Slqot" role="2OqNvi">
+                    <ref role="3TtcxE" to="ibwz:1x69AmkdY_N" resolve="content" />
+                  </node>
+                </node>
+                <node concept="v3k3i" id="5ycts4SlteK" role="2OqNvi">
+                  <node concept="chp4Y" id="5ycts4Sltkj" role="v3oSu">
+                    <ref role="cht4Q" to="ibwz:1x69AmkdY_S" resolve="Function" />
                   </node>
                 </node>
               </node>

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells.sandboxlang/models/com/mbeddr/mpsutil/grammarcells/sandboxlang/editor.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells.sandboxlang/models/com/mbeddr/mpsutil/grammarcells/sandboxlang/editor.mps
@@ -1143,6 +1143,9 @@
       </node>
       <node concept="3F0ifn" id="3KoBPk0IGrw" role="3EZMnx">
         <property role="3F0ifm" value="optionalType" />
+        <node concept="2SqB2G" id="7vt_0AXtA$R" role="2SqHTX">
+          <property role="TrG5h" value="c56" />
+        </node>
       </node>
       <node concept="l2Vlx" id="3KoBPk0IGrp" role="2iSdaV" />
     </node>

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells.sandboxlang/models/com/mbeddr/mpsutil/grammarcells/sandboxlang/editor.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells.sandboxlang/models/com/mbeddr/mpsutil/grammarcells/sandboxlang/editor.mps
@@ -16,11 +16,9 @@
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
     <import index="guwi" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.io(JDK/)" implicit="true" />
     <import index="r23f" ref="r:01829650-3984-4e50-a84c-5b318a048a6a(com.mbeddr.mpsutil.grammarcells.sandboxlang.behavior)" implicit="true" />
-    <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" implicit="true" />
   </imports>
   <registry>
     <language id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor">
-      <concept id="5991739802479784074" name="jetbrains.mps.lang.editor.structure.MenuTypeNamed" flags="ng" index="22hDWg" />
       <concept id="5991739802479784073" name="jetbrains.mps.lang.editor.structure.MenuTypeDefault" flags="ng" index="22hDWj" />
       <concept id="2000375450116423800" name="jetbrains.mps.lang.editor.structure.SubstituteMenu" flags="ng" index="22mcaB" />
       <concept id="1071666914219" name="jetbrains.mps.lang.editor.structure.ConceptEditorDeclaration" flags="ig" index="24kQdi">
@@ -28,7 +26,6 @@
       </concept>
       <concept id="1176897764478" name="jetbrains.mps.lang.editor.structure.QueryFunction_NodeFactory" flags="in" index="4$FPG" />
       <concept id="1597643335227097138" name="jetbrains.mps.lang.editor.structure.QueryFunctionParameter_TransformationMenu_node" flags="ng" index="7Obwk" />
-      <concept id="6516520003787916624" name="jetbrains.mps.lang.editor.structure.QueryFunction_TransformationMenu_Condition" flags="ig" index="27VH4U" />
       <concept id="1140524381322" name="jetbrains.mps.lang.editor.structure.CellModel_ListWithRole" flags="ng" index="2czfm3">
         <property id="1140524450557" name="separatorText" index="2czwfO" />
         <child id="1176897874615" name="nodeFactory" index="4_6I_" />
@@ -46,16 +43,10 @@
       <concept id="1080736578640" name="jetbrains.mps.lang.editor.structure.BaseEditorComponent" flags="ig" index="2wURMF">
         <child id="1080736633877" name="cellModel" index="2wV5jI" />
       </concept>
-      <concept id="6718020819487620873" name="jetbrains.mps.lang.editor.structure.TransformationMenuReference_Named" flags="ng" index="A1WHu">
-        <reference id="6718020819487620874" name="menu" index="A1WHt" />
-      </concept>
+      <concept id="6718020819487620876" name="jetbrains.mps.lang.editor.structure.TransformationMenuReference_Default" flags="ng" index="A1WHr" />
       <concept id="8383079901754291618" name="jetbrains.mps.lang.editor.structure.CellModel_NextEditor" flags="ng" index="B$lHz" />
-      <concept id="3473224453637651916" name="jetbrains.mps.lang.editor.structure.TransformationLocation_SideTransform_PlaceInCellHolder" flags="ng" index="CtIbL">
-        <property id="3473224453637651917" name="placeInCell" index="CtIbK" />
-      </concept>
       <concept id="1638911550608610798" name="jetbrains.mps.lang.editor.structure.QueryFunction_TransformationMenu_Execute" flags="ig" index="IWg2L" />
       <concept id="1638911550608610278" name="jetbrains.mps.lang.editor.structure.TransformationMenuPart_Action" flags="ng" index="IWgqT">
-        <child id="6202297022026447496" name="canExecuteFunction" index="2jiSrf" />
         <child id="1638911550608610281" name="executeFunction" index="IWgqQ" />
         <child id="5692353713941573325" name="textFunction" index="1hCUd6" />
       </concept>
@@ -63,6 +54,7 @@
       <concept id="1078939183254" name="jetbrains.mps.lang.editor.structure.CellModel_Component" flags="sg" stub="3162947552742194261" index="PMmxH">
         <reference id="1078939183255" name="editorComponent" index="PMmxG" />
       </concept>
+      <concept id="4323500428121233431" name="jetbrains.mps.lang.editor.structure.EditorCellId" flags="ng" index="2SqB2G" />
       <concept id="1186403694788" name="jetbrains.mps.lang.editor.structure.ColorStyleClassItem" flags="ln" index="VaVBg">
         <property id="1186403713874" name="color" index="Vb096" />
         <child id="1186403803051" name="query" index="VblUZ" />
@@ -83,29 +75,24 @@
       </concept>
       <concept id="1233758997495" name="jetbrains.mps.lang.editor.structure.PunctuationLeftStyleClassItem" flags="ln" index="11L4FC" />
       <concept id="1233759184865" name="jetbrains.mps.lang.editor.structure.PunctuationRightStyleClassItem" flags="ln" index="11LMrY" />
-      <concept id="1838685759388685703" name="jetbrains.mps.lang.editor.structure.TransformationFeature_DescriptionText" flags="ng" index="3cqGtN">
-        <child id="1838685759388685704" name="query" index="3cqGtW" />
-      </concept>
-      <concept id="1838685759388690401" name="jetbrains.mps.lang.editor.structure.QueryFunction_TransformationMenu_DescriptionText" flags="ig" index="3cqJkl" />
-      <concept id="2896773699153795590" name="jetbrains.mps.lang.editor.structure.TransformationLocation_SideTransform" flags="ng" index="3cWJ9i">
-        <child id="3473224453637651919" name="placeInCell" index="CtIbM" />
-      </concept>
       <concept id="5692353713941573329" name="jetbrains.mps.lang.editor.structure.QueryFunction_TransformationMenu_ActionLabelText" flags="ig" index="1hCUdq" />
-      <concept id="7291101478617127464" name="jetbrains.mps.lang.editor.structure.IExtensibleTransformationMenuPart" flags="ng" index="1joUw2">
-        <child id="8954657570916349207" name="features" index="2jZA2a" />
+      <concept id="1088013125922" name="jetbrains.mps.lang.editor.structure.CellModel_RefCell" flags="sg" stub="730538219795941030" index="1iCGBv">
+        <child id="1088186146602" name="editorComponent" index="1sWHZn" />
       </concept>
       <concept id="3308396621974588243" name="jetbrains.mps.lang.editor.structure.SubstituteMenu_Contribution" flags="ng" index="3p309x">
         <child id="7173407872095451092" name="menuReference" index="1IG6uw" />
       </concept>
+      <concept id="1088185857835" name="jetbrains.mps.lang.editor.structure.InlineEditorComponent" flags="ig" index="1sVBvm" />
       <concept id="1075375595203" name="jetbrains.mps.lang.editor.structure.CellModel_Error" flags="sg" stub="8104358048506729356" index="1xolST">
         <property id="1075375595204" name="text" index="1xolSY" />
       </concept>
       <concept id="1139848536355" name="jetbrains.mps.lang.editor.structure.CellModel_WithRole" flags="ng" index="1$h60E">
+        <property id="1140017977771" name="readOnly" index="1Intyy" />
         <reference id="1140103550593" name="relationDeclaration" index="1NtTu8" />
       </concept>
       <concept id="1073389214265" name="jetbrains.mps.lang.editor.structure.EditorCellModel" flags="ng" index="3EYTF0">
         <child id="1142887637401" name="renderingCondition" index="pqm2j" />
-        <child id="4202667662392416064" name="transformationMenu" index="3vIgyS" />
+        <child id="4323500428121274054" name="id" index="2SqHTX" />
       </concept>
       <concept id="1073389446423" name="jetbrains.mps.lang.editor.structure.CellModel_Collection" flags="sn" stub="3013115976261988961" index="3EZMnI">
         <child id="1106270802874" name="cellLayout" index="2iSdaV" />
@@ -120,9 +107,11 @@
       </concept>
       <concept id="1073389882823" name="jetbrains.mps.lang.editor.structure.CellModel_RefNode" flags="sg" stub="730538219795960754" index="3F1sOY" />
       <concept id="1073390211982" name="jetbrains.mps.lang.editor.structure.CellModel_RefNodeList" flags="sg" stub="2794558372793454595" index="3F2HdR" />
-      <concept id="5624877018226900666" name="jetbrains.mps.lang.editor.structure.TransformationMenu" flags="ng" index="3ICUPy" />
       <concept id="5624877018228267058" name="jetbrains.mps.lang.editor.structure.ITransformationMenu" flags="ng" index="3INCJE">
         <child id="1638911550608572412" name="sections" index="IW6Ez" />
+      </concept>
+      <concept id="5624877018228264944" name="jetbrains.mps.lang.editor.structure.TransformationMenuContribution" flags="ng" index="3INDKC">
+        <child id="6718020819489956031" name="menuReference" index="AmTjC" />
       </concept>
       <concept id="1088612959204" name="jetbrains.mps.lang.editor.structure.CellModel_Alternation" flags="sg" stub="8104358048506729361" index="1QoScp">
         <property id="1088613081987" name="vertical" index="1QpmdY" />
@@ -171,16 +160,10 @@
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
-      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
-        <property id="1068580123138" name="value" index="3clFbU" />
-      </concept>
       <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
         <property id="1068580320021" name="value" index="3cmrfH" />
       </concept>
       <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
-      <concept id="1081516740877" name="jetbrains.mps.baseLanguage.structure.NotExpression" flags="nn" index="3fqX7Q">
-        <child id="1081516765348" name="expression" index="3fr31v" />
-      </concept>
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
@@ -190,7 +173,6 @@
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
-      <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
     </language>
     <language id="9d69e719-78c8-4286-90db-fb19c107d049" name="com.mbeddr.mpsutil.grammarcells">
       <concept id="1954385921685809440" name="com.mbeddr.mpsutil.grammarcells.structure.Parameter_node" flags="ng" index="313q4" />
@@ -205,6 +187,8 @@
       <concept id="3921456275302774825" name="com.mbeddr.mpsutil.grammarcells.structure.SplittableCell" flags="sg" stub="3921456275302774831" index="2lNzut">
         <child id="3921456275305506525" name="tokenizer" index="2lD6_D" />
       </concept>
+      <concept id="1997572252229165641" name="com.mbeddr.mpsutil.grammarcells.structure.TransformationLocation_Before" flags="ng" index="wWMWC" />
+      <concept id="1997572252229165700" name="com.mbeddr.mpsutil.grammarcells.structure.TransformationLocation_After" flags="ng" index="wWMZ_" />
       <concept id="5083944728300220902" name="com.mbeddr.mpsutil.grammarcells.structure.SubstituteCell" flags="ng" index="yw3OH">
         <child id="5083944728300220903" name="wrapped" index="yw3OG" />
       </concept>
@@ -250,35 +234,31 @@
       </concept>
       <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
       <concept id="7453996997717780434" name="jetbrains.mps.lang.smodel.structure.Node_GetSConceptOperation" flags="nn" index="2yIwOk" />
-      <concept id="2396822768958367367" name="jetbrains.mps.lang.smodel.structure.AbstractTypeCastExpression" flags="nn" index="$5XWr">
-        <child id="6733348108486823193" name="leftExpression" index="1m5AlR" />
-        <child id="3906496115198199033" name="conceptArgument" index="3oSUPX" />
-      </concept>
       <concept id="7835263205327057228" name="jetbrains.mps.lang.smodel.structure.Node_GetChildrenAndChildAttributesOperation" flags="ng" index="Bykcj" />
-      <concept id="2644386474302386080" name="jetbrains.mps.lang.smodel.structure.PropertyIdRefExpression" flags="nn" index="355D3s">
-        <reference id="2644386474302386081" name="conceptDeclaration" index="355D3t" />
-        <reference id="2644386474302386082" name="propertyDeclaration" index="355D3u" />
-      </concept>
       <concept id="5168775467716640652" name="jetbrains.mps.lang.smodel.structure.OperationParm_LinkQualifier" flags="ng" index="1aIX9F">
         <child id="5168775467716640653" name="linkQualifier" index="1aIX9E" />
-      </concept>
-      <concept id="1139613262185" name="jetbrains.mps.lang.smodel.structure.Node_GetParentOperation" flags="nn" index="1mfA1w" />
-      <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
-        <child id="1177027386292" name="conceptArgument" index="cj9EA" />
       </concept>
       <concept id="6870613620390542976" name="jetbrains.mps.lang.smodel.structure.ConceptAliasOperation" flags="ng" index="3n3YKJ" />
       <concept id="1180636770613" name="jetbrains.mps.lang.smodel.structure.SNodeCreator" flags="nn" index="3zrR0B">
         <child id="1180636770616" name="createdType" index="3zrR0E" />
       </concept>
+      <concept id="1139867745658" name="jetbrains.mps.lang.smodel.structure.Node_ReplaceWithNewOperation" flags="nn" index="1_qnLN">
+        <reference id="1139867957129" name="concept" index="1_rbq0" />
+      </concept>
       <concept id="1172326502327" name="jetbrains.mps.lang.smodel.structure.Concept_IsExactlyOperation" flags="nn" index="3O6GUB">
         <child id="1206733650006" name="conceptArgument" index="3QVz_e" />
       </concept>
-      <concept id="1140137987495" name="jetbrains.mps.lang.smodel.structure.SNodeTypeCastExpression" flags="nn" index="1PxgMI" />
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
         <reference id="1138405853777" name="concept" index="ehGHo" />
       </concept>
       <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
         <reference id="1138056395725" name="property" index="3TsBF5" />
+      </concept>
+      <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="nn" index="3TrEf2">
+        <reference id="1138056516764" name="link" index="3Tt5mk" />
+      </concept>
+      <concept id="1138056282393" name="jetbrains.mps.lang.smodel.structure.SLinkListAccess" flags="nn" index="3Tsc0h">
+        <reference id="1138056546658" name="link" index="3TtcxE" />
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
@@ -287,6 +267,10 @@
       </concept>
     </language>
     <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="nn" index="25WWJ4">
+        <child id="540871147943773366" name="argument" index="25WWJ7" />
+      </concept>
+      <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
       <concept id="1176501494711" name="jetbrains.mps.baseLanguage.collections.structure.IsNotEmptyOperation" flags="nn" index="3GX2aA" />
     </language>
     <language id="b1ab8c10-c118-4755-bf2a-cebab35cf533" name="jetbrains.mps.lang.editor.tooltips">
@@ -520,9 +504,6 @@
         <node concept="1kIj98" id="RbLMy68PdQ" role="3EZMnx">
           <node concept="3F1sOY" id="RbLMy68PdR" role="1kIj9b">
             <ref role="1NtTu8" to="ibwz:6oKG1kMxn7U" resolve="type" />
-            <node concept="A1WHu" id="4RoNWgx3u9S" role="3vIgyS">
-              <ref role="A1WHt" node="4RoNWgwUIbg" resolve="leftOfType" />
-            </node>
           </node>
         </node>
         <node concept="1kHk_G" id="RbLMy69LP2" role="3EZMnx">
@@ -1237,108 +1218,37 @@
       </node>
     </node>
   </node>
-  <node concept="3ICUPy" id="4RoNWgwUIbg">
-    <ref role="aqKnT" to="ibwz:1x69Amke5PV" resolve="Type" />
-    <node concept="22hDWg" id="4RoNWgwUIbY" role="22hAXT">
-      <property role="TrG5h" value="leftOfType" />
+  <node concept="3INDKC" id="5fS8LrnVwcW">
+    <property role="TrG5h" value="Wrap_Type_with_ArrayType" />
+    <node concept="A1WHr" id="5fS8LrnVweQ" role="AmTjC">
+      <ref role="2ZyFGn" to="ibwz:1x69Amke5PV" resolve="Type" />
     </node>
-    <node concept="1Qtc8_" id="4RoNWgwUIc2" role="IW6Ez">
-      <node concept="3cWJ9i" id="4RoNWgwUIc6" role="1Qtc8$">
-        <node concept="CtIbL" id="4RoNWgwUIc8" role="CtIbM">
-          <property role="CtIbK" value="1A4kJjlVmVt/LEFT" />
-        </node>
-      </node>
-      <node concept="IWgqT" id="4RoNWgwUIcE" role="1Qtc8A">
-        <node concept="1hCUdq" id="4RoNWgwUIcF" role="1hCUd6">
-          <node concept="3clFbS" id="4RoNWgwUIcG" role="2VODD2">
-            <node concept="3clFbF" id="4RoNWgwUIhu" role="3cqZAp">
-              <node concept="Xl_RD" id="4RoNWgwUIht" role="3clFbG">
-                <property role="Xl_RC" value="static" />
+    <node concept="1Qtc8_" id="5fS8LrnVwiD" role="IW6Ez">
+      <node concept="wWMZ_" id="5fS8LrnVwk_" role="1Qtc8$" />
+      <node concept="IWgqT" id="5fS8LrnVwkC" role="1Qtc8A">
+        <node concept="1hCUdq" id="5fS8LrnVwkD" role="1hCUd6">
+          <node concept="3clFbS" id="5fS8LrnVwkE" role="2VODD2">
+            <node concept="3clFbF" id="5fS8LrnVwpr" role="3cqZAp">
+              <node concept="Xl_RD" id="5fS8LrnVwpq" role="3clFbG">
+                <property role="Xl_RC" value="[]" />
               </node>
             </node>
           </node>
         </node>
-        <node concept="IWg2L" id="4RoNWgwUIcH" role="IWgqQ">
-          <node concept="3clFbS" id="4RoNWgwUIcI" role="2VODD2">
-            <node concept="3clFbF" id="4RoNWgwUImK" role="3cqZAp">
-              <node concept="37vLTI" id="4RoNWgwUJ7z" role="3clFbG">
-                <node concept="3clFbT" id="4RoNWgwUJ7X" role="37vLTx">
-                  <property role="3clFbU" value="true" />
-                </node>
-                <node concept="2OqwBi" id="4RoNWgwUIx2" role="37vLTJ">
-                  <node concept="3TrcHB" id="4RoNWgwUIMo" role="2OqNvi">
-                    <ref role="3TsBF5" to="ibwz:qT5MFml3Gb" resolve="static" />
-                  </node>
-                  <node concept="1PxgMI" id="4RoNWgx1iMU" role="2Oq$k0">
-                    <node concept="chp4Y" id="4RoNWgx1iMV" role="3oSUPX">
-                      <ref role="cht4Q" to="ibwz:6oKG1kMxn82" resolve="LocalVariableDeclaration" />
-                    </node>
-                    <node concept="2OqwBi" id="4RoNWgx1iMW" role="1m5AlR">
-                      <node concept="7Obwk" id="4RoNWgx1iMX" role="2Oq$k0" />
-                      <node concept="1mfA1w" id="4RoNWgx1iMY" role="2OqNvi" />
+        <node concept="IWg2L" id="5fS8LrnVwkF" role="IWgqQ">
+          <node concept="3clFbS" id="5fS8LrnVwkG" role="2VODD2">
+            <node concept="3clFbF" id="5fS8LrnVwuG" role="3cqZAp">
+              <node concept="37vLTI" id="5fS8LrnVxHu" role="3clFbG">
+                <node concept="7Obwk" id="5fS8LrnVxI3" role="37vLTx" />
+                <node concept="2OqwBi" id="5fS8LrnVxg8" role="37vLTJ">
+                  <node concept="2OqwBi" id="5fS8LrnVwAs" role="2Oq$k0">
+                    <node concept="7Obwk" id="5fS8LrnVwuF" role="2Oq$k0" />
+                    <node concept="1_qnLN" id="5fS8LrnVx3n" role="2OqNvi">
+                      <ref role="1_rbq0" to="ibwz:RbLMy6d5VT" resolve="ArrayType" />
                     </node>
                   </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="27VH4U" id="4RoNWgwUJey" role="2jiSrf">
-          <node concept="3clFbS" id="4RoNWgwUJez" role="2VODD2">
-            <node concept="3clFbF" id="4RoNWgwUJiW" role="3cqZAp">
-              <node concept="1Wc70l" id="4RoNWgx1h0Z" role="3clFbG">
-                <node concept="2OqwBi" id="4RoNWgx1hFp" role="3uHU7B">
-                  <node concept="2OqwBi" id="4RoNWgx1hlb" role="2Oq$k0">
-                    <node concept="7Obwk" id="4RoNWgx1h7$" role="2Oq$k0" />
-                    <node concept="1mfA1w" id="4RoNWgx1hwx" role="2OqNvi" />
-                  </node>
-                  <node concept="1mIQ4w" id="4RoNWgx1i1H" role="2OqNvi">
-                    <node concept="chp4Y" id="4RoNWgx1i6x" role="cj9EA">
-                      <ref role="cht4Q" to="ibwz:6oKG1kMxn82" resolve="LocalVariableDeclaration" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="3fqX7Q" id="4RoNWgwUJVz" role="3uHU7w">
-                  <node concept="2OqwBi" id="4RoNWgwUJV_" role="3fr31v">
-                    <node concept="1PxgMI" id="4RoNWgx1iqK" role="2Oq$k0">
-                      <node concept="chp4Y" id="4RoNWgx1i_o" role="3oSUPX">
-                        <ref role="cht4Q" to="ibwz:6oKG1kMxn82" resolve="LocalVariableDeclaration" />
-                      </node>
-                      <node concept="2OqwBi" id="4RoNWgx1g_0" role="1m5AlR">
-                        <node concept="7Obwk" id="4RoNWgwUJVA" role="2Oq$k0" />
-                        <node concept="1mfA1w" id="4RoNWgx1gRb" role="2OqNvi" />
-                      </node>
-                    </node>
-                    <node concept="3TrcHB" id="4RoNWgwUJVB" role="2OqNvi">
-                      <ref role="3TsBF5" to="ibwz:qT5MFml3Gb" resolve="static" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3cqGtN" id="4RoNWgwUK6M" role="2jZA2a">
-          <node concept="3cqJkl" id="4RoNWgwUK6N" role="3cqGtW">
-            <node concept="3clFbS" id="4RoNWgwUK6O" role="2VODD2">
-              <node concept="3clFbF" id="4RoNWgwUKcy" role="3cqZAp">
-                <node concept="3cpWs3" id="4RoNWgwUKYR" role="3clFbG">
-                  <node concept="Xl_RD" id="4RoNWgwUKXr" role="3uHU7w">
-                    <property role="Xl_RC" value="'" />
-                  </node>
-                  <node concept="3cpWs3" id="4RoNWgwUKXn" role="3uHU7B">
-                    <node concept="Xl_RD" id="4RoNWgwUKqm" role="3uHU7B">
-                      <property role="Xl_RC" value="Set flag '" />
-                    </node>
-                    <node concept="2OqwBi" id="4RoNWgwULst" role="3uHU7w">
-                      <node concept="355D3s" id="4RoNWgwUKZx" role="2Oq$k0">
-                        <ref role="355D3t" to="ibwz:6oKG1kMxn82" resolve="LocalVariableDeclaration" />
-                        <ref role="355D3u" to="ibwz:qT5MFml3Gb" resolve="static" />
-                      </node>
-                      <node concept="liA8E" id="4RoNWgwULMo" role="2OqNvi">
-                        <ref role="37wK5l" to="c17a:~SProperty.getName()" resolve="getName" />
-                      </node>
-                    </node>
+                  <node concept="3TrEf2" id="5fS8LrnVxvi" role="2OqNvi">
+                    <ref role="3Tt5mk" to="ibwz:RbLMy6d5VU" resolve="type" />
                   </node>
                 </node>
               </node>
@@ -1346,6 +1256,148 @@
           </node>
         </node>
       </node>
+    </node>
+  </node>
+  <node concept="3INDKC" id="5fS8LrnY8ZC">
+    <property role="TrG5h" value="Wrap_Statement_with_BlockExpression" />
+    <node concept="A1WHr" id="5fS8LrnY8ZD" role="AmTjC">
+      <ref role="2ZyFGn" to="ibwz:1x69AmkdYA2" resolve="IStatement" />
+    </node>
+    <node concept="1Qtc8_" id="5fS8LrnY8ZE" role="IW6Ez">
+      <node concept="wWMWC" id="5fS8LrnZGSI" role="1Qtc8$" />
+      <node concept="IWgqT" id="5fS8LrnY8ZG" role="1Qtc8A">
+        <node concept="1hCUdq" id="5fS8LrnY8ZH" role="1hCUd6">
+          <node concept="3clFbS" id="5fS8LrnY8ZI" role="2VODD2">
+            <node concept="3clFbF" id="5fS8LrnY8ZJ" role="3cqZAp">
+              <node concept="Xl_RD" id="5fS8LrnY8ZK" role="3clFbG">
+                <property role="Xl_RC" value="{" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="IWg2L" id="5fS8LrnY8ZL" role="IWgqQ">
+          <node concept="3clFbS" id="5fS8LrnY8ZM" role="2VODD2">
+            <node concept="3clFbF" id="5fS8LrnY8ZN" role="3cqZAp">
+              <node concept="2OqwBi" id="5fS8LrnYbeR" role="3clFbG">
+                <node concept="2OqwBi" id="5fS8LrnY8ZQ" role="2Oq$k0">
+                  <node concept="2OqwBi" id="5fS8LrnY8ZR" role="2Oq$k0">
+                    <node concept="7Obwk" id="5fS8LrnY8ZS" role="2Oq$k0" />
+                    <node concept="1_qnLN" id="5fS8LrnY8ZT" role="2OqNvi">
+                      <ref role="1_rbq0" to="ibwz:4qdNcH$71LM" resolve="BlockExpression" />
+                    </node>
+                  </node>
+                  <node concept="3Tsc0h" id="5fS8LrnYa3K" role="2OqNvi">
+                    <ref role="3TtcxE" to="ibwz:1x69AmkdYA3" resolve="statements" />
+                  </node>
+                </node>
+                <node concept="TSZUe" id="5fS8LrnYdIy" role="2OqNvi">
+                  <node concept="7Obwk" id="5fS8LrnYdT7" role="25WWJ7" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1Qtc8_" id="5fS8Lro19cT" role="IW6Ez">
+      <node concept="wWMZ_" id="5fS8Lro19xz" role="1Qtc8$" />
+      <node concept="IWgqT" id="5fS8Lro19cV" role="1Qtc8A">
+        <node concept="1hCUdq" id="5fS8Lro19cW" role="1hCUd6">
+          <node concept="3clFbS" id="5fS8Lro19cX" role="2VODD2">
+            <node concept="3clFbF" id="5fS8Lro19cY" role="3cqZAp">
+              <node concept="Xl_RD" id="5fS8Lro19cZ" role="3clFbG">
+                <property role="Xl_RC" value="}" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="IWg2L" id="5fS8Lro19d0" role="IWgqQ">
+          <node concept="3clFbS" id="5fS8Lro19d1" role="2VODD2">
+            <node concept="3clFbF" id="5fS8Lro19d2" role="3cqZAp">
+              <node concept="2OqwBi" id="5fS8Lro19d3" role="3clFbG">
+                <node concept="2OqwBi" id="5fS8Lro19d4" role="2Oq$k0">
+                  <node concept="2OqwBi" id="5fS8Lro19d5" role="2Oq$k0">
+                    <node concept="7Obwk" id="5fS8Lro19d6" role="2Oq$k0" />
+                    <node concept="1_qnLN" id="5fS8Lro19d7" role="2OqNvi">
+                      <ref role="1_rbq0" to="ibwz:4qdNcH$71LM" resolve="BlockExpression" />
+                    </node>
+                  </node>
+                  <node concept="3Tsc0h" id="5fS8Lro19d8" role="2OqNvi">
+                    <ref role="3TtcxE" to="ibwz:1x69AmkdYA3" resolve="statements" />
+                  </node>
+                </node>
+                <node concept="TSZUe" id="5fS8Lro19d9" role="2OqNvi">
+                  <node concept="7Obwk" id="5fS8Lro19da" role="25WWJ7" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="24kQdi" id="5ycts4RUtB$">
+    <ref role="1XX52x" to="ibwz:5ycts4RUb7K" resolve="TEST_OptionalWithoutText_Single" />
+    <node concept="3EZMnI" id="5ycts4RUtBA" role="2wV5jI">
+      <node concept="3F0ifn" id="5ycts4RUtBH" role="3EZMnx">
+        <property role="3F0ifm" value="optional without text" />
+        <node concept="2SqB2G" id="5ycts4S3nuW" role="2SqHTX">
+          <property role="TrG5h" value="c33" />
+        </node>
+      </node>
+      <node concept="_tjkj" id="5ycts4RUtBV" role="3EZMnx">
+        <node concept="3F1sOY" id="5ycts4RUtC3" role="_tjki">
+          <ref role="1NtTu8" to="ibwz:5ycts4RUtB8" resolve="child" />
+        </node>
+      </node>
+      <node concept="3F0ifn" id="5ycts4RUtBN" role="3EZMnx">
+        <property role="3F0ifm" value=";" />
+      </node>
+      <node concept="l2Vlx" id="5ycts4RUtBD" role="2iSdaV" />
+    </node>
+  </node>
+  <node concept="24kQdi" id="5ycts4RWGBY">
+    <ref role="1XX52x" to="ibwz:5ycts4RWGBx" resolve="TEST_OptionalWithoutText_Multiple" />
+    <node concept="3EZMnI" id="5ycts4RWGC0" role="2wV5jI">
+      <node concept="3F0ifn" id="5ycts4RWGC1" role="3EZMnx">
+        <property role="3F0ifm" value="optional without text (multiple)" />
+        <node concept="2SqB2G" id="5ycts4S3nv6" role="2SqHTX">
+          <property role="TrG5h" value="c33" />
+        </node>
+      </node>
+      <node concept="_tjkj" id="5ycts4RWGC2" role="3EZMnx">
+        <node concept="3F2HdR" id="5ycts4RWGCe" role="_tjki">
+          <property role="2czwfO" value="," />
+          <ref role="1NtTu8" to="ibwz:5ycts4RWGBy" resolve="child" />
+        </node>
+      </node>
+      <node concept="3F0ifn" id="5ycts4RWGC4" role="3EZMnx">
+        <property role="3F0ifm" value=";" />
+      </node>
+      <node concept="l2Vlx" id="5ycts4RWGC5" role="2iSdaV" />
+    </node>
+  </node>
+  <node concept="24kQdi" id="5ycts4Sb$sQ">
+    <ref role="1XX52x" to="ibwz:5ycts4Sb$rO" resolve="TEST_OptionalWithoutText_Reference" />
+    <node concept="3EZMnI" id="5ycts4Sb$sS" role="2wV5jI">
+      <node concept="3F0ifn" id="5ycts4Sb$sZ" role="3EZMnx">
+        <property role="3F0ifm" value="optional reference" />
+        <node concept="2SqB2G" id="5ycts4SjW3R" role="2SqHTX">
+          <property role="TrG5h" value="c33" />
+        </node>
+      </node>
+      <node concept="_tjkj" id="5ycts4Sb$t9" role="3EZMnx">
+        <node concept="1iCGBv" id="5ycts4Sb$tg" role="_tjki">
+          <ref role="1NtTu8" to="ibwz:5ycts4Sb$rR" resolve="refTarget" />
+          <node concept="1sVBvm" id="5ycts4Sb$ti" role="1sWHZn">
+            <node concept="3F0A7n" id="5ycts4Sb$ts" role="2wV5jI">
+              <property role="1Intyy" value="true" />
+              <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="l2Vlx" id="5ycts4Sb$sV" role="2iSdaV" />
     </node>
   </node>
 </model>

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells.sandboxlang/models/com/mbeddr/mpsutil/grammarcells/sandboxlang/structure.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells.sandboxlang/models/com/mbeddr/mpsutil/grammarcells/sandboxlang/structure.mps
@@ -2,7 +2,6 @@
 <model ref="r:ad27d4b4-fc2c-4b6d-9e22-455eb0ccf354(com.mbeddr.mpsutil.grammarcells.sandboxlang.structure)">
   <persistence version="9" />
   <languages>
-    <use id="982eb8df-2c96-4bd7-9963-11712ea622e5" name="jetbrains.mps.lang.resources" version="2" />
     <devkit ref="78434eb8-b0e5-444b-850d-e7c4ad2da9ab(jetbrains.mps.devkit.aspect.structure)" />
   </languages>
   <imports>
@@ -746,6 +745,54 @@
       <ref role="AX2Wp" to="tpck:fKAQMTB" resolve="boolean" />
     </node>
     <node concept="PrWs8" id="6TEPcwQO0k8" role="PzmwI">
+      <ref role="PrY4T" node="1x69AmkdYA2" resolve="IStatement" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="5ycts4RUb7K">
+    <property role="EcuMT" value="6380604244804284912" />
+    <property role="TrG5h" value="TEST_OptionalWithoutText_Single" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+    <node concept="1TJgyj" id="5ycts4RUtB8" role="1TKVEi">
+      <property role="IQ2ns" value="6380604244804360648" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="child" />
+      <ref role="20lvS9" node="6oKG1kMxn8A" resolve="IExpression" />
+    </node>
+    <node concept="PrWs8" id="5ycts4RUtB6" role="PzmwI">
+      <ref role="PrY4T" node="1x69AmkdYA2" resolve="IStatement" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="5ycts4RWGBx">
+    <property role="EcuMT" value="6380604244804946401" />
+    <property role="TrG5h" value="TEST_OptionalWithoutText_Multiple" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+    <node concept="1TJgyj" id="5ycts4RWGBy" role="1TKVEi">
+      <property role="IQ2ns" value="6380604244804360648" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="child" />
+      <property role="20lbJX" value="fLJekj5/_0__n" />
+      <ref role="20lvS9" node="6oKG1kMxn8A" resolve="IExpression" />
+    </node>
+    <node concept="PrWs8" id="5ycts4RWGBz" role="PzmwI">
+      <ref role="PrY4T" node="1x69AmkdYA2" resolve="IStatement" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="5ycts4Sb$rO">
+    <property role="EcuMT" value="6380604244808845044" />
+    <property role="TrG5h" value="TEST_OptionalWithoutText_Reference" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+    <node concept="1TJgyj" id="5ycts4Sb$rR" role="1TKVEi">
+      <property role="IQ2ns" value="6380604244808845047" />
+      <property role="20kJfa" value="refTarget" />
+      <ref role="20lvS9" node="1x69AmkdY_S" resolve="Function" />
+    </node>
+    <node concept="1TJgyj" id="5ycts4Sb$rP" role="1TKVEi">
+      <property role="IQ2ns" value="6380604244804360648" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="child" />
+      <ref role="20lvS9" node="6oKG1kMxn8A" resolve="IExpression" />
+    </node>
+    <node concept="PrWs8" id="5ycts4Sb$rQ" role="PzmwI">
       <ref role="PrY4T" node="1x69AmkdYA2" resolve="IStatement" />
     </node>
   </node>

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/com.mbeddr.mpsutil.grammarcells.mpl
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/com.mbeddr.mpsutil.grammarcells.mpl
@@ -263,6 +263,34 @@
             </external-mapping>
           </lesser-priority-mapping>
         </mapping-priority-rule>
+        <mapping-priority-rule kind="strictly_together">
+          <greater-priority-mapping>
+            <generator generatorUID="3caaaa06-4186-4d6e-8cb4-37c75a1dbcaf(com.mbeddr.mpsutil.grammarcells#1749127723000258530)" />
+            <external-mapping>
+              <mapping-node modelUID="r:0e2d0780-27a1-4dda-a429-65b192261fcc(com.mbeddr.mpsutil.grammarcells.generator.template.main@generator)" nodeID="1997572252229170351" />
+            </external-mapping>
+          </greater-priority-mapping>
+          <lesser-priority-mapping>
+            <generator generatorUID="0647eca7-da98-422a-8a8b-6ebc0bd014ea(jetbrains.mps.lang.editor#1129914002149)" />
+            <external-mapping>
+              <mapping-node modelUID="r:00000000-0000-4000-0000-011c8959029f(jetbrains.mps.lang.editor.generator.baseLanguage.template.main@generator)" nodeID="1638911550611211454" />
+            </external-mapping>
+          </lesser-priority-mapping>
+        </mapping-priority-rule>
+        <mapping-priority-rule kind="strictly_together">
+          <greater-priority-mapping>
+            <generator generatorUID="3caaaa06-4186-4d6e-8cb4-37c75a1dbcaf(com.mbeddr.mpsutil.grammarcells#1749127723000258530)" />
+            <external-mapping>
+              <mapping-node modelUID="r:0e2d0780-27a1-4dda-a429-65b192261fcc(com.mbeddr.mpsutil.grammarcells.generator.template.main@generator)" nodeID="1749127723000258531" />
+            </external-mapping>
+          </greater-priority-mapping>
+          <lesser-priority-mapping>
+            <generator generatorUID="3caaaa06-4186-4d6e-8cb4-37c75a1dbcaf(com.mbeddr.mpsutil.grammarcells#1749127723000258530)" />
+            <external-mapping>
+              <mapping-node modelUID="r:0e2d0780-27a1-4dda-a429-65b192261fcc(com.mbeddr.mpsutil.grammarcells.generator.template.main@generator)" nodeID="745148820868185776" />
+            </external-mapping>
+          </lesser-priority-mapping>
+        </mapping-priority-rule>
       </mapping-priorities>
     </generator>
   </generators>

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/generator/template/main@generator.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/generator/template/main@generator.mps
@@ -11,6 +11,7 @@
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="-1" />
     <use id="aee9cad2-acd4-4608-aef2-0004f6a1cdbd" name="jetbrains.mps.lang.actions" version="-1" />
     <use id="13744753-c81f-424a-9c1b-cf8943bf4e86" name="jetbrains.mps.lang.sharedConcepts" version="-1" />
+    <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="14" />
     <use id="654422bf-e75f-44dc-936d-188890a746ce" name="de.slisson.mps.reflection" version="0" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
@@ -59,6 +60,7 @@
     <import index="qvne" ref="r:8ff33705-85bf-4855-805c-06d68fbe233c(jetbrains.mps.editor.runtime.descriptor)" />
     <import index="pdwk" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.core.aspects.constraints.rules.kinds(MPS.Core/)" />
     <import index="x4mf" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.menus(MPS.Editor/)" implicit="true" />
+    <import index="tpcn" ref="r:00000000-0000-4000-0000-011c8959028b(jetbrains.mps.lang.structure.behavior)" implicit="true" />
     <import index="hox0" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.style(MPS.Editor/)" implicit="true" />
     <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" implicit="true" />
   </imports>
@@ -86,6 +88,12 @@
     <language id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor">
       <concept id="2000375450116454183" name="jetbrains.mps.lang.editor.structure.ISubstituteMenu" flags="ng" index="22mbnS">
         <child id="414384289274416996" name="parts" index="3ft7WO" />
+      </concept>
+      <concept id="1597643335227097138" name="jetbrains.mps.lang.editor.structure.QueryFunctionParameter_TransformationMenu_node" flags="ng" index="7Obwk" />
+      <concept id="6516520003787916624" name="jetbrains.mps.lang.editor.structure.QueryFunction_TransformationMenu_Condition" flags="ig" index="27VH4U" />
+      <concept id="7429591467341004871" name="jetbrains.mps.lang.editor.structure.TransformationMenuPart_Group" flags="ng" index="aenpk">
+        <child id="7429591467341004872" name="parts" index="aenpr" />
+        <child id="7429591467341004877" name="condition" index="aenpu" />
       </concept>
       <concept id="4510086454722552739" name="jetbrains.mps.lang.editor.structure.PropertyDeclarationCellSelector" flags="ng" index="eBIwv">
         <reference id="4510086454740628767" name="propertyDeclaration" index="fyFUz" />
@@ -149,13 +157,24 @@
         <child id="1948540814635895774" name="cellSelector" index="lGT1i" />
         <child id="3604384757217586546" name="selectionStart" index="3dN3m$" />
       </concept>
+      <concept id="422708224287891156" name="jetbrains.mps.lang.editor.structure.TransformationMenuPart_ReferenceMenu" flags="ng" index="3PzhKR" />
       <concept id="1161622981231" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameter_editorContext" flags="nn" index="1Q80Hx" />
+      <concept id="1088612959204" name="jetbrains.mps.lang.editor.structure.CellModel_Alternation" flags="sg" stub="8104358048506729361" index="1QoScp">
+        <property id="1088613081987" name="vertical" index="1QpmdY" />
+        <child id="1145918517974" name="alternationCondition" index="3e4ffs" />
+        <child id="1088612958265" name="ifTrueCellModel" index="1QoS34" />
+        <child id="1088612973955" name="ifFalseCellModel" index="1QoVPY" />
+      </concept>
       <concept id="7980428675268276156" name="jetbrains.mps.lang.editor.structure.TransformationMenuSection" flags="ng" index="1Qtc8_">
         <child id="7980428675268276157" name="locations" index="1Qtc8$" />
         <child id="7980428675268276159" name="parts" index="1Qtc8A" />
       </concept>
     </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1224071154655" name="jetbrains.mps.baseLanguage.structure.AsExpression" flags="nn" index="0kSF2">
+        <child id="1224071154657" name="classifierType" index="0kSFW" />
+        <child id="1224071154656" name="expression" index="0kSFX" />
+      </concept>
       <concept id="1080223426719" name="jetbrains.mps.baseLanguage.structure.OrExpression" flags="nn" index="22lmx$" />
       <concept id="1082485599095" name="jetbrains.mps.baseLanguage.structure.BlockStatement" flags="nn" index="9aQIb">
         <child id="1082485599096" name="statements" index="9aQI4" />
@@ -305,6 +324,9 @@
         <property id="521412098689998745" name="nonStatic" index="2bfB8j" />
         <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
       </concept>
+      <concept id="7812454656619025416" name="jetbrains.mps.baseLanguage.structure.MethodDeclaration" flags="ng" index="1rXfSm">
+        <property id="8355037393041754995" name="isNative" index="2aFKle" />
+      </concept>
       <concept id="7812454656619025412" name="jetbrains.mps.baseLanguage.structure.LocalMethodCall" flags="nn" index="1rXfSq" />
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
@@ -377,6 +399,7 @@
         <child id="1167088157977" name="createRootRule" index="2VS0gm" />
         <child id="1167172143858" name="weavingMappingRule" index="30SoJX" />
         <child id="1167328349397" name="reductionMappingRule" index="3acgRq" />
+        <child id="1167514678247" name="rootMappingRule" index="3lj3bC" />
       </concept>
       <concept id="1177093525992" name="jetbrains.mps.lang.generator.structure.InlineTemplate_RuleConsequence" flags="lg" index="gft3U">
         <child id="1177093586806" name="templateNode" index="gfFT$" />
@@ -433,6 +456,10 @@
         <child id="1169672767469" name="ruleConsequence" index="1lVwrX" />
       </concept>
       <concept id="1184616041890" name="jetbrains.mps.lang.generator.structure.Weaving_MappingRule_ContextNodeQuery" flags="in" index="3gB$ML" />
+      <concept id="1167514355419" name="jetbrains.mps.lang.generator.structure.Root_MappingRule" flags="lg" index="3lhOvk">
+        <property id="1177959072138" name="keepSourceRoot" index="13Pg2o" />
+        <reference id="1167514355421" name="template" index="3lhOvi" />
+      </concept>
       <concept id="1169670156577" name="jetbrains.mps.lang.generator.structure.GeneratorMessage" flags="lg" index="1lLz0L">
         <property id="1169670173015" name="messageText" index="1lLB17" />
         <property id="1169670356567" name="messageType" index="1lMjX7" />
@@ -489,14 +516,6 @@
       </concept>
     </language>
     <language id="9d69e719-78c8-4286-90db-fb19c107d049" name="com.mbeddr.mpsutil.grammarcells">
-      <concept id="7408935449000704338" name="com.mbeddr.mpsutil.grammarcells.structure.SideTransformationCell3" flags="ng" index="7FqFr">
-        <property id="6418684662171979747" name="multipleEntries" index="n4v1i" />
-        <child id="7408935449000784411" name="isApplicable" index="7F66i" />
-        <child id="7408935449000784413" name="execute" index="7F66k" />
-        <child id="7408935449000784412" name="matchingText" index="7F66l" />
-        <child id="7408935449000704339" name="wrapped" index="7FqFq" />
-      </concept>
-      <concept id="6418684662168756838" name="com.mbeddr.mpsutil.grammarcells.structure.Parameter_Pattern" flags="ng" index="kKDRn" />
       <concept id="7272510943426055326" name="com.mbeddr.mpsutil.grammarcells.structure.SideTransformationCell_Factory" flags="ig" index="2kS2EP" />
       <concept id="7272510943426093121" name="com.mbeddr.mpsutil.grammarcells.structure.Parameter_SideTransformActionsBuilderContext" flags="ng" index="2kS8pE" />
       <concept id="7272510943425988699" name="com.mbeddr.mpsutil.grammarcells.structure.SideTransformationCell" flags="ng" index="2kSiTK">
@@ -513,6 +532,21 @@
       <concept id="8995338446579071288" name="com.mbeddr.mpsutil.grammarcells.structure.Parameter_expectedOutputConceptExactly" flags="ng" index="q5Umg" />
       <concept id="2312097807576509776" name="com.mbeddr.mpsutil.grammarcells.structure.ConceptEditorClassReference" flags="ng" index="2qA9n$" />
       <concept id="8995338446584721100" name="com.mbeddr.mpsutil.grammarcells.structure.GrammarCellsSubstituteMenuPart" flags="ng" index="rNn9$" />
+      <concept id="745148820870387403" name="com.mbeddr.mpsutil.grammarcells.structure.SideTransformationHolderProcessor" flags="ng" index="2u$9CG">
+        <child id="745148820870387404" name="wrappedCell" index="2u$9CF" />
+      </concept>
+      <concept id="745148820867185554" name="com.mbeddr.mpsutil.grammarcells.structure.SideTransformationCell4" flags="ng" index="2uKrtP">
+        <property id="745148820908747612" name="description" index="2thAuV" />
+        <child id="745148820874363426" name="section" index="2vkWV5" />
+      </concept>
+      <concept id="745148820879066261" name="com.mbeddr.mpsutil.grammarcells.structure.TransformationLocation_SideTransformationCell" flags="ng" index="2v6KxM" />
+      <concept id="1997572252229165641" name="com.mbeddr.mpsutil.grammarcells.structure.TransformationLocation_Before" flags="ng" index="wWMWC" />
+      <concept id="1997572252229165700" name="com.mbeddr.mpsutil.grammarcells.structure.TransformationLocation_After" flags="ng" index="wWMZ_" />
+      <concept id="7416540197334827155" name="com.mbeddr.mpsutil.grammarcells.structure.LowLevelMenuPart_Function" flags="ig" index="2Mo9yg" />
+      <concept id="7416540197334827182" name="com.mbeddr.mpsutil.grammarcells.structure.LowLevelMenuPart_parameter" flags="ng" index="2Mo9yH" />
+      <concept id="7416540197333137586" name="com.mbeddr.mpsutil.grammarcells.structure.GenericMenuPart" flags="ng" index="2MBE2L">
+        <child id="7416540197335105457" name="implementation" index="2MvauM" />
+      </concept>
       <concept id="2283544813052478257" name="com.mbeddr.mpsutil.grammarcells.structure.GrammarCellsTransformationMenuPart" flags="ng" index="2X7gjp" />
       <concept id="6856661361479784881" name="com.mbeddr.mpsutil.grammarcells.structure.InlineActionMapItem_Param_node" flags="ng" index="130tyv" />
       <concept id="6856661361479784527" name="com.mbeddr.mpsutil.grammarcells.structure.InlineActionMapItem" flags="ng" index="130t_x">
@@ -529,7 +563,6 @@
       <concept id="4874944647490522665" name="com.mbeddr.mpsutil.grammarcells.structure.SideTransformationCell2_IsApplicable" flags="ig" index="1eYwpX" />
       <concept id="4874944647490524676" name="com.mbeddr.mpsutil.grammarcells.structure.SideTransformationCell2_Execute" flags="ig" index="1eYxTg" />
       <concept id="4874944647490471126" name="com.mbeddr.mpsutil.grammarcells.structure.SideTransformationCell2" flags="ng" index="1eYWM2">
-        <property id="6418684662171814692" name="multipleEntries" index="kV7il" />
         <child id="4874944647490523335" name="matchingText" index="1eYxyj" />
         <child id="4874944647490523330" name="isApplicable" index="1eYxym" />
         <child id="4874944647490524677" name="execute" index="1eYxTh" />
@@ -600,6 +633,9 @@
       <concept id="1138411891628" name="jetbrains.mps.lang.smodel.structure.SNodeOperation" flags="nn" index="eCIE_">
         <child id="1144104376918" name="parameter" index="1xVPHs" />
       </concept>
+      <concept id="1803469493727536395" name="jetbrains.mps.lang.smodel.structure.OperationParm_StopConceptList" flags="ng" index="hTh3S">
+        <child id="1803469493727536396" name="concept" index="hTh3Z" />
+      </concept>
       <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
       <concept id="4693937538533521280" name="jetbrains.mps.lang.smodel.structure.OfConceptOperation" flags="ng" index="v3k3i">
         <child id="4693937538533538124" name="requestedConcept" index="v3oSu" />
@@ -619,7 +655,6 @@
         <child id="1143224127716" name="insertedNode" index="HtX7I" />
       </concept>
       <concept id="1143226024141" name="jetbrains.mps.lang.smodel.structure.SModelType" flags="in" index="H_c77" />
-      <concept id="1143234257716" name="jetbrains.mps.lang.smodel.structure.Node_GetModelOperation" flags="nn" index="I4A8Y" />
       <concept id="1145383075378" name="jetbrains.mps.lang.smodel.structure.SNodeListType" flags="in" index="2I9FWS" />
       <concept id="1145404486709" name="jetbrains.mps.lang.smodel.structure.SemanticDowncastExpression" flags="nn" index="2JrnkZ">
         <child id="1145404616321" name="leftExpression" index="2JrQYb" />
@@ -637,8 +672,6 @@
       <concept id="1966870290088668520" name="jetbrains.mps.lang.smodel.structure.Enum_MembersOperation" flags="ng" index="2ViDtN" />
       <concept id="1139184414036" name="jetbrains.mps.lang.smodel.structure.LinkList_AddNewChildOperation" flags="nn" index="WFELt" />
       <concept id="1171407110247" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorOperation" flags="nn" index="2Xjw5R" />
-      <concept id="1143511969223" name="jetbrains.mps.lang.smodel.structure.Node_GetPrevSiblingOperation" flags="nn" index="YBYNd" />
-      <concept id="1143512015885" name="jetbrains.mps.lang.smodel.structure.Node_GetNextSiblingOperation" flags="nn" index="YCak7" />
       <concept id="1180031783296" name="jetbrains.mps.lang.smodel.structure.Concept_IsSubConceptOfOperation" flags="nn" index="2Zo12i">
         <child id="1180031783297" name="conceptArgument" index="2Zo12j" />
       </concept>
@@ -666,6 +699,9 @@
       </concept>
       <concept id="6677504323281689838" name="jetbrains.mps.lang.smodel.structure.SConceptType" flags="in" index="3bZ5Sz">
         <reference id="6677504323281689839" name="conceptDeclaraton" index="3bZ5Sy" />
+      </concept>
+      <concept id="1154546950173" name="jetbrains.mps.lang.smodel.structure.ConceptReference" flags="ng" index="3gn64h">
+        <reference id="1154546997487" name="concept" index="3gnhBz" />
       </concept>
       <concept id="1139613262185" name="jetbrains.mps.lang.smodel.structure.Node_GetParentOperation" flags="nn" index="1mfA1w" />
       <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
@@ -734,13 +770,6 @@
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
-      <concept id="709746936026466394" name="jetbrains.mps.lang.core.structure.ChildAttribute" flags="ng" index="3VBwX9">
-        <property id="709746936026609031" name="linkId" index="3V$3ak" />
-        <property id="709746936026609029" name="role_DebugInfo" index="3V$3am" />
-      </concept>
-      <concept id="4452961908202556907" name="jetbrains.mps.lang.core.structure.BaseCommentAttribute" flags="ng" index="1X3_iC">
-        <child id="3078666699043039389" name="commentedNode" index="8Wnug" />
-      </concept>
     </language>
     <language id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text">
       <concept id="155656958578482948" name="jetbrains.mps.lang.text.structure.Word" flags="nn" index="3oM_SD">
@@ -782,6 +811,7 @@
         <child id="1235573187520" name="singletonValue" index="2HTEbv" />
       </concept>
       <concept id="1237721394592" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerCreator" flags="nn" index="HWqM0">
+        <child id="1237721435808" name="initValue" index="HW$Y0" />
         <child id="1237721435807" name="elementType" index="HW$YZ" />
       </concept>
       <concept id="1227022159410" name="jetbrains.mps.baseLanguage.collections.structure.AddFirstElementOperation" flags="nn" index="2Ke4WJ" />
@@ -807,6 +837,11 @@
   </registry>
   <node concept="bUwia" id="1x69AmkdXZz">
     <property role="TrG5h" value="mc04_cells" />
+    <node concept="3lhOvk" id="5fS8Lropfvd" role="3lj3bC">
+      <property role="13Pg2o" value="h94ayQF/true_" />
+      <ref role="30HIoZ" to="teg0:1vi_twqJeLl" resolve="BracketsCell" />
+      <ref role="3lhOvi" node="5fS8LropwrX" resolve="map_BracketsCell_SideTransformations" />
+    </node>
     <node concept="3aamgX" id="6oKG1kMysiD" role="3acgRq">
       <ref role="30HIoZ" to="teg0:6oKG1kMyo9t" resolve="WrapperCell" />
       <node concept="1Koe21" id="RbLMy6ae3n" role="1lVwrX">
@@ -1751,79 +1786,84 @@
                 </node>
               </node>
             </node>
-            <node concept="2kSiTK" id="6jH9yJK4yEG" role="2kYc5E">
-              <property role="2kSiWS" value="38nmGbCPLik/both_sides" />
-              <node concept="2kS2EP" id="6jH9yJK4yEH" role="2kS9vO">
-                <node concept="3clFbS" id="6jH9yJK4yEI" role="2VODD2">
-                  <node concept="3cpWs8" id="6jH9yJK4yEJ" role="3cqZAp">
-                    <node concept="3cpWsn" id="6jH9yJK4yEK" role="3cpWs9">
-                      <property role="TrG5h" value="result" />
-                      <node concept="_YKpA" id="6jH9yJK4yEL" role="1tU5fm">
-                        <node concept="3uibUv" id="2mvFNoS5fAR" role="_ZDj9">
-                          <ref role="3uigEE" to="uddc:~TransformationMenuItem" resolve="TransformationMenuItem" />
-                        </node>
+            <node concept="raruj" id="qT5MFmnJvd" role="lGtFl" />
+            <node concept="1QoScp" id="Dnjeumz7NT" role="2kYc5E">
+              <property role="1QpmdY" value="true" />
+              <node concept="pkWqt" id="Dnjeumz7NW" role="3e4ffs">
+                <node concept="3clFbS" id="Dnjeumz7NY" role="2VODD2">
+                  <node concept="3cpWs8" id="4AuGfbNXzje" role="3cqZAp">
+                    <node concept="3cpWsn" id="4AuGfbNXzjf" role="3cpWs9">
+                      <property role="TrG5h" value="access" />
+                      <node concept="3uibUv" id="4AuGfbNXzjg" role="1tU5fm">
+                        <ref role="3uigEE" to="czm:4AuGfbNRhNO" resolve="IFlagModelAccess" />
                       </node>
-                      <node concept="2ShNRf" id="6jH9yJK4yEN" role="33vP2m">
-                        <node concept="Tc6Ow" id="6jH9yJK4yEO" role="2ShVmc">
-                          <node concept="3uibUv" id="2mvFNoS5fRD" role="HW$YZ">
-                            <ref role="3uigEE" to="uddc:~TransformationMenuItem" resolve="TransformationMenuItem" />
-                          </node>
+                      <node concept="2ShNRf" id="4AuGfbNX_p6" role="33vP2m">
+                        <node concept="1pGfFk" id="4AuGfbNXA$v" role="2ShVmc">
+                          <ref role="37wK5l" to="czm:4AuGfbNRor$" resolve="DefaultFlagModelAccess" />
+                          <node concept="10Nm6u" id="4AuGfbNXB2H" role="37wK5m" />
                         </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="1X3_iC" id="4JqtTEflbnC" role="lGtFl">
-                    <property role="3V$3am" value="statement" />
-                    <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-                    <node concept="9aQIb" id="4JqtTEfl7bW" role="8Wnug">
-                      <node concept="3clFbS" id="4JqtTEfl7bY" role="9aQI4">
-                        <node concept="3clFbF" id="6jH9yJK4yEQ" role="3cqZAp">
-                          <node concept="2OqwBi" id="6jH9yJK4yER" role="3clFbG">
-                            <node concept="37vLTw" id="6jH9yJK4yES" role="2Oq$k0">
-                              <ref role="3cqZAo" node="6jH9yJK4yEK" resolve="result" />
-                            </node>
-                            <node concept="TSZUe" id="6jH9yJK4yET" role="2OqNvi">
-                              <node concept="10Nm6u" id="6jH9yJK4yEU" role="25WWJ7" />
-                            </node>
-                          </node>
-                          <node concept="1sPUBX" id="6jH9yJK4yEV" role="lGtFl">
-                            <ref role="v9R2y" node="RbLMy69ng$" resolve="switch_sideTransformations" />
-                          </node>
+                        <node concept="5jKBG" id="4AuGfbNXBYX" role="lGtFl">
+                          <ref role="v9R2y" node="4AuGfbNTl2e" resolve="template_FlagCell_ModelAccess" />
                         </node>
                       </node>
                     </node>
                   </node>
-                  <node concept="3cpWs6" id="6jH9yJK4yEW" role="3cqZAp">
-                    <node concept="2OqwBi" id="6jH9yJK4yEX" role="3cqZAk">
-                      <node concept="2OqwBi" id="6jH9yJK4yEY" role="2Oq$k0">
-                        <node concept="37vLTw" id="6jH9yJK4yEZ" role="2Oq$k0">
-                          <ref role="3cqZAo" node="6jH9yJK4yEK" resolve="result" />
+                  <node concept="3clFbJ" id="6jH9yJK4zo0" role="3cqZAp">
+                    <node concept="3clFbS" id="6jH9yJK4zo1" role="3clFbx">
+                      <node concept="3cpWs6" id="6jH9yJK4zo2" role="3cqZAp">
+                        <node concept="3clFbT" id="6jH9yJK4zo3" role="3cqZAk">
+                          <property role="3clFbU" value="false" />
                         </node>
-                        <node concept="3zZkjj" id="6jH9yJK4yF0" role="2OqNvi">
-                          <node concept="1bVj0M" id="6jH9yJK4yF1" role="23t8la">
-                            <node concept="3clFbS" id="6jH9yJK4yF2" role="1bW5cS">
-                              <node concept="3clFbF" id="6jH9yJK4yF3" role="3cqZAp">
-                                <node concept="3y3z36" id="6jH9yJK4yF4" role="3clFbG">
-                                  <node concept="10Nm6u" id="6jH9yJK4yF5" role="3uHU7w" />
-                                  <node concept="37vLTw" id="6jH9yJK4yF6" role="3uHU7B">
-                                    <ref role="3cqZAo" node="6jH9yJK4yF7" resolve="it" />
+                      </node>
+                    </node>
+                    <node concept="3fqX7Q" id="6jH9yJK4zo4" role="3clFbw">
+                      <node concept="2OqwBi" id="4AuGfbNXEic" role="3fr31v">
+                        <node concept="37vLTw" id="4AuGfbNXDOj" role="2Oq$k0">
+                          <ref role="3cqZAo" node="4AuGfbNXzjf" resolve="access" />
+                        </node>
+                        <node concept="liA8E" id="4AuGfbNXEKl" role="2OqNvi">
+                          <ref role="37wK5l" to="czm:4AuGfbNRhOg" resolve="read" />
+                          <node concept="pncrf" id="4AuGfbNXFbf" role="37wK5m" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbH" id="6jH9yJK4zof" role="3cqZAp" />
+                  <node concept="3clFbH" id="6jH9yJK4zog" role="3cqZAp">
+                    <node concept="2b32R4" id="6jH9yJK4zoh" role="lGtFl">
+                      <node concept="3JmXsc" id="6jH9yJK4zoi" role="2P8S$">
+                        <node concept="3clFbS" id="6jH9yJK4zoj" role="2VODD2">
+                          <node concept="3clFbF" id="6jH9yJK4zok" role="3cqZAp">
+                            <node concept="2OqwBi" id="6jH9yJK4zol" role="3clFbG">
+                              <node concept="2OqwBi" id="6jH9yJK4zom" role="2Oq$k0">
+                                <node concept="2OqwBi" id="6jH9yJK4zon" role="2Oq$k0">
+                                  <node concept="3TrEf2" id="6jH9yJK4zoo" role="2OqNvi">
+                                    <ref role="3Tt5mk" to="tpc2:gCpqm6p" resolve="renderingCondition" />
                                   </node>
+                                  <node concept="30H73N" id="6jH9yJK4zop" role="2Oq$k0" />
+                                </node>
+                                <node concept="3TrEf2" id="6jH9yJK4zoq" role="2OqNvi">
+                                  <ref role="3Tt5mk" to="tpee:gyVODHa" resolve="body" />
                                 </node>
                               </node>
-                            </node>
-                            <node concept="Rh6nW" id="6jH9yJK4yF7" role="1bW2Oz">
-                              <property role="TrG5h" value="it" />
-                              <node concept="2jxLKc" id="6jH9yJK4yF8" role="1tU5fm" />
+                              <node concept="3Tsc0h" id="6jH9yJK4zor" role="2OqNvi">
+                                <ref role="3TtcxE" to="tpee:fzcqZ_x" resolve="statement" />
+                              </node>
                             </node>
                           </node>
                         </node>
                       </node>
-                      <node concept="ANE8D" id="6jH9yJK4yF9" role="2OqNvi" />
+                    </node>
+                  </node>
+                  <node concept="3clFbH" id="6jH9yJK4zos" role="3cqZAp" />
+                  <node concept="3cpWs6" id="6jH9yJK4zot" role="3cqZAp">
+                    <node concept="3clFbT" id="6jH9yJK4zou" role="3cqZAk">
+                      <property role="3clFbU" value="true" />
                     </node>
                   </node>
                 </node>
               </node>
-              <node concept="130CD5" id="6jH9yJK4zmJ" role="2kSiZZ">
+              <node concept="130CD5" id="6jH9yJK4zmJ" role="1QoS34">
                 <node concept="130t_x" id="6jH9yJK4zmK" role="130p63">
                   <property role="1hAc7j" value="g_hAxAO/delete_action_id" />
                   <node concept="130t_S" id="6jH9yJK4zmL" role="130oVf">
@@ -2004,80 +2044,6 @@
                       </node>
                     </node>
                   </node>
-                  <node concept="pkWqt" id="6jH9yJK4znY" role="pqm2j">
-                    <node concept="3clFbS" id="6jH9yJK4znZ" role="2VODD2">
-                      <node concept="3cpWs8" id="4AuGfbNXzje" role="3cqZAp">
-                        <node concept="3cpWsn" id="4AuGfbNXzjf" role="3cpWs9">
-                          <property role="TrG5h" value="access" />
-                          <node concept="3uibUv" id="4AuGfbNXzjg" role="1tU5fm">
-                            <ref role="3uigEE" to="czm:4AuGfbNRhNO" resolve="IFlagModelAccess" />
-                          </node>
-                          <node concept="2ShNRf" id="4AuGfbNX_p6" role="33vP2m">
-                            <node concept="1pGfFk" id="4AuGfbNXA$v" role="2ShVmc">
-                              <ref role="37wK5l" to="czm:4AuGfbNRor$" resolve="DefaultFlagModelAccess" />
-                              <node concept="10Nm6u" id="4AuGfbNXB2H" role="37wK5m" />
-                            </node>
-                            <node concept="5jKBG" id="4AuGfbNXBYX" role="lGtFl">
-                              <ref role="v9R2y" node="4AuGfbNTl2e" resolve="template_FlagCell_ModelAccess" />
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="3clFbJ" id="6jH9yJK4zo0" role="3cqZAp">
-                        <node concept="3clFbS" id="6jH9yJK4zo1" role="3clFbx">
-                          <node concept="3cpWs6" id="6jH9yJK4zo2" role="3cqZAp">
-                            <node concept="3clFbT" id="6jH9yJK4zo3" role="3cqZAk">
-                              <property role="3clFbU" value="false" />
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="3fqX7Q" id="6jH9yJK4zo4" role="3clFbw">
-                          <node concept="2OqwBi" id="4AuGfbNXEic" role="3fr31v">
-                            <node concept="37vLTw" id="4AuGfbNXDOj" role="2Oq$k0">
-                              <ref role="3cqZAo" node="4AuGfbNXzjf" resolve="access" />
-                            </node>
-                            <node concept="liA8E" id="4AuGfbNXEKl" role="2OqNvi">
-                              <ref role="37wK5l" to="czm:4AuGfbNRhOg" resolve="read" />
-                              <node concept="pncrf" id="4AuGfbNXFbf" role="37wK5m" />
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="3clFbH" id="6jH9yJK4zof" role="3cqZAp" />
-                      <node concept="3clFbH" id="6jH9yJK4zog" role="3cqZAp">
-                        <node concept="2b32R4" id="6jH9yJK4zoh" role="lGtFl">
-                          <node concept="3JmXsc" id="6jH9yJK4zoi" role="2P8S$">
-                            <node concept="3clFbS" id="6jH9yJK4zoj" role="2VODD2">
-                              <node concept="3clFbF" id="6jH9yJK4zok" role="3cqZAp">
-                                <node concept="2OqwBi" id="6jH9yJK4zol" role="3clFbG">
-                                  <node concept="2OqwBi" id="6jH9yJK4zom" role="2Oq$k0">
-                                    <node concept="2OqwBi" id="6jH9yJK4zon" role="2Oq$k0">
-                                      <node concept="3TrEf2" id="6jH9yJK4zoo" role="2OqNvi">
-                                        <ref role="3Tt5mk" to="tpc2:gCpqm6p" resolve="renderingCondition" />
-                                      </node>
-                                      <node concept="30H73N" id="6jH9yJK4zop" role="2Oq$k0" />
-                                    </node>
-                                    <node concept="3TrEf2" id="6jH9yJK4zoq" role="2OqNvi">
-                                      <ref role="3Tt5mk" to="tpee:gyVODHa" resolve="body" />
-                                    </node>
-                                  </node>
-                                  <node concept="3Tsc0h" id="6jH9yJK4zor" role="2OqNvi">
-                                    <ref role="3TtcxE" to="tpee:fzcqZ_x" resolve="statement" />
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="3clFbH" id="6jH9yJK4zos" role="3cqZAp" />
-                      <node concept="3cpWs6" id="6jH9yJK4zot" role="3cqZAp">
-                        <node concept="3clFbT" id="6jH9yJK4zou" role="3cqZAk">
-                          <property role="3clFbU" value="true" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
                   <node concept="1ZhdrF" id="6jH9yJK4zov" role="lGtFl">
                     <property role="P3scX" value="18bc6592-03a6-4e29-a83a-7ff23bde13ba/1381004262292414836/1381004262292426837" />
                     <property role="2qtEX8" value="parentStyleClass" />
@@ -2141,252 +2107,523 @@
                   </node>
                 </node>
               </node>
-            </node>
-            <node concept="raruj" id="qT5MFmnJvd" role="lGtFl" />
-          </node>
-          <node concept="1eYWM2" id="4JqtTEfjseS" role="3EZMnx">
-            <node concept="1eYxTg" id="4JqtTEfjseU" role="1eYxTh">
-              <node concept="3clFbS" id="4JqtTEfjseW" role="2VODD2">
-                <node concept="3cpWs8" id="4JqtTEfjKxs" role="3cqZAp">
-                  <node concept="3cpWsn" id="4JqtTEfjKxt" role="3cpWs9">
-                    <property role="TrG5h" value="node" />
-                    <node concept="3Tqbb2" id="4JqtTEfjKxu" role="1tU5fm">
-                      <ref role="ehGHo" to="tpck:gw2VY9q" resolve="BaseConcept" />
-                      <node concept="1ZhdrF" id="4JqtTEfjKxv" role="lGtFl">
-                        <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/1138055754698/1138405853777" />
-                        <property role="2qtEX8" value="concept" />
-                        <node concept="3$xsQk" id="4JqtTEfjKxw" role="3$ytzL">
-                          <node concept="3clFbS" id="4JqtTEfjKxx" role="2VODD2">
-                            <node concept="3clFbF" id="4JqtTEfjKxy" role="3cqZAp">
-                              <node concept="2OqwBi" id="4JqtTEfjKxz" role="3clFbG">
-                                <node concept="2OqwBi" id="4JqtTEfjKx$" role="2Oq$k0">
-                                  <node concept="30H73N" id="4JqtTEfjKx_" role="2Oq$k0" />
-                                  <node concept="2Xjw5R" id="4JqtTEfjKxA" role="2OqNvi">
-                                    <node concept="1xMEDy" id="4JqtTEfjKxB" role="1xVPHs">
-                                      <node concept="chp4Y" id="4JqtTEfjKxC" role="ri$Ld">
-                                        <ref role="cht4Q" to="tpc2:gXXWOiD" resolve="AbstractComponent" />
-                                      </node>
-                                    </node>
-                                  </node>
-                                </node>
-                                <node concept="2qgKlT" id="4JqtTEfjKxD" role="2OqNvi">
-                                  <ref role="37wK5l" to="tpcb:67EYkym$wx3" resolve="getConceptDeclaration" />
+              <node concept="2uKrtP" id="Dnjeumzcb4" role="1QoVPY">
+                <property role="2thAuV" value="description" />
+                <node concept="1Qtc8_" id="Dnjeumzcb6" role="2vkWV5">
+                  <node concept="2MBE2L" id="Dnjeumzcb7" role="1Qtc8A">
+                    <node concept="2Mo9yg" id="Dnjeumzcb8" role="2MvauM">
+                      <node concept="3clFbS" id="Dnjeumzcb9" role="2VODD2">
+                        <node concept="3cpWs8" id="Dnjeumzcba" role="3cqZAp">
+                          <node concept="3cpWsn" id="Dnjeumzcbb" role="3cpWs9">
+                            <property role="TrG5h" value="result" />
+                            <node concept="_YKpA" id="Dnjeumzcbc" role="1tU5fm">
+                              <node concept="3uibUv" id="Dnjeumzcbd" role="_ZDj9">
+                                <ref role="3uigEE" to="uddc:~TransformationMenuItem" resolve="TransformationMenuItem" />
+                              </node>
+                            </node>
+                            <node concept="2ShNRf" id="Dnjeumzcbe" role="33vP2m">
+                              <node concept="Tc6Ow" id="Dnjeumzcbf" role="2ShVmc">
+                                <node concept="3uibUv" id="Dnjeumzcbg" role="HW$YZ">
+                                  <ref role="3uigEE" to="uddc:~TransformationMenuItem" resolve="TransformationMenuItem" />
                                 </node>
                               </node>
                             </node>
                           </node>
                         </node>
-                      </node>
-                    </node>
-                    <node concept="1PxgMI" id="4JqtTEfjKxE" role="33vP2m">
-                      <node concept="chp4Y" id="1SbcsM_INT2" role="3oSUPX">
-                        <ref role="cht4Q" to="tpck:gw2VY9q" resolve="BaseConcept" />
-                        <node concept="1ZhdrF" id="4JqtTEfjKxG" role="lGtFl">
-                          <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/1177026924588/1177026940964" />
-                          <property role="2qtEX8" value="conceptDeclaration" />
-                          <node concept="3$xsQk" id="4JqtTEfjKxH" role="3$ytzL">
-                            <node concept="3clFbS" id="4JqtTEfjKxI" role="2VODD2">
-                              <node concept="3clFbF" id="4JqtTEfjKxJ" role="3cqZAp">
-                                <node concept="2OqwBi" id="4JqtTEfjKxK" role="3clFbG">
-                                  <node concept="2OqwBi" id="4JqtTEfjKxL" role="2Oq$k0">
-                                    <node concept="30H73N" id="4JqtTEfjKxM" role="2Oq$k0" />
-                                    <node concept="2Xjw5R" id="4JqtTEfjKxN" role="2OqNvi">
-                                      <node concept="1xMEDy" id="4JqtTEfjKxO" role="1xVPHs">
-                                        <node concept="chp4Y" id="4JqtTEfjKxP" role="ri$Ld">
-                                          <ref role="cht4Q" to="tpc2:gXXWOiD" resolve="AbstractComponent" />
+                        <node concept="3cpWs8" id="Dnjeumzcbh" role="3cqZAp">
+                          <node concept="3cpWsn" id="Dnjeumzcbi" role="3cpWs9">
+                            <property role="TrG5h" value="isApplicable" />
+                            <property role="3TUv4t" value="true" />
+                            <node concept="10P_77" id="Dnjeumzcbj" role="1tU5fm" />
+                            <node concept="2OqwBi" id="Dnjeumzcbk" role="33vP2m">
+                              <node concept="2ShNRf" id="Dnjeumzcbl" role="2Oq$k0">
+                                <node concept="YeOm9" id="Dnjeumzcbm" role="2ShVmc">
+                                  <node concept="1Y3b0j" id="Dnjeumzcbn" role="YeSDq">
+                                    <property role="2bfB8j" value="true" />
+                                    <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
+                                    <ref role="1Y3XeK" to="wyt6:~Object" resolve="Object" />
+                                    <node concept="3Tm1VV" id="Dnjeumzcbo" role="1B3o_S" />
+                                    <node concept="3clFb_" id="Dnjeumzcbp" role="jymVt">
+                                      <property role="TrG5h" value="query" />
+                                      <node concept="10P_77" id="Dnjeumzcbq" role="3clF45" />
+                                      <node concept="3Tm1VV" id="Dnjeumzcbr" role="1B3o_S" />
+                                      <node concept="3clFbS" id="Dnjeumzcbs" role="3clF47">
+                                        <node concept="3cpWs8" id="Dnjeumzcbt" role="3cqZAp">
+                                          <node concept="3cpWsn" id="Dnjeumzcbu" role="3cpWs9">
+                                            <property role="TrG5h" value="node" />
+                                            <property role="3TUv4t" value="true" />
+                                            <node concept="3Tqbb2" id="Dnjeumzcbv" role="1tU5fm" />
+                                            <node concept="2OqwBi" id="Dnjeumzcbw" role="33vP2m">
+                                              <node concept="2Mo9yH" id="Dnjeumzcbx" role="2Oq$k0" />
+                                              <node concept="liA8E" id="Dnjeumzcby" role="2OqNvi">
+                                                <ref role="37wK5l" to="uddc:~TransformationMenuContext.getNode()" resolve="getNode" />
+                                              </node>
+                                            </node>
+                                          </node>
+                                        </node>
+                                        <node concept="3cpWs8" id="Dnjeumzcbz" role="3cqZAp">
+                                          <node concept="3cpWsn" id="Dnjeumzcb$" role="3cpWs9">
+                                            <property role="TrG5h" value="access" />
+                                            <node concept="3uibUv" id="Dnjeumzcb_" role="1tU5fm">
+                                              <ref role="3uigEE" to="czm:4AuGfbNRhNO" resolve="IFlagModelAccess" />
+                                            </node>
+                                            <node concept="2ShNRf" id="DnjeumzcbA" role="33vP2m">
+                                              <node concept="1pGfFk" id="DnjeumzcbB" role="2ShVmc">
+                                                <ref role="37wK5l" to="czm:4AuGfbNRor$" resolve="DefaultFlagModelAccess" />
+                                                <node concept="10Nm6u" id="DnjeumzcbC" role="37wK5m" />
+                                              </node>
+                                              <node concept="5jKBG" id="DnjeumzcbD" role="lGtFl">
+                                                <ref role="v9R2y" node="4AuGfbNTl2e" resolve="template_FlagCell_ModelAccess" />
+                                              </node>
+                                            </node>
+                                          </node>
+                                        </node>
+                                        <node concept="3cpWs8" id="DnjeumzcbE" role="3cqZAp">
+                                          <node concept="3cpWsn" id="DnjeumzcbF" role="3cpWs9">
+                                            <property role="TrG5h" value="applicable" />
+                                            <node concept="10P_77" id="DnjeumzcbG" role="1tU5fm" />
+                                            <node concept="3fqX7Q" id="DnjeumzcbH" role="33vP2m">
+                                              <node concept="2OqwBi" id="DnjeumzcbI" role="3fr31v">
+                                                <node concept="37vLTw" id="DnjeumzcbJ" role="2Oq$k0">
+                                                  <ref role="3cqZAo" node="Dnjeumzcb$" resolve="access" />
+                                                </node>
+                                                <node concept="liA8E" id="DnjeumzcbK" role="2OqNvi">
+                                                  <ref role="37wK5l" to="czm:4AuGfbNRhOg" resolve="read" />
+                                                  <node concept="37vLTw" id="DnjeumzcbL" role="37wK5m">
+                                                    <ref role="3cqZAo" node="Dnjeumzcbu" resolve="node" />
+                                                  </node>
+                                                </node>
+                                              </node>
+                                            </node>
+                                          </node>
+                                        </node>
+                                        <node concept="3clFbF" id="DnjeumzcbM" role="3cqZAp">
+                                          <node concept="3vZ8ra" id="DnjeumzcbN" role="3clFbG">
+                                            <node concept="37vLTw" id="DnjeumzcbO" role="37vLTJ">
+                                              <ref role="3cqZAo" node="DnjeumzcbF" resolve="applicable" />
+                                            </node>
+                                            <node concept="2OqwBi" id="DnjeumzcbP" role="37vLTx">
+                                              <node concept="2ShNRf" id="DnjeumzcbQ" role="2Oq$k0">
+                                                <node concept="YeOm9" id="DnjeumzcbR" role="2ShVmc">
+                                                  <node concept="1Y3b0j" id="DnjeumzcbS" role="YeSDq">
+                                                    <property role="2bfB8j" value="true" />
+                                                    <ref role="1Y3XeK" to="wyt6:~Object" resolve="Object" />
+                                                    <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
+                                                    <node concept="3Tm1VV" id="DnjeumzcbT" role="1B3o_S" />
+                                                    <node concept="3clFb_" id="DnjeumzcbU" role="jymVt">
+                                                      <property role="TrG5h" value="query" />
+                                                      <node concept="10P_77" id="DnjeumzcbV" role="3clF45" />
+                                                      <node concept="3Tm1VV" id="DnjeumzcbW" role="1B3o_S" />
+                                                      <node concept="3clFbS" id="DnjeumzcbX" role="3clF47">
+                                                        <node concept="3clFbF" id="DnjeumzcbY" role="3cqZAp">
+                                                          <node concept="3clFbT" id="DnjeumzcbZ" role="3clFbG">
+                                                            <property role="3clFbU" value="true" />
+                                                          </node>
+                                                          <node concept="2b32R4" id="Dnjeumzcc0" role="lGtFl">
+                                                            <node concept="3JmXsc" id="Dnjeumzcc1" role="2P8S$">
+                                                              <node concept="3clFbS" id="Dnjeumzcc2" role="2VODD2">
+                                                                <node concept="3clFbF" id="Dnjeumzcc3" role="3cqZAp">
+                                                                  <node concept="2OqwBi" id="Dnjeumzcc4" role="3clFbG">
+                                                                    <node concept="2OqwBi" id="Dnjeumzcc5" role="2Oq$k0">
+                                                                      <node concept="2OqwBi" id="Dnjeumzcc6" role="2Oq$k0">
+                                                                        <node concept="30H73N" id="Dnjeumzcc7" role="2Oq$k0" />
+                                                                        <node concept="3TrEf2" id="Dnjeumzcc8" role="2OqNvi">
+                                                                          <ref role="3Tt5mk" to="teg0:yuUZPu3Zn9" resolve="sideTransformCondition" />
+                                                                        </node>
+                                                                      </node>
+                                                                      <node concept="3TrEf2" id="Dnjeumzcc9" role="2OqNvi">
+                                                                        <ref role="3Tt5mk" to="tpee:gyVODHa" resolve="body" />
+                                                                      </node>
+                                                                    </node>
+                                                                    <node concept="3Tsc0h" id="Dnjeumzcca" role="2OqNvi">
+                                                                      <ref role="3TtcxE" to="tpee:fzcqZ_x" resolve="statement" />
+                                                                    </node>
+                                                                  </node>
+                                                                </node>
+                                                              </node>
+                                                            </node>
+                                                          </node>
+                                                        </node>
+                                                      </node>
+                                                    </node>
+                                                  </node>
+                                                </node>
+                                              </node>
+                                              <node concept="liA8E" id="Dnjeumzccb" role="2OqNvi">
+                                                <ref role="37wK5l" node="DnjeumzcbU" resolve="query" />
+                                              </node>
+                                            </node>
+                                          </node>
+                                          <node concept="1W57fq" id="Dnjeumzccc" role="lGtFl">
+                                            <node concept="3IZrLx" id="Dnjeumzccd" role="3IZSJc">
+                                              <node concept="3clFbS" id="Dnjeumzcce" role="2VODD2">
+                                                <node concept="3clFbF" id="Dnjeumzccf" role="3cqZAp">
+                                                  <node concept="2OqwBi" id="Dnjeumzccg" role="3clFbG">
+                                                    <node concept="2OqwBi" id="Dnjeumzcch" role="2Oq$k0">
+                                                      <node concept="30H73N" id="Dnjeumzcci" role="2Oq$k0" />
+                                                      <node concept="3TrEf2" id="Dnjeumzccj" role="2OqNvi">
+                                                        <ref role="3Tt5mk" to="teg0:yuUZPu3Zn9" resolve="sideTransformCondition" />
+                                                      </node>
+                                                    </node>
+                                                    <node concept="3x8VRR" id="Dnjeumzcck" role="2OqNvi" />
+                                                  </node>
+                                                </node>
+                                              </node>
+                                            </node>
+                                          </node>
+                                        </node>
+                                        <node concept="3clFbF" id="Dnjeumzccl" role="3cqZAp">
+                                          <node concept="3vZ8ra" id="Dnjeumzccm" role="3clFbG">
+                                            <node concept="22lmx$" id="Dnjeumzccn" role="37vLTx">
+                                              <node concept="3y3z36" id="Dnjeumzcco" role="3uHU7w">
+                                                <node concept="2OqwBi" id="Dnjeumzccp" role="3uHU7B">
+                                                  <node concept="2Mo9yH" id="Dnjeumzccq" role="2Oq$k0" />
+                                                  <node concept="liA8E" id="Dnjeumzccr" role="2OqNvi">
+                                                    <ref role="37wK5l" to="uddc:~TransformationMenuContext.getMenuLocation()" resolve="getMenuLocation" />
+                                                  </node>
+                                                </node>
+                                                <node concept="10M0yZ" id="Dnjeumzccs" role="3uHU7w">
+                                                  <ref role="1PxDUh" to="9eyi:~MenuLocations" resolve="MenuLocations" />
+                                                  <ref role="3cqZAo" to="9eyi:~MenuLocations.RIGHT_SIDE_TRANSFORM" resolve="RIGHT_SIDE_TRANSFORM" />
+                                                </node>
+                                              </node>
+                                              <node concept="3fqX7Q" id="Dnjeumzcct" role="3uHU7B">
+                                                <node concept="2YIFZM" id="Dnjeumzccu" role="3fr31v">
+                                                  <ref role="37wK5l" to="czm:1DVF61P3qzQ" resolve="isProperty" />
+                                                  <ref role="1Pybhc" to="czm:RbLMy696h3" resolve="GrammarCellsUtil" />
+                                                  <node concept="2OqwBi" id="Dnjeumzccv" role="37wK5m">
+                                                    <node concept="2OqwBi" id="Dnjeumzccw" role="2Oq$k0">
+                                                      <node concept="2Mo9yH" id="Dnjeumzccx" role="2Oq$k0" />
+                                                      <node concept="liA8E" id="Dnjeumzccy" role="2OqNvi">
+                                                        <ref role="37wK5l" to="uddc:~TransformationMenuContext.getEditorContext()" resolve="getEditorContext" />
+                                                      </node>
+                                                    </node>
+                                                    <node concept="liA8E" id="Dnjeumzccz" role="2OqNvi">
+                                                      <ref role="37wK5l" to="cj4x:~EditorContext.getSelectedCell()" resolve="getSelectedCell" />
+                                                    </node>
+                                                  </node>
+                                                </node>
+                                              </node>
+                                            </node>
+                                            <node concept="37vLTw" id="Dnjeumzcc$" role="37vLTJ">
+                                              <ref role="3cqZAo" node="DnjeumzcbF" resolve="applicable" />
+                                            </node>
+                                          </node>
+                                        </node>
+                                        <node concept="3clFbF" id="Dnjeumzcc_" role="3cqZAp">
+                                          <node concept="37vLTw" id="DnjeumzccA" role="3clFbG">
+                                            <ref role="3cqZAo" node="DnjeumzcbF" resolve="applicable" />
+                                          </node>
                                         </node>
                                       </node>
                                     </node>
                                   </node>
-                                  <node concept="2qgKlT" id="4JqtTEfjKxQ" role="2OqNvi">
-                                    <ref role="37wK5l" to="tpcb:67EYkym$wx3" resolve="getConceptDeclaration" />
-                                  </node>
                                 </node>
+                              </node>
+                              <node concept="liA8E" id="DnjeumzccB" role="2OqNvi">
+                                <ref role="37wK5l" node="Dnjeumzcbp" resolve="query" />
                               </node>
                             </node>
                           </node>
                         </node>
-                      </node>
-                      <node concept="2OqwBi" id="4JqtTEfjMGj" role="1m5AlR">
-                        <node concept="2kS8pE" id="4JqtTEfjMGk" role="2Oq$k0" />
-                        <node concept="liA8E" id="4JqtTEfjMGl" role="2OqNvi">
-                          <ref role="37wK5l" to="uddc:~TransformationMenuContext.getNode()" resolve="getNode" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="3cpWs8" id="4AuGfbO1bI8" role="3cqZAp">
-                  <node concept="3cpWsn" id="4AuGfbO1bI9" role="3cpWs9">
-                    <property role="TrG5h" value="access" />
-                    <node concept="3uibUv" id="4AuGfbO1bIa" role="1tU5fm">
-                      <ref role="3uigEE" to="czm:4AuGfbNRhNO" resolve="IFlagModelAccess" />
-                    </node>
-                    <node concept="2ShNRf" id="4AuGfbO1bIb" role="33vP2m">
-                      <node concept="1pGfFk" id="4AuGfbO1bIc" role="2ShVmc">
-                        <ref role="37wK5l" to="czm:4AuGfbNRor$" resolve="DefaultFlagModelAccess" />
-                        <node concept="10Nm6u" id="4AuGfbO1bId" role="37wK5m" />
-                      </node>
-                      <node concept="5jKBG" id="4AuGfbO1bIe" role="lGtFl">
-                        <ref role="v9R2y" node="4AuGfbNTl2e" resolve="template_FlagCell_ModelAccess" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="3clFbF" id="4AuGfbO1bIf" role="3cqZAp">
-                  <node concept="2OqwBi" id="4AuGfbO1bIg" role="3clFbG">
-                    <node concept="37vLTw" id="4AuGfbO1bIh" role="2Oq$k0">
-                      <ref role="3cqZAo" node="4AuGfbO1bI9" resolve="access" />
-                    </node>
-                    <node concept="liA8E" id="4AuGfbO1bIi" role="2OqNvi">
-                      <ref role="37wK5l" to="czm:4AuGfbNRhRa" resolve="write" />
-                      <node concept="37vLTw" id="4AuGfbO1lU9" role="37wK5m">
-                        <ref role="3cqZAo" node="4JqtTEfjKxt" resolve="node" />
-                      </node>
-                      <node concept="3clFbT" id="4AuGfbO1bIk" role="37wK5m">
-                        <property role="3clFbU" value="true" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="3clFbF" id="4JqtTEfjKy4" role="3cqZAp">
-                  <node concept="2OqwBi" id="4JqtTEfjKy5" role="3clFbG">
-                    <node concept="37vLTw" id="4JqtTEfjKy6" role="2Oq$k0">
-                      <ref role="3cqZAo" node="4JqtTEfjKxt" resolve="node" />
-                    </node>
-                    <node concept="1OKiuA" id="4JqtTEfjKy7" role="2OqNvi">
-                      <node concept="1Q80Hx" id="4JqtTEfjShJ" role="lBI5i" />
-                      <node concept="1lyA5W" id="4JqtTEfjKy9" role="lGT1i">
-                        <property role="1lUG9U" value="flag_propertyName" />
-                        <node concept="17Uvod" id="4JqtTEfjKya" role="lGtFl">
-                          <property role="P4ACc" value="18bc6592-03a6-4e29-a83a-7ff23bde13ba/2162403111523059536/2162403111529391190" />
-                          <property role="2qtEX9" value="cellId" />
-                          <node concept="3zFVjK" id="4JqtTEfjKyb" role="3zH0cK">
-                            <node concept="3clFbS" id="4JqtTEfjKyc" role="2VODD2">
-                              <node concept="3clFbF" id="4JqtTEfjKyd" role="3cqZAp">
-                                <node concept="3cpWs3" id="4JqtTEfjKye" role="3clFbG">
-                                  <node concept="2OqwBi" id="4JqtTEfjKyf" role="3uHU7w">
-                                    <node concept="2OqwBi" id="4JqtTEfjKyg" role="2Oq$k0">
-                                      <node concept="30H73N" id="4JqtTEfjKyh" role="2Oq$k0" />
-                                      <node concept="3TrEf2" id="4JqtTEfjKyi" role="2OqNvi">
-                                        <ref role="3Tt5mk" to="tpc2:fBF1KQc" resolve="propertyDeclaration" />
+                        <node concept="3clFbJ" id="DnjeumzccC" role="3cqZAp">
+                          <node concept="3clFbS" id="DnjeumzccD" role="3clFbx">
+                            <node concept="3cpWs8" id="DnjeumzccE" role="3cqZAp">
+                              <node concept="3cpWsn" id="DnjeumzccF" role="3cpWs9">
+                                <property role="TrG5h" value="item" />
+                                <node concept="3uibUv" id="DnjeumzccG" role="1tU5fm">
+                                  <ref role="3uigEE" to="gdpt:1YKLYyyGBzT" resolve="GrammarCellsSideTransformTransformationMenuItem" />
+                                </node>
+                                <node concept="2ShNRf" id="DnjeumzccH" role="33vP2m">
+                                  <node concept="YeOm9" id="DnjeumzccI" role="2ShVmc">
+                                    <node concept="1Y3b0j" id="DnjeumzccJ" role="YeSDq">
+                                      <property role="2bfB8j" value="true" />
+                                      <ref role="1Y3XeK" to="gdpt:1YKLYyyGBzT" resolve="GrammarCellsSideTransformTransformationMenuItem" />
+                                      <ref role="37wK5l" to="gdpt:My09KinEek" resolve="GrammarCellsSideTransformTransformationMenuItem" />
+                                      <node concept="2Mo9yH" id="DnjeumzccK" role="37wK5m" />
+                                      <node concept="3Tm1VV" id="DnjeumzccL" role="1B3o_S" />
+                                      <node concept="3clFb_" id="DnjeumzccM" role="jymVt">
+                                        <property role="1EzhhJ" value="false" />
+                                        <property role="TrG5h" value="getDescriptionText" />
+                                        <property role="DiZV1" value="false" />
+                                        <property role="od$2w" value="false" />
+                                        <node concept="3Tm1VV" id="DnjeumzccN" role="1B3o_S" />
+                                        <node concept="17QB3L" id="DnjeumzccO" role="3clF45" />
+                                        <node concept="37vLTG" id="DnjeumzccP" role="3clF46">
+                                          <property role="TrG5h" value="pattern" />
+                                          <node concept="17QB3L" id="DnjeumzccQ" role="1tU5fm" />
+                                        </node>
+                                        <node concept="3clFbS" id="DnjeumzccR" role="3clF47">
+                                          <node concept="3clFbF" id="DnjeumzccS" role="3cqZAp">
+                                            <node concept="10Nm6u" id="DnjeumzccT" role="3clFbG" />
+                                          </node>
+                                        </node>
                                       </node>
-                                    </node>
-                                    <node concept="3TrcHB" id="4JqtTEfjKyj" role="2OqNvi">
-                                      <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
-                                    </node>
-                                  </node>
-                                  <node concept="Xl_RD" id="4JqtTEfjKyk" role="3uHU7B">
-                                    <property role="Xl_RC" value="flag_" />
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="3cmrfG" id="4JqtTEfjKyl" role="3dN3m$">
-                        <property role="3cmrfH" value="-1" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="3cpWs6" id="4JqtTEfjKym" role="3cqZAp">
-                  <node concept="10Nm6u" id="4JqtTEfjKyn" role="3cqZAk" />
-                </node>
-              </node>
-            </node>
-            <node concept="1eYwpX" id="4JqtTEfjseY" role="1eYxym">
-              <node concept="3clFbS" id="4JqtTEfjsf0" role="2VODD2">
-                <node concept="3cpWs8" id="4JqtTEfj$FY" role="3cqZAp">
-                  <node concept="3cpWsn" id="4JqtTEfj$FZ" role="3cpWs9">
-                    <property role="TrG5h" value="node" />
-                    <property role="3TUv4t" value="true" />
-                    <node concept="3Tqbb2" id="4JqtTEfj$Vn" role="1tU5fm" />
-                    <node concept="2OqwBi" id="4JqtTEfj$G0" role="33vP2m">
-                      <node concept="2kS8pE" id="4JqtTEfj$G1" role="2Oq$k0" />
-                      <node concept="liA8E" id="4JqtTEfj$G2" role="2OqNvi">
-                        <ref role="37wK5l" to="uddc:~TransformationMenuContext.getNode()" resolve="getNode" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="3cpWs8" id="4AuGfbO1oxp" role="3cqZAp">
-                  <node concept="3cpWsn" id="4AuGfbO1oxq" role="3cpWs9">
-                    <property role="TrG5h" value="access" />
-                    <node concept="3uibUv" id="4AuGfbO1oxr" role="1tU5fm">
-                      <ref role="3uigEE" to="czm:4AuGfbNRhNO" resolve="IFlagModelAccess" />
-                    </node>
-                    <node concept="2ShNRf" id="4AuGfbO1oxs" role="33vP2m">
-                      <node concept="1pGfFk" id="4AuGfbO1oxt" role="2ShVmc">
-                        <ref role="37wK5l" to="czm:4AuGfbNRor$" resolve="DefaultFlagModelAccess" />
-                        <node concept="10Nm6u" id="4AuGfbO1oxu" role="37wK5m" />
-                      </node>
-                      <node concept="5jKBG" id="4AuGfbO1oxv" role="lGtFl">
-                        <ref role="v9R2y" node="4AuGfbNTl2e" resolve="template_FlagCell_ModelAccess" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="3cpWs8" id="yuUZPu0QDy" role="3cqZAp">
-                  <node concept="3cpWsn" id="yuUZPu0QDz" role="3cpWs9">
-                    <property role="TrG5h" value="applicable" />
-                    <node concept="10P_77" id="yuUZPu0QDs" role="1tU5fm" />
-                    <node concept="3fqX7Q" id="yuUZPu0QD$" role="33vP2m">
-                      <node concept="2OqwBi" id="4AuGfbO1qF4" role="3fr31v">
-                        <node concept="37vLTw" id="4AuGfbO1q5E" role="2Oq$k0">
-                          <ref role="3cqZAo" node="4AuGfbO1oxq" resolve="access" />
-                        </node>
-                        <node concept="liA8E" id="4AuGfbO1r0F" role="2OqNvi">
-                          <ref role="37wK5l" to="czm:4AuGfbNRhOg" resolve="read" />
-                          <node concept="37vLTw" id="4AuGfbO1rAM" role="37wK5m">
-                            <ref role="3cqZAo" node="4JqtTEfj$FZ" resolve="node" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="3clFbF" id="yuUZPu0RNd" role="3cqZAp">
-                  <node concept="3vZ8ra" id="yuUZPu0RNe" role="3clFbG">
-                    <node concept="37vLTw" id="yuUZPu0RNf" role="37vLTJ">
-                      <ref role="3cqZAo" node="yuUZPu0QDz" resolve="applicable" />
-                    </node>
-                    <node concept="2OqwBi" id="yuUZPu0RNg" role="37vLTx">
-                      <node concept="2ShNRf" id="yuUZPu0RNh" role="2Oq$k0">
-                        <node concept="YeOm9" id="yuUZPu0RNi" role="2ShVmc">
-                          <node concept="1Y3b0j" id="yuUZPu0RNj" role="YeSDq">
-                            <property role="2bfB8j" value="true" />
-                            <ref role="1Y3XeK" to="wyt6:~Object" resolve="Object" />
-                            <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
-                            <node concept="3Tm1VV" id="yuUZPu0RNk" role="1B3o_S" />
-                            <node concept="3clFb_" id="yuUZPu0RNl" role="jymVt">
-                              <property role="TrG5h" value="query" />
-                              <node concept="10P_77" id="yuUZPu0RNm" role="3clF45" />
-                              <node concept="3Tm1VV" id="yuUZPu0RNn" role="1B3o_S" />
-                              <node concept="3clFbS" id="yuUZPu0RNo" role="3clF47">
-                                <node concept="3clFbF" id="yuUZPu0RNp" role="3cqZAp">
-                                  <node concept="3clFbT" id="yuUZPu0RNq" role="3clFbG">
-                                    <property role="3clFbU" value="true" />
-                                  </node>
-                                  <node concept="2b32R4" id="yuUZPu0RNr" role="lGtFl">
-                                    <node concept="3JmXsc" id="yuUZPu0RNs" role="2P8S$">
-                                      <node concept="3clFbS" id="yuUZPu0RNt" role="2VODD2">
-                                        <node concept="3clFbF" id="yuUZPu0RNu" role="3cqZAp">
-                                          <node concept="2OqwBi" id="yuUZPu0RNv" role="3clFbG">
-                                            <node concept="2OqwBi" id="yuUZPu0RNw" role="2Oq$k0">
-                                              <node concept="2OqwBi" id="yuUZPu0RNx" role="2Oq$k0">
-                                                <node concept="30H73N" id="yuUZPu0RNy" role="2Oq$k0" />
-                                                <node concept="3TrEf2" id="yuUZPu4gnE" role="2OqNvi">
-                                                  <ref role="3Tt5mk" to="teg0:yuUZPu3Zn9" resolve="sideTransformCondition" />
+                                      <node concept="3clFb_" id="DnjeumzccU" role="jymVt">
+                                        <property role="1EzhhJ" value="false" />
+                                        <property role="TrG5h" value="getMatchingText" />
+                                        <property role="DiZV1" value="false" />
+                                        <property role="od$2w" value="false" />
+                                        <node concept="3Tm1VV" id="DnjeumzccV" role="1B3o_S" />
+                                        <node concept="17QB3L" id="DnjeumzccW" role="3clF45" />
+                                        <node concept="37vLTG" id="DnjeumzccX" role="3clF46">
+                                          <property role="TrG5h" value="pattern" />
+                                          <node concept="17QB3L" id="DnjeumzccY" role="1tU5fm" />
+                                        </node>
+                                        <node concept="3clFbS" id="DnjeumzccZ" role="3clF47">
+                                          <node concept="3clFbF" id="Dnjeumzcd0" role="3cqZAp">
+                                            <node concept="Xl_RD" id="Dnjeumzcd1" role="3clFbG">
+                                              <property role="Xl_RC" value="flagText" />
+                                              <node concept="17Uvod" id="Dnjeumzcd2" role="lGtFl">
+                                                <property role="P4ACc" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1070475926800/1070475926801" />
+                                                <property role="2qtEX9" value="value" />
+                                                <node concept="3zFVjK" id="Dnjeumzcd3" role="3zH0cK">
+                                                  <node concept="3clFbS" id="Dnjeumzcd4" role="2VODD2">
+                                                    <node concept="3clFbF" id="Dnjeumzcd5" role="3cqZAp">
+                                                      <node concept="2OqwBi" id="Dnjeumzcd6" role="3clFbG">
+                                                        <node concept="30H73N" id="Dnjeumzcd7" role="2Oq$k0" />
+                                                        <node concept="2qgKlT" id="Dnjeumzcd8" role="2OqNvi">
+                                                          <ref role="37wK5l" to="karh:6ASs6LmXZEr" resolve="getFlagText" />
+                                                        </node>
+                                                      </node>
+                                                    </node>
+                                                  </node>
                                                 </node>
                                               </node>
-                                              <node concept="3TrEf2" id="yuUZPu0RN$" role="2OqNvi">
-                                                <ref role="3Tt5mk" to="tpee:gyVODHa" resolve="body" />
+                                            </node>
+                                          </node>
+                                        </node>
+                                      </node>
+                                      <node concept="2tJIrI" id="Dnjeumzcd9" role="jymVt" />
+                                      <node concept="3clFb_" id="Dnjeumzcda" role="jymVt">
+                                        <property role="1EzhhJ" value="false" />
+                                        <property role="TrG5h" value="execute" />
+                                        <property role="DiZV1" value="false" />
+                                        <property role="od$2w" value="false" />
+                                        <node concept="3Tm1VV" id="Dnjeumzcdb" role="1B3o_S" />
+                                        <node concept="3cqZAl" id="Dnjeumzcdc" role="3clF45" />
+                                        <node concept="37vLTG" id="Dnjeumzcdd" role="3clF46">
+                                          <property role="TrG5h" value="pattern" />
+                                          <node concept="17QB3L" id="Dnjeumzcde" role="1tU5fm" />
+                                          <node concept="2AHcQZ" id="Dnjeumzcdf" role="2AJF6D">
+                                            <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+                                          </node>
+                                        </node>
+                                        <node concept="3clFbS" id="Dnjeumzcdg" role="3clF47">
+                                          <node concept="3clFbF" id="Dnjeumzcdh" role="3cqZAp">
+                                            <node concept="1rXfSq" id="Dnjeumzcdi" role="3clFbG">
+                                              <ref role="37wK5l" node="Dnjeumzcdl" resolve="doSubstitute" />
+                                              <node concept="37vLTw" id="Dnjeumzcdj" role="37wK5m">
+                                                <ref role="3cqZAo" node="Dnjeumzcdd" resolve="pattern" />
                                               </node>
                                             </node>
-                                            <node concept="3Tsc0h" id="yuUZPu0RN_" role="2OqNvi">
-                                              <ref role="3TtcxE" to="tpee:fzcqZ_x" resolve="statement" />
+                                          </node>
+                                        </node>
+                                        <node concept="2AHcQZ" id="Dnjeumzcdk" role="2AJF6D">
+                                          <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                                        </node>
+                                      </node>
+                                      <node concept="3clFb_" id="Dnjeumzcdl" role="jymVt">
+                                        <property role="TrG5h" value="doSubstitute" />
+                                        <node concept="37vLTG" id="Dnjeumzcdm" role="3clF46">
+                                          <property role="TrG5h" value="pattern" />
+                                          <node concept="17QB3L" id="Dnjeumzcdn" role="1tU5fm" />
+                                        </node>
+                                        <node concept="3Tqbb2" id="Dnjeumzcdo" role="3clF45" />
+                                        <node concept="3Tm1VV" id="Dnjeumzcdp" role="1B3o_S" />
+                                        <node concept="3clFbS" id="Dnjeumzcdq" role="3clF47">
+                                          <node concept="3cpWs8" id="Dnjeumzcdr" role="3cqZAp">
+                                            <node concept="3cpWsn" id="Dnjeumzcds" role="3cpWs9">
+                                              <property role="TrG5h" value="node" />
+                                              <node concept="3Tqbb2" id="Dnjeumzcdt" role="1tU5fm">
+                                                <ref role="ehGHo" to="tpck:gw2VY9q" resolve="BaseConcept" />
+                                                <node concept="1ZhdrF" id="Dnjeumzcdu" role="lGtFl">
+                                                  <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/1138055754698/1138405853777" />
+                                                  <property role="2qtEX8" value="concept" />
+                                                  <node concept="3$xsQk" id="Dnjeumzcdv" role="3$ytzL">
+                                                    <node concept="3clFbS" id="Dnjeumzcdw" role="2VODD2">
+                                                      <node concept="3clFbF" id="Dnjeumzcdx" role="3cqZAp">
+                                                        <node concept="2OqwBi" id="Dnjeumzcdy" role="3clFbG">
+                                                          <node concept="2OqwBi" id="Dnjeumzcdz" role="2Oq$k0">
+                                                            <node concept="30H73N" id="Dnjeumzcd$" role="2Oq$k0" />
+                                                            <node concept="2Xjw5R" id="Dnjeumzcd_" role="2OqNvi">
+                                                              <node concept="1xMEDy" id="DnjeumzcdA" role="1xVPHs">
+                                                                <node concept="chp4Y" id="DnjeumzcdB" role="ri$Ld">
+                                                                  <ref role="cht4Q" to="tpc2:gXXWOiD" resolve="AbstractComponent" />
+                                                                </node>
+                                                              </node>
+                                                            </node>
+                                                          </node>
+                                                          <node concept="2qgKlT" id="DnjeumzcdC" role="2OqNvi">
+                                                            <ref role="37wK5l" to="tpcb:67EYkym$wx3" resolve="getConceptDeclaration" />
+                                                          </node>
+                                                        </node>
+                                                      </node>
+                                                    </node>
+                                                  </node>
+                                                </node>
+                                              </node>
+                                              <node concept="1PxgMI" id="DnjeumzcdD" role="33vP2m">
+                                                <node concept="chp4Y" id="DnjeumzcdE" role="3oSUPX">
+                                                  <ref role="cht4Q" to="tpck:gw2VY9q" resolve="BaseConcept" />
+                                                  <node concept="1ZhdrF" id="DnjeumzcdF" role="lGtFl">
+                                                    <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/1177026924588/1177026940964" />
+                                                    <property role="2qtEX8" value="conceptDeclaration" />
+                                                    <node concept="3$xsQk" id="DnjeumzcdG" role="3$ytzL">
+                                                      <node concept="3clFbS" id="DnjeumzcdH" role="2VODD2">
+                                                        <node concept="3clFbF" id="DnjeumzcdI" role="3cqZAp">
+                                                          <node concept="2OqwBi" id="DnjeumzcdJ" role="3clFbG">
+                                                            <node concept="2OqwBi" id="DnjeumzcdK" role="2Oq$k0">
+                                                              <node concept="30H73N" id="DnjeumzcdL" role="2Oq$k0" />
+                                                              <node concept="2Xjw5R" id="DnjeumzcdM" role="2OqNvi">
+                                                                <node concept="1xMEDy" id="DnjeumzcdN" role="1xVPHs">
+                                                                  <node concept="chp4Y" id="DnjeumzcdO" role="ri$Ld">
+                                                                    <ref role="cht4Q" to="tpc2:gXXWOiD" resolve="AbstractComponent" />
+                                                                  </node>
+                                                                </node>
+                                                              </node>
+                                                            </node>
+                                                            <node concept="2qgKlT" id="DnjeumzcdP" role="2OqNvi">
+                                                              <ref role="37wK5l" to="tpcb:67EYkym$wx3" resolve="getConceptDeclaration" />
+                                                            </node>
+                                                          </node>
+                                                        </node>
+                                                      </node>
+                                                    </node>
+                                                  </node>
+                                                </node>
+                                                <node concept="2OqwBi" id="DnjeumzcdQ" role="1m5AlR">
+                                                  <node concept="2Mo9yH" id="DnjeumzcdR" role="2Oq$k0" />
+                                                  <node concept="liA8E" id="DnjeumzcdS" role="2OqNvi">
+                                                    <ref role="37wK5l" to="uddc:~TransformationMenuContext.getNode()" resolve="getNode" />
+                                                  </node>
+                                                </node>
+                                              </node>
+                                            </node>
+                                          </node>
+                                          <node concept="3cpWs8" id="DnjeumzcdT" role="3cqZAp">
+                                            <node concept="3cpWsn" id="DnjeumzcdU" role="3cpWs9">
+                                              <property role="TrG5h" value="access" />
+                                              <node concept="3uibUv" id="DnjeumzcdV" role="1tU5fm">
+                                                <ref role="3uigEE" to="czm:4AuGfbNRhNO" resolve="IFlagModelAccess" />
+                                              </node>
+                                              <node concept="2ShNRf" id="DnjeumzcdW" role="33vP2m">
+                                                <node concept="1pGfFk" id="DnjeumzcdX" role="2ShVmc">
+                                                  <ref role="37wK5l" to="czm:4AuGfbNRor$" resolve="DefaultFlagModelAccess" />
+                                                  <node concept="10Nm6u" id="DnjeumzcdY" role="37wK5m" />
+                                                </node>
+                                                <node concept="5jKBG" id="DnjeumzcdZ" role="lGtFl">
+                                                  <ref role="v9R2y" node="4AuGfbNTl2e" resolve="template_FlagCell_ModelAccess" />
+                                                </node>
+                                              </node>
+                                            </node>
+                                          </node>
+                                          <node concept="3clFbF" id="Dnjeumzce0" role="3cqZAp">
+                                            <node concept="2OqwBi" id="Dnjeumzce1" role="3clFbG">
+                                              <node concept="37vLTw" id="Dnjeumzce2" role="2Oq$k0">
+                                                <ref role="3cqZAo" node="DnjeumzcdU" resolve="access" />
+                                              </node>
+                                              <node concept="liA8E" id="Dnjeumzce3" role="2OqNvi">
+                                                <ref role="37wK5l" to="czm:4AuGfbNRhRa" resolve="write" />
+                                                <node concept="37vLTw" id="Dnjeumzce4" role="37wK5m">
+                                                  <ref role="3cqZAo" node="Dnjeumzcds" resolve="node" />
+                                                </node>
+                                                <node concept="3clFbT" id="Dnjeumzce5" role="37wK5m">
+                                                  <property role="3clFbU" value="true" />
+                                                </node>
+                                              </node>
+                                            </node>
+                                          </node>
+                                          <node concept="3clFbF" id="Dnjeumzce6" role="3cqZAp">
+                                            <node concept="2OqwBi" id="Dnjeumzce7" role="3clFbG">
+                                              <node concept="37vLTw" id="Dnjeumzce8" role="2Oq$k0">
+                                                <ref role="3cqZAo" node="Dnjeumzcds" resolve="node" />
+                                              </node>
+                                              <node concept="1OKiuA" id="Dnjeumzce9" role="2OqNvi">
+                                                <node concept="1lyA5W" id="Dnjeumzcea" role="lGT1i">
+                                                  <property role="1lUG9U" value="flag_propertyName" />
+                                                  <node concept="17Uvod" id="Dnjeumzceb" role="lGtFl">
+                                                    <property role="P4ACc" value="18bc6592-03a6-4e29-a83a-7ff23bde13ba/2162403111523059536/2162403111529391190" />
+                                                    <property role="2qtEX9" value="cellId" />
+                                                    <node concept="3zFVjK" id="Dnjeumzcec" role="3zH0cK">
+                                                      <node concept="3clFbS" id="Dnjeumzced" role="2VODD2">
+                                                        <node concept="3clFbF" id="Dnjeumzcee" role="3cqZAp">
+                                                          <node concept="3cpWs3" id="Dnjeumzcef" role="3clFbG">
+                                                            <node concept="2OqwBi" id="Dnjeumzceg" role="3uHU7w">
+                                                              <node concept="2OqwBi" id="Dnjeumzceh" role="2Oq$k0">
+                                                                <node concept="30H73N" id="Dnjeumzcei" role="2Oq$k0" />
+                                                                <node concept="3TrEf2" id="Dnjeumzcej" role="2OqNvi">
+                                                                  <ref role="3Tt5mk" to="tpc2:fBF1KQc" resolve="propertyDeclaration" />
+                                                                </node>
+                                                              </node>
+                                                              <node concept="3TrcHB" id="Dnjeumzcek" role="2OqNvi">
+                                                                <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                                                              </node>
+                                                            </node>
+                                                            <node concept="Xl_RD" id="Dnjeumzcel" role="3uHU7B">
+                                                              <property role="Xl_RC" value="flag_" />
+                                                            </node>
+                                                          </node>
+                                                        </node>
+                                                      </node>
+                                                    </node>
+                                                  </node>
+                                                </node>
+                                                <node concept="3cmrfG" id="Dnjeumzcem" role="3dN3m$">
+                                                  <property role="3cmrfH" value="-1" />
+                                                </node>
+                                                <node concept="2OqwBi" id="Dnjeumzcen" role="lBI5i">
+                                                  <node concept="2Mo9yH" id="Dnjeumzceo" role="2Oq$k0" />
+                                                  <node concept="liA8E" id="Dnjeumzcep" role="2OqNvi">
+                                                    <ref role="37wK5l" to="uddc:~TransformationMenuContext.getEditorContext()" resolve="getEditorContext" />
+                                                  </node>
+                                                </node>
+                                              </node>
+                                            </node>
+                                          </node>
+                                          <node concept="3cpWs6" id="Dnjeumzceq" role="3cqZAp">
+                                            <node concept="10Nm6u" id="Dnjeumzcer" role="3cqZAk" />
+                                          </node>
+                                        </node>
+                                      </node>
+                                      <node concept="3clFb_" id="Dnjeumzces" role="jymVt">
+                                        <property role="1EzhhJ" value="false" />
+                                        <property role="TrG5h" value="getOutputConcept" />
+                                        <property role="DiZV1" value="false" />
+                                        <property role="od$2w" value="false" />
+                                        <node concept="3uibUv" id="Dnjeumzcet" role="3clF45">
+                                          <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
+                                        </node>
+                                        <node concept="3Tm1VV" id="Dnjeumzceu" role="1B3o_S" />
+                                        <node concept="3clFbS" id="Dnjeumzcev" role="3clF47">
+                                          <node concept="3clFbF" id="Dnjeumzcew" role="3cqZAp">
+                                            <node concept="35c_gC" id="Dnjeumzcex" role="3clFbG">
+                                              <ref role="35c_gD" to="tpck:gw2VY9q" resolve="BaseConcept" />
+                                              <node concept="1ZhdrF" id="Dnjeumzcey" role="lGtFl">
+                                                <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/2644386474300074836/2644386474300074837" />
+                                                <property role="2qtEX8" value="conceptDeclaration" />
+                                                <node concept="3$xsQk" id="Dnjeumzcez" role="3$ytzL">
+                                                  <node concept="3clFbS" id="Dnjeumzce$" role="2VODD2">
+                                                    <node concept="3clFbF" id="Dnjeumzce_" role="3cqZAp">
+                                                      <node concept="2OqwBi" id="DnjeumzceA" role="3clFbG">
+                                                        <node concept="2OqwBi" id="DnjeumzceB" role="2Oq$k0">
+                                                          <node concept="30H73N" id="DnjeumzceC" role="2Oq$k0" />
+                                                          <node concept="2Xjw5R" id="DnjeumzceD" role="2OqNvi">
+                                                            <node concept="1xMEDy" id="DnjeumzceE" role="1xVPHs">
+                                                              <node concept="chp4Y" id="DnjeumzceF" role="ri$Ld">
+                                                                <ref role="cht4Q" to="tpc2:gXXWOiD" resolve="AbstractComponent" />
+                                                              </node>
+                                                            </node>
+                                                          </node>
+                                                        </node>
+                                                        <node concept="2qgKlT" id="DnjeumzceG" role="2OqNvi">
+                                                          <ref role="37wK5l" to="tpcb:67EYkym$wx3" resolve="getConceptDeclaration" />
+                                                        </node>
+                                                      </node>
+                                                    </node>
+                                                  </node>
+                                                </node>
+                                              </node>
                                             </node>
                                           </node>
                                         </node>
@@ -2396,91 +2633,50 @@
                                 </node>
                               </node>
                             </node>
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="liA8E" id="yuUZPu0RNA" role="2OqNvi">
-                        <ref role="37wK5l" node="yuUZPu0RNl" resolve="query" />
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="1W57fq" id="yuUZPu0RNB" role="lGtFl">
-                    <node concept="3IZrLx" id="yuUZPu0RNC" role="3IZSJc">
-                      <node concept="3clFbS" id="yuUZPu0RND" role="2VODD2">
-                        <node concept="3clFbF" id="yuUZPu0RNE" role="3cqZAp">
-                          <node concept="2OqwBi" id="yuUZPu0RNF" role="3clFbG">
-                            <node concept="2OqwBi" id="yuUZPu0RNG" role="2Oq$k0">
-                              <node concept="30H73N" id="yuUZPu0RNH" role="2Oq$k0" />
-                              <node concept="3TrEf2" id="yuUZPu4e_c" role="2OqNvi">
-                                <ref role="3Tt5mk" to="teg0:yuUZPu3Zn9" resolve="sideTransformCondition" />
+                            <node concept="3clFbF" id="DnjeumzceH" role="3cqZAp">
+                              <node concept="2OqwBi" id="DnjeumzceI" role="3clFbG">
+                                <node concept="37vLTw" id="DnjeumzceJ" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="Dnjeumzcbb" resolve="result" />
+                                </node>
+                                <node concept="TSZUe" id="DnjeumzceK" role="2OqNvi">
+                                  <node concept="37vLTw" id="DnjeumzceL" role="25WWJ7">
+                                    <ref role="3cqZAo" node="DnjeumzccF" resolve="item" />
+                                  </node>
+                                </node>
                               </node>
                             </node>
-                            <node concept="3x8VRR" id="yuUZPu0RNJ" role="2OqNvi" />
+                          </node>
+                          <node concept="37vLTw" id="DnjeumzceM" role="3clFbw">
+                            <ref role="3cqZAo" node="Dnjeumzcbi" resolve="isApplicable" />
+                          </node>
+                        </node>
+                        <node concept="3clFbF" id="DnjeumzceN" role="3cqZAp">
+                          <node concept="37vLTw" id="DnjeumzceO" role="3clFbG">
+                            <ref role="3cqZAo" node="Dnjeumzcbb" resolve="result" />
                           </node>
                         </node>
                       </node>
                     </node>
                   </node>
+                  <node concept="2v6KxM" id="DnjeumzceP" role="1Qtc8$" />
                 </node>
-                <node concept="3clFbF" id="4chWjC2NYCl" role="3cqZAp">
-                  <node concept="3vZ8ra" id="4chWjC2NZrE" role="3clFbG">
-                    <node concept="22lmx$" id="4chWjC39z_R" role="37vLTx">
-                      <node concept="3y3z36" id="4chWjC39FeO" role="3uHU7w">
-                        <node concept="2OqwBi" id="4chWjC39$NV" role="3uHU7B">
-                          <node concept="2kS8pE" id="4chWjC39$dT" role="2Oq$k0" />
-                          <node concept="liA8E" id="4chWjC39CF3" role="2OqNvi">
-                            <ref role="37wK5l" to="uddc:~TransformationMenuContext.getMenuLocation()" resolve="getMenuLocation" />
+                <node concept="17Uvod" id="Dnjeun6$bI" role="lGtFl">
+                  <property role="2qtEX9" value="description" />
+                  <property role="P4ACc" value="9d69e719-78c8-4286-90db-fb19c107d049/745148820867185554/745148820908747612" />
+                  <node concept="3zFVjK" id="Dnjeun6$bJ" role="3zH0cK">
+                    <node concept="3clFbS" id="Dnjeun6$bK" role="2VODD2">
+                      <node concept="3clFbF" id="Dnjeun6_wN" role="3cqZAp">
+                        <node concept="3cpWs3" id="Dnjeun6_Z9" role="3clFbG">
+                          <node concept="Xl_RD" id="Dnjeun6_Qa" role="3uHU7w">
+                            <property role="Xl_RC" value="'" />
                           </node>
-                        </node>
-                        <node concept="10M0yZ" id="4chWjC39EEW" role="3uHU7w">
-                          <ref role="3cqZAo" to="9eyi:~MenuLocations.RIGHT_SIDE_TRANSFORM" resolve="RIGHT_SIDE_TRANSFORM" />
-                          <ref role="1PxDUh" to="9eyi:~MenuLocations" resolve="MenuLocations" />
-                        </node>
-                      </node>
-                      <node concept="3fqX7Q" id="1DVF61P5p1t" role="3uHU7B">
-                        <node concept="2YIFZM" id="1DVF61P5p1v" role="3fr31v">
-                          <ref role="37wK5l" to="czm:1DVF61P3qzQ" resolve="isProperty" />
-                          <ref role="1Pybhc" to="czm:RbLMy696h3" resolve="GrammarCellsUtil" />
-                          <node concept="2OqwBi" id="1DVF61P5p1w" role="37wK5m">
-                            <node concept="2OqwBi" id="1DVF61P5p1x" role="2Oq$k0">
-                              <node concept="2kS8pE" id="1DVF61P5p1y" role="2Oq$k0" />
-                              <node concept="liA8E" id="1DVF61P5p1z" role="2OqNvi">
-                                <ref role="37wK5l" to="uddc:~TransformationMenuContext.getEditorContext()" resolve="getEditorContext" />
-                              </node>
+                          <node concept="3cpWs3" id="Dnjeun6_Q2" role="3uHU7B">
+                            <node concept="Xl_RD" id="Dnjeun6_Q8" role="3uHU7B">
+                              <property role="Xl_RC" value="flag '" />
                             </node>
-                            <node concept="liA8E" id="1DVF61P5p1$" role="2OqNvi">
-                              <ref role="37wK5l" to="cj4x:~EditorContext.getSelectedCell()" resolve="getSelectedCell" />
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="37vLTw" id="4chWjC2NYCj" role="37vLTJ">
-                      <ref role="3cqZAo" node="yuUZPu0QDz" resolve="applicable" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="3clFbF" id="4JqtTEfj$nh" role="3cqZAp">
-                  <node concept="37vLTw" id="yuUZPu0QDJ" role="3clFbG">
-                    <ref role="3cqZAo" node="yuUZPu0QDz" resolve="applicable" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="1eYWSL" id="4JqtTEfjsf2" role="1eYxyj">
-              <node concept="3clFbS" id="4JqtTEfjsf4" role="2VODD2">
-                <node concept="3clFbF" id="4JqtTEfj_0V" role="3cqZAp">
-                  <node concept="Xl_RD" id="4JqtTEfj__I" role="3clFbG">
-                    <property role="Xl_RC" value="flagText" />
-                    <node concept="17Uvod" id="4JqtTEfj__J" role="lGtFl">
-                      <property role="P4ACc" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1070475926800/1070475926801" />
-                      <property role="2qtEX9" value="value" />
-                      <node concept="3zFVjK" id="4JqtTEfj__K" role="3zH0cK">
-                        <node concept="3clFbS" id="4JqtTEfj__L" role="2VODD2">
-                          <node concept="3clFbF" id="4JqtTEfj__M" role="3cqZAp">
-                            <node concept="2OqwBi" id="4JqtTEfj__N" role="3clFbG">
-                              <node concept="30H73N" id="4JqtTEfj__O" role="2Oq$k0" />
-                              <node concept="2qgKlT" id="4JqtTEfj__P" role="2OqNvi">
+                            <node concept="2OqwBi" id="Dnjeun6Azs" role="3uHU7w">
+                              <node concept="30H73N" id="Dnjeun6A40" role="2Oq$k0" />
+                              <node concept="2qgKlT" id="Dnjeun6Bhl" role="2OqNvi">
                                 <ref role="37wK5l" to="karh:6ASs6LmXZEr" resolve="getFlagText" />
                               </node>
                             </node>
@@ -2492,7 +2688,6 @@
                 </node>
               </node>
             </node>
-            <node concept="raruj" id="4JqtTEfjFz4" role="lGtFl" />
           </node>
         </node>
       </node>
@@ -2501,204 +2696,34 @@
       <ref role="30HIoZ" to="teg0:4qdNcHzYfBo" resolve="OptionalCell" />
       <node concept="1Koe21" id="4qdNcHzYX1w" role="1lVwrX">
         <node concept="3EZMnI" id="6jH9yJK4DYM" role="1Koe22">
-          <node concept="1eYWM2" id="4eBi5gdnESW" role="3EZMnx">
-            <node concept="1eYxTg" id="4eBi5gdnESY" role="1eYxTh">
-              <node concept="3clFbS" id="4eBi5gdnET0" role="2VODD2">
-                <node concept="3cpWs8" id="4eBi5gdo1Sl" role="3cqZAp">
-                  <node concept="3cpWsn" id="4eBi5gdo1Sm" role="3cpWs9">
-                    <property role="TrG5h" value="sourceNode" />
-                    <property role="3TUv4t" value="true" />
-                    <node concept="3Tqbb2" id="4eBi5gdo1Sn" role="1tU5fm" />
-                    <node concept="2OqwBi" id="4eBi5gdo1So" role="33vP2m">
-                      <node concept="2kS8pE" id="4eBi5gdoB2_" role="2Oq$k0" />
-                      <node concept="liA8E" id="4eBi5gdo1Sq" role="2OqNvi">
-                        <ref role="37wK5l" to="uddc:~TransformationMenuContext.getNode()" resolve="getNode" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="3cpWs8" id="65e5JdYKlui" role="3cqZAp">
-                  <node concept="3cpWsn" id="65e5JdYKluj" role="3cpWs9">
-                    <property role="TrG5h" value="result" />
-                    <node concept="3Tqbb2" id="65e5JdYKltU" role="1tU5fm">
-                      <ref role="ehGHo" to="tpee:fz3vP1J" resolve="Expression" />
-                    </node>
-                    <node concept="2OqwBi" id="65e5JdYKluk" role="33vP2m">
-                      <node concept="2OqwBi" id="65e5JdYKlul" role="2Oq$k0">
-                        <node concept="1PxgMI" id="65e5JdYKlum" role="2Oq$k0">
-                          <node concept="chp4Y" id="1SbcsM_INTT" role="3oSUPX">
-                            <ref role="cht4Q" to="tpck:gw2VY9q" resolve="BaseConcept" />
-                            <node concept="1ZhdrF" id="65e5JdYKluo" role="lGtFl">
-                              <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/1177026924588/1177026940964" />
-                              <property role="2qtEX8" value="conceptDeclaration" />
-                              <node concept="3$xsQk" id="65e5JdYKlup" role="3$ytzL">
-                                <node concept="3clFbS" id="65e5JdYKluq" role="2VODD2">
-                                  <node concept="3clFbF" id="65e5JdYKlur" role="3cqZAp">
-                                    <node concept="2OqwBi" id="65e5JdYKlus" role="3clFbG">
-                                      <node concept="2OqwBi" id="65e5JdYKlut" role="2Oq$k0">
-                                        <node concept="30H73N" id="65e5JdYKluu" role="2Oq$k0" />
-                                        <node concept="2Xjw5R" id="65e5JdYKluv" role="2OqNvi">
-                                          <node concept="1xMEDy" id="65e5JdYKluw" role="1xVPHs">
-                                            <node concept="chp4Y" id="65e5JdYKlux" role="ri$Ld">
-                                              <ref role="cht4Q" to="tpc2:gXXWOiD" resolve="AbstractComponent" />
-                                            </node>
-                                          </node>
-                                        </node>
-                                      </node>
-                                      <node concept="2qgKlT" id="65e5JdYKluy" role="2OqNvi">
-                                        <ref role="37wK5l" to="tpcb:67EYkym$wx3" resolve="getConceptDeclaration" />
-                                      </node>
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                          <node concept="37vLTw" id="65e5JdYKlun" role="1m5AlR">
-                            <ref role="3cqZAo" node="4eBi5gdo1Sm" resolve="sourceNode" />
-                          </node>
-                        </node>
-                        <node concept="3TrEf2" id="65e5JdYKluz" role="2OqNvi">
-                          <ref role="3Tt5mk" to="tpee:fz3vP1I" resolve="initializer" />
-                          <node concept="1ZhdrF" id="65e5JdYKlu$" role="lGtFl">
-                            <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/1138056143562/1138056516764" />
-                            <property role="2qtEX8" value="link" />
-                            <node concept="3$xsQk" id="65e5JdYKlu_" role="3$ytzL">
-                              <node concept="3clFbS" id="65e5JdYKluA" role="2VODD2">
-                                <node concept="3clFbF" id="65e5JdYKluB" role="3cqZAp">
-                                  <node concept="2OqwBi" id="65e5JdYKluC" role="3clFbG">
-                                    <node concept="1PxgMI" id="65e5JdYKluD" role="2Oq$k0">
-                                      <node concept="chp4Y" id="1SbcsM_INUa" role="3oSUPX">
-                                        <ref role="cht4Q" to="tpc2:fBF1sR7" resolve="CellModel_RefNode" />
-                                      </node>
-                                      <node concept="2OqwBi" id="65e5JdYKluE" role="1m5AlR">
-                                        <node concept="30H73N" id="65e5JdYKluF" role="2Oq$k0" />
-                                        <node concept="2qgKlT" id="65e5JdYKluG" role="2OqNvi">
-                                          <ref role="37wK5l" to="karh:7KznU_3XzU4" resolve="getFirstNonConst" />
-                                        </node>
-                                      </node>
-                                    </node>
-                                    <node concept="3TrEf2" id="65e5JdYKluH" role="2OqNvi">
-                                      <ref role="3Tt5mk" to="tpc2:fBF1sR8" resolve="linkDeclaration" />
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="2DeJnY" id="65e5JdYKluI" role="2OqNvi" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="3clFbF" id="65e5JdYJPWL" role="3cqZAp">
-                  <node concept="2OqwBi" id="65e5JdYKjQS" role="3clFbG">
-                    <node concept="2ShNRf" id="65e5JdYJPWH" role="2Oq$k0">
-                      <node concept="YeOm9" id="65e5JdYKfNn" role="2ShVmc">
-                        <node concept="1Y3b0j" id="65e5JdYKfNq" role="YeSDq">
-                          <property role="2bfB8j" value="true" />
-                          <ref role="1Y3XeK" to="wyt6:~Object" resolve="Object" />
-                          <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
-                          <node concept="3Tm1VV" id="65e5JdYKfNr" role="1B3o_S" />
-                          <node concept="3clFb_" id="65e5JdYKgNe" role="jymVt">
-                            <property role="TrG5h" value="postprocess" />
-                            <node concept="37vLTG" id="65e5JdYKjfR" role="3clF46">
-                              <property role="TrG5h" value="node" />
-                              <node concept="3Tqbb2" id="65e5JdYKjJu" role="1tU5fm" />
-                            </node>
-                            <node concept="3cqZAl" id="65e5JdYKgNg" role="3clF45" />
-                            <node concept="3Tm1VV" id="65e5JdYKgNh" role="1B3o_S" />
-                            <node concept="3clFbS" id="65e5JdYKgNi" role="3clF47">
-                              <node concept="3clFbH" id="65e5JdYKxQX" role="3cqZAp">
-                                <node concept="2b32R4" id="65e5JdYKxV8" role="lGtFl">
-                                  <node concept="3JmXsc" id="65e5JdYKxVa" role="2P8S$">
-                                    <node concept="3clFbS" id="65e5JdYKxVc" role="2VODD2">
-                                      <node concept="3clFbF" id="65e5JdYKy2b" role="3cqZAp">
-                                        <node concept="2OqwBi" id="65e5JdYK$Bf" role="3clFbG">
-                                          <node concept="2OqwBi" id="65e5JdYKzvw" role="2Oq$k0">
-                                            <node concept="2OqwBi" id="65e5JdYKyiM" role="2Oq$k0">
-                                              <node concept="30H73N" id="65e5JdYKy2a" role="2Oq$k0" />
-                                              <node concept="3TrEf2" id="65e5JdYKyS6" role="2OqNvi">
-                                                <ref role="3Tt5mk" to="teg0:65e5JdYJiFg" resolve="postprocess" />
-                                              </node>
-                                            </node>
-                                            <node concept="3TrEf2" id="65e5JdYKzVa" role="2OqNvi">
-                                              <ref role="3Tt5mk" to="tpee:gyVODHa" resolve="body" />
-                                            </node>
-                                          </node>
-                                          <node concept="3Tsc0h" id="65e5JdYK_hb" role="2OqNvi">
-                                            <ref role="3TtcxE" to="tpee:fzcqZ_x" resolve="statement" />
-                                          </node>
-                                        </node>
-                                      </node>
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="liA8E" id="65e5JdYKkh7" role="2OqNvi">
-                      <ref role="37wK5l" node="65e5JdYKgNe" resolve="postprocess" />
-                      <node concept="37vLTw" id="65e5JdYKkMZ" role="37wK5m">
-                        <ref role="3cqZAo" node="4eBi5gdo1Sm" resolve="sourceNode" />
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="1W57fq" id="65e5JdYKAor" role="lGtFl">
-                    <node concept="3IZrLx" id="65e5JdYKAot" role="3IZSJc">
-                      <node concept="3clFbS" id="65e5JdYKAov" role="2VODD2">
-                        <node concept="3clFbF" id="65e5JdYKBsk" role="3cqZAp">
-                          <node concept="2OqwBi" id="65e5JdYKEuX" role="3clFbG">
-                            <node concept="2OqwBi" id="65e5JdYKBWy" role="2Oq$k0">
-                              <node concept="30H73N" id="65e5JdYKBsj" role="2Oq$k0" />
-                              <node concept="3TrEf2" id="65e5JdYKDfv" role="2OqNvi">
-                                <ref role="3Tt5mk" to="teg0:65e5JdYJiFg" resolve="postprocess" />
-                              </node>
-                            </node>
-                            <node concept="3x8VRR" id="65e5JdYKFp8" role="2OqNvi" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="3clFbF" id="4eBi5gdo1U3" role="3cqZAp">
-                  <node concept="37vLTw" id="65e5JdYKluJ" role="3clFbG">
-                    <ref role="3cqZAo" node="65e5JdYKluj" resolve="result" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="1eYwpX" id="4eBi5gdnET2" role="1eYxym">
-              <node concept="3clFbS" id="4eBi5gdnET4" role="2VODD2">
-                <node concept="3clFbF" id="4eBi5gdoMrk" role="3cqZAp">
-                  <node concept="2OqwBi" id="4eBi5gdo1SE" role="3clFbG">
-                    <node concept="2OqwBi" id="4eBi5gdo1SF" role="2Oq$k0">
-                      <node concept="1PxgMI" id="6rhOS_xvphU" role="2Oq$k0">
-                        <node concept="chp4Y" id="1SbcsM_INU4" role="3oSUPX">
+          <node concept="1QoScp" id="5fS8LroE5zX" role="3EZMnx">
+            <property role="1QpmdY" value="true" />
+            <node concept="pkWqt" id="5fS8LroE5$0" role="3e4ffs">
+              <node concept="3clFbS" id="5fS8LroE5$2" role="2VODD2">
+                <node concept="3clFbF" id="5fS8LroE9gJ" role="3cqZAp">
+                  <node concept="2OqwBi" id="5fS8LroE9gK" role="3clFbG">
+                    <node concept="2OqwBi" id="5fS8LroE9gL" role="2Oq$k0">
+                      <node concept="1PxgMI" id="5fS8LroE9gM" role="2Oq$k0">
+                        <node concept="chp4Y" id="5fS8LroE9gN" role="3oSUPX">
                           <ref role="cht4Q" to="tpck:gw2VY9q" resolve="BaseConcept" />
-                          <node concept="1ZhdrF" id="6rhOS_xvpIF" role="lGtFl">
+                          <node concept="1ZhdrF" id="5fS8LroE9gO" role="lGtFl">
                             <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/1177026924588/1177026940964" />
                             <property role="2qtEX8" value="conceptDeclaration" />
-                            <node concept="3$xsQk" id="6rhOS_xvpIG" role="3$ytzL">
-                              <node concept="3clFbS" id="6rhOS_xvpIH" role="2VODD2">
-                                <node concept="3clFbF" id="6rhOS_xvq0H" role="3cqZAp">
-                                  <node concept="2OqwBi" id="6rhOS_xvq0I" role="3clFbG">
-                                    <node concept="2OqwBi" id="6rhOS_xvq0J" role="2Oq$k0">
-                                      <node concept="30H73N" id="6rhOS_xvq0K" role="2Oq$k0" />
-                                      <node concept="2Xjw5R" id="6rhOS_xvq0L" role="2OqNvi">
-                                        <node concept="1xMEDy" id="6rhOS_xvq0M" role="1xVPHs">
-                                          <node concept="chp4Y" id="6rhOS_xvq0N" role="ri$Ld">
+                            <node concept="3$xsQk" id="5fS8LroE9gP" role="3$ytzL">
+                              <node concept="3clFbS" id="5fS8LroE9gQ" role="2VODD2">
+                                <node concept="3clFbF" id="5fS8LroE9gR" role="3cqZAp">
+                                  <node concept="2OqwBi" id="5fS8LroE9gS" role="3clFbG">
+                                    <node concept="2OqwBi" id="5fS8LroE9gT" role="2Oq$k0">
+                                      <node concept="30H73N" id="5fS8LroE9gU" role="2Oq$k0" />
+                                      <node concept="2Xjw5R" id="5fS8LroE9gV" role="2OqNvi">
+                                        <node concept="1xMEDy" id="5fS8LroE9gW" role="1xVPHs">
+                                          <node concept="chp4Y" id="5fS8LroE9gX" role="ri$Ld">
                                             <ref role="cht4Q" to="tpc2:gXXWOiD" resolve="AbstractComponent" />
                                           </node>
                                         </node>
                                       </node>
                                     </node>
-                                    <node concept="2qgKlT" id="6rhOS_xvq0O" role="2OqNvi">
+                                    <node concept="2qgKlT" id="5fS8LroE9gY" role="2OqNvi">
                                       <ref role="37wK5l" to="tpcb:67EYkym$wx3" resolve="getConceptDeclaration" />
                                     </node>
                                   </node>
@@ -2707,34 +2732,29 @@
                             </node>
                           </node>
                         </node>
-                        <node concept="2OqwBi" id="4eBi5gdoLY_" role="1m5AlR">
-                          <node concept="2kS8pE" id="4eBi5gdoLYA" role="2Oq$k0" />
-                          <node concept="liA8E" id="4eBi5gdoLYB" role="2OqNvi">
-                            <ref role="37wK5l" to="uddc:~TransformationMenuContext.getNode()" resolve="getNode" />
-                          </node>
-                        </node>
+                        <node concept="pncrf" id="5fS8LroEaum" role="1m5AlR" />
                       </node>
-                      <node concept="3TrEf2" id="4eBi5gdo1SH" role="2OqNvi">
+                      <node concept="3TrEf2" id="5fS8LroE9h2" role="2OqNvi">
                         <ref role="3Tt5mk" to="tpee:fz3vP1I" resolve="initializer" />
-                        <node concept="1ZhdrF" id="4eBi5gdo1SI" role="lGtFl">
+                        <node concept="1ZhdrF" id="5fS8LroE9h3" role="lGtFl">
                           <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/1138056143562/1138056516764" />
                           <property role="2qtEX8" value="link" />
-                          <node concept="3$xsQk" id="4eBi5gdo1SJ" role="3$ytzL">
-                            <node concept="3clFbS" id="4eBi5gdo1SK" role="2VODD2">
-                              <node concept="3clFbF" id="4eBi5gdo1SL" role="3cqZAp">
-                                <node concept="2OqwBi" id="4eBi5gdo1SM" role="3clFbG">
-                                  <node concept="1PxgMI" id="4eBi5gdo1SN" role="2Oq$k0">
-                                    <node concept="chp4Y" id="1SbcsM_INTb" role="3oSUPX">
+                          <node concept="3$xsQk" id="5fS8LroE9h4" role="3$ytzL">
+                            <node concept="3clFbS" id="5fS8LroE9h5" role="2VODD2">
+                              <node concept="3clFbF" id="5fS8LroE9h6" role="3cqZAp">
+                                <node concept="2OqwBi" id="5fS8LroE9h7" role="3clFbG">
+                                  <node concept="1PxgMI" id="5fS8LroE9h8" role="2Oq$k0">
+                                    <node concept="chp4Y" id="5fS8LroE9h9" role="3oSUPX">
                                       <ref role="cht4Q" to="tpc2:fBF1sR7" resolve="CellModel_RefNode" />
                                     </node>
-                                    <node concept="2OqwBi" id="4eBi5gdoLxX" role="1m5AlR">
-                                      <node concept="30H73N" id="4eBi5gdoLqA" role="2Oq$k0" />
-                                      <node concept="2qgKlT" id="4eBi5gdoLQd" role="2OqNvi">
+                                    <node concept="2OqwBi" id="5fS8LroE9ha" role="1m5AlR">
+                                      <node concept="30H73N" id="5fS8LroE9hb" role="2Oq$k0" />
+                                      <node concept="2qgKlT" id="5fS8LroE9hc" role="2OqNvi">
                                         <ref role="37wK5l" to="karh:7KznU_3XzU4" resolve="getFirstNonConst" />
                                       </node>
                                     </node>
                                   </node>
-                                  <node concept="3TrEf2" id="4eBi5gdo1SR" role="2OqNvi">
+                                  <node concept="3TrEf2" id="5fS8LroE9hd" role="2OqNvi">
                                     <ref role="3Tt5mk" to="tpc2:fBF1sR8" resolve="linkDeclaration" />
                                   </node>
                                 </node>
@@ -2744,397 +2764,796 @@
                         </node>
                       </node>
                     </node>
-                    <node concept="3w_OXm" id="4eBi5gdoMAt" role="2OqNvi" />
+                    <node concept="3x8VRR" id="5fS8LroEb0o" role="2OqNvi" />
                   </node>
                 </node>
               </node>
             </node>
-            <node concept="1eYWSL" id="4eBi5gdnET6" role="1eYxyj">
-              <node concept="3clFbS" id="4eBi5gdnET8" role="2VODD2">
-                <node concept="3clFbF" id="4eBi5gdnSAm" role="3cqZAp">
-                  <node concept="Xl_RD" id="4eBi5gdnSAl" role="3clFbG">
-                    <property role="Xl_RC" value="" />
-                    <node concept="1sPUBX" id="4eBi5gdnUz0" role="lGtFl">
-                      <ref role="v9R2y" node="2uT2PLn1V4k" resolve="switch_constantTextSequence" />
-                      <node concept="3NFfHV" id="4eBi5gdqcZ1" role="1sPUBK">
-                        <node concept="3clFbS" id="4eBi5gdqcZ2" role="2VODD2">
-                          <node concept="3clFbF" id="4eBi5gdqd5v" role="3cqZAp">
-                            <node concept="2OqwBi" id="4eBi5gdqdaJ" role="3clFbG">
-                              <node concept="30H73N" id="4eBi5gdqd5u" role="2Oq$k0" />
-                              <node concept="2qgKlT" id="4eBi5gdqdsT" role="2OqNvi">
-                                <ref role="37wK5l" to="karh:7KznU_45kn7" resolve="getTransformationText" />
+            <node concept="2uKrtP" id="5fS8LroEePh" role="1QoVPY">
+              <property role="2thAuV" value="o" />
+              <node concept="1Qtc8_" id="5fS8LroEePi" role="2vkWV5">
+                <node concept="2v6KxM" id="5fS8LroEePk" role="1Qtc8$" />
+                <node concept="2MBE2L" id="5fS8LroEqrZ" role="1Qtc8A">
+                  <node concept="2Mo9yg" id="5fS8LroEqs0" role="2MvauM">
+                    <node concept="3clFbS" id="5fS8LroEqs1" role="2VODD2">
+                      <node concept="3cpWs8" id="5fS8LroEvbr" role="3cqZAp">
+                        <node concept="3cpWsn" id="5fS8LroEvbu" role="3cpWs9">
+                          <property role="TrG5h" value="result" />
+                          <node concept="_YKpA" id="5fS8LroEvbn" role="1tU5fm">
+                            <node concept="3uibUv" id="5fS8LroEwFv" role="_ZDj9">
+                              <ref role="3uigEE" to="uddc:~TransformationMenuItem" resolve="TransformationMenuItem" />
+                            </node>
+                          </node>
+                          <node concept="2ShNRf" id="5fS8LroE$n_" role="33vP2m">
+                            <node concept="Tc6Ow" id="5fS8LroE$m0" role="2ShVmc">
+                              <node concept="3uibUv" id="5fS8LroE$m1" role="HW$YZ">
+                                <ref role="3uigEE" to="uddc:~TransformationMenuItem" resolve="TransformationMenuItem" />
                               </node>
                             </node>
                           </node>
                         </node>
                       </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="raruj" id="4eBi5gdnUuP" role="lGtFl" />
-          </node>
-          <node concept="130CD5" id="5V9BP5IUIfZ" role="3EZMnx">
-            <node concept="130t_x" id="5V9BP5IUIX7" role="130p63">
-              <property role="1hAc7j" value="7P1WhNABvta/backspace_action_id" />
-              <node concept="130t_S" id="5V9BP5IUIX8" role="130oVf">
-                <node concept="3clFbS" id="5V9BP5IUIX9" role="2VODD2">
-                  <node concept="3cpWs8" id="5V9BP5IUJYw" role="3cqZAp">
-                    <node concept="3cpWsn" id="5V9BP5IUJYx" role="3cpWs9">
-                      <property role="TrG5h" value="caretPosition" />
-                      <node concept="3uibUv" id="5V9BP5IUJYy" role="1tU5fm">
-                        <ref role="3uigEE" to="czm:1xDazL6RYY7" resolve="SavedCaretPosition" />
-                      </node>
-                      <node concept="2ShNRf" id="5V9BP5IUK1N" role="33vP2m">
-                        <node concept="1pGfFk" id="5V9BP5IV0hR" role="2ShVmc">
-                          <ref role="37wK5l" to="czm:3NNwv8WqPSm" resolve="SavedCaretPosition" />
-                          <node concept="1XNTG" id="5V9BP5IV0i8" role="37wK5m" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3clFbF" id="5V9BP5IV0lw" role="3cqZAp">
-                    <node concept="2OqwBi" id="5V9BP5IV0no" role="3clFbG">
-                      <node concept="37vLTw" id="5V9BP5IV0lu" role="2Oq$k0">
-                        <ref role="3cqZAo" node="5V9BP5IUJYx" resolve="caretPosition" />
-                      </node>
-                      <node concept="liA8E" id="5V9BP5IV0ra" role="2OqNvi">
-                        <ref role="37wK5l" to="czm:76BPPvEi375" resolve="save" />
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3clFbF" id="5V9BP5IUIZg" role="3cqZAp">
-                    <node concept="2OqwBi" id="5V9BP5IUJIm" role="3clFbG">
-                      <node concept="2OqwBi" id="5V9BP5IUJa4" role="2Oq$k0">
-                        <node concept="130tyv" id="5V9BP5IUIZf" role="2Oq$k0" />
-                        <node concept="3TrEf2" id="5V9BP5IUJra" role="2OqNvi">
-                          <ref role="3Tt5mk" to="tpee:fz3vP1I" resolve="initializer" />
-                          <node concept="1ZhdrF" id="5V9BP5IV0UP" role="lGtFl">
-                            <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/1138056143562/1138056516764" />
-                            <property role="2qtEX8" value="link" />
-                            <node concept="3$xsQk" id="5V9BP5IV0UQ" role="3$ytzL">
-                              <node concept="3clFbS" id="5V9BP5IV0UR" role="2VODD2">
-                                <node concept="3clFbF" id="5V9BP5IV14Y" role="3cqZAp">
-                                  <node concept="2OqwBi" id="5V9BP5IV1R8" role="3clFbG">
-                                    <node concept="1PxgMI" id="5V9BP5IV1Bu" role="2Oq$k0">
-                                      <node concept="chp4Y" id="1SbcsM_INT9" role="3oSUPX">
-                                        <ref role="cht4Q" to="tpc2:fBF1sR7" resolve="CellModel_RefNode" />
-                                      </node>
-                                      <node concept="2OqwBi" id="5V9BP5IV1ao" role="1m5AlR">
-                                        <node concept="30H73N" id="5V9BP5IV14X" role="2Oq$k0" />
-                                        <node concept="2qgKlT" id="5V9BP5IV1wx" role="2OqNvi">
-                                          <ref role="37wK5l" to="karh:7KznU_3XzU4" resolve="getFirstNonConst" />
-                                        </node>
-                                      </node>
-                                    </node>
-                                    <node concept="3TrEf2" id="5V9BP5IV28t" role="2OqNvi">
-                                      <ref role="3Tt5mk" to="tpc2:fBF1sR8" resolve="linkDeclaration" />
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
+                      <node concept="3cpWs8" id="czMm1Gg3Ja" role="3cqZAp">
+                        <node concept="3cpWsn" id="czMm1Gg3Jd" role="3cpWs9">
+                          <property role="TrG5h" value="sourceNode" />
+                          <property role="3TUv4t" value="true" />
+                          <node concept="3Tqbb2" id="czMm1Gg3J8" role="1tU5fm" />
+                          <node concept="2OqwBi" id="czMm1Gg81S" role="33vP2m">
+                            <node concept="2Mo9yH" id="czMm1Gg77p" role="2Oq$k0" />
+                            <node concept="liA8E" id="czMm1Gg9gp" role="2OqNvi">
+                              <ref role="37wK5l" to="uddc:~TransformationMenuContext.getNode()" resolve="getNode" />
                             </node>
                           </node>
                         </node>
                       </node>
-                      <node concept="3YRAZt" id="5V9BP5IUJQT" role="2OqNvi" />
-                    </node>
-                  </node>
-                  <node concept="3clFbF" id="5V9BP5IV0uX" role="3cqZAp">
-                    <node concept="2OqwBi" id="5V9BP5IV0xi" role="3clFbG">
-                      <node concept="1XNTG" id="5V9BP5IV0uV" role="2Oq$k0" />
-                      <node concept="liA8E" id="5V9BP5IV0$e" role="2OqNvi">
-                        <ref role="37wK5l" to="cj4x:~EditorContext.flushEvents()" resolve="flushEvents" />
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3clFbF" id="5V9BP5IV0Ct" role="3cqZAp">
-                    <node concept="2OqwBi" id="5V9BP5IV0GO" role="3clFbG">
-                      <node concept="37vLTw" id="5V9BP5IV0Cr" role="2Oq$k0">
-                        <ref role="3cqZAo" node="5V9BP5IUJYx" resolve="caretPosition" />
-                      </node>
-                      <node concept="liA8E" id="5V9BP5IV0L1" role="2OqNvi">
-                        <ref role="37wK5l" to="czm:3NNwv8W$qrW" resolve="restore" />
-                        <node concept="3clFbT" id="5V9BP5IVdBW" role="37wK5m">
-                          <property role="3clFbU" value="true" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="130t_x" id="5V9BP5IVdC_" role="130p63">
-              <property role="1hAc7j" value="g_hAxAO/delete_action_id" />
-              <node concept="130t_S" id="5V9BP5IVdCA" role="130oVf">
-                <node concept="3clFbS" id="5V9BP5IVdCB" role="2VODD2">
-                  <node concept="3cpWs8" id="5V9BP5IVdCC" role="3cqZAp">
-                    <node concept="3cpWsn" id="5V9BP5IVdCD" role="3cpWs9">
-                      <property role="TrG5h" value="caretPosition" />
-                      <node concept="3uibUv" id="5V9BP5IVdCE" role="1tU5fm">
-                        <ref role="3uigEE" to="czm:1xDazL6RYY7" resolve="SavedCaretPosition" />
-                      </node>
-                      <node concept="2ShNRf" id="5V9BP5IVdCF" role="33vP2m">
-                        <node concept="1pGfFk" id="5V9BP5IVdCG" role="2ShVmc">
-                          <ref role="37wK5l" to="czm:3NNwv8WqPSm" resolve="SavedCaretPosition" />
-                          <node concept="1XNTG" id="5V9BP5IVdCH" role="37wK5m" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3clFbF" id="5V9BP5IVdCI" role="3cqZAp">
-                    <node concept="2OqwBi" id="5V9BP5IVdCJ" role="3clFbG">
-                      <node concept="37vLTw" id="5V9BP5IVdCK" role="2Oq$k0">
-                        <ref role="3cqZAo" node="5V9BP5IVdCD" resolve="caretPosition" />
-                      </node>
-                      <node concept="liA8E" id="5V9BP5IVdCL" role="2OqNvi">
-                        <ref role="37wK5l" to="czm:76BPPvEi375" resolve="save" />
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3clFbF" id="5V9BP5IVdCM" role="3cqZAp">
-                    <node concept="2OqwBi" id="5V9BP5IVdCN" role="3clFbG">
-                      <node concept="2OqwBi" id="5V9BP5IVdCO" role="2Oq$k0">
-                        <node concept="130tyv" id="5V9BP5IVdCP" role="2Oq$k0" />
-                        <node concept="3TrEf2" id="5V9BP5IVdCQ" role="2OqNvi">
-                          <ref role="3Tt5mk" to="tpee:fz3vP1I" resolve="initializer" />
-                          <node concept="1ZhdrF" id="5V9BP5IVdCR" role="lGtFl">
-                            <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/1138056143562/1138056516764" />
-                            <property role="2qtEX8" value="link" />
-                            <node concept="3$xsQk" id="5V9BP5IVdCS" role="3$ytzL">
-                              <node concept="3clFbS" id="5V9BP5IVdCT" role="2VODD2">
-                                <node concept="3clFbF" id="5V9BP5IVdCU" role="3cqZAp">
-                                  <node concept="2OqwBi" id="5V9BP5IVdCV" role="3clFbG">
-                                    <node concept="1PxgMI" id="5V9BP5IVdCW" role="2Oq$k0">
-                                      <node concept="chp4Y" id="1SbcsM_INT5" role="3oSUPX">
-                                        <ref role="cht4Q" to="tpc2:fBF1sR7" resolve="CellModel_RefNode" />
-                                      </node>
-                                      <node concept="2OqwBi" id="5V9BP5IVdCX" role="1m5AlR">
-                                        <node concept="30H73N" id="5V9BP5IVdCY" role="2Oq$k0" />
-                                        <node concept="2qgKlT" id="5V9BP5IVdCZ" role="2OqNvi">
-                                          <ref role="37wK5l" to="karh:7KznU_3XzU4" resolve="getFirstNonConst" />
-                                        </node>
-                                      </node>
-                                    </node>
-                                    <node concept="3TrEf2" id="5V9BP5IVdD0" role="2OqNvi">
-                                      <ref role="3Tt5mk" to="tpc2:fBF1sR8" resolve="linkDeclaration" />
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
+                      <node concept="3cpWs8" id="5fS8LroEq_2" role="3cqZAp">
+                        <node concept="3cpWsn" id="5fS8LroEq_3" role="3cpWs9">
+                          <property role="TrG5h" value="matchingTexts" />
+                          <property role="3TUv4t" value="true" />
+                          <node concept="A3Dl8" id="5fS8LroEq_4" role="1tU5fm">
+                            <node concept="17QB3L" id="5fS8LroEq_5" role="A3Ik2" />
                           </node>
-                        </node>
-                      </node>
-                      <node concept="3YRAZt" id="5V9BP5IVdD1" role="2OqNvi" />
-                    </node>
-                  </node>
-                  <node concept="3clFbF" id="5V9BP5IVdD2" role="3cqZAp">
-                    <node concept="2OqwBi" id="5V9BP5IVdD3" role="3clFbG">
-                      <node concept="1XNTG" id="5V9BP5IVdD4" role="2Oq$k0" />
-                      <node concept="liA8E" id="5V9BP5IVdD5" role="2OqNvi">
-                        <ref role="37wK5l" to="cj4x:~EditorContext.flushEvents()" resolve="flushEvents" />
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3clFbF" id="5V9BP5IVdD6" role="3cqZAp">
-                    <node concept="2OqwBi" id="5V9BP5IVdD7" role="3clFbG">
-                      <node concept="37vLTw" id="5V9BP5IVdD8" role="2Oq$k0">
-                        <ref role="3cqZAo" node="5V9BP5IVdCD" resolve="caretPosition" />
-                      </node>
-                      <node concept="liA8E" id="5V9BP5IVdD9" role="2OqNvi">
-                        <ref role="37wK5l" to="czm:3NNwv8W$qrW" resolve="restore" />
-                        <node concept="3clFbT" id="5V9BP5IVdDa" role="37wK5m" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="raruj" id="5V9BP5IUIUB" role="lGtFl" />
-            <node concept="3ZSo5i" id="5V9BP5IYcfq" role="130CDr">
-              <node concept="3F0ifn" id="6jH9yJK4E1S" role="3EZMny">
-                <node concept="29HgVG" id="6jH9yJK4E1T" role="lGtFl">
-                  <node concept="3NFfHV" id="6jH9yJK4E1U" role="3NFExx">
-                    <node concept="3clFbS" id="6jH9yJK4E1V" role="2VODD2">
-                      <node concept="3clFbF" id="6jH9yJK4E1W" role="3cqZAp">
-                        <node concept="2OqwBi" id="6jH9yJK4E1X" role="3clFbG">
-                          <node concept="30H73N" id="6jH9yJK4E1Y" role="2Oq$k0" />
-                          <node concept="3TrEf2" id="6jH9yJK4EtK" role="2OqNvi">
-                            <ref role="3Tt5mk" to="teg0:4qdNcHzYfBp" resolve="option" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3VJUX4" id="5V9BP5IYcp2" role="3ZZHOD">
-                <node concept="3clFbS" id="5V9BP5IYcp3" role="2VODD2">
-                  <node concept="3cpWs8" id="5V9BP5IYd5R" role="3cqZAp">
-                    <node concept="3cpWsn" id="5V9BP5IYd5U" role="3cpWs9">
-                      <property role="TrG5h" value="childNode" />
-                      <property role="3TUv4t" value="true" />
-                      <node concept="3Tqbb2" id="5V9BP5IYd5P" role="1tU5fm" />
-                      <node concept="2OqwBi" id="5V9BP5IYdbS" role="33vP2m">
-                        <node concept="pncrf" id="5V9BP5IYdav" role="2Oq$k0" />
-                        <node concept="3TrEf2" id="5V9BP5IYdW6" role="2OqNvi">
-                          <ref role="3Tt5mk" to="tpee:fz3vP1I" resolve="initializer" />
-                          <node concept="1ZhdrF" id="5V9BP5IYe0x" role="lGtFl">
-                            <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/1138056143562/1138056516764" />
-                            <property role="2qtEX8" value="link" />
-                            <node concept="3$xsQk" id="5V9BP5IYe0y" role="3$ytzL">
-                              <node concept="3clFbS" id="5V9BP5IYe0z" role="2VODD2">
-                                <node concept="3clFbF" id="5V9BP5IYe3s" role="3cqZAp">
-                                  <node concept="2OqwBi" id="5V9BP5IYeUl" role="3clFbG">
-                                    <node concept="1PxgMI" id="5V9BP5IYeCT" role="2Oq$k0">
-                                      <node concept="chp4Y" id="1SbcsM_INTf" role="3oSUPX">
-                                        <ref role="cht4Q" to="tpc2:fBF1sR7" resolve="CellModel_RefNode" />
-                                      </node>
-                                      <node concept="2OqwBi" id="5V9BP5IYe9x" role="1m5AlR">
-                                        <node concept="30H73N" id="5V9BP5IYe3r" role="2Oq$k0" />
-                                        <node concept="2qgKlT" id="5V9BP5IYewS" role="2OqNvi">
-                                          <ref role="37wK5l" to="karh:7KznU_3XzU4" resolve="getFirstNonConst" />
-                                        </node>
-                                      </node>
+                          <node concept="2OqwBi" id="5fS8LroEq_6" role="33vP2m">
+                            <node concept="2ShNRf" id="5fS8LroEq_7" role="2Oq$k0">
+                              <node concept="YeOm9" id="5fS8LroEq_8" role="2ShVmc">
+                                <node concept="1Y3b0j" id="5fS8LroEq_9" role="YeSDq">
+                                  <property role="2bfB8j" value="true" />
+                                  <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
+                                  <ref role="1Y3XeK" to="czm:mEdliw9W0N" resolve="StringOrSequenceQuery" />
+                                  <node concept="3Tm1VV" id="5fS8LroEq_a" role="1B3o_S" />
+                                  <node concept="3clFb_" id="5fS8LroEq_b" role="jymVt">
+                                    <property role="TrG5h" value="queryStringOrSequence" />
+                                    <property role="1EzhhJ" value="false" />
+                                    <node concept="3uibUv" id="5fS8LroEq_c" role="3clF45">
+                                      <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
                                     </node>
-                                    <node concept="3TrEf2" id="5V9BP5IYfnA" role="2OqNvi">
-                                      <ref role="3Tt5mk" to="tpc2:fBF1sR8" resolve="linkDeclaration" />
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3clFbF" id="5V9BP5IYcrA" role="3cqZAp">
-                    <node concept="2OqwBi" id="5V9BP5IYgz2" role="3clFbG">
-                      <node concept="2ShNRf" id="5V9BP5IYcr$" role="2Oq$k0">
-                        <node concept="YeOm9" id="5V9BP5IYd2i" role="2ShVmc">
-                          <node concept="1Y3b0j" id="5V9BP5IYd2l" role="YeSDq">
-                            <property role="2bfB8j" value="true" />
-                            <ref role="1Y3XeK" to="wyt6:~Object" resolve="Object" />
-                            <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
-                            <node concept="3Tm1VV" id="5V9BP5IYd2m" role="1B3o_S" />
-                            <node concept="3clFb_" id="5V9BP5IYf_B" role="jymVt">
-                              <property role="TrG5h" value="removeDeleteAction" />
-                              <node concept="37vLTG" id="5V9BP5IYgiA" role="3clF46">
-                                <property role="TrG5h" value="descendantCell" />
-                                <node concept="3uibUv" id="5V9BP5IYgqq" role="1tU5fm">
-                                  <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
-                                </node>
-                              </node>
-                              <node concept="3cqZAl" id="5V9BP5IYf_C" role="3clF45" />
-                              <node concept="3Tm1VV" id="5V9BP5IYf_D" role="1B3o_S" />
-                              <node concept="3clFbS" id="5V9BP5IYf_E" role="3clF47">
-                                <node concept="3clFbJ" id="5V9BP5IYgTf" role="3cqZAp">
-                                  <node concept="3clFbS" id="5V9BP5IYgTg" role="3clFbx">
-                                    <node concept="3clFbF" id="5V9BP5IYh3i" role="3cqZAp">
-                                      <node concept="2OqwBi" id="5V9BP5IYh4q" role="3clFbG">
-                                        <node concept="37vLTw" id="5V9BP5IZ58t" role="2Oq$k0">
-                                          <ref role="3cqZAo" node="5V9BP5IYgiA" resolve="descendantCell" />
-                                        </node>
-                                        <node concept="liA8E" id="5V9BP5IYh7F" role="2OqNvi">
-                                          <ref role="37wK5l" to="f4zo:~EditorCell.setAction(jetbrains.mps.openapi.editor.cells.CellActionType,jetbrains.mps.openapi.editor.cells.CellAction)" resolve="setAction" />
-                                          <node concept="Rm8GO" id="5V9BP5IYhaI" role="37wK5m">
-                                            <ref role="Rm8GQ" to="f4zo:~CellActionType.DELETE" resolve="DELETE" />
-                                            <ref role="1Px2BO" to="f4zo:~CellActionType" resolve="CellActionType" />
-                                          </node>
-                                          <node concept="2ShNRf" id="4UbrmdUJuXG" role="37wK5m">
-                                            <node concept="1pGfFk" id="4UbrmdUJK7_" role="2ShVmc">
-                                              <ref role="37wK5l" to="czm:4UbrmdUI2qC" resolve="DelegateToParentCellAction" />
-                                              <node concept="37vLTw" id="4UbrmdUJK90" role="37wK5m">
-                                                <ref role="3cqZAo" node="5V9BP5IYgiA" resolve="descendantCell" />
-                                              </node>
-                                              <node concept="Rm8GO" id="4UbrmdUJKdF" role="37wK5m">
-                                                <ref role="Rm8GQ" to="f4zo:~CellActionType.DELETE" resolve="DELETE" />
-                                                <ref role="1Px2BO" to="f4zo:~CellActionType" resolve="CellActionType" />
-                                              </node>
-                                            </node>
-                                          </node>
-                                        </node>
-                                      </node>
-                                    </node>
-                                    <node concept="3clFbF" id="5V9BP5IYhdB" role="3cqZAp">
-                                      <node concept="2OqwBi" id="5V9BP5IYhdC" role="3clFbG">
-                                        <node concept="37vLTw" id="5V9BP5IZ5ah" role="2Oq$k0">
-                                          <ref role="3cqZAo" node="5V9BP5IYgiA" resolve="descendantCell" />
-                                        </node>
-                                        <node concept="liA8E" id="5V9BP5IYhdE" role="2OqNvi">
-                                          <ref role="37wK5l" to="f4zo:~EditorCell.setAction(jetbrains.mps.openapi.editor.cells.CellActionType,jetbrains.mps.openapi.editor.cells.CellAction)" resolve="setAction" />
-                                          <node concept="Rm8GO" id="5V9BP5IYhoK" role="37wK5m">
-                                            <ref role="Rm8GQ" to="f4zo:~CellActionType.BACKSPACE" resolve="BACKSPACE" />
-                                            <ref role="1Px2BO" to="f4zo:~CellActionType" resolve="CellActionType" />
-                                          </node>
-                                          <node concept="2ShNRf" id="4UbrmdUJKeI" role="37wK5m">
-                                            <node concept="1pGfFk" id="4UbrmdUJKeJ" role="2ShVmc">
-                                              <ref role="37wK5l" to="czm:4UbrmdUI2qC" resolve="DelegateToParentCellAction" />
-                                              <node concept="37vLTw" id="4UbrmdUJKeK" role="37wK5m">
-                                                <ref role="3cqZAo" node="5V9BP5IYgiA" resolve="descendantCell" />
-                                              </node>
-                                              <node concept="Rm8GO" id="4UbrmdUJKgZ" role="37wK5m">
-                                                <ref role="Rm8GQ" to="f4zo:~CellActionType.BACKSPACE" resolve="BACKSPACE" />
-                                                <ref role="1Px2BO" to="f4zo:~CellActionType" resolve="CellActionType" />
-                                              </node>
-                                            </node>
-                                          </node>
-                                        </node>
-                                      </node>
-                                    </node>
-                                  </node>
-                                  <node concept="3clFbC" id="5V9BP5IYh06" role="3clFbw">
-                                    <node concept="37vLTw" id="5V9BP5IYh1S" role="3uHU7w">
-                                      <ref role="3cqZAo" node="5V9BP5IYd5U" resolve="childNode" />
-                                    </node>
-                                    <node concept="2OqwBi" id="5V9BP5IYgVg" role="3uHU7B">
-                                      <node concept="37vLTw" id="5V9BP5IZ578" role="2Oq$k0">
-                                        <ref role="3cqZAo" node="5V9BP5IYgiA" resolve="descendantCell" />
-                                      </node>
-                                      <node concept="liA8E" id="5V9BP5IYgY_" role="2OqNvi">
-                                        <ref role="37wK5l" to="f4zo:~EditorCell.getSNode()" resolve="getSNode" />
-                                      </node>
-                                    </node>
-                                  </node>
-                                  <node concept="9aQIb" id="5V9BP5IYhqw" role="9aQIa">
-                                    <node concept="3clFbS" id="5V9BP5IYhqx" role="9aQI4">
-                                      <node concept="3clFbJ" id="5V9BP5IYhwq" role="3cqZAp">
-                                        <node concept="3clFbS" id="5V9BP5IYhws" role="3clFbx">
-                                          <node concept="2Gpval" id="5V9BP5IYhte" role="3cqZAp">
-                                            <node concept="2GrKxI" id="5V9BP5IYhtf" role="2Gsz3X">
-                                              <property role="TrG5h" value="childCell" />
-                                            </node>
-                                            <node concept="3clFbS" id="5V9BP5IYhtg" role="2LFqv$">
-                                              <node concept="3clFbF" id="5V9BP5IYhH0" role="3cqZAp">
-                                                <node concept="1rXfSq" id="5V9BP5IYhGZ" role="3clFbG">
-                                                  <ref role="37wK5l" node="5V9BP5IYf_B" resolve="removeDeleteAction" />
-                                                  <node concept="2GrUjf" id="5V9BP5IYhIg" role="37wK5m">
-                                                    <ref role="2Gs0qQ" node="5V9BP5IYhtf" resolve="childCell" />
+                                    <node concept="3Tm1VV" id="5fS8LroEq_d" role="1B3o_S" />
+                                    <node concept="3clFbS" id="5fS8LroEq_e" role="3clF47">
+                                      <node concept="3clFbF" id="5fS8LroEA$N" role="3cqZAp">
+                                        <node concept="Xl_RD" id="5fS8LroEA$P" role="3clFbG">
+                                          <property role="Xl_RC" value="" />
+                                          <node concept="1sPUBX" id="5fS8LroEA$Q" role="lGtFl">
+                                            <ref role="v9R2y" node="2uT2PLn1V4k" resolve="switch_constantTextSequence" />
+                                            <node concept="3NFfHV" id="5fS8LroEA$R" role="1sPUBK">
+                                              <node concept="3clFbS" id="5fS8LroEA$S" role="2VODD2">
+                                                <node concept="3clFbF" id="5fS8LroEA$T" role="3cqZAp">
+                                                  <node concept="2OqwBi" id="5fS8LroEA$U" role="3clFbG">
+                                                    <node concept="30H73N" id="5fS8LroEA$V" role="2Oq$k0" />
+                                                    <node concept="2qgKlT" id="5fS8LroEA$W" role="2OqNvi">
+                                                      <ref role="37wK5l" to="karh:7KznU_45kn7" resolve="getTransformationText" />
+                                                    </node>
                                                   </node>
                                                 </node>
                                               </node>
                                             </node>
-                                            <node concept="1eOMI4" id="5V9BP5IYhEa" role="2GsD0m">
-                                              <node concept="10QFUN" id="5V9BP5IYhEb" role="1eOMHV">
-                                                <node concept="37vLTw" id="5V9BP5IYhE9" role="10QFUP">
-                                                  <ref role="3cqZAo" node="5V9BP5IYgiA" resolve="descendantCell" />
+                                          </node>
+                                        </node>
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="liA8E" id="5fS8LroEq_s" role="2OqNvi">
+                              <ref role="37wK5l" to="czm:mEdliw8IXH" resolve="query" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbH" id="5fS8LroEq_R" role="3cqZAp" />
+                      <node concept="3clFbJ" id="5fS8LroEq_S" role="3cqZAp">
+                        <node concept="3clFbS" id="5fS8LroEq_T" role="3clFbx">
+                          <node concept="3clFbF" id="5fS8LroEq_U" role="3cqZAp">
+                            <node concept="2OqwBi" id="5fS8LroEq_V" role="3clFbG">
+                              <node concept="37vLTw" id="5fS8LroEKVS" role="2Oq$k0">
+                                <ref role="3cqZAo" node="5fS8LroEvbu" resolve="result" />
+                              </node>
+                              <node concept="TSZUe" id="5fS8LroEq_X" role="2OqNvi">
+                                <node concept="2ShNRf" id="5fS8LroEq_Y" role="25WWJ7">
+                                  <node concept="YeOm9" id="5fS8LroEq_Z" role="2ShVmc">
+                                    <node concept="1Y3b0j" id="5fS8LroEqA0" role="YeSDq">
+                                      <property role="2bfB8j" value="true" />
+                                      <ref role="1Y3XeK" to="czm:1YKLYyyOIFO" resolve="MultiTextActionItem" />
+                                      <ref role="37wK5l" to="czm:1YKLYyyOIFX" resolve="MultiTextActionItem" />
+                                      <node concept="3clFb_" id="5fS8LroEqA1" role="jymVt">
+                                        <property role="1EzhhJ" value="false" />
+                                        <property role="TrG5h" value="execute" />
+                                        <property role="DiZV1" value="false" />
+                                        <property role="od$2w" value="false" />
+                                        <node concept="3Tm1VV" id="5fS8LroEqA2" role="1B3o_S" />
+                                        <node concept="3cqZAl" id="5fS8LroEqA3" role="3clF45" />
+                                        <node concept="37vLTG" id="5fS8LroEqA4" role="3clF46">
+                                          <property role="TrG5h" value="pattern" />
+                                          <node concept="17QB3L" id="5fS8LroEqA5" role="1tU5fm" />
+                                          <node concept="2AHcQZ" id="5fS8LroEqA6" role="2AJF6D">
+                                            <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+                                          </node>
+                                        </node>
+                                        <node concept="3clFbS" id="5fS8LroEqA7" role="3clF47">
+                                          <node concept="3cpWs8" id="5fS8LroEMHh" role="3cqZAp">
+                                            <node concept="3cpWsn" id="5fS8LroEMHi" role="3cpWs9">
+                                              <property role="TrG5h" value="sourceNode" />
+                                              <property role="3TUv4t" value="true" />
+                                              <node concept="3Tqbb2" id="5fS8LroEMHj" role="1tU5fm" />
+                                              <node concept="2OqwBi" id="5fS8LroEMHk" role="33vP2m">
+                                                <node concept="2Mo9yH" id="5fS8LroESu5" role="2Oq$k0" />
+                                                <node concept="liA8E" id="5fS8LroEMHm" role="2OqNvi">
+                                                  <ref role="37wK5l" to="uddc:~TransformationMenuContext.getNode()" resolve="getNode" />
                                                 </node>
-                                                <node concept="3uibUv" id="5V9BP5IYhEX" role="10QFUM">
-                                                  <ref role="3uigEE" to="f4zo:~EditorCell_Collection" resolve="EditorCell_Collection" />
+                                              </node>
+                                            </node>
+                                          </node>
+                                          <node concept="3cpWs8" id="5fS8LroEMHn" role="3cqZAp">
+                                            <node concept="3cpWsn" id="5fS8LroEMHo" role="3cpWs9">
+                                              <property role="TrG5h" value="newNode" />
+                                              <node concept="3Tqbb2" id="5fS8LroEMHp" role="1tU5fm">
+                                                <ref role="ehGHo" to="tpee:fz3vP1J" resolve="Expression" />
+                                              </node>
+                                              <node concept="2OqwBi" id="5fS8LroEMHq" role="33vP2m">
+                                                <node concept="2OqwBi" id="5fS8LroEMHr" role="2Oq$k0">
+                                                  <node concept="1PxgMI" id="5fS8LroEMHs" role="2Oq$k0">
+                                                    <node concept="chp4Y" id="5fS8LroEMHt" role="3oSUPX">
+                                                      <ref role="cht4Q" to="tpck:gw2VY9q" resolve="BaseConcept" />
+                                                      <node concept="1ZhdrF" id="5fS8LroEMHu" role="lGtFl">
+                                                        <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/1177026924588/1177026940964" />
+                                                        <property role="2qtEX8" value="conceptDeclaration" />
+                                                        <node concept="3$xsQk" id="5fS8LroEMHv" role="3$ytzL">
+                                                          <node concept="3clFbS" id="5fS8LroEMHw" role="2VODD2">
+                                                            <node concept="3clFbF" id="5fS8LroEMHx" role="3cqZAp">
+                                                              <node concept="2OqwBi" id="5fS8LroEMHy" role="3clFbG">
+                                                                <node concept="2OqwBi" id="5fS8LroEMHz" role="2Oq$k0">
+                                                                  <node concept="30H73N" id="5fS8LroEMH$" role="2Oq$k0" />
+                                                                  <node concept="2Xjw5R" id="5fS8LroEMH_" role="2OqNvi">
+                                                                    <node concept="1xMEDy" id="5fS8LroEMHA" role="1xVPHs">
+                                                                      <node concept="chp4Y" id="5fS8LroEMHB" role="ri$Ld">
+                                                                        <ref role="cht4Q" to="tpc2:gXXWOiD" resolve="AbstractComponent" />
+                                                                      </node>
+                                                                    </node>
+                                                                  </node>
+                                                                </node>
+                                                                <node concept="2qgKlT" id="5fS8LroEMHC" role="2OqNvi">
+                                                                  <ref role="37wK5l" to="tpcb:67EYkym$wx3" resolve="getConceptDeclaration" />
+                                                                </node>
+                                                              </node>
+                                                            </node>
+                                                          </node>
+                                                        </node>
+                                                      </node>
+                                                    </node>
+                                                    <node concept="37vLTw" id="5fS8LroEMHD" role="1m5AlR">
+                                                      <ref role="3cqZAo" node="5fS8LroEMHi" resolve="sourceNode" />
+                                                    </node>
+                                                  </node>
+                                                  <node concept="3TrEf2" id="5fS8LroEMHE" role="2OqNvi">
+                                                    <ref role="3Tt5mk" to="tpee:fz3vP1I" resolve="initializer" />
+                                                    <node concept="1ZhdrF" id="5fS8LroEMHF" role="lGtFl">
+                                                      <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/1138056143562/1138056516764" />
+                                                      <property role="2qtEX8" value="link" />
+                                                      <node concept="3$xsQk" id="5fS8LroEMHG" role="3$ytzL">
+                                                        <node concept="3clFbS" id="5fS8LroEMHH" role="2VODD2">
+                                                          <node concept="3clFbF" id="5fS8LroEMHI" role="3cqZAp">
+                                                            <node concept="2OqwBi" id="5fS8LroEMHJ" role="3clFbG">
+                                                              <node concept="1PxgMI" id="5fS8LroEMHK" role="2Oq$k0">
+                                                                <node concept="chp4Y" id="5fS8LroEMHL" role="3oSUPX">
+                                                                  <ref role="cht4Q" to="tpc2:fBF1sR7" resolve="CellModel_RefNode" />
+                                                                </node>
+                                                                <node concept="2OqwBi" id="5fS8LroEMHM" role="1m5AlR">
+                                                                  <node concept="30H73N" id="5fS8LroEMHN" role="2Oq$k0" />
+                                                                  <node concept="2qgKlT" id="5fS8LroEMHO" role="2OqNvi">
+                                                                    <ref role="37wK5l" to="karh:7KznU_3XzU4" resolve="getFirstNonConst" />
+                                                                  </node>
+                                                                </node>
+                                                              </node>
+                                                              <node concept="3TrEf2" id="5fS8LroEMHP" role="2OqNvi">
+                                                                <ref role="3Tt5mk" to="tpc2:fBF1sR8" resolve="linkDeclaration" />
+                                                              </node>
+                                                            </node>
+                                                          </node>
+                                                        </node>
+                                                      </node>
+                                                    </node>
+                                                  </node>
+                                                </node>
+                                                <node concept="2DeJnY" id="5fS8LroEMHQ" role="2OqNvi" />
+                                              </node>
+                                            </node>
+                                          </node>
+                                          <node concept="3clFbF" id="5fS8LroEMHR" role="3cqZAp">
+                                            <node concept="2OqwBi" id="5fS8LroEMHS" role="3clFbG">
+                                              <node concept="2ShNRf" id="5fS8LroEMHT" role="2Oq$k0">
+                                                <node concept="YeOm9" id="5fS8LroEMHU" role="2ShVmc">
+                                                  <node concept="1Y3b0j" id="5fS8LroEMHV" role="YeSDq">
+                                                    <property role="2bfB8j" value="true" />
+                                                    <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
+                                                    <ref role="1Y3XeK" to="wyt6:~Object" resolve="Object" />
+                                                    <node concept="3Tm1VV" id="5fS8LroEMHW" role="1B3o_S" />
+                                                    <node concept="3clFb_" id="5fS8LroEMHX" role="jymVt">
+                                                      <property role="TrG5h" value="postprocess" />
+                                                      <node concept="37vLTG" id="5fS8LroEMHY" role="3clF46">
+                                                        <property role="TrG5h" value="node" />
+                                                        <node concept="3Tqbb2" id="5fS8LroEMHZ" role="1tU5fm" />
+                                                      </node>
+                                                      <node concept="3cqZAl" id="5fS8LroEMI0" role="3clF45" />
+                                                      <node concept="3Tm1VV" id="5fS8LroEMI1" role="1B3o_S" />
+                                                      <node concept="3clFbS" id="5fS8LroEMI2" role="3clF47">
+                                                        <node concept="3clFbH" id="5fS8LroEMI3" role="3cqZAp">
+                                                          <node concept="2b32R4" id="5fS8LroEMI4" role="lGtFl">
+                                                            <node concept="3JmXsc" id="5fS8LroEMI5" role="2P8S$">
+                                                              <node concept="3clFbS" id="5fS8LroEMI6" role="2VODD2">
+                                                                <node concept="3clFbF" id="5fS8LroEMI7" role="3cqZAp">
+                                                                  <node concept="2OqwBi" id="5fS8LroEMI8" role="3clFbG">
+                                                                    <node concept="2OqwBi" id="5fS8LroEMI9" role="2Oq$k0">
+                                                                      <node concept="2OqwBi" id="5fS8LroEMIa" role="2Oq$k0">
+                                                                        <node concept="30H73N" id="5fS8LroEMIb" role="2Oq$k0" />
+                                                                        <node concept="3TrEf2" id="5fS8LroEMIc" role="2OqNvi">
+                                                                          <ref role="3Tt5mk" to="teg0:65e5JdYJiFg" resolve="postprocess" />
+                                                                        </node>
+                                                                      </node>
+                                                                      <node concept="3TrEf2" id="5fS8LroEMId" role="2OqNvi">
+                                                                        <ref role="3Tt5mk" to="tpee:gyVODHa" resolve="body" />
+                                                                      </node>
+                                                                    </node>
+                                                                    <node concept="3Tsc0h" id="5fS8LroEMIe" role="2OqNvi">
+                                                                      <ref role="3TtcxE" to="tpee:fzcqZ_x" resolve="statement" />
+                                                                    </node>
+                                                                  </node>
+                                                                </node>
+                                                              </node>
+                                                            </node>
+                                                          </node>
+                                                        </node>
+                                                      </node>
+                                                    </node>
+                                                  </node>
+                                                </node>
+                                              </node>
+                                              <node concept="liA8E" id="5fS8LroEMIf" role="2OqNvi">
+                                                <ref role="37wK5l" node="5fS8LroEMHX" resolve="postprocess" />
+                                                <node concept="37vLTw" id="5fS8LroEMIg" role="37wK5m">
+                                                  <ref role="3cqZAo" node="5fS8LroEMHi" resolve="sourceNode" />
+                                                </node>
+                                              </node>
+                                            </node>
+                                            <node concept="1W57fq" id="5fS8LroEMIh" role="lGtFl">
+                                              <node concept="3IZrLx" id="5fS8LroEMIi" role="3IZSJc">
+                                                <node concept="3clFbS" id="5fS8LroEMIj" role="2VODD2">
+                                                  <node concept="3clFbF" id="5fS8LroEMIk" role="3cqZAp">
+                                                    <node concept="2OqwBi" id="5fS8LroEMIl" role="3clFbG">
+                                                      <node concept="2OqwBi" id="5fS8LroEMIm" role="2Oq$k0">
+                                                        <node concept="30H73N" id="5fS8LroEMIn" role="2Oq$k0" />
+                                                        <node concept="3TrEf2" id="5fS8LroEMIo" role="2OqNvi">
+                                                          <ref role="3Tt5mk" to="teg0:65e5JdYJiFg" resolve="postprocess" />
+                                                        </node>
+                                                      </node>
+                                                      <node concept="3x8VRR" id="5fS8LroEMIp" role="2OqNvi" />
+                                                    </node>
+                                                  </node>
                                                 </node>
                                               </node>
                                             </node>
                                           </node>
                                         </node>
-                                        <node concept="2ZW3vV" id="5V9BP5IYhzH" role="3clFbw">
-                                          <node concept="3uibUv" id="5V9BP5IYh$H" role="2ZW6by">
-                                            <ref role="3uigEE" to="f4zo:~EditorCell_Collection" resolve="EditorCell_Collection" />
+                                        <node concept="2AHcQZ" id="5fS8LroEqAb" role="2AJF6D">
+                                          <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                                        </node>
+                                      </node>
+                                      <node concept="3clFb_" id="5fS8LroEqAw" role="jymVt">
+                                        <property role="1EzhhJ" value="false" />
+                                        <property role="TrG5h" value="getOutputConcept" />
+                                        <property role="DiZV1" value="false" />
+                                        <property role="od$2w" value="false" />
+                                        <node concept="3Tm1VV" id="5fS8LroEqAx" role="1B3o_S" />
+                                        <node concept="3uibUv" id="5fS8LroEqAy" role="3clF45">
+                                          <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
+                                        </node>
+                                        <node concept="3clFbS" id="5fS8LroEqAz" role="3clF47">
+                                          <node concept="3clFbF" id="5fS8LroEqA$" role="3cqZAp">
+                                            <node concept="35c_gC" id="5fS8LroEqA_" role="3clFbG">
+                                              <ref role="35c_gD" to="tpck:gw2VY9q" resolve="BaseConcept" />
+                                              <node concept="1ZhdrF" id="5fS8LroEqAA" role="lGtFl">
+                                                <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/2644386474300074836/2644386474300074837" />
+                                                <property role="2qtEX8" value="conceptDeclaration" />
+                                                <node concept="3$xsQk" id="5fS8LroEqAB" role="3$ytzL">
+                                                  <node concept="3clFbS" id="5fS8LroEqAC" role="2VODD2">
+                                                    <node concept="3clFbF" id="5fS8LroEqAD" role="3cqZAp">
+                                                      <node concept="2OqwBi" id="5fS8LroEqAE" role="3clFbG">
+                                                        <node concept="2OqwBi" id="5fS8LroEqAF" role="2Oq$k0">
+                                                          <node concept="30H73N" id="5fS8LroEqAG" role="2Oq$k0" />
+                                                          <node concept="2Xjw5R" id="5fS8LroEqAH" role="2OqNvi">
+                                                            <node concept="1xMEDy" id="5fS8LroEqAI" role="1xVPHs">
+                                                              <node concept="chp4Y" id="5fS8LroEqAJ" role="ri$Ld">
+                                                                <ref role="cht4Q" to="tpc2:gXXWOiD" resolve="AbstractComponent" />
+                                                              </node>
+                                                            </node>
+                                                          </node>
+                                                        </node>
+                                                        <node concept="2qgKlT" id="5fS8LroEqAK" role="2OqNvi">
+                                                          <ref role="37wK5l" to="tpcb:67EYkym$wx3" resolve="getConceptDeclaration" />
+                                                        </node>
+                                                      </node>
+                                                    </node>
+                                                  </node>
+                                                </node>
+                                              </node>
+                                            </node>
                                           </node>
-                                          <node concept="37vLTw" id="5V9BP5IYhxY" role="2ZW6bz">
-                                            <ref role="3cqZAo" node="5V9BP5IYgiA" resolve="descendantCell" />
+                                        </node>
+                                        <node concept="2AHcQZ" id="5fS8LroEqAL" role="2AJF6D">
+                                          <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                                        </node>
+                                      </node>
+                                      <node concept="3Tm1VV" id="5fS8LroEqAM" role="1B3o_S" />
+                                      <node concept="37vLTw" id="5fS8LroEqAN" role="37wK5m">
+                                        <ref role="3cqZAo" node="5fS8LroEq_3" resolve="matchingTexts" />
+                                      </node>
+                                      <node concept="2Mo9yH" id="5fS8LroELOc" role="37wK5m" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="2OqwBi" id="5fS8LroEqCj" role="3clFbw">
+                          <node concept="37vLTw" id="5fS8LroEqCk" role="2Oq$k0">
+                            <ref role="3cqZAo" node="5fS8LroEq_3" resolve="matchingTexts" />
+                          </node>
+                          <node concept="3GX2aA" id="5fS8LroEqCl" role="2OqNvi" />
+                        </node>
+                      </node>
+                      <node concept="3cpWs6" id="5fS8LroEGcY" role="3cqZAp">
+                        <node concept="37vLTw" id="5fS8LroEHhZ" role="3cqZAk">
+                          <ref role="3cqZAo" node="5fS8LroEvbu" resolve="result" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="17Uvod" id="5fS8LroF0c8" role="lGtFl">
+                <property role="2qtEX9" value="description" />
+                <property role="P4ACc" value="9d69e719-78c8-4286-90db-fb19c107d049/745148820867185554/745148820908747612" />
+                <node concept="3zFVjK" id="5fS8LroF0c9" role="3zH0cK">
+                  <node concept="3clFbS" id="5fS8LroF0ca" role="2VODD2">
+                    <node concept="3clFbF" id="5fS8LroF2Rq" role="3cqZAp">
+                      <node concept="3cpWs3" id="5fS8LroF62u" role="3clFbG">
+                        <node concept="2OqwBi" id="5fS8LroFa9R" role="3uHU7w">
+                          <node concept="2OqwBi" id="5fS8LroF8gh" role="2Oq$k0">
+                            <node concept="1PxgMI" id="5fS8LroF7fa" role="2Oq$k0">
+                              <node concept="chp4Y" id="5fS8LroF7G4" role="3oSUPX">
+                                <ref role="cht4Q" to="tpc2:fBF1sR7" resolve="CellModel_RefNode" />
+                              </node>
+                              <node concept="2OqwBi" id="5fS8LroF6AM" role="1m5AlR">
+                                <node concept="30H73N" id="5fS8LroF6qs" role="2Oq$k0" />
+                                <node concept="2qgKlT" id="5fS8LroF6O3" role="2OqNvi">
+                                  <ref role="37wK5l" to="karh:7KznU_3XzU4" resolve="getFirstNonConst" />
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="3TrEf2" id="5fS8LroF8Wv" role="2OqNvi">
+                              <ref role="3Tt5mk" to="tpc2:fBF1sR8" resolve="linkDeclaration" />
+                            </node>
+                          </node>
+                          <node concept="3TrcHB" id="5fS8LroFb8y" role="2OqNvi">
+                            <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                          </node>
+                        </node>
+                        <node concept="3cpWs3" id="5fS8LroF5iq" role="3uHU7B">
+                          <node concept="3cpWs3" id="5fS8LroF3aU" role="3uHU7B">
+                            <node concept="Xl_RD" id="5fS8LroF2Rp" role="3uHU7B">
+                              <property role="Xl_RC" value="grammar.optional for " />
+                            </node>
+                            <node concept="2OqwBi" id="5fS8LroF4ug" role="3uHU7w">
+                              <node concept="2OqwBi" id="5fS8LroF3Xu" role="2Oq$k0">
+                                <node concept="2OqwBi" id="5fS8LroF3wr" role="2Oq$k0">
+                                  <node concept="30H73N" id="5fS8LroF3b2" role="2Oq$k0" />
+                                  <node concept="2Xjw5R" id="5fS8LroF3CO" role="2OqNvi">
+                                    <node concept="1xMEDy" id="5fS8LroF3CQ" role="1xVPHs">
+                                      <node concept="chp4Y" id="5fS8LroF3JA" role="ri$Ld">
+                                        <ref role="cht4Q" to="tpc2:gXXWOiD" resolve="AbstractComponent" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                                <node concept="2qgKlT" id="5fS8LroF4iW" role="2OqNvi">
+                                  <ref role="37wK5l" to="tpcb:67EYkym$wx3" resolve="getConceptDeclaration" />
+                                </node>
+                              </node>
+                              <node concept="3TrcHB" id="5fS8LroF4_d" role="2OqNvi">
+                                <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="Xl_RD" id="5fS8LroF5iu" role="3uHU7w">
+                            <property role="Xl_RC" value="." />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="130CD5" id="5fS8LroEbrX" role="1QoS34">
+              <node concept="130t_x" id="5fS8LroEbrY" role="130p63">
+                <property role="1hAc7j" value="7P1WhNABvta/backspace_action_id" />
+                <node concept="130t_S" id="5fS8LroEbrZ" role="130oVf">
+                  <node concept="3clFbS" id="5fS8LroEbs0" role="2VODD2">
+                    <node concept="3cpWs8" id="5fS8LroEbs1" role="3cqZAp">
+                      <node concept="3cpWsn" id="5fS8LroEbs2" role="3cpWs9">
+                        <property role="TrG5h" value="caretPosition" />
+                        <node concept="3uibUv" id="5fS8LroEbs3" role="1tU5fm">
+                          <ref role="3uigEE" to="czm:1xDazL6RYY7" resolve="SavedCaretPosition" />
+                        </node>
+                        <node concept="2ShNRf" id="5fS8LroEbs4" role="33vP2m">
+                          <node concept="1pGfFk" id="5fS8LroEbs5" role="2ShVmc">
+                            <ref role="37wK5l" to="czm:3NNwv8WqPSm" resolve="SavedCaretPosition" />
+                            <node concept="1XNTG" id="5fS8LroEbs6" role="37wK5m" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbF" id="5fS8LroEbs7" role="3cqZAp">
+                      <node concept="2OqwBi" id="5fS8LroEbs8" role="3clFbG">
+                        <node concept="37vLTw" id="5fS8LroEbs9" role="2Oq$k0">
+                          <ref role="3cqZAo" node="5fS8LroEbs2" resolve="caretPosition" />
+                        </node>
+                        <node concept="liA8E" id="5fS8LroEbsa" role="2OqNvi">
+                          <ref role="37wK5l" to="czm:76BPPvEi375" resolve="save" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbF" id="5fS8LroEbsb" role="3cqZAp">
+                      <node concept="2OqwBi" id="5fS8LroEbsc" role="3clFbG">
+                        <node concept="2OqwBi" id="5fS8LroEbsd" role="2Oq$k0">
+                          <node concept="130tyv" id="5fS8LroEbse" role="2Oq$k0" />
+                          <node concept="3TrEf2" id="5fS8LroEbsf" role="2OqNvi">
+                            <ref role="3Tt5mk" to="tpee:fz3vP1I" resolve="initializer" />
+                            <node concept="1ZhdrF" id="5fS8LroEbsg" role="lGtFl">
+                              <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/1138056143562/1138056516764" />
+                              <property role="2qtEX8" value="link" />
+                              <node concept="3$xsQk" id="5fS8LroEbsh" role="3$ytzL">
+                                <node concept="3clFbS" id="5fS8LroEbsi" role="2VODD2">
+                                  <node concept="3clFbF" id="5fS8LroEbsj" role="3cqZAp">
+                                    <node concept="2OqwBi" id="5fS8LroEbsk" role="3clFbG">
+                                      <node concept="1PxgMI" id="5fS8LroEbsl" role="2Oq$k0">
+                                        <node concept="chp4Y" id="5fS8LroEbsm" role="3oSUPX">
+                                          <ref role="cht4Q" to="tpc2:fBF1sR7" resolve="CellModel_RefNode" />
+                                        </node>
+                                        <node concept="2OqwBi" id="5fS8LroEbsn" role="1m5AlR">
+                                          <node concept="30H73N" id="5fS8LroEbso" role="2Oq$k0" />
+                                          <node concept="2qgKlT" id="5fS8LroEbsp" role="2OqNvi">
+                                            <ref role="37wK5l" to="karh:7KznU_3XzU4" resolve="getFirstNonConst" />
+                                          </node>
+                                        </node>
+                                      </node>
+                                      <node concept="3TrEf2" id="5fS8LroEbsq" role="2OqNvi">
+                                        <ref role="3Tt5mk" to="tpc2:fBF1sR8" resolve="linkDeclaration" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3YRAZt" id="5fS8LroEbsr" role="2OqNvi" />
+                      </node>
+                    </node>
+                    <node concept="3clFbF" id="5fS8LroEbss" role="3cqZAp">
+                      <node concept="2OqwBi" id="5fS8LroEbst" role="3clFbG">
+                        <node concept="1XNTG" id="5fS8LroEbsu" role="2Oq$k0" />
+                        <node concept="liA8E" id="5fS8LroEbsv" role="2OqNvi">
+                          <ref role="37wK5l" to="cj4x:~EditorContext.flushEvents()" resolve="flushEvents" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbF" id="5fS8LroEbsw" role="3cqZAp">
+                      <node concept="2OqwBi" id="5fS8LroEbsx" role="3clFbG">
+                        <node concept="37vLTw" id="5fS8LroEbsy" role="2Oq$k0">
+                          <ref role="3cqZAo" node="5fS8LroEbs2" resolve="caretPosition" />
+                        </node>
+                        <node concept="liA8E" id="5fS8LroEbsz" role="2OqNvi">
+                          <ref role="37wK5l" to="czm:3NNwv8W$qrW" resolve="restore" />
+                          <node concept="3clFbT" id="5fS8LroEbs$" role="37wK5m">
+                            <property role="3clFbU" value="true" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="130t_x" id="5fS8LroEbs_" role="130p63">
+                <property role="1hAc7j" value="g_hAxAO/delete_action_id" />
+                <node concept="130t_S" id="5fS8LroEbsA" role="130oVf">
+                  <node concept="3clFbS" id="5fS8LroEbsB" role="2VODD2">
+                    <node concept="3cpWs8" id="5fS8LroEbsC" role="3cqZAp">
+                      <node concept="3cpWsn" id="5fS8LroEbsD" role="3cpWs9">
+                        <property role="TrG5h" value="caretPosition" />
+                        <node concept="3uibUv" id="5fS8LroEbsE" role="1tU5fm">
+                          <ref role="3uigEE" to="czm:1xDazL6RYY7" resolve="SavedCaretPosition" />
+                        </node>
+                        <node concept="2ShNRf" id="5fS8LroEbsF" role="33vP2m">
+                          <node concept="1pGfFk" id="5fS8LroEbsG" role="2ShVmc">
+                            <ref role="37wK5l" to="czm:3NNwv8WqPSm" resolve="SavedCaretPosition" />
+                            <node concept="1XNTG" id="5fS8LroEbsH" role="37wK5m" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbF" id="5fS8LroEbsI" role="3cqZAp">
+                      <node concept="2OqwBi" id="5fS8LroEbsJ" role="3clFbG">
+                        <node concept="37vLTw" id="5fS8LroEbsK" role="2Oq$k0">
+                          <ref role="3cqZAo" node="5fS8LroEbsD" resolve="caretPosition" />
+                        </node>
+                        <node concept="liA8E" id="5fS8LroEbsL" role="2OqNvi">
+                          <ref role="37wK5l" to="czm:76BPPvEi375" resolve="save" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbF" id="5fS8LroEbsM" role="3cqZAp">
+                      <node concept="2OqwBi" id="5fS8LroEbsN" role="3clFbG">
+                        <node concept="2OqwBi" id="5fS8LroEbsO" role="2Oq$k0">
+                          <node concept="130tyv" id="5fS8LroEbsP" role="2Oq$k0" />
+                          <node concept="3TrEf2" id="5fS8LroEbsQ" role="2OqNvi">
+                            <ref role="3Tt5mk" to="tpee:fz3vP1I" resolve="initializer" />
+                            <node concept="1ZhdrF" id="5fS8LroEbsR" role="lGtFl">
+                              <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/1138056143562/1138056516764" />
+                              <property role="2qtEX8" value="link" />
+                              <node concept="3$xsQk" id="5fS8LroEbsS" role="3$ytzL">
+                                <node concept="3clFbS" id="5fS8LroEbsT" role="2VODD2">
+                                  <node concept="3clFbF" id="5fS8LroEbsU" role="3cqZAp">
+                                    <node concept="2OqwBi" id="5fS8LroEbsV" role="3clFbG">
+                                      <node concept="1PxgMI" id="5fS8LroEbsW" role="2Oq$k0">
+                                        <node concept="chp4Y" id="5fS8LroEbsX" role="3oSUPX">
+                                          <ref role="cht4Q" to="tpc2:fBF1sR7" resolve="CellModel_RefNode" />
+                                        </node>
+                                        <node concept="2OqwBi" id="5fS8LroEbsY" role="1m5AlR">
+                                          <node concept="30H73N" id="5fS8LroEbsZ" role="2Oq$k0" />
+                                          <node concept="2qgKlT" id="5fS8LroEbt0" role="2OqNvi">
+                                            <ref role="37wK5l" to="karh:7KznU_3XzU4" resolve="getFirstNonConst" />
+                                          </node>
+                                        </node>
+                                      </node>
+                                      <node concept="3TrEf2" id="5fS8LroEbt1" role="2OqNvi">
+                                        <ref role="3Tt5mk" to="tpc2:fBF1sR8" resolve="linkDeclaration" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3YRAZt" id="5fS8LroEbt2" role="2OqNvi" />
+                      </node>
+                    </node>
+                    <node concept="3clFbF" id="5fS8LroEbt3" role="3cqZAp">
+                      <node concept="2OqwBi" id="5fS8LroEbt4" role="3clFbG">
+                        <node concept="1XNTG" id="5fS8LroEbt5" role="2Oq$k0" />
+                        <node concept="liA8E" id="5fS8LroEbt6" role="2OqNvi">
+                          <ref role="37wK5l" to="cj4x:~EditorContext.flushEvents()" resolve="flushEvents" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbF" id="5fS8LroEbt7" role="3cqZAp">
+                      <node concept="2OqwBi" id="5fS8LroEbt8" role="3clFbG">
+                        <node concept="37vLTw" id="5fS8LroEbt9" role="2Oq$k0">
+                          <ref role="3cqZAo" node="5fS8LroEbsD" resolve="caretPosition" />
+                        </node>
+                        <node concept="liA8E" id="5fS8LroEbta" role="2OqNvi">
+                          <ref role="37wK5l" to="czm:3NNwv8W$qrW" resolve="restore" />
+                          <node concept="3clFbT" id="5fS8LroEbtb" role="37wK5m" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3ZSo5i" id="5fS8LroEbtd" role="130CDr">
+                <node concept="3F0ifn" id="5fS8LroEbte" role="3EZMny">
+                  <node concept="29HgVG" id="5fS8LroEbtf" role="lGtFl">
+                    <node concept="3NFfHV" id="5fS8LroEbtg" role="3NFExx">
+                      <node concept="3clFbS" id="5fS8LroEbth" role="2VODD2">
+                        <node concept="3clFbF" id="5fS8LroEbti" role="3cqZAp">
+                          <node concept="2OqwBi" id="5fS8LroEbtj" role="3clFbG">
+                            <node concept="30H73N" id="5fS8LroEbtk" role="2Oq$k0" />
+                            <node concept="3TrEf2" id="5fS8LroEbtl" role="2OqNvi">
+                              <ref role="3Tt5mk" to="teg0:4qdNcHzYfBp" resolve="option" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3VJUX4" id="5fS8LroEbtm" role="3ZZHOD">
+                  <node concept="3clFbS" id="5fS8LroEbtn" role="2VODD2">
+                    <node concept="3cpWs8" id="5fS8LroEbto" role="3cqZAp">
+                      <node concept="3cpWsn" id="5fS8LroEbtp" role="3cpWs9">
+                        <property role="TrG5h" value="childNode" />
+                        <property role="3TUv4t" value="true" />
+                        <node concept="3Tqbb2" id="5fS8LroEbtq" role="1tU5fm" />
+                        <node concept="2OqwBi" id="5fS8LroEbtr" role="33vP2m">
+                          <node concept="pncrf" id="5fS8LroEbts" role="2Oq$k0" />
+                          <node concept="3TrEf2" id="5fS8LroEbtt" role="2OqNvi">
+                            <ref role="3Tt5mk" to="tpee:fz3vP1I" resolve="initializer" />
+                            <node concept="1ZhdrF" id="5fS8LroEbtu" role="lGtFl">
+                              <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/1138056143562/1138056516764" />
+                              <property role="2qtEX8" value="link" />
+                              <node concept="3$xsQk" id="5fS8LroEbtv" role="3$ytzL">
+                                <node concept="3clFbS" id="5fS8LroEbtw" role="2VODD2">
+                                  <node concept="3clFbF" id="5fS8LroEbtx" role="3cqZAp">
+                                    <node concept="2OqwBi" id="5fS8LroEbty" role="3clFbG">
+                                      <node concept="1PxgMI" id="5fS8LroEbtz" role="2Oq$k0">
+                                        <node concept="chp4Y" id="5fS8LroEbt$" role="3oSUPX">
+                                          <ref role="cht4Q" to="tpc2:fBF1sR7" resolve="CellModel_RefNode" />
+                                        </node>
+                                        <node concept="2OqwBi" id="5fS8LroEbt_" role="1m5AlR">
+                                          <node concept="30H73N" id="5fS8LroEbtA" role="2Oq$k0" />
+                                          <node concept="2qgKlT" id="5fS8LroEbtB" role="2OqNvi">
+                                            <ref role="37wK5l" to="karh:7KznU_3XzU4" resolve="getFirstNonConst" />
+                                          </node>
+                                        </node>
+                                      </node>
+                                      <node concept="3TrEf2" id="5fS8LroEbtC" role="2OqNvi">
+                                        <ref role="3Tt5mk" to="tpc2:fBF1sR8" resolve="linkDeclaration" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbF" id="5fS8LroEbtD" role="3cqZAp">
+                      <node concept="2OqwBi" id="5fS8LroEbtE" role="3clFbG">
+                        <node concept="2ShNRf" id="5fS8LroEbtF" role="2Oq$k0">
+                          <node concept="YeOm9" id="5fS8LroEbtG" role="2ShVmc">
+                            <node concept="1Y3b0j" id="5fS8LroEbtH" role="YeSDq">
+                              <property role="2bfB8j" value="true" />
+                              <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
+                              <ref role="1Y3XeK" to="wyt6:~Object" resolve="Object" />
+                              <node concept="3Tm1VV" id="5fS8LroEbtI" role="1B3o_S" />
+                              <node concept="3clFb_" id="5fS8LroEbtJ" role="jymVt">
+                                <property role="TrG5h" value="removeDeleteAction" />
+                                <node concept="37vLTG" id="5fS8LroEbtK" role="3clF46">
+                                  <property role="TrG5h" value="descendantCell" />
+                                  <node concept="3uibUv" id="5fS8LroEbtL" role="1tU5fm">
+                                    <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+                                  </node>
+                                </node>
+                                <node concept="3cqZAl" id="5fS8LroEbtM" role="3clF45" />
+                                <node concept="3Tm1VV" id="5fS8LroEbtN" role="1B3o_S" />
+                                <node concept="3clFbS" id="5fS8LroEbtO" role="3clF47">
+                                  <node concept="3clFbJ" id="5fS8LroEbtP" role="3cqZAp">
+                                    <node concept="3clFbS" id="5fS8LroEbtQ" role="3clFbx">
+                                      <node concept="3clFbF" id="5fS8LroEbtR" role="3cqZAp">
+                                        <node concept="2OqwBi" id="5fS8LroEbtS" role="3clFbG">
+                                          <node concept="37vLTw" id="5fS8LroEbtT" role="2Oq$k0">
+                                            <ref role="3cqZAo" node="5fS8LroEbtK" resolve="descendantCell" />
+                                          </node>
+                                          <node concept="liA8E" id="5fS8LroEbtU" role="2OqNvi">
+                                            <ref role="37wK5l" to="f4zo:~EditorCell.setAction(jetbrains.mps.openapi.editor.cells.CellActionType,jetbrains.mps.openapi.editor.cells.CellAction)" resolve="setAction" />
+                                            <node concept="Rm8GO" id="5fS8LroEbtV" role="37wK5m">
+                                              <ref role="Rm8GQ" to="f4zo:~CellActionType.DELETE" resolve="DELETE" />
+                                              <ref role="1Px2BO" to="f4zo:~CellActionType" resolve="CellActionType" />
+                                            </node>
+                                            <node concept="2ShNRf" id="5fS8LroEbtW" role="37wK5m">
+                                              <node concept="1pGfFk" id="5fS8LroEbtX" role="2ShVmc">
+                                                <ref role="37wK5l" to="czm:4UbrmdUI2qC" resolve="DelegateToParentCellAction" />
+                                                <node concept="37vLTw" id="5fS8LroEbtY" role="37wK5m">
+                                                  <ref role="3cqZAo" node="5fS8LroEbtK" resolve="descendantCell" />
+                                                </node>
+                                                <node concept="Rm8GO" id="5fS8LroEbtZ" role="37wK5m">
+                                                  <ref role="1Px2BO" to="f4zo:~CellActionType" resolve="CellActionType" />
+                                                  <ref role="Rm8GQ" to="f4zo:~CellActionType.DELETE" resolve="DELETE" />
+                                                </node>
+                                              </node>
+                                            </node>
+                                          </node>
+                                        </node>
+                                      </node>
+                                      <node concept="3clFbF" id="5fS8LroEbu0" role="3cqZAp">
+                                        <node concept="2OqwBi" id="5fS8LroEbu1" role="3clFbG">
+                                          <node concept="37vLTw" id="5fS8LroEbu2" role="2Oq$k0">
+                                            <ref role="3cqZAo" node="5fS8LroEbtK" resolve="descendantCell" />
+                                          </node>
+                                          <node concept="liA8E" id="5fS8LroEbu3" role="2OqNvi">
+                                            <ref role="37wK5l" to="f4zo:~EditorCell.setAction(jetbrains.mps.openapi.editor.cells.CellActionType,jetbrains.mps.openapi.editor.cells.CellAction)" resolve="setAction" />
+                                            <node concept="Rm8GO" id="5fS8LroEbu4" role="37wK5m">
+                                              <ref role="1Px2BO" to="f4zo:~CellActionType" resolve="CellActionType" />
+                                              <ref role="Rm8GQ" to="f4zo:~CellActionType.BACKSPACE" resolve="BACKSPACE" />
+                                            </node>
+                                            <node concept="2ShNRf" id="5fS8LroEbu5" role="37wK5m">
+                                              <node concept="1pGfFk" id="5fS8LroEbu6" role="2ShVmc">
+                                                <ref role="37wK5l" to="czm:4UbrmdUI2qC" resolve="DelegateToParentCellAction" />
+                                                <node concept="37vLTw" id="5fS8LroEbu7" role="37wK5m">
+                                                  <ref role="3cqZAo" node="5fS8LroEbtK" resolve="descendantCell" />
+                                                </node>
+                                                <node concept="Rm8GO" id="5fS8LroEbu8" role="37wK5m">
+                                                  <ref role="1Px2BO" to="f4zo:~CellActionType" resolve="CellActionType" />
+                                                  <ref role="Rm8GQ" to="f4zo:~CellActionType.BACKSPACE" resolve="BACKSPACE" />
+                                                </node>
+                                              </node>
+                                            </node>
+                                          </node>
+                                        </node>
+                                      </node>
+                                    </node>
+                                    <node concept="3clFbC" id="5fS8LroEbu9" role="3clFbw">
+                                      <node concept="37vLTw" id="5fS8LroEbua" role="3uHU7w">
+                                        <ref role="3cqZAo" node="5fS8LroEbtp" resolve="childNode" />
+                                      </node>
+                                      <node concept="2OqwBi" id="5fS8LroEbub" role="3uHU7B">
+                                        <node concept="37vLTw" id="5fS8LroEbuc" role="2Oq$k0">
+                                          <ref role="3cqZAo" node="5fS8LroEbtK" resolve="descendantCell" />
+                                        </node>
+                                        <node concept="liA8E" id="5fS8LroEbud" role="2OqNvi">
+                                          <ref role="37wK5l" to="f4zo:~EditorCell.getSNode()" resolve="getSNode" />
+                                        </node>
+                                      </node>
+                                    </node>
+                                    <node concept="9aQIb" id="5fS8LroEbue" role="9aQIa">
+                                      <node concept="3clFbS" id="5fS8LroEbuf" role="9aQI4">
+                                        <node concept="3clFbJ" id="5fS8LroEbug" role="3cqZAp">
+                                          <node concept="3clFbS" id="5fS8LroEbuh" role="3clFbx">
+                                            <node concept="2Gpval" id="5fS8LroEbui" role="3cqZAp">
+                                              <node concept="2GrKxI" id="5fS8LroEbuj" role="2Gsz3X">
+                                                <property role="TrG5h" value="childCell" />
+                                              </node>
+                                              <node concept="3clFbS" id="5fS8LroEbuk" role="2LFqv$">
+                                                <node concept="3clFbF" id="5fS8LroEbul" role="3cqZAp">
+                                                  <node concept="1rXfSq" id="5fS8LroEbum" role="3clFbG">
+                                                    <ref role="37wK5l" node="5fS8LroEbtJ" resolve="removeDeleteAction" />
+                                                    <node concept="2GrUjf" id="5fS8LroEbun" role="37wK5m">
+                                                      <ref role="2Gs0qQ" node="5fS8LroEbuj" resolve="childCell" />
+                                                    </node>
+                                                  </node>
+                                                </node>
+                                              </node>
+                                              <node concept="1eOMI4" id="5fS8LroEbuo" role="2GsD0m">
+                                                <node concept="10QFUN" id="5fS8LroEbup" role="1eOMHV">
+                                                  <node concept="37vLTw" id="5fS8LroEbuq" role="10QFUP">
+                                                    <ref role="3cqZAo" node="5fS8LroEbtK" resolve="descendantCell" />
+                                                  </node>
+                                                  <node concept="3uibUv" id="5fS8LroEbur" role="10QFUM">
+                                                    <ref role="3uigEE" to="f4zo:~EditorCell_Collection" resolve="EditorCell_Collection" />
+                                                  </node>
+                                                </node>
+                                              </node>
+                                            </node>
+                                          </node>
+                                          <node concept="2ZW3vV" id="5fS8LroEbus" role="3clFbw">
+                                            <node concept="3uibUv" id="5fS8LroEbut" role="2ZW6by">
+                                              <ref role="3uigEE" to="f4zo:~EditorCell_Collection" resolve="EditorCell_Collection" />
+                                            </node>
+                                            <node concept="37vLTw" id="5fS8LroEbuu" role="2ZW6bz">
+                                              <ref role="3cqZAo" node="5fS8LroEbtK" resolve="descendantCell" />
+                                            </node>
                                           </node>
                                         </node>
                                       </node>
@@ -3145,19 +3564,20 @@
                             </node>
                           </node>
                         </node>
-                      </node>
-                      <node concept="liA8E" id="5V9BP5IYgEq" role="2OqNvi">
-                        <ref role="37wK5l" node="5V9BP5IYf_B" resolve="removeDeleteAction" />
-                        <node concept="1Q80Hy" id="5V9BP5IYgLE" role="37wK5m" />
+                        <node concept="liA8E" id="5fS8LroEbuv" role="2OqNvi">
+                          <ref role="37wK5l" node="5fS8LroEbtJ" resolve="removeDeleteAction" />
+                          <node concept="1Q80Hy" id="5fS8LroEbuw" role="37wK5m" />
+                        </node>
                       </node>
                     </node>
-                  </node>
-                  <node concept="3cpWs6" id="5V9BP5IYhVx" role="3cqZAp">
-                    <node concept="1Q80Hy" id="5V9BP5IYi4r" role="3cqZAk" />
+                    <node concept="3cpWs6" id="5fS8LroEbux" role="3cqZAp">
+                      <node concept="1Q80Hy" id="5fS8LroEbuy" role="3cqZAk" />
+                    </node>
                   </node>
                 </node>
               </node>
             </node>
+            <node concept="raruj" id="5fS8LroF1o9" role="lGtFl" />
           </node>
           <node concept="2iRkQZ" id="4eBi5gdnRPX" role="2iSdaV" />
         </node>
@@ -3187,6 +3607,512 @@
                   </node>
                 </node>
                 <node concept="3x8VRR" id="4eBi5gdnVUN" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3aamgX" id="3KoBPk0GRQu" role="3acgRq">
+      <ref role="30HIoZ" to="teg0:4qdNcHzYfBo" resolve="OptionalCell" />
+      <node concept="1Koe21" id="3KoBPk0GRQv" role="1lVwrX">
+        <node concept="3EZMnI" id="3KoBPk0GRQw" role="1Koe22">
+          <node concept="2uKrtP" id="5ycts4S0$W1" role="3EZMnx">
+            <property role="2thAuV" value="a" />
+            <node concept="1Qtc8_" id="5ycts4S0$W2" role="2vkWV5">
+              <node concept="aenpk" id="5ycts4S0Boo" role="1Qtc8A">
+                <node concept="2MBE2L" id="5ycts4S5aDK" role="aenpr">
+                  <node concept="2Mo9yg" id="5ycts4S5aDM" role="2MvauM">
+                    <node concept="3clFbS" id="5ycts4S5aDO" role="2VODD2">
+                      <node concept="3cpWs8" id="5ycts4S5E_U" role="3cqZAp">
+                        <node concept="3cpWsn" id="5ycts4S5E_V" role="3cpWs9">
+                          <property role="TrG5h" value="link" />
+                          <node concept="3uibUv" id="5ycts4S5E_2" role="1tU5fm">
+                            <ref role="3uigEE" to="c17a:~SContainmentLink" resolve="SContainmentLink" />
+                          </node>
+                          <node concept="359W_D" id="5ycts4S5E_W" role="33vP2m">
+                            <ref role="359W_E" to="tpee:fzcpWvJ" resolve="LocalVariableDeclaration" />
+                            <ref role="359W_F" to="tpee:fz3vP1I" resolve="initializer" />
+                            <node concept="1ZhdrF" id="5ycts4S5HAf" role="lGtFl">
+                              <property role="2qtEX8" value="conceptDeclaration" />
+                              <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/2644386474301421077/2644386474301421078" />
+                              <node concept="3$xsQk" id="5ycts4S5HAg" role="3$ytzL">
+                                <node concept="3clFbS" id="5ycts4S5HAh" role="2VODD2">
+                                  <node concept="3clFbF" id="5ycts4S5I4n" role="3cqZAp">
+                                    <node concept="2OqwBi" id="5ycts4S5I4o" role="3clFbG">
+                                      <node concept="2OqwBi" id="5ycts4S5I4p" role="2Oq$k0">
+                                        <node concept="30H73N" id="5ycts4S5I4q" role="2Oq$k0" />
+                                        <node concept="2Xjw5R" id="5ycts4S5I4r" role="2OqNvi">
+                                          <node concept="1xMEDy" id="5ycts4S5I4s" role="1xVPHs">
+                                            <node concept="chp4Y" id="5ycts4S5I4t" role="ri$Ld">
+                                              <ref role="cht4Q" to="tpc2:gXXWOiD" resolve="AbstractComponent" />
+                                            </node>
+                                          </node>
+                                        </node>
+                                      </node>
+                                      <node concept="2qgKlT" id="5ycts4S5I4u" role="2OqNvi">
+                                        <ref role="37wK5l" to="tpcb:67EYkym$wx3" resolve="getConceptDeclaration" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="1ZhdrF" id="5ycts4S5HNs" role="lGtFl">
+                              <property role="2qtEX8" value="linkDeclaration" />
+                              <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/2644386474301421077/2644386474301421079" />
+                              <node concept="3$xsQk" id="5ycts4S5HNt" role="3$ytzL">
+                                <node concept="3clFbS" id="5ycts4S5HNu" role="2VODD2">
+                                  <node concept="3clFbF" id="5ycts4S5IEF" role="3cqZAp">
+                                    <node concept="2OqwBi" id="5ycts4S5IEG" role="3clFbG">
+                                      <node concept="1PxgMI" id="5ycts4S5IEH" role="2Oq$k0">
+                                        <node concept="chp4Y" id="5ycts4S5IEI" role="3oSUPX">
+                                          <ref role="cht4Q" to="tpc2:fBF1sR7" resolve="CellModel_RefNode" />
+                                        </node>
+                                        <node concept="2OqwBi" id="5ycts4S5IEJ" role="1m5AlR">
+                                          <node concept="30H73N" id="5ycts4S5IEK" role="2Oq$k0" />
+                                          <node concept="2qgKlT" id="5ycts4S5IEL" role="2OqNvi">
+                                            <ref role="37wK5l" to="karh:7KznU_3XzU4" resolve="getFirstNonConst" />
+                                          </node>
+                                        </node>
+                                      </node>
+                                      <node concept="3TrEf2" id="5ycts4S5IEM" role="2OqNvi">
+                                        <ref role="3Tt5mk" to="tpc2:fBF1sR8" resolve="linkDeclaration" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="5ycts4S5z$u" role="3cqZAp">
+                        <node concept="2OqwBi" id="5ycts4S5GZJ" role="3clFbG">
+                          <node concept="2ShNRf" id="5ycts4S5z$q" role="2Oq$k0">
+                            <node concept="1pGfFk" id="5ycts4S5$wc" role="2ShVmc">
+                              <ref role="37wK5l" to="9eyi:~SubstituteItemsCollector.&lt;init&gt;(org.jetbrains.mps.openapi.model.SNode,org.jetbrains.mps.openapi.model.SNode,org.jetbrains.mps.openapi.language.SContainmentLink,jetbrains.mps.openapi.editor.EditorContext,jetbrains.mps.openapi.editor.menus.substitute.SubstituteMenuLookup)" resolve="SubstituteItemsCollector" />
+                              <node concept="2OqwBi" id="5ycts4S5$Zf" role="37wK5m">
+                                <node concept="2Mo9yH" id="5ycts4S5$HP" role="2Oq$k0" />
+                                <node concept="liA8E" id="5ycts4S5_9c" role="2OqNvi">
+                                  <ref role="37wK5l" to="uddc:~TransformationMenuContext.getNode()" resolve="getNode" />
+                                </node>
+                              </node>
+                              <node concept="10Nm6u" id="5ycts4S5_$Z" role="37wK5m" />
+                              <node concept="37vLTw" id="5ycts4S5E_X" role="37wK5m">
+                                <ref role="3cqZAo" node="5ycts4S5E_V" resolve="link" />
+                              </node>
+                              <node concept="2OqwBi" id="5ycts4S5At2" role="37wK5m">
+                                <node concept="2Mo9yH" id="5ycts4S5AbG" role="2Oq$k0" />
+                                <node concept="liA8E" id="5ycts4S5AKz" role="2OqNvi">
+                                  <ref role="37wK5l" to="uddc:~TransformationMenuContext.getEditorContext()" resolve="getEditorContext" />
+                                </node>
+                              </node>
+                              <node concept="2ShNRf" id="5ycts4S5B3n" role="37wK5m">
+                                <node concept="1pGfFk" id="5ycts4S5C0M" role="2ShVmc">
+                                  <ref role="37wK5l" to="qtqj:~DefaultSubstituteMenuLookup.&lt;init&gt;(jetbrains.mps.smodel.language.LanguageRegistry,org.jetbrains.mps.openapi.language.SAbstractConcept)" resolve="DefaultSubstituteMenuLookup" />
+                                  <node concept="2YIFZM" id="5ycts4S5CSA" role="37wK5m">
+                                    <ref role="1Pybhc" to="vndm:~LanguageRegistry" resolve="LanguageRegistry" />
+                                    <ref role="37wK5l" to="vndm:~LanguageRegistry.getInstance(org.jetbrains.mps.openapi.module.SRepository)" resolve="getInstance" />
+                                    <node concept="2OqwBi" id="5ycts4S5DVz" role="37wK5m">
+                                      <node concept="2OqwBi" id="5ycts4S5DsR" role="2Oq$k0">
+                                        <node concept="2Mo9yH" id="5ycts4S5D9d" role="2Oq$k0" />
+                                        <node concept="liA8E" id="5ycts4S5D_H" role="2OqNvi">
+                                          <ref role="37wK5l" to="uddc:~TransformationMenuContext.getEditorContext()" resolve="getEditorContext" />
+                                        </node>
+                                      </node>
+                                      <node concept="liA8E" id="5ycts4S5Ev3" role="2OqNvi">
+                                        <ref role="37wK5l" to="cj4x:~EditorContext.getRepository()" resolve="getRepository" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                  <node concept="2OqwBi" id="5ycts4S5FZp" role="37wK5m">
+                                    <node concept="37vLTw" id="5ycts4S5FzR" role="2Oq$k0">
+                                      <ref role="3cqZAo" node="5ycts4S5E_V" resolve="link" />
+                                    </node>
+                                    <node concept="liA8E" id="5ycts4S5GE6" role="2OqNvi">
+                                      <ref role="37wK5l" to="c17a:~SAbstractLink.getTargetConcept()" resolve="getTargetConcept" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="liA8E" id="5ycts4S5HyL" role="2OqNvi">
+                            <ref role="37wK5l" to="9eyi:~SubstituteItemsCollector.collect()" resolve="collect" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="27VH4U" id="5ycts4S0Bpk" role="aenpu">
+                  <node concept="3clFbS" id="5ycts4S0Bpl" role="2VODD2">
+                    <node concept="3clFbF" id="5ycts4S0BXd" role="3cqZAp">
+                      <node concept="2OqwBi" id="5ycts4S0FEF" role="3clFbG">
+                        <node concept="2OqwBi" id="5ycts4S0DsI" role="2Oq$k0">
+                          <node concept="1PxgMI" id="5ycts4S0CFn" role="2Oq$k0">
+                            <node concept="chp4Y" id="5ycts4S0E75" role="3oSUPX">
+                              <ref role="cht4Q" to="tpee:fzcpWvJ" resolve="LocalVariableDeclaration" />
+                              <node concept="1ZhdrF" id="5ycts4S0G9l" role="lGtFl">
+                                <property role="2qtEX8" value="conceptDeclaration" />
+                                <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/1177026924588/1177026940964" />
+                                <node concept="3$xsQk" id="5ycts4S0G9m" role="3$ytzL">
+                                  <node concept="3clFbS" id="5ycts4S0G9n" role="2VODD2">
+                                    <node concept="3clFbF" id="5ycts4S0Kna" role="3cqZAp">
+                                      <node concept="2OqwBi" id="5ycts4S0I2e" role="3clFbG">
+                                        <node concept="2OqwBi" id="5ycts4S0I2f" role="2Oq$k0">
+                                          <node concept="30H73N" id="5ycts4S0I2g" role="2Oq$k0" />
+                                          <node concept="2Xjw5R" id="5ycts4S0I2h" role="2OqNvi">
+                                            <node concept="1xMEDy" id="5ycts4S0I2i" role="1xVPHs">
+                                              <node concept="chp4Y" id="5ycts4S0I2j" role="ri$Ld">
+                                                <ref role="cht4Q" to="tpc2:gXXWOiD" resolve="AbstractComponent" />
+                                              </node>
+                                            </node>
+                                          </node>
+                                        </node>
+                                        <node concept="2qgKlT" id="5ycts4S0I2k" role="2OqNvi">
+                                          <ref role="37wK5l" to="tpcb:67EYkym$wx3" resolve="getConceptDeclaration" />
+                                        </node>
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="1eOMI4" id="5ycts4S0Cyd" role="1m5AlR">
+                              <node concept="10QFUN" id="5ycts4S0CmT" role="1eOMHV">
+                                <node concept="7Obwk" id="5ycts4S0CmS" role="10QFUP" />
+                                <node concept="3Tqbb2" id="5ycts4S0CqR" role="10QFUM" />
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="3TrEf2" id="5ycts4S0FmT" role="2OqNvi">
+                            <ref role="3Tt5mk" to="tpee:fz3vP1I" resolve="initializer" />
+                            <node concept="1ZhdrF" id="5ycts4S0Gz8" role="lGtFl">
+                              <property role="2qtEX8" value="link" />
+                              <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/1138056143562/1138056516764" />
+                              <node concept="3$xsQk" id="5ycts4S0Gz9" role="3$ytzL">
+                                <node concept="3clFbS" id="5ycts4S0Gza" role="2VODD2">
+                                  <node concept="3clFbF" id="5ycts4S0KHu" role="3cqZAp">
+                                    <node concept="2OqwBi" id="5ycts4S0KHw" role="3clFbG">
+                                      <node concept="1PxgMI" id="5ycts4S0KHx" role="2Oq$k0">
+                                        <node concept="chp4Y" id="5ycts4S0KHy" role="3oSUPX">
+                                          <ref role="cht4Q" to="tpc2:fBF1sR7" resolve="CellModel_RefNode" />
+                                        </node>
+                                        <node concept="2OqwBi" id="5ycts4S0KHz" role="1m5AlR">
+                                          <node concept="30H73N" id="5ycts4S0KH$" role="2Oq$k0" />
+                                          <node concept="2qgKlT" id="5ycts4S0KH_" role="2OqNvi">
+                                            <ref role="37wK5l" to="karh:7KznU_3XzU4" resolve="getFirstNonConst" />
+                                          </node>
+                                        </node>
+                                      </node>
+                                      <node concept="3TrEf2" id="5ycts4S0KHA" role="2OqNvi">
+                                        <ref role="3Tt5mk" to="tpc2:fBF1sR8" resolve="linkDeclaration" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3w_OXm" id="5ycts4S0FSK" role="2OqNvi" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="2v6KxM" id="5ycts4S0$W4" role="1Qtc8$" />
+            </node>
+            <node concept="raruj" id="5ycts4S0_IB" role="lGtFl" />
+            <node concept="17Uvod" id="5ycts4S0_IC" role="lGtFl">
+              <property role="2qtEX9" value="description" />
+              <property role="P4ACc" value="9d69e719-78c8-4286-90db-fb19c107d049/745148820867185554/745148820908747612" />
+              <node concept="3zFVjK" id="5ycts4S0_ID" role="3zH0cK">
+                <node concept="3clFbS" id="5ycts4S0_IE" role="2VODD2">
+                  <node concept="3clFbF" id="5ycts4S0GRw" role="3cqZAp">
+                    <node concept="3cpWs3" id="5ycts4S0GRx" role="3clFbG">
+                      <node concept="2OqwBi" id="5ycts4S0GRy" role="3uHU7w">
+                        <node concept="2OqwBi" id="5ycts4S0GRz" role="2Oq$k0">
+                          <node concept="1PxgMI" id="5ycts4S0GR$" role="2Oq$k0">
+                            <node concept="chp4Y" id="5ycts4S0GR_" role="3oSUPX">
+                              <ref role="cht4Q" to="tpc2:fBF1sR7" resolve="CellModel_RefNode" />
+                            </node>
+                            <node concept="2OqwBi" id="5ycts4S0GRA" role="1m5AlR">
+                              <node concept="30H73N" id="5ycts4S0GRB" role="2Oq$k0" />
+                              <node concept="2qgKlT" id="5ycts4S0GRC" role="2OqNvi">
+                                <ref role="37wK5l" to="karh:7KznU_3XzU4" resolve="getFirstNonConst" />
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="3TrEf2" id="5ycts4S0GRD" role="2OqNvi">
+                            <ref role="3Tt5mk" to="tpc2:fBF1sR8" resolve="linkDeclaration" />
+                          </node>
+                        </node>
+                        <node concept="3TrcHB" id="5ycts4S0GRE" role="2OqNvi">
+                          <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                        </node>
+                      </node>
+                      <node concept="3cpWs3" id="5ycts4S0GRF" role="3uHU7B">
+                        <node concept="3cpWs3" id="5ycts4S0GRG" role="3uHU7B">
+                          <node concept="Xl_RD" id="5ycts4S0GRH" role="3uHU7B">
+                            <property role="Xl_RC" value="grammar.optional for " />
+                          </node>
+                          <node concept="2OqwBi" id="5ycts4S0GRI" role="3uHU7w">
+                            <node concept="2OqwBi" id="5ycts4S0GRJ" role="2Oq$k0">
+                              <node concept="2OqwBi" id="5ycts4S0GRK" role="2Oq$k0">
+                                <node concept="30H73N" id="5ycts4S0GRL" role="2Oq$k0" />
+                                <node concept="2Xjw5R" id="5ycts4S0GRM" role="2OqNvi">
+                                  <node concept="1xMEDy" id="5ycts4S0GRN" role="1xVPHs">
+                                    <node concept="chp4Y" id="5ycts4S0GRO" role="ri$Ld">
+                                      <ref role="cht4Q" to="tpc2:gXXWOiD" resolve="AbstractComponent" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                              <node concept="2qgKlT" id="5ycts4S0GRP" role="2OqNvi">
+                                <ref role="37wK5l" to="tpcb:67EYkym$wx3" resolve="getConceptDeclaration" />
+                              </node>
+                            </node>
+                            <node concept="3TrcHB" id="5ycts4S0GRQ" role="2OqNvi">
+                              <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="Xl_RD" id="5ycts4S0GRR" role="3uHU7w">
+                          <property role="Xl_RC" value="." />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="130CD5" id="5cbCx5gTGZy" role="3EZMnx">
+            <node concept="130t_x" id="5cbCx5gTUuP" role="130p63">
+              <property role="1hAc7j" value="7P1WhNABvta/backspace_action_id" />
+              <node concept="130t_S" id="5cbCx5gTUuQ" role="130oVf">
+                <node concept="3clFbS" id="5cbCx5gTUuR" role="2VODD2">
+                  <node concept="3cpWs8" id="5cbCx5gTUuS" role="3cqZAp">
+                    <node concept="3cpWsn" id="5cbCx5gTUuT" role="3cpWs9">
+                      <property role="TrG5h" value="caretPosition" />
+                      <node concept="3uibUv" id="5cbCx5gTUuU" role="1tU5fm">
+                        <ref role="3uigEE" to="czm:1xDazL6RYY7" resolve="SavedCaretPosition" />
+                      </node>
+                      <node concept="2ShNRf" id="5cbCx5gTUuV" role="33vP2m">
+                        <node concept="1pGfFk" id="5cbCx5gTUuW" role="2ShVmc">
+                          <ref role="37wK5l" to="czm:3NNwv8WqPSm" resolve="SavedCaretPosition" />
+                          <node concept="1XNTG" id="5cbCx5gTUuX" role="37wK5m" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbF" id="5cbCx5gTUuY" role="3cqZAp">
+                    <node concept="2OqwBi" id="5cbCx5gTUuZ" role="3clFbG">
+                      <node concept="37vLTw" id="5cbCx5gTUv0" role="2Oq$k0">
+                        <ref role="3cqZAo" node="5cbCx5gTUuT" resolve="caretPosition" />
+                      </node>
+                      <node concept="liA8E" id="5cbCx5gTUv1" role="2OqNvi">
+                        <ref role="37wK5l" to="czm:76BPPvEi375" resolve="save" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbF" id="5cbCx5gTUv2" role="3cqZAp">
+                    <node concept="2OqwBi" id="5cbCx5gTUv3" role="3clFbG">
+                      <node concept="2OqwBi" id="5cbCx5gTUv4" role="2Oq$k0">
+                        <node concept="130tyv" id="5cbCx5gTUv5" role="2Oq$k0" />
+                        <node concept="3TrEf2" id="5cbCx5gTUv6" role="2OqNvi">
+                          <ref role="3Tt5mk" to="tpee:fz3vP1I" resolve="initializer" />
+                          <node concept="1ZhdrF" id="5cbCx5gTUv7" role="lGtFl">
+                            <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/1138056143562/1138056516764" />
+                            <property role="2qtEX8" value="link" />
+                            <node concept="3$xsQk" id="5cbCx5gTUv8" role="3$ytzL">
+                              <node concept="3clFbS" id="5cbCx5gTUv9" role="2VODD2">
+                                <node concept="3clFbF" id="5cbCx5gTUva" role="3cqZAp">
+                                  <node concept="2OqwBi" id="5cbCx5gTUvb" role="3clFbG">
+                                    <node concept="1PxgMI" id="5cbCx5gTUvc" role="2Oq$k0">
+                                      <node concept="chp4Y" id="1SbcsM_INT$" role="3oSUPX">
+                                        <ref role="cht4Q" to="tpc2:fBF1sR7" resolve="CellModel_RefNode" />
+                                      </node>
+                                      <node concept="2OqwBi" id="5cbCx5gTUvd" role="1m5AlR">
+                                        <node concept="30H73N" id="5cbCx5gTUve" role="2Oq$k0" />
+                                        <node concept="2qgKlT" id="5cbCx5gTUvf" role="2OqNvi">
+                                          <ref role="37wK5l" to="karh:7KznU_3XzU4" resolve="getFirstNonConst" />
+                                        </node>
+                                      </node>
+                                    </node>
+                                    <node concept="3TrEf2" id="5cbCx5gTUvg" role="2OqNvi">
+                                      <ref role="3Tt5mk" to="tpc2:fBF1sR8" resolve="linkDeclaration" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3YRAZt" id="5cbCx5gTUvh" role="2OqNvi" />
+                    </node>
+                  </node>
+                  <node concept="3clFbF" id="5cbCx5gTUvi" role="3cqZAp">
+                    <node concept="2OqwBi" id="5cbCx5gTUvj" role="3clFbG">
+                      <node concept="1XNTG" id="5cbCx5gTUvk" role="2Oq$k0" />
+                      <node concept="liA8E" id="5cbCx5gTUvl" role="2OqNvi">
+                        <ref role="37wK5l" to="cj4x:~EditorContext.flushEvents()" resolve="flushEvents" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbF" id="5cbCx5gTUvm" role="3cqZAp">
+                    <node concept="2OqwBi" id="5cbCx5gTUvn" role="3clFbG">
+                      <node concept="37vLTw" id="5cbCx5gTUvo" role="2Oq$k0">
+                        <ref role="3cqZAo" node="5cbCx5gTUuT" resolve="caretPosition" />
+                      </node>
+                      <node concept="liA8E" id="5cbCx5gTUvp" role="2OqNvi">
+                        <ref role="37wK5l" to="czm:3NNwv8W$qrW" resolve="restore" />
+                        <node concept="3clFbT" id="5cbCx5gTUvq" role="37wK5m">
+                          <property role="3clFbU" value="true" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="130t_x" id="5cbCx5gTUvr" role="130p63">
+              <property role="1hAc7j" value="g_hAxAO/delete_action_id" />
+              <node concept="130t_S" id="5cbCx5gTUvs" role="130oVf">
+                <node concept="3clFbS" id="5cbCx5gTUvt" role="2VODD2">
+                  <node concept="3cpWs8" id="5cbCx5gTUvu" role="3cqZAp">
+                    <node concept="3cpWsn" id="5cbCx5gTUvv" role="3cpWs9">
+                      <property role="TrG5h" value="caretPosition" />
+                      <node concept="3uibUv" id="5cbCx5gTUvw" role="1tU5fm">
+                        <ref role="3uigEE" to="czm:1xDazL6RYY7" resolve="SavedCaretPosition" />
+                      </node>
+                      <node concept="2ShNRf" id="5cbCx5gTUvx" role="33vP2m">
+                        <node concept="1pGfFk" id="5cbCx5gTUvy" role="2ShVmc">
+                          <ref role="37wK5l" to="czm:3NNwv8WqPSm" resolve="SavedCaretPosition" />
+                          <node concept="1XNTG" id="5cbCx5gTUvz" role="37wK5m" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbF" id="5cbCx5gTUv$" role="3cqZAp">
+                    <node concept="2OqwBi" id="5cbCx5gTUv_" role="3clFbG">
+                      <node concept="37vLTw" id="5cbCx5gTUvA" role="2Oq$k0">
+                        <ref role="3cqZAo" node="5cbCx5gTUvv" resolve="caretPosition" />
+                      </node>
+                      <node concept="liA8E" id="5cbCx5gTUvB" role="2OqNvi">
+                        <ref role="37wK5l" to="czm:76BPPvEi375" resolve="save" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbF" id="5cbCx5gTUvC" role="3cqZAp">
+                    <node concept="2OqwBi" id="5cbCx5gTUvD" role="3clFbG">
+                      <node concept="2OqwBi" id="5cbCx5gTUvE" role="2Oq$k0">
+                        <node concept="130tyv" id="5cbCx5gTUvF" role="2Oq$k0" />
+                        <node concept="3TrEf2" id="5cbCx5gTUvG" role="2OqNvi">
+                          <ref role="3Tt5mk" to="tpee:fz3vP1I" resolve="initializer" />
+                          <node concept="1ZhdrF" id="5cbCx5gTUvH" role="lGtFl">
+                            <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/1138056143562/1138056516764" />
+                            <property role="2qtEX8" value="link" />
+                            <node concept="3$xsQk" id="5cbCx5gTUvI" role="3$ytzL">
+                              <node concept="3clFbS" id="5cbCx5gTUvJ" role="2VODD2">
+                                <node concept="3clFbF" id="5cbCx5gTUvK" role="3cqZAp">
+                                  <node concept="2OqwBi" id="5cbCx5gTUvL" role="3clFbG">
+                                    <node concept="1PxgMI" id="5cbCx5gTUvM" role="2Oq$k0">
+                                      <node concept="chp4Y" id="1SbcsM_INTv" role="3oSUPX">
+                                        <ref role="cht4Q" to="tpc2:fBF1sR7" resolve="CellModel_RefNode" />
+                                      </node>
+                                      <node concept="2OqwBi" id="5cbCx5gTUvN" role="1m5AlR">
+                                        <node concept="30H73N" id="5cbCx5gTUvO" role="2Oq$k0" />
+                                        <node concept="2qgKlT" id="5cbCx5gTUvP" role="2OqNvi">
+                                          <ref role="37wK5l" to="karh:7KznU_3XzU4" resolve="getFirstNonConst" />
+                                        </node>
+                                      </node>
+                                    </node>
+                                    <node concept="3TrEf2" id="5cbCx5gTUvQ" role="2OqNvi">
+                                      <ref role="3Tt5mk" to="tpc2:fBF1sR8" resolve="linkDeclaration" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3YRAZt" id="5cbCx5gTUvR" role="2OqNvi" />
+                    </node>
+                  </node>
+                  <node concept="3clFbF" id="5cbCx5gTUvS" role="3cqZAp">
+                    <node concept="2OqwBi" id="5cbCx5gTUvT" role="3clFbG">
+                      <node concept="1XNTG" id="5cbCx5gTUvU" role="2Oq$k0" />
+                      <node concept="liA8E" id="5cbCx5gTUvV" role="2OqNvi">
+                        <ref role="37wK5l" to="cj4x:~EditorContext.flushEvents()" resolve="flushEvents" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbF" id="5cbCx5gTUvW" role="3cqZAp">
+                    <node concept="2OqwBi" id="5cbCx5gTUvX" role="3clFbG">
+                      <node concept="37vLTw" id="5cbCx5gTUvY" role="2Oq$k0">
+                        <ref role="3cqZAo" node="5cbCx5gTUvv" resolve="caretPosition" />
+                      </node>
+                      <node concept="liA8E" id="5cbCx5gTUvZ" role="2OqNvi">
+                        <ref role="37wK5l" to="czm:3NNwv8W$qrW" resolve="restore" />
+                        <node concept="3clFbT" id="5cbCx5gTUw0" role="37wK5m" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="raruj" id="5cbCx5gTTji" role="lGtFl" />
+            <node concept="3F0ifn" id="3KoBPk0GRT1" role="130CDr">
+              <node concept="29HgVG" id="3KoBPk0GRT2" role="lGtFl">
+                <node concept="3NFfHV" id="3KoBPk0GRT3" role="3NFExx">
+                  <node concept="3clFbS" id="3KoBPk0GRT4" role="2VODD2">
+                    <node concept="3clFbF" id="3KoBPk0GRT5" role="3cqZAp">
+                      <node concept="2OqwBi" id="3KoBPk0GRT6" role="3clFbG">
+                        <node concept="30H73N" id="3KoBPk0GRT7" role="2Oq$k0" />
+                        <node concept="3TrEf2" id="3KoBPk0GRT8" role="2OqNvi">
+                          <ref role="3Tt5mk" to="teg0:4qdNcHzYfBp" resolve="option" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2iRkQZ" id="3KoBPk0GRUl" role="2iSdaV" />
+        </node>
+      </node>
+      <node concept="30G5F_" id="3KoBPk0GRUm" role="30HLyM">
+        <node concept="3clFbS" id="3KoBPk0GRUn" role="2VODD2">
+          <node concept="3clFbF" id="3KoBPk0GRUo" role="3cqZAp">
+            <node concept="1Wc70l" id="3KoBPk0GRUp" role="3clFbG">
+              <node concept="2OqwBi" id="3KoBPk0GRUq" role="3uHU7w">
+                <node concept="2OqwBi" id="3KoBPk0GRUr" role="2Oq$k0">
+                  <node concept="30H73N" id="3KoBPk0GRUs" role="2Oq$k0" />
+                  <node concept="2qgKlT" id="3KoBPk0GRUt" role="2OqNvi">
+                    <ref role="37wK5l" to="karh:7KznU_3XzU4" resolve="getFirstNonConst" />
+                  </node>
+                </node>
+                <node concept="1mIQ4w" id="3KoBPk0GRUu" role="2OqNvi">
+                  <node concept="chp4Y" id="3KoBPk0GRUv" role="cj9EA">
+                    <ref role="cht4Q" to="tpc2:fBF1sR7" resolve="CellModel_RefNode" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2OqwBi" id="3KoBPk0GRUw" role="3uHU7B">
+                <node concept="2OqwBi" id="3KoBPk0GRUx" role="2Oq$k0">
+                  <node concept="30H73N" id="3KoBPk0GRUy" role="2Oq$k0" />
+                  <node concept="2qgKlT" id="3KoBPk0GRUz" role="2OqNvi">
+                    <ref role="37wK5l" to="karh:7KznU_45kn7" resolve="getTransformationText" />
+                  </node>
+                </node>
+                <node concept="3w_OXm" id="3KoBPk0GUoP" role="2OqNvi" />
               </node>
             </node>
           </node>
@@ -3931,312 +4857,85 @@
         </node>
       </node>
     </node>
-    <node concept="3aamgX" id="3KoBPk0GRQu" role="3acgRq">
+    <node concept="3aamgX" id="4eBi5gdpi1r" role="3acgRq">
       <ref role="30HIoZ" to="teg0:4qdNcHzYfBo" resolve="OptionalCell" />
-      <node concept="1Koe21" id="3KoBPk0GRQv" role="1lVwrX">
-        <node concept="3EZMnI" id="3KoBPk0GRQw" role="1Koe22">
-          <node concept="130CD5" id="5cbCx5gTGZy" role="3EZMnx">
-            <node concept="130t_x" id="5cbCx5gTUuP" role="130p63">
-              <property role="1hAc7j" value="7P1WhNABvta/backspace_action_id" />
-              <node concept="130t_S" id="5cbCx5gTUuQ" role="130oVf">
-                <node concept="3clFbS" id="5cbCx5gTUuR" role="2VODD2">
-                  <node concept="3cpWs8" id="5cbCx5gTUuS" role="3cqZAp">
-                    <node concept="3cpWsn" id="5cbCx5gTUuT" role="3cpWs9">
-                      <property role="TrG5h" value="caretPosition" />
-                      <node concept="3uibUv" id="5cbCx5gTUuU" role="1tU5fm">
-                        <ref role="3uigEE" to="czm:1xDazL6RYY7" resolve="SavedCaretPosition" />
-                      </node>
-                      <node concept="2ShNRf" id="5cbCx5gTUuV" role="33vP2m">
-                        <node concept="1pGfFk" id="5cbCx5gTUuW" role="2ShVmc">
-                          <ref role="37wK5l" to="czm:3NNwv8WqPSm" resolve="SavedCaretPosition" />
-                          <node concept="1XNTG" id="5cbCx5gTUuX" role="37wK5m" />
+      <node concept="1Koe21" id="4eBi5gdpi1s" role="1lVwrX">
+        <node concept="3EZMnI" id="4eBi5gdpi1t" role="1Koe22">
+          <node concept="2uKrtP" id="15DZatOPZfY" role="3EZMnx">
+            <property role="2thAuV" value="optional" />
+            <node concept="1Qtc8_" id="15DZatOPZfZ" role="2vkWV5">
+              <node concept="2v6KxM" id="15DZatOPZg1" role="1Qtc8$" />
+              <node concept="2MBE2L" id="15DZatORg6Z" role="1Qtc8A">
+                <node concept="2Mo9yg" id="15DZatORg70" role="2MvauM">
+                  <node concept="3clFbS" id="15DZatORg71" role="2VODD2">
+                    <node concept="3cpWs8" id="15DZatOSo7f" role="3cqZAp">
+                      <node concept="3cpWsn" id="15DZatOSo7i" role="3cpWs9">
+                        <property role="TrG5h" value="items" />
+                        <node concept="_YKpA" id="15DZatOSo7b" role="1tU5fm">
+                          <node concept="3uibUv" id="15DZatOSrl4" role="_ZDj9">
+                            <ref role="3uigEE" to="uddc:~TransformationMenuItem" resolve="TransformationMenuItem" />
+                          </node>
                         </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3clFbF" id="5cbCx5gTUuY" role="3cqZAp">
-                    <node concept="2OqwBi" id="5cbCx5gTUuZ" role="3clFbG">
-                      <node concept="37vLTw" id="5cbCx5gTUv0" role="2Oq$k0">
-                        <ref role="3cqZAo" node="5cbCx5gTUuT" resolve="caretPosition" />
-                      </node>
-                      <node concept="liA8E" id="5cbCx5gTUv1" role="2OqNvi">
-                        <ref role="37wK5l" to="czm:76BPPvEi375" resolve="save" />
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3clFbF" id="5cbCx5gTUv2" role="3cqZAp">
-                    <node concept="2OqwBi" id="5cbCx5gTUv3" role="3clFbG">
-                      <node concept="2OqwBi" id="5cbCx5gTUv4" role="2Oq$k0">
-                        <node concept="130tyv" id="5cbCx5gTUv5" role="2Oq$k0" />
-                        <node concept="3TrEf2" id="5cbCx5gTUv6" role="2OqNvi">
-                          <ref role="3Tt5mk" to="tpee:fz3vP1I" resolve="initializer" />
-                          <node concept="1ZhdrF" id="5cbCx5gTUv7" role="lGtFl">
-                            <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/1138056143562/1138056516764" />
-                            <property role="2qtEX8" value="link" />
-                            <node concept="3$xsQk" id="5cbCx5gTUv8" role="3$ytzL">
-                              <node concept="3clFbS" id="5cbCx5gTUv9" role="2VODD2">
-                                <node concept="3clFbF" id="5cbCx5gTUva" role="3cqZAp">
-                                  <node concept="2OqwBi" id="5cbCx5gTUvb" role="3clFbG">
-                                    <node concept="1PxgMI" id="5cbCx5gTUvc" role="2Oq$k0">
-                                      <node concept="chp4Y" id="1SbcsM_INT$" role="3oSUPX">
-                                        <ref role="cht4Q" to="tpc2:fBF1sR7" resolve="CellModel_RefNode" />
-                                      </node>
-                                      <node concept="2OqwBi" id="5cbCx5gTUvd" role="1m5AlR">
-                                        <node concept="30H73N" id="5cbCx5gTUve" role="2Oq$k0" />
-                                        <node concept="2qgKlT" id="5cbCx5gTUvf" role="2OqNvi">
-                                          <ref role="37wK5l" to="karh:7KznU_3XzU4" resolve="getFirstNonConst" />
-                                        </node>
-                                      </node>
-                                    </node>
-                                    <node concept="3TrEf2" id="5cbCx5gTUvg" role="2OqNvi">
-                                      <ref role="3Tt5mk" to="tpc2:fBF1sR8" resolve="linkDeclaration" />
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
+                        <node concept="2ShNRf" id="15DZatOSzrF" role="33vP2m">
+                          <node concept="Tc6Ow" id="15DZatOSzrB" role="2ShVmc">
+                            <node concept="3uibUv" id="15DZatOSzrC" role="HW$YZ">
+                              <ref role="3uigEE" to="uddc:~TransformationMenuItem" resolve="TransformationMenuItem" />
                             </node>
                           </node>
                         </node>
                       </node>
-                      <node concept="3YRAZt" id="5cbCx5gTUvh" role="2OqNvi" />
                     </node>
-                  </node>
-                  <node concept="3clFbF" id="5cbCx5gTUvi" role="3cqZAp">
-                    <node concept="2OqwBi" id="5cbCx5gTUvj" role="3clFbG">
-                      <node concept="1XNTG" id="5cbCx5gTUvk" role="2Oq$k0" />
-                      <node concept="liA8E" id="5cbCx5gTUvl" role="2OqNvi">
-                        <ref role="37wK5l" to="cj4x:~EditorContext.flushEvents()" resolve="flushEvents" />
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3clFbF" id="5cbCx5gTUvm" role="3cqZAp">
-                    <node concept="2OqwBi" id="5cbCx5gTUvn" role="3clFbG">
-                      <node concept="37vLTw" id="5cbCx5gTUvo" role="2Oq$k0">
-                        <ref role="3cqZAo" node="5cbCx5gTUuT" resolve="caretPosition" />
-                      </node>
-                      <node concept="liA8E" id="5cbCx5gTUvp" role="2OqNvi">
-                        <ref role="37wK5l" to="czm:3NNwv8W$qrW" resolve="restore" />
-                        <node concept="3clFbT" id="5cbCx5gTUvq" role="37wK5m">
-                          <property role="3clFbU" value="true" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="130t_x" id="5cbCx5gTUvr" role="130p63">
-              <property role="1hAc7j" value="g_hAxAO/delete_action_id" />
-              <node concept="130t_S" id="5cbCx5gTUvs" role="130oVf">
-                <node concept="3clFbS" id="5cbCx5gTUvt" role="2VODD2">
-                  <node concept="3cpWs8" id="5cbCx5gTUvu" role="3cqZAp">
-                    <node concept="3cpWsn" id="5cbCx5gTUvv" role="3cpWs9">
-                      <property role="TrG5h" value="caretPosition" />
-                      <node concept="3uibUv" id="5cbCx5gTUvw" role="1tU5fm">
-                        <ref role="3uigEE" to="czm:1xDazL6RYY7" resolve="SavedCaretPosition" />
-                      </node>
-                      <node concept="2ShNRf" id="5cbCx5gTUvx" role="33vP2m">
-                        <node concept="1pGfFk" id="5cbCx5gTUvy" role="2ShVmc">
-                          <ref role="37wK5l" to="czm:3NNwv8WqPSm" resolve="SavedCaretPosition" />
-                          <node concept="1XNTG" id="5cbCx5gTUvz" role="37wK5m" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3clFbF" id="5cbCx5gTUv$" role="3cqZAp">
-                    <node concept="2OqwBi" id="5cbCx5gTUv_" role="3clFbG">
-                      <node concept="37vLTw" id="5cbCx5gTUvA" role="2Oq$k0">
-                        <ref role="3cqZAo" node="5cbCx5gTUvv" resolve="caretPosition" />
-                      </node>
-                      <node concept="liA8E" id="5cbCx5gTUvB" role="2OqNvi">
-                        <ref role="37wK5l" to="czm:76BPPvEi375" resolve="save" />
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3clFbF" id="5cbCx5gTUvC" role="3cqZAp">
-                    <node concept="2OqwBi" id="5cbCx5gTUvD" role="3clFbG">
-                      <node concept="2OqwBi" id="5cbCx5gTUvE" role="2Oq$k0">
-                        <node concept="130tyv" id="5cbCx5gTUvF" role="2Oq$k0" />
-                        <node concept="3TrEf2" id="5cbCx5gTUvG" role="2OqNvi">
-                          <ref role="3Tt5mk" to="tpee:fz3vP1I" resolve="initializer" />
-                          <node concept="1ZhdrF" id="5cbCx5gTUvH" role="lGtFl">
-                            <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/1138056143562/1138056516764" />
-                            <property role="2qtEX8" value="link" />
-                            <node concept="3$xsQk" id="5cbCx5gTUvI" role="3$ytzL">
-                              <node concept="3clFbS" id="5cbCx5gTUvJ" role="2VODD2">
-                                <node concept="3clFbF" id="5cbCx5gTUvK" role="3cqZAp">
-                                  <node concept="2OqwBi" id="5cbCx5gTUvL" role="3clFbG">
-                                    <node concept="1PxgMI" id="5cbCx5gTUvM" role="2Oq$k0">
-                                      <node concept="chp4Y" id="1SbcsM_INTv" role="3oSUPX">
-                                        <ref role="cht4Q" to="tpc2:fBF1sR7" resolve="CellModel_RefNode" />
-                                      </node>
-                                      <node concept="2OqwBi" id="5cbCx5gTUvN" role="1m5AlR">
-                                        <node concept="30H73N" id="5cbCx5gTUvO" role="2Oq$k0" />
-                                        <node concept="2qgKlT" id="5cbCx5gTUvP" role="2OqNvi">
-                                          <ref role="37wK5l" to="karh:7KznU_3XzU4" resolve="getFirstNonConst" />
-                                        </node>
-                                      </node>
-                                    </node>
-                                    <node concept="3TrEf2" id="5cbCx5gTUvQ" role="2OqNvi">
-                                      <ref role="3Tt5mk" to="tpc2:fBF1sR8" resolve="linkDeclaration" />
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
+                    <node concept="3cpWs8" id="15DZatPfj7K" role="3cqZAp">
+                      <node concept="3cpWsn" id="15DZatPfj7L" role="3cpWs9">
+                        <property role="TrG5h" value="sourceNode" />
+                        <property role="3TUv4t" value="true" />
+                        <node concept="3Tqbb2" id="15DZatPfj7M" role="1tU5fm" />
+                        <node concept="2OqwBi" id="15DZatPfj7N" role="33vP2m">
+                          <node concept="2Mo9yH" id="15DZatPfj7O" role="2Oq$k0" />
+                          <node concept="liA8E" id="15DZatPfj7P" role="2OqNvi">
+                            <ref role="37wK5l" to="uddc:~TransformationMenuContext.getNode()" resolve="getNode" />
                           </node>
                         </node>
                       </node>
-                      <node concept="3YRAZt" id="5cbCx5gTUvR" role="2OqNvi" />
                     </node>
-                  </node>
-                  <node concept="3clFbF" id="5cbCx5gTUvS" role="3cqZAp">
-                    <node concept="2OqwBi" id="5cbCx5gTUvT" role="3clFbG">
-                      <node concept="1XNTG" id="5cbCx5gTUvU" role="2Oq$k0" />
-                      <node concept="liA8E" id="5cbCx5gTUvV" role="2OqNvi">
-                        <ref role="37wK5l" to="cj4x:~EditorContext.flushEvents()" resolve="flushEvents" />
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3clFbF" id="5cbCx5gTUvW" role="3cqZAp">
-                    <node concept="2OqwBi" id="5cbCx5gTUvX" role="3clFbG">
-                      <node concept="37vLTw" id="5cbCx5gTUvY" role="2Oq$k0">
-                        <ref role="3cqZAo" node="5cbCx5gTUvv" resolve="caretPosition" />
-                      </node>
-                      <node concept="liA8E" id="5cbCx5gTUvZ" role="2OqNvi">
-                        <ref role="37wK5l" to="czm:3NNwv8W$qrW" resolve="restore" />
-                        <node concept="3clFbT" id="5cbCx5gTUw0" role="37wK5m" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="2kSiTK" id="3KoBPk0GZ1j" role="130CDr">
-              <property role="2kSiWS" value="38nmGbCPLik/both_sides" />
-              <node concept="2kS2EP" id="3KoBPk0GZ1n" role="2kS9vO">
-                <node concept="3clFbS" id="3KoBPk0GZ1p" role="2VODD2">
-                  <node concept="3clFbF" id="4Fanv3VaPun" role="3cqZAp">
-                    <node concept="2OqwBi" id="4Fanv3VaPuo" role="3clFbG">
-                      <node concept="2OqwBi" id="4Fanv3VaPup" role="2Oq$k0">
-                        <node concept="2kS8pE" id="4Fanv3VaSlx" role="2Oq$k0" />
-                        <node concept="liA8E" id="4Fanv3VaPur" role="2OqNvi">
-                          <ref role="37wK5l" to="uddc:~TransformationMenuContext.getEditorMenuTrace()" resolve="getEditorMenuTrace" />
+                    <node concept="3cpWs8" id="15DZatORrFQ" role="3cqZAp">
+                      <node concept="3cpWsn" id="15DZatORrFR" role="3cpWs9">
+                        <property role="TrG5h" value="matchingTexts" />
+                        <property role="3TUv4t" value="true" />
+                        <node concept="A3Dl8" id="15DZatORrFS" role="1tU5fm">
+                          <node concept="17QB3L" id="15DZatORrFT" role="A3Ik2" />
                         </node>
-                      </node>
-                      <node concept="liA8E" id="4Fanv3VaPus" role="2OqNvi">
-                        <ref role="37wK5l" to="x4mf:~EditorMenuTrace.pushTraceInfo()" resolve="pushTraceInfo" />
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3clFbF" id="4Fanv3VaPut" role="3cqZAp">
-                    <node concept="2OqwBi" id="4Fanv3VaPuu" role="3clFbG">
-                      <node concept="2OqwBi" id="4Fanv3VaPuv" role="2Oq$k0">
-                        <node concept="2kS8pE" id="4Fanv3VaTsL" role="2Oq$k0" />
-                        <node concept="liA8E" id="4Fanv3VaPux" role="2OqNvi">
-                          <ref role="37wK5l" to="uddc:~TransformationMenuContext.getEditorMenuTrace()" resolve="getEditorMenuTrace" />
-                        </node>
-                      </node>
-                      <node concept="liA8E" id="4Fanv3VaPuy" role="2OqNvi">
-                        <ref role="37wK5l" to="x4mf:~EditorMenuTrace.setDescriptor(jetbrains.mps.openapi.editor.menus.EditorMenuDescriptor)" resolve="setDescriptor" />
-                        <node concept="2ShNRf" id="4Fanv3VaPuz" role="37wK5m">
-                          <node concept="1pGfFk" id="4Fanv3VaPu$" role="2ShVmc">
-                            <ref role="37wK5l" to="v95p:~EditorMenuDescriptorBase.&lt;init&gt;(java.lang.String,org.jetbrains.mps.openapi.model.SNodeReference)" resolve="EditorMenuDescriptorBase" />
-                            <node concept="3cpWs3" id="4Fanv3WbN5k" role="37wK5m">
-                              <node concept="Xl_RD" id="4Fanv3VaPu_" role="3uHU7B">
-                                <property role="Xl_RC" value="grammar.optional in " />
-                              </node>
-                              <node concept="Xl_RD" id="4Fanv3WbOfz" role="3uHU7w">
-                                <property role="Xl_RC" value="ConceptName" />
-                                <node concept="17Uvod" id="4Fanv3WbOf$" role="lGtFl">
-                                  <property role="P4ACc" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1070475926800/1070475926801" />
-                                  <property role="2qtEX9" value="value" />
-                                  <node concept="3zFVjK" id="4Fanv3WbOf_" role="3zH0cK">
-                                    <node concept="3clFbS" id="4Fanv3WbOfA" role="2VODD2">
-                                      <node concept="3clFbF" id="4Fanv3WbOfB" role="3cqZAp">
-                                        <node concept="2OqwBi" id="4Fanv3WbOfC" role="3clFbG">
-                                          <node concept="2OqwBi" id="4Fanv3WbOfD" role="2Oq$k0">
-                                            <node concept="2OqwBi" id="4Fanv3WbOfE" role="2Oq$k0">
-                                              <node concept="30H73N" id="4Fanv3WbOfF" role="2Oq$k0" />
-                                              <node concept="2Xjw5R" id="4Fanv3WbOfG" role="2OqNvi">
-                                                <node concept="1xMEDy" id="4Fanv3WbOfH" role="1xVPHs">
-                                                  <node concept="chp4Y" id="4Fanv3WbOfI" role="ri$Ld">
-                                                    <ref role="cht4Q" to="tpc2:gXXWOiD" resolve="AbstractComponent" />
-                                                  </node>
-                                                </node>
-                                                <node concept="1xLf8o" id="4Fanv3WbOfJ" role="1xVPHs" />
-                                              </node>
-                                            </node>
-                                            <node concept="2qgKlT" id="4Fanv3WbOfK" role="2OqNvi">
-                                              <ref role="37wK5l" to="tpcb:67EYkym$wx3" resolve="getConceptDeclaration" />
-                                            </node>
-                                          </node>
-                                          <node concept="3TrcHB" id="4Fanv3WbOfL" role="2OqNvi">
-                                            <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
-                                          </node>
-                                        </node>
-                                      </node>
-                                    </node>
+                        <node concept="2OqwBi" id="15DZatORrFU" role="33vP2m">
+                          <node concept="2ShNRf" id="15DZatORrFV" role="2Oq$k0">
+                            <node concept="YeOm9" id="15DZatORrFW" role="2ShVmc">
+                              <node concept="1Y3b0j" id="15DZatORrFX" role="YeSDq">
+                                <property role="2bfB8j" value="true" />
+                                <ref role="1Y3XeK" to="czm:mEdliw9W0N" resolve="StringOrSequenceQuery" />
+                                <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
+                                <node concept="3Tm1VV" id="15DZatORrFY" role="1B3o_S" />
+                                <node concept="3clFb_" id="15DZatORrFZ" role="jymVt">
+                                  <property role="TrG5h" value="queryStringOrSequence" />
+                                  <property role="1EzhhJ" value="false" />
+                                  <node concept="3uibUv" id="15DZatORrG0" role="3clF45">
+                                    <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
                                   </node>
-                                </node>
-                              </node>
-                            </node>
-                            <node concept="2ShNRf" id="4Fanv3VaPuA" role="37wK5m">
-                              <node concept="1pGfFk" id="4Fanv3VaPuB" role="2ShVmc">
-                                <ref role="37wK5l" to="w1kc:~SNodePointer.&lt;init&gt;(java.lang.String,java.lang.String)" resolve="SNodePointer" />
-                                <node concept="Xl_RD" id="4Fanv3VaPuC" role="37wK5m">
-                                  <property role="Xl_RC" value="modelUID" />
-                                  <node concept="17Uvod" id="4Fanv3VaPuD" role="lGtFl">
-                                    <property role="2qtEX9" value="value" />
-                                    <property role="P4ACc" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1070475926800/1070475926801" />
-                                    <node concept="3zFVjK" id="4Fanv3VaPuE" role="3zH0cK">
-                                      <node concept="3clFbS" id="4Fanv3VaPuF" role="2VODD2">
-                                        <node concept="3cpWs6" id="4Fanv3VaPuG" role="3cqZAp">
-                                          <node concept="2OqwBi" id="4Fanv3VaPuH" role="3cqZAk">
-                                            <node concept="2OqwBi" id="4Fanv3VaPuI" role="2Oq$k0">
-                                              <node concept="liA8E" id="4Fanv3VaPuJ" role="2OqNvi">
-                                                <ref role="37wK5l" to="mhbf:~SModel.getReference()" resolve="getReference" />
-                                              </node>
-                                              <node concept="2JrnkZ" id="4Fanv3VaPuK" role="2Oq$k0">
-                                                <node concept="2OqwBi" id="4Fanv3VaPuL" role="2JrQYb">
-                                                  <node concept="1iwH7S" id="4Fanv3VaPuM" role="2Oq$k0" />
-                                                  <node concept="1st3f0" id="4Fanv3VaPuN" role="2OqNvi" />
-                                                </node>
-                                              </node>
-                                            </node>
-                                            <node concept="liA8E" id="4Fanv3VaPuO" role="2OqNvi">
-                                              <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
-                                            </node>
-                                          </node>
-                                        </node>
-                                      </node>
-                                    </node>
-                                  </node>
-                                </node>
-                                <node concept="Xl_RD" id="4Fanv3VaPuP" role="37wK5m">
-                                  <property role="Xl_RC" value="nodeID" />
-                                  <node concept="17Uvod" id="4Fanv3VaPuQ" role="lGtFl">
-                                    <property role="2qtEX9" value="value" />
-                                    <property role="P4ACc" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1070475926800/1070475926801" />
-                                    <node concept="3zFVjK" id="4Fanv3VaPuR" role="3zH0cK">
-                                      <node concept="3clFbS" id="4Fanv3VaPuS" role="2VODD2">
-                                        <node concept="3cpWs6" id="4Fanv3VaPuT" role="3cqZAp">
-                                          <node concept="2OqwBi" id="4Fanv3VaPuU" role="3cqZAk">
-                                            <node concept="2OqwBi" id="4Fanv3VaPuV" role="2Oq$k0">
-                                              <node concept="2JrnkZ" id="4Fanv3VaPuW" role="2Oq$k0">
-                                                <node concept="2OqwBi" id="4Fanv3VaPuX" role="2JrQYb">
-                                                  <node concept="1iwH7S" id="4Fanv3VaPuY" role="2Oq$k0" />
-                                                  <node concept="12$id9" id="4Fanv3VaPuZ" role="2OqNvi">
-                                                    <node concept="30H73N" id="4Fanv3VaPv0" role="12$y8L" />
+                                  <node concept="3Tm1VV" id="15DZatORrG1" role="1B3o_S" />
+                                  <node concept="3clFbS" id="15DZatORrG2" role="3clF47">
+                                    <node concept="3clFbF" id="15DZatORxdl" role="3cqZAp">
+                                      <node concept="Xl_RD" id="15DZatORxdm" role="3clFbG">
+                                        <property role="Xl_RC" value="" />
+                                        <node concept="1sPUBX" id="15DZatORxdn" role="lGtFl">
+                                          <ref role="v9R2y" node="2uT2PLn1V4k" resolve="switch_constantTextSequence" />
+                                          <node concept="3NFfHV" id="15DZatORxdo" role="1sPUBK">
+                                            <node concept="3clFbS" id="15DZatORxdp" role="2VODD2">
+                                              <node concept="3clFbF" id="15DZatORxdq" role="3cqZAp">
+                                                <node concept="2OqwBi" id="15DZatORxdr" role="3clFbG">
+                                                  <node concept="30H73N" id="15DZatORxds" role="2Oq$k0" />
+                                                  <node concept="2qgKlT" id="15DZatORxdt" role="2OqNvi">
+                                                    <ref role="37wK5l" to="karh:7KznU_45kn7" resolve="getTransformationText" />
                                                   </node>
                                                 </node>
                                               </node>
-                                              <node concept="liA8E" id="4Fanv3VaPv1" role="2OqNvi">
-                                                <ref role="37wK5l" to="mhbf:~SNode.getNodeId()" resolve="getNodeId" />
-                                              </node>
-                                            </node>
-                                            <node concept="liA8E" id="4Fanv3VaPv2" role="2OqNvi">
-                                              <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
                                             </node>
                                           </node>
                                         </node>
@@ -4247,62 +4946,40 @@
                               </node>
                             </node>
                           </node>
+                          <node concept="liA8E" id="15DZatORrGg" role="2OqNvi">
+                            <ref role="37wK5l" to="czm:mEdliw8IXH" resolve="query" />
+                          </node>
                         </node>
                       </node>
                     </node>
-                  </node>
-                  <node concept="3J1_TO" id="4Fanv3VaPv3" role="3cqZAp">
-                    <node concept="3clFbS" id="4Fanv3VaPv4" role="1zxBo7">
-                      <node concept="3cpWs8" id="3KoBPk0RCBz" role="3cqZAp">
-                        <node concept="3cpWsn" id="3KoBPk0RCB$" role="3cpWs9">
-                          <property role="TrG5h" value="sourceNode" />
-                          <node concept="3Tqbb2" id="3KoBPk0RDFH" role="1tU5fm" />
-                          <node concept="2OqwBi" id="3KoBPk0RCB_" role="33vP2m">
-                            <node concept="2kS8pE" id="3KoBPk0RCBA" role="2Oq$k0" />
-                            <node concept="liA8E" id="3KoBPk0RCBB" role="2OqNvi">
-                              <ref role="37wK5l" to="uddc:~TransformationMenuContext.getNode()" resolve="getNode" />
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="3clFbJ" id="3KoBPk0Rx59" role="3cqZAp">
-                        <node concept="3clFbS" id="3KoBPk0Rx5b" role="3clFbx">
-                          <node concept="3cpWs6" id="3KoBPk0RIEY" role="3cqZAp">
-                            <node concept="2ShNRf" id="3KoBPk0RKDz" role="3cqZAk">
-                              <node concept="kMnCb" id="3KoBPk0RKDv" role="2ShVmc">
-                                <node concept="3uibUv" id="2mvFNoS3XWx" role="kMuH3">
-                                  <ref role="3uigEE" to="uddc:~TransformationMenuItem" resolve="TransformationMenuItem" />
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="3fqX7Q" id="3KoBPk0RHFQ" role="3clFbw">
-                          <node concept="2OqwBi" id="3KoBPk0RHFS" role="3fr31v">
-                            <node concept="37vLTw" id="2mvFNoS3OK0" role="2Oq$k0">
-                              <ref role="3cqZAo" node="3KoBPk0RCB$" resolve="sourceNode" />
-                            </node>
-                            <node concept="1mIQ4w" id="3KoBPk0RHFU" role="2OqNvi">
-                              <node concept="chp4Y" id="3KoBPk0RHFV" role="cj9EA">
-                                <ref role="cht4Q" to="tpee:fz3uBXI" resolve="VariableDeclaration" />
-                                <node concept="1ZhdrF" id="3KoBPk0RLDX" role="lGtFl">
+                    <node concept="3cpWs8" id="15DZatORrGh" role="3cqZAp">
+                      <node concept="3cpWsn" id="15DZatORrGi" role="3cpWs9">
+                        <property role="TrG5h" value="isApplicable" />
+                        <property role="3TUv4t" value="true" />
+                        <node concept="10P_77" id="15DZatORrGj" role="1tU5fm" />
+                        <node concept="2OqwBi" id="15DZatOSPiN" role="33vP2m">
+                          <node concept="2OqwBi" id="15DZatOSPiO" role="2Oq$k0">
+                            <node concept="1PxgMI" id="15DZatOSPiP" role="2Oq$k0">
+                              <node concept="chp4Y" id="15DZatOSPiQ" role="3oSUPX">
+                                <ref role="cht4Q" to="tpck:gw2VY9q" resolve="BaseConcept" />
+                                <node concept="1ZhdrF" id="15DZatOSPiR" role="lGtFl">
                                   <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/1177026924588/1177026940964" />
                                   <property role="2qtEX8" value="conceptDeclaration" />
-                                  <node concept="3$xsQk" id="3KoBPk0RLDY" role="3$ytzL">
-                                    <node concept="3clFbS" id="3KoBPk0RLDZ" role="2VODD2">
-                                      <node concept="3clFbF" id="3KoBPk0RMzQ" role="3cqZAp">
-                                        <node concept="2OqwBi" id="3KoBPk0RMzS" role="3clFbG">
-                                          <node concept="2OqwBi" id="3KoBPk0RMzT" role="2Oq$k0">
-                                            <node concept="30H73N" id="3KoBPk0RMzU" role="2Oq$k0" />
-                                            <node concept="2Xjw5R" id="3KoBPk0RMzV" role="2OqNvi">
-                                              <node concept="1xMEDy" id="3KoBPk0RMzW" role="1xVPHs">
-                                                <node concept="chp4Y" id="3KoBPk0RMzX" role="ri$Ld">
+                                  <node concept="3$xsQk" id="15DZatOSPiS" role="3$ytzL">
+                                    <node concept="3clFbS" id="15DZatOSPiT" role="2VODD2">
+                                      <node concept="3clFbF" id="15DZatOSPiU" role="3cqZAp">
+                                        <node concept="2OqwBi" id="15DZatOSPiV" role="3clFbG">
+                                          <node concept="2OqwBi" id="15DZatOSPiW" role="2Oq$k0">
+                                            <node concept="30H73N" id="15DZatOSPiX" role="2Oq$k0" />
+                                            <node concept="2Xjw5R" id="15DZatOSPiY" role="2OqNvi">
+                                              <node concept="1xMEDy" id="15DZatOSPiZ" role="1xVPHs">
+                                                <node concept="chp4Y" id="15DZatOSPj0" role="ri$Ld">
                                                   <ref role="cht4Q" to="tpc2:gXXWOiD" resolve="AbstractComponent" />
                                                 </node>
                                               </node>
                                             </node>
                                           </node>
-                                          <node concept="2qgKlT" id="3KoBPk0RMzY" role="2OqNvi">
+                                          <node concept="2qgKlT" id="15DZatOSPj1" role="2OqNvi">
                                             <ref role="37wK5l" to="tpcb:67EYkym$wx3" resolve="getConceptDeclaration" />
                                           </node>
                                         </node>
@@ -4311,203 +4988,35 @@
                                   </node>
                                 </node>
                               </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="3cpWs8" id="3KoBPk0Hhz8" role="3cqZAp">
-                        <node concept="3cpWsn" id="3KoBPk0Hhzb" role="3cpWs9">
-                          <property role="TrG5h" value="parentNode" />
-                          <node concept="3Tqbb2" id="3KoBPk0Hhz6" role="1tU5fm">
-                            <ref role="ehGHo" to="tpee:fz3uBXI" resolve="VariableDeclaration" />
-                            <node concept="1ZhdrF" id="3KoBPk0HQrF" role="lGtFl">
-                              <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/1138055754698/1138405853777" />
-                              <property role="2qtEX8" value="concept" />
-                              <node concept="3$xsQk" id="3KoBPk0HQrG" role="3$ytzL">
-                                <node concept="3clFbS" id="3KoBPk0HQrH" role="2VODD2">
-                                  <node concept="3clFbF" id="3KoBPk0HQBK" role="3cqZAp">
-                                    <node concept="2OqwBi" id="3KoBPk0HWbQ" role="3clFbG">
-                                      <node concept="2OqwBi" id="3KoBPk0HQPp" role="2Oq$k0">
-                                        <node concept="30H73N" id="3KoBPk0HQBJ" role="2Oq$k0" />
-                                        <node concept="2Xjw5R" id="3KoBPk0HRpZ" role="2OqNvi">
-                                          <node concept="1xMEDy" id="3KoBPk0HRq1" role="1xVPHs">
-                                            <node concept="chp4Y" id="3KoBPk0HVQA" role="ri$Ld">
-                                              <ref role="cht4Q" to="tpc2:gXXWOiD" resolve="AbstractComponent" />
-                                            </node>
-                                          </node>
-                                        </node>
-                                      </node>
-                                      <node concept="2qgKlT" id="3KoBPk0HWCi" role="2OqNvi">
-                                        <ref role="37wK5l" to="tpcb:67EYkym$wx3" resolve="getConceptDeclaration" />
-                                      </node>
-                                    </node>
-                                  </node>
+                              <node concept="2OqwBi" id="15DZatOSPj2" role="1m5AlR">
+                                <node concept="2Mo9yH" id="15DZatOSVkt" role="2Oq$k0" />
+                                <node concept="liA8E" id="15DZatOSPj4" role="2OqNvi">
+                                  <ref role="37wK5l" to="uddc:~TransformationMenuContext.getNode()" resolve="getNode" />
                                 </node>
                               </node>
                             </node>
-                          </node>
-                          <node concept="1PxgMI" id="3KoBPk0HHmE" role="33vP2m">
-                            <node concept="chp4Y" id="1SbcsM_INTc" role="3oSUPX">
-                              <ref role="cht4Q" to="tpee:fz3uBXI" resolve="VariableDeclaration" />
-                              <node concept="1ZhdrF" id="3KoBPk0HXjN" role="lGtFl">
-                                <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/1177026924588/1177026940964" />
-                                <property role="2qtEX8" value="conceptDeclaration" />
-                                <node concept="3$xsQk" id="3KoBPk0HXjO" role="3$ytzL">
-                                  <node concept="3clFbS" id="3KoBPk0HXjP" role="2VODD2">
-                                    <node concept="3clFbF" id="3KoBPk0HXA4" role="3cqZAp">
-                                      <node concept="2OqwBi" id="3KoBPk0HXA5" role="3clFbG">
-                                        <node concept="2OqwBi" id="3KoBPk0HXA6" role="2Oq$k0">
-                                          <node concept="30H73N" id="3KoBPk0HXA7" role="2Oq$k0" />
-                                          <node concept="2Xjw5R" id="3KoBPk0HXA8" role="2OqNvi">
-                                            <node concept="1xMEDy" id="3KoBPk0HXA9" role="1xVPHs">
-                                              <node concept="chp4Y" id="3KoBPk0HXAa" role="ri$Ld">
-                                                <ref role="cht4Q" to="tpc2:gXXWOiD" resolve="AbstractComponent" />
-                                              </node>
-                                            </node>
-                                          </node>
-                                        </node>
-                                        <node concept="2qgKlT" id="3KoBPk0HXAb" role="2OqNvi">
-                                          <ref role="37wK5l" to="tpcb:67EYkym$wx3" resolve="getConceptDeclaration" />
-                                        </node>
-                                      </node>
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                            <node concept="37vLTw" id="2mvFNoS3QL4" role="1m5AlR">
-                              <ref role="3cqZAo" node="3KoBPk0RCB$" resolve="sourceNode" />
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="3cpWs8" id="3KoBPk0Hidx" role="3cqZAp">
-                        <node concept="3cpWsn" id="3KoBPk0Hidy" role="3cpWs9">
-                          <property role="TrG5h" value="link" />
-                          <property role="3TUv4t" value="true" />
-                          <node concept="3uibUv" id="3KoBPk0Hidw" role="1tU5fm">
-                            <ref role="3uigEE" to="c17a:~SContainmentLink" resolve="SContainmentLink" />
-                          </node>
-                          <node concept="359W_D" id="3KoBPk0Hidz" role="33vP2m">
-                            <ref role="359W_E" to="tpee:fz3uBXI" resolve="VariableDeclaration" />
-                            <ref role="359W_F" to="tpee:4VkOLwjf83e" resolve="type" />
-                            <node concept="1ZhdrF" id="3KoBPk0HYj3" role="lGtFl">
-                              <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/2644386474301421077/2644386474301421078" />
-                              <property role="2qtEX8" value="conceptDeclaration" />
-                              <node concept="3$xsQk" id="3KoBPk0HYj4" role="3$ytzL">
-                                <node concept="3clFbS" id="3KoBPk0HYj5" role="2VODD2">
-                                  <node concept="3clFbF" id="3KoBPk0HY_O" role="3cqZAp">
-                                    <node concept="2OqwBi" id="3KoBPk0HY_P" role="3clFbG">
-                                      <node concept="2OqwBi" id="3KoBPk0HY_Q" role="2Oq$k0">
-                                        <node concept="30H73N" id="3KoBPk0HY_R" role="2Oq$k0" />
-                                        <node concept="2Xjw5R" id="3KoBPk0HY_S" role="2OqNvi">
-                                          <node concept="1xMEDy" id="3KoBPk0HY_T" role="1xVPHs">
-                                            <node concept="chp4Y" id="3KoBPk0HY_U" role="ri$Ld">
-                                              <ref role="cht4Q" to="tpc2:gXXWOiD" resolve="AbstractComponent" />
-                                            </node>
-                                          </node>
-                                        </node>
-                                      </node>
-                                      <node concept="2qgKlT" id="3KoBPk0HY_V" role="2OqNvi">
-                                        <ref role="37wK5l" to="tpcb:67EYkym$wx3" resolve="getConceptDeclaration" />
-                                      </node>
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                            <node concept="1ZhdrF" id="3KoBPk0IcsE" role="lGtFl">
-                              <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/2644386474301421077/2644386474301421079" />
-                              <property role="2qtEX8" value="linkDeclaration" />
-                              <node concept="3$xsQk" id="3KoBPk0IcsF" role="3$ytzL">
-                                <node concept="3clFbS" id="3KoBPk0IcsG" role="2VODD2">
-                                  <node concept="3clFbF" id="3KoBPk0Iddr" role="3cqZAp">
-                                    <node concept="2OqwBi" id="3KoBPk0Iddu" role="3clFbG">
-                                      <node concept="1PxgMI" id="3KoBPk0Iddv" role="2Oq$k0">
-                                        <node concept="chp4Y" id="1SbcsM_INTo" role="3oSUPX">
-                                          <ref role="cht4Q" to="tpc2:fBF1sR7" resolve="CellModel_RefNode" />
-                                        </node>
-                                        <node concept="2OqwBi" id="3KoBPk0Iddw" role="1m5AlR">
-                                          <node concept="30H73N" id="3KoBPk0Iddx" role="2Oq$k0" />
-                                          <node concept="2qgKlT" id="3KoBPk0Iddy" role="2OqNvi">
-                                            <ref role="37wK5l" to="karh:7KznU_3XzU4" resolve="getFirstNonConst" />
-                                          </node>
-                                        </node>
-                                      </node>
-                                      <node concept="3TrEf2" id="3KoBPk0Iddz" role="2OqNvi">
-                                        <ref role="3Tt5mk" to="tpc2:fBF1sR8" resolve="linkDeclaration" />
-                                      </node>
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="3cpWs8" id="3KoBPk0Hit$" role="3cqZAp">
-                        <node concept="3cpWsn" id="3KoBPk0HitB" role="3cpWs9">
-                          <property role="TrG5h" value="currentChild" />
-                          <node concept="3Tqbb2" id="3KoBPk0Hity" role="1tU5fm">
-                            <ref role="ehGHo" to="tpee:fz3vP1H" resolve="Type" />
-                            <node concept="1ZhdrF" id="3KoBPk0HZJk" role="lGtFl">
-                              <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/1138055754698/1138405853777" />
-                              <property role="2qtEX8" value="concept" />
-                              <node concept="3$xsQk" id="3KoBPk0HZJl" role="3$ytzL">
-                                <node concept="3clFbS" id="3KoBPk0HZJm" role="2VODD2">
-                                  <node concept="3clFbF" id="3KoBPk0I0e_" role="3cqZAp">
-                                    <node concept="2OqwBi" id="3KoBPk0I5E_" role="3clFbG">
-                                      <node concept="2OqwBi" id="3KoBPk0I3Wo" role="2Oq$k0">
-                                        <node concept="1PxgMI" id="3KoBPk0I2KM" role="2Oq$k0">
-                                          <node concept="chp4Y" id="1SbcsM_INTp" role="3oSUPX">
-                                            <ref role="cht4Q" to="tpc2:fBF1sR7" resolve="CellModel_RefNode" />
-                                          </node>
-                                          <node concept="2OqwBi" id="3KoBPk0I0Hu" role="1m5AlR">
-                                            <node concept="30H73N" id="3KoBPk0I0e$" role="2Oq$k0" />
-                                            <node concept="2qgKlT" id="3KoBPk0I1$q" role="2OqNvi">
-                                              <ref role="37wK5l" to="karh:7KznU_3XzU4" resolve="getFirstNonConst" />
-                                            </node>
-                                          </node>
-                                        </node>
-                                        <node concept="3TrEf2" id="3KoBPk0I4LT" role="2OqNvi">
-                                          <ref role="3Tt5mk" to="tpc2:fBF1sR8" resolve="linkDeclaration" />
-                                        </node>
-                                      </node>
-                                      <node concept="3TrEf2" id="3KoBPk0I6Bl" role="2OqNvi">
-                                        <ref role="3Tt5mk" to="tpce:fA0lvVK" resolve="target" />
-                                      </node>
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                          <node concept="2OqwBi" id="3KoBPk0HiMb" role="33vP2m">
-                            <node concept="37vLTw" id="2mvFNoS3SMe" role="2Oq$k0">
-                              <ref role="3cqZAo" node="3KoBPk0Hhzb" resolve="parentNode" />
-                            </node>
-                            <node concept="3TrEf2" id="3KoBPk0HIkS" role="2OqNvi">
-                              <ref role="3Tt5mk" to="tpee:4VkOLwjf83e" resolve="type" />
-                              <node concept="1ZhdrF" id="3KoBPk0Ihrn" role="lGtFl">
-                                <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/1138056143562/1138056516764" />
+                            <node concept="3Tsc0h" id="15DZatOSPj5" role="2OqNvi">
+                              <ref role="3TtcxE" to="tpee:fzcqZ_x" resolve="statement" />
+                              <node concept="1ZhdrF" id="15DZatOSPj6" role="lGtFl">
+                                <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/1138056282393/1138056546658" />
                                 <property role="2qtEX8" value="link" />
-                                <node concept="3$xsQk" id="3KoBPk0Ihro" role="3$ytzL">
-                                  <node concept="3clFbS" id="3KoBPk0Ihrp" role="2VODD2">
-                                    <node concept="3clFbF" id="3KoBPk0IinC" role="3cqZAp">
-                                      <node concept="2OqwBi" id="3KoBPk0IinF" role="3clFbG">
-                                        <node concept="1PxgMI" id="3KoBPk0IinG" role="2Oq$k0">
-                                          <node concept="chp4Y" id="1SbcsM_INU1" role="3oSUPX">
-                                            <ref role="cht4Q" to="tpc2:fBF1sR7" resolve="CellModel_RefNode" />
+                                <node concept="3$xsQk" id="15DZatOSPj7" role="3$ytzL">
+                                  <node concept="3clFbS" id="15DZatOSPj8" role="2VODD2">
+                                    <node concept="3clFbF" id="15DZatOSPj9" role="3cqZAp">
+                                      <node concept="2OqwBi" id="15DZatOSPja" role="3clFbG">
+                                        <node concept="1PxgMI" id="15DZatOSPjb" role="2Oq$k0">
+                                          <node concept="chp4Y" id="15DZatOSPjc" role="3oSUPX">
+                                            <ref role="cht4Q" to="tpc2:fBF2Hee" resolve="CellModel_RefNodeList" />
                                           </node>
-                                          <node concept="2OqwBi" id="3KoBPk0IinH" role="1m5AlR">
-                                            <node concept="30H73N" id="3KoBPk0IinI" role="2Oq$k0" />
-                                            <node concept="2qgKlT" id="3KoBPk0IinJ" role="2OqNvi">
+                                          <node concept="2OqwBi" id="15DZatOSPjd" role="1m5AlR">
+                                            <node concept="30H73N" id="15DZatOSPje" role="2Oq$k0" />
+                                            <node concept="2qgKlT" id="15DZatOSPjf" role="2OqNvi">
                                               <ref role="37wK5l" to="karh:7KznU_3XzU4" resolve="getFirstNonConst" />
                                             </node>
                                           </node>
                                         </node>
-                                        <node concept="3TrEf2" id="3KoBPk0IinK" role="2OqNvi">
-                                          <ref role="3Tt5mk" to="tpc2:fBF1sR8" resolve="linkDeclaration" />
+                                        <node concept="3TrEf2" id="15DZatOSPjg" role="2OqNvi">
+                                          <ref role="3Tt5mk" to="tpc2:fBF2Hej" resolve="linkDeclaration" />
                                         </node>
                                       </node>
                                     </node>
@@ -4516,382 +5025,320 @@
                               </node>
                             </node>
                           </node>
+                          <node concept="1v1jN8" id="6zUT77XzMf9" role="2OqNvi" />
                         </node>
                       </node>
-                      <node concept="3cpWs6" id="4Fanv3VbMMI" role="3cqZAp">
-                        <node concept="2OqwBi" id="4Fanv3VbMMK" role="3cqZAk">
-                          <node concept="2ShNRf" id="4Fanv3VbMML" role="2Oq$k0">
-                            <node concept="1pGfFk" id="4Fanv3VbMMM" role="2ShVmc">
-                              <ref role="37wK5l" to="9eyi:~SubstituteItemsCollector.&lt;init&gt;(org.jetbrains.mps.openapi.model.SNode,org.jetbrains.mps.openapi.model.SNode,org.jetbrains.mps.openapi.language.SContainmentLink,jetbrains.mps.openapi.editor.EditorContext,jetbrains.mps.openapi.editor.menus.substitute.SubstituteMenuLookup)" resolve="SubstituteItemsCollector" />
-                              <node concept="37vLTw" id="4Fanv3VbMMN" role="37wK5m">
-                                <ref role="3cqZAo" node="3KoBPk0Hhzb" resolve="parentNode" />
-                              </node>
-                              <node concept="37vLTw" id="4Fanv3VbMMO" role="37wK5m">
-                                <ref role="3cqZAo" node="3KoBPk0HitB" resolve="currentChild" />
-                              </node>
-                              <node concept="37vLTw" id="4Fanv3VbMMP" role="37wK5m">
-                                <ref role="3cqZAo" node="3KoBPk0Hidy" resolve="link" />
-                              </node>
-                              <node concept="2OqwBi" id="4Fanv3VbMMQ" role="37wK5m">
-                                <node concept="2kS8pE" id="4Fanv3VbMMR" role="2Oq$k0" />
-                                <node concept="liA8E" id="4Fanv3VbMMS" role="2OqNvi">
-                                  <ref role="37wK5l" to="uddc:~TransformationMenuContext.getEditorContext()" resolve="getEditorContext" />
-                                </node>
-                              </node>
-                              <node concept="10Nm6u" id="4Fanv3VbMMT" role="37wK5m" />
+                    </node>
+                    <node concept="3clFbH" id="15DZatORrGF" role="3cqZAp" />
+                    <node concept="3clFbJ" id="15DZatORrGG" role="3cqZAp">
+                      <node concept="3clFbS" id="15DZatORrGH" role="3clFbx">
+                        <node concept="3clFbF" id="15DZatORrGI" role="3cqZAp">
+                          <node concept="2OqwBi" id="15DZatORrGJ" role="3clFbG">
+                            <node concept="37vLTw" id="15DZatOT5mG" role="2Oq$k0">
+                              <ref role="3cqZAo" node="15DZatOSo7i" resolve="items" />
                             </node>
-                          </node>
-                          <node concept="liA8E" id="4Fanv3VbMMU" role="2OqNvi">
-                            <ref role="37wK5l" to="9eyi:~SubstituteItemsCollector.collect()" resolve="collect" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="1wplmZ" id="d1YgGmqaFLb" role="1zxBo6">
-                      <node concept="3clFbS" id="4Fanv3VaPvb" role="1wplMD">
-                        <node concept="3clFbF" id="4Fanv3VaPvc" role="3cqZAp">
-                          <node concept="2OqwBi" id="4Fanv3VaPvd" role="3clFbG">
-                            <node concept="2OqwBi" id="4Fanv3VaPve" role="2Oq$k0">
-                              <node concept="2kS8pE" id="4Fanv3VaU$1" role="2Oq$k0" />
-                              <node concept="liA8E" id="4Fanv3VaPvg" role="2OqNvi">
-                                <ref role="37wK5l" to="uddc:~TransformationMenuContext.getEditorMenuTrace()" resolve="getEditorMenuTrace" />
-                              </node>
-                            </node>
-                            <node concept="liA8E" id="4Fanv3VaPvh" role="2OqNvi">
-                              <ref role="37wK5l" to="x4mf:~EditorMenuTrace.popTraceInfo()" resolve="popTraceInfo" />
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3F0ifn" id="3KoBPk0GRT1" role="2kSiZZ">
-                <node concept="29HgVG" id="3KoBPk0GRT2" role="lGtFl">
-                  <node concept="3NFfHV" id="3KoBPk0GRT3" role="3NFExx">
-                    <node concept="3clFbS" id="3KoBPk0GRT4" role="2VODD2">
-                      <node concept="3clFbF" id="3KoBPk0GRT5" role="3cqZAp">
-                        <node concept="2OqwBi" id="3KoBPk0GRT6" role="3clFbG">
-                          <node concept="30H73N" id="3KoBPk0GRT7" role="2Oq$k0" />
-                          <node concept="3TrEf2" id="3KoBPk0GRT8" role="2OqNvi">
-                            <ref role="3Tt5mk" to="teg0:4qdNcHzYfBp" resolve="option" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="raruj" id="5cbCx5gTTji" role="lGtFl" />
-          </node>
-          <node concept="2iRkQZ" id="3KoBPk0GRUl" role="2iSdaV" />
-        </node>
-      </node>
-      <node concept="30G5F_" id="3KoBPk0GRUm" role="30HLyM">
-        <node concept="3clFbS" id="3KoBPk0GRUn" role="2VODD2">
-          <node concept="3clFbF" id="3KoBPk0GRUo" role="3cqZAp">
-            <node concept="1Wc70l" id="3KoBPk0GRUp" role="3clFbG">
-              <node concept="2OqwBi" id="3KoBPk0GRUq" role="3uHU7w">
-                <node concept="2OqwBi" id="3KoBPk0GRUr" role="2Oq$k0">
-                  <node concept="30H73N" id="3KoBPk0GRUs" role="2Oq$k0" />
-                  <node concept="2qgKlT" id="3KoBPk0GRUt" role="2OqNvi">
-                    <ref role="37wK5l" to="karh:7KznU_3XzU4" resolve="getFirstNonConst" />
-                  </node>
-                </node>
-                <node concept="1mIQ4w" id="3KoBPk0GRUu" role="2OqNvi">
-                  <node concept="chp4Y" id="3KoBPk0GRUv" role="cj9EA">
-                    <ref role="cht4Q" to="tpc2:fBF1sR7" resolve="CellModel_RefNode" />
-                  </node>
-                </node>
-              </node>
-              <node concept="2OqwBi" id="3KoBPk0GRUw" role="3uHU7B">
-                <node concept="2OqwBi" id="3KoBPk0GRUx" role="2Oq$k0">
-                  <node concept="30H73N" id="3KoBPk0GRUy" role="2Oq$k0" />
-                  <node concept="2qgKlT" id="3KoBPk0GRUz" role="2OqNvi">
-                    <ref role="37wK5l" to="karh:7KznU_45kn7" resolve="getTransformationText" />
-                  </node>
-                </node>
-                <node concept="3w_OXm" id="3KoBPk0GUoP" role="2OqNvi" />
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="3aamgX" id="4eBi5gdpi1r" role="3acgRq">
-      <ref role="30HIoZ" to="teg0:4qdNcHzYfBo" resolve="OptionalCell" />
-      <node concept="1Koe21" id="4eBi5gdpi1s" role="1lVwrX">
-        <node concept="3EZMnI" id="4eBi5gdpi1t" role="1Koe22">
-          <node concept="1eYWM2" id="4eBi5gdpi1u" role="3EZMnx">
-            <node concept="1eYxTg" id="4eBi5gdpi1v" role="1eYxTh">
-              <node concept="3clFbS" id="4eBi5gdpi1w" role="2VODD2">
-                <node concept="3cpWs8" id="65e5JdYL11F" role="3cqZAp">
-                  <node concept="3cpWsn" id="65e5JdYL11G" role="3cpWs9">
-                    <property role="TrG5h" value="result" />
-                    <node concept="3Tqbb2" id="65e5JdYL0Zk" role="1tU5fm">
-                      <ref role="ehGHo" to="tpee:fzclF8l" resolve="Statement" />
-                    </node>
-                    <node concept="2OqwBi" id="65e5JdYL11H" role="33vP2m">
-                      <node concept="2OqwBi" id="65e5JdYL11I" role="2Oq$k0">
-                        <node concept="1PxgMI" id="65e5JdYL11J" role="2Oq$k0">
-                          <node concept="chp4Y" id="1SbcsM_INTJ" role="3oSUPX">
-                            <ref role="cht4Q" to="tpck:gw2VY9q" resolve="BaseConcept" />
-                            <node concept="1ZhdrF" id="65e5JdYL11N" role="lGtFl">
-                              <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/1177026924588/1177026940964" />
-                              <property role="2qtEX8" value="conceptDeclaration" />
-                              <node concept="3$xsQk" id="65e5JdYL11O" role="3$ytzL">
-                                <node concept="3clFbS" id="65e5JdYL11P" role="2VODD2">
-                                  <node concept="3clFbF" id="65e5JdYL11Q" role="3cqZAp">
-                                    <node concept="2OqwBi" id="65e5JdYL11R" role="3clFbG">
-                                      <node concept="2OqwBi" id="65e5JdYL11S" role="2Oq$k0">
-                                        <node concept="30H73N" id="65e5JdYL11T" role="2Oq$k0" />
-                                        <node concept="2Xjw5R" id="65e5JdYL11U" role="2OqNvi">
-                                          <node concept="1xMEDy" id="65e5JdYL11V" role="1xVPHs">
-                                            <node concept="chp4Y" id="65e5JdYL11W" role="ri$Ld">
-                                              <ref role="cht4Q" to="tpc2:gXXWOiD" resolve="AbstractComponent" />
+                            <node concept="TSZUe" id="15DZatORrGL" role="2OqNvi">
+                              <node concept="2ShNRf" id="15DZatORrGM" role="25WWJ7">
+                                <node concept="YeOm9" id="15DZatORrGN" role="2ShVmc">
+                                  <node concept="1Y3b0j" id="15DZatORrGO" role="YeSDq">
+                                    <property role="2bfB8j" value="true" />
+                                    <ref role="37wK5l" to="czm:1YKLYyyOIFX" resolve="MultiTextActionItem" />
+                                    <ref role="1Y3XeK" to="czm:1YKLYyyOIFO" resolve="MultiTextActionItem" />
+                                    <node concept="3clFb_" id="15DZatORrGP" role="jymVt">
+                                      <property role="1EzhhJ" value="false" />
+                                      <property role="TrG5h" value="execute" />
+                                      <property role="DiZV1" value="false" />
+                                      <property role="od$2w" value="false" />
+                                      <node concept="3Tm1VV" id="15DZatORrGQ" role="1B3o_S" />
+                                      <node concept="3cqZAl" id="15DZatORrGR" role="3clF45" />
+                                      <node concept="37vLTG" id="15DZatORrGS" role="3clF46">
+                                        <property role="TrG5h" value="pattern" />
+                                        <node concept="17QB3L" id="15DZatORrGT" role="1tU5fm" />
+                                        <node concept="2AHcQZ" id="15DZatORrGU" role="2AJF6D">
+                                          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+                                        </node>
+                                      </node>
+                                      <node concept="3clFbS" id="15DZatORrGV" role="3clF47">
+                                        <node concept="3clFbF" id="15DZatORrGW" role="3cqZAp">
+                                          <node concept="1rXfSq" id="15DZatORrGX" role="3clFbG">
+                                            <ref role="37wK5l" node="15DZatORrH0" resolve="doSubstitute" />
+                                            <node concept="37vLTw" id="15DZatORrGY" role="37wK5m">
+                                              <ref role="3cqZAo" node="15DZatORrGS" resolve="pattern" />
                                             </node>
                                           </node>
                                         </node>
                                       </node>
-                                      <node concept="2qgKlT" id="65e5JdYL11X" role="2OqNvi">
-                                        <ref role="37wK5l" to="tpcb:67EYkym$wx3" resolve="getConceptDeclaration" />
+                                      <node concept="2AHcQZ" id="15DZatORrGZ" role="2AJF6D">
+                                        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
                                       </node>
                                     </node>
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                          <node concept="2OqwBi" id="65e5JdYL11K" role="1m5AlR">
-                            <node concept="2kS8pE" id="65e5JdYL11L" role="2Oq$k0" />
-                            <node concept="liA8E" id="65e5JdYL11M" role="2OqNvi">
-                              <ref role="37wK5l" to="uddc:~TransformationMenuContext.getNode()" resolve="getNode" />
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="3Tsc0h" id="65e5JdYL11Y" role="2OqNvi">
-                          <ref role="3TtcxE" to="tpee:fzcqZ_x" resolve="statement" />
-                          <node concept="1ZhdrF" id="65e5JdYL11Z" role="lGtFl">
-                            <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/1138056282393/1138056546658" />
-                            <property role="2qtEX8" value="link" />
-                            <node concept="3$xsQk" id="65e5JdYL120" role="3$ytzL">
-                              <node concept="3clFbS" id="65e5JdYL121" role="2VODD2">
-                                <node concept="3clFbF" id="65e5JdYL122" role="3cqZAp">
-                                  <node concept="2OqwBi" id="65e5JdYL123" role="3clFbG">
-                                    <node concept="1PxgMI" id="65e5JdYL124" role="2Oq$k0">
-                                      <node concept="chp4Y" id="1SbcsM_INTG" role="3oSUPX">
-                                        <ref role="cht4Q" to="tpc2:fBF2Hee" resolve="CellModel_RefNodeList" />
-                                      </node>
-                                      <node concept="2OqwBi" id="65e5JdYL125" role="1m5AlR">
-                                        <node concept="30H73N" id="65e5JdYL126" role="2Oq$k0" />
-                                        <node concept="2qgKlT" id="65e5JdYL127" role="2OqNvi">
-                                          <ref role="37wK5l" to="karh:7KznU_3XzU4" resolve="getFirstNonConst" />
+                                    <node concept="3clFb_" id="15DZatORrH0" role="jymVt">
+                                      <property role="1EzhhJ" value="false" />
+                                      <property role="TrG5h" value="doSubstitute" />
+                                      <property role="DiZV1" value="false" />
+                                      <property role="od$2w" value="false" />
+                                      <node concept="3Tm1VV" id="15DZatORrH1" role="1B3o_S" />
+                                      <node concept="3Tqbb2" id="15DZatORrH2" role="3clF45" />
+                                      <node concept="37vLTG" id="15DZatORrH3" role="3clF46">
+                                        <property role="TrG5h" value="pattern" />
+                                        <node concept="17QB3L" id="15DZatORrH4" role="1tU5fm" />
+                                        <node concept="2AHcQZ" id="15DZatORrH5" role="2AJF6D">
+                                          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
                                         </node>
                                       </node>
-                                    </node>
-                                    <node concept="3TrEf2" id="65e5JdYL128" role="2OqNvi">
-                                      <ref role="3Tt5mk" to="tpc2:fBF2Hej" resolve="linkDeclaration" />
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="2Ke4WJ" id="65e5JdYL129" role="2OqNvi">
-                        <node concept="2ShNRf" id="65e5JdYL12a" role="25WWJ7">
-                          <node concept="2fJWfE" id="65e5JdYL12b" role="2ShVmc">
-                            <node concept="3Tqbb2" id="65e5JdYL12c" role="3zrR0E">
-                              <ref role="ehGHo" to="tpee:fzclF8l" resolve="Statement" />
-                              <node concept="1ZhdrF" id="65e5JdYL12d" role="lGtFl">
-                                <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/1138055754698/1138405853777" />
-                                <property role="2qtEX8" value="concept" />
-                                <node concept="3$xsQk" id="65e5JdYL12e" role="3$ytzL">
-                                  <node concept="3clFbS" id="65e5JdYL12f" role="2VODD2">
-                                    <node concept="3clFbF" id="65e5JdYL12g" role="3cqZAp">
-                                      <node concept="2OqwBi" id="65e5JdYL12h" role="3clFbG">
-                                        <node concept="2OqwBi" id="65e5JdYL12i" role="2Oq$k0">
-                                          <node concept="1PxgMI" id="65e5JdYL12j" role="2Oq$k0">
-                                            <node concept="chp4Y" id="1SbcsM_INTN" role="3oSUPX">
-                                              <ref role="cht4Q" to="tpc2:fBF2Hee" resolve="CellModel_RefNodeList" />
+                                      <node concept="3clFbS" id="15DZatORrH6" role="3clF47">
+                                        <node concept="3cpWs8" id="15DZatORB3A" role="3cqZAp">
+                                          <node concept="3cpWsn" id="15DZatORB3B" role="3cpWs9">
+                                            <property role="TrG5h" value="result" />
+                                            <node concept="3Tqbb2" id="15DZatORB3C" role="1tU5fm">
+                                              <ref role="ehGHo" to="tpee:fzclF8l" resolve="Statement" />
                                             </node>
-                                            <node concept="2OqwBi" id="65e5JdYL12k" role="1m5AlR">
-                                              <node concept="30H73N" id="65e5JdYL12l" role="2Oq$k0" />
-                                              <node concept="2qgKlT" id="65e5JdYL12m" role="2OqNvi">
-                                                <ref role="37wK5l" to="karh:7KznU_3XzU4" resolve="getFirstNonConst" />
+                                            <node concept="2OqwBi" id="15DZatORB3D" role="33vP2m">
+                                              <node concept="2OqwBi" id="15DZatORB3E" role="2Oq$k0">
+                                                <node concept="1PxgMI" id="15DZatORB3F" role="2Oq$k0">
+                                                  <node concept="chp4Y" id="15DZatORB3G" role="3oSUPX">
+                                                    <ref role="cht4Q" to="tpck:gw2VY9q" resolve="BaseConcept" />
+                                                    <node concept="1ZhdrF" id="15DZatORB3H" role="lGtFl">
+                                                      <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/1177026924588/1177026940964" />
+                                                      <property role="2qtEX8" value="conceptDeclaration" />
+                                                      <node concept="3$xsQk" id="15DZatORB3I" role="3$ytzL">
+                                                        <node concept="3clFbS" id="15DZatORB3J" role="2VODD2">
+                                                          <node concept="3clFbF" id="15DZatORB3K" role="3cqZAp">
+                                                            <node concept="2OqwBi" id="15DZatORB3L" role="3clFbG">
+                                                              <node concept="2OqwBi" id="15DZatORB3M" role="2Oq$k0">
+                                                                <node concept="30H73N" id="15DZatORB3N" role="2Oq$k0" />
+                                                                <node concept="2Xjw5R" id="15DZatORB3O" role="2OqNvi">
+                                                                  <node concept="1xMEDy" id="15DZatORB3P" role="1xVPHs">
+                                                                    <node concept="chp4Y" id="15DZatORB3Q" role="ri$Ld">
+                                                                      <ref role="cht4Q" to="tpc2:gXXWOiD" resolve="AbstractComponent" />
+                                                                    </node>
+                                                                  </node>
+                                                                </node>
+                                                              </node>
+                                                              <node concept="2qgKlT" id="15DZatORB3R" role="2OqNvi">
+                                                                <ref role="37wK5l" to="tpcb:67EYkym$wx3" resolve="getConceptDeclaration" />
+                                                              </node>
+                                                            </node>
+                                                          </node>
+                                                        </node>
+                                                      </node>
+                                                    </node>
+                                                  </node>
+                                                  <node concept="2OqwBi" id="15DZatORXf1" role="1m5AlR">
+                                                    <node concept="2Mo9yH" id="15DZatORTYm" role="2Oq$k0" />
+                                                    <node concept="liA8E" id="15DZatOS19q" role="2OqNvi">
+                                                      <ref role="37wK5l" to="uddc:~TransformationMenuContext.getNode()" resolve="getNode" />
+                                                    </node>
+                                                  </node>
+                                                </node>
+                                                <node concept="3Tsc0h" id="15DZatORB3V" role="2OqNvi">
+                                                  <ref role="3TtcxE" to="tpee:fzcqZ_x" resolve="statement" />
+                                                  <node concept="1ZhdrF" id="15DZatORB3W" role="lGtFl">
+                                                    <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/1138056282393/1138056546658" />
+                                                    <property role="2qtEX8" value="link" />
+                                                    <node concept="3$xsQk" id="15DZatORB3X" role="3$ytzL">
+                                                      <node concept="3clFbS" id="15DZatORB3Y" role="2VODD2">
+                                                        <node concept="3clFbF" id="15DZatORB3Z" role="3cqZAp">
+                                                          <node concept="2OqwBi" id="15DZatORB40" role="3clFbG">
+                                                            <node concept="1PxgMI" id="15DZatORB41" role="2Oq$k0">
+                                                              <node concept="chp4Y" id="15DZatORB42" role="3oSUPX">
+                                                                <ref role="cht4Q" to="tpc2:fBF2Hee" resolve="CellModel_RefNodeList" />
+                                                              </node>
+                                                              <node concept="2OqwBi" id="15DZatORB43" role="1m5AlR">
+                                                                <node concept="30H73N" id="15DZatORB44" role="2Oq$k0" />
+                                                                <node concept="2qgKlT" id="15DZatORB45" role="2OqNvi">
+                                                                  <ref role="37wK5l" to="karh:7KznU_3XzU4" resolve="getFirstNonConst" />
+                                                                </node>
+                                                              </node>
+                                                            </node>
+                                                            <node concept="3TrEf2" id="15DZatORB46" role="2OqNvi">
+                                                              <ref role="3Tt5mk" to="tpc2:fBF2Hej" resolve="linkDeclaration" />
+                                                            </node>
+                                                          </node>
+                                                        </node>
+                                                      </node>
+                                                    </node>
+                                                  </node>
+                                                </node>
+                                              </node>
+                                              <node concept="2Ke4WJ" id="15DZatORB47" role="2OqNvi">
+                                                <node concept="2ShNRf" id="15DZatORB48" role="25WWJ7">
+                                                  <node concept="2fJWfE" id="15DZatORB49" role="2ShVmc">
+                                                    <node concept="3Tqbb2" id="15DZatORB4a" role="3zrR0E">
+                                                      <ref role="ehGHo" to="tpee:fzclF8l" resolve="Statement" />
+                                                      <node concept="1ZhdrF" id="15DZatORB4b" role="lGtFl">
+                                                        <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/1138055754698/1138405853777" />
+                                                        <property role="2qtEX8" value="concept" />
+                                                        <node concept="3$xsQk" id="15DZatORB4c" role="3$ytzL">
+                                                          <node concept="3clFbS" id="15DZatORB4d" role="2VODD2">
+                                                            <node concept="3clFbF" id="15DZatORB4e" role="3cqZAp">
+                                                              <node concept="2OqwBi" id="15DZatORB4f" role="3clFbG">
+                                                                <node concept="2OqwBi" id="15DZatORB4g" role="2Oq$k0">
+                                                                  <node concept="1PxgMI" id="15DZatORB4h" role="2Oq$k0">
+                                                                    <node concept="chp4Y" id="15DZatORB4i" role="3oSUPX">
+                                                                      <ref role="cht4Q" to="tpc2:fBF2Hee" resolve="CellModel_RefNodeList" />
+                                                                    </node>
+                                                                    <node concept="2OqwBi" id="15DZatORB4j" role="1m5AlR">
+                                                                      <node concept="30H73N" id="15DZatORB4k" role="2Oq$k0" />
+                                                                      <node concept="2qgKlT" id="15DZatORB4l" role="2OqNvi">
+                                                                        <ref role="37wK5l" to="karh:7KznU_3XzU4" resolve="getFirstNonConst" />
+                                                                      </node>
+                                                                    </node>
+                                                                  </node>
+                                                                  <node concept="3TrEf2" id="15DZatORB4m" role="2OqNvi">
+                                                                    <ref role="3Tt5mk" to="tpc2:fBF2Hej" resolve="linkDeclaration" />
+                                                                  </node>
+                                                                </node>
+                                                                <node concept="3TrEf2" id="15DZatORB4n" role="2OqNvi">
+                                                                  <ref role="3Tt5mk" to="tpce:fA0lvVK" resolve="target" />
+                                                                </node>
+                                                              </node>
+                                                            </node>
+                                                          </node>
+                                                        </node>
+                                                      </node>
+                                                    </node>
+                                                  </node>
+                                                </node>
                                               </node>
                                             </node>
                                           </node>
-                                          <node concept="3TrEf2" id="65e5JdYL12n" role="2OqNvi">
-                                            <ref role="3Tt5mk" to="tpc2:fBF2Hej" resolve="linkDeclaration" />
-                                          </node>
                                         </node>
-                                        <node concept="3TrEf2" id="65e5JdYL12o" role="2OqNvi">
-                                          <ref role="3Tt5mk" to="tpce:fA0lvVK" resolve="target" />
-                                        </node>
-                                      </node>
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="3clFbF" id="65e5JdYL53r" role="3cqZAp">
-                  <node concept="2OqwBi" id="65e5JdYL53s" role="3clFbG">
-                    <node concept="2ShNRf" id="65e5JdYL53t" role="2Oq$k0">
-                      <node concept="YeOm9" id="65e5JdYL53u" role="2ShVmc">
-                        <node concept="1Y3b0j" id="65e5JdYL53v" role="YeSDq">
-                          <property role="2bfB8j" value="true" />
-                          <ref role="1Y3XeK" to="wyt6:~Object" resolve="Object" />
-                          <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
-                          <node concept="3Tm1VV" id="65e5JdYL53w" role="1B3o_S" />
-                          <node concept="3clFb_" id="65e5JdYL53x" role="jymVt">
-                            <property role="TrG5h" value="postprocess" />
-                            <node concept="37vLTG" id="65e5JdYL53y" role="3clF46">
-                              <property role="TrG5h" value="node" />
-                              <node concept="3Tqbb2" id="65e5JdYL53z" role="1tU5fm" />
-                            </node>
-                            <node concept="3cqZAl" id="65e5JdYL53$" role="3clF45" />
-                            <node concept="3Tm1VV" id="65e5JdYL53_" role="1B3o_S" />
-                            <node concept="3clFbS" id="65e5JdYL53A" role="3clF47">
-                              <node concept="3clFbH" id="65e5JdYL53B" role="3cqZAp">
-                                <node concept="2b32R4" id="65e5JdYL53C" role="lGtFl">
-                                  <node concept="3JmXsc" id="65e5JdYL53D" role="2P8S$">
-                                    <node concept="3clFbS" id="65e5JdYL53E" role="2VODD2">
-                                      <node concept="3clFbF" id="65e5JdYL53F" role="3cqZAp">
-                                        <node concept="2OqwBi" id="65e5JdYL53G" role="3clFbG">
-                                          <node concept="2OqwBi" id="65e5JdYL53H" role="2Oq$k0">
-                                            <node concept="2OqwBi" id="65e5JdYL53I" role="2Oq$k0">
-                                              <node concept="30H73N" id="65e5JdYL53J" role="2Oq$k0" />
-                                              <node concept="3TrEf2" id="65e5JdYL53K" role="2OqNvi">
-                                                <ref role="3Tt5mk" to="teg0:65e5JdYJiFg" resolve="postprocess" />
+                                        <node concept="3clFbF" id="15DZatORB4o" role="3cqZAp">
+                                          <node concept="2OqwBi" id="15DZatORB4p" role="3clFbG">
+                                            <node concept="2ShNRf" id="15DZatORB4q" role="2Oq$k0">
+                                              <node concept="YeOm9" id="15DZatORB4r" role="2ShVmc">
+                                                <node concept="1Y3b0j" id="15DZatORB4s" role="YeSDq">
+                                                  <property role="2bfB8j" value="true" />
+                                                  <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
+                                                  <ref role="1Y3XeK" to="wyt6:~Object" resolve="Object" />
+                                                  <node concept="3Tm1VV" id="15DZatORB4t" role="1B3o_S" />
+                                                  <node concept="3clFb_" id="15DZatORB4u" role="jymVt">
+                                                    <property role="TrG5h" value="postprocess" />
+                                                    <node concept="37vLTG" id="15DZatORB4v" role="3clF46">
+                                                      <property role="TrG5h" value="node" />
+                                                      <node concept="3Tqbb2" id="15DZatORB4w" role="1tU5fm" />
+                                                    </node>
+                                                    <node concept="3cqZAl" id="15DZatORB4x" role="3clF45" />
+                                                    <node concept="3Tm1VV" id="15DZatORB4y" role="1B3o_S" />
+                                                    <node concept="3clFbS" id="15DZatORB4z" role="3clF47">
+                                                      <node concept="3clFbH" id="15DZatORB4$" role="3cqZAp">
+                                                        <node concept="2b32R4" id="15DZatORB4_" role="lGtFl">
+                                                          <node concept="3JmXsc" id="15DZatORB4A" role="2P8S$">
+                                                            <node concept="3clFbS" id="15DZatORB4B" role="2VODD2">
+                                                              <node concept="3clFbF" id="15DZatORB4C" role="3cqZAp">
+                                                                <node concept="2OqwBi" id="15DZatORB4D" role="3clFbG">
+                                                                  <node concept="2OqwBi" id="15DZatORB4E" role="2Oq$k0">
+                                                                    <node concept="2OqwBi" id="15DZatORB4F" role="2Oq$k0">
+                                                                      <node concept="30H73N" id="15DZatORB4G" role="2Oq$k0" />
+                                                                      <node concept="3TrEf2" id="15DZatORB4H" role="2OqNvi">
+                                                                        <ref role="3Tt5mk" to="teg0:65e5JdYJiFg" resolve="postprocess" />
+                                                                      </node>
+                                                                    </node>
+                                                                    <node concept="3TrEf2" id="15DZatORB4I" role="2OqNvi">
+                                                                      <ref role="3Tt5mk" to="tpee:gyVODHa" resolve="body" />
+                                                                    </node>
+                                                                  </node>
+                                                                  <node concept="3Tsc0h" id="15DZatORB4J" role="2OqNvi">
+                                                                    <ref role="3TtcxE" to="tpee:fzcqZ_x" resolve="statement" />
+                                                                  </node>
+                                                                </node>
+                                                              </node>
+                                                            </node>
+                                                          </node>
+                                                        </node>
+                                                      </node>
+                                                    </node>
+                                                  </node>
+                                                </node>
                                               </node>
                                             </node>
-                                            <node concept="3TrEf2" id="65e5JdYL53L" role="2OqNvi">
-                                              <ref role="3Tt5mk" to="tpee:gyVODHa" resolve="body" />
+                                            <node concept="liA8E" id="15DZatORB4K" role="2OqNvi">
+                                              <ref role="37wK5l" node="15DZatORB4u" resolve="postprocess" />
+                                              <node concept="2OqwBi" id="15DZatORB4L" role="37wK5m">
+                                                <node concept="2Mo9yH" id="15DZatOS56v" role="2Oq$k0" />
+                                                <node concept="liA8E" id="15DZatOS8Ks" role="2OqNvi">
+                                                  <ref role="37wK5l" to="uddc:~TransformationMenuContext.getNode()" resolve="getNode" />
+                                                </node>
+                                              </node>
                                             </node>
                                           </node>
-                                          <node concept="3Tsc0h" id="65e5JdYL53M" role="2OqNvi">
-                                            <ref role="3TtcxE" to="tpee:fzcqZ_x" resolve="statement" />
+                                          <node concept="1W57fq" id="15DZatORB4O" role="lGtFl">
+                                            <node concept="3IZrLx" id="15DZatORB4P" role="3IZSJc">
+                                              <node concept="3clFbS" id="15DZatORB4Q" role="2VODD2">
+                                                <node concept="3clFbF" id="15DZatORB4R" role="3cqZAp">
+                                                  <node concept="2OqwBi" id="15DZatORB4S" role="3clFbG">
+                                                    <node concept="2OqwBi" id="15DZatORB4T" role="2Oq$k0">
+                                                      <node concept="30H73N" id="15DZatORB4U" role="2Oq$k0" />
+                                                      <node concept="3TrEf2" id="15DZatORB4V" role="2OqNvi">
+                                                        <ref role="3Tt5mk" to="teg0:65e5JdYJiFg" resolve="postprocess" />
+                                                      </node>
+                                                    </node>
+                                                    <node concept="3x8VRR" id="15DZatORB4W" role="2OqNvi" />
+                                                  </node>
+                                                </node>
+                                              </node>
+                                            </node>
+                                          </node>
+                                        </node>
+                                        <node concept="3clFbH" id="15DZatORB4X" role="3cqZAp" />
+                                        <node concept="3clFbF" id="15DZatORB4Y" role="3cqZAp">
+                                          <node concept="37vLTw" id="15DZatORB4Z" role="3clFbG">
+                                            <ref role="3cqZAo" node="15DZatORB3B" resolve="result" />
                                           </node>
                                         </node>
                                       </node>
                                     </node>
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="liA8E" id="65e5JdYL53N" role="2OqNvi">
-                      <ref role="37wK5l" node="65e5JdYL53x" resolve="postprocess" />
-                      <node concept="2OqwBi" id="65e5JdYLaAM" role="37wK5m">
-                        <node concept="2kS8pE" id="65e5JdYL8co" role="2Oq$k0" />
-                        <node concept="liA8E" id="65e5JdYLdr3" role="2OqNvi">
-                          <ref role="37wK5l" to="uddc:~TransformationMenuContext.getNode()" resolve="getNode" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="1W57fq" id="65e5JdYL53P" role="lGtFl">
-                    <node concept="3IZrLx" id="65e5JdYL53Q" role="3IZSJc">
-                      <node concept="3clFbS" id="65e5JdYL53R" role="2VODD2">
-                        <node concept="3clFbF" id="65e5JdYL53S" role="3cqZAp">
-                          <node concept="2OqwBi" id="65e5JdYL53T" role="3clFbG">
-                            <node concept="2OqwBi" id="65e5JdYL53U" role="2Oq$k0">
-                              <node concept="30H73N" id="65e5JdYL53V" role="2Oq$k0" />
-                              <node concept="3TrEf2" id="65e5JdYL53W" role="2OqNvi">
-                                <ref role="3Tt5mk" to="teg0:65e5JdYJiFg" resolve="postprocess" />
-                              </node>
-                            </node>
-                            <node concept="3x8VRR" id="65e5JdYL53X" role="2OqNvi" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="3clFbH" id="65e5JdYL4nk" role="3cqZAp" />
-                <node concept="3clFbF" id="4eBi5gdpi1B" role="3cqZAp">
-                  <node concept="37vLTw" id="65e5JdYL12p" role="3clFbG">
-                    <ref role="3cqZAo" node="65e5JdYL11G" resolve="result" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="1eYwpX" id="4eBi5gdpi1R" role="1eYxym">
-              <node concept="3clFbS" id="4eBi5gdpi1S" role="2VODD2">
-                <node concept="3clFbF" id="6rhOS_xnKTh" role="3cqZAp">
-                  <node concept="2OqwBi" id="6rhOS_xnLLF" role="3clFbG">
-                    <node concept="2OqwBi" id="6rhOS_xnKTj" role="2Oq$k0">
-                      <node concept="1PxgMI" id="6rhOS_xvh8O" role="2Oq$k0">
-                        <node concept="chp4Y" id="1SbcsM_INSP" role="3oSUPX">
-                          <ref role="cht4Q" to="tpck:gw2VY9q" resolve="BaseConcept" />
-                          <node concept="1ZhdrF" id="6rhOS_xvhxs" role="lGtFl">
-                            <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/1177026924588/1177026940964" />
-                            <property role="2qtEX8" value="conceptDeclaration" />
-                            <node concept="3$xsQk" id="6rhOS_xvhxt" role="3$ytzL">
-                              <node concept="3clFbS" id="6rhOS_xvhxu" role="2VODD2">
-                                <node concept="3clFbF" id="6rhOS_xvhP6" role="3cqZAp">
-                                  <node concept="2OqwBi" id="6rhOS_xviP$" role="3clFbG">
-                                    <node concept="2OqwBi" id="6rhOS_xvhWT" role="2Oq$k0">
-                                      <node concept="30H73N" id="6rhOS_xvhP5" role="2Oq$k0" />
-                                      <node concept="2Xjw5R" id="6rhOS_xvimL" role="2OqNvi">
-                                        <node concept="1xMEDy" id="6rhOS_xvimN" role="1xVPHs">
-                                          <node concept="chp4Y" id="6rhOS_xviEp" role="ri$Ld">
-                                            <ref role="cht4Q" to="tpc2:gXXWOiD" resolve="AbstractComponent" />
+                                    <node concept="3clFb_" id="15DZatORrHk" role="jymVt">
+                                      <property role="1EzhhJ" value="false" />
+                                      <property role="TrG5h" value="getOutputConcept" />
+                                      <property role="DiZV1" value="false" />
+                                      <property role="od$2w" value="false" />
+                                      <node concept="3Tm1VV" id="15DZatORrHl" role="1B3o_S" />
+                                      <node concept="3uibUv" id="15DZatORrHm" role="3clF45">
+                                        <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
+                                      </node>
+                                      <node concept="3clFbS" id="15DZatORrHn" role="3clF47">
+                                        <node concept="3clFbF" id="15DZatORrHo" role="3cqZAp">
+                                          <node concept="35c_gC" id="15DZatORrHp" role="3clFbG">
+                                            <ref role="35c_gD" to="tpck:gw2VY9q" resolve="BaseConcept" />
+                                            <node concept="1ZhdrF" id="15DZatORrHq" role="lGtFl">
+                                              <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/2644386474300074836/2644386474300074837" />
+                                              <property role="2qtEX8" value="conceptDeclaration" />
+                                              <node concept="3$xsQk" id="15DZatORrHr" role="3$ytzL">
+                                                <node concept="3clFbS" id="15DZatORrHs" role="2VODD2">
+                                                  <node concept="3clFbF" id="15DZatORrHt" role="3cqZAp">
+                                                    <node concept="2OqwBi" id="15DZatORrHu" role="3clFbG">
+                                                      <node concept="2OqwBi" id="15DZatORrHv" role="2Oq$k0">
+                                                        <node concept="30H73N" id="15DZatORrHw" role="2Oq$k0" />
+                                                        <node concept="2Xjw5R" id="15DZatORrHx" role="2OqNvi">
+                                                          <node concept="1xMEDy" id="15DZatORrHy" role="1xVPHs">
+                                                            <node concept="chp4Y" id="15DZatORrHz" role="ri$Ld">
+                                                              <ref role="cht4Q" to="tpc2:gXXWOiD" resolve="AbstractComponent" />
+                                                            </node>
+                                                          </node>
+                                                        </node>
+                                                      </node>
+                                                      <node concept="2qgKlT" id="15DZatORrH$" role="2OqNvi">
+                                                        <ref role="37wK5l" to="tpcb:67EYkym$wx3" resolve="getConceptDeclaration" />
+                                                      </node>
+                                                    </node>
+                                                  </node>
+                                                </node>
+                                              </node>
+                                            </node>
                                           </node>
                                         </node>
                                       </node>
-                                    </node>
-                                    <node concept="2qgKlT" id="6rhOS_xvj57" role="2OqNvi">
-                                      <ref role="37wK5l" to="tpcb:67EYkym$wx3" resolve="getConceptDeclaration" />
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="2OqwBi" id="6rhOS_xnKTk" role="1m5AlR">
-                          <node concept="2kS8pE" id="6rhOS_xnKTl" role="2Oq$k0" />
-                          <node concept="liA8E" id="6rhOS_xnKTm" role="2OqNvi">
-                            <ref role="37wK5l" to="uddc:~TransformationMenuContext.getNode()" resolve="getNode" />
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="3Tsc0h" id="6rhOS_xnKTn" role="2OqNvi">
-                        <ref role="3TtcxE" to="tpee:fzcqZ_x" resolve="statement" />
-                        <node concept="1ZhdrF" id="6rhOS_xnKTo" role="lGtFl">
-                          <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/1138056282393/1138056546658" />
-                          <property role="2qtEX8" value="link" />
-                          <node concept="3$xsQk" id="6rhOS_xnKTp" role="3$ytzL">
-                            <node concept="3clFbS" id="6rhOS_xnKTq" role="2VODD2">
-                              <node concept="3clFbF" id="6rhOS_xnKTr" role="3cqZAp">
-                                <node concept="2OqwBi" id="6rhOS_xnKTs" role="3clFbG">
-                                  <node concept="1PxgMI" id="6rhOS_xnKTt" role="2Oq$k0">
-                                    <node concept="chp4Y" id="1SbcsM_INTE" role="3oSUPX">
-                                      <ref role="cht4Q" to="tpc2:fBF2Hee" resolve="CellModel_RefNodeList" />
-                                    </node>
-                                    <node concept="2OqwBi" id="6rhOS_xnKTu" role="1m5AlR">
-                                      <node concept="30H73N" id="6rhOS_xnKTv" role="2Oq$k0" />
-                                      <node concept="2qgKlT" id="6rhOS_xnKTw" role="2OqNvi">
-                                        <ref role="37wK5l" to="karh:7KznU_3XzU4" resolve="getFirstNonConst" />
+                                      <node concept="2AHcQZ" id="15DZatORrH_" role="2AJF6D">
+                                        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
                                       </node>
                                     </node>
-                                  </node>
-                                  <node concept="3TrEf2" id="6rhOS_xnKTx" role="2OqNvi">
-                                    <ref role="3Tt5mk" to="tpc2:fBF2Hej" resolve="linkDeclaration" />
+                                    <node concept="3Tm1VV" id="15DZatORrHA" role="1B3o_S" />
+                                    <node concept="37vLTw" id="15DZatORrHB" role="37wK5m">
+                                      <ref role="3cqZAo" node="15DZatORrFR" resolve="matchingTexts" />
+                                    </node>
+                                    <node concept="2Mo9yH" id="15DZatOT8s7" role="37wK5m" />
                                   </node>
                                 </node>
                               </node>
@@ -4899,29 +5346,84 @@
                           </node>
                         </node>
                       </node>
+                      <node concept="1Wc70l" id="15DZatORrJ6" role="3clFbw">
+                        <node concept="2OqwBi" id="15DZatORrJ7" role="3uHU7w">
+                          <node concept="37vLTw" id="15DZatORrJ8" role="2Oq$k0">
+                            <ref role="3cqZAo" node="15DZatORrFR" resolve="matchingTexts" />
+                          </node>
+                          <node concept="3GX2aA" id="15DZatORrJ9" role="2OqNvi" />
+                        </node>
+                        <node concept="37vLTw" id="15DZatORrJa" role="3uHU7B">
+                          <ref role="3cqZAo" node="15DZatORrGi" resolve="isApplicable" />
+                        </node>
+                      </node>
                     </node>
-                    <node concept="3GX2aA" id="6rhOS_xnOkg" role="2OqNvi" />
+                    <node concept="3cpWs6" id="15DZatOSDys" role="3cqZAp">
+                      <node concept="37vLTw" id="15DZatOSJ1h" role="3cqZAk">
+                        <ref role="3cqZAo" node="15DZatOSo7i" resolve="items" />
+                      </node>
+                    </node>
                   </node>
                 </node>
               </node>
             </node>
-            <node concept="1eYWSL" id="4eBi5gdpi2b" role="1eYxyj">
-              <node concept="3clFbS" id="4eBi5gdpi2c" role="2VODD2">
-                <node concept="3clFbF" id="4eBi5gdpi2d" role="3cqZAp">
-                  <node concept="Xl_RD" id="4eBi5gdpi2e" role="3clFbG">
-                    <property role="Xl_RC" value="" />
-                    <node concept="1sPUBX" id="4eBi5gdpi2f" role="lGtFl">
-                      <ref role="v9R2y" node="2uT2PLn1V4k" resolve="switch_constantTextSequence" />
-                      <node concept="3NFfHV" id="4eBi5gdqctg" role="1sPUBK">
-                        <node concept="3clFbS" id="4eBi5gdqcth" role="2VODD2">
-                          <node concept="3clFbF" id="4eBi5gdqc$C" role="3cqZAp">
-                            <node concept="2OqwBi" id="4eBi5gdqcD2" role="3clFbG">
-                              <node concept="30H73N" id="4eBi5gdqc$B" role="2Oq$k0" />
-                              <node concept="2qgKlT" id="4eBi5gdqcVc" role="2OqNvi">
-                                <ref role="37wK5l" to="karh:7KznU_45kn7" resolve="getTransformationText" />
+            <node concept="raruj" id="15DZatOQVJ3" role="lGtFl" />
+            <node concept="17Uvod" id="15DZatOQVJ4" role="lGtFl">
+              <property role="2qtEX9" value="description" />
+              <property role="P4ACc" value="9d69e719-78c8-4286-90db-fb19c107d049/745148820867185554/745148820908747612" />
+              <node concept="3zFVjK" id="15DZatOQVJ5" role="3zH0cK">
+                <node concept="3clFbS" id="15DZatOQVJ6" role="2VODD2">
+                  <node concept="3clFbF" id="15DZatOQVNO" role="3cqZAp">
+                    <node concept="3cpWs3" id="15DZatOQVNP" role="3clFbG">
+                      <node concept="2OqwBi" id="15DZatOQVNQ" role="3uHU7w">
+                        <node concept="2OqwBi" id="15DZatOQVNR" role="2Oq$k0">
+                          <node concept="1PxgMI" id="15DZatOQVNS" role="2Oq$k0">
+                            <node concept="chp4Y" id="15DZatOQWSG" role="3oSUPX">
+                              <ref role="cht4Q" to="tpc2:fBF2Hee" resolve="CellModel_RefNodeList" />
+                            </node>
+                            <node concept="2OqwBi" id="15DZatOQVNU" role="1m5AlR">
+                              <node concept="30H73N" id="15DZatOQVNV" role="2Oq$k0" />
+                              <node concept="2qgKlT" id="15DZatOQVNW" role="2OqNvi">
+                                <ref role="37wK5l" to="karh:7KznU_3XzU4" resolve="getFirstNonConst" />
                               </node>
                             </node>
                           </node>
+                          <node concept="3TrEf2" id="15DZatOQXZJ" role="2OqNvi">
+                            <ref role="3Tt5mk" to="tpc2:fBF2Hej" resolve="linkDeclaration" />
+                          </node>
+                        </node>
+                        <node concept="3TrcHB" id="15DZatOQVNY" role="2OqNvi">
+                          <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                        </node>
+                      </node>
+                      <node concept="3cpWs3" id="15DZatOQVNZ" role="3uHU7B">
+                        <node concept="3cpWs3" id="15DZatOQVO0" role="3uHU7B">
+                          <node concept="Xl_RD" id="15DZatOQVO1" role="3uHU7B">
+                            <property role="Xl_RC" value="grammar.optional for " />
+                          </node>
+                          <node concept="2OqwBi" id="15DZatOQVO2" role="3uHU7w">
+                            <node concept="2OqwBi" id="15DZatOQVO3" role="2Oq$k0">
+                              <node concept="2OqwBi" id="15DZatOQVO4" role="2Oq$k0">
+                                <node concept="30H73N" id="15DZatOQVO5" role="2Oq$k0" />
+                                <node concept="2Xjw5R" id="15DZatOQVO6" role="2OqNvi">
+                                  <node concept="1xMEDy" id="15DZatOQVO7" role="1xVPHs">
+                                    <node concept="chp4Y" id="15DZatOQVO8" role="ri$Ld">
+                                      <ref role="cht4Q" to="tpc2:gXXWOiD" resolve="AbstractComponent" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                              <node concept="2qgKlT" id="15DZatOQVO9" role="2OqNvi">
+                                <ref role="37wK5l" to="tpcb:67EYkym$wx3" resolve="getConceptDeclaration" />
+                              </node>
+                            </node>
+                            <node concept="3TrcHB" id="15DZatOQVOa" role="2OqNvi">
+                              <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="Xl_RD" id="15DZatOQVOb" role="3uHU7w">
+                          <property role="Xl_RC" value="." />
                         </node>
                       </node>
                     </node>
@@ -4929,434 +5431,16 @@
                 </node>
               </node>
             </node>
-            <node concept="raruj" id="4eBi5gdpi2g" role="lGtFl" />
           </node>
-          <node concept="7FqFr" id="6rhOS_xvNvT" role="3EZMnx">
-            <node concept="1eYWSL" id="6rhOS_xvNvV" role="7F66l">
-              <node concept="3clFbS" id="6rhOS_xvNvX" role="2VODD2">
-                <node concept="3clFbF" id="6rhOS_xvSBY" role="3cqZAp">
-                  <node concept="Xl_RD" id="6rhOS_xvSBZ" role="3clFbG">
-                    <property role="Xl_RC" value="" />
-                    <node concept="1sPUBX" id="6rhOS_xvSC0" role="lGtFl">
-                      <ref role="v9R2y" node="2uT2PLn1V4k" resolve="switch_constantTextSequence" />
-                      <node concept="3NFfHV" id="6rhOS_xvSC1" role="1sPUBK">
-                        <node concept="3clFbS" id="6rhOS_xvSC2" role="2VODD2">
-                          <node concept="3clFbF" id="6rhOS_xvSC3" role="3cqZAp">
-                            <node concept="2OqwBi" id="6rhOS_xvSC4" role="3clFbG">
-                              <node concept="30H73N" id="6rhOS_xvSC5" role="2Oq$k0" />
-                              <node concept="2qgKlT" id="6rhOS_xvSC6" role="2OqNvi">
-                                <ref role="37wK5l" to="karh:7KznU_45kn7" resolve="getTransformationText" />
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="1eYxTg" id="6rhOS_xvNvZ" role="7F66k">
-              <node concept="3clFbS" id="6rhOS_xvNw1" role="2VODD2">
-                <node concept="3cpWs8" id="5$jJV5er$9o" role="3cqZAp">
-                  <node concept="3cpWsn" id="5$jJV5er$9r" role="3cpWs9">
-                    <property role="TrG5h" value="listElement" />
-                    <node concept="3Tqbb2" id="5$jJV5er$9s" role="1tU5fm" />
-                    <node concept="2YIFZM" id="5$jJV5er$9t" role="33vP2m">
-                      <ref role="1Pybhc" to="czm:RbLMy696h3" resolve="GrammarCellsUtil" />
-                      <ref role="37wK5l" to="czm:5$jJV5eqaC7" resolve="getListElementForSideTransformation" />
-                      <node concept="2OqwBi" id="5$jJV5er$9u" role="37wK5m">
-                        <node concept="2kS8pE" id="5$jJV5er$9v" role="2Oq$k0" />
-                        <node concept="liA8E" id="5$jJV5er$9w" role="2OqNvi">
-                          <ref role="37wK5l" to="uddc:~TransformationMenuContext.getNode()" resolve="getNode" />
-                        </node>
-                      </node>
-                      <node concept="359W_D" id="5$jJV5er$9x" role="37wK5m">
-                        <ref role="359W_E" to="tpck:gw2VY9q" resolve="BaseConcept" />
-                        <ref role="359W_F" to="tpck:4uZwTti3__2" resolve="smodelAttribute" />
-                        <node concept="1ZhdrF" id="5$jJV5er$9y" role="lGtFl">
-                          <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/2644386474301421077/2644386474301421078" />
-                          <property role="2qtEX8" value="conceptDeclaration" />
-                          <node concept="3$xsQk" id="5$jJV5er$9z" role="3$ytzL">
-                            <node concept="3clFbS" id="5$jJV5er$9$" role="2VODD2">
-                              <node concept="3clFbF" id="5$jJV5er$9_" role="3cqZAp">
-                                <node concept="2OqwBi" id="5$jJV5er$9A" role="3clFbG">
-                                  <node concept="2OqwBi" id="5$jJV5er$9B" role="2Oq$k0">
-                                    <node concept="30H73N" id="5$jJV5er$9C" role="2Oq$k0" />
-                                    <node concept="2Xjw5R" id="5$jJV5er$9D" role="2OqNvi">
-                                      <node concept="1xMEDy" id="5$jJV5er$9E" role="1xVPHs">
-                                        <node concept="chp4Y" id="5$jJV5er$9F" role="ri$Ld">
-                                          <ref role="cht4Q" to="tpc2:gXXWOiD" resolve="AbstractComponent" />
-                                        </node>
-                                      </node>
-                                    </node>
-                                  </node>
-                                  <node concept="2qgKlT" id="5$jJV5er$9G" role="2OqNvi">
-                                    <ref role="37wK5l" to="tpcb:67EYkym$wx3" resolve="getConceptDeclaration" />
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="1ZhdrF" id="5$jJV5er$9H" role="lGtFl">
-                          <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/2644386474301421077/2644386474301421079" />
-                          <property role="2qtEX8" value="linkDeclaration" />
-                          <node concept="3$xsQk" id="5$jJV5er$9I" role="3$ytzL">
-                            <node concept="3clFbS" id="5$jJV5er$9J" role="2VODD2">
-                              <node concept="3clFbF" id="5$jJV5er$9K" role="3cqZAp">
-                                <node concept="2OqwBi" id="5$jJV5er$9L" role="3clFbG">
-                                  <node concept="1PxgMI" id="5$jJV5er$9M" role="2Oq$k0">
-                                    <node concept="chp4Y" id="1SbcsM_INTL" role="3oSUPX">
-                                      <ref role="cht4Q" to="tpc2:fBF2Hee" resolve="CellModel_RefNodeList" />
-                                    </node>
-                                    <node concept="2OqwBi" id="5$jJV5er$9N" role="1m5AlR">
-                                      <node concept="30H73N" id="5$jJV5er$9O" role="2Oq$k0" />
-                                      <node concept="2qgKlT" id="5$jJV5er$9P" role="2OqNvi">
-                                        <ref role="37wK5l" to="karh:7KznU_3XzU4" resolve="getFirstNonConst" />
-                                      </node>
-                                    </node>
-                                  </node>
-                                  <node concept="3TrEf2" id="5$jJV5er$9Q" role="2OqNvi">
-                                    <ref role="3Tt5mk" to="tpc2:fBF2Hej" resolve="linkDeclaration" />
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="3clFbC" id="2mvFNoREt54" role="37wK5m">
-                        <node concept="10M0yZ" id="2mvFNoREt55" role="3uHU7w">
-                          <ref role="3cqZAo" to="9eyi:~MenuLocations.LEFT_SIDE_TRANSFORM" resolve="LEFT_SIDE_TRANSFORM" />
-                          <ref role="1PxDUh" to="9eyi:~MenuLocations" resolve="MenuLocations" />
-                        </node>
-                        <node concept="2OqwBi" id="2mvFNoREt56" role="3uHU7B">
-                          <node concept="2kS8pE" id="2mvFNoREuch" role="2Oq$k0" />
-                          <node concept="liA8E" id="2mvFNoREt58" role="2OqNvi">
-                            <ref role="37wK5l" to="uddc:~TransformationMenuContext.getMenuLocation()" resolve="getMenuLocation" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="3cpWs8" id="6rhOS_xwnqg" role="3cqZAp">
-                  <node concept="3cpWsn" id="6rhOS_xwnqj" role="3cpWs9">
-                    <property role="TrG5h" value="newNode" />
-                    <node concept="3Tqbb2" id="6rhOS_xwnqe" role="1tU5fm" />
-                    <node concept="2ShNRf" id="6rhOS_xwoMa" role="33vP2m">
-                      <node concept="2fJWfE" id="6rhOS_xwD3B" role="2ShVmc">
-                        <node concept="3Tqbb2" id="6rhOS_xwD3D" role="3zrR0E">
-                          <ref role="ehGHo" to="tpck:gw2VY9q" resolve="BaseConcept" />
-                          <node concept="1ZhdrF" id="6rhOS_xwDyD" role="lGtFl">
-                            <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/1138055754698/1138405853777" />
-                            <property role="2qtEX8" value="concept" />
-                            <node concept="3$xsQk" id="6rhOS_xwDyE" role="3$ytzL">
-                              <node concept="3clFbS" id="6rhOS_xwDyF" role="2VODD2">
-                                <node concept="3clFbF" id="6rhOS_xwDNa" role="3cqZAp">
-                                  <node concept="2OqwBi" id="6rhOS_xwDNc" role="3clFbG">
-                                    <node concept="2OqwBi" id="6rhOS_xwDNd" role="2Oq$k0">
-                                      <node concept="1PxgMI" id="6rhOS_xwDNe" role="2Oq$k0">
-                                        <node concept="chp4Y" id="1SbcsM_INSV" role="3oSUPX">
-                                          <ref role="cht4Q" to="tpc2:fBF2Hee" resolve="CellModel_RefNodeList" />
-                                        </node>
-                                        <node concept="2OqwBi" id="6rhOS_xwDNf" role="1m5AlR">
-                                          <node concept="30H73N" id="6rhOS_xwDNg" role="2Oq$k0" />
-                                          <node concept="2qgKlT" id="6rhOS_xwDNh" role="2OqNvi">
-                                            <ref role="37wK5l" to="karh:7KznU_3XzU4" resolve="getFirstNonConst" />
-                                          </node>
-                                        </node>
-                                      </node>
-                                      <node concept="3TrEf2" id="6rhOS_xwDNi" role="2OqNvi">
-                                        <ref role="3Tt5mk" to="tpc2:fBF2Hej" resolve="linkDeclaration" />
-                                      </node>
-                                    </node>
-                                    <node concept="3TrEf2" id="6rhOS_xwDNj" role="2OqNvi">
-                                      <ref role="3Tt5mk" to="tpce:fA0lvVK" resolve="target" />
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="3clFbJ" id="6rhOS_xwmFp" role="3cqZAp">
-                  <node concept="3clFbC" id="2mvFNoREwlu" role="3clFbw">
-                    <node concept="10M0yZ" id="2mvFNoREwlv" role="3uHU7w">
-                      <ref role="1PxDUh" to="9eyi:~MenuLocations" resolve="MenuLocations" />
-                      <ref role="3cqZAo" to="9eyi:~MenuLocations.LEFT_SIDE_TRANSFORM" resolve="LEFT_SIDE_TRANSFORM" />
-                    </node>
-                    <node concept="2OqwBi" id="2mvFNoREwlw" role="3uHU7B">
-                      <node concept="2kS8pE" id="2mvFNoRExqF" role="2Oq$k0" />
-                      <node concept="liA8E" id="2mvFNoREwly" role="2OqNvi">
-                        <ref role="37wK5l" to="uddc:~TransformationMenuContext.getMenuLocation()" resolve="getMenuLocation" />
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3clFbS" id="6rhOS_xwmFr" role="3clFbx">
-                    <node concept="3clFbF" id="6rhOS_xwmWO" role="3cqZAp">
-                      <node concept="2OqwBi" id="6rhOS_xwEop" role="3clFbG">
-                        <node concept="37vLTw" id="5$jJV5er_uN" role="2Oq$k0">
-                          <ref role="3cqZAo" node="5$jJV5er$9r" resolve="listElement" />
-                        </node>
-                        <node concept="HtX7F" id="6rhOS_xwEMY" role="2OqNvi">
-                          <node concept="37vLTw" id="6rhOS_xwFad" role="HtX7I">
-                            <ref role="3cqZAo" node="6rhOS_xwnqj" resolve="newNode" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="9aQIb" id="6rhOS_xwFxt" role="9aQIa">
-                    <node concept="3clFbS" id="6rhOS_xwFxu" role="9aQI4">
-                      <node concept="3clFbF" id="6rhOS_xwFSH" role="3cqZAp">
-                        <node concept="2OqwBi" id="6rhOS_xwGgK" role="3clFbG">
-                          <node concept="37vLTw" id="5$jJV5erA1a" role="2Oq$k0">
-                            <ref role="3cqZAo" node="5$jJV5er$9r" resolve="listElement" />
-                          </node>
-                          <node concept="HtI8k" id="6rhOS_xwGFx" role="2OqNvi">
-                            <node concept="37vLTw" id="6rhOS_xwH2W" role="HtI8F">
-                              <ref role="3cqZAo" node="6rhOS_xwnqj" resolve="newNode" />
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="3clFbF" id="65e5JdYLp$K" role="3cqZAp">
-                  <node concept="2OqwBi" id="65e5JdYLp$L" role="3clFbG">
-                    <node concept="2ShNRf" id="65e5JdYLp$M" role="2Oq$k0">
-                      <node concept="YeOm9" id="65e5JdYLp$N" role="2ShVmc">
-                        <node concept="1Y3b0j" id="65e5JdYLp$O" role="YeSDq">
-                          <property role="2bfB8j" value="true" />
-                          <ref role="1Y3XeK" to="wyt6:~Object" resolve="Object" />
-                          <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
-                          <node concept="3Tm1VV" id="65e5JdYLp$P" role="1B3o_S" />
-                          <node concept="3clFb_" id="65e5JdYLp$Q" role="jymVt">
-                            <property role="TrG5h" value="postprocess" />
-                            <node concept="37vLTG" id="65e5JdYLp$R" role="3clF46">
-                              <property role="TrG5h" value="node" />
-                              <node concept="3Tqbb2" id="65e5JdYLp$S" role="1tU5fm" />
-                            </node>
-                            <node concept="3cqZAl" id="65e5JdYLp$T" role="3clF45" />
-                            <node concept="3Tm1VV" id="65e5JdYLp$U" role="1B3o_S" />
-                            <node concept="3clFbS" id="65e5JdYLp$V" role="3clF47">
-                              <node concept="3clFbH" id="65e5JdYLp$W" role="3cqZAp">
-                                <node concept="2b32R4" id="65e5JdYLp$X" role="lGtFl">
-                                  <node concept="3JmXsc" id="65e5JdYLp$Y" role="2P8S$">
-                                    <node concept="3clFbS" id="65e5JdYLp$Z" role="2VODD2">
-                                      <node concept="3clFbF" id="65e5JdYLp_0" role="3cqZAp">
-                                        <node concept="2OqwBi" id="65e5JdYLp_1" role="3clFbG">
-                                          <node concept="2OqwBi" id="65e5JdYLp_2" role="2Oq$k0">
-                                            <node concept="2OqwBi" id="65e5JdYLp_3" role="2Oq$k0">
-                                              <node concept="30H73N" id="65e5JdYLp_4" role="2Oq$k0" />
-                                              <node concept="3TrEf2" id="65e5JdYLp_5" role="2OqNvi">
-                                                <ref role="3Tt5mk" to="teg0:65e5JdYJiFg" resolve="postprocess" />
-                                              </node>
-                                            </node>
-                                            <node concept="3TrEf2" id="65e5JdYLp_6" role="2OqNvi">
-                                              <ref role="3Tt5mk" to="tpee:gyVODHa" resolve="body" />
-                                            </node>
-                                          </node>
-                                          <node concept="3Tsc0h" id="65e5JdYLp_7" role="2OqNvi">
-                                            <ref role="3TtcxE" to="tpee:fzcqZ_x" resolve="statement" />
-                                          </node>
-                                        </node>
-                                      </node>
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="liA8E" id="65e5JdYLp_8" role="2OqNvi">
-                      <ref role="37wK5l" node="65e5JdYLp$Q" resolve="postprocess" />
-                      <node concept="2OqwBi" id="65e5JdYLv7x" role="37wK5m">
-                        <node concept="2kS8pE" id="65e5JdYLt7F" role="2Oq$k0" />
-                        <node concept="liA8E" id="65e5JdYLxbC" role="2OqNvi">
-                          <ref role="37wK5l" to="uddc:~TransformationMenuContext.getNode()" resolve="getNode" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="1W57fq" id="65e5JdYLp_a" role="lGtFl">
-                    <node concept="3IZrLx" id="65e5JdYLp_b" role="3IZSJc">
-                      <node concept="3clFbS" id="65e5JdYLp_c" role="2VODD2">
-                        <node concept="3clFbF" id="65e5JdYLp_d" role="3cqZAp">
-                          <node concept="2OqwBi" id="65e5JdYLp_e" role="3clFbG">
-                            <node concept="2OqwBi" id="65e5JdYLp_f" role="2Oq$k0">
-                              <node concept="30H73N" id="65e5JdYLp_g" role="2Oq$k0" />
-                              <node concept="3TrEf2" id="65e5JdYLp_h" role="2OqNvi">
-                                <ref role="3Tt5mk" to="teg0:65e5JdYJiFg" resolve="postprocess" />
-                              </node>
-                            </node>
-                            <node concept="3x8VRR" id="65e5JdYLp_i" role="2OqNvi" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="3cpWs6" id="3KoBPk0Tu6m" role="3cqZAp">
-                  <node concept="37vLTw" id="3KoBPk0Tv9T" role="3cqZAk">
-                    <ref role="3cqZAo" node="6rhOS_xwnqj" resolve="newNode" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="1eYwpX" id="6rhOS_xvNw6" role="7F66i">
-              <node concept="3clFbS" id="6rhOS_xvNw8" role="2VODD2">
-                <node concept="3cpWs8" id="5$jJV5erzvO" role="3cqZAp">
-                  <node concept="3cpWsn" id="5$jJV5erzvP" role="3cpWs9">
-                    <property role="TrG5h" value="listElement" />
-                    <node concept="3Tqbb2" id="5$jJV5erzvQ" role="1tU5fm" />
-                    <node concept="2YIFZM" id="5$jJV5erzvR" role="33vP2m">
-                      <ref role="1Pybhc" to="czm:RbLMy696h3" resolve="GrammarCellsUtil" />
-                      <ref role="37wK5l" to="czm:5$jJV5eqaC7" resolve="getListElementForSideTransformation" />
-                      <node concept="2OqwBi" id="5$jJV5erzvS" role="37wK5m">
-                        <node concept="2kS8pE" id="5$jJV5erzvT" role="2Oq$k0" />
-                        <node concept="liA8E" id="5$jJV5erzvU" role="2OqNvi">
-                          <ref role="37wK5l" to="uddc:~TransformationMenuContext.getNode()" resolve="getNode" />
-                        </node>
-                      </node>
-                      <node concept="359W_D" id="5$jJV5erzvV" role="37wK5m">
-                        <ref role="359W_E" to="tpck:gw2VY9q" resolve="BaseConcept" />
-                        <ref role="359W_F" to="tpck:4uZwTti3__2" resolve="smodelAttribute" />
-                        <node concept="1ZhdrF" id="5$jJV5erzvW" role="lGtFl">
-                          <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/2644386474301421077/2644386474301421078" />
-                          <property role="2qtEX8" value="conceptDeclaration" />
-                          <node concept="3$xsQk" id="5$jJV5erzvX" role="3$ytzL">
-                            <node concept="3clFbS" id="5$jJV5erzvY" role="2VODD2">
-                              <node concept="3clFbF" id="5$jJV5erzvZ" role="3cqZAp">
-                                <node concept="2OqwBi" id="5$jJV5erzw0" role="3clFbG">
-                                  <node concept="2OqwBi" id="5$jJV5erzw1" role="2Oq$k0">
-                                    <node concept="30H73N" id="5$jJV5erzw2" role="2Oq$k0" />
-                                    <node concept="2Xjw5R" id="5$jJV5erzw3" role="2OqNvi">
-                                      <node concept="1xMEDy" id="5$jJV5erzw4" role="1xVPHs">
-                                        <node concept="chp4Y" id="5$jJV5erzw5" role="ri$Ld">
-                                          <ref role="cht4Q" to="tpc2:gXXWOiD" resolve="AbstractComponent" />
-                                        </node>
-                                      </node>
-                                    </node>
-                                  </node>
-                                  <node concept="2qgKlT" id="5$jJV5erzw6" role="2OqNvi">
-                                    <ref role="37wK5l" to="tpcb:67EYkym$wx3" resolve="getConceptDeclaration" />
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="1ZhdrF" id="5$jJV5erzw7" role="lGtFl">
-                          <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/2644386474301421077/2644386474301421079" />
-                          <property role="2qtEX8" value="linkDeclaration" />
-                          <node concept="3$xsQk" id="5$jJV5erzw8" role="3$ytzL">
-                            <node concept="3clFbS" id="5$jJV5erzw9" role="2VODD2">
-                              <node concept="3clFbF" id="5$jJV5erzwa" role="3cqZAp">
-                                <node concept="2OqwBi" id="5$jJV5erzwb" role="3clFbG">
-                                  <node concept="1PxgMI" id="5$jJV5erzwc" role="2Oq$k0">
-                                    <node concept="chp4Y" id="1SbcsM_INTl" role="3oSUPX">
-                                      <ref role="cht4Q" to="tpc2:fBF2Hee" resolve="CellModel_RefNodeList" />
-                                    </node>
-                                    <node concept="2OqwBi" id="5$jJV5erzwd" role="1m5AlR">
-                                      <node concept="30H73N" id="5$jJV5erzwe" role="2Oq$k0" />
-                                      <node concept="2qgKlT" id="5$jJV5erzwf" role="2OqNvi">
-                                        <ref role="37wK5l" to="karh:7KznU_3XzU4" resolve="getFirstNonConst" />
-                                      </node>
-                                    </node>
-                                  </node>
-                                  <node concept="3TrEf2" id="5$jJV5erzwg" role="2OqNvi">
-                                    <ref role="3Tt5mk" to="tpc2:fBF2Hej" resolve="linkDeclaration" />
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="3clFbC" id="2mvFNoREyv8" role="37wK5m">
-                        <node concept="10M0yZ" id="2mvFNoREyv9" role="3uHU7w">
-                          <ref role="3cqZAo" to="9eyi:~MenuLocations.LEFT_SIDE_TRANSFORM" resolve="LEFT_SIDE_TRANSFORM" />
-                          <ref role="1PxDUh" to="9eyi:~MenuLocations" resolve="MenuLocations" />
-                        </node>
-                        <node concept="2OqwBi" id="2mvFNoREyva" role="3uHU7B">
-                          <node concept="2kS8pE" id="2mvFNoREz_U" role="2Oq$k0" />
-                          <node concept="liA8E" id="2mvFNoREyvc" role="2OqNvi">
-                            <ref role="37wK5l" to="uddc:~TransformationMenuContext.getMenuLocation()" resolve="getMenuLocation" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="3clFbJ" id="5$jJV5erzwm" role="3cqZAp">
-                  <node concept="3clFbS" id="5$jJV5erzwn" role="3clFbx">
-                    <node concept="3cpWs6" id="5$jJV5erzwo" role="3cqZAp">
-                      <node concept="3clFbT" id="5$jJV5erzwp" role="3cqZAk">
-                        <property role="3clFbU" value="false" />
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3clFbC" id="5$jJV5erzwq" role="3clFbw">
-                    <node concept="10Nm6u" id="5$jJV5erzwr" role="3uHU7w" />
-                    <node concept="37vLTw" id="5$jJV5erzws" role="3uHU7B">
-                      <ref role="3cqZAo" node="5$jJV5erzvP" resolve="listElement" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="3cpWs6" id="5$jJV5erzwt" role="3cqZAp">
-                  <node concept="3K4zz7" id="5$jJV5erzwu" role="3cqZAk">
-                    <node concept="3clFbC" id="2mvFNoRE$Em" role="3K4Cdx">
-                      <node concept="10M0yZ" id="2mvFNoRE$En" role="3uHU7w">
-                        <ref role="1PxDUh" to="9eyi:~MenuLocations" resolve="MenuLocations" />
-                        <ref role="3cqZAo" to="9eyi:~MenuLocations.LEFT_SIDE_TRANSFORM" resolve="LEFT_SIDE_TRANSFORM" />
-                      </node>
-                      <node concept="2OqwBi" id="2mvFNoRE$Eo" role="3uHU7B">
-                        <node concept="2kS8pE" id="2mvFNoREBSw" role="2Oq$k0" />
-                        <node concept="liA8E" id="2mvFNoRE$Eq" role="2OqNvi">
-                          <ref role="37wK5l" to="uddc:~TransformationMenuContext.getMenuLocation()" resolve="getMenuLocation" />
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="2OqwBi" id="5$jJV5erzwv" role="3K4E3e">
-                      <node concept="2OqwBi" id="5$jJV5erzww" role="2Oq$k0">
-                        <node concept="37vLTw" id="5$jJV5erzwx" role="2Oq$k0">
-                          <ref role="3cqZAo" node="5$jJV5erzvP" resolve="listElement" />
-                        </node>
-                        <node concept="YBYNd" id="5$jJV5erzwy" role="2OqNvi" />
-                      </node>
-                      <node concept="3x8VRR" id="5$jJV5erzwz" role="2OqNvi" />
-                    </node>
-                    <node concept="2OqwBi" id="5$jJV5erzwD" role="3K4GZi">
-                      <node concept="2OqwBi" id="5$jJV5erzwE" role="2Oq$k0">
-                        <node concept="37vLTw" id="5$jJV5erzwF" role="2Oq$k0">
-                          <ref role="3cqZAo" node="5$jJV5erzvP" resolve="listElement" />
-                        </node>
-                        <node concept="YCak7" id="5$jJV5erzwG" role="2OqNvi" />
-                      </node>
-                      <node concept="3x8VRR" id="5$jJV5erzwH" role="2OqNvi" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3F0ifn" id="6rhOS_xvPWW" role="7FqFq">
-              <node concept="29HgVG" id="6rhOS_xvPWX" role="lGtFl">
-                <node concept="3NFfHV" id="6rhOS_xvPWY" role="3NFExx">
-                  <node concept="3clFbS" id="6rhOS_xvPWZ" role="2VODD2">
-                    <node concept="3clFbF" id="6rhOS_xvPX0" role="3cqZAp">
-                      <node concept="2OqwBi" id="6rhOS_xvPX1" role="3clFbG">
-                        <node concept="30H73N" id="6rhOS_xvPX2" role="2Oq$k0" />
-                        <node concept="3TrEf2" id="6rhOS_xvPX3" role="2OqNvi">
+          <node concept="3ZSo5i" id="15DZatOUKSl" role="3EZMnx">
+            <node concept="3F0ifn" id="15DZatOUPBu" role="3EZMny">
+              <node concept="29HgVG" id="15DZatOUPBv" role="lGtFl">
+                <node concept="3NFfHV" id="15DZatOUPBw" role="3NFExx">
+                  <node concept="3clFbS" id="15DZatOUPBx" role="2VODD2">
+                    <node concept="3clFbF" id="15DZatOUPBy" role="3cqZAp">
+                      <node concept="2OqwBi" id="15DZatOUPBz" role="3clFbG">
+                        <node concept="30H73N" id="15DZatOUPB$" role="2Oq$k0" />
+                        <node concept="3TrEf2" id="15DZatOUPB_" role="2OqNvi">
                           <ref role="3Tt5mk" to="teg0:4qdNcHzYfBp" resolve="option" />
                         </node>
                       </node>
@@ -5365,129 +5449,427 @@
                 </node>
               </node>
             </node>
-            <node concept="raruj" id="6rhOS_xvR58" role="lGtFl" />
-          </node>
-          <node concept="1eYWM2" id="4eBi5gdqoBU" role="3EZMnx">
-            <node concept="1eYxTg" id="4eBi5gdqoBV" role="1eYxTh">
-              <node concept="3clFbS" id="4eBi5gdqoBW" role="2VODD2">
-                <node concept="3cpWs8" id="65e5JdYLf14" role="3cqZAp">
-                  <node concept="3cpWsn" id="65e5JdYLf15" role="3cpWs9">
-                    <property role="TrG5h" value="result" />
-                    <node concept="3Tqbb2" id="65e5JdYLf0Q" role="1tU5fm">
-                      <ref role="ehGHo" to="tpee:fzclF8l" resolve="Statement" />
+            <node concept="raruj" id="15DZatOUPJj" role="lGtFl" />
+            <node concept="3VJUX4" id="15DZatOUPOL" role="3ZZHOD">
+              <node concept="3clFbS" id="15DZatOUPOM" role="2VODD2">
+                <node concept="3cpWs8" id="15DZatOUQd2" role="3cqZAp">
+                  <node concept="3cpWsn" id="15DZatOUQd3" role="3cpWs9">
+                    <property role="TrG5h" value="collection" />
+                    <node concept="3uibUv" id="15DZatOUQcN" role="1tU5fm">
+                      <ref role="3uigEE" to="f4zo:~EditorCell_Collection" resolve="EditorCell_Collection" />
                     </node>
-                    <node concept="2OqwBi" id="65e5JdYLf16" role="33vP2m">
-                      <node concept="2OqwBi" id="65e5JdYLf17" role="2Oq$k0">
-                        <node concept="1PxgMI" id="65e5JdYLf18" role="2Oq$k0">
-                          <node concept="chp4Y" id="1SbcsM_INU8" role="3oSUPX">
-                            <ref role="cht4Q" to="tpck:gw2VY9q" resolve="BaseConcept" />
-                            <node concept="1ZhdrF" id="65e5JdYLf1c" role="lGtFl">
-                              <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/1177026924588/1177026940964" />
-                              <property role="2qtEX8" value="conceptDeclaration" />
-                              <node concept="3$xsQk" id="65e5JdYLf1d" role="3$ytzL">
-                                <node concept="3clFbS" id="65e5JdYLf1e" role="2VODD2">
-                                  <node concept="3clFbF" id="65e5JdYLf1f" role="3cqZAp">
-                                    <node concept="2OqwBi" id="65e5JdYLf1g" role="3clFbG">
-                                      <node concept="2OqwBi" id="65e5JdYLf1h" role="2Oq$k0">
-                                        <node concept="30H73N" id="65e5JdYLf1i" role="2Oq$k0" />
-                                        <node concept="2Xjw5R" id="65e5JdYLf1j" role="2OqNvi">
-                                          <node concept="1xMEDy" id="65e5JdYLf1k" role="1xVPHs">
-                                            <node concept="chp4Y" id="65e5JdYLf1l" role="ri$Ld">
-                                              <ref role="cht4Q" to="tpc2:gXXWOiD" resolve="AbstractComponent" />
-                                            </node>
-                                          </node>
-                                        </node>
-                                      </node>
-                                      <node concept="2qgKlT" id="65e5JdYLf1m" role="2OqNvi">
-                                        <ref role="37wK5l" to="tpcb:67EYkym$wx3" resolve="getConceptDeclaration" />
-                                      </node>
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                          <node concept="2OqwBi" id="65e5JdYLf19" role="1m5AlR">
-                            <node concept="2kS8pE" id="65e5JdYLf1a" role="2Oq$k0" />
-                            <node concept="liA8E" id="65e5JdYLf1b" role="2OqNvi">
-                              <ref role="37wK5l" to="uddc:~TransformationMenuContext.getNode()" resolve="getNode" />
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="3Tsc0h" id="65e5JdYLf1n" role="2OqNvi">
-                          <ref role="3TtcxE" to="tpee:fzcqZ_x" resolve="statement" />
-                          <node concept="1ZhdrF" id="65e5JdYLf1o" role="lGtFl">
-                            <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/1138056282393/1138056546658" />
-                            <property role="2qtEX8" value="link" />
-                            <node concept="3$xsQk" id="65e5JdYLf1p" role="3$ytzL">
-                              <node concept="3clFbS" id="65e5JdYLf1q" role="2VODD2">
-                                <node concept="3clFbF" id="65e5JdYLf1r" role="3cqZAp">
-                                  <node concept="2OqwBi" id="65e5JdYLf1s" role="3clFbG">
-                                    <node concept="1PxgMI" id="65e5JdYLf1t" role="2Oq$k0">
-                                      <node concept="chp4Y" id="1SbcsM_INSX" role="3oSUPX">
-                                        <ref role="cht4Q" to="tpc2:fBF2Hee" resolve="CellModel_RefNodeList" />
-                                      </node>
-                                      <node concept="2OqwBi" id="65e5JdYLf1u" role="1m5AlR">
-                                        <node concept="30H73N" id="65e5JdYLf1v" role="2Oq$k0" />
-                                        <node concept="2qgKlT" id="65e5JdYLf1w" role="2OqNvi">
-                                          <ref role="37wK5l" to="karh:7KznU_3XzU4" resolve="getFirstNonConst" />
-                                        </node>
-                                      </node>
-                                    </node>
-                                    <node concept="3TrEf2" id="65e5JdYLf1x" role="2OqNvi">
-                                      <ref role="3Tt5mk" to="tpc2:fBF2Hej" resolve="linkDeclaration" />
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
+                    <node concept="0kSF2" id="15DZatOUQd4" role="33vP2m">
+                      <node concept="3uibUv" id="15DZatOUQd5" role="0kSFW">
+                        <ref role="3uigEE" to="f4zo:~EditorCell_Collection" resolve="EditorCell_Collection" />
                       </node>
-                      <node concept="2DeJg1" id="65e5JdYLf1y" role="2OqNvi" />
+                      <node concept="1Q80Hy" id="15DZatOUQd6" role="0kSFX" />
                     </node>
                   </node>
                 </node>
-                <node concept="3clFbF" id="65e5JdYLhBs" role="3cqZAp">
-                  <node concept="2OqwBi" id="65e5JdYLhBt" role="3clFbG">
-                    <node concept="2ShNRf" id="65e5JdYLhBu" role="2Oq$k0">
-                      <node concept="YeOm9" id="65e5JdYLhBv" role="2ShVmc">
-                        <node concept="1Y3b0j" id="65e5JdYLhBw" role="YeSDq">
-                          <property role="2bfB8j" value="true" />
-                          <ref role="1Y3XeK" to="wyt6:~Object" resolve="Object" />
-                          <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
-                          <node concept="3Tm1VV" id="65e5JdYLhBx" role="1B3o_S" />
-                          <node concept="3clFb_" id="65e5JdYLhBy" role="jymVt">
-                            <property role="TrG5h" value="postprocess" />
-                            <node concept="37vLTG" id="65e5JdYLhBz" role="3clF46">
-                              <property role="TrG5h" value="node" />
-                              <node concept="3Tqbb2" id="65e5JdYLhB$" role="1tU5fm" />
-                            </node>
-                            <node concept="3cqZAl" id="65e5JdYLhB_" role="3clF45" />
-                            <node concept="3Tm1VV" id="65e5JdYLhBA" role="1B3o_S" />
-                            <node concept="3clFbS" id="65e5JdYLhBB" role="3clF47">
-                              <node concept="3clFbH" id="65e5JdYLhBC" role="3cqZAp">
-                                <node concept="2b32R4" id="65e5JdYLhBD" role="lGtFl">
-                                  <node concept="3JmXsc" id="65e5JdYLhBE" role="2P8S$">
-                                    <node concept="3clFbS" id="65e5JdYLhBF" role="2VODD2">
-                                      <node concept="3clFbF" id="65e5JdYLhBG" role="3cqZAp">
-                                        <node concept="2OqwBi" id="65e5JdYLhBH" role="3clFbG">
-                                          <node concept="2OqwBi" id="65e5JdYLhBI" role="2Oq$k0">
-                                            <node concept="2OqwBi" id="65e5JdYLhBJ" role="2Oq$k0">
-                                              <node concept="30H73N" id="65e5JdYLhBK" role="2Oq$k0" />
-                                              <node concept="3TrEf2" id="65e5JdYLhBL" role="2OqNvi">
-                                                <ref role="3Tt5mk" to="teg0:65e5JdYJiFg" resolve="postprocess" />
+                <node concept="3clFbJ" id="15DZatOUQf6" role="3cqZAp">
+                  <node concept="3clFbS" id="15DZatOUQf8" role="3clFbx">
+                    <node concept="3cpWs8" id="15DZatPzQxs" role="3cqZAp">
+                      <node concept="3cpWsn" id="15DZatPzQxt" role="3cpWs9">
+                        <property role="TrG5h" value="sourceNode" />
+                        <property role="3TUv4t" value="true" />
+                        <node concept="3Tqbb2" id="15DZatPzQxu" role="1tU5fm" />
+                        <node concept="pncrf" id="15DZatPBQxf" role="33vP2m" />
+                      </node>
+                    </node>
+                    <node concept="3cpWs8" id="15DZatPzQxy" role="3cqZAp">
+                      <node concept="3cpWsn" id="15DZatPzQxz" role="3cpWs9">
+                        <property role="TrG5h" value="matchingTexts" />
+                        <property role="3TUv4t" value="true" />
+                        <node concept="_YKpA" id="15DZatPzVwQ" role="1tU5fm">
+                          <node concept="17QB3L" id="15DZatPzVwS" role="_ZDj9" />
+                        </node>
+                        <node concept="2OqwBi" id="15DZatPzSsU" role="33vP2m">
+                          <node concept="2OqwBi" id="15DZatPzQxA" role="2Oq$k0">
+                            <node concept="2ShNRf" id="15DZatPzQxB" role="2Oq$k0">
+                              <node concept="YeOm9" id="15DZatPzQxC" role="2ShVmc">
+                                <node concept="1Y3b0j" id="15DZatPzQxD" role="YeSDq">
+                                  <property role="2bfB8j" value="true" />
+                                  <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
+                                  <ref role="1Y3XeK" to="czm:mEdliw9W0N" resolve="StringOrSequenceQuery" />
+                                  <node concept="3Tm1VV" id="15DZatPzQxE" role="1B3o_S" />
+                                  <node concept="3clFb_" id="15DZatPzQxF" role="jymVt">
+                                    <property role="TrG5h" value="queryStringOrSequence" />
+                                    <property role="1EzhhJ" value="false" />
+                                    <node concept="3uibUv" id="15DZatPzQxG" role="3clF45">
+                                      <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+                                    </node>
+                                    <node concept="3Tm1VV" id="15DZatPzQxH" role="1B3o_S" />
+                                    <node concept="3clFbS" id="15DZatPzQxI" role="3clF47">
+                                      <node concept="3clFbF" id="15DZatPzQxJ" role="3cqZAp">
+                                        <node concept="Xl_RD" id="15DZatPzQxK" role="3clFbG">
+                                          <property role="Xl_RC" value="" />
+                                          <node concept="1sPUBX" id="15DZatPzQxL" role="lGtFl">
+                                            <ref role="v9R2y" node="2uT2PLn1V4k" resolve="switch_constantTextSequence" />
+                                            <node concept="3NFfHV" id="15DZatPzQxM" role="1sPUBK">
+                                              <node concept="3clFbS" id="15DZatPzQxN" role="2VODD2">
+                                                <node concept="3clFbF" id="15DZatPzQxO" role="3cqZAp">
+                                                  <node concept="2OqwBi" id="15DZatPzQxP" role="3clFbG">
+                                                    <node concept="30H73N" id="15DZatPzQxQ" role="2Oq$k0" />
+                                                    <node concept="2qgKlT" id="15DZatPzQxR" role="2OqNvi">
+                                                      <ref role="37wK5l" to="karh:7KznU_45kn7" resolve="getTransformationText" />
+                                                    </node>
+                                                  </node>
+                                                </node>
                                               </node>
                                             </node>
-                                            <node concept="3TrEf2" id="65e5JdYLhBM" role="2OqNvi">
-                                              <ref role="3Tt5mk" to="tpee:gyVODHa" resolve="body" />
-                                            </node>
-                                          </node>
-                                          <node concept="3Tsc0h" id="65e5JdYLhBN" role="2OqNvi">
-                                            <ref role="3TtcxE" to="tpee:fzcqZ_x" resolve="statement" />
                                           </node>
                                         </node>
                                       </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="liA8E" id="15DZatPzQxS" role="2OqNvi">
+                              <ref role="37wK5l" to="czm:mEdliw8IXH" resolve="query" />
+                            </node>
+                          </node>
+                          <node concept="ANE8D" id="15DZatPzUAO" role="2OqNvi" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2Gpval" id="15DZatOUQLH" role="3cqZAp">
+                      <node concept="2GrKxI" id="15DZatOUQLJ" role="2Gsz3X">
+                        <property role="TrG5h" value="child" />
+                      </node>
+                      <node concept="2YIFZM" id="4ntVsBGky79" role="2GsD0m">
+                        <ref role="37wK5l" to="czm:4ntVsBGjBHL" resolve="getUnwrappedChildren" />
+                        <ref role="1Pybhc" to="czm:RbLMy696h3" resolve="GrammarCellsUtil" />
+                        <node concept="37vLTw" id="4ntVsBGkyPT" role="37wK5m">
+                          <ref role="3cqZAo" node="15DZatOUQd3" resolve="collection" />
+                        </node>
+                      </node>
+                      <node concept="3clFbS" id="15DZatOUQLN" role="2LFqv$">
+                        <node concept="3clFbJ" id="15DZatOUQU1" role="3cqZAp">
+                          <node concept="17R0WA" id="4ntVsBGdkbA" role="3clFbw">
+                            <node concept="2OqwBi" id="4ntVsBGdhmd" role="3uHU7B">
+                              <node concept="2OqwBi" id="15DZatOUR3r" role="2Oq$k0">
+                                <node concept="2GrUjf" id="15DZatOUQW0" role="2Oq$k0">
+                                  <ref role="2Gs0qQ" node="15DZatOUQLJ" resolve="child" />
+                                </node>
+                                <node concept="liA8E" id="15DZatOURKT" role="2OqNvi">
+                                  <ref role="37wK5l" to="f4zo:~EditorCell.getSNode()" resolve="getSNode" />
+                                </node>
+                              </node>
+                              <node concept="liA8E" id="4ntVsBGdj2a" role="2OqNvi">
+                                <ref role="37wK5l" to="mhbf:~SNode.getContainmentLink()" resolve="getContainmentLink" />
+                              </node>
+                            </node>
+                            <node concept="359W_D" id="4ntVsBGdn6P" role="3uHU7w">
+                              <ref role="359W_F" to="tpck:4uZwTti3__2" resolve="smodelAttribute" />
+                              <ref role="359W_E" to="tpck:gw2VY9q" resolve="BaseConcept" />
+                              <node concept="1ZhdrF" id="4ntVsBGdqqd" role="lGtFl">
+                                <property role="2qtEX8" value="conceptDeclaration" />
+                                <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/2644386474301421077/2644386474301421078" />
+                                <node concept="3$xsQk" id="4ntVsBGdqqe" role="3$ytzL">
+                                  <node concept="3clFbS" id="4ntVsBGdqqf" role="2VODD2">
+                                    <node concept="3clFbF" id="4ntVsBGdrQM" role="3cqZAp">
+                                      <node concept="2OqwBi" id="4ntVsBGdyT6" role="3clFbG">
+                                        <node concept="2OqwBi" id="4ntVsBGdwfK" role="2Oq$k0">
+                                          <node concept="1PxgMI" id="4ntVsBGdujc" role="2Oq$k0">
+                                            <node concept="chp4Y" id="4ntVsBGdva6" role="3oSUPX">
+                                              <ref role="cht4Q" to="tpc2:fBF2Hee" resolve="CellModel_RefNodeList" />
+                                            </node>
+                                            <node concept="2OqwBi" id="4ntVsBGdrQP" role="1m5AlR">
+                                              <node concept="30H73N" id="4ntVsBGdrQQ" role="2Oq$k0" />
+                                              <node concept="2qgKlT" id="4ntVsBGdrQR" role="2OqNvi">
+                                                <ref role="37wK5l" to="karh:7KznU_3XzU4" resolve="getFirstNonConst" />
+                                              </node>
+                                            </node>
+                                          </node>
+                                          <node concept="3TrEf2" id="4ntVsBGdxcV" role="2OqNvi">
+                                            <ref role="3Tt5mk" to="tpc2:fBF2Hej" resolve="linkDeclaration" />
+                                          </node>
+                                        </node>
+                                        <node concept="2qgKlT" id="4ntVsBGdzLo" role="2OqNvi">
+                                          <ref role="37wK5l" to="tpcn:7jb4LXpbWaP" resolve="getConceptDeclaration" />
+                                        </node>
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                              <node concept="1ZhdrF" id="4ntVsBGdr5R" role="lGtFl">
+                                <property role="2qtEX8" value="linkDeclaration" />
+                                <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/2644386474301421077/2644386474301421079" />
+                                <node concept="3$xsQk" id="4ntVsBGdr5S" role="3$ytzL">
+                                  <node concept="3clFbS" id="4ntVsBGdr5T" role="2VODD2">
+                                    <node concept="3clFbF" id="4ntVsBGd$M8" role="3cqZAp">
+                                      <node concept="2OqwBi" id="4ntVsBGd$Ma" role="3clFbG">
+                                        <node concept="1PxgMI" id="4ntVsBGd$Mb" role="2Oq$k0">
+                                          <node concept="chp4Y" id="4ntVsBGd$Mc" role="3oSUPX">
+                                            <ref role="cht4Q" to="tpc2:fBF2Hee" resolve="CellModel_RefNodeList" />
+                                          </node>
+                                          <node concept="2OqwBi" id="4ntVsBGd$Md" role="1m5AlR">
+                                            <node concept="30H73N" id="4ntVsBGd$Me" role="2Oq$k0" />
+                                            <node concept="2qgKlT" id="4ntVsBGd$Mf" role="2OqNvi">
+                                              <ref role="37wK5l" to="karh:7KznU_3XzU4" resolve="getFirstNonConst" />
+                                            </node>
+                                          </node>
+                                        </node>
+                                        <node concept="3TrEf2" id="4ntVsBGd$Mg" role="2OqNvi">
+                                          <ref role="3Tt5mk" to="tpc2:fBF2Hej" resolve="linkDeclaration" />
+                                        </node>
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="3clFbS" id="15DZatOUQU3" role="3clFbx">
+                            <node concept="3cpWs8" id="15DZatOXJzz" role="3cqZAp">
+                              <node concept="3cpWsn" id="15DZatOXJz$" role="3cpWs9">
+                                <property role="TrG5h" value="parentCellId" />
+                                <node concept="17QB3L" id="15DZatOXKOs" role="1tU5fm" />
+                                <node concept="2OqwBi" id="15DZatOXJz_" role="33vP2m">
+                                  <node concept="37vLTw" id="15DZatOXJzA" role="2Oq$k0">
+                                    <ref role="3cqZAo" node="15DZatOUQd3" resolve="collection" />
+                                  </node>
+                                  <node concept="liA8E" id="15DZatOXJzB" role="2OqNvi">
+                                    <ref role="37wK5l" to="f4zo:~EditorCell.getCellId()" resolve="getCellId" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="3clFbF" id="15DZatOWSeA" role="3cqZAp">
+                              <node concept="2YIFZM" id="15DZatOWTJs" role="3clFbG">
+                                <ref role="37wK5l" to="gdpt:DnjeukUIla" resolve="filter" />
+                                <ref role="1Pybhc" to="gdpt:1_3xoKENxnx" resolve="CompositeTransformationMenuLookup" />
+                                <node concept="2GrUjf" id="15DZatOWTQN" role="37wK5m">
+                                  <ref role="2Gs0qQ" node="15DZatOUQLJ" resolve="child" />
+                                </node>
+                                <node concept="1bVj0M" id="15DZatOWU3w" role="37wK5m">
+                                  <node concept="37vLTG" id="15DZatOWUaA" role="1bW2Oz">
+                                    <property role="TrG5h" value="l" />
+                                    <node concept="3uibUv" id="15DZatOWUlv" role="1tU5fm">
+                                      <ref role="3uigEE" to="uddc:~TransformationMenuLookup" resolve="TransformationMenuLookup" />
+                                    </node>
+                                  </node>
+                                  <node concept="3clFbS" id="15DZatOWU3y" role="1bW5cS">
+                                    <node concept="3clFbF" id="15DZatOWUDZ" role="3cqZAp">
+                                      <node concept="3fqX7Q" id="15DZatOXd87" role="3clFbG">
+                                        <node concept="1eOMI4" id="15DZatOXd8m" role="3fr31v">
+                                          <node concept="1Wc70l" id="15DZatOX8eE" role="1eOMHV">
+                                            <node concept="17R0WA" id="15DZatOXbN_" role="3uHU7w">
+                                              <node concept="37vLTw" id="15DZatOXJzD" role="3uHU7w">
+                                                <ref role="3cqZAo" node="15DZatOXJz$" resolve="parentCellId" />
+                                              </node>
+                                              <node concept="2OqwBi" id="15DZatOXbaF" role="3uHU7B">
+                                                <node concept="1eOMI4" id="15DZatOXaKS" role="2Oq$k0">
+                                                  <node concept="10QFUN" id="15DZatOXaKP" role="1eOMHV">
+                                                    <node concept="3uibUv" id="15DZatOXaSN" role="10QFUM">
+                                                      <ref role="3uigEE" to="czm:15DZatOV8lJ" resolve="ListInsertActionLookup" />
+                                                    </node>
+                                                    <node concept="37vLTw" id="15DZatOXb0C" role="10QFUP">
+                                                      <ref role="3cqZAo" node="15DZatOWUaA" resolve="l" />
+                                                    </node>
+                                                  </node>
+                                                </node>
+                                                <node concept="liA8E" id="15DZatOXbmx" role="2OqNvi">
+                                                  <ref role="37wK5l" to="czm:15DZatOVt1j" resolve="getSourceCellId" />
+                                                </node>
+                                              </node>
+                                            </node>
+                                            <node concept="2ZW3vV" id="15DZatOX7FY" role="3uHU7B">
+                                              <node concept="3uibUv" id="15DZatOX7P9" role="2ZW6by">
+                                                <ref role="3uigEE" to="czm:15DZatOV8lJ" resolve="ListInsertActionLookup" />
+                                              </node>
+                                              <node concept="37vLTw" id="15DZatOWUDY" role="2ZW6bz">
+                                                <ref role="3cqZAo" node="15DZatOWUaA" resolve="l" />
+                                              </node>
+                                            </node>
+                                          </node>
+                                        </node>
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="3cpWs8" id="15DZatOXLST" role="3cqZAp">
+                              <node concept="3cpWsn" id="15DZatOXLSU" role="3cpWs9">
+                                <property role="TrG5h" value="description" />
+                                <node concept="17QB3L" id="15DZatOXKXN" role="1tU5fm" />
+                                <node concept="3cpWs3" id="15DZatOXLSV" role="33vP2m">
+                                  <node concept="2OqwBi" id="15DZatOXLSW" role="3uHU7w">
+                                    <node concept="2OqwBi" id="15DZatOXLSX" role="2Oq$k0">
+                                      <node concept="2GrUjf" id="15DZatOXLSY" role="2Oq$k0">
+                                        <ref role="2Gs0qQ" node="15DZatOUQLJ" resolve="child" />
+                                      </node>
+                                      <node concept="liA8E" id="15DZatOXLSZ" role="2OqNvi">
+                                        <ref role="37wK5l" to="f4zo:~EditorCell.getSNode()" resolve="getSNode" />
+                                      </node>
+                                    </node>
+                                    <node concept="liA8E" id="15DZatOXLT0" role="2OqNvi">
+                                      <ref role="37wK5l" to="mhbf:~SNode.getContainmentLink()" resolve="getContainmentLink" />
+                                    </node>
+                                  </node>
+                                  <node concept="Xl_RD" id="15DZatOXLT1" role="3uHU7B">
+                                    <property role="Xl_RC" value="Insert child into " />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="3cpWs8" id="15DZatOXMK7" role="3cqZAp">
+                              <node concept="3cpWsn" id="15DZatOXMK8" role="3cpWs9">
+                                <property role="TrG5h" value="trace" />
+                                <node concept="3uibUv" id="15DZatOXMWw" role="1tU5fm">
+                                  <ref role="3uigEE" to="mhbf:~SNodeReference" resolve="SNodeReference" />
+                                </node>
+                                <node concept="10Nm6u" id="15DZatOXMK9" role="33vP2m">
+                                  <node concept="5jKBG" id="15DZatOXMKa" role="lGtFl">
+                                    <ref role="v9R2y" to="tpc3:WbWijtZvbb" resolve="Menu_NodeReference" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="3cpWs8" id="15DZatOYp4E" role="3cqZAp">
+                              <node concept="3cpWsn" id="15DZatOYp4H" role="3cpWs9">
+                                <property role="TrG5h" value="postprocessor" />
+                                <node concept="1ajhzC" id="15DZatOYp4A" role="1tU5fm">
+                                  <node concept="3Tqbb2" id="15DZatOYzu_" role="1ajw0F" />
+                                  <node concept="3cqZAl" id="15DZatOYpBT" role="1ajl9A" />
+                                </node>
+                                <node concept="10Nm6u" id="15DZatOYr7l" role="33vP2m" />
+                              </node>
+                            </node>
+                            <node concept="3clFbF" id="15DZatOYsYH" role="3cqZAp">
+                              <node concept="37vLTI" id="15DZatOYtJE" role="3clFbG">
+                                <node concept="1bVj0M" id="15DZatOYuto" role="37vLTx">
+                                  <node concept="37vLTG" id="15DZatOYuF3" role="1bW2Oz">
+                                    <property role="TrG5h" value="node" />
+                                    <node concept="3Tqbb2" id="15DZatOYvdG" role="1tU5fm" />
+                                  </node>
+                                  <node concept="3clFbS" id="15DZatOYutq" role="1bW5cS">
+                                    <node concept="3clFbH" id="15DZatOYy03" role="3cqZAp">
+                                      <node concept="2b32R4" id="15DZatOYy04" role="lGtFl">
+                                        <node concept="3JmXsc" id="15DZatOYy05" role="2P8S$">
+                                          <node concept="3clFbS" id="15DZatOYy06" role="2VODD2">
+                                            <node concept="3clFbF" id="15DZatOYy07" role="3cqZAp">
+                                              <node concept="2OqwBi" id="15DZatOYy08" role="3clFbG">
+                                                <node concept="2OqwBi" id="15DZatOYy09" role="2Oq$k0">
+                                                  <node concept="2OqwBi" id="15DZatOYy0a" role="2Oq$k0">
+                                                    <node concept="30H73N" id="15DZatOYy0b" role="2Oq$k0" />
+                                                    <node concept="3TrEf2" id="15DZatOYy0c" role="2OqNvi">
+                                                      <ref role="3Tt5mk" to="teg0:65e5JdYJiFg" resolve="postprocess" />
+                                                    </node>
+                                                  </node>
+                                                  <node concept="3TrEf2" id="15DZatOYy0d" role="2OqNvi">
+                                                    <ref role="3Tt5mk" to="tpee:gyVODHa" resolve="body" />
+                                                  </node>
+                                                </node>
+                                                <node concept="3Tsc0h" id="15DZatOYy0e" role="2OqNvi">
+                                                  <ref role="3TtcxE" to="tpee:fzcqZ_x" resolve="statement" />
+                                                </node>
+                                              </node>
+                                            </node>
+                                          </node>
+                                        </node>
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                                <node concept="37vLTw" id="15DZatOYsYF" role="37vLTJ">
+                                  <ref role="3cqZAo" node="15DZatOYp4H" resolve="postprocessor" />
+                                </node>
+                              </node>
+                              <node concept="1W57fq" id="15DZatOY$B3" role="lGtFl">
+                                <node concept="3IZrLx" id="15DZatOY$B4" role="3IZSJc">
+                                  <node concept="3clFbS" id="15DZatOY$B5" role="2VODD2">
+                                    <node concept="3clFbF" id="15DZatOY_9_" role="3cqZAp">
+                                      <node concept="2OqwBi" id="15DZatOY_9A" role="3clFbG">
+                                        <node concept="2OqwBi" id="15DZatOY_9B" role="2Oq$k0">
+                                          <node concept="30H73N" id="15DZatOY_9C" role="2Oq$k0" />
+                                          <node concept="3TrEf2" id="15DZatOY_9D" role="2OqNvi">
+                                            <ref role="3Tt5mk" to="teg0:65e5JdYJiFg" resolve="postprocess" />
+                                          </node>
+                                        </node>
+                                        <node concept="3x8VRR" id="15DZatOY_9E" role="2OqNvi" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="3clFbF" id="15DZatOXdr5" role="3cqZAp">
+                              <node concept="2YIFZM" id="15DZatOXd$T" role="3clFbG">
+                                <ref role="37wK5l" to="gdpt:DnjeukELVT" resolve="add" />
+                                <ref role="1Pybhc" to="gdpt:1_3xoKENxnx" resolve="CompositeTransformationMenuLookup" />
+                                <node concept="2GrUjf" id="15DZatOXd$X" role="37wK5m">
+                                  <ref role="2Gs0qQ" node="15DZatOUQLJ" resolve="child" />
+                                </node>
+                                <node concept="2ShNRf" id="15DZatOXdI7" role="37wK5m">
+                                  <node concept="1pGfFk" id="15DZatOXe_I" role="2ShVmc">
+                                    <ref role="37wK5l" to="czm:15DZatOWMT$" resolve="ListInsertActionLookup" />
+                                    <node concept="37vLTw" id="15DZatP_xi5" role="37wK5m">
+                                      <ref role="3cqZAo" node="15DZatPzQxz" resolve="matchingTexts" />
+                                    </node>
+                                    <node concept="3clFbT" id="15DZatOXeJs" role="37wK5m" />
+                                    <node concept="37vLTw" id="15DZatOXJzC" role="37wK5m">
+                                      <ref role="3cqZAo" node="15DZatOXJz$" resolve="parentCellId" />
+                                    </node>
+                                    <node concept="37vLTw" id="15DZatOXLT2" role="37wK5m">
+                                      <ref role="3cqZAo" node="15DZatOXLSU" resolve="description" />
+                                    </node>
+                                    <node concept="2OqwBi" id="15DZatOXpR$" role="37wK5m">
+                                      <node concept="2GrUjf" id="15DZatOXpBx" role="2Oq$k0">
+                                        <ref role="2Gs0qQ" node="15DZatOUQLJ" resolve="child" />
+                                      </node>
+                                      <node concept="liA8E" id="15DZatOXqE2" role="2OqNvi">
+                                        <ref role="37wK5l" to="f4zo:~EditorCell.getSNode()" resolve="getSNode" />
+                                      </node>
+                                    </node>
+                                    <node concept="37vLTw" id="15DZatOXMKb" role="37wK5m">
+                                      <ref role="3cqZAo" node="15DZatOXMK8" resolve="trace" />
+                                    </node>
+                                    <node concept="37vLTw" id="15DZatOYCeX" role="37wK5m">
+                                      <ref role="3cqZAo" node="15DZatOYp4H" resolve="postprocessor" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="3clFbF" id="15DZatOXNjr" role="3cqZAp">
+                              <node concept="2YIFZM" id="15DZatOXNjs" role="3clFbG">
+                                <ref role="37wK5l" to="gdpt:DnjeukELVT" resolve="add" />
+                                <ref role="1Pybhc" to="gdpt:1_3xoKENxnx" resolve="CompositeTransformationMenuLookup" />
+                                <node concept="2GrUjf" id="15DZatOXNjt" role="37wK5m">
+                                  <ref role="2Gs0qQ" node="15DZatOUQLJ" resolve="child" />
+                                </node>
+                                <node concept="2ShNRf" id="15DZatOXNju" role="37wK5m">
+                                  <node concept="1pGfFk" id="15DZatOXNjv" role="2ShVmc">
+                                    <ref role="37wK5l" to="czm:15DZatOWMT$" resolve="ListInsertActionLookup" />
+                                    <node concept="37vLTw" id="15DZatP_y_P" role="37wK5m">
+                                      <ref role="3cqZAo" node="15DZatPzQxz" resolve="matchingTexts" />
+                                    </node>
+                                    <node concept="3clFbT" id="15DZatOXNjw" role="37wK5m">
+                                      <property role="3clFbU" value="true" />
+                                    </node>
+                                    <node concept="37vLTw" id="15DZatOXNjx" role="37wK5m">
+                                      <ref role="3cqZAo" node="15DZatOXJz$" resolve="parentCellId" />
+                                    </node>
+                                    <node concept="37vLTw" id="15DZatOXNjy" role="37wK5m">
+                                      <ref role="3cqZAo" node="15DZatOXLSU" resolve="description" />
+                                    </node>
+                                    <node concept="2OqwBi" id="15DZatOXNjz" role="37wK5m">
+                                      <node concept="2GrUjf" id="15DZatOXNj$" role="2Oq$k0">
+                                        <ref role="2Gs0qQ" node="15DZatOUQLJ" resolve="child" />
+                                      </node>
+                                      <node concept="liA8E" id="15DZatOXNj_" role="2OqNvi">
+                                        <ref role="37wK5l" to="f4zo:~EditorCell.getSNode()" resolve="getSNode" />
+                                      </node>
+                                    </node>
+                                    <node concept="37vLTw" id="15DZatOXNjA" role="37wK5m">
+                                      <ref role="3cqZAo" node="15DZatOXMK8" resolve="trace" />
+                                    </node>
+                                    <node concept="37vLTw" id="15DZatOYDgV" role="37wK5m">
+                                      <ref role="3cqZAo" node="15DZatOYp4H" resolve="postprocessor" />
                                     </node>
                                   </node>
                                 </node>
@@ -5497,75 +5879,19 @@
                         </node>
                       </node>
                     </node>
-                    <node concept="liA8E" id="65e5JdYLhBO" role="2OqNvi">
-                      <ref role="37wK5l" node="65e5JdYLhBy" resolve="postprocess" />
-                      <node concept="2OqwBi" id="65e5JdYLmao" role="37wK5m">
-                        <node concept="2kS8pE" id="65e5JdYLkhy" role="2Oq$k0" />
-                        <node concept="liA8E" id="65e5JdYLo2K" role="2OqNvi">
-                          <ref role="37wK5l" to="uddc:~TransformationMenuContext.getNode()" resolve="getNode" />
-                        </node>
-                      </node>
-                    </node>
                   </node>
-                  <node concept="1W57fq" id="65e5JdYLhBQ" role="lGtFl">
-                    <node concept="3IZrLx" id="65e5JdYLhBR" role="3IZSJc">
-                      <node concept="3clFbS" id="65e5JdYLhBS" role="2VODD2">
-                        <node concept="3clFbF" id="65e5JdYLhBT" role="3cqZAp">
-                          <node concept="2OqwBi" id="65e5JdYLhBU" role="3clFbG">
-                            <node concept="2OqwBi" id="65e5JdYLhBV" role="2Oq$k0">
-                              <node concept="30H73N" id="65e5JdYLhBW" role="2Oq$k0" />
-                              <node concept="3TrEf2" id="65e5JdYLhBX" role="2OqNvi">
-                                <ref role="3Tt5mk" to="teg0:65e5JdYJiFg" resolve="postprocess" />
-                              </node>
-                            </node>
-                            <node concept="3x8VRR" id="65e5JdYLhBY" role="2OqNvi" />
-                          </node>
-                        </node>
-                      </node>
+                  <node concept="3y3z36" id="15DZatOUQ_B" role="3clFbw">
+                    <node concept="10Nm6u" id="15DZatOUQIX" role="3uHU7w" />
+                    <node concept="37vLTw" id="15DZatOUQhh" role="3uHU7B">
+                      <ref role="3cqZAo" node="15DZatOUQd3" resolve="collection" />
                     </node>
                   </node>
                 </node>
-                <node concept="3clFbF" id="4eBi5gdqoBX" role="3cqZAp">
-                  <node concept="37vLTw" id="65e5JdYLf1z" role="3clFbG">
-                    <ref role="3cqZAo" node="65e5JdYLf15" resolve="result" />
-                  </node>
+                <node concept="3cpWs6" id="15DZatOUPZE" role="3cqZAp">
+                  <node concept="1Q80Hy" id="15DZatOUPZG" role="3cqZAk" />
                 </node>
               </node>
             </node>
-            <node concept="1eYwpX" id="4eBi5gdqoCv" role="1eYxym">
-              <node concept="3clFbS" id="4eBi5gdqoCw" role="2VODD2">
-                <node concept="3clFbF" id="4eBi5gdFsKb" role="3cqZAp">
-                  <node concept="3clFbT" id="4eBi5gdFsKa" role="3clFbG">
-                    <property role="3clFbU" value="true" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="1eYWSL" id="4eBi5gdqoCN" role="1eYxyj">
-              <node concept="3clFbS" id="4eBi5gdqoCO" role="2VODD2">
-                <node concept="3clFbF" id="4eBi5gdqoCP" role="3cqZAp">
-                  <node concept="Xl_RD" id="4eBi5gdqoCQ" role="3clFbG">
-                    <property role="Xl_RC" value="" />
-                    <node concept="1sPUBX" id="4eBi5gdqoCR" role="lGtFl">
-                      <ref role="v9R2y" node="2uT2PLn1V4k" resolve="switch_constantTextSequence" />
-                      <node concept="3NFfHV" id="4eBi5gdqoCS" role="1sPUBK">
-                        <node concept="3clFbS" id="4eBi5gdqoCT" role="2VODD2">
-                          <node concept="3clFbF" id="4eBi5gdqoCU" role="3cqZAp">
-                            <node concept="2OqwBi" id="4eBi5gdqoCV" role="3clFbG">
-                              <node concept="30H73N" id="4eBi5gdqoCW" role="2Oq$k0" />
-                              <node concept="2qgKlT" id="4eBi5gdqoCX" role="2OqNvi">
-                                <ref role="37wK5l" to="karh:7KznU_45kn7" resolve="getTransformationText" />
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="raruj" id="4eBi5gdqoCY" role="lGtFl" />
           </node>
           <node concept="2iRkQZ" id="4eBi5gdpi2S" role="2iSdaV" />
         </node>
@@ -5605,1229 +5931,40 @@
       <ref role="30HIoZ" to="teg0:4qdNcHzYfBo" resolve="OptionalCell" />
       <node concept="1Koe21" id="5$jJV5dP7s8" role="1lVwrX">
         <node concept="3EZMnI" id="5$jJV5dP7s9" role="1Koe22">
-          <node concept="1eYWM2" id="5$jJV5dP7sa" role="3EZMnx">
-            <property role="kV7il" value="true" />
-            <node concept="1eYxTg" id="5$jJV5dP7sb" role="1eYxTh">
-              <node concept="3clFbS" id="5$jJV5dP7sc" role="2VODD2">
-                <node concept="3cpWs8" id="5$jJV5dPrHQ" role="3cqZAp">
-                  <node concept="3cpWsn" id="5$jJV5dPrHR" role="3cpWs9">
-                    <property role="TrG5h" value="subconcept" />
-                    <node concept="2OqwBi" id="5$jJV5dPrHS" role="33vP2m">
-                      <node concept="2YIFZM" id="20mebiUgXtr" role="2Oq$k0">
-                        <ref role="1Pybhc" to="czm:RbLMy696h3" resolve="GrammarCellsUtil" />
-                        <ref role="37wK5l" to="czm:5$jJV5e9K8Y" resolve="getVisibleSubconceptsNonAbstract" />
-                        <node concept="35c_gC" id="20mebiUgXts" role="37wK5m">
-                          <ref role="35c_gD" to="tpck:gw2VY9q" resolve="BaseConcept" />
-                          <node concept="1ZhdrF" id="20mebiUgXtt" role="lGtFl">
-                            <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/2644386474300074836/2644386474300074837" />
-                            <property role="2qtEX8" value="conceptDeclaration" />
-                            <node concept="3$xsQk" id="20mebiUgXtu" role="3$ytzL">
-                              <node concept="3clFbS" id="20mebiUgXtv" role="2VODD2">
-                                <node concept="3clFbF" id="20mebiUgXtw" role="3cqZAp">
-                                  <node concept="2OqwBi" id="20mebiUgXtx" role="3clFbG">
-                                    <node concept="2OqwBi" id="20mebiUgXty" role="2Oq$k0">
-                                      <node concept="1PxgMI" id="20mebiUgXtz" role="2Oq$k0">
-                                        <node concept="chp4Y" id="1SbcsM_INU9" role="3oSUPX">
-                                          <ref role="cht4Q" to="tpc2:fBF2Hee" resolve="CellModel_RefNodeList" />
-                                        </node>
-                                        <node concept="2OqwBi" id="20mebiUgXt$" role="1m5AlR">
-                                          <node concept="30H73N" id="20mebiUgXt_" role="2Oq$k0" />
-                                          <node concept="2qgKlT" id="20mebiUgXtA" role="2OqNvi">
-                                            <ref role="37wK5l" to="karh:7KznU_3XzU4" resolve="getFirstNonConst" />
-                                          </node>
-                                        </node>
-                                      </node>
-                                      <node concept="3TrEf2" id="20mebiUgXtB" role="2OqNvi">
-                                        <ref role="3Tt5mk" to="tpc2:fBF2Hej" resolve="linkDeclaration" />
-                                      </node>
-                                    </node>
-                                    <node concept="3TrEf2" id="20mebiUgXtC" role="2OqNvi">
-                                      <ref role="3Tt5mk" to="tpce:fA0lvVK" resolve="target" />
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
+          <node concept="2uKrtP" id="5ycts4S8j04" role="3EZMnx">
+            <property role="2thAuV" value="a" />
+            <node concept="1Qtc8_" id="5ycts4S8j05" role="2vkWV5">
+              <node concept="aenpk" id="5ycts4S8j06" role="1Qtc8A">
+                <node concept="2MBE2L" id="5ycts4S8j07" role="aenpr">
+                  <node concept="2Mo9yg" id="5ycts4S8j08" role="2MvauM">
+                    <node concept="3clFbS" id="5ycts4S8j09" role="2VODD2">
+                      <node concept="3cpWs8" id="5ycts4S8j0a" role="3cqZAp">
+                        <node concept="3cpWsn" id="5ycts4S8j0b" role="3cpWs9">
+                          <property role="TrG5h" value="link" />
+                          <node concept="3uibUv" id="5ycts4S8j0c" role="1tU5fm">
+                            <ref role="3uigEE" to="c17a:~SContainmentLink" resolve="SContainmentLink" />
                           </node>
-                        </node>
-                        <node concept="2OqwBi" id="20mebiUgXtD" role="37wK5m">
-                          <node concept="2kS8pE" id="20mebiUgXtE" role="2Oq$k0" />
-                          <node concept="liA8E" id="20mebiUgXtF" role="2OqNvi">
-                            <ref role="37wK5l" to="uddc:~TransformationMenuContext.getModel()" resolve="getModel" />
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="1z4cxt" id="5$jJV5dPrIa" role="2OqNvi">
-                        <node concept="1bVj0M" id="5$jJV5dPrIb" role="23t8la">
-                          <node concept="3clFbS" id="5$jJV5dPrIc" role="1bW5cS">
-                            <node concept="3clFbF" id="5$jJV5dPrId" role="3cqZAp">
-                              <node concept="17R0WA" id="5$jJV5dPrIe" role="3clFbG">
-                                <node concept="kKDRn" id="5$jJV5dPrIf" role="3uHU7w" />
-                                <node concept="2YIFZM" id="5$jJV5dYHKO" role="3uHU7B">
-                                  <ref role="37wK5l" to="czm:5$jJV5dYioC" resolve="getSubstitutionText" />
-                                  <ref role="1Pybhc" to="czm:RbLMy696h3" resolve="GrammarCellsUtil" />
-                                  <node concept="37vLTw" id="5$jJV5dYIzI" role="37wK5m">
-                                    <ref role="3cqZAo" node="5$jJV5dPrIj" resolve="it" />
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                          <node concept="Rh6nW" id="5$jJV5dPrIj" role="1bW2Oz">
-                            <property role="TrG5h" value="it" />
-                            <node concept="2jxLKc" id="5$jJV5dPrIk" role="1tU5fm" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="3bZ5Sz" id="5$jJV5dQ51w" role="1tU5fm" />
-                  </node>
-                </node>
-                <node concept="3clFbJ" id="5$jJV5dPve7" role="3cqZAp">
-                  <node concept="3clFbS" id="5$jJV5dPve9" role="3clFbx">
-                    <node concept="3clFbF" id="5$jJV5dPyuS" role="3cqZAp">
-                      <node concept="37vLTI" id="5$jJV5dPzeJ" role="3clFbG">
-                        <node concept="35c_gC" id="5$jJV5dP_Rw" role="37vLTx">
-                          <ref role="35c_gD" to="tpck:gw2VY9q" resolve="BaseConcept" />
-                          <node concept="1ZhdrF" id="5$jJV5dPCzz" role="lGtFl">
-                            <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/2644386474300074836/2644386474300074837" />
-                            <property role="2qtEX8" value="conceptDeclaration" />
-                            <node concept="3$xsQk" id="5$jJV5dPCz$" role="3$ytzL">
-                              <node concept="3clFbS" id="5$jJV5dPCz_" role="2VODD2">
-                                <node concept="3clFbF" id="5$jJV5dPEn1" role="3cqZAp">
-                                  <node concept="2OqwBi" id="5$jJV5dPEn3" role="3clFbG">
-                                    <node concept="2OqwBi" id="5$jJV5dPEn4" role="2Oq$k0">
-                                      <node concept="1PxgMI" id="5$jJV5dPEn5" role="2Oq$k0">
-                                        <node concept="chp4Y" id="1SbcsM_INTi" role="3oSUPX">
-                                          <ref role="cht4Q" to="tpc2:fBF2Hee" resolve="CellModel_RefNodeList" />
-                                        </node>
-                                        <node concept="2OqwBi" id="5$jJV5dPEn6" role="1m5AlR">
-                                          <node concept="30H73N" id="5$jJV5dPEn7" role="2Oq$k0" />
-                                          <node concept="2qgKlT" id="5$jJV5dPEn8" role="2OqNvi">
-                                            <ref role="37wK5l" to="karh:7KznU_3XzU4" resolve="getFirstNonConst" />
-                                          </node>
-                                        </node>
-                                      </node>
-                                      <node concept="3TrEf2" id="5$jJV5dPEn9" role="2OqNvi">
-                                        <ref role="3Tt5mk" to="tpc2:fBF2Hej" resolve="linkDeclaration" />
-                                      </node>
-                                    </node>
-                                    <node concept="3TrEf2" id="5$jJV5dPEna" role="2OqNvi">
-                                      <ref role="3Tt5mk" to="tpce:fA0lvVK" resolve="target" />
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="37vLTw" id="5$jJV5dPyuQ" role="37vLTJ">
-                          <ref role="3cqZAo" node="5$jJV5dPrHR" resolve="subconcept" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3clFbC" id="5$jJV5dPwUI" role="3clFbw">
-                    <node concept="10Nm6u" id="5$jJV5dPxDT" role="3uHU7w" />
-                    <node concept="37vLTw" id="5$jJV5dPw4V" role="3uHU7B">
-                      <ref role="3cqZAo" node="5$jJV5dPrHR" resolve="subconcept" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="3clFbH" id="5$jJV5dPgnW" role="3cqZAp" />
-                <node concept="3cpWs8" id="2mvFNoRFCc0" role="3cqZAp">
-                  <node concept="3cpWsn" id="2mvFNoRFCc1" role="3cpWs9">
-                    <property role="TrG5h" value="newNode" />
-                    <node concept="3Tqbb2" id="2mvFNoRFCbB" role="1tU5fm" />
-                    <node concept="2OqwBi" id="2mvFNoRFCc2" role="33vP2m">
-                      <node concept="37vLTw" id="2mvFNoRFCc3" role="2Oq$k0">
-                        <ref role="3cqZAo" node="5$jJV5dPrHR" resolve="subconcept" />
-                      </node>
-                      <node concept="q_SaT" id="2mvFNoRFCc4" role="2OqNvi" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="3clFbF" id="5$jJV5dP7sd" role="3cqZAp">
-                  <node concept="2OqwBi" id="5$jJV5dP7se" role="3clFbG">
-                    <node concept="2OqwBi" id="5$jJV5dP7sf" role="2Oq$k0">
-                      <node concept="1PxgMI" id="5$jJV5dP7sg" role="2Oq$k0">
-                        <node concept="chp4Y" id="1SbcsM_INTq" role="3oSUPX">
-                          <ref role="cht4Q" to="tpck:gw2VY9q" resolve="BaseConcept" />
-                          <node concept="1ZhdrF" id="5$jJV5dP7sk" role="lGtFl">
-                            <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/1177026924588/1177026940964" />
-                            <property role="2qtEX8" value="conceptDeclaration" />
-                            <node concept="3$xsQk" id="5$jJV5dP7sl" role="3$ytzL">
-                              <node concept="3clFbS" id="5$jJV5dP7sm" role="2VODD2">
-                                <node concept="3clFbF" id="5$jJV5dP7sn" role="3cqZAp">
-                                  <node concept="2OqwBi" id="5$jJV5dP7so" role="3clFbG">
-                                    <node concept="2OqwBi" id="5$jJV5dP7sp" role="2Oq$k0">
-                                      <node concept="30H73N" id="5$jJV5dP7sq" role="2Oq$k0" />
-                                      <node concept="2Xjw5R" id="5$jJV5dP7sr" role="2OqNvi">
-                                        <node concept="1xMEDy" id="5$jJV5dP7ss" role="1xVPHs">
-                                          <node concept="chp4Y" id="5$jJV5dP7st" role="ri$Ld">
-                                            <ref role="cht4Q" to="tpc2:gXXWOiD" resolve="AbstractComponent" />
-                                          </node>
-                                        </node>
-                                      </node>
-                                    </node>
-                                    <node concept="2qgKlT" id="5$jJV5dP7su" role="2OqNvi">
-                                      <ref role="37wK5l" to="tpcb:67EYkym$wx3" resolve="getConceptDeclaration" />
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="2OqwBi" id="5$jJV5dP7sh" role="1m5AlR">
-                          <node concept="2kS8pE" id="5$jJV5dP7si" role="2Oq$k0" />
-                          <node concept="liA8E" id="5$jJV5dP7sj" role="2OqNvi">
-                            <ref role="37wK5l" to="uddc:~TransformationMenuContext.getNode()" resolve="getNode" />
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="3Tsc0h" id="5$jJV5dP7sv" role="2OqNvi">
-                        <ref role="3TtcxE" to="tpee:fzcqZ_x" resolve="statement" />
-                        <node concept="1ZhdrF" id="5$jJV5dP7sw" role="lGtFl">
-                          <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/1138056282393/1138056546658" />
-                          <property role="2qtEX8" value="link" />
-                          <node concept="3$xsQk" id="5$jJV5dP7sx" role="3$ytzL">
-                            <node concept="3clFbS" id="5$jJV5dP7sy" role="2VODD2">
-                              <node concept="3clFbF" id="5$jJV5dP7sz" role="3cqZAp">
-                                <node concept="2OqwBi" id="5$jJV5dP7s$" role="3clFbG">
-                                  <node concept="1PxgMI" id="5$jJV5dP7s_" role="2Oq$k0">
-                                    <node concept="chp4Y" id="1SbcsM_INT0" role="3oSUPX">
-                                      <ref role="cht4Q" to="tpc2:fBF2Hee" resolve="CellModel_RefNodeList" />
-                                    </node>
-                                    <node concept="2OqwBi" id="5$jJV5dP7sA" role="1m5AlR">
-                                      <node concept="30H73N" id="5$jJV5dP7sB" role="2Oq$k0" />
-                                      <node concept="2qgKlT" id="5$jJV5dP7sC" role="2OqNvi">
-                                        <ref role="37wK5l" to="karh:7KznU_3XzU4" resolve="getFirstNonConst" />
-                                      </node>
-                                    </node>
-                                  </node>
-                                  <node concept="3TrEf2" id="5$jJV5dP7sD" role="2OqNvi">
-                                    <ref role="3Tt5mk" to="tpc2:fBF2Hej" resolve="linkDeclaration" />
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="2Ke4WJ" id="5$jJV5dP7sE" role="2OqNvi">
-                      <node concept="1PxgMI" id="2mvFNoRIyrF" role="25WWJ7">
-                        <node concept="chp4Y" id="1SbcsM_INU6" role="3oSUPX">
-                          <ref role="cht4Q" to="tpee:fzclF8l" resolve="Statement" />
-                          <node concept="1ZhdrF" id="2mvFNoRICFO" role="lGtFl">
-                            <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/1177026924588/1177026940964" />
-                            <property role="2qtEX8" value="conceptDeclaration" />
-                            <node concept="3$xsQk" id="2mvFNoRICFP" role="3$ytzL">
-                              <node concept="3clFbS" id="2mvFNoRICFQ" role="2VODD2">
-                                <node concept="3clFbF" id="2mvFNoRILEA" role="3cqZAp">
-                                  <node concept="2OqwBi" id="2mvFNoRIOyO" role="3clFbG">
-                                    <node concept="2OqwBi" id="2mvFNoRILEB" role="2Oq$k0">
-                                      <node concept="1PxgMI" id="2mvFNoRILEC" role="2Oq$k0">
-                                        <node concept="2OqwBi" id="2mvFNoRILED" role="1m5AlR">
-                                          <node concept="30H73N" id="2mvFNoRILEE" role="2Oq$k0" />
-                                          <node concept="2qgKlT" id="2mvFNoRILEF" role="2OqNvi">
-                                            <ref role="37wK5l" to="karh:7KznU_3XzU4" resolve="getFirstNonConst" />
-                                          </node>
-                                        </node>
-                                        <node concept="chp4Y" id="1SbcsM_INTO" role="3oSUPX">
-                                          <ref role="cht4Q" to="tpc2:fBF2Hee" resolve="CellModel_RefNodeList" />
-                                        </node>
-                                      </node>
-                                      <node concept="3TrEf2" id="2mvFNoRILEG" role="2OqNvi">
-                                        <ref role="3Tt5mk" to="tpc2:fBF2Hej" resolve="linkDeclaration" />
-                                      </node>
-                                    </node>
-                                    <node concept="3TrEf2" id="2mvFNoRIQBH" role="2OqNvi">
-                                      <ref role="3Tt5mk" to="tpce:fA0lvVK" resolve="target" />
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="37vLTw" id="2mvFNoRFCc5" role="1m5AlR">
-                          <ref role="3cqZAo" node="2mvFNoRFCc1" resolve="newNode" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="3clFbF" id="65e5JdYL_e$" role="3cqZAp">
-                  <node concept="2OqwBi" id="65e5JdYL_e_" role="3clFbG">
-                    <node concept="2ShNRf" id="65e5JdYL_eA" role="2Oq$k0">
-                      <node concept="YeOm9" id="65e5JdYL_eB" role="2ShVmc">
-                        <node concept="1Y3b0j" id="65e5JdYL_eC" role="YeSDq">
-                          <property role="2bfB8j" value="true" />
-                          <ref role="1Y3XeK" to="wyt6:~Object" resolve="Object" />
-                          <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
-                          <node concept="3Tm1VV" id="65e5JdYL_eD" role="1B3o_S" />
-                          <node concept="3clFb_" id="65e5JdYL_eE" role="jymVt">
-                            <property role="TrG5h" value="postprocess" />
-                            <node concept="37vLTG" id="65e5JdYL_eF" role="3clF46">
-                              <property role="TrG5h" value="node" />
-                              <node concept="3Tqbb2" id="65e5JdYL_eG" role="1tU5fm" />
-                            </node>
-                            <node concept="3cqZAl" id="65e5JdYL_eH" role="3clF45" />
-                            <node concept="3Tm1VV" id="65e5JdYL_eI" role="1B3o_S" />
-                            <node concept="3clFbS" id="65e5JdYL_eJ" role="3clF47">
-                              <node concept="3clFbH" id="65e5JdYL_eK" role="3cqZAp">
-                                <node concept="2b32R4" id="65e5JdYL_eL" role="lGtFl">
-                                  <node concept="3JmXsc" id="65e5JdYL_eM" role="2P8S$">
-                                    <node concept="3clFbS" id="65e5JdYL_eN" role="2VODD2">
-                                      <node concept="3clFbF" id="65e5JdYL_eO" role="3cqZAp">
-                                        <node concept="2OqwBi" id="65e5JdYL_eP" role="3clFbG">
-                                          <node concept="2OqwBi" id="65e5JdYL_eQ" role="2Oq$k0">
-                                            <node concept="2OqwBi" id="65e5JdYL_eR" role="2Oq$k0">
-                                              <node concept="30H73N" id="65e5JdYL_eS" role="2Oq$k0" />
-                                              <node concept="3TrEf2" id="65e5JdYL_eT" role="2OqNvi">
-                                                <ref role="3Tt5mk" to="teg0:65e5JdYJiFg" resolve="postprocess" />
-                                              </node>
-                                            </node>
-                                            <node concept="3TrEf2" id="65e5JdYL_eU" role="2OqNvi">
-                                              <ref role="3Tt5mk" to="tpee:gyVODHa" resolve="body" />
-                                            </node>
-                                          </node>
-                                          <node concept="3Tsc0h" id="65e5JdYL_eV" role="2OqNvi">
-                                            <ref role="3TtcxE" to="tpee:fzcqZ_x" resolve="statement" />
-                                          </node>
-                                        </node>
-                                      </node>
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="liA8E" id="65e5JdYL_eW" role="2OqNvi">
-                      <ref role="37wK5l" node="65e5JdYL_eE" resolve="postprocess" />
-                      <node concept="2OqwBi" id="65e5JdYL_eX" role="37wK5m">
-                        <node concept="2kS8pE" id="65e5JdYL_eY" role="2Oq$k0" />
-                        <node concept="liA8E" id="65e5JdYL_eZ" role="2OqNvi">
-                          <ref role="37wK5l" to="uddc:~TransformationMenuContext.getNode()" resolve="getNode" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="1W57fq" id="65e5JdYL_f0" role="lGtFl">
-                    <node concept="3IZrLx" id="65e5JdYL_f1" role="3IZSJc">
-                      <node concept="3clFbS" id="65e5JdYL_f2" role="2VODD2">
-                        <node concept="3clFbF" id="65e5JdYL_f3" role="3cqZAp">
-                          <node concept="2OqwBi" id="65e5JdYL_f4" role="3clFbG">
-                            <node concept="2OqwBi" id="65e5JdYL_f5" role="2Oq$k0">
-                              <node concept="30H73N" id="65e5JdYL_f6" role="2Oq$k0" />
-                              <node concept="3TrEf2" id="65e5JdYL_f7" role="2OqNvi">
-                                <ref role="3Tt5mk" to="teg0:65e5JdYJiFg" resolve="postprocess" />
-                              </node>
-                            </node>
-                            <node concept="3x8VRR" id="65e5JdYL_f8" role="2OqNvi" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="3clFbF" id="2mvFNoRFIOP" role="3cqZAp">
-                  <node concept="37vLTw" id="2mvFNoRFION" role="3clFbG">
-                    <ref role="3cqZAo" node="2mvFNoRFCc1" resolve="newNode" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="1eYwpX" id="5$jJV5dP7sU" role="1eYxym">
-              <node concept="3clFbS" id="5$jJV5dP7sV" role="2VODD2">
-                <node concept="3clFbF" id="5$jJV5dP7sW" role="3cqZAp">
-                  <node concept="2OqwBi" id="5$jJV5dP7sX" role="3clFbG">
-                    <node concept="2OqwBi" id="5$jJV5dP7sY" role="2Oq$k0">
-                      <node concept="1PxgMI" id="5$jJV5dP7sZ" role="2Oq$k0">
-                        <node concept="chp4Y" id="1SbcsM_INTC" role="3oSUPX">
-                          <ref role="cht4Q" to="tpck:gw2VY9q" resolve="BaseConcept" />
-                          <node concept="1ZhdrF" id="5$jJV5dP7t3" role="lGtFl">
-                            <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/1177026924588/1177026940964" />
-                            <property role="2qtEX8" value="conceptDeclaration" />
-                            <node concept="3$xsQk" id="5$jJV5dP7t4" role="3$ytzL">
-                              <node concept="3clFbS" id="5$jJV5dP7t5" role="2VODD2">
-                                <node concept="3clFbF" id="5$jJV5dP7t6" role="3cqZAp">
-                                  <node concept="2OqwBi" id="5$jJV5dP7t7" role="3clFbG">
-                                    <node concept="2OqwBi" id="5$jJV5dP7t8" role="2Oq$k0">
-                                      <node concept="30H73N" id="5$jJV5dP7t9" role="2Oq$k0" />
-                                      <node concept="2Xjw5R" id="5$jJV5dP7ta" role="2OqNvi">
-                                        <node concept="1xMEDy" id="5$jJV5dP7tb" role="1xVPHs">
-                                          <node concept="chp4Y" id="5$jJV5dP7tc" role="ri$Ld">
-                                            <ref role="cht4Q" to="tpc2:gXXWOiD" resolve="AbstractComponent" />
-                                          </node>
-                                        </node>
-                                      </node>
-                                    </node>
-                                    <node concept="2qgKlT" id="5$jJV5dP7td" role="2OqNvi">
-                                      <ref role="37wK5l" to="tpcb:67EYkym$wx3" resolve="getConceptDeclaration" />
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="2OqwBi" id="5$jJV5dP7t0" role="1m5AlR">
-                          <node concept="2kS8pE" id="5$jJV5dP7t1" role="2Oq$k0" />
-                          <node concept="liA8E" id="5$jJV5dP7t2" role="2OqNvi">
-                            <ref role="37wK5l" to="uddc:~TransformationMenuContext.getNode()" resolve="getNode" />
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="3Tsc0h" id="5$jJV5dP7te" role="2OqNvi">
-                        <ref role="3TtcxE" to="tpee:fzcqZ_x" resolve="statement" />
-                        <node concept="1ZhdrF" id="5$jJV5dP7tf" role="lGtFl">
-                          <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/1138056282393/1138056546658" />
-                          <property role="2qtEX8" value="link" />
-                          <node concept="3$xsQk" id="5$jJV5dP7tg" role="3$ytzL">
-                            <node concept="3clFbS" id="5$jJV5dP7th" role="2VODD2">
-                              <node concept="3clFbF" id="5$jJV5dP7ti" role="3cqZAp">
-                                <node concept="2OqwBi" id="5$jJV5dP7tj" role="3clFbG">
-                                  <node concept="1PxgMI" id="5$jJV5dP7tk" role="2Oq$k0">
-                                    <node concept="chp4Y" id="1SbcsM_INSW" role="3oSUPX">
-                                      <ref role="cht4Q" to="tpc2:fBF2Hee" resolve="CellModel_RefNodeList" />
-                                    </node>
-                                    <node concept="2OqwBi" id="5$jJV5dP7tl" role="1m5AlR">
-                                      <node concept="30H73N" id="5$jJV5dP7tm" role="2Oq$k0" />
-                                      <node concept="2qgKlT" id="5$jJV5dP7tn" role="2OqNvi">
-                                        <ref role="37wK5l" to="karh:7KznU_3XzU4" resolve="getFirstNonConst" />
-                                      </node>
-                                    </node>
-                                  </node>
-                                  <node concept="3TrEf2" id="5$jJV5dP7to" role="2OqNvi">
-                                    <ref role="3Tt5mk" to="tpc2:fBF2Hej" resolve="linkDeclaration" />
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="3GX2aA" id="5$jJV5dP7tp" role="2OqNvi" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="1eYWSL" id="5$jJV5dP7tq" role="1eYxyj">
-              <node concept="3clFbS" id="5$jJV5dP7tr" role="2VODD2">
-                <node concept="3clFbF" id="5$jJV5dPbvW" role="3cqZAp">
-                  <node concept="2OqwBi" id="5$jJV5dPeH0" role="3clFbG">
-                    <node concept="2YIFZM" id="5$jJV5eah5K" role="2Oq$k0">
-                      <ref role="1Pybhc" to="czm:RbLMy696h3" resolve="GrammarCellsUtil" />
-                      <ref role="37wK5l" to="czm:5$jJV5e9K8Y" resolve="getVisibleSubconceptsNonAbstract" />
-                      <node concept="35c_gC" id="5$jJV5eah5L" role="37wK5m">
-                        <ref role="35c_gD" to="tpck:gw2VY9q" resolve="BaseConcept" />
-                        <node concept="1ZhdrF" id="5$jJV5eah5M" role="lGtFl">
-                          <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/2644386474300074836/2644386474300074837" />
-                          <property role="2qtEX8" value="conceptDeclaration" />
-                          <node concept="3$xsQk" id="5$jJV5eah5N" role="3$ytzL">
-                            <node concept="3clFbS" id="5$jJV5eah5O" role="2VODD2">
-                              <node concept="3clFbF" id="5$jJV5eah5P" role="3cqZAp">
-                                <node concept="2OqwBi" id="5$jJV5eah5Q" role="3clFbG">
-                                  <node concept="2OqwBi" id="5$jJV5eah5R" role="2Oq$k0">
-                                    <node concept="1PxgMI" id="5$jJV5eah5S" role="2Oq$k0">
-                                      <node concept="chp4Y" id="1SbcsM_INST" role="3oSUPX">
-                                        <ref role="cht4Q" to="tpc2:fBF2Hee" resolve="CellModel_RefNodeList" />
-                                      </node>
-                                      <node concept="2OqwBi" id="5$jJV5eah5T" role="1m5AlR">
-                                        <node concept="30H73N" id="5$jJV5eah5U" role="2Oq$k0" />
-                                        <node concept="2qgKlT" id="5$jJV5eah5V" role="2OqNvi">
-                                          <ref role="37wK5l" to="karh:7KznU_3XzU4" resolve="getFirstNonConst" />
-                                        </node>
-                                      </node>
-                                    </node>
-                                    <node concept="3TrEf2" id="5$jJV5eah5W" role="2OqNvi">
-                                      <ref role="3Tt5mk" to="tpc2:fBF2Hej" resolve="linkDeclaration" />
-                                    </node>
-                                  </node>
-                                  <node concept="3TrEf2" id="5$jJV5eah5X" role="2OqNvi">
-                                    <ref role="3Tt5mk" to="tpce:fA0lvVK" resolve="target" />
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="2OqwBi" id="5$jJV5eah5Y" role="37wK5m">
-                        <node concept="2kS8pE" id="5$jJV5eah5Z" role="2Oq$k0" />
-                        <node concept="liA8E" id="5$jJV5eah60" role="2OqNvi">
-                          <ref role="37wK5l" to="uddc:~TransformationMenuContext.getModel()" resolve="getModel" />
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="3$u5V9" id="5$jJV5dPfy$" role="2OqNvi">
-                      <node concept="1bVj0M" id="5$jJV5dPfyA" role="23t8la">
-                        <node concept="3clFbS" id="5$jJV5dPfyB" role="1bW5cS">
-                          <node concept="3clFbF" id="5$jJV5dPfH7" role="3cqZAp">
-                            <node concept="2YIFZM" id="5$jJV5dYFUd" role="3clFbG">
-                              <ref role="37wK5l" to="czm:5$jJV5dYioC" resolve="getSubstitutionText" />
-                              <ref role="1Pybhc" to="czm:RbLMy696h3" resolve="GrammarCellsUtil" />
-                              <node concept="37vLTw" id="5$jJV5dYG4w" role="37wK5m">
-                                <ref role="3cqZAo" node="5$jJV5dPfyC" resolve="it" />
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="Rh6nW" id="5$jJV5dPfyC" role="1bW2Oz">
-                          <property role="TrG5h" value="it" />
-                          <node concept="2jxLKc" id="5$jJV5dPfyD" role="1tU5fm" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="raruj" id="5$jJV5dP7t_" role="lGtFl" />
-          </node>
-          <node concept="7FqFr" id="5$jJV5dP7tA" role="3EZMnx">
-            <property role="n4v1i" value="true" />
-            <node concept="1eYWSL" id="5$jJV5dP7tB" role="7F66l">
-              <node concept="3clFbS" id="5$jJV5dP7tC" role="2VODD2">
-                <node concept="3clFbF" id="5$jJV5dQmVg" role="3cqZAp">
-                  <node concept="2OqwBi" id="5$jJV5dQmVh" role="3clFbG">
-                    <node concept="2YIFZM" id="5$jJV5eahM0" role="2Oq$k0">
-                      <ref role="1Pybhc" to="czm:RbLMy696h3" resolve="GrammarCellsUtil" />
-                      <ref role="37wK5l" to="czm:5$jJV5e9K8Y" resolve="getVisibleSubconceptsNonAbstract" />
-                      <node concept="35c_gC" id="5$jJV5eahM1" role="37wK5m">
-                        <ref role="35c_gD" to="tpck:gw2VY9q" resolve="BaseConcept" />
-                        <node concept="1ZhdrF" id="5$jJV5eahM2" role="lGtFl">
-                          <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/2644386474300074836/2644386474300074837" />
-                          <property role="2qtEX8" value="conceptDeclaration" />
-                          <node concept="3$xsQk" id="5$jJV5eahM3" role="3$ytzL">
-                            <node concept="3clFbS" id="5$jJV5eahM4" role="2VODD2">
-                              <node concept="3clFbF" id="5$jJV5eahM5" role="3cqZAp">
-                                <node concept="2OqwBi" id="5$jJV5eahM6" role="3clFbG">
-                                  <node concept="2OqwBi" id="5$jJV5eahM7" role="2Oq$k0">
-                                    <node concept="1PxgMI" id="5$jJV5eahM8" role="2Oq$k0">
-                                      <node concept="chp4Y" id="1SbcsM_INT_" role="3oSUPX">
-                                        <ref role="cht4Q" to="tpc2:fBF2Hee" resolve="CellModel_RefNodeList" />
-                                      </node>
-                                      <node concept="2OqwBi" id="5$jJV5eahM9" role="1m5AlR">
-                                        <node concept="30H73N" id="5$jJV5eahMa" role="2Oq$k0" />
-                                        <node concept="2qgKlT" id="5$jJV5eahMb" role="2OqNvi">
-                                          <ref role="37wK5l" to="karh:7KznU_3XzU4" resolve="getFirstNonConst" />
-                                        </node>
-                                      </node>
-                                    </node>
-                                    <node concept="3TrEf2" id="5$jJV5eahMc" role="2OqNvi">
-                                      <ref role="3Tt5mk" to="tpc2:fBF2Hej" resolve="linkDeclaration" />
-                                    </node>
-                                  </node>
-                                  <node concept="3TrEf2" id="5$jJV5eahMd" role="2OqNvi">
-                                    <ref role="3Tt5mk" to="tpce:fA0lvVK" resolve="target" />
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="2OqwBi" id="5$jJV5eahMe" role="37wK5m">
-                        <node concept="2kS8pE" id="5$jJV5eahMf" role="2Oq$k0" />
-                        <node concept="liA8E" id="5$jJV5eahMg" role="2OqNvi">
-                          <ref role="37wK5l" to="uddc:~TransformationMenuContext.getModel()" resolve="getModel" />
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="3$u5V9" id="5$jJV5dQmVz" role="2OqNvi">
-                      <node concept="1bVj0M" id="5$jJV5dQmV$" role="23t8la">
-                        <node concept="3clFbS" id="5$jJV5dQmV_" role="1bW5cS">
-                          <node concept="3clFbF" id="5$jJV5dQmVA" role="3cqZAp">
-                            <node concept="2YIFZM" id="5$jJV5dYYCy" role="3clFbG">
-                              <ref role="37wK5l" to="czm:5$jJV5dYioC" resolve="getSubstitutionText" />
-                              <ref role="1Pybhc" to="czm:RbLMy696h3" resolve="GrammarCellsUtil" />
-                              <node concept="37vLTw" id="5$jJV5dYYMR" role="37wK5m">
-                                <ref role="3cqZAo" node="5$jJV5dQmVE" resolve="it" />
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="Rh6nW" id="5$jJV5dQmVE" role="1bW2Oz">
-                          <property role="TrG5h" value="it" />
-                          <node concept="2jxLKc" id="5$jJV5dQmVF" role="1tU5fm" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="1eYxTg" id="5$jJV5dP7tM" role="7F66k">
-              <node concept="3clFbS" id="5$jJV5dP7tN" role="2VODD2">
-                <node concept="3cpWs8" id="5$jJV5dQnjR" role="3cqZAp">
-                  <node concept="3cpWsn" id="5$jJV5dQnjS" role="3cpWs9">
-                    <property role="TrG5h" value="subconcept" />
-                    <node concept="2OqwBi" id="5$jJV5dQnjT" role="33vP2m">
-                      <node concept="2YIFZM" id="20mebiUgZ8_" role="2Oq$k0">
-                        <ref role="1Pybhc" to="czm:RbLMy696h3" resolve="GrammarCellsUtil" />
-                        <ref role="37wK5l" to="czm:5$jJV5e9K8Y" resolve="getVisibleSubconceptsNonAbstract" />
-                        <node concept="35c_gC" id="20mebiUgZ8A" role="37wK5m">
-                          <ref role="35c_gD" to="tpck:gw2VY9q" resolve="BaseConcept" />
-                          <node concept="1ZhdrF" id="20mebiUgZ8B" role="lGtFl">
-                            <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/2644386474300074836/2644386474300074837" />
-                            <property role="2qtEX8" value="conceptDeclaration" />
-                            <node concept="3$xsQk" id="20mebiUgZ8C" role="3$ytzL">
-                              <node concept="3clFbS" id="20mebiUgZ8D" role="2VODD2">
-                                <node concept="3clFbF" id="20mebiUgZ8E" role="3cqZAp">
-                                  <node concept="2OqwBi" id="20mebiUgZ8F" role="3clFbG">
-                                    <node concept="2OqwBi" id="20mebiUgZ8G" role="2Oq$k0">
-                                      <node concept="1PxgMI" id="20mebiUgZ8H" role="2Oq$k0">
-                                        <node concept="chp4Y" id="1SbcsM_INTW" role="3oSUPX">
-                                          <ref role="cht4Q" to="tpc2:fBF2Hee" resolve="CellModel_RefNodeList" />
-                                        </node>
-                                        <node concept="2OqwBi" id="20mebiUgZ8I" role="1m5AlR">
-                                          <node concept="30H73N" id="20mebiUgZ8J" role="2Oq$k0" />
-                                          <node concept="2qgKlT" id="20mebiUgZ8K" role="2OqNvi">
-                                            <ref role="37wK5l" to="karh:7KznU_3XzU4" resolve="getFirstNonConst" />
-                                          </node>
-                                        </node>
-                                      </node>
-                                      <node concept="3TrEf2" id="20mebiUgZ8L" role="2OqNvi">
-                                        <ref role="3Tt5mk" to="tpc2:fBF2Hej" resolve="linkDeclaration" />
-                                      </node>
-                                    </node>
-                                    <node concept="3TrEf2" id="20mebiUgZ8M" role="2OqNvi">
-                                      <ref role="3Tt5mk" to="tpce:fA0lvVK" resolve="target" />
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="2OqwBi" id="20mebiUgZ8N" role="37wK5m">
-                          <node concept="2kS8pE" id="20mebiUgZ8O" role="2Oq$k0" />
-                          <node concept="liA8E" id="20mebiUgZ8P" role="2OqNvi">
-                            <ref role="37wK5l" to="uddc:~TransformationMenuContext.getModel()" resolve="getModel" />
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="1z4cxt" id="5$jJV5dQnkb" role="2OqNvi">
-                        <node concept="1bVj0M" id="5$jJV5dQnkc" role="23t8la">
-                          <node concept="3clFbS" id="5$jJV5dQnkd" role="1bW5cS">
-                            <node concept="3clFbF" id="5$jJV5dQnke" role="3cqZAp">
-                              <node concept="17R0WA" id="5$jJV5dQnkf" role="3clFbG">
-                                <node concept="kKDRn" id="5$jJV5dQnkg" role="3uHU7w" />
-                                <node concept="2YIFZM" id="5$jJV5dZ052" role="3uHU7B">
-                                  <ref role="37wK5l" to="czm:5$jJV5dYioC" resolve="getSubstitutionText" />
-                                  <ref role="1Pybhc" to="czm:RbLMy696h3" resolve="GrammarCellsUtil" />
-                                  <node concept="37vLTw" id="5$jJV5dZ0Ck" role="37wK5m">
-                                    <ref role="3cqZAo" node="5$jJV5dQnkk" resolve="it" />
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                          <node concept="Rh6nW" id="5$jJV5dQnkk" role="1bW2Oz">
-                            <property role="TrG5h" value="it" />
-                            <node concept="2jxLKc" id="5$jJV5dQnkl" role="1tU5fm" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="3bZ5Sz" id="5$jJV5dQnkm" role="1tU5fm" />
-                  </node>
-                </node>
-                <node concept="3clFbJ" id="5$jJV5dQnkn" role="3cqZAp">
-                  <node concept="3clFbS" id="5$jJV5dQnko" role="3clFbx">
-                    <node concept="3clFbF" id="5$jJV5dQnkp" role="3cqZAp">
-                      <node concept="37vLTI" id="5$jJV5dQnkq" role="3clFbG">
-                        <node concept="35c_gC" id="5$jJV5dQnkr" role="37vLTx">
-                          <ref role="35c_gD" to="tpck:gw2VY9q" resolve="BaseConcept" />
-                          <node concept="1ZhdrF" id="5$jJV5dQnks" role="lGtFl">
-                            <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/2644386474300074836/2644386474300074837" />
-                            <property role="2qtEX8" value="conceptDeclaration" />
-                            <node concept="3$xsQk" id="5$jJV5dQnkt" role="3$ytzL">
-                              <node concept="3clFbS" id="5$jJV5dQnku" role="2VODD2">
-                                <node concept="3clFbF" id="5$jJV5dQnkv" role="3cqZAp">
-                                  <node concept="2OqwBi" id="5$jJV5dQnkw" role="3clFbG">
-                                    <node concept="2OqwBi" id="5$jJV5dQnkx" role="2Oq$k0">
-                                      <node concept="1PxgMI" id="5$jJV5dQnky" role="2Oq$k0">
-                                        <node concept="chp4Y" id="1SbcsM_INU2" role="3oSUPX">
-                                          <ref role="cht4Q" to="tpc2:fBF2Hee" resolve="CellModel_RefNodeList" />
-                                        </node>
-                                        <node concept="2OqwBi" id="5$jJV5dQnkz" role="1m5AlR">
-                                          <node concept="30H73N" id="5$jJV5dQnk$" role="2Oq$k0" />
-                                          <node concept="2qgKlT" id="5$jJV5dQnk_" role="2OqNvi">
-                                            <ref role="37wK5l" to="karh:7KznU_3XzU4" resolve="getFirstNonConst" />
-                                          </node>
-                                        </node>
-                                      </node>
-                                      <node concept="3TrEf2" id="5$jJV5dQnkA" role="2OqNvi">
-                                        <ref role="3Tt5mk" to="tpc2:fBF2Hej" resolve="linkDeclaration" />
-                                      </node>
-                                    </node>
-                                    <node concept="3TrEf2" id="5$jJV5dQnkB" role="2OqNvi">
-                                      <ref role="3Tt5mk" to="tpce:fA0lvVK" resolve="target" />
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="37vLTw" id="5$jJV5dQnkC" role="37vLTJ">
-                          <ref role="3cqZAo" node="5$jJV5dQnjS" resolve="subconcept" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3clFbC" id="5$jJV5dQnkD" role="3clFbw">
-                    <node concept="10Nm6u" id="5$jJV5dQnkE" role="3uHU7w" />
-                    <node concept="37vLTw" id="5$jJV5dQnkF" role="3uHU7B">
-                      <ref role="3cqZAo" node="5$jJV5dQnjS" resolve="subconcept" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="3clFbH" id="5$jJV5dQo4X" role="3cqZAp" />
-                <node concept="3cpWs8" id="5$jJV5ervre" role="3cqZAp">
-                  <node concept="3cpWsn" id="5$jJV5ervrh" role="3cpWs9">
-                    <property role="TrG5h" value="listElement" />
-                    <node concept="3Tqbb2" id="5$jJV5ervri" role="1tU5fm" />
-                    <node concept="2YIFZM" id="5$jJV5ervrj" role="33vP2m">
-                      <ref role="37wK5l" to="czm:5$jJV5eqaC7" resolve="getListElementForSideTransformation" />
-                      <ref role="1Pybhc" to="czm:RbLMy696h3" resolve="GrammarCellsUtil" />
-                      <node concept="2OqwBi" id="5$jJV5ervrk" role="37wK5m">
-                        <node concept="2kS8pE" id="5$jJV5ervrl" role="2Oq$k0" />
-                        <node concept="liA8E" id="5$jJV5ervrm" role="2OqNvi">
-                          <ref role="37wK5l" to="uddc:~TransformationMenuContext.getNode()" resolve="getNode" />
-                        </node>
-                      </node>
-                      <node concept="359W_D" id="5$jJV5ervrn" role="37wK5m">
-                        <ref role="359W_E" to="tpck:gw2VY9q" resolve="BaseConcept" />
-                        <ref role="359W_F" to="tpck:4uZwTti3__2" resolve="smodelAttribute" />
-                        <node concept="1ZhdrF" id="5$jJV5ervro" role="lGtFl">
-                          <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/2644386474301421077/2644386474301421078" />
-                          <property role="2qtEX8" value="conceptDeclaration" />
-                          <node concept="3$xsQk" id="5$jJV5ervrp" role="3$ytzL">
-                            <node concept="3clFbS" id="5$jJV5ervrq" role="2VODD2">
-                              <node concept="3clFbF" id="5$jJV5ervrr" role="3cqZAp">
-                                <node concept="2OqwBi" id="5$jJV5ervrs" role="3clFbG">
-                                  <node concept="2OqwBi" id="5$jJV5ervrt" role="2Oq$k0">
-                                    <node concept="30H73N" id="5$jJV5ervru" role="2Oq$k0" />
-                                    <node concept="2Xjw5R" id="5$jJV5ervrv" role="2OqNvi">
-                                      <node concept="1xMEDy" id="5$jJV5ervrw" role="1xVPHs">
-                                        <node concept="chp4Y" id="5$jJV5ervrx" role="ri$Ld">
-                                          <ref role="cht4Q" to="tpc2:gXXWOiD" resolve="AbstractComponent" />
-                                        </node>
-                                      </node>
-                                    </node>
-                                  </node>
-                                  <node concept="2qgKlT" id="5$jJV5ervry" role="2OqNvi">
-                                    <ref role="37wK5l" to="tpcb:67EYkym$wx3" resolve="getConceptDeclaration" />
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="1ZhdrF" id="5$jJV5ervrz" role="lGtFl">
-                          <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/2644386474301421077/2644386474301421079" />
-                          <property role="2qtEX8" value="linkDeclaration" />
-                          <node concept="3$xsQk" id="5$jJV5ervr$" role="3$ytzL">
-                            <node concept="3clFbS" id="5$jJV5ervr_" role="2VODD2">
-                              <node concept="3clFbF" id="5$jJV5ervrA" role="3cqZAp">
-                                <node concept="2OqwBi" id="5$jJV5ervrB" role="3clFbG">
-                                  <node concept="1PxgMI" id="5$jJV5ervrC" role="2Oq$k0">
-                                    <node concept="chp4Y" id="1SbcsM_INTs" role="3oSUPX">
-                                      <ref role="cht4Q" to="tpc2:fBF2Hee" resolve="CellModel_RefNodeList" />
-                                    </node>
-                                    <node concept="2OqwBi" id="5$jJV5ervrD" role="1m5AlR">
-                                      <node concept="30H73N" id="5$jJV5ervrE" role="2Oq$k0" />
-                                      <node concept="2qgKlT" id="5$jJV5ervrF" role="2OqNvi">
-                                        <ref role="37wK5l" to="karh:7KznU_3XzU4" resolve="getFirstNonConst" />
-                                      </node>
-                                    </node>
-                                  </node>
-                                  <node concept="3TrEf2" id="5$jJV5ervrG" role="2OqNvi">
-                                    <ref role="3Tt5mk" to="tpc2:fBF2Hej" resolve="linkDeclaration" />
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="3clFbC" id="2mvFNoRF9Ym" role="37wK5m">
-                        <node concept="10M0yZ" id="2mvFNoRF9Yn" role="3uHU7w">
-                          <ref role="1PxDUh" to="9eyi:~MenuLocations" resolve="MenuLocations" />
-                          <ref role="3cqZAo" to="9eyi:~MenuLocations.LEFT_SIDE_TRANSFORM" resolve="LEFT_SIDE_TRANSFORM" />
-                        </node>
-                        <node concept="2OqwBi" id="2mvFNoRF9Yo" role="3uHU7B">
-                          <node concept="2kS8pE" id="2mvFNoRFca7" role="2Oq$k0" />
-                          <node concept="liA8E" id="2mvFNoRF9Yq" role="2OqNvi">
-                            <ref role="37wK5l" to="uddc:~TransformationMenuContext.getMenuLocation()" resolve="getMenuLocation" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="3cpWs8" id="5$jJV5dP7tU" role="3cqZAp">
-                  <node concept="3cpWsn" id="5$jJV5dP7tV" role="3cpWs9">
-                    <property role="TrG5h" value="newNode" />
-                    <node concept="3Tqbb2" id="5$jJV5dP7tW" role="1tU5fm" />
-                    <node concept="2OqwBi" id="5$jJV5dQq0F" role="33vP2m">
-                      <node concept="37vLTw" id="5$jJV5dQpsz" role="2Oq$k0">
-                        <ref role="3cqZAo" node="5$jJV5dQnjS" resolve="subconcept" />
-                      </node>
-                      <node concept="q_SaT" id="5$jJV5dQqBS" role="2OqNvi" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="3clFbJ" id="5$jJV5dP7uc" role="3cqZAp">
-                  <node concept="3clFbC" id="2mvFNoRECXd" role="3clFbw">
-                    <node concept="10M0yZ" id="2mvFNoRECXe" role="3uHU7w">
-                      <ref role="1PxDUh" to="9eyi:~MenuLocations" resolve="MenuLocations" />
-                      <ref role="3cqZAo" to="9eyi:~MenuLocations.LEFT_SIDE_TRANSFORM" resolve="LEFT_SIDE_TRANSFORM" />
-                    </node>
-                    <node concept="2OqwBi" id="2mvFNoRECXf" role="3uHU7B">
-                      <node concept="2kS8pE" id="2mvFNoREE2n" role="2Oq$k0" />
-                      <node concept="liA8E" id="2mvFNoRECXh" role="2OqNvi">
-                        <ref role="37wK5l" to="uddc:~TransformationMenuContext.getMenuLocation()" resolve="getMenuLocation" />
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3clFbS" id="5$jJV5dP7ud" role="3clFbx">
-                    <node concept="3clFbF" id="5$jJV5dP7ue" role="3cqZAp">
-                      <node concept="2OqwBi" id="5$jJV5dP7uf" role="3clFbG">
-                        <node concept="37vLTw" id="5$jJV5erym5" role="2Oq$k0">
-                          <ref role="3cqZAo" node="5$jJV5ervrh" resolve="listElement" />
-                        </node>
-                        <node concept="HtX7F" id="5$jJV5dP7uh" role="2OqNvi">
-                          <node concept="37vLTw" id="5$jJV5dP7ui" role="HtX7I">
-                            <ref role="3cqZAo" node="5$jJV5dP7tV" resolve="newNode" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="9aQIb" id="5$jJV5dP7uo" role="9aQIa">
-                    <node concept="3clFbS" id="5$jJV5dP7up" role="9aQI4">
-                      <node concept="3clFbF" id="5$jJV5dP7uq" role="3cqZAp">
-                        <node concept="2OqwBi" id="5$jJV5dP7ur" role="3clFbG">
-                          <node concept="37vLTw" id="5$jJV5eryUx" role="2Oq$k0">
-                            <ref role="3cqZAo" node="5$jJV5ervrh" resolve="listElement" />
-                          </node>
-                          <node concept="HtI8k" id="5$jJV5dP7ut" role="2OqNvi">
-                            <node concept="37vLTw" id="5$jJV5dP7uu" role="HtI8F">
-                              <ref role="3cqZAo" node="5$jJV5dP7tV" resolve="newNode" />
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="3clFbF" id="65e5JdYLJ5c" role="3cqZAp">
-                  <node concept="2OqwBi" id="65e5JdYLJ5d" role="3clFbG">
-                    <node concept="2ShNRf" id="65e5JdYLJ5e" role="2Oq$k0">
-                      <node concept="YeOm9" id="65e5JdYLJ5f" role="2ShVmc">
-                        <node concept="1Y3b0j" id="65e5JdYLJ5g" role="YeSDq">
-                          <property role="2bfB8j" value="true" />
-                          <ref role="1Y3XeK" to="wyt6:~Object" resolve="Object" />
-                          <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
-                          <node concept="3Tm1VV" id="65e5JdYLJ5h" role="1B3o_S" />
-                          <node concept="3clFb_" id="65e5JdYLJ5i" role="jymVt">
-                            <property role="TrG5h" value="postprocess" />
-                            <node concept="37vLTG" id="65e5JdYLJ5j" role="3clF46">
-                              <property role="TrG5h" value="node" />
-                              <node concept="3Tqbb2" id="65e5JdYLJ5k" role="1tU5fm" />
-                            </node>
-                            <node concept="3cqZAl" id="65e5JdYLJ5l" role="3clF45" />
-                            <node concept="3Tm1VV" id="65e5JdYLJ5m" role="1B3o_S" />
-                            <node concept="3clFbS" id="65e5JdYLJ5n" role="3clF47">
-                              <node concept="3clFbH" id="65e5JdYLJ5o" role="3cqZAp">
-                                <node concept="2b32R4" id="65e5JdYLJ5p" role="lGtFl">
-                                  <node concept="3JmXsc" id="65e5JdYLJ5q" role="2P8S$">
-                                    <node concept="3clFbS" id="65e5JdYLJ5r" role="2VODD2">
-                                      <node concept="3clFbF" id="65e5JdYLJ5s" role="3cqZAp">
-                                        <node concept="2OqwBi" id="65e5JdYLJ5t" role="3clFbG">
-                                          <node concept="2OqwBi" id="65e5JdYLJ5u" role="2Oq$k0">
-                                            <node concept="2OqwBi" id="65e5JdYLJ5v" role="2Oq$k0">
-                                              <node concept="30H73N" id="65e5JdYLJ5w" role="2Oq$k0" />
-                                              <node concept="3TrEf2" id="65e5JdYLJ5x" role="2OqNvi">
-                                                <ref role="3Tt5mk" to="teg0:65e5JdYJiFg" resolve="postprocess" />
-                                              </node>
-                                            </node>
-                                            <node concept="3TrEf2" id="65e5JdYLJ5y" role="2OqNvi">
-                                              <ref role="3Tt5mk" to="tpee:gyVODHa" resolve="body" />
-                                            </node>
-                                          </node>
-                                          <node concept="3Tsc0h" id="65e5JdYLJ5z" role="2OqNvi">
-                                            <ref role="3TtcxE" to="tpee:fzcqZ_x" resolve="statement" />
-                                          </node>
-                                        </node>
-                                      </node>
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="liA8E" id="65e5JdYLJ5$" role="2OqNvi">
-                      <ref role="37wK5l" node="65e5JdYLJ5i" resolve="postprocess" />
-                      <node concept="2OqwBi" id="65e5JdYLJ5_" role="37wK5m">
-                        <node concept="2kS8pE" id="65e5JdYLJ5A" role="2Oq$k0" />
-                        <node concept="liA8E" id="65e5JdYLJ5B" role="2OqNvi">
-                          <ref role="37wK5l" to="uddc:~TransformationMenuContext.getNode()" resolve="getNode" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="1W57fq" id="65e5JdYLJ5C" role="lGtFl">
-                    <node concept="3IZrLx" id="65e5JdYLJ5D" role="3IZSJc">
-                      <node concept="3clFbS" id="65e5JdYLJ5E" role="2VODD2">
-                        <node concept="3clFbF" id="65e5JdYLJ5F" role="3cqZAp">
-                          <node concept="2OqwBi" id="65e5JdYLJ5G" role="3clFbG">
-                            <node concept="2OqwBi" id="65e5JdYLJ5H" role="2Oq$k0">
-                              <node concept="30H73N" id="65e5JdYLJ5I" role="2Oq$k0" />
-                              <node concept="3TrEf2" id="65e5JdYLJ5J" role="2OqNvi">
-                                <ref role="3Tt5mk" to="teg0:65e5JdYJiFg" resolve="postprocess" />
-                              </node>
-                            </node>
-                            <node concept="3x8VRR" id="65e5JdYLJ5K" role="2OqNvi" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="3clFbF" id="2mvFNoRF8Oy" role="3cqZAp">
-                  <node concept="37vLTw" id="2mvFNoRF8Ow" role="3clFbG">
-                    <ref role="3cqZAo" node="5$jJV5dP7tV" resolve="newNode" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="1eYwpX" id="5$jJV5dP7uv" role="7F66i">
-              <node concept="3clFbS" id="5$jJV5dP7uw" role="2VODD2">
-                <node concept="3cpWs8" id="5$jJV5erknY" role="3cqZAp">
-                  <node concept="3cpWsn" id="5$jJV5erknZ" role="3cpWs9">
-                    <property role="TrG5h" value="listElement" />
-                    <node concept="3Tqbb2" id="5$jJV5erknC" role="1tU5fm" />
-                    <node concept="2YIFZM" id="5$jJV5erko0" role="33vP2m">
-                      <ref role="37wK5l" to="czm:5$jJV5eqaC7" resolve="getListElementForSideTransformation" />
-                      <ref role="1Pybhc" to="czm:RbLMy696h3" resolve="GrammarCellsUtil" />
-                      <node concept="2OqwBi" id="5$jJV5erko1" role="37wK5m">
-                        <node concept="2kS8pE" id="5$jJV5erko2" role="2Oq$k0" />
-                        <node concept="liA8E" id="5$jJV5erko3" role="2OqNvi">
-                          <ref role="37wK5l" to="uddc:~TransformationMenuContext.getNode()" resolve="getNode" />
-                        </node>
-                      </node>
-                      <node concept="359W_D" id="5$jJV5erko4" role="37wK5m">
-                        <ref role="359W_E" to="tpck:gw2VY9q" resolve="BaseConcept" />
-                        <ref role="359W_F" to="tpck:4uZwTti3__2" resolve="smodelAttribute" />
-                        <node concept="1ZhdrF" id="5$jJV5erko5" role="lGtFl">
-                          <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/2644386474301421077/2644386474301421078" />
-                          <property role="2qtEX8" value="conceptDeclaration" />
-                          <node concept="3$xsQk" id="5$jJV5erko6" role="3$ytzL">
-                            <node concept="3clFbS" id="5$jJV5erko7" role="2VODD2">
-                              <node concept="3clFbF" id="5$jJV5erko8" role="3cqZAp">
-                                <node concept="2OqwBi" id="5$jJV5erko9" role="3clFbG">
-                                  <node concept="2OqwBi" id="5$jJV5erkoa" role="2Oq$k0">
-                                    <node concept="30H73N" id="5$jJV5erkob" role="2Oq$k0" />
-                                    <node concept="2Xjw5R" id="5$jJV5erkoc" role="2OqNvi">
-                                      <node concept="1xMEDy" id="5$jJV5erkod" role="1xVPHs">
-                                        <node concept="chp4Y" id="5$jJV5erkoe" role="ri$Ld">
-                                          <ref role="cht4Q" to="tpc2:gXXWOiD" resolve="AbstractComponent" />
-                                        </node>
-                                      </node>
-                                    </node>
-                                  </node>
-                                  <node concept="2qgKlT" id="5$jJV5erkof" role="2OqNvi">
-                                    <ref role="37wK5l" to="tpcb:67EYkym$wx3" resolve="getConceptDeclaration" />
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="1ZhdrF" id="5$jJV5erkog" role="lGtFl">
-                          <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/2644386474301421077/2644386474301421079" />
-                          <property role="2qtEX8" value="linkDeclaration" />
-                          <node concept="3$xsQk" id="5$jJV5erkoh" role="3$ytzL">
-                            <node concept="3clFbS" id="5$jJV5erkoi" role="2VODD2">
-                              <node concept="3clFbF" id="5$jJV5erkoj" role="3cqZAp">
-                                <node concept="2OqwBi" id="5$jJV5erkok" role="3clFbG">
-                                  <node concept="1PxgMI" id="5$jJV5erkol" role="2Oq$k0">
-                                    <node concept="chp4Y" id="1SbcsM_INTy" role="3oSUPX">
-                                      <ref role="cht4Q" to="tpc2:fBF2Hee" resolve="CellModel_RefNodeList" />
-                                    </node>
-                                    <node concept="2OqwBi" id="5$jJV5erkom" role="1m5AlR">
-                                      <node concept="30H73N" id="5$jJV5erkon" role="2Oq$k0" />
-                                      <node concept="2qgKlT" id="5$jJV5erkoo" role="2OqNvi">
-                                        <ref role="37wK5l" to="karh:7KznU_3XzU4" resolve="getFirstNonConst" />
-                                      </node>
-                                    </node>
-                                  </node>
-                                  <node concept="3TrEf2" id="5$jJV5erkop" role="2OqNvi">
-                                    <ref role="3Tt5mk" to="tpc2:fBF2Hej" resolve="linkDeclaration" />
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="3clFbC" id="2mvFNoRFgtm" role="37wK5m">
-                        <node concept="10M0yZ" id="2mvFNoRFgtn" role="3uHU7w">
-                          <ref role="1PxDUh" to="9eyi:~MenuLocations" resolve="MenuLocations" />
-                          <ref role="3cqZAo" to="9eyi:~MenuLocations.LEFT_SIDE_TRANSFORM" resolve="LEFT_SIDE_TRANSFORM" />
-                        </node>
-                        <node concept="2OqwBi" id="2mvFNoRFgto" role="3uHU7B">
-                          <node concept="2kS8pE" id="2mvFNoRFgtp" role="2Oq$k0" />
-                          <node concept="liA8E" id="2mvFNoRFgtq" role="2OqNvi">
-                            <ref role="37wK5l" to="uddc:~TransformationMenuContext.getMenuLocation()" resolve="getMenuLocation" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="3clFbJ" id="5$jJV5erozb" role="3cqZAp">
-                  <node concept="3clFbS" id="5$jJV5erozd" role="3clFbx">
-                    <node concept="3cpWs6" id="5$jJV5errkW" role="3cqZAp">
-                      <node concept="3clFbT" id="5$jJV5ersoI" role="3cqZAk">
-                        <property role="3clFbU" value="false" />
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3clFbC" id="5$jJV5erq7H" role="3clFbw">
-                    <node concept="10Nm6u" id="5$jJV5erqDL" role="3uHU7w" />
-                    <node concept="37vLTw" id="5$jJV5erpr$" role="3uHU7B">
-                      <ref role="3cqZAo" node="5$jJV5erknZ" resolve="listElement" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="3cpWs6" id="5$jJV5dP7vJ" role="3cqZAp">
-                  <node concept="3K4zz7" id="5$jJV5dP7vK" role="3cqZAk">
-                    <node concept="3clFbC" id="2mvFNoRFdeG" role="3K4Cdx">
-                      <node concept="10M0yZ" id="2mvFNoRFdeH" role="3uHU7w">
-                        <ref role="3cqZAo" to="9eyi:~MenuLocations.LEFT_SIDE_TRANSFORM" resolve="LEFT_SIDE_TRANSFORM" />
-                        <ref role="1PxDUh" to="9eyi:~MenuLocations" resolve="MenuLocations" />
-                      </node>
-                      <node concept="2OqwBi" id="2mvFNoRFdeI" role="3uHU7B">
-                        <node concept="2kS8pE" id="2mvFNoRFejX" role="2Oq$k0" />
-                        <node concept="liA8E" id="2mvFNoRFdeK" role="2OqNvi">
-                          <ref role="37wK5l" to="uddc:~TransformationMenuContext.getMenuLocation()" resolve="getMenuLocation" />
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="2OqwBi" id="5$jJV5dP7vL" role="3K4E3e">
-                      <node concept="2OqwBi" id="5$jJV5dP7vM" role="2Oq$k0">
-                        <node concept="37vLTw" id="5$jJV5ertHI" role="2Oq$k0">
-                          <ref role="3cqZAo" node="5$jJV5erknZ" resolve="listElement" />
-                        </node>
-                        <node concept="YBYNd" id="5$jJV5dP7vO" role="2OqNvi" />
-                      </node>
-                      <node concept="3x8VRR" id="5$jJV5dP7vP" role="2OqNvi" />
-                    </node>
-                    <node concept="2OqwBi" id="5$jJV5dP7vV" role="3K4GZi">
-                      <node concept="2OqwBi" id="5$jJV5dP7vW" role="2Oq$k0">
-                        <node concept="37vLTw" id="5$jJV5erugk" role="2Oq$k0">
-                          <ref role="3cqZAo" node="5$jJV5erknZ" resolve="listElement" />
-                        </node>
-                        <node concept="YCak7" id="5$jJV5dP7vY" role="2OqNvi" />
-                      </node>
-                      <node concept="3x8VRR" id="5$jJV5dP7vZ" role="2OqNvi" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3F0ifn" id="5$jJV5dP7w0" role="7FqFq">
-              <node concept="29HgVG" id="5$jJV5dP7w1" role="lGtFl">
-                <node concept="3NFfHV" id="5$jJV5dP7w2" role="3NFExx">
-                  <node concept="3clFbS" id="5$jJV5dP7w3" role="2VODD2">
-                    <node concept="3clFbF" id="5$jJV5dP7w4" role="3cqZAp">
-                      <node concept="2OqwBi" id="5$jJV5dP7w5" role="3clFbG">
-                        <node concept="30H73N" id="5$jJV5dP7w6" role="2Oq$k0" />
-                        <node concept="3TrEf2" id="5$jJV5dP7w7" role="2OqNvi">
-                          <ref role="3Tt5mk" to="teg0:4qdNcHzYfBp" resolve="option" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="raruj" id="5$jJV5dP7w8" role="lGtFl" />
-          </node>
-          <node concept="1eYWM2" id="5$jJV5dQ7l7" role="3EZMnx">
-            <property role="kV7il" value="true" />
-            <node concept="1eYxTg" id="5$jJV5dQ7l8" role="1eYxTh">
-              <node concept="3clFbS" id="5$jJV5dQ7l9" role="2VODD2">
-                <node concept="3cpWs8" id="5$jJV5dQ7la" role="3cqZAp">
-                  <node concept="3cpWsn" id="5$jJV5dQ7lb" role="3cpWs9">
-                    <property role="TrG5h" value="subconcept" />
-                    <node concept="2OqwBi" id="5$jJV5dQ7lc" role="33vP2m">
-                      <node concept="2YIFZM" id="20mebiUgZJb" role="2Oq$k0">
-                        <ref role="1Pybhc" to="czm:RbLMy696h3" resolve="GrammarCellsUtil" />
-                        <ref role="37wK5l" to="czm:5$jJV5e9K8Y" resolve="getVisibleSubconceptsNonAbstract" />
-                        <node concept="35c_gC" id="20mebiUgZJc" role="37wK5m">
-                          <ref role="35c_gD" to="tpck:gw2VY9q" resolve="BaseConcept" />
-                          <node concept="1ZhdrF" id="20mebiUgZJd" role="lGtFl">
-                            <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/2644386474300074836/2644386474300074837" />
-                            <property role="2qtEX8" value="conceptDeclaration" />
-                            <node concept="3$xsQk" id="20mebiUgZJe" role="3$ytzL">
-                              <node concept="3clFbS" id="20mebiUgZJf" role="2VODD2">
-                                <node concept="3clFbF" id="20mebiUgZJg" role="3cqZAp">
-                                  <node concept="2OqwBi" id="20mebiUgZJh" role="3clFbG">
-                                    <node concept="2OqwBi" id="20mebiUgZJi" role="2Oq$k0">
-                                      <node concept="1PxgMI" id="20mebiUgZJj" role="2Oq$k0">
-                                        <node concept="chp4Y" id="1SbcsM_INTk" role="3oSUPX">
-                                          <ref role="cht4Q" to="tpc2:fBF2Hee" resolve="CellModel_RefNodeList" />
-                                        </node>
-                                        <node concept="2OqwBi" id="20mebiUgZJk" role="1m5AlR">
-                                          <node concept="30H73N" id="20mebiUgZJl" role="2Oq$k0" />
-                                          <node concept="2qgKlT" id="20mebiUgZJm" role="2OqNvi">
-                                            <ref role="37wK5l" to="karh:7KznU_3XzU4" resolve="getFirstNonConst" />
-                                          </node>
-                                        </node>
-                                      </node>
-                                      <node concept="3TrEf2" id="20mebiUgZJn" role="2OqNvi">
-                                        <ref role="3Tt5mk" to="tpc2:fBF2Hej" resolve="linkDeclaration" />
-                                      </node>
-                                    </node>
-                                    <node concept="3TrEf2" id="20mebiUgZJo" role="2OqNvi">
-                                      <ref role="3Tt5mk" to="tpce:fA0lvVK" resolve="target" />
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="2OqwBi" id="20mebiUgZJp" role="37wK5m">
-                          <node concept="2kS8pE" id="20mebiUgZJq" role="2Oq$k0" />
-                          <node concept="liA8E" id="20mebiUgZJr" role="2OqNvi">
-                            <ref role="37wK5l" to="uddc:~TransformationMenuContext.getModel()" resolve="getModel" />
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="1z4cxt" id="5$jJV5dQ7lu" role="2OqNvi">
-                        <node concept="1bVj0M" id="5$jJV5dQ7lv" role="23t8la">
-                          <node concept="3clFbS" id="5$jJV5dQ7lw" role="1bW5cS">
-                            <node concept="3clFbF" id="5$jJV5dQ7lx" role="3cqZAp">
-                              <node concept="17R0WA" id="5$jJV5dQ7ly" role="3clFbG">
-                                <node concept="kKDRn" id="5$jJV5dQ7lz" role="3uHU7w" />
-                                <node concept="2YIFZM" id="5$jJV5dYXxI" role="3uHU7B">
-                                  <ref role="37wK5l" to="czm:5$jJV5dYioC" resolve="getSubstitutionText" />
-                                  <ref role="1Pybhc" to="czm:RbLMy696h3" resolve="GrammarCellsUtil" />
-                                  <node concept="37vLTw" id="5$jJV5dYXV1" role="37wK5m">
-                                    <ref role="3cqZAo" node="5$jJV5dQ7lB" resolve="it" />
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                          <node concept="Rh6nW" id="5$jJV5dQ7lB" role="1bW2Oz">
-                            <property role="TrG5h" value="it" />
-                            <node concept="2jxLKc" id="5$jJV5dQ7lC" role="1tU5fm" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="3bZ5Sz" id="5$jJV5dQ7lD" role="1tU5fm" />
-                  </node>
-                </node>
-                <node concept="3clFbJ" id="5$jJV5dQ7lE" role="3cqZAp">
-                  <node concept="3clFbS" id="5$jJV5dQ7lF" role="3clFbx">
-                    <node concept="3clFbF" id="5$jJV5dQ7lG" role="3cqZAp">
-                      <node concept="37vLTI" id="5$jJV5dQ7lH" role="3clFbG">
-                        <node concept="35c_gC" id="5$jJV5dQ7lI" role="37vLTx">
-                          <ref role="35c_gD" to="tpck:gw2VY9q" resolve="BaseConcept" />
-                          <node concept="1ZhdrF" id="5$jJV5dQ7lJ" role="lGtFl">
-                            <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/2644386474300074836/2644386474300074837" />
-                            <property role="2qtEX8" value="conceptDeclaration" />
-                            <node concept="3$xsQk" id="5$jJV5dQ7lK" role="3$ytzL">
-                              <node concept="3clFbS" id="5$jJV5dQ7lL" role="2VODD2">
-                                <node concept="3clFbF" id="5$jJV5dQ7lM" role="3cqZAp">
-                                  <node concept="2OqwBi" id="5$jJV5dQ7lN" role="3clFbG">
-                                    <node concept="2OqwBi" id="5$jJV5dQ7lO" role="2Oq$k0">
-                                      <node concept="1PxgMI" id="5$jJV5dQ7lP" role="2Oq$k0">
-                                        <node concept="chp4Y" id="1SbcsM_INTX" role="3oSUPX">
-                                          <ref role="cht4Q" to="tpc2:fBF2Hee" resolve="CellModel_RefNodeList" />
-                                        </node>
-                                        <node concept="2OqwBi" id="5$jJV5dQ7lQ" role="1m5AlR">
-                                          <node concept="30H73N" id="5$jJV5dQ7lR" role="2Oq$k0" />
-                                          <node concept="2qgKlT" id="5$jJV5dQ7lS" role="2OqNvi">
-                                            <ref role="37wK5l" to="karh:7KznU_3XzU4" resolve="getFirstNonConst" />
-                                          </node>
-                                        </node>
-                                      </node>
-                                      <node concept="3TrEf2" id="5$jJV5dQ7lT" role="2OqNvi">
-                                        <ref role="3Tt5mk" to="tpc2:fBF2Hej" resolve="linkDeclaration" />
-                                      </node>
-                                    </node>
-                                    <node concept="3TrEf2" id="5$jJV5dQ7lU" role="2OqNvi">
-                                      <ref role="3Tt5mk" to="tpce:fA0lvVK" resolve="target" />
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="37vLTw" id="5$jJV5dQ7lV" role="37vLTJ">
-                          <ref role="3cqZAo" node="5$jJV5dQ7lb" resolve="subconcept" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3clFbC" id="5$jJV5dQ7lW" role="3clFbw">
-                    <node concept="10Nm6u" id="5$jJV5dQ7lX" role="3uHU7w" />
-                    <node concept="37vLTw" id="5$jJV5dQ7lY" role="3uHU7B">
-                      <ref role="3cqZAo" node="5$jJV5dQ7lb" resolve="subconcept" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="3cpWs8" id="65e5JdYLLCc" role="3cqZAp">
-                  <node concept="3cpWsn" id="65e5JdYLLCd" role="3cpWs9">
-                    <property role="TrG5h" value="result" />
-                    <node concept="3Tqbb2" id="65e5JdYLLB_" role="1tU5fm">
-                      <ref role="ehGHo" to="tpee:fzclF8l" resolve="Statement" />
-                    </node>
-                    <node concept="2OqwBi" id="65e5JdYLLCe" role="33vP2m">
-                      <node concept="2OqwBi" id="65e5JdYLLCf" role="2Oq$k0">
-                        <node concept="1PxgMI" id="65e5JdYLLCg" role="2Oq$k0">
-                          <node concept="chp4Y" id="1SbcsM_INSY" role="3oSUPX">
-                            <ref role="cht4Q" to="tpck:gw2VY9q" resolve="BaseConcept" />
-                            <node concept="1ZhdrF" id="65e5JdYLLCk" role="lGtFl">
-                              <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/1177026924588/1177026940964" />
+                          <node concept="359W_D" id="5ycts4S8j0d" role="33vP2m">
+                            <ref role="359W_E" to="tpee:fzcpWvJ" resolve="LocalVariableDeclaration" />
+                            <ref role="359W_F" to="tpee:fz3vP1I" resolve="initializer" />
+                            <node concept="1ZhdrF" id="5ycts4S8j0e" role="lGtFl">
                               <property role="2qtEX8" value="conceptDeclaration" />
-                              <node concept="3$xsQk" id="65e5JdYLLCl" role="3$ytzL">
-                                <node concept="3clFbS" id="65e5JdYLLCm" role="2VODD2">
-                                  <node concept="3clFbF" id="65e5JdYLLCn" role="3cqZAp">
-                                    <node concept="2OqwBi" id="65e5JdYLLCo" role="3clFbG">
-                                      <node concept="2OqwBi" id="65e5JdYLLCp" role="2Oq$k0">
-                                        <node concept="30H73N" id="65e5JdYLLCq" role="2Oq$k0" />
-                                        <node concept="2Xjw5R" id="65e5JdYLLCr" role="2OqNvi">
-                                          <node concept="1xMEDy" id="65e5JdYLLCs" role="1xVPHs">
-                                            <node concept="chp4Y" id="65e5JdYLLCt" role="ri$Ld">
+                              <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/2644386474301421077/2644386474301421078" />
+                              <node concept="3$xsQk" id="5ycts4S8j0f" role="3$ytzL">
+                                <node concept="3clFbS" id="5ycts4S8j0g" role="2VODD2">
+                                  <node concept="3clFbF" id="5ycts4S8j0h" role="3cqZAp">
+                                    <node concept="2OqwBi" id="5ycts4S8j0i" role="3clFbG">
+                                      <node concept="2OqwBi" id="5ycts4S8j0j" role="2Oq$k0">
+                                        <node concept="30H73N" id="5ycts4S8j0k" role="2Oq$k0" />
+                                        <node concept="2Xjw5R" id="5ycts4S8j0l" role="2OqNvi">
+                                          <node concept="1xMEDy" id="5ycts4S8j0m" role="1xVPHs">
+                                            <node concept="chp4Y" id="5ycts4S8j0n" role="ri$Ld">
                                               <ref role="cht4Q" to="tpc2:gXXWOiD" resolve="AbstractComponent" />
                                             </node>
                                           </node>
                                         </node>
                                       </node>
-                                      <node concept="2qgKlT" id="65e5JdYLLCu" role="2OqNvi">
+                                      <node concept="2qgKlT" id="5ycts4S8j0o" role="2OqNvi">
                                         <ref role="37wK5l" to="tpcb:67EYkym$wx3" resolve="getConceptDeclaration" />
                                       </node>
                                     </node>
@@ -6835,36 +5972,27 @@
                                 </node>
                               </node>
                             </node>
-                          </node>
-                          <node concept="2OqwBi" id="65e5JdYLLCh" role="1m5AlR">
-                            <node concept="2kS8pE" id="65e5JdYLLCi" role="2Oq$k0" />
-                            <node concept="liA8E" id="65e5JdYLLCj" role="2OqNvi">
-                              <ref role="37wK5l" to="uddc:~TransformationMenuContext.getNode()" resolve="getNode" />
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="3Tsc0h" id="65e5JdYLLCv" role="2OqNvi">
-                          <ref role="3TtcxE" to="tpee:fzcqZ_x" resolve="statement" />
-                          <node concept="1ZhdrF" id="65e5JdYLLCw" role="lGtFl">
-                            <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/1138056282393/1138056546658" />
-                            <property role="2qtEX8" value="link" />
-                            <node concept="3$xsQk" id="65e5JdYLLCx" role="3$ytzL">
-                              <node concept="3clFbS" id="65e5JdYLLCy" role="2VODD2">
-                                <node concept="3clFbF" id="65e5JdYLLCz" role="3cqZAp">
-                                  <node concept="2OqwBi" id="65e5JdYLLC$" role="3clFbG">
-                                    <node concept="1PxgMI" id="65e5JdYLLC_" role="2Oq$k0">
-                                      <node concept="chp4Y" id="1SbcsM_INT3" role="3oSUPX">
-                                        <ref role="cht4Q" to="tpc2:fBF2Hee" resolve="CellModel_RefNodeList" />
-                                      </node>
-                                      <node concept="2OqwBi" id="65e5JdYLLCA" role="1m5AlR">
-                                        <node concept="30H73N" id="65e5JdYLLCB" role="2Oq$k0" />
-                                        <node concept="2qgKlT" id="65e5JdYLLCC" role="2OqNvi">
-                                          <ref role="37wK5l" to="karh:7KznU_3XzU4" resolve="getFirstNonConst" />
+                            <node concept="1ZhdrF" id="5ycts4S8j0p" role="lGtFl">
+                              <property role="2qtEX8" value="linkDeclaration" />
+                              <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/2644386474301421077/2644386474301421079" />
+                              <node concept="3$xsQk" id="5ycts4S8j0q" role="3$ytzL">
+                                <node concept="3clFbS" id="5ycts4S8j0r" role="2VODD2">
+                                  <node concept="3clFbF" id="5ycts4S8j0s" role="3cqZAp">
+                                    <node concept="2OqwBi" id="5ycts4S8j0t" role="3clFbG">
+                                      <node concept="1PxgMI" id="5ycts4S8j0u" role="2Oq$k0">
+                                        <node concept="chp4Y" id="5ycts4S9009" role="3oSUPX">
+                                          <ref role="cht4Q" to="tpc2:fBF2Hee" resolve="CellModel_RefNodeList" />
+                                        </node>
+                                        <node concept="2OqwBi" id="5ycts4S8j0w" role="1m5AlR">
+                                          <node concept="30H73N" id="5ycts4S8j0x" role="2Oq$k0" />
+                                          <node concept="2qgKlT" id="5ycts4S8j0y" role="2OqNvi">
+                                            <ref role="37wK5l" to="karh:7KznU_3XzU4" resolve="getFirstNonConst" />
+                                          </node>
                                         </node>
                                       </node>
-                                    </node>
-                                    <node concept="3TrEf2" id="65e5JdYLLCD" role="2OqNvi">
-                                      <ref role="3Tt5mk" to="tpc2:fBF2Hej" resolve="linkDeclaration" />
+                                      <node concept="3TrEf2" id="5ycts4S917e" role="2OqNvi">
+                                        <ref role="3Tt5mk" to="tpc2:fBF2Hej" resolve="linkDeclaration" />
+                                      </node>
                                     </node>
                                   </node>
                                 </node>
@@ -6873,56 +6001,128 @@
                           </node>
                         </node>
                       </node>
-                      <node concept="TSZUe" id="65e5JdYLLCE" role="2OqNvi">
-                        <node concept="2OqwBi" id="65e5JdYLLCF" role="25WWJ7">
-                          <node concept="37vLTw" id="65e5JdYLLCG" role="2Oq$k0">
-                            <ref role="3cqZAo" node="5$jJV5dQ7lb" resolve="subconcept" />
+                      <node concept="3clFbF" id="5ycts4S8j0$" role="3cqZAp">
+                        <node concept="2OqwBi" id="5ycts4S8j0_" role="3clFbG">
+                          <node concept="2ShNRf" id="5ycts4S8j0A" role="2Oq$k0">
+                            <node concept="1pGfFk" id="5ycts4S8j0B" role="2ShVmc">
+                              <ref role="37wK5l" to="9eyi:~SubstituteItemsCollector.&lt;init&gt;(org.jetbrains.mps.openapi.model.SNode,org.jetbrains.mps.openapi.model.SNode,org.jetbrains.mps.openapi.language.SContainmentLink,jetbrains.mps.openapi.editor.EditorContext,jetbrains.mps.openapi.editor.menus.substitute.SubstituteMenuLookup)" resolve="SubstituteItemsCollector" />
+                              <node concept="2OqwBi" id="5ycts4S8j0C" role="37wK5m">
+                                <node concept="2Mo9yH" id="5ycts4S8j0D" role="2Oq$k0" />
+                                <node concept="liA8E" id="5ycts4S8j0E" role="2OqNvi">
+                                  <ref role="37wK5l" to="uddc:~TransformationMenuContext.getNode()" resolve="getNode" />
+                                </node>
+                              </node>
+                              <node concept="10Nm6u" id="5ycts4S8j0F" role="37wK5m" />
+                              <node concept="37vLTw" id="5ycts4S8j0G" role="37wK5m">
+                                <ref role="3cqZAo" node="5ycts4S8j0b" resolve="link" />
+                              </node>
+                              <node concept="2OqwBi" id="5ycts4S8j0H" role="37wK5m">
+                                <node concept="2Mo9yH" id="5ycts4S8j0I" role="2Oq$k0" />
+                                <node concept="liA8E" id="5ycts4S8j0J" role="2OqNvi">
+                                  <ref role="37wK5l" to="uddc:~TransformationMenuContext.getEditorContext()" resolve="getEditorContext" />
+                                </node>
+                              </node>
+                              <node concept="2ShNRf" id="5ycts4S8j0K" role="37wK5m">
+                                <node concept="1pGfFk" id="5ycts4S8j0L" role="2ShVmc">
+                                  <ref role="37wK5l" to="qtqj:~DefaultSubstituteMenuLookup.&lt;init&gt;(jetbrains.mps.smodel.language.LanguageRegistry,org.jetbrains.mps.openapi.language.SAbstractConcept)" resolve="DefaultSubstituteMenuLookup" />
+                                  <node concept="2YIFZM" id="5ycts4S8j0M" role="37wK5m">
+                                    <ref role="37wK5l" to="vndm:~LanguageRegistry.getInstance(org.jetbrains.mps.openapi.module.SRepository)" resolve="getInstance" />
+                                    <ref role="1Pybhc" to="vndm:~LanguageRegistry" resolve="LanguageRegistry" />
+                                    <node concept="2OqwBi" id="5ycts4S8j0N" role="37wK5m">
+                                      <node concept="2OqwBi" id="5ycts4S8j0O" role="2Oq$k0">
+                                        <node concept="2Mo9yH" id="5ycts4S8j0P" role="2Oq$k0" />
+                                        <node concept="liA8E" id="5ycts4S8j0Q" role="2OqNvi">
+                                          <ref role="37wK5l" to="uddc:~TransformationMenuContext.getEditorContext()" resolve="getEditorContext" />
+                                        </node>
+                                      </node>
+                                      <node concept="liA8E" id="5ycts4S8j0R" role="2OqNvi">
+                                        <ref role="37wK5l" to="cj4x:~EditorContext.getRepository()" resolve="getRepository" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                  <node concept="2OqwBi" id="5ycts4S8j0S" role="37wK5m">
+                                    <node concept="37vLTw" id="5ycts4S8j0T" role="2Oq$k0">
+                                      <ref role="3cqZAo" node="5ycts4S8j0b" resolve="link" />
+                                    </node>
+                                    <node concept="liA8E" id="5ycts4S8j0U" role="2OqNvi">
+                                      <ref role="37wK5l" to="c17a:~SAbstractLink.getTargetConcept()" resolve="getTargetConcept" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
                           </node>
-                          <node concept="q_SaT" id="65e5JdYLLCH" role="2OqNvi" />
+                          <node concept="liA8E" id="5ycts4S8j0V" role="2OqNvi">
+                            <ref role="37wK5l" to="9eyi:~SubstituteItemsCollector.collect()" resolve="collect" />
+                          </node>
                         </node>
                       </node>
                     </node>
                   </node>
                 </node>
-                <node concept="3clFbF" id="65e5JdYLNTG" role="3cqZAp">
-                  <node concept="2OqwBi" id="65e5JdYLNTH" role="3clFbG">
-                    <node concept="2ShNRf" id="65e5JdYLNTI" role="2Oq$k0">
-                      <node concept="YeOm9" id="65e5JdYLNTJ" role="2ShVmc">
-                        <node concept="1Y3b0j" id="65e5JdYLNTK" role="YeSDq">
-                          <property role="2bfB8j" value="true" />
-                          <ref role="1Y3XeK" to="wyt6:~Object" resolve="Object" />
-                          <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
-                          <node concept="3Tm1VV" id="65e5JdYLNTL" role="1B3o_S" />
-                          <node concept="3clFb_" id="65e5JdYLNTM" role="jymVt">
-                            <property role="TrG5h" value="postprocess" />
-                            <node concept="37vLTG" id="65e5JdYLNTN" role="3clF46">
-                              <property role="TrG5h" value="node" />
-                              <node concept="3Tqbb2" id="65e5JdYLNTO" role="1tU5fm" />
-                            </node>
-                            <node concept="3cqZAl" id="65e5JdYLNTP" role="3clF45" />
-                            <node concept="3Tm1VV" id="65e5JdYLNTQ" role="1B3o_S" />
-                            <node concept="3clFbS" id="65e5JdYLNTR" role="3clF47">
-                              <node concept="3clFbH" id="65e5JdYLNTS" role="3cqZAp">
-                                <node concept="2b32R4" id="65e5JdYLNTT" role="lGtFl">
-                                  <node concept="3JmXsc" id="65e5JdYLNTU" role="2P8S$">
-                                    <node concept="3clFbS" id="65e5JdYLNTV" role="2VODD2">
-                                      <node concept="3clFbF" id="65e5JdYLNTW" role="3cqZAp">
-                                        <node concept="2OqwBi" id="65e5JdYLNTX" role="3clFbG">
-                                          <node concept="2OqwBi" id="65e5JdYLNTY" role="2Oq$k0">
-                                            <node concept="2OqwBi" id="65e5JdYLNTZ" role="2Oq$k0">
-                                              <node concept="30H73N" id="65e5JdYLNU0" role="2Oq$k0" />
-                                              <node concept="3TrEf2" id="65e5JdYLNU1" role="2OqNvi">
-                                                <ref role="3Tt5mk" to="teg0:65e5JdYJiFg" resolve="postprocess" />
+                <node concept="27VH4U" id="5ycts4S8j0W" role="aenpu">
+                  <node concept="3clFbS" id="5ycts4S8j0X" role="2VODD2">
+                    <node concept="3clFbF" id="5ycts4S8j0Y" role="3cqZAp">
+                      <node concept="2OqwBi" id="5ycts4S8j0Z" role="3clFbG">
+                        <node concept="2OqwBi" id="5ycts4S8j10" role="2Oq$k0">
+                          <node concept="1PxgMI" id="5ycts4S8j11" role="2Oq$k0">
+                            <node concept="chp4Y" id="5ycts4S8j12" role="3oSUPX">
+                              <ref role="cht4Q" to="tpee:fzcpWvJ" resolve="LocalVariableDeclaration" />
+                              <node concept="1ZhdrF" id="5ycts4S8j13" role="lGtFl">
+                                <property role="2qtEX8" value="conceptDeclaration" />
+                                <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/1177026924588/1177026940964" />
+                                <node concept="3$xsQk" id="5ycts4S8j14" role="3$ytzL">
+                                  <node concept="3clFbS" id="5ycts4S8j15" role="2VODD2">
+                                    <node concept="3clFbF" id="5ycts4S8j16" role="3cqZAp">
+                                      <node concept="2OqwBi" id="5ycts4S8j17" role="3clFbG">
+                                        <node concept="2OqwBi" id="5ycts4S8j18" role="2Oq$k0">
+                                          <node concept="30H73N" id="5ycts4S8j19" role="2Oq$k0" />
+                                          <node concept="2Xjw5R" id="5ycts4S8j1a" role="2OqNvi">
+                                            <node concept="1xMEDy" id="5ycts4S8j1b" role="1xVPHs">
+                                              <node concept="chp4Y" id="5ycts4S8j1c" role="ri$Ld">
+                                                <ref role="cht4Q" to="tpc2:gXXWOiD" resolve="AbstractComponent" />
                                               </node>
                                             </node>
-                                            <node concept="3TrEf2" id="65e5JdYLNU2" role="2OqNvi">
-                                              <ref role="3Tt5mk" to="tpee:gyVODHa" resolve="body" />
-                                            </node>
-                                          </node>
-                                          <node concept="3Tsc0h" id="65e5JdYLNU3" role="2OqNvi">
-                                            <ref role="3TtcxE" to="tpee:fzcqZ_x" resolve="statement" />
                                           </node>
                                         </node>
+                                        <node concept="2qgKlT" id="5ycts4S8j1d" role="2OqNvi">
+                                          <ref role="37wK5l" to="tpcb:67EYkym$wx3" resolve="getConceptDeclaration" />
+                                        </node>
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="1eOMI4" id="5ycts4S8j1e" role="1m5AlR">
+                              <node concept="10QFUN" id="5ycts4S8j1f" role="1eOMHV">
+                                <node concept="7Obwk" id="5ycts4S8j1g" role="10QFUP" />
+                                <node concept="3Tqbb2" id="5ycts4S8j1h" role="10QFUM" />
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="3TrEf2" id="5ycts4S8j1i" role="2OqNvi">
+                            <ref role="3Tt5mk" to="tpee:fz3vP1I" resolve="initializer" />
+                            <node concept="1ZhdrF" id="5ycts4S8j1j" role="lGtFl">
+                              <property role="2qtEX8" value="link" />
+                              <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/1138056143562/1138056516764" />
+                              <node concept="3$xsQk" id="5ycts4S8j1k" role="3$ytzL">
+                                <node concept="3clFbS" id="5ycts4S8j1l" role="2VODD2">
+                                  <node concept="3clFbF" id="5ycts4S8j1m" role="3cqZAp">
+                                    <node concept="2OqwBi" id="5ycts4S8j1n" role="3clFbG">
+                                      <node concept="1PxgMI" id="5ycts4S8j1o" role="2Oq$k0">
+                                        <node concept="chp4Y" id="5ycts4S8YDt" role="3oSUPX">
+                                          <ref role="cht4Q" to="tpc2:fBF2Hee" resolve="CellModel_RefNodeList" />
+                                        </node>
+                                        <node concept="2OqwBi" id="5ycts4S8j1q" role="1m5AlR">
+                                          <node concept="30H73N" id="5ycts4S8j1r" role="2Oq$k0" />
+                                          <node concept="2qgKlT" id="5ycts4S8j1s" role="2OqNvi">
+                                            <ref role="37wK5l" to="karh:7KznU_3XzU4" resolve="getFirstNonConst" />
+                                          </node>
+                                        </node>
+                                      </node>
+                                      <node concept="3TrEf2" id="5ycts4S8ZQa" role="2OqNvi">
+                                        <ref role="3Tt5mk" to="tpc2:fBF2Hej" resolve="linkDeclaration" />
                                       </node>
                                     </node>
                                   </node>
@@ -6931,116 +6131,71 @@
                             </node>
                           </node>
                         </node>
-                      </node>
-                    </node>
-                    <node concept="liA8E" id="65e5JdYLNU4" role="2OqNvi">
-                      <ref role="37wK5l" node="65e5JdYLNTM" resolve="postprocess" />
-                      <node concept="2OqwBi" id="65e5JdYLNU5" role="37wK5m">
-                        <node concept="2kS8pE" id="65e5JdYLNU6" role="2Oq$k0" />
-                        <node concept="liA8E" id="65e5JdYLNU7" role="2OqNvi">
-                          <ref role="37wK5l" to="uddc:~TransformationMenuContext.getNode()" resolve="getNode" />
-                        </node>
+                        <node concept="3w_OXm" id="5ycts4S8j1u" role="2OqNvi" />
                       </node>
                     </node>
                   </node>
-                  <node concept="1W57fq" id="65e5JdYLNU8" role="lGtFl">
-                    <node concept="3IZrLx" id="65e5JdYLNU9" role="3IZSJc">
-                      <node concept="3clFbS" id="65e5JdYLNUa" role="2VODD2">
-                        <node concept="3clFbF" id="65e5JdYLNUb" role="3cqZAp">
-                          <node concept="2OqwBi" id="65e5JdYLNUc" role="3clFbG">
-                            <node concept="2OqwBi" id="65e5JdYLNUd" role="2Oq$k0">
-                              <node concept="30H73N" id="65e5JdYLNUe" role="2Oq$k0" />
-                              <node concept="3TrEf2" id="65e5JdYLNUf" role="2OqNvi">
-                                <ref role="3Tt5mk" to="teg0:65e5JdYJiFg" resolve="postprocess" />
+                </node>
+              </node>
+              <node concept="2v6KxM" id="5ycts4S8j1v" role="1Qtc8$" />
+            </node>
+            <node concept="raruj" id="5ycts4S8j1w" role="lGtFl" />
+            <node concept="17Uvod" id="5ycts4S8j1x" role="lGtFl">
+              <property role="2qtEX9" value="description" />
+              <property role="P4ACc" value="9d69e719-78c8-4286-90db-fb19c107d049/745148820867185554/745148820908747612" />
+              <node concept="3zFVjK" id="5ycts4S8j1y" role="3zH0cK">
+                <node concept="3clFbS" id="5ycts4S8j1z" role="2VODD2">
+                  <node concept="3clFbF" id="5ycts4S8j1$" role="3cqZAp">
+                    <node concept="3cpWs3" id="5ycts4S8j1_" role="3clFbG">
+                      <node concept="2OqwBi" id="5ycts4S8j1A" role="3uHU7w">
+                        <node concept="2OqwBi" id="5ycts4S8j1B" role="2Oq$k0">
+                          <node concept="1PxgMI" id="5ycts4S8j1C" role="2Oq$k0">
+                            <node concept="chp4Y" id="5ycts4S8Ydh" role="3oSUPX">
+                              <ref role="cht4Q" to="tpc2:fBF2Hee" resolve="CellModel_RefNodeList" />
+                            </node>
+                            <node concept="2OqwBi" id="5ycts4S8j1E" role="1m5AlR">
+                              <node concept="30H73N" id="5ycts4S8j1F" role="2Oq$k0" />
+                              <node concept="2qgKlT" id="5ycts4S8j1G" role="2OqNvi">
+                                <ref role="37wK5l" to="karh:7KznU_3XzU4" resolve="getFirstNonConst" />
                               </node>
                             </node>
-                            <node concept="3x8VRR" id="65e5JdYLNUg" role="2OqNvi" />
+                          </node>
+                          <node concept="3TrEf2" id="5ycts4S93dZ" role="2OqNvi">
+                            <ref role="3Tt5mk" to="tpc2:fBF2Hej" resolve="linkDeclaration" />
                           </node>
                         </node>
+                        <node concept="3TrcHB" id="5ycts4S8j1I" role="2OqNvi">
+                          <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                        </node>
                       </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="3clFbF" id="5$jJV5dQ7m0" role="3cqZAp">
-                  <node concept="37vLTw" id="65e5JdYLLCI" role="3clFbG">
-                    <ref role="3cqZAo" node="65e5JdYLLCd" resolve="result" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="1eYwpX" id="5$jJV5dQ7mx" role="1eYxym">
-              <node concept="3clFbS" id="5$jJV5dQ7my" role="2VODD2">
-                <node concept="3clFbF" id="5$jJV5dXjLx" role="3cqZAp">
-                  <node concept="3clFbT" id="5$jJV5dXjLw" role="3clFbG">
-                    <property role="3clFbU" value="true" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="1eYWSL" id="5$jJV5dQ7n1" role="1eYxyj">
-              <node concept="3clFbS" id="5$jJV5dQ7n2" role="2VODD2">
-                <node concept="3clFbF" id="5$jJV5dQ7n3" role="3cqZAp">
-                  <node concept="2OqwBi" id="5$jJV5dQ7n4" role="3clFbG">
-                    <node concept="2YIFZM" id="5$jJV5eahrS" role="2Oq$k0">
-                      <ref role="1Pybhc" to="czm:RbLMy696h3" resolve="GrammarCellsUtil" />
-                      <ref role="37wK5l" to="czm:5$jJV5e9K8Y" resolve="getVisibleSubconceptsNonAbstract" />
-                      <node concept="35c_gC" id="5$jJV5eahrT" role="37wK5m">
-                        <ref role="35c_gD" to="tpck:gw2VY9q" resolve="BaseConcept" />
-                        <node concept="1ZhdrF" id="5$jJV5eahrU" role="lGtFl">
-                          <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/2644386474300074836/2644386474300074837" />
-                          <property role="2qtEX8" value="conceptDeclaration" />
-                          <node concept="3$xsQk" id="5$jJV5eahrV" role="3$ytzL">
-                            <node concept="3clFbS" id="5$jJV5eahrW" role="2VODD2">
-                              <node concept="3clFbF" id="5$jJV5eahrX" role="3cqZAp">
-                                <node concept="2OqwBi" id="5$jJV5eahrY" role="3clFbG">
-                                  <node concept="2OqwBi" id="5$jJV5eahrZ" role="2Oq$k0">
-                                    <node concept="1PxgMI" id="5$jJV5eahs0" role="2Oq$k0">
-                                      <node concept="chp4Y" id="1SbcsM_INTd" role="3oSUPX">
-                                        <ref role="cht4Q" to="tpc2:fBF2Hee" resolve="CellModel_RefNodeList" />
-                                      </node>
-                                      <node concept="2OqwBi" id="5$jJV5eahs1" role="1m5AlR">
-                                        <node concept="30H73N" id="5$jJV5eahs2" role="2Oq$k0" />
-                                        <node concept="2qgKlT" id="5$jJV5eahs3" role="2OqNvi">
-                                          <ref role="37wK5l" to="karh:7KznU_3XzU4" resolve="getFirstNonConst" />
-                                        </node>
-                                      </node>
+                      <node concept="3cpWs3" id="5ycts4S8j1J" role="3uHU7B">
+                        <node concept="3cpWs3" id="5ycts4S8j1K" role="3uHU7B">
+                          <node concept="Xl_RD" id="5ycts4S8j1L" role="3uHU7B">
+                            <property role="Xl_RC" value="grammar.optional for " />
+                          </node>
+                          <node concept="2OqwBi" id="5ycts4S8j1M" role="3uHU7w">
+                            <node concept="2OqwBi" id="5ycts4S8j1N" role="2Oq$k0">
+                              <node concept="2OqwBi" id="5ycts4S8j1O" role="2Oq$k0">
+                                <node concept="30H73N" id="5ycts4S8j1P" role="2Oq$k0" />
+                                <node concept="2Xjw5R" id="5ycts4S8j1Q" role="2OqNvi">
+                                  <node concept="1xMEDy" id="5ycts4S8j1R" role="1xVPHs">
+                                    <node concept="chp4Y" id="5ycts4S8j1S" role="ri$Ld">
+                                      <ref role="cht4Q" to="tpc2:gXXWOiD" resolve="AbstractComponent" />
                                     </node>
-                                    <node concept="3TrEf2" id="5$jJV5eahs4" role="2OqNvi">
-                                      <ref role="3Tt5mk" to="tpc2:fBF2Hej" resolve="linkDeclaration" />
-                                    </node>
-                                  </node>
-                                  <node concept="3TrEf2" id="5$jJV5eahs5" role="2OqNvi">
-                                    <ref role="3Tt5mk" to="tpce:fA0lvVK" resolve="target" />
                                   </node>
                                 </node>
                               </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="2OqwBi" id="5$jJV5eahs6" role="37wK5m">
-                        <node concept="2kS8pE" id="5$jJV5eahs7" role="2Oq$k0" />
-                        <node concept="liA8E" id="5$jJV5eahs8" role="2OqNvi">
-                          <ref role="37wK5l" to="uddc:~TransformationMenuContext.getModel()" resolve="getModel" />
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="3$u5V9" id="5$jJV5dQ7nm" role="2OqNvi">
-                      <node concept="1bVj0M" id="5$jJV5dQ7nn" role="23t8la">
-                        <node concept="3clFbS" id="5$jJV5dQ7no" role="1bW5cS">
-                          <node concept="3clFbF" id="5$jJV5dQ7np" role="3cqZAp">
-                            <node concept="2YIFZM" id="5$jJV5dYWt7" role="3clFbG">
-                              <ref role="37wK5l" to="czm:5$jJV5dYioC" resolve="getSubstitutionText" />
-                              <ref role="1Pybhc" to="czm:RbLMy696h3" resolve="GrammarCellsUtil" />
-                              <node concept="37vLTw" id="5$jJV5dYWBr" role="37wK5m">
-                                <ref role="3cqZAo" node="5$jJV5dQ7nt" resolve="it" />
+                              <node concept="2qgKlT" id="5ycts4S8j1T" role="2OqNvi">
+                                <ref role="37wK5l" to="tpcb:67EYkym$wx3" resolve="getConceptDeclaration" />
                               </node>
                             </node>
+                            <node concept="3TrcHB" id="5ycts4S8j1U" role="2OqNvi">
+                              <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                            </node>
                           </node>
                         </node>
-                        <node concept="Rh6nW" id="5$jJV5dQ7nt" role="1bW2Oz">
-                          <property role="TrG5h" value="it" />
-                          <node concept="2jxLKc" id="5$jJV5dQ7nu" role="1tU5fm" />
+                        <node concept="Xl_RD" id="5ycts4S8j1V" role="3uHU7w">
+                          <property role="Xl_RC" value="." />
                         </node>
                       </node>
                     </node>
@@ -7048,7 +6203,23 @@
                 </node>
               </node>
             </node>
-            <node concept="raruj" id="5$jJV5dQ7nv" role="lGtFl" />
+          </node>
+          <node concept="3F0ifn" id="5ycts4S8vNM" role="3EZMnx">
+            <node concept="raruj" id="5ycts4S8xYr" role="lGtFl" />
+            <node concept="29HgVG" id="5ycts4S8vNN" role="lGtFl">
+              <node concept="3NFfHV" id="5ycts4S8vNO" role="3NFExx">
+                <node concept="3clFbS" id="5ycts4S8vNP" role="2VODD2">
+                  <node concept="3clFbF" id="5ycts4S8vNQ" role="3cqZAp">
+                    <node concept="2OqwBi" id="5ycts4S8vNR" role="3clFbG">
+                      <node concept="30H73N" id="5ycts4S8vNS" role="2Oq$k0" />
+                      <node concept="3TrEf2" id="5ycts4S8vNT" role="2OqNvi">
+                        <ref role="3Tt5mk" to="teg0:4qdNcHzYfBp" resolve="option" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
           </node>
           <node concept="2iRkQZ" id="5$jJV5dP7wU" role="2iSdaV" />
         </node>
@@ -7084,223 +6255,265 @@
         </node>
       </node>
     </node>
+    <node concept="3aamgX" id="5ycts4Sc27N" role="3acgRq">
+      <ref role="30HIoZ" to="teg0:4qdNcHzYfBo" resolve="OptionalCell" />
+      <node concept="1Koe21" id="5ycts4Sc27O" role="1lVwrX">
+        <node concept="3EZMnI" id="5ycts4Sc27P" role="1Koe22">
+          <node concept="2uKrtP" id="5ycts4Sc27Q" role="3EZMnx">
+            <property role="2thAuV" value="a" />
+            <node concept="1Qtc8_" id="5ycts4Sc27R" role="2vkWV5">
+              <node concept="aenpk" id="5ycts4Sc27S" role="1Qtc8A">
+                <node concept="3PzhKR" id="5ycts4Scdsu" role="aenpr">
+                  <node concept="1ZhdrF" id="5ycts4ScegH" role="lGtFl">
+                    <property role="2qtEX8" value="referenceLink" />
+                    <property role="P3scX" value="18bc6592-03a6-4e29-a83a-7ff23bde13ba/422708224287891156/422708224287891157" />
+                    <node concept="3$xsQk" id="5ycts4ScegI" role="3$ytzL">
+                      <node concept="3clFbS" id="5ycts4ScegJ" role="2VODD2">
+                        <node concept="3clFbF" id="5ycts4Scfe7" role="3cqZAp">
+                          <node concept="2OqwBi" id="5ycts4Scfe8" role="3clFbG">
+                            <node concept="1PxgMI" id="5ycts4Scfe9" role="2Oq$k0">
+                              <node concept="chp4Y" id="5ycts4ScfGz" role="3oSUPX">
+                                <ref role="cht4Q" to="tpc2:fPiCG$y" resolve="CellModel_RefCell" />
+                              </node>
+                              <node concept="2OqwBi" id="5ycts4Scfeb" role="1m5AlR">
+                                <node concept="30H73N" id="5ycts4Scfec" role="2Oq$k0" />
+                                <node concept="2qgKlT" id="5ycts4Scfed" role="2OqNvi">
+                                  <ref role="37wK5l" to="karh:7KznU_3XzU4" resolve="getFirstNonConst" />
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="3TrEf2" id="5ycts4ScgtD" role="2OqNvi">
+                              <ref role="3Tt5mk" to="tpc2:fPiD8ey" resolve="linkDeclaration" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="27VH4U" id="5ycts4Sc28I" role="aenpu">
+                  <node concept="3clFbS" id="5ycts4Sc28J" role="2VODD2">
+                    <node concept="3clFbF" id="5ycts4Sc28K" role="3cqZAp">
+                      <node concept="2OqwBi" id="5ycts4Sc28L" role="3clFbG">
+                        <node concept="2OqwBi" id="5ycts4Sc28M" role="2Oq$k0">
+                          <node concept="1PxgMI" id="5ycts4Sc28N" role="2Oq$k0">
+                            <node concept="chp4Y" id="5ycts4Sc28O" role="3oSUPX">
+                              <ref role="cht4Q" to="tpee:fzcpWvJ" resolve="LocalVariableDeclaration" />
+                              <node concept="1ZhdrF" id="5ycts4Sc28P" role="lGtFl">
+                                <property role="2qtEX8" value="conceptDeclaration" />
+                                <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/1177026924588/1177026940964" />
+                                <node concept="3$xsQk" id="5ycts4Sc28Q" role="3$ytzL">
+                                  <node concept="3clFbS" id="5ycts4Sc28R" role="2VODD2">
+                                    <node concept="3clFbF" id="5ycts4Sc28S" role="3cqZAp">
+                                      <node concept="2OqwBi" id="5ycts4Sc28T" role="3clFbG">
+                                        <node concept="2OqwBi" id="5ycts4Sc28U" role="2Oq$k0">
+                                          <node concept="30H73N" id="5ycts4Sc28V" role="2Oq$k0" />
+                                          <node concept="2Xjw5R" id="5ycts4Sc28W" role="2OqNvi">
+                                            <node concept="1xMEDy" id="5ycts4Sc28X" role="1xVPHs">
+                                              <node concept="chp4Y" id="5ycts4Sc28Y" role="ri$Ld">
+                                                <ref role="cht4Q" to="tpc2:gXXWOiD" resolve="AbstractComponent" />
+                                              </node>
+                                            </node>
+                                          </node>
+                                        </node>
+                                        <node concept="2qgKlT" id="5ycts4Sc28Z" role="2OqNvi">
+                                          <ref role="37wK5l" to="tpcb:67EYkym$wx3" resolve="getConceptDeclaration" />
+                                        </node>
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="1eOMI4" id="5ycts4Sc290" role="1m5AlR">
+                              <node concept="10QFUN" id="5ycts4Sc291" role="1eOMHV">
+                                <node concept="7Obwk" id="5ycts4Sc292" role="10QFUP" />
+                                <node concept="3Tqbb2" id="5ycts4Sc293" role="10QFUM" />
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="3TrEf2" id="5ycts4Sc294" role="2OqNvi">
+                            <ref role="3Tt5mk" to="tpee:fz3vP1I" resolve="initializer" />
+                            <node concept="1ZhdrF" id="5ycts4Sc295" role="lGtFl">
+                              <property role="2qtEX8" value="link" />
+                              <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/1138056143562/1138056516764" />
+                              <node concept="3$xsQk" id="5ycts4Sc296" role="3$ytzL">
+                                <node concept="3clFbS" id="5ycts4Sc297" role="2VODD2">
+                                  <node concept="3clFbF" id="5ycts4Sc298" role="3cqZAp">
+                                    <node concept="2OqwBi" id="5ycts4Sc299" role="3clFbG">
+                                      <node concept="1PxgMI" id="5ycts4Sc29a" role="2Oq$k0">
+                                        <node concept="chp4Y" id="5ycts4Scg_d" role="3oSUPX">
+                                          <ref role="cht4Q" to="tpc2:fPiCG$y" resolve="CellModel_RefCell" />
+                                        </node>
+                                        <node concept="2OqwBi" id="5ycts4Sc29c" role="1m5AlR">
+                                          <node concept="30H73N" id="5ycts4Sc29d" role="2Oq$k0" />
+                                          <node concept="2qgKlT" id="5ycts4Sc29e" role="2OqNvi">
+                                            <ref role="37wK5l" to="karh:7KznU_3XzU4" resolve="getFirstNonConst" />
+                                          </node>
+                                        </node>
+                                      </node>
+                                      <node concept="3TrEf2" id="5ycts4SchMr" role="2OqNvi">
+                                        <ref role="3Tt5mk" to="tpc2:fPiD8ey" resolve="linkDeclaration" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3w_OXm" id="5ycts4Sc29g" role="2OqNvi" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="2v6KxM" id="5ycts4Sc29h" role="1Qtc8$" />
+            </node>
+            <node concept="raruj" id="5ycts4Sc29i" role="lGtFl" />
+            <node concept="17Uvod" id="5ycts4Sc29j" role="lGtFl">
+              <property role="2qtEX9" value="description" />
+              <property role="P4ACc" value="9d69e719-78c8-4286-90db-fb19c107d049/745148820867185554/745148820908747612" />
+              <node concept="3zFVjK" id="5ycts4Sc29k" role="3zH0cK">
+                <node concept="3clFbS" id="5ycts4Sc29l" role="2VODD2">
+                  <node concept="3clFbF" id="5ycts4Sc29m" role="3cqZAp">
+                    <node concept="3cpWs3" id="5ycts4Sc29n" role="3clFbG">
+                      <node concept="2OqwBi" id="5ycts4Sc29o" role="3uHU7w">
+                        <node concept="2OqwBi" id="5ycts4Sc29p" role="2Oq$k0">
+                          <node concept="1PxgMI" id="5ycts4Sc29q" role="2Oq$k0">
+                            <node concept="chp4Y" id="5ycts4Sd1qM" role="3oSUPX">
+                              <ref role="cht4Q" to="tpc2:fPiCG$y" resolve="CellModel_RefCell" />
+                            </node>
+                            <node concept="2OqwBi" id="5ycts4Sc29s" role="1m5AlR">
+                              <node concept="30H73N" id="5ycts4Sc29t" role="2Oq$k0" />
+                              <node concept="2qgKlT" id="5ycts4Sc29u" role="2OqNvi">
+                                <ref role="37wK5l" to="karh:7KznU_3XzU4" resolve="getFirstNonConst" />
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="3TrEf2" id="5ycts4Sd2$i" role="2OqNvi">
+                            <ref role="3Tt5mk" to="tpc2:fPiD8ey" resolve="linkDeclaration" />
+                          </node>
+                        </node>
+                        <node concept="3TrcHB" id="5ycts4Sc29w" role="2OqNvi">
+                          <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                        </node>
+                      </node>
+                      <node concept="3cpWs3" id="5ycts4Sc29x" role="3uHU7B">
+                        <node concept="3cpWs3" id="5ycts4Sc29y" role="3uHU7B">
+                          <node concept="Xl_RD" id="5ycts4Sc29z" role="3uHU7B">
+                            <property role="Xl_RC" value="grammar.optional for " />
+                          </node>
+                          <node concept="2OqwBi" id="5ycts4Sc29$" role="3uHU7w">
+                            <node concept="2OqwBi" id="5ycts4Sc29_" role="2Oq$k0">
+                              <node concept="2OqwBi" id="5ycts4Sc29A" role="2Oq$k0">
+                                <node concept="30H73N" id="5ycts4Sc29B" role="2Oq$k0" />
+                                <node concept="2Xjw5R" id="5ycts4Sc29C" role="2OqNvi">
+                                  <node concept="1xMEDy" id="5ycts4Sc29D" role="1xVPHs">
+                                    <node concept="chp4Y" id="5ycts4Sc29E" role="ri$Ld">
+                                      <ref role="cht4Q" to="tpc2:gXXWOiD" resolve="AbstractComponent" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                              <node concept="2qgKlT" id="5ycts4Sc29F" role="2OqNvi">
+                                <ref role="37wK5l" to="tpcb:67EYkym$wx3" resolve="getConceptDeclaration" />
+                              </node>
+                            </node>
+                            <node concept="3TrcHB" id="5ycts4Sc29G" role="2OqNvi">
+                              <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="Xl_RD" id="5ycts4Sc29H" role="3uHU7w">
+                          <property role="Xl_RC" value="." />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3F0ifn" id="5ycts4Sc29I" role="3EZMnx">
+            <node concept="raruj" id="5ycts4Sc29J" role="lGtFl" />
+            <node concept="29HgVG" id="5ycts4Sc29K" role="lGtFl">
+              <node concept="3NFfHV" id="5ycts4Sc29L" role="3NFExx">
+                <node concept="3clFbS" id="5ycts4Sc29M" role="2VODD2">
+                  <node concept="3clFbF" id="5ycts4Sc29N" role="3cqZAp">
+                    <node concept="2OqwBi" id="5ycts4Sc29O" role="3clFbG">
+                      <node concept="30H73N" id="5ycts4Sc29P" role="2Oq$k0" />
+                      <node concept="3TrEf2" id="5ycts4Sc29Q" role="2OqNvi">
+                        <ref role="3Tt5mk" to="teg0:4qdNcHzYfBp" resolve="option" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2iRkQZ" id="5ycts4Sc29R" role="2iSdaV" />
+        </node>
+      </node>
+      <node concept="30G5F_" id="5ycts4Sc29S" role="30HLyM">
+        <node concept="3clFbS" id="5ycts4Sc29T" role="2VODD2">
+          <node concept="3clFbF" id="5ycts4Sc29U" role="3cqZAp">
+            <node concept="1Wc70l" id="5ycts4Sc29V" role="3clFbG">
+              <node concept="2OqwBi" id="5ycts4Sc29W" role="3uHU7w">
+                <node concept="2OqwBi" id="5ycts4Sc29X" role="2Oq$k0">
+                  <node concept="30H73N" id="5ycts4Sc29Y" role="2Oq$k0" />
+                  <node concept="2qgKlT" id="5ycts4Sc29Z" role="2OqNvi">
+                    <ref role="37wK5l" to="karh:7KznU_3XzU4" resolve="getFirstNonConst" />
+                  </node>
+                </node>
+                <node concept="1mIQ4w" id="5ycts4Sc2a0" role="2OqNvi">
+                  <node concept="chp4Y" id="5ycts4Scbhs" role="cj9EA">
+                    <ref role="cht4Q" to="tpc2:fPiCG$y" resolve="CellModel_RefCell" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2OqwBi" id="5ycts4Sc2a2" role="3uHU7B">
+                <node concept="2OqwBi" id="5ycts4Sc2a3" role="2Oq$k0">
+                  <node concept="30H73N" id="5ycts4Sc2a4" role="2Oq$k0" />
+                  <node concept="2qgKlT" id="5ycts4Sc2a5" role="2OqNvi">
+                    <ref role="37wK5l" to="karh:7KznU_45kn7" resolve="getTransformationText" />
+                  </node>
+                </node>
+                <node concept="3w_OXm" id="5ycts4Sc2a6" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
     <node concept="3aamgX" id="3lRTV5HrhmY" role="3acgRq">
       <ref role="30HIoZ" to="teg0:1vi_twqJeLl" resolve="BracketsCell" />
       <node concept="1Koe21" id="3lRTV5HrhmZ" role="1lVwrX">
         <node concept="3EZMnI" id="6jH9yJK4FHa" role="1Koe22">
-          <node concept="2kSiTK" id="6jH9yJK4GAW" role="3EZMnx">
-            <property role="2kSiWS" value="38nmGbCPLik/both_sides" />
-            <node concept="2kS2EP" id="6jH9yJK4GB0" role="2kS9vO">
-              <node concept="3clFbS" id="6jH9yJK4GB2" role="2VODD2">
-                <node concept="3clFbF" id="4Fanv3VboVc" role="3cqZAp">
-                  <node concept="2OqwBi" id="4Fanv3VboVd" role="3clFbG">
-                    <node concept="2OqwBi" id="4Fanv3VboVe" role="2Oq$k0">
-                      <node concept="2kS8pE" id="4Fanv3VbrNX" role="2Oq$k0" />
-                      <node concept="liA8E" id="4Fanv3VboVg" role="2OqNvi">
-                        <ref role="37wK5l" to="uddc:~TransformationMenuContext.getEditorMenuTrace()" resolve="getEditorMenuTrace" />
-                      </node>
-                    </node>
-                    <node concept="liA8E" id="4Fanv3VboVh" role="2OqNvi">
-                      <ref role="37wK5l" to="x4mf:~EditorMenuTrace.pushTraceInfo()" resolve="pushTraceInfo" />
-                    </node>
+          <node concept="3EZMnI" id="6jH9yJK4GHU" role="3EZMnx">
+            <node concept="130CD5" id="6jH9yJK4GHV" role="3EZMnx">
+              <node concept="130t_x" id="6jH9yJK4GHW" role="130p63">
+                <property role="1hAc7j" value="g_hAxAO/delete_action_id" />
+                <node concept="130t_S" id="6jH9yJK4GHX" role="130oVf">
+                  <node concept="3clFbS" id="6jH9yJK4GHY" role="2VODD2" />
+                </node>
+                <node concept="5jKBG" id="6jH9yJK4GHZ" role="lGtFl">
+                  <ref role="v9R2y" node="1PeMnAN42Da" resolve="template_BracketsCell_DeleteBracket" />
+                  <node concept="3clFbT" id="6jH9yJK4GI0" role="v9R3O">
+                    <property role="3clFbU" value="true" />
                   </node>
                 </node>
-                <node concept="3clFbF" id="4Fanv3VboVi" role="3cqZAp">
-                  <node concept="2OqwBi" id="4Fanv3VboVj" role="3clFbG">
-                    <node concept="2OqwBi" id="4Fanv3VboVk" role="2Oq$k0">
-                      <node concept="2kS8pE" id="4Fanv3Vbs0i" role="2Oq$k0" />
-                      <node concept="liA8E" id="4Fanv3VboVm" role="2OqNvi">
-                        <ref role="37wK5l" to="uddc:~TransformationMenuContext.getEditorMenuTrace()" resolve="getEditorMenuTrace" />
-                      </node>
-                    </node>
-                    <node concept="liA8E" id="4Fanv3VboVn" role="2OqNvi">
-                      <ref role="37wK5l" to="x4mf:~EditorMenuTrace.setDescriptor(jetbrains.mps.openapi.editor.menus.EditorMenuDescriptor)" resolve="setDescriptor" />
-                      <node concept="2ShNRf" id="4Fanv3VboVo" role="37wK5m">
-                        <node concept="1pGfFk" id="4Fanv3VboVp" role="2ShVmc">
-                          <ref role="37wK5l" to="v95p:~EditorMenuDescriptorBase.&lt;init&gt;(java.lang.String,org.jetbrains.mps.openapi.model.SNodeReference)" resolve="EditorMenuDescriptorBase" />
-                          <node concept="3cpWs3" id="4Fanv3WbQhc" role="37wK5m">
-                            <node concept="Xl_RD" id="4Fanv3VboVq" role="3uHU7B">
-                              <property role="Xl_RC" value="grammar.brackets in " />
-                            </node>
-                            <node concept="Xl_RD" id="4Fanv3WbQwi" role="3uHU7w">
-                              <property role="Xl_RC" value="ConceptName" />
-                              <node concept="17Uvod" id="4Fanv3WbQwj" role="lGtFl">
-                                <property role="P4ACc" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1070475926800/1070475926801" />
-                                <property role="2qtEX9" value="value" />
-                                <node concept="3zFVjK" id="4Fanv3WbQwk" role="3zH0cK">
-                                  <node concept="3clFbS" id="4Fanv3WbQwl" role="2VODD2">
-                                    <node concept="3clFbF" id="4Fanv3WbQwm" role="3cqZAp">
-                                      <node concept="2OqwBi" id="4Fanv3WbQwn" role="3clFbG">
-                                        <node concept="2OqwBi" id="4Fanv3WbQwo" role="2Oq$k0">
-                                          <node concept="2OqwBi" id="4Fanv3WbQwp" role="2Oq$k0">
-                                            <node concept="30H73N" id="4Fanv3WbQwq" role="2Oq$k0" />
-                                            <node concept="2Xjw5R" id="4Fanv3WbQwr" role="2OqNvi">
-                                              <node concept="1xMEDy" id="4Fanv3WbQws" role="1xVPHs">
-                                                <node concept="chp4Y" id="4Fanv3WbQwt" role="ri$Ld">
-                                                  <ref role="cht4Q" to="tpc2:gXXWOiD" resolve="AbstractComponent" />
-                                                </node>
-                                              </node>
-                                              <node concept="1xLf8o" id="4Fanv3WbQwu" role="1xVPHs" />
-                                            </node>
-                                          </node>
-                                          <node concept="2qgKlT" id="4Fanv3WbQwv" role="2OqNvi">
-                                            <ref role="37wK5l" to="tpcb:67EYkym$wx3" resolve="getConceptDeclaration" />
-                                          </node>
-                                        </node>
-                                        <node concept="3TrcHB" id="4Fanv3WbQww" role="2OqNvi">
-                                          <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
-                                        </node>
-                                      </node>
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
+              </node>
+              <node concept="3F0ifn" id="6jH9yJK4GI1" role="130CDr">
+                <node concept="29HgVG" id="6jH9yJK4GI2" role="lGtFl">
+                  <node concept="3NFfHV" id="6jH9yJK4GI3" role="3NFExx">
+                    <node concept="3clFbS" id="6jH9yJK4GI4" role="2VODD2">
+                      <node concept="3clFbF" id="6jH9yJK4GI5" role="3cqZAp">
+                        <node concept="2OqwBi" id="6jH9yJK4GI6" role="3clFbG">
+                          <node concept="3TrEf2" id="6jH9yJK4GI7" role="2OqNvi">
+                            <ref role="3Tt5mk" to="teg0:1vi_twqJeLv" resolve="left" />
                           </node>
-                          <node concept="2ShNRf" id="4Fanv3VboVr" role="37wK5m">
-                            <node concept="1pGfFk" id="4Fanv3VboVs" role="2ShVmc">
-                              <ref role="37wK5l" to="w1kc:~SNodePointer.&lt;init&gt;(java.lang.String,java.lang.String)" resolve="SNodePointer" />
-                              <node concept="Xl_RD" id="4Fanv3VboVt" role="37wK5m">
-                                <property role="Xl_RC" value="modelUID" />
-                                <node concept="17Uvod" id="4Fanv3VboVu" role="lGtFl">
-                                  <property role="2qtEX9" value="value" />
-                                  <property role="P4ACc" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1070475926800/1070475926801" />
-                                  <node concept="3zFVjK" id="4Fanv3VboVv" role="3zH0cK">
-                                    <node concept="3clFbS" id="4Fanv3VboVw" role="2VODD2">
-                                      <node concept="3cpWs6" id="4Fanv3VboVx" role="3cqZAp">
-                                        <node concept="2OqwBi" id="4Fanv3VboVy" role="3cqZAk">
-                                          <node concept="2OqwBi" id="4Fanv3VboVz" role="2Oq$k0">
-                                            <node concept="liA8E" id="4Fanv3VboV$" role="2OqNvi">
-                                              <ref role="37wK5l" to="mhbf:~SModel.getReference()" resolve="getReference" />
-                                            </node>
-                                            <node concept="2JrnkZ" id="4Fanv3VboV_" role="2Oq$k0">
-                                              <node concept="2OqwBi" id="4Fanv3VboVA" role="2JrQYb">
-                                                <node concept="1iwH7S" id="4Fanv3VboVB" role="2Oq$k0" />
-                                                <node concept="1st3f0" id="4Fanv3VboVC" role="2OqNvi" />
-                                              </node>
-                                            </node>
-                                          </node>
-                                          <node concept="liA8E" id="4Fanv3VboVD" role="2OqNvi">
-                                            <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
-                                          </node>
-                                        </node>
-                                      </node>
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                              <node concept="Xl_RD" id="4Fanv3VboVE" role="37wK5m">
-                                <property role="Xl_RC" value="nodeID" />
-                                <node concept="17Uvod" id="4Fanv3VboVF" role="lGtFl">
-                                  <property role="2qtEX9" value="value" />
-                                  <property role="P4ACc" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1070475926800/1070475926801" />
-                                  <node concept="3zFVjK" id="4Fanv3VboVG" role="3zH0cK">
-                                    <node concept="3clFbS" id="4Fanv3VboVH" role="2VODD2">
-                                      <node concept="3cpWs6" id="4Fanv3VboVI" role="3cqZAp">
-                                        <node concept="2OqwBi" id="4Fanv3VboVJ" role="3cqZAk">
-                                          <node concept="2OqwBi" id="4Fanv3VboVK" role="2Oq$k0">
-                                            <node concept="2JrnkZ" id="4Fanv3VboVL" role="2Oq$k0">
-                                              <node concept="2OqwBi" id="4Fanv3VboVM" role="2JrQYb">
-                                                <node concept="1iwH7S" id="4Fanv3VboVN" role="2Oq$k0" />
-                                                <node concept="12$id9" id="4Fanv3VboVO" role="2OqNvi">
-                                                  <node concept="30H73N" id="4Fanv3VboVP" role="12$y8L" />
-                                                </node>
-                                              </node>
-                                            </node>
-                                            <node concept="liA8E" id="4Fanv3VboVQ" role="2OqNvi">
-                                              <ref role="37wK5l" to="mhbf:~SNode.getNodeId()" resolve="getNodeId" />
-                                            </node>
-                                          </node>
-                                          <node concept="liA8E" id="4Fanv3VboVR" role="2OqNvi">
-                                            <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
-                                          </node>
-                                        </node>
-                                      </node>
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="3J1_TO" id="4Fanv3VboVS" role="3cqZAp">
-                  <node concept="3clFbS" id="4Fanv3VboVT" role="1zxBo7">
-                    <node concept="3cpWs8" id="6jH9yJK4H1r" role="3cqZAp">
-                      <node concept="3cpWsn" id="6jH9yJK4H1s" role="3cpWs9">
-                        <property role="TrG5h" value="result" />
-                        <node concept="_YKpA" id="6jH9yJK4H1t" role="1tU5fm">
-                          <node concept="3uibUv" id="2mvFNoS5g0B" role="_ZDj9">
-                            <ref role="3uigEE" to="uddc:~TransformationMenuItem" resolve="TransformationMenuItem" />
-                          </node>
-                        </node>
-                        <node concept="2ShNRf" id="6jH9yJK4H1v" role="33vP2m">
-                          <node concept="Tc6Ow" id="6jH9yJK4H1w" role="2ShVmc">
-                            <node concept="3uibUv" id="2mvFNoS5giD" role="HW$YZ">
-                              <ref role="3uigEE" to="uddc:~TransformationMenuItem" resolve="TransformationMenuItem" />
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="3clFbF" id="6jH9yJK4H1y" role="3cqZAp">
-                      <node concept="2OqwBi" id="6jH9yJK4H1z" role="3clFbG">
-                        <node concept="37vLTw" id="6jH9yJK4H1$" role="2Oq$k0">
-                          <ref role="3cqZAo" node="6jH9yJK4H1s" resolve="result" />
-                        </node>
-                        <node concept="TSZUe" id="6jH9yJK4H1_" role="2OqNvi">
-                          <node concept="10Nm6u" id="6jH9yJK4H1A" role="25WWJ7" />
-                        </node>
-                      </node>
-                      <node concept="1sPUBX" id="6jH9yJK4H1B" role="lGtFl">
-                        <ref role="v9R2y" node="RbLMy69ng$" resolve="switch_sideTransformations" />
-                      </node>
-                    </node>
-                    <node concept="3cpWs6" id="6jH9yJK4H1C" role="3cqZAp">
-                      <node concept="2OqwBi" id="6jH9yJK4H1D" role="3cqZAk">
-                        <node concept="2OqwBi" id="6jH9yJK4H1E" role="2Oq$k0">
-                          <node concept="37vLTw" id="6jH9yJK4H1F" role="2Oq$k0">
-                            <ref role="3cqZAo" node="6jH9yJK4H1s" resolve="result" />
-                          </node>
-                          <node concept="3zZkjj" id="6jH9yJK4H1G" role="2OqNvi">
-                            <node concept="1bVj0M" id="6jH9yJK4H1H" role="23t8la">
-                              <node concept="3clFbS" id="6jH9yJK4H1I" role="1bW5cS">
-                                <node concept="3clFbF" id="6jH9yJK4H1J" role="3cqZAp">
-                                  <node concept="3y3z36" id="6jH9yJK4H1K" role="3clFbG">
-                                    <node concept="10Nm6u" id="6jH9yJK4H1L" role="3uHU7w" />
-                                    <node concept="37vLTw" id="6jH9yJK4H1M" role="3uHU7B">
-                                      <ref role="3cqZAo" node="6jH9yJK4H1N" resolve="it" />
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                              <node concept="Rh6nW" id="6jH9yJK4H1N" role="1bW2Oz">
-                                <property role="TrG5h" value="it" />
-                                <node concept="2jxLKc" id="6jH9yJK4H1O" role="1tU5fm" />
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="ANE8D" id="6jH9yJK4H1P" role="2OqNvi" />
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="1wplmZ" id="d1YgGmq9KSX" role="1zxBo6">
-                    <node concept="3clFbS" id="4Fanv3VboW0" role="1wplMD">
-                      <node concept="3clFbF" id="4Fanv3VboW1" role="3cqZAp">
-                        <node concept="2OqwBi" id="4Fanv3VboW2" role="3clFbG">
-                          <node concept="2OqwBi" id="4Fanv3VboW3" role="2Oq$k0">
-                            <node concept="2kS8pE" id="4Fanv3VbscB" role="2Oq$k0" />
-                            <node concept="liA8E" id="4Fanv3VboW5" role="2OqNvi">
-                              <ref role="37wK5l" to="uddc:~TransformationMenuContext.getEditorMenuTrace()" resolve="getEditorMenuTrace" />
-                            </node>
-                          </node>
-                          <node concept="liA8E" id="4Fanv3VboW6" role="2OqNvi">
-                            <ref role="37wK5l" to="x4mf:~EditorMenuTrace.popTraceInfo()" resolve="popTraceInfo" />
-                          </node>
+                          <node concept="30H73N" id="6jH9yJK4GI8" role="2Oq$k0" />
                         </node>
                       </node>
                     </node>
@@ -7308,84 +6521,52 @@
                 </node>
               </node>
             </node>
-            <node concept="3EZMnI" id="6jH9yJK4GHU" role="2kSiZZ">
-              <node concept="130CD5" id="6jH9yJK4GHV" role="3EZMnx">
-                <node concept="130t_x" id="6jH9yJK4GHW" role="130p63">
-                  <property role="1hAc7j" value="g_hAxAO/delete_action_id" />
-                  <node concept="130t_S" id="6jH9yJK4GHX" role="130oVf">
-                    <node concept="3clFbS" id="6jH9yJK4GHY" role="2VODD2" />
-                  </node>
-                  <node concept="5jKBG" id="6jH9yJK4GHZ" role="lGtFl">
-                    <ref role="v9R2y" node="1PeMnAN42Da" resolve="template_BracketsCell_DeleteBracket" />
-                    <node concept="3clFbT" id="6jH9yJK4GI0" role="v9R3O">
-                      <property role="3clFbU" value="true" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="3F0ifn" id="6jH9yJK4GI1" role="130CDr">
-                  <node concept="29HgVG" id="6jH9yJK4GI2" role="lGtFl">
-                    <node concept="3NFfHV" id="6jH9yJK4GI3" role="3NFExx">
-                      <node concept="3clFbS" id="6jH9yJK4GI4" role="2VODD2">
-                        <node concept="3clFbF" id="6jH9yJK4GI5" role="3cqZAp">
-                          <node concept="2OqwBi" id="6jH9yJK4GI6" role="3clFbG">
-                            <node concept="3TrEf2" id="6jH9yJK4GI7" role="2OqNvi">
-                              <ref role="3Tt5mk" to="teg0:1vi_twqJeLv" resolve="left" />
-                            </node>
-                            <node concept="30H73N" id="6jH9yJK4GI8" role="2Oq$k0" />
-                          </node>
+            <node concept="3F0ifn" id="6jH9yJK4GI9" role="3EZMnx">
+              <node concept="29HgVG" id="6jH9yJK4GIa" role="lGtFl">
+                <node concept="3NFfHV" id="6jH9yJK4GIb" role="3NFExx">
+                  <node concept="3clFbS" id="6jH9yJK4GIc" role="2VODD2">
+                    <node concept="3clFbF" id="6jH9yJK4GId" role="3cqZAp">
+                      <node concept="2OqwBi" id="6jH9yJK4GIe" role="3clFbG">
+                        <node concept="3TrEf2" id="6jH9yJK4GIf" role="2OqNvi">
+                          <ref role="3Tt5mk" to="teg0:1vi_twqJeLy" resolve="inner" />
                         </node>
+                        <node concept="30H73N" id="6jH9yJK4GIg" role="2Oq$k0" />
                       </node>
                     </node>
                   </node>
                 </node>
               </node>
-              <node concept="3F0ifn" id="6jH9yJK4GI9" role="3EZMnx">
-                <node concept="29HgVG" id="6jH9yJK4GIa" role="lGtFl">
-                  <node concept="3NFfHV" id="6jH9yJK4GIb" role="3NFExx">
-                    <node concept="3clFbS" id="6jH9yJK4GIc" role="2VODD2">
-                      <node concept="3clFbF" id="6jH9yJK4GId" role="3cqZAp">
-                        <node concept="2OqwBi" id="6jH9yJK4GIe" role="3clFbG">
-                          <node concept="3TrEf2" id="6jH9yJK4GIf" role="2OqNvi">
-                            <ref role="3Tt5mk" to="teg0:1vi_twqJeLy" resolve="inner" />
-                          </node>
-                          <node concept="30H73N" id="6jH9yJK4GIg" role="2Oq$k0" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="130CD5" id="6jH9yJK4GIh" role="3EZMnx">
-                <node concept="130t_x" id="6jH9yJK4GIi" role="130p63">
-                  <property role="1hAc7j" value="g_hAxAO/delete_action_id" />
-                  <node concept="130t_S" id="6jH9yJK4GIj" role="130oVf">
-                    <node concept="3clFbS" id="6jH9yJK4GIk" role="2VODD2" />
-                  </node>
-                  <node concept="5jKBG" id="6jH9yJK4GIl" role="lGtFl">
-                    <ref role="v9R2y" node="1PeMnAN42Da" resolve="template_BracketsCell_DeleteBracket" />
-                    <node concept="3clFbT" id="6jH9yJK4GIm" role="v9R3O" />
-                  </node>
-                </node>
-                <node concept="3F0ifn" id="6jH9yJK4GIn" role="130CDr">
-                  <node concept="29HgVG" id="6jH9yJK4GIo" role="lGtFl">
-                    <node concept="3NFfHV" id="6jH9yJK4GIp" role="3NFExx">
-                      <node concept="3clFbS" id="6jH9yJK4GIq" role="2VODD2">
-                        <node concept="3clFbF" id="6jH9yJK4GIr" role="3cqZAp">
-                          <node concept="2OqwBi" id="6jH9yJK4GIs" role="3clFbG">
-                            <node concept="3TrEf2" id="6jH9yJK4GIt" role="2OqNvi">
-                              <ref role="3Tt5mk" to="teg0:1vi_twqJeLB" resolve="right" />
-                            </node>
-                            <node concept="30H73N" id="6jH9yJK4GIu" role="2Oq$k0" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="l2Vlx" id="6jH9yJK4GIw" role="2iSdaV" />
             </node>
-            <node concept="raruj" id="6jH9yJK4GU$" role="lGtFl" />
+            <node concept="130CD5" id="6jH9yJK4GIh" role="3EZMnx">
+              <node concept="130t_x" id="6jH9yJK4GIi" role="130p63">
+                <property role="1hAc7j" value="g_hAxAO/delete_action_id" />
+                <node concept="130t_S" id="6jH9yJK4GIj" role="130oVf">
+                  <node concept="3clFbS" id="6jH9yJK4GIk" role="2VODD2" />
+                </node>
+                <node concept="5jKBG" id="6jH9yJK4GIl" role="lGtFl">
+                  <ref role="v9R2y" node="1PeMnAN42Da" resolve="template_BracketsCell_DeleteBracket" />
+                  <node concept="3clFbT" id="6jH9yJK4GIm" role="v9R3O" />
+                </node>
+              </node>
+              <node concept="3F0ifn" id="6jH9yJK4GIn" role="130CDr">
+                <node concept="29HgVG" id="6jH9yJK4GIo" role="lGtFl">
+                  <node concept="3NFfHV" id="6jH9yJK4GIp" role="3NFExx">
+                    <node concept="3clFbS" id="6jH9yJK4GIq" role="2VODD2">
+                      <node concept="3clFbF" id="6jH9yJK4GIr" role="3cqZAp">
+                        <node concept="2OqwBi" id="6jH9yJK4GIs" role="3clFbG">
+                          <node concept="3TrEf2" id="6jH9yJK4GIt" role="2OqNvi">
+                            <ref role="3Tt5mk" to="teg0:1vi_twqJeLB" resolve="right" />
+                          </node>
+                          <node concept="30H73N" id="6jH9yJK4GIu" role="2Oq$k0" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="l2Vlx" id="6jH9yJK4GIw" role="2iSdaV" />
+            <node concept="raruj" id="5fS8Lrorjok" role="lGtFl" />
           </node>
         </node>
       </node>
@@ -7396,6 +6577,90 @@
         <node concept="1lLz0L" id="1RK7yEgItok" role="1lHHLF">
           <property role="1lMjX7" value="h1lM37o/error" />
           <property role="1lLB17" value="Content of optional cell is not supported" />
+        </node>
+      </node>
+    </node>
+    <node concept="3aamgX" id="DnjeukMKqz" role="3acgRq">
+      <property role="36QftV" value="true" />
+      <ref role="30HIoZ" to="tpc2:fBEZMkn" resolve="CellModel_Collection" />
+      <node concept="gft3U" id="DnjeukN4Ro" role="1lVwrX">
+        <node concept="2u$9CG" id="DnjeukN4Ru" role="gfFT$">
+          <node concept="3F0ifn" id="DnjeukN4Ry" role="2u$9CF">
+            <node concept="29HgVG" id="DnjeukN4RA" role="lGtFl">
+              <node concept="3NFfHV" id="DnjeukN4RB" role="3NFExx">
+                <node concept="3clFbS" id="DnjeukN4RC" role="2VODD2">
+                  <node concept="3clFbF" id="DnjeukN4RI" role="3cqZAp">
+                    <node concept="30H73N" id="DnjeukN4RH" role="3clFbG" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="pkWqt" id="DnjeukO8lM" role="pqm2j">
+            <node concept="3clFbS" id="DnjeukO8lN" role="2VODD2">
+              <node concept="3clFbF" id="DnjeukO8lS" role="3cqZAp">
+                <node concept="3clFbT" id="DnjeukO8lR" role="3clFbG">
+                  <property role="3clFbU" value="true" />
+                </node>
+              </node>
+            </node>
+            <node concept="29HgVG" id="DnjeukO8sh" role="lGtFl">
+              <node concept="3NFfHV" id="DnjeukO8si" role="3NFExx">
+                <node concept="3clFbS" id="DnjeukO8sj" role="2VODD2">
+                  <node concept="3clFbF" id="DnjeukO8sp" role="3cqZAp">
+                    <node concept="2OqwBi" id="DnjeukO8sk" role="3clFbG">
+                      <node concept="3TrEf2" id="DnjeukO8sn" role="2OqNvi">
+                        <ref role="3Tt5mk" to="tpc2:gCpqm6p" resolve="renderingCondition" />
+                      </node>
+                      <node concept="30H73N" id="DnjeukO8so" role="2Oq$k0" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="30G5F_" id="DnjeukN5al" role="30HLyM">
+        <node concept="3clFbS" id="DnjeukN5am" role="2VODD2">
+          <node concept="3clFbJ" id="DnjeumMGoz" role="3cqZAp">
+            <node concept="3clFbS" id="DnjeumMGo_" role="3clFbx">
+              <node concept="3cpWs6" id="DnjeumMJ2c" role="3cqZAp">
+                <node concept="3clFbT" id="DnjeumMJ2n" role="3cqZAk" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="DnjeumMIiz" role="3clFbw">
+              <node concept="2OqwBi" id="DnjeumMH3U" role="2Oq$k0">
+                <node concept="30H73N" id="DnjeumMG_N" role="2Oq$k0" />
+                <node concept="1mfA1w" id="DnjeumMHPu" role="2OqNvi" />
+              </node>
+              <node concept="1mIQ4w" id="DnjeumMIBP" role="2OqNvi">
+                <node concept="chp4Y" id="DnjeumMIP0" role="cj9EA">
+                  <ref role="cht4Q" to="teg0:DnjeukLXrb" resolve="SideTransformationHolderProcessor" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="DnjeumMJj1" role="3cqZAp">
+            <node concept="2OqwBi" id="DnjeumMXoz" role="3clFbG">
+              <node concept="2OqwBi" id="DnjeumMJFA" role="2Oq$k0">
+                <node concept="30H73N" id="DnjeumMJj0" role="2Oq$k0" />
+                <node concept="2Rf3mk" id="DnjeumMKrn" role="2OqNvi">
+                  <node concept="1xMEDy" id="DnjeumMKrp" role="1xVPHs">
+                    <node concept="chp4Y" id="DnjeumMKNj" role="ri$Ld">
+                      <ref role="cht4Q" to="teg0:Dnjeuk_JIi" resolve="SideTransformationCell4" />
+                    </node>
+                  </node>
+                  <node concept="hTh3S" id="DnjeumNvI7" role="1xVPHs">
+                    <node concept="3gn64h" id="DnjeumNw1l" role="hTh3Z">
+                      <ref role="3gnhBz" to="tpc2:fBEZMkn" resolve="CellModel_Collection" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3GX2aA" id="DnjeumMY0O" role="2OqNvi" />
+            </node>
+          </node>
         </node>
       </node>
     </node>
@@ -8057,6 +7322,9 @@
     </node>
     <node concept="2VPoh5" id="7NlRaxB7kwz" role="2VS0gm">
       <ref role="2VPoh2" node="7NlRaxB7lg4" resolve="template_GrammarCellsSubstituteMenu" />
+    </node>
+    <node concept="2VPoh5" id="DnjeuksvMv" role="2VS0gm">
+      <ref role="2VPoh2" node="DnjeukswAW" resolve="template_IncludeBeforeAfterTransformations" />
     </node>
   </node>
   <node concept="jVnub" id="6oKG1kMyAVF">
@@ -15832,591 +15100,6 @@
         </node>
       </node>
     </node>
-    <node concept="3aamgX" id="3lRTV5HqIms" role="3aUrZf">
-      <property role="36QftV" value="true" />
-      <ref role="30HIoZ" to="teg0:1vi_twqJeLl" resolve="BracketsCell" />
-      <node concept="1Koe21" id="3lRTV5HqImt" role="1lVwrX">
-        <node concept="3clFb_" id="3lRTV5HqImu" role="1Koe22">
-          <property role="1EzhhJ" value="false" />
-          <property role="TrG5h" value="getActions" />
-          <node concept="37vLTG" id="3lRTV5HqImx" role="3clF46">
-            <property role="TrG5h" value="_context" />
-            <property role="3TUv4t" value="true" />
-            <node concept="3uibUv" id="1YKLYyyKtnT" role="1tU5fm">
-              <ref role="3uigEE" to="uddc:~TransformationMenuContext" resolve="TransformationMenuContext" />
-            </node>
-          </node>
-          <node concept="_YKpA" id="3lRTV5HqImz" role="3clF45">
-            <node concept="3uibUv" id="2mvFNoS08a7" role="_ZDj9">
-              <ref role="3uigEE" to="uddc:~TransformationMenuItem" resolve="TransformationMenuItem" />
-            </node>
-          </node>
-          <node concept="3Tm1VV" id="3lRTV5HqIm_" role="1B3o_S" />
-          <node concept="3clFbS" id="3lRTV5HqImA" role="3clF47">
-            <node concept="3cpWs8" id="3lRTV5HqImB" role="3cqZAp">
-              <node concept="3cpWsn" id="3lRTV5HqImC" role="3cpWs9">
-                <property role="TrG5h" value="result" />
-                <node concept="_YKpA" id="3lRTV5HqImD" role="1tU5fm">
-                  <node concept="3uibUv" id="2mvFNoS09k0" role="_ZDj9">
-                    <ref role="3uigEE" to="uddc:~TransformationMenuItem" resolve="TransformationMenuItem" />
-                  </node>
-                </node>
-                <node concept="2ShNRf" id="3lRTV5HqImF" role="33vP2m">
-                  <node concept="Tc6Ow" id="3lRTV5HqImG" role="2ShVmc">
-                    <node concept="3uibUv" id="2mvFNoS0asc" role="HW$YZ">
-                      <ref role="3uigEE" to="uddc:~TransformationMenuItem" resolve="TransformationMenuItem" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbH" id="3lRTV5HqImI" role="3cqZAp" />
-            <node concept="9aQIb" id="3lRTV5HqImJ" role="3cqZAp">
-              <node concept="3clFbS" id="3lRTV5HqImK" role="9aQI4">
-                <node concept="3cpWs8" id="3lRTV5HqImR" role="3cqZAp">
-                  <node concept="3cpWsn" id="3lRTV5HqImS" role="3cpWs9">
-                    <property role="TrG5h" value="sourceNode" />
-                    <property role="3TUv4t" value="true" />
-                    <node concept="3Tqbb2" id="3lRTV5HqImT" role="1tU5fm" />
-                    <node concept="2OqwBi" id="6B579NGDV1B" role="33vP2m">
-                      <node concept="2ShNRf" id="6B579NGDV1C" role="2Oq$k0">
-                        <node concept="1pGfFk" id="6B579NGDV1D" role="2ShVmc">
-                          <ref role="37wK5l" to="czm:5OsvY4g$ZXe" resolve="Parser" />
-                          <node concept="2OqwBi" id="6B579NGDV1E" role="37wK5m">
-                            <node concept="37vLTw" id="6B579NGDV1F" role="2Oq$k0">
-                              <ref role="3cqZAo" node="3lRTV5HqImx" resolve="_context" />
-                            </node>
-                            <node concept="liA8E" id="6B579NGDV1G" role="2OqNvi">
-                              <ref role="37wK5l" to="uddc:~TransformationMenuContext.getModel()" resolve="getModel" />
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="liA8E" id="6B579NGDV1H" role="2OqNvi">
-                        <ref role="37wK5l" to="czm:7K_2cV$Ps7w" resolve="isEndOf" />
-                        <node concept="2OqwBi" id="6B579NGDV1I" role="37wK5m">
-                          <node concept="37vLTw" id="6B579NGDV1J" role="2Oq$k0">
-                            <ref role="3cqZAo" node="3lRTV5HqImx" resolve="_context" />
-                          </node>
-                          <node concept="liA8E" id="6B579NGDV1K" role="2OqNvi">
-                            <ref role="37wK5l" to="uddc:~TransformationMenuContext.getNode()" resolve="getNode" />
-                          </node>
-                        </node>
-                        <node concept="3clFbC" id="2mvFNoREkIc" role="37wK5m">
-                          <node concept="10M0yZ" id="2mvFNoREkId" role="3uHU7w">
-                            <ref role="3cqZAo" to="9eyi:~MenuLocations.LEFT_SIDE_TRANSFORM" resolve="LEFT_SIDE_TRANSFORM" />
-                            <ref role="1PxDUh" to="9eyi:~MenuLocations" resolve="MenuLocations" />
-                          </node>
-                          <node concept="2OqwBi" id="2mvFNoREkIe" role="3uHU7B">
-                            <node concept="37vLTw" id="2mvFNoREkIf" role="2Oq$k0">
-                              <ref role="3cqZAo" node="3lRTV5HqImx" resolve="_context" />
-                            </node>
-                            <node concept="liA8E" id="2mvFNoREkIg" role="2OqNvi">
-                              <ref role="37wK5l" to="uddc:~TransformationMenuContext.getMenuLocation()" resolve="getMenuLocation" />
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="35c_gC" id="6B579NGDV1Q" role="37wK5m">
-                          <ref role="35c_gD" to="tpck:gw2VY9q" resolve="BaseConcept" />
-                          <node concept="1ZhdrF" id="6B579NGDV1R" role="lGtFl">
-                            <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/2644386474300074836/2644386474300074837" />
-                            <property role="2qtEX8" value="conceptDeclaration" />
-                            <node concept="3$xsQk" id="6B579NGDV1S" role="3$ytzL">
-                              <node concept="3clFbS" id="6B579NGDV1T" role="2VODD2">
-                                <node concept="3clFbF" id="6B579NGDV1U" role="3cqZAp">
-                                  <node concept="2OqwBi" id="6B579NGDV1V" role="3clFbG">
-                                    <node concept="2OqwBi" id="6B579NGDV1W" role="2Oq$k0">
-                                      <node concept="2OqwBi" id="6B579NGDV1X" role="2Oq$k0">
-                                        <node concept="30H73N" id="6B579NGDV1Y" role="2Oq$k0" />
-                                        <node concept="3TrEf2" id="6B579NGDV1Z" role="2OqNvi">
-                                          <ref role="3Tt5mk" to="teg0:1vi_twqJeLy" resolve="inner" />
-                                        </node>
-                                      </node>
-                                      <node concept="3TrEf2" id="6B579NGDV20" role="2OqNvi">
-                                        <ref role="3Tt5mk" to="tpc2:fBF1sR8" resolve="linkDeclaration" />
-                                      </node>
-                                    </node>
-                                    <node concept="3TrEf2" id="6B579NGDV21" role="2OqNvi">
-                                      <ref role="3Tt5mk" to="tpce:fA0lvVK" resolve="target" />
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="10Nm6u" id="6B579NGDV22" role="37wK5m" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="3clFbJ" id="3lRTV5HqIn3" role="3cqZAp">
-                  <node concept="3clFbS" id="3lRTV5HqIn4" role="3clFbx">
-                    <node concept="3clFbF" id="3lRTV5HqIn5" role="3cqZAp">
-                      <node concept="2OqwBi" id="3lRTV5HqIn6" role="3clFbG">
-                        <node concept="37vLTw" id="3lRTV5HqIn7" role="2Oq$k0">
-                          <ref role="3cqZAo" node="3lRTV5HqImC" resolve="result" />
-                        </node>
-                        <node concept="TSZUe" id="3lRTV5HqIn8" role="2OqNvi">
-                          <node concept="2ShNRf" id="3lRTV5HqIn9" role="25WWJ7">
-                            <node concept="YeOm9" id="3lRTV5HqIna" role="2ShVmc">
-                              <node concept="1Y3b0j" id="3lRTV5HqInb" role="YeSDq">
-                                <property role="2bfB8j" value="true" />
-                                <ref role="1Y3XeK" to="gdpt:1YKLYyyGBzT" resolve="GrammarCellsSideTransformTransformationMenuItem" />
-                                <ref role="37wK5l" to="gdpt:My09KinEek" resolve="GrammarCellsSideTransformTransformationMenuItem" />
-                                <node concept="37vLTw" id="My09KioPBz" role="37wK5m">
-                                  <ref role="3cqZAo" node="3lRTV5HqImx" resolve="_context" />
-                                </node>
-                                <node concept="3Tm1VV" id="3lRTV5HqInc" role="1B3o_S" />
-                                <node concept="3clFb_" id="3lRTV5HqIne" role="jymVt">
-                                  <property role="1EzhhJ" value="false" />
-                                  <property role="TrG5h" value="getDescriptionText" />
-                                  <property role="DiZV1" value="false" />
-                                  <property role="od$2w" value="false" />
-                                  <node concept="3Tm1VV" id="3lRTV5HqInf" role="1B3o_S" />
-                                  <node concept="17QB3L" id="3lRTV5HqIng" role="3clF45" />
-                                  <node concept="37vLTG" id="3lRTV5HqInh" role="3clF46">
-                                    <property role="TrG5h" value="string" />
-                                    <node concept="17QB3L" id="3lRTV5HqIni" role="1tU5fm" />
-                                  </node>
-                                  <node concept="3clFbS" id="3lRTV5HqInj" role="3clF47">
-                                    <node concept="3clFbF" id="3lRTV5Hsc76" role="3cqZAp">
-                                      <node concept="Xl_RD" id="3lRTV5Hsc75" role="3clFbG">
-                                        <property role="Xl_RC" value="conceptName" />
-                                        <node concept="17Uvod" id="3lRTV5Hsc85" role="lGtFl">
-                                          <property role="P4ACc" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1070475926800/1070475926801" />
-                                          <property role="2qtEX9" value="value" />
-                                          <node concept="3zFVjK" id="3lRTV5Hsc86" role="3zH0cK">
-                                            <node concept="3clFbS" id="3lRTV5Hsc87" role="2VODD2">
-                                              <node concept="3clFbF" id="3lRTV5HsdPk" role="3cqZAp">
-                                                <node concept="2OqwBi" id="3lRTV5Hsetv" role="3clFbG">
-                                                  <node concept="2OqwBi" id="3lRTV5Hsehk" role="2Oq$k0">
-                                                    <node concept="2OqwBi" id="3lRTV5HsdTj" role="2Oq$k0">
-                                                      <node concept="30H73N" id="3lRTV5HsdPj" role="2Oq$k0" />
-                                                      <node concept="2Xjw5R" id="3lRTV5Hse8C" role="2OqNvi">
-                                                        <node concept="1xMEDy" id="3lRTV5Hse8E" role="1xVPHs">
-                                                          <node concept="chp4Y" id="3lRTV5Hsec4" role="ri$Ld">
-                                                            <ref role="cht4Q" to="tpc2:gXXWOiD" resolve="AbstractComponent" />
-                                                          </node>
-                                                        </node>
-                                                      </node>
-                                                    </node>
-                                                    <node concept="2qgKlT" id="3lRTV5HsenJ" role="2OqNvi">
-                                                      <ref role="37wK5l" to="tpcb:67EYkym$wx3" resolve="getConceptDeclaration" />
-                                                    </node>
-                                                  </node>
-                                                  <node concept="3TrcHB" id="3lRTV5HseAP" role="2OqNvi">
-                                                    <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
-                                                  </node>
-                                                </node>
-                                              </node>
-                                            </node>
-                                          </node>
-                                        </node>
-                                      </node>
-                                    </node>
-                                  </node>
-                                </node>
-                                <node concept="3clFb_" id="3lRTV5HqInm" role="jymVt">
-                                  <property role="1EzhhJ" value="false" />
-                                  <property role="TrG5h" value="getMatchingText" />
-                                  <property role="DiZV1" value="false" />
-                                  <property role="od$2w" value="false" />
-                                  <node concept="3Tm1VV" id="3lRTV5HqInn" role="1B3o_S" />
-                                  <node concept="17QB3L" id="3lRTV5HqIno" role="3clF45" />
-                                  <node concept="37vLTG" id="3lRTV5HqInp" role="3clF46">
-                                    <property role="TrG5h" value="pattern" />
-                                    <node concept="17QB3L" id="3lRTV5HqInq" role="1tU5fm" />
-                                  </node>
-                                  <node concept="3clFbS" id="3lRTV5HqInr" role="3clF47">
-                                    <node concept="3clFbF" id="3lRTV5HqW2E" role="3cqZAp">
-                                      <node concept="3K4zz7" id="3lRTV5HqWoz" role="3clFbG">
-                                        <node concept="3clFbC" id="2mvFNoREmeN" role="3K4Cdx">
-                                          <node concept="10M0yZ" id="2mvFNoREmeO" role="3uHU7w">
-                                            <ref role="1PxDUh" to="9eyi:~MenuLocations" resolve="MenuLocations" />
-                                            <ref role="3cqZAo" to="9eyi:~MenuLocations.LEFT_SIDE_TRANSFORM" resolve="LEFT_SIDE_TRANSFORM" />
-                                          </node>
-                                          <node concept="2OqwBi" id="2mvFNoREmeP" role="3uHU7B">
-                                            <node concept="37vLTw" id="2mvFNoREmeQ" role="2Oq$k0">
-                                              <ref role="3cqZAo" node="3lRTV5HqImx" resolve="_context" />
-                                            </node>
-                                            <node concept="liA8E" id="2mvFNoREmeR" role="2OqNvi">
-                                              <ref role="37wK5l" to="uddc:~TransformationMenuContext.getMenuLocation()" resolve="getMenuLocation" />
-                                            </node>
-                                          </node>
-                                        </node>
-                                        <node concept="Xl_RD" id="3lRTV5HqInt" role="3K4E3e">
-                                          <property role="Xl_RC" value="transformText" />
-                                          <node concept="17Uvod" id="3lRTV5HqInu" role="lGtFl">
-                                            <property role="P4ACc" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1070475926800/1070475926801" />
-                                            <property role="2qtEX9" value="value" />
-                                            <node concept="3zFVjK" id="3lRTV5HqInv" role="3zH0cK">
-                                              <node concept="3clFbS" id="3lRTV5HqInw" role="2VODD2">
-                                                <node concept="3clFbF" id="3lRTV5HqVUk" role="3cqZAp">
-                                                  <node concept="2OqwBi" id="3lRTV5HqX5z" role="3clFbG">
-                                                    <node concept="2OqwBi" id="3lRTV5HqVYj" role="2Oq$k0">
-                                                      <node concept="30H73N" id="3lRTV5HqVUj" role="2Oq$k0" />
-                                                      <node concept="3TrEf2" id="3lRTV5HqWRC" role="2OqNvi">
-                                                        <ref role="3Tt5mk" to="teg0:1vi_twqJeLv" resolve="left" />
-                                                      </node>
-                                                    </node>
-                                                    <node concept="3TrcHB" id="3lRTV5HqXjk" role="2OqNvi">
-                                                      <ref role="3TsBF5" to="tpc2:fBF0icJ" resolve="text" />
-                                                    </node>
-                                                  </node>
-                                                </node>
-                                              </node>
-                                            </node>
-                                          </node>
-                                        </node>
-                                        <node concept="Xl_RD" id="3lRTV5HqXra" role="3K4GZi">
-                                          <property role="Xl_RC" value="transformText" />
-                                          <node concept="17Uvod" id="3lRTV5HqXrb" role="lGtFl">
-                                            <property role="P4ACc" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1070475926800/1070475926801" />
-                                            <property role="2qtEX9" value="value" />
-                                            <node concept="3zFVjK" id="3lRTV5HqXrc" role="3zH0cK">
-                                              <node concept="3clFbS" id="3lRTV5HqXrd" role="2VODD2">
-                                                <node concept="3clFbF" id="3lRTV5HqXre" role="3cqZAp">
-                                                  <node concept="2OqwBi" id="3lRTV5HqXrf" role="3clFbG">
-                                                    <node concept="2OqwBi" id="3lRTV5HqXrg" role="2Oq$k0">
-                                                      <node concept="30H73N" id="3lRTV5HqXrh" role="2Oq$k0" />
-                                                      <node concept="3TrEf2" id="3lRTV5HqXIq" role="2OqNvi">
-                                                        <ref role="3Tt5mk" to="teg0:1vi_twqJeLB" resolve="right" />
-                                                      </node>
-                                                    </node>
-                                                    <node concept="3TrcHB" id="3lRTV5HqXrj" role="2OqNvi">
-                                                      <ref role="3TsBF5" to="tpc2:fBF0icJ" resolve="text" />
-                                                    </node>
-                                                  </node>
-                                                </node>
-                                              </node>
-                                            </node>
-                                          </node>
-                                        </node>
-                                      </node>
-                                    </node>
-                                  </node>
-                                </node>
-                                <node concept="3clFb_" id="2mvFNoS0i7$" role="jymVt">
-                                  <property role="1EzhhJ" value="false" />
-                                  <property role="TrG5h" value="execute" />
-                                  <property role="DiZV1" value="false" />
-                                  <property role="od$2w" value="false" />
-                                  <node concept="3Tm1VV" id="2mvFNoS0i7_" role="1B3o_S" />
-                                  <node concept="3cqZAl" id="2mvFNoS0i7B" role="3clF45" />
-                                  <node concept="37vLTG" id="2mvFNoS0i7C" role="3clF46">
-                                    <property role="TrG5h" value="pattern" />
-                                    <node concept="3uibUv" id="2mvFNoS0i7D" role="1tU5fm">
-                                      <ref role="3uigEE" to="wyt6:~String" resolve="String" />
-                                    </node>
-                                    <node concept="2AHcQZ" id="2mvFNoS0i7E" role="2AJF6D">
-                                      <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
-                                    </node>
-                                  </node>
-                                  <node concept="3clFbS" id="2mvFNoS0i7G" role="3clF47">
-                                    <node concept="3clFbF" id="2mvFNoS0j$c" role="3cqZAp">
-                                      <node concept="1rXfSq" id="2mvFNoS0j$b" role="3clFbG">
-                                        <ref role="37wK5l" node="3lRTV5HqIn_" resolve="doSubstitute" />
-                                        <node concept="2OqwBi" id="2mvFNoS0jVe" role="37wK5m">
-                                          <node concept="37vLTw" id="2mvFNoS0jKy" role="2Oq$k0">
-                                            <ref role="3cqZAo" node="3lRTV5HqImx" resolve="_context" />
-                                          </node>
-                                          <node concept="liA8E" id="2mvFNoS0kd8" role="2OqNvi">
-                                            <ref role="37wK5l" to="uddc:~TransformationMenuContext.getEditorContext()" resolve="getEditorContext" />
-                                          </node>
-                                        </node>
-                                        <node concept="37vLTw" id="2mvFNoS0jB_" role="37wK5m">
-                                          <ref role="3cqZAo" node="2mvFNoS0i7C" resolve="pattern" />
-                                        </node>
-                                      </node>
-                                    </node>
-                                  </node>
-                                  <node concept="2AHcQZ" id="2mvFNoS0i7H" role="2AJF6D">
-                                    <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-                                  </node>
-                                </node>
-                                <node concept="3clFb_" id="3lRTV5HqIn_" role="jymVt">
-                                  <property role="1EzhhJ" value="false" />
-                                  <property role="TrG5h" value="doSubstitute" />
-                                  <property role="DiZV1" value="false" />
-                                  <property role="od$2w" value="false" />
-                                  <node concept="3Tmbuc" id="3lRTV5HqInA" role="1B3o_S" />
-                                  <node concept="3uibUv" id="3lRTV5HqInB" role="3clF45">
-                                    <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
-                                  </node>
-                                  <node concept="37vLTG" id="3lRTV5HqInC" role="3clF46">
-                                    <property role="TrG5h" value="editorContext" />
-                                    <node concept="3uibUv" id="3lRTV5HqInD" role="1tU5fm">
-                                      <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
-                                    </node>
-                                    <node concept="2AHcQZ" id="3lRTV5HqInE" role="2AJF6D">
-                                      <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
-                                    </node>
-                                  </node>
-                                  <node concept="37vLTG" id="3lRTV5HqInF" role="3clF46">
-                                    <property role="TrG5h" value="pattern" />
-                                    <node concept="17QB3L" id="3lRTV5HqInG" role="1tU5fm" />
-                                  </node>
-                                  <node concept="3clFbS" id="3lRTV5HqInH" role="3clF47">
-                                    <node concept="3cpWs8" id="3lRTV5Hr2ik" role="3cqZAp">
-                                      <node concept="3cpWsn" id="3lRTV5Hr2il" role="3cpWs9">
-                                        <property role="TrG5h" value="annotation" />
-                                        <node concept="3Tqbb2" id="3lRTV5Hr2ie" role="1tU5fm">
-                                          <ref role="ehGHo" to="878o:4qdNcH$7CYT" resolve="ArbitraryTextAnnotation" />
-                                        </node>
-                                        <node concept="2OqwBi" id="3lRTV5Hr2im" role="33vP2m">
-                                          <node concept="2OqwBi" id="3lRTV5Hr2in" role="2Oq$k0">
-                                            <node concept="37vLTw" id="3lRTV5Hr2io" role="2Oq$k0">
-                                              <ref role="3cqZAo" node="3lRTV5HqImS" resolve="sourceNode" />
-                                            </node>
-                                            <node concept="3CFZ6_" id="3lRTV5Hr2ip" role="2OqNvi">
-                                              <node concept="3CFYIy" id="3lRTV5Hr2iq" role="3CFYIz">
-                                                <ref role="3CFYIx" to="878o:4qdNcH$7CYT" resolve="ArbitraryTextAnnotation" />
-                                              </node>
-                                            </node>
-                                          </node>
-                                          <node concept="2DeJg1" id="3lRTV5Hr2ir" role="2OqNvi" />
-                                        </node>
-                                      </node>
-                                    </node>
-                                    <node concept="3clFbF" id="3lRTV5HqYk6" role="3cqZAp">
-                                      <node concept="37vLTI" id="3lRTV5Hr2Ep" role="3clFbG">
-                                        <node concept="1rXfSq" id="3lRTV5Hr2GB" role="37vLTx">
-                                          <ref role="37wK5l" node="3lRTV5HqInm" resolve="getMatchingText" />
-                                          <node concept="37vLTw" id="3lRTV5Hr2KN" role="37wK5m">
-                                            <ref role="3cqZAo" node="3lRTV5HqInF" resolve="pattern" />
-                                          </node>
-                                        </node>
-                                        <node concept="2OqwBi" id="3lRTV5Hr2sl" role="37vLTJ">
-                                          <node concept="37vLTw" id="3lRTV5Hr2is" role="2Oq$k0">
-                                            <ref role="3cqZAo" node="3lRTV5Hr2il" resolve="annotation" />
-                                          </node>
-                                          <node concept="3TrcHB" id="3lRTV5Hr2yx" role="2OqNvi">
-                                            <ref role="3TsBF5" to="878o:4qdNcH$7DAQ" resolve="text" />
-                                          </node>
-                                        </node>
-                                      </node>
-                                    </node>
-                                    <node concept="3clFbF" id="3lRTV5HrFCL" role="3cqZAp">
-                                      <node concept="37vLTI" id="3lRTV5HrG2k" role="3clFbG">
-                                        <node concept="3clFbC" id="2mvFNoREpe$" role="37vLTx">
-                                          <node concept="10M0yZ" id="2mvFNoREpe_" role="3uHU7w">
-                                            <ref role="1PxDUh" to="9eyi:~MenuLocations" resolve="MenuLocations" />
-                                            <ref role="3cqZAo" to="9eyi:~MenuLocations.LEFT_SIDE_TRANSFORM" resolve="LEFT_SIDE_TRANSFORM" />
-                                          </node>
-                                          <node concept="2OqwBi" id="2mvFNoREpeA" role="3uHU7B">
-                                            <node concept="37vLTw" id="2mvFNoREpeB" role="2Oq$k0">
-                                              <ref role="3cqZAo" node="3lRTV5HqImx" resolve="_context" />
-                                            </node>
-                                            <node concept="liA8E" id="2mvFNoREpeC" role="2OqNvi">
-                                              <ref role="37wK5l" to="uddc:~TransformationMenuContext.getMenuLocation()" resolve="getMenuLocation" />
-                                            </node>
-                                          </node>
-                                        </node>
-                                        <node concept="2OqwBi" id="3lRTV5HrFPm" role="37vLTJ">
-                                          <node concept="37vLTw" id="3lRTV5HrFCJ" role="2Oq$k0">
-                                            <ref role="3cqZAo" node="3lRTV5Hr2il" resolve="annotation" />
-                                          </node>
-                                          <node concept="3TrcHB" id="3lRTV5HrFUP" role="2OqNvi">
-                                            <ref role="3TsBF5" to="878o:4qdNcH$7DA9" resolve="left" />
-                                          </node>
-                                        </node>
-                                      </node>
-                                    </node>
-                                    <node concept="3clFbF" id="6YjZr6QhUPr" role="3cqZAp">
-                                      <node concept="2OqwBi" id="6YjZr6QhVak" role="3clFbG">
-                                        <node concept="37vLTw" id="6YjZr6QhUPp" role="2Oq$k0">
-                                          <ref role="3cqZAo" node="3lRTV5Hr2il" resolve="annotation" />
-                                        </node>
-                                        <node concept="1OKiuA" id="6YjZr6QhVr6" role="2OqNvi">
-                                          <node concept="37vLTw" id="6YjZr6QhVHu" role="lBI5i">
-                                            <ref role="3cqZAo" node="3lRTV5HqInC" resolve="editorContext" />
-                                          </node>
-                                          <node concept="3cmrfG" id="6YjZr6Qm1YX" role="3dN3m$">
-                                            <property role="3cmrfH" value="-1" />
-                                          </node>
-                                          <node concept="eBIwv" id="6YjZr6Qmivn" role="lGT1i">
-                                            <ref role="fyFUz" to="878o:4qdNcH$7DAQ" resolve="text" />
-                                          </node>
-                                        </node>
-                                      </node>
-                                    </node>
-                                    <node concept="3clFbH" id="5OsvY4h0oPb" role="3cqZAp" />
-                                    <node concept="3cpWs8" id="76BPPvEkmzc" role="3cqZAp">
-                                      <node concept="3cpWsn" id="76BPPvEkmzd" role="3cpWs9">
-                                        <property role="TrG5h" value="caretPosition" />
-                                        <node concept="3uibUv" id="76BPPvEkmza" role="1tU5fm">
-                                          <ref role="3uigEE" to="czm:1xDazL6RYY7" resolve="SavedCaretPosition" />
-                                        </node>
-                                        <node concept="2ShNRf" id="76BPPvEkmze" role="33vP2m">
-                                          <node concept="1pGfFk" id="3NNwv8WtHgp" role="2ShVmc">
-                                            <ref role="37wK5l" to="czm:3NNwv8WqPSm" resolve="SavedCaretPosition" />
-                                            <node concept="37vLTw" id="3NNwv8WtHiA" role="37wK5m">
-                                              <ref role="3cqZAo" node="3lRTV5HqInC" resolve="editorContext" />
-                                            </node>
-                                          </node>
-                                        </node>
-                                      </node>
-                                    </node>
-                                    <node concept="3clFbF" id="76BPPvEkgT$" role="3cqZAp">
-                                      <node concept="2OqwBi" id="76BPPvEkn1L" role="3clFbG">
-                                        <node concept="37vLTw" id="76BPPvEkmzg" role="2Oq$k0">
-                                          <ref role="3cqZAo" node="76BPPvEkmzd" resolve="caretPosition" />
-                                        </node>
-                                        <node concept="liA8E" id="76BPPvEknel" role="2OqNvi">
-                                          <ref role="37wK5l" to="czm:76BPPvEi375" resolve="save" />
-                                        </node>
-                                      </node>
-                                    </node>
-                                    <node concept="3cpWs8" id="1QxZEGNZWPc" role="3cqZAp">
-                                      <node concept="3cpWsn" id="1QxZEGNZWPd" role="3cpWs9">
-                                        <property role="TrG5h" value="parser" />
-                                        <node concept="3uibUv" id="1QxZEGNZWP7" role="1tU5fm">
-                                          <ref role="3uigEE" to="czm:2TSIj8m0Ksb" resolve="Parser" />
-                                        </node>
-                                        <node concept="2ShNRf" id="1QxZEGNZWPe" role="33vP2m">
-                                          <node concept="1pGfFk" id="1QxZEGNZWPf" role="2ShVmc">
-                                            <ref role="37wK5l" to="czm:5OsvY4g$ZXe" resolve="Parser" />
-                                            <node concept="2OqwBi" id="1QxZEGNZWPg" role="37wK5m">
-                                              <node concept="37vLTw" id="1QxZEGNZWPh" role="2Oq$k0">
-                                                <ref role="3cqZAo" node="3lRTV5HqImS" resolve="sourceNode" />
-                                              </node>
-                                              <node concept="I4A8Y" id="1QxZEGNZWPi" role="2OqNvi" />
-                                            </node>
-                                          </node>
-                                        </node>
-                                      </node>
-                                    </node>
-                                    <node concept="3cpWs8" id="5OsvY4h1v6z" role="3cqZAp">
-                                      <node concept="3cpWsn" id="5OsvY4h1v6$" role="3cpWs9">
-                                        <property role="TrG5h" value="newTree" />
-                                        <node concept="3Tqbb2" id="5OsvY4h1v6p" role="1tU5fm" />
-                                        <node concept="2OqwBi" id="5OsvY4h1v6_" role="33vP2m">
-                                          <node concept="37vLTw" id="1QxZEGNZWPj" role="2Oq$k0">
-                                            <ref role="3cqZAo" node="1QxZEGNZWPd" resolve="parser" />
-                                          </node>
-                                          <node concept="liA8E" id="5OsvY4h1v6F" role="2OqNvi">
-                                            <ref role="37wK5l" to="czm:2TSIj8m0Kt6" resolve="processAfterTextInsert" />
-                                            <node concept="2OqwBi" id="1QxZEGNZXWa" role="37wK5m">
-                                              <node concept="37vLTw" id="1QxZEGNZXU4" role="2Oq$k0">
-                                                <ref role="3cqZAo" node="1QxZEGNZWPd" resolve="parser" />
-                                              </node>
-                                              <node concept="liA8E" id="1QxZEGNZYvw" role="2OqNvi">
-                                                <ref role="37wK5l" to="czm:1QxZEGNZN1b" resolve="findRootExpression" />
-                                                <node concept="37vLTw" id="1QxZEGO0cJY" role="37wK5m">
-                                                  <ref role="3cqZAo" node="3lRTV5HqImS" resolve="sourceNode" />
-                                                </node>
-                                              </node>
-                                            </node>
-                                          </node>
-                                        </node>
-                                      </node>
-                                    </node>
-                                    <node concept="3clFbJ" id="5OsvY4h1whJ" role="3cqZAp">
-                                      <node concept="3clFbS" id="5OsvY4h1whL" role="3clFbx">
-                                        <node concept="3clFbF" id="76BPPvEknPu" role="3cqZAp">
-                                          <node concept="2OqwBi" id="76BPPvEkoc7" role="3clFbG">
-                                            <node concept="37vLTw" id="76BPPvEknPt" role="2Oq$k0">
-                                              <ref role="3cqZAo" node="3lRTV5HqInC" resolve="editorContext" />
-                                            </node>
-                                            <node concept="liA8E" id="76BPPvEkohi" role="2OqNvi">
-                                              <ref role="37wK5l" to="cj4x:~EditorContext.flushEvents()" resolve="flushEvents" />
-                                            </node>
-                                          </node>
-                                        </node>
-                                        <node concept="3clFbF" id="76BPPvEkoDp" role="3cqZAp">
-                                          <node concept="2OqwBi" id="76BPPvEkoP5" role="3clFbG">
-                                            <node concept="37vLTw" id="76BPPvEkoDn" role="2Oq$k0">
-                                              <ref role="3cqZAo" node="76BPPvEkmzd" resolve="caretPosition" />
-                                            </node>
-                                            <node concept="liA8E" id="76BPPvEkoTC" role="2OqNvi">
-                                              <ref role="37wK5l" to="czm:76BPPvEi3ct" resolve="restore" />
-                                            </node>
-                                          </node>
-                                        </node>
-                                      </node>
-                                      <node concept="3y3z36" id="5OsvY4h1wRv" role="3clFbw">
-                                        <node concept="10Nm6u" id="5OsvY4h1wYK" role="3uHU7w" />
-                                        <node concept="37vLTw" id="5OsvY4h1wzc" role="3uHU7B">
-                                          <ref role="3cqZAo" node="5OsvY4h1v6$" resolve="newTree" />
-                                        </node>
-                                      </node>
-                                    </node>
-                                    <node concept="3clFbH" id="5OsvY4h0pa5" role="3cqZAp" />
-                                    <node concept="3cpWs6" id="3lRTV5Hr2Xo" role="3cqZAp">
-                                      <node concept="10Nm6u" id="6YjZr6QpUHz" role="3cqZAk" />
-                                    </node>
-                                  </node>
-                                </node>
-                                <node concept="3clFb_" id="2c84p9Pul56" role="jymVt">
-                                  <property role="1EzhhJ" value="false" />
-                                  <property role="TrG5h" value="getOutputConcept" />
-                                  <property role="DiZV1" value="false" />
-                                  <property role="od$2w" value="false" />
-                                  <node concept="3uibUv" id="My09KioQkP" role="3clF45">
-                                    <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
-                                  </node>
-                                  <node concept="3Tm1VV" id="2c84p9Pul57" role="1B3o_S" />
-                                  <node concept="3clFbS" id="2c84p9Pul59" role="3clF47">
-                                    <node concept="3clFbF" id="2c84p9Pul5a" role="3cqZAp">
-                                      <node concept="35c_gC" id="2c84p9Pul5b" role="3clFbG">
-                                        <ref role="35c_gD" to="tpck:gw2VY9q" resolve="BaseConcept" />
-                                        <node concept="1ZhdrF" id="2c84p9Pul5c" role="lGtFl">
-                                          <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/2644386474300074836/2644386474300074837" />
-                                          <property role="2qtEX8" value="conceptDeclaration" />
-                                          <node concept="3$xsQk" id="2c84p9Pul5d" role="3$ytzL">
-                                            <node concept="3clFbS" id="2c84p9Pul5e" role="2VODD2">
-                                              <node concept="3clFbF" id="2c84p9Pul5f" role="3cqZAp">
-                                                <node concept="2OqwBi" id="2c84p9Pul5g" role="3clFbG">
-                                                  <node concept="2OqwBi" id="2c84p9Pul5h" role="2Oq$k0">
-                                                    <node concept="30H73N" id="2c84p9Pul5i" role="2Oq$k0" />
-                                                    <node concept="2Xjw5R" id="2c84p9Pul5j" role="2OqNvi">
-                                                      <node concept="1xMEDy" id="2c84p9Pul5k" role="1xVPHs">
-                                                        <node concept="chp4Y" id="2c84p9Pul5l" role="ri$Ld">
-                                                          <ref role="cht4Q" to="tpc2:gXXWOiD" resolve="AbstractComponent" />
-                                                        </node>
-                                                      </node>
-                                                    </node>
-                                                  </node>
-                                                  <node concept="2qgKlT" id="2c84p9Pul5m" role="2OqNvi">
-                                                    <ref role="37wK5l" to="tpcb:67EYkym$wx3" resolve="getConceptDeclaration" />
-                                                  </node>
-                                                </node>
-                                              </node>
-                                            </node>
-                                          </node>
-                                        </node>
-                                      </node>
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3y3z36" id="6B579NGDYIe" role="3clFbw">
-                    <node concept="10Nm6u" id="6B579NGDYNZ" role="3uHU7w" />
-                    <node concept="37vLTw" id="6B579NGDY_t" role="3uHU7B">
-                      <ref role="3cqZAo" node="3lRTV5HqImS" resolve="sourceNode" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="raruj" id="3lRTV5HqIpR" role="lGtFl" />
-            </node>
-            <node concept="3clFbH" id="3lRTV5HqIpS" role="3cqZAp" />
-            <node concept="3cpWs6" id="3lRTV5HqIpT" role="3cqZAp">
-              <node concept="37vLTw" id="3lRTV5HqIpU" role="3cqZAk">
-                <ref role="3cqZAo" node="3lRTV5HqImC" resolve="result" />
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-    </node>
     <node concept="3aamgX" id="4eBi5gdp21V" role="3aUrZf">
       <property role="36QftV" value="true" />
       <ref role="30HIoZ" to="teg0:6jH9yJK30xr" resolve="SideTransformationCell" />
@@ -18370,36 +17053,48 @@
             </node>
           </node>
           <node concept="3clFbF" id="4qdNcHzYzb4" role="3cqZAp">
-            <node concept="22lmx$" id="3KoBPk189JJ" role="3clFbG">
-              <node concept="2OqwBi" id="3KoBPk18a3J" role="3uHU7w">
-                <node concept="37vLTw" id="3KoBPk189SX" role="2Oq$k0">
-                  <ref role="3cqZAo" node="4qdNcHzYKEB" resolve="firstNonConst" />
+            <node concept="22lmx$" id="5ycts4Sf7oV" role="3clFbG">
+              <node concept="22lmx$" id="3KoBPk189JJ" role="3uHU7B">
+                <node concept="22lmx$" id="7KznU_3Xr_S" role="3uHU7B">
+                  <node concept="2OqwBi" id="4qdNcHzYJWi" role="3uHU7B">
+                    <node concept="37vLTw" id="4qdNcHzYKF4" role="2Oq$k0">
+                      <ref role="3cqZAo" node="4qdNcHzYKEB" resolve="firstNonConst" />
+                    </node>
+                    <node concept="1mIQ4w" id="4qdNcHzYKhe" role="2OqNvi">
+                      <node concept="chp4Y" id="4qdNcHzYKpU" role="cj9EA">
+                        <ref role="cht4Q" to="tpc2:fBF1sR7" resolve="CellModel_RefNode" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="7KznU_3XrRG" role="3uHU7w">
+                    <node concept="37vLTw" id="7KznU_3XrGl" role="2Oq$k0">
+                      <ref role="3cqZAo" node="4qdNcHzYKEB" resolve="firstNonConst" />
+                    </node>
+                    <node concept="1mIQ4w" id="7KznU_3XsaD" role="2OqNvi">
+                      <node concept="chp4Y" id="7KznU_3Xskp" role="cj9EA">
+                        <ref role="cht4Q" to="tpc2:fBF2Hee" resolve="CellModel_RefNodeList" />
+                      </node>
+                    </node>
+                  </node>
                 </node>
-                <node concept="1mIQ4w" id="3KoBPk18alZ" role="2OqNvi">
-                  <node concept="chp4Y" id="3KoBPk18av8" role="cj9EA">
-                    <ref role="cht4Q" to="tpc2:fBF0A4I" resolve="CellModel_Property" />
+                <node concept="2OqwBi" id="3KoBPk18a3J" role="3uHU7w">
+                  <node concept="37vLTw" id="3KoBPk189SX" role="2Oq$k0">
+                    <ref role="3cqZAo" node="4qdNcHzYKEB" resolve="firstNonConst" />
+                  </node>
+                  <node concept="1mIQ4w" id="3KoBPk18alZ" role="2OqNvi">
+                    <node concept="chp4Y" id="3KoBPk18av8" role="cj9EA">
+                      <ref role="cht4Q" to="tpc2:fBF0A4I" resolve="CellModel_Property" />
+                    </node>
                   </node>
                 </node>
               </node>
-              <node concept="22lmx$" id="7KznU_3Xr_S" role="3uHU7B">
-                <node concept="2OqwBi" id="4qdNcHzYJWi" role="3uHU7B">
-                  <node concept="37vLTw" id="4qdNcHzYKF4" role="2Oq$k0">
-                    <ref role="3cqZAo" node="4qdNcHzYKEB" resolve="firstNonConst" />
-                  </node>
-                  <node concept="1mIQ4w" id="4qdNcHzYKhe" role="2OqNvi">
-                    <node concept="chp4Y" id="4qdNcHzYKpU" role="cj9EA">
-                      <ref role="cht4Q" to="tpc2:fBF1sR7" resolve="CellModel_RefNode" />
-                    </node>
-                  </node>
+              <node concept="2OqwBi" id="5ycts4Sf7Y0" role="3uHU7w">
+                <node concept="37vLTw" id="5ycts4Sf7Y1" role="2Oq$k0">
+                  <ref role="3cqZAo" node="4qdNcHzYKEB" resolve="firstNonConst" />
                 </node>
-                <node concept="2OqwBi" id="7KznU_3XrRG" role="3uHU7w">
-                  <node concept="37vLTw" id="7KznU_3XrGl" role="2Oq$k0">
-                    <ref role="3cqZAo" node="4qdNcHzYKEB" resolve="firstNonConst" />
-                  </node>
-                  <node concept="1mIQ4w" id="7KznU_3XsaD" role="2OqNvi">
-                    <node concept="chp4Y" id="7KznU_3Xskp" role="cj9EA">
-                      <ref role="cht4Q" to="tpc2:fBF2Hee" resolve="CellModel_RefNodeList" />
-                    </node>
+                <node concept="1mIQ4w" id="5ycts4Sf7Y2" role="2OqNvi">
+                  <node concept="chp4Y" id="5ycts4Sf8E3" role="cj9EA">
+                    <ref role="cht4Q" to="tpc2:fPiCG$y" resolve="CellModel_RefCell" />
                   </node>
                 </node>
               </node>
@@ -18656,9 +17351,6 @@
                     </node>
                     <node concept="3clFbF" id="ifzjJo5yaX" role="3cqZAp">
                       <node concept="3vZ8ra" id="ifzjJo5yaY" role="3clFbG">
-                        <node concept="37vLTw" id="ifzjJo5yb8" role="37vLTJ">
-                          <ref role="3cqZAo" node="ifzjJo5yaJ" resolve="transformationEnabled" />
-                        </node>
                         <node concept="2YIFZM" id="1iGw5CbiNfh" role="37vLTx">
                           <ref role="37wK5l" to="czm:1iGw5Cbi$yl" resolve="canBeAncestor" />
                           <ref role="1Pybhc" to="czm:RbLMy696h3" resolve="GrammarCellsUtil" />
@@ -18683,6 +17375,9 @@
                               <ref role="37wK5l" to="mhbf:~SNode.getContainmentLink()" resolve="getContainmentLink" />
                             </node>
                           </node>
+                        </node>
+                        <node concept="37vLTw" id="ifzjJo5yb8" role="37vLTJ">
+                          <ref role="3cqZAo" node="ifzjJo5yaJ" resolve="transformationEnabled" />
                         </node>
                       </node>
                     </node>
@@ -20713,9 +19408,6 @@
                                           </node>
                                           <node concept="3clFbF" id="1MG9P_Yg8e0" role="3cqZAp">
                                             <node concept="3vZ8ra" id="1MG9P_Yg9_E" role="3clFbG">
-                                              <node concept="37vLTw" id="1MG9P_Yg8dY" role="37vLTJ">
-                                                <ref role="3cqZAo" node="49FqtR5VyJY" resolve="sideTransformationEnabled" />
-                                              </node>
                                               <node concept="2YIFZM" id="1iGw5CbiQF5" role="37vLTx">
                                                 <ref role="37wK5l" to="czm:1iGw5Cbi$yl" resolve="canBeAncestor" />
                                                 <ref role="1Pybhc" to="czm:RbLMy696h3" resolve="GrammarCellsUtil" />
@@ -20739,13 +19431,13 @@
                                                   </node>
                                                 </node>
                                               </node>
+                                              <node concept="37vLTw" id="1MG9P_Yg8dY" role="37vLTJ">
+                                                <ref role="3cqZAo" node="49FqtR5VyJY" resolve="sideTransformationEnabled" />
+                                              </node>
                                             </node>
                                           </node>
                                           <node concept="3clFbF" id="2ILUSdpDRKJ" role="3cqZAp">
                                             <node concept="3vZ8ra" id="2ILUSdpDRKK" role="3clFbG">
-                                              <node concept="37vLTw" id="2ILUSdpDRKV" role="37vLTJ">
-                                                <ref role="3cqZAo" node="49FqtR5VyJY" resolve="sideTransformationEnabled" />
-                                              </node>
                                               <node concept="2OqwBi" id="6g_o1CJEY$S" role="37vLTx">
                                                 <node concept="2YIFZM" id="6g_o1CJEWBT" role="2Oq$k0">
                                                   <ref role="37wK5l" to="ykok:~ConstraintsCanBeFacade.checkCanBeChild(jetbrains.mps.core.aspects.constraints.rules.kinds.ContainmentContext)" resolve="checkCanBeChild" />
@@ -20798,6 +19490,9 @@
                                                 <node concept="liA8E" id="6g_o1CJF09R" role="2OqNvi">
                                                   <ref role="37wK5l" to="33ny:~List.isEmpty()" resolve="isEmpty" />
                                                 </node>
+                                              </node>
+                                              <node concept="37vLTw" id="2ILUSdpDRKV" role="37vLTJ">
+                                                <ref role="3cqZAo" node="49FqtR5VyJY" resolve="sideTransformationEnabled" />
                                               </node>
                                             </node>
                                           </node>
@@ -25457,6 +24152,138 @@
         </node>
       </node>
     </node>
+    <node concept="3aamgX" id="5ycts4SicY1" role="3aUrZf">
+      <property role="36QftV" value="true" />
+      <ref role="30HIoZ" to="teg0:4qdNcHzYfBo" resolve="OptionalCell" />
+      <node concept="1Koe21" id="5ycts4SicY2" role="1lVwrX">
+        <node concept="pkWqt" id="5ycts4SicY3" role="1Koe22">
+          <node concept="3clFbS" id="5ycts4SicY4" role="2VODD2">
+            <node concept="3clFbF" id="5ycts4SicY5" role="3cqZAp">
+              <node concept="3y3z36" id="5ycts4SicY6" role="3clFbG">
+                <node concept="2OqwBi" id="5ycts4SicY7" role="3uHU7B">
+                  <node concept="2JrnkZ" id="5ycts4SicY8" role="2Oq$k0">
+                    <node concept="pncrf" id="5ycts4SicY9" role="2JrQYb" />
+                  </node>
+                  <node concept="liA8E" id="5ycts4SicYa" role="2OqNvi">
+                    <ref role="37wK5l" to="mhbf:~SNode.getReference(org.jetbrains.mps.openapi.language.SReferenceLink)" resolve="getReference" />
+                    <node concept="359W_D" id="5ycts4Sif5s" role="37wK5m">
+                      <ref role="359W_E" to="tpee:fz7vLUo" resolve="VariableReference" />
+                      <ref role="359W_F" to="tpee:fzcqZ_w" resolve="variableDeclaration" />
+                      <node concept="1ZhdrF" id="5ycts4SifZw" role="lGtFl">
+                        <property role="2qtEX8" value="conceptDeclaration" />
+                        <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/2644386474301421077/2644386474301421078" />
+                        <node concept="3$xsQk" id="5ycts4SifZx" role="3$ytzL">
+                          <node concept="3clFbS" id="5ycts4SifZy" role="2VODD2">
+                            <node concept="3clFbF" id="5ycts4SignK" role="3cqZAp">
+                              <node concept="2OqwBi" id="5ycts4SignL" role="3clFbG">
+                                <node concept="2OqwBi" id="5ycts4SignM" role="2Oq$k0">
+                                  <node concept="30H73N" id="5ycts4SignN" role="2Oq$k0" />
+                                  <node concept="2Xjw5R" id="5ycts4SignO" role="2OqNvi">
+                                    <node concept="1xMEDy" id="5ycts4SignP" role="1xVPHs">
+                                      <node concept="chp4Y" id="5ycts4SignQ" role="ri$Ld">
+                                        <ref role="cht4Q" to="tpc2:gXXWOiD" resolve="AbstractComponent" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                                <node concept="2qgKlT" id="5ycts4SignR" role="2OqNvi">
+                                  <ref role="37wK5l" to="tpcb:67EYkym$wx3" resolve="getConceptDeclaration" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="1ZhdrF" id="5ycts4SigWA" role="lGtFl">
+                        <property role="2qtEX8" value="linkDeclaration" />
+                        <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/2644386474301421077/2644386474301421079" />
+                        <node concept="3$xsQk" id="5ycts4SigWB" role="3$ytzL">
+                          <node concept="3clFbS" id="5ycts4SigWC" role="2VODD2">
+                            <node concept="3clFbF" id="5ycts4Sih1X" role="3cqZAp">
+                              <node concept="2OqwBi" id="5ycts4Sih1Y" role="3clFbG">
+                                <node concept="1PxgMI" id="5ycts4Sih1Z" role="2Oq$k0">
+                                  <node concept="chp4Y" id="5ycts4SihQm" role="3oSUPX">
+                                    <ref role="cht4Q" to="tpc2:fPiCG$y" resolve="CellModel_RefCell" />
+                                  </node>
+                                  <node concept="2OqwBi" id="5ycts4Sih21" role="1m5AlR">
+                                    <node concept="30H73N" id="5ycts4Sih22" role="2Oq$k0" />
+                                    <node concept="2qgKlT" id="5ycts4Sih23" role="2OqNvi">
+                                      <ref role="37wK5l" to="karh:7KznU_3XzU4" resolve="getFirstNonConst" />
+                                    </node>
+                                  </node>
+                                </node>
+                                <node concept="3TrEf2" id="5ycts4Sij8u" role="2OqNvi">
+                                  <ref role="3Tt5mk" to="tpc2:fPiD8ey" resolve="linkDeclaration" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="10Nm6u" id="5ycts4SicYy" role="3uHU7w" />
+                <node concept="raruj" id="5ycts4SicYz" role="lGtFl" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="30G5F_" id="5ycts4SicY$" role="30HLyM">
+        <node concept="3clFbS" id="5ycts4SicY_" role="2VODD2">
+          <node concept="3clFbJ" id="5ycts4SicYA" role="3cqZAp">
+            <node concept="3clFbS" id="5ycts4SicYB" role="3clFbx">
+              <node concept="3cpWs6" id="5ycts4SicYC" role="3cqZAp">
+                <node concept="3clFbT" id="5ycts4SicYD" role="3cqZAk">
+                  <property role="3clFbU" value="false" />
+                </node>
+              </node>
+            </node>
+            <node concept="2OqwBi" id="5ycts4SicYE" role="3clFbw">
+              <node concept="2OqwBi" id="5ycts4SicYF" role="2Oq$k0">
+                <node concept="2OqwBi" id="5ycts4SicYG" role="2Oq$k0">
+                  <node concept="30H73N" id="5ycts4SicYH" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="5ycts4SicYI" role="2OqNvi">
+                    <ref role="3Tt5mk" to="teg0:4qdNcHzYfBp" resolve="option" />
+                  </node>
+                </node>
+                <node concept="3TrEf2" id="5ycts4SicYJ" role="2OqNvi">
+                  <ref role="3Tt5mk" to="tpc2:gCpqm6p" resolve="renderingCondition" />
+                </node>
+              </node>
+              <node concept="3x8VRR" id="5ycts4SicYK" role="2OqNvi" />
+            </node>
+          </node>
+          <node concept="3cpWs8" id="5ycts4SicYL" role="3cqZAp">
+            <node concept="3cpWsn" id="5ycts4SicYM" role="3cpWs9">
+              <property role="TrG5h" value="firstNonConst" />
+              <node concept="3Tqbb2" id="5ycts4SicYN" role="1tU5fm">
+                <ref role="ehGHo" to="tpc2:fBEYTCT" resolve="EditorCellModel" />
+              </node>
+              <node concept="2OqwBi" id="5ycts4SicYO" role="33vP2m">
+                <node concept="30H73N" id="5ycts4SicYP" role="2Oq$k0" />
+                <node concept="2qgKlT" id="5ycts4SicYQ" role="2OqNvi">
+                  <ref role="37wK5l" to="karh:7KznU_3XzU4" resolve="getFirstNonConst" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="5ycts4SicYR" role="3cqZAp">
+            <node concept="2OqwBi" id="5ycts4SicYS" role="3clFbG">
+              <node concept="37vLTw" id="5ycts4SicYT" role="2Oq$k0">
+                <ref role="3cqZAo" node="5ycts4SicYM" resolve="firstNonConst" />
+              </node>
+              <node concept="1mIQ4w" id="5ycts4SicYU" role="2OqNvi">
+                <node concept="chp4Y" id="5ycts4Sie9J" role="cj9EA">
+                  <ref role="cht4Q" to="tpc2:fPiCG$y" resolve="CellModel_RefCell" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
     <node concept="gft3U" id="4eBi5gdxGbZ" role="jxRDz">
       <node concept="3clFbT" id="4eBi5gdxGc9" role="gfFT$">
         <property role="3clFbU" value="true" />
@@ -25543,7 +24370,7 @@
     </node>
   </node>
   <node concept="bUwia" id="3pFNVizFeDW">
-    <property role="TrG5h" value="mc09_splittableCell" />
+    <property role="TrG5h" value="mc09_reduceCells" />
     <node concept="3aamgX" id="48TKAW3Vg0C" role="3acgRq">
       <ref role="30HIoZ" to="teg0:3pFNVizDvwD" resolve="SplittableCell" />
       <node concept="1Koe21" id="48TKAW3Vg0D" role="1lVwrX">
@@ -25591,6 +24418,50 @@
                     </node>
                   </node>
                 </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3aamgX" id="DnjeukFymF" role="3acgRq">
+      <ref role="30HIoZ" to="teg0:Dnjeuk_JIi" resolve="SideTransformationCell4" />
+      <node concept="1Koe21" id="DnjeukFymG" role="1lVwrX">
+        <node concept="9aQIb" id="DnjeukFymH" role="1Koe22">
+          <node concept="3clFbS" id="DnjeukFymI" role="9aQI4">
+            <node concept="3clFbH" id="DnjeukFymJ" role="3cqZAp">
+              <node concept="raruj" id="DnjeukFymK" role="lGtFl" />
+              <node concept="5jKBG" id="DnjeukFymL" role="lGtFl">
+                <property role="34cw8o" value="Replaces original reduce_CellModel_WithRole with some code from reduce_CellModel_Property to properly provide cell context" />
+                <ref role="v9R2y" node="DnjeukFysO" resolve="reduce_SideTransformationCell4" />
+              </node>
+            </node>
+            <node concept="3clFbH" id="DnjeukFymM" role="3cqZAp">
+              <node concept="raruj" id="DnjeukFymN" role="lGtFl" />
+              <node concept="5jKBG" id="DnjeukFymO" role="lGtFl">
+                <ref role="v9R2y" to="tpc3:2dv1ickkgDx" resolve="template_EditorCellModel_CommonMethods" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3aamgX" id="DnjeukPq03" role="3acgRq">
+      <ref role="30HIoZ" to="teg0:DnjeukLXrb" resolve="SideTransformationHolderProcessor" />
+      <node concept="1Koe21" id="DnjeukPq04" role="1lVwrX">
+        <node concept="9aQIb" id="DnjeukPq05" role="1Koe22">
+          <node concept="3clFbS" id="DnjeukPq06" role="9aQI4">
+            <node concept="3clFbH" id="DnjeukPq07" role="3cqZAp">
+              <node concept="raruj" id="DnjeukPq08" role="lGtFl" />
+              <node concept="5jKBG" id="DnjeukPq09" role="lGtFl">
+                <property role="34cw8o" value="Replaces original reduce_CellModel_WithRole with some code from reduce_CellModel_Property to properly provide cell context" />
+                <ref role="v9R2y" node="DnjeukO96L" resolve="reduce_SideTransformationHolderProcessor" />
+              </node>
+            </node>
+            <node concept="3clFbH" id="DnjeukPq0a" role="3cqZAp">
+              <node concept="raruj" id="DnjeukPq0b" role="lGtFl" />
+              <node concept="5jKBG" id="DnjeukPq0c" role="lGtFl">
+                <ref role="v9R2y" to="tpc3:2dv1ickkgDx" resolve="template_EditorCellModel_CommonMethods" />
               </node>
             </node>
           </node>
@@ -26147,13 +25018,20 @@
       <property role="36QftV" value="true" />
       <ref role="30HIoZ" to="teg0:1YKLYyyFscL" resolve="GrammarCellsTransformationMenuPart" />
       <node concept="j$656" id="1YKLYyyGeZL" role="1lVwrX">
-        <ref role="v9R2y" node="4sA1wziPZCJ" resolve="GrammarCellsTransformationMenuPart_declar" />
+        <ref role="v9R2y" node="4sA1wziPZCJ" resolve="GrammarCellsTransformationMenuPart_declare" />
+      </node>
+    </node>
+    <node concept="3aamgX" id="6rGQ0fkujsm" role="3aUrZf">
+      <property role="36QftV" value="true" />
+      <ref role="30HIoZ" to="teg0:6rGQ0fksByM" resolve="GenericMenuPart" />
+      <node concept="j$656" id="6rGQ0fkukQ7" role="1lVwrX">
+        <ref role="v9R2y" node="6rGQ0fkujJE" resolve="GenericTransformationMenuPart_declare" />
       </node>
     </node>
   </node>
   <node concept="13MO4I" id="4sA1wziPZCJ">
     <property role="3GE5qa" value="menu" />
-    <property role="TrG5h" value="GrammarCellsTransformationMenuPart_declar" />
+    <property role="TrG5h" value="GrammarCellsTransformationMenuPart_declare" />
     <ref role="3gUMe" to="teg0:1YKLYyyFscL" resolve="GrammarCellsTransformationMenuPart" />
     <node concept="312cEu" id="4sA1wziPZCL" role="13RCb5">
       <property role="2bfB8j" value="true" />
@@ -27422,6 +26300,1104 @@
       <node concept="3Tm1VV" id="3dIwcSTz3I$" role="1B3o_S" />
       <node concept="3uibUv" id="3dIwcSTACR6" role="1zkMxy">
         <ref role="3uigEE" to="tpc3:7GOmDNDyRby" resolve="CellFactoryContextClass" />
+      </node>
+    </node>
+  </node>
+  <node concept="jVnub" id="1_3xoKENt9Q">
+    <property role="TrG5h" value="switch_TransformationMenuReference_grammarCells" />
+    <ref role="phYkn" to="tpc3:5OVd5tVfkL1" resolve="switch_TransformationMenuReference" />
+    <node concept="3aamgX" id="5OVd5tVfkL2" role="3aUrZf">
+      <property role="36QftV" value="true" />
+      <ref role="30HIoZ" to="teg0:1_3xoKEN8C6" resolve="CompositeTransformationMenuReference" />
+      <node concept="1Koe21" id="2iPX_MahQRe" role="1lVwrX">
+        <node concept="312cEu" id="6Gy7Oe2S8Db" role="1Koe22">
+          <property role="TrG5h" value="ContextClass" />
+          <property role="1sVAO0" value="true" />
+          <node concept="3uibUv" id="13IiccQfPae" role="1zkMxy">
+            <ref role="3uigEE" to="tpc3:7GOmDNDyRby" resolve="CellFactoryContextClass" />
+          </node>
+          <node concept="2tJIrI" id="6Gy7Oe2S8Dk" role="jymVt" />
+          <node concept="3clFb_" id="7_xM8AG1Qtn" role="jymVt">
+            <property role="DiZV1" value="false" />
+            <property role="od$2w" value="false" />
+            <property role="2aFKle" value="false" />
+            <property role="TrG5h" value="lookup" />
+            <node concept="3cqZAl" id="1_3xoKENPdV" role="3clF45" />
+            <node concept="3clFbS" id="7_xM8AG1Qtp" role="3clF47">
+              <node concept="3cpWs8" id="1_3xoKENwd6" role="3cqZAp">
+                <node concept="3cpWsn" id="1_3xoKENwd7" role="3cpWs9">
+                  <property role="TrG5h" value="editorCell" />
+                  <node concept="3uibUv" id="1_3xoKENwd8" role="1tU5fm">
+                    <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+                  </node>
+                  <node concept="10Nm6u" id="1_3xoKENP0o" role="33vP2m" />
+                </node>
+              </node>
+              <node concept="3clFbF" id="1_3xoKENwqX" role="3cqZAp">
+                <node concept="2OqwBi" id="1_3xoKENwB7" role="3clFbG">
+                  <node concept="37vLTw" id="1_3xoKENwqV" role="2Oq$k0">
+                    <ref role="3cqZAo" node="1_3xoKENwd7" resolve="editorCell" />
+                  </node>
+                  <node concept="liA8E" id="1_3xoKENwO_" role="2OqNvi">
+                    <ref role="37wK5l" to="f4zo:~EditorCell.setTransformationMenuLookup(jetbrains.mps.openapi.editor.menus.transformation.TransformationMenuLookup)" resolve="setTransformationMenuLookup" />
+                    <node concept="2YIFZM" id="1_3xoKENN56" role="37wK5m">
+                      <ref role="37wK5l" to="gdpt:1_3xoKENEY7" resolve="combine" />
+                      <ref role="1Pybhc" to="gdpt:1_3xoKENxnx" resolve="CompositeTransformationMenuLookup" />
+                      <node concept="2OqwBi" id="1_3xoKENwY5" role="37wK5m">
+                        <node concept="37vLTw" id="1_3xoKENwQj" role="2Oq$k0">
+                          <ref role="3cqZAo" node="1_3xoKENwd7" resolve="editorCell" />
+                        </node>
+                        <node concept="liA8E" id="1_3xoKENxbE" role="2OqNvi">
+                          <ref role="37wK5l" to="f4zo:~EditorCell.getTransformationMenuLookup()" resolve="getTransformationMenuLookup" />
+                        </node>
+                      </node>
+                      <node concept="10Nm6u" id="1_3xoKENNb$" role="37wK5m">
+                        <node concept="1sPUBX" id="1_3xoKENNfA" role="lGtFl">
+                          <ref role="v9R2y" to="tpc3:5OVd5tVfkL1" resolve="switch_TransformationMenuReference" />
+                          <node concept="v3LJS" id="1_3xoKENNk9" role="v9R3O">
+                            <ref role="v3LJV" node="1_3xoKENtba" resolve="useEditorContextVar" />
+                          </node>
+                          <node concept="3NFfHV" id="1_3xoKERvT5" role="1sPUBK">
+                            <node concept="3clFbS" id="1_3xoKERvT6" role="2VODD2">
+                              <node concept="3clFbF" id="1_3xoKERvT_" role="3cqZAp">
+                                <node concept="2OqwBi" id="1_3xoKERw5J" role="3clFbG">
+                                  <node concept="30H73N" id="1_3xoKERvT$" role="2Oq$k0" />
+                                  <node concept="3TrEf2" id="1_3xoKERwmX" role="2OqNvi">
+                                    <ref role="3Tt5mk" to="teg0:1_3xoKEN8Cp" resolve="menu" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="raruj" id="1_3xoKENNo7" role="lGtFl" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3Tm1VV" id="7_xM8AG1Qts" role="1B3o_S" />
+            <node concept="37vLTG" id="7_xM8AG2h5G" role="3clF46">
+              <property role="TrG5h" value="editorContext" />
+              <node concept="3uibUv" id="7_xM8AG2h5F" role="1tU5fm">
+                <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+              </node>
+            </node>
+          </node>
+          <node concept="2tJIrI" id="6Gy7Oe2S8Dm" role="jymVt" />
+          <node concept="3Tm1VV" id="6Gy7Oe2S8Dc" role="1B3o_S" />
+        </node>
+      </node>
+      <node concept="30G5F_" id="1_3xoKETzFV" role="30HLyM">
+        <node concept="3clFbS" id="1_3xoKETzFW" role="2VODD2">
+          <node concept="3clFbF" id="1_3xoKETzNE" role="3cqZAp">
+            <node concept="3fqX7Q" id="1_3xoKET$MK" role="3clFbG">
+              <node concept="v3LJS" id="1_3xoKET$MM" role="3fr31v">
+                <ref role="v3LJV" node="1_3xoKENtba" resolve="useEditorContextVar" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1N15co" id="1_3xoKENtba" role="1s_3oS">
+      <property role="TrG5h" value="useEditorContextVar" />
+      <node concept="10P_77" id="1_3xoKENtbb" role="1N15GL" />
+    </node>
+  </node>
+  <node concept="bUwia" id="1ISNm4ViZiJ">
+    <property role="3GE5qa" value="menu" />
+    <property role="TrG5h" value="mc_menus" />
+    <node concept="3aamgX" id="1ISNm4ViZiK" role="3acgRq">
+      <ref role="30HIoZ" to="teg0:1ISNm4ViY99" resolve="TransformationLocation_Before" />
+      <node concept="gft3U" id="1ISNm4ViZiO" role="1lVwrX">
+        <node concept="10M0yZ" id="1ISNm4ViZjb" role="gfFT$">
+          <ref role="3cqZAo" to="gdpt:1ISNm4ViWfM" resolve="BEFORE" />
+          <ref role="1PxDUh" to="gdpt:1ISNm4ViWc0" resolve="GrammarCellsMenuLocations" />
+        </node>
+      </node>
+    </node>
+    <node concept="3aamgX" id="1ISNm4ViZpc" role="3acgRq">
+      <ref role="30HIoZ" to="teg0:1ISNm4ViYa4" resolve="TransformationLocation_After" />
+      <node concept="gft3U" id="1ISNm4ViZpd" role="1lVwrX">
+        <node concept="10M0yZ" id="1ISNm4ViZpL" role="gfFT$">
+          <ref role="3cqZAo" to="gdpt:1ISNm4ViXAF" resolve="AFTER" />
+          <ref role="1PxDUh" to="gdpt:1ISNm4ViWc0" resolve="GrammarCellsMenuLocations" />
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="jVnub" id="1ISNm4Vo25w">
+    <property role="3GE5qa" value="menu" />
+    <property role="TrG5h" value="switch_TransformationLocation_asExpressions_grammarcells" />
+    <ref role="phYkn" to="tpc3:3EZUZhmTWq7" resolve="switch_TransformationLocation_asExpressions" />
+    <node concept="3aamgX" id="Z45Y15hY9a" role="3aUrZf">
+      <ref role="30HIoZ" to="teg0:1ISNm4ViY99" resolve="TransformationLocation_Before" />
+      <node concept="gft3U" id="2fjyZB6_vOq" role="1lVwrX">
+        <node concept="10M0yZ" id="1ISNm4Vo26l" role="gfFT$">
+          <ref role="3cqZAo" to="gdpt:1ISNm4ViWfM" resolve="BEFORE" />
+          <ref role="1PxDUh" to="gdpt:1ISNm4ViWc0" resolve="GrammarCellsMenuLocations" />
+        </node>
+      </node>
+    </node>
+    <node concept="3aamgX" id="1ISNm4Vo2cm" role="3aUrZf">
+      <ref role="30HIoZ" to="teg0:1ISNm4ViYa4" resolve="TransformationLocation_After" />
+      <node concept="gft3U" id="1ISNm4Vo2cn" role="1lVwrX">
+        <node concept="10M0yZ" id="1ISNm4Vo2cV" role="gfFT$">
+          <ref role="3cqZAo" to="gdpt:1ISNm4ViXAF" resolve="AFTER" />
+          <ref role="1PxDUh" to="gdpt:1ISNm4ViWc0" resolve="GrammarCellsMenuLocations" />
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="jVnub" id="1ISNm4V$kyP">
+    <property role="3GE5qa" value="menu" />
+    <property role="TrG5h" value="switch_TransformationLocation_actionItemInterfaces_grammarcells" />
+    <ref role="phYkn" to="tpc3:6VgTvK0odUq" resolve="switch_TransformationLocation_actionItemInterfaces" />
+    <node concept="3aamgX" id="30NnNOohxj0" role="3aUrZf">
+      <property role="36QftV" value="true" />
+      <ref role="30HIoZ" to="teg0:1ISNm4Vw3eE" resolve="TransformationLocation_ContributionsToSideTranformation" />
+      <node concept="gft3U" id="6VgTvK0ospZ" role="1lVwrX">
+        <node concept="3uibUv" id="7QIuLTEdcTb" role="gfFT$">
+          <ref role="3uigEE" to="6lvu:~SideTransformCompletionActionItem" resolve="SideTransformCompletionActionItem" />
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="13MO4I" id="6rGQ0fkujJE">
+    <property role="3GE5qa" value="menu" />
+    <property role="TrG5h" value="GenericTransformationMenuPart_declare" />
+    <ref role="3gUMe" to="teg0:6rGQ0fksByM" resolve="GenericMenuPart" />
+    <node concept="312cEu" id="6rGQ0fkujJF" role="13RCb5">
+      <property role="2bfB8j" value="true" />
+      <property role="TrG5h" value="ContextClass" />
+      <node concept="312cEu" id="6rGQ0fkujJG" role="jymVt">
+        <property role="2bfB8j" value="true" />
+        <property role="1sVAO0" value="false" />
+        <property role="1EXbeo" value="false" />
+        <property role="TrG5h" value="GenericMenuPart" />
+        <node concept="2tJIrI" id="6rGQ0fkCQeg" role="jymVt" />
+        <node concept="3Tm6S6" id="6rGQ0fkujKg" role="1B3o_S" />
+        <node concept="raruj" id="6rGQ0fkujKh" role="lGtFl">
+          <ref role="2sdACS" to="tpc3:hG00Hig" resolve="generatedClass" />
+        </node>
+        <node concept="3uibUv" id="h6sCaJPX0e" role="EKbjA">
+          <ref role="3uigEE" to="v95p:~MenuPart" resolve="MenuPart" />
+          <node concept="3uibUv" id="h6sCaJPYFo" role="11_B2D">
+            <ref role="3uigEE" to="uddc:~TransformationMenuItem" resolve="TransformationMenuItem" />
+          </node>
+          <node concept="3uibUv" id="h6sCaJQ0no" role="11_B2D">
+            <ref role="3uigEE" to="uddc:~TransformationMenuContext" resolve="TransformationMenuContext" />
+          </node>
+        </node>
+        <node concept="3clFb_" id="6rGQ0fkCQkf" role="jymVt">
+          <property role="TrG5h" value="createItems" />
+          <node concept="3Tm1VV" id="6rGQ0fkCQkg" role="1B3o_S" />
+          <node concept="2AHcQZ" id="6rGQ0fkCQki" role="2AJF6D">
+            <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+          </node>
+          <node concept="3uibUv" id="6rGQ0fkCQkj" role="3clF45">
+            <ref role="3uigEE" to="33ny:~List" resolve="List" />
+            <node concept="3uibUv" id="6rGQ0fkCQko" role="11_B2D">
+              <ref role="3uigEE" to="uddc:~TransformationMenuItem" resolve="TransformationMenuItem" />
+            </node>
+          </node>
+          <node concept="37vLTG" id="6rGQ0fkCQkl" role="3clF46">
+            <property role="TrG5h" value="ctx" />
+            <property role="3TUv4t" value="true" />
+            <node concept="3uibUv" id="6rGQ0fkCQkn" role="1tU5fm">
+              <ref role="3uigEE" to="uddc:~TransformationMenuContext" resolve="TransformationMenuContext" />
+            </node>
+          </node>
+          <node concept="3clFbS" id="6rGQ0fkCQkp" role="3clF47">
+            <node concept="3clFbF" id="6rGQ0fkCQks" role="3cqZAp">
+              <node concept="10Nm6u" id="6rGQ0fkCQkr" role="3clFbG" />
+              <node concept="2b32R4" id="6rGQ0fkCQuw" role="lGtFl">
+                <node concept="3JmXsc" id="6rGQ0fkCQux" role="2P8S$">
+                  <node concept="3clFbS" id="6rGQ0fkCQuy" role="2VODD2">
+                    <node concept="3clFbF" id="6rGQ0fkCQy3" role="3cqZAp">
+                      <node concept="2OqwBi" id="6rGQ0fkCSkY" role="3clFbG">
+                        <node concept="2OqwBi" id="6rGQ0fkCRw8" role="2Oq$k0">
+                          <node concept="2OqwBi" id="6rGQ0fkCQJf" role="2Oq$k0">
+                            <node concept="30H73N" id="6rGQ0fkCQy2" role="2Oq$k0" />
+                            <node concept="3TrEf2" id="6rGQ0fkCRcr" role="2OqNvi">
+                              <ref role="3Tt5mk" to="teg0:6rGQ0fk$7YL" resolve="implementation" />
+                            </node>
+                          </node>
+                          <node concept="3TrEf2" id="6rGQ0fkCS3j" role="2OqNvi">
+                            <ref role="3Tt5mk" to="tpee:gyVODHa" resolve="body" />
+                          </node>
+                        </node>
+                        <node concept="3Tsc0h" id="6rGQ0fkCSW5" role="2OqNvi">
+                          <ref role="3TtcxE" to="tpee:fzcqZ_x" resolve="statement" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2AHcQZ" id="6rGQ0fkCQkq" role="2AJF6D">
+            <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+          </node>
+        </node>
+        <node concept="17Uvod" id="DnjeukfcNq" role="lGtFl">
+          <property role="2qtEX9" value="name" />
+          <property role="P4ACc" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c/1169194658468/1169194664001" />
+          <node concept="3zFVjK" id="DnjeukfcNr" role="3zH0cK">
+            <node concept="3clFbS" id="DnjeukfcNs" role="2VODD2">
+              <node concept="3clFbF" id="Dnjeukfdaf" role="3cqZAp">
+                <node concept="2OqwBi" id="Dnjeukfdm8" role="3clFbG">
+                  <node concept="1iwH7S" id="Dnjeukfdae" role="2Oq$k0" />
+                  <node concept="2piZGk" id="Dnjeukfd$z" role="2OqNvi">
+                    <node concept="Xl_RD" id="Dnjeukfd_g" role="2piZGb">
+                      <property role="Xl_RC" value="GenericMenuPart" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2tJIrI" id="6rGQ0fkujKw" role="jymVt" />
+      <node concept="3Tm1VV" id="6rGQ0fkujKx" role="1B3o_S" />
+    </node>
+  </node>
+  <node concept="3INDKC" id="DnjeukswAW">
+    <property role="TrG5h" value="template_IncludeBeforeAfterTransformations" />
+    <node concept="1Qtc8_" id="6rGQ0fktrQw" role="IW6Ez">
+      <node concept="3cWJ9i" id="6rGQ0fktrRo" role="1Qtc8$">
+        <node concept="CtIbL" id="6rGQ0fktrRq" role="CtIbM">
+          <property role="CtIbK" value="1A4kJjlVmVt/LEFT" />
+        </node>
+      </node>
+      <node concept="2MBE2L" id="6rGQ0fktrRu" role="1Qtc8A">
+        <node concept="2Mo9yg" id="6rGQ0fk$FNz" role="2MvauM">
+          <node concept="3clFbS" id="6rGQ0fk$FN$" role="2VODD2">
+            <node concept="3clFbF" id="39$RJBbHOoT" role="3cqZAp">
+              <node concept="2OqwBi" id="39$RJBbHQew" role="3clFbG">
+                <node concept="2ShNRf" id="39$RJBbHOoP" role="2Oq$k0">
+                  <node concept="1pGfFk" id="39$RJBbHPlv" role="2ShVmc">
+                    <ref role="37wK5l" to="gdpt:39$RJBbHJHb" resolve="RedirectToBeforeAndAfter" />
+                    <node concept="3clFbT" id="39$RJBbHPOg" role="37wK5m">
+                      <property role="3clFbU" value="true" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="liA8E" id="39$RJBbHR7w" role="2OqNvi">
+                  <ref role="37wK5l" to="gdpt:39$RJBbGOxw" resolve="createItems" />
+                  <node concept="2Mo9yH" id="39$RJBbHRu1" role="37wK5m" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1Qtc8_" id="Dnjeukdfuw" role="IW6Ez">
+      <node concept="2MBE2L" id="DnjeukdfvJ" role="1Qtc8A">
+        <node concept="2Mo9yg" id="DnjeukdfvK" role="2MvauM">
+          <node concept="3clFbS" id="DnjeukdfvL" role="2VODD2">
+            <node concept="3clFbF" id="DnjeukdfvM" role="3cqZAp">
+              <node concept="2OqwBi" id="DnjeukdfvN" role="3clFbG">
+                <node concept="2ShNRf" id="DnjeukdfvO" role="2Oq$k0">
+                  <node concept="1pGfFk" id="DnjeukdfvP" role="2ShVmc">
+                    <ref role="37wK5l" to="gdpt:39$RJBbHJHb" resolve="RedirectToBeforeAndAfter" />
+                    <node concept="3clFbT" id="DnjeukdfvQ" role="37wK5m" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="DnjeukdfvR" role="2OqNvi">
+                  <ref role="37wK5l" to="gdpt:39$RJBbGOxw" resolve="createItems" />
+                  <node concept="2Mo9yH" id="DnjeukdfvS" role="37wK5m" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3cWJ9i" id="DnjeukdfvD" role="1Qtc8$">
+        <node concept="CtIbL" id="DnjeukdfvF" role="CtIbM">
+          <property role="CtIbK" value="30NnNOohrQL/RIGHT" />
+        </node>
+      </node>
+    </node>
+    <node concept="n94m4" id="DnjeukswAY" role="lGtFl" />
+    <node concept="A1WHr" id="1ISNm4VruKv" role="AmTjC">
+      <ref role="2ZyFGn" to="tpck:gw2VY9q" resolve="BaseConcept" />
+    </node>
+    <node concept="17Uvod" id="DnjeuksxLL" role="lGtFl">
+      <property role="2qtEX9" value="name" />
+      <property role="P4ACc" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c/1169194658468/1169194664001" />
+      <node concept="3zFVjK" id="DnjeuksxLM" role="3zH0cK">
+        <node concept="3clFbS" id="DnjeuksxLN" role="2VODD2">
+          <node concept="3clFbF" id="DnjeuksxQx" role="3cqZAp">
+            <node concept="Xl_RD" id="DnjeuksxQw" role="3clFbG">
+              <property role="Xl_RC" value="IncludeBeforeAfterTransformations" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="bUwia" id="DnjeukDzUK">
+    <property role="TrG5h" value="mc04_SideTransformationCell4" />
+  </node>
+  <node concept="13MO4I" id="DnjeukFysO">
+    <property role="TrG5h" value="reduce_SideTransformationCell4" />
+    <ref role="3gUMe" to="teg0:Dnjeuk_JIi" resolve="SideTransformationCell4" />
+    <node concept="312cEu" id="DnjeukFysP" role="13RCb5">
+      <property role="TrG5h" value="_context_class_" />
+      <property role="1sVAO0" value="true" />
+      <node concept="3clFb_" id="DnjeukFysQ" role="jymVt">
+        <property role="TrG5h" value="_cell_factory_method_" />
+        <node concept="3clFbS" id="DnjeukFysR" role="3clF47">
+          <node concept="3cpWs8" id="DnjeukFHCG" role="3cqZAp">
+            <node concept="3cpWsn" id="DnjeukFHCH" role="3cpWs9">
+              <property role="TrG5h" value="editorCell" />
+              <node concept="3uibUv" id="DnjeukFHrT" role="1tU5fm">
+                <ref role="3uigEE" to="czm:DnjeukE0JQ" resolve="SideTransformationHolderCell" />
+              </node>
+              <node concept="2ShNRf" id="DnjeukFHCI" role="33vP2m">
+                <node concept="YeOm9" id="DnjeukGzi2" role="2ShVmc">
+                  <node concept="1Y3b0j" id="DnjeukGzi5" role="YeSDq">
+                    <property role="2bfB8j" value="true" />
+                    <ref role="37wK5l" to="czm:DnjeukE0Yz" resolve="SideTransformationHolderCell" />
+                    <ref role="1Y3XeK" to="czm:DnjeukE0JQ" resolve="SideTransformationHolderCell" />
+                    <node concept="3Tm1VV" id="DnjeukGzi6" role="1B3o_S" />
+                    <node concept="1rXfSq" id="DnjeukFHCK" role="37wK5m">
+                      <ref role="37wK5l" to="qvne:6OQfiPCHBdf" resolve="getEditorContext" />
+                    </node>
+                    <node concept="37vLTw" id="DnjeukFHCL" role="37wK5m">
+                      <ref role="3cqZAo" to="tpc3:7GOmDNDA2zg" resolve="myNode" />
+                    </node>
+                    <node concept="10Nm6u" id="4TGwyKDzNjg" role="37wK5m">
+                      <node concept="5jKBG" id="za$VMvkNP5" role="lGtFl">
+                        <ref role="v9R2y" to="tpc3:WbWijtZvbb" resolve="Menu_NodeReference" />
+                      </node>
+                    </node>
+                    <node concept="Xl_RD" id="Dnjeun4k41" role="37wK5m">
+                      <property role="Xl_RC" value="description" />
+                      <node concept="1W57fq" id="Dnjeun4lcZ" role="lGtFl">
+                        <node concept="3IZrLx" id="Dnjeun4ld0" role="3IZSJc">
+                          <node concept="3clFbS" id="Dnjeun4ld1" role="2VODD2">
+                            <node concept="3clFbF" id="Dnjeun4lqb" role="3cqZAp">
+                              <node concept="2OqwBi" id="Dnjeun4mZE" role="3clFbG">
+                                <node concept="2OqwBi" id="Dnjeun4lHt" role="2Oq$k0">
+                                  <node concept="30H73N" id="Dnjeun4lqa" role="2Oq$k0" />
+                                  <node concept="3TrcHB" id="Dnjeun4m_u" role="2OqNvi">
+                                    <ref role="3TsBF5" to="teg0:Dnjeun4iHs" resolve="description" />
+                                  </node>
+                                </node>
+                                <node concept="17RvpY" id="Dnjeun4nwG" role="2OqNvi" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="gft3U" id="Dnjeun4nB0" role="UU_$l">
+                          <node concept="10Nm6u" id="Dnjeun4o3V" role="gfFT$" />
+                        </node>
+                      </node>
+                      <node concept="17Uvod" id="Dnjeun4o8o" role="lGtFl">
+                        <property role="2qtEX9" value="value" />
+                        <property role="P4ACc" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1070475926800/1070475926801" />
+                        <node concept="3zFVjK" id="Dnjeun4o8p" role="3zH0cK">
+                          <node concept="3clFbS" id="Dnjeun4o8q" role="2VODD2">
+                            <node concept="3clFbF" id="Dnjeun4oHO" role="3cqZAp">
+                              <node concept="2OqwBi" id="Dnjeun4oZ4" role="3clFbG">
+                                <node concept="30H73N" id="Dnjeun4oHN" role="2Oq$k0" />
+                                <node concept="3TrcHB" id="Dnjeun4ptR" role="2OqNvi">
+                                  <ref role="3TsBF5" to="teg0:Dnjeun4iHs" resolve="description" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFb_" id="DnjeukGzFM" role="jymVt">
+                      <property role="TrG5h" value="createMenuParts" />
+                      <node concept="_YKpA" id="DnjeukGzFN" role="3clF45">
+                        <node concept="3uibUv" id="DnjeukGzFO" role="_ZDj9">
+                          <ref role="3uigEE" to="v95p:~MenuPart" resolve="MenuPart" />
+                          <node concept="3uibUv" id="DnjeukGzFP" role="11_B2D">
+                            <ref role="3uigEE" to="uddc:~TransformationMenuItem" resolve="TransformationMenuItem" />
+                          </node>
+                          <node concept="3uibUv" id="DnjeukGzFQ" role="11_B2D">
+                            <ref role="3uigEE" to="uddc:~TransformationMenuContext" resolve="TransformationMenuContext" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3Tm1VV" id="DnjeukGzFR" role="1B3o_S" />
+                      <node concept="3clFbS" id="DnjeukGzFU" role="3clF47">
+                        <node concept="3clFbF" id="DnjeukG$60" role="3cqZAp">
+                          <node concept="2ShNRf" id="DnjeukG$5Y" role="3clFbG">
+                            <node concept="Tc6Ow" id="DnjeukG$XI" role="2ShVmc">
+                              <node concept="10Nm6u" id="DnjeukGAi0" role="HW$Y0">
+                                <node concept="1WS0z7" id="DnjeukGAtR" role="lGtFl">
+                                  <node concept="3JmXsc" id="DnjeukGAtU" role="3Jn$fo">
+                                    <node concept="3clFbS" id="DnjeukGAtV" role="2VODD2">
+                                      <node concept="3clFbF" id="DnjeukGAu1" role="3cqZAp">
+                                        <node concept="2OqwBi" id="DnjeukGAtW" role="3clFbG">
+                                          <node concept="3Tsc0h" id="Dnjeul2f2R" role="2OqNvi">
+                                            <ref role="3TtcxE" to="tpc2:6V0bp$oHeYZ" resolve="parts" />
+                                          </node>
+                                          <node concept="2OqwBi" id="Dnjeul2ecd" role="2Oq$k0">
+                                            <node concept="30H73N" id="DnjeukGAu0" role="2Oq$k0" />
+                                            <node concept="3TrEf2" id="Dnjeul2eCn" role="2OqNvi">
+                                              <ref role="3Tt5mk" to="teg0:Dnjeul188y" resolve="section" />
+                                            </node>
+                                          </node>
+                                        </node>
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                                <node concept="1sPUBX" id="DnjeukGAWN" role="lGtFl">
+                                  <ref role="v9R2y" to="tpc3:20qY$3H6Q0h" resolve="switch_TransformationMenuPart_create" />
+                                </node>
+                              </node>
+                              <node concept="3uibUv" id="DnjeukGBkC" role="HW$YZ">
+                                <ref role="3uigEE" to="v95p:~MenuPart" resolve="MenuPart" />
+                                <node concept="3uibUv" id="DnjeukGBkD" role="11_B2D">
+                                  <ref role="3uigEE" to="uddc:~TransformationMenuItem" resolve="TransformationMenuItem" />
+                                </node>
+                                <node concept="3uibUv" id="DnjeukGBkE" role="11_B2D">
+                                  <ref role="3uigEE" to="uddc:~TransformationMenuContext" resolve="TransformationMenuContext" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="2AHcQZ" id="DnjeukGzFV" role="2AJF6D">
+                        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbH" id="DnjeukUV4K" role="3cqZAp">
+            <node concept="5jKBG" id="DnjeukUVD1" role="lGtFl">
+              <ref role="v9R2y" to="tpc3:4v1iCryNDHi" resolve="template_cellSetupBlock" />
+            </node>
+          </node>
+          <node concept="3cpWs6" id="DnjeukFHJN" role="3cqZAp">
+            <node concept="37vLTw" id="DnjeukFHJP" role="3cqZAk">
+              <ref role="3cqZAo" node="DnjeukFHCH" resolve="editorCell" />
+            </node>
+          </node>
+        </node>
+        <node concept="3uibUv" id="DnjeukFyxx" role="3clF45">
+          <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+        </node>
+        <node concept="3Tm6S6" id="DnjeukFyxy" role="1B3o_S" />
+        <node concept="raruj" id="DnjeukFyxz" role="lGtFl">
+          <ref role="2sdACS" to="tpc3:2dNBF9rpTiT" resolve="cellFactory.factoryMethod" />
+        </node>
+        <node concept="17Uvod" id="DnjeukFyx$" role="lGtFl">
+          <property role="2qtEX9" value="name" />
+          <property role="P4ACc" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c/1169194658468/1169194664001" />
+          <node concept="3zFVjK" id="DnjeukFyx_" role="3zH0cK">
+            <node concept="3clFbS" id="DnjeukFyxA" role="2VODD2">
+              <node concept="3clFbF" id="DnjeukFyxB" role="3cqZAp">
+                <node concept="2OqwBi" id="DnjeukFyxC" role="3clFbG">
+                  <node concept="30H73N" id="DnjeukFyxD" role="2Oq$k0" />
+                  <node concept="2qgKlT" id="DnjeukFyxE" role="2OqNvi">
+                    <ref role="37wK5l" to="tpcb:hHfE2BD" resolve="getFactoryMethodName" />
+                    <node concept="1iwH7S" id="DnjeukFyxF" role="37wK5m" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2tJIrI" id="DnjeukFVMG" role="jymVt">
+        <node concept="raruj" id="DnjeukFW3e" role="lGtFl" />
+        <node concept="1WS0z7" id="DnjeukFW3g" role="lGtFl">
+          <node concept="3JmXsc" id="DnjeukFW3j" role="3Jn$fo">
+            <node concept="3clFbS" id="DnjeukFW3k" role="2VODD2">
+              <node concept="3clFbF" id="DnjeukFW3q" role="3cqZAp">
+                <node concept="2OqwBi" id="DnjeukFW3l" role="3clFbG">
+                  <node concept="3Tsc0h" id="Dnjeul2djW" role="2OqNvi">
+                    <ref role="3TtcxE" to="tpc2:6V0bp$oHeYZ" resolve="parts" />
+                  </node>
+                  <node concept="2OqwBi" id="Dnjeul2bRS" role="2Oq$k0">
+                    <node concept="30H73N" id="DnjeukFW3p" role="2Oq$k0" />
+                    <node concept="3TrEf2" id="Dnjeul2ck9" role="2OqNvi">
+                      <ref role="3Tt5mk" to="teg0:Dnjeul188y" resolve="section" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1sPUBX" id="DnjeukFWFS" role="lGtFl">
+          <ref role="v9R2y" to="tpc3:291CjQFbWfJ" resolve="switch_TransformationMenuPart_declare" />
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="DnjeukFyxG" role="1B3o_S" />
+      <node concept="3uibUv" id="DnjeukFyxH" role="1zkMxy">
+        <ref role="3uigEE" to="tpc3:7GOmDNDyRby" resolve="CellFactoryContextClass" />
+      </node>
+    </node>
+  </node>
+  <node concept="13MO4I" id="DnjeukO96L">
+    <property role="TrG5h" value="reduce_SideTransformationHolderProcessor" />
+    <ref role="3gUMe" to="teg0:DnjeukLXrb" resolve="SideTransformationHolderProcessor" />
+    <node concept="312cEu" id="DnjeukO96M" role="13RCb5">
+      <property role="TrG5h" value="_context_class_" />
+      <property role="1sVAO0" value="true" />
+      <node concept="3clFb_" id="DnjeukO96N" role="jymVt">
+        <property role="TrG5h" value="_cell_factory_method_" />
+        <node concept="3clFbS" id="DnjeukO96O" role="3clF47">
+          <node concept="3cpWs8" id="DnjeukOb8K" role="3cqZAp">
+            <node concept="3cpWsn" id="DnjeukOb8L" role="3cpWs9">
+              <property role="TrG5h" value="editorCell" />
+              <property role="3TUv4t" value="true" />
+              <node concept="3uibUv" id="DnjeukOb8M" role="1tU5fm">
+                <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+              </node>
+              <node concept="10Nm6u" id="DnjeukObdl" role="33vP2m">
+                <node concept="5jKBG" id="DnjeukOgz0" role="lGtFl">
+                  <ref role="v9R2y" to="tpc3:gXIFsmA" resolve="template_CreateCellExpression" />
+                  <node concept="3NFfHV" id="DnjeukP5Qr" role="5jGum">
+                    <node concept="3clFbS" id="DnjeukP5Qs" role="2VODD2">
+                      <node concept="3clFbF" id="DnjeukP5QV" role="3cqZAp">
+                        <node concept="2OqwBi" id="DnjeukP6fR" role="3clFbG">
+                          <node concept="30H73N" id="DnjeukP5QU" role="2Oq$k0" />
+                          <node concept="3TrEf2" id="DnjeukP6R0" role="2OqNvi">
+                            <ref role="3Tt5mk" to="teg0:DnjeukLXrc" resolve="wrappedCell" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbJ" id="DnjeukOh$Y" role="3cqZAp">
+            <node concept="3clFbS" id="DnjeukOh_0" role="3clFbx">
+              <node concept="3clFbF" id="DnjeukOh2p" role="3cqZAp">
+                <node concept="2YIFZM" id="DnjeukOhj6" role="3clFbG">
+                  <ref role="37wK5l" to="czm:DnjeukE1nh" resolve="processParentCollection" />
+                  <ref role="1Pybhc" to="czm:DnjeukE0JQ" resolve="SideTransformationHolderCell" />
+                  <node concept="10QFUN" id="DnjeukOi12" role="37wK5m">
+                    <node concept="37vLTw" id="DnjeukOi11" role="10QFUP">
+                      <ref role="3cqZAo" node="DnjeukOb8L" resolve="editorCell" />
+                    </node>
+                    <node concept="3uibUv" id="DnjeukOi10" role="10QFUM">
+                      <ref role="3uigEE" to="f4zo:~EditorCell_Collection" resolve="EditorCell_Collection" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="2ZW3vV" id="DnjeukOhGQ" role="3clFbw">
+              <node concept="3uibUv" id="DnjeukOhJb" role="2ZW6by">
+                <ref role="3uigEE" to="f4zo:~EditorCell_Collection" resolve="EditorCell_Collection" />
+              </node>
+              <node concept="37vLTw" id="DnjeukOhCR" role="2ZW6bz">
+                <ref role="3cqZAo" node="DnjeukOb8L" resolve="editorCell" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="308lJa6VzhG" role="3cqZAp">
+            <node concept="2OqwBi" id="308lJa6VzhH" role="3clFbG">
+              <node concept="37vLTw" id="308lJa6VzhI" role="2Oq$k0">
+                <ref role="3cqZAo" node="DnjeukOb8L" resolve="editorCell" />
+              </node>
+              <node concept="liA8E" id="308lJa6VzhJ" role="2OqNvi">
+                <ref role="37wK5l" to="f4zo:~EditorCell.setBig(boolean)" resolve="setBig" />
+                <node concept="3clFbT" id="308lJa6VzhK" role="37wK5m">
+                  <property role="3clFbU" value="true" />
+                </node>
+              </node>
+            </node>
+            <node concept="1sPUBX" id="308lJa6VzhM" role="lGtFl">
+              <ref role="v9R2y" to="tpc3:4AbVKpmvegw" resolve="SetBigCellProperty" />
+            </node>
+          </node>
+          <node concept="3cpWs6" id="DnjeukO97l" role="3cqZAp">
+            <node concept="37vLTw" id="DnjeukOg$7" role="3cqZAk">
+              <ref role="3cqZAo" node="DnjeukOb8L" resolve="editorCell" />
+            </node>
+          </node>
+        </node>
+        <node concept="3uibUv" id="DnjeukO97n" role="3clF45">
+          <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+        </node>
+        <node concept="3Tm6S6" id="DnjeukO97o" role="1B3o_S" />
+        <node concept="raruj" id="DnjeukO97p" role="lGtFl">
+          <ref role="2sdACS" to="tpc3:2dNBF9rpTiT" resolve="cellFactory.factoryMethod" />
+        </node>
+        <node concept="17Uvod" id="DnjeukO97q" role="lGtFl">
+          <property role="2qtEX9" value="name" />
+          <property role="P4ACc" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c/1169194658468/1169194664001" />
+          <node concept="3zFVjK" id="DnjeukO97r" role="3zH0cK">
+            <node concept="3clFbS" id="DnjeukO97s" role="2VODD2">
+              <node concept="3clFbF" id="DnjeukO97t" role="3cqZAp">
+                <node concept="2OqwBi" id="DnjeukO97u" role="3clFbG">
+                  <node concept="30H73N" id="DnjeukO97v" role="2Oq$k0" />
+                  <node concept="2qgKlT" id="DnjeukO97w" role="2OqNvi">
+                    <ref role="37wK5l" to="tpcb:hHfE2BD" resolve="getFactoryMethodName" />
+                    <node concept="1iwH7S" id="DnjeukO97x" role="37wK5m" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2tJIrI" id="DnjeukP782" role="jymVt">
+        <node concept="raruj" id="DnjeukP7a$" role="lGtFl" />
+        <node concept="29HgVG" id="DnjeukP7aA" role="lGtFl">
+          <node concept="3NFfHV" id="DnjeukP7aB" role="3NFExx">
+            <node concept="3clFbS" id="DnjeukP7aC" role="2VODD2">
+              <node concept="3clFbF" id="DnjeukP7aI" role="3cqZAp">
+                <node concept="2OqwBi" id="DnjeukP7aD" role="3clFbG">
+                  <node concept="3TrEf2" id="DnjeukP7aG" role="2OqNvi">
+                    <ref role="3Tt5mk" to="teg0:DnjeukLXrc" resolve="wrappedCell" />
+                  </node>
+                  <node concept="30H73N" id="DnjeukP7aH" role="2Oq$k0" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="DnjeukO97G" role="1B3o_S" />
+      <node concept="3uibUv" id="DnjeukO97H" role="1zkMxy">
+        <ref role="3uigEE" to="tpc3:7GOmDNDyRby" resolve="CellFactoryContextClass" />
+      </node>
+    </node>
+  </node>
+  <node concept="3INDKC" id="5fS8LropwrX">
+    <property role="TrG5h" value="map_BracketsCell_SideTransformations" />
+    <node concept="n94m4" id="5fS8LropwrZ" role="lGtFl">
+      <ref role="n9lRv" to="teg0:1vi_twqJeLl" resolve="BracketsCell" />
+    </node>
+    <node concept="A1WHr" id="5fS8LrnY8ZD" role="AmTjC">
+      <ref role="2ZyFGn" to="tpck:gw2VY9q" resolve="BaseConcept" />
+      <node concept="1ZhdrF" id="5fS8LrovhkT" role="lGtFl">
+        <property role="2qtEX8" value="concept" />
+        <property role="P3scX" value="18bc6592-03a6-4e29-a83a-7ff23bde13ba/1630016958697718209/1630016958698373342" />
+        <node concept="3$xsQk" id="5fS8LrovhkU" role="3$ytzL">
+          <node concept="3clFbS" id="5fS8LrovhkV" role="2VODD2">
+            <node concept="3clFbF" id="5fS8Lrovhm0" role="3cqZAp">
+              <node concept="2OqwBi" id="5fS8Lrovhm2" role="3clFbG">
+                <node concept="2OqwBi" id="5fS8Lrovhm3" role="2Oq$k0">
+                  <node concept="2OqwBi" id="5fS8Lrovhm4" role="2Oq$k0">
+                    <node concept="30H73N" id="5fS8Lrovhm5" role="2Oq$k0" />
+                    <node concept="3TrEf2" id="5fS8Lrovhm6" role="2OqNvi">
+                      <ref role="3Tt5mk" to="teg0:1vi_twqJeLy" resolve="inner" />
+                    </node>
+                  </node>
+                  <node concept="3TrEf2" id="5fS8Lrovhm7" role="2OqNvi">
+                    <ref role="3Tt5mk" to="tpc2:fBF1sR8" resolve="linkDeclaration" />
+                  </node>
+                </node>
+                <node concept="3TrEf2" id="5fS8Lrovhm8" role="2OqNvi">
+                  <ref role="3Tt5mk" to="tpce:fA0lvVK" resolve="target" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1Qtc8_" id="5fS8LropI3V" role="IW6Ez">
+      <node concept="wWMWC" id="5fS8LropIPz" role="1Qtc8$" />
+      <node concept="2MBE2L" id="5fS8LropIQN" role="1Qtc8A">
+        <node concept="2Mo9yg" id="5fS8LropIQO" role="2MvauM">
+          <node concept="3clFbS" id="5fS8LropIQP" role="2VODD2">
+            <node concept="3clFbF" id="5fS8Lro$Rxz" role="3cqZAp">
+              <node concept="2OqwBi" id="5fS8Lro$Tdm" role="3clFbG">
+                <node concept="2OqwBi" id="5fS8Lro$RXE" role="2Oq$k0">
+                  <node concept="2Mo9yH" id="5fS8Lro$Rxy" role="2Oq$k0" />
+                  <node concept="liA8E" id="5fS8Lro$SAp" role="2OqNvi">
+                    <ref role="37wK5l" to="uddc:~TransformationMenuContext.getEditorMenuTrace()" resolve="getEditorMenuTrace" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="5fS8Lro$Tv5" role="2OqNvi">
+                  <ref role="37wK5l" to="x4mf:~EditorMenuTrace.pushTraceInfo()" resolve="pushTraceInfo" />
+                </node>
+              </node>
+            </node>
+            <node concept="3J1_TO" id="5fS8Lro$U5O" role="3cqZAp">
+              <node concept="3clFbS" id="5fS8Lro$U5Q" role="1zxBo7">
+                <node concept="3clFbF" id="5fS8Lro$Ygg" role="3cqZAp">
+                  <node concept="2OqwBi" id="5fS8Lro$Zcv" role="3clFbG">
+                    <node concept="2OqwBi" id="5fS8Lro$Yrg" role="2Oq$k0">
+                      <node concept="2Mo9yH" id="5fS8Lro$Ygf" role="2Oq$k0" />
+                      <node concept="liA8E" id="5fS8Lro$Z30" role="2OqNvi">
+                        <ref role="37wK5l" to="uddc:~TransformationMenuContext.getEditorMenuTrace()" resolve="getEditorMenuTrace" />
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="5fS8Lro_0xy" role="2OqNvi">
+                      <ref role="37wK5l" to="x4mf:~EditorMenuTrace.setDescriptor(jetbrains.mps.openapi.editor.menus.EditorMenuDescriptor)" resolve="setDescriptor" />
+                      <node concept="2ShNRf" id="5fS8Lro_0Ak" role="37wK5m">
+                        <node concept="1pGfFk" id="5fS8Lro_1I1" role="2ShVmc">
+                          <ref role="37wK5l" to="v95p:~EditorMenuDescriptorBase.&lt;init&gt;(java.lang.String,org.jetbrains.mps.openapi.model.SNodeReference)" resolve="EditorMenuDescriptorBase" />
+                          <node concept="Xl_RD" id="5fS8Lro_2gh" role="37wK5m">
+                            <property role="Xl_RC" value="grammar.brackets in " />
+                            <node concept="17Uvod" id="5fS8Lro_6jD" role="lGtFl">
+                              <property role="2qtEX9" value="value" />
+                              <property role="P4ACc" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1070475926800/1070475926801" />
+                              <node concept="3zFVjK" id="5fS8Lro_6jE" role="3zH0cK">
+                                <node concept="3clFbS" id="5fS8Lro_6jF" role="2VODD2">
+                                  <node concept="3clFbF" id="5fS8Lro_6Jh" role="3cqZAp">
+                                    <node concept="3cpWs3" id="5fS8Lro_8cm" role="3clFbG">
+                                      <node concept="2OqwBi" id="5fS8Lro_bJA" role="3uHU7w">
+                                        <node concept="2OqwBi" id="5fS8Lro_aCH" role="2Oq$k0">
+                                          <node concept="2OqwBi" id="5fS8Lro_8Jx" role="2Oq$k0">
+                                            <node concept="30H73N" id="5fS8Lro_8cu" role="2Oq$k0" />
+                                            <node concept="2Xjw5R" id="5fS8Lro_9BS" role="2OqNvi">
+                                              <node concept="1xMEDy" id="5fS8Lro_9BU" role="1xVPHs">
+                                                <node concept="chp4Y" id="5fS8Lro_aqp" role="ri$Ld">
+                                                  <ref role="cht4Q" to="tpc2:gXXWOiD" resolve="AbstractComponent" />
+                                                </node>
+                                              </node>
+                                            </node>
+                                          </node>
+                                          <node concept="2qgKlT" id="5fS8Lro_btj" role="2OqNvi">
+                                            <ref role="37wK5l" to="tpcb:67EYkym$wx3" resolve="getConceptDeclaration" />
+                                          </node>
+                                        </node>
+                                        <node concept="3TrcHB" id="5fS8Lro_c2e" role="2OqNvi">
+                                          <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                                        </node>
+                                      </node>
+                                      <node concept="Xl_RD" id="5fS8Lro_6Jg" role="3uHU7B">
+                                        <property role="Xl_RC" value="grammar.brackets in " />
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="10Nm6u" id="5fS8Lro_d1X" role="37wK5m">
+                            <node concept="5jKBG" id="5fS8Lro_dAC" role="lGtFl">
+                              <ref role="v9R2y" to="tpc3:WbWijtZvbb" resolve="Menu_NodeReference" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3cpWs6" id="5fS8Lro_ea6" role="3cqZAp">
+                  <node concept="2ShNRf" id="5fS8Lro_ea8" role="3cqZAk">
+                    <node concept="Tc6Ow" id="5fS8Lro_ea9" role="2ShVmc">
+                      <node concept="3uibUv" id="5fS8Lro_eaa" role="HW$YZ">
+                        <ref role="3uigEE" to="uddc:~TransformationMenuItem" resolve="TransformationMenuItem" />
+                      </node>
+                      <node concept="2ShNRf" id="5fS8Lro_eab" role="HW$Y0">
+                        <node concept="1pGfFk" id="5fS8Lro_eac" role="2ShVmc">
+                          <ref role="37wK5l" to="gdpt:5fS8Lroq_4_" resolve="BracketsSideTranformationAction" />
+                          <node concept="2Mo9yH" id="5fS8Lro_ead" role="37wK5m" />
+                          <node concept="35c_gC" id="5fS8Lro_eae" role="37wK5m">
+                            <ref role="35c_gD" to="tpck:gw2VY9q" resolve="BaseConcept" />
+                            <node concept="1ZhdrF" id="5fS8Lro_eaf" role="lGtFl">
+                              <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/2644386474300074836/2644386474300074837" />
+                              <property role="2qtEX8" value="conceptDeclaration" />
+                              <node concept="3$xsQk" id="5fS8Lro_eag" role="3$ytzL">
+                                <node concept="3clFbS" id="5fS8Lro_eah" role="2VODD2">
+                                  <node concept="3clFbF" id="5fS8Lro_eai" role="3cqZAp">
+                                    <node concept="2OqwBi" id="5fS8Lro_eaj" role="3clFbG">
+                                      <node concept="2OqwBi" id="5fS8Lro_eak" role="2Oq$k0">
+                                        <node concept="30H73N" id="5fS8Lro_eal" role="2Oq$k0" />
+                                        <node concept="2Xjw5R" id="5fS8Lro_eam" role="2OqNvi">
+                                          <node concept="1xMEDy" id="5fS8Lro_ean" role="1xVPHs">
+                                            <node concept="chp4Y" id="5fS8Lro_eao" role="ri$Ld">
+                                              <ref role="cht4Q" to="tpc2:gXXWOiD" resolve="AbstractComponent" />
+                                            </node>
+                                          </node>
+                                        </node>
+                                      </node>
+                                      <node concept="2qgKlT" id="5fS8Lro_eap" role="2OqNvi">
+                                        <ref role="37wK5l" to="tpcb:67EYkym$wx3" resolve="getConceptDeclaration" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="Xl_RD" id="5fS8Lro_eaq" role="37wK5m">
+                            <property role="Xl_RC" value="transformText" />
+                            <node concept="17Uvod" id="5fS8Lro_ear" role="lGtFl">
+                              <property role="P4ACc" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1070475926800/1070475926801" />
+                              <property role="2qtEX9" value="value" />
+                              <node concept="3zFVjK" id="5fS8Lro_eas" role="3zH0cK">
+                                <node concept="3clFbS" id="5fS8Lro_eat" role="2VODD2">
+                                  <node concept="3clFbF" id="5fS8Lro_eau" role="3cqZAp">
+                                    <node concept="2OqwBi" id="5fS8Lro_eav" role="3clFbG">
+                                      <node concept="2OqwBi" id="5fS8Lro_eaw" role="2Oq$k0">
+                                        <node concept="30H73N" id="5fS8Lro_eax" role="2Oq$k0" />
+                                        <node concept="3TrEf2" id="5fS8Lro_eay" role="2OqNvi">
+                                          <ref role="3Tt5mk" to="teg0:1vi_twqJeLv" resolve="left" />
+                                        </node>
+                                      </node>
+                                      <node concept="3TrcHB" id="5fS8Lro_eaz" role="2OqNvi">
+                                        <ref role="3TsBF5" to="tpc2:fBF0icJ" resolve="text" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="3clFbT" id="5fS8Lro_ea$" role="37wK5m">
+                            <property role="3clFbU" value="true" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="1wplmZ" id="5fS8Lro$UBU" role="1zxBo6">
+                <node concept="3clFbS" id="5fS8Lro$UBV" role="1wplMD">
+                  <node concept="3clFbF" id="5fS8Lro$UGW" role="3cqZAp">
+                    <node concept="2OqwBi" id="5fS8Lro$WeL" role="3clFbG">
+                      <node concept="2OqwBi" id="5fS8Lro$V8X" role="2Oq$k0">
+                        <node concept="2Mo9yH" id="5fS8Lro$UGV" role="2Oq$k0" />
+                        <node concept="liA8E" id="5fS8Lro$VM6" role="2OqNvi">
+                          <ref role="37wK5l" to="uddc:~TransformationMenuContext.getEditorMenuTrace()" resolve="getEditorMenuTrace" />
+                        </node>
+                      </node>
+                      <node concept="liA8E" id="5fS8Lro$WSl" role="2OqNvi">
+                        <ref role="37wK5l" to="x4mf:~EditorMenuTrace.popTraceInfo()" resolve="popTraceInfo" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1Qtc8_" id="5fS8LropIQ8" role="IW6Ez">
+      <node concept="wWMZ_" id="5fS8LropIQe" role="1Qtc8$" />
+      <node concept="2MBE2L" id="5fS8Lror02C" role="1Qtc8A">
+        <node concept="2Mo9yg" id="5fS8Lror02D" role="2MvauM">
+          <node concept="3clFbS" id="5fS8Lror02E" role="2VODD2">
+            <node concept="3clFbF" id="5fS8Lro_eQL" role="3cqZAp">
+              <node concept="2OqwBi" id="5fS8Lro_eQM" role="3clFbG">
+                <node concept="2OqwBi" id="5fS8Lro_eQN" role="2Oq$k0">
+                  <node concept="2Mo9yH" id="5fS8Lro_eQO" role="2Oq$k0" />
+                  <node concept="liA8E" id="5fS8Lro_eQP" role="2OqNvi">
+                    <ref role="37wK5l" to="uddc:~TransformationMenuContext.getEditorMenuTrace()" resolve="getEditorMenuTrace" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="5fS8Lro_eQQ" role="2OqNvi">
+                  <ref role="37wK5l" to="x4mf:~EditorMenuTrace.pushTraceInfo()" resolve="pushTraceInfo" />
+                </node>
+              </node>
+            </node>
+            <node concept="3J1_TO" id="5fS8Lro_eQR" role="3cqZAp">
+              <node concept="3clFbS" id="5fS8Lro_eQS" role="1zxBo7">
+                <node concept="3clFbF" id="5fS8Lro_eQT" role="3cqZAp">
+                  <node concept="2OqwBi" id="5fS8Lro_eQU" role="3clFbG">
+                    <node concept="2OqwBi" id="5fS8Lro_eQV" role="2Oq$k0">
+                      <node concept="2Mo9yH" id="5fS8Lro_eQW" role="2Oq$k0" />
+                      <node concept="liA8E" id="5fS8Lro_eQX" role="2OqNvi">
+                        <ref role="37wK5l" to="uddc:~TransformationMenuContext.getEditorMenuTrace()" resolve="getEditorMenuTrace" />
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="5fS8Lro_eQY" role="2OqNvi">
+                      <ref role="37wK5l" to="x4mf:~EditorMenuTrace.setDescriptor(jetbrains.mps.openapi.editor.menus.EditorMenuDescriptor)" resolve="setDescriptor" />
+                      <node concept="2ShNRf" id="5fS8Lro_eQZ" role="37wK5m">
+                        <node concept="1pGfFk" id="5fS8Lro_eR0" role="2ShVmc">
+                          <ref role="37wK5l" to="v95p:~EditorMenuDescriptorBase.&lt;init&gt;(java.lang.String,org.jetbrains.mps.openapi.model.SNodeReference)" resolve="EditorMenuDescriptorBase" />
+                          <node concept="Xl_RD" id="5fS8Lro_eR1" role="37wK5m">
+                            <property role="Xl_RC" value="grammar.brackets in " />
+                            <node concept="17Uvod" id="5fS8Lro_eR2" role="lGtFl">
+                              <property role="2qtEX9" value="value" />
+                              <property role="P4ACc" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1070475926800/1070475926801" />
+                              <node concept="3zFVjK" id="5fS8Lro_eR3" role="3zH0cK">
+                                <node concept="3clFbS" id="5fS8Lro_eR4" role="2VODD2">
+                                  <node concept="3clFbF" id="5fS8Lro_eR5" role="3cqZAp">
+                                    <node concept="3cpWs3" id="5fS8Lro_eR6" role="3clFbG">
+                                      <node concept="2OqwBi" id="5fS8Lro_eR7" role="3uHU7w">
+                                        <node concept="2OqwBi" id="5fS8Lro_eR8" role="2Oq$k0">
+                                          <node concept="2OqwBi" id="5fS8Lro_eR9" role="2Oq$k0">
+                                            <node concept="30H73N" id="5fS8Lro_eRa" role="2Oq$k0" />
+                                            <node concept="2Xjw5R" id="5fS8Lro_eRb" role="2OqNvi">
+                                              <node concept="1xMEDy" id="5fS8Lro_eRc" role="1xVPHs">
+                                                <node concept="chp4Y" id="5fS8Lro_eRd" role="ri$Ld">
+                                                  <ref role="cht4Q" to="tpc2:gXXWOiD" resolve="AbstractComponent" />
+                                                </node>
+                                              </node>
+                                            </node>
+                                          </node>
+                                          <node concept="2qgKlT" id="5fS8Lro_eRe" role="2OqNvi">
+                                            <ref role="37wK5l" to="tpcb:67EYkym$wx3" resolve="getConceptDeclaration" />
+                                          </node>
+                                        </node>
+                                        <node concept="3TrcHB" id="5fS8Lro_eRf" role="2OqNvi">
+                                          <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                                        </node>
+                                      </node>
+                                      <node concept="Xl_RD" id="5fS8Lro_eRg" role="3uHU7B">
+                                        <property role="Xl_RC" value="grammar.brackets in " />
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="10Nm6u" id="5fS8Lro_eRh" role="37wK5m">
+                            <node concept="5jKBG" id="5fS8Lro_eRi" role="lGtFl">
+                              <ref role="v9R2y" to="tpc3:WbWijtZvbb" resolve="Menu_NodeReference" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3cpWs6" id="5fS8Lro_gcL" role="3cqZAp">
+                  <node concept="2ShNRf" id="5fS8Lro_gcN" role="3cqZAk">
+                    <node concept="Tc6Ow" id="5fS8Lro_gcO" role="2ShVmc">
+                      <node concept="3uibUv" id="5fS8Lro_gcP" role="HW$YZ">
+                        <ref role="3uigEE" to="uddc:~TransformationMenuItem" resolve="TransformationMenuItem" />
+                      </node>
+                      <node concept="2ShNRf" id="5fS8Lro_gcQ" role="HW$Y0">
+                        <node concept="1pGfFk" id="5fS8Lro_gcR" role="2ShVmc">
+                          <ref role="37wK5l" to="gdpt:5fS8Lroq_4_" resolve="BracketsSideTranformationAction" />
+                          <node concept="2Mo9yH" id="5fS8Lro_gcS" role="37wK5m" />
+                          <node concept="35c_gC" id="5fS8Lro_gcT" role="37wK5m">
+                            <ref role="35c_gD" to="tpck:gw2VY9q" resolve="BaseConcept" />
+                            <node concept="1ZhdrF" id="5fS8Lro_gcU" role="lGtFl">
+                              <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/2644386474300074836/2644386474300074837" />
+                              <property role="2qtEX8" value="conceptDeclaration" />
+                              <node concept="3$xsQk" id="5fS8Lro_gcV" role="3$ytzL">
+                                <node concept="3clFbS" id="5fS8Lro_gcW" role="2VODD2">
+                                  <node concept="3clFbF" id="5fS8Lro_gcX" role="3cqZAp">
+                                    <node concept="2OqwBi" id="5fS8Lro_gcY" role="3clFbG">
+                                      <node concept="2OqwBi" id="5fS8Lro_gcZ" role="2Oq$k0">
+                                        <node concept="30H73N" id="5fS8Lro_gd0" role="2Oq$k0" />
+                                        <node concept="2Xjw5R" id="5fS8Lro_gd1" role="2OqNvi">
+                                          <node concept="1xMEDy" id="5fS8Lro_gd2" role="1xVPHs">
+                                            <node concept="chp4Y" id="5fS8Lro_gd3" role="ri$Ld">
+                                              <ref role="cht4Q" to="tpc2:gXXWOiD" resolve="AbstractComponent" />
+                                            </node>
+                                          </node>
+                                        </node>
+                                      </node>
+                                      <node concept="2qgKlT" id="5fS8Lro_gd4" role="2OqNvi">
+                                        <ref role="37wK5l" to="tpcb:67EYkym$wx3" resolve="getConceptDeclaration" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="Xl_RD" id="5fS8Lro_gd5" role="37wK5m">
+                            <property role="Xl_RC" value="transformText" />
+                            <node concept="17Uvod" id="5fS8Lro_gd6" role="lGtFl">
+                              <property role="P4ACc" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1070475926800/1070475926801" />
+                              <property role="2qtEX9" value="value" />
+                              <node concept="3zFVjK" id="5fS8Lro_gd7" role="3zH0cK">
+                                <node concept="3clFbS" id="5fS8Lro_gd8" role="2VODD2">
+                                  <node concept="3clFbF" id="5fS8Lro_gd9" role="3cqZAp">
+                                    <node concept="2OqwBi" id="5fS8Lro_gda" role="3clFbG">
+                                      <node concept="2OqwBi" id="5fS8Lro_gdb" role="2Oq$k0">
+                                        <node concept="30H73N" id="5fS8Lro_gdc" role="2Oq$k0" />
+                                        <node concept="3TrEf2" id="5fS8Lro_gdd" role="2OqNvi">
+                                          <ref role="3Tt5mk" to="teg0:1vi_twqJeLB" resolve="right" />
+                                        </node>
+                                      </node>
+                                      <node concept="3TrcHB" id="5fS8Lro_gde" role="2OqNvi">
+                                        <ref role="3TsBF5" to="tpc2:fBF0icJ" resolve="text" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="3clFbT" id="5fS8Lro_gdf" role="37wK5m" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="1wplmZ" id="5fS8Lro_eRL" role="1zxBo6">
+                <node concept="3clFbS" id="5fS8Lro_eRM" role="1wplMD">
+                  <node concept="3clFbF" id="5fS8Lro_eRN" role="3cqZAp">
+                    <node concept="2OqwBi" id="5fS8Lro_eRO" role="3clFbG">
+                      <node concept="2OqwBi" id="5fS8Lro_eRP" role="2Oq$k0">
+                        <node concept="2Mo9yH" id="5fS8Lro_eRQ" role="2Oq$k0" />
+                        <node concept="liA8E" id="5fS8Lro_eRR" role="2OqNvi">
+                          <ref role="37wK5l" to="uddc:~TransformationMenuContext.getEditorMenuTrace()" resolve="getEditorMenuTrace" />
+                        </node>
+                      </node>
+                      <node concept="liA8E" id="5fS8Lro_eRS" role="2OqNvi">
+                        <ref role="37wK5l" to="x4mf:~EditorMenuTrace.popTraceInfo()" resolve="popTraceInfo" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbH" id="5fS8Lro_eMg" role="3cqZAp" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="17Uvod" id="5fS8LroxX_6" role="lGtFl">
+      <property role="2qtEX9" value="name" />
+      <property role="P4ACc" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c/1169194658468/1169194664001" />
+      <node concept="3zFVjK" id="5fS8LroxX_7" role="3zH0cK">
+        <node concept="3clFbS" id="5fS8LroxX_8" role="2VODD2">
+          <node concept="3clFbF" id="5fS8LroxYkA" role="3cqZAp">
+            <node concept="2OqwBi" id="5fS8LroxYvT" role="3clFbG">
+              <node concept="1iwH7S" id="5fS8LroxYk_" role="2Oq$k0" />
+              <node concept="2piZGk" id="5fS8LroxYSq" role="2OqNvi">
+                <node concept="3cpWs3" id="5fS8LroxZy2" role="2piZGb">
+                  <node concept="Xl_RD" id="5fS8LroxYXN" role="3uHU7B">
+                    <property role="Xl_RC" value="BracketsCell_SideTransformations_" />
+                  </node>
+                  <node concept="2OqwBi" id="5fS8Lroy1J4" role="3uHU7w">
+                    <node concept="2OqwBi" id="5fS8Lroy10S" role="2Oq$k0">
+                      <node concept="2OqwBi" id="5fS8LroxZTE" role="2Oq$k0">
+                        <node concept="30H73N" id="5fS8LroxZya" role="2Oq$k0" />
+                        <node concept="2Xjw5R" id="5fS8Lroy0rT" role="2OqNvi">
+                          <node concept="1xMEDy" id="5fS8Lroy0rV" role="1xVPHs">
+                            <node concept="chp4Y" id="5fS8Lroy0J0" role="ri$Ld">
+                              <ref role="cht4Q" to="tpc2:gXXWOiD" resolve="AbstractComponent" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="2qgKlT" id="5fS8Lroy1ma" role="2OqNvi">
+                        <ref role="37wK5l" to="tpcb:67EYkym$wx3" resolve="getConceptDeclaration" />
+                      </node>
+                    </node>
+                    <node concept="3TrcHB" id="5fS8Lroy2eD" role="2OqNvi">
+                      <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
       </node>
     </node>
   </node>

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/models/com.mbeddr.mpsutil.grammarcells.migration.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/models/com.mbeddr.mpsutil.grammarcells.migration.mps
@@ -15,7 +15,6 @@
     <import index="slm6" ref="90746344-04fd-4286-97d5-b46ae6a81709/r:52a3d974-bd4f-4651-ba6e-a2de5e336d95(jetbrains.mps.lang.migration/jetbrains.mps.lang.migration.methods)" />
     <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" />
     <import index="9anm" ref="r:6f374023-1b4e-4a80-8bf6-2cc3148faa52(jetbrains.mps.lang.editor.plugin)" />
-    <import index="9wy5" ref="r:345e56f8-982b-405c-9f27-571d664de0b4(com.mbeddr.mpsutil.grammarcells.migration)" />
     <import index="cttk" ref="r:5ff047e0-2953-4750-806a-bdc16824aa89(jetbrains.mps.smodel)" />
     <import index="tpc2" ref="r:00000000-0000-4000-0000-011c8959029e(jetbrains.mps.lang.editor.structure)" />
     <import index="teg0" ref="r:96165ed2-ef22-48c7-bfe5-8fce083cbabb(com.mbeddr.mpsutil.grammarcells.structure)" />

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/models/com/mbeddr/mpsutil/grammarcells/behavior.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/models/com/mbeddr/mpsutil/grammarcells/behavior.mps
@@ -4,6 +4,7 @@
   <languages>
     <use id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior" version="-1" />
     <use id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem" version="5" />
+    <use id="aee9cad2-acd4-4608-aef2-0004f6a1cdbd" name="jetbrains.mps.lang.actions" version="4" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -22,8 +23,11 @@
     <import index="78sh" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.menus.substitute(MPS.Editor/)" />
     <import index="cj4x" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor(MPS.Editor/)" />
     <import index="twe9" ref="r:28e6d713-c3c3-493e-8d97-e9a2c49f28ce(jetbrains.mps.lang.structure.util)" />
+    <import index="v95p" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.lang.editor.menus(MPS.Editor/)" />
+    <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
     <import index="tpdg" ref="r:00000000-0000-4000-0000-011c895902a8(jetbrains.mps.lang.actions.structure)" implicit="true" />
+    <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" implicit="true" />
   </imports>
   <registry>
     <language id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior">
@@ -121,6 +125,7 @@
       </concept>
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
+        <child id="1109201940907" name="parameter" index="11_B2D" />
       </concept>
       <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
@@ -165,6 +170,10 @@
         <child id="1179479418730" name="argument" index="2usUpS" />
       </concept>
     </language>
+    <language id="aee9cad2-acd4-4608-aef2-0004f6a1cdbd" name="jetbrains.mps.lang.actions">
+      <concept id="767145758118872833" name="jetbrains.mps.lang.actions.structure.NF_LinkList_AddNewChildOperation" flags="nn" index="2DeJg1" />
+      <concept id="767145758118872830" name="jetbrains.mps.lang.actions.structure.NF_Link_SetNewChildOperation" flags="nn" index="2DeJnY" />
+    </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
       <concept id="4705942098322609812" name="jetbrains.mps.lang.smodel.structure.EnumMember_IsOperation" flags="ng" index="21noJN">
         <child id="4705942098322609813" name="member" index="21noJM" />
@@ -200,6 +209,9 @@
       <concept id="1883223317721008713" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfVariable" flags="ng" index="JncvC" />
       <concept id="1883223317721107059" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfVarReference" flags="nn" index="Jnkvi" />
       <concept id="1171305280644" name="jetbrains.mps.lang.smodel.structure.Node_GetDescendantsOperation" flags="nn" index="2Rf3mk" />
+      <concept id="1139184414036" name="jetbrains.mps.lang.smodel.structure.LinkList_AddNewChildOperation" flags="nn" index="WFELt">
+        <reference id="1139877738879" name="concept" index="1A0vxQ" />
+      </concept>
       <concept id="1171407110247" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorOperation" flags="nn" index="2Xjw5R" />
       <concept id="1180031783296" name="jetbrains.mps.lang.smodel.structure.Concept_IsSubConceptOfOperation" flags="nn" index="2Zo12i">
         <child id="1180031783297" name="conceptArgument" index="2Zo12j" />
@@ -270,6 +282,7 @@
       <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="nn" index="25WWJ4">
         <child id="540871147943773366" name="argument" index="25WWJ7" />
       </concept>
+      <concept id="1226516258405" name="jetbrains.mps.baseLanguage.collections.structure.HashSetCreator" flags="nn" index="2i4dXS" />
       <concept id="1151688443754" name="jetbrains.mps.baseLanguage.collections.structure.ListType" flags="in" index="_YKpA">
         <child id="1151688676805" name="elementType" index="_ZDj9" />
       </concept>
@@ -289,6 +302,7 @@
         <child id="1237721435808" name="initValue" index="HW$Y0" />
         <child id="1237721435807" name="elementType" index="HW$YZ" />
       </concept>
+      <concept id="1227022210526" name="jetbrains.mps.baseLanguage.collections.structure.ClearAllElementsOperation" flags="nn" index="2Kehj3" />
       <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
       <concept id="1160600644654" name="jetbrains.mps.baseLanguage.collections.structure.ListCreatorWithInit" flags="nn" index="Tc6Ow" />
       <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
@@ -296,9 +310,13 @@
       <concept id="1240687580870" name="jetbrains.mps.baseLanguage.collections.structure.JoinOperation" flags="nn" index="3uJxvA">
         <child id="1240687658305" name="delimiter" index="3uJOhx" />
       </concept>
+      <concept id="7125221305512719026" name="jetbrains.mps.baseLanguage.collections.structure.CollectionType" flags="in" index="3vKaQO" />
       <concept id="1225727723840" name="jetbrains.mps.baseLanguage.collections.structure.FindFirstOperation" flags="nn" index="1z4cxt" />
       <concept id="1202120902084" name="jetbrains.mps.baseLanguage.collections.structure.WhereOperation" flags="nn" index="3zZkjj" />
       <concept id="1202128969694" name="jetbrains.mps.baseLanguage.collections.structure.SelectOperation" flags="nn" index="3$u5V9" />
+      <concept id="5686963296372573083" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerType" flags="in" index="3O5elB">
+        <child id="5686963296372573084" name="elementType" index="3O5elw" />
+      </concept>
     </language>
   </registry>
   <node concept="13h7C7" id="6oKG1kMxvGa">
@@ -1602,21 +1620,52 @@
             </node>
           </node>
         </node>
-        <node concept="3clFbJ" id="5$jJV5dOFjc" role="3cqZAp">
-          <node concept="3clFbS" id="5$jJV5dOFje" role="3clFbx">
-            <node concept="3cpWs6" id="5$jJV5dOFN1" role="3cqZAp">
-              <node concept="Xl_RD" id="5$jJV5dOFRL" role="3cqZAk">
-                <property role="Xl_RC" value="subconcept.conceptAlias" />
+        <node concept="3clFbJ" id="5ycts4RYfEV" role="3cqZAp">
+          <node concept="3clFbS" id="5ycts4RYfEW" role="3clFbx">
+            <node concept="3cpWs6" id="5ycts4RYfEX" role="3cqZAp">
+              <node concept="Xl_RD" id="5ycts4RYfEY" role="3cqZAk">
+                <property role="Xl_RC" value="&lt;substitute menu&gt;" />
               </node>
             </node>
           </node>
-          <node concept="2OqwBi" id="5$jJV5dOF_$" role="3clFbw">
-            <node concept="37vLTw" id="5$jJV5dOFsc" role="2Oq$k0">
+          <node concept="22lmx$" id="5ycts4RYg8A" role="3clFbw">
+            <node concept="2OqwBi" id="5ycts4RYfEZ" role="3uHU7w">
+              <node concept="37vLTw" id="5ycts4RYfF0" role="2Oq$k0">
+                <ref role="3cqZAo" node="5$jJV5dOFsa" resolve="firstNonConst" />
+              </node>
+              <node concept="1mIQ4w" id="5ycts4RYfF1" role="2OqNvi">
+                <node concept="chp4Y" id="5ycts4RYfF2" role="cj9EA">
+                  <ref role="cht4Q" to="tpc2:fBF2Hee" resolve="CellModel_RefNodeList" />
+                </node>
+              </node>
+            </node>
+            <node concept="2OqwBi" id="5ycts4RYgzb" role="3uHU7B">
+              <node concept="37vLTw" id="5ycts4RYgzc" role="2Oq$k0">
+                <ref role="3cqZAo" node="5$jJV5dOFsa" resolve="firstNonConst" />
+              </node>
+              <node concept="1mIQ4w" id="5ycts4RYgzd" role="2OqNvi">
+                <node concept="chp4Y" id="5ycts4RYgze" role="cj9EA">
+                  <ref role="cht4Q" to="tpc2:fBF1sR7" resolve="CellModel_RefNode" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="5ycts4Sb_eM" role="3cqZAp">
+          <node concept="3clFbS" id="5ycts4Sb_eN" role="3clFbx">
+            <node concept="3cpWs6" id="5ycts4Sb_eO" role="3cqZAp">
+              <node concept="Xl_RD" id="5ycts4Sb_eP" role="3cqZAk">
+                <property role="Xl_RC" value="&lt;reference menu&gt;" />
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="5ycts4Sb_eV" role="3clFbw">
+            <node concept="37vLTw" id="5ycts4Sb_eW" role="2Oq$k0">
               <ref role="3cqZAo" node="5$jJV5dOFsa" resolve="firstNonConst" />
             </node>
-            <node concept="1mIQ4w" id="5$jJV5dOFJf" role="2OqNvi">
-              <node concept="chp4Y" id="5$jJV5dOFKw" role="cj9EA">
-                <ref role="cht4Q" to="tpc2:fBF2Hee" resolve="CellModel_RefNodeList" />
+            <node concept="1mIQ4w" id="5ycts4Sb_eX" role="2OqNvi">
+              <node concept="chp4Y" id="5ycts4Sb_jh" role="cj9EA">
+                <ref role="cht4Q" to="tpc2:fPiCG$y" resolve="CellModel_RefCell" />
               </node>
             </node>
           </node>
@@ -2849,8 +2898,13 @@
         <node concept="3clFbH" id="5ewxJLJnX3b" role="3cqZAp" />
         <node concept="3cpWs6" id="5ewxJLJnXb1" role="3cqZAp">
           <node concept="3cpWs3" id="5ewxJLJnXlL" role="3cqZAk">
-            <node concept="37vLTw" id="5ewxJLJnXp5" role="3uHU7w">
-              <ref role="3cqZAo" node="5ewxJLJnVYI" resolve="cell" />
+            <node concept="2OqwBi" id="czMm1GWYc_" role="3uHU7w">
+              <node concept="37vLTw" id="5ewxJLJnXp5" role="2Oq$k0">
+                <ref role="3cqZAo" node="5ewxJLJnVYI" resolve="cell" />
+              </node>
+              <node concept="2qgKlT" id="czMm1GWYvb" role="2OqNvi">
+                <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+              </node>
             </node>
             <node concept="Xl_RD" id="5ewxJLJnXgM" role="3uHU7B">
               <property role="Xl_RC" value="" />
@@ -3920,6 +3974,213 @@
       </node>
       <node concept="3Tqbb2" id="Mf8p5ha6q$" role="3clF45">
         <ref role="ehGHo" to="tpee:fz3vP1H" resolve="Type" />
+      </node>
+    </node>
+  </node>
+  <node concept="13h7C7" id="1ISNm4Vw3fv">
+    <ref role="13h7C2" to="teg0:1ISNm4Vw3eE" resolve="TransformationLocation_ContributionsToSideTranformation" />
+    <node concept="13i0hz" id="1A4kJjm4$Ob" role="13h7CS">
+      <property role="TrG5h" value="getAvailableFeatures" />
+      <property role="13i0it" value="false" />
+      <property role="13i0iv" value="false" />
+      <ref role="13i0hy" to="tpcb:1A4kJjlZ$rL" resolve="getAvailableFeatures" />
+      <node concept="3Tm1VV" id="1A4kJjm4$Oc" role="1B3o_S" />
+      <node concept="3clFbS" id="1A4kJjm4$Oi" role="3clF47">
+        <node concept="3cpWs6" id="7L5lpRJILWk" role="3cqZAp">
+          <node concept="2ShNRf" id="7L5lpRJIM13" role="3cqZAk">
+            <node concept="2i4dXS" id="7L5lpRJIMAj" role="2ShVmc">
+              <node concept="3bZ5Sz" id="7L5lpRJIN55" role="HW$YZ">
+                <ref role="3bZ5Sy" to="tpc2:7L5lpRJH$E_" resolve="TransformationFeature" />
+              </node>
+              <node concept="35c_gC" id="7L5lpRJIN6Q" role="HW$Y0">
+                <ref role="35c_gD" to="tpc2:1A4kJjlVAph" resolve="TransformationFeature_Icon" />
+              </node>
+              <node concept="35c_gC" id="7L5lpRJINbI" role="HW$Y0">
+                <ref role="35c_gD" to="tpc2:1A4kJjlVEvM" resolve="TransformationFeature_ActionType" />
+              </node>
+              <node concept="35c_gC" id="1A4kJjm4_F3" role="HW$Y0">
+                <ref role="35c_gD" to="tpc2:1A4kJjlVDm7" resolve="TransformationFeature_DescriptionText" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3vKaQO" id="1A4kJjm4$Oj" role="3clF45">
+        <node concept="3bZ5Sz" id="1A4kJjm4$Ok" role="3O5elw">
+          <ref role="3bZ5Sy" to="tpc2:7L5lpRJH$E_" resolve="TransformationFeature" />
+        </node>
+      </node>
+    </node>
+    <node concept="13hLZK" id="1ISNm4Vw3fw" role="13h7CW">
+      <node concept="3clFbS" id="1ISNm4Vw3fx" role="2VODD2" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="6rGQ0fksB$4">
+    <ref role="13h7C2" to="teg0:6rGQ0fksByM" resolve="GenericMenuPart" />
+    <node concept="13hLZK" id="6rGQ0fksB$5" role="13h7CW">
+      <node concept="3clFbS" id="6rGQ0fksB$6" role="2VODD2" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="6rGQ0fkz4fv">
+    <ref role="13h7C2" to="teg0:6rGQ0fkz42j" resolve="LowLevelMenuPart_Function" />
+    <node concept="13hLZK" id="6rGQ0fkz4fw" role="13h7CW">
+      <node concept="3clFbS" id="6rGQ0fkz4fx" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="6rGQ0fkz4fE" role="13h7CS">
+      <property role="TrG5h" value="getExpectedReturnType" />
+      <ref role="13i0hy" to="tpek:hEwIGRD" resolve="getExpectedReturnType" />
+      <node concept="3Tm1VV" id="6rGQ0fkz4fI" role="1B3o_S" />
+      <node concept="3clFbS" id="6rGQ0fkz4fK" role="3clF47">
+        <node concept="3clFbF" id="6rGQ0fkz4oV" role="3cqZAp">
+          <node concept="2c44tf" id="6rGQ0fkz4oT" role="3clFbG">
+            <node concept="3uibUv" id="6rGQ0fktrVT" role="2c44tc">
+              <ref role="3uigEE" to="33ny:~List" resolve="List" />
+              <node concept="3uibUv" id="6rGQ0fktrVX" role="11_B2D">
+                <ref role="3uigEE" to="uddc:~TransformationMenuItem" resolve="TransformationMenuItem" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tqbb2" id="6rGQ0fkz4fL" role="3clF45" />
+    </node>
+    <node concept="13i0hz" id="6rGQ0fkz4vG" role="13h7CS">
+      <property role="TrG5h" value="getParameterConcepts" />
+      <ref role="13i0hy" to="tpek:2xELmDxyi2v" resolve="getParameterConcepts" />
+      <node concept="3Tm1VV" id="6rGQ0fkz4vO" role="1B3o_S" />
+      <node concept="3clFbS" id="6rGQ0fkz4vP" role="3clF47">
+        <node concept="3clFbF" id="6rGQ0fkz4EX" role="3cqZAp">
+          <node concept="2ShNRf" id="6rGQ0fkz4EN" role="3clFbG">
+            <node concept="Tc6Ow" id="6rGQ0fkz4WV" role="2ShVmc">
+              <node concept="3bZ5Sz" id="6rGQ0fkz5k1" role="HW$YZ">
+                <ref role="3bZ5Sy" to="tpee:g76ryKb" resolve="ConceptFunctionParameter" />
+              </node>
+              <node concept="35c_gC" id="6rGQ0fkz5Bp" role="HW$Y0">
+                <ref role="35c_gD" to="teg0:6rGQ0fkz42I" resolve="LowLevelMenuPart_parameter" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="_YKpA" id="6rGQ0fkz4vQ" role="3clF45">
+        <node concept="3bZ5Sz" id="6rGQ0fkz4vR" role="_ZDj9">
+          <ref role="3bZ5Sy" to="tpee:g76ryKb" resolve="ConceptFunctionParameter" />
+        </node>
+      </node>
+    </node>
+    <node concept="13i0hz" id="6rGQ0fk_1TA" role="13h7CS">
+      <property role="2Ki8OM" value="true" />
+      <property role="TrG5h" value="showName" />
+      <ref role="13i0hy" to="tpek:1653mnvAgry" resolve="showName" />
+      <node concept="3Tm1VV" id="6rGQ0fk_1TB" role="1B3o_S" />
+      <node concept="3clFbS" id="6rGQ0fk_1TG" role="3clF47">
+        <node concept="3clFbF" id="6rGQ0fk_22x" role="3cqZAp">
+          <node concept="3clFbT" id="6rGQ0fk_22w" role="3clFbG">
+            <property role="3clFbU" value="true" />
+          </node>
+        </node>
+      </node>
+      <node concept="10P_77" id="6rGQ0fk_1TH" role="3clF45" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="6rGQ0fkz5Lx">
+    <ref role="13h7C2" to="teg0:6rGQ0fkz42I" resolve="LowLevelMenuPart_parameter" />
+    <node concept="13hLZK" id="6rGQ0fkz5Ly" role="13h7CW">
+      <node concept="3clFbS" id="6rGQ0fkz5Lz" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="6rGQ0fkz5LG" role="13h7CS">
+      <property role="TrG5h" value="getType" />
+      <ref role="13i0hy" to="tpek:27DJnJtIQ9C" resolve="getType" />
+      <node concept="3Tm1VV" id="6rGQ0fkz5LH" role="1B3o_S" />
+      <node concept="3clFbS" id="6rGQ0fkz5LM" role="3clF47">
+        <node concept="3clFbF" id="6rGQ0fkz5SU" role="3cqZAp">
+          <node concept="2c44tf" id="6rGQ0fkz5SS" role="3clFbG">
+            <node concept="3uibUv" id="6rGQ0fkz5W7" role="2c44tc">
+              <ref role="3uigEE" to="uddc:~TransformationMenuContext" resolve="TransformationMenuContext" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tqbb2" id="6rGQ0fkz5LN" role="3clF45">
+        <ref role="ehGHo" to="tpee:fz3vP1H" resolve="Type" />
+      </node>
+    </node>
+  </node>
+  <node concept="13h7C7" id="DnjeukDzVf">
+    <property role="3GE5qa" value="cells" />
+    <ref role="13h7C2" to="teg0:Dnjeuk_JIi" resolve="SideTransformationCell4" />
+    <node concept="13hLZK" id="DnjeukDzVg" role="13h7CW">
+      <node concept="3clFbS" id="DnjeukDzVh" role="2VODD2">
+        <node concept="3clFbF" id="Dnjeulj4i$" role="3cqZAp">
+          <node concept="2OqwBi" id="Dnjeulj4Zf" role="3clFbG">
+            <node concept="2OqwBi" id="Dnjeulj4vq" role="2Oq$k0">
+              <node concept="13iPFW" id="Dnjeulj4iz" role="2Oq$k0" />
+              <node concept="3TrEf2" id="Dnjeulj4NI" role="2OqNvi">
+                <ref role="3Tt5mk" to="teg0:Dnjeul188y" resolve="section" />
+              </node>
+            </node>
+            <node concept="2DeJnY" id="Dnjeulj5d9" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="3clFbF" id="Dnjeulko$g" role="3cqZAp">
+          <node concept="2OqwBi" id="DnjeulkrDz" role="3clFbG">
+            <node concept="2OqwBi" id="DnjeulkpWB" role="2Oq$k0">
+              <node concept="2OqwBi" id="Dnjeulkp4h" role="2Oq$k0">
+                <node concept="13iPFW" id="Dnjeulko$e" role="2Oq$k0" />
+                <node concept="3TrEf2" id="DnjeulkpJk" role="2OqNvi">
+                  <ref role="3Tt5mk" to="teg0:Dnjeul188y" resolve="section" />
+                </node>
+              </node>
+              <node concept="3Tsc0h" id="Dnjeulkq7r" role="2OqNvi">
+                <ref role="3TtcxE" to="tpc2:6V0bp$oHeYX" resolve="locations" />
+              </node>
+            </node>
+            <node concept="2Kehj3" id="DnjeulktsC" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="3clFbF" id="Dnjeulky6G" role="3cqZAp">
+          <node concept="2OqwBi" id="DnjeulkB7u" role="3clFbG">
+            <node concept="2OqwBi" id="Dnjeulk_g2" role="2Oq$k0">
+              <node concept="2OqwBi" id="Dnjeulk$Hy" role="2Oq$k0">
+                <node concept="13iPFW" id="Dnjeulky6E" role="2Oq$k0" />
+                <node concept="3TrEf2" id="Dnjeulk_4r" role="2OqNvi">
+                  <ref role="3Tt5mk" to="teg0:Dnjeul188y" resolve="section" />
+                </node>
+              </node>
+              <node concept="3Tsc0h" id="Dnjeulk_t4" role="2OqNvi">
+                <ref role="3TtcxE" to="tpc2:6V0bp$oHeYX" resolve="locations" />
+              </node>
+            </node>
+            <node concept="2DeJg1" id="DnjeulkDsF" role="2OqNvi">
+              <ref role="1A0vxQ" to="teg0:Dnjeulj4il" resolve="TransformationLocation_SideTransformationCell" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="13h7C7" id="DnjeukLXrL">
+    <property role="3GE5qa" value="cells" />
+    <ref role="13h7C2" to="teg0:DnjeukLXrb" resolve="SideTransformationHolderProcessor" />
+    <node concept="13hLZK" id="DnjeukLXrM" role="13h7CW">
+      <node concept="3clFbS" id="DnjeukLXrN" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="DnjeukLXrW" role="13h7CS">
+      <property role="TrG5h" value="getWrappedCell" />
+      <ref role="13i0hy" node="3O7ZvCZLQjf" resolve="getWrappedCell" />
+      <node concept="3Tm1VV" id="DnjeukLXrX" role="1B3o_S" />
+      <node concept="3clFbS" id="DnjeukLXs0" role="3clF47">
+        <node concept="3clFbF" id="DnjeukLXsf" role="3cqZAp">
+          <node concept="2OqwBi" id="DnjeukLXDX" role="3clFbG">
+            <node concept="13iPFW" id="DnjeukLXse" role="2Oq$k0" />
+            <node concept="3TrEf2" id="DnjeukLXYh" role="2OqNvi">
+              <ref role="3Tt5mk" to="teg0:DnjeukLXrc" resolve="wrappedCell" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tqbb2" id="DnjeukLXs1" role="3clF45">
+        <ref role="ehGHo" to="tpc2:fBEYTCT" resolve="EditorCellModel" />
       </node>
     </node>
   </node>

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/models/com/mbeddr/mpsutil/grammarcells/constraints.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/models/com/mbeddr/mpsutil/grammarcells/constraints.mps
@@ -2,6 +2,7 @@
 <model ref="r:a10fe53e-c32b-4712-baaa-5a506a791f09(com.mbeddr.mpsutil.grammarcells.constraints)">
   <persistence version="9" />
   <languages>
+    <use id="3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1" name="jetbrains.mps.lang.constraints" version="6" />
     <devkit ref="00000000-0000-4000-0000-5604ebd4f22c(jetbrains.mps.devkit.aspect.constraints)" />
   </languages>
   <imports>
@@ -106,6 +107,30 @@
               </node>
               <node concept="3x8VRR" id="5RIakkDIV$u" role="2OqNvi" />
             </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1M2fIO" id="DnjeuljD05">
+    <property role="3GE5qa" value="cells" />
+    <ref role="1M2myG" to="teg0:Dnjeulj4il" resolve="TransformationLocation_SideTransformationCell" />
+    <node concept="9S07l" id="DnjeuljD06" role="9Vyp8">
+      <node concept="3clFbS" id="DnjeuljD07" role="2VODD2">
+        <node concept="3clFbF" id="DnjeuljD41" role="3cqZAp">
+          <node concept="2OqwBi" id="DnjeuljDVh" role="3clFbG">
+            <node concept="2OqwBi" id="DnjeuljDeE" role="2Oq$k0">
+              <node concept="nLn13" id="DnjeuljD40" role="2Oq$k0" />
+              <node concept="2Xjw5R" id="DnjeuljDt2" role="2OqNvi">
+                <node concept="1xMEDy" id="DnjeuljDt4" role="1xVPHs">
+                  <node concept="chp4Y" id="DnjeuljDwW" role="ri$Ld">
+                    <ref role="cht4Q" to="teg0:Dnjeuk_JIi" resolve="SideTransformationCell4" />
+                  </node>
+                </node>
+                <node concept="1xIGOp" id="DnjeuljDB$" role="1xVPHs" />
+              </node>
+            </node>
+            <node concept="3x8VRR" id="DnjeuljEh0" role="2OqNvi" />
           </node>
         </node>
       </node>

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/models/com/mbeddr/mpsutil/grammarcells/editor.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/models/com/mbeddr/mpsutil/grammarcells/editor.mps
@@ -2296,5 +2296,82 @@
       <node concept="2iRfu4" id="2cruuiKBFCv" role="2iSdaV" />
     </node>
   </node>
+  <node concept="24kQdi" id="6rGQ0fksBzf">
+    <ref role="1XX52x" to="teg0:6rGQ0fksByM" resolve="GenericMenuPart" />
+    <node concept="3EZMnI" id="6rGQ0fksBzh" role="2wV5jI">
+      <node concept="PMmxH" id="6rGQ0fksBzo" role="3EZMnx">
+        <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
+      </node>
+      <node concept="3F0ifn" id="6rGQ0fksBzt" role="3EZMnx">
+        <property role="3F0ifm" value=":" />
+      </node>
+      <node concept="3F1sOY" id="6rGQ0fk$7YT" role="3EZMnx">
+        <ref role="1NtTu8" to="teg0:6rGQ0fk$7YL" resolve="implementation" />
+      </node>
+      <node concept="l2Vlx" id="6rGQ0fksBzk" role="2iSdaV" />
+    </node>
+  </node>
+  <node concept="24kQdi" id="Dnjeuk_JIS">
+    <property role="3GE5qa" value="cells" />
+    <ref role="1XX52x" to="teg0:Dnjeuk_JIi" resolve="SideTransformationCell4" />
+    <node concept="3F0ifn" id="Dnjeuk_JIU" role="2wV5jI">
+      <property role="3F0ifm" value="ST" />
+      <node concept="VPXOz" id="Dnjeuk_JIV" role="3F10Kt">
+        <property role="VOm3f" value="true" />
+      </node>
+      <node concept="Veino" id="Dnjeuk_JIW" role="3F10Kt">
+        <node concept="1iSF2X" id="Dnjeuk_JIX" role="VblUZ">
+          <property role="1iTho6" value="f5803b" />
+        </node>
+      </node>
+    </node>
+    <node concept="3EZMnI" id="Dnjeun4pIE" role="6VMZX">
+      <node concept="3F1sOY" id="Dnjeul18aU" role="3EZMnx">
+        <ref role="1NtTu8" to="teg0:Dnjeul188y" resolve="section" />
+      </node>
+      <node concept="3F0ifn" id="Dnjeun4pIM" role="3EZMnx" />
+      <node concept="3EZMnI" id="Dnjeun4pKL" role="3EZMnx">
+        <node concept="2iRfu4" id="Dnjeun4pKM" role="2iSdaV" />
+        <node concept="3F0ifn" id="Dnjeun4pIP" role="3EZMnx">
+          <property role="3F0ifm" value="description for trace:" />
+        </node>
+        <node concept="3F0A7n" id="Dnjeun4pOG" role="3EZMnx">
+          <ref role="1NtTu8" to="teg0:Dnjeun4iHs" resolve="description" />
+        </node>
+      </node>
+      <node concept="2iRkQZ" id="Dnjeun4pIH" role="2iSdaV" />
+    </node>
+  </node>
+  <node concept="24kQdi" id="1_3xoKEN8CR">
+    <ref role="1XX52x" to="teg0:1_3xoKEN8C6" resolve="CompositeTransformationMenuReference" />
+    <node concept="3EZMnI" id="1_3xoKEN8CU" role="2wV5jI">
+      <node concept="PMmxH" id="1_3xoKEN8D1" role="3EZMnx">
+        <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
+      </node>
+      <node concept="3F1sOY" id="1_3xoKEN8D6" role="3EZMnx">
+        <ref role="1NtTu8" to="teg0:1_3xoKEN8Cp" resolve="menu" />
+      </node>
+      <node concept="l2Vlx" id="1_3xoKEN8CX" role="2iSdaV" />
+    </node>
+  </node>
+  <node concept="24kQdi" id="DnjeukLY4e">
+    <property role="3GE5qa" value="cells" />
+    <ref role="1XX52x" to="teg0:DnjeukLXrb" resolve="SideTransformationHolderProcessor" />
+    <node concept="3EZMnI" id="DnjeukLY4s" role="2wV5jI">
+      <node concept="3F0ifn" id="DnjeukLY4z" role="3EZMnx">
+        <property role="3F0ifm" value="STP" />
+      </node>
+      <node concept="3F1sOY" id="DnjeukLY4L" role="3EZMnx">
+        <ref role="1NtTu8" to="teg0:DnjeukLXrc" resolve="wrappedCell" />
+      </node>
+      <node concept="3F0ifn" id="DnjeukLY4D" role="3EZMnx">
+        <property role="3F0ifm" value="STP" />
+      </node>
+      <node concept="2iRfu4" id="DnjeukLY4v" role="2iSdaV" />
+    </node>
+    <node concept="PMmxH" id="DnjeukNh21" role="6VMZX">
+      <ref role="PMmxG" to="tpc5:hF4ssnw" resolve="_CellModel_Common" />
+    </node>
+  </node>
 </model>
 

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/models/com/mbeddr/mpsutil/grammarcells/structure.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/models/com/mbeddr/mpsutil/grammarcells/structure.mps
@@ -18,7 +18,9 @@
       <concept id="6491077959632463275" name="jetbrains.mps.lang.structure.structure.EnumPropertyMigrationInfo" flags="ng" index="3l_iC">
         <child id="6491077959632463286" name="oldProperty" index="3l_iP" />
       </concept>
-      <concept id="1224240836180" name="jetbrains.mps.lang.structure.structure.DeprecatedNodeAnnotation" flags="ig" index="asaX9" />
+      <concept id="1224240836180" name="jetbrains.mps.lang.structure.structure.DeprecatedNodeAnnotation" flags="ig" index="asaX9">
+        <property id="1225118933224" name="comment" index="YLQ7P" />
+      </concept>
       <concept id="6054523464627964745" name="jetbrains.mps.lang.structure.structure.AttributeInfo_AttributedConcept" flags="ng" index="trNpa">
         <reference id="6054523464627965081" name="concept" index="trN6q" />
       </concept>
@@ -28,6 +30,7 @@
       </concept>
       <concept id="1169125787135" name="jetbrains.mps.lang.structure.structure.AbstractConceptDeclaration" flags="ig" index="PkWjJ">
         <property id="6714410169261853888" name="conceptId" index="EcuMT" />
+        <property id="4628067390765956802" name="abstract" index="R5$K7" />
         <property id="5092175715804935370" name="conceptAlias" index="34LRSv" />
         <child id="1071489727083" name="linkDeclaration" index="1TKVEi" />
         <child id="1071489727084" name="propertyDeclaration" index="1TKVEl" />
@@ -544,6 +547,9 @@
       <property role="IQ2ns" value="8945565919535383566" />
       <ref role="20lvS9" node="7K_2cV$JzCl" resolve="IncludeParentSideTransformations_Condition" />
     </node>
+    <node concept="asaX9" id="15DZatOJlqA" role="lGtFl">
+      <property role="YLQ7P" value="try using before/after actions of the sideTransformation cell instead" />
+    </node>
   </node>
   <node concept="PlHQZ" id="3O7ZvCZLPYU">
     <property role="TrG5h" value="ICellWrapper" />
@@ -1018,6 +1024,115 @@
         <ref role="trN6q" to="tpc2:fGPMmym" resolve="CellModel_Component" />
       </node>
     </node>
+  </node>
+  <node concept="1TIwiD" id="1_3xoKEN8C6">
+    <property role="EcuMT" value="1820445511447775750" />
+    <property role="TrG5h" value="CompositeTransformationMenuReference" />
+    <property role="34LRSv" value="existing and" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+    <node concept="1TJgyj" id="1_3xoKEN8Cp" role="1TKVEi">
+      <property role="IQ2ns" value="1820445511447775769" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="menu" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <ref role="20lvS9" to="tpc2:3rSzFHWJPbd" resolve="ITransformationMenuReference" />
+    </node>
+    <node concept="PrWs8" id="1_3xoKEN8Ci" role="PzmwI">
+      <ref role="PrY4T" to="tpc2:3rSzFHWJPbd" resolve="ITransformationMenuReference" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="1ISNm4ViYa4">
+    <property role="EcuMT" value="1997572252229165700" />
+    <property role="TrG5h" value="TransformationLocation_After" />
+    <property role="34LRSv" value="after" />
+    <ref role="1TJDcQ" node="1ISNm4Vw3eE" resolve="TransformationLocation_ContributionsToSideTranformation" />
+  </node>
+  <node concept="1TIwiD" id="6rGQ0fksByM">
+    <property role="EcuMT" value="7416540197333137586" />
+    <property role="TrG5h" value="GenericMenuPart" />
+    <property role="34LRSv" value="generic" />
+    <ref role="1TJDcQ" to="tpc2:1qY_lWSjJZY" resolve="TransformationMenuPart" />
+    <node concept="1TJgyj" id="6rGQ0fk$7YL" role="1TKVEi">
+      <property role="IQ2ns" value="7416540197335105457" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="implementation" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <ref role="20lvS9" node="6rGQ0fkz42j" resolve="LowLevelMenuPart_Function" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="Dnjeuk_JIi">
+    <property role="EcuMT" value="745148820867185554" />
+    <property role="3GE5qa" value="cells" />
+    <property role="TrG5h" value="SideTransformationCell4" />
+    <property role="34LRSv" value="grammar.sideTransformation4" />
+    <ref role="1TJDcQ" to="tpc2:fBEYTCT" resolve="EditorCellModel" />
+    <node concept="1TJgyi" id="Dnjeun4iHs" role="1TKVEl">
+      <property role="IQ2nx" value="745148820908747612" />
+      <property role="TrG5h" value="description" />
+      <ref role="AX2Wp" to="tpck:fKAOsGN" resolve="string" />
+    </node>
+    <node concept="1TJgyj" id="Dnjeul188y" role="1TKVEi">
+      <property role="IQ2ns" value="745148820874363426" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="section" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <ref role="20lvS9" to="tpc2:6V0bp$oHeYW" resolve="TransformationMenuSection" />
+    </node>
+    <node concept="PrWs8" id="Dnjeuk_JIj" role="PzmwI">
+      <ref role="PrY4T" node="6oKG1kMyAVO" resolve="IActionGeneratingCell" />
+    </node>
+    <node concept="PrWs8" id="Dnjeuk_JIo" role="PzmwI">
+      <ref role="PrY4T" node="4eBi5gdADMe" resolve="INotALeaf" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="DnjeukLXrb">
+    <property role="EcuMT" value="745148820870387403" />
+    <property role="3GE5qa" value="cells" />
+    <property role="TrG5h" value="SideTransformationHolderProcessor" />
+    <ref role="1TJDcQ" to="tpc2:fBEYTCT" resolve="EditorCellModel" />
+    <node concept="1TJgyj" id="DnjeukLXrc" role="1TKVEi">
+      <property role="IQ2ns" value="745148820870387404" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="wrappedCell" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <ref role="20lvS9" to="tpc2:fBEYTCT" resolve="EditorCellModel" />
+    </node>
+    <node concept="PrWs8" id="DnjeukLXre" role="PzmwI">
+      <ref role="PrY4T" node="3O7ZvCZLPYU" resolve="ICellWrapper" />
+    </node>
+    <node concept="PrWs8" id="DnjeukLXrj" role="PzmwI">
+      <ref role="PrY4T" node="6rhOS_xv5cy" resolve="IGeneratorOnly" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="6rGQ0fkz42I">
+    <property role="EcuMT" value="7416540197334827182" />
+    <property role="TrG5h" value="LowLevelMenuPart_parameter" />
+    <property role="34LRSv" value="ctx" />
+    <ref role="1TJDcQ" to="tpee:g76ryKb" resolve="ConceptFunctionParameter" />
+  </node>
+  <node concept="1TIwiD" id="1ISNm4ViY99">
+    <property role="EcuMT" value="1997572252229165641" />
+    <property role="TrG5h" value="TransformationLocation_Before" />
+    <property role="34LRSv" value="before" />
+    <ref role="1TJDcQ" node="1ISNm4Vw3eE" resolve="TransformationLocation_ContributionsToSideTranformation" />
+  </node>
+  <node concept="1TIwiD" id="Dnjeulj4il">
+    <property role="EcuMT" value="745148820879066261" />
+    <property role="TrG5h" value="TransformationLocation_SideTransformationCell" />
+    <property role="34LRSv" value="side-transformation-cell" />
+    <ref role="1TJDcQ" node="1ISNm4Vw3eE" resolve="TransformationLocation_ContributionsToSideTranformation" />
+  </node>
+  <node concept="1TIwiD" id="6rGQ0fkz42j">
+    <property role="EcuMT" value="7416540197334827155" />
+    <property role="TrG5h" value="LowLevelMenuPart_Function" />
+    <property role="34LRSv" value="createItems" />
+    <ref role="1TJDcQ" to="tpee:gyVMwX8" resolve="ConceptFunction" />
+  </node>
+  <node concept="1TIwiD" id="1ISNm4Vw3eE">
+    <property role="EcuMT" value="1997572252232594346" />
+    <property role="TrG5h" value="TransformationLocation_ContributionsToSideTranformation" />
+    <property role="R5$K7" value="true" />
+    <ref role="1TJDcQ" to="tpc2:7L5lpRJH$EA" resolve="TransformationLocation" />
   </node>
 </model>
 

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/models/generatorutils.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/models/generatorutils.mps
@@ -2198,6 +2198,40 @@
                   </node>
                 </node>
               </node>
+              <node concept="3eNFk2" id="czMm1GX1gA" role="3eNLev">
+                <node concept="2OqwBi" id="czMm1GX3eD" role="3eO9$A">
+                  <node concept="37vLTw" id="czMm1GX2GD" role="2Oq$k0">
+                    <ref role="3cqZAo" node="5OsvY4gZFCS" resolve="cell" />
+                  </node>
+                  <node concept="1mIQ4w" id="czMm1GX3QT" role="2OqNvi">
+                    <node concept="chp4Y" id="czMm1GX3UI" role="cj9EA">
+                      <ref role="cht4Q" to="tpc2:fPQoSf$" resolve="CellModel_Alternation" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbS" id="czMm1GX1gC" role="3eOfB_">
+                  <node concept="3cpWs6" id="czMm1GX3Zy" role="3cqZAp">
+                    <node concept="2ShNRf" id="czMm1GX3Zz" role="3cqZAk">
+                      <node concept="Tc6Ow" id="czMm1GX3Z$" role="2ShVmc">
+                        <node concept="3Tqbb2" id="czMm1GX3Z_" role="HW$YZ" />
+                        <node concept="2OqwBi" id="czMm1GX3ZA" role="HW$Y0">
+                          <node concept="1PxgMI" id="czMm1GX3ZB" role="2Oq$k0">
+                            <node concept="37vLTw" id="czMm1GX3ZC" role="1m5AlR">
+                              <ref role="3cqZAo" node="5OsvY4gZFCS" resolve="cell" />
+                            </node>
+                            <node concept="chp4Y" id="czMm1GX5uV" role="3oSUPX">
+                              <ref role="cht4Q" to="tpc2:fPQoSf$" resolve="CellModel_Alternation" />
+                            </node>
+                          </node>
+                          <node concept="3TrEf2" id="czMm1GX6Vm" role="2OqNvi">
+                            <ref role="3Tt5mk" to="tpc2:fPQoS0T" resolve="ifTrueCellModel" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
           <node concept="2OqwBi" id="4MmBx0ao5IU" role="3clFbw">

--- a/code/grammarcells/solutions/com.mbeddr.mpsutil.grammarcells.runtime/com.mbeddr.mpsutil.grammarcells.runtime.msd
+++ b/code/grammarcells/solutions/com.mbeddr.mpsutil.grammarcells.runtime/com.mbeddr.mpsutil.grammarcells.runtime.msd
@@ -25,6 +25,7 @@
     <dependency reexport="false">498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)</dependency>
   </dependencies>
   <languageVersions>
+    <language slang="l:654422bf-e75f-44dc-936d-188890a746ce:de.slisson.mps.reflection" version="0" />
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
     <language slang="l:774bf8a0-62e5-41e1-af63-f4812e60e48b:jetbrains.mps.baseLanguage.checkedDots" version="0" />
     <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />

--- a/code/grammarcells/solutions/com.mbeddr.mpsutil.grammarcells.runtime/models/com/mbeddr/mpsutil/grammarcells/runtime.mps
+++ b/code/grammarcells/solutions/com.mbeddr.mpsutil.grammarcells.runtime/models/com/mbeddr/mpsutil/grammarcells/runtime.mps
@@ -60,7 +60,11 @@
     <import index="bd8o" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.application(MPS.IDEA/)" />
     <import index="5b0" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel.presentation(MPS.Core/)" />
     <import index="pdwk" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.core.aspects.constraints.rules.kinds(MPS.Core/)" />
+    <import index="4my4" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor.sidetransform(MPS.Editor/)" />
+    <import index="v95p" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.lang.editor.menus(MPS.Editor/)" />
+    <import index="5ueo" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.editor.runtime.style(MPS.Editor/)" />
     <import index="lwvz" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.selection(MPS.Editor/)" implicit="true" />
+    <import index="hox0" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.style(MPS.Editor/)" implicit="true" />
     <import index="z8iw" ref="r:dfdf3542-dbcf-43df-870a-3c3504b3c840(jetbrains.mps.baseLanguage.collections.custom)" implicit="true" />
     <import index="1m72" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.components(MPS.IDEA/)" implicit="true" />
   </imports>
@@ -377,9 +381,16 @@
       <concept id="4079382982702596667" name="jetbrains.mps.baseLanguage.checkedDots.structure.CheckedDotExpression" flags="nn" index="2EnYce" />
     </language>
     <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
+      <concept id="1199542442495" name="jetbrains.mps.baseLanguage.closures.structure.FunctionType" flags="in" index="1ajhzC">
+        <child id="1199542457201" name="resultType" index="1ajl9A" />
+        <child id="1199542501692" name="parameterType" index="1ajw0F" />
+      </concept>
       <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
         <child id="1199569906740" name="parameter" index="1bW2Oz" />
         <child id="1199569916463" name="body" index="1bW5cS" />
+      </concept>
+      <concept id="1225797177491" name="jetbrains.mps.baseLanguage.closures.structure.InvokeFunctionOperation" flags="nn" index="1Bd96e">
+        <child id="1225797361612" name="parameter" index="1BdPVh" />
       </concept>
     </language>
     <language id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc">
@@ -413,6 +424,7 @@
       <concept id="1204834851141" name="jetbrains.mps.lang.smodel.structure.PoundExpression" flags="ng" index="25Kdxt">
         <child id="1204834868751" name="expression" index="25KhWn" />
       </concept>
+      <concept id="1179168000618" name="jetbrains.mps.lang.smodel.structure.Node_GetIndexInParentOperation" flags="nn" index="2bSWHS" />
       <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
         <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
       </concept>
@@ -432,12 +444,21 @@
         <child id="1145404616321" name="leftExpression" index="2JrQYb" />
       </concept>
       <concept id="1181949435690" name="jetbrains.mps.lang.smodel.structure.Concept_NewInstance" flags="nn" index="LFhST" />
+      <concept id="7504436213544206332" name="jetbrains.mps.lang.smodel.structure.Node_ContainingLinkOperation" flags="nn" index="2NL2c5" />
       <concept id="1171305280644" name="jetbrains.mps.lang.smodel.structure.Node_GetDescendantsOperation" flags="nn" index="2Rf3mk" />
+      <concept id="1143511969223" name="jetbrains.mps.lang.smodel.structure.Node_GetPrevSiblingOperation" flags="nn" index="YBYNd" />
       <concept id="1180028149140" name="jetbrains.mps.lang.smodel.structure.Concept_IsSuperConceptOfOperation" flags="nn" index="2Za9M6">
         <child id="1180028346304" name="conceptArgument" index="2ZaTVi" />
       </concept>
       <concept id="1180031783296" name="jetbrains.mps.lang.smodel.structure.Concept_IsSubConceptOfOperation" flags="nn" index="2Zo12i">
         <child id="1180031783297" name="conceptArgument" index="2Zo12j" />
+      </concept>
+      <concept id="1171500988903" name="jetbrains.mps.lang.smodel.structure.Node_GetChildrenOperation" flags="nn" index="32TBzR" />
+      <concept id="2644386474300074836" name="jetbrains.mps.lang.smodel.structure.ConceptIdRefExpression" flags="nn" index="35c_gC">
+        <reference id="2644386474300074837" name="conceptDeclaration" index="35c_gD" />
+      </concept>
+      <concept id="5168775467716640652" name="jetbrains.mps.lang.smodel.structure.OperationParm_LinkQualifier" flags="ng" index="1aIX9F">
+        <child id="5168775467716640653" name="linkQualifier" index="1aIX9E" />
       </concept>
       <concept id="6677504323281689838" name="jetbrains.mps.lang.smodel.structure.SConceptType" flags="in" index="3bZ5Sz" />
       <concept id="1139613262185" name="jetbrains.mps.lang.smodel.structure.Node_GetParentOperation" flags="nn" index="1mfA1w" />
@@ -516,6 +537,12 @@
       <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="nn" index="25WWJ4">
         <child id="540871147943773366" name="argument" index="25WWJ7" />
       </concept>
+      <concept id="1172650591544" name="jetbrains.mps.baseLanguage.collections.structure.SkipOperation" flags="nn" index="7r0gD">
+        <child id="1172658456740" name="elementsToSkip" index="7T0AP" />
+      </concept>
+      <concept id="1172664342967" name="jetbrains.mps.baseLanguage.collections.structure.TakeOperation" flags="nn" index="8ftyA">
+        <child id="1172664372046" name="elementsToTake" index="8f$Dv" />
+      </concept>
       <concept id="1204980550705" name="jetbrains.mps.baseLanguage.collections.structure.VisitAllOperation" flags="nn" index="2es0OD" />
       <concept id="1226511727824" name="jetbrains.mps.baseLanguage.collections.structure.SetType" flags="in" index="2hMVRd">
         <child id="1226511765987" name="elementType" index="2hN53Y" />
@@ -556,6 +583,7 @@
         <child id="1235573187520" name="singletonValue" index="2HTEbv" />
       </concept>
       <concept id="1237721394592" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerCreator" flags="nn" index="HWqM0">
+        <child id="1237721435808" name="initValue" index="HW$Y0" />
         <child id="1237721435807" name="elementType" index="HW$YZ" />
         <child id="1237731803878" name="copyFrom" index="I$8f6" />
       </concept>
@@ -598,6 +626,10 @@
       <concept id="1197686869805" name="jetbrains.mps.baseLanguage.collections.structure.HashMapCreator" flags="nn" index="3rGOSV">
         <child id="1197687026896" name="keyType" index="3rHrn6" />
         <child id="1197687035757" name="valueType" index="3rHtpV" />
+      </concept>
+      <concept id="1225621920911" name="jetbrains.mps.baseLanguage.collections.structure.InsertElementOperation" flags="nn" index="1sK_Qi">
+        <child id="1225621943565" name="element" index="1sKFgg" />
+        <child id="1225621960341" name="index" index="1sKJu8" />
       </concept>
       <concept id="1576845966386891367" name="jetbrains.mps.baseLanguage.collections.structure.CustomMapCreator" flags="nn" index="1u7pXE">
         <reference id="1576845966386891370" name="containerDeclaration" index="1u7pXB" />
@@ -2378,8 +2410,8 @@
         </node>
         <node concept="3clFbF" id="6rVC5beYLyY" role="3cqZAp">
           <node concept="2YIFZM" id="6rVC5beYM5j" role="3clFbG">
-            <ref role="1Pybhc" to="ykok:~ModelConstraints" resolve="ModelConstraints" />
             <ref role="37wK5l" to="ykok:~ModelConstraints.validatePropertyValue(org.jetbrains.mps.openapi.model.SNode,org.jetbrains.mps.openapi.language.SProperty,java.lang.Object,jetbrains.mps.smodel.runtime.CheckingNodeContext)" resolve="validatePropertyValue" />
+            <ref role="1Pybhc" to="ykok:~ModelConstraints" resolve="ModelConstraints" />
             <node concept="37vLTw" id="6rVC5beYSXu" role="37wK5m">
               <ref role="3cqZAo" node="4qdNcH$28X0" resolve="dummyNode" />
             </node>
@@ -3701,6 +3733,291 @@
       </node>
       <node concept="3Tm1VV" id="1E6FxvcSkkq" role="1B3o_S" />
     </node>
+    <node concept="2tJIrI" id="15DZatOAPG1" role="jymVt" />
+    <node concept="2YIFZL" id="15DZatOARrD" role="jymVt">
+      <property role="TrG5h" value="isSyntaxCell" />
+      <node concept="3clFbS" id="15DZatOARrE" role="3clF47">
+        <node concept="3clFbJ" id="15DZatOARrF" role="3cqZAp">
+          <node concept="3clFbS" id="15DZatOARrG" role="3clFbx">
+            <node concept="3cpWs6" id="15DZatOARrH" role="3cqZAp">
+              <node concept="3clFbT" id="15DZatOARrI" role="3cqZAk" />
+            </node>
+          </node>
+          <node concept="2ZW3vV" id="15DZatOARrN" role="3clFbw">
+            <node concept="3uibUv" id="15DZatOARrO" role="2ZW6by">
+              <ref role="3uigEE" to="4my4:~EditorCell_STHint" resolve="EditorCell_STHint" />
+            </node>
+            <node concept="37vLTw" id="15DZatOARrP" role="2ZW6bz">
+              <ref role="3cqZAo" node="15DZatOARsn" resolve="cell" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="15DZatOB54o" role="3cqZAp">
+          <node concept="3clFbS" id="15DZatOB54p" role="3clFbx">
+            <node concept="3cpWs6" id="15DZatOB54q" role="3cqZAp">
+              <node concept="3clFbT" id="15DZatOB54r" role="3cqZAk" />
+            </node>
+          </node>
+          <node concept="2ZW3vV" id="15DZatOB54t" role="3clFbw">
+            <node concept="3uibUv" id="15DZatOB54u" role="2ZW6by">
+              <ref role="3uigEE" node="DnjeukE0JQ" resolve="SideTransformationHolderCell" />
+            </node>
+            <node concept="37vLTw" id="15DZatOB54v" role="2ZW6bz">
+              <ref role="3cqZAo" node="15DZatOARsn" resolve="cell" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="15DZatOARrQ" role="3cqZAp">
+          <node concept="3clFbS" id="15DZatOARrR" role="3clFbx">
+            <node concept="3SKdUt" id="15DZatOARrS" role="3cqZAp">
+              <node concept="1PaTwC" id="15DZatOARrT" role="1aUNEU">
+                <node concept="3oM_SD" id="15DZatOARrU" role="1PaTwD">
+                  <property role="3oM_SC" value="this" />
+                </node>
+                <node concept="3oM_SD" id="15DZatOARrV" role="1PaTwD">
+                  <property role="3oM_SC" value="is" />
+                </node>
+                <node concept="3oM_SD" id="15DZatOARrW" role="1PaTwD">
+                  <property role="3oM_SC" value="probably" />
+                </node>
+                <node concept="3oM_SD" id="15DZatOARrX" role="1PaTwD">
+                  <property role="3oM_SC" value="just" />
+                </node>
+                <node concept="3oM_SD" id="15DZatOARrY" role="1PaTwD">
+                  <property role="3oM_SC" value="some" />
+                </node>
+                <node concept="3oM_SD" id="15DZatOARrZ" role="1PaTwD">
+                  <property role="3oM_SC" value="additional" />
+                </node>
+                <node concept="3oM_SD" id="15DZatOARs0" role="1PaTwD">
+                  <property role="3oM_SC" value="information" />
+                </node>
+                <node concept="3oM_SD" id="15DZatOARs1" role="1PaTwD">
+                  <property role="3oM_SC" value="that" />
+                </node>
+                <node concept="3oM_SD" id="15DZatOARs2" role="1PaTwD">
+                  <property role="3oM_SC" value="is" />
+                </node>
+                <node concept="3oM_SD" id="15DZatOARs3" role="1PaTwD">
+                  <property role="3oM_SC" value="not" />
+                </node>
+                <node concept="3oM_SD" id="15DZatOARs4" role="1PaTwD">
+                  <property role="3oM_SC" value="part" />
+                </node>
+                <node concept="3oM_SD" id="15DZatOARs5" role="1PaTwD">
+                  <property role="3oM_SC" value="of" />
+                </node>
+                <node concept="3oM_SD" id="15DZatOARs6" role="1PaTwD">
+                  <property role="3oM_SC" value="the" />
+                </node>
+                <node concept="3oM_SD" id="15DZatOARs7" role="1PaTwD">
+                  <property role="3oM_SC" value="syntax" />
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs6" id="15DZatOARs8" role="3cqZAp">
+              <node concept="3clFbT" id="15DZatOARs9" role="3cqZAk" />
+            </node>
+          </node>
+          <node concept="1Wc70l" id="15DZatOARsa" role="3clFbw">
+            <node concept="3fqX7Q" id="15DZatOARsb" role="3uHU7w">
+              <node concept="2OqwBi" id="15DZatOARsc" role="3fr31v">
+                <node concept="2OqwBi" id="15DZatOARsd" role="2Oq$k0">
+                  <node concept="37vLTw" id="15DZatOARse" role="2Oq$k0">
+                    <ref role="3cqZAo" node="15DZatOARsn" resolve="cell" />
+                  </node>
+                  <node concept="liA8E" id="15DZatOARsf" role="2OqNvi">
+                    <ref role="37wK5l" to="f4zo:~EditorCell.getStyle()" resolve="getStyle" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="15DZatOARsg" role="2OqNvi">
+                  <ref role="37wK5l" to="hox0:~Style.get(jetbrains.mps.openapi.editor.style.StyleAttribute)" resolve="get" />
+                  <node concept="10M0yZ" id="15DZatOARsh" role="37wK5m">
+                    <ref role="3cqZAo" to="5ueo:~StyleAttributes.SELECTABLE" resolve="SELECTABLE" />
+                    <ref role="1PxDUh" to="5ueo:~StyleAttributes" resolve="StyleAttributes" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="2ZW3vV" id="15DZatOARsi" role="3uHU7B">
+              <node concept="3uibUv" id="15DZatOARsj" role="2ZW6by">
+                <ref role="3uigEE" to="f4zo:~EditorCell_Label" resolve="EditorCell_Label" />
+              </node>
+              <node concept="37vLTw" id="15DZatOARsk" role="2ZW6bz">
+                <ref role="3cqZAo" node="15DZatOARsn" resolve="cell" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="15DZatOARsl" role="3cqZAp">
+          <node concept="3clFbT" id="15DZatOARsm" role="3cqZAk">
+            <property role="3clFbU" value="true" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="15DZatOARsn" role="3clF46">
+        <property role="TrG5h" value="cell" />
+        <node concept="3uibUv" id="15DZatOARso" role="1tU5fm">
+          <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+        </node>
+      </node>
+      <node concept="10P_77" id="15DZatOARsp" role="3clF45" />
+      <node concept="3Tm1VV" id="15DZatOARsq" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="4ntVsBGiQlz" role="jymVt" />
+    <node concept="2YIFZL" id="4ntVsBGjBHL" role="jymVt">
+      <property role="TrG5h" value="getUnwrappedChildren" />
+      <node concept="3clFbS" id="4ntVsBGjlFv" role="3clF47">
+        <node concept="3clFbJ" id="4ntVsBGjtsl" role="3cqZAp">
+          <node concept="2ZW3vV" id="4ntVsBGjvLB" role="3clFbw">
+            <node concept="3uibUv" id="4ntVsBGjwVk" role="2ZW6by">
+              <ref role="3uigEE" to="f4zo:~EditorCell_Collection" resolve="EditorCell_Collection" />
+            </node>
+            <node concept="37vLTw" id="4ntVsBGjuBm" role="2ZW6bz">
+              <ref role="3cqZAo" node="4ntVsBGjqCk" resolve="parent" />
+            </node>
+          </node>
+          <node concept="3clFbS" id="4ntVsBGjtsn" role="3clFbx">
+            <node concept="3cpWs8" id="4ntVsBGjN$K" role="3cqZAp">
+              <node concept="3cpWsn" id="4ntVsBGjN$N" role="3cpWs9">
+                <property role="TrG5h" value="children" />
+                <node concept="A3Dl8" id="4ntVsBGjN$I" role="1tU5fm">
+                  <node concept="3uibUv" id="4ntVsBGjOIM" role="A3Ik2">
+                    <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+                  </node>
+                </node>
+                <node concept="1eOMI4" id="4ntVsBGjEvk" role="33vP2m">
+                  <node concept="10QFUN" id="4ntVsBGjEvh" role="1eOMHV">
+                    <node concept="3uibUv" id="4ntVsBGjEvm" role="10QFUM">
+                      <ref role="3uigEE" to="f4zo:~EditorCell_Collection" resolve="EditorCell_Collection" />
+                    </node>
+                    <node concept="37vLTw" id="4ntVsBGjEvn" role="10QFUP">
+                      <ref role="3cqZAo" node="4ntVsBGjqCk" resolve="parent" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs6" id="4ntVsBGkq5s" role="3cqZAp">
+              <node concept="2OqwBi" id="4ntVsBGkq5u" role="3cqZAk">
+                <node concept="37vLTw" id="4ntVsBGkq5v" role="2Oq$k0">
+                  <ref role="3cqZAo" node="4ntVsBGjN$N" resolve="children" />
+                </node>
+                <node concept="3goQfb" id="4ntVsBGkq5w" role="2OqNvi">
+                  <node concept="1bVj0M" id="4ntVsBGkq5x" role="23t8la">
+                    <node concept="3clFbS" id="4ntVsBGkq5y" role="1bW5cS">
+                      <node concept="3clFbJ" id="4ntVsBGkq5z" role="3cqZAp">
+                        <node concept="1rXfSq" id="4ntVsBGkq5$" role="3clFbw">
+                          <ref role="37wK5l" node="4ntVsBGj4zv" resolve="isNonSyntaxWrapper" />
+                          <node concept="37vLTw" id="4ntVsBGkq5_" role="37wK5m">
+                            <ref role="3cqZAo" node="4ntVsBGkq5L" resolve="child" />
+                          </node>
+                        </node>
+                        <node concept="3clFbS" id="4ntVsBGkq5A" role="3clFbx">
+                          <node concept="3cpWs6" id="4ntVsBGkq5B" role="3cqZAp">
+                            <node concept="1rXfSq" id="4ntVsBGkq5C" role="3cqZAk">
+                              <ref role="37wK5l" node="4ntVsBGjBHL" resolve="getUnwrappedChildren" />
+                              <node concept="37vLTw" id="4ntVsBGkq5D" role="37wK5m">
+                                <ref role="3cqZAo" node="4ntVsBGkq5L" resolve="child" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="9aQIb" id="4ntVsBGkq5E" role="9aQIa">
+                          <node concept="3clFbS" id="4ntVsBGkq5F" role="9aQI4">
+                            <node concept="3cpWs6" id="4ntVsBGkq5G" role="3cqZAp">
+                              <node concept="2ShNRf" id="4ntVsBGkq5H" role="3cqZAk">
+                                <node concept="2HTt$P" id="4ntVsBGkq5I" role="2ShVmc">
+                                  <node concept="3uibUv" id="4ntVsBGkq5J" role="2HTBi0">
+                                    <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+                                  </node>
+                                  <node concept="37vLTw" id="4ntVsBGkq5K" role="2HTEbv">
+                                    <ref role="3cqZAo" node="4ntVsBGkq5L" resolve="child" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="Rh6nW" id="4ntVsBGkq5L" role="1bW2Oz">
+                      <property role="TrG5h" value="child" />
+                      <node concept="2jxLKc" id="4ntVsBGkq5M" role="1tU5fm" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="9aQIb" id="4ntVsBGjy3_" role="9aQIa">
+            <node concept="3clFbS" id="4ntVsBGjy3A" role="9aQI4">
+              <node concept="3cpWs6" id="4ntVsBGjDgc" role="3cqZAp">
+                <node concept="2YIFZM" id="4ntVsBGjDge" role="3cqZAk">
+                  <ref role="37wK5l" to="33ny:~Collections.emptyList()" resolve="emptyList" />
+                  <ref role="1Pybhc" to="33ny:~Collections" resolve="Collections" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="4ntVsBGjqCk" role="3clF46">
+        <property role="TrG5h" value="parent" />
+        <node concept="3uibUv" id="4ntVsBGjrKy" role="1tU5fm">
+          <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+        </node>
+      </node>
+      <node concept="A3Dl8" id="4ntVsBGjzbV" role="3clF45">
+        <node concept="3uibUv" id="4ntVsBGj$cE" role="A3Ik2">
+          <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="4ntVsBGjlFu" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="4ntVsBGjkdt" role="jymVt" />
+    <node concept="2YIFZL" id="4ntVsBGj4zv" role="jymVt">
+      <property role="TrG5h" value="isNonSyntaxWrapper" />
+      <node concept="3clFbS" id="4ntVsBGiW3D" role="3clF47">
+        <node concept="3clFbJ" id="4ntVsBGjdWM" role="3cqZAp">
+          <node concept="3clFbS" id="4ntVsBGjdWO" role="3clFbx">
+            <node concept="3cpWs6" id="4ntVsBGjfVq" role="3cqZAp">
+              <node concept="3clFbT" id="4ntVsBGjgR2" role="3cqZAk">
+                <property role="3clFbU" value="true" />
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="4ntVsBGj8Qk" role="3clFbw">
+            <node concept="2OqwBi" id="4ntVsBGj7lK" role="2Oq$k0">
+              <node concept="37vLTw" id="4ntVsBGj643" role="2Oq$k0">
+                <ref role="3cqZAo" node="4ntVsBGj0Em" resolve="cell" />
+              </node>
+              <node concept="liA8E" id="4ntVsBGj7O1" role="2OqNvi">
+                <ref role="37wK5l" to="f4zo:~EditorCell.getSNode()" resolve="getSNode" />
+              </node>
+            </node>
+            <node concept="liA8E" id="4ntVsBGj92H" role="2OqNvi">
+              <ref role="37wK5l" to="mhbf:~SNode.isInstanceOfConcept(org.jetbrains.mps.openapi.language.SAbstractConcept)" resolve="isInstanceOfConcept" />
+              <node concept="35c_gC" id="4ntVsBGja2L" role="37wK5m">
+                <ref role="35c_gD" to="tpck:4uZwTti3_$T" resolve="Attribute" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4ntVsBGjiO5" role="3cqZAp">
+          <node concept="3clFbT" id="4ntVsBGjiO4" role="3clFbG" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="4ntVsBGj0Em" role="3clF46">
+        <property role="TrG5h" value="cell" />
+        <node concept="3uibUv" id="4ntVsBGj2DJ" role="1tU5fm">
+          <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+        </node>
+      </node>
+      <node concept="10P_77" id="4ntVsBGj3ru" role="3clF45" />
+      <node concept="3Tm1VV" id="4ntVsBGiW3C" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="15DZatOAPZ7" role="jymVt" />
     <node concept="3Tm1VV" id="RbLMy696h4" role="1B3o_S" />
   </node>
   <node concept="312cEu" id="RbLMy69lMx">
@@ -30569,6 +30886,1915 @@
       <node concept="3Tmbuc" id="4F4X830WNan" role="1B3o_S" />
     </node>
     <node concept="3Tm1VV" id="4F4X830W9je" role="1B3o_S" />
+  </node>
+  <node concept="312cEu" id="DnjeukE0JQ">
+    <property role="TrG5h" value="SideTransformationHolderCell" />
+    <property role="1sVAO0" value="true" />
+    <node concept="2tJIrI" id="DnjeukE0W3" role="jymVt" />
+    <node concept="2YIFZL" id="DnjeukE1nh" role="jymVt">
+      <property role="TrG5h" value="processParentCollection" />
+      <node concept="37vLTG" id="DnjeukE1z2" role="3clF46">
+        <property role="TrG5h" value="parentCollection" />
+        <node concept="3uibUv" id="DnjeukE1Ka" role="1tU5fm">
+          <ref role="3uigEE" to="f4zo:~EditorCell_Collection" resolve="EditorCell_Collection" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="DnjeukE1ir" role="3clF47">
+        <node concept="3cpWs8" id="DnjeukV3MX" role="3cqZAp">
+          <node concept="3cpWsn" id="DnjeukV3MY" role="3cpWs9">
+            <property role="TrG5h" value="removeOldLookups" />
+            <node concept="1ajhzC" id="DnjeukV3MU" role="1tU5fm">
+              <node concept="3uibUv" id="DnjeukV3MV" role="1ajw0F">
+                <ref role="3uigEE" to="uddc:~TransformationMenuLookup" resolve="TransformationMenuLookup" />
+              </node>
+              <node concept="10P_77" id="DnjeukV3MW" role="1ajl9A" />
+            </node>
+            <node concept="1bVj0M" id="DnjeukV3MZ" role="33vP2m">
+              <node concept="37vLTG" id="DnjeukV3N0" role="1bW2Oz">
+                <property role="TrG5h" value="l" />
+                <node concept="3uibUv" id="DnjeukV3N1" role="1tU5fm">
+                  <ref role="3uigEE" to="uddc:~TransformationMenuLookup" resolve="TransformationMenuLookup" />
+                </node>
+              </node>
+              <node concept="3clFbS" id="DnjeukV3N2" role="1bW5cS">
+                <node concept="3cpWs8" id="5fS8LrnNRfI" role="3cqZAp">
+                  <node concept="3cpWsn" id="5fS8LrnNRfJ" role="3cpWs9">
+                    <property role="TrG5h" value="lookup" />
+                    <node concept="3uibUv" id="5fS8LrnN6pb" role="1tU5fm">
+                      <ref role="3uigEE" node="DnjeukGjQt" resolve="SideTransformationHolderCell.Lookup" />
+                    </node>
+                    <node concept="0kSF2" id="5fS8LrnNRfK" role="33vP2m">
+                      <node concept="3uibUv" id="5fS8LrnNRfL" role="0kSFW">
+                        <ref role="3uigEE" node="DnjeukGjQt" resolve="SideTransformationHolderCell.Lookup" />
+                      </node>
+                      <node concept="37vLTw" id="5fS8LrnNRfM" role="0kSFX">
+                        <ref role="3cqZAo" node="DnjeukV3N0" resolve="l" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3cpWs8" id="5fS8LrnLNiu" role="3cqZAp">
+                  <node concept="3cpWsn" id="5fS8LrnLNiv" role="3cpWs9">
+                    <property role="TrG5h" value="holderCellNode" />
+                    <node concept="3uibUv" id="5fS8LrnLM_G" role="1tU5fm">
+                      <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
+                    </node>
+                    <node concept="2EnYce" id="5fS8LrnLNiw" role="33vP2m">
+                      <node concept="2EnYce" id="5fS8LrnLNix" role="2Oq$k0">
+                        <node concept="37vLTw" id="5fS8LrnNRfN" role="2Oq$k0">
+                          <ref role="3cqZAo" node="5fS8LrnNRfJ" resolve="lookup" />
+                        </node>
+                        <node concept="liA8E" id="5fS8LrnLNi_" role="2OqNvi">
+                          <ref role="37wK5l" node="DnjeukUNRw" resolve="getHolderCell" />
+                        </node>
+                      </node>
+                      <node concept="liA8E" id="5fS8LrnLNiA" role="2OqNvi">
+                        <ref role="37wK5l" to="g51k:~EditorCell_Basic.getSNode()" resolve="getSNode" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3cpWs8" id="5fS8LrnLOt4" role="3cqZAp">
+                  <node concept="3cpWsn" id="5fS8LrnLOt5" role="3cpWs9">
+                    <property role="TrG5h" value="parentCollectionNode" />
+                    <node concept="3uibUv" id="5fS8LrnLOp9" role="1tU5fm">
+                      <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
+                    </node>
+                    <node concept="2OqwBi" id="5fS8LrnLOt6" role="33vP2m">
+                      <node concept="37vLTw" id="5fS8LrnLOt7" role="2Oq$k0">
+                        <ref role="3cqZAo" node="DnjeukE1z2" resolve="parentCollection" />
+                      </node>
+                      <node concept="liA8E" id="5fS8LrnLOt8" role="2OqNvi">
+                        <ref role="37wK5l" to="f4zo:~EditorCell.getSNode()" resolve="getSNode" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbF" id="DnjeukV3N3" role="3cqZAp">
+                  <node concept="3fqX7Q" id="5fS8LrnNLYv" role="3clFbG">
+                    <node concept="1eOMI4" id="5fS8LrnNLYz" role="3fr31v">
+                      <node concept="1Wc70l" id="5fS8LrnNN4n" role="1eOMHV">
+                        <node concept="17R0WA" id="5fS8LrnNQFT" role="3uHU7w">
+                          <node concept="2OqwBi" id="5fS8LrnNSBN" role="3uHU7w">
+                            <node concept="37vLTw" id="5fS8LrnNRQM" role="2Oq$k0">
+                              <ref role="3cqZAo" node="5fS8LrnNRfJ" resolve="lookup" />
+                            </node>
+                            <node concept="liA8E" id="5fS8LrnNTjb" role="2OqNvi">
+                              <ref role="37wK5l" node="5fS8LrnN3$I" resolve="getSourceCellId" />
+                            </node>
+                          </node>
+                          <node concept="2OqwBi" id="5fS8LrnNOcC" role="3uHU7B">
+                            <node concept="37vLTw" id="5fS8LrnNOZ3" role="2Oq$k0">
+                              <ref role="3cqZAo" node="DnjeukE1z2" resolve="parentCollection" />
+                            </node>
+                            <node concept="liA8E" id="5fS8LrnNPRp" role="2OqNvi">
+                              <ref role="37wK5l" to="f4zo:~EditorCell.getCellId()" resolve="getCellId" />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="17R0WA" id="5fS8LrnNLjW" role="3uHU7B">
+                          <node concept="37vLTw" id="5fS8LrnLNiB" role="3uHU7B">
+                            <ref role="3cqZAo" node="5fS8LrnLNiv" resolve="holderCellNode" />
+                          </node>
+                          <node concept="37vLTw" id="5fS8LrnLOt9" role="3uHU7w">
+                            <ref role="3cqZAo" node="5fS8LrnLOt5" resolve="parentCollectionNode" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="DnjeukE58H" role="3cqZAp">
+          <node concept="3cpWsn" id="DnjeukE58I" role="3cpWs9">
+            <property role="TrG5h" value="children" />
+            <node concept="_YKpA" id="DnjeukE577" role="1tU5fm">
+              <node concept="3uibUv" id="DnjeukE57a" role="_ZDj9">
+                <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+              </node>
+            </node>
+            <node concept="2ShNRf" id="DnjeukE58J" role="33vP2m">
+              <node concept="Tc6Ow" id="DnjeukE58K" role="2ShVmc">
+                <node concept="3uibUv" id="DnjeukE58L" role="HW$YZ">
+                  <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+                </node>
+                <node concept="37vLTw" id="DnjeukE58M" role="I$8f6">
+                  <ref role="3cqZAo" node="DnjeukE1z2" resolve="parentCollection" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="DnjeukUX0j" role="3cqZAp">
+          <node concept="2YIFZM" id="DnjeukUXEL" role="3clFbG">
+            <ref role="37wK5l" to="gdpt:DnjeukUIla" resolve="filter" />
+            <ref role="1Pybhc" to="gdpt:1_3xoKENxnx" resolve="CompositeTransformationMenuLookup" />
+            <node concept="37vLTw" id="DnjeukUY3q" role="37wK5m">
+              <ref role="3cqZAo" node="DnjeukE1z2" resolve="parentCollection" />
+            </node>
+            <node concept="37vLTw" id="DnjeukV3Nf" role="37wK5m">
+              <ref role="3cqZAo" node="DnjeukV3MY" resolve="removeOldLookups" />
+            </node>
+          </node>
+        </node>
+        <node concept="2Gpval" id="DnjeukV65a" role="3cqZAp">
+          <node concept="2GrKxI" id="DnjeukV65c" role="2Gsz3X">
+            <property role="TrG5h" value="child" />
+          </node>
+          <node concept="37vLTw" id="DnjeukV6M0" role="2GsD0m">
+            <ref role="3cqZAo" node="DnjeukE58I" resolve="children" />
+          </node>
+          <node concept="3clFbS" id="DnjeukV65g" role="2LFqv$">
+            <node concept="3clFbF" id="DnjeukV79N" role="3cqZAp">
+              <node concept="2YIFZM" id="DnjeukV79P" role="3clFbG">
+                <ref role="37wK5l" to="gdpt:DnjeukUIla" resolve="filter" />
+                <ref role="1Pybhc" to="gdpt:1_3xoKENxnx" resolve="CompositeTransformationMenuLookup" />
+                <node concept="2GrUjf" id="DnjeukV7gD" role="37wK5m">
+                  <ref role="2Gs0qQ" node="DnjeukV65c" resolve="child" />
+                </node>
+                <node concept="37vLTw" id="DnjeukV79R" role="37wK5m">
+                  <ref role="3cqZAo" node="DnjeukV3MY" resolve="removeOldLookups" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2Gpval" id="DnjeukE9Ey" role="3cqZAp">
+          <node concept="2GrKxI" id="DnjeukE9E$" role="2Gsz3X">
+            <property role="TrG5h" value="holderCell" />
+          </node>
+          <node concept="2OqwBi" id="DnjeukEaoY" role="2GsD0m">
+            <node concept="37vLTw" id="DnjeukE9I2" role="2Oq$k0">
+              <ref role="3cqZAo" node="DnjeukE58I" resolve="children" />
+            </node>
+            <node concept="UnYns" id="DnjeukEaJY" role="2OqNvi">
+              <node concept="3uibUv" id="DnjeukEaMh" role="UnYnz">
+                <ref role="3uigEE" node="DnjeukE0JQ" resolve="SideTransformationHolderCell" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbS" id="DnjeukE9EC" role="2LFqv$">
+            <node concept="3cpWs8" id="DnjeukEbYP" role="3cqZAp">
+              <node concept="3cpWsn" id="DnjeukEbYQ" role="3cpWs9">
+                <property role="TrG5h" value="holderCellIndex" />
+                <node concept="10Oyi0" id="DnjeukEbY_" role="1tU5fm" />
+                <node concept="2OqwBi" id="DnjeukEbYR" role="33vP2m">
+                  <node concept="37vLTw" id="DnjeukEbYS" role="2Oq$k0">
+                    <ref role="3cqZAo" node="DnjeukE58I" resolve="children" />
+                  </node>
+                  <node concept="2WmjW8" id="DnjeukEbYT" role="2OqNvi">
+                    <node concept="2GrUjf" id="DnjeukEbYU" role="25WWJ7">
+                      <ref role="2Gs0qQ" node="DnjeukE9E$" resolve="holderCell" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs8" id="DnjeukEfbq" role="3cqZAp">
+              <node concept="3cpWsn" id="DnjeukEfbr" role="3cpWs9">
+                <property role="TrG5h" value="prevSiblings" />
+                <node concept="A3Dl8" id="DnjeukEfaO" role="1tU5fm">
+                  <node concept="3uibUv" id="DnjeukEfaR" role="A3Ik2">
+                    <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="DnjeukEfbs" role="33vP2m">
+                  <node concept="37vLTw" id="DnjeukEfbt" role="2Oq$k0">
+                    <ref role="3cqZAo" node="DnjeukE58I" resolve="children" />
+                  </node>
+                  <node concept="8ftyA" id="DnjeukEfbu" role="2OqNvi">
+                    <node concept="37vLTw" id="DnjeukEfbv" role="8f$Dv">
+                      <ref role="3cqZAo" node="DnjeukEbYQ" resolve="holderCellIndex" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs8" id="DnjeukEdwl" role="3cqZAp">
+              <node concept="3cpWsn" id="DnjeukEdwm" role="3cpWs9">
+                <property role="TrG5h" value="nextSiblings" />
+                <node concept="A3Dl8" id="DnjeukEdvN" role="1tU5fm">
+                  <node concept="3uibUv" id="DnjeukEdvQ" role="A3Ik2">
+                    <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="DnjeukEdwn" role="33vP2m">
+                  <node concept="37vLTw" id="DnjeukEdwo" role="2Oq$k0">
+                    <ref role="3cqZAo" node="DnjeukE58I" resolve="children" />
+                  </node>
+                  <node concept="7r0gD" id="DnjeukEdwp" role="2OqNvi">
+                    <node concept="3cpWs3" id="DnjeukEfY6" role="7T0AP">
+                      <node concept="3cmrfG" id="DnjeukEfZa" role="3uHU7w">
+                        <property role="3cmrfH" value="1" />
+                      </node>
+                      <node concept="37vLTw" id="DnjeukEdwq" role="3uHU7B">
+                        <ref role="3cqZAo" node="DnjeukEbYQ" resolve="holderCellIndex" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="DnjeukEBPW" role="3cqZAp">
+              <node concept="37vLTI" id="DnjeukECwX" role="3clFbG">
+                <node concept="37vLTw" id="DnjeukEBPU" role="37vLTJ">
+                  <ref role="3cqZAo" node="DnjeukEdwm" resolve="nextSiblings" />
+                </node>
+                <node concept="2OqwBi" id="DnjeukECyR" role="37vLTx">
+                  <node concept="37vLTw" id="DnjeukECyS" role="2Oq$k0">
+                    <ref role="3cqZAo" node="DnjeukEdwm" resolve="nextSiblings" />
+                  </node>
+                  <node concept="3zZkjj" id="DnjeukECyT" role="2OqNvi">
+                    <node concept="1bVj0M" id="DnjeukECyU" role="23t8la">
+                      <node concept="3clFbS" id="DnjeukECyV" role="1bW5cS">
+                        <node concept="3clFbF" id="DnjeukECyW" role="3cqZAp">
+                          <node concept="3fqX7Q" id="DnjeukECyX" role="3clFbG">
+                            <node concept="1rXfSq" id="DnjeukECyY" role="3fr31v">
+                              <ref role="37wK5l" node="DnjeukEnC8" resolve="ignoreSibling" />
+                              <node concept="37vLTw" id="DnjeukECyZ" role="37wK5m">
+                                <ref role="3cqZAo" node="DnjeukECz0" resolve="it" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="Rh6nW" id="DnjeukECz0" role="1bW2Oz">
+                        <property role="TrG5h" value="it" />
+                        <node concept="2jxLKc" id="DnjeukECz1" role="1tU5fm" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="DnjeukEDdl" role="3cqZAp">
+              <node concept="37vLTI" id="DnjeukEDH_" role="3clFbG">
+                <node concept="37vLTw" id="DnjeukEDdj" role="37vLTJ">
+                  <ref role="3cqZAo" node="DnjeukEfbr" resolve="prevSiblings" />
+                </node>
+                <node concept="2OqwBi" id="DnjeukEDJv" role="37vLTx">
+                  <node concept="37vLTw" id="DnjeukEDJw" role="2Oq$k0">
+                    <ref role="3cqZAo" node="DnjeukEfbr" resolve="prevSiblings" />
+                  </node>
+                  <node concept="3zZkjj" id="DnjeukEDJx" role="2OqNvi">
+                    <node concept="1bVj0M" id="DnjeukEDJy" role="23t8la">
+                      <node concept="3clFbS" id="DnjeukEDJz" role="1bW5cS">
+                        <node concept="3clFbF" id="DnjeukEDJ$" role="3cqZAp">
+                          <node concept="3fqX7Q" id="DnjeukEDJ_" role="3clFbG">
+                            <node concept="1rXfSq" id="DnjeukEDJA" role="3fr31v">
+                              <ref role="37wK5l" node="DnjeukEnC8" resolve="ignoreSibling" />
+                              <node concept="37vLTw" id="DnjeukEDJB" role="37wK5m">
+                                <ref role="3cqZAo" node="DnjeukEDJC" resolve="it" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="Rh6nW" id="DnjeukEDJC" role="1bW2Oz">
+                        <property role="TrG5h" value="it" />
+                        <node concept="2jxLKc" id="DnjeukEDJD" role="1tU5fm" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbJ" id="DnjeukEgnK" role="3cqZAp">
+              <node concept="3clFbS" id="DnjeukEgnM" role="3clFbx">
+                <node concept="3clFbF" id="DnjeukENb7" role="3cqZAp">
+                  <node concept="2YIFZM" id="DnjeukENu8" role="3clFbG">
+                    <ref role="37wK5l" to="gdpt:DnjeukELVT" resolve="add" />
+                    <ref role="1Pybhc" to="gdpt:1_3xoKENxnx" resolve="CompositeTransformationMenuLookup" />
+                    <node concept="37vLTw" id="DnjeukENwC" role="37wK5m">
+                      <ref role="3cqZAo" node="DnjeukE1z2" resolve="parentCollection" />
+                    </node>
+                    <node concept="2OqwBi" id="DnjeukEOa_" role="37wK5m">
+                      <node concept="2GrUjf" id="DnjeukEN_E" role="2Oq$k0">
+                        <ref role="2Gs0qQ" node="DnjeukE9E$" resolve="holderCell" />
+                      </node>
+                      <node concept="liA8E" id="5fS8LrnNxhz" role="2OqNvi">
+                        <ref role="37wK5l" node="5fS8LrnN867" resolve="createLookup" />
+                        <node concept="3clFbT" id="5fS8LrnNxGz" role="37wK5m" />
+                        <node concept="2OqwBi" id="5fS8LrnNznq" role="37wK5m">
+                          <node concept="37vLTw" id="5fS8LrnNyHd" role="2Oq$k0">
+                            <ref role="3cqZAo" node="DnjeukE1z2" resolve="parentCollection" />
+                          </node>
+                          <node concept="liA8E" id="5fS8LrnN$nq" role="2OqNvi">
+                            <ref role="37wK5l" to="f4zo:~EditorCell.getCellId()" resolve="getCellId" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3N13vt" id="DnjeukEq3k" role="3cqZAp" />
+              </node>
+              <node concept="2OqwBi" id="DnjeukEpDv" role="3clFbw">
+                <node concept="37vLTw" id="DnjeukEgqU" role="2Oq$k0">
+                  <ref role="3cqZAo" node="DnjeukEdwm" resolve="nextSiblings" />
+                </node>
+                <node concept="1v1jN8" id="DnjeukEq0A" role="2OqNvi" />
+              </node>
+            </node>
+            <node concept="3clFbJ" id="DnjeukE_Ac" role="3cqZAp">
+              <node concept="3clFbS" id="DnjeukE_Ad" role="3clFbx">
+                <node concept="3clFbF" id="DnjeukEQDD" role="3cqZAp">
+                  <node concept="2YIFZM" id="DnjeukEQDE" role="3clFbG">
+                    <ref role="1Pybhc" to="gdpt:1_3xoKENxnx" resolve="CompositeTransformationMenuLookup" />
+                    <ref role="37wK5l" to="gdpt:DnjeukELVT" resolve="add" />
+                    <node concept="37vLTw" id="DnjeukEQDF" role="37wK5m">
+                      <ref role="3cqZAo" node="DnjeukE1z2" resolve="parentCollection" />
+                    </node>
+                    <node concept="2OqwBi" id="5fS8LrnN_no" role="37wK5m">
+                      <node concept="2GrUjf" id="5fS8LrnN_np" role="2Oq$k0">
+                        <ref role="2Gs0qQ" node="DnjeukE9E$" resolve="holderCell" />
+                      </node>
+                      <node concept="liA8E" id="5fS8LrnN_nq" role="2OqNvi">
+                        <ref role="37wK5l" node="5fS8LrnN867" resolve="createLookup" />
+                        <node concept="3clFbT" id="5fS8LrnN_nr" role="37wK5m">
+                          <property role="3clFbU" value="true" />
+                        </node>
+                        <node concept="2OqwBi" id="5fS8LrnN_ns" role="37wK5m">
+                          <node concept="37vLTw" id="5fS8LrnN_nt" role="2Oq$k0">
+                            <ref role="3cqZAo" node="DnjeukE1z2" resolve="parentCollection" />
+                          </node>
+                          <node concept="liA8E" id="5fS8LrnN_nu" role="2OqNvi">
+                            <ref role="37wK5l" to="f4zo:~EditorCell.getCellId()" resolve="getCellId" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3N13vt" id="DnjeukE_Ap" role="3cqZAp" />
+              </node>
+              <node concept="2OqwBi" id="DnjeukE_Aq" role="3clFbw">
+                <node concept="37vLTw" id="DnjeukE_XI" role="2Oq$k0">
+                  <ref role="3cqZAo" node="DnjeukEfbr" resolve="prevSiblings" />
+                </node>
+                <node concept="1v1jN8" id="DnjeukE_AA" role="2OqNvi" />
+              </node>
+            </node>
+            <node concept="3clFbJ" id="DnjeukEFTM" role="3cqZAp">
+              <node concept="3clFbS" id="DnjeukEFTO" role="3clFbx">
+                <node concept="3clFbF" id="DnjeukESC_" role="3cqZAp">
+                  <node concept="2YIFZM" id="DnjeukESCA" role="3clFbG">
+                    <ref role="1Pybhc" to="gdpt:1_3xoKENxnx" resolve="CompositeTransformationMenuLookup" />
+                    <ref role="37wK5l" to="gdpt:DnjeukELVT" resolve="add" />
+                    <node concept="2OqwBi" id="DnjeukETm_" role="37wK5m">
+                      <node concept="37vLTw" id="DnjeukET5h" role="2Oq$k0">
+                        <ref role="3cqZAo" node="DnjeukEfbr" resolve="prevSiblings" />
+                      </node>
+                      <node concept="1yVyf7" id="DnjeukEU5X" role="2OqNvi" />
+                    </node>
+                    <node concept="2OqwBi" id="5fS8LrnNHeU" role="37wK5m">
+                      <node concept="2GrUjf" id="5fS8LrnNHeV" role="2Oq$k0">
+                        <ref role="2Gs0qQ" node="DnjeukE9E$" resolve="holderCell" />
+                      </node>
+                      <node concept="liA8E" id="5fS8LrnNHeW" role="2OqNvi">
+                        <ref role="37wK5l" node="5fS8LrnN867" resolve="createLookup" />
+                        <node concept="3clFbT" id="5fS8LrnNHeX" role="37wK5m" />
+                        <node concept="2OqwBi" id="5fS8LrnNHeY" role="37wK5m">
+                          <node concept="37vLTw" id="5fS8LrnNHeZ" role="2Oq$k0">
+                            <ref role="3cqZAo" node="DnjeukE1z2" resolve="parentCollection" />
+                          </node>
+                          <node concept="liA8E" id="5fS8LrnNHf0" role="2OqNvi">
+                            <ref role="37wK5l" to="f4zo:~EditorCell.getCellId()" resolve="getCellId" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3N13vt" id="DnjeukEVLa" role="3cqZAp" />
+              </node>
+              <node concept="2OqwBi" id="DnjeukEHfE" role="3clFbw">
+                <node concept="37vLTw" id="DnjeukEGd9" role="2Oq$k0">
+                  <ref role="3cqZAo" node="DnjeukEfbr" resolve="prevSiblings" />
+                </node>
+                <node concept="3GX2aA" id="DnjeukEHtF" role="2OqNvi" />
+              </node>
+            </node>
+            <node concept="3clFbJ" id="DnjeukEW0h" role="3cqZAp">
+              <node concept="3clFbS" id="DnjeukEW0i" role="3clFbx">
+                <node concept="3clFbF" id="DnjeukEW0j" role="3cqZAp">
+                  <node concept="2YIFZM" id="DnjeukEW0k" role="3clFbG">
+                    <ref role="1Pybhc" to="gdpt:1_3xoKENxnx" resolve="CompositeTransformationMenuLookup" />
+                    <ref role="37wK5l" to="gdpt:DnjeukELVT" resolve="add" />
+                    <node concept="2OqwBi" id="DnjeukEW0l" role="37wK5m">
+                      <node concept="37vLTw" id="DnjeuleqYg" role="2Oq$k0">
+                        <ref role="3cqZAo" node="DnjeukEdwm" resolve="nextSiblings" />
+                      </node>
+                      <node concept="1uHKPH" id="DnjeulerwA" role="2OqNvi" />
+                    </node>
+                    <node concept="2OqwBi" id="5fS8LrnNHP0" role="37wK5m">
+                      <node concept="2GrUjf" id="5fS8LrnNHP1" role="2Oq$k0">
+                        <ref role="2Gs0qQ" node="DnjeukE9E$" resolve="holderCell" />
+                      </node>
+                      <node concept="liA8E" id="5fS8LrnNHP2" role="2OqNvi">
+                        <ref role="37wK5l" node="5fS8LrnN867" resolve="createLookup" />
+                        <node concept="3clFbT" id="5fS8LrnNHP3" role="37wK5m">
+                          <property role="3clFbU" value="true" />
+                        </node>
+                        <node concept="2OqwBi" id="5fS8LrnNHP4" role="37wK5m">
+                          <node concept="37vLTw" id="5fS8LrnNHP5" role="2Oq$k0">
+                            <ref role="3cqZAo" node="DnjeukE1z2" resolve="parentCollection" />
+                          </node>
+                          <node concept="liA8E" id="5fS8LrnNHP6" role="2OqNvi">
+                            <ref role="37wK5l" to="f4zo:~EditorCell.getCellId()" resolve="getCellId" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3N13vt" id="DnjeukEW0r" role="3cqZAp" />
+              </node>
+              <node concept="2OqwBi" id="DnjeukEW0s" role="3clFbw">
+                <node concept="37vLTw" id="DnjeukEWq7" role="2Oq$k0">
+                  <ref role="3cqZAo" node="DnjeukEdwm" resolve="nextSiblings" />
+                </node>
+                <node concept="3GX2aA" id="DnjeukEW0u" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="DnjeukE5hR" role="3cqZAp">
+          <node concept="2OqwBi" id="DnjeukE8jh" role="3clFbG">
+            <node concept="2OqwBi" id="DnjeukE5VZ" role="2Oq$k0">
+              <node concept="37vLTw" id="DnjeukE5hP" role="2Oq$k0">
+                <ref role="3cqZAo" node="DnjeukE58I" resolve="children" />
+              </node>
+              <node concept="UnYns" id="DnjeukE7yv" role="2OqNvi">
+                <node concept="3uibUv" id="DnjeukE7$w" role="UnYnz">
+                  <ref role="3uigEE" node="DnjeukE0JQ" resolve="SideTransformationHolderCell" />
+                </node>
+              </node>
+            </node>
+            <node concept="2es0OD" id="DnjeukE8uy" role="2OqNvi">
+              <node concept="1bVj0M" id="DnjeukE8u$" role="23t8la">
+                <node concept="3clFbS" id="DnjeukE8u_" role="1bW5cS">
+                  <node concept="3clFbF" id="DnjeukE8zH" role="3cqZAp">
+                    <node concept="2OqwBi" id="DnjeukE8Rb" role="3clFbG">
+                      <node concept="37vLTw" id="DnjeukE8zG" role="2Oq$k0">
+                        <ref role="3cqZAo" node="DnjeukE1z2" resolve="parentCollection" />
+                      </node>
+                      <node concept="liA8E" id="DnjeukE9eD" role="2OqNvi">
+                        <ref role="37wK5l" to="f4zo:~EditorCell_Collection.removeCell(jetbrains.mps.openapi.editor.cells.EditorCell)" resolve="removeCell" />
+                        <node concept="37vLTw" id="DnjeukE9jD" role="37wK5m">
+                          <ref role="3cqZAo" node="DnjeukE8uA" resolve="it" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="Rh6nW" id="DnjeukE8uA" role="1bW2Oz">
+                  <property role="TrG5h" value="it" />
+                  <node concept="2jxLKc" id="DnjeukE8uB" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3cqZAl" id="DnjeukE1ip" role="3clF45" />
+      <node concept="3Tm1VV" id="DnjeukE1iq" role="1B3o_S" />
+      <node concept="P$JXv" id="DnjeukE1Ec" role="lGtFl">
+        <node concept="TZ5HA" id="DnjeukE1Ed" role="TZ5H$">
+          <node concept="1dT_AC" id="DnjeukE1Ee" role="1dT_Ay">
+            <property role="1dT_AB" value="Is executed on the collection cell that contains instances of this class." />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="DnjeukE1GS" role="TZ5H$">
+          <node concept="1dT_AC" id="DnjeukE1GT" role="1dT_Ay">
+            <property role="1dT_AB" value="These instances are removed and the transformation menu is attached to one of the remaining cells." />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="DnjeukEije" role="jymVt" />
+    <node concept="2YIFZL" id="DnjeukEnC8" role="jymVt">
+      <property role="TrG5h" value="ignoreSibling" />
+      <node concept="3clFbS" id="DnjeukEiUf" role="3clF47">
+        <node concept="3clFbF" id="15DZatOBigb" role="3cqZAp">
+          <node concept="3fqX7Q" id="15DZatOBjCe" role="3clFbG">
+            <node concept="2YIFZM" id="15DZatOBjCg" role="3fr31v">
+              <ref role="37wK5l" node="15DZatOARrD" resolve="isSyntaxCell" />
+              <ref role="1Pybhc" node="RbLMy696h3" resolve="GrammarCellsUtil" />
+              <node concept="37vLTw" id="15DZatOBjCh" role="37wK5m">
+                <ref role="3cqZAo" node="DnjeukEmOz" resolve="cell" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="DnjeukEmOz" role="3clF46">
+        <property role="TrG5h" value="cell" />
+        <node concept="3uibUv" id="DnjeukEnYR" role="1tU5fm">
+          <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+        </node>
+      </node>
+      <node concept="10P_77" id="DnjeukEo4K" role="3clF45" />
+      <node concept="3Tm6S6" id="DnjeukEnVK" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="DnjeukE1fl" role="jymVt" />
+    <node concept="312cEg" id="DnjeulfKk7" role="jymVt">
+      <property role="TrG5h" value="trace" />
+      <node concept="3Tm6S6" id="DnjeulfKk8" role="1B3o_S" />
+      <node concept="3uibUv" id="DnjeulfLto" role="1tU5fm">
+        <ref role="3uigEE" to="mhbf:~SNodeReference" resolve="SNodeReference" />
+      </node>
+    </node>
+    <node concept="312cEg" id="Dnjeun41Zx" role="jymVt">
+      <property role="TrG5h" value="description" />
+      <node concept="3Tm6S6" id="Dnjeun41Zy" role="1B3o_S" />
+      <node concept="17QB3L" id="Dnjeun431Y" role="1tU5fm" />
+    </node>
+    <node concept="2tJIrI" id="DnjeukExge" role="jymVt" />
+    <node concept="3Tm1VV" id="DnjeukE0JR" role="1B3o_S" />
+    <node concept="3uibUv" id="DnjeukE0TX" role="1zkMxy">
+      <ref role="3uigEE" to="g51k:~EditorCell_Constant" resolve="EditorCell_Constant" />
+    </node>
+    <node concept="3clFbW" id="DnjeukE0Yz" role="jymVt">
+      <node concept="3cqZAl" id="DnjeukE0Y$" role="3clF45" />
+      <node concept="3Tm1VV" id="DnjeukE0Y_" role="1B3o_S" />
+      <node concept="3clFbS" id="DnjeukE0YB" role="3clF47">
+        <node concept="XkiVB" id="DnjeukE0YD" role="3cqZAp">
+          <ref role="37wK5l" to="g51k:~EditorCell_Constant.&lt;init&gt;(jetbrains.mps.openapi.editor.EditorContext,org.jetbrains.mps.openapi.model.SNode,java.lang.String,boolean)" resolve="EditorCell_Constant" />
+          <node concept="37vLTw" id="DnjeukE0YI" role="37wK5m">
+            <ref role="3cqZAo" node="DnjeukE0YE" resolve="editorContext" />
+          </node>
+          <node concept="37vLTw" id="DnjeukE0YM" role="37wK5m">
+            <ref role="3cqZAo" node="DnjeukE0YJ" resolve="node" />
+          </node>
+          <node concept="Xl_RD" id="DnjeukE16z" role="37wK5m">
+            <property role="Xl_RC" value="SIDE_TRANSFORMATION" />
+          </node>
+          <node concept="3clFbT" id="DnjeukE14f" role="37wK5m" />
+        </node>
+        <node concept="3clFbF" id="DnjeulfLLh" role="3cqZAp">
+          <node concept="37vLTI" id="DnjeulfNnC" role="3clFbG">
+            <node concept="37vLTw" id="DnjeulfNpN" role="37vLTx">
+              <ref role="3cqZAo" node="DnjeulfLAt" resolve="trace" />
+            </node>
+            <node concept="2OqwBi" id="DnjeulfMmU" role="37vLTJ">
+              <node concept="Xjq3P" id="DnjeulfLLf" role="2Oq$k0" />
+              <node concept="2OwXpG" id="DnjeulfN6Z" role="2OqNvi">
+                <ref role="2Oxat5" node="DnjeulfKk7" resolve="trace" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="Dnjeun43qO" role="3cqZAp">
+          <node concept="37vLTI" id="Dnjeun45SK" role="3clFbG">
+            <node concept="3K4zz7" id="Dnjeun4irP" role="37vLTx">
+              <node concept="37vLTw" id="Dnjeun4iw$" role="3K4E3e">
+                <ref role="3cqZAo" node="Dnjeun43b3" resolve="description" />
+              </node>
+              <node concept="Xl_RD" id="Dnjeun4i$V" role="3K4GZi">
+                <property role="Xl_RC" value="side transformation cell" />
+              </node>
+              <node concept="3y3z36" id="Dnjeun4i7t" role="3K4Cdx">
+                <node concept="10Nm6u" id="Dnjeun4iq7" role="3uHU7w" />
+                <node concept="37vLTw" id="Dnjeun463o" role="3uHU7B">
+                  <ref role="3cqZAo" node="Dnjeun43b3" resolve="description" />
+                </node>
+              </node>
+            </node>
+            <node concept="2OqwBi" id="Dnjeun441t" role="37vLTJ">
+              <node concept="Xjq3P" id="Dnjeun43qM" role="2Oq$k0" />
+              <node concept="2OwXpG" id="Dnjeun45rz" role="2OqNvi">
+                <ref role="2Oxat5" node="Dnjeun41Zx" resolve="description" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="DnjeukE0YE" role="3clF46">
+        <property role="TrG5h" value="editorContext" />
+        <node concept="3uibUv" id="DnjeukE0YG" role="1tU5fm">
+          <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+        </node>
+        <node concept="2AHcQZ" id="DnjeukE0YH" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="DnjeukE0YJ" role="3clF46">
+        <property role="TrG5h" value="node" />
+        <node concept="3uibUv" id="DnjeukE0YL" role="1tU5fm">
+          <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="DnjeulfLAt" role="3clF46">
+        <property role="TrG5h" value="trace" />
+        <node concept="3uibUv" id="DnjeulfLJ2" role="1tU5fm">
+          <ref role="3uigEE" to="mhbf:~SNodeReference" resolve="SNodeReference" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="Dnjeun43b3" role="3clF46">
+        <property role="TrG5h" value="description" />
+        <node concept="17QB3L" id="Dnjeun43ku" role="1tU5fm" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="DnjeukFSLw" role="jymVt" />
+    <node concept="3clFb_" id="5fS8LrnN867" role="jymVt">
+      <property role="TrG5h" value="createLookup" />
+      <node concept="37vLTG" id="5fS8LrnNbe9" role="3clF46">
+        <property role="TrG5h" value="before" />
+        <node concept="10P_77" id="5fS8LrnNc9R" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="5fS8LrnNci8" role="3clF46">
+        <property role="TrG5h" value="sourceCellId" />
+        <node concept="17QB3L" id="5fS8LrnNdlS" role="1tU5fm" />
+      </node>
+      <node concept="3uibUv" id="5fS8LrnNdxm" role="3clF45">
+        <ref role="3uigEE" node="DnjeukGjQt" resolve="SideTransformationHolderCell.Lookup" />
+      </node>
+      <node concept="3Tm1VV" id="5fS8LrnN86a" role="1B3o_S" />
+      <node concept="3clFbS" id="5fS8LrnN86b" role="3clF47">
+        <node concept="3clFbF" id="5fS8LrnNeCf" role="3cqZAp">
+          <node concept="2ShNRf" id="5fS8LrnNeCd" role="3clFbG">
+            <node concept="1pGfFk" id="5fS8LrnNuv$" role="2ShVmc">
+              <ref role="37wK5l" node="DnjeukGnsi" resolve="SideTransformationHolderCell.Lookup" />
+              <node concept="37vLTw" id="5fS8LrnNuB7" role="37wK5m">
+                <ref role="3cqZAo" node="5fS8LrnNbe9" resolve="before" />
+              </node>
+              <node concept="37vLTw" id="5fS8LrnNuN7" role="37wK5m">
+                <ref role="3cqZAo" node="5fS8LrnNci8" resolve="sourceCellId" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="5fS8LrnN6WF" role="jymVt" />
+    <node concept="3clFb_" id="Dnjeun46E6" role="jymVt">
+      <property role="TrG5h" value="toString" />
+      <node concept="3Tm1VV" id="Dnjeun46E7" role="1B3o_S" />
+      <node concept="17QB3L" id="Dnjeun4azq" role="3clF45" />
+      <node concept="3clFbS" id="Dnjeun46Ec" role="3clF47">
+        <node concept="3clFbF" id="Dnjeun48Qn" role="3cqZAp">
+          <node concept="37vLTw" id="Dnjeun48Qk" role="3clFbG">
+            <ref role="3cqZAo" node="Dnjeun41Zx" resolve="description" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="Dnjeun46Ed" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="Dnjeun48XR" role="jymVt" />
+    <node concept="3clFb_" id="DnjeukGthN" role="jymVt">
+      <property role="TrG5h" value="createMenuParts" />
+      <property role="1EzhhJ" value="true" />
+      <node concept="_YKpA" id="DnjeukGuPf" role="3clF45">
+        <node concept="3uibUv" id="DnjeukGvwR" role="_ZDj9">
+          <ref role="3uigEE" to="v95p:~MenuPart" resolve="MenuPart" />
+          <node concept="3uibUv" id="DnjeukGvxI" role="11_B2D">
+            <ref role="3uigEE" to="uddc:~TransformationMenuItem" resolve="TransformationMenuItem" />
+          </node>
+          <node concept="3uibUv" id="DnjeukGvE8" role="11_B2D">
+            <ref role="3uigEE" to="uddc:~TransformationMenuContext" resolve="TransformationMenuContext" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="DnjeukGthQ" role="1B3o_S" />
+      <node concept="3clFbS" id="DnjeukGthR" role="3clF47" />
+    </node>
+    <node concept="2tJIrI" id="DnjeukGsjX" role="jymVt" />
+    <node concept="312cEu" id="DnjeukGjQt" role="jymVt">
+      <property role="2bfB8j" value="true" />
+      <property role="TrG5h" value="Lookup" />
+      <node concept="312cEg" id="DnjeukGmGe" role="jymVt">
+        <property role="TrG5h" value="before" />
+        <node concept="3Tm6S6" id="DnjeukGmGf" role="1B3o_S" />
+        <node concept="10P_77" id="DnjeukGn2z" role="1tU5fm" />
+      </node>
+      <node concept="312cEg" id="5fS8LrnN1fB" role="jymVt">
+        <property role="TrG5h" value="sourceCellId" />
+        <node concept="3Tm6S6" id="5fS8LrnN1fC" role="1B3o_S" />
+        <node concept="17QB3L" id="5fS8LrnN2af" role="1tU5fm" />
+      </node>
+      <node concept="2tJIrI" id="DnjeukV9mr" role="jymVt" />
+      <node concept="3clFbW" id="DnjeukGnsi" role="jymVt">
+        <node concept="3cqZAl" id="DnjeukGnsj" role="3clF45" />
+        <node concept="3Tm1VV" id="DnjeukGnsk" role="1B3o_S" />
+        <node concept="3clFbS" id="DnjeukGnsm" role="3clF47">
+          <node concept="3clFbF" id="DnjeukGnsq" role="3cqZAp">
+            <node concept="37vLTI" id="DnjeukGnss" role="3clFbG">
+              <node concept="2OqwBi" id="DnjeukGnsw" role="37vLTJ">
+                <node concept="Xjq3P" id="DnjeukGnsx" role="2Oq$k0" />
+                <node concept="2OwXpG" id="DnjeukGnsy" role="2OqNvi">
+                  <ref role="2Oxat5" node="DnjeukGmGe" resolve="before" />
+                </node>
+              </node>
+              <node concept="37vLTw" id="DnjeukGnsz" role="37vLTx">
+                <ref role="3cqZAo" node="DnjeukGnsp" resolve="before" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="5fS8LrnN2yM" role="3cqZAp">
+            <node concept="37vLTI" id="5fS8LrnN3hL" role="3clFbG">
+              <node concept="37vLTw" id="5fS8LrnN3pA" role="37vLTx">
+                <ref role="3cqZAo" node="5fS8LrnN2hw" resolve="sourceCellId" />
+              </node>
+              <node concept="2OqwBi" id="5fS8LrnN2Gv" role="37vLTJ">
+                <node concept="Xjq3P" id="5fS8LrnN2yK" role="2Oq$k0" />
+                <node concept="2OwXpG" id="5fS8LrnN2Ui" role="2OqNvi">
+                  <ref role="2Oxat5" node="5fS8LrnN1fB" resolve="sourceCellId" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="37vLTG" id="DnjeukGnsp" role="3clF46">
+          <property role="TrG5h" value="before" />
+          <node concept="10P_77" id="DnjeukGnso" role="1tU5fm" />
+        </node>
+        <node concept="37vLTG" id="5fS8LrnN2hw" role="3clF46">
+          <property role="TrG5h" value="sourceCellId" />
+          <node concept="17QB3L" id="5fS8LrnN2q1" role="1tU5fm" />
+        </node>
+      </node>
+      <node concept="3clFb_" id="Dnjeun4bF9" role="jymVt">
+        <property role="TrG5h" value="toString" />
+        <node concept="3Tm1VV" id="Dnjeun4bFa" role="1B3o_S" />
+        <node concept="17QB3L" id="Dnjeun4d6X" role="3clF45" />
+        <node concept="3clFbS" id="Dnjeun4bFd" role="3clF47">
+          <node concept="3clFbF" id="Dnjeun4eV2" role="3cqZAp">
+            <node concept="3cpWs3" id="Dnjeunm1FW" role="3clFbG">
+              <node concept="37vLTw" id="Dnjeun4g32" role="3uHU7B">
+                <ref role="3cqZAo" node="Dnjeun41Zx" resolve="description" />
+              </node>
+              <node concept="1eOMI4" id="Dnjeun4ft3" role="3uHU7w">
+                <node concept="3K4zz7" id="Dnjeun4eUY" role="1eOMHV">
+                  <node concept="37vLTw" id="Dnjeun4eYE" role="3K4Cdx">
+                    <ref role="3cqZAo" node="DnjeukGmGe" resolve="before" />
+                  </node>
+                  <node concept="Xl_RD" id="Dnjeun4f5b" role="3K4E3e">
+                    <property role="Xl_RC" value=" (before)" />
+                  </node>
+                  <node concept="Xl_RD" id="Dnjeun4f8k" role="3K4GZi">
+                    <property role="Xl_RC" value=" (after)" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2AHcQZ" id="Dnjeun4bFe" role="2AJF6D">
+          <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+        </node>
+      </node>
+      <node concept="3clFb_" id="5fS8LrnN3$I" role="jymVt">
+        <property role="TrG5h" value="getSourceCellId" />
+        <node concept="17QB3L" id="5fS8LrnN3$J" role="3clF45" />
+        <node concept="3Tm1VV" id="5fS8LrnN3$K" role="1B3o_S" />
+        <node concept="3clFbS" id="5fS8LrnN3$L" role="3clF47">
+          <node concept="3clFbF" id="5fS8LrnN3$M" role="3cqZAp">
+            <node concept="2OqwBi" id="5fS8LrnN3$F" role="3clFbG">
+              <node concept="Xjq3P" id="5fS8LrnN3$G" role="2Oq$k0" />
+              <node concept="2OwXpG" id="5fS8LrnN3$H" role="2OqNvi">
+                <ref role="2Oxat5" node="5fS8LrnN1fB" resolve="sourceCellId" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3clFb_" id="DnjeukUNRw" role="jymVt">
+        <property role="TrG5h" value="getHolderCell" />
+        <node concept="3uibUv" id="DnjeukUSGR" role="3clF45">
+          <ref role="3uigEE" node="DnjeukE0JQ" resolve="SideTransformationHolderCell" />
+        </node>
+        <node concept="3Tm1VV" id="DnjeukUNRz" role="1B3o_S" />
+        <node concept="3clFbS" id="DnjeukUNR$" role="3clF47">
+          <node concept="3clFbF" id="DnjeukUTfc" role="3cqZAp">
+            <node concept="Xjq3P" id="DnjeukUTfb" role="3clFbG">
+              <ref role="1HBi2w" node="DnjeukE0JQ" resolve="SideTransformationHolderCell" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3clFb_" id="DnjeukGlhO" role="jymVt">
+        <property role="TrG5h" value="lookup" />
+        <node concept="3Tm1VV" id="DnjeukGlhP" role="1B3o_S" />
+        <node concept="2AHcQZ" id="DnjeukGlhQ" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+        <node concept="3uibUv" id="DnjeukGlhR" role="3clF45">
+          <ref role="3uigEE" to="33ny:~Collection" resolve="Collection" />
+          <node concept="3uibUv" id="DnjeukGlhS" role="11_B2D">
+            <ref role="3uigEE" to="iwf0:~TransformationMenu" resolve="TransformationMenu" />
+          </node>
+        </node>
+        <node concept="37vLTG" id="DnjeukGlhT" role="3clF46">
+          <property role="TrG5h" value="p1" />
+          <node concept="3uibUv" id="DnjeukGlhU" role="1tU5fm">
+            <ref role="3uigEE" to="33ny:~Collection" resolve="Collection" />
+            <node concept="3uibUv" id="DnjeukGlhV" role="11_B2D">
+              <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
+            </node>
+          </node>
+          <node concept="2AHcQZ" id="DnjeukGlhW" role="2AJF6D">
+            <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+          </node>
+        </node>
+        <node concept="37vLTG" id="DnjeukGlhX" role="3clF46">
+          <property role="TrG5h" value="p2" />
+          <node concept="17QB3L" id="DnjeukGlhY" role="1tU5fm" />
+          <node concept="2AHcQZ" id="DnjeukGlhZ" role="2AJF6D">
+            <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+          </node>
+        </node>
+        <node concept="3clFbS" id="DnjeukGli0" role="3clF47">
+          <node concept="3clFbF" id="DnjeukGli1" role="3cqZAp">
+            <node concept="2YIFZM" id="DnjeukGli2" role="3clFbG">
+              <ref role="37wK5l" to="33ny:~Collections.singleton(java.lang.Object)" resolve="singleton" />
+              <ref role="1Pybhc" to="33ny:~Collections" resolve="Collections" />
+              <node concept="2ShNRf" id="DnjeukGli3" role="37wK5m">
+                <node concept="YeOm9" id="DnjeukGli4" role="2ShVmc">
+                  <node concept="1Y3b0j" id="DnjeukGli5" role="YeSDq">
+                    <property role="2bfB8j" value="true" />
+                    <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
+                    <ref role="1Y3XeK" to="iwf0:~TransformationMenu" resolve="TransformationMenu" />
+                    <node concept="3Tm1VV" id="DnjeukGli6" role="1B3o_S" />
+                    <node concept="3clFb_" id="DnjeukGli7" role="jymVt">
+                      <property role="TrG5h" value="createMenuItems" />
+                      <node concept="3Tm1VV" id="DnjeukGli8" role="1B3o_S" />
+                      <node concept="2AHcQZ" id="DnjeukGli9" role="2AJF6D">
+                        <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+                      </node>
+                      <node concept="3uibUv" id="DnjeukGlia" role="3clF45">
+                        <ref role="3uigEE" to="33ny:~List" resolve="List" />
+                        <node concept="3uibUv" id="DnjeukGlib" role="11_B2D">
+                          <ref role="3uigEE" to="uddc:~TransformationMenuItem" resolve="TransformationMenuItem" />
+                        </node>
+                      </node>
+                      <node concept="37vLTG" id="DnjeukGlic" role="3clF46">
+                        <property role="TrG5h" value="context" />
+                        <node concept="3uibUv" id="DnjeukGlid" role="1tU5fm">
+                          <ref role="3uigEE" to="uddc:~TransformationMenuContext" resolve="TransformationMenuContext" />
+                        </node>
+                        <node concept="2AHcQZ" id="DnjeukGlie" role="2AJF6D">
+                          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+                        </node>
+                      </node>
+                      <node concept="3clFbS" id="DnjeukGlif" role="3clF47">
+                        <node concept="3clFbJ" id="Dnjeuld23P" role="3cqZAp">
+                          <node concept="3clFbS" id="Dnjeuld23R" role="3clFbx">
+                            <node concept="3cpWs6" id="Dnjeuld4a2" role="3cqZAp">
+                              <node concept="2YIFZM" id="Dnjeuld5$X" role="3cqZAk">
+                                <ref role="37wK5l" to="33ny:~Collections.emptyList()" resolve="emptyList" />
+                                <ref role="1Pybhc" to="33ny:~Collections" resolve="Collections" />
+                                <node concept="3uibUv" id="DnjeulfOXy" role="3PaCim">
+                                  <ref role="3uigEE" to="uddc:~TransformationMenuItem" resolve="TransformationMenuItem" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="3fqX7Q" id="Dnjeuld2L7" role="3clFbw">
+                            <node concept="1rXfSq" id="Dnjeuld3vk" role="3fr31v">
+                              <ref role="37wK5l" node="DnjeukGliO" resolve="isApplicableToLocation" />
+                              <node concept="2OqwBi" id="Dnjeuld3Mh" role="37wK5m">
+                                <node concept="37vLTw" id="Dnjeuld3DV" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="DnjeukGlic" resolve="context" />
+                                </node>
+                                <node concept="liA8E" id="Dnjeuld44v" role="2OqNvi">
+                                  <ref role="37wK5l" to="uddc:~TransformationMenuContext.getMenuLocation()" resolve="getMenuLocation" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3clFbF" id="DnjeulacZ2" role="3cqZAp">
+                          <node concept="2OqwBi" id="DnjeuladSK" role="3clFbG">
+                            <node concept="2OqwBi" id="Dnjeuladjo" role="2Oq$k0">
+                              <node concept="37vLTw" id="DnjeulacZ0" role="2Oq$k0">
+                                <ref role="3cqZAo" node="DnjeukGlic" resolve="context" />
+                              </node>
+                              <node concept="liA8E" id="DnjeuladLC" role="2OqNvi">
+                                <ref role="37wK5l" to="uddc:~TransformationMenuContext.getEditorMenuTrace()" resolve="getEditorMenuTrace" />
+                              </node>
+                            </node>
+                            <node concept="liA8E" id="Dnjeulaeo$" role="2OqNvi">
+                              <ref role="37wK5l" to="x4mf:~EditorMenuTrace.pushTraceInfo()" resolve="pushTraceInfo" />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3J1_TO" id="DnjeulaeHA" role="3cqZAp">
+                          <node concept="3clFbS" id="DnjeulaeHC" role="1zxBo7">
+                            <node concept="3clFbF" id="Dnjeulagv$" role="3cqZAp">
+                              <node concept="2OqwBi" id="Dnjeulahcg" role="3clFbG">
+                                <node concept="2OqwBi" id="DnjeulagNr" role="2Oq$k0">
+                                  <node concept="37vLTw" id="Dnjeulagvy" role="2Oq$k0">
+                                    <ref role="3cqZAo" node="DnjeukGlic" resolve="context" />
+                                  </node>
+                                  <node concept="liA8E" id="Dnjeulah55" role="2OqNvi">
+                                    <ref role="37wK5l" to="uddc:~TransformationMenuContext.getEditorMenuTrace()" resolve="getEditorMenuTrace" />
+                                  </node>
+                                </node>
+                                <node concept="liA8E" id="Dnjeulahun" role="2OqNvi">
+                                  <ref role="37wK5l" to="x4mf:~EditorMenuTrace.setDescriptor(jetbrains.mps.openapi.editor.menus.EditorMenuDescriptor)" resolve="setDescriptor" />
+                                  <node concept="2ShNRf" id="Dnjeulahyq" role="37wK5m">
+                                    <node concept="1pGfFk" id="Dnjeulainx" role="2ShVmc">
+                                      <ref role="37wK5l" to="v95p:~EditorMenuDescriptorBase.&lt;init&gt;(java.lang.String,org.jetbrains.mps.openapi.model.SNodeReference)" resolve="EditorMenuDescriptorBase" />
+                                      <node concept="1rXfSq" id="Dnjeun4qoK" role="37wK5m">
+                                        <ref role="37wK5l" node="Dnjeun4bF9" resolve="toString" />
+                                      </node>
+                                      <node concept="37vLTw" id="DnjeulfN_2" role="37wK5m">
+                                        <ref role="3cqZAo" node="DnjeulfKk7" resolve="trace" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="3cpWs6" id="DnjeulaiJz" role="3cqZAp">
+                              <node concept="2OqwBi" id="DnjeulaiJ_" role="3cqZAk">
+                                <node concept="2OqwBi" id="DnjeulaiJA" role="2Oq$k0">
+                                  <node concept="3goQfb" id="DnjeulaiJB" role="2OqNvi">
+                                    <node concept="1bVj0M" id="DnjeulaiJC" role="23t8la">
+                                      <node concept="3clFbS" id="DnjeulaiJD" role="1bW5cS">
+                                        <node concept="3clFbF" id="DnjeulaiJE" role="3cqZAp">
+                                          <node concept="2OqwBi" id="DnjeulaiJF" role="3clFbG">
+                                            <node concept="37vLTw" id="DnjeulaiJG" role="2Oq$k0">
+                                              <ref role="3cqZAo" node="DnjeulaiJJ" resolve="it" />
+                                            </node>
+                                            <node concept="liA8E" id="DnjeulaiJH" role="2OqNvi">
+                                              <ref role="37wK5l" to="v95p:~MenuPart.createItems(java.lang.Object)" resolve="createItems" />
+                                              <node concept="2OqwBi" id="6zUT77XxDM8" role="37wK5m">
+                                                <node concept="37vLTw" id="DnjeulaiJI" role="2Oq$k0">
+                                                  <ref role="3cqZAo" node="DnjeukGlic" resolve="context" />
+                                                </node>
+                                                <node concept="liA8E" id="6zUT77XxFgs" role="2OqNvi">
+                                                  <ref role="37wK5l" to="uddc:~TransformationMenuContext.withNode(org.jetbrains.mps.openapi.model.SNode)" resolve="withNode" />
+                                                  <node concept="1rXfSq" id="6zUT77XxGvc" role="37wK5m">
+                                                    <ref role="37wK5l" to="g51k:~EditorCell_Basic.getSNode()" resolve="getSNode" />
+                                                  </node>
+                                                </node>
+                                              </node>
+                                            </node>
+                                          </node>
+                                        </node>
+                                      </node>
+                                      <node concept="Rh6nW" id="DnjeulaiJJ" role="1bW2Oz">
+                                        <property role="TrG5h" value="it" />
+                                        <node concept="2jxLKc" id="DnjeulaiJK" role="1tU5fm" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                  <node concept="1rXfSq" id="DnjeulaiJL" role="2Oq$k0">
+                                    <ref role="37wK5l" node="DnjeukGthN" resolve="createMenuParts" />
+                                  </node>
+                                </node>
+                                <node concept="ANE8D" id="DnjeulaiJM" role="2OqNvi" />
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="1wplmZ" id="DnjeulaeWR" role="1zxBo6">
+                            <node concept="3clFbS" id="DnjeulaeWS" role="1wplMD">
+                              <node concept="3clFbF" id="DnjeulafS$" role="3cqZAp">
+                                <node concept="2OqwBi" id="DnjeulafS_" role="3clFbG">
+                                  <node concept="2OqwBi" id="DnjeulafSA" role="2Oq$k0">
+                                    <node concept="37vLTw" id="DnjeulafSB" role="2Oq$k0">
+                                      <ref role="3cqZAo" node="DnjeukGlic" resolve="context" />
+                                    </node>
+                                    <node concept="liA8E" id="DnjeulafSC" role="2OqNvi">
+                                      <ref role="37wK5l" to="uddc:~TransformationMenuContext.getEditorMenuTrace()" resolve="getEditorMenuTrace" />
+                                    </node>
+                                  </node>
+                                  <node concept="liA8E" id="Dnjeulage2" role="2OqNvi">
+                                    <ref role="37wK5l" to="x4mf:~EditorMenuTrace.popTraceInfo()" resolve="popTraceInfo" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="2AHcQZ" id="DnjeukGliE" role="2AJF6D">
+                        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                      </node>
+                    </node>
+                    <node concept="2tJIrI" id="DnjeukGliF" role="jymVt" />
+                    <node concept="3clFb_" id="DnjeukGliG" role="jymVt">
+                      <property role="TrG5h" value="isContribution" />
+                      <node concept="3Tm1VV" id="DnjeukGliH" role="1B3o_S" />
+                      <node concept="10P_77" id="DnjeukGliI" role="3clF45" />
+                      <node concept="3clFbS" id="DnjeukGliJ" role="3clF47">
+                        <node concept="3clFbF" id="DnjeukGliK" role="3cqZAp">
+                          <node concept="3clFbT" id="DnjeukGliL" role="3clFbG">
+                            <property role="3clFbU" value="true" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="2AHcQZ" id="DnjeukGliM" role="2AJF6D">
+                        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                      </node>
+                    </node>
+                    <node concept="2tJIrI" id="DnjeukGliN" role="jymVt" />
+                    <node concept="3clFb_" id="DnjeukGliO" role="jymVt">
+                      <property role="TrG5h" value="isApplicableToLocation" />
+                      <node concept="3Tm1VV" id="DnjeukGliP" role="1B3o_S" />
+                      <node concept="10P_77" id="DnjeukGliQ" role="3clF45" />
+                      <node concept="37vLTG" id="DnjeukGliR" role="3clF46">
+                        <property role="TrG5h" value="location" />
+                        <node concept="17QB3L" id="DnjeukGliS" role="1tU5fm" />
+                      </node>
+                      <node concept="3clFbS" id="DnjeukGliT" role="3clF47">
+                        <node concept="3clFbF" id="DnjeukGliU" role="3cqZAp">
+                          <node concept="17R0WA" id="DnjeukGliV" role="3clFbG">
+                            <node concept="1eOMI4" id="DnjeukGozI" role="3uHU7w">
+                              <node concept="3K4zz7" id="DnjeukGp5E" role="1eOMHV">
+                                <node concept="37vLTw" id="DnjeukGoA$" role="3K4Cdx">
+                                  <ref role="3cqZAo" node="DnjeukGmGe" resolve="before" />
+                                </node>
+                                <node concept="10M0yZ" id="DnjeukGpcw" role="3K4E3e">
+                                  <ref role="3cqZAo" to="gdpt:1ISNm4ViWfM" resolve="BEFORE" />
+                                  <ref role="1PxDUh" to="gdpt:1ISNm4ViWc0" resolve="GrammarCellsMenuLocations" />
+                                </node>
+                                <node concept="10M0yZ" id="DnjeukGpay" role="3K4GZi">
+                                  <ref role="1PxDUh" to="gdpt:1ISNm4ViWc0" resolve="GrammarCellsMenuLocations" />
+                                  <ref role="3cqZAo" to="gdpt:1ISNm4ViXAF" resolve="AFTER" />
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="37vLTw" id="DnjeukGliX" role="3uHU7B">
+                              <ref role="3cqZAo" node="DnjeukGliR" resolve="location" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="2AHcQZ" id="DnjeukGliY" role="2AJF6D">
+                        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3uibUv" id="DnjeukGliZ" role="3PaCim">
+                <ref role="3uigEE" to="iwf0:~TransformationMenu" resolve="TransformationMenu" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2AHcQZ" id="DnjeukGlj0" role="2AJF6D">
+          <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+        </node>
+      </node>
+      <node concept="2tJIrI" id="DnjeukGlcJ" role="jymVt" />
+      <node concept="3Tm1VV" id="DnjeukGjQu" role="1B3o_S" />
+      <node concept="3uibUv" id="DnjeukGl67" role="EKbjA">
+        <ref role="3uigEE" to="uddc:~TransformationMenuLookup" resolve="TransformationMenuLookup" />
+      </node>
+    </node>
+  </node>
+  <node concept="312cEu" id="15DZatOV8lJ">
+    <property role="TrG5h" value="ListInsertActionLookup" />
+    <node concept="312cEg" id="15DZatPzXAD" role="jymVt">
+      <property role="TrG5h" value="matchingTexts" />
+      <node concept="3Tm6S6" id="15DZatPzXAE" role="1B3o_S" />
+      <node concept="_YKpA" id="15DZatPzYEX" role="1tU5fm">
+        <node concept="17QB3L" id="15DZatPzYIw" role="_ZDj9" />
+      </node>
+    </node>
+    <node concept="3Tm1VV" id="15DZatOV8pu" role="1B3o_S" />
+    <node concept="312cEg" id="15DZatOVt0B" role="jymVt">
+      <property role="TrG5h" value="before" />
+      <node concept="3Tm6S6" id="15DZatOVt0C" role="1B3o_S" />
+      <node concept="10P_77" id="15DZatOVt0D" role="1tU5fm" />
+    </node>
+    <node concept="312cEg" id="15DZatOVt0E" role="jymVt">
+      <property role="TrG5h" value="sourceCellId" />
+      <node concept="3Tm6S6" id="15DZatOVt0F" role="1B3o_S" />
+      <node concept="17QB3L" id="15DZatOVt0G" role="1tU5fm" />
+    </node>
+    <node concept="312cEg" id="15DZatOVvkr" role="jymVt">
+      <property role="TrG5h" value="description" />
+      <node concept="3Tm6S6" id="15DZatOVvks" role="1B3o_S" />
+      <node concept="17QB3L" id="15DZatOVvRD" role="1tU5fm" />
+    </node>
+    <node concept="312cEg" id="15DZatOVPYV" role="jymVt">
+      <property role="TrG5h" value="anchorNode" />
+      <node concept="3Tm6S6" id="15DZatOVPYW" role="1B3o_S" />
+      <node concept="3Tqbb2" id="15DZatOVQNM" role="1tU5fm" />
+    </node>
+    <node concept="312cEg" id="15DZatOWi9y" role="jymVt">
+      <property role="TrG5h" value="trace" />
+      <node concept="3Tm6S6" id="15DZatOWi9z" role="1B3o_S" />
+      <node concept="3uibUv" id="15DZatOWi9$" role="1tU5fm">
+        <ref role="3uigEE" to="mhbf:~SNodeReference" resolve="SNodeReference" />
+      </node>
+    </node>
+    <node concept="312cEg" id="15DZatOYew_" role="jymVt">
+      <property role="TrG5h" value="afterInsert" />
+      <node concept="3Tm6S6" id="15DZatOYewA" role="1B3o_S" />
+      <node concept="1ajhzC" id="15DZatOYftO" role="1tU5fm">
+        <node concept="3Tqbb2" id="15DZatOYE7P" role="1ajw0F" />
+        <node concept="3cqZAl" id="15DZatOYfxi" role="1ajl9A" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="15DZatOVt0H" role="jymVt" />
+    <node concept="3clFbW" id="15DZatOWMT$" role="jymVt">
+      <node concept="3cqZAl" id="15DZatOWMT_" role="3clF45" />
+      <node concept="3Tm1VV" id="15DZatOWMTA" role="1B3o_S" />
+      <node concept="3clFbS" id="15DZatOWMTC" role="3clF47">
+        <node concept="3clFbF" id="15DZatPzZ5Q" role="3cqZAp">
+          <node concept="37vLTI" id="15DZatP$0vT" role="3clFbG">
+            <node concept="37vLTw" id="15DZatP$0L8" role="37vLTx">
+              <ref role="3cqZAo" node="15DZatPzWi2" resolve="matchingTexts" />
+            </node>
+            <node concept="2OqwBi" id="15DZatPzZkq" role="37vLTJ">
+              <node concept="Xjq3P" id="15DZatPzZ5O" role="2Oq$k0" />
+              <node concept="2OwXpG" id="15DZatPzZDz" role="2OqNvi">
+                <ref role="2Oxat5" node="15DZatPzXAD" resolve="matchingTexts" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="15DZatOWMTG" role="3cqZAp">
+          <node concept="37vLTI" id="15DZatOWMTI" role="3clFbG">
+            <node concept="2OqwBi" id="15DZatOWMTM" role="37vLTJ">
+              <node concept="Xjq3P" id="15DZatOWMTN" role="2Oq$k0" />
+              <node concept="2OwXpG" id="15DZatOWMTO" role="2OqNvi">
+                <ref role="2Oxat5" node="15DZatOVt0B" resolve="before" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="15DZatOWMTP" role="37vLTx">
+              <ref role="3cqZAo" node="15DZatOWMTF" resolve="before" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="15DZatOWMTS" role="3cqZAp">
+          <node concept="37vLTI" id="15DZatOWMTU" role="3clFbG">
+            <node concept="2OqwBi" id="15DZatOWMTY" role="37vLTJ">
+              <node concept="Xjq3P" id="15DZatOWMTZ" role="2Oq$k0" />
+              <node concept="2OwXpG" id="15DZatOWMU0" role="2OqNvi">
+                <ref role="2Oxat5" node="15DZatOVt0E" resolve="sourceCellId" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="15DZatOWMU1" role="37vLTx">
+              <ref role="3cqZAo" node="15DZatOWMTR" resolve="sourceCellId" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="15DZatOWMU4" role="3cqZAp">
+          <node concept="37vLTI" id="15DZatOWMU6" role="3clFbG">
+            <node concept="2OqwBi" id="15DZatOWMUa" role="37vLTJ">
+              <node concept="Xjq3P" id="15DZatOWMUb" role="2Oq$k0" />
+              <node concept="2OwXpG" id="15DZatOWMUc" role="2OqNvi">
+                <ref role="2Oxat5" node="15DZatOVvkr" resolve="description" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="15DZatOWMUd" role="37vLTx">
+              <ref role="3cqZAo" node="15DZatOWMU3" resolve="description" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="15DZatOWMUg" role="3cqZAp">
+          <node concept="37vLTI" id="15DZatOWMUi" role="3clFbG">
+            <node concept="2OqwBi" id="15DZatOWMUm" role="37vLTJ">
+              <node concept="Xjq3P" id="15DZatOWMUn" role="2Oq$k0" />
+              <node concept="2OwXpG" id="15DZatOWMUo" role="2OqNvi">
+                <ref role="2Oxat5" node="15DZatOVPYV" resolve="anchorNode" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="15DZatOWMUp" role="37vLTx">
+              <ref role="3cqZAo" node="15DZatOWMUf" resolve="anchorNode" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="15DZatOWMUs" role="3cqZAp">
+          <node concept="37vLTI" id="15DZatOWMUu" role="3clFbG">
+            <node concept="2OqwBi" id="15DZatOWMUy" role="37vLTJ">
+              <node concept="Xjq3P" id="15DZatOWMUz" role="2Oq$k0" />
+              <node concept="2OwXpG" id="15DZatOWMU$" role="2OqNvi">
+                <ref role="2Oxat5" node="15DZatOWi9y" resolve="trace" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="15DZatOWMU_" role="37vLTx">
+              <ref role="3cqZAo" node="15DZatOWMUr" resolve="trace" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="15DZatOYEjv" role="3cqZAp">
+          <node concept="37vLTI" id="15DZatOYEKI" role="3clFbG">
+            <node concept="37vLTw" id="15DZatOYERO" role="37vLTx">
+              <ref role="3cqZAo" node="15DZatOYdmm" resolve="afterInsert" />
+            </node>
+            <node concept="2OqwBi" id="15DZatOYEqt" role="37vLTJ">
+              <node concept="Xjq3P" id="15DZatOYEjt" role="2Oq$k0" />
+              <node concept="2OwXpG" id="15DZatOYEBt" role="2OqNvi">
+                <ref role="2Oxat5" node="15DZatOYew_" resolve="afterInsert" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="15DZatPzWi2" role="3clF46">
+        <property role="TrG5h" value="matchingTexts" />
+        <node concept="_YKpA" id="15DZatPzWs$" role="1tU5fm">
+          <node concept="17QB3L" id="15DZatPzWut" role="_ZDj9" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="15DZatOWMTF" role="3clF46">
+        <property role="TrG5h" value="before" />
+        <node concept="10P_77" id="15DZatOWMTE" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="15DZatOWMTR" role="3clF46">
+        <property role="TrG5h" value="sourceCellId" />
+        <node concept="17QB3L" id="15DZatOWMTQ" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="15DZatOWMU3" role="3clF46">
+        <property role="TrG5h" value="description" />
+        <node concept="17QB3L" id="15DZatOWMU2" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="15DZatOWMUf" role="3clF46">
+        <property role="TrG5h" value="anchorNode" />
+        <node concept="3Tqbb2" id="15DZatOWMUe" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="15DZatOWMUr" role="3clF46">
+        <property role="TrG5h" value="trace" />
+        <node concept="3uibUv" id="15DZatOWMUq" role="1tU5fm">
+          <ref role="3uigEE" to="mhbf:~SNodeReference" resolve="SNodeReference" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="15DZatOYdmm" role="3clF46">
+        <property role="TrG5h" value="afterInsert" />
+        <node concept="1ajhzC" id="15DZatOYdv_" role="1tU5fm">
+          <node concept="3cqZAl" id="15DZatOYdxM" role="1ajl9A" />
+          <node concept="3Tqbb2" id="15DZatOYDVy" role="1ajw0F" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="15DZatOWNWn" role="jymVt" />
+    <node concept="3clFb_" id="15DZatOVt16" role="jymVt">
+      <property role="TrG5h" value="toString" />
+      <node concept="3Tm1VV" id="15DZatOVt17" role="1B3o_S" />
+      <node concept="17QB3L" id="15DZatOVt18" role="3clF45" />
+      <node concept="3clFbS" id="15DZatOVt19" role="3clF47">
+        <node concept="3clFbF" id="15DZatOVt1a" role="3cqZAp">
+          <node concept="37vLTw" id="15DZatOVt1c" role="3clFbG">
+            <ref role="3cqZAo" node="15DZatOVvkr" resolve="description" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="15DZatOVt1i" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="15DZatOVt1j" role="jymVt">
+      <property role="TrG5h" value="getSourceCellId" />
+      <node concept="17QB3L" id="15DZatOVt1k" role="3clF45" />
+      <node concept="3Tm1VV" id="15DZatOVt1l" role="1B3o_S" />
+      <node concept="3clFbS" id="15DZatOVt1m" role="3clF47">
+        <node concept="3clFbF" id="15DZatOVt1n" role="3cqZAp">
+          <node concept="2OqwBi" id="15DZatOVt1o" role="3clFbG">
+            <node concept="Xjq3P" id="15DZatOVt1p" role="2Oq$k0" />
+            <node concept="2OwXpG" id="15DZatOVt1q" role="2OqNvi">
+              <ref role="2Oxat5" node="15DZatOVt0E" resolve="sourceCellId" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3clFb_" id="15DZatOVt1x" role="jymVt">
+      <property role="TrG5h" value="lookup" />
+      <node concept="3Tm1VV" id="15DZatOVt1y" role="1B3o_S" />
+      <node concept="2AHcQZ" id="15DZatOVt1z" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+      </node>
+      <node concept="3uibUv" id="15DZatOVt1$" role="3clF45">
+        <ref role="3uigEE" to="33ny:~Collection" resolve="Collection" />
+        <node concept="3uibUv" id="15DZatOVt1_" role="11_B2D">
+          <ref role="3uigEE" to="iwf0:~TransformationMenu" resolve="TransformationMenu" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="15DZatOVt1A" role="3clF46">
+        <property role="TrG5h" value="p1" />
+        <node concept="3uibUv" id="15DZatOVt1B" role="1tU5fm">
+          <ref role="3uigEE" to="33ny:~Collection" resolve="Collection" />
+          <node concept="3uibUv" id="15DZatOVt1C" role="11_B2D">
+            <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
+          </node>
+        </node>
+        <node concept="2AHcQZ" id="15DZatOVt1D" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="15DZatOVt1E" role="3clF46">
+        <property role="TrG5h" value="location" />
+        <property role="3TUv4t" value="true" />
+        <node concept="17QB3L" id="15DZatOVt1F" role="1tU5fm" />
+        <node concept="2AHcQZ" id="15DZatOVt1G" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="15DZatOVt1H" role="3clF47">
+        <node concept="3clFbF" id="15DZatOVt1I" role="3cqZAp">
+          <node concept="2YIFZM" id="15DZatOVt1J" role="3clFbG">
+            <ref role="37wK5l" to="33ny:~Collections.singleton(java.lang.Object)" resolve="singleton" />
+            <ref role="1Pybhc" to="33ny:~Collections" resolve="Collections" />
+            <node concept="2ShNRf" id="15DZatOVt1K" role="37wK5m">
+              <node concept="YeOm9" id="15DZatOVt1L" role="2ShVmc">
+                <node concept="1Y3b0j" id="15DZatOVt1M" role="YeSDq">
+                  <property role="2bfB8j" value="true" />
+                  <ref role="1Y3XeK" to="iwf0:~TransformationMenu" resolve="TransformationMenu" />
+                  <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
+                  <node concept="3Tm1VV" id="15DZatOVt1N" role="1B3o_S" />
+                  <node concept="3clFb_" id="15DZatOVt1O" role="jymVt">
+                    <property role="TrG5h" value="createMenuItems" />
+                    <node concept="3Tm1VV" id="15DZatOVt1P" role="1B3o_S" />
+                    <node concept="2AHcQZ" id="15DZatOVt1Q" role="2AJF6D">
+                      <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+                    </node>
+                    <node concept="3uibUv" id="15DZatOVt1R" role="3clF45">
+                      <ref role="3uigEE" to="33ny:~List" resolve="List" />
+                      <node concept="3uibUv" id="15DZatOVt1S" role="11_B2D">
+                        <ref role="3uigEE" to="uddc:~TransformationMenuItem" resolve="TransformationMenuItem" />
+                      </node>
+                    </node>
+                    <node concept="37vLTG" id="15DZatOVt1T" role="3clF46">
+                      <property role="TrG5h" value="context" />
+                      <node concept="3uibUv" id="15DZatOVt1U" role="1tU5fm">
+                        <ref role="3uigEE" to="uddc:~TransformationMenuContext" resolve="TransformationMenuContext" />
+                      </node>
+                      <node concept="2AHcQZ" id="15DZatOVt1V" role="2AJF6D">
+                        <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+                      </node>
+                    </node>
+                    <node concept="3clFbS" id="15DZatOVt1W" role="3clF47">
+                      <node concept="3clFbJ" id="15DZatOVt1X" role="3cqZAp">
+                        <node concept="3clFbS" id="15DZatOVt1Y" role="3clFbx">
+                          <node concept="3cpWs6" id="15DZatOVt1Z" role="3cqZAp">
+                            <node concept="2YIFZM" id="15DZatOVt20" role="3cqZAk">
+                              <ref role="1Pybhc" to="33ny:~Collections" resolve="Collections" />
+                              <ref role="37wK5l" to="33ny:~Collections.emptyList()" resolve="emptyList" />
+                              <node concept="3uibUv" id="15DZatOVt21" role="3PaCim">
+                                <ref role="3uigEE" to="uddc:~TransformationMenuItem" resolve="TransformationMenuItem" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3fqX7Q" id="15DZatOVt22" role="3clFbw">
+                          <node concept="1rXfSq" id="15DZatOVt23" role="3fr31v">
+                            <ref role="37wK5l" node="15DZatOVt2U" resolve="isApplicableToLocation" />
+                            <node concept="2OqwBi" id="15DZatOVt24" role="37wK5m">
+                              <node concept="37vLTw" id="15DZatOVt25" role="2Oq$k0">
+                                <ref role="3cqZAo" node="15DZatOVt1T" resolve="context" />
+                              </node>
+                              <node concept="liA8E" id="15DZatOVt26" role="2OqNvi">
+                                <ref role="37wK5l" to="uddc:~TransformationMenuContext.getMenuLocation()" resolve="getMenuLocation" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="15DZatOVt27" role="3cqZAp">
+                        <node concept="2OqwBi" id="15DZatOVt28" role="3clFbG">
+                          <node concept="2OqwBi" id="15DZatOVt29" role="2Oq$k0">
+                            <node concept="37vLTw" id="15DZatOVt2a" role="2Oq$k0">
+                              <ref role="3cqZAo" node="15DZatOVt1T" resolve="context" />
+                            </node>
+                            <node concept="liA8E" id="15DZatOVt2b" role="2OqNvi">
+                              <ref role="37wK5l" to="uddc:~TransformationMenuContext.getEditorMenuTrace()" resolve="getEditorMenuTrace" />
+                            </node>
+                          </node>
+                          <node concept="liA8E" id="15DZatOVt2c" role="2OqNvi">
+                            <ref role="37wK5l" to="x4mf:~EditorMenuTrace.pushTraceInfo()" resolve="pushTraceInfo" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3J1_TO" id="15DZatOVt2d" role="3cqZAp">
+                        <node concept="3clFbS" id="15DZatOVt2e" role="1zxBo7">
+                          <node concept="3clFbF" id="15DZatOVt2f" role="3cqZAp">
+                            <node concept="2OqwBi" id="15DZatOVt2g" role="3clFbG">
+                              <node concept="2OqwBi" id="15DZatOVt2h" role="2Oq$k0">
+                                <node concept="37vLTw" id="15DZatOVt2i" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="15DZatOVt1T" resolve="context" />
+                                </node>
+                                <node concept="liA8E" id="15DZatOVt2j" role="2OqNvi">
+                                  <ref role="37wK5l" to="uddc:~TransformationMenuContext.getEditorMenuTrace()" resolve="getEditorMenuTrace" />
+                                </node>
+                              </node>
+                              <node concept="liA8E" id="15DZatOVt2k" role="2OqNvi">
+                                <ref role="37wK5l" to="x4mf:~EditorMenuTrace.setDescriptor(jetbrains.mps.openapi.editor.menus.EditorMenuDescriptor)" resolve="setDescriptor" />
+                                <node concept="2ShNRf" id="15DZatOVt2l" role="37wK5m">
+                                  <node concept="1pGfFk" id="15DZatOVt2m" role="2ShVmc">
+                                    <ref role="37wK5l" to="v95p:~EditorMenuDescriptorBase.&lt;init&gt;(java.lang.String,org.jetbrains.mps.openapi.model.SNodeReference)" resolve="EditorMenuDescriptorBase" />
+                                    <node concept="1rXfSq" id="15DZatOVt2n" role="37wK5m">
+                                      <ref role="37wK5l" node="15DZatOVt16" resolve="toString" />
+                                    </node>
+                                    <node concept="37vLTw" id="15DZatOVt2o" role="37wK5m">
+                                      <ref role="3cqZAo" node="15DZatOWi9y" resolve="trace" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="3cpWs6" id="15DZatOWKUT" role="3cqZAp">
+                            <node concept="2ShNRf" id="15DZatOWKUV" role="3cqZAk">
+                              <node concept="Tc6Ow" id="15DZatOWKUW" role="2ShVmc">
+                                <node concept="3uibUv" id="15DZatOWKUX" role="HW$YZ">
+                                  <ref role="3uigEE" to="uddc:~TransformationMenuItem" resolve="TransformationMenuItem" />
+                                </node>
+                                <node concept="2ShNRf" id="15DZatOWKUY" role="HW$Y0">
+                                  <node concept="1pGfFk" id="15DZatP_si_" role="2ShVmc">
+                                    <ref role="37wK5l" node="15DZatP$3aR" resolve="ListInsertActionLookup.Item" />
+                                    <node concept="37vLTw" id="15DZatP_t0T" role="37wK5m">
+                                      <ref role="3cqZAo" node="15DZatOVt1T" resolve="context" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="1wplmZ" id="15DZatOVt2C" role="1zxBo6">
+                          <node concept="3clFbS" id="15DZatOVt2D" role="1wplMD">
+                            <node concept="3clFbF" id="15DZatOVt2E" role="3cqZAp">
+                              <node concept="2OqwBi" id="15DZatOVt2F" role="3clFbG">
+                                <node concept="2OqwBi" id="15DZatOVt2G" role="2Oq$k0">
+                                  <node concept="37vLTw" id="15DZatOVt2H" role="2Oq$k0">
+                                    <ref role="3cqZAo" node="15DZatOVt1T" resolve="context" />
+                                  </node>
+                                  <node concept="liA8E" id="15DZatOVt2I" role="2OqNvi">
+                                    <ref role="37wK5l" to="uddc:~TransformationMenuContext.getEditorMenuTrace()" resolve="getEditorMenuTrace" />
+                                  </node>
+                                </node>
+                                <node concept="liA8E" id="15DZatOVt2J" role="2OqNvi">
+                                  <ref role="37wK5l" to="x4mf:~EditorMenuTrace.popTraceInfo()" resolve="popTraceInfo" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2AHcQZ" id="15DZatOVt2K" role="2AJF6D">
+                      <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                    </node>
+                  </node>
+                  <node concept="2tJIrI" id="15DZatOVt2L" role="jymVt" />
+                  <node concept="3clFb_" id="15DZatOVt2M" role="jymVt">
+                    <property role="TrG5h" value="isContribution" />
+                    <node concept="3Tm1VV" id="15DZatOVt2N" role="1B3o_S" />
+                    <node concept="10P_77" id="15DZatOVt2O" role="3clF45" />
+                    <node concept="3clFbS" id="15DZatOVt2P" role="3clF47">
+                      <node concept="3clFbF" id="15DZatOVt2Q" role="3cqZAp">
+                        <node concept="3clFbT" id="15DZatOVt2R" role="3clFbG">
+                          <property role="3clFbU" value="true" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2AHcQZ" id="15DZatOVt2S" role="2AJF6D">
+                      <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                    </node>
+                  </node>
+                  <node concept="2tJIrI" id="15DZatOVt2T" role="jymVt" />
+                  <node concept="3clFb_" id="15DZatOVt2U" role="jymVt">
+                    <property role="TrG5h" value="isApplicableToLocation" />
+                    <node concept="3Tm1VV" id="15DZatOVt2V" role="1B3o_S" />
+                    <node concept="10P_77" id="15DZatOVt2W" role="3clF45" />
+                    <node concept="37vLTG" id="15DZatOVt2X" role="3clF46">
+                      <property role="TrG5h" value="location" />
+                      <node concept="17QB3L" id="15DZatOVt2Y" role="1tU5fm" />
+                    </node>
+                    <node concept="3clFbS" id="15DZatOVt2Z" role="3clF47">
+                      <node concept="3clFbF" id="15DZatOVt30" role="3cqZAp">
+                        <node concept="17R0WA" id="15DZatOVt31" role="3clFbG">
+                          <node concept="1eOMI4" id="15DZatOVt32" role="3uHU7w">
+                            <node concept="3K4zz7" id="15DZatOVt33" role="1eOMHV">
+                              <node concept="37vLTw" id="15DZatOVt34" role="3K4Cdx">
+                                <ref role="3cqZAo" node="15DZatOVt0B" resolve="before" />
+                              </node>
+                              <node concept="10M0yZ" id="15DZatOVt35" role="3K4E3e">
+                                <ref role="1PxDUh" to="gdpt:1ISNm4ViWc0" resolve="GrammarCellsMenuLocations" />
+                                <ref role="3cqZAo" to="gdpt:1ISNm4ViWfM" resolve="BEFORE" />
+                              </node>
+                              <node concept="10M0yZ" id="15DZatOVt36" role="3K4GZi">
+                                <ref role="3cqZAo" to="gdpt:1ISNm4ViXAF" resolve="AFTER" />
+                                <ref role="1PxDUh" to="gdpt:1ISNm4ViWc0" resolve="GrammarCellsMenuLocations" />
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="37vLTw" id="15DZatOVt37" role="3uHU7B">
+                            <ref role="3cqZAo" node="15DZatOVt2X" resolve="location" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2AHcQZ" id="15DZatOVt38" role="2AJF6D">
+                      <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3uibUv" id="15DZatOVt39" role="3PaCim">
+              <ref role="3uigEE" to="iwf0:~TransformationMenu" resolve="TransformationMenu" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="15DZatOVt3a" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="15DZatOVAeF" role="jymVt" />
+    <node concept="312cEu" id="15DZatOVBe0" role="jymVt">
+      <property role="2bfB8j" value="true" />
+      <property role="TrG5h" value="Item" />
+      <node concept="3Tm1VV" id="15DZatOVBe1" role="1B3o_S" />
+      <node concept="3uibUv" id="15DZatOVC2x" role="EKbjA">
+        <ref role="3uigEE" to="uddc:~TransformationMenuItem" resolve="TransformationMenuItem" />
+      </node>
+      <node concept="3uibUv" id="1YKLYyyGCs5" role="EKbjA">
+        <ref role="3uigEE" to="6lvu:~SideTransformCompletionActionItem" resolve="SideTransformCompletionActionItem" />
+      </node>
+      <node concept="3uibUv" id="2mvFNoSqbcv" role="EKbjA">
+        <ref role="3uigEE" to="uddc:~CompletionActionItem" resolve="CompletionActionItem" />
+      </node>
+      <node concept="3uibUv" id="My09KinxtM" role="EKbjA">
+        <ref role="3uigEE" to="uddc:~ConstraintsVerifiableActionItem" resolve="ConstraintsVerifiableActionItem" />
+      </node>
+      <node concept="3uibUv" id="4ntVsBGt8ui" role="EKbjA">
+        <ref role="3uigEE" to="gdpt:5fS8LroB3DY" resolve="IShadowingTransformationAction" />
+      </node>
+      <node concept="3clFbW" id="15DZatP$3aR" role="jymVt">
+        <node concept="3cqZAl" id="15DZatP$3aS" role="3clF45" />
+        <node concept="3Tm1VV" id="15DZatP$3aT" role="1B3o_S" />
+        <node concept="37vLTG" id="15DZatP$3b8" role="3clF46">
+          <property role="TrG5h" value="context" />
+          <node concept="3uibUv" id="15DZatP$3b9" role="1tU5fm">
+            <ref role="3uigEE" to="uddc:~TransformationMenuContext" resolve="TransformationMenuContext" />
+          </node>
+        </node>
+        <node concept="3clFbS" id="15DZatP$3ba" role="3clF47">
+          <node concept="XkiVB" id="15DZatP$3bb" role="3cqZAp">
+            <ref role="37wK5l" node="1YKLYyyOIFX" resolve="MultiTextActionItem" />
+            <node concept="37vLTw" id="15DZatP$3bc" role="37wK5m">
+              <ref role="3cqZAo" node="15DZatPzXAD" resolve="matchingTexts" />
+            </node>
+            <node concept="37vLTw" id="15DZatP$3bd" role="37wK5m">
+              <ref role="3cqZAo" node="15DZatP$3b8" resolve="context" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3clFb_" id="4ntVsBGv5U$" role="jymVt">
+        <property role="TrG5h" value="getLookup" />
+        <node concept="3uibUv" id="4ntVsBGv9mv" role="3clF45">
+          <ref role="3uigEE" node="15DZatOV8lJ" resolve="ListInsertActionLookup" />
+        </node>
+        <node concept="3Tm1VV" id="4ntVsBGv5UB" role="1B3o_S" />
+        <node concept="3clFbS" id="4ntVsBGv5UC" role="3clF47">
+          <node concept="3clFbF" id="4ntVsBGvavQ" role="3cqZAp">
+            <node concept="Xjq3P" id="4ntVsBGvavP" role="3clFbG">
+              <ref role="1HBi2w" node="15DZatOV8lJ" resolve="ListInsertActionLookup" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3clFb_" id="4ntVsBGvlJ7" role="jymVt">
+        <property role="TrG5h" value="getAnchorNode" />
+        <node concept="3Tqbb2" id="4ntVsBGvokf" role="3clF45" />
+        <node concept="3Tm1VV" id="4ntVsBGvlJa" role="1B3o_S" />
+        <node concept="3clFbS" id="4ntVsBGvlJb" role="3clF47">
+          <node concept="3clFbF" id="4ntVsBGvpqJ" role="3cqZAp">
+            <node concept="37vLTw" id="4ntVsBGvpqI" role="3clFbG">
+              <ref role="3cqZAo" node="15DZatOVPYV" resolve="anchorNode" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3clFb_" id="4ntVsBGvrjr" role="jymVt">
+        <property role="TrG5h" value="isBefore" />
+        <node concept="10P_77" id="4ntVsBGvtZV" role="3clF45" />
+        <node concept="3Tm1VV" id="4ntVsBGvrju" role="1B3o_S" />
+        <node concept="3clFbS" id="4ntVsBGvrjv" role="3clF47">
+          <node concept="3clFbF" id="4ntVsBGvv5f" role="3cqZAp">
+            <node concept="37vLTw" id="4ntVsBGvv5e" role="3clFbG">
+              <ref role="3cqZAo" node="15DZatOVt0B" resolve="before" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3clFb_" id="15DZatOVFZH" role="jymVt">
+        <property role="TrG5h" value="getOutputConcept" />
+        <node concept="3Tm1VV" id="15DZatOVFZI" role="1B3o_S" />
+        <node concept="2AHcQZ" id="15DZatOVFZK" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+        </node>
+        <node concept="3uibUv" id="15DZatOVFZL" role="3clF45">
+          <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
+        </node>
+        <node concept="3clFbS" id="15DZatOVFZP" role="3clF47">
+          <node concept="3clFbF" id="15DZatOWeOY" role="3cqZAp">
+            <node concept="2OqwBi" id="15DZatOWfpD" role="3clFbG">
+              <node concept="37vLTw" id="15DZatOWeOX" role="2Oq$k0">
+                <ref role="3cqZAo" node="15DZatOVPYV" resolve="anchorNode" />
+              </node>
+              <node concept="2yIwOk" id="15DZatOWgzk" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+        <node concept="2AHcQZ" id="15DZatOVFZQ" role="2AJF6D">
+          <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+        </node>
+      </node>
+      <node concept="3clFb_" id="15DZatOVG08" role="jymVt">
+        <property role="TrG5h" value="execute" />
+        <node concept="3Tm1VV" id="15DZatOVG09" role="1B3o_S" />
+        <node concept="3cqZAl" id="15DZatOVG0b" role="3clF45" />
+        <node concept="37vLTG" id="15DZatOVG0c" role="3clF46">
+          <property role="TrG5h" value="pattern" />
+          <node concept="17QB3L" id="15DZatOVNZJ" role="1tU5fm" />
+          <node concept="2AHcQZ" id="15DZatOVG0e" role="2AJF6D">
+            <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+          </node>
+        </node>
+        <node concept="3clFbS" id="15DZatOVG0j" role="3clF47">
+          <node concept="3cpWs8" id="15DZatOYF0o" role="3cqZAp">
+            <node concept="3cpWsn" id="15DZatOYF0p" role="3cpWs9">
+              <property role="TrG5h" value="newChild" />
+              <node concept="3Tqbb2" id="15DZatOYeV8" role="1tU5fm" />
+              <node concept="2OqwBi" id="15DZatOYF0q" role="33vP2m">
+                <node concept="2OqwBi" id="15DZatOYF0r" role="2Oq$k0">
+                  <node concept="37vLTw" id="15DZatOYF0s" role="2Oq$k0">
+                    <ref role="3cqZAo" node="15DZatOVPYV" resolve="anchorNode" />
+                  </node>
+                  <node concept="2yIwOk" id="15DZatOYF0t" role="2OqNvi" />
+                </node>
+                <node concept="q_SaT" id="15DZatOYF0u" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="15DZatOVUgM" role="3cqZAp">
+            <node concept="2OqwBi" id="15DZatOW0UO" role="3clFbG">
+              <node concept="2OqwBi" id="15DZatOVVO4" role="2Oq$k0">
+                <node concept="2OqwBi" id="15DZatOVUOp" role="2Oq$k0">
+                  <node concept="37vLTw" id="15DZatOVUgL" role="2Oq$k0">
+                    <ref role="3cqZAo" node="15DZatOVPYV" resolve="anchorNode" />
+                  </node>
+                  <node concept="1mfA1w" id="15DZatOVVhN" role="2OqNvi" />
+                </node>
+                <node concept="32TBzR" id="15DZatOVW9a" role="2OqNvi">
+                  <node concept="1aIX9F" id="15DZatOVXRx" role="1xVPHs">
+                    <node concept="25Kdxt" id="15DZatOVYbR" role="1aIX9E">
+                      <node concept="2OqwBi" id="15DZatOVZ8b" role="25KhWn">
+                        <node concept="37vLTw" id="15DZatOVY$9" role="2Oq$k0">
+                          <ref role="3cqZAo" node="15DZatOVPYV" resolve="anchorNode" />
+                        </node>
+                        <node concept="2NL2c5" id="15DZatOVZGi" role="2OqNvi" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="1sK_Qi" id="15DZatOW3uJ" role="2OqNvi">
+                <node concept="37vLTw" id="15DZatOYF0v" role="1sKFgg">
+                  <ref role="3cqZAo" node="15DZatOYF0p" resolve="newChild" />
+                </node>
+                <node concept="3cpWs3" id="15DZatOW8xL" role="1sKJu8">
+                  <node concept="1eOMI4" id="15DZatOW8Vz" role="3uHU7w">
+                    <node concept="3K4zz7" id="15DZatOWadK" role="1eOMHV">
+                      <node concept="3cmrfG" id="15DZatOWaAb" role="3K4E3e">
+                        <property role="3cmrfH" value="0" />
+                      </node>
+                      <node concept="3cmrfG" id="15DZatOWaBt" role="3K4GZi">
+                        <property role="3cmrfH" value="1" />
+                      </node>
+                      <node concept="37vLTw" id="15DZatOW9q2" role="3K4Cdx">
+                        <ref role="3cqZAo" node="15DZatOVt0B" resolve="before" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="15DZatOW4GY" role="3uHU7B">
+                    <node concept="37vLTw" id="15DZatOW3Yl" role="2Oq$k0">
+                      <ref role="3cqZAo" node="15DZatOVPYV" resolve="anchorNode" />
+                    </node>
+                    <node concept="2bSWHS" id="15DZatOW5gN" role="2OqNvi" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbJ" id="15DZatOYIGV" role="3cqZAp">
+            <node concept="3clFbS" id="15DZatOYIGX" role="3clFbx">
+              <node concept="3clFbF" id="15DZatOYMeD" role="3cqZAp">
+                <node concept="2OqwBi" id="15DZatOYNbq" role="3clFbG">
+                  <node concept="37vLTw" id="15DZatOYMeB" role="2Oq$k0">
+                    <ref role="3cqZAo" node="15DZatOYew_" resolve="afterInsert" />
+                  </node>
+                  <node concept="1Bd96e" id="15DZatOYOAZ" role="2OqNvi">
+                    <node concept="37vLTw" id="15DZatOYPqD" role="1BdPVh">
+                      <ref role="3cqZAo" node="15DZatOYF0p" resolve="newChild" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3y3z36" id="15DZatOYKw3" role="3clFbw">
+              <node concept="10Nm6u" id="15DZatOYLh5" role="3uHU7w" />
+              <node concept="37vLTw" id="15DZatOYJEp" role="3uHU7B">
+                <ref role="3cqZAo" node="15DZatOYew_" resolve="afterInsert" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2AHcQZ" id="15DZatOVG0k" role="2AJF6D">
+          <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+        </node>
+      </node>
+      <node concept="3clFb_" id="15DZatOVG0l" role="jymVt">
+        <property role="TrG5h" value="getCommandPolicy" />
+        <node concept="3Tm1VV" id="15DZatOVG0m" role="1B3o_S" />
+        <node concept="2AHcQZ" id="15DZatOVG0o" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+        <node concept="3uibUv" id="15DZatOVG0p" role="3clF45">
+          <ref role="3uigEE" to="uddc:~CommandPolicy" resolve="CommandPolicy" />
+        </node>
+        <node concept="3clFbS" id="15DZatOVG0u" role="3clF47">
+          <node concept="3clFbF" id="15DZatOVLXO" role="3cqZAp">
+            <node concept="Rm8GO" id="15DZatOVMmV" role="3clFbG">
+              <ref role="Rm8GQ" to="uddc:~CommandPolicy.COMMAND_REQUIRED" resolve="COMMAND_REQUIRED" />
+              <ref role="1Px2BO" to="uddc:~CommandPolicy" resolve="CommandPolicy" />
+            </node>
+          </node>
+        </node>
+        <node concept="2AHcQZ" id="15DZatOVG0v" role="2AJF6D">
+          <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+        </node>
+      </node>
+      <node concept="2tJIrI" id="15DZatPzLPl" role="jymVt" />
+      <node concept="3uibUv" id="15DZatP$2fN" role="1zkMxy">
+        <ref role="3uigEE" node="1YKLYyyOIFO" resolve="MultiTextActionItem" />
+      </node>
+      <node concept="3clFb_" id="15DZatP$kWG" role="jymVt">
+        <property role="TrG5h" value="getDescriptionText" />
+        <property role="DiZV1" value="false" />
+        <property role="od$2w" value="false" />
+        <node concept="2AHcQZ" id="15DZatP$kWH" role="2AJF6D">
+          <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
+        </node>
+        <node concept="3Tm1VV" id="15DZatP$kWM" role="1B3o_S" />
+        <node concept="17QB3L" id="15DZatP$kWN" role="3clF45" />
+        <node concept="37vLTG" id="15DZatP$kWO" role="3clF46">
+          <property role="TrG5h" value="pattern" />
+          <node concept="17QB3L" id="15DZatP$kWP" role="1tU5fm" />
+        </node>
+        <node concept="3clFbS" id="15DZatP$kWT" role="3clF47">
+          <node concept="3clFbF" id="15DZatP$o3B" role="3cqZAp">
+            <node concept="37vLTw" id="15DZatP$o3z" role="3clFbG">
+              <ref role="3cqZAo" node="15DZatOVvkr" resolve="description" />
+            </node>
+          </node>
+        </node>
+        <node concept="2AHcQZ" id="15DZatP$kWU" role="2AJF6D">
+          <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+        </node>
+      </node>
+      <node concept="3clFb_" id="4ntVsBGt9mB" role="jymVt">
+        <property role="TrG5h" value="shadows" />
+        <node concept="37vLTG" id="4ntVsBGt9mC" role="3clF46">
+          <property role="TrG5h" value="shadowed_" />
+          <node concept="3uibUv" id="4ntVsBGt9mD" role="1tU5fm">
+            <ref role="3uigEE" to="uddc:~TransformationMenuItem" resolve="TransformationMenuItem" />
+          </node>
+        </node>
+        <node concept="10P_77" id="4ntVsBGt9mE" role="3clF45" />
+        <node concept="3Tm1VV" id="4ntVsBGt9mF" role="1B3o_S" />
+        <node concept="3clFbS" id="4ntVsBGt9mL" role="3clF47">
+          <node concept="3clFbJ" id="4ntVsBGtcrw" role="3cqZAp">
+            <node concept="2ZW3vV" id="4ntVsBGteob" role="3clFbw">
+              <node concept="3uibUv" id="4ntVsBGv0bb" role="2ZW6by">
+                <ref role="3uigEE" node="15DZatOVBe0" resolve="ListInsertActionLookup.Item" />
+              </node>
+              <node concept="37vLTw" id="4ntVsBGtdik" role="2ZW6bz">
+                <ref role="3cqZAo" node="4ntVsBGt9mC" resolve="shadowed_" />
+              </node>
+            </node>
+            <node concept="3clFbS" id="4ntVsBGtcry" role="3clFbx">
+              <node concept="3cpWs8" id="4ntVsBGtkKy" role="3cqZAp">
+                <node concept="3cpWsn" id="4ntVsBGtkKz" role="3cpWs9">
+                  <property role="TrG5h" value="shadowed" />
+                  <node concept="3uibUv" id="4ntVsBGv1cU" role="1tU5fm">
+                    <ref role="3uigEE" node="15DZatOVBe0" resolve="ListInsertActionLookup.Item" />
+                  </node>
+                  <node concept="1eOMI4" id="4ntVsBGtkK$" role="33vP2m">
+                    <node concept="10QFUN" id="4ntVsBGtkK_" role="1eOMHV">
+                      <node concept="3uibUv" id="4ntVsBGv1Y_" role="10QFUM">
+                        <ref role="3uigEE" node="15DZatOVBe0" resolve="ListInsertActionLookup.Item" />
+                      </node>
+                      <node concept="37vLTw" id="4ntVsBGtkKB" role="10QFUP">
+                        <ref role="3cqZAo" node="4ntVsBGt9mC" resolve="shadowed_" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbJ" id="4ntVsBGtohP" role="3cqZAp">
+                <node concept="3clFbS" id="4ntVsBGtohR" role="3clFbx">
+                  <node concept="3cpWs6" id="4ntVsBGtG5X" role="3cqZAp">
+                    <node concept="3clFbT" id="4ntVsBGtHYx" role="3cqZAk">
+                      <property role="3clFbU" value="true" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="1Wc70l" id="4ntVsBGtxQd" role="3clFbw">
+                  <node concept="17R0WA" id="4ntVsBGtBOo" role="3uHU7w">
+                    <node concept="2OqwBi" id="4ntVsBGvhfn" role="3uHU7w">
+                      <node concept="37vLTw" id="4ntVsBGtCNE" role="2Oq$k0">
+                        <ref role="3cqZAo" node="4ntVsBGtkKz" resolve="shadowed" />
+                      </node>
+                      <node concept="liA8E" id="4ntVsBGv$f1" role="2OqNvi">
+                        <ref role="37wK5l" node="4ntVsBGvlJ7" resolve="getAnchorNode" />
+                      </node>
+                    </node>
+                    <node concept="2OqwBi" id="4ntVsBGtzQ7" role="3uHU7B">
+                      <node concept="37vLTw" id="4ntVsBGtyEm" role="2Oq$k0">
+                        <ref role="3cqZAo" node="15DZatOVPYV" resolve="anchorNode" />
+                      </node>
+                      <node concept="YBYNd" id="4ntVsBGt$RD" role="2OqNvi" />
+                    </node>
+                  </node>
+                  <node concept="1Wc70l" id="4ntVsBGtso6" role="3uHU7B">
+                    <node concept="37vLTw" id="4ntVsBGtr3t" role="3uHU7B">
+                      <ref role="3cqZAo" node="15DZatOVt0B" resolve="before" />
+                    </node>
+                    <node concept="3fqX7Q" id="4ntVsBGtwns" role="3uHU7w">
+                      <node concept="2OqwBi" id="4ntVsBGvcNT" role="3fr31v">
+                        <node concept="37vLTw" id="4ntVsBGtwnv" role="2Oq$k0">
+                          <ref role="3cqZAo" node="4ntVsBGtkKz" resolve="shadowed" />
+                        </node>
+                        <node concept="liA8E" id="4ntVsBGvwR8" role="2OqNvi">
+                          <ref role="37wK5l" node="4ntVsBGvrjr" resolve="isBefore" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs6" id="4ntVsBGtjJL" role="3cqZAp">
+            <node concept="3clFbT" id="4ntVsBGtjJN" role="3cqZAk" />
+          </node>
+        </node>
+        <node concept="2AHcQZ" id="4ntVsBGt9mM" role="2AJF6D">
+          <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+        </node>
+      </node>
+    </node>
+    <node concept="3uibUv" id="15DZatOVm4q" role="EKbjA">
+      <ref role="3uigEE" to="uddc:~TransformationMenuLookup" resolve="TransformationMenuLookup" />
+    </node>
   </node>
 </model>
 

--- a/code/grammarcells/solutions/com.mbeddr.mpsutil.grammarcells.runtime/models/com/mbeddr/mpsutil/grammarcells/runtime/menu.mps
+++ b/code/grammarcells/solutions/com.mbeddr.mpsutil.grammarcells.runtime/models/com/mbeddr/mpsutil/grammarcells/runtime/menu.mps
@@ -5,6 +5,10 @@
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="11" />
     <use id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections" version="1" />
     <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="18" />
+    <use id="654422bf-e75f-44dc-936d-188890a746ce" name="de.slisson.mps.reflection" version="0" />
+    <use id="774bf8a0-62e5-41e1-af63-f4812e60e48b" name="jetbrains.mps.baseLanguage.checkedDots" version="0" />
+    <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="14" />
+    <use id="aee9cad2-acd4-4608-aef2-0004f6a1cdbd" name="jetbrains.mps.lang.actions" version="4" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -28,9 +32,39 @@
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" />
     <import index="z8iw" ref="r:dfdf3542-dbcf-43df-870a-3c3504b3c840(jetbrains.mps.baseLanguage.collections.custom)" />
     <import index="x4mf" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.menus(MPS.Editor/)" />
+    <import index="iwf0" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.descriptor(MPS.Editor/)" />
+    <import index="4my4" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor.sidetransform(MPS.Editor/)" />
+    <import index="y49u" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.util(MPS.OpenAPI/)" />
+    <import index="9eyi" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.lang.editor.menus.transformation(MPS.Editor/)" />
+    <import index="vndm" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel.language(MPS.Core/)" />
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
+    <import index="878o" ref="r:46fddec3-0db9-4b86-8274-957463dd4499(com.mbeddr.mpsutil.grammarcells.runtimelang.structure)" implicit="true" />
   </imports>
   <registry>
+    <language id="654422bf-e75f-44dc-936d-188890a746ce" name="de.slisson.mps.reflection">
+      <concept id="8473566765275063380" name="de.slisson.mps.reflection.structure.ReflectionFieldAccess" flags="ng" index="1PnCL0">
+        <reference id="1197029500499" name="fieldDeclaration" index="2Oxat5" />
+      </concept>
+    </language>
+    <language id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor">
+      <concept id="4510086454722552739" name="jetbrains.mps.lang.editor.structure.PropertyDeclarationCellSelector" flags="ng" index="eBIwv">
+        <reference id="4510086454740628767" name="propertyDeclaration" index="fyFUz" />
+      </concept>
+      <concept id="3647146066980922272" name="jetbrains.mps.lang.editor.structure.SelectInEditorOperation" flags="nn" index="1OKiuA">
+        <child id="1948540814633499358" name="editorContext" index="lBI5i" />
+        <child id="1948540814635895774" name="cellSelector" index="lGT1i" />
+        <child id="3604384757217586546" name="selectionStart" index="3dN3m$" />
+      </concept>
+    </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1224071154655" name="jetbrains.mps.baseLanguage.structure.AsExpression" flags="nn" index="0kSF2">
+        <child id="1224071154657" name="classifierType" index="0kSFW" />
+        <child id="1224071154656" name="expression" index="0kSFX" />
+      </concept>
+      <concept id="1080223426719" name="jetbrains.mps.baseLanguage.structure.OrExpression" flags="nn" index="22lmx$" />
+      <concept id="1219920932475" name="jetbrains.mps.baseLanguage.structure.VariableArityType" flags="in" index="8X2XB">
+        <child id="1219921048460" name="componentType" index="8Xvag" />
+      </concept>
       <concept id="1082485599095" name="jetbrains.mps.baseLanguage.structure.BlockStatement" flags="nn" index="9aQIb">
         <child id="1082485599096" name="statements" index="9aQI4" />
       </concept>
@@ -41,6 +75,13 @@
       <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
       <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
+      <concept id="1239714755177" name="jetbrains.mps.baseLanguage.structure.AbstractUnaryNumberOperation" flags="nn" index="2$Kvd9">
+        <child id="1239714902950" name="expression" index="2$L3a6" />
+      </concept>
+      <concept id="1173175405605" name="jetbrains.mps.baseLanguage.structure.ArrayAccessExpression" flags="nn" index="AH0OO">
+        <child id="1173175577737" name="index" index="AHEQo" />
+        <child id="1173175590490" name="array" index="AHHXb" />
+      </concept>
       <concept id="1188207840427" name="jetbrains.mps.baseLanguage.structure.AnnotationInstance" flags="nn" index="2AHcQZ">
         <reference id="1188208074048" name="annotation" index="2AI5Lk" />
       </concept>
@@ -50,9 +91,15 @@
       <concept id="2820489544401957797" name="jetbrains.mps.baseLanguage.structure.DefaultClassCreator" flags="nn" index="HV5vD">
         <reference id="2820489544401957798" name="classifier" index="HV5vE" />
       </concept>
+      <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
+        <child id="1154032183016" name="body" index="2LFqv$" />
+      </concept>
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1197029447546" name="jetbrains.mps.baseLanguage.structure.FieldReferenceOperation" flags="nn" index="2OwXpG">
+        <reference id="1197029500499" name="fieldDeclaration" index="2Oxat6" />
       </concept>
       <concept id="1083260308424" name="jetbrains.mps.baseLanguage.structure.EnumConstantReference" flags="nn" index="Rm8GO">
         <reference id="1083260308426" name="enumConstantDeclaration" index="Rm8GQ" />
@@ -63,6 +110,7 @@
       </concept>
       <concept id="1070462154015" name="jetbrains.mps.baseLanguage.structure.StaticFieldDeclaration" flags="ig" index="Wx3nA" />
       <concept id="1070475354124" name="jetbrains.mps.baseLanguage.structure.ThisExpression" flags="nn" index="Xjq3P" />
+      <concept id="1070475587102" name="jetbrains.mps.baseLanguage.structure.SuperConstructorInvocation" flags="nn" index="XkiVB" />
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
       </concept>
@@ -74,8 +122,15 @@
         <child id="1081256993305" name="classType" index="2ZW6by" />
         <child id="1081256993304" name="leftExpression" index="2ZW6bz" />
       </concept>
+      <concept id="1070533707846" name="jetbrains.mps.baseLanguage.structure.StaticFieldReference" flags="nn" index="10M0yZ">
+        <reference id="1144433057691" name="classifier" index="1PxDUh" />
+      </concept>
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
+      <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
       <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
+      <concept id="1070534760951" name="jetbrains.mps.baseLanguage.structure.ArrayType" flags="in" index="10Q1$e">
+        <child id="1070534760952" name="componentType" index="10Q1$1" />
+      </concept>
       <concept id="1070534934090" name="jetbrains.mps.baseLanguage.structure.CastExpression" flags="nn" index="10QFUN">
         <child id="1070534934091" name="type" index="10QFUM" />
         <child id="1070534934092" name="expression" index="10QFUP" />
@@ -84,6 +139,7 @@
       <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu">
         <property id="1075300953594" name="abstractClass" index="1sVAO0" />
         <child id="1095933932569" name="implementedInterface" index="EKbjA" />
+        <child id="1165602531693" name="superclass" index="1zkMxy" />
       </concept>
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <property id="1176718929932" name="isFinal" index="3TUv4t" />
@@ -102,6 +158,7 @@
       <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
       <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
       <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
+      <concept id="1225271221393" name="jetbrains.mps.baseLanguage.structure.NPENotEqualsExpression" flags="nn" index="17QLQc" />
       <concept id="1225271283259" name="jetbrains.mps.baseLanguage.structure.NPEEqualsExpression" flags="nn" index="17R0WA" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
@@ -120,6 +177,7 @@
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
       <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
         <child id="1082485599094" name="ifFalseStatement" index="9aQIa" />
         <child id="1068580123160" name="condition" index="3clFbw" />
@@ -132,6 +190,10 @@
         <property id="1068580123138" name="value" index="3clFbU" />
       </concept>
       <concept id="1068580123140" name="jetbrains.mps.baseLanguage.structure.ConstructorDeclaration" flags="ig" index="3clFbW" />
+      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
+        <property id="1068580320021" name="value" index="3cmrfH" />
+      </concept>
+      <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
       <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
         <child id="1068581517676" name="expression" index="3cqZAk" />
       </concept>
@@ -143,12 +205,19 @@
       <concept id="1079359253375" name="jetbrains.mps.baseLanguage.structure.ParenthesizedExpression" flags="nn" index="1eOMI4">
         <child id="1079359253376" name="expression" index="1eOMHV" />
       </concept>
+      <concept id="1081506762703" name="jetbrains.mps.baseLanguage.structure.GreaterThanExpression" flags="nn" index="3eOSWO" />
+      <concept id="1081506773034" name="jetbrains.mps.baseLanguage.structure.LessThanExpression" flags="nn" index="3eOVzh" />
+      <concept id="1081516740877" name="jetbrains.mps.baseLanguage.structure.NotExpression" flags="nn" index="3fqX7Q">
+        <child id="1081516765348" name="expression" index="3fr31v" />
+      </concept>
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
         <child id="4972241301747169160" name="typeArgument" index="3PaCim" />
       </concept>
+      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
       <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
+        <property id="521412098689998745" name="nonStatic" index="2bfB8j" />
         <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
       </concept>
       <concept id="7812454656619025412" name="jetbrains.mps.baseLanguage.structure.LocalMethodCall" flags="nn" index="1rXfSq" />
@@ -160,31 +229,103 @@
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
+      <concept id="1214918800624" name="jetbrains.mps.baseLanguage.structure.PostfixIncrementExpression" flags="nn" index="3uNrnE" />
+      <concept id="1214918975462" name="jetbrains.mps.baseLanguage.structure.PostfixDecrementExpression" flags="nn" index="3uO5VW" />
+      <concept id="8276990574909231788" name="jetbrains.mps.baseLanguage.structure.FinallyClause" flags="ng" index="1wplmZ">
+        <child id="8276990574909234106" name="finallyBody" index="1wplMD" />
+      </concept>
       <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
+      <concept id="1081855346303" name="jetbrains.mps.baseLanguage.structure.BreakStatement" flags="nn" index="3zACq4" />
       <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
+      <concept id="1144230876926" name="jetbrains.mps.baseLanguage.structure.AbstractForStatement" flags="nn" index="1DupvO">
+        <child id="1144230900587" name="variable" index="1Duv9x" />
+      </concept>
+      <concept id="1144231330558" name="jetbrains.mps.baseLanguage.structure.ForStatement" flags="nn" index="1Dw8fO">
+        <child id="1144231399730" name="condition" index="1Dwp0S" />
+        <child id="1144231408325" name="iteration" index="1Dwrff" />
+      </concept>
+      <concept id="1107796713796" name="jetbrains.mps.baseLanguage.structure.Interface" flags="ig" index="3HP615">
+        <child id="1107797138135" name="extendedInterface" index="3HQHJm" />
+      </concept>
+      <concept id="5351203823916750322" name="jetbrains.mps.baseLanguage.structure.TryUniversalStatement" flags="nn" index="3J1_TO">
+        <child id="8276990574886367509" name="finallyClause" index="1zxBo6" />
+        <child id="8276990574886367508" name="body" index="1zxBo7" />
+      </concept>
+      <concept id="1163668896201" name="jetbrains.mps.baseLanguage.structure.TernaryOperatorExpression" flags="nn" index="3K4zz7">
+        <child id="1163668914799" name="condition" index="3K4Cdx" />
+        <child id="1163668922816" name="ifTrue" index="3K4E3e" />
+        <child id="1163668934364" name="ifFalse" index="3K4GZi" />
+      </concept>
+      <concept id="1082113931046" name="jetbrains.mps.baseLanguage.structure.ContinueStatement" flags="nn" index="3N13vt" />
+      <concept id="1208890769693" name="jetbrains.mps.baseLanguage.structure.ArrayLengthOperation" flags="nn" index="1Rwk04" />
+      <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
+        <child id="8356039341262087992" name="line" index="1aUNEU" />
+      </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
       <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
+      <concept id="1146644641414" name="jetbrains.mps.baseLanguage.structure.ProtectedVisibility" flags="nn" index="3Tmbuc" />
+      <concept id="1116615150612" name="jetbrains.mps.baseLanguage.structure.ClassifierClassExpression" flags="nn" index="3VsKOn">
+        <reference id="1116615189566" name="classifier" index="3VsUkX" />
+      </concept>
+      <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
     </language>
     <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
+      <concept id="1199542442495" name="jetbrains.mps.baseLanguage.closures.structure.FunctionType" flags="in" index="1ajhzC">
+        <child id="1199542457201" name="resultType" index="1ajl9A" />
+        <child id="1199542501692" name="parameterType" index="1ajw0F" />
+      </concept>
       <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
         <child id="1199569906740" name="parameter" index="1bW2Oz" />
         <child id="1199569916463" name="body" index="1bW5cS" />
       </concept>
+      <concept id="1225797177491" name="jetbrains.mps.baseLanguage.closures.structure.InvokeFunctionOperation" flags="nn" index="1Bd96e">
+        <child id="1225797361612" name="parameter" index="1BdPVh" />
+      </concept>
+    </language>
+    <language id="aee9cad2-acd4-4608-aef2-0004f6a1cdbd" name="jetbrains.mps.lang.actions">
+      <concept id="767145758118872833" name="jetbrains.mps.lang.actions.structure.NF_LinkList_AddNewChildOperation" flags="nn" index="2DeJg1" />
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1173122760281" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorsOperation" flags="nn" index="z$bX8" />
+      <concept id="1143234257716" name="jetbrains.mps.lang.smodel.structure.Node_GetModelOperation" flags="nn" index="I4A8Y" />
+      <concept id="2644386474300074836" name="jetbrains.mps.lang.smodel.structure.ConceptIdRefExpression" flags="nn" index="35c_gC">
+        <reference id="2644386474300074837" name="conceptDeclaration" index="35c_gD" />
+      </concept>
       <concept id="6677504323281689838" name="jetbrains.mps.lang.smodel.structure.SConceptType" flags="in" index="3bZ5Sz" />
-      <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2" />
+      <concept id="6407023681583036853" name="jetbrains.mps.lang.smodel.structure.NodeAttributeQualifier" flags="ng" index="3CFYIy">
+        <reference id="6407023681583036854" name="attributeConcept" index="3CFYIx" />
+      </concept>
+      <concept id="6407023681583031218" name="jetbrains.mps.lang.smodel.structure.AttributeAccess" flags="nn" index="3CFZ6_">
+        <child id="6407023681583036852" name="qualifier" index="3CFYIz" />
+      </concept>
+      <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
+        <reference id="1138405853777" name="concept" index="ehGHo" />
+      </concept>
+      <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
+        <reference id="1138056395725" name="property" index="3TsBF5" />
+      </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
     </language>
+    <language id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text">
+      <concept id="155656958578482948" name="jetbrains.mps.lang.text.structure.Word" flags="nn" index="3oM_SD">
+        <property id="155656958578482949" name="value" index="3oM_SC" />
+      </concept>
+      <concept id="2535923850359271782" name="jetbrains.mps.lang.text.structure.Line" flags="nn" index="1PaTwC">
+        <child id="2535923850359271783" name="elements" index="1PaTwD" />
+      </concept>
+    </language>
     <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
       <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
         <child id="1204796294226" name="closure" index="23t8la" />
+      </concept>
+      <concept id="1176906603202" name="jetbrains.mps.baseLanguage.collections.structure.BinaryOperation" flags="nn" index="56pJg">
+        <child id="1176906787974" name="rightExpression" index="576Qk" />
       </concept>
       <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="nn" index="25WWJ4">
         <child id="540871147943773366" name="argument" index="25WWJ7" />
@@ -193,15 +334,37 @@
         <child id="1226511765987" name="elementType" index="2hN53Y" />
       </concept>
       <concept id="1226516258405" name="jetbrains.mps.baseLanguage.collections.structure.HashSetCreator" flags="nn" index="2i4dXS" />
+      <concept id="1224414427926" name="jetbrains.mps.baseLanguage.collections.structure.SequenceCreator" flags="nn" index="kMnCb">
+        <child id="1224414456414" name="elementType" index="kMuH3" />
+      </concept>
       <concept id="1151688443754" name="jetbrains.mps.baseLanguage.collections.structure.ListType" flags="in" index="_YKpA">
         <child id="1151688676805" name="elementType" index="_ZDj9" />
       </concept>
+      <concept id="1151689724996" name="jetbrains.mps.baseLanguage.collections.structure.SequenceType" flags="in" index="A3Dl8">
+        <child id="1151689745422" name="elementType" index="A3Ik2" />
+      </concept>
       <concept id="1151702311717" name="jetbrains.mps.baseLanguage.collections.structure.ToListOperation" flags="nn" index="ANE8D" />
+      <concept id="1235573135402" name="jetbrains.mps.baseLanguage.collections.structure.SingletonSequenceCreator" flags="nn" index="2HTt$P">
+        <child id="1235573175711" name="elementType" index="2HTBi0" />
+        <child id="1235573187520" name="singletonValue" index="2HTEbv" />
+      </concept>
       <concept id="1237721394592" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerCreator" flags="nn" index="HWqM0">
+        <child id="1237721435808" name="initValue" index="HW$Y0" />
         <child id="1237721435807" name="elementType" index="HW$YZ" />
+        <child id="1237731803878" name="copyFrom" index="I$8f6" />
+      </concept>
+      <concept id="1227022196108" name="jetbrains.mps.baseLanguage.collections.structure.RemoveAtElementOperation" flags="nn" index="2KedMh">
+        <child id="1227022274197" name="index" index="2KewY8" />
       </concept>
       <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
+      <concept id="1160600644654" name="jetbrains.mps.baseLanguage.collections.structure.ListCreatorWithInit" flags="nn" index="Tc6Ow" />
       <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
+      <concept id="4611582986551314327" name="jetbrains.mps.baseLanguage.collections.structure.OfTypeOperation" flags="nn" index="UnYns">
+        <child id="4611582986551314344" name="requestedType" index="UnYnz" />
+      </concept>
+      <concept id="1160666733551" name="jetbrains.mps.baseLanguage.collections.structure.AddAllElementsOperation" flags="nn" index="X8dFx" />
+      <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
+      <concept id="1240325842691" name="jetbrains.mps.baseLanguage.collections.structure.AsSequenceOperation" flags="nn" index="39bAoz" />
       <concept id="1201792049884" name="jetbrains.mps.baseLanguage.collections.structure.TranslateOperation" flags="nn" index="3goQfb" />
       <concept id="1197683403723" name="jetbrains.mps.baseLanguage.collections.structure.MapType" flags="in" index="3rvAFt">
         <child id="1197683466920" name="keyType" index="3rvQeY" />
@@ -214,11 +377,25 @@
       <concept id="1576845966386891367" name="jetbrains.mps.baseLanguage.collections.structure.CustomMapCreator" flags="nn" index="1u7pXE">
         <reference id="1576845966386891370" name="containerDeclaration" index="1u7pXB" />
       </concept>
+      <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
+      <concept id="1240687580870" name="jetbrains.mps.baseLanguage.collections.structure.JoinOperation" flags="nn" index="3uJxvA">
+        <child id="1240687658305" name="delimiter" index="3uJOhx" />
+      </concept>
+      <concept id="1165530316231" name="jetbrains.mps.baseLanguage.collections.structure.IsEmptyOperation" flags="nn" index="1v1jN8" />
+      <concept id="1225711141656" name="jetbrains.mps.baseLanguage.collections.structure.ListElementAccessExpression" flags="nn" index="1y4W85">
+        <child id="1225711182005" name="list" index="1y566C" />
+        <child id="1225711191269" name="index" index="1y58nS" />
+      </concept>
+      <concept id="1202120902084" name="jetbrains.mps.baseLanguage.collections.structure.WhereOperation" flags="nn" index="3zZkjj" />
+      <concept id="1202128969694" name="jetbrains.mps.baseLanguage.collections.structure.SelectOperation" flags="nn" index="3$u5V9" />
+      <concept id="1184963466173" name="jetbrains.mps.baseLanguage.collections.structure.ToArrayOperation" flags="nn" index="3_kTaI" />
       <concept id="1197932370469" name="jetbrains.mps.baseLanguage.collections.structure.MapElement" flags="nn" index="3EllGN">
         <child id="1197932505799" name="map" index="3ElQJh" />
         <child id="1197932525128" name="key" index="3ElVtu" />
       </concept>
       <concept id="1172254888721" name="jetbrains.mps.baseLanguage.collections.structure.ContainsOperation" flags="nn" index="3JPx81" />
+      <concept id="1180964022718" name="jetbrains.mps.baseLanguage.collections.structure.ConcatOperation" flags="nn" index="3QWeyG" />
+      <concept id="1178894719932" name="jetbrains.mps.baseLanguage.collections.structure.DistinctOperation" flags="nn" index="1VAtEI" />
     </language>
   </registry>
   <node concept="312cEu" id="1YKLYyyGx8h">
@@ -345,7 +522,8 @@
     <node concept="2tJIrI" id="1YKLYyyGKrP" role="jymVt" />
     <node concept="312cEg" id="My09KinAU6" role="jymVt">
       <property role="TrG5h" value="myContext" />
-      <node concept="3Tm6S6" id="My09KinAU7" role="1B3o_S" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="5fS8LrorpuB" role="1B3o_S" />
       <node concept="3uibUv" id="My09KinBBr" role="1tU5fm">
         <ref role="3uigEE" to="uddc:~TransformationMenuContext" resolve="TransformationMenuContext" />
       </node>
@@ -401,6 +579,21 @@
       </node>
     </node>
     <node concept="2tJIrI" id="My09Kin_LS" role="jymVt" />
+    <node concept="3clFb_" id="5fS8LrorqMN" role="jymVt">
+      <property role="TrG5h" value="getContext" />
+      <node concept="3uibUv" id="5fS8Lrort6q" role="3clF45">
+        <ref role="3uigEE" to="uddc:~TransformationMenuContext" resolve="TransformationMenuContext" />
+      </node>
+      <node concept="3Tm1VV" id="5fS8LrorqMQ" role="1B3o_S" />
+      <node concept="3clFbS" id="5fS8LrorqMR" role="3clF47">
+        <node concept="3clFbF" id="5fS8LrortM0" role="3cqZAp">
+          <node concept="37vLTw" id="5fS8LrortLZ" role="3clFbG">
+            <ref role="3cqZAo" node="My09KinAU6" resolve="myContext" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="5fS8Lrorq5g" role="jymVt" />
     <node concept="3clFb_" id="4Fanv3UR5IV" role="jymVt">
       <property role="1EzhhJ" value="false" />
       <property role="TrG5h" value="getTraceInfo" />
@@ -1497,6 +1690,3304 @@
       </node>
     </node>
     <node concept="3Tm1VV" id="My09Kin8_t" role="1B3o_S" />
+  </node>
+  <node concept="312cEu" id="1_3xoKENxnx">
+    <property role="TrG5h" value="CompositeTransformationMenuLookup" />
+    <node concept="2YIFZL" id="1_3xoKENEY7" role="jymVt">
+      <property role="TrG5h" value="combine" />
+      <node concept="3clFbS" id="1_3xoKENDYy" role="3clF47">
+        <node concept="3clFbJ" id="1_3xoKENFku" role="3cqZAp">
+          <node concept="3clFbC" id="1_3xoKENFtZ" role="3clFbw">
+            <node concept="10Nm6u" id="1_3xoKENFy0" role="3uHU7w" />
+            <node concept="37vLTw" id="1_3xoKENFlJ" role="3uHU7B">
+              <ref role="3cqZAo" node="1_3xoKENEHm" resolve="lookup1" />
+            </node>
+          </node>
+          <node concept="3clFbS" id="1_3xoKENFkw" role="3clFbx">
+            <node concept="3cpWs6" id="1_3xoKENFyR" role="3cqZAp">
+              <node concept="37vLTw" id="1_3xoKENF_d" role="3cqZAk">
+                <ref role="3cqZAo" node="1_3xoKENFhO" resolve="lookup2" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="1_3xoKENFDe" role="3cqZAp">
+          <node concept="3clFbS" id="1_3xoKENFDg" role="3clFbx">
+            <node concept="3cpWs6" id="1_3xoKENFSZ" role="3cqZAp">
+              <node concept="37vLTw" id="1_3xoKENFTN" role="3cqZAk">
+                <ref role="3cqZAo" node="1_3xoKENEHm" resolve="lookup1" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbC" id="1_3xoKENFOh" role="3clFbw">
+            <node concept="10Nm6u" id="1_3xoKENFS7" role="3uHU7w" />
+            <node concept="37vLTw" id="1_3xoKENFGb" role="3uHU7B">
+              <ref role="3cqZAo" node="1_3xoKENFhO" resolve="lookup2" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="1_3xoKENLGv" role="3cqZAp">
+          <node concept="2OqwBi" id="DnjeukUd_1" role="3cqZAk">
+            <node concept="2ShNRf" id="1_3xoKENLK5" role="2Oq$k0">
+              <node concept="1pGfFk" id="1_3xoKENMgk" role="2ShVmc">
+                <ref role="37wK5l" node="1_3xoKENxth" resolve="CompositeTransformationMenuLookup" />
+                <node concept="37vLTw" id="1_3xoKENMk2" role="37wK5m">
+                  <ref role="3cqZAo" node="1_3xoKENEHm" resolve="lookup1" />
+                </node>
+                <node concept="37vLTw" id="1_3xoKENMqb" role="37wK5m">
+                  <ref role="3cqZAo" node="1_3xoKENFhO" resolve="lookup2" />
+                </node>
+              </node>
+            </node>
+            <node concept="liA8E" id="DnjeukUdNa" role="2OqNvi">
+              <ref role="37wK5l" node="DnjeukTMb0" resolve="flatten" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="1_3xoKENEHm" role="3clF46">
+        <property role="TrG5h" value="lookup1" />
+        <node concept="3uibUv" id="1_3xoKENEHl" role="1tU5fm">
+          <ref role="3uigEE" to="uddc:~TransformationMenuLookup" resolve="TransformationMenuLookup" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="1_3xoKENFhO" role="3clF46">
+        <property role="TrG5h" value="lookup2" />
+        <node concept="3uibUv" id="1_3xoKENFhP" role="1tU5fm">
+          <ref role="3uigEE" to="uddc:~TransformationMenuLookup" resolve="TransformationMenuLookup" />
+        </node>
+      </node>
+      <node concept="3uibUv" id="1_3xoKENFfj" role="3clF45">
+        <ref role="3uigEE" to="uddc:~TransformationMenuLookup" resolve="TransformationMenuLookup" />
+      </node>
+      <node concept="3Tm1VV" id="1_3xoKENDYx" role="1B3o_S" />
+    </node>
+    <node concept="2YIFZL" id="DnjeukELVT" role="jymVt">
+      <property role="TrG5h" value="add" />
+      <node concept="3clFbS" id="DnjeukEKdB" role="3clF47">
+        <node concept="3clFbF" id="DnjeukEMbn" role="3cqZAp">
+          <node concept="2OqwBi" id="DnjeukEMdu" role="3clFbG">
+            <node concept="37vLTw" id="DnjeukEMbm" role="2Oq$k0">
+              <ref role="3cqZAo" node="DnjeukEKUv" resolve="cell" />
+            </node>
+            <node concept="liA8E" id="DnjeukEMkE" role="2OqNvi">
+              <ref role="37wK5l" to="f4zo:~EditorCell.setTransformationMenuLookup(jetbrains.mps.openapi.editor.menus.transformation.TransformationMenuLookup)" resolve="setTransformationMenuLookup" />
+              <node concept="1rXfSq" id="DnjeukEMmg" role="37wK5m">
+                <ref role="37wK5l" node="1_3xoKENEY7" resolve="combine" />
+                <node concept="2OqwBi" id="DnjeukEMrT" role="37wK5m">
+                  <node concept="37vLTw" id="DnjeukEMpm" role="2Oq$k0">
+                    <ref role="3cqZAo" node="DnjeukEKUv" resolve="cell" />
+                  </node>
+                  <node concept="liA8E" id="DnjeukEMvI" role="2OqNvi">
+                    <ref role="37wK5l" to="f4zo:~EditorCell.getTransformationMenuLookup()" resolve="getTransformationMenuLookup" />
+                  </node>
+                </node>
+                <node concept="37vLTw" id="DnjeukEM$_" role="37wK5m">
+                  <ref role="3cqZAo" node="DnjeukEL9q" resolve="lookup" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="DnjeukEKUv" role="3clF46">
+        <property role="TrG5h" value="cell" />
+        <node concept="3uibUv" id="DnjeukEL8l" role="1tU5fm">
+          <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="DnjeukEL9q" role="3clF46">
+        <property role="TrG5h" value="lookup" />
+        <node concept="3uibUv" id="DnjeukELqt" role="1tU5fm">
+          <ref role="3uigEE" to="uddc:~TransformationMenuLookup" resolve="TransformationMenuLookup" />
+        </node>
+      </node>
+      <node concept="3cqZAl" id="DnjeukEKd_" role="3clF45" />
+      <node concept="3Tm1VV" id="DnjeukEKdA" role="1B3o_S" />
+    </node>
+    <node concept="2YIFZL" id="DnjeukUIla" role="jymVt">
+      <property role="TrG5h" value="filter" />
+      <node concept="3clFbS" id="DnjeukUIlb" role="3clF47">
+        <node concept="3cpWs8" id="DnjeukUJyz" role="3cqZAp">
+          <node concept="3cpWsn" id="DnjeukUJy$" role="3cpWs9">
+            <property role="TrG5h" value="lookup" />
+            <node concept="3uibUv" id="DnjeukUJvJ" role="1tU5fm">
+              <ref role="3uigEE" to="uddc:~TransformationMenuLookup" resolve="TransformationMenuLookup" />
+            </node>
+            <node concept="2OqwBi" id="DnjeukUJy_" role="33vP2m">
+              <node concept="37vLTw" id="DnjeukUJyA" role="2Oq$k0">
+                <ref role="3cqZAo" node="DnjeukUIll" resolve="cell" />
+              </node>
+              <node concept="liA8E" id="DnjeukUJyB" role="2OqNvi">
+                <ref role="37wK5l" to="f4zo:~EditorCell.getTransformationMenuLookup()" resolve="getTransformationMenuLookup" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="5fS8LrnLx5s" role="3cqZAp">
+          <node concept="3clFbS" id="5fS8LrnLx5u" role="3clFbx">
+            <node concept="3cpWs6" id="5fS8LrnLxot" role="3cqZAp" />
+          </node>
+          <node concept="3clFbC" id="5fS8LrnLxi_" role="3clFbw">
+            <node concept="10Nm6u" id="5fS8LrnLxnB" role="3uHU7w" />
+            <node concept="37vLTw" id="5fS8LrnLx9k" role="3uHU7B">
+              <ref role="3cqZAo" node="DnjeukUJy$" resolve="lookup" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="DnjeukUJRk" role="3cqZAp">
+          <node concept="3cpWsn" id="DnjeukUJRl" role="3cpWs9">
+            <property role="TrG5h" value="compositeLookup" />
+            <node concept="3uibUv" id="DnjeukUJRm" role="1tU5fm">
+              <ref role="3uigEE" node="1_3xoKENxnx" resolve="CompositeTransformationMenuLookup" />
+            </node>
+            <node concept="3K4zz7" id="DnjeukUKux" role="33vP2m">
+              <node concept="1eOMI4" id="DnjeukUKzF" role="3K4E3e">
+                <node concept="10QFUN" id="DnjeukUKzC" role="1eOMHV">
+                  <node concept="3uibUv" id="DnjeukUK$u" role="10QFUM">
+                    <ref role="3uigEE" node="1_3xoKENxnx" resolve="CompositeTransformationMenuLookup" />
+                  </node>
+                  <node concept="37vLTw" id="DnjeukUKCT" role="10QFUP">
+                    <ref role="3cqZAo" node="DnjeukUJy$" resolve="lookup" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2ShNRf" id="DnjeukUKDV" role="3K4GZi">
+                <node concept="1pGfFk" id="DnjeukULaV" role="2ShVmc">
+                  <ref role="37wK5l" node="1_3xoKENxth" resolve="CompositeTransformationMenuLookup" />
+                  <node concept="37vLTw" id="DnjeukULeC" role="37wK5m">
+                    <ref role="3cqZAo" node="DnjeukUJy$" resolve="lookup" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2ZW3vV" id="DnjeukUK2T" role="3K4Cdx">
+                <node concept="3uibUv" id="DnjeukUK8B" role="2ZW6by">
+                  <ref role="3uigEE" node="1_3xoKENxnx" resolve="CompositeTransformationMenuLookup" />
+                </node>
+                <node concept="37vLTw" id="DnjeukUJXx" role="2ZW6bz">
+                  <ref role="3cqZAo" node="DnjeukUJy$" resolve="lookup" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="DnjeukUIlc" role="3cqZAp">
+          <node concept="2OqwBi" id="DnjeukUIld" role="3clFbG">
+            <node concept="37vLTw" id="DnjeukUIle" role="2Oq$k0">
+              <ref role="3cqZAo" node="DnjeukUIll" resolve="cell" />
+            </node>
+            <node concept="liA8E" id="DnjeukUIlf" role="2OqNvi">
+              <ref role="37wK5l" to="f4zo:~EditorCell.setTransformationMenuLookup(jetbrains.mps.openapi.editor.menus.transformation.TransformationMenuLookup)" resolve="setTransformationMenuLookup" />
+              <node concept="2OqwBi" id="DnjeukULto" role="37wK5m">
+                <node concept="37vLTw" id="DnjeukULn3" role="2Oq$k0">
+                  <ref role="3cqZAo" node="DnjeukUJRl" resolve="compositeLookup" />
+                </node>
+                <node concept="liA8E" id="DnjeukULC5" role="2OqNvi">
+                  <ref role="37wK5l" node="DnjeukUw7$" resolve="filter" />
+                  <node concept="37vLTw" id="DnjeukULGk" role="37wK5m">
+                    <ref role="3cqZAo" node="DnjeukUJuT" resolve="condition" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="DnjeukUIll" role="3clF46">
+        <property role="TrG5h" value="cell" />
+        <node concept="3uibUv" id="DnjeukUIlm" role="1tU5fm">
+          <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="DnjeukUJuT" role="3clF46">
+        <property role="TrG5h" value="condition" />
+        <node concept="1ajhzC" id="DnjeukUJuU" role="1tU5fm">
+          <node concept="10P_77" id="DnjeukUJuV" role="1ajl9A" />
+          <node concept="3uibUv" id="DnjeukUJuW" role="1ajw0F">
+            <ref role="3uigEE" to="uddc:~TransformationMenuLookup" resolve="TransformationMenuLookup" />
+          </node>
+        </node>
+      </node>
+      <node concept="3cqZAl" id="DnjeukUIlp" role="3clF45" />
+      <node concept="3Tm1VV" id="DnjeukUIlq" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="1_3xoKENDHP" role="jymVt" />
+    <node concept="312cEg" id="1_3xoKENxrm" role="jymVt">
+      <property role="TrG5h" value="lookups" />
+      <node concept="3Tm6S6" id="1_3xoKENxrn" role="1B3o_S" />
+      <node concept="10Q1$e" id="1_3xoKENy64" role="1tU5fm">
+        <node concept="3uibUv" id="1_3xoKENxrW" role="10Q1$1">
+          <ref role="3uigEE" to="uddc:~TransformationMenuLookup" resolve="TransformationMenuLookup" />
+        </node>
+      </node>
+    </node>
+    <node concept="3clFbW" id="1_3xoKENxth" role="jymVt">
+      <node concept="3cqZAl" id="1_3xoKENxtj" role="3clF45" />
+      <node concept="3Tm6S6" id="1_3xoKENDqG" role="1B3o_S" />
+      <node concept="3clFbS" id="1_3xoKENxtl" role="3clF47">
+        <node concept="3clFbF" id="1_3xoKENxvK" role="3cqZAp">
+          <node concept="37vLTI" id="1_3xoKENxZS" role="3clFbG">
+            <node concept="37vLTw" id="1_3xoKENy2r" role="37vLTx">
+              <ref role="3cqZAo" node="1_3xoKENxu1" resolve="lookups" />
+            </node>
+            <node concept="2OqwBi" id="1_3xoKENxCo" role="37vLTJ">
+              <node concept="Xjq3P" id="1_3xoKENxvJ" role="2Oq$k0" />
+              <node concept="2OwXpG" id="1_3xoKENxRD" role="2OqNvi">
+                <ref role="2Oxat6" node="1_3xoKENxrm" resolve="lookups" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="1_3xoKENxu1" role="3clF46">
+        <property role="TrG5h" value="lookups" />
+        <node concept="8X2XB" id="1_3xoKENxu$" role="1tU5fm">
+          <node concept="3uibUv" id="1_3xoKENxu0" role="8Xvag">
+            <ref role="3uigEE" to="uddc:~TransformationMenuLookup" resolve="TransformationMenuLookup" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="DnjeukUq0N" role="jymVt" />
+    <node concept="3clFb_" id="DnjeukUw7$" role="jymVt">
+      <property role="TrG5h" value="filter" />
+      <node concept="37vLTG" id="DnjeukUzs4" role="3clF46">
+        <property role="TrG5h" value="condition" />
+        <node concept="1ajhzC" id="DnjeukUzUG" role="1tU5fm">
+          <node concept="10P_77" id="DnjeukUzYA" role="1ajl9A" />
+          <node concept="3uibUv" id="DnjeukUzVY" role="1ajw0F">
+            <ref role="3uigEE" to="uddc:~TransformationMenuLookup" resolve="TransformationMenuLookup" />
+          </node>
+        </node>
+      </node>
+      <node concept="3uibUv" id="DnjeukUyw$" role="3clF45">
+        <ref role="3uigEE" to="uddc:~TransformationMenuLookup" resolve="TransformationMenuLookup" />
+      </node>
+      <node concept="3Tm1VV" id="DnjeukUw7B" role="1B3o_S" />
+      <node concept="3clFbS" id="DnjeukUw7C" role="3clF47">
+        <node concept="3cpWs8" id="DnjeukU_C4" role="3cqZAp">
+          <node concept="3cpWsn" id="DnjeukU_C5" role="3cpWs9">
+            <property role="TrG5h" value="filtered" />
+            <node concept="10Q1$e" id="DnjeukU_BD" role="1tU5fm">
+              <node concept="3uibUv" id="DnjeukU_BG" role="10Q1$1">
+                <ref role="3uigEE" to="uddc:~TransformationMenuLookup" resolve="TransformationMenuLookup" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="DnjeukU_C6" role="33vP2m">
+              <node concept="2OqwBi" id="DnjeukU_C7" role="2Oq$k0">
+                <node concept="1rXfSq" id="DnjeukU_C8" role="2Oq$k0">
+                  <ref role="37wK5l" node="DnjeukUr12" resolve="getLookups" />
+                </node>
+                <node concept="3zZkjj" id="DnjeukU_C9" role="2OqNvi">
+                  <node concept="1bVj0M" id="DnjeukU_Ca" role="23t8la">
+                    <node concept="3clFbS" id="DnjeukU_Cb" role="1bW5cS">
+                      <node concept="3clFbF" id="DnjeukU_Cc" role="3cqZAp">
+                        <node concept="2OqwBi" id="DnjeukU_Cd" role="3clFbG">
+                          <node concept="37vLTw" id="DnjeukU_Ce" role="2Oq$k0">
+                            <ref role="3cqZAo" node="DnjeukUzs4" resolve="condition" />
+                          </node>
+                          <node concept="1Bd96e" id="DnjeukU_Cf" role="2OqNvi">
+                            <node concept="37vLTw" id="DnjeukU_Cg" role="1BdPVh">
+                              <ref role="3cqZAo" node="DnjeukU_Ch" resolve="it" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="Rh6nW" id="DnjeukU_Ch" role="1bW2Oz">
+                      <property role="TrG5h" value="it" />
+                      <node concept="2jxLKc" id="DnjeukU_Ci" role="1tU5fm" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3_kTaI" id="DnjeukU_Cj" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="DnjeukU_VQ" role="3cqZAp">
+          <node concept="3clFbS" id="DnjeukU_VS" role="3clFbx">
+            <node concept="3cpWs6" id="DnjeukUBSl" role="3cqZAp">
+              <node concept="AH0OO" id="DnjeukUD0I" role="3cqZAk">
+                <node concept="3cmrfG" id="DnjeukUD$6" role="AHEQo">
+                  <property role="3cmrfH" value="0" />
+                </node>
+                <node concept="37vLTw" id="DnjeukUBVQ" role="AHHXb">
+                  <ref role="3cqZAo" node="DnjeukU_C5" resolve="filtered" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbC" id="DnjeukUBm4" role="3clFbw">
+            <node concept="3cmrfG" id="DnjeukUBRl" role="3uHU7w">
+              <property role="3cmrfH" value="1" />
+            </node>
+            <node concept="2OqwBi" id="DnjeukUAcv" role="3uHU7B">
+              <node concept="37vLTw" id="DnjeukUA3r" role="2Oq$k0">
+                <ref role="3cqZAo" node="DnjeukU_C5" resolve="filtered" />
+              </node>
+              <node concept="1Rwk04" id="DnjeukUAqC" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="DnjeukUGfj" role="3cqZAp">
+          <node concept="2ShNRf" id="DnjeukUGfl" role="3cqZAk">
+            <node concept="1pGfFk" id="DnjeukUGfm" role="2ShVmc">
+              <ref role="37wK5l" node="1_3xoKENxth" resolve="CompositeTransformationMenuLookup" />
+              <node concept="37vLTw" id="DnjeukUGfn" role="37wK5m">
+                <ref role="3cqZAo" node="DnjeukU_C5" resolve="filtered" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="DnjeukUv99" role="jymVt" />
+    <node concept="3clFb_" id="DnjeukUr12" role="jymVt">
+      <property role="TrG5h" value="getLookups" />
+      <node concept="A3Dl8" id="DnjeukUtOM" role="3clF45">
+        <node concept="3uibUv" id="DnjeukUuJD" role="A3Ik2">
+          <ref role="3uigEE" to="uddc:~TransformationMenuLookup" resolve="TransformationMenuLookup" />
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="DnjeukUr15" role="1B3o_S" />
+      <node concept="3clFbS" id="DnjeukUr16" role="3clF47">
+        <node concept="3clFbF" id="DnjeukUuMl" role="3cqZAp">
+          <node concept="2OqwBi" id="DnjeukUuU9" role="3clFbG">
+            <node concept="37vLTw" id="DnjeukUuMk" role="2Oq$k0">
+              <ref role="3cqZAo" node="1_3xoKENxrm" resolve="lookups" />
+            </node>
+            <node concept="39bAoz" id="DnjeukUv4Y" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="1_3xoKENMDF" role="jymVt" />
+    <node concept="3Tm1VV" id="1_3xoKENxny" role="1B3o_S" />
+    <node concept="3uibUv" id="1_3xoKENxo7" role="EKbjA">
+      <ref role="3uigEE" to="uddc:~TransformationMenuLookup" resolve="TransformationMenuLookup" />
+    </node>
+    <node concept="3clFb_" id="1_3xoKENy7O" role="jymVt">
+      <property role="TrG5h" value="lookup" />
+      <node concept="3Tm1VV" id="1_3xoKENy7P" role="1B3o_S" />
+      <node concept="2AHcQZ" id="1_3xoKENy7R" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+      </node>
+      <node concept="3uibUv" id="1_3xoKENy7S" role="3clF45">
+        <ref role="3uigEE" to="33ny:~Collection" resolve="Collection" />
+        <node concept="3uibUv" id="1_3xoKENy7T" role="11_B2D">
+          <ref role="3uigEE" to="iwf0:~TransformationMenu" resolve="TransformationMenu" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="1_3xoKENy7U" role="3clF46">
+        <property role="TrG5h" value="usedLanguages" />
+        <node concept="3uibUv" id="1_3xoKENy7V" role="1tU5fm">
+          <ref role="3uigEE" to="33ny:~Collection" resolve="Collection" />
+          <node concept="3uibUv" id="1_3xoKENy7W" role="11_B2D">
+            <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
+          </node>
+        </node>
+        <node concept="2AHcQZ" id="1_3xoKENy7X" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="1_3xoKENy7Y" role="3clF46">
+        <property role="TrG5h" value="menuLocation" />
+        <node concept="17QB3L" id="1_3xoKENyiV" role="1tU5fm" />
+        <node concept="2AHcQZ" id="1_3xoKENy80" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="1_3xoKENy81" role="3clF47">
+        <node concept="3clFbF" id="1_3xoKENylx" role="3cqZAp">
+          <node concept="2OqwBi" id="1_3xoKENC6$" role="3clFbG">
+            <node concept="2OqwBi" id="1_3xoKENyPR" role="2Oq$k0">
+              <node concept="2OqwBi" id="1_3xoKENys2" role="2Oq$k0">
+                <node concept="37vLTw" id="1_3xoKENylw" role="2Oq$k0">
+                  <ref role="3cqZAo" node="1_3xoKENxrm" resolve="lookups" />
+                </node>
+                <node concept="39bAoz" id="1_3xoKENy$E" role="2OqNvi" />
+              </node>
+              <node concept="3goQfb" id="1_3xoKENz9d" role="2OqNvi">
+                <node concept="1bVj0M" id="1_3xoKENz9f" role="23t8la">
+                  <node concept="3clFbS" id="1_3xoKENz9g" role="1bW5cS">
+                    <node concept="3clFbF" id="1_3xoKENzgo" role="3cqZAp">
+                      <node concept="2OqwBi" id="1_3xoKENzsb" role="3clFbG">
+                        <node concept="37vLTw" id="1_3xoKENzgn" role="2Oq$k0">
+                          <ref role="3cqZAo" node="1_3xoKENz9h" resolve="it" />
+                        </node>
+                        <node concept="liA8E" id="1_3xoKENzBW" role="2OqNvi">
+                          <ref role="37wK5l" to="uddc:~TransformationMenuLookup.lookup(java.util.Collection,java.lang.String)" resolve="lookup" />
+                          <node concept="37vLTw" id="1_3xoKENzPf" role="37wK5m">
+                            <ref role="3cqZAo" node="1_3xoKENy7U" resolve="usedLanguages" />
+                          </node>
+                          <node concept="37vLTw" id="1_3xoKENBH_" role="37wK5m">
+                            <ref role="3cqZAo" node="1_3xoKENy7Y" resolve="menuLocation" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Rh6nW" id="1_3xoKENz9h" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="1_3xoKENz9i" role="1tU5fm" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="ANE8D" id="1_3xoKEND8o" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="1_3xoKENy82" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="DnjeukTLCc" role="jymVt" />
+    <node concept="3clFb_" id="DnjeukTMb0" role="jymVt">
+      <property role="TrG5h" value="flatten" />
+      <node concept="3uibUv" id="DnjeukTMHd" role="3clF45">
+        <ref role="3uigEE" to="uddc:~TransformationMenuLookup" resolve="TransformationMenuLookup" />
+      </node>
+      <node concept="3Tm1VV" id="DnjeukTMb3" role="1B3o_S" />
+      <node concept="3clFbS" id="DnjeukTMb4" role="3clF47">
+        <node concept="3clFbJ" id="DnjeukUaN8" role="3cqZAp">
+          <node concept="3clFbS" id="DnjeukUaNa" role="3clFbx">
+            <node concept="3cpWs6" id="DnjeukUcyT" role="3cqZAp">
+              <node concept="Xjq3P" id="DnjeukUczD" role="3cqZAk" />
+            </node>
+          </node>
+          <node concept="2OqwBi" id="DnjeukUcdO" role="3clFbw">
+            <node concept="2OqwBi" id="DnjeukUbA$" role="2Oq$k0">
+              <node concept="2OqwBi" id="DnjeukUbaf" role="2Oq$k0">
+                <node concept="37vLTw" id="DnjeukUb2E" role="2Oq$k0">
+                  <ref role="3cqZAo" node="1_3xoKENxrm" resolve="lookups" />
+                </node>
+                <node concept="39bAoz" id="DnjeukUbkJ" role="2OqNvi" />
+              </node>
+              <node concept="UnYns" id="DnjeukUbSK" role="2OqNvi">
+                <node concept="3uibUv" id="DnjeukUbWw" role="UnYnz">
+                  <ref role="3uigEE" node="1_3xoKENxnx" resolve="CompositeTransformationMenuLookup" />
+                </node>
+              </node>
+            </node>
+            <node concept="1v1jN8" id="DnjeukUcwV" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="3cpWs8" id="DnjeukU0J_" role="3cqZAp">
+          <node concept="3cpWsn" id="DnjeukU0JA" role="3cpWs9">
+            <property role="TrG5h" value="flatList" />
+            <node concept="_YKpA" id="DnjeukU0HH" role="1tU5fm">
+              <node concept="3uibUv" id="DnjeukU0HK" role="_ZDj9">
+                <ref role="3uigEE" to="uddc:~TransformationMenuLookup" resolve="TransformationMenuLookup" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="DnjeukU0JB" role="33vP2m">
+              <node concept="2OqwBi" id="DnjeukU0JC" role="2Oq$k0">
+                <node concept="2OqwBi" id="DnjeukU0JD" role="2Oq$k0">
+                  <node concept="2OqwBi" id="DnjeukU0JE" role="2Oq$k0">
+                    <node concept="37vLTw" id="DnjeukU0JF" role="2Oq$k0">
+                      <ref role="3cqZAo" node="1_3xoKENxrm" resolve="lookups" />
+                    </node>
+                    <node concept="39bAoz" id="DnjeukU0JG" role="2OqNvi" />
+                  </node>
+                  <node concept="3$u5V9" id="DnjeukU0JH" role="2OqNvi">
+                    <node concept="1bVj0M" id="DnjeukU0JI" role="23t8la">
+                      <node concept="3clFbS" id="DnjeukU0JJ" role="1bW5cS">
+                        <node concept="3clFbF" id="DnjeukU0JK" role="3cqZAp">
+                          <node concept="3K4zz7" id="DnjeukU0JL" role="3clFbG">
+                            <node concept="2OqwBi" id="DnjeukU0JM" role="3K4E3e">
+                              <node concept="1eOMI4" id="DnjeukU0JN" role="2Oq$k0">
+                                <node concept="10QFUN" id="DnjeukU0JO" role="1eOMHV">
+                                  <node concept="3uibUv" id="DnjeukU0JP" role="10QFUM">
+                                    <ref role="3uigEE" node="1_3xoKENxnx" resolve="CompositeTransformationMenuLookup" />
+                                  </node>
+                                  <node concept="37vLTw" id="DnjeukU0JQ" role="10QFUP">
+                                    <ref role="3cqZAo" node="DnjeukU0JW" resolve="it" />
+                                  </node>
+                                </node>
+                              </node>
+                              <node concept="liA8E" id="DnjeukU0JR" role="2OqNvi">
+                                <ref role="37wK5l" node="DnjeukTMb0" resolve="flatten" />
+                              </node>
+                            </node>
+                            <node concept="37vLTw" id="DnjeukU0JS" role="3K4GZi">
+                              <ref role="3cqZAo" node="DnjeukU0JW" resolve="it" />
+                            </node>
+                            <node concept="2ZW3vV" id="DnjeukU0JT" role="3K4Cdx">
+                              <node concept="3uibUv" id="DnjeukU0JU" role="2ZW6by">
+                                <ref role="3uigEE" node="1_3xoKENxnx" resolve="CompositeTransformationMenuLookup" />
+                              </node>
+                              <node concept="37vLTw" id="DnjeukU0JV" role="2ZW6bz">
+                                <ref role="3cqZAo" node="DnjeukU0JW" resolve="it" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="Rh6nW" id="DnjeukU0JW" role="1bW2Oz">
+                        <property role="TrG5h" value="it" />
+                        <node concept="2jxLKc" id="DnjeukU0JX" role="1tU5fm" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3goQfb" id="DnjeukU0JY" role="2OqNvi">
+                  <node concept="1bVj0M" id="DnjeukU0JZ" role="23t8la">
+                    <node concept="3clFbS" id="DnjeukU0K0" role="1bW5cS">
+                      <node concept="3clFbF" id="DnjeukU0K1" role="3cqZAp">
+                        <node concept="3K4zz7" id="DnjeukU0K2" role="3clFbG">
+                          <node concept="2OqwBi" id="DnjeukU0K3" role="3K4E3e">
+                            <node concept="2OqwBi" id="DnjeukU0K4" role="2Oq$k0">
+                              <node concept="1eOMI4" id="DnjeukU0K5" role="2Oq$k0">
+                                <node concept="10QFUN" id="DnjeukU0K6" role="1eOMHV">
+                                  <node concept="3uibUv" id="DnjeukU0K7" role="10QFUM">
+                                    <ref role="3uigEE" node="1_3xoKENxnx" resolve="CompositeTransformationMenuLookup" />
+                                  </node>
+                                  <node concept="37vLTw" id="DnjeukU0K8" role="10QFUP">
+                                    <ref role="3cqZAo" node="DnjeukU0Ki" resolve="it" />
+                                  </node>
+                                </node>
+                              </node>
+                              <node concept="2OwXpG" id="DnjeukU0K9" role="2OqNvi">
+                                <ref role="2Oxat6" node="1_3xoKENxrm" resolve="lookups" />
+                              </node>
+                            </node>
+                            <node concept="39bAoz" id="DnjeukU0Ka" role="2OqNvi" />
+                          </node>
+                          <node concept="2ShNRf" id="DnjeukU0Kb" role="3K4GZi">
+                            <node concept="2HTt$P" id="DnjeukU0Kc" role="2ShVmc">
+                              <node concept="3uibUv" id="DnjeukU0Kd" role="2HTBi0">
+                                <ref role="3uigEE" to="uddc:~TransformationMenuLookup" resolve="TransformationMenuLookup" />
+                              </node>
+                              <node concept="37vLTw" id="DnjeukU0Ke" role="2HTEbv">
+                                <ref role="3cqZAo" node="DnjeukU0Ki" resolve="it" />
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="2ZW3vV" id="DnjeukU0Kf" role="3K4Cdx">
+                            <node concept="3uibUv" id="DnjeukU0Kg" role="2ZW6by">
+                              <ref role="3uigEE" node="1_3xoKENxnx" resolve="CompositeTransformationMenuLookup" />
+                            </node>
+                            <node concept="37vLTw" id="DnjeukU0Kh" role="2ZW6bz">
+                              <ref role="3cqZAo" node="DnjeukU0Ki" resolve="it" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="Rh6nW" id="DnjeukU0Ki" role="1bW2Oz">
+                      <property role="TrG5h" value="it" />
+                      <node concept="2jxLKc" id="DnjeukU0Kj" role="1tU5fm" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="ANE8D" id="DnjeukU0Kk" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="DnjeukU1Zl" role="3cqZAp">
+          <node concept="3K4zz7" id="DnjeukU5AA" role="3clFbG">
+            <node concept="2OqwBi" id="DnjeukU6J7" role="3K4E3e">
+              <node concept="37vLTw" id="DnjeukU647" role="2Oq$k0">
+                <ref role="3cqZAo" node="DnjeukU0JA" resolve="flatList" />
+              </node>
+              <node concept="1uHKPH" id="DnjeukU6Sf" role="2OqNvi" />
+            </node>
+            <node concept="2ShNRf" id="DnjeukU6UL" role="3K4GZi">
+              <node concept="1pGfFk" id="DnjeukU7RL" role="2ShVmc">
+                <ref role="37wK5l" node="1_3xoKENxth" resolve="CompositeTransformationMenuLookup" />
+                <node concept="2OqwBi" id="DnjeukU9lo" role="37wK5m">
+                  <node concept="37vLTw" id="DnjeukU7X5" role="2Oq$k0">
+                    <ref role="3cqZAo" node="DnjeukU0JA" resolve="flatList" />
+                  </node>
+                  <node concept="3_kTaI" id="DnjeukUa3X" role="2OqNvi" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbC" id="DnjeukU53V" role="3K4Cdx">
+              <node concept="3cmrfG" id="DnjeukU5$j" role="3uHU7w">
+                <property role="3cmrfH" value="1" />
+              </node>
+              <node concept="2OqwBi" id="DnjeukU2TM" role="3uHU7B">
+                <node concept="37vLTw" id="DnjeukU1Zj" role="2Oq$k0">
+                  <ref role="3cqZAo" node="DnjeukU0JA" resolve="flatList" />
+                </node>
+                <node concept="34oBXx" id="DnjeukU48g" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="Dnjeul9T_Y" role="jymVt" />
+    <node concept="3clFb_" id="Dnjeul9VqT" role="jymVt">
+      <property role="TrG5h" value="toString" />
+      <node concept="17QB3L" id="Dnjeul9XOM" role="3clF45" />
+      <node concept="3Tm1VV" id="Dnjeul9VqW" role="1B3o_S" />
+      <node concept="3clFbS" id="Dnjeul9VqX" role="3clF47">
+        <node concept="3clFbJ" id="5fS8LrnLiMa" role="3cqZAp">
+          <node concept="3clFbS" id="5fS8LrnLiMc" role="3clFbx">
+            <node concept="3cpWs6" id="5fS8LrnLkDP" role="3cqZAp">
+              <node concept="Xl_RD" id="5fS8LrnLlMw" role="3cqZAk">
+                <property role="Xl_RC" value="empty composite" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbC" id="5fS8LrnLk8W" role="3clFbw">
+            <node concept="3cmrfG" id="5fS8LrnLkCE" role="3uHU7w">
+              <property role="3cmrfH" value="0" />
+            </node>
+            <node concept="2OqwBi" id="5fS8LrnLj3n" role="3uHU7B">
+              <node concept="37vLTw" id="5fS8LrnLiTw" role="2Oq$k0">
+                <ref role="3cqZAo" node="1_3xoKENxrm" resolve="lookups" />
+              </node>
+              <node concept="1Rwk04" id="5fS8LrnLjg8" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="Dnjeul9YUn" role="3cqZAp">
+          <node concept="2OqwBi" id="Dnjeula0JD" role="3clFbG">
+            <node concept="2OqwBi" id="Dnjeul9ZGW" role="2Oq$k0">
+              <node concept="2OqwBi" id="Dnjeul9Z40" role="2Oq$k0">
+                <node concept="37vLTw" id="Dnjeul9YUm" role="2Oq$k0">
+                  <ref role="3cqZAo" node="1_3xoKENxrm" resolve="lookups" />
+                </node>
+                <node concept="39bAoz" id="Dnjeul9ZgS" role="2OqNvi" />
+              </node>
+              <node concept="3$u5V9" id="Dnjeula01l" role="2OqNvi">
+                <node concept="1bVj0M" id="Dnjeula01n" role="23t8la">
+                  <node concept="3clFbS" id="Dnjeula01o" role="1bW5cS">
+                    <node concept="3clFbF" id="Dnjeula06N" role="3cqZAp">
+                      <node concept="2OqwBi" id="Dnjeula0di" role="3clFbG">
+                        <node concept="37vLTw" id="Dnjeula06M" role="2Oq$k0">
+                          <ref role="3cqZAo" node="Dnjeula01p" resolve="it" />
+                        </node>
+                        <node concept="liA8E" id="Dnjeula0qd" role="2OqNvi">
+                          <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Rh6nW" id="Dnjeula01p" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="Dnjeula01q" role="1tU5fm" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3uJxvA" id="Dnjeula1ck" role="2OqNvi">
+              <node concept="Xl_RD" id="Dnjeula1FA" role="3uJOhx">
+                <property role="Xl_RC" value=" + " />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="Dnjeul9XcS" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+  </node>
+  <node concept="312cEu" id="1ISNm4ViWc0">
+    <property role="TrG5h" value="GrammarCellsMenuLocations" />
+    <node concept="Wx3nA" id="1ISNm4ViWfM" role="jymVt">
+      <property role="TrG5h" value="BEFORE" />
+      <property role="3TUv4t" value="true" />
+      <node concept="17QB3L" id="1ISNm4ViWdU" role="1tU5fm" />
+      <node concept="3Tm1VV" id="1ISNm4ViWfy" role="1B3o_S" />
+      <node concept="3cpWs3" id="1ISNm4ViXn9" role="33vP2m">
+        <node concept="Xl_RD" id="1ISNm4ViXnt" role="3uHU7w">
+          <property role="Xl_RC" value=".BEFORE" />
+        </node>
+        <node concept="2OqwBi" id="1ISNm4ViWAD" role="3uHU7B">
+          <node concept="3VsKOn" id="1ISNm4ViWi2" role="2Oq$k0">
+            <ref role="3VsUkX" node="1ISNm4ViWc0" resolve="GrammarCellsMenuLocations" />
+          </node>
+          <node concept="liA8E" id="1ISNm4ViX58" role="2OqNvi">
+            <ref role="37wK5l" to="wyt6:~Class.getName()" resolve="getName" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="Wx3nA" id="1ISNm4ViXAF" role="jymVt">
+      <property role="TrG5h" value="AFTER" />
+      <property role="3TUv4t" value="true" />
+      <node concept="17QB3L" id="1ISNm4ViXAG" role="1tU5fm" />
+      <node concept="3Tm1VV" id="1ISNm4ViXAH" role="1B3o_S" />
+      <node concept="3cpWs3" id="1ISNm4ViXAI" role="33vP2m">
+        <node concept="Xl_RD" id="1ISNm4ViXAJ" role="3uHU7w">
+          <property role="Xl_RC" value=".AFTER" />
+        </node>
+        <node concept="2OqwBi" id="1ISNm4ViXAK" role="3uHU7B">
+          <node concept="3VsKOn" id="1ISNm4ViXAL" role="2Oq$k0">
+            <ref role="3VsUkX" node="1ISNm4ViWc0" resolve="GrammarCellsMenuLocations" />
+          </node>
+          <node concept="liA8E" id="1ISNm4ViXAM" role="2OqNvi">
+            <ref role="37wK5l" to="wyt6:~Class.getName()" resolve="getName" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3clFbW" id="1ISNm4ViY4v" role="jymVt">
+      <node concept="3cqZAl" id="1ISNm4ViY4x" role="3clF45" />
+      <node concept="3Tm6S6" id="1ISNm4ViY85" role="1B3o_S" />
+      <node concept="3clFbS" id="1ISNm4ViY4z" role="3clF47" />
+    </node>
+    <node concept="3Tm1VV" id="1ISNm4ViWc1" role="1B3o_S" />
+  </node>
+  <node concept="312cEu" id="39$RJBbGOfb">
+    <property role="TrG5h" value="RedirectToBeforeAndAfter" />
+    <node concept="Wx3nA" id="4ntVsBG$2hU" role="jymVt">
+      <property role="TrG5h" value="SYNTAX_CELL_CONDITION" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3uibUv" id="4ntVsBG$1bP" role="1tU5fm">
+        <ref role="3uigEE" to="y49u:~Condition" resolve="Condition" />
+        <node concept="3uibUv" id="4ntVsBG$1bQ" role="11_B2D">
+          <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="4ntVsBG$1bN" role="1B3o_S" />
+      <node concept="1bVj0M" id="4ntVsBG$1bR" role="33vP2m">
+        <node concept="37vLTG" id="4ntVsBG$1bS" role="1bW2Oz">
+          <property role="TrG5h" value="c" />
+          <node concept="3uibUv" id="4ntVsBG$1bT" role="1tU5fm">
+            <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+          </node>
+        </node>
+        <node concept="3clFbS" id="4ntVsBG$1bU" role="1bW5cS">
+          <node concept="3clFbF" id="4ntVsBG$1bV" role="3cqZAp">
+            <node concept="2YIFZM" id="4ntVsBG$1bW" role="3clFbG">
+              <ref role="1Pybhc" to="czm:RbLMy696h3" resolve="GrammarCellsUtil" />
+              <ref role="37wK5l" to="czm:15DZatOARrD" resolve="isSyntaxCell" />
+              <node concept="37vLTw" id="4ntVsBG$1bX" role="37wK5m">
+                <ref role="3cqZAo" node="4ntVsBG$1bS" resolve="c" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="39$RJBbGOx3" role="jymVt" />
+    <node concept="312cEg" id="39$RJBbGRUI" role="jymVt">
+      <property role="TrG5h" value="forLeftSideTransformation" />
+      <node concept="3Tm6S6" id="39$RJBbGRUJ" role="1B3o_S" />
+      <node concept="10P_77" id="39$RJBbGS0h" role="1tU5fm" />
+    </node>
+    <node concept="2tJIrI" id="39$RJBbGRNQ" role="jymVt" />
+    <node concept="3Tm1VV" id="39$RJBbGOfc" role="1B3o_S" />
+    <node concept="3uibUv" id="39$RJBbGOwF" role="EKbjA">
+      <ref role="3uigEE" to="v95p:~MenuPart" resolve="MenuPart" />
+      <node concept="3uibUv" id="39$RJBbGOwG" role="11_B2D">
+        <ref role="3uigEE" to="uddc:~TransformationMenuItem" resolve="TransformationMenuItem" />
+      </node>
+      <node concept="3uibUv" id="39$RJBbGOwH" role="11_B2D">
+        <ref role="3uigEE" to="uddc:~TransformationMenuContext" resolve="TransformationMenuContext" />
+      </node>
+    </node>
+    <node concept="3clFbW" id="39$RJBbHJHb" role="jymVt">
+      <node concept="3cqZAl" id="39$RJBbHJHc" role="3clF45" />
+      <node concept="3Tm1VV" id="39$RJBbHJHd" role="1B3o_S" />
+      <node concept="3clFbS" id="39$RJBbHJHf" role="3clF47">
+        <node concept="3clFbF" id="39$RJBbHJHj" role="3cqZAp">
+          <node concept="37vLTI" id="39$RJBbHJHl" role="3clFbG">
+            <node concept="2OqwBi" id="39$RJBbHJHp" role="37vLTJ">
+              <node concept="Xjq3P" id="39$RJBbHJHq" role="2Oq$k0" />
+              <node concept="2OwXpG" id="39$RJBbHJHr" role="2OqNvi">
+                <ref role="2Oxat6" node="39$RJBbGRUI" resolve="forLeftSideTransformation" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="39$RJBbHJHs" role="37vLTx">
+              <ref role="3cqZAo" node="39$RJBbHJHi" resolve="forLeftSideTransformation" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="39$RJBbHJHi" role="3clF46">
+        <property role="TrG5h" value="forLeftSideTransformation" />
+        <node concept="10P_77" id="39$RJBbHJHh" role="1tU5fm" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="39$RJBbHKuv" role="jymVt" />
+    <node concept="3clFb_" id="39$RJBbGOxw" role="jymVt">
+      <property role="TrG5h" value="createItems" />
+      <node concept="3Tm1VV" id="39$RJBbGOxx" role="1B3o_S" />
+      <node concept="2AHcQZ" id="39$RJBbGOxz" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+      </node>
+      <node concept="3uibUv" id="39$RJBbGOx$" role="3clF45">
+        <ref role="3uigEE" to="33ny:~List" resolve="List" />
+        <node concept="3uibUv" id="39$RJBbGOxD" role="11_B2D">
+          <ref role="3uigEE" to="uddc:~TransformationMenuItem" resolve="TransformationMenuItem" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="39$RJBbGOxA" role="3clF46">
+        <property role="TrG5h" value="context" />
+        <node concept="3uibUv" id="39$RJBbGOxC" role="1tU5fm">
+          <ref role="3uigEE" to="uddc:~TransformationMenuContext" resolve="TransformationMenuContext" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="39$RJBbGOxE" role="3clF47">
+        <node concept="3SKdUt" id="Dnjeukol1D" role="3cqZAp">
+          <node concept="1PaTwC" id="Dnjeukol1E" role="1aUNEU">
+            <node concept="3oM_SD" id="Dnjeukol1F" role="1PaTwD">
+              <property role="3oM_SC" value="We" />
+            </node>
+            <node concept="3oM_SD" id="Dnjeukol3i" role="1PaTwD">
+              <property role="3oM_SC" value="could" />
+            </node>
+            <node concept="3oM_SD" id="Dnjeukol3l" role="1PaTwD">
+              <property role="3oM_SC" value="create" />
+            </node>
+            <node concept="3oM_SD" id="Dnjeukol3x" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="Dnjeukol3I" role="1PaTwD">
+              <property role="3oM_SC" value="items" />
+            </node>
+            <node concept="3oM_SD" id="Dnjeukol3O" role="1PaTwD">
+              <property role="3oM_SC" value="here" />
+            </node>
+            <node concept="3oM_SD" id="Dnjeukol4b" role="1PaTwD">
+              <property role="3oM_SC" value="directly," />
+            </node>
+          </node>
+        </node>
+        <node concept="3SKdUt" id="DnjeukodR1" role="3cqZAp">
+          <node concept="1PaTwC" id="DnjeukodR2" role="1aUNEU">
+            <node concept="3oM_SD" id="4ntVsBGy$oS" role="1PaTwD">
+              <property role="3oM_SC" value="but" />
+            </node>
+            <node concept="3oM_SD" id="4ntVsBGy$os" role="1PaTwD">
+              <property role="3oM_SC" value="Lookup" />
+            </node>
+            <node concept="3oM_SD" id="DnjeukodTN" role="1PaTwD">
+              <property role="3oM_SC" value="is" />
+            </node>
+            <node concept="3oM_SD" id="DnjeukodU6" role="1PaTwD">
+              <property role="3oM_SC" value="used" />
+            </node>
+            <node concept="3oM_SD" id="DnjeukodUa" role="1PaTwD">
+              <property role="3oM_SC" value="to" />
+            </node>
+            <node concept="3oM_SD" id="DnjeukodUn" role="1PaTwD">
+              <property role="3oM_SC" value="prevent" />
+            </node>
+            <node concept="3oM_SD" id="DnjeukodU_" role="1PaTwD">
+              <property role="3oM_SC" value="duplicate" />
+            </node>
+            <node concept="3oM_SD" id="DnjeukodUW" role="1PaTwD">
+              <property role="3oM_SC" value="items" />
+            </node>
+            <node concept="3oM_SD" id="DnjeukodWk" role="1PaTwD">
+              <property role="3oM_SC" value="by" />
+            </node>
+            <node concept="3oM_SD" id="DnjeukodW_" role="1PaTwD">
+              <property role="3oM_SC" value="using" />
+            </node>
+            <node concept="3oM_SD" id="DnjeukodWJ" role="1PaTwD">
+              <property role="3oM_SC" value="this" />
+            </node>
+            <node concept="3oM_SD" id="DnjeukodWU" role="1PaTwD">
+              <property role="3oM_SC" value="class" />
+            </node>
+            <node concept="3oM_SD" id="DnjeukodXu" role="1PaTwD">
+              <property role="3oM_SC" value="multiple" />
+            </node>
+            <node concept="3oM_SD" id="DnjeukodXV" role="1PaTwD">
+              <property role="3oM_SC" value="times" />
+            </node>
+            <node concept="3oM_SD" id="DnjeukodYh" role="1PaTwD">
+              <property role="3oM_SC" value="for" />
+            </node>
+            <node concept="3oM_SD" id="DnjeukodYw" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="DnjeukodYK" role="1PaTwD">
+              <property role="3oM_SC" value="same" />
+            </node>
+            <node concept="3oM_SD" id="DnjeukodZ1" role="1PaTwD">
+              <property role="3oM_SC" value="context" />
+            </node>
+          </node>
+        </node>
+        <node concept="3SKdUt" id="Dnjeukol8z" role="3cqZAp">
+          <node concept="1PaTwC" id="Dnjeukol8$" role="1aUNEU">
+            <node concept="3oM_SD" id="Dnjeukol8_" role="1PaTwD">
+              <property role="3oM_SC" value="this" />
+            </node>
+            <node concept="3oM_SD" id="DnjeukolbM" role="1PaTwD">
+              <property role="3oM_SC" value="allows" />
+            </node>
+            <node concept="3oM_SD" id="DnjeukolbP" role="1PaTwD">
+              <property role="3oM_SC" value="to" />
+            </node>
+            <node concept="3oM_SD" id="Dnjeukolc1" role="1PaTwD">
+              <property role="3oM_SC" value="just" />
+            </node>
+            <node concept="3oM_SD" id="Dnjeukolfa" role="1PaTwD">
+              <property role="3oM_SC" value="generate" />
+            </node>
+            <node concept="3oM_SD" id="Dnjeukolcm" role="1PaTwD">
+              <property role="3oM_SC" value="a" />
+            </node>
+            <node concept="3oM_SD" id="Dnjeukolc$" role="1PaTwD">
+              <property role="3oM_SC" value="usage" />
+            </node>
+            <node concept="3oM_SD" id="DnjeukolcV" role="1PaTwD">
+              <property role="3oM_SC" value="of" />
+            </node>
+            <node concept="3oM_SD" id="Dnjeukold3" role="1PaTwD">
+              <property role="3oM_SC" value="this" />
+            </node>
+            <node concept="3oM_SD" id="Dnjeukoldc" role="1PaTwD">
+              <property role="3oM_SC" value="class" />
+            </node>
+            <node concept="3oM_SD" id="Dnjeukoldu" role="1PaTwD">
+              <property role="3oM_SC" value="into" />
+            </node>
+            <node concept="3oM_SD" id="DnjeukoldL" role="1PaTwD">
+              <property role="3oM_SC" value="every" />
+            </node>
+            <node concept="3oM_SD" id="Dnjeukolel" role="1PaTwD">
+              <property role="3oM_SC" value="language." />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="DnjeukmCDt" role="3cqZAp">
+          <node concept="2OqwBi" id="DnjeukmDQK" role="3clFbG">
+            <node concept="37vLTw" id="DnjeukmCDr" role="2Oq$k0">
+              <ref role="3cqZAo" node="39$RJBbGOxA" resolve="context" />
+            </node>
+            <node concept="liA8E" id="DnjeukmKL9" role="2OqNvi">
+              <ref role="37wK5l" to="uddc:~TransformationMenuContext.createItems(jetbrains.mps.openapi.editor.menus.transformation.TransformationMenuLookup)" resolve="createItems" />
+              <node concept="2ShNRf" id="DnjeukmKNN" role="37wK5m">
+                <node concept="1pGfFk" id="DnjeukmLkd" role="2ShVmc">
+                  <ref role="37wK5l" node="DnjeukmHT5" resolve="RedirectToBeforeAndAfter.Lookup" />
+                  <node concept="37vLTw" id="DnjeukmLo$" role="37wK5m">
+                    <ref role="3cqZAo" node="39$RJBbGRUI" resolve="forLeftSideTransformation" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="39$RJBbGOxF" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="39$RJBbH6xw" role="jymVt" />
+    <node concept="2YIFZL" id="Dnjeuko29G" role="jymVt">
+      <property role="TrG5h" value="getBeforeAfterActions" />
+      <node concept="3clFbS" id="39$RJBbH7jb" role="3clF47">
+        <node concept="3cpWs8" id="39$RJBbHiKl" role="3cqZAp">
+          <node concept="3cpWsn" id="39$RJBbHiKm" role="3cpWs9">
+            <property role="TrG5h" value="beforeAfterContext" />
+            <node concept="3uibUv" id="39$RJBbHiDK" role="1tU5fm">
+              <ref role="3uigEE" to="uddc:~TransformationMenuContext" resolve="TransformationMenuContext" />
+            </node>
+            <node concept="2OqwBi" id="39$RJBbHiKn" role="33vP2m">
+              <node concept="37vLTw" id="39$RJBbHiKo" role="2Oq$k0">
+                <ref role="3cqZAo" node="39$RJBbHbpS" resolve="context" />
+              </node>
+              <node concept="liA8E" id="39$RJBbHiKp" role="2OqNvi">
+                <ref role="37wK5l" to="uddc:~TransformationMenuContext.withLocation(java.lang.String)" resolve="withLocation" />
+                <node concept="3K4zz7" id="39$RJBbHiKq" role="37wK5m">
+                  <node concept="37vLTw" id="39$RJBbHiKr" role="3K4Cdx">
+                    <ref role="3cqZAo" node="39$RJBbH9Qf" resolve="before" />
+                  </node>
+                  <node concept="10M0yZ" id="39$RJBbHiKs" role="3K4E3e">
+                    <ref role="3cqZAo" node="1ISNm4ViWfM" resolve="BEFORE" />
+                    <ref role="1PxDUh" node="1ISNm4ViWc0" resolve="GrammarCellsMenuLocations" />
+                  </node>
+                  <node concept="10M0yZ" id="39$RJBbHiKt" role="3K4GZi">
+                    <ref role="3cqZAo" node="1ISNm4ViXAF" resolve="AFTER" />
+                    <ref role="1PxDUh" node="1ISNm4ViWc0" resolve="GrammarCellsMenuLocations" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="5Jw_kf6k5IL" role="3cqZAp">
+          <node concept="3cpWsn" id="5Jw_kf6k5IM" role="3cpWs9">
+            <property role="TrG5h" value="alignedCells" />
+            <node concept="_YKpA" id="5Jw_kf6k37e" role="1tU5fm">
+              <node concept="3uibUv" id="5Jw_kf6k37h" role="_ZDj9">
+                <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+              </node>
+            </node>
+            <node concept="1rXfSq" id="5Jw_kf6k5IN" role="33vP2m">
+              <ref role="37wK5l" node="DnjeuknZAo" resolve="getAlignedCells" />
+              <node concept="37vLTw" id="5Jw_kf6k5IO" role="37wK5m">
+                <ref role="3cqZAo" node="39$RJBbH9hB" resolve="anchorCell" />
+              </node>
+              <node concept="37vLTw" id="5Jw_kf6k5IP" role="37wK5m">
+                <ref role="3cqZAo" node="39$RJBbH9Qf" resolve="before" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="5Jw_kf6uHgH" role="3cqZAp" />
+        <node concept="3SKdUt" id="5Jw_kf6uMcz" role="3cqZAp">
+          <node concept="1PaTwC" id="5Jw_kf6uMc$" role="1aUNEU">
+            <node concept="3oM_SD" id="5Jw_kf6uOni" role="1PaTwD">
+              <property role="3oM_SC" value="A" />
+            </node>
+            <node concept="3oM_SD" id="5Jw_kf6uOnk" role="1PaTwD">
+              <property role="3oM_SC" value="BracketsCell" />
+            </node>
+            <node concept="3oM_SD" id="5Jw_kf6uOnt" role="1PaTwD">
+              <property role="3oM_SC" value="inserts" />
+            </node>
+            <node concept="3oM_SD" id="5Jw_kf6uOnx" role="1PaTwD">
+              <property role="3oM_SC" value="an" />
+            </node>
+            <node concept="3oM_SD" id="5Jw_kf6uOnA" role="1PaTwD">
+              <property role="3oM_SC" value="ArbitraryTextAnnotation." />
+            </node>
+            <node concept="3oM_SD" id="5Jw_kf6uOnG" role="1PaTwD">
+              <property role="3oM_SC" value="To" />
+            </node>
+            <node concept="3oM_SD" id="5Jw_kf6uOnN" role="1PaTwD">
+              <property role="3oM_SC" value="allow" />
+            </node>
+            <node concept="3oM_SD" id="5Jw_kf6uOnV" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="5Jw_kf6uOo4" role="1PaTwD">
+              <property role="3oM_SC" value="insertion" />
+            </node>
+            <node concept="3oM_SD" id="5Jw_kf6uOoe" role="1PaTwD">
+              <property role="3oM_SC" value="of" />
+            </node>
+            <node concept="3oM_SD" id="5Jw_kf6uOop" role="1PaTwD">
+              <property role="3oM_SC" value="multiple" />
+            </node>
+            <node concept="3oM_SD" id="5Jw_kf6uOo_" role="1PaTwD">
+              <property role="3oM_SC" value="brackets," />
+            </node>
+            <node concept="3oM_SD" id="5Jw_kf6uOoM" role="1PaTwD">
+              <property role="3oM_SC" value="we" />
+            </node>
+            <node concept="3oM_SD" id="5Jw_kf6uOp0" role="1PaTwD">
+              <property role="3oM_SC" value="have" />
+            </node>
+            <node concept="3oM_SD" id="5Jw_kf6uOpf" role="1PaTwD">
+              <property role="3oM_SC" value="to" />
+            </node>
+            <node concept="3oM_SD" id="5Jw_kf6uOpv" role="1PaTwD">
+              <property role="3oM_SC" value="include" />
+            </node>
+            <node concept="3oM_SD" id="5Jw_kf6uOpK" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="5Jw_kf6uOq2" role="1PaTwD">
+              <property role="3oM_SC" value="actions" />
+            </node>
+            <node concept="3oM_SD" id="5Jw_kf6uOql" role="1PaTwD">
+              <property role="3oM_SC" value="from" />
+            </node>
+            <node concept="3oM_SD" id="5Jw_kf6uOqD" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="5Jw_kf6uOqY" role="1PaTwD">
+              <property role="3oM_SC" value="cell" />
+            </node>
+            <node concept="3oM_SD" id="5Jw_kf6uOrk" role="1PaTwD">
+              <property role="3oM_SC" value="next" />
+            </node>
+            <node concept="3oM_SD" id="5Jw_kf6uOrF" role="1PaTwD">
+              <property role="3oM_SC" value="to" />
+            </node>
+            <node concept="3oM_SD" id="5Jw_kf6uOs3" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="5Jw_kf6uOss" role="1PaTwD">
+              <property role="3oM_SC" value="bracket." />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="5Jw_kf6k91p" role="3cqZAp">
+          <node concept="3clFbS" id="5Jw_kf6k91r" role="3clFbx">
+            <node concept="3cpWs8" id="5Jw_kf6mnMD" role="3cqZAp">
+              <node concept="3cpWsn" id="5Jw_kf6mnME" role="3cpWs9">
+                <property role="TrG5h" value="attributedCell" />
+                <node concept="3uibUv" id="5Jw_kf6mnMF" role="1tU5fm">
+                  <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+                </node>
+                <node concept="1rXfSq" id="5Jw_kf6oiIF" role="33vP2m">
+                  <ref role="37wK5l" node="5Jw_kf6ofT$" resolve="getPreviousNextLeaf" />
+                  <node concept="3fqX7Q" id="5Jw_kf6pgqb" role="37wK5m">
+                    <node concept="37vLTw" id="5Jw_kf6pgqd" role="3fr31v">
+                      <ref role="3cqZAo" node="39$RJBbH9Qf" resolve="before" />
+                    </node>
+                  </node>
+                  <node concept="37vLTw" id="5Jw_kf6onRA" role="37wK5m">
+                    <ref role="3cqZAo" node="39$RJBbH9hB" resolve="anchorCell" />
+                  </node>
+                  <node concept="1bVj0M" id="5Jw_kf6nJH3" role="37wK5m">
+                    <node concept="37vLTG" id="5Jw_kf6nJH4" role="1bW2Oz">
+                      <property role="TrG5h" value="c" />
+                      <node concept="3uibUv" id="5Jw_kf6nJH5" role="1tU5fm">
+                        <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+                      </node>
+                    </node>
+                    <node concept="3clFbS" id="5Jw_kf6nJH6" role="1bW5cS">
+                      <node concept="3clFbF" id="5Jw_kf6nJH7" role="3cqZAp">
+                        <node concept="1Wc70l" id="5Jw_kf6nJH8" role="3clFbG">
+                          <node concept="2YIFZM" id="5Jw_kf6nJH9" role="3uHU7w">
+                            <ref role="37wK5l" to="czm:15DZatOARrD" resolve="isSyntaxCell" />
+                            <ref role="1Pybhc" to="czm:RbLMy696h3" resolve="GrammarCellsUtil" />
+                            <node concept="37vLTw" id="5Jw_kf6nJHa" role="37wK5m">
+                              <ref role="3cqZAo" node="5Jw_kf6nJH4" resolve="c" />
+                            </node>
+                          </node>
+                          <node concept="1Wc70l" id="5Jw_kf6uOFi" role="3uHU7B">
+                            <node concept="3fqX7Q" id="5Jw_kf6v3Ut" role="3uHU7w">
+                              <node concept="2OqwBi" id="5Jw_kf6v3Uv" role="3fr31v">
+                                <node concept="2OqwBi" id="5Jw_kf6v3Uw" role="2Oq$k0">
+                                  <node concept="37vLTw" id="5Jw_kf6v3Ux" role="2Oq$k0">
+                                    <ref role="3cqZAo" node="5Jw_kf6nJH4" resolve="c" />
+                                  </node>
+                                  <node concept="liA8E" id="5Jw_kf6v3Uy" role="2OqNvi">
+                                    <ref role="37wK5l" to="f4zo:~EditorCell.getSNode()" resolve="getSNode" />
+                                  </node>
+                                </node>
+                                <node concept="liA8E" id="5Jw_kf6v3Uz" role="2OqNvi">
+                                  <ref role="37wK5l" to="mhbf:~SNode.isInstanceOfConcept(org.jetbrains.mps.openapi.language.SAbstractConcept)" resolve="isInstanceOfConcept" />
+                                  <node concept="35c_gC" id="5Jw_kf6v3U$" role="37wK5m">
+                                    <ref role="35c_gD" to="tpck:4uZwTti3_$T" resolve="Attribute" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="17QLQc" id="5Jw_kf6nJHb" role="3uHU7B">
+                              <node concept="2OqwBi" id="5Jw_kf6nJHc" role="3uHU7B">
+                                <node concept="37vLTw" id="5Jw_kf6nJHd" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="5Jw_kf6nJH4" resolve="c" />
+                                </node>
+                                <node concept="liA8E" id="5Jw_kf6nJHe" role="2OqNvi">
+                                  <ref role="37wK5l" to="f4zo:~EditorCell.getSNode()" resolve="getSNode" />
+                                </node>
+                              </node>
+                              <node concept="2OqwBi" id="5Jw_kf6nJHf" role="3uHU7w">
+                                <node concept="37vLTw" id="5Jw_kf6nJHg" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="39$RJBbH9hB" resolve="anchorCell" />
+                                </node>
+                                <node concept="liA8E" id="5Jw_kf6nJHh" role="2OqNvi">
+                                  <ref role="37wK5l" to="f4zo:~EditorCell.getSNode()" resolve="getSNode" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbJ" id="5Jw_kf6oTf5" role="3cqZAp">
+              <node concept="3clFbS" id="5Jw_kf6oTf7" role="3clFbx">
+                <node concept="3clFbF" id="5Jw_kf6ovuF" role="3cqZAp">
+                  <node concept="37vLTI" id="5Jw_kf6oFnb" role="3clFbG">
+                    <node concept="2OqwBi" id="5Jw_kf6parE" role="37vLTx">
+                      <node concept="2OqwBi" id="5Jw_kf6p3sp" role="2Oq$k0">
+                        <node concept="2OqwBi" id="5Jw_kf6oJsn" role="2Oq$k0">
+                          <node concept="37vLTw" id="5Jw_kf6oHgD" role="2Oq$k0">
+                            <ref role="3cqZAo" node="5Jw_kf6k5IM" resolve="alignedCells" />
+                          </node>
+                          <node concept="3QWeyG" id="5Jw_kf6oM5R" role="2OqNvi">
+                            <node concept="1rXfSq" id="5Jw_kf6oNxx" role="576Qk">
+                              <ref role="37wK5l" node="DnjeuknZAo" resolve="getAlignedCells" />
+                              <node concept="37vLTw" id="5Jw_kf6oPio" role="37wK5m">
+                                <ref role="3cqZAo" node="5Jw_kf6mnME" resolve="attributedCell" />
+                              </node>
+                              <node concept="37vLTw" id="5Jw_kf6pidW" role="37wK5m">
+                                <ref role="3cqZAo" node="39$RJBbH9Qf" resolve="before" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="1VAtEI" id="5Jw_kf6p8qN" role="2OqNvi" />
+                      </node>
+                      <node concept="ANE8D" id="5Jw_kf6pcyP" role="2OqNvi" />
+                    </node>
+                    <node concept="37vLTw" id="5Jw_kf6ovuD" role="37vLTJ">
+                      <ref role="3cqZAo" node="5Jw_kf6k5IM" resolve="alignedCells" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3y3z36" id="5Jw_kf6oX9T" role="3clFbw">
+                <node concept="10Nm6u" id="5Jw_kf6oXP5" role="3uHU7w" />
+                <node concept="37vLTw" id="5Jw_kf6oVyb" role="3uHU7B">
+                  <ref role="3cqZAo" node="5Jw_kf6mnME" resolve="attributedCell" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="5Jw_kf6koqu" role="3clFbw">
+            <node concept="2OqwBi" id="5Jw_kf6kl4O" role="2Oq$k0">
+              <node concept="37vLTw" id="5Jw_kf6kjcJ" role="2Oq$k0">
+                <ref role="3cqZAo" node="39$RJBbH9hB" resolve="anchorCell" />
+              </node>
+              <node concept="liA8E" id="5Jw_kf6kmCm" role="2OqNvi">
+                <ref role="37wK5l" to="f4zo:~EditorCell.getSNode()" resolve="getSNode" />
+              </node>
+            </node>
+            <node concept="liA8E" id="5Jw_kf6kqgf" role="2OqNvi">
+              <ref role="37wK5l" to="mhbf:~SNode.isInstanceOfConcept(org.jetbrains.mps.openapi.language.SAbstractConcept)" resolve="isInstanceOfConcept" />
+              <node concept="35c_gC" id="5Jw_kf6krWD" role="37wK5m">
+                <ref role="35c_gD" to="tpck:4uZwTti3_$T" resolve="Attribute" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="5Jw_kf6uIPR" role="3cqZAp" />
+        <node concept="3cpWs8" id="39$RJBbHb04" role="3cqZAp">
+          <node concept="3cpWsn" id="39$RJBbHb05" role="3cpWs9">
+            <property role="TrG5h" value="result" />
+            <node concept="_YKpA" id="39$RJBbHb06" role="1tU5fm">
+              <node concept="3uibUv" id="39$RJBbHb07" role="_ZDj9">
+                <ref role="3uigEE" to="uddc:~TransformationMenuItem" resolve="TransformationMenuItem" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="39$RJBbHb08" role="33vP2m">
+              <node concept="2OqwBi" id="39$RJBbHb09" role="2Oq$k0">
+                <node concept="37vLTw" id="5Jw_kf6k5IQ" role="2Oq$k0">
+                  <ref role="3cqZAo" node="5Jw_kf6k5IM" resolve="alignedCells" />
+                </node>
+                <node concept="3goQfb" id="39$RJBbHb0d" role="2OqNvi">
+                  <node concept="1bVj0M" id="39$RJBbHb0e" role="23t8la">
+                    <node concept="3clFbS" id="39$RJBbHb0f" role="1bW5cS">
+                      <node concept="3cpWs8" id="5fS8LrnX17L" role="3cqZAp">
+                        <node concept="3cpWsn" id="5fS8LrnX17O" role="3cpWs9">
+                          <property role="TrG5h" value="result" />
+                          <node concept="A3Dl8" id="5fS8LrnX3LC" role="1tU5fm">
+                            <node concept="3uibUv" id="5fS8LrnX3LE" role="A3Ik2">
+                              <ref role="3uigEE" to="uddc:~TransformationMenuItem" resolve="TransformationMenuItem" />
+                            </node>
+                          </node>
+                          <node concept="2ShNRf" id="5fS8LrnX5Sw" role="33vP2m">
+                            <node concept="kMnCb" id="5fS8LrnX7Zn" role="2ShVmc">
+                              <node concept="3uibUv" id="5fS8LrnX94y" role="kMuH3">
+                                <ref role="3uigEE" to="uddc:~TransformationMenuItem" resolve="TransformationMenuItem" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3cpWs8" id="5fS8LrnXvbz" role="3cqZAp">
+                        <node concept="3cpWsn" id="5fS8LrnXvb$" role="3cpWs9">
+                          <property role="TrG5h" value="contextForCellNode" />
+                          <node concept="3uibUv" id="5fS8LrnXv1f" role="1tU5fm">
+                            <ref role="3uigEE" to="uddc:~TransformationMenuContext" resolve="TransformationMenuContext" />
+                          </node>
+                          <node concept="2OqwBi" id="5fS8LrnXvb_" role="33vP2m">
+                            <node concept="37vLTw" id="5fS8LrnXvbA" role="2Oq$k0">
+                              <ref role="3cqZAo" node="39$RJBbHiKm" resolve="beforeAfterContext" />
+                            </node>
+                            <node concept="liA8E" id="5fS8LrnXvbB" role="2OqNvi">
+                              <ref role="37wK5l" to="uddc:~TransformationMenuContext.withNode(org.jetbrains.mps.openapi.model.SNode)" resolve="withNode" />
+                              <node concept="2OqwBi" id="5fS8LrnXvbC" role="37wK5m">
+                                <node concept="37vLTw" id="5fS8LrnXvbD" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="39$RJBbHb0D" resolve="cell" />
+                                </node>
+                                <node concept="liA8E" id="5fS8LrnXvbE" role="2OqNvi">
+                                  <ref role="37wK5l" to="f4zo:~EditorCell.getSNode()" resolve="getSNode" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3cpWs8" id="39$RJBbHb0g" role="3cqZAp">
+                        <node concept="3cpWsn" id="39$RJBbHb0h" role="3cpWs9">
+                          <property role="TrG5h" value="lookup" />
+                          <node concept="3uibUv" id="39$RJBbHb0i" role="1tU5fm">
+                            <ref role="3uigEE" to="uddc:~TransformationMenuLookup" resolve="TransformationMenuLookup" />
+                          </node>
+                          <node concept="2OqwBi" id="39$RJBbHb0j" role="33vP2m">
+                            <node concept="37vLTw" id="39$RJBbHb0k" role="2Oq$k0">
+                              <ref role="3cqZAo" node="39$RJBbHb0D" resolve="cell" />
+                            </node>
+                            <node concept="liA8E" id="39$RJBbHb0l" role="2OqNvi">
+                              <ref role="37wK5l" to="f4zo:~EditorCell.getTransformationMenuLookup()" resolve="getTransformationMenuLookup" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbJ" id="39$RJBbHb0m" role="3cqZAp">
+                        <node concept="3clFbS" id="39$RJBbHb0n" role="3clFbx">
+                          <node concept="3clFbF" id="5fS8LrnXdZd" role="3cqZAp">
+                            <node concept="37vLTI" id="5fS8LrnXeNU" role="3clFbG">
+                              <node concept="2OqwBi" id="5fS8LrnXfUt" role="37vLTx">
+                                <node concept="37vLTw" id="5fS8LrnXfua" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="5fS8LrnX17O" resolve="result" />
+                                </node>
+                                <node concept="3QWeyG" id="5fS8LrnXgtn" role="2OqNvi">
+                                  <node concept="2OqwBi" id="39$RJBbHb0w" role="576Qk">
+                                    <node concept="37vLTw" id="5fS8LrnXvbF" role="2Oq$k0">
+                                      <ref role="3cqZAo" node="5fS8LrnXvb$" resolve="contextForCellNode" />
+                                    </node>
+                                    <node concept="liA8E" id="39$RJBbHb0B" role="2OqNvi">
+                                      <ref role="37wK5l" to="uddc:~TransformationMenuContext.createItems(jetbrains.mps.openapi.editor.menus.transformation.TransformationMenuLookup)" resolve="createItems" />
+                                      <node concept="37vLTw" id="39$RJBbHb0C" role="37wK5m">
+                                        <ref role="3cqZAo" node="39$RJBbHb0h" resolve="lookup" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                              <node concept="37vLTw" id="5fS8LrnXdZ2" role="37vLTJ">
+                                <ref role="3cqZAo" node="5fS8LrnX17O" resolve="result" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3y3z36" id="5fS8LrnX9Qi" role="3clFbw">
+                          <node concept="37vLTw" id="39$RJBbHb0u" role="3uHU7B">
+                            <ref role="3cqZAo" node="39$RJBbHb0h" resolve="lookup" />
+                          </node>
+                          <node concept="10Nm6u" id="39$RJBbHb0t" role="3uHU7w" />
+                        </node>
+                      </node>
+                      <node concept="3clFbJ" id="5fS8LrnXj18" role="3cqZAp">
+                        <node concept="3clFbS" id="5fS8LrnXj1a" role="3clFbx">
+                          <node concept="3cpWs8" id="5fS8LrnXYRO" role="3cqZAp">
+                            <node concept="3cpWsn" id="5fS8LrnXYRP" role="3cpWs9">
+                              <property role="TrG5h" value="lookupForNode" />
+                              <node concept="3uibUv" id="5fS8LrnXYHt" role="1tU5fm">
+                                <ref role="3uigEE" to="9eyi:~DefaultTransformationMenuLookup" resolve="DefaultTransformationMenuLookup" />
+                              </node>
+                              <node concept="2ShNRf" id="5fS8LrnXYRQ" role="33vP2m">
+                                <node concept="1pGfFk" id="5fS8LrnXYRR" role="2ShVmc">
+                                  <ref role="37wK5l" to="9eyi:~DefaultTransformationMenuLookup.&lt;init&gt;(jetbrains.mps.smodel.language.LanguageRegistry,org.jetbrains.mps.openapi.language.SAbstractConcept)" resolve="DefaultTransformationMenuLookup" />
+                                  <node concept="2YIFZM" id="5fS8LrnXYRS" role="37wK5m">
+                                    <ref role="1Pybhc" to="vndm:~LanguageRegistry" resolve="LanguageRegistry" />
+                                    <ref role="37wK5l" to="vndm:~LanguageRegistry.getInstance(org.jetbrains.mps.openapi.module.SRepository)" resolve="getInstance" />
+                                    <node concept="2OqwBi" id="5fS8LrnXYRT" role="37wK5m">
+                                      <node concept="2OqwBi" id="5fS8LrnXYRU" role="2Oq$k0">
+                                        <node concept="37vLTw" id="5fS8LrnXYRV" role="2Oq$k0">
+                                          <ref role="3cqZAo" node="39$RJBbHbpS" resolve="context" />
+                                        </node>
+                                        <node concept="liA8E" id="5fS8LrnXYRW" role="2OqNvi">
+                                          <ref role="37wK5l" to="uddc:~TransformationMenuContext.getEditorContext()" resolve="getEditorContext" />
+                                        </node>
+                                      </node>
+                                      <node concept="liA8E" id="5fS8LrnXYRX" role="2OqNvi">
+                                        <ref role="37wK5l" to="cj4x:~EditorContext.getRepository()" resolve="getRepository" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                  <node concept="2OqwBi" id="5fS8LrnXYRY" role="37wK5m">
+                                    <node concept="2OqwBi" id="5fS8LrnXYRZ" role="2Oq$k0">
+                                      <node concept="37vLTw" id="5fS8LrnXYS0" role="2Oq$k0">
+                                        <ref role="3cqZAo" node="39$RJBbHb0D" resolve="cell" />
+                                      </node>
+                                      <node concept="liA8E" id="5fS8LrnXYS1" role="2OqNvi">
+                                        <ref role="37wK5l" to="f4zo:~EditorCell.getSNode()" resolve="getSNode" />
+                                      </node>
+                                    </node>
+                                    <node concept="liA8E" id="5fS8LrnXYS2" role="2OqNvi">
+                                      <ref role="37wK5l" to="mhbf:~SNode.getConcept()" resolve="getConcept" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="3clFbF" id="5fS8LrnXmMX" role="3cqZAp">
+                            <node concept="37vLTI" id="5fS8LrnXpEv" role="3clFbG">
+                              <node concept="2OqwBi" id="5fS8LrnXrbT" role="37vLTx">
+                                <node concept="37vLTw" id="5fS8LrnXqrX" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="5fS8LrnX17O" resolve="result" />
+                                </node>
+                                <node concept="3QWeyG" id="5fS8LrnXrVE" role="2OqNvi">
+                                  <node concept="2OqwBi" id="5fS8LrnXCiV" role="576Qk">
+                                    <node concept="37vLTw" id="5fS8LrnXDXv" role="2Oq$k0">
+                                      <ref role="3cqZAo" node="5fS8LrnXvb$" resolve="contextForCellNode" />
+                                    </node>
+                                    <node concept="liA8E" id="5fS8LrnXE$o" role="2OqNvi">
+                                      <ref role="37wK5l" to="uddc:~TransformationMenuContext.createItems(jetbrains.mps.openapi.editor.menus.transformation.TransformationMenuLookup)" resolve="createItems" />
+                                      <node concept="37vLTw" id="5fS8LrnXYS3" role="37wK5m">
+                                        <ref role="3cqZAo" node="5fS8LrnXYRP" resolve="lookupForNode" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                              <node concept="37vLTw" id="5fS8LrnXmMV" role="37vLTJ">
+                                <ref role="3cqZAo" node="5fS8LrnX17O" resolve="result" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="2OqwBi" id="5fS8LrnXlCD" role="3clFbw">
+                          <node concept="37vLTw" id="5fS8LrnXkoW" role="2Oq$k0">
+                            <ref role="3cqZAo" node="39$RJBbHb0D" resolve="cell" />
+                          </node>
+                          <node concept="liA8E" id="5fS8LrnXmoC" role="2OqNvi">
+                            <ref role="37wK5l" to="f4zo:~EditorCell.isBig()" resolve="isBig" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3cpWs6" id="5fS8LrnXcqa" role="3cqZAp">
+                        <node concept="37vLTw" id="5fS8LrnXd_J" role="3cqZAk">
+                          <ref role="3cqZAo" node="5fS8LrnX17O" resolve="result" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="Rh6nW" id="39$RJBbHb0D" role="1bW2Oz">
+                      <property role="TrG5h" value="cell" />
+                      <node concept="2jxLKc" id="39$RJBbHb0E" role="1tU5fm" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="ANE8D" id="39$RJBbHb0F" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="39$RJBbHb0G" role="3cqZAp">
+          <node concept="37vLTw" id="39$RJBbHb0H" role="3cqZAk">
+            <ref role="3cqZAo" node="39$RJBbHb05" resolve="result" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="39$RJBbH9hB" role="3clF46">
+        <property role="TrG5h" value="anchorCell" />
+        <node concept="3uibUv" id="39$RJBbH9M5" role="1tU5fm">
+          <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="39$RJBbH9Qf" role="3clF46">
+        <property role="TrG5h" value="before" />
+        <node concept="10P_77" id="39$RJBbHamt" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="39$RJBbHbpS" role="3clF46">
+        <property role="TrG5h" value="context" />
+        <node concept="3uibUv" id="39$RJBbHc2f" role="1tU5fm">
+          <ref role="3uigEE" to="uddc:~TransformationMenuContext" resolve="TransformationMenuContext" />
+        </node>
+      </node>
+      <node concept="_YKpA" id="39$RJBbHaoE" role="3clF45">
+        <node concept="3uibUv" id="39$RJBbHaSK" role="_ZDj9">
+          <ref role="3uigEE" to="uddc:~TransformationMenuItem" resolve="TransformationMenuItem" />
+        </node>
+      </node>
+      <node concept="3Tmbuc" id="39$RJBbHLma" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="39$RJBbH3ex" role="jymVt" />
+    <node concept="2YIFZL" id="DnjeuknZAo" role="jymVt">
+      <property role="TrG5h" value="getAlignedCells" />
+      <node concept="3clFbS" id="39$RJBbGXn8" role="3clF47">
+        <node concept="3cpWs8" id="39$RJBbGXUU" role="3cqZAp">
+          <node concept="3cpWsn" id="39$RJBbGXUV" role="3cpWs9">
+            <property role="TrG5h" value="alignedCells" />
+            <node concept="_YKpA" id="39$RJBbGXUW" role="1tU5fm">
+              <node concept="3uibUv" id="39$RJBbGXUX" role="_ZDj9">
+                <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+              </node>
+            </node>
+            <node concept="2ShNRf" id="39$RJBbGXUY" role="33vP2m">
+              <node concept="Tc6Ow" id="39$RJBbGXUZ" role="2ShVmc">
+                <node concept="3uibUv" id="39$RJBbGXV0" role="HW$YZ">
+                  <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+                </node>
+                <node concept="37vLTw" id="39$RJBbGXV1" role="HW$Y0">
+                  <ref role="3cqZAo" node="39$RJBbGYeW" resolve="anchorCell" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="39$RJBbGXV4" role="3cqZAp">
+          <node concept="3cpWsn" id="39$RJBbGXV5" role="3cpWs9">
+            <property role="TrG5h" value="anchorFirstLeaf" />
+            <node concept="3uibUv" id="39$RJBbGXV6" role="1tU5fm">
+              <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+            </node>
+            <node concept="1rXfSq" id="4ntVsBGzFCe" role="33vP2m">
+              <ref role="37wK5l" node="4ntVsBGyUPf" resolve="getFirstLastLeaf" />
+              <node concept="37vLTw" id="4ntVsBGzGVg" role="37wK5m">
+                <ref role="3cqZAo" node="39$RJBbGYeW" resolve="anchorCell" />
+              </node>
+              <node concept="37vLTw" id="4ntVsBG$juN" role="37wK5m">
+                <ref role="3cqZAo" node="39$RJBbGXPd" resolve="left" />
+              </node>
+              <node concept="37vLTw" id="4ntVsBG$8z5" role="37wK5m">
+                <ref role="3cqZAo" node="4ntVsBG$2hU" resolve="SYNTAX_CELL_CONDITION" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1Dw8fO" id="39$RJBbGXV9" role="3cqZAp">
+          <node concept="3clFbS" id="39$RJBbGXVa" role="2LFqv$">
+            <node concept="3clFbJ" id="39$RJBbGXVb" role="3cqZAp">
+              <node concept="3clFbS" id="39$RJBbGXVc" role="3clFbx">
+                <node concept="3N13vt" id="39$RJBbGXVd" role="3cqZAp" />
+              </node>
+              <node concept="3clFbC" id="39$RJBbGXVe" role="3clFbw">
+                <node concept="37vLTw" id="39$RJBbGXVf" role="3uHU7w">
+                  <ref role="3cqZAo" node="39$RJBbGYeW" resolve="anchorCell" />
+                </node>
+                <node concept="37vLTw" id="39$RJBbGXVg" role="3uHU7B">
+                  <ref role="3cqZAo" node="39$RJBbGXVA" resolve="alignedCell" />
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs8" id="39$RJBbGXVh" role="3cqZAp">
+              <node concept="3cpWsn" id="39$RJBbGXVi" role="3cpWs9">
+                <property role="TrG5h" value="firstLeaf" />
+                <node concept="3uibUv" id="39$RJBbGXVj" role="1tU5fm">
+                  <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+                </node>
+                <node concept="1rXfSq" id="4ntVsBG$p9I" role="33vP2m">
+                  <ref role="37wK5l" node="4ntVsBGyUPf" resolve="getFirstLastLeaf" />
+                  <node concept="37vLTw" id="4ntVsBG$r7L" role="37wK5m">
+                    <ref role="3cqZAo" node="39$RJBbGXVA" resolve="alignedCell" />
+                  </node>
+                  <node concept="37vLTw" id="4ntVsBG$p9K" role="37wK5m">
+                    <ref role="3cqZAo" node="39$RJBbGXPd" resolve="left" />
+                  </node>
+                  <node concept="37vLTw" id="4ntVsBG$p9N" role="37wK5m">
+                    <ref role="3cqZAo" node="4ntVsBG$2hU" resolve="SYNTAX_CELL_CONDITION" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbJ" id="39$RJBbGXVm" role="3cqZAp">
+              <node concept="3clFbS" id="39$RJBbGXVn" role="3clFbx">
+                <node concept="3zACq4" id="39$RJBbGXVo" role="3cqZAp" />
+              </node>
+              <node concept="3y3z36" id="39$RJBbGXVu" role="3clFbw">
+                <node concept="37vLTw" id="39$RJBbGXVv" role="3uHU7B">
+                  <ref role="3cqZAo" node="39$RJBbGXVi" resolve="firstLeaf" />
+                </node>
+                <node concept="37vLTw" id="39$RJBbGXVw" role="3uHU7w">
+                  <ref role="3cqZAo" node="39$RJBbGXV5" resolve="anchorFirstLeaf" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="39$RJBbGXVx" role="3cqZAp">
+              <node concept="2OqwBi" id="39$RJBbGXVy" role="3clFbG">
+                <node concept="37vLTw" id="39$RJBbGXVz" role="2Oq$k0">
+                  <ref role="3cqZAo" node="39$RJBbGXUV" resolve="alignedCells" />
+                </node>
+                <node concept="TSZUe" id="39$RJBbGXV$" role="2OqNvi">
+                  <node concept="37vLTw" id="39$RJBbGXV_" role="25WWJ7">
+                    <ref role="3cqZAo" node="39$RJBbGXVA" resolve="alignedCell" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWsn" id="39$RJBbGXVA" role="1Duv9x">
+            <property role="TrG5h" value="alignedCell" />
+            <node concept="3uibUv" id="39$RJBbGXVB" role="1tU5fm">
+              <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+            </node>
+            <node concept="37vLTw" id="39$RJBbGXVC" role="33vP2m">
+              <ref role="3cqZAo" node="39$RJBbGXV5" resolve="anchorFirstLeaf" />
+            </node>
+          </node>
+          <node concept="3y3z36" id="39$RJBbGXVD" role="1Dwp0S">
+            <node concept="10Nm6u" id="39$RJBbGXVE" role="3uHU7w" />
+            <node concept="37vLTw" id="39$RJBbGXVF" role="3uHU7B">
+              <ref role="3cqZAo" node="39$RJBbGXVA" resolve="alignedCell" />
+            </node>
+          </node>
+          <node concept="37vLTI" id="39$RJBbGXVG" role="1Dwrff">
+            <node concept="2OqwBi" id="39$RJBbGXVH" role="37vLTx">
+              <node concept="37vLTw" id="39$RJBbGXVI" role="2Oq$k0">
+                <ref role="3cqZAo" node="39$RJBbGXVA" resolve="alignedCell" />
+              </node>
+              <node concept="liA8E" id="39$RJBbGXVJ" role="2OqNvi">
+                <ref role="37wK5l" to="f4zo:~EditorCell.getParent()" resolve="getParent" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="39$RJBbGXVK" role="37vLTJ">
+              <ref role="3cqZAo" node="39$RJBbGXVA" resolve="alignedCell" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="39$RJBbGZle" role="3cqZAp">
+          <node concept="37vLTw" id="39$RJBbGZyN" role="3cqZAk">
+            <ref role="3cqZAo" node="39$RJBbGXUV" resolve="alignedCells" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="39$RJBbGYeW" role="3clF46">
+        <property role="TrG5h" value="anchorCell" />
+        <node concept="3uibUv" id="39$RJBbGYt9" role="1tU5fm">
+          <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="39$RJBbGXPd" role="3clF46">
+        <property role="TrG5h" value="left" />
+        <node concept="10P_77" id="39$RJBbGXT9" role="1tU5fm" />
+      </node>
+      <node concept="_YKpA" id="39$RJBbGYMx" role="3clF45">
+        <node concept="3uibUv" id="39$RJBbGZ4O" role="_ZDj9">
+          <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+        </node>
+      </node>
+      <node concept="3Tmbuc" id="39$RJBbHM7t" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="DnjeukmEyy" role="jymVt" />
+    <node concept="312cEu" id="DnjeukmFSK" role="jymVt">
+      <property role="TrG5h" value="Lookup" />
+      <node concept="312cEg" id="DnjeukmHK6" role="jymVt">
+        <property role="TrG5h" value="forLeftSideTransformation" />
+        <node concept="3Tm6S6" id="DnjeukmHK7" role="1B3o_S" />
+        <node concept="10P_77" id="DnjeukmHK8" role="1tU5fm" />
+      </node>
+      <node concept="2tJIrI" id="DnjeukmHQy" role="jymVt" />
+      <node concept="3Tm1VV" id="DnjeukmFSL" role="1B3o_S" />
+      <node concept="3clFbW" id="DnjeukmHT5" role="jymVt">
+        <node concept="3cqZAl" id="DnjeukmHT6" role="3clF45" />
+        <node concept="3Tm1VV" id="DnjeukmHT7" role="1B3o_S" />
+        <node concept="3clFbS" id="DnjeukmHT9" role="3clF47">
+          <node concept="3clFbF" id="DnjeukmHTd" role="3cqZAp">
+            <node concept="37vLTI" id="DnjeukmHTf" role="3clFbG">
+              <node concept="2OqwBi" id="DnjeukmHTj" role="37vLTJ">
+                <node concept="Xjq3P" id="DnjeukmHTk" role="2Oq$k0" />
+                <node concept="2OwXpG" id="DnjeukmHTl" role="2OqNvi">
+                  <ref role="2Oxat6" node="DnjeukmHK6" resolve="forLeftSideTransformation" />
+                </node>
+              </node>
+              <node concept="37vLTw" id="DnjeukmHTm" role="37vLTx">
+                <ref role="3cqZAo" node="DnjeukmHTc" resolve="forLeftSideTransformation" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="37vLTG" id="DnjeukmHTc" role="3clF46">
+          <property role="TrG5h" value="forLeftSideTransformation" />
+          <node concept="10P_77" id="DnjeukmHTb" role="1tU5fm" />
+        </node>
+      </node>
+      <node concept="2tJIrI" id="DnjeukmIQb" role="jymVt" />
+      <node concept="3clFb_" id="DnjeukmHXY" role="jymVt">
+        <property role="TrG5h" value="equals" />
+        <node concept="10P_77" id="DnjeukmHXZ" role="3clF45" />
+        <node concept="3Tm1VV" id="DnjeukmHY0" role="1B3o_S" />
+        <node concept="3clFbS" id="DnjeukmHY1" role="3clF47">
+          <node concept="3clFbJ" id="DnjeukmHY2" role="3cqZAp">
+            <node concept="3clFbS" id="DnjeukmHY3" role="3clFbx">
+              <node concept="3cpWs6" id="DnjeukmHY4" role="3cqZAp">
+                <node concept="3clFbT" id="DnjeukmHY5" role="3cqZAk">
+                  <property role="3clFbU" value="true" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbC" id="DnjeukmHY6" role="3clFbw">
+              <node concept="Xjq3P" id="DnjeukmHXX" role="3uHU7B" />
+              <node concept="37vLTw" id="DnjeukmHY7" role="3uHU7w">
+                <ref role="3cqZAo" node="DnjeukmHYu" resolve="o" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbJ" id="DnjeukmHY8" role="3cqZAp">
+            <node concept="3clFbS" id="DnjeukmHY9" role="3clFbx">
+              <node concept="3cpWs6" id="DnjeukmHYa" role="3cqZAp">
+                <node concept="3clFbT" id="DnjeukmHYb" role="3cqZAk">
+                  <property role="3clFbU" value="false" />
+                </node>
+              </node>
+            </node>
+            <node concept="22lmx$" id="DnjeukmHYc" role="3clFbw">
+              <node concept="3clFbC" id="DnjeukmHYd" role="3uHU7B">
+                <node concept="37vLTw" id="DnjeukmHYe" role="3uHU7B">
+                  <ref role="3cqZAo" node="DnjeukmHYu" resolve="o" />
+                </node>
+                <node concept="10Nm6u" id="DnjeukmHYf" role="3uHU7w" />
+              </node>
+              <node concept="3y3z36" id="DnjeukmHYg" role="3uHU7w">
+                <node concept="2OqwBi" id="DnjeukmHYh" role="3uHU7B">
+                  <node concept="Xjq3P" id="DnjeukmHYi" role="2Oq$k0" />
+                  <node concept="liA8E" id="DnjeukmHYj" role="2OqNvi">
+                    <ref role="37wK5l" to="wyt6:~Object.getClass()" resolve="getClass" />
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="DnjeukmHYk" role="3uHU7w">
+                  <node concept="37vLTw" id="DnjeukmHYl" role="2Oq$k0">
+                    <ref role="3cqZAo" node="DnjeukmHYu" resolve="o" />
+                  </node>
+                  <node concept="liA8E" id="DnjeukmHYm" role="2OqNvi">
+                    <ref role="37wK5l" to="wyt6:~Object.getClass()" resolve="getClass" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbH" id="DnjeukmHYn" role="3cqZAp" />
+          <node concept="3cpWs8" id="DnjeukmHYo" role="3cqZAp">
+            <node concept="3cpWsn" id="DnjeukmHYp" role="3cpWs9">
+              <property role="TrG5h" value="that" />
+              <node concept="3uibUv" id="DnjeukmHYq" role="1tU5fm">
+                <ref role="3uigEE" node="DnjeukmFSK" resolve="RedirectToBeforeAndAfter.Lookup" />
+              </node>
+              <node concept="10QFUN" id="DnjeukmHYr" role="33vP2m">
+                <node concept="3uibUv" id="DnjeukmHYs" role="10QFUM">
+                  <ref role="3uigEE" node="DnjeukmFSK" resolve="RedirectToBeforeAndAfter.Lookup" />
+                </node>
+                <node concept="37vLTw" id="DnjeukmHYt" role="10QFUP">
+                  <ref role="3cqZAo" node="DnjeukmHYu" resolve="o" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbJ" id="DnjeukmHYA" role="3cqZAp">
+            <node concept="3y3z36" id="DnjeukmHYB" role="3clFbw">
+              <node concept="2OqwBi" id="DnjeukmHYC" role="3uHU7w">
+                <node concept="37vLTw" id="DnjeukmHYx" role="2Oq$k0">
+                  <ref role="3cqZAo" node="DnjeukmHYp" resolve="that" />
+                </node>
+                <node concept="2OwXpG" id="DnjeukmHY$" role="2OqNvi">
+                  <ref role="2Oxat6" node="DnjeukmHK6" resolve="forLeftSideTransformation" />
+                </node>
+              </node>
+              <node concept="37vLTw" id="DnjeukmHY_" role="3uHU7B">
+                <ref role="3cqZAo" node="DnjeukmHK6" resolve="forLeftSideTransformation" />
+              </node>
+            </node>
+            <node concept="3clFbS" id="DnjeukmHYD" role="3clFbx">
+              <node concept="3cpWs6" id="DnjeukmHYE" role="3cqZAp">
+                <node concept="3clFbT" id="DnjeukmHYF" role="3cqZAk">
+                  <property role="3clFbU" value="false" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbH" id="DnjeukmHYG" role="3cqZAp" />
+          <node concept="3clFbF" id="DnjeukmHYH" role="3cqZAp">
+            <node concept="3clFbT" id="DnjeukmHYI" role="3clFbG">
+              <property role="3clFbU" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="37vLTG" id="DnjeukmHYu" role="3clF46">
+          <property role="TrG5h" value="o" />
+          <node concept="3uibUv" id="DnjeukmHYv" role="1tU5fm">
+            <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+          </node>
+        </node>
+        <node concept="2AHcQZ" id="DnjeukmHYw" role="2AJF6D">
+          <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+        </node>
+      </node>
+      <node concept="2tJIrI" id="DnjeukmJ0o" role="jymVt" />
+      <node concept="3clFb_" id="DnjeukmHYJ" role="jymVt">
+        <property role="TrG5h" value="hashCode" />
+        <node concept="10Oyi0" id="DnjeukmHYK" role="3clF45" />
+        <node concept="3Tm1VV" id="DnjeukmHYL" role="1B3o_S" />
+        <node concept="3clFbS" id="DnjeukmHYM" role="3clF47">
+          <node concept="3cpWs6" id="DnjeukmK4Q" role="3cqZAp">
+            <node concept="3K4zz7" id="DnjeukmHZ5" role="3cqZAk">
+              <node concept="3cmrfG" id="DnjeukmHZ6" role="3K4GZi">
+                <property role="3cmrfH" value="0" />
+              </node>
+              <node concept="37vLTw" id="DnjeukmHYZ" role="3K4Cdx">
+                <ref role="3cqZAo" node="DnjeukmHK6" resolve="forLeftSideTransformation" />
+              </node>
+              <node concept="3cmrfG" id="DnjeukmJSd" role="3K4E3e">
+                <property role="3cmrfH" value="1" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2AHcQZ" id="DnjeukmHYN" role="2AJF6D">
+          <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+        </node>
+      </node>
+      <node concept="2tJIrI" id="DnjeukmMiT" role="jymVt" />
+      <node concept="3uibUv" id="DnjeukmM65" role="EKbjA">
+        <ref role="3uigEE" to="uddc:~TransformationMenuLookup" resolve="TransformationMenuLookup" />
+      </node>
+      <node concept="3clFb_" id="DnjeukmMUj" role="jymVt">
+        <property role="TrG5h" value="lookup" />
+        <node concept="3Tm1VV" id="DnjeukmMUk" role="1B3o_S" />
+        <node concept="2AHcQZ" id="DnjeukmMUm" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+        <node concept="3uibUv" id="DnjeukmMUn" role="3clF45">
+          <ref role="3uigEE" to="33ny:~Collection" resolve="Collection" />
+          <node concept="3uibUv" id="DnjeukmMUo" role="11_B2D">
+            <ref role="3uigEE" to="iwf0:~TransformationMenu" resolve="TransformationMenu" />
+          </node>
+        </node>
+        <node concept="37vLTG" id="DnjeukmMUp" role="3clF46">
+          <property role="TrG5h" value="usedLanguages" />
+          <node concept="3uibUv" id="DnjeukmMUq" role="1tU5fm">
+            <ref role="3uigEE" to="33ny:~Collection" resolve="Collection" />
+            <node concept="3uibUv" id="DnjeukmMUr" role="11_B2D">
+              <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
+            </node>
+          </node>
+          <node concept="2AHcQZ" id="DnjeukmMUs" role="2AJF6D">
+            <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+          </node>
+        </node>
+        <node concept="37vLTG" id="DnjeukmMUt" role="3clF46">
+          <property role="TrG5h" value="menuLocation" />
+          <node concept="17QB3L" id="DnjeukmOju" role="1tU5fm" />
+          <node concept="2AHcQZ" id="DnjeukmMUv" role="2AJF6D">
+            <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+          </node>
+        </node>
+        <node concept="3clFbS" id="DnjeukmMUw" role="3clF47">
+          <node concept="3clFbF" id="DnjeuknLzV" role="3cqZAp">
+            <node concept="2ShNRf" id="DnjeuknLzT" role="3clFbG">
+              <node concept="Tc6Ow" id="DnjeuknNry" role="2ShVmc">
+                <node concept="3uibUv" id="DnjeuknNWr" role="HW$YZ">
+                  <ref role="3uigEE" to="iwf0:~TransformationMenu" resolve="TransformationMenu" />
+                </node>
+                <node concept="2ShNRf" id="DnjeuknOsO" role="HW$Y0">
+                  <node concept="HV5vD" id="DnjeuknZdT" role="2ShVmc">
+                    <ref role="HV5vE" node="DnjeuknTuv" resolve="RedirectToBeforeAndAfter.Lookup.Menu" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2AHcQZ" id="DnjeukmMUx" role="2AJF6D">
+          <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+        </node>
+      </node>
+      <node concept="2tJIrI" id="DnjeuknR$C" role="jymVt" />
+      <node concept="312cEu" id="DnjeuknTuv" role="jymVt">
+        <property role="2bfB8j" value="true" />
+        <property role="TrG5h" value="Menu" />
+        <node concept="3clFb_" id="DnjeuknP0_" role="jymVt">
+          <property role="TrG5h" value="createMenuItems" />
+          <node concept="3Tm1VV" id="DnjeuknP0A" role="1B3o_S" />
+          <node concept="2AHcQZ" id="DnjeuknP0C" role="2AJF6D">
+            <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+          </node>
+          <node concept="3uibUv" id="DnjeuknP0D" role="3clF45">
+            <ref role="3uigEE" to="33ny:~List" resolve="List" />
+            <node concept="3uibUv" id="DnjeuknQjc" role="11_B2D">
+              <ref role="3uigEE" to="uddc:~TransformationMenuItem" resolve="TransformationMenuItem" />
+            </node>
+          </node>
+          <node concept="37vLTG" id="DnjeuknP0F" role="3clF46">
+            <property role="TrG5h" value="context" />
+            <node concept="3uibUv" id="DnjeuknQ3W" role="1tU5fm">
+              <ref role="3uigEE" to="uddc:~TransformationMenuContext" resolve="TransformationMenuContext" />
+            </node>
+            <node concept="2AHcQZ" id="DnjeuknP0H" role="2AJF6D">
+              <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+            </node>
+          </node>
+          <node concept="3clFbS" id="DnjeuknP0I" role="3clF47">
+            <node concept="3clFbF" id="DnjeukjxBC" role="3cqZAp">
+              <node concept="2OqwBi" id="DnjeukjyTO" role="3clFbG">
+                <node concept="2OqwBi" id="Dnjeukjygy" role="2Oq$k0">
+                  <node concept="37vLTw" id="DnjeukjxBA" role="2Oq$k0">
+                    <ref role="3cqZAo" node="DnjeuknP0F" resolve="context" />
+                  </node>
+                  <node concept="liA8E" id="DnjeukjyMS" role="2OqNvi">
+                    <ref role="37wK5l" to="uddc:~TransformationMenuContext.getEditorMenuTrace()" resolve="getEditorMenuTrace" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="DnjeukjzS3" role="2OqNvi">
+                  <ref role="37wK5l" to="x4mf:~EditorMenuTrace.pushTraceInfo()" resolve="pushTraceInfo" />
+                </node>
+              </node>
+            </node>
+            <node concept="3J1_TO" id="DnjeukjsuW" role="3cqZAp">
+              <node concept="3clFbS" id="DnjeukjsuY" role="1zxBo7">
+                <node concept="3clFbF" id="Dnjeukj$Ci" role="3cqZAp">
+                  <node concept="2OqwBi" id="DnjeukjDpz" role="3clFbG">
+                    <node concept="2OqwBi" id="Dnjeukj_q4" role="2Oq$k0">
+                      <node concept="37vLTw" id="Dnjeukj$Cg" role="2Oq$k0">
+                        <ref role="3cqZAo" node="DnjeuknP0F" resolve="context" />
+                      </node>
+                      <node concept="liA8E" id="DnjeukjAdm" role="2OqNvi">
+                        <ref role="37wK5l" to="uddc:~TransformationMenuContext.getEditorMenuTrace()" resolve="getEditorMenuTrace" />
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="DnjeukjE3a" role="2OqNvi">
+                      <ref role="37wK5l" to="x4mf:~EditorMenuTrace.setDescriptor(jetbrains.mps.openapi.editor.menus.EditorMenuDescriptor)" resolve="setDescriptor" />
+                      <node concept="2ShNRf" id="DnjeukjUbz" role="37wK5m">
+                        <node concept="1pGfFk" id="DnjeukkgK1" role="2ShVmc">
+                          <ref role="37wK5l" to="v95p:~EditorMenuDescriptorBase.&lt;init&gt;(java.lang.String,org.jetbrains.mps.openapi.model.SNodeReference)" resolve="EditorMenuDescriptorBase" />
+                          <node concept="3cpWs3" id="Dnjeukki_X" role="37wK5m">
+                            <node concept="3cpWs3" id="Dnjeukki_Y" role="3uHU7B">
+                              <node concept="1eOMI4" id="Dnjeukki_Z" role="3uHU7w">
+                                <node concept="3K4zz7" id="DnjeukkiA0" role="1eOMHV">
+                                  <node concept="Xl_RD" id="DnjeukkiA1" role="3K4E3e">
+                                    <property role="Xl_RC" value="left" />
+                                  </node>
+                                  <node concept="Xl_RD" id="DnjeukkiA2" role="3K4GZi">
+                                    <property role="Xl_RC" value="right" />
+                                  </node>
+                                  <node concept="37vLTw" id="DnjeukkiA3" role="3K4Cdx">
+                                    <ref role="3cqZAo" node="DnjeukmHK6" resolve="forLeftSideTransformation" />
+                                  </node>
+                                </node>
+                              </node>
+                              <node concept="Xl_RD" id="DnjeukkiA4" role="3uHU7B">
+                                <property role="Xl_RC" value="include before/after transformations in " />
+                              </node>
+                            </node>
+                            <node concept="Xl_RD" id="DnjeukkiA5" role="3uHU7w">
+                              <property role="Xl_RC" value=" side transformation" />
+                            </node>
+                          </node>
+                          <node concept="10Nm6u" id="DnjeukkiQQ" role="37wK5m" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3cpWs8" id="6rGQ0fkJjZN" role="3cqZAp">
+                  <node concept="3cpWsn" id="6rGQ0fkJjZO" role="3cpWs9">
+                    <property role="TrG5h" value="anchorCell" />
+                    <node concept="3uibUv" id="6rGQ0fkJjZP" role="1tU5fm">
+                      <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+                    </node>
+                    <node concept="2OqwBi" id="6rGQ0fkJjZQ" role="33vP2m">
+                      <node concept="2OqwBi" id="6rGQ0fkJkK0" role="2Oq$k0">
+                        <node concept="37vLTw" id="39$RJBbGQ$f" role="2Oq$k0">
+                          <ref role="3cqZAo" node="DnjeuknP0F" resolve="context" />
+                        </node>
+                        <node concept="liA8E" id="6rGQ0fkJl5s" role="2OqNvi">
+                          <ref role="37wK5l" to="uddc:~TransformationMenuContext.getEditorContext()" resolve="getEditorContext" />
+                        </node>
+                      </node>
+                      <node concept="liA8E" id="6rGQ0fkJjZS" role="2OqNvi">
+                        <ref role="37wK5l" to="cj4x:~EditorContext.getSelectedCell()" resolve="getSelectedCell" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3cpWs8" id="6rGQ0fkJjZT" role="3cqZAp">
+                  <node concept="3cpWsn" id="6rGQ0fkJjZU" role="3cpWs9">
+                    <property role="TrG5h" value="stHint" />
+                    <node concept="3uibUv" id="6rGQ0fkJjZV" role="1tU5fm">
+                      <ref role="3uigEE" to="4my4:~EditorCell_STHint" resolve="EditorCell_STHint" />
+                    </node>
+                    <node concept="0kSF2" id="6rGQ0fkJjZW" role="33vP2m">
+                      <node concept="3uibUv" id="6rGQ0fkJjZX" role="0kSFW">
+                        <ref role="3uigEE" to="4my4:~EditorCell_STHint" resolve="EditorCell_STHint" />
+                      </node>
+                      <node concept="37vLTw" id="6rGQ0fkJjZY" role="0kSFX">
+                        <ref role="3cqZAo" node="6rGQ0fkJjZO" resolve="anchorCell" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbJ" id="6rGQ0fkJjZZ" role="3cqZAp">
+                  <node concept="3clFbS" id="6rGQ0fkJk00" role="3clFbx">
+                    <node concept="3clFbF" id="6rGQ0fkJk01" role="3cqZAp">
+                      <node concept="37vLTI" id="6rGQ0fkJk02" role="3clFbG">
+                        <node concept="2OqwBi" id="6rGQ0fkJk03" role="37vLTx">
+                          <node concept="37vLTw" id="6rGQ0fkJk04" role="2Oq$k0">
+                            <ref role="3cqZAo" node="6rGQ0fkJjZU" resolve="stHint" />
+                          </node>
+                          <node concept="1PnCL0" id="6rGQ0fkJk05" role="2OqNvi">
+                            <ref role="2Oxat5" to="4my4:~EditorCell_STHint.myAnchorCell" resolve="myAnchorCell" />
+                          </node>
+                        </node>
+                        <node concept="37vLTw" id="6rGQ0fkJk06" role="37vLTJ">
+                          <ref role="3cqZAo" node="6rGQ0fkJjZO" resolve="anchorCell" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3y3z36" id="6rGQ0fkJk07" role="3clFbw">
+                    <node concept="37vLTw" id="6rGQ0fkJk08" role="3uHU7B">
+                      <ref role="3cqZAo" node="6rGQ0fkJjZU" resolve="stHint" />
+                    </node>
+                    <node concept="10Nm6u" id="6rGQ0fkJk09" role="3uHU7w" />
+                  </node>
+                </node>
+                <node concept="3clFbH" id="39$RJBb_9UR" role="3cqZAp" />
+                <node concept="3cpWs8" id="39$RJBb_9eF" role="3cqZAp">
+                  <node concept="3cpWsn" id="39$RJBb_9eG" role="3cpWs9">
+                    <property role="TrG5h" value="result" />
+                    <node concept="_YKpA" id="39$RJBb_993" role="1tU5fm">
+                      <node concept="3uibUv" id="39$RJBb_996" role="_ZDj9">
+                        <ref role="3uigEE" to="uddc:~TransformationMenuItem" resolve="TransformationMenuItem" />
+                      </node>
+                    </node>
+                    <node concept="2ShNRf" id="39$RJBbHuPV" role="33vP2m">
+                      <node concept="Tc6Ow" id="39$RJBbHuPs" role="2ShVmc">
+                        <node concept="3uibUv" id="39$RJBbHuPt" role="HW$YZ">
+                          <ref role="3uigEE" to="uddc:~TransformationMenuItem" resolve="TransformationMenuItem" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbJ" id="39$RJBbHvpK" role="3cqZAp">
+                  <node concept="3clFbS" id="39$RJBbHvpM" role="3clFbx">
+                    <node concept="3clFbF" id="39$RJBbHxYA" role="3cqZAp">
+                      <node concept="2OqwBi" id="39$RJBbHyS3" role="3clFbG">
+                        <node concept="37vLTw" id="39$RJBbHxY$" role="2Oq$k0">
+                          <ref role="3cqZAo" node="39$RJBb_9eG" resolve="result" />
+                        </node>
+                        <node concept="X8dFx" id="39$RJBbHzMN" role="2OqNvi">
+                          <node concept="1rXfSq" id="39$RJBbH$39" role="25WWJ7">
+                            <ref role="37wK5l" node="Dnjeuko29G" resolve="getBeforeAfterActions" />
+                            <node concept="37vLTw" id="39$RJBbH$vr" role="37wK5m">
+                              <ref role="3cqZAo" node="6rGQ0fkJjZO" resolve="anchorCell" />
+                            </node>
+                            <node concept="37vLTw" id="39$RJBbH_29" role="37wK5m">
+                              <ref role="3cqZAo" node="DnjeukmHK6" resolve="forLeftSideTransformation" />
+                            </node>
+                            <node concept="37vLTw" id="39$RJBbH_G6" role="37wK5m">
+                              <ref role="3cqZAo" node="DnjeuknP0F" resolve="context" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3cpWs8" id="39$RJBbHDwe" role="3cqZAp">
+                      <node concept="3cpWsn" id="39$RJBbHDwf" role="3cpWs9">
+                        <property role="TrG5h" value="isSyntaxCell" />
+                        <node concept="1bVj0M" id="39$RJBbHDwg" role="33vP2m">
+                          <node concept="37vLTG" id="39$RJBbHDwh" role="1bW2Oz">
+                            <property role="TrG5h" value="c" />
+                            <node concept="3uibUv" id="39$RJBbHDwi" role="1tU5fm">
+                              <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+                            </node>
+                          </node>
+                          <node concept="3clFbS" id="39$RJBbHDwj" role="1bW5cS">
+                            <node concept="3clFbF" id="39$RJBbHDwk" role="3cqZAp">
+                              <node concept="2YIFZM" id="15DZatOBDPj" role="3clFbG">
+                                <ref role="37wK5l" to="czm:15DZatOARrD" resolve="isSyntaxCell" />
+                                <ref role="1Pybhc" to="czm:RbLMy696h3" resolve="GrammarCellsUtil" />
+                                <node concept="37vLTw" id="15DZatOBEP$" role="37wK5m">
+                                  <ref role="3cqZAo" node="39$RJBbHDwh" resolve="c" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3uibUv" id="39$RJBb$1XB" role="1tU5fm">
+                          <ref role="3uigEE" to="y49u:~Condition" resolve="Condition" />
+                          <node concept="3uibUv" id="39$RJBb$1XC" role="11_B2D">
+                            <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3cpWs8" id="39$RJBbHClX" role="3cqZAp">
+                      <node concept="3cpWsn" id="39$RJBbHClY" role="3cpWs9">
+                        <property role="TrG5h" value="previousNextLeaf" />
+                        <node concept="3uibUv" id="39$RJBbHClZ" role="1tU5fm">
+                          <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+                        </node>
+                        <node concept="3K4zz7" id="39$RJBbHFhU" role="33vP2m">
+                          <node concept="37vLTw" id="39$RJBbHEQK" role="3K4Cdx">
+                            <ref role="3cqZAo" node="DnjeukmHK6" resolve="forLeftSideTransformation" />
+                          </node>
+                          <node concept="2YIFZM" id="39$RJBbHCOr" role="3K4E3e">
+                            <ref role="37wK5l" to="f4zo:~CellTraversalUtil.getPrevLeaf(jetbrains.mps.openapi.editor.cells.EditorCell,org.jetbrains.mps.util.Condition)" resolve="getPrevLeaf" />
+                            <ref role="1Pybhc" to="f4zo:~CellTraversalUtil" resolve="CellTraversalUtil" />
+                            <node concept="37vLTw" id="39$RJBbHCYQ" role="37wK5m">
+                              <ref role="3cqZAo" node="6rGQ0fkJjZO" resolve="anchorCell" />
+                            </node>
+                            <node concept="37vLTw" id="39$RJBbHDwp" role="37wK5m">
+                              <ref role="3cqZAo" node="39$RJBbHDwf" resolve="isSyntaxCell" />
+                            </node>
+                          </node>
+                          <node concept="2YIFZM" id="39$RJBbHFqt" role="3K4GZi">
+                            <ref role="37wK5l" to="f4zo:~CellTraversalUtil.getNextLeaf(jetbrains.mps.openapi.editor.cells.EditorCell,org.jetbrains.mps.util.Condition)" resolve="getNextLeaf" />
+                            <ref role="1Pybhc" to="f4zo:~CellTraversalUtil" resolve="CellTraversalUtil" />
+                            <node concept="37vLTw" id="39$RJBbHFqu" role="37wK5m">
+                              <ref role="3cqZAo" node="6rGQ0fkJjZO" resolve="anchorCell" />
+                            </node>
+                            <node concept="37vLTw" id="39$RJBbHFqv" role="37wK5m">
+                              <ref role="3cqZAo" node="39$RJBbHDwf" resolve="isSyntaxCell" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbJ" id="39$RJBbHIuv" role="3cqZAp">
+                      <node concept="3clFbS" id="39$RJBbHIux" role="3clFbx">
+                        <node concept="3clFbF" id="39$RJBbHIOG" role="3cqZAp">
+                          <node concept="2OqwBi" id="39$RJBbHIOH" role="3clFbG">
+                            <node concept="37vLTw" id="39$RJBbHIOI" role="2Oq$k0">
+                              <ref role="3cqZAo" node="39$RJBb_9eG" resolve="result" />
+                            </node>
+                            <node concept="X8dFx" id="39$RJBbHIOJ" role="2OqNvi">
+                              <node concept="1rXfSq" id="39$RJBbHIOK" role="25WWJ7">
+                                <ref role="37wK5l" node="Dnjeuko29G" resolve="getBeforeAfterActions" />
+                                <node concept="37vLTw" id="39$RJBbHJax" role="37wK5m">
+                                  <ref role="3cqZAo" node="39$RJBbHClY" resolve="previousNextLeaf" />
+                                </node>
+                                <node concept="3fqX7Q" id="Dnjeukmx6v" role="37wK5m">
+                                  <node concept="37vLTw" id="Dnjeukmx6x" role="3fr31v">
+                                    <ref role="3cqZAo" node="DnjeukmHK6" resolve="forLeftSideTransformation" />
+                                  </node>
+                                </node>
+                                <node concept="37vLTw" id="39$RJBbHION" role="37wK5m">
+                                  <ref role="3cqZAo" node="DnjeuknP0F" resolve="context" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3y3z36" id="39$RJBbHIJK" role="3clFbw">
+                        <node concept="10Nm6u" id="39$RJBbHINP" role="3uHU7w" />
+                        <node concept="37vLTw" id="39$RJBbHIBI" role="3uHU7B">
+                          <ref role="3cqZAo" node="39$RJBbHClY" resolve="previousNextLeaf" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3y3z36" id="39$RJBbHw5i" role="3clFbw">
+                    <node concept="10Nm6u" id="39$RJBbHwtn" role="3uHU7w" />
+                    <node concept="37vLTw" id="39$RJBbHvK3" role="3uHU7B">
+                      <ref role="3cqZAo" node="6rGQ0fkJjZO" resolve="anchorCell" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3cpWs6" id="39$RJBb_7ev" role="3cqZAp">
+                  <node concept="2YIFZM" id="5fS8LroC4T0" role="3cqZAk">
+                    <ref role="37wK5l" node="5fS8LroC3LX" resolve="applyShadowing" />
+                    <ref role="1Pybhc" node="5fS8LroBJd7" resolve="ShadowingUtil" />
+                    <node concept="37vLTw" id="5fS8LroC5rS" role="37wK5m">
+                      <ref role="3cqZAo" node="39$RJBb_9eG" resolve="result" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="1wplmZ" id="Dnjeukjttq" role="1zxBo6">
+                <node concept="3clFbS" id="Dnjeukjttr" role="1wplMD">
+                  <node concept="3clFbF" id="DnjeukkoO1" role="3cqZAp">
+                    <node concept="2OqwBi" id="DnjeukkpcH" role="3clFbG">
+                      <node concept="2OqwBi" id="DnjeukkoUw" role="2Oq$k0">
+                        <node concept="37vLTw" id="DnjeukkoO0" role="2Oq$k0">
+                          <ref role="3cqZAo" node="DnjeuknP0F" resolve="context" />
+                        </node>
+                        <node concept="liA8E" id="Dnjeukkp5B" role="2OqNvi">
+                          <ref role="37wK5l" to="uddc:~TransformationMenuContext.getEditorMenuTrace()" resolve="getEditorMenuTrace" />
+                        </node>
+                      </node>
+                      <node concept="liA8E" id="DnjeukkpmP" role="2OqNvi">
+                        <ref role="37wK5l" to="x4mf:~EditorMenuTrace.popTraceInfo()" resolve="popTraceInfo" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2AHcQZ" id="DnjeuknP0K" role="2AJF6D">
+            <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+          </node>
+        </node>
+        <node concept="2tJIrI" id="DnjeuknP0L" role="jymVt" />
+        <node concept="3clFb_" id="DnjeuknP0M" role="jymVt">
+          <property role="TrG5h" value="isContribution" />
+          <node concept="3Tm1VV" id="DnjeuknP0N" role="1B3o_S" />
+          <node concept="10P_77" id="DnjeuknP0P" role="3clF45" />
+          <node concept="3clFbS" id="DnjeuknP0Q" role="3clF47">
+            <node concept="3clFbF" id="DnjeuknReg" role="3cqZAp">
+              <node concept="3clFbT" id="DnjeuknRef" role="3clFbG">
+                <property role="3clFbU" value="true" />
+              </node>
+            </node>
+          </node>
+          <node concept="2AHcQZ" id="DnjeuknP0S" role="2AJF6D">
+            <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+          </node>
+        </node>
+        <node concept="2tJIrI" id="DnjeuknP0T" role="jymVt" />
+        <node concept="3clFb_" id="DnjeuknP0U" role="jymVt">
+          <property role="TrG5h" value="isApplicableToLocation" />
+          <node concept="3Tm1VV" id="DnjeuknP0V" role="1B3o_S" />
+          <node concept="10P_77" id="DnjeuknP0X" role="3clF45" />
+          <node concept="37vLTG" id="DnjeuknP0Y" role="3clF46">
+            <property role="TrG5h" value="location" />
+            <node concept="17QB3L" id="DnjeuknQuG" role="1tU5fm" />
+          </node>
+          <node concept="3clFbS" id="DnjeuknP10" role="3clF47">
+            <node concept="3clFbF" id="DnjeuknR8W" role="3cqZAp">
+              <node concept="3clFbT" id="DnjeuknR8V" role="3clFbG">
+                <property role="3clFbU" value="true" />
+              </node>
+            </node>
+          </node>
+          <node concept="2AHcQZ" id="DnjeuknP12" role="2AJF6D">
+            <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+          </node>
+        </node>
+        <node concept="3Tm1VV" id="DnjeuknTuw" role="1B3o_S" />
+        <node concept="3uibUv" id="DnjeuknV3X" role="EKbjA">
+          <ref role="3uigEE" to="iwf0:~TransformationMenu" resolve="TransformationMenu" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="4ntVsBGyZYF" role="jymVt" />
+    <node concept="2YIFZL" id="4ntVsBGyUPf" role="jymVt">
+      <property role="TrG5h" value="getFirstLastLeaf" />
+      <node concept="3clFbS" id="4ntVsBGyO29" role="3clF47">
+        <node concept="3cpWs8" id="4ntVsBGz2Yg" role="3cqZAp">
+          <node concept="3cpWsn" id="4ntVsBGz2Yh" role="3cpWs9">
+            <property role="TrG5h" value="leaf" />
+            <node concept="3uibUv" id="4ntVsBGz2Yi" role="1tU5fm">
+              <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+            </node>
+            <node concept="3K4zz7" id="4ntVsBGz46x" role="33vP2m">
+              <node concept="2YIFZM" id="4ntVsBGz4pG" role="3K4E3e">
+                <ref role="37wK5l" to="f4zo:~CellTraversalUtil.getFirstLeaf(jetbrains.mps.openapi.editor.cells.EditorCell)" resolve="getFirstLeaf" />
+                <ref role="1Pybhc" to="f4zo:~CellTraversalUtil" resolve="CellTraversalUtil" />
+                <node concept="37vLTw" id="4ntVsBGz4z9" role="37wK5m">
+                  <ref role="3cqZAo" node="4ntVsBGyR3I" resolve="ancestor" />
+                </node>
+              </node>
+              <node concept="2YIFZM" id="4ntVsBGz4QI" role="3K4GZi">
+                <ref role="37wK5l" to="f4zo:~CellTraversalUtil.getLastLeaf(jetbrains.mps.openapi.editor.cells.EditorCell)" resolve="getLastLeaf" />
+                <ref role="1Pybhc" to="f4zo:~CellTraversalUtil" resolve="CellTraversalUtil" />
+                <node concept="37vLTw" id="4ntVsBGz51X" role="37wK5m">
+                  <ref role="3cqZAo" node="4ntVsBGyR3I" resolve="ancestor" />
+                </node>
+              </node>
+              <node concept="37vLTw" id="4ntVsBGz3Ct" role="3K4Cdx">
+                <ref role="3cqZAo" node="4ntVsBGyRY0" resolve="first" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="4ntVsBGzulY" role="3cqZAp">
+          <node concept="3clFbS" id="4ntVsBGzum0" role="3clFbx">
+            <node concept="3cpWs6" id="4ntVsBGzwcp" role="3cqZAp">
+              <node concept="37vLTw" id="4ntVsBGzwsQ" role="3cqZAk">
+                <ref role="3cqZAo" node="4ntVsBGz2Yh" resolve="leaf" />
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="4ntVsBGzvg7" role="3clFbw">
+            <node concept="37vLTw" id="4ntVsBGzuPp" role="2Oq$k0">
+              <ref role="3cqZAo" node="4ntVsBGySQ8" resolve="condition" />
+            </node>
+            <node concept="liA8E" id="4ntVsBGzvF3" role="2OqNvi">
+              <ref role="37wK5l" to="y49u:~Condition.met(java.lang.Object)" resolve="met" />
+              <node concept="37vLTw" id="4ntVsBGzvUQ" role="37wK5m">
+                <ref role="3cqZAo" node="4ntVsBGz2Yh" resolve="leaf" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="4ntVsBGzejx" role="3cqZAp">
+          <node concept="3cpWsn" id="4ntVsBGzejy" role="3cpWs9">
+            <property role="TrG5h" value="alsoCheckAncestor" />
+            <node concept="3uibUv" id="4ntVsBGzejv" role="1tU5fm">
+              <ref role="3uigEE" to="y49u:~Condition" resolve="Condition" />
+              <node concept="3uibUv" id="4ntVsBGzfbU" role="11_B2D">
+                <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+              </node>
+            </node>
+            <node concept="1bVj0M" id="4ntVsBGzgb9" role="33vP2m">
+              <node concept="37vLTG" id="4ntVsBGzgn1" role="1bW2Oz">
+                <property role="TrG5h" value="c" />
+                <node concept="3uibUv" id="4ntVsBGzgAX" role="1tU5fm">
+                  <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+                </node>
+              </node>
+              <node concept="3clFbS" id="4ntVsBGzgbb" role="1bW5cS">
+                <node concept="3clFbF" id="4ntVsBGzh7e" role="3cqZAp">
+                  <node concept="1Wc70l" id="4ntVsBGziFP" role="3clFbG">
+                    <node concept="2OqwBi" id="4ntVsBGzhvz" role="3uHU7B">
+                      <node concept="37vLTw" id="4ntVsBGzh7d" role="2Oq$k0">
+                        <ref role="3cqZAo" node="4ntVsBGySQ8" resolve="condition" />
+                      </node>
+                      <node concept="liA8E" id="4ntVsBGzhTU" role="2OqNvi">
+                        <ref role="37wK5l" to="y49u:~Condition.met(java.lang.Object)" resolve="met" />
+                        <node concept="37vLTw" id="4ntVsBGzi8e" role="37wK5m">
+                          <ref role="3cqZAo" node="4ntVsBGzgn1" resolve="c" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2YIFZM" id="4ntVsBGziVH" role="3uHU7w">
+                      <ref role="37wK5l" to="f4zo:~CellTraversalUtil.isAncestorOrEquals(jetbrains.mps.openapi.editor.cells.EditorCell,jetbrains.mps.openapi.editor.cells.EditorCell)" resolve="isAncestorOrEquals" />
+                      <ref role="1Pybhc" to="f4zo:~CellTraversalUtil" resolve="CellTraversalUtil" />
+                      <node concept="37vLTw" id="4ntVsBGziVI" role="37wK5m">
+                        <ref role="3cqZAo" node="4ntVsBGyR3I" resolve="ancestor" />
+                      </node>
+                      <node concept="37vLTw" id="4ntVsBGzj9H" role="37wK5m">
+                        <ref role="3cqZAo" node="4ntVsBGzgn1" resolve="c" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="4ntVsBGz_jZ" role="3cqZAp">
+          <node concept="3K4zz7" id="4ntVsBGz_k3" role="3cqZAk">
+            <node concept="2YIFZM" id="4ntVsBGz_k4" role="3K4E3e">
+              <ref role="37wK5l" to="f4zo:~CellTraversalUtil.getNextLeaf(jetbrains.mps.openapi.editor.cells.EditorCell,org.jetbrains.mps.util.Condition)" resolve="getNextLeaf" />
+              <ref role="1Pybhc" to="f4zo:~CellTraversalUtil" resolve="CellTraversalUtil" />
+              <node concept="37vLTw" id="4ntVsBGz_k5" role="37wK5m">
+                <ref role="3cqZAo" node="4ntVsBGz2Yh" resolve="leaf" />
+              </node>
+              <node concept="37vLTw" id="4ntVsBGz_k6" role="37wK5m">
+                <ref role="3cqZAo" node="4ntVsBGzejy" resolve="alsoCheckAncestor" />
+              </node>
+            </node>
+            <node concept="2YIFZM" id="4ntVsBGz_k7" role="3K4GZi">
+              <ref role="37wK5l" to="f4zo:~CellTraversalUtil.getPrevLeaf(jetbrains.mps.openapi.editor.cells.EditorCell,org.jetbrains.mps.util.Condition)" resolve="getPrevLeaf" />
+              <ref role="1Pybhc" to="f4zo:~CellTraversalUtil" resolve="CellTraversalUtil" />
+              <node concept="37vLTw" id="4ntVsBGz_k8" role="37wK5m">
+                <ref role="3cqZAo" node="4ntVsBGz2Yh" resolve="leaf" />
+              </node>
+              <node concept="37vLTw" id="4ntVsBGz_k9" role="37wK5m">
+                <ref role="3cqZAo" node="4ntVsBGzejy" resolve="alsoCheckAncestor" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="4ntVsBGz_ka" role="3K4Cdx">
+              <ref role="3cqZAo" node="4ntVsBGyRY0" resolve="first" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="4ntVsBGyR3I" role="3clF46">
+        <property role="TrG5h" value="ancestor" />
+        <node concept="3uibUv" id="4ntVsBGyRPu" role="1tU5fm">
+          <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="4ntVsBGyRY0" role="3clF46">
+        <property role="TrG5h" value="first" />
+        <node concept="10P_77" id="4ntVsBGySMV" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="4ntVsBGySQ8" role="3clF46">
+        <property role="TrG5h" value="condition" />
+        <node concept="3uibUv" id="4ntVsBGyTFR" role="1tU5fm">
+          <ref role="3uigEE" to="y49u:~Condition" resolve="Condition" />
+          <node concept="3uibUv" id="4ntVsBGyTNl" role="11_B2D">
+            <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+          </node>
+        </node>
+      </node>
+      <node concept="3uibUv" id="4ntVsBGyTYE" role="3clF45">
+        <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+      </node>
+      <node concept="3Tm1VV" id="4ntVsBGyO28" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="5Jw_kf6ruWI" role="jymVt" />
+    <node concept="2YIFZL" id="5Jw_kf6ofT$" role="jymVt">
+      <property role="TrG5h" value="getPreviousNextLeaf" />
+      <node concept="3clFbS" id="5Jw_kf6nUs8" role="3clF47">
+        <node concept="3clFbF" id="5Jw_kf6o4kw" role="3cqZAp">
+          <node concept="3K4zz7" id="5Jw_kf6o5zv" role="3clFbG">
+            <node concept="2YIFZM" id="5Jw_kf6o6Ys" role="3K4E3e">
+              <ref role="1Pybhc" to="f4zo:~CellTraversalUtil" resolve="CellTraversalUtil" />
+              <ref role="37wK5l" to="f4zo:~CellTraversalUtil.getPrevLeaf(jetbrains.mps.openapi.editor.cells.EditorCell,org.jetbrains.mps.util.Condition)" resolve="getPrevLeaf" />
+              <node concept="37vLTw" id="5Jw_kf6o7Rv" role="37wK5m">
+                <ref role="3cqZAo" node="5Jw_kf6o0Hm" resolve="cell" />
+              </node>
+              <node concept="37vLTw" id="5Jw_kf6o9zU" role="37wK5m">
+                <ref role="3cqZAo" node="5Jw_kf6o1LR" resolve="condition" />
+              </node>
+            </node>
+            <node concept="2YIFZM" id="5Jw_kf6obnD" role="3K4GZi">
+              <ref role="1Pybhc" to="f4zo:~CellTraversalUtil" resolve="CellTraversalUtil" />
+              <ref role="37wK5l" to="f4zo:~CellTraversalUtil.getNextLeaf(jetbrains.mps.openapi.editor.cells.EditorCell,org.jetbrains.mps.util.Condition)" resolve="getNextLeaf" />
+              <node concept="37vLTw" id="5Jw_kf6ocgE" role="37wK5m">
+                <ref role="3cqZAo" node="5Jw_kf6o0Hm" resolve="cell" />
+              </node>
+              <node concept="37vLTw" id="5Jw_kf6od5G" role="37wK5m">
+                <ref role="3cqZAo" node="5Jw_kf6o1LR" resolve="condition" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="5Jw_kf6o4kv" role="3K4Cdx">
+              <ref role="3cqZAo" node="5Jw_kf6o059" resolve="previous" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="5Jw_kf6o059" role="3clF46">
+        <property role="TrG5h" value="previous" />
+        <node concept="10P_77" id="5Jw_kf6o0Bw" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="5Jw_kf6o0Hm" role="3clF46">
+        <property role="TrG5h" value="cell" />
+        <node concept="3uibUv" id="5Jw_kf6o1AY" role="1tU5fm">
+          <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="5Jw_kf6o1LR" role="3clF46">
+        <property role="TrG5h" value="condition" />
+        <node concept="3uibUv" id="5Jw_kf6o3a7" role="1tU5fm">
+          <ref role="3uigEE" to="y49u:~Condition" resolve="Condition" />
+          <node concept="3uibUv" id="5Jw_kf6o3iy" role="11_B2D">
+            <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+          </node>
+        </node>
+      </node>
+      <node concept="3uibUv" id="5Jw_kf6o3rh" role="3clF45">
+        <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+      </node>
+      <node concept="3Tm6S6" id="5Jw_kf6nVvS" role="1B3o_S" />
+    </node>
+  </node>
+  <node concept="312cEu" id="5fS8LroqjMR">
+    <property role="TrG5h" value="BracketsSideTranformationAction" />
+    <node concept="2tJIrI" id="5fS8LroqjW8" role="jymVt" />
+    <node concept="312cEg" id="5fS8LroqmXP" role="jymVt">
+      <property role="TrG5h" value="outputConcept" />
+      <node concept="3Tm6S6" id="5fS8LroqmXQ" role="1B3o_S" />
+      <node concept="3bZ5Sz" id="5fS8LroqniH" role="1tU5fm" />
+    </node>
+    <node concept="312cEg" id="5fS8LroqrI7" role="jymVt">
+      <property role="TrG5h" value="matchingText" />
+      <node concept="3Tm6S6" id="5fS8LroqrI8" role="1B3o_S" />
+      <node concept="17QB3L" id="5fS8LroqseW" role="1tU5fm" />
+    </node>
+    <node concept="312cEg" id="5fS8Lroqy4E" role="jymVt">
+      <property role="TrG5h" value="leftSide" />
+      <node concept="3Tm6S6" id="5fS8Lroqy4F" role="1B3o_S" />
+      <node concept="10P_77" id="5fS8Lroqz0s" role="1tU5fm" />
+    </node>
+    <node concept="2tJIrI" id="5fS8LroqmDK" role="jymVt" />
+    <node concept="3Tm1VV" id="5fS8LroqjMS" role="1B3o_S" />
+    <node concept="3uibUv" id="5fS8LroqjVL" role="1zkMxy">
+      <ref role="3uigEE" node="1YKLYyyGBzT" resolve="GrammarCellsSideTransformTransformationMenuItem" />
+    </node>
+    <node concept="3clFbW" id="5fS8Lroq_4_" role="jymVt">
+      <node concept="3cqZAl" id="5fS8Lroq_4A" role="3clF45" />
+      <node concept="3Tm1VV" id="5fS8Lroq_4B" role="1B3o_S" />
+      <node concept="3clFbS" id="5fS8Lroq_4D" role="3clF47">
+        <node concept="XkiVB" id="5fS8Lroq_4F" role="3cqZAp">
+          <ref role="37wK5l" node="My09KinEek" resolve="GrammarCellsSideTransformTransformationMenuItem" />
+          <node concept="37vLTw" id="5fS8Lroq_4J" role="37wK5m">
+            <ref role="3cqZAo" node="5fS8Lroq_4G" resolve="context" />
+          </node>
+        </node>
+        <node concept="3clFbF" id="5fS8Lroq_4M" role="3cqZAp">
+          <node concept="37vLTI" id="5fS8Lroq_4O" role="3clFbG">
+            <node concept="2OqwBi" id="5fS8Lroq_4S" role="37vLTJ">
+              <node concept="Xjq3P" id="5fS8Lroq_4T" role="2Oq$k0" />
+              <node concept="2OwXpG" id="5fS8Lroq_4U" role="2OqNvi">
+                <ref role="2Oxat6" node="5fS8LroqmXP" resolve="outputConcept" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="5fS8Lroq_4V" role="37vLTx">
+              <ref role="3cqZAo" node="5fS8Lroq_4L" resolve="outputConcept" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="5fS8Lroq_4Y" role="3cqZAp">
+          <node concept="37vLTI" id="5fS8Lroq_50" role="3clFbG">
+            <node concept="2OqwBi" id="5fS8Lroq_54" role="37vLTJ">
+              <node concept="Xjq3P" id="5fS8Lroq_55" role="2Oq$k0" />
+              <node concept="2OwXpG" id="5fS8Lroq_56" role="2OqNvi">
+                <ref role="2Oxat6" node="5fS8LroqrI7" resolve="matchingText" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="5fS8Lroq_57" role="37vLTx">
+              <ref role="3cqZAo" node="5fS8Lroq_4X" resolve="matchingText" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="5fS8Lroq_5a" role="3cqZAp">
+          <node concept="37vLTI" id="5fS8Lroq_5c" role="3clFbG">
+            <node concept="2OqwBi" id="5fS8Lroq_5g" role="37vLTJ">
+              <node concept="Xjq3P" id="5fS8Lroq_5h" role="2Oq$k0" />
+              <node concept="2OwXpG" id="5fS8Lroq_5i" role="2OqNvi">
+                <ref role="2Oxat6" node="5fS8Lroqy4E" resolve="leftSide" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="5fS8Lroq_5j" role="37vLTx">
+              <ref role="3cqZAo" node="5fS8Lroq_59" resolve="leftSide" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="5fS8Lroq_4G" role="3clF46">
+        <property role="TrG5h" value="context" />
+        <node concept="3uibUv" id="5fS8Lroq_4I" role="1tU5fm">
+          <ref role="3uigEE" to="uddc:~TransformationMenuContext" resolve="TransformationMenuContext" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="5fS8Lroq_4L" role="3clF46">
+        <property role="TrG5h" value="outputConcept" />
+        <node concept="3bZ5Sz" id="5fS8Lroq_4K" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="5fS8Lroq_4X" role="3clF46">
+        <property role="TrG5h" value="matchingText" />
+        <node concept="17QB3L" id="5fS8Lroq_4W" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="5fS8Lroq_59" role="3clF46">
+        <property role="TrG5h" value="leftSide" />
+        <node concept="10P_77" id="5fS8Lroq_58" role="1tU5fm" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="5fS8LropL7P" role="jymVt">
+      <property role="1EzhhJ" value="false" />
+      <property role="TrG5h" value="getDescriptionText" />
+      <property role="DiZV1" value="false" />
+      <property role="od$2w" value="false" />
+      <node concept="3Tm1VV" id="5fS8LropL7Q" role="1B3o_S" />
+      <node concept="17QB3L" id="5fS8LropL7R" role="3clF45" />
+      <node concept="37vLTG" id="5fS8LropL7S" role="3clF46">
+        <property role="TrG5h" value="string" />
+        <node concept="17QB3L" id="5fS8LropL7T" role="1tU5fm" />
+      </node>
+      <node concept="3clFbS" id="5fS8LropL7U" role="3clF47">
+        <node concept="3clFbF" id="5fS8LroqnFw" role="3cqZAp">
+          <node concept="2OqwBi" id="5fS8Lroqo2s" role="3clFbG">
+            <node concept="37vLTw" id="5fS8LroqnFv" role="2Oq$k0">
+              <ref role="3cqZAo" node="5fS8LroqmXP" resolve="outputConcept" />
+            </node>
+            <node concept="liA8E" id="5fS8LroqolY" role="2OqNvi">
+              <ref role="37wK5l" to="c17a:~SAbstractConcept.getName()" resolve="getName" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3clFb_" id="5fS8LropL8a" role="jymVt">
+      <property role="1EzhhJ" value="false" />
+      <property role="TrG5h" value="getMatchingText" />
+      <property role="DiZV1" value="false" />
+      <property role="od$2w" value="false" />
+      <node concept="3Tm1VV" id="5fS8LropL8b" role="1B3o_S" />
+      <node concept="17QB3L" id="5fS8LropL8c" role="3clF45" />
+      <node concept="37vLTG" id="5fS8LropL8d" role="3clF46">
+        <property role="TrG5h" value="pattern" />
+        <node concept="17QB3L" id="5fS8LropL8e" role="1tU5fm" />
+      </node>
+      <node concept="3clFbS" id="5fS8LropL8f" role="3clF47">
+        <node concept="3clFbF" id="5fS8LropL8g" role="3cqZAp">
+          <node concept="37vLTw" id="5fS8LroqsGl" role="3clFbG">
+            <ref role="3cqZAo" node="5fS8LroqrI7" resolve="matchingText" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3clFb_" id="5fS8LropL8F" role="jymVt">
+      <property role="1EzhhJ" value="false" />
+      <property role="TrG5h" value="execute" />
+      <property role="DiZV1" value="false" />
+      <property role="od$2w" value="false" />
+      <node concept="3Tm1VV" id="5fS8LropL8G" role="1B3o_S" />
+      <node concept="3cqZAl" id="5fS8LropL8H" role="3clF45" />
+      <node concept="37vLTG" id="5fS8LropL8I" role="3clF46">
+        <property role="TrG5h" value="pattern" />
+        <node concept="17QB3L" id="5fS8LroqiL4" role="1tU5fm" />
+        <node concept="2AHcQZ" id="5fS8LropL8K" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="5fS8LropL8L" role="3clF47">
+        <node concept="3clFbF" id="5fS8LropL8M" role="3cqZAp">
+          <node concept="1rXfSq" id="5fS8LropL8N" role="3clFbG">
+            <ref role="37wK5l" node="5fS8LropL8T" resolve="doSubstitute" />
+            <node concept="2OqwBi" id="5fS8LropL8O" role="37wK5m">
+              <node concept="liA8E" id="5fS8LropL8Q" role="2OqNvi">
+                <ref role="37wK5l" to="uddc:~TransformationMenuContext.getEditorContext()" resolve="getEditorContext" />
+              </node>
+              <node concept="1rXfSq" id="5fS8Lrorvbl" role="2Oq$k0">
+                <ref role="37wK5l" node="5fS8LrorqMN" resolve="getContext" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="5fS8LropL8R" role="37wK5m">
+              <ref role="3cqZAo" node="5fS8LropL8I" resolve="pattern" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="5fS8LropL8S" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="5fS8LropL8T" role="jymVt">
+      <property role="1EzhhJ" value="false" />
+      <property role="TrG5h" value="doSubstitute" />
+      <property role="DiZV1" value="false" />
+      <property role="od$2w" value="false" />
+      <node concept="3Tmbuc" id="5fS8LropL8U" role="1B3o_S" />
+      <node concept="3uibUv" id="5fS8LropL8V" role="3clF45">
+        <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
+      </node>
+      <node concept="37vLTG" id="5fS8LropL8W" role="3clF46">
+        <property role="TrG5h" value="editorContext" />
+        <node concept="3uibUv" id="5fS8LropL8X" role="1tU5fm">
+          <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+        </node>
+        <node concept="2AHcQZ" id="5fS8LropL8Y" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="5fS8LropL8Z" role="3clF46">
+        <property role="TrG5h" value="pattern" />
+        <node concept="17QB3L" id="5fS8LropL90" role="1tU5fm" />
+      </node>
+      <node concept="3clFbS" id="5fS8LropL91" role="3clF47">
+        <node concept="3cpWs8" id="5fS8LroquAZ" role="3cqZAp">
+          <node concept="3cpWsn" id="5fS8LroquB0" role="3cpWs9">
+            <property role="TrG5h" value="sourceNode" />
+            <node concept="3Tqbb2" id="5fS8Lroqw9T" role="1tU5fm" />
+            <node concept="2OqwBi" id="5fS8LroquB1" role="33vP2m">
+              <node concept="1rXfSq" id="5fS8Lrorvm_" role="2Oq$k0">
+                <ref role="37wK5l" node="5fS8LrorqMN" resolve="getContext" />
+              </node>
+              <node concept="liA8E" id="5fS8LroquB3" role="2OqNvi">
+                <ref role="37wK5l" to="uddc:~TransformationMenuContext.getNode()" resolve="getNode" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="5fS8LropL92" role="3cqZAp">
+          <node concept="3cpWsn" id="5fS8LropL93" role="3cpWs9">
+            <property role="TrG5h" value="annotation" />
+            <node concept="3Tqbb2" id="5fS8LropL94" role="1tU5fm">
+              <ref role="ehGHo" to="878o:4qdNcH$7CYT" resolve="ArbitraryTextAnnotation" />
+            </node>
+            <node concept="2OqwBi" id="5fS8LropL95" role="33vP2m">
+              <node concept="2OqwBi" id="5fS8LropL96" role="2Oq$k0">
+                <node concept="37vLTw" id="5fS8LroquB4" role="2Oq$k0">
+                  <ref role="3cqZAo" node="5fS8LroquB0" resolve="sourceNode" />
+                </node>
+                <node concept="3CFZ6_" id="5fS8LropL98" role="2OqNvi">
+                  <node concept="3CFYIy" id="5fS8LropL99" role="3CFYIz">
+                    <ref role="3CFYIx" to="878o:4qdNcH$7CYT" resolve="ArbitraryTextAnnotation" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2DeJg1" id="5fS8LropL9a" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="5fS8LropL9b" role="3cqZAp">
+          <node concept="37vLTI" id="5fS8LropL9c" role="3clFbG">
+            <node concept="1rXfSq" id="5fS8LropL9d" role="37vLTx">
+              <ref role="37wK5l" node="5fS8LropL8a" resolve="getMatchingText" />
+              <node concept="37vLTw" id="5fS8LropL9e" role="37wK5m">
+                <ref role="3cqZAo" node="5fS8LropL8Z" resolve="pattern" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="5fS8LropL9f" role="37vLTJ">
+              <node concept="37vLTw" id="5fS8LropL9g" role="2Oq$k0">
+                <ref role="3cqZAo" node="5fS8LropL93" resolve="annotation" />
+              </node>
+              <node concept="3TrcHB" id="5fS8LropL9h" role="2OqNvi">
+                <ref role="3TsBF5" to="878o:4qdNcH$7DAQ" resolve="text" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="5fS8LropL9i" role="3cqZAp">
+          <node concept="37vLTI" id="5fS8LropL9j" role="3clFbG">
+            <node concept="37vLTw" id="5fS8Lroqzqj" role="37vLTx">
+              <ref role="3cqZAo" node="5fS8Lroqy4E" resolve="leftSide" />
+            </node>
+            <node concept="2OqwBi" id="5fS8LropL9p" role="37vLTJ">
+              <node concept="37vLTw" id="5fS8LropL9q" role="2Oq$k0">
+                <ref role="3cqZAo" node="5fS8LropL93" resolve="annotation" />
+              </node>
+              <node concept="3TrcHB" id="5fS8LropL9r" role="2OqNvi">
+                <ref role="3TsBF5" to="878o:4qdNcH$7DA9" resolve="left" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="5fS8LropL9s" role="3cqZAp">
+          <node concept="2OqwBi" id="5fS8LropL9t" role="3clFbG">
+            <node concept="37vLTw" id="5fS8LropL9u" role="2Oq$k0">
+              <ref role="3cqZAo" node="5fS8LropL93" resolve="annotation" />
+            </node>
+            <node concept="1OKiuA" id="5fS8LropL9v" role="2OqNvi">
+              <node concept="37vLTw" id="5fS8LropL9w" role="lBI5i">
+                <ref role="3cqZAo" node="5fS8LropL8W" resolve="editorContext" />
+              </node>
+              <node concept="3cmrfG" id="5fS8LropL9x" role="3dN3m$">
+                <property role="3cmrfH" value="-1" />
+              </node>
+              <node concept="eBIwv" id="5fS8LropL9y" role="lGT1i">
+                <ref role="fyFUz" to="878o:4qdNcH$7DAQ" resolve="text" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="5fS8LropL9z" role="3cqZAp" />
+        <node concept="3cpWs8" id="5fS8LropL9$" role="3cqZAp">
+          <node concept="3cpWsn" id="5fS8LropL9_" role="3cpWs9">
+            <property role="TrG5h" value="caretPosition" />
+            <node concept="3uibUv" id="5fS8LropL9A" role="1tU5fm">
+              <ref role="3uigEE" to="czm:1xDazL6RYY7" resolve="SavedCaretPosition" />
+            </node>
+            <node concept="2ShNRf" id="5fS8LropL9B" role="33vP2m">
+              <node concept="1pGfFk" id="5fS8LropL9C" role="2ShVmc">
+                <ref role="37wK5l" to="czm:3NNwv8WqPSm" resolve="SavedCaretPosition" />
+                <node concept="37vLTw" id="5fS8LropL9D" role="37wK5m">
+                  <ref role="3cqZAo" node="5fS8LropL8W" resolve="editorContext" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="5fS8LropL9E" role="3cqZAp">
+          <node concept="2OqwBi" id="5fS8LropL9F" role="3clFbG">
+            <node concept="37vLTw" id="5fS8LropL9G" role="2Oq$k0">
+              <ref role="3cqZAo" node="5fS8LropL9_" resolve="caretPosition" />
+            </node>
+            <node concept="liA8E" id="5fS8LropL9H" role="2OqNvi">
+              <ref role="37wK5l" to="czm:76BPPvEi375" resolve="save" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="5fS8LropL9I" role="3cqZAp">
+          <node concept="3cpWsn" id="5fS8LropL9J" role="3cpWs9">
+            <property role="TrG5h" value="parser" />
+            <node concept="3uibUv" id="5fS8LropL9K" role="1tU5fm">
+              <ref role="3uigEE" to="czm:2TSIj8m0Ksb" resolve="Parser" />
+            </node>
+            <node concept="2ShNRf" id="5fS8LropL9L" role="33vP2m">
+              <node concept="1pGfFk" id="5fS8LropL9M" role="2ShVmc">
+                <ref role="37wK5l" to="czm:5OsvY4g$ZXe" resolve="Parser" />
+                <node concept="2OqwBi" id="5fS8LropL9N" role="37wK5m">
+                  <node concept="37vLTw" id="5fS8LropL9O" role="2Oq$k0">
+                    <ref role="3cqZAo" node="5fS8LroquB0" resolve="sourceNode" />
+                  </node>
+                  <node concept="I4A8Y" id="5fS8LropL9P" role="2OqNvi" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="5fS8LropL9Q" role="3cqZAp">
+          <node concept="3cpWsn" id="5fS8LropL9R" role="3cpWs9">
+            <property role="TrG5h" value="newTree" />
+            <node concept="3Tqbb2" id="5fS8LropL9S" role="1tU5fm" />
+            <node concept="2OqwBi" id="5fS8LropL9T" role="33vP2m">
+              <node concept="37vLTw" id="5fS8LropL9U" role="2Oq$k0">
+                <ref role="3cqZAo" node="5fS8LropL9J" resolve="parser" />
+              </node>
+              <node concept="liA8E" id="5fS8LropL9V" role="2OqNvi">
+                <ref role="37wK5l" to="czm:2TSIj8m0Kt6" resolve="processAfterTextInsert" />
+                <node concept="2OqwBi" id="5fS8LropL9W" role="37wK5m">
+                  <node concept="37vLTw" id="5fS8LropL9X" role="2Oq$k0">
+                    <ref role="3cqZAo" node="5fS8LropL9J" resolve="parser" />
+                  </node>
+                  <node concept="liA8E" id="5fS8LropL9Y" role="2OqNvi">
+                    <ref role="37wK5l" to="czm:1QxZEGNZN1b" resolve="findRootExpression" />
+                    <node concept="37vLTw" id="5fS8LropL9Z" role="37wK5m">
+                      <ref role="3cqZAo" node="5fS8LroquB0" resolve="sourceNode" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="5fS8LropLa0" role="3cqZAp">
+          <node concept="3clFbS" id="5fS8LropLa1" role="3clFbx">
+            <node concept="3clFbF" id="5fS8LropLa2" role="3cqZAp">
+              <node concept="2OqwBi" id="5fS8LropLa3" role="3clFbG">
+                <node concept="37vLTw" id="5fS8LropLa4" role="2Oq$k0">
+                  <ref role="3cqZAo" node="5fS8LropL8W" resolve="editorContext" />
+                </node>
+                <node concept="liA8E" id="5fS8LropLa5" role="2OqNvi">
+                  <ref role="37wK5l" to="cj4x:~EditorContext.flushEvents()" resolve="flushEvents" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="5fS8LropLa6" role="3cqZAp">
+              <node concept="2OqwBi" id="5fS8LropLa7" role="3clFbG">
+                <node concept="37vLTw" id="5fS8LropLa8" role="2Oq$k0">
+                  <ref role="3cqZAo" node="5fS8LropL9_" resolve="caretPosition" />
+                </node>
+                <node concept="liA8E" id="5fS8LropLa9" role="2OqNvi">
+                  <ref role="37wK5l" to="czm:76BPPvEi3ct" resolve="restore" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3y3z36" id="5fS8LropLaa" role="3clFbw">
+            <node concept="10Nm6u" id="5fS8LropLab" role="3uHU7w" />
+            <node concept="37vLTw" id="5fS8LropLac" role="3uHU7B">
+              <ref role="3cqZAo" node="5fS8LropL9R" resolve="newTree" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="5fS8LropLad" role="3cqZAp" />
+        <node concept="3cpWs6" id="5fS8LropLae" role="3cqZAp">
+          <node concept="10Nm6u" id="5fS8LropLaf" role="3cqZAk" />
+        </node>
+      </node>
+    </node>
+    <node concept="3clFb_" id="5fS8LropLag" role="jymVt">
+      <property role="1EzhhJ" value="false" />
+      <property role="TrG5h" value="getOutputConcept" />
+      <property role="DiZV1" value="false" />
+      <property role="od$2w" value="false" />
+      <node concept="3uibUv" id="5fS8LropLah" role="3clF45">
+        <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
+      </node>
+      <node concept="3Tm1VV" id="5fS8LropLai" role="1B3o_S" />
+      <node concept="3clFbS" id="5fS8LropLaj" role="3clF47">
+        <node concept="3clFbF" id="5fS8Lroq$62" role="3cqZAp">
+          <node concept="37vLTw" id="5fS8Lroq$5O" role="3clFbG">
+            <ref role="3cqZAo" node="5fS8LroqmXP" resolve="outputConcept" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="5fS8Lroql5Z" role="jymVt" />
+    <node concept="3uibUv" id="5fS8LroB4FK" role="EKbjA">
+      <ref role="3uigEE" node="5fS8LroB3DY" resolve="IShadowingTransformationAction" />
+    </node>
+    <node concept="3clFb_" id="5fS8LroB55w" role="jymVt">
+      <property role="TrG5h" value="shadows" />
+      <node concept="37vLTG" id="5fS8LroB55x" role="3clF46">
+        <property role="TrG5h" value="shadowed" />
+        <node concept="3uibUv" id="5fS8LroBWoq" role="1tU5fm">
+          <ref role="3uigEE" to="uddc:~TransformationMenuItem" resolve="TransformationMenuItem" />
+        </node>
+      </node>
+      <node concept="10P_77" id="5fS8LroB55z" role="3clF45" />
+      <node concept="3Tm1VV" id="5fS8LroB55$" role="1B3o_S" />
+      <node concept="3clFbS" id="5fS8LroB55D" role="3clF47">
+        <node concept="3clFbJ" id="5fS8LroB7H4" role="3cqZAp">
+          <node concept="3fqX7Q" id="5fS8LroB7IV" role="3clFbw">
+            <node concept="2ZW3vV" id="5fS8LroB6Mz" role="3fr31v">
+              <node concept="3uibUv" id="5fS8LroB6Xx" role="2ZW6by">
+                <ref role="3uigEE" node="5fS8LroqjMR" resolve="BracketsSideTranformationAction" />
+              </node>
+              <node concept="37vLTw" id="5fS8LroB68Z" role="2ZW6bz">
+                <ref role="3cqZAo" node="5fS8LroB55x" resolve="shadowed" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbS" id="5fS8LroB7H6" role="3clFbx">
+            <node concept="3cpWs6" id="5fS8LroB811" role="3cqZAp">
+              <node concept="3clFbT" id="5fS8LroB827" role="3cqZAk" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="5fS8LroB9TG" role="3cqZAp">
+          <node concept="3cpWsn" id="5fS8LroB9TH" role="3cpWs9">
+            <property role="TrG5h" value="shadowedBracketsAction" />
+            <node concept="3uibUv" id="5fS8LroB9LP" role="1tU5fm">
+              <ref role="3uigEE" node="5fS8LroqjMR" resolve="BracketsSideTranformationAction" />
+            </node>
+            <node concept="10QFUN" id="5fS8LroB9TI" role="33vP2m">
+              <node concept="3uibUv" id="5fS8LroB9TJ" role="10QFUM">
+                <ref role="3uigEE" node="5fS8LroqjMR" resolve="BracketsSideTranformationAction" />
+              </node>
+              <node concept="37vLTw" id="5fS8LroB9TK" role="10QFUP">
+                <ref role="3cqZAo" node="5fS8LroB55x" resolve="shadowed" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="5fS8LroBbWJ" role="3cqZAp">
+          <node concept="3clFbS" id="5fS8LroBbWL" role="3clFbx">
+            <node concept="3cpWs8" id="5fS8LroBsIu" role="3cqZAp">
+              <node concept="3cpWsn" id="5fS8LroBsIv" role="3cpWs9">
+                <property role="TrG5h" value="shadowedNode" />
+                <node concept="3Tqbb2" id="5fS8LroBt2q" role="1tU5fm" />
+                <node concept="2OqwBi" id="5fS8LroBsIw" role="33vP2m">
+                  <node concept="2OqwBi" id="5fS8LroBsIx" role="2Oq$k0">
+                    <node concept="37vLTw" id="5fS8LroBsIy" role="2Oq$k0">
+                      <ref role="3cqZAo" node="5fS8LroB9TH" resolve="shadowedBracketsAction" />
+                    </node>
+                    <node concept="liA8E" id="5fS8LroBsIz" role="2OqNvi">
+                      <ref role="37wK5l" node="5fS8LrorqMN" resolve="getContext" />
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="5fS8LroBsI$" role="2OqNvi">
+                    <ref role="37wK5l" to="uddc:~TransformationMenuContext.getNode()" resolve="getNode" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs8" id="5fS8LroBtOT" role="3cqZAp">
+              <node concept="3cpWsn" id="5fS8LroBtOU" role="3cpWs9">
+                <property role="TrG5h" value="ownNode" />
+                <node concept="3Tqbb2" id="5fS8LroBu96" role="1tU5fm" />
+                <node concept="2OqwBi" id="5fS8LroBtOV" role="33vP2m">
+                  <node concept="1rXfSq" id="5fS8LroBtOW" role="2Oq$k0">
+                    <ref role="37wK5l" node="5fS8LrorqMN" resolve="getContext" />
+                  </node>
+                  <node concept="liA8E" id="5fS8LroBtOX" role="2OqNvi">
+                    <ref role="37wK5l" to="uddc:~TransformationMenuContext.getNode()" resolve="getNode" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3SKdUt" id="5fS8LroB$Lh" role="3cqZAp">
+              <node concept="1PaTwC" id="5fS8LroB$Li" role="1aUNEU">
+                <node concept="3oM_SD" id="5fS8LroB$Lj" role="1PaTwD">
+                  <property role="3oM_SC" value="use" />
+                </node>
+                <node concept="3oM_SD" id="5fS8LroB_cD" role="1PaTwD">
+                  <property role="3oM_SC" value="the" />
+                </node>
+                <node concept="3oM_SD" id="5fS8LroB_cG" role="1PaTwD">
+                  <property role="3oM_SC" value="action" />
+                </node>
+                <node concept="3oM_SD" id="5fS8LroB_cK" role="1PaTwD">
+                  <property role="3oM_SC" value="that" />
+                </node>
+                <node concept="3oM_SD" id="5fS8LroB_cX" role="1PaTwD">
+                  <property role="3oM_SC" value="is" />
+                </node>
+                <node concept="3oM_SD" id="5fS8LroB_db" role="1PaTwD">
+                  <property role="3oM_SC" value="closer" />
+                </node>
+                <node concept="3oM_SD" id="5fS8LroB_dE" role="1PaTwD">
+                  <property role="3oM_SC" value="to" />
+                </node>
+                <node concept="3oM_SD" id="5fS8LroB_dM" role="1PaTwD">
+                  <property role="3oM_SC" value="the" />
+                </node>
+                <node concept="3oM_SD" id="5fS8LroB_e3" role="1PaTwD">
+                  <property role="3oM_SC" value="selected" />
+                </node>
+                <node concept="3oM_SD" id="5fS8LroB_et" role="1PaTwD">
+                  <property role="3oM_SC" value="cell" />
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs6" id="5fS8LroByl_" role="3cqZAp">
+              <node concept="2OqwBi" id="5fS8LroBylB" role="3cqZAk">
+                <node concept="2OqwBi" id="5fS8LroBylC" role="2Oq$k0">
+                  <node concept="37vLTw" id="5fS8LroBylD" role="2Oq$k0">
+                    <ref role="3cqZAo" node="5fS8LroBtOU" resolve="ownNode" />
+                  </node>
+                  <node concept="z$bX8" id="5fS8LroBylE" role="2OqNvi" />
+                </node>
+                <node concept="3JPx81" id="5fS8LroBylF" role="2OqNvi">
+                  <node concept="37vLTw" id="5fS8LroByxU" role="25WWJ7">
+                    <ref role="3cqZAo" node="5fS8LroBsIv" resolve="shadowedNode" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1Wc70l" id="5fS8LroBkk7" role="3clFbw">
+            <node concept="17R0WA" id="5fS8LroBmz0" role="3uHU7w">
+              <node concept="2OqwBi" id="5fS8LroBnGI" role="3uHU7w">
+                <node concept="Xjq3P" id="5fS8LroBmZV" role="2Oq$k0" />
+                <node concept="2OwXpG" id="5fS8LroBouk" role="2OqNvi">
+                  <ref role="2Oxat6" node="5fS8Lroqy4E" resolve="leftSide" />
+                </node>
+              </node>
+              <node concept="2OqwBi" id="5fS8LroBl9Y" role="3uHU7B">
+                <node concept="37vLTw" id="5fS8LroBkFe" role="2Oq$k0">
+                  <ref role="3cqZAo" node="5fS8LroB9TH" resolve="shadowedBracketsAction" />
+                </node>
+                <node concept="2OwXpG" id="5fS8LroBlUl" role="2OqNvi">
+                  <ref role="2Oxat6" node="5fS8Lroqy4E" resolve="leftSide" />
+                </node>
+              </node>
+            </node>
+            <node concept="1Wc70l" id="5fS8LroBgFB" role="3uHU7B">
+              <node concept="17R0WA" id="5fS8LroBexu" role="3uHU7B">
+                <node concept="2OqwBi" id="5fS8LroBcUr" role="3uHU7B">
+                  <node concept="37vLTw" id="5fS8LroBclV" role="2Oq$k0">
+                    <ref role="3cqZAo" node="5fS8LroB9TH" resolve="shadowedBracketsAction" />
+                  </node>
+                  <node concept="2OwXpG" id="5fS8LroBd$0" role="2OqNvi">
+                    <ref role="2Oxat6" node="5fS8LroqmXP" resolve="outputConcept" />
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="5fS8LroBfrr" role="3uHU7w">
+                  <node concept="Xjq3P" id="5fS8LroBeF_" role="2Oq$k0" />
+                  <node concept="2OwXpG" id="5fS8LroBgbQ" role="2OqNvi">
+                    <ref role="2Oxat6" node="5fS8LroqmXP" resolve="outputConcept" />
+                  </node>
+                </node>
+              </node>
+              <node concept="17R0WA" id="5fS8LroBiwU" role="3uHU7w">
+                <node concept="2OqwBi" id="5fS8LroBhuD" role="3uHU7B">
+                  <node concept="37vLTw" id="5fS8LroBh0s" role="2Oq$k0">
+                    <ref role="3cqZAo" node="5fS8LroB9TH" resolve="shadowedBracketsAction" />
+                  </node>
+                  <node concept="2OwXpG" id="5fS8LroBi6A" role="2OqNvi">
+                    <ref role="2Oxat6" node="5fS8LroqrI7" resolve="matchingText" />
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="5fS8LroBjn$" role="3uHU7w">
+                  <node concept="Xjq3P" id="5fS8LroBiFs" role="2Oq$k0" />
+                  <node concept="2OwXpG" id="5fS8LroBk8f" role="2OqNvi">
+                    <ref role="2Oxat6" node="5fS8LroqrI7" resolve="matchingText" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="5fS8LroBoOA" role="3cqZAp">
+          <node concept="3clFbT" id="5fS8LroBqd4" role="3cqZAk" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="5fS8LroB55E" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+  </node>
+  <node concept="312cEu" id="5fS8LroBJd7">
+    <property role="TrG5h" value="ShadowingUtil" />
+    <node concept="2YIFZL" id="5fS8LroC3LX" role="jymVt">
+      <property role="TrG5h" value="applyShadowing" />
+      <node concept="3clFbS" id="5fS8LroBJe0" role="3clF47">
+        <node concept="3cpWs8" id="5fS8LroBKBi" role="3cqZAp">
+          <node concept="3cpWsn" id="5fS8LroBKBl" role="3cpWs9">
+            <property role="TrG5h" value="filtered" />
+            <node concept="_YKpA" id="5fS8LroBKBg" role="1tU5fm">
+              <node concept="3uibUv" id="5fS8LroBKBR" role="_ZDj9">
+                <ref role="3uigEE" to="uddc:~TransformationMenuItem" resolve="TransformationMenuItem" />
+              </node>
+            </node>
+            <node concept="2ShNRf" id="5fS8LroBKEX" role="33vP2m">
+              <node concept="Tc6Ow" id="5fS8LroBKDd" role="2ShVmc">
+                <node concept="3uibUv" id="5fS8LroBKDe" role="HW$YZ">
+                  <ref role="3uigEE" to="uddc:~TransformationMenuItem" resolve="TransformationMenuItem" />
+                </node>
+                <node concept="37vLTw" id="5fS8LroBM88" role="I$8f6">
+                  <ref role="3cqZAo" node="5fS8LroBKyz" resolve="unfiltered" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="5fS8LroBKGh" role="3cqZAp" />
+        <node concept="1Dw8fO" id="5fS8LroBMxi" role="3cqZAp">
+          <node concept="3clFbS" id="5fS8LroBMxk" role="2LFqv$">
+            <node concept="3cpWs8" id="5fS8LroBTb7" role="3cqZAp">
+              <node concept="3cpWsn" id="5fS8LroBTb8" role="3cpWs9">
+                <property role="TrG5h" value="action1_" />
+                <node concept="3uibUv" id="5fS8LroBTaj" role="1tU5fm">
+                  <ref role="3uigEE" to="uddc:~TransformationMenuItem" resolve="TransformationMenuItem" />
+                </node>
+                <node concept="1y4W85" id="5fS8LroBTb9" role="33vP2m">
+                  <node concept="37vLTw" id="5fS8LroBTba" role="1y58nS">
+                    <ref role="3cqZAo" node="5fS8LroBMxl" resolve="i" />
+                  </node>
+                  <node concept="37vLTw" id="5fS8LroBTbb" role="1y566C">
+                    <ref role="3cqZAo" node="5fS8LroBKBl" resolve="filtered" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbJ" id="5fS8LroBS_v" role="3cqZAp">
+              <node concept="3clFbS" id="5fS8LroBS_x" role="3clFbx">
+                <node concept="3N13vt" id="5fS8LroBTg0" role="3cqZAp" />
+              </node>
+              <node concept="3fqX7Q" id="5fS8LroBT9t" role="3clFbw">
+                <node concept="2ZW3vV" id="5fS8LroBT9v" role="3fr31v">
+                  <node concept="3uibUv" id="5fS8LroBT9w" role="2ZW6by">
+                    <ref role="3uigEE" node="5fS8LroB3DY" resolve="IShadowingTransformationAction" />
+                  </node>
+                  <node concept="37vLTw" id="5fS8LroBTbc" role="2ZW6bz">
+                    <ref role="3cqZAo" node="5fS8LroBTb8" resolve="action1_" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs8" id="5fS8LroBUeg" role="3cqZAp">
+              <node concept="3cpWsn" id="5fS8LroBUeh" role="3cpWs9">
+                <property role="TrG5h" value="action1" />
+                <node concept="3uibUv" id="5fS8LroBU9T" role="1tU5fm">
+                  <ref role="3uigEE" node="5fS8LroB3DY" resolve="IShadowingTransformationAction" />
+                </node>
+                <node concept="10QFUN" id="5fS8LroBUei" role="33vP2m">
+                  <node concept="37vLTw" id="5fS8LroBUej" role="10QFUP">
+                    <ref role="3cqZAo" node="5fS8LroBTb8" resolve="action1_" />
+                  </node>
+                  <node concept="3uibUv" id="5fS8LroBUek" role="10QFUM">
+                    <ref role="3uigEE" node="5fS8LroB3DY" resolve="IShadowingTransformationAction" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="1Dw8fO" id="5fS8LroBPWj" role="3cqZAp">
+              <node concept="3clFbS" id="5fS8LroBPWk" role="2LFqv$">
+                <node concept="3clFbJ" id="5fS8LroBQ6m" role="3cqZAp">
+                  <node concept="3clFbS" id="5fS8LroBQ6o" role="3clFbx">
+                    <node concept="3N13vt" id="5fS8LroBRqo" role="3cqZAp" />
+                  </node>
+                  <node concept="3clFbC" id="5fS8LroBQWr" role="3clFbw">
+                    <node concept="37vLTw" id="5fS8LroBQXh" role="3uHU7w">
+                      <ref role="3cqZAo" node="5fS8LroBPWm" resolve="k" />
+                    </node>
+                    <node concept="37vLTw" id="5fS8LroBQ7$" role="3uHU7B">
+                      <ref role="3cqZAo" node="5fS8LroBMxl" resolve="i" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3cpWs8" id="5fS8LroBTA2" role="3cqZAp">
+                  <node concept="3cpWsn" id="5fS8LroBTA3" role="3cpWs9">
+                    <property role="TrG5h" value="action2" />
+                    <node concept="3uibUv" id="5fS8LroBT$3" role="1tU5fm">
+                      <ref role="3uigEE" to="uddc:~TransformationMenuItem" resolve="TransformationMenuItem" />
+                    </node>
+                    <node concept="1y4W85" id="5fS8LroBTA4" role="33vP2m">
+                      <node concept="37vLTw" id="5fS8LroBTA5" role="1y58nS">
+                        <ref role="3cqZAo" node="5fS8LroBPWm" resolve="k" />
+                      </node>
+                      <node concept="37vLTw" id="5fS8LroBTA6" role="1y566C">
+                        <ref role="3cqZAo" node="5fS8LroBKBl" resolve="filtered" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbJ" id="5fS8LroBTFB" role="3cqZAp">
+                  <node concept="3clFbS" id="5fS8LroBTFD" role="3clFbx">
+                    <node concept="3clFbF" id="5fS8LroBYai" role="3cqZAp">
+                      <node concept="2OqwBi" id="5fS8LroBYkZ" role="3clFbG">
+                        <node concept="37vLTw" id="5fS8LroBYag" role="2Oq$k0">
+                          <ref role="3cqZAo" node="5fS8LroBKBl" resolve="filtered" />
+                        </node>
+                        <node concept="2KedMh" id="5fS8LroBYLA" role="2OqNvi">
+                          <node concept="37vLTw" id="5fS8LroBYPy" role="2KewY8">
+                            <ref role="3cqZAo" node="5fS8LroBPWm" resolve="k" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbJ" id="5fS8LroC0yI" role="3cqZAp">
+                      <node concept="3clFbS" id="5fS8LroC0yK" role="3clFbx">
+                        <node concept="3clFbF" id="5fS8LroC1$8" role="3cqZAp">
+                          <node concept="3uO5VW" id="5fS8LroC1Hd" role="3clFbG">
+                            <node concept="37vLTw" id="5fS8LroC1Hf" role="2$L3a6">
+                              <ref role="3cqZAo" node="5fS8LroBMxl" resolve="i" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3eOSWO" id="5fS8LroC1qx" role="3clFbw">
+                        <node concept="37vLTw" id="5fS8LroC1rj" role="3uHU7w">
+                          <ref role="3cqZAo" node="5fS8LroBPWm" resolve="k" />
+                        </node>
+                        <node concept="37vLTw" id="5fS8LroC0$A" role="3uHU7B">
+                          <ref role="3cqZAo" node="5fS8LroBMxl" resolve="i" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbF" id="5fS8LroBZzh" role="3cqZAp">
+                      <node concept="3uO5VW" id="5fS8LroC0h3" role="3clFbG">
+                        <node concept="37vLTw" id="5fS8LroC0h5" role="2$L3a6">
+                          <ref role="3cqZAo" node="5fS8LroBPWm" resolve="k" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="5fS8LroBUGq" role="3clFbw">
+                    <node concept="37vLTw" id="5fS8LroBU_J" role="2Oq$k0">
+                      <ref role="3cqZAo" node="5fS8LroBUeh" resolve="action1" />
+                    </node>
+                    <node concept="liA8E" id="5fS8LroBUMW" role="2OqNvi">
+                      <ref role="37wK5l" node="5fS8LroB3Fv" resolve="shadows" />
+                      <node concept="37vLTw" id="5fS8LroBY7c" role="37wK5m">
+                        <ref role="3cqZAo" node="5fS8LroBTA3" resolve="action2" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3cpWsn" id="5fS8LroBPWm" role="1Duv9x">
+                <property role="TrG5h" value="k" />
+                <node concept="10Oyi0" id="5fS8LroBPWn" role="1tU5fm" />
+                <node concept="3cmrfG" id="5fS8LroBPWo" role="33vP2m">
+                  <property role="3cmrfH" value="0" />
+                </node>
+              </node>
+              <node concept="3eOVzh" id="5fS8LroBPWp" role="1Dwp0S">
+                <node concept="2OqwBi" id="5fS8LroBPWq" role="3uHU7w">
+                  <node concept="37vLTw" id="5fS8LroBPWr" role="2Oq$k0">
+                    <ref role="3cqZAo" node="5fS8LroBKBl" resolve="filtered" />
+                  </node>
+                  <node concept="34oBXx" id="5fS8LroBPWs" role="2OqNvi" />
+                </node>
+                <node concept="37vLTw" id="5fS8LroBPWt" role="3uHU7B">
+                  <ref role="3cqZAo" node="5fS8LroBPWm" resolve="k" />
+                </node>
+              </node>
+              <node concept="3uNrnE" id="5fS8LroBPWu" role="1Dwrff">
+                <node concept="37vLTw" id="5fS8LroBPWv" role="2$L3a6">
+                  <ref role="3cqZAo" node="5fS8LroBPWm" resolve="k" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWsn" id="5fS8LroBMxl" role="1Duv9x">
+            <property role="TrG5h" value="i" />
+            <node concept="10Oyi0" id="5fS8LroBMzO" role="1tU5fm" />
+            <node concept="3cmrfG" id="5fS8LroBM_B" role="33vP2m">
+              <property role="3cmrfH" value="0" />
+            </node>
+          </node>
+          <node concept="3eOVzh" id="5fS8LroBNs5" role="1Dwp0S">
+            <node concept="2OqwBi" id="5fS8LroBOgv" role="3uHU7w">
+              <node concept="37vLTw" id="5fS8LroBNuM" role="2Oq$k0">
+                <ref role="3cqZAo" node="5fS8LroBKBl" resolve="filtered" />
+              </node>
+              <node concept="34oBXx" id="5fS8LroBP5j" role="2OqNvi" />
+            </node>
+            <node concept="37vLTw" id="5fS8LroBMAV" role="3uHU7B">
+              <ref role="3cqZAo" node="5fS8LroBMxl" resolve="i" />
+            </node>
+          </node>
+          <node concept="3uNrnE" id="5fS8LroBPUR" role="1Dwrff">
+            <node concept="37vLTw" id="5fS8LroBPUT" role="2$L3a6">
+              <ref role="3cqZAo" node="5fS8LroBMxl" resolve="i" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="5fS8LroBKM_" role="3cqZAp" />
+        <node concept="3cpWs6" id="5fS8LroBKHB" role="3cqZAp">
+          <node concept="37vLTw" id="5fS8LroBKJ3" role="3cqZAk">
+            <ref role="3cqZAo" node="5fS8LroBKBl" resolve="filtered" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="5fS8LroBKyz" role="3clF46">
+        <property role="TrG5h" value="unfiltered" />
+        <node concept="_YKpA" id="5fS8LroBKyY" role="1tU5fm">
+          <node concept="3uibUv" id="5fS8LroBK$A" role="_ZDj9">
+            <ref role="3uigEE" to="uddc:~TransformationMenuItem" resolve="TransformationMenuItem" />
+          </node>
+        </node>
+      </node>
+      <node concept="_YKpA" id="5fS8LroBJeZ" role="3clF45">
+        <node concept="3uibUv" id="5fS8LroBKyo" role="_ZDj9">
+          <ref role="3uigEE" to="uddc:~TransformationMenuItem" resolve="TransformationMenuItem" />
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="5fS8LroBJdZ" role="1B3o_S" />
+    </node>
+    <node concept="3Tm1VV" id="5fS8LroBJd8" role="1B3o_S" />
+  </node>
+  <node concept="3HP615" id="5fS8LroB3DY">
+    <property role="TrG5h" value="IShadowingTransformationAction" />
+    <node concept="3clFb_" id="5fS8LroB3Fv" role="jymVt">
+      <property role="TrG5h" value="shadows" />
+      <node concept="37vLTG" id="5fS8LroB3FU" role="3clF46">
+        <property role="TrG5h" value="shadowed" />
+        <node concept="3uibUv" id="5fS8LroBUOO" role="1tU5fm">
+          <ref role="3uigEE" to="uddc:~TransformationMenuItem" resolve="TransformationMenuItem" />
+        </node>
+      </node>
+      <node concept="10P_77" id="5fS8LroB3Hg" role="3clF45" />
+      <node concept="3Tm1VV" id="5fS8LroB3Fy" role="1B3o_S" />
+      <node concept="3clFbS" id="5fS8LroB3Fz" role="3clF47" />
+    </node>
+    <node concept="3Tm1VV" id="5fS8LroB3DZ" role="1B3o_S" />
+    <node concept="3uibUv" id="5fS8LroBKwN" role="3HQHJm">
+      <ref role="3uigEE" to="uddc:~TransformationMenuItem" resolve="TransformationMenuItem" />
+    </node>
   </node>
 </model>
 

--- a/code/grammarcells/solutions/com.mbeddr.mpsutil.grammarcells.tests/models/com/mbeddr/mpsutil/grammarcells/tests@tests.mps
+++ b/code/grammarcells/solutions/com.mbeddr.mpsutil.grammarcells.tests/models/com/mbeddr/mpsutil/grammarcells/tests@tests.mps
@@ -2192,7 +2192,7 @@
                 <property role="OXtK3" value="true" />
                 <property role="p6zMq" value="0" />
                 <property role="p6zMs" value="0" />
-                <property role="LIFWd" value="Constant_g1jvih_b0" />
+                <property role="LIFWd" value="c56" />
               </node>
             </node>
           </node>

--- a/code/grammarcells/solutions/com.mbeddr.mpsutil.grammarcells.tests/models/com/mbeddr/mpsutil/grammarcells/tests@tests.mps
+++ b/code/grammarcells/solutions/com.mbeddr.mpsutil.grammarcells.tests/models/com/mbeddr/mpsutil/grammarcells/tests@tests.mps
@@ -207,6 +207,7 @@
       <concept id="5083944728299528547" name="com.mbeddr.mpsutil.grammarcells.sandboxlang.structure.Visibility" flags="ng" index="yzEQC" />
       <concept id="5083944728299528551" name="com.mbeddr.mpsutil.grammarcells.sandboxlang.structure.PrivateVisibility" flags="ng" index="yzEQG" />
       <concept id="5083944728299528550" name="com.mbeddr.mpsutil.grammarcells.sandboxlang.structure.PublicVisibility" flags="ng" index="yzEQH" />
+      <concept id="5083944728301149298" name="com.mbeddr.mpsutil.grammarcells.sandboxlang.structure.BlockExpression" flags="ng" index="y$t2T" />
       <concept id="5083944728300729103" name="com.mbeddr.mpsutil.grammarcells.sandboxlang.structure.IntLiteral" flags="ng" index="yA7Z4">
         <property id="5083944728300729107" name="value" index="yA7Zo" />
       </concept>
@@ -244,6 +245,15 @@
       <concept id="7956405648081552647" name="com.mbeddr.mpsutil.grammarcells.sandboxlang.structure.TEST_FlagAndTooltip" flags="ng" index="1oIH7f">
         <property id="7956405648081552650" name="flagAndTooltip" index="1oIH72" />
         <child id="7956405648081552652" name="expr" index="1oIH74" />
+      </concept>
+      <concept id="6380604244808845044" name="com.mbeddr.mpsutil.grammarcells.sandboxlang.structure.TEST_OptionalWithoutText_Reference" flags="ng" index="1wCzcP">
+        <reference id="6380604244808845047" name="refTarget" index="1wCzcQ" />
+      </concept>
+      <concept id="6380604244804284912" name="com.mbeddr.mpsutil.grammarcells.sandboxlang.structure.TEST_OptionalWithoutText_Single" flags="ng" index="1JpcgL">
+        <child id="6380604244804360648" name="child" index="1JpqK9" />
+      </concept>
+      <concept id="6380604244804946401" name="com.mbeddr.mpsutil.grammarcells.sandboxlang.structure.TEST_OptionalWithoutText_Multiple" flags="ng" index="1JvFKw">
+        <child id="6380604244804360648" name="child" index="1JpqKa" />
       </concept>
       <concept id="2862331529395169336" name="com.mbeddr.mpsutil.grammarcells.sandboxlang.structure.BinaryExpression" flags="ng" index="1LhId$">
         <child id="5083944728300233289" name="right" index="ywYU2" />
@@ -1953,12 +1963,12 @@
               <node concept="yA7Z4" id="3efHud99IhK" role="1Uxo1g">
                 <property role="yA7Zo" value="1" />
               </node>
-              <node concept="LIFWc" id="65G7Yo_4AsT" role="lGtFl">
+              <node concept="LIFWc" id="czMm1H3I0o" role="lGtFl">
                 <property role="ZRATv" value="true" />
                 <property role="OXtK3" value="true" />
                 <property role="p6zMq" value="1" />
                 <property role="p6zMs" value="1" />
-                <property role="LIFWd" value="Constant_84ih13_c2a" />
+                <property role="LIFWd" value="Constant_84ih13_c2a0" />
               </node>
             </node>
           </node>
@@ -2526,6 +2536,394 @@
           <node concept="yzEQH" id="4RoNWgwUiZX" role="yzEPe" />
         </node>
         <node concept="2cssZD" id="4RoNWgwUbYC" role="2cssWm" />
+      </node>
+    </node>
+  </node>
+  <node concept="LiM7Y" id="5fS8Lro2Bji">
+    <property role="TrG5h" value="LVD_WrapWith_BlockExpression_before_2" />
+    <node concept="3clFbS" id="5fS8Lro2Bjj" role="LjaKd">
+      <node concept="2TK7Tu" id="5fS8Lro2Bjk" role="3cqZAp">
+        <property role="2TTd_B" value="}" />
+      </node>
+      <node concept="3clFbH" id="5fS8Lro2Bjl" role="3cqZAp" />
+    </node>
+    <node concept="1qefOq" id="5fS8Lro2Bjm" role="25YQCW">
+      <node concept="2cssWn" id="5fS8Lro2Bjn" role="1qenE9">
+        <property role="TrG5h" value="m" />
+        <node concept="2cssWt" id="5fS8Lro2Bjo" role="2cssWm">
+          <property role="TrG5h" value="f" />
+          <node concept="2cssWo" id="5fS8Lro2Bjp" role="2cssWr">
+            <node concept="2cssZR" id="5fS8Lro2BsL" role="2cssZA" />
+            <node concept="1kHs8n" id="5fS8Lro4bn8" role="2cssZA">
+              <property role="TrG5h" value="a" />
+              <node concept="2cvBGp" id="5fS8Lro4bn6" role="1kHs7J" />
+            </node>
+            <node concept="1kHs8n" id="5fS8Lro2Bnj" role="2cssZA">
+              <property role="TrG5h" value="b" />
+              <node concept="2cvBGp" id="5fS8Lro2Bnh" role="1kHs7J">
+                <node concept="LIFWc" id="5fS8Lro2BAL" role="lGtFl">
+                  <property role="LIFWa" value="0" />
+                  <property role="OXtK3" value="true" />
+                  <property role="p6zMq" value="0" />
+                  <property role="p6zMs" value="0" />
+                  <property role="LIFWd" value="ALIAS_EDITOR_COMPONENT" />
+                </node>
+              </node>
+            </node>
+            <node concept="2cssZR" id="5fS8Lro2Bor" role="2cssZA" />
+          </node>
+          <node concept="yzEQC" id="5fS8Lro2Bjv" role="yzEPe" />
+        </node>
+        <node concept="2cssZD" id="5fS8Lro2Bjw" role="2cssWm" />
+      </node>
+    </node>
+    <node concept="1qefOq" id="5fS8Lro2Bjx" role="25YQFr">
+      <node concept="2cssWn" id="5fS8Lro2Bjy" role="1qenE9">
+        <property role="TrG5h" value="m" />
+        <node concept="2cssWt" id="5fS8Lro2Bjz" role="2cssWm">
+          <property role="TrG5h" value="f" />
+          <node concept="2cssWo" id="5fS8Lro2Bj$" role="2cssWr">
+            <node concept="2cssZR" id="5fS8Lro2B$w" role="2cssZA" />
+            <node concept="y$t2T" id="5fS8Lro2BCT" role="2cssZA">
+              <node concept="1kHs8n" id="5fS8Lro2BnW" role="2cssZA">
+                <property role="TrG5h" value="a" />
+                <node concept="2cvBGp" id="5fS8Lro2BnU" role="1kHs7J" />
+              </node>
+            </node>
+            <node concept="1kHs8n" id="5fS8Lro4bnL" role="2cssZA">
+              <property role="TrG5h" value="b" />
+              <node concept="2cvBGp" id="5fS8Lro4bnJ" role="1kHs7J" />
+            </node>
+            <node concept="2cssZR" id="5fS8Lro2B$G" role="2cssZA" />
+          </node>
+          <node concept="yzEQC" id="5fS8Lro2BjH" role="yzEPe" />
+        </node>
+        <node concept="2cssZD" id="5fS8Lro2BjI" role="2cssWm" />
+      </node>
+    </node>
+  </node>
+  <node concept="LiM7Y" id="5fS8Lro2BFK">
+    <property role="TrG5h" value="LVD_WrapWith_BlockExpression_before_ArrayType" />
+    <node concept="3clFbS" id="5fS8Lro2BFL" role="LjaKd">
+      <node concept="2TK7Tu" id="5fS8Lro2BFM" role="3cqZAp">
+        <property role="2TTd_B" value="{" />
+      </node>
+      <node concept="3clFbH" id="5fS8Lro2BFN" role="3cqZAp" />
+    </node>
+    <node concept="1qefOq" id="5fS8Lro2BFO" role="25YQCW">
+      <node concept="2cssWn" id="5fS8Lro2BFP" role="1qenE9">
+        <property role="TrG5h" value="m" />
+        <node concept="2cssWt" id="5fS8Lro2BFQ" role="2cssWm">
+          <property role="TrG5h" value="f" />
+          <node concept="2cssWo" id="5fS8Lro2BFR" role="2cssWr">
+            <node concept="2cssZR" id="5fS8Lro2BFS" role="2cssZA" />
+            <node concept="1kHs8n" id="5fS8Lro2BFT" role="2cssZA">
+              <property role="TrG5h" value="a" />
+              <node concept="2bZTBh" id="5fS8Lro2BGP" role="1kHs7J">
+                <node concept="2cvBGp" id="5fS8Lro2BFU" role="2bZTBi">
+                  <node concept="LIFWc" id="5fS8Lro2BJf" role="lGtFl">
+                    <property role="LIFWa" value="0" />
+                    <property role="OXtK3" value="true" />
+                    <property role="p6zMq" value="0" />
+                    <property role="p6zMs" value="0" />
+                    <property role="LIFWd" value="ALIAS_EDITOR_COMPONENT" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="2cssZR" id="5fS8Lro2BFW" role="2cssZA" />
+          </node>
+          <node concept="yzEQC" id="5fS8Lro2BFX" role="yzEPe" />
+        </node>
+        <node concept="2cssZD" id="5fS8Lro2BFY" role="2cssWm" />
+      </node>
+    </node>
+    <node concept="1qefOq" id="5fS8Lro2BFZ" role="25YQFr">
+      <node concept="2cssWn" id="5fS8Lro2BG0" role="1qenE9">
+        <property role="TrG5h" value="m" />
+        <node concept="2cssWt" id="5fS8Lro2BG1" role="2cssWm">
+          <property role="TrG5h" value="f" />
+          <node concept="2cssWo" id="5fS8Lro2BG2" role="2cssWr">
+            <node concept="2cssZR" id="5fS8Lro2BG3" role="2cssZA" />
+            <node concept="y$t2T" id="5fS8Lro2BG4" role="2cssZA">
+              <node concept="1kHs8n" id="5fS8Lro2BG5" role="2cssZA">
+                <property role="TrG5h" value="a" />
+                <node concept="2bZTBh" id="5fS8Lro2HFM" role="1kHs7J">
+                  <node concept="2cvBGp" id="5fS8Lro2BG6" role="2bZTBi" />
+                </node>
+              </node>
+            </node>
+            <node concept="2cssZR" id="5fS8Lro2BG7" role="2cssZA" />
+          </node>
+          <node concept="yzEQC" id="5fS8Lro2BG8" role="yzEPe" />
+        </node>
+        <node concept="2cssZD" id="5fS8Lro2BG9" role="2cssWm" />
+      </node>
+    </node>
+  </node>
+  <node concept="LiM7Y" id="5fS8Lro2BWF">
+    <property role="TrG5h" value="LVD_WrapWith_BlockExpression_after" />
+    <node concept="3clFbS" id="5fS8Lro2BWG" role="LjaKd">
+      <node concept="2TK7Tu" id="5fS8Lro2BWH" role="3cqZAp">
+        <property role="2TTd_B" value="}" />
+      </node>
+      <node concept="3clFbH" id="5fS8Lro2BWI" role="3cqZAp" />
+    </node>
+    <node concept="1qefOq" id="5fS8Lro2BWJ" role="25YQCW">
+      <node concept="2cssWn" id="5fS8Lro2BWK" role="1qenE9">
+        <property role="TrG5h" value="m" />
+        <node concept="2cssWt" id="5fS8Lro2BWL" role="2cssWm">
+          <property role="TrG5h" value="f" />
+          <node concept="2cssWo" id="5fS8Lro2BWM" role="2cssWr">
+            <node concept="2cssZR" id="5fS8Lro2BWN" role="2cssZA" />
+            <node concept="1kHs8n" id="5fS8Lro2BWO" role="2cssZA">
+              <property role="TrG5h" value="a" />
+              <node concept="2cvBGp" id="5fS8Lro2BWP" role="1kHs7J" />
+              <node concept="LIFWc" id="5fS8Lro2C1d" role="lGtFl">
+                <property role="ZRATv" value="true" />
+                <property role="OXtK3" value="true" />
+                <property role="p6zMq" value="1" />
+                <property role="p6zMs" value="1" />
+                <property role="LIFWd" value="Constant_i0gfbw_a6a0" />
+              </node>
+            </node>
+            <node concept="2cssZR" id="5fS8Lro2BWR" role="2cssZA" />
+          </node>
+          <node concept="yzEQC" id="5fS8Lro2BWS" role="yzEPe" />
+        </node>
+        <node concept="2cssZD" id="5fS8Lro2BWT" role="2cssWm" />
+      </node>
+    </node>
+    <node concept="1qefOq" id="5fS8Lro2BWU" role="25YQFr">
+      <node concept="2cssWn" id="5fS8Lro2BWV" role="1qenE9">
+        <property role="TrG5h" value="m" />
+        <node concept="2cssWt" id="5fS8Lro2BWW" role="2cssWm">
+          <property role="TrG5h" value="f" />
+          <node concept="2cssWo" id="5fS8Lro2BWX" role="2cssWr">
+            <node concept="2cssZR" id="5fS8Lro2BWY" role="2cssZA" />
+            <node concept="y$t2T" id="5fS8Lro2BWZ" role="2cssZA">
+              <node concept="1kHs8n" id="5fS8Lro2BX0" role="2cssZA">
+                <property role="TrG5h" value="a" />
+                <node concept="2cvBGp" id="5fS8Lro2BX1" role="1kHs7J" />
+              </node>
+            </node>
+            <node concept="2cssZR" id="5fS8Lro2BX2" role="2cssZA" />
+          </node>
+          <node concept="yzEQC" id="5fS8Lro2BX3" role="yzEPe" />
+        </node>
+        <node concept="2cssZD" id="5fS8Lro2BX4" role="2cssWm" />
+      </node>
+    </node>
+  </node>
+  <node concept="LiM7Y" id="5fS8Lro4bhd">
+    <property role="TrG5h" value="LVD_WrapWith_BlockExpression_after_2" />
+    <node concept="3clFbS" id="5fS8Lro4bhe" role="LjaKd">
+      <node concept="2TK7Tu" id="5fS8Lro4bhf" role="3cqZAp">
+        <property role="2TTd_B" value="{" />
+      </node>
+      <node concept="3clFbH" id="5fS8Lro4bhg" role="3cqZAp" />
+    </node>
+    <node concept="1qefOq" id="5fS8Lro4bhh" role="25YQCW">
+      <node concept="2cssWn" id="5fS8Lro4bhi" role="1qenE9">
+        <property role="TrG5h" value="m" />
+        <node concept="2cssWt" id="5fS8Lro4bhj" role="2cssWm">
+          <property role="TrG5h" value="f" />
+          <node concept="2cssWo" id="5fS8Lro4bhk" role="2cssWr">
+            <node concept="2cssZR" id="5fS8Lro4bhl" role="2cssZA" />
+            <node concept="1kHs8n" id="5fS8Lro4bhm" role="2cssZA">
+              <property role="TrG5h" value="a" />
+              <node concept="2cvBGp" id="5fS8Lro4bhn" role="1kHs7J" />
+              <node concept="LIFWc" id="5fS8Lro4bho" role="lGtFl">
+                <property role="ZRATv" value="true" />
+                <property role="OXtK3" value="true" />
+                <property role="p6zMq" value="1" />
+                <property role="p6zMs" value="1" />
+                <property role="LIFWd" value="Constant_i0gfbw_a6a0" />
+              </node>
+            </node>
+            <node concept="1kHs8n" id="5fS8Lro4bkX" role="2cssZA">
+              <property role="TrG5h" value="b" />
+              <node concept="2cvBGp" id="5fS8Lro4bkV" role="1kHs7J" />
+            </node>
+          </node>
+          <node concept="yzEQC" id="5fS8Lro4bhq" role="yzEPe" />
+        </node>
+        <node concept="2cssZD" id="5fS8Lro4bhr" role="2cssWm" />
+      </node>
+    </node>
+    <node concept="1qefOq" id="5fS8Lro4bhs" role="25YQFr">
+      <node concept="2cssWn" id="5fS8Lro4bht" role="1qenE9">
+        <property role="TrG5h" value="m" />
+        <node concept="2cssWt" id="5fS8Lro4bhu" role="2cssWm">
+          <property role="TrG5h" value="f" />
+          <node concept="2cssWo" id="5fS8Lro4bhv" role="2cssWr">
+            <node concept="2cssZR" id="5fS8Lro4bhw" role="2cssZA" />
+            <node concept="1kHs8n" id="5fS8Lro4bhy" role="2cssZA">
+              <property role="TrG5h" value="a" />
+              <node concept="2cvBGp" id="5fS8Lro4bhz" role="1kHs7J" />
+            </node>
+            <node concept="y$t2T" id="5fS8Lro4bkr" role="2cssZA">
+              <node concept="1kHs8n" id="5fS8Lro4bjj" role="2cssZA">
+                <property role="TrG5h" value="b" />
+                <node concept="2cvBGp" id="5fS8Lro4bjh" role="1kHs7J" />
+              </node>
+            </node>
+          </node>
+          <node concept="yzEQC" id="5fS8Lro4bh_" role="yzEPe" />
+        </node>
+        <node concept="2cssZD" id="5fS8Lro4bhA" role="2cssWm" />
+      </node>
+    </node>
+  </node>
+  <node concept="LiM7Y" id="5ycts4RW_Im">
+    <property role="TrG5h" value="OptionalChildWithoutText_Single" />
+    <node concept="3clFbS" id="5ycts4RW_In" role="LjaKd">
+      <node concept="2TK7Tu" id="5ycts4RW_Io" role="3cqZAp">
+        <property role="2TTd_B" value="1+1" />
+      </node>
+    </node>
+    <node concept="1qefOq" id="5ycts4RW_Ip" role="25YQCW">
+      <node concept="2cssWn" id="5ycts4RW_Iq" role="1qenE9">
+        <property role="TrG5h" value="m" />
+        <node concept="2cssWt" id="5ycts4RW_Ir" role="2cssWm">
+          <property role="TrG5h" value="f" />
+          <node concept="2cssWo" id="5ycts4RW_Is" role="2cssWr">
+            <node concept="1JpcgL" id="5ycts4RW_JC" role="2cssZA">
+              <node concept="LIFWc" id="5ycts4S0g3X" role="lGtFl">
+                <property role="ZRATv" value="true" />
+                <property role="OXtK3" value="true" />
+                <property role="p6zMq" value="21" />
+                <property role="p6zMs" value="21" />
+                <property role="LIFWd" value="c33" />
+              </node>
+            </node>
+          </node>
+          <node concept="yzEQC" id="5ycts4RW_Iw" role="yzEPe" />
+        </node>
+        <node concept="2cssZD" id="5ycts4RW_Ix" role="2cssWm" />
+      </node>
+    </node>
+    <node concept="1qefOq" id="5ycts4RW_Iy" role="25YQFr">
+      <node concept="2cssWn" id="5ycts4RW_Iz" role="1qenE9">
+        <property role="TrG5h" value="m" />
+        <node concept="2cssWt" id="5ycts4RW_I$" role="2cssWm">
+          <property role="TrG5h" value="f" />
+          <node concept="2cssWo" id="5ycts4RW_I_" role="2cssWr">
+            <node concept="1JpcgL" id="5ycts4RW_KS" role="2cssZA">
+              <node concept="ywmH7" id="5ycts4RW_Lu" role="1JpqK9">
+                <node concept="yA7Z4" id="5ycts4RW_LC" role="ywYU2">
+                  <property role="yA7Zo" value="1" />
+                </node>
+                <node concept="yA7Z4" id="5ycts4RW_Lo" role="ywYUd">
+                  <property role="yA7Zo" value="1" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="yzEQC" id="5ycts4RW_ID" role="yzEPe" />
+        </node>
+        <node concept="2cssZD" id="5ycts4RW_IE" role="2cssWm" />
+      </node>
+    </node>
+  </node>
+  <node concept="LiM7Y" id="5ycts4S0fah">
+    <property role="TrG5h" value="OptionalChildWithoutText_Multiple" />
+    <node concept="3clFbS" id="5ycts4S0fai" role="LjaKd">
+      <node concept="2TK7Tu" id="5ycts4S0faj" role="3cqZAp">
+        <property role="2TTd_B" value="1,2" />
+      </node>
+    </node>
+    <node concept="1qefOq" id="5ycts4S0fak" role="25YQCW">
+      <node concept="2cssWn" id="5ycts4S0fal" role="1qenE9">
+        <property role="TrG5h" value="m" />
+        <node concept="2cssWt" id="5ycts4S0fam" role="2cssWm">
+          <property role="TrG5h" value="f" />
+          <node concept="2cssWo" id="5ycts4S0fan" role="2cssWr">
+            <node concept="1JvFKw" id="5ycts4S0fbm" role="2cssZA">
+              <node concept="LIFWc" id="5ycts4S0fc6" role="lGtFl">
+                <property role="ZRATv" value="true" />
+                <property role="OXtK3" value="true" />
+                <property role="p6zMq" value="32" />
+                <property role="p6zMs" value="32" />
+                <property role="LIFWd" value="c33" />
+              </node>
+            </node>
+          </node>
+          <node concept="yzEQC" id="5ycts4S0faq" role="yzEPe" />
+        </node>
+        <node concept="2cssZD" id="5ycts4S0far" role="2cssWm" />
+      </node>
+    </node>
+    <node concept="1qefOq" id="5ycts4S0fas" role="25YQFr">
+      <node concept="2cssWn" id="5ycts4S0fat" role="1qenE9">
+        <property role="TrG5h" value="m" />
+        <node concept="2cssWt" id="5ycts4S0fau" role="2cssWm">
+          <property role="TrG5h" value="f" />
+          <node concept="2cssWo" id="5ycts4S0fav" role="2cssWr">
+            <node concept="1JvFKw" id="5ycts4S0fbw" role="2cssZA">
+              <node concept="yA7Z4" id="5ycts4S0fbS" role="1JpqKa">
+                <property role="yA7Zo" value="1" />
+              </node>
+              <node concept="yA7Z4" id="5ycts4S0fc3" role="1JpqKa">
+                <property role="yA7Zo" value="2" />
+              </node>
+            </node>
+          </node>
+          <node concept="yzEQC" id="5ycts4S0fa$" role="yzEPe" />
+        </node>
+        <node concept="2cssZD" id="5ycts4S0fa_" role="2cssWm" />
+      </node>
+    </node>
+  </node>
+  <node concept="LiM7Y" id="5ycts4Sf5BX">
+    <property role="TrG5h" value="OptionalChildWithoutText_Reference" />
+    <node concept="3clFbS" id="5ycts4Sf5BY" role="LjaKd">
+      <node concept="2TK7Tu" id="5ycts4Sf5BZ" role="3cqZAp">
+        <property role="2TTd_B" value="f12" />
+      </node>
+    </node>
+    <node concept="1qefOq" id="5ycts4Sf5C0" role="25YQCW">
+      <node concept="2cssWn" id="5ycts4Sf5C1" role="1qenE9">
+        <property role="TrG5h" value="m" />
+        <node concept="2cssWt" id="5ycts4Sf5C2" role="2cssWm">
+          <property role="TrG5h" value="f1" />
+          <node concept="2cssWo" id="5ycts4Sf5C3" role="2cssWr">
+            <node concept="1wCzcP" id="5ycts4Sf5CI" role="2cssZA">
+              <node concept="LIFWc" id="5ycts4SlkyU" role="lGtFl">
+                <property role="ZRATv" value="true" />
+                <property role="OXtK3" value="true" />
+                <property role="p6zMq" value="18" />
+                <property role="p6zMs" value="18" />
+                <property role="LIFWd" value="c33" />
+              </node>
+            </node>
+          </node>
+          <node concept="yzEQC" id="5ycts4Sf5C6" role="yzEPe" />
+        </node>
+        <node concept="2cssWt" id="5ycts4SjW27" role="2cssWm">
+          <property role="TrG5h" value="f12" />
+          <node concept="2cssWo" id="5ycts4SjW29" role="2cssWr" />
+          <node concept="yzEQC" id="5ycts4SjW2b" role="yzEPe" />
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="5ycts4Sf5C8" role="25YQFr">
+      <node concept="2cssWn" id="5ycts4Slml0" role="1qenE9">
+        <property role="TrG5h" value="m" />
+        <node concept="2cssWt" id="5ycts4Slml1" role="2cssWm">
+          <property role="TrG5h" value="f1" />
+          <node concept="2cssWo" id="5ycts4Slml2" role="2cssWr">
+            <node concept="1wCzcP" id="5ycts4Slml3" role="2cssZA">
+              <ref role="1wCzcQ" node="5ycts4Slml6" resolve="f12" />
+            </node>
+          </node>
+          <node concept="yzEQC" id="5ycts4Slml5" role="yzEPe" />
+        </node>
+        <node concept="2cssWt" id="5ycts4Slml6" role="2cssWm">
+          <property role="TrG5h" value="f12" />
+          <node concept="2cssWo" id="5ycts4Slml7" role="2cssWr" />
+          <node concept="yzEQC" id="5ycts4Slml8" role="yzEPe" />
+        </node>
       </node>
     </node>
   </node>


### PR DESCRIPTION
When grammar cells were implemented, transformation actions were part of the actions aspect. Later MPS introduced a new transformation menu language as part of the editor. The most relevant change is that the actions aspect doesn't have access to editor while the new transformation language does.

The goal of this PR is not just to use the transformation language in the generator, but to improve the grammar cells behavior by using information available in the editor. The first step was to introduce new high level concepts that don't just make the implementation easier, but can also be used by language developers directly.

As a replacement for left and right transformations there are now the new "before" and "after" transformations. While left/right transformations only show the transformations for the current selected leaf cell and you have to include transformations from the parent explicitly, before and after transformations always include transformations from the whole cell hierarchy. They also include the transformations from the opposite side. It's more like attaching actions to the gap before/after a cell instead of a cell itself.

Then there is a cell "grammar.sideTransformation4". The difference to the other cells with a similar name is that it supports the new transformation menu language from MPS. Instead of creating a new "Transformation menu" root, you can define the menu directly inside the editor. All the entries will be shown at exactly the position of the cell (the cell itself is not visible) with all the benefits of the before/after transformations (works on the left and right side and across the cell hierarchy).