### PR TITLE
Bug fix for fringe case in incremental model merger

### DIFF
--- a/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
+++ b/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
@@ -13383,6 +13383,11 @@
             </node>
           </node>
         </node>
+        <node concept="1SiIV0" id="59_ttdjbdCz" role="3bR37C">
+          <node concept="3bR9La" id="59_ttdjbdC$" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:7Kfy9QB6KXW" resolve="jetbrains.mps.lang.core" />
+          </node>
+        </node>
       </node>
       <node concept="1E1JtD" id="GuygFg7AfB" role="2G$12L">
         <property role="BnDLt" value="true" />

--- a/code/solutions/de.itemis.mps.modelmerger.runtime/models/plugin.mps
+++ b/code/solutions/de.itemis.mps.modelmerger.runtime/models/plugin.mps
@@ -531,7 +531,7 @@
               </node>
               <node concept="2Gpval" id="1tkLcpYJUUK" role="3cqZAp">
                 <node concept="2GrKxI" id="1tkLcpYJUUM" role="2Gsz3X">
-                  <property role="TrG5h" value="nodeToRemoce" />
+                  <property role="TrG5h" value="nodeToRemove" />
                 </node>
                 <node concept="37vLTw" id="1tkLcpYJWOQ" role="2GsD0m">
                   <ref role="3cqZAo" node="6NDRJQ9ur$q" resolve="nodesToRemove" />
@@ -543,7 +543,7 @@
                         <node concept="10QFUN" id="1tkLcpYKwEc" role="1eOMHV">
                           <node concept="3Tqbb2" id="1tkLcpYKxP3" role="10QFUM" />
                           <node concept="2GrUjf" id="1tkLcpYKsgZ" role="10QFUP">
-                            <ref role="2Gs0qQ" node="1tkLcpYJUUM" resolve="nodeToRemoce" />
+                            <ref role="2Gs0qQ" node="1tkLcpYJUUM" resolve="nodeToRemove" />
                           </node>
                         </node>
                       </node>

--- a/code/solutions/de.itemis.mps.modelmerger.runtime/models/plugin.mps
+++ b/code/solutions/de.itemis.mps.modelmerger.runtime/models/plugin.mps
@@ -9,6 +9,7 @@
     <use id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections" version="1" />
     <use id="ef7bf5ac-d06c-4342-b11d-e42104eb9343" name="jetbrains.mps.lang.plugin.standalone" version="0" />
     <use id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc" version="2" />
+    <use id="760a0a8c-eabb-4521-8bfd-65db761a9ba3" name="jetbrains.mps.baseLanguage.logging" version="0" />
   </languages>
   <imports>
     <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" />
@@ -45,9 +46,15 @@
         <property id="6468716278899126575" name="isVolatile" index="2dlcS1" />
         <property id="6468716278899125786" name="isTransient" index="2dld4O" />
       </concept>
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
       <concept id="1081236700938" name="jetbrains.mps.baseLanguage.structure.StaticMethodDeclaration" flags="ig" index="2YIFZL" />
       <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
+      </concept>
+      <concept id="1164991038168" name="jetbrains.mps.baseLanguage.structure.ThrowStatement" flags="nn" index="YS8fn">
+        <child id="1164991057263" name="throwable" index="YScLw" />
       </concept>
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
       <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
@@ -135,6 +142,7 @@
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
       <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
+      <concept id="1081855346303" name="jetbrains.mps.baseLanguage.structure.BreakStatement" flags="nn" index="3zACq4" />
       <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
@@ -1123,10 +1131,7 @@
             <node concept="3oM_SD" id="7WTFIQIcYhY" role="1PaTwD">
               <property role="3oM_SC" value="a" />
             </node>
-            <node concept="3oM_SD" id="7WTFIQIcYhZ" role="1PaTwD">
-              <property role="3oM_SC" value="root" />
-            </node>
-            <node concept="3oM_SD" id="7WTFIQIcYi0" role="1PaTwD">
+            <node concept="3oM_SD" id="6QnTwqHhUZI" role="1PaTwD">
               <property role="3oM_SC" value="node" />
             </node>
             <node concept="3oM_SD" id="7WTFIQIcYi1" role="1PaTwD">
@@ -1138,10 +1143,7 @@
             <node concept="3oM_SD" id="7WTFIQIcYi3" role="1PaTwD">
               <property role="3oM_SC" value="source" />
             </node>
-            <node concept="3oM_SD" id="7WTFIQIcYi4" role="1PaTwD">
-              <property role="3oM_SC" value="" />
-            </node>
-            <node concept="3oM_SD" id="7WTFIQIcYi5" role="1PaTwD">
+            <node concept="3oM_SD" id="6QnTwqHhV0d" role="1PaTwD">
               <property role="3oM_SC" value="does" />
             </node>
             <node concept="3oM_SD" id="7WTFIQIcYi6" role="1PaTwD">
@@ -1306,6 +1308,131 @@
           </node>
         </node>
         <node concept="3clFbH" id="36T3QpoUTQq" role="3cqZAp" />
+        <node concept="3SKdUt" id="6QnTwqHi1xE" role="3cqZAp">
+          <node concept="1PaTwC" id="6QnTwqHi1xF" role="1aUNEU">
+            <node concept="3oM_SD" id="6QnTwqHi1xG" role="1PaTwD">
+              <property role="3oM_SC" value="Find" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHiz2z" role="1PaTwD">
+              <property role="3oM_SC" value="whether" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHiz2I" role="1PaTwD">
+              <property role="3oM_SC" value="there" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHiz2U" role="1PaTwD">
+              <property role="3oM_SC" value="is" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHiz2Z" role="1PaTwD">
+              <property role="3oM_SC" value="any" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHiz35" role="1PaTwD">
+              <property role="3oM_SC" value="matching" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHiz3k" role="1PaTwD">
+              <property role="3oM_SC" value="imported" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHiz4A" role="1PaTwD">
+              <property role="3oM_SC" value="node" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHiz3$" role="1PaTwD">
+              <property role="3oM_SC" value="in" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHiz3H" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHiz3R" role="1PaTwD">
+              <property role="3oM_SC" value="original" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHiz4i" role="1PaTwD">
+              <property role="3oM_SC" value="node," />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHkZWy" role="1PaTwD">
+              <property role="3oM_SC" value="used" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHkZWZ" role="1PaTwD">
+              <property role="3oM_SC" value="for" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHkZTe" role="1PaTwD">
+              <property role="3oM_SC" value="an" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHkZTH" role="1PaTwD">
+              <property role="3oM_SC" value="edge" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHkZTX" role="1PaTwD">
+              <property role="3oM_SC" value="case" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHkZUm" role="1PaTwD">
+              <property role="3oM_SC" value="in" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHkZUC" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHkZUV" role="1PaTwD">
+              <property role="3oM_SC" value="insertion" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHkZVv" role="1PaTwD">
+              <property role="3oM_SC" value="later" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="6QnTwqHis7j" role="3cqZAp">
+          <node concept="3cpWsn" id="6QnTwqHis7m" role="3cpWs9">
+            <property role="TrG5h" value="hasMatchInOrigNode" />
+            <node concept="10P_77" id="6QnTwqHis7h" role="1tU5fm" />
+            <node concept="3clFbT" id="6QnTwqHit1e" role="33vP2m" />
+          </node>
+        </node>
+        <node concept="2Gpval" id="6QnTwqHhLGh" role="3cqZAp">
+          <node concept="2GrKxI" id="6QnTwqHhLGi" role="2Gsz3X">
+            <property role="TrG5h" value="importedNodeChild" />
+          </node>
+          <node concept="2OqwBi" id="6QnTwqHhLGj" role="2GsD0m">
+            <node concept="37vLTw" id="6QnTwqHhLGk" role="2Oq$k0">
+              <ref role="3cqZAo" node="36T3QpoUTRB" resolve="importedNode" />
+            </node>
+            <node concept="liA8E" id="6QnTwqHhLGl" role="2OqNvi">
+              <ref role="37wK5l" to="mhbf:~SNode.getChildren()" resolve="getChildren" />
+            </node>
+          </node>
+          <node concept="3clFbS" id="6QnTwqHhLGm" role="2LFqv$">
+            <node concept="3clFbJ" id="6QnTwqHhLGw" role="3cqZAp">
+              <node concept="3clFbS" id="6QnTwqHhLGx" role="3clFbx">
+                <node concept="3clFbF" id="6QnTwqHixjv" role="3cqZAp">
+                  <node concept="37vLTI" id="6QnTwqHixz2" role="3clFbG">
+                    <node concept="3clFbT" id="6QnTwqHixzA" role="37vLTx">
+                      <property role="3clFbU" value="true" />
+                    </node>
+                    <node concept="37vLTw" id="6QnTwqHixjt" role="37vLTJ">
+                      <ref role="3cqZAo" node="6QnTwqHis7m" resolve="hasMatchInOrigNode" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3zACq4" id="6QnTwqHhYJO" role="3cqZAp" />
+              </node>
+              <node concept="3y3z36" id="6QnTwqHhWS6" role="3clFbw">
+                <node concept="10Nm6u" id="6QnTwqHhLHe" role="3uHU7w" />
+                <node concept="1rXfSq" id="6QnTwqHhLGq" role="3uHU7B">
+                  <ref role="37wK5l" node="6NDRJQ9t1yD" resolve="findNodeIn" />
+                  <node concept="2GrUjf" id="6QnTwqHhLGr" role="37wK5m">
+                    <ref role="2Gs0qQ" node="6QnTwqHhLGi" resolve="importedNodeChild" />
+                  </node>
+                  <node concept="2OqwBi" id="6QnTwqHhLGs" role="37wK5m">
+                    <node concept="37vLTw" id="6QnTwqHhLGt" role="2Oq$k0">
+                      <ref role="3cqZAo" node="36T3QpoUTR_" resolve="origNode" />
+                    </node>
+                    <node concept="liA8E" id="6QnTwqHhLGu" role="2OqNvi">
+                      <ref role="37wK5l" to="mhbf:~SNode.getChildren()" resolve="getChildren" />
+                    </node>
+                  </node>
+                  <node concept="37vLTw" id="6QnTwqHhLGv" role="37wK5m">
+                    <ref role="3cqZAo" node="36T3QpoUTRD" resolve="identityCalculatorReg" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6QnTwqHhL0p" role="3cqZAp" />
         <node concept="3SKdUt" id="36T3QpoUTQr" role="3cqZAp">
           <node concept="1PaTwC" id="7WTFIQIcYij" role="1aUNEU">
             <node concept="3oM_SD" id="7WTFIQIcYik" role="1PaTwD">
@@ -1359,25 +1486,13 @@
             <node concept="3oM_SD" id="7WTFIQIcYi$" role="1PaTwD">
               <property role="3oM_SC" value="be" />
             </node>
-            <node concept="3oM_SD" id="7WTFIQIcYi_" role="1PaTwD">
-              <property role="3oM_SC" value="considered" />
-            </node>
-            <node concept="3oM_SD" id="7WTFIQIcYiA" role="1PaTwD">
-              <property role="3oM_SC" value="as" />
-            </node>
-            <node concept="3oM_SD" id="7WTFIQIcYiB" role="1PaTwD">
-              <property role="3oM_SC" value="to" />
-            </node>
-            <node concept="3oM_SD" id="7WTFIQIcYiC" role="1PaTwD">
-              <property role="3oM_SC" value="be" />
-            </node>
-            <node concept="3oM_SD" id="7WTFIQIcYiD" role="1PaTwD">
+            <node concept="3oM_SD" id="6QnTwqHkZRv" role="1PaTwD">
               <property role="3oM_SC" value="added" />
             </node>
-            <node concept="3oM_SD" id="7WTFIQIcYiE" role="1PaTwD">
-              <property role="3oM_SC" value="o" />
+            <node concept="3oM_SD" id="6QnTwqHkZRX" role="1PaTwD">
+              <property role="3oM_SC" value="to" />
             </node>
-            <node concept="3oM_SD" id="7WTFIQIcYiF" role="1PaTwD">
+            <node concept="3oM_SD" id="6QnTwqHkZSq" role="1PaTwD">
               <property role="3oM_SC" value="the" />
             </node>
             <node concept="3oM_SD" id="7WTFIQIcYiG" role="1PaTwD">
@@ -1387,7 +1502,7 @@
         </node>
         <node concept="3cpWs8" id="36T3QpoUTQt" role="3cqZAp">
           <node concept="3cpWsn" id="36T3QpoUTQu" role="3cpWs9">
-            <property role="TrG5h" value="lastmatchInOrigNode" />
+            <property role="TrG5h" value="lastMatchInOrigNode" />
             <node concept="3uibUv" id="36T3QpoUTQv" role="1tU5fm">
               <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
             </node>
@@ -1406,12 +1521,12 @@
               <property role="3oM_SC" value="is" />
             </node>
             <node concept="3oM_SD" id="7WTFIQIcYiL" role="1PaTwD">
-              <property role="3oM_SC" value="a" />
+              <property role="3oM_SC" value="an" />
             </node>
-            <node concept="3oM_SD" id="7WTFIQIcYiM" role="1PaTwD">
-              <property role="3oM_SC" value="pointer" />
+            <node concept="3oM_SD" id="6QnTwqHhV0F" role="1PaTwD">
+              <property role="3oM_SC" value="anchor" />
             </node>
-            <node concept="3oM_SD" id="7WTFIQIcYiN" role="1PaTwD">
+            <node concept="3oM_SD" id="6QnTwqHhV1e" role="1PaTwD">
               <property role="3oM_SC" value="to" />
             </node>
             <node concept="3oM_SD" id="7WTFIQIcYiO" role="1PaTwD">
@@ -1491,7 +1606,7 @@
               <property role="3oM_SC" value="from" />
             </node>
             <node concept="3oM_SD" id="7WTFIQIcYjd" role="1PaTwD">
-              <property role="3oM_SC" value="happen" />
+              <property role="3oM_SC" value="happens" />
             </node>
             <node concept="3oM_SD" id="7WTFIQIcYje" role="1PaTwD">
               <property role="3oM_SC" value="at" />
@@ -1520,9 +1635,46 @@
             </node>
           </node>
           <node concept="3clFbS" id="36T3QpoUTQE" role="2LFqv$">
