### PR TITLE
Fix de.itemis.mps.editor.celllayout.VerticalLineCell's y position

### DIFF
--- a/code/celllayout/solutions/de.slisson.mps.editor.celllayout.runtime/models/de/itemis/mps/editor/celllayout/runtime/cells.mps
+++ b/code/celllayout/solutions/de.slisson.mps.editor.celllayout.runtime/models/de/itemis/mps/editor/celllayout/runtime/cells.mps
@@ -1321,8 +1321,13 @@
                   <node concept="1rXfSq" id="7d0q5VH9zRH" role="37wK5m">
                     <ref role="37wK5l" to="g51k:~EditorCell_Basic.getX()" resolve="getX" />
                   </node>
-                  <node concept="1rXfSq" id="7d0q5VHdND1" role="37wK5m">
-                    <ref role="37wK5l" to="g51k:~EditorCell_Basic.getY()" resolve="getY" />
+                  <node concept="2OqwBi" id="1Al6CJbRgpw" role="37wK5m">
+                    <node concept="37vLTw" id="1Al6CJbRfrv" role="2Oq$k0">
+                      <ref role="3cqZAo" node="7d0q5VHdtJZ" resolve="parent" />
+                    </node>
+                    <node concept="liA8E" id="1Al6CJbRhAH" role="2OqNvi">
+                      <ref role="37wK5l" to="g51k:~EditorCell_Basic.getY()" resolve="getY" />
+                    </node>
                   </node>
                   <node concept="1rXfSq" id="7d0q5VH9zRJ" role="37wK5m">
                     <ref role="37wK5l" to="g51k:~EditorCell_Basic.getWidth()" resolve="getWidth" />


### PR DESCRIPTION
- Use the parent y position instead of the cell's own y position.
- Fixes #170

<img width="504" alt="Screenshot 2021-08-27 at 13 24 44" src="https://user-images.githubusercontent.com/88385944/131120382-4343b5f2-affb-4d53-b3cf-ba50e3a85585.png">