+            <node concept="3cpWs8" id="6QnTwqHjmKW" role="3cqZAp">
+              <node concept="3cpWsn" id="6QnTwqHjmKX" role="3cpWs9">
+                <property role="TrG5h" value="childContainmentLink" />
+                <node concept="3uibUv" id="6QnTwqHjl60" role="1tU5fm">
+                  <ref role="3uigEE" to="c17a:~SContainmentLink" resolve="SContainmentLink" />
+                </node>
+                <node concept="2OqwBi" id="6QnTwqHjmKY" role="33vP2m">
+                  <node concept="2GrUjf" id="6QnTwqHjmKZ" role="2Oq$k0">
+                    <ref role="2Gs0qQ" node="36T3QpoUTQA" resolve="importedNodeChild" />
+                  </node>
+                  <node concept="liA8E" id="6QnTwqHjmL0" role="2OqNvi">
+                    <ref role="37wK5l" to="mhbf:~SNode.getContainmentLink()" resolve="getContainmentLink" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbJ" id="6QnTwqHjohm" role="3cqZAp">
+              <node concept="3clFbS" id="6QnTwqHjoho" role="3clFbx">
+                <node concept="YS8fn" id="6QnTwqHjsQy" role="3cqZAp">
+                  <node concept="2ShNRf" id="6QnTwqHjsRc" role="YScLw">
+                    <node concept="1pGfFk" id="6QnTwqHjIdu" role="2ShVmc">
+                      <ref role="37wK5l" to="wyt6:~IllegalStateException.&lt;init&gt;(java.lang.String)" resolve="IllegalStateException" />
+                      <node concept="Xl_RD" id="6QnTwqHjIh2" role="37wK5m">
+                        <property role="Xl_RC" value="Child Containment link cannot be null" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbC" id="6QnTwqHjoG_" role="3clFbw">
+                <node concept="10Nm6u" id="6QnTwqHjoNd" role="3uHU7w" />
+                <node concept="37vLTw" id="6QnTwqHjor3" role="3uHU7B">
+                  <ref role="3cqZAo" node="6QnTwqHjmKX" resolve="childContainmentLink" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbH" id="6QnTwqHjIze" role="3cqZAp" />
             <node concept="3cpWs8" id="36T3QpoUTQF" role="3cqZAp">
               <node concept="3cpWsn" id="36T3QpoUTQG" role="3cpWs9">
-                <property role="TrG5h" value="correspondingRoot" />
+                <property role="TrG5h" value="correspondingNode" />
                 <node concept="3uibUv" id="36T3QpoUTQH" role="1tU5fm">
                   <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
                 </node>
@@ -1593,19 +1745,14 @@
                         </node>
                         <node concept="liA8E" id="36T3QpoUTR5" role="2OqNvi">
                           <ref role="37wK5l" to="mhbf:~SNode.insertChildAfter(org.jetbrains.mps.openapi.language.SContainmentLink,org.jetbrains.mps.openapi.model.SNode,org.jetbrains.mps.openapi.model.SNode)" resolve="insertChildAfter" />
-                          <node concept="2OqwBi" id="36T3QpoUTR6" role="37wK5m">
-                            <node concept="2GrUjf" id="36T3QpoUTR7" role="2Oq$k0">
-                              <ref role="2Gs0qQ" node="36T3QpoUTQA" resolve="importedNodeChild" />
-                            </node>
-                            <node concept="liA8E" id="36T3QpoUTR8" role="2OqNvi">
-                              <ref role="37wK5l" to="mhbf:~SNode.getContainmentLink()" resolve="getContainmentLink" />
-                            </node>
+                          <node concept="37vLTw" id="6QnTwqHjmL2" role="37wK5m">
+                            <ref role="3cqZAo" node="6QnTwqHjmKX" resolve="childContainmentLink" />
                           </node>
                           <node concept="37vLTw" id="36T3QpoUTR9" role="37wK5m">
                             <ref role="3cqZAo" node="36T3QpoUTQV" resolve="copy" />
                           </node>
                           <node concept="37vLTw" id="36T3QpoUTRa" role="37wK5m">
-                            <ref role="3cqZAo" node="36T3QpoUTQu" resolve="lastmatchInOrigNode" />
+                            <ref role="3cqZAo" node="36T3QpoUTQu" resolve="lastMatchInOrigNode" />
                           </node>
                         </node>
                       </node>
@@ -1614,30 +1761,222 @@
                   <node concept="3y3z36" id="36T3QpoUTRb" role="3clFbw">
                     <node concept="10Nm6u" id="36T3QpoUTRc" role="3uHU7w" />
                     <node concept="37vLTw" id="36T3QpoUTRd" role="3uHU7B">
-                      <ref role="3cqZAo" node="36T3QpoUTQu" resolve="lastmatchInOrigNode" />
+                      <ref role="3cqZAo" node="36T3QpoUTQu" resolve="lastMatchInOrigNode" />
                     </node>
                   </node>
                   <node concept="9aQIb" id="36T3QpoUTRe" role="9aQIa">
                     <node concept="3clFbS" id="36T3QpoUTRf" role="9aQI4">
-                      <node concept="3clFbF" id="36T3QpoUTRg" role="3cqZAp">
-                        <node concept="2OqwBi" id="36T3QpoUTRh" role="3clFbG">
-                          <node concept="37vLTw" id="36T3QpoUTRP" role="2Oq$k0">
-                            <ref role="3cqZAo" node="36T3QpoUTR_" resolve="origNode" />
+                      <node concept="3SKdUt" id="6QnTwqHiBgT" role="3cqZAp">
+                        <node concept="1PaTwC" id="6QnTwqHiBgU" role="1aUNEU">
+                          <node concept="3oM_SD" id="6QnTwqHiB$9" role="1PaTwD">
+                            <property role="3oM_SC" value="If" />
                           </node>
-                          <node concept="liA8E" id="36T3QpoUTRj" role="2OqNvi">
-                            <ref role="37wK5l" to="mhbf:~SNode.addChild(org.jetbrains.mps.openapi.language.SContainmentLink,org.jetbrains.mps.openapi.model.SNode)" resolve="addChild" />
-                            <node concept="2OqwBi" id="36T3QpoUTRk" role="37wK5m">
-                              <node concept="2GrUjf" id="36T3QpoUTRl" role="2Oq$k0">
-                                <ref role="2Gs0qQ" node="36T3QpoUTQA" resolve="importedNodeChild" />
+                          <node concept="3oM_SD" id="6QnTwqHiB$j" role="1PaTwD">
+                            <property role="3oM_SC" value="lastMatchInOriginNode" />
+                          </node>
+                          <node concept="3oM_SD" id="6QnTwqHiB$Q" role="1PaTwD">
+                            <property role="3oM_SC" value="is" />
+                          </node>
+                          <node concept="3oM_SD" id="6QnTwqHiBHm" role="1PaTwD">
+                            <property role="3oM_SC" value="null," />
+                          </node>
+                          <node concept="3oM_SD" id="6QnTwqHiB_d" role="1PaTwD">
+                            <property role="3oM_SC" value="then" />
+                          </node>
+                          <node concept="3oM_SD" id="6QnTwqHiBCj" role="1PaTwD">
+                            <property role="3oM_SC" value="no" />
+                          </node>
+                          <node concept="3oM_SD" id="6QnTwqHiBFd" role="1PaTwD">
+                            <property role="3oM_SC" value="match" />
+                          </node>
+                          <node concept="3oM_SD" id="6QnTwqHiBFz" role="1PaTwD">
+                            <property role="3oM_SC" value="was" />
+                          </node>
+                          <node concept="3oM_SD" id="6QnTwqHiBFM" role="1PaTwD">
+                            <property role="3oM_SC" value="found/copy" />
+                          </node>
+                          <node concept="3oM_SD" id="6QnTwqHkXP8" role="1PaTwD">
+                            <property role="3oM_SC" value="was" />
+                          </node>
+                          <node concept="3oM_SD" id="6QnTwqHkXPr" role="1PaTwD">
+                            <property role="3oM_SC" value="made" />
+                          </node>
+                          <node concept="3oM_SD" id="6QnTwqHkXTu" role="1PaTwD">
+                            <property role="3oM_SC" value="before." />
+                          </node>
+                          <node concept="3oM_SD" id="6QnTwqHkXVK" role="1PaTwD">
+                            <property role="3oM_SC" value="The" />
+                          </node>
+                          <node concept="3oM_SD" id="6QnTwqHkXWe" role="1PaTwD">
+                            <property role="3oM_SC" value="correspondingNode" />
+                          </node>
+                          <node concept="3oM_SD" id="6QnTwqHkXW_" role="1PaTwD">
+                            <property role="3oM_SC" value="was" />
+                          </node>
+                          <node concept="3oM_SD" id="6QnTwqHkXWX" role="1PaTwD">
+                            <property role="3oM_SC" value="" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3SKdUt" id="6QnTwqHkXXX" role="3cqZAp">
+                        <node concept="1PaTwC" id="6QnTwqHkXXW" role="1aUNEU">
+                          <node concept="3oM_SD" id="6QnTwqHkXXV" role="1PaTwD">
+                            <property role="3oM_SC" value="null" />
+                          </node>
+                          <node concept="3oM_SD" id="6QnTwqHkXXe" role="1PaTwD">
+                            <property role="3oM_SC" value="too," />
+                          </node>
+                          <node concept="3oM_SD" id="6QnTwqHkXXw" role="1PaTwD">
+                            <property role="3oM_SC" value="so" />
+                          </node>
+                          <node concept="3oM_SD" id="6QnTwqHkY4z" role="1PaTwD">
+                            <property role="3oM_SC" value="if" />
+                          </node>
+                          <node concept="3oM_SD" id="6QnTwqHkY4K" role="1PaTwD">
+                            <property role="3oM_SC" value="there" />
+                          </node>
+                          <node concept="3oM_SD" id="6QnTwqHkY4Q" role="1PaTwD">
+                            <property role="3oM_SC" value="are" />
+                          </node>
+                          <node concept="3oM_SD" id="6QnTwqHkY4X" role="1PaTwD">
+                            <property role="3oM_SC" value="any" />
+                          </node>
+                          <node concept="3oM_SD" id="6QnTwqHkY5d" role="1PaTwD">
+                            <property role="3oM_SC" value="matching" />
+                          </node>
+                          <node concept="3oM_SD" id="6QnTwqHkY5m" role="1PaTwD">
+                            <property role="3oM_SC" value="nodes," />
+                          </node>
+                          <node concept="3oM_SD" id="6QnTwqHkY5w" role="1PaTwD">
+                            <property role="3oM_SC" value="this" />
+                          </node>
+                          <node concept="3oM_SD" id="6QnTwqHkY5N" role="1PaTwD">
+                            <property role="3oM_SC" value="must" />
+                          </node>
+                          <node concept="3oM_SD" id="6QnTwqHkY5Z" role="1PaTwD">
+                            <property role="3oM_SC" value="be" />
+                          </node>
+                          <node concept="3oM_SD" id="6QnTwqHkY6L" role="1PaTwD">
+                            <property role="3oM_SC" value="before" />
+                          </node>
+                          <node concept="3oM_SD" id="6QnTwqHkY6Z" role="1PaTwD">
+                            <property role="3oM_SC" value="the" />
+                          </node>
+                          <node concept="3oM_SD" id="6QnTwqHkY7e" role="1PaTwD">
+                            <property role="3oM_SC" value="first" />
+                          </node>
+                          <node concept="3oM_SD" id="6QnTwqHkY7A" role="1PaTwD">
+                            <property role="3oM_SC" value="matching" />
+                          </node>
+                          <node concept="3oM_SD" id="6QnTwqHkY7Z" role="1PaTwD">
+                            <property role="3oM_SC" value="node." />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbJ" id="6QnTwqHi2Dx" role="3cqZAp">
+                        <node concept="3clFbS" id="6QnTwqHi2Dz" role="3clFbx">
+                          <node concept="3cpWs8" id="6QnTwqHkYeo" role="3cqZAp">
+                            <node concept="3cpWsn" id="6QnTwqHkYep" role="3cpWs9">
+                              <property role="TrG5h" value="firstChildInOrigNode" />
+                              <node concept="3uibUv" id="6QnTwqHkYeq" role="1tU5fm">
+                                <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
                               </node>
-                              <node concept="liA8E" id="36T3QpoUTRm" role="2OqNvi">
-                                <ref role="37wK5l" to="mhbf:~SNode.getContainmentLink()" resolve="getContainmentLink" />
+                              <node concept="2OqwBi" id="6QnTwqHkYer" role="33vP2m">
+                                <node concept="2OqwBi" id="6QnTwqHkYes" role="2Oq$k0">
+                                  <node concept="2OqwBi" id="6QnTwqHkYet" role="2Oq$k0">
+                                    <node concept="37vLTw" id="6QnTwqHkYeu" role="2Oq$k0">
+                                      <ref role="3cqZAo" node="36T3QpoUTR_" resolve="origNode" />
+                                    </node>
+                                    <node concept="liA8E" id="6QnTwqHkYev" role="2OqNvi">
+                                      <ref role="37wK5l" to="mhbf:~SNode.getChildren()" resolve="getChildren" />
+                                    </node>
+                                  </node>
+                                  <node concept="liA8E" id="6QnTwqHkYew" role="2OqNvi">
+                                    <ref role="37wK5l" to="wyt6:~Iterable.iterator()" resolve="iterator" />
+                                  </node>
+                                </node>
+                                <node concept="liA8E" id="6QnTwqHkYex" role="2OqNvi">
+                                  <ref role="37wK5l" to="33ny:~Iterator.next()" resolve="next" />
+                                </node>
                               </node>
                             </node>
-                            <node concept="37vLTw" id="36T3QpoUTRn" role="37wK5m">
-                              <ref role="3cqZAo" node="36T3QpoUTQV" resolve="copy" />
+                          </node>
+                          <node concept="3clFbF" id="6QnTwqHiDoY" role="3cqZAp">
+                            <node concept="2OqwBi" id="6QnTwqHiDoZ" role="3clFbG">
+                              <node concept="37vLTw" id="6QnTwqHiDp0" role="2Oq$k0">
+                                <ref role="3cqZAo" node="36T3QpoUTR_" resolve="origNode" />
+                              </node>
+                              <node concept="liA8E" id="6QnTwqHiDp1" role="2OqNvi">
+                                <ref role="37wK5l" to="mhbf:~SNode.insertChildBefore(org.jetbrains.mps.openapi.language.SContainmentLink,org.jetbrains.mps.openapi.model.SNode,org.jetbrains.mps.openapi.model.SNode)" resolve="insertChildBefore" />
+                                <node concept="37vLTw" id="6QnTwqHjmL1" role="37wK5m">
+                                  <ref role="3cqZAo" node="6QnTwqHjmKX" resolve="childContainmentLink" />
+                                </node>
+                                <node concept="37vLTw" id="6QnTwqHiDp5" role="37wK5m">
+                                  <ref role="3cqZAo" node="36T3QpoUTQV" resolve="copy" />
+                                </node>
+                                <node concept="37vLTw" id="6QnTwqHkYey" role="37wK5m">
+                                  <ref role="3cqZAo" node="6QnTwqHkYep" resolve="firstChildInOrigNode" />
+                                </node>
+                              </node>
                             </node>
                           </node>
+                        </node>
+                        <node concept="9aQIb" id="6QnTwqHi63P" role="9aQIa">
+                          <node concept="3clFbS" id="6QnTwqHi63Q" role="9aQI4">
+                            <node concept="3SKdUt" id="6QnTwqHi7_M" role="3cqZAp">
+                              <node concept="1PaTwC" id="6QnTwqHi7_N" role="1aUNEU">
+                                <node concept="3oM_SD" id="6QnTwqHi7AF" role="1PaTwD">
+                                  <property role="3oM_SC" value="Add" />
+                                </node>
+                                <node concept="3oM_SD" id="6QnTwqHi7AP" role="1PaTwD">
+                                  <property role="3oM_SC" value="it" />
+                                </node>
+                                <node concept="3oM_SD" id="6QnTwqHi7AS" role="1PaTwD">
+                                  <property role="3oM_SC" value="to" />
+                                </node>
+                                <node concept="3oM_SD" id="6QnTwqHi7AW" role="1PaTwD">
+                                  <property role="3oM_SC" value="the" />
+                                </node>
+                                <node concept="3oM_SD" id="6QnTwqHi7EU" role="1PaTwD">
+                                  <property role="3oM_SC" value="end" />
+                                </node>
+                                <node concept="3oM_SD" id="6QnTwqHi7F8" role="1PaTwD">
+                                  <property role="3oM_SC" value="of" />
+                                </node>
+                                <node concept="3oM_SD" id="6QnTwqHi7FK" role="1PaTwD">
+                                  <property role="3oM_SC" value="the" />
+                                </node>
+                                <node concept="3oM_SD" id="6QnTwqHi7G8" role="1PaTwD">
+                                  <property role="3oM_SC" value="merged" />
+                                </node>
+                                <node concept="3oM_SD" id="6QnTwqHi7Gh" role="1PaTwD">
+                                  <property role="3oM_SC" value="children" />
+                                </node>
+                                <node concept="3oM_SD" id="6QnTwqHi7Gr" role="1PaTwD">
+                                  <property role="3oM_SC" value="list" />
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="3clFbF" id="36T3QpoUTRg" role="3cqZAp">
+                              <node concept="2OqwBi" id="36T3QpoUTRh" role="3clFbG">
+                                <node concept="37vLTw" id="36T3QpoUTRP" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="36T3QpoUTR_" resolve="origNode" />
+                                </node>
+                                <node concept="liA8E" id="36T3QpoUTRj" role="2OqNvi">
+                                  <ref role="37wK5l" to="mhbf:~SNode.addChild(org.jetbrains.mps.openapi.language.SContainmentLink,org.jetbrains.mps.openapi.model.SNode)" resolve="addChild" />
+                                  <node concept="37vLTw" id="6QnTwqHjmL3" role="37wK5m">
+                                    <ref role="3cqZAo" node="6QnTwqHjmKX" resolve="childContainmentLink" />
+                                  </node>
+                                  <node concept="37vLTw" id="36T3QpoUTRn" role="37wK5m">
+                                    <ref role="3cqZAo" node="36T3QpoUTQV" resolve="copy" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="37vLTw" id="6QnTwqHiDjN" role="3clFbw">
+                          <ref role="3cqZAo" node="6QnTwqHis7m" resolve="hasMatchInOrigNode" />
                         </node>
                       </node>
                     </node>
@@ -1649,7 +1988,7 @@
                       <ref role="3cqZAo" node="36T3QpoUTQV" resolve="copy" />
                     </node>
                     <node concept="37vLTw" id="36T3QpoUTRr" role="37vLTJ">
-                      <ref role="3cqZAo" node="36T3QpoUTQu" resolve="lastmatchInOrigNode" />
+                      <ref role="3cqZAo" node="36T3QpoUTQu" resolve="lastMatchInOrigNode" />
                     </node>
                   </node>
                 </node>
@@ -1657,7 +1996,7 @@
               <node concept="3clFbC" id="36T3QpoUTRs" role="3clFbw">
                 <node concept="10Nm6u" id="36T3QpoUTRt" role="3uHU7w" />
                 <node concept="37vLTw" id="36T3QpoUTRu" role="3uHU7B">
-                  <ref role="3cqZAo" node="36T3QpoUTQG" resolve="correspondingRoot" />
+                  <ref role="3cqZAo" node="36T3QpoUTQG" resolve="correspondingNode" />
                 </node>
               </node>
               <node concept="9aQIb" id="36T3QpoUTRv" role="9aQIa">
@@ -1665,10 +2004,10 @@
                   <node concept="3clFbF" id="36T3QpoUTRx" role="3cqZAp">
                     <node concept="37vLTI" id="36T3QpoUTRy" role="3clFbG">
                       <node concept="37vLTw" id="36T3QpoUTRz" role="37vLTx">
-                        <ref role="3cqZAo" node="36T3QpoUTQG" resolve="correspondingRoot" />
+                        <ref role="3cqZAo" node="36T3QpoUTQG" resolve="correspondingNode" />
                       </node>
                       <node concept="37vLTw" id="36T3QpoUTR$" role="37vLTJ">
-                        <ref role="3cqZAo" node="36T3QpoUTQu" resolve="lastmatchInOrigNode" />
+                        <ref role="3cqZAo" node="36T3QpoUTQu" resolve="lastMatchInOrigNode" />
                       </node>
                     </node>
                   </node>

--- a/code/solutions/tests.de.itemis.mps.modelmerger/models/basictest@tests.mps
+++ b/code/solutions/tests.de.itemis.mps.modelmerger/models/basictest@tests.mps
@@ -17,12 +17,14 @@
     <import index="k6li" ref="r:7c40b043-67ab-4fff-a68c-bb3e633629e4(test.de.itemis.mps.modelmerger.testlanguage.structure)" />
     <import index="vxmj" ref="r:177139eb-5c36-4470-b440-3a70f7e15410(de.itemis.mps.modelmerger.runtime.plugin)" />
     <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" />
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" />
   </imports>
   <registry>
     <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
       <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
         <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
       </concept>
+      <concept id="1225469856668" name="jetbrains.mps.lang.test.structure.ModelExpression" flags="nn" index="1jGwE1" />
       <concept id="1216913645126" name="jetbrains.mps.lang.test.structure.NodesTestCase" flags="lg" index="1lH9Xt">
         <child id="1217501822150" name="nodesToCheck" index="1SKRRt" />
         <child id="1217501895093" name="testMethods" index="1SL9yI" />
@@ -50,6 +52,9 @@
       <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
         <child id="1145553007750" name="creator" index="2ShVmc" />
       </concept>
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
       <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
       </concept>
@@ -60,6 +65,7 @@
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
       <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
+      <concept id="1225271283259" name="jetbrains.mps.baseLanguage.structure.NPEEqualsExpression" flags="nn" index="17R0WA" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
@@ -70,10 +76,14 @@
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
       <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT" />
+      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
+        <property id="1068580320021" name="value" index="3cmrfH" />
+      </concept>
       <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
         <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
       </concept>
@@ -85,6 +95,10 @@
       </concept>
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
+      </concept>
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
+        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
+        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
       <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
         <child id="8356039341262087992" name="line" index="1aUNEU" />
@@ -125,14 +139,34 @@
         <child id="5932312848598539785" name="subComponents" index="2Ro54j" />
       </concept>
     </language>
+    <language id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi">
+      <concept id="361130699826193248" name="jetbrains.mps.lang.modelapi.structure.ModelPointer" flags="ng" index="1dCxOl">
+        <property id="1863527487546097494" name="modelId" index="1XweGQ" />
+        <child id="679099339649067980" name="name" index="1j$8Uc" />
+      </concept>
+      <concept id="679099339649053840" name="jetbrains.mps.lang.modelapi.structure.ModelName" flags="ng" index="1j_P7g">
+        <property id="679099339649053841" name="value" index="1j_P7h" />
+      </concept>
+    </language>
     <language id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest">
       <concept id="8427750732757990717" name="jetbrains.mps.baseLanguage.unitTest.structure.BinaryAssert" flags="nn" index="3tpDYu">
         <child id="8427750732757990725" name="actual" index="3tpDZA" />
         <child id="8427750732757990724" name="expected" index="3tpDZB" />
       </concept>
       <concept id="1171978097730" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertEquals" flags="nn" index="3vlDli" />
+      <concept id="1172073500303" name="jetbrains.mps.baseLanguage.unitTest.structure.Message" flags="ng" index="3_1$Yv">
+        <child id="1172073511101" name="message" index="3_1BAH" />
+      </concept>
+      <concept id="1172075514136" name="jetbrains.mps.baseLanguage.unitTest.structure.MessageHolder" flags="ng" index="3_9gw8">
+        <child id="1172075534298" name="message" index="3_9lra" />
+      </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1179168000618" name="jetbrains.mps.lang.smodel.structure.Node_GetIndexInParentOperation" flags="nn" index="2bSWHS" />
+      <concept id="4065387505485742666" name="jetbrains.mps.lang.smodel.structure.ModelPointer_ResolveOperation" flags="ng" index="2yCiCJ" />
+      <concept id="4065387505485742749" name="jetbrains.mps.lang.smodel.structure.AbstractPointerResolveOperation" flags="ng" index="2yCiFS">
+        <child id="3648723375513868575" name="repositoryArg" index="Vysub" />
+      </concept>
       <concept id="1143226024141" name="jetbrains.mps.lang.smodel.structure.SModelType" flags="in" index="H_c77" />
       <concept id="1145404486709" name="jetbrains.mps.lang.smodel.structure.SemanticDowncastExpression" flags="nn" index="2JrnkZ">
         <child id="1145404616321" name="leftExpression" index="2JrQYb" />
@@ -146,8 +180,14 @@
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
         <reference id="1138405853777" name="concept" index="ehGHo" />
       </concept>
+      <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
+        <reference id="1138056395725" name="property" index="3TsBF5" />
+      </concept>
       <concept id="1138056282393" name="jetbrains.mps.lang.smodel.structure.SLinkListAccess" flags="nn" index="3Tsc0h">
         <reference id="1138056546658" name="link" index="3TtcxE" />
+      </concept>
+      <concept id="1863527487546129879" name="jetbrains.mps.lang.smodel.structure.ModelPointerExpression" flags="ng" index="1Xw6AR">
+        <child id="1863527487546132519" name="modelRef" index="1XwpL7" />
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
@@ -156,6 +196,13 @@
       </concept>
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+      <concept id="709746936026466394" name="jetbrains.mps.lang.core.structure.ChildAttribute" flags="ng" index="3VBwX9">
+        <property id="709746936026609031" name="linkId" index="3V$3ak" />
+        <property id="709746936026609029" name="role_DebugInfo" index="3V$3am" />
+      </concept>
+      <concept id="4452961908202556907" name="jetbrains.mps.lang.core.structure.BaseCommentAttribute" flags="ng" index="1X3_iC">
+        <child id="3078666699043039389" name="commentedNode" index="8Wnug" />
       </concept>
     </language>
     <language id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text">
@@ -182,6 +229,7 @@
         <child id="1197687035757" name="valueType" index="3rHtpV" />
       </concept>
       <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
+      <concept id="1225727723840" name="jetbrains.mps.baseLanguage.collections.structure.FindFirstOperation" flags="nn" index="1z4cxt" />
       <concept id="1197932370469" name="jetbrains.mps.baseLanguage.collections.structure.MapElement" flags="nn" index="3EllGN">
         <child id="1197932505799" name="map" index="3ElQJh" />
         <child id="1197932525128" name="key" index="3ElVtu" />
@@ -300,6 +348,37 @@
       <property role="TrG5h" value="simpleModelMergeTest" />
       <node concept="3cqZAl" id="lVcTBwuwxO" role="3clF45" />
       <node concept="3clFbS" id="lVcTBwuwxP" role="3clF47">
+        <node concept="3SKdUt" id="6IWRPdWKoeP" role="3cqZAp">
+          <node concept="1PaTwC" id="6IWRPdWKoeQ" role="1aUNEU">
+            <node concept="3oM_SD" id="6IWRPdWKoeR" role="1PaTwD">
+              <property role="3oM_SC" value="Set" />
+            </node>
+            <node concept="3oM_SD" id="6IWRPdWKonh" role="1PaTwD">
+              <property role="3oM_SC" value="up" />
+            </node>
+            <node concept="3oM_SD" id="6IWRPdWKonk" role="1PaTwD">
+              <property role="3oM_SC" value="source" />
+            </node>
+            <node concept="3oM_SD" id="6IWRPdWKopm" role="1PaTwD">
+              <property role="3oM_SC" value="test" />
+            </node>
+            <node concept="3oM_SD" id="6IWRPdWKonx" role="1PaTwD">
+              <property role="3oM_SC" value="model" />
+            </node>
+            <node concept="3oM_SD" id="6IWRPdWKonA" role="1PaTwD">
+              <property role="3oM_SC" value="containing" />
+            </node>
+            <node concept="3oM_SD" id="6IWRPdWKpxd" role="1PaTwD">
+              <property role="3oM_SC" value="test" />
+            </node>
+            <node concept="3oM_SD" id="6IWRPdWKood" role="1PaTwD">
+              <property role="3oM_SC" value="root" />
+            </node>
+            <node concept="3oM_SD" id="6IWRPdWKooU" role="1PaTwD">
+              <property role="3oM_SC" value="object" />
+            </node>
+          </node>
+        </node>
         <node concept="3cpWs8" id="lVcTBwuwOH" role="3cqZAp">
           <node concept="3cpWsn" id="lVcTBwuwOK" role="3cpWs9">
             <property role="TrG5h" value="testMdlSource" />
@@ -310,29 +389,9 @@
                 <ref role="1Pybhc" to="tqvn:~TemporaryModels" resolve="TemporaryModels" />
               </node>
               <node concept="liA8E" id="lVcTBwu_1X" role="2OqNvi">
-                <ref role="37wK5l" to="tqvn:~TemporaryModels.create(boolean,jetbrains.mps.smodel.tempmodel.TempModuleOptions)" resolve="create" />
+                <ref role="37wK5l" to="tqvn:~TemporaryModels.createEditable(boolean,jetbrains.mps.smodel.tempmodel.TempModuleOptions)" resolve="createEditable" />
                 <node concept="3clFbT" id="lVcTBwu_3r" role="37wK5m" />
                 <node concept="2YIFZM" id="lVcTBwuA50" role="37wK5m">
-                  <ref role="37wK5l" to="tqvn:~TempModuleOptions.forDefaultModule()" resolve="forDefaultModule" />
-                  <ref role="1Pybhc" to="tqvn:~TempModuleOptions" resolve="TempModuleOptions" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3cpWs8" id="lVcTBwuA8x" role="3cqZAp">
-          <node concept="3cpWsn" id="lVcTBwuA8y" role="3cpWs9">
-            <property role="TrG5h" value="testMdlDestination" />
-            <node concept="H_c77" id="lVcTBwuA8z" role="1tU5fm" />
-            <node concept="2OqwBi" id="lVcTBwuA8$" role="33vP2m">
-              <node concept="2YIFZM" id="lVcTBwuA8_" role="2Oq$k0">
-                <ref role="1Pybhc" to="tqvn:~TemporaryModels" resolve="TemporaryModels" />
-                <ref role="37wK5l" to="tqvn:~TemporaryModels.getInstance()" resolve="getInstance" />
-              </node>
-              <node concept="liA8E" id="lVcTBwuA8A" role="2OqNvi">
-                <ref role="37wK5l" to="tqvn:~TemporaryModels.create(boolean,jetbrains.mps.smodel.tempmodel.TempModuleOptions)" resolve="create" />
-                <node concept="3clFbT" id="lVcTBwuA8B" role="37wK5m" />
-                <node concept="2YIFZM" id="lVcTBwuA8C" role="37wK5m">
                   <ref role="37wK5l" to="tqvn:~TempModuleOptions.forDefaultModule()" resolve="forDefaultModule" />
                   <ref role="1Pybhc" to="tqvn:~TempModuleOptions" resolve="TempModuleOptions" />
                 </node>
@@ -349,6 +408,46 @@
               <node concept="3xONca" id="lVcTBwuADV" role="3BYIHq">
                 <ref role="3xOPvv" node="lVcTBwuwxk" resolve="testSource" />
               </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3SKdUt" id="6IWRPdWKpHN" role="3cqZAp">
+          <node concept="1PaTwC" id="6IWRPdWKpHO" role="1aUNEU">
+            <node concept="3oM_SD" id="6IWRPdWKpHP" role="1PaTwD">
+              <property role="3oM_SC" value="Store" />
+            </node>
+            <node concept="3oM_SD" id="6IWRPdWKpU1" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="6IWRPdWKpU4" role="1PaTwD">
+              <property role="3oM_SC" value="current" />
+            </node>
+            <node concept="3oM_SD" id="6IWRPdWKpUh" role="1PaTwD">
+              <property role="3oM_SC" value="tSystem" />
+            </node>
+            <node concept="3oM_SD" id="6IWRPdWKpUC" role="1PaTwD">
+              <property role="3oM_SC" value="root" />
+            </node>
+            <node concept="3oM_SD" id="6IWRPdWKpVD" role="1PaTwD">
+              <property role="3oM_SC" value="+" />
+            </node>
+            <node concept="3oM_SD" id="6IWRPdWKpVW" role="1PaTwD">
+              <property role="3oM_SC" value="its" />
+            </node>
+            <node concept="3oM_SD" id="6IWRPdWKpWg" role="1PaTwD">
+              <property role="3oM_SC" value="node" />
+            </node>
+            <node concept="3oM_SD" id="6IWRPdWKpWI" role="1PaTwD">
+              <property role="3oM_SC" value="ID" />
+            </node>
+            <node concept="3oM_SD" id="6IWRPdWKpUI" role="1PaTwD">
+              <property role="3oM_SC" value="for" />
+            </node>
+            <node concept="3oM_SD" id="6IWRPdWKpUP" role="1PaTwD">
+              <property role="3oM_SC" value="later" />
+            </node>
+            <node concept="3oM_SD" id="6IWRPdWKpV6" role="1PaTwD">
+              <property role="3oM_SC" value="reference." />
             </node>
           </node>
         </node>
@@ -385,6 +484,57 @@
               </node>
               <node concept="liA8E" id="lVcTBwuL39" role="2OqNvi">
                 <ref role="37wK5l" to="mhbf:~SNode.getNodeId()" resolve="getNodeId" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3SKdUt" id="6IWRPdWKpl2" role="3cqZAp">
+          <node concept="1PaTwC" id="6IWRPdWKpl3" role="1aUNEU">
+            <node concept="3oM_SD" id="6IWRPdWKpl4" role="1PaTwD">
+              <property role="3oM_SC" value="Set" />
+            </node>
+            <node concept="3oM_SD" id="6IWRPdWKptE" role="1PaTwD">
+              <property role="3oM_SC" value="up" />
+            </node>
+            <node concept="3oM_SD" id="6IWRPdWKptH" role="1PaTwD">
+              <property role="3oM_SC" value="destination" />
+            </node>
+            <node concept="3oM_SD" id="6IWRPdWKpu3" role="1PaTwD">
+              <property role="3oM_SC" value="test" />
+            </node>
+            <node concept="3oM_SD" id="6IWRPdWKpuB" role="1PaTwD">
+              <property role="3oM_SC" value="model" />
+            </node>
+            <node concept="3oM_SD" id="6IWRPdWKpvD" role="1PaTwD">
+              <property role="3oM_SC" value="containing" />
+            </node>
+            <node concept="3oM_SD" id="6IWRPdWKpwU" role="1PaTwD">
+              <property role="3oM_SC" value="test" />
+            </node>
+            <node concept="3oM_SD" id="6IWRPdWKpw1" role="1PaTwD">
+              <property role="3oM_SC" value="root" />
+            </node>
+            <node concept="3oM_SD" id="6IWRPdWKpwj" role="1PaTwD">
+              <property role="3oM_SC" value="object" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="lVcTBwuA8x" role="3cqZAp">
+          <node concept="3cpWsn" id="lVcTBwuA8y" role="3cpWs9">
+            <property role="TrG5h" value="testMdlDestination" />
+            <node concept="H_c77" id="lVcTBwuA8z" role="1tU5fm" />
+            <node concept="2OqwBi" id="lVcTBwuA8$" role="33vP2m">
+              <node concept="2YIFZM" id="lVcTBwuA8_" role="2Oq$k0">
+                <ref role="1Pybhc" to="tqvn:~TemporaryModels" resolve="TemporaryModels" />
+                <ref role="37wK5l" to="tqvn:~TemporaryModels.getInstance()" resolve="getInstance" />
+              </node>
+              <node concept="liA8E" id="lVcTBwuA8A" role="2OqNvi">
+                <ref role="37wK5l" to="tqvn:~TemporaryModels.createEditable(boolean,jetbrains.mps.smodel.tempmodel.TempModuleOptions)" resolve="createEditable" />
+                <node concept="3clFbT" id="lVcTBwuA8B" role="37wK5m" />
+                <node concept="2YIFZM" id="lVcTBwuA8C" role="37wK5m">
+                  <ref role="37wK5l" to="tqvn:~TempModuleOptions.forDefaultModule()" resolve="forDefaultModule" />
+                  <ref role="1Pybhc" to="tqvn:~TempModuleOptions" resolve="TempModuleOptions" />
+                </node>
               </node>
             </node>
           </node>
@@ -476,6 +626,43 @@
             </node>
             <node concept="37vLTw" id="4Z26wkKk7Nu" role="37wK5m">
               <ref role="3cqZAo" node="4Z26wkKjBLd" resolve="testLangRegistry" />
+            </node>
+          </node>
+        </node>
+        <node concept="3SKdUt" id="6IWRPdWKqv4" role="3cqZAp">
+          <node concept="1PaTwC" id="6IWRPdWKqv5" role="1aUNEU">
+            <node concept="3oM_SD" id="6IWRPdWKqv6" role="1PaTwD">
+              <property role="3oM_SC" value="Store" />
+            </node>
+            <node concept="3oM_SD" id="6IWRPdWKqv7" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="6IWRPdWKqv8" role="1PaTwD">
+              <property role="3oM_SC" value="resulting" />
+            </node>
+            <node concept="3oM_SD" id="6IWRPdWKqv9" role="1PaTwD">
+              <property role="3oM_SC" value="tSystem" />
+            </node>
+            <node concept="3oM_SD" id="6IWRPdWKqva" role="1PaTwD">
+              <property role="3oM_SC" value="root" />
+            </node>
+            <node concept="3oM_SD" id="6IWRPdWKqvb" role="1PaTwD">
+              <property role="3oM_SC" value="+" />
+            </node>
+            <node concept="3oM_SD" id="6IWRPdWKqvc" role="1PaTwD">
+              <property role="3oM_SC" value="its" />
+            </node>
+            <node concept="3oM_SD" id="6IWRPdWKqvd" role="1PaTwD">
+              <property role="3oM_SC" value="node" />
+            </node>
+            <node concept="3oM_SD" id="6IWRPdWKqve" role="1PaTwD">
+              <property role="3oM_SC" value="ID" />
+            </node>
+            <node concept="3oM_SD" id="6IWRPdWKqvf" role="1PaTwD">
+              <property role="3oM_SC" value="for" />
+            </node>
+            <node concept="3oM_SD" id="6IWRPdWKqCF" role="1PaTwD">
+              <property role="3oM_SC" value="comparison" />
             </node>
           </node>
         </node>
@@ -576,6 +763,11 @@
             </node>
             <node concept="34oBXx" id="4zKvG_YAZlw" role="2OqNvi" />
           </node>
+          <node concept="3_1$Yv" id="6IWRPdWKtBX" role="3_9lra">
+            <node concept="Xl_RD" id="6IWRPdWKtI8" role="3_1BAH">
+              <property role="Xl_RC" value="Outports were not merged correctly" />
+            </node>
+          </node>
         </node>
         <node concept="3SKdUt" id="lVcTBwveTr" role="3cqZAp">
           <node concept="1PaTwC" id="7WTFIQIcYkk" role="1aUNEU">
@@ -627,12 +819,1012 @@
           <node concept="37vLTw" id="4zKvG_YB1BX" role="3tpDZA">
             <ref role="3cqZAo" node="lVcTBwuBpZ" resolve="rootIdBeforeImport" />
           </node>
+          <node concept="3_1$Yv" id="6IWRPdWKbmB" role="3_9lra">
+            <node concept="Xl_RD" id="6IWRPdWKbXK" role="3_1BAH">
+              <property role="Xl_RC" value="Root ID of model has changed. Import is not incremental" />
+            </node>
+          </node>
         </node>
+        <node concept="3clFbH" id="6IWRPdWKqPx" role="3cqZAp" />
       </node>
     </node>
   </node>
   <node concept="2XOHcx" id="lVcTBwvlbl">
     <property role="2XOHcw" value="${extensions.home}/code" />
+  </node>
+  <node concept="1lH9Xt" id="6IWRPdWGVTs">
+    <property role="TrG5h" value="MergedOrder" />
+    <node concept="1qefOq" id="6IWRPdWGWri" role="1SKRRt">
+      <node concept="2Ro1FD" id="6IWRPdWGWrj" role="1qenE9">
+        <property role="TrG5h" value="sys1" />
+        <node concept="2Ro54h" id="6IWRPdWLD4j" role="2Ro1FG">
+          <property role="TrG5h" value="B" />
+          <property role="2Ro54k" value="1" />
+        </node>
+        <node concept="3xLA65" id="6IWRPdWGWrl" role="lGtFl">
+          <property role="TrG5h" value="testSource" />
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="6IWRPdWGVTt" role="1SKRRt">
+      <node concept="2Ro1FD" id="6IWRPdWGVTu" role="1qenE9">
+        <property role="TrG5h" value="sys1" />
+        <node concept="2Ro54h" id="6IWRPdWJzhC" role="2Ro1FG">
+          <property role="TrG5h" value="A" />
+          <property role="2Ro54k" value="2" />
+        </node>
+        <node concept="2Ro54h" id="6IWRPdWGWtK" role="2Ro1FG">
+          <property role="TrG5h" value="B" />
+          <property role="2Ro54k" value="3" />
+        </node>
+        <node concept="2Ro54h" id="6IWRPdWGWqD" role="2Ro1FG">
+          <property role="TrG5h" value="C" />
+          <property role="2Ro54k" value="4" />
+        </node>
+        <node concept="3xLA65" id="6IWRPdWGVTC" role="lGtFl">
+          <property role="TrG5h" value="testDestination" />
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="6IWRPdWGVTS" role="1SL9yI">
+      <property role="TrG5h" value="childSequenceTest" />
+      <node concept="3cqZAl" id="6IWRPdWGVTT" role="3clF45" />
+      <node concept="3clFbS" id="6IWRPdWGVTU" role="3clF47">
+        <node concept="3SKdUt" id="6QnTwqHhaYK" role="3cqZAp">
+          <node concept="1PaTwC" id="6QnTwqHhaYL" role="1aUNEU">
+            <node concept="3oM_SD" id="6QnTwqHhaYM" role="1PaTwD">
+              <property role="3oM_SC" value="Create" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHhbm_" role="1PaTwD">
+              <property role="3oM_SC" value="test" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHhbmL" role="1PaTwD">
+              <property role="3oM_SC" value="models" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHhbmY" role="1PaTwD">
+              <property role="3oM_SC" value="with" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHhbnc" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHhbni" role="1PaTwD">
+              <property role="3oM_SC" value="test" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHhbny" role="1PaTwD">
+              <property role="3oM_SC" value="objects" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHhbnE" role="1PaTwD">
+              <property role="3oM_SC" value="as" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHhbnN" role="1PaTwD">
+              <property role="3oM_SC" value="respective" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHhbo6" role="1PaTwD">
+              <property role="3oM_SC" value="roots" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="6IWRPdWGVTV" role="3cqZAp">
+          <node concept="3cpWsn" id="6IWRPdWGVTW" role="3cpWs9">
+            <property role="TrG5h" value="testMdlSource" />
+            <node concept="H_c77" id="6IWRPdWGVTX" role="1tU5fm" />
+            <node concept="2OqwBi" id="6IWRPdWGVTY" role="33vP2m">
+              <node concept="2YIFZM" id="6IWRPdWGVTZ" role="2Oq$k0">
+                <ref role="1Pybhc" to="tqvn:~TemporaryModels" resolve="TemporaryModels" />
+                <ref role="37wK5l" to="tqvn:~TemporaryModels.getInstance()" resolve="getInstance" />
+              </node>
+              <node concept="liA8E" id="6IWRPdWGVU0" role="2OqNvi">
+                <ref role="37wK5l" to="tqvn:~TemporaryModels.createEditable(boolean,jetbrains.mps.smodel.tempmodel.TempModuleOptions)" resolve="createEditable" />
+                <node concept="3clFbT" id="6IWRPdWGVU1" role="37wK5m" />
+                <node concept="2YIFZM" id="6IWRPdWGVU2" role="37wK5m">
+                  <ref role="37wK5l" to="tqvn:~TempModuleOptions.forDefaultModule()" resolve="forDefaultModule" />
+                  <ref role="1Pybhc" to="tqvn:~TempModuleOptions" resolve="TempModuleOptions" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3SKdUt" id="6IWRPdWLwpp" role="3cqZAp">
+          <node concept="1PaTwC" id="6IWRPdWLwpq" role="1aUNEU">
+            <node concept="3oM_SD" id="6IWRPdWLwTF" role="1PaTwD">
+              <property role="3oM_SC" value="To" />
+            </node>
+            <node concept="3oM_SD" id="6IWRPdWLwTQ" role="1PaTwD">
+              <property role="3oM_SC" value="inspect" />
+            </node>
+            <node concept="3oM_SD" id="6IWRPdWLwU1" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="6IWRPdWLwU5" role="1PaTwD">
+              <property role="3oM_SC" value="results" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHh9BR" role="1PaTwD">
+              <property role="3oM_SC" value="in" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHh9Ck" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHh9CD" role="1PaTwD">
+              <property role="3oM_SC" value="IDE," />
+            </node>
+            <node concept="3oM_SD" id="6IWRPdWLwUa" role="1PaTwD">
+              <property role="3oM_SC" value="use" />
+            </node>
+            <node concept="3oM_SD" id="6IWRPdWLwUg" role="1PaTwD">
+              <property role="3oM_SC" value="a" />
+            </node>
+            <node concept="3oM_SD" id="6IWRPdWLwUn" role="1PaTwD">
+              <property role="3oM_SC" value="resolved" />
+            </node>
+            <node concept="3oM_SD" id="6IWRPdWLwV3" role="1PaTwD">
+              <property role="3oM_SC" value="model-ptr" />
+            </node>
+            <node concept="3oM_SD" id="6IWRPdWLwVl" role="1PaTwD">
+              <property role="3oM_SC" value="to" />
+            </node>
+            <node concept="3oM_SD" id="6IWRPdWLwWh" role="1PaTwD">
+              <property role="3oM_SC" value="an" />
+            </node>
+            <node concept="3oM_SD" id="6IWRPdWLwWs" role="1PaTwD">
+              <property role="3oM_SC" value="existing" />
+            </node>
+            <node concept="3oM_SD" id="6IWRPdWLwWC" role="1PaTwD">
+              <property role="3oM_SC" value="model" />
+            </node>
+            <node concept="3oM_SD" id="6IWRPdWLwWP" role="1PaTwD">
+              <property role="3oM_SC" value="in" />
+            </node>
+            <node concept="3oM_SD" id="6IWRPdWLwX3" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="6IWRPdWLwXi" role="1PaTwD">
+              <property role="3oM_SC" value="current" />
+            </node>
+            <node concept="3oM_SD" id="6IWRPdWLwYw" role="1PaTwD">
+              <property role="3oM_SC" value="repository," />
+            </node>
+            <node concept="3oM_SD" id="6IWRPdWLwYW" role="1PaTwD">
+              <property role="3oM_SC" value="such" />
+            </node>
+            <node concept="3oM_SD" id="6IWRPdWLwZe" role="1PaTwD">
+              <property role="3oM_SC" value="as:" />
+            </node>
+          </node>
+        </node>
+        <node concept="1X3_iC" id="6IWRPdWLvgJ" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="6IWRPdWJ7De" role="8Wnug">
+            <node concept="37vLTI" id="6IWRPdWJ8dN" role="3clFbG">
+              <node concept="2OqwBi" id="6IWRPdWJ8X2" role="37vLTx">
+                <node concept="1Xw6AR" id="6IWRPdWJ8NY" role="2Oq$k0">
+                  <node concept="1dCxOl" id="6IWRPdWJ8R5" role="1XwpL7">
+                    <property role="1XweGQ" value="r:cafcc752-b2e0-44a9-aa42-52b4ce70f4d0" />
+                    <node concept="1j_P7g" id="6IWRPdWJ8R6" role="1j$8Uc">
+                      <property role="1j_P7h" value="tests.de.itemis.mps.modelmerger.output" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2yCiCJ" id="6IWRPdWJ97K" role="2OqNvi">
+                  <node concept="2OqwBi" id="6IWRPdWJ9iX" role="Vysub">
+                    <node concept="1jGwE1" id="6IWRPdWJ99H" role="2Oq$k0" />
+                    <node concept="liA8E" id="6IWRPdWJ9tC" role="2OqNvi">
+                      <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="37vLTw" id="6IWRPdWJ7Dc" role="37vLTJ">
+                <ref role="3cqZAo" node="6IWRPdWGVTW" resolve="testMdlSource" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="6IWRPdWGX7A" role="3cqZAp">
+          <node concept="3cpWsn" id="6IWRPdWGX7B" role="3cpWs9">
+            <property role="TrG5h" value="testMdlDestination" />
+            <node concept="H_c77" id="6IWRPdWGX7C" role="1tU5fm" />
+            <node concept="2OqwBi" id="6IWRPdWGX7D" role="33vP2m">
+              <node concept="2YIFZM" id="6IWRPdWGX7E" role="2Oq$k0">
+                <ref role="1Pybhc" to="tqvn:~TemporaryModels" resolve="TemporaryModels" />
+                <ref role="37wK5l" to="tqvn:~TemporaryModels.getInstance()" resolve="getInstance" />
+              </node>
+              <node concept="liA8E" id="6IWRPdWGX7F" role="2OqNvi">
+                <ref role="37wK5l" to="tqvn:~TemporaryModels.createEditable(boolean,jetbrains.mps.smodel.tempmodel.TempModuleOptions)" resolve="createEditable" />
+                <node concept="3clFbT" id="6IWRPdWGX7G" role="37wK5m" />
+                <node concept="2YIFZM" id="6IWRPdWGX7H" role="37wK5m">
+                  <ref role="37wK5l" to="tqvn:~TempModuleOptions.forDefaultModule()" resolve="forDefaultModule" />
+                  <ref role="1Pybhc" to="tqvn:~TempModuleOptions" resolve="TempModuleOptions" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6IWRPdWGXqt" role="3cqZAp">
+          <node concept="2OqwBi" id="6IWRPdWGXqu" role="3clFbG">
+            <node concept="37vLTw" id="6IWRPdWGXqv" role="2Oq$k0">
+              <ref role="3cqZAo" node="6IWRPdWGVTW" resolve="testMdlSource" />
+            </node>
+            <node concept="3BYIHo" id="6IWRPdWGXqw" role="2OqNvi">
+              <node concept="3xONca" id="6IWRPdWGYK9" role="3BYIHq">
+                <ref role="3xOPvv" node="6IWRPdWGWrl" resolve="testSource" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6IWRPdWGVUb" role="3cqZAp">
+          <node concept="2OqwBi" id="6IWRPdWGVUc" role="3clFbG">
+            <node concept="37vLTw" id="6IWRPdWGXDk" role="2Oq$k0">
+              <ref role="3cqZAo" node="6IWRPdWGX7B" resolve="testMdlDestination" />
+            </node>
+            <node concept="3BYIHo" id="6IWRPdWGVUe" role="2OqNvi">
+              <node concept="3xONca" id="6IWRPdWGVUf" role="3BYIHq">
+                <ref role="3xOPvv" node="6IWRPdWGVTC" resolve="testDestination" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6IWRPdWINYZ" role="3cqZAp" />
+        <node concept="3SKdUt" id="6QnTwqHha6c" role="3cqZAp">
+          <node concept="1PaTwC" id="6QnTwqHha6d" role="1aUNEU">
+            <node concept="3oM_SD" id="6QnTwqHha6e" role="1PaTwD">
+              <property role="3oM_SC" value="Initialize" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHhatP" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHhau_" role="1PaTwD">
+              <property role="3oM_SC" value="identity" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHhauO" role="1PaTwD">
+              <property role="3oM_SC" value="calculator" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHhauT" role="1PaTwD">
+              <property role="3oM_SC" value="rules" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHhav8" role="1PaTwD">
+              <property role="3oM_SC" value="associated" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHhavo" role="1PaTwD">
+              <property role="3oM_SC" value="with" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHhavw" role="1PaTwD">
+              <property role="3oM_SC" value="this" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHhavD" role="1PaTwD">
+              <property role="3oM_SC" value="test" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHhavN" role="1PaTwD">
+              <property role="3oM_SC" value="case" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="6IWRPdWGVU$" role="3cqZAp">
+          <node concept="3cpWsn" id="6IWRPdWGVU_" role="3cpWs9">
+            <property role="TrG5h" value="testLangRegistry" />
+            <node concept="3rvAFt" id="6IWRPdWGVUA" role="1tU5fm">
+              <node concept="3uibUv" id="6IWRPdWGVUB" role="3rvQeY">
+                <ref role="3uigEE" to="c17a:~SConcept" resolve="SConcept" />
+              </node>
+              <node concept="3uibUv" id="6IWRPdWGVUC" role="3rvSg0">
+                <ref role="3uigEE" to="vxmj:6NDRJQ9pWGW" resolve="IdentityCalculator" />
+              </node>
+            </node>
+            <node concept="2ShNRf" id="6IWRPdWGVUD" role="33vP2m">
+              <node concept="3rGOSV" id="6IWRPdWGVUE" role="2ShVmc">
+                <node concept="3uibUv" id="6IWRPdWGVUF" role="3rHrn6">
+                  <ref role="3uigEE" to="c17a:~SConcept" resolve="SConcept" />
+                </node>
+                <node concept="3uibUv" id="6IWRPdWGVUG" role="3rHtpV">
+                  <ref role="3uigEE" to="vxmj:6NDRJQ9pWGW" resolve="IdentityCalculator" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6IWRPdWGVUH" role="3cqZAp">
+          <node concept="2OqwBi" id="6IWRPdWGVUI" role="3clFbG">
+            <node concept="2OqwBi" id="6IWRPdWGVUJ" role="2Oq$k0">
+              <node concept="2O5UvJ" id="6IWRPdWGVUK" role="2Oq$k0">
+                <ref role="2O5UnU" to="vxmj:2VC4eVXUC8b" resolve="IdentityCalculators" />
+              </node>
+              <node concept="SfwO_" id="6IWRPdWGVUL" role="2OqNvi" />
+            </node>
+            <node concept="2es0OD" id="6IWRPdWGVUM" role="2OqNvi">
+              <node concept="1bVj0M" id="6IWRPdWGVUN" role="23t8la">
+                <node concept="3clFbS" id="6IWRPdWGVUO" role="1bW5cS">
+                  <node concept="3clFbF" id="6IWRPdWGVUP" role="3cqZAp">
+                    <node concept="37vLTI" id="6IWRPdWGVUQ" role="3clFbG">
+                      <node concept="37vLTw" id="6IWRPdWGVUR" role="37vLTx">
+                        <ref role="3cqZAo" node="6IWRPdWGVUX" resolve="extPoint" />
+                      </node>
+                      <node concept="3EllGN" id="6IWRPdWGVUS" role="37vLTJ">
+                        <node concept="2OqwBi" id="6IWRPdWGVUT" role="3ElVtu">
+                          <node concept="37vLTw" id="6IWRPdWGVUU" role="2Oq$k0">
+                            <ref role="3cqZAo" node="6IWRPdWGVUX" resolve="extPoint" />
+                          </node>
+                          <node concept="liA8E" id="6IWRPdWGVUV" role="2OqNvi">
+                            <ref role="37wK5l" to="vxmj:6NDRJQ9pWJ3" resolve="applicableConcept" />
+                          </node>
+                        </node>
+                        <node concept="37vLTw" id="6IWRPdWGVUW" role="3ElQJh">
+                          <ref role="3cqZAo" node="6IWRPdWGVU_" resolve="testLangRegistry" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="Rh6nW" id="6IWRPdWGVUX" role="1bW2Oz">
+                  <property role="TrG5h" value="extPoint" />
+                  <node concept="2jxLKc" id="6IWRPdWGVUY" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6IWRPdWHHY2" role="3cqZAp" />
+        <node concept="3SKdUt" id="6QnTwqHhbvQ" role="3cqZAp">
+          <node concept="1PaTwC" id="6QnTwqHhbvR" role="1aUNEU">
+            <node concept="3oM_SD" id="6QnTwqHhbvS" role="1PaTwD">
+              <property role="3oM_SC" value="Store" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHhbXe" role="1PaTwD">
+              <property role="3oM_SC" value="test" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHhbXq" role="1PaTwD">
+              <property role="3oM_SC" value="system" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHhbXu" role="1PaTwD">
+              <property role="3oM_SC" value="and" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHhbXz" role="1PaTwD">
+              <property role="3oM_SC" value="node" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHhbXM" role="1PaTwD">
+              <property role="3oM_SC" value="IDs" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHhbYb" role="1PaTwD">
+              <property role="3oM_SC" value="of" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHhbYs" role="1PaTwD">
+              <property role="3oM_SC" value="root" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHhbY_" role="1PaTwD">
+              <property role="3oM_SC" value="and" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHhbYS" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHhbZ3" role="1PaTwD">
+              <property role="3oM_SC" value="single" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHhbZf" role="1PaTwD">
+              <property role="3oM_SC" value="inport" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHhbZR" role="1PaTwD">
+              <property role="3oM_SC" value="(&quot;B&quot;)" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="6IWRPdWHInG" role="3cqZAp">
+          <node concept="3cpWsn" id="6IWRPdWHInJ" role="3cpWs9">
+            <property role="TrG5h" value="sysBeforeImport" />
+            <node concept="3Tqbb2" id="6IWRPdWHInK" role="1tU5fm">
+              <ref role="ehGHo" to="k6li:59jNLF_cXnN" resolve="tSystem" />
+            </node>
+            <node concept="2OqwBi" id="6IWRPdWHInL" role="33vP2m">
+              <node concept="2OqwBi" id="6IWRPdWHInM" role="2Oq$k0">
+                <node concept="37vLTw" id="6IWRPdWHInN" role="2Oq$k0">
+                  <ref role="3cqZAo" node="6IWRPdWGVTW" resolve="testMdlSource" />
+                </node>
+                <node concept="2RRcyG" id="6IWRPdWHInO" role="2OqNvi">
+                  <ref role="2RRcyH" to="k6li:59jNLF_cXnN" resolve="tSystem" />
+                </node>
+              </node>
+              <node concept="1uHKPH" id="6IWRPdWHInP" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="6IWRPdWIQ6C" role="3cqZAp">
+          <node concept="3cpWsn" id="6IWRPdWIQ6F" role="3cpWs9">
+            <property role="TrG5h" value="rootIdBeforeImport" />
+            <node concept="3uibUv" id="6IWRPdWIQ6G" role="1tU5fm">
+              <ref role="3uigEE" to="mhbf:~SNodeId" resolve="SNodeId" />
+            </node>
+            <node concept="2OqwBi" id="6IWRPdWIQ6H" role="33vP2m">
+              <node concept="2JrnkZ" id="6IWRPdWIQ6I" role="2Oq$k0">
+                <node concept="37vLTw" id="6IWRPdWIS0_" role="2JrQYb">
+                  <ref role="3cqZAo" node="6IWRPdWHInJ" resolve="sysBeforeImport" />
+                </node>
+              </node>
+              <node concept="liA8E" id="6IWRPdWIQ6K" role="2OqNvi">
+                <ref role="37wK5l" to="mhbf:~SNode.getNodeId()" resolve="getNodeId" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="6IWRPdWM8CP" role="3cqZAp">
+          <node concept="3cpWsn" id="6IWRPdWM8CQ" role="3cpWs9">
+            <property role="TrG5h" value="inPortBIdBeforeImport" />
+            <node concept="3uibUv" id="6IWRPdWM8CR" role="1tU5fm">
+              <ref role="3uigEE" to="mhbf:~SNodeId" resolve="SNodeId" />
+            </node>
+            <node concept="2OqwBi" id="6IWRPdWM8CS" role="33vP2m">
+              <node concept="2JrnkZ" id="6IWRPdWM8CT" role="2Oq$k0">
+                <node concept="2OqwBi" id="6IWRPdWMaHV" role="2JrQYb">
+                  <node concept="2OqwBi" id="6IWRPdWM9bL" role="2Oq$k0">
+                    <node concept="37vLTw" id="6IWRPdWM8CU" role="2Oq$k0">
+                      <ref role="3cqZAo" node="6IWRPdWHInJ" resolve="sysBeforeImport" />
+                    </node>
+                    <node concept="3Tsc0h" id="6IWRPdWM9qu" role="2OqNvi">
+                      <ref role="3TtcxE" to="k6li:59jNLF_cXnQ" resolve="inports" />
+                    </node>
+                  </node>
+                  <node concept="1uHKPH" id="6IWRPdWMd53" role="2OqNvi" />
+                </node>
+              </node>
+              <node concept="liA8E" id="6IWRPdWM8CV" role="2OqNvi">
+                <ref role="37wK5l" to="mhbf:~SNode.getNodeId()" resolve="getNodeId" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6IWRPdWM8$H" role="3cqZAp" />
+        <node concept="3SKdUt" id="6QnTwqHhctU" role="3cqZAp">
+          <node concept="1PaTwC" id="6QnTwqHhctV" role="1aUNEU">
+            <node concept="3oM_SD" id="6QnTwqHhctW" role="1PaTwD">
+              <property role="3oM_SC" value="Do" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHhcVx" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHhcVH" role="1PaTwD">
+              <property role="3oM_SC" value="actual" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHhcVU" role="1PaTwD">
+              <property role="3oM_SC" value="merging" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6IWRPdWGVUZ" role="3cqZAp">
+          <node concept="2YIFZM" id="6IWRPdWGVV0" role="3clFbG">
+            <ref role="37wK5l" to="vxmj:6NDRJQ9sJiH" resolve="matchModelsInto" />
+            <ref role="1Pybhc" to="vxmj:3pOHGY6giq2" resolve="ModelMerger" />
+            <node concept="37vLTw" id="6IWRPdWGVV1" role="37wK5m">
+              <ref role="3cqZAo" node="6IWRPdWGVTW" resolve="testMdlSource" />
+            </node>
+            <node concept="37vLTw" id="6IWRPdWLKYv" role="37wK5m">
+              <ref role="3cqZAo" node="6IWRPdWGX7B" resolve="testMdlDestination" />
+            </node>
+            <node concept="37vLTw" id="6IWRPdWGVV3" role="37wK5m">
+              <ref role="3cqZAo" node="6IWRPdWGVU_" resolve="testLangRegistry" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6IWRPdWHg_x" role="3cqZAp" />
+        <node concept="3SKdUt" id="6QnTwqHhdkq" role="3cqZAp">
+          <node concept="1PaTwC" id="6QnTwqHhdNQ" role="1aUNEU">
+            <node concept="3oM_SD" id="6QnTwqHhedQ" role="1PaTwD">
+              <property role="3oM_SC" value="Compare" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHhebW" role="1PaTwD">
+              <property role="3oM_SC" value="test" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHhec8" role="1PaTwD">
+              <property role="3oM_SC" value="system" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHhecc" role="1PaTwD">
+              <property role="3oM_SC" value="and" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHhee7" role="1PaTwD">
+              <property role="3oM_SC" value="inport" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHhefK" role="1PaTwD">
+              <property role="3oM_SC" value="&quot;B&quot;'s" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHhefU" role="1PaTwD">
+              <property role="3oM_SC" value="" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHhecX" role="1PaTwD">
+              <property role="3oM_SC" value="node" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHhed3" role="1PaTwD">
+              <property role="3oM_SC" value="IDs" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHhedj" role="1PaTwD">
+              <property role="3oM_SC" value="" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="6IWRPdWGVV4" role="3cqZAp">
+          <node concept="3cpWsn" id="6IWRPdWGVV5" role="3cpWs9">
+            <property role="TrG5h" value="sysAfterImport" />
+            <node concept="3Tqbb2" id="6IWRPdWGVV6" role="1tU5fm">
+              <ref role="ehGHo" to="k6li:59jNLF_cXnN" resolve="tSystem" />
+            </node>
+            <node concept="2OqwBi" id="6IWRPdWGVV7" role="33vP2m">
+              <node concept="2OqwBi" id="6IWRPdWGVV8" role="2Oq$k0">
+                <node concept="37vLTw" id="6IWRPdWGVV9" role="2Oq$k0">
+                  <ref role="3cqZAo" node="6IWRPdWGVTW" resolve="testMdlSource" />
+                </node>
+                <node concept="2RRcyG" id="6IWRPdWGVVa" role="2OqNvi">
+                  <ref role="2RRcyH" to="k6li:59jNLF_cXnN" resolve="tSystem" />
+                </node>
+              </node>
+              <node concept="1uHKPH" id="6IWRPdWGVVb" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="6IWRPdWIPnw" role="3cqZAp">
+          <node concept="3cpWsn" id="6IWRPdWIPnz" role="3cpWs9">
+            <property role="TrG5h" value="rootIdAfterImport" />
+            <node concept="3uibUv" id="6IWRPdWIPn$" role="1tU5fm">
+              <ref role="3uigEE" to="mhbf:~SNodeId" resolve="SNodeId" />
+            </node>
+            <node concept="2OqwBi" id="6IWRPdWIPn_" role="33vP2m">
+              <node concept="2JrnkZ" id="6IWRPdWIPnA" role="2Oq$k0">
+                <node concept="37vLTw" id="6IWRPdWITB6" role="2JrQYb">
+                  <ref role="3cqZAo" node="6IWRPdWGVV5" resolve="sysAfterImport" />
+                </node>
+              </node>
+              <node concept="liA8E" id="6IWRPdWIPnC" role="2OqNvi">
+                <ref role="37wK5l" to="mhbf:~SNode.getNodeId()" resolve="getNodeId" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="6IWRPdWIOBa" role="3cqZAp">
+          <node concept="37vLTw" id="6IWRPdWIOBb" role="3tpDZB">
+            <ref role="3cqZAo" node="6IWRPdWIPnz" resolve="rootIdAfterImport" />
+          </node>
+          <node concept="37vLTw" id="6IWRPdWIOBc" role="3tpDZA">
+            <ref role="3cqZAo" node="6IWRPdWIQ6F" resolve="rootIdBeforeImport" />
+          </node>
+          <node concept="3_1$Yv" id="6IWRPdWJE_K" role="3_9lra">
+            <node concept="Xl_RD" id="6IWRPdWJMsB" role="3_1BAH">
+              <property role="Xl_RC" value="ID of the test root has changed." />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6IWRPdWMkk_" role="3cqZAp" />
+        <node concept="3SKdUt" id="6IWRPdWMlfW" role="3cqZAp">
+          <node concept="1PaTwC" id="6IWRPdWMlfX" role="1aUNEU">
+            <node concept="3oM_SD" id="6IWRPdWMlfY" role="1PaTwD">
+              <property role="3oM_SC" value="Ensure" />
+            </node>
+            <node concept="3oM_SD" id="6IWRPdWMm4e" role="1PaTwD">
+              <property role="3oM_SC" value="that" />
+            </node>
+            <node concept="3oM_SD" id="6IWRPdWMm4h" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="6IWRPdWMm4l" role="1PaTwD">
+              <property role="3oM_SC" value="old" />
+            </node>
+            <node concept="3oM_SD" id="6IWRPdWMm4q" role="1PaTwD">
+              <property role="3oM_SC" value="inport" />
+            </node>
+            <node concept="3oM_SD" id="6IWRPdWMm4w" role="1PaTwD">
+              <property role="3oM_SC" value="has" />
+            </node>
+            <node concept="3oM_SD" id="6IWRPdWMm4K" role="1PaTwD">
+              <property role="3oM_SC" value="not" />
+            </node>
+            <node concept="3oM_SD" id="6IWRPdWMm4S" role="1PaTwD">
+              <property role="3oM_SC" value="been" />
+            </node>
+            <node concept="3oM_SD" id="6IWRPdWMm51" role="1PaTwD">
+              <property role="3oM_SC" value="removed" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHhegD" role="1PaTwD">
+              <property role="3oM_SC" value="and" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHhegX" role="1PaTwD">
+              <property role="3oM_SC" value="re-added" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHheh9" role="1PaTwD">
+              <property role="3oM_SC" value="with" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHhehm" role="1PaTwD">
+              <property role="3oM_SC" value="a" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHheh$" role="1PaTwD">
+              <property role="3oM_SC" value="different" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHhehN" role="1PaTwD">
+              <property role="3oM_SC" value="node" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHheib" role="1PaTwD">
+              <property role="3oM_SC" value="ID" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="6IWRPdWMd9j" role="3cqZAp">
+          <node concept="3cpWsn" id="6IWRPdWMd9k" role="3cpWs9">
+            <property role="TrG5h" value="inPortBIdAfterImport" />
+            <node concept="3uibUv" id="6IWRPdWMd9l" role="1tU5fm">
+              <ref role="3uigEE" to="mhbf:~SNodeId" resolve="SNodeId" />
+            </node>
+            <node concept="2OqwBi" id="6IWRPdWMd9m" role="33vP2m">
+              <node concept="2JrnkZ" id="6IWRPdWMd9n" role="2Oq$k0">
+                <node concept="2OqwBi" id="6IWRPdWMd9o" role="2JrQYb">
+                  <node concept="2OqwBi" id="6IWRPdWMd9p" role="2Oq$k0">
+                    <node concept="37vLTw" id="6IWRPdWMd9q" role="2Oq$k0">
+                      <ref role="3cqZAo" node="6IWRPdWHInJ" resolve="sysBeforeImport" />
+                    </node>
+                    <node concept="3Tsc0h" id="6IWRPdWMd9r" role="2OqNvi">
+                      <ref role="3TtcxE" to="k6li:59jNLF_cXnQ" resolve="inports" />
+                    </node>
+                  </node>
+                  <node concept="1z4cxt" id="6IWRPdWMgLG" role="2OqNvi">
+                    <node concept="1bVj0M" id="6IWRPdWMgLI" role="23t8la">
+                      <node concept="3clFbS" id="6IWRPdWMgLJ" role="1bW5cS">
+                        <node concept="3clFbF" id="6IWRPdWMgRG" role="3cqZAp">
+                          <node concept="17R0WA" id="6IWRPdWMtN4" role="3clFbG">
+                            <node concept="2OqwBi" id="6IWRPdWMh35" role="3uHU7B">
+                              <node concept="37vLTw" id="6IWRPdWMgRF" role="2Oq$k0">
+                                <ref role="3cqZAo" node="6IWRPdWMgLK" resolve="it" />
+                              </node>
+                              <node concept="3TrcHB" id="6IWRPdWMhiD" role="2OqNvi">
+                                <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                              </node>
+                            </node>
+                            <node concept="Xl_RD" id="6IWRPdWMhTl" role="3uHU7w">
+                              <property role="Xl_RC" value="B" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="Rh6nW" id="6IWRPdWMgLK" role="1bW2Oz">
+                        <property role="TrG5h" value="it" />
+                        <node concept="2jxLKc" id="6IWRPdWMgLL" role="1tU5fm" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="6IWRPdWMd9t" role="2OqNvi">
+                <ref role="37wK5l" to="mhbf:~SNode.getNodeId()" resolve="getNodeId" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="6IWRPdWMifE" role="3cqZAp">
+          <node concept="37vLTw" id="6IWRPdWMm5J" role="3tpDZB">
+            <ref role="3cqZAo" node="6IWRPdWMd9k" resolve="inPortBIdAfterImport" />
+          </node>
+          <node concept="37vLTw" id="6IWRPdWMmP5" role="3tpDZA">
+            <ref role="3cqZAo" node="6IWRPdWM8CQ" resolve="inPortBIdBeforeImport" />
+          </node>
+          <node concept="3_1$Yv" id="6IWRPdWMifH" role="3_9lra">
+            <node concept="Xl_RD" id="6IWRPdWMifI" role="3_1BAH">
+              <property role="Xl_RC" value="ID of existing inport (B) has changed." />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6IWRPdWIT3J" role="3cqZAp" />
+        <node concept="3SKdUt" id="6QnTwqHgSwE" role="3cqZAp">
+          <node concept="1PaTwC" id="6QnTwqHgSwF" role="1aUNEU">
+            <node concept="3oM_SD" id="6QnTwqHgTIQ" role="1PaTwD">
+              <property role="3oM_SC" value="All" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHgTJ1" role="1PaTwD">
+              <property role="3oM_SC" value="inports" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHgTJC" role="1PaTwD">
+              <property role="3oM_SC" value="should" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHgTJG" role="1PaTwD">
+              <property role="3oM_SC" value="have" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHgTJL" role="1PaTwD">
+              <property role="3oM_SC" value="been" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHgTJR" role="1PaTwD">
+              <property role="3oM_SC" value="merged" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHgTKp" role="1PaTwD">
+              <property role="3oM_SC" value="into" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHgTKE" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHh9B7" role="1PaTwD">
+              <property role="3oM_SC" value="source" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHh9Bq" role="1PaTwD">
+              <property role="3oM_SC" value="model" />
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="6IWRPdWGVVw" role="3cqZAp">
+          <node concept="2OqwBi" id="6IWRPdWGVVx" role="3tpDZB">
+            <node concept="2OqwBi" id="6IWRPdWGVVy" role="2Oq$k0">
+              <node concept="37vLTw" id="6IWRPdWGVVz" role="2Oq$k0">
+                <ref role="3cqZAo" node="6IWRPdWGVV5" resolve="sysAfterImport" />
+              </node>
+              <node concept="3Tsc0h" id="6IWRPdWHkhZ" role="2OqNvi">
+                <ref role="3TtcxE" to="k6li:59jNLF_cXnQ" resolve="inports" />
+              </node>
+            </node>
+            <node concept="34oBXx" id="6IWRPdWGVV_" role="2OqNvi" />
+          </node>
+          <node concept="2OqwBi" id="6IWRPdWGVVA" role="3tpDZA">
+            <node concept="2OqwBi" id="6IWRPdWGVVB" role="2Oq$k0">
+              <node concept="3xONca" id="6IWRPdWLKZS" role="2Oq$k0">
+                <ref role="3xOPvv" node="6IWRPdWGVTC" resolve="testDestination" />
+              </node>
+              <node concept="3Tsc0h" id="6IWRPdWHkl$" role="2OqNvi">
+                <ref role="3TtcxE" to="k6li:59jNLF_cXnQ" resolve="inports" />
+              </node>
+            </node>
+            <node concept="34oBXx" id="6IWRPdWGVVE" role="2OqNvi" />
+          </node>
+          <node concept="3_1$Yv" id="6QnTwqHgTKW" role="3_9lra">
+            <node concept="Xl_RD" id="6QnTwqHgXnU" role="3_1BAH">
+              <property role="Xl_RC" value="Size of merged inports list does not match expectation" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6IWRPdWHgM2" role="3cqZAp" />
+        <node concept="3SKdUt" id="6QnTwqHgomr" role="3cqZAp">
+          <node concept="1PaTwC" id="6QnTwqHgoms" role="1aUNEU">
+            <node concept="3oM_SD" id="6QnTwqHgoXE" role="1PaTwD">
+              <property role="3oM_SC" value="Check" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHgoYt" role="1PaTwD">
+              <property role="3oM_SC" value="ordering" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHgoYw" role="1PaTwD">
+              <property role="3oM_SC" value="of" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHgoY$" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHgoYD" role="1PaTwD">
+              <property role="3oM_SC" value="merged" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHgoZ1" role="1PaTwD">
+              <property role="3oM_SC" value="elements" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHgoZ8" role="1PaTwD">
+              <property role="3oM_SC" value="after" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHgoZg" role="1PaTwD">
+              <property role="3oM_SC" value="inserting" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHgoZy" role="1PaTwD">
+              <property role="3oM_SC" value="a" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHgoZP" role="1PaTwD">
+              <property role="3oM_SC" value="new" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHgp0y" role="1PaTwD">
+              <property role="3oM_SC" value="before" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHgp0R" role="1PaTwD">
+              <property role="3oM_SC" value="and" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHgp14" role="1PaTwD">
+              <property role="3oM_SC" value="after" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHgp1i" role="1PaTwD">
+              <property role="3oM_SC" value="an" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHgp1x" role="1PaTwD">
+              <property role="3oM_SC" value="existing" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHgp1U" role="1PaTwD">
+              <property role="3oM_SC" value="item" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="6QnTwqHgp2t" role="3cqZAp">
+          <node concept="3cpWsn" id="6QnTwqHgp2u" role="3cpWs9">
+            <property role="TrG5h" value="inA" />
+            <node concept="3Tqbb2" id="6QnTwqHgoKZ" role="1tU5fm">
+              <ref role="ehGHo" to="k6li:59jNLF_cTSb" resolve="tInPort" />
+            </node>
+            <node concept="2OqwBi" id="6QnTwqHgp2v" role="33vP2m">
+              <node concept="2OqwBi" id="6QnTwqHgp2w" role="2Oq$k0">
+                <node concept="37vLTw" id="6QnTwqHgp2x" role="2Oq$k0">
+                  <ref role="3cqZAo" node="6IWRPdWGVV5" resolve="sysAfterImport" />
+                </node>
+                <node concept="3Tsc0h" id="6QnTwqHgp2y" role="2OqNvi">
+                  <ref role="3TtcxE" to="k6li:59jNLF_cXnQ" resolve="inports" />
+                </node>
+              </node>
+              <node concept="1z4cxt" id="6QnTwqHgp2z" role="2OqNvi">
+                <node concept="1bVj0M" id="6QnTwqHgp2$" role="23t8la">
+                  <node concept="3clFbS" id="6QnTwqHgp2_" role="1bW5cS">
+                    <node concept="3clFbF" id="6QnTwqHgp2A" role="3cqZAp">
+                      <node concept="17R0WA" id="6QnTwqHgp2B" role="3clFbG">
+                        <node concept="2OqwBi" id="6QnTwqHgp2C" role="3uHU7B">
+                          <node concept="37vLTw" id="6QnTwqHgp2D" role="2Oq$k0">
+                            <ref role="3cqZAo" node="6QnTwqHgp2G" resolve="it" />
+                          </node>
+                          <node concept="3TrcHB" id="6QnTwqHgp2E" role="2OqNvi">
+                            <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                          </node>
+                        </node>
+                        <node concept="Xl_RD" id="6QnTwqHgp2F" role="3uHU7w">
+                          <property role="Xl_RC" value="A" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Rh6nW" id="6QnTwqHgp2G" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="6QnTwqHgp2H" role="1tU5fm" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="6QnTwqHgqtC" role="3cqZAp">
+          <node concept="3cpWsn" id="6QnTwqHgqtF" role="3cpWs9">
+            <property role="TrG5h" value="inB" />
+            <node concept="3Tqbb2" id="6QnTwqHgqtG" role="1tU5fm">
+              <ref role="ehGHo" to="k6li:59jNLF_cTSb" resolve="tInPort" />
+            </node>
+            <node concept="2OqwBi" id="6QnTwqHgqtH" role="33vP2m">
+              <node concept="2OqwBi" id="6QnTwqHgqtI" role="2Oq$k0">
+                <node concept="37vLTw" id="6QnTwqHgqtJ" role="2Oq$k0">
+                  <ref role="3cqZAo" node="6IWRPdWGVV5" resolve="sysAfterImport" />
+                </node>
+                <node concept="3Tsc0h" id="6QnTwqHgqtK" role="2OqNvi">
+                  <ref role="3TtcxE" to="k6li:59jNLF_cXnQ" resolve="inports" />
+                </node>
+              </node>
+              <node concept="1z4cxt" id="6QnTwqHgqtL" role="2OqNvi">
+                <node concept="1bVj0M" id="6QnTwqHgqtM" role="23t8la">
+                  <node concept="3clFbS" id="6QnTwqHgqtN" role="1bW5cS">
+                    <node concept="3clFbF" id="6QnTwqHgqtO" role="3cqZAp">
+                      <node concept="17R0WA" id="6QnTwqHgqtP" role="3clFbG">
+                        <node concept="2OqwBi" id="6QnTwqHgqtQ" role="3uHU7B">
+                          <node concept="37vLTw" id="6QnTwqHgqtR" role="2Oq$k0">
+                            <ref role="3cqZAo" node="6QnTwqHgqtU" resolve="it" />
+                          </node>
+                          <node concept="3TrcHB" id="6QnTwqHgqtS" role="2OqNvi">
+                            <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                          </node>
+                        </node>
+                        <node concept="Xl_RD" id="6QnTwqHgqtT" role="3uHU7w">
+                          <property role="Xl_RC" value="B" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Rh6nW" id="6QnTwqHgqtU" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="6QnTwqHgqtV" role="1tU5fm" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="6QnTwqHgr9b" role="3cqZAp">
+          <node concept="3cpWsn" id="6QnTwqHgr9e" role="3cpWs9">
+            <property role="TrG5h" value="inC" />
+            <node concept="3Tqbb2" id="6QnTwqHgr9f" role="1tU5fm">
+              <ref role="ehGHo" to="k6li:59jNLF_cTSb" resolve="tInPort" />
+            </node>
+            <node concept="2OqwBi" id="6QnTwqHgr9g" role="33vP2m">
+              <node concept="2OqwBi" id="6QnTwqHgr9h" role="2Oq$k0">
+                <node concept="37vLTw" id="6QnTwqHgr9i" role="2Oq$k0">
+                  <ref role="3cqZAo" node="6IWRPdWGVV5" resolve="sysAfterImport" />
+                </node>
+                <node concept="3Tsc0h" id="6QnTwqHgr9j" role="2OqNvi">
+                  <ref role="3TtcxE" to="k6li:59jNLF_cXnQ" resolve="inports" />
+                </node>
+              </node>
+              <node concept="1z4cxt" id="6QnTwqHgr9k" role="2OqNvi">
+                <node concept="1bVj0M" id="6QnTwqHgr9l" role="23t8la">
+                  <node concept="3clFbS" id="6QnTwqHgr9m" role="1bW5cS">
+                    <node concept="3clFbF" id="6QnTwqHgr9n" role="3cqZAp">
+                      <node concept="17R0WA" id="6QnTwqHgr9o" role="3clFbG">
+                        <node concept="2OqwBi" id="6QnTwqHgr9p" role="3uHU7B">
+                          <node concept="37vLTw" id="6QnTwqHgr9q" role="2Oq$k0">
+                            <ref role="3cqZAo" node="6QnTwqHgr9t" resolve="it" />
+                          </node>
+                          <node concept="3TrcHB" id="6QnTwqHgr9r" role="2OqNvi">
+                            <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                          </node>
+                        </node>
+                        <node concept="Xl_RD" id="6QnTwqHgr9s" role="3uHU7w">
+                          <property role="Xl_RC" value="C" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Rh6nW" id="6QnTwqHgr9t" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="6QnTwqHgr9u" role="1tU5fm" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6QnTwqHgr3D" role="3cqZAp" />
+        <node concept="3vlDli" id="6IWRPdWLWQW" role="3cqZAp">
+          <node concept="3cmrfG" id="6QnTwqHg3jk" role="3tpDZB">
+            <property role="3cmrfH" value="0" />
+          </node>
+          <node concept="2OqwBi" id="6QnTwqHgdbX" role="3tpDZA">
+            <node concept="37vLTw" id="6QnTwqHgp2I" role="2Oq$k0">
+              <ref role="3cqZAo" node="6QnTwqHgp2u" resolve="inA" />
+            </node>
+            <node concept="2bSWHS" id="6QnTwqHge00" role="2OqNvi" />
+          </node>
+          <node concept="3_1$Yv" id="6QnTwqHg_xo" role="3_9lra">
+            <node concept="Xl_RD" id="6QnTwqHgA8L" role="3_1BAH">
+              <property role="Xl_RC" value="Inport A does not occur as first item in merged inport list" />
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="6QnTwqHgsBs" role="3cqZAp">
+          <node concept="3cmrfG" id="6QnTwqHgsBt" role="3tpDZB">
+            <property role="3cmrfH" value="1" />
+          </node>
+          <node concept="2OqwBi" id="6QnTwqHgsBu" role="3tpDZA">
+            <node concept="37vLTw" id="6QnTwqHgtT2" role="2Oq$k0">
+              <ref role="3cqZAo" node="6QnTwqHgqtF" resolve="inB" />
+            </node>
+            <node concept="2bSWHS" id="6QnTwqHgsBw" role="2OqNvi" />
+          </node>
+          <node concept="3_1$Yv" id="6QnTwqHgD3F" role="3_9lra">
+            <node concept="Xl_RD" id="6QnTwqHgDF4" role="3_1BAH">
+              <property role="Xl_RC" value="Inport B does not occur as second item in merged inport list" />
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="6QnTwqHgtbc" role="3cqZAp">
+          <node concept="3cmrfG" id="6QnTwqHgtbd" role="3tpDZB">
+            <property role="3cmrfH" value="2" />
+          </node>
+          <node concept="2OqwBi" id="6QnTwqHgtbe" role="3tpDZA">
+            <node concept="37vLTw" id="6QnTwqHgtTz" role="2Oq$k0">
+              <ref role="3cqZAo" node="6QnTwqHgr9e" resolve="inC" />
+            </node>
+            <node concept="2bSWHS" id="6QnTwqHgtbg" role="2OqNvi" />
+          </node>
+          <node concept="3_1$Yv" id="6QnTwqHgDFl" role="3_9lra">
+            <node concept="Xl_RD" id="6QnTwqHgE90" role="3_1BAH">
+              <property role="Xl_RC" value="Inport C does not occur as third item in merged inport list" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6IWRPdWI90i" role="3cqZAp" />
+        <node concept="3vlDli" id="6IWRPdWHkoF" role="3cqZAp">
+          <node concept="2OqwBi" id="6IWRPdWHkoG" role="3tpDZB">
+            <node concept="2OqwBi" id="6IWRPdWHkoH" role="2Oq$k0">
+              <node concept="37vLTw" id="6IWRPdWLLQD" role="2Oq$k0">
+                <ref role="3cqZAo" node="6IWRPdWGVV5" resolve="sysAfterImport" />
+              </node>
+              <node concept="3Tsc0h" id="6IWRPdWHkoJ" role="2OqNvi">
+                <ref role="3TtcxE" to="k6li:59jNLF_cXnQ" resolve="inports" />
+              </node>
+            </node>
+            <node concept="34oBXx" id="6IWRPdWHkoK" role="2OqNvi" />
+          </node>
+          <node concept="2OqwBi" id="6IWRPdWHkoL" role="3tpDZA">
+            <node concept="2OqwBi" id="6IWRPdWHkoM" role="2Oq$k0">
+              <node concept="3xONca" id="6IWRPdWHkDU" role="2Oq$k0">
+                <ref role="3xOPvv" node="6IWRPdWGVTC" resolve="testDestination" />
+              </node>
+              <node concept="3Tsc0h" id="6IWRPdWHkoO" role="2OqNvi">
+                <ref role="3TtcxE" to="k6li:59jNLF_cXnQ" resolve="inports" />
+              </node>
+            </node>
+            <node concept="34oBXx" id="6IWRPdWHkoP" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="6IWRPdWHvbB" role="3cqZAp" />
+      </node>
+    </node>
   </node>
 </model>
 

--- a/code/solutions/tests.de.itemis.mps.modelmerger/models/basictest@tests.mps
+++ b/code/solutions/tests.de.itemis.mps.modelmerger/models/basictest@tests.mps
@@ -411,6 +411,7 @@
             </node>
           </node>
         </node>
+        <node concept="3clFbH" id="6QnTwqHltWh" role="3cqZAp" />
         <node concept="3SKdUt" id="6IWRPdWKpHN" role="3cqZAp">
           <node concept="1PaTwC" id="6IWRPdWKpHO" role="1aUNEU">
             <node concept="3oM_SD" id="6IWRPdWKpHP" role="1PaTwD">
@@ -488,6 +489,7 @@
             </node>
           </node>
         </node>
+        <node concept="3clFbH" id="6QnTwqHltJL" role="3cqZAp" />
         <node concept="3SKdUt" id="6IWRPdWKpl2" role="3cqZAp">
           <node concept="1PaTwC" id="6IWRPdWKpl3" role="1aUNEU">
             <node concept="3oM_SD" id="6IWRPdWKpl4" role="1PaTwD">
@@ -548,6 +550,41 @@
               <node concept="3xONca" id="lVcTBwuB7I" role="3BYIHq">
                 <ref role="3xOPvv" node="lVcTBwuwxL" resolve="testDestination" />
               </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6QnTwqHlu5s" role="3cqZAp" />
+        <node concept="3SKdUt" id="6QnTwqHluxR" role="3cqZAp">
+          <node concept="1PaTwC" id="6QnTwqHluxS" role="1aUNEU">
+            <node concept="3oM_SD" id="6QnTwqHluxT" role="1PaTwD">
+              <property role="3oM_SC" value="Initialize" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHluxU" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHluxV" role="1PaTwD">
+              <property role="3oM_SC" value="identity" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHluxW" role="1PaTwD">
+              <property role="3oM_SC" value="calculator" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHluxX" role="1PaTwD">
+              <property role="3oM_SC" value="rules" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHluxY" role="1PaTwD">
+              <property role="3oM_SC" value="associated" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHluxZ" role="1PaTwD">
+              <property role="3oM_SC" value="with" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHluy0" role="1PaTwD">
+              <property role="3oM_SC" value="this" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHluy1" role="1PaTwD">
+              <property role="3oM_SC" value="test" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHluy2" role="1PaTwD">
+              <property role="3oM_SC" value="case" />
             </node>
           </node>
         </node>
@@ -614,6 +651,26 @@
             </node>
           </node>
         </node>
+        <node concept="3clFbH" id="6QnTwqHlv3P" role="3cqZAp" />
+        <node concept="3SKdUt" id="6QnTwqHlvLr" role="3cqZAp">
+          <node concept="1PaTwC" id="6QnTwqHlvLs" role="1aUNEU">
+            <node concept="3oM_SD" id="6QnTwqHlvLt" role="1PaTwD">
+              <property role="3oM_SC" value="Perform" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHlvXf" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHlvXi" role="1PaTwD">
+              <property role="3oM_SC" value="actual" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHlvXv" role="1PaTwD">
+              <property role="3oM_SC" value="incremental" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHlwlN" role="1PaTwD">
+              <property role="3oM_SC" value="merging" />
+            </node>
+          </node>
+        </node>
         <node concept="3clFbF" id="5Vsx_8fx15X" role="3cqZAp">
           <node concept="2YIFZM" id="4JOeV7knFeb" role="3clFbG">
             <ref role="37wK5l" to="vxmj:6NDRJQ9sJiH" resolve="matchModelsInto" />
@@ -629,6 +686,7 @@
             </node>
           </node>
         </node>
+        <node concept="3clFbH" id="6QnTwqHlwm2" role="3cqZAp" />
         <node concept="3SKdUt" id="6IWRPdWKqv4" role="3cqZAp">
           <node concept="1PaTwC" id="6IWRPdWKqv5" role="1aUNEU">
             <node concept="3oM_SD" id="6IWRPdWKqv6" role="1PaTwD">
@@ -703,6 +761,7 @@
             </node>
           </node>
         </node>
+        <node concept="3clFbH" id="6QnTwqHlwvz" role="3cqZAp" />
         <node concept="3SKdUt" id="lVcTBwuReT" role="3cqZAp">
           <node concept="1PaTwC" id="7WTFIQIcYk8" role="1aUNEU">
             <node concept="3oM_SD" id="7WTFIQIcYk9" role="1PaTwD">
@@ -838,7 +897,7 @@
       <node concept="2Ro1FD" id="6IWRPdWGWrj" role="1qenE9">
         <property role="TrG5h" value="sys1" />
         <node concept="2Ro54h" id="6IWRPdWLD4j" role="2Ro1FG">
-          <property role="TrG5h" value="B" />
+          <property role="TrG5h" value="C" />
           <property role="2Ro54k" value="1" />
         </node>
         <node concept="3xLA65" id="6IWRPdWGWrl" role="lGtFl">
@@ -860,6 +919,14 @@
         <node concept="2Ro54h" id="6IWRPdWGWqD" role="2Ro1FG">
           <property role="TrG5h" value="C" />
           <property role="2Ro54k" value="4" />
+        </node>
+        <node concept="2Ro54h" id="6QnTwqHl5Yy" role="2Ro1FG">
+          <property role="TrG5h" value="D" />
+          <property role="2Ro54k" value="5" />
+        </node>
+        <node concept="2Ro54h" id="6QnTwqHl632" role="2Ro1FG">
+          <property role="TrG5h" value="E" />
+          <property role="2Ro54k" value="6" />
         </node>
         <node concept="3xLA65" id="6IWRPdWGVTC" role="lGtFl">
           <property role="TrG5h" value="testDestination" />
@@ -991,16 +1058,16 @@
             </node>
           </node>
         </node>
-        <node concept="1X3_iC" id="6IWRPdWLvgJ" role="lGtFl">
+        <node concept="1X3_iC" id="6QnTwqHl00a" role="lGtFl">
           <property role="3V$3am" value="statement" />
           <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
           <node concept="3clFbF" id="6IWRPdWJ7De" role="8Wnug">
             <node concept="37vLTI" id="6IWRPdWJ8dN" role="3clFbG">
               <node concept="2OqwBi" id="6IWRPdWJ8X2" role="37vLTx">
                 <node concept="1Xw6AR" id="6IWRPdWJ8NY" role="2Oq$k0">
-                  <node concept="1dCxOl" id="6IWRPdWJ8R5" role="1XwpL7">
-                    <property role="1XweGQ" value="r:cafcc752-b2e0-44a9-aa42-52b4ce70f4d0" />
-                    <node concept="1j_P7g" id="6IWRPdWJ8R6" role="1j$8Uc">
+                  <node concept="1dCxOl" id="6QnTwqHj4ad" role="1XwpL7">
+                    <property role="1XweGQ" value="r:7efd6b4f-ed49-492c-b1ba-8f0b802f5984" />
+                    <node concept="1j_P7g" id="6QnTwqHj4ae" role="1j$8Uc">
                       <property role="1j_P7h" value="tests.de.itemis.mps.modelmerger.output" />
                     </node>
                   </node>
@@ -1202,7 +1269,7 @@
               <property role="3oM_SC" value="inport" />
             </node>
             <node concept="3oM_SD" id="6QnTwqHhbZR" role="1PaTwD">
-              <property role="3oM_SC" value="(&quot;B&quot;)" />
+              <property role="3oM_SC" value="(&quot;C&quot;)" />
             </node>
           </node>
         </node>
@@ -1245,7 +1312,7 @@
         </node>
         <node concept="3cpWs8" id="6IWRPdWM8CP" role="3cqZAp">
           <node concept="3cpWsn" id="6IWRPdWM8CQ" role="3cpWs9">
-            <property role="TrG5h" value="inPortBIdBeforeImport" />
+            <property role="TrG5h" value="inPortCIdBeforeImport" />
             <node concept="3uibUv" id="6IWRPdWM8CR" role="1tU5fm">
               <ref role="3uigEE" to="mhbf:~SNodeId" resolve="SNodeId" />
             </node>
@@ -1320,7 +1387,7 @@
               <property role="3oM_SC" value="inport" />
             </node>
             <node concept="3oM_SD" id="6QnTwqHhefK" role="1PaTwD">
-              <property role="3oM_SC" value="&quot;B&quot;'s" />
+              <property role="3oM_SC" value="&quot;C&quot;'s" />
             </node>
             <node concept="3oM_SD" id="6QnTwqHhefU" role="1PaTwD">
               <property role="3oM_SC" value="" />
@@ -1405,6 +1472,9 @@
               <property role="3oM_SC" value="inport" />
             </node>
             <node concept="3oM_SD" id="6IWRPdWMm4w" role="1PaTwD">
+              <property role="3oM_SC" value="&quot;C&quot;" />
+            </node>
+            <node concept="3oM_SD" id="6QnTwqHlb9I" role="1PaTwD">
               <property role="3oM_SC" value="has" />
             </node>
             <node concept="3oM_SD" id="6IWRPdWMm4K" role="1PaTwD">
@@ -1441,7 +1511,7 @@
         </node>
         <node concept="3cpWs8" id="6IWRPdWMd9j" role="3cqZAp">
           <node concept="3cpWsn" id="6IWRPdWMd9k" role="3cpWs9">
-            <property role="TrG5h" value="inPortBIdAfterImport" />
+            <property role="TrG5h" value="inPortCIdAfterImport" />
             <node concept="3uibUv" id="6IWRPdWMd9l" role="1tU5fm">
               <ref role="3uigEE" to="mhbf:~SNodeId" resolve="SNodeId" />
             </node>
@@ -1470,7 +1540,7 @@
                               </node>
                             </node>
                             <node concept="Xl_RD" id="6IWRPdWMhTl" role="3uHU7w">
-                              <property role="Xl_RC" value="B" />
+                              <property role="Xl_RC" value="C" />
                             </node>
                           </node>
                         </node>
@@ -1491,14 +1561,14 @@
         </node>
         <node concept="3vlDli" id="6IWRPdWMifE" role="3cqZAp">
           <node concept="37vLTw" id="6IWRPdWMm5J" role="3tpDZB">
-            <ref role="3cqZAo" node="6IWRPdWMd9k" resolve="inPortBIdAfterImport" />
+            <ref role="3cqZAo" node="6IWRPdWMd9k" resolve="inPortCIdAfterImport" />
           </node>
           <node concept="37vLTw" id="6IWRPdWMmP5" role="3tpDZA">
-            <ref role="3cqZAo" node="6IWRPdWM8CQ" resolve="inPortBIdBeforeImport" />
+            <ref role="3cqZAo" node="6IWRPdWM8CQ" resolve="inPortCIdBeforeImport" />
           </node>
           <node concept="3_1$Yv" id="6IWRPdWMifH" role="3_9lra">
             <node concept="Xl_RD" id="6IWRPdWMifI" role="3_1BAH">
-              <property role="Xl_RC" value="ID of existing inport (B) has changed." />
+              <property role="Xl_RC" value="ID of existing inport (C) has changed." />
             </node>
           </node>
         </node>
@@ -1748,6 +1818,92 @@
             </node>
           </node>
         </node>
+        <node concept="3cpWs8" id="6QnTwqHllvy" role="3cqZAp">
+          <node concept="3cpWsn" id="6QnTwqHllvz" role="3cpWs9">
+            <property role="TrG5h" value="inD" />
+            <node concept="3Tqbb2" id="6QnTwqHllv$" role="1tU5fm">
+              <ref role="ehGHo" to="k6li:59jNLF_cTSb" resolve="tInPort" />
+            </node>
+            <node concept="2OqwBi" id="6QnTwqHllv_" role="33vP2m">
+              <node concept="2OqwBi" id="6QnTwqHllvA" role="2Oq$k0">
+                <node concept="37vLTw" id="6QnTwqHllvB" role="2Oq$k0">
+                  <ref role="3cqZAo" node="6IWRPdWGVV5" resolve="sysAfterImport" />
+                </node>
+                <node concept="3Tsc0h" id="6QnTwqHllvC" role="2OqNvi">
+                  <ref role="3TtcxE" to="k6li:59jNLF_cXnQ" resolve="inports" />
+                </node>
+              </node>
+              <node concept="1z4cxt" id="6QnTwqHllvD" role="2OqNvi">
+                <node concept="1bVj0M" id="6QnTwqHllvE" role="23t8la">
+                  <node concept="3clFbS" id="6QnTwqHllvF" role="1bW5cS">
+                    <node concept="3clFbF" id="6QnTwqHllvG" role="3cqZAp">
+                      <node concept="17R0WA" id="6QnTwqHllvH" role="3clFbG">
+                        <node concept="2OqwBi" id="6QnTwqHllvI" role="3uHU7B">
+                          <node concept="37vLTw" id="6QnTwqHllvJ" role="2Oq$k0">
+                            <ref role="3cqZAo" node="6QnTwqHllvM" resolve="it" />
+                          </node>
+                          <node concept="3TrcHB" id="6QnTwqHllvK" role="2OqNvi">
+                            <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                          </node>
+                        </node>
+                        <node concept="Xl_RD" id="6QnTwqHllvL" role="3uHU7w">
+                          <property role="Xl_RC" value="D" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Rh6nW" id="6QnTwqHllvM" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="6QnTwqHllvN" role="1tU5fm" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="6QnTwqHllXD" role="3cqZAp">
+          <node concept="3cpWsn" id="6QnTwqHllXE" role="3cpWs9">
+            <property role="TrG5h" value="inE" />
+            <node concept="3Tqbb2" id="6QnTwqHllXF" role="1tU5fm">
+              <ref role="ehGHo" to="k6li:59jNLF_cTSb" resolve="tInPort" />
+            </node>
+            <node concept="2OqwBi" id="6QnTwqHllXG" role="33vP2m">
+              <node concept="2OqwBi" id="6QnTwqHllXH" role="2Oq$k0">
+                <node concept="37vLTw" id="6QnTwqHllXI" role="2Oq$k0">
+                  <ref role="3cqZAo" node="6IWRPdWGVV5" resolve="sysAfterImport" />
+                </node>
+                <node concept="3Tsc0h" id="6QnTwqHllXJ" role="2OqNvi">
+                  <ref role="3TtcxE" to="k6li:59jNLF_cXnQ" resolve="inports" />
+                </node>
+              </node>
+              <node concept="1z4cxt" id="6QnTwqHllXK" role="2OqNvi">
+                <node concept="1bVj0M" id="6QnTwqHllXL" role="23t8la">
+                  <node concept="3clFbS" id="6QnTwqHllXM" role="1bW5cS">
+                    <node concept="3clFbF" id="6QnTwqHllXN" role="3cqZAp">
+                      <node concept="17R0WA" id="6QnTwqHllXO" role="3clFbG">
+                        <node concept="2OqwBi" id="6QnTwqHllXP" role="3uHU7B">
+                          <node concept="37vLTw" id="6QnTwqHllXQ" role="2Oq$k0">
+                            <ref role="3cqZAo" node="6QnTwqHllXT" resolve="it" />
+                          </node>
+                          <node concept="3TrcHB" id="6QnTwqHllXR" role="2OqNvi">
+                            <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                          </node>
+                        </node>
+                        <node concept="Xl_RD" id="6QnTwqHllXS" role="3uHU7w">
+                          <property role="Xl_RC" value="E" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Rh6nW" id="6QnTwqHllXT" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="6QnTwqHllXU" role="1tU5fm" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
         <node concept="3clFbH" id="6QnTwqHgr3D" role="3cqZAp" />
         <node concept="3vlDli" id="6IWRPdWLWQW" role="3cqZAp">
           <node concept="3cmrfG" id="6QnTwqHg3jk" role="3tpDZB">
@@ -1781,19 +1937,51 @@
             </node>
           </node>
         </node>
-        <node concept="3vlDli" id="6QnTwqHgtbc" role="3cqZAp">
-          <node concept="3cmrfG" id="6QnTwqHgtbd" role="3tpDZB">
+        <node concept="3vlDli" id="6QnTwqHlbaR" role="3cqZAp">
+          <node concept="3cmrfG" id="6QnTwqHlbaS" role="3tpDZB">
             <property role="3cmrfH" value="2" />
           </node>
-          <node concept="2OqwBi" id="6QnTwqHgtbe" role="3tpDZA">
-            <node concept="37vLTw" id="6QnTwqHgtTz" role="2Oq$k0">
+          <node concept="2OqwBi" id="6QnTwqHlbaT" role="3tpDZA">
+            <node concept="37vLTw" id="6QnTwqHlbaU" role="2Oq$k0">
               <ref role="3cqZAo" node="6QnTwqHgr9e" resolve="inC" />
+            </node>
+            <node concept="2bSWHS" id="6QnTwqHlbaV" role="2OqNvi" />
+          </node>
+          <node concept="3_1$Yv" id="6QnTwqHlbaW" role="3_9lra">
+            <node concept="Xl_RD" id="6QnTwqHlbaX" role="3_1BAH">
+              <property role="Xl_RC" value="Inport C does not occur as third item in merged inport list" />
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="6QnTwqHgtbc" role="3cqZAp">
+          <node concept="3cmrfG" id="6QnTwqHgtbd" role="3tpDZB">
+            <property role="3cmrfH" value="3" />
+          </node>
+          <node concept="2OqwBi" id="6QnTwqHgtbe" role="3tpDZA">
+            <node concept="37vLTw" id="6QnTwqHlm_P" role="2Oq$k0">
+              <ref role="3cqZAo" node="6QnTwqHllvz" resolve="inD" />
             </node>
             <node concept="2bSWHS" id="6QnTwqHgtbg" role="2OqNvi" />
           </node>
           <node concept="3_1$Yv" id="6QnTwqHgDFl" role="3_9lra">
             <node concept="Xl_RD" id="6QnTwqHgE90" role="3_1BAH">
-              <property role="Xl_RC" value="Inport C does not occur as third item in merged inport list" />
+              <property role="Xl_RC" value="Inport D does not occur as fourth item in merged inport list" />
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="6QnTwqHlbJn" role="3cqZAp">
+          <node concept="3cmrfG" id="6QnTwqHlbJo" role="3tpDZB">
+            <property role="3cmrfH" value="4" />
+          </node>
+          <node concept="2OqwBi" id="6QnTwqHlbJp" role="3tpDZA">
+            <node concept="37vLTw" id="6QnTwqHlmAt" role="2Oq$k0">
+              <ref role="3cqZAo" node="6QnTwqHllXE" resolve="inE" />
+            </node>
+            <node concept="2bSWHS" id="6QnTwqHlbJr" role="2OqNvi" />
+          </node>
+          <node concept="3_1$Yv" id="6QnTwqHlbJs" role="3_9lra">
+            <node concept="Xl_RD" id="6QnTwqHlbJt" role="3_1BAH">
+              <property role="Xl_RC" value="Inport E does not occur as fifth item in merged inport list" />
             </node>
           </node>
         </node>

--- a/code/solutions/tests.de.itemis.mps.modelmerger/tests.de.itemis.mps.modelmerger.msd
+++ b/code/solutions/tests.de.itemis.mps.modelmerger/tests.de.itemis.mps.modelmerger.msd
@@ -16,6 +16,7 @@
     <dependency reexport="false">efc9f360-4711-4223-b9a5-469bba1c960d(de.itemis.mps.modelmerger.runtime)</dependency>
     <dependency reexport="false">6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)</dependency>
     <dependency reexport="false">d119cd03-ed7e-477f-adb6-22a3d2e6ea77(test.de.itemis.mps.modelmerger.testlanguage)</dependency>
+    <dependency reexport="false">ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />


### PR DESCRIPTION
This PR adds a test case that fails before applying the fix to correct the insertion behavior of the incremental model merger.

If the first node in a child list in the imported model is an unmatched node (i.e., does not appear in the original parent's child listl) then the first node is inserted at the end of the child list. The expectation is that it would be inserted at the start of the list.

This PR adds a check whether it is indeed the first unmatched node, and if there are any unmatched nodes, it simply adds the new node before the first node of the child list.