### PR TITLE
Deleted all empty generators

### DIFF
--- a/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
+++ b/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
@@ -4182,38 +4182,6 @@
             </node>
           </node>
         </node>
-        <node concept="1yeLz9" id="5VXqMluaZQg" role="1TViLv">
-          <property role="TrG5h" value="de.slisson.mps.conditionalEditor.hints#2669483033691476665" />
-          <property role="3LESm3" value="6c43adf5-a74d-4d1e-9cbe-67c85acd3190" />
-          <node concept="1BupzO" id="2eucapX07Pd" role="3bR31x">
-            <property role="3ZfqAx" value="generator/template" />
-            <property role="1Hdu6h" value="true" />
-            <property role="1HemKv" value="true" />
-            <node concept="3LXTmp" id="2eucapX07Pe" role="1HemKq">
-              <node concept="398BVA" id="2eucapX07P0" role="3LXTmr">
-                <ref role="398BVh" node="2fo8bJE$D4t" resolve="extensions.code" />
-                <node concept="2Ry0Ak" id="2eucapX07P1" role="iGT6I">
-                  <property role="2Ry0Am" value="conditional-editor" />
-                  <node concept="2Ry0Ak" id="2eucapX07P2" role="2Ry0An">
-                    <property role="2Ry0Am" value="languages" />
-                    <node concept="2Ry0Ak" id="2eucapX07P3" role="2Ry0An">
-                      <property role="2Ry0Am" value="de.slisson.mps.conditionalEditor.hints" />
-                      <node concept="2Ry0Ak" id="2eucapX07P4" role="2Ry0An">
-                        <property role="2Ry0Am" value="generator" />
-                        <node concept="2Ry0Ak" id="2eucapX07P5" role="2Ry0An">
-                          <property role="2Ry0Am" value="template" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3qWCbU" id="2eucapX07Pf" role="3LXTna">
-                <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-              </node>
-            </node>
-          </node>
-        </node>
         <node concept="3rtmxn" id="3xFG3bj5Mmv" role="3bR31x">
           <node concept="3LXTmp" id="3xFG3bj5Mmw" role="3rtmxm">
             <node concept="3qWCbU" id="3xFG3bj5Mmx" role="3LXTna">
@@ -4338,38 +4306,6 @@
         <node concept="1SiIV0" id="TAJODzTeN6" role="3bR37C">
           <node concept="1Busua" id="TAJODzTeN7" role="1SiIV1">
             <ref role="1Busuk" to="ffeo:307DWrMiIBc" resolve="jetbrains.mps.lang.generator.plan" />
-          </node>
-        </node>
-        <node concept="1yeLz9" id="TAJODzTeN8" role="1TViLv">
-          <property role="TrG5h" value="de.slisson.mps.hacks.xmodelgen#961590472824343780" />
-          <property role="3LESm3" value="98b4b625-da69-443b-a553-2f746fe85c4a" />
-          <node concept="1BupzO" id="2eucapX07PF" role="3bR31x">
-            <property role="3ZfqAx" value="generator/template" />
-            <property role="1Hdu6h" value="true" />
-            <property role="1HemKv" value="true" />
-            <node concept="3LXTmp" id="2eucapX07PG" role="1HemKq">
-              <node concept="398BVA" id="2eucapX07Pu" role="3LXTmr">
-                <ref role="398BVh" node="2fo8bJE$D4t" resolve="extensions.code" />
-                <node concept="2Ry0Ak" id="2eucapX07Pv" role="iGT6I">
-                  <property role="2Ry0Am" value="hacks" />
-                  <node concept="2Ry0Ak" id="2eucapX07Pw" role="2Ry0An">
-                    <property role="2Ry0Am" value="languages" />
-                    <node concept="2Ry0Ak" id="2eucapX07Px" role="2Ry0An">
-                      <property role="2Ry0Am" value="de.slisson.mps.hacks.xmodelgen" />
-                      <node concept="2Ry0Ak" id="2eucapX07Py" role="2Ry0An">
-                        <property role="2Ry0Am" value="generator" />
-                        <node concept="2Ry0Ak" id="2eucapX07Pz" role="2Ry0An">
-                          <property role="2Ry0Am" value="template" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3qWCbU" id="2eucapX07PH" role="3LXTna">
-                <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-              </node>
-            </node>
           </node>
         </node>
         <node concept="3rtmxn" id="3xFG3bj5MlT" role="3bR31x">
@@ -5444,38 +5380,6 @@
             </node>
           </node>
         </node>
-        <node concept="1yeLz9" id="4frYVBf39$A" role="1TViLv">
-          <property role="TrG5h" value="de.itemis.mps.editor.diagram.styles#5014430417954750349" />
-          <property role="3LESm3" value="6c1c3da8-77db-4cfa-a468-3fb956cd7040" />
-          <node concept="1BupzO" id="2eucapX07VO" role="3bR31x">
-            <property role="3ZfqAx" value="generator/template" />
-            <property role="1Hdu6h" value="true" />
-            <property role="1HemKv" value="true" />
-            <node concept="3LXTmp" id="2eucapX07VP" role="1HemKq">
-              <node concept="398BVA" id="2eucapX07VB" role="3LXTmr">
-                <ref role="398BVh" node="2fo8bJE$D4t" resolve="extensions.code" />
-                <node concept="2Ry0Ak" id="2eucapX07VC" role="iGT6I">
-                  <property role="2Ry0Am" value="diagram" />
-                  <node concept="2Ry0Ak" id="2eucapX07VD" role="2Ry0An">
-                    <property role="2Ry0Am" value="languages" />
-                    <node concept="2Ry0Ak" id="2eucapX07VE" role="2Ry0An">
-                      <property role="2Ry0Am" value="de.itemis.mps.editor.diagram.styles" />
-                      <node concept="2Ry0Ak" id="2eucapX07VF" role="2Ry0An">
-                        <property role="2Ry0Am" value="generator" />
-                        <node concept="2Ry0Ak" id="2eucapX07VG" role="2Ry0An">
-                          <property role="2Ry0Am" value="template" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3qWCbU" id="2eucapX07VQ" role="3LXTna">
-                <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-              </node>
-            </node>
-          </node>
-        </node>
         <node concept="1SiIV0" id="5S8_I2FlGgw" role="3bR37C">
           <node concept="3bR9La" id="5S8_I2FlGgx" role="1SiIV1">
             <ref role="3bR37D" to="ffeo:1TaHNgiIbIZ" resolve="MPS.Editor" />
@@ -5553,38 +5457,6 @@
         <node concept="1SiIV0" id="5mBxd1UNpnl" role="3bR37C">
           <node concept="1Busua" id="5mBxd1UNpnm" role="1SiIV1">
             <ref role="1Busuk" to="ffeo:7Kfy9QB6KXW" resolve="jetbrains.mps.lang.core" />
-          </node>
-        </node>
-        <node concept="1yeLz9" id="56Tfdun3v$J" role="1TViLv">
-          <property role="TrG5h" value="de.itemis.mps.editor.diagram.layout#4341402299005877448" />
-          <property role="3LESm3" value="50fd4dec-4494-4a71-a0ca-d35c48af6670" />
-          <node concept="1BupzO" id="2eucapX07Wi" role="3bR31x">
-            <property role="3ZfqAx" value="generator/template" />
-            <property role="1Hdu6h" value="true" />
-            <property role="1HemKv" value="true" />
-            <node concept="3LXTmp" id="2eucapX07Wj" role="1HemKq">
-              <node concept="398BVA" id="2eucapX07W5" role="3LXTmr">
-                <ref role="398BVh" node="2fo8bJE$D4t" resolve="extensions.code" />
-                <node concept="2Ry0Ak" id="2eucapX07W6" role="iGT6I">
-                  <property role="2Ry0Am" value="diagram" />
-                  <node concept="2Ry0Ak" id="2eucapX07W7" role="2Ry0An">
-                    <property role="2Ry0Am" value="languages" />
-                    <node concept="2Ry0Ak" id="2eucapX07W8" role="2Ry0An">
-                      <property role="2Ry0Am" value="de.itemis.mps.editor.diagram.layout" />
-                      <node concept="2Ry0Ak" id="2eucapX07W9" role="2Ry0An">
-                        <property role="2Ry0Am" value="generator" />
-                        <node concept="2Ry0Ak" id="2eucapX07Wa" role="2Ry0An">
-                          <property role="2Ry0Am" value="template" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3qWCbU" id="2eucapX07Wk" role="3LXTna">
-                <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-              </node>
-            </node>
           </node>
         </node>
         <node concept="3rtmxn" id="3xFG3bj5Mm8" role="3bR31x">
@@ -6086,38 +5958,6 @@
                 <node concept="2Ry0Ak" id="1QLFoGON0Lh" role="2Ry0An">
                   <property role="2Ry0Am" value="de.itemis.mps.editor.celllayout.styles.mpl" />
                 </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1yeLz9" id="6SVXTgIemz1" role="1TViLv">
-          <property role="TrG5h" value="de.itemis.mps.editor.celllayout.styles#861697192441877541" />
-          <property role="3LESm3" value="fd8466c2-d497-44e8-87f3-18d15c3a2a49" />
-          <node concept="1BupzO" id="2eucapX07XI" role="3bR31x">
-            <property role="3ZfqAx" value="generator/template" />
-            <property role="1Hdu6h" value="true" />
-            <property role="1HemKv" value="true" />
-            <node concept="3LXTmp" id="2eucapX07XJ" role="1HemKq">
-              <node concept="398BVA" id="2eucapX07Xx" role="3LXTmr">
-                <ref role="398BVh" node="2fo8bJE$D4t" resolve="extensions.code" />
-                <node concept="2Ry0Ak" id="2eucapX07Xy" role="iGT6I">
-                  <property role="2Ry0Am" value="celllayout" />
-                  <node concept="2Ry0Ak" id="2eucapX07Xz" role="2Ry0An">
-                    <property role="2Ry0Am" value="languages" />
-                    <node concept="2Ry0Ak" id="2eucapX07X$" role="2Ry0An">
-                      <property role="2Ry0Am" value="de.itemis.mps.celllayout" />
-                      <node concept="2Ry0Ak" id="2eucapX07X_" role="2Ry0An">
-                        <property role="2Ry0Am" value="generator" />
-                        <node concept="2Ry0Ak" id="2eucapX07XA" role="2Ry0An">
-                          <property role="2Ry0Am" value="template" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3qWCbU" id="2eucapX07XK" role="3LXTna">
-                <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
               </node>
             </node>
           </node>
@@ -7056,38 +6896,6 @@
             </node>
           </node>
         </node>
-        <node concept="1yeLz9" id="457TI2XWjdn" role="1TViLv">
-          <property role="TrG5h" value="de.itemis.mps.nodeversioning#6525061419584643890" />
-          <property role="3LESm3" value="fd3d0e89-8881-49ed-815d-6fc731a8b022" />
-          <node concept="1BupzO" id="2eucapX080g" role="3bR31x">
-            <property role="3ZfqAx" value="generator/template" />
-            <property role="1Hdu6h" value="true" />
-            <property role="1HemKv" value="true" />
-            <node concept="3LXTmp" id="2eucapX080h" role="1HemKq">
-              <node concept="398BVA" id="2eucapX0803" role="3LXTmr">
-                <ref role="398BVh" node="2fo8bJE$D4t" resolve="extensions.code" />
-                <node concept="2Ry0Ak" id="2eucapX0804" role="iGT6I">
-                  <property role="2Ry0Am" value="nodeversioning" />
-                  <node concept="2Ry0Ak" id="2eucapX0805" role="2Ry0An">
-                    <property role="2Ry0Am" value="languages" />
-                    <node concept="2Ry0Ak" id="2eucapX0806" role="2Ry0An">
-                      <property role="2Ry0Am" value="de.itemis.mps.nodeversioning" />
-                      <node concept="2Ry0Ak" id="2eucapX0807" role="2Ry0An">
-                        <property role="2Ry0Am" value="generator" />
-                        <node concept="2Ry0Ak" id="2eucapX0808" role="2Ry0An">
-                          <property role="2Ry0Am" value="template" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3qWCbU" id="2eucapX080i" role="3LXTna">
-                <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-              </node>
-            </node>
-          </node>
-        </node>
         <node concept="1BupzO" id="2eucapX0800" role="3bR31x">
           <property role="3ZfqAx" value="models" />
           <property role="1Hdu6h" value="true" />
@@ -7574,38 +7382,6 @@
           <node concept="3bR9La" id="F1NWDqqyTU" role="1SiIV1">
             <property role="3bR36h" value="true" />
             <ref role="3bR37D" to="ffeo:1TaHNgiIbIZ" resolve="MPS.Editor" />
-          </node>
-        </node>
-        <node concept="1yeLz9" id="F1NWDqqyTV" role="1TViLv">
-          <property role="TrG5h" value="com.mbeddr.mpsutil.grammarcells.runtimelang#5083944728301309305" />
-          <property role="3LESm3" value="79e1a72a-662e-4384-882a-49dd59eb455c" />
-          <node concept="1BupzO" id="2eucapX081Y" role="3bR31x">
-            <property role="3ZfqAx" value="generator/template" />
-            <property role="1Hdu6h" value="true" />
-            <property role="1HemKv" value="true" />
-            <node concept="3LXTmp" id="2eucapX081Z" role="1HemKq">
-              <node concept="398BVA" id="2eucapX081L" role="3LXTmr">
-                <ref role="398BVh" node="2fo8bJE$D4t" resolve="extensions.code" />
-                <node concept="2Ry0Ak" id="2eucapX081M" role="iGT6I">
-                  <property role="2Ry0Am" value="grammarcells" />
-                  <node concept="2Ry0Ak" id="2eucapX081N" role="2Ry0An">
-                    <property role="2Ry0Am" value="languages" />
-                    <node concept="2Ry0Ak" id="2eucapX081O" role="2Ry0An">
-                      <property role="2Ry0Am" value="com.mbeddr.mpsutil.grammarcells.runtimelang" />
-                      <node concept="2Ry0Ak" id="2eucapX081P" role="2Ry0An">
-                        <property role="2Ry0Am" value="generator" />
-                        <node concept="2Ry0Ak" id="2eucapX081Q" role="2Ry0An">
-                          <property role="2Ry0Am" value="template" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3qWCbU" id="2eucapX0820" role="3LXTna">
-                <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-              </node>
-            </node>
           </node>
         </node>
         <node concept="3rtmxn" id="5py4VqXmLLE" role="3bR31x">
@@ -8211,38 +7987,6 @@
         <node concept="1SiIV0" id="2NTGYE$JTHp" role="3bR37C">
           <node concept="3bR9La" id="2NTGYE$JTHq" role="1SiIV1">
             <ref role="3bR37D" to="ffeo:1TaHNgiIbIZ" resolve="MPS.Editor" />
-          </node>
-        </node>
-        <node concept="1yeLz9" id="2NTGYE$JTIt" role="1TViLv">
-          <property role="TrG5h" value="com.dslfoundry.plaintextgen#5198309202559528987" />
-          <property role="3LESm3" value="ebbc2a81-6618-40a2-b3b8-997fd1520167" />
-          <node concept="1BupzO" id="2eucapX0838" role="3bR31x">
-            <property role="3ZfqAx" value="generator/template" />
-            <property role="1Hdu6h" value="true" />
-            <property role="1HemKv" value="true" />
-            <node concept="3LXTmp" id="2eucapX0839" role="1HemKq">
-              <node concept="398BVA" id="2eucapX082V" role="3LXTmr">
-                <ref role="398BVh" node="2fo8bJE$D4t" resolve="extensions.code" />
-                <node concept="2Ry0Ak" id="2eucapX082W" role="iGT6I">
-                  <property role="2Ry0Am" value="plaintextgen" />
-                  <node concept="2Ry0Ak" id="2eucapX082X" role="2Ry0An">
-                    <property role="2Ry0Am" value="languages" />
-                    <node concept="2Ry0Ak" id="2eucapX082Y" role="2Ry0An">
-                      <property role="2Ry0Am" value="com.dslfoundry.plaintextgen" />
-                      <node concept="2Ry0Ak" id="2eucapX082Z" role="2Ry0An">
-                        <property role="2Ry0Am" value="generator" />
-                        <node concept="2Ry0Ak" id="2eucapX0830" role="2Ry0An">
-                          <property role="2Ry0Am" value="template" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3qWCbU" id="2eucapX083a" role="3LXTna">
-                <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-              </node>
-            </node>
           </node>
         </node>
         <node concept="1SiIV0" id="4GbnmmUeWl$" role="3bR37C">
@@ -10034,38 +9778,6 @@
             <ref role="3bR37D" to="ffeo:1TaHNgiIbIZ" resolve="MPS.Editor" />
           </node>
         </node>
-        <node concept="1yeLz9" id="4iIKqJTZ5Ja" role="1TViLv">
-          <property role="TrG5h" value="de.q60.mps.shadowmodels.target.editor#01" />
-          <property role="3LESm3" value="28036230-ca8e-4a87-ba2b-7d1c304f9681" />
-          <node concept="1BupzO" id="2eucapX088K" role="3bR31x">
-            <property role="3ZfqAx" value="generator/template" />
-            <property role="1Hdu6h" value="true" />
-            <property role="1HemKv" value="true" />
-            <node concept="3LXTmp" id="2eucapX088L" role="1HemKq">
-              <node concept="398BVA" id="2eucapX088z" role="3LXTmr">
-                <ref role="398BVh" node="2fo8bJE$D4t" resolve="extensions.code" />
-                <node concept="2Ry0Ak" id="2eucapX088$" role="iGT6I">
-                  <property role="2Ry0Am" value="shadowmodels" />
-                  <node concept="2Ry0Ak" id="2eucapX088_" role="2Ry0An">
-                    <property role="2Ry0Am" value="languages" />
-                    <node concept="2Ry0Ak" id="2eucapX088A" role="2Ry0An">
-                      <property role="2Ry0Am" value="de.q60.mps.shadowmodels.target.editor" />
-                      <node concept="2Ry0Ak" id="2eucapX088B" role="2Ry0An">
-                        <property role="2Ry0Am" value="generator" />
-                        <node concept="2Ry0Ak" id="2eucapX088C" role="2Ry0An">
-                          <property role="2Ry0Am" value="template" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3qWCbU" id="2eucapX088M" role="3LXTna">
-                <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-              </node>
-            </node>
-          </node>
-        </node>
         <node concept="1SiIV0" id="2sNIAl_Wwft" role="3bR37C">
           <node concept="3bR9La" id="2sNIAl_Wwfu" role="1SiIV1">
             <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
@@ -10141,38 +9853,6 @@
                 <node concept="2Ry0Ak" id="BRK1N8p1Tz" role="2Ry0An">
                   <property role="2Ry0Am" value="de.q60.mps.shadowmodels.target.text.mpl" />
                 </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1yeLz9" id="BRK1N8p1Q$" role="1TViLv">
-          <property role="TrG5h" value="de.q60.mps.shadowmodels.target.text#01" />
-          <property role="3LESm3" value="ecc7bf4b-c8ec-4b14-87e5-e9f512860567" />
-          <node concept="1BupzO" id="2eucapX089e" role="3bR31x">
-            <property role="3ZfqAx" value="generator/template" />
-            <property role="1Hdu6h" value="true" />
-            <property role="1HemKv" value="true" />
-            <node concept="3LXTmp" id="2eucapX089f" role="1HemKq">
-              <node concept="398BVA" id="2eucapX0891" role="3LXTmr">
-                <ref role="398BVh" node="2fo8bJE$D4t" resolve="extensions.code" />
-                <node concept="2Ry0Ak" id="2eucapX0892" role="iGT6I">
-                  <property role="2Ry0Am" value="shadowmodels" />
-                  <node concept="2Ry0Ak" id="2eucapX0893" role="2Ry0An">
-                    <property role="2Ry0Am" value="languages" />
-                    <node concept="2Ry0Ak" id="2eucapX0894" role="2Ry0An">
-                      <property role="2Ry0Am" value="de.q60.mps.shadowmodels.target.text" />
-                      <node concept="2Ry0Ak" id="2eucapX0895" role="2Ry0An">
-                        <property role="2Ry0Am" value="generator" />
-                        <node concept="2Ry0Ak" id="2eucapX0896" role="2Ry0An">
-                          <property role="2Ry0Am" value="template" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3qWCbU" id="2eucapX089g" role="3LXTna">
-                <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
               </node>
             </node>
           </node>
@@ -10373,38 +10053,6 @@
                 <node concept="2Ry0Ak" id="4iIKqJTZ5HG" role="2Ry0An">
                   <property role="2Ry0Am" value="de.q60.mps.shadowmodels.runtimelang.mpl" />
                 </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1yeLz9" id="4iIKqJTZ5Ju" role="1TViLv">
-          <property role="TrG5h" value="de.q60.mps.shadowmodels.runtimelang#01" />
-          <property role="3LESm3" value="d81a5946-dea0-44cd-93bb-ab50632b69c4" />
-          <node concept="1BupzO" id="2eucapX08aa" role="3bR31x">
-            <property role="3ZfqAx" value="generator/template" />
-            <property role="1Hdu6h" value="true" />
-            <property role="1HemKv" value="true" />
-            <node concept="3LXTmp" id="2eucapX08ab" role="1HemKq">
-              <node concept="398BVA" id="2eucapX089X" role="3LXTmr">
-                <ref role="398BVh" node="2fo8bJE$D4t" resolve="extensions.code" />
-                <node concept="2Ry0Ak" id="2eucapX089Y" role="iGT6I">
-                  <property role="2Ry0Am" value="shadowmodels" />
-                  <node concept="2Ry0Ak" id="2eucapX089Z" role="2Ry0An">
-                    <property role="2Ry0Am" value="languages" />
-                    <node concept="2Ry0Ak" id="2eucapX08a0" role="2Ry0An">
-                      <property role="2Ry0Am" value="de.q60.mps.shadowmodels.runtimelang" />
-                      <node concept="2Ry0Ak" id="2eucapX08a1" role="2Ry0An">
-                        <property role="2Ry0Am" value="generator" />
-                        <node concept="2Ry0Ak" id="2eucapX08a2" role="2Ry0An">
-                          <property role="2Ry0Am" value="template" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3qWCbU" id="2eucapX08ac" role="3LXTna">
-                <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
               </node>
             </node>
           </node>
@@ -10700,38 +10348,6 @@
                 <node concept="2Ry0Ak" id="4iIKqJTZ5HY" role="2Ry0An">
                   <property role="2Ry0Am" value="de.q60.mps.shadowmodels.repository.mpl" />
                 </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1yeLz9" id="4iIKqJTZ5JY" role="1TViLv">
-          <property role="TrG5h" value="de.q60.mps.shadowmodels.repository#01" />
-          <property role="3LESm3" value="3047c9fb-b7ce-45c0-b3d9-a11e5bde9906" />
-          <node concept="1BupzO" id="2eucapX08b6" role="3bR31x">
-            <property role="3ZfqAx" value="generator/template" />
-            <property role="1Hdu6h" value="true" />
-            <property role="1HemKv" value="true" />
-            <node concept="3LXTmp" id="2eucapX08b7" role="1HemKq">
-              <node concept="398BVA" id="2eucapX08aT" role="3LXTmr">
-                <ref role="398BVh" node="2fo8bJE$D4t" resolve="extensions.code" />
-                <node concept="2Ry0Ak" id="2eucapX08aU" role="iGT6I">
-                  <property role="2Ry0Am" value="shadowmodels" />
-                  <node concept="2Ry0Ak" id="2eucapX08aV" role="2Ry0An">
-                    <property role="2Ry0Am" value="languages" />
-                    <node concept="2Ry0Ak" id="2eucapX08aW" role="2Ry0An">
-                      <property role="2Ry0Am" value="de.q60.mps.shadowmodels.repository" />
-                      <node concept="2Ry0Ak" id="2eucapX08aX" role="2Ry0An">
-                        <property role="2Ry0Am" value="generator" />
-                        <node concept="2Ry0Ak" id="2eucapX08aY" role="2Ry0An">
-                          <property role="2Ry0Am" value="template" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3qWCbU" id="2eucapX08b8" role="3LXTna">
-                <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
               </node>
             </node>
           </node>
@@ -11463,38 +11079,6 @@
             <ref role="1Busuk" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
           </node>
         </node>
-        <node concept="1yeLz9" id="BRK1N8p1yt" role="1TViLv">
-          <property role="TrG5h" value="de.q60.mps.shadowmodels.examples.blext#01" />
-          <property role="3LESm3" value="e89c1be2-df3a-444d-9766-b255bcee5e73" />
-          <node concept="1BupzO" id="2eucapX08cG" role="3bR31x">
-            <property role="3ZfqAx" value="generator/template" />
-            <property role="1Hdu6h" value="true" />
-            <property role="1HemKv" value="true" />
-            <node concept="3LXTmp" id="2eucapX08cH" role="1HemKq">
-              <node concept="398BVA" id="2eucapX08cv" role="3LXTmr">
-                <ref role="398BVh" node="2fo8bJE$D4t" resolve="extensions.code" />
-                <node concept="2Ry0Ak" id="2eucapX08cw" role="iGT6I">
-                  <property role="2Ry0Am" value="shadowmodels" />
-                  <node concept="2Ry0Ak" id="2eucapX08cx" role="2Ry0An">
-                    <property role="2Ry0Am" value="languages" />
-                    <node concept="2Ry0Ak" id="2eucapX08cy" role="2Ry0An">
-                      <property role="2Ry0Am" value="de.q60.mps.shadowmodels.examples.blext" />
-                      <node concept="2Ry0Ak" id="2eucapX08cz" role="2Ry0An">
-                        <property role="2Ry0Am" value="generator" />
-                        <node concept="2Ry0Ak" id="2eucapX08c$" role="2Ry0An">
-                          <property role="2Ry0Am" value="template" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3qWCbU" id="2eucapX08cI" role="3LXTna">
-                <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-              </node>
-            </node>
-          </node>
-        </node>
         <node concept="1SiIV0" id="2qi4B7uzvIW" role="3bR37C">
           <node concept="3bR9La" id="2qi4B7uzvIX" role="1SiIV1">
             <ref role="3bR37D" to="ffeo:7Kfy9QB6KXW" resolve="jetbrains.mps.lang.core" />
@@ -11599,38 +11183,6 @@
             <ref role="3bR37D" node="4iIKqJTZ5HI" resolve="de.q60.mps.shadowmodels.runtimelang" />
           </node>
         </node>
-        <node concept="1yeLz9" id="BRK1N8p1qH" role="1TViLv">
-          <property role="TrG5h" value="de.q60.mps.shadowmodels.examples.entities#01" />
-          <property role="3LESm3" value="4b81b271-0a0f-4f4b-9d1b-c2c6711961a5" />
-          <node concept="1BupzO" id="2eucapX08da" role="3bR31x">
-            <property role="3ZfqAx" value="generator/template" />
-            <property role="1Hdu6h" value="true" />
-            <property role="1HemKv" value="true" />
-            <node concept="3LXTmp" id="2eucapX08db" role="1HemKq">
-              <node concept="398BVA" id="2eucapX08cX" role="3LXTmr">
-                <ref role="398BVh" node="2fo8bJE$D4t" resolve="extensions.code" />
-                <node concept="2Ry0Ak" id="2eucapX08cY" role="iGT6I">
-                  <property role="2Ry0Am" value="shadowmodels" />
-                  <node concept="2Ry0Ak" id="2eucapX08cZ" role="2Ry0An">
-                    <property role="2Ry0Am" value="languages" />
-                    <node concept="2Ry0Ak" id="2eucapX08d0" role="2Ry0An">
-                      <property role="2Ry0Am" value="de.q60.mps.shadowmodels.examples.entities" />
-                      <node concept="2Ry0Ak" id="2eucapX08d1" role="2Ry0An">
-                        <property role="2Ry0Am" value="generator" />
-                        <node concept="2Ry0Ak" id="2eucapX08d2" role="2Ry0An">
-                          <property role="2Ry0Am" value="template" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3qWCbU" id="2eucapX08dc" role="3LXTna">
-                <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-              </node>
-            </node>
-          </node>
-        </node>
         <node concept="1SiIV0" id="BRK1N8p1T_" role="3bR37C">
           <node concept="3bR9La" id="BRK1N8p1TA" role="1SiIV1">
             <ref role="3bR37D" node="BRK1N8p1Qt" resolve="de.q60.mps.shadowmodels.target.text" />
@@ -11718,38 +11270,6 @@
         <node concept="1SiIV0" id="BRK1N8p1y$" role="3bR37C">
           <node concept="3bR9La" id="BRK1N8p1y_" role="1SiIV1">
             <ref role="3bR37D" node="4iIKqJTZ5HI" resolve="de.q60.mps.shadowmodels.runtimelang" />
-          </node>
-        </node>
-        <node concept="1yeLz9" id="BRK1N8p1yA" role="1TViLv">
-          <property role="TrG5h" value="de.q60.mps.shadowmodels.examples.statemachine#6069004802152564660" />
-          <property role="3LESm3" value="f48d6c1a-9b4c-4196-ab78-21a90a729163" />
-          <node concept="1BupzO" id="2eucapX08dC" role="3bR31x">
-            <property role="3ZfqAx" value="generator/template" />
-            <property role="1Hdu6h" value="true" />
-            <property role="1HemKv" value="true" />
-            <node concept="3LXTmp" id="2eucapX08dD" role="1HemKq">
-              <node concept="398BVA" id="2eucapX08dr" role="3LXTmr">
-                <ref role="398BVh" node="2fo8bJE$D4t" resolve="extensions.code" />
-                <node concept="2Ry0Ak" id="2eucapX08ds" role="iGT6I">
-                  <property role="2Ry0Am" value="shadowmodels" />
-                  <node concept="2Ry0Ak" id="2eucapX08dt" role="2Ry0An">
-                    <property role="2Ry0Am" value="languages" />
-                    <node concept="2Ry0Ak" id="2eucapX08du" role="2Ry0An">
-                      <property role="2Ry0Am" value="de.q60.mps.shadowmodels.examples.statemachine" />
-                      <node concept="2Ry0Ak" id="2eucapX08dv" role="2Ry0An">
-                        <property role="2Ry0Am" value="generator" />
-                        <node concept="2Ry0Ak" id="2eucapX08dw" role="2Ry0An">
-                          <property role="2Ry0Am" value="template" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3qWCbU" id="2eucapX08dE" role="3LXTna">
-                <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-              </node>
-            </node>
           </node>
         </node>
         <node concept="1SiIV0" id="2FosA_pFQLQ" role="3bR37C">
@@ -12188,35 +11708,6 @@
             </node>
             <node concept="3qWCbU" id="5U8hsWC7aH8" role="3LXTna">
               <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-        <node concept="1yeLz9" id="5U8hsWC7aH9" role="1TViLv">
-          <property role="TrG5h" value="org.modelix.model.repositoryconcepts.generator" />
-          <property role="3LESm3" value="51731586-2c9b-4758-912e-a0e5dfe2d6f2" />
-          <node concept="1BupzO" id="5U8hsWC7aHl" role="3bR31x">
-            <property role="3ZfqAx" value="generator/templates" />
-            <property role="1Hdu6h" value="true" />
-            <property role="1HemKv" value="true" />
-            <node concept="3LXTmp" id="5U8hsWC7aHm" role="1HemKq">
-              <node concept="398BVA" id="5U8hsWC7aHa" role="3LXTmr">
-                <ref role="398BVh" node="2fo8bJE$D4t" resolve="extensions.code" />
-                <node concept="2Ry0Ak" id="5U8hsWC7aHb" role="iGT6I">
-                  <property role="2Ry0Am" value="model-api" />
-                  <node concept="2Ry0Ak" id="5U8hsWC7aHc" role="2Ry0An">
-                    <property role="2Ry0Am" value="org.modelix.model.repositoryconcepts" />
-                    <node concept="2Ry0Ak" id="5U8hsWC7aHd" role="2Ry0An">
-                      <property role="2Ry0Am" value="generator" />
-                      <node concept="2Ry0Ak" id="5U8hsWC7aHe" role="2Ry0An">
-                        <property role="2Ry0Am" value="templates" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3qWCbU" id="5U8hsWC7aHn" role="3LXTna">
-                <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-              </node>
             </node>
           </node>
         </node>
@@ -14312,35 +13803,6 @@
             <ref role="3bR37D" to="ffeo:1TaHNgiIbIZ" resolve="MPS.Editor" />
           </node>
         </node>
-        <node concept="1yeLz9" id="F1NWDqwgsY" role="1TViLv">
-          <property role="TrG5h" value="com.mbeddr.mpsutil.grammarcells.sandboxlang#1749127723000259754" />
-          <property role="3LESm3" value="70c639aa-2028-47e9-88c9-7d69c9b405e3" />
-          <node concept="1BupzO" id="7q24334ZK$3" role="3bR31x">
-            <property role="3ZfqAx" value="generator/template" />
-            <property role="1Hdu6h" value="true" />
-            <property role="1HemKv" value="true" />
-            <node concept="3LXTmp" id="7q24334ZK$4" role="1HemKq">
-              <node concept="398BVA" id="7q24334ZKzE" role="3LXTmr">
-                <ref role="398BVh" node="F1NWDquQCJ" resolve="grammarcells.home" />
-                <node concept="2Ry0Ak" id="7q24334ZKzF" role="iGT6I">
-                  <property role="2Ry0Am" value="languages" />
-                  <node concept="2Ry0Ak" id="7q24334ZKzG" role="2Ry0An">
-                    <property role="2Ry0Am" value="com.mbeddr.mpsutil.grammarcells.sandboxlang" />
-                    <node concept="2Ry0Ak" id="7q24334ZKzH" role="2Ry0An">
-                      <property role="2Ry0Am" value="generator" />
-                      <node concept="2Ry0Ak" id="7q24334ZKzI" role="2Ry0An">
-                        <property role="2Ry0Am" value="template" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3qWCbU" id="7q24334ZK$5" role="3LXTna">
-                <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-              </node>
-            </node>
-          </node>
-        </node>
         <node concept="3rtmxn" id="5py4VqXmLNU" role="3bR31x">
           <node concept="3LXTmp" id="5py4VqXmLNV" role="3rtmxm">
             <node concept="3qWCbU" id="5py4VqXmLNW" role="3LXTna">
@@ -14737,35 +14199,6 @@
         <node concept="1SiIV0" id="5mH$9t6eA1V" role="3bR37C">
           <node concept="1Busua" id="5mH$9t6eA1W" role="1SiIV1">
             <ref role="1Busuk" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
-          </node>
-        </node>
-        <node concept="1yeLz9" id="5mH$9t6eA1X" role="1TViLv">
-          <property role="TrG5h" value="de.slisson.mps.tables.demolang#1397920687865224039" />
-          <property role="3LESm3" value="20b297e4-a2b3-4766-b3b4-d8e7046ea638" />
-          <node concept="1BupzO" id="7q24334ZKAA" role="3bR31x">
-            <property role="3ZfqAx" value="generator/template" />
-            <property role="1Hdu6h" value="true" />
-            <property role="1HemKv" value="true" />
-            <node concept="3LXTmp" id="7q24334ZKAB" role="1HemKq">
-              <node concept="398BVA" id="7q24334ZKAd" role="3LXTmr">
-                <ref role="398BVh" node="5mH$9t6e_IG" resolve="tables.home" />
-                <node concept="2Ry0Ak" id="7q24334ZKAe" role="iGT6I">
-                  <property role="2Ry0Am" value="languages" />
-                  <node concept="2Ry0Ak" id="7q24334ZKAf" role="2Ry0An">
-                    <property role="2Ry0Am" value="de.slisson.mps.tables.demolang" />
-                    <node concept="2Ry0Ak" id="7q24334ZKAg" role="2Ry0An">
-                      <property role="2Ry0Am" value="generator" />
-                      <node concept="2Ry0Ak" id="7q24334ZKAh" role="2Ry0An">
-                        <property role="2Ry0Am" value="template" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3qWCbU" id="7q24334ZKAC" role="3LXTna">
-                <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-              </node>
-            </node>
           </node>
         </node>
         <node concept="3rtmxn" id="5mH$9t6eA22" role="3bR31x">
@@ -16215,35 +15648,6 @@
             </node>
           </node>
         </node>
-        <node concept="1yeLz9" id="3$$s$wOI_Iq" role="1TViLv">
-          <property role="TrG5h" value="de.itemis.mps.editor.collapsible.testlang#01" />
-          <property role="3LESm3" value="7f15d063-5431-4c8f-819e-740eb30699a2" />
-          <node concept="1BupzO" id="7q24334ZKHN" role="3bR31x">
-            <property role="3ZfqAx" value="generator/template" />
-            <property role="1Hdu6h" value="true" />
-            <property role="1HemKv" value="true" />
-            <node concept="3LXTmp" id="7q24334ZKHO" role="1HemKq">
-              <node concept="398BVA" id="7q24334ZKHq" role="3LXTmr">
-                <ref role="398BVh" node="3$$s$wOI_hD" resolve="widgets.home" />
-                <node concept="2Ry0Ak" id="7q24334ZKHr" role="iGT6I">
-                  <property role="2Ry0Am" value="languages" />
-                  <node concept="2Ry0Ak" id="7q24334ZKHs" role="2Ry0An">
-                    <property role="2Ry0Am" value="de.itemis.mps.editor.collapsible.testlang" />
-                    <node concept="2Ry0Ak" id="7q24334ZKHt" role="2Ry0An">
-                      <property role="2Ry0Am" value="generator" />
-                      <node concept="2Ry0Ak" id="7q24334ZKHu" role="2Ry0An">
-                        <property role="2Ry0Am" value="template" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3qWCbU" id="7q24334ZKHP" role="3LXTna">
-                <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-              </node>
-            </node>
-          </node>
-        </node>
         <node concept="1BupzO" id="7q24334ZKHn" role="3bR31x">
           <property role="3ZfqAx" value="models" />
           <property role="1Hdu6h" value="true" />
@@ -16299,35 +15703,6 @@
             </node>
           </node>
         </node>
-        <node concept="1yeLz9" id="7CKpyI71csd" role="1TViLv">
-          <property role="TrG5h" value="de.itemis.mps.editor.enumeration.demolang#2135528801629813660" />
-          <property role="3LESm3" value="0d5cbe1a-9a43-4d2f-9d53-60f15cd45fd3" />
-          <node concept="1BupzO" id="7q24334ZKIB" role="3bR31x">
-            <property role="3ZfqAx" value="generator/template" />
-            <property role="1Hdu6h" value="true" />
-            <property role="1HemKv" value="true" />
-            <node concept="3LXTmp" id="7q24334ZKIC" role="1HemKq">
-              <node concept="398BVA" id="7q24334ZKIe" role="3LXTmr">
-                <ref role="398BVh" node="3$$s$wOI_hD" resolve="widgets.home" />
-                <node concept="2Ry0Ak" id="7q24334ZKIf" role="iGT6I">
-                  <property role="2Ry0Am" value="languages" />
-                  <node concept="2Ry0Ak" id="7q24334ZKIg" role="2Ry0An">
-                    <property role="2Ry0Am" value="de.itemis.mps.editor.enumeration.demolang" />
-                    <node concept="2Ry0Ak" id="7q24334ZKIh" role="2Ry0An">
-                      <property role="2Ry0Am" value="generator" />
-                      <node concept="2Ry0Ak" id="7q24334ZKIi" role="2Ry0An">
-                        <property role="2Ry0Am" value="template" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3qWCbU" id="7q24334ZKID" role="3LXTna">
-                <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-              </node>
-            </node>
-          </node>
-        </node>
         <node concept="1BupzO" id="7q24334ZKIb" role="3bR31x">
           <property role="3ZfqAx" value="models" />
           <property role="1Hdu6h" value="true" />
@@ -16380,35 +15755,6 @@
             </node>
             <node concept="3qWCbU" id="7CKpyI71ctn" role="3LXTna">
               <property role="3qWCbO" value="icons/**" />
-            </node>
-          </node>
-        </node>
-        <node concept="1yeLz9" id="7CKpyI71ctq" role="1TViLv">
-          <property role="TrG5h" value="de.itemis.mps.editor.dropdown.demolang#671762723175673162" />
-          <property role="3LESm3" value="11a6287a-f1ce-468e-bcad-0ac609eb39af" />
-          <node concept="1BupzO" id="7q24334ZKJr" role="3bR31x">
-            <property role="3ZfqAx" value="generator/template" />
-            <property role="1Hdu6h" value="true" />
-            <property role="1HemKv" value="true" />
-            <node concept="3LXTmp" id="7q24334ZKJs" role="1HemKq">
-              <node concept="398BVA" id="7q24334ZKJ2" role="3LXTmr">
-                <ref role="398BVh" node="3$$s$wOI_hD" resolve="widgets.home" />
-                <node concept="2Ry0Ak" id="7q24334ZKJ3" role="iGT6I">
-                  <property role="2Ry0Am" value="languages" />
-                  <node concept="2Ry0Ak" id="7q24334ZKJ4" role="2Ry0An">
-                    <property role="2Ry0Am" value="de.itemis.mps.editor.dropdown.demolang" />
-                    <node concept="2Ry0Ak" id="7q24334ZKJ5" role="2Ry0An">
-                      <property role="2Ry0Am" value="generator" />
-                      <node concept="2Ry0Ak" id="7q24334ZKJ6" role="2Ry0An">
-                        <property role="2Ry0Am" value="template" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3qWCbU" id="7q24334ZKJt" role="3LXTna">
-                <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-              </node>
             </node>
           </node>
         </node>
@@ -16469,35 +15815,6 @@
             </node>
             <node concept="3qWCbU" id="7CKpyI71cuM" role="3LXTna">
               <property role="3qWCbO" value="icons/**" />
-            </node>
-          </node>
-        </node>
-        <node concept="1yeLz9" id="7CKpyI71cuP" role="1TViLv">
-          <property role="TrG5h" value="de.itemis.mps.editor.bool.demolang#4900677560560046179" />
-          <property role="3LESm3" value="1f538166-ed71-448e-98a4-258176a5d557" />
-          <node concept="1BupzO" id="7q24334ZKKf" role="3bR31x">
-            <property role="3ZfqAx" value="generator/template" />
-            <property role="1Hdu6h" value="true" />
-            <property role="1HemKv" value="true" />
-            <node concept="3LXTmp" id="7q24334ZKKg" role="1HemKq">
-              <node concept="398BVA" id="7q24334ZKJQ" role="3LXTmr">
-                <ref role="398BVh" node="3$$s$wOI_hD" resolve="widgets.home" />
-                <node concept="2Ry0Ak" id="7q24334ZKJR" role="iGT6I">
-                  <property role="2Ry0Am" value="languages" />
-                  <node concept="2Ry0Ak" id="7q24334ZKJS" role="2Ry0An">
-                    <property role="2Ry0Am" value="de.itemis.mps.editor.bool.demolang" />
-                    <node concept="2Ry0Ak" id="7q24334ZKJT" role="2Ry0An">
-                      <property role="2Ry0Am" value="generator" />
-                      <node concept="2Ry0Ak" id="7q24334ZKJU" role="2Ry0An">
-                        <property role="2Ry0Am" value="template" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3qWCbU" id="7q24334ZKKh" role="3LXTna">
-                <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-              </node>
             </node>
           </node>
         </node>
@@ -16983,35 +16300,6 @@
             <ref role="1Busuk" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
           </node>
         </node>
-        <node concept="1yeLz9" id="7qi8mU1OzzC" role="1TViLv">
-          <property role="TrG5h" value="de.slisson.mps.conditionalEditor.demolang#2877762237607057987" />
-          <property role="3LESm3" value="54cfdf41-6c53-4d51-a1ba-da41647509d8" />
-          <node concept="1BupzO" id="7q24334ZKO7" role="3bR31x">
-            <property role="3ZfqAx" value="generator/template" />
-            <property role="1Hdu6h" value="true" />
-            <property role="1HemKv" value="true" />
-            <node concept="3LXTmp" id="7q24334ZKO8" role="1HemKq">
-              <node concept="398BVA" id="7q24334ZKNI" role="3LXTmr">
-                <ref role="398BVh" node="7qi8mU1OzW7" resolve="conditionalEditor.home" />
-                <node concept="2Ry0Ak" id="7q24334ZKNJ" role="iGT6I">
-                  <property role="2Ry0Am" value="languages" />
-                  <node concept="2Ry0Ak" id="7q24334ZKNK" role="2Ry0An">
-                    <property role="2Ry0Am" value="de.slisson.mps.conditionalEditor.demolang" />
-                    <node concept="2Ry0Ak" id="7q24334ZKNL" role="2Ry0An">
-                      <property role="2Ry0Am" value="generator" />
-                      <node concept="2Ry0Ak" id="7q24334ZKNM" role="2Ry0An">
-                        <property role="2Ry0Am" value="template" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3qWCbU" id="7q24334ZKO9" role="3LXTna">
-                <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-              </node>
-            </node>
-          </node>
-        </node>
         <node concept="3rtmxn" id="3D0nl1ssJIU" role="3bR31x">
           <node concept="3LXTmp" id="3D0nl1ssJIV" role="3rtmxm">
             <node concept="3qWCbU" id="3D0nl1ssJIW" role="3LXTna">
@@ -17138,35 +16426,6 @@
         <node concept="1SiIV0" id="34tM7SkU5ca" role="3bR37C">
           <node concept="1Busua" id="34tM7SkU5cb" role="1SiIV1">
             <ref role="1Busuk" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
-          </node>
-        </node>
-        <node concept="1yeLz9" id="34tM7SkU5cc" role="1TViLv">
-          <property role="TrG5h" value="de.itemis.mps.editor.math.demolang#175930839491777503" />
-          <property role="3LESm3" value="55125df6-64d8-46e2-b523-daf2c2e95338" />
-          <node concept="1BupzO" id="7q24334ZKPj" role="3bR31x">
-            <property role="3ZfqAx" value="generator/template" />
-            <property role="1Hdu6h" value="true" />
-            <property role="1HemKv" value="true" />
-            <node concept="3LXTmp" id="7q24334ZKPk" role="1HemKq">
-              <node concept="398BVA" id="7q24334ZKOU" role="3LXTmr">
-                <ref role="398BVh" node="7qi8mU1Ozyi" resolve="math.home" />
-                <node concept="2Ry0Ak" id="7q24334ZKOV" role="iGT6I">
-                  <property role="2Ry0Am" value="languages" />
-                  <node concept="2Ry0Ak" id="7q24334ZKOW" role="2Ry0An">
-                    <property role="2Ry0Am" value="de.itemis.mps.editor.math.demolang" />
-                    <node concept="2Ry0Ak" id="7q24334ZKOX" role="2Ry0An">
-                      <property role="2Ry0Am" value="generator" />
-                      <node concept="2Ry0Ak" id="7q24334ZKOY" role="2Ry0An">
-                        <property role="2Ry0Am" value="template" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3qWCbU" id="7q24334ZKPl" role="3LXTna">
-                <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-              </node>
-            </node>
           </node>
         </node>
         <node concept="1SiIV0" id="34tM7SkU5d$" role="3bR37C">
@@ -17484,35 +16743,6 @@
         <node concept="1E0d5M" id="5mH$9t6eBsZ" role="1E1XAP">
           <ref role="1E0d5P" node="6$6tsX_CURF" resolve="de.slisson.mps.structurecheck.runtime" />
         </node>
-        <node concept="1yeLz9" id="5mH$9t6eBt2" role="1TViLv">
-          <property role="TrG5h" value="test.de.itemis.mps.editor.celllayout.lang#492440529733453404" />
-          <property role="3LESm3" value="142bdcb2-0f12-4915-95e2-8bf1f55b8be7" />
-          <node concept="1BupzO" id="7q24334ZKRF" role="3bR31x">
-            <property role="3ZfqAx" value="generator/template" />
-            <property role="1Hdu6h" value="true" />
-            <property role="1HemKv" value="true" />
-            <node concept="3LXTmp" id="7q24334ZKRG" role="1HemKq">
-              <node concept="398BVA" id="7q24334ZKRi" role="3LXTmr">
-                <ref role="398BVh" node="5mH$9t6eA_$" resolve="celllayout.home" />
-                <node concept="2Ry0Ak" id="7q24334ZKRj" role="iGT6I">
-                  <property role="2Ry0Am" value="languages" />
-                  <node concept="2Ry0Ak" id="7q24334ZKRk" role="2Ry0An">
-                    <property role="2Ry0Am" value="test.de.itemis.mps.editor.celllayout.lang" />
-                    <node concept="2Ry0Ak" id="7q24334ZKRl" role="2Ry0An">
-                      <property role="2Ry0Am" value="generator" />
-                      <node concept="2Ry0Ak" id="7q24334ZKRm" role="2Ry0An">
-                        <property role="2Ry0Am" value="template" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3qWCbU" id="7q24334ZKRH" role="3LXTna">
-                <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-              </node>
-            </node>
-          </node>
-        </node>
         <node concept="3rtmxn" id="5mH$9t6eBt3" role="3bR31x">
           <node concept="3LXTmp" id="5mH$9t6eBt4" role="3rtmxm">
             <node concept="3qWCbU" id="5mH$9t6eBt5" role="3LXTna">
@@ -17596,35 +16826,6 @@
               <property role="2Ry0Am" value="de.itemis.mps.editor.celllayout.sandboxlang" />
               <node concept="2Ry0Ak" id="7qi8mU1O$bJ" role="2Ry0An">
                 <property role="2Ry0Am" value="de.itemis.mps.editor.celllayout.sandboxlang.mpl" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1yeLz9" id="7qi8mU1OzZA" role="1TViLv">
-          <property role="TrG5h" value="de.itemis.mps.editor.celllayout.sandboxlang#861697192441878790" />
-          <property role="3LESm3" value="fd967edc-5bcb-4b74-a7b3-864a175b81b8" />
-          <node concept="1BupzO" id="7q24334ZKSv" role="3bR31x">
-            <property role="3ZfqAx" value="generator/template" />
-            <property role="1Hdu6h" value="true" />
-            <property role="1HemKv" value="true" />
-            <node concept="3LXTmp" id="7q24334ZKSw" role="1HemKq">
-              <node concept="398BVA" id="7q24334ZKS6" role="3LXTmr">
-                <ref role="398BVh" node="5mH$9t6eA_$" resolve="celllayout.home" />
-                <node concept="2Ry0Ak" id="7q24334ZKS7" role="iGT6I">
-                  <property role="2Ry0Am" value="languages" />
-                  <node concept="2Ry0Ak" id="7q24334ZKS8" role="2Ry0An">
-                    <property role="2Ry0Am" value="de.itemis.mps.editor.celllayout.sandboxlang" />
-                    <node concept="2Ry0Ak" id="7q24334ZKS9" role="2Ry0An">
-                      <property role="2Ry0Am" value="generator" />
-                      <node concept="2Ry0Ak" id="7q24334ZKSa" role="2Ry0An">
-                        <property role="2Ry0Am" value="template" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3qWCbU" id="7q24334ZKSx" role="3LXTna">
-                <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
               </node>
             </node>
           </node>
@@ -17762,35 +16963,6 @@
             <ref role="1Busuk" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
           </node>
         </node>
-        <node concept="1yeLz9" id="6$6tsX_CJvc" role="1TViLv">
-          <property role="TrG5h" value="de.itemis.mps.editor.diagram.demo.activity#5725606875425068161" />
-          <property role="3LESm3" value="bce65e08-dc07-459a-82dc-c9e5a7039a98" />
-          <node concept="1BupzO" id="7q24334ZKTF" role="3bR31x">
-            <property role="3ZfqAx" value="generator/template" />
-            <property role="1Hdu6h" value="true" />
-            <property role="1HemKv" value="true" />
-            <node concept="3LXTmp" id="7q24334ZKTG" role="1HemKq">
-              <node concept="398BVA" id="7q24334ZKTi" role="3LXTmr">
-                <ref role="398BVh" node="6$6tsX_CF7m" resolve="diagram.home" />
-                <node concept="2Ry0Ak" id="7q24334ZKTj" role="iGT6I">
-                  <property role="2Ry0Am" value="languages" />
-                  <node concept="2Ry0Ak" id="7q24334ZKTk" role="2Ry0An">
-                    <property role="2Ry0Am" value="de.itemis.mps.editor.diagram.demo.activity" />
-                    <node concept="2Ry0Ak" id="7q24334ZKTl" role="2Ry0An">
-                      <property role="2Ry0Am" value="generator" />
-                      <node concept="2Ry0Ak" id="7q24334ZKTm" role="2Ry0An">
-                        <property role="2Ry0Am" value="template" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3qWCbU" id="7q24334ZKTH" role="3LXTna">
-                <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-              </node>
-            </node>
-          </node>
-        </node>
         <node concept="3rtmxn" id="3xFG3bj5MnI" role="3bR31x">
           <node concept="3LXTmp" id="3xFG3bj5MnJ" role="3rtmxm">
             <node concept="3qWCbU" id="3xFG3bj5MnK" role="3LXTna">
@@ -17859,35 +17031,6 @@
         <node concept="1SiIV0" id="6$6tsX_CJtc" role="3bR37C">
           <node concept="3bR9La" id="6$6tsX_CJtd" role="1SiIV1">
             <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
-          </node>
-        </node>
-        <node concept="1yeLz9" id="6$6tsX_CJtg" role="1TViLv">
-          <property role="TrG5h" value="test.de.itemis.mps.editor.diagram.lang#6137251545971652545" />
-          <property role="3LESm3" value="0ec087f2-d6a4-49c1-8bd8-7a06bc979430" />
-          <node concept="1BupzO" id="7q24334ZKUv" role="3bR31x">
-            <property role="3ZfqAx" value="generator/template" />
-            <property role="1Hdu6h" value="true" />
-            <property role="1HemKv" value="true" />
-            <node concept="3LXTmp" id="7q24334ZKUw" role="1HemKq">
-              <node concept="398BVA" id="7q24334ZKU6" role="3LXTmr">
-                <ref role="398BVh" node="6$6tsX_CF7m" resolve="diagram.home" />
-                <node concept="2Ry0Ak" id="7q24334ZKU7" role="iGT6I">
-                  <property role="2Ry0Am" value="languages" />
-                  <node concept="2Ry0Ak" id="7q24334ZKU8" role="2Ry0An">
-                    <property role="2Ry0Am" value="test.de.itemis.mps.editor.diagram.lang" />
-                    <node concept="2Ry0Ak" id="7q24334ZKU9" role="2Ry0An">
-                      <property role="2Ry0Am" value="generator" />
-                      <node concept="2Ry0Ak" id="7q24334ZKUa" role="2Ry0An">
-                        <property role="2Ry0Am" value="template" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3qWCbU" id="7q24334ZKUx" role="3LXTna">
-                <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-              </node>
-            </node>
           </node>
         </node>
         <node concept="3rtmxn" id="3xFG3bj5Mlq" role="3bR31x">
@@ -18158,35 +17301,6 @@
         <node concept="1E0d5M" id="7qi8mU1Oz$E" role="1E1XAP">
           <ref role="1E0d5P" node="PE3B26QCrP" resolve="org.apache.commons" />
         </node>
-        <node concept="1yeLz9" id="7qi8mU1Oz$H" role="1TViLv">
-          <property role="TrG5h" value="de.itemis.mps.editor.diagram.demoentities#5285801562344837634" />
-          <property role="3LESm3" value="63b981d5-8123-4b93-8f69-23f693398d92" />
-          <node concept="1BupzO" id="7q24334ZKWQ" role="3bR31x">
-            <property role="3ZfqAx" value="generator/template" />
-            <property role="1Hdu6h" value="true" />
-            <property role="1HemKv" value="true" />
-            <node concept="3LXTmp" id="7q24334ZKWR" role="1HemKq">
-              <node concept="398BVA" id="7q24334ZKWt" role="3LXTmr">
-                <ref role="398BVh" node="6$6tsX_CF7m" resolve="diagram.home" />
-                <node concept="2Ry0Ak" id="7q24334ZKWu" role="iGT6I">
-                  <property role="2Ry0Am" value="languages" />
-                  <node concept="2Ry0Ak" id="7q24334ZKWv" role="2Ry0An">
-                    <property role="2Ry0Am" value="de.itemis.mps.editor.diagram.demoentities" />
-                    <node concept="2Ry0Ak" id="7q24334ZKWw" role="2Ry0An">
-                      <property role="2Ry0Am" value="generator" />
-                      <node concept="2Ry0Ak" id="7q24334ZKWx" role="2Ry0An">
-                        <property role="2Ry0Am" value="template" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3qWCbU" id="7q24334ZKWS" role="3LXTna">
-                <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-              </node>
-            </node>
-          </node>
-        </node>
         <node concept="1SiIV0" id="7qi8mU1OzTm" role="3bR37C">
           <node concept="3bR9La" id="7qi8mU1OzTn" role="1SiIV1">
             <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
@@ -18259,35 +17373,6 @@
         </node>
         <node concept="1E0d5M" id="7qi8mU1OzPa" role="1E1XAP">
           <ref role="1E0d5P" node="PE3B26QCrP" resolve="org.apache.commons" />
-        </node>
-        <node concept="1yeLz9" id="7qi8mU1OzPd" role="1TViLv">
-          <property role="TrG5h" value="de.itemis.mps.editor.diagram.demo.callgraph#6554619383009423435" />
-          <property role="3LESm3" value="15f8379e-a1f0-432c-ad29-5268f23b2b26" />
-          <node concept="1BupzO" id="7q24334ZKXE" role="3bR31x">
-            <property role="3ZfqAx" value="generator/template" />
-            <property role="1Hdu6h" value="true" />
-            <property role="1HemKv" value="true" />
-            <node concept="3LXTmp" id="7q24334ZKXF" role="1HemKq">
-              <node concept="398BVA" id="7q24334ZKXh" role="3LXTmr">
-                <ref role="398BVh" node="6$6tsX_CF7m" resolve="diagram.home" />
-                <node concept="2Ry0Ak" id="7q24334ZKXi" role="iGT6I">
-                  <property role="2Ry0Am" value="languages" />
-                  <node concept="2Ry0Ak" id="7q24334ZKXj" role="2Ry0An">
-                    <property role="2Ry0Am" value="de.itemis.mps.editor.diagram.demo.callgraph" />
-                    <node concept="2Ry0Ak" id="7q24334ZKXk" role="2Ry0An">
-                      <property role="2Ry0Am" value="generator" />
-                      <node concept="2Ry0Ak" id="7q24334ZKXl" role="2Ry0An">
-                        <property role="2Ry0Am" value="template" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3qWCbU" id="7q24334ZKXG" role="3LXTna">
-                <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-              </node>
-            </node>
-          </node>
         </node>
         <node concept="1SiIV0" id="7qi8mU1OzTs" role="3bR37C">
           <node concept="3bR9La" id="7qi8mU1OzTt" role="1SiIV1">

--- a/code/celllayout/languages/de.itemis.mps.celllayout/de.itemis.mps.editor.celllayout.styles.mpl
+++ b/code/celllayout/languages/de.itemis.mps.celllayout/de.itemis.mps.editor.celllayout.styles.mpl
@@ -11,38 +11,6 @@
     </facet>
   </facets>
   <accessoryModels />
-  <generators>
-    <generator namespace="de.itemis.mps.editor.celllayout.styles#861697192441877541" uuid="fd8466c2-d497-44e8-87f3-18d15c3a2a49">
-      <models>
-        <modelRoot contentPath="${module}" type="default">
-          <sourceRoot location="generator/template" />
-        </modelRoot>
-      </models>
-      <facets>
-        <facet type="java">
-          <classes generated="true" path="${module}/generator/classes_gen" />
-        </facet>
-      </facets>
-      <external-templates />
-      <languageVersions>
-        <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
-        <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
-        <language slang="l:b401a680-8325-4110-8fd3-84331ff25bef:jetbrains.mps.lang.generator" version="3" />
-        <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
-      </languageVersions>
-      <dependencyVersions>
-        <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
-        <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
-        <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
-        <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
-        <module reference="24c96a96-b7a1-4f30-82da-0f8e279a2661(de.itemis.mps.editor.celllayout.styles)" version="0" />
-        <module reference="fd8466c2-d497-44e8-87f3-18d15c3a2a49(de.itemis.mps.editor.celllayout.styles#861697192441877541)" version="0" />
-        <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
-        <module reference="9e98f4e2-decf-4e97-bf80-9109e8b759aa(jetbrains.mps.lang.feedback.context)" version="0" />
-      </dependencyVersions>
-      <mapping-priorities />
-    </generator>
-  </generators>
   <sourcePath />
   <dependencies>
     <dependency reexport="false">1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)</dependency>

--- a/code/celllayout/languages/de.itemis.mps.editor.celllayout.sandboxlang/de.itemis.mps.editor.celllayout.sandboxlang.mpl
+++ b/code/celllayout/languages/de.itemis.mps.editor.celllayout.sandboxlang/de.itemis.mps.editor.celllayout.sandboxlang.mpl
@@ -11,38 +11,6 @@
     </facet>
   </facets>
   <accessoryModels />
-  <generators>
-    <generator namespace="de.itemis.mps.editor.celllayout.sandboxlang#861697192441878790" uuid="fd967edc-5bcb-4b74-a7b3-864a175b81b8">
-      <models>
-        <modelRoot contentPath="${module}" type="default">
-          <sourceRoot location="generator/template" />
-        </modelRoot>
-      </models>
-      <facets>
-        <facet type="java">
-          <classes generated="true" path="${module}/generator/classes_gen" />
-        </facet>
-      </facets>
-      <external-templates />
-      <languageVersions>
-        <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
-        <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
-        <language slang="l:b401a680-8325-4110-8fd3-84331ff25bef:jetbrains.mps.lang.generator" version="3" />
-        <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
-      </languageVersions>
-      <dependencyVersions>
-        <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
-        <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
-        <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
-        <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
-        <module reference="a49c7665-6e20-479f-8483-903f65b74ed2(de.itemis.mps.editor.celllayout.sandboxlang)" version="0" />
-        <module reference="fd967edc-5bcb-4b74-a7b3-864a175b81b8(de.itemis.mps.editor.celllayout.sandboxlang#861697192441878790)" version="0" />
-        <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
-        <module reference="9e98f4e2-decf-4e97-bf80-9109e8b759aa(jetbrains.mps.lang.feedback.context)" version="0" />
-      </dependencyVersions>
-      <mapping-priorities />
-    </generator>
-  </generators>
   <sourcePath />
   <languageVersions>
     <language slang="l:1919c723-b60b-4592-9318-9ce96d91da44:de.itemis.mps.editor.celllayout" version="0" />

--- a/code/celllayout/languages/test.de.itemis.mps.editor.celllayout.lang/test.de.itemis.mps.editor.celllayout.lang.mpl
+++ b/code/celllayout/languages/test.de.itemis.mps.editor.celllayout.lang/test.de.itemis.mps.editor.celllayout.lang.mpl
@@ -11,44 +11,6 @@
     </facet>
   </facets>
   <accessoryModels />
-  <generators>
-    <generator namespace="test.de.itemis.mps.editor.celllayout.lang#492440529733453404" uuid="142bdcb2-0f12-4915-95e2-8bf1f55b8be7">
-      <models>
-        <modelRoot contentPath="${module}" type="default">
-          <sourceRoot location="generator/template" />
-        </modelRoot>
-      </models>
-      <facets>
-        <facet type="java">
-          <classes generated="true" path="${module}/generator/classes_gen" />
-        </facet>
-      </facets>
-      <external-templates />
-      <languageVersions>
-        <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
-        <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
-        <language slang="l:b401a680-8325-4110-8fd3-84331ff25bef:jetbrains.mps.lang.generator" version="3" />
-        <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
-      </languageVersions>
-      <dependencyVersions>
-        <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
-        <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
-        <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
-        <module reference="1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)" version="0" />
-        <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
-        <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
-        <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
-        <module reference="848ef45d-e560-4e35-853c-f35a64cc135c(de.itemis.mps.editor.celllayout.runtime)" version="0" />
-        <module reference="24c96a96-b7a1-4f30-82da-0f8e279a2661(de.itemis.mps.editor.celllayout.styles)" version="0" />
-        <module reference="f0fff802-6d26-4d2e-b89d-391357265626(de.slisson.mps.hacks.editor)" version="0" />
-        <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
-        <module reference="9e98f4e2-decf-4e97-bf80-9109e8b759aa(jetbrains.mps.lang.feedback.context)" version="0" />
-        <module reference="e0fad6e1-a8d0-4af5-9a40-01cc391c0908(test.de.itemis.mps.editor.celllayout.lang)" version="0" />
-        <module reference="142bdcb2-0f12-4915-95e2-8bf1f55b8be7(test.de.itemis.mps.editor.celllayout.lang#492440529733453404)" version="0" />
-      </dependencyVersions>
-      <mapping-priorities />
-    </generator>
-  </generators>
   <sourcePath />
   <dependencies>
     <dependency reexport="false">8585453e-6bfb-4d80-98de-b16074f1d86c(jetbrains.mps.lang.test)</dependency>

--- a/code/conditional-editor/languages/de.slisson.mps.conditionalEditor.demolang/de.slisson.mps.conditionalEditor.demolang.mpl
+++ b/code/conditional-editor/languages/de.slisson.mps.conditionalEditor.demolang/de.slisson.mps.conditionalEditor.demolang.mpl
@@ -11,43 +11,6 @@
     </facet>
   </facets>
   <accessoryModels />
-  <generators>
-    <generator namespace="de.slisson.mps.conditionalEditor.demolang#2877762237607057987" uuid="54cfdf41-6c53-4d51-a1ba-da41647509d8">
-      <models>
-        <modelRoot contentPath="${module}" type="default">
-          <sourceRoot location="generator/template" />
-        </modelRoot>
-      </models>
-      <facets>
-        <facet type="java">
-          <classes generated="true" path="${module}/generator/classes_gen" />
-        </facet>
-      </facets>
-      <external-templates />
-      <languageVersions>
-        <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
-        <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
-        <language slang="l:b401a680-8325-4110-8fd3-84331ff25bef:jetbrains.mps.lang.generator" version="3" />
-        <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
-      </languageVersions>
-      <dependencyVersions>
-        <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
-        <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
-        <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
-        <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
-        <module reference="1831633c-aea1-4345-beff-4a6e7fb4f813(de.slisson.mps.conditionalEditor.demolang)" version="0" />
-        <module reference="54cfdf41-6c53-4d51-a1ba-da41647509d8(de.slisson.mps.conditionalEditor.demolang#2877762237607057987)" version="0" />
-        <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
-        <module reference="52b81ac7-93fd-4e9e-b972-4995882da6d4(jetbrains.mps.baseLanguage.references.runtime)" version="0" />
-        <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
-        <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
-        <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
-        <module reference="9e98f4e2-decf-4e97-bf80-9109e8b759aa(jetbrains.mps.lang.feedback.context)" version="0" />
-        <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
-      </dependencyVersions>
-      <mapping-priorities />
-    </generator>
-  </generators>
   <sourcePath />
   <dependencies>
     <dependency reexport="false">1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)</dependency>

--- a/code/conditional-editor/languages/de.slisson.mps.conditionalEditor.hints/de.slisson.mps.conditionalEditor.hints.mpl
+++ b/code/conditional-editor/languages/de.slisson.mps.conditionalEditor.hints/de.slisson.mps.conditionalEditor.hints.mpl
@@ -11,38 +11,6 @@
     </facet>
   </facets>
   <accessoryModels />
-  <generators>
-    <generator namespace="de.slisson.mps.conditionalEditor.hints#2669483033691476665" uuid="6c43adf5-a74d-4d1e-9cbe-67c85acd3190">
-      <models>
-        <modelRoot contentPath="${module}" type="default">
-          <sourceRoot location="generator/template" />
-        </modelRoot>
-      </models>
-      <facets>
-        <facet type="java">
-          <classes generated="true" path="${module}/generator/classes_gen" />
-        </facet>
-      </facets>
-      <external-templates />
-      <languageVersions>
-        <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
-        <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
-        <language slang="l:b401a680-8325-4110-8fd3-84331ff25bef:jetbrains.mps.lang.generator" version="3" />
-        <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
-      </languageVersions>
-      <dependencyVersions>
-        <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
-        <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
-        <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
-        <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
-        <module reference="5474e4cd-6621-4b33-a39a-75552543ba57(de.slisson.mps.conditionalEditor.hints)" version="0" />
-        <module reference="6c43adf5-a74d-4d1e-9cbe-67c85acd3190(de.slisson.mps.conditionalEditor.hints#2669483033691476665)" version="0" />
-        <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
-        <module reference="9e98f4e2-decf-4e97-bf80-9109e8b759aa(jetbrains.mps.lang.feedback.context)" version="0" />
-      </dependencyVersions>
-      <mapping-priorities />
-    </generator>
-  </generators>
   <sourcePath />
   <languageVersions>
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />

--- a/code/diagram/languages/de.itemis.mps.editor.diagram.demo.activity/de.itemis.mps.editor.diagram.demo.activity.mpl
+++ b/code/diagram/languages/de.itemis.mps.editor.diagram.demo.activity/de.itemis.mps.editor.diagram.demo.activity.mpl
@@ -11,43 +11,6 @@
     </facet>
   </facets>
   <accessoryModels />
-  <generators>
-    <generator namespace="de.itemis.mps.editor.diagram.demo.activity#5725606875425068161" uuid="bce65e08-dc07-459a-82dc-c9e5a7039a98">
-      <models>
-        <modelRoot contentPath="${module}" type="default">
-          <sourceRoot location="generator/template" />
-        </modelRoot>
-      </models>
-      <facets>
-        <facet type="java">
-          <classes generated="true" path="${module}/generator/classes_gen" />
-        </facet>
-      </facets>
-      <external-templates />
-      <languageVersions>
-        <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
-        <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
-        <language slang="l:b401a680-8325-4110-8fd3-84331ff25bef:jetbrains.mps.lang.generator" version="3" />
-        <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
-      </languageVersions>
-      <dependencyVersions>
-        <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
-        <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
-        <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
-        <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
-        <module reference="5a82b7b8-2303-45be-b960-4e3ff16e82ce(de.itemis.mps.editor.diagram.demo.activity)" version="0" />
-        <module reference="bce65e08-dc07-459a-82dc-c9e5a7039a98(de.itemis.mps.editor.diagram.demo.activity#5725606875425068161)" version="0" />
-        <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
-        <module reference="52b81ac7-93fd-4e9e-b972-4995882da6d4(jetbrains.mps.baseLanguage.references.runtime)" version="0" />
-        <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
-        <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
-        <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
-        <module reference="9e98f4e2-decf-4e97-bf80-9109e8b759aa(jetbrains.mps.lang.feedback.context)" version="0" />
-        <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
-      </dependencyVersions>
-      <mapping-priorities />
-    </generator>
-  </generators>
   <sourcePath />
   <dependencies>
     <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>

--- a/code/diagram/languages/de.itemis.mps.editor.diagram.demo.callgraph/de.itemis.mps.editor.diagram.demo.callgraph.mpl
+++ b/code/diagram/languages/de.itemis.mps.editor.diagram.demo.callgraph/de.itemis.mps.editor.diagram.demo.callgraph.mpl
@@ -11,38 +11,6 @@
     </facet>
   </facets>
   <accessoryModels />
-  <generators>
-    <generator namespace="de.itemis.mps.editor.diagram.demo.callgraph#6554619383009423435" uuid="15f8379e-a1f0-432c-ad29-5268f23b2b26">
-      <models>
-        <modelRoot contentPath="${module}" type="default">
-          <sourceRoot location="generator/template" />
-        </modelRoot>
-      </models>
-      <facets>
-        <facet type="java">
-          <classes generated="true" path="${module}/generator/classes_gen" />
-        </facet>
-      </facets>
-      <external-templates />
-      <languageVersions>
-        <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
-        <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
-        <language slang="l:b401a680-8325-4110-8fd3-84331ff25bef:jetbrains.mps.lang.generator" version="3" />
-        <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
-      </languageVersions>
-      <dependencyVersions>
-        <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
-        <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
-        <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
-        <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
-        <module reference="3ba72f2f-a5c2-46e4-8b7e-b7ef6fb0cfc7(de.itemis.mps.editor.diagram.demo.callgraph)" version="0" />
-        <module reference="15f8379e-a1f0-432c-ad29-5268f23b2b26(de.itemis.mps.editor.diagram.demo.callgraph#6554619383009423435)" version="0" />
-        <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
-        <module reference="9e98f4e2-decf-4e97-bf80-9109e8b759aa(jetbrains.mps.lang.feedback.context)" version="0" />
-      </dependencyVersions>
-      <mapping-priorities />
-    </generator>
-  </generators>
   <sourcePath />
   <dependencies>
     <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>

--- a/code/diagram/languages/de.itemis.mps.editor.diagram.demoentities/de.itemis.mps.editor.diagram.demoentities.mpl
+++ b/code/diagram/languages/de.itemis.mps.editor.diagram.demoentities/de.itemis.mps.editor.diagram.demoentities.mpl
@@ -11,38 +11,6 @@
     </facet>
   </facets>
   <accessoryModels />
-  <generators>
-    <generator namespace="de.itemis.mps.editor.diagram.demoentities#5285801562344837634" uuid="63b981d5-8123-4b93-8f69-23f693398d92">
-      <models>
-        <modelRoot contentPath="${module}" type="default">
-          <sourceRoot location="generator/template" />
-        </modelRoot>
-      </models>
-      <facets>
-        <facet type="java">
-          <classes generated="true" path="${module}/generator/classes_gen" />
-        </facet>
-      </facets>
-      <external-templates />
-      <languageVersions>
-        <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
-        <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
-        <language slang="l:b401a680-8325-4110-8fd3-84331ff25bef:jetbrains.mps.lang.generator" version="3" />
-        <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
-      </languageVersions>
-      <dependencyVersions>
-        <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
-        <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
-        <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
-        <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
-        <module reference="46b1f1f4-3955-4255-af94-7acb92d5711a(de.itemis.mps.editor.diagram.demoentities)" version="0" />
-        <module reference="63b981d5-8123-4b93-8f69-23f693398d92(de.itemis.mps.editor.diagram.demoentities#5285801562344837634)" version="0" />
-        <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
-        <module reference="9e98f4e2-decf-4e97-bf80-9109e8b759aa(jetbrains.mps.lang.feedback.context)" version="0" />
-      </dependencyVersions>
-      <mapping-priorities />
-    </generator>
-  </generators>
   <sourcePath />
   <dependencies>
     <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>

--- a/code/diagram/languages/de.itemis.mps.editor.diagram.layout/de.itemis.mps.editor.diagram.layout.mpl
+++ b/code/diagram/languages/de.itemis.mps.editor.diagram.layout/de.itemis.mps.editor.diagram.layout.mpl
@@ -11,38 +11,6 @@
     </facet>
   </facets>
   <accessoryModels />
-  <generators>
-    <generator namespace="de.itemis.mps.editor.diagram.layout#4341402299005877448" uuid="50fd4dec-4494-4a71-a0ca-d35c48af6670">
-      <models>
-        <modelRoot contentPath="${module}" type="default">
-          <sourceRoot location="generator/template" />
-        </modelRoot>
-      </models>
-      <facets>
-        <facet type="java">
-          <classes generated="true" path="${module}/generator/classes_gen" />
-        </facet>
-      </facets>
-      <external-templates />
-      <languageVersions>
-        <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
-        <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
-        <language slang="l:b401a680-8325-4110-8fd3-84331ff25bef:jetbrains.mps.lang.generator" version="3" />
-        <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
-      </languageVersions>
-      <dependencyVersions>
-        <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
-        <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
-        <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
-        <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
-        <module reference="8ca79d43-eb45-4791-bdd4-0d6130ff895b(de.itemis.mps.editor.diagram.layout)" version="0" />
-        <module reference="50fd4dec-4494-4a71-a0ca-d35c48af6670(de.itemis.mps.editor.diagram.layout#4341402299005877448)" version="0" />
-        <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
-        <module reference="9e98f4e2-decf-4e97-bf80-9109e8b759aa(jetbrains.mps.lang.feedback.context)" version="0" />
-      </dependencyVersions>
-      <mapping-priorities />
-    </generator>
-  </generators>
   <sourcePath />
   <dependencies>
     <dependency reexport="false">1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)</dependency>

--- a/code/diagram/languages/de.itemis.mps.editor.diagram.styles/de.itemis.mps.editor.diagram.styles.mpl
+++ b/code/diagram/languages/de.itemis.mps.editor.diagram.styles/de.itemis.mps.editor.diagram.styles.mpl
@@ -11,38 +11,6 @@
     </facet>
   </facets>
   <accessoryModels />
-  <generators>
-    <generator namespace="de.itemis.mps.editor.diagram.styles#5014430417954750349" uuid="6c1c3da8-77db-4cfa-a468-3fb956cd7040">
-      <models>
-        <modelRoot contentPath="${module}" type="default">
-          <sourceRoot location="generator/template" />
-        </modelRoot>
-      </models>
-      <facets>
-        <facet type="java">
-          <classes generated="true" path="${module}/generator/classes_gen" />
-        </facet>
-      </facets>
-      <external-templates />
-      <languageVersions>
-        <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
-        <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
-        <language slang="l:b401a680-8325-4110-8fd3-84331ff25bef:jetbrains.mps.lang.generator" version="3" />
-        <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
-      </languageVersions>
-      <dependencyVersions>
-        <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
-        <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
-        <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
-        <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
-        <module reference="56c81845-acaf-48a7-bcd8-e29b36c98dd7(de.itemis.mps.editor.diagram.styles)" version="0" />
-        <module reference="6c1c3da8-77db-4cfa-a468-3fb956cd7040(de.itemis.mps.editor.diagram.styles#5014430417954750349)" version="0" />
-        <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
-        <module reference="9e98f4e2-decf-4e97-bf80-9109e8b759aa(jetbrains.mps.lang.feedback.context)" version="0" />
-      </dependencyVersions>
-      <mapping-priorities />
-    </generator>
-  </generators>
   <sourcePath />
   <dependencies>
     <dependency reexport="false">1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)</dependency>

--- a/code/diagram/languages/test.de.itemis.mps.editor.diagram.lang/test.de.itemis.mps.editor.diagram.lang.mpl
+++ b/code/diagram/languages/test.de.itemis.mps.editor.diagram.lang/test.de.itemis.mps.editor.diagram.lang.mpl
@@ -11,38 +11,6 @@
     </facet>
   </facets>
   <accessoryModels />
-  <generators>
-    <generator namespace="test.de.itemis.mps.editor.diagram.lang#6137251545971652545" uuid="0ec087f2-d6a4-49c1-8bd8-7a06bc979430">
-      <models>
-        <modelRoot contentPath="${module}" type="default">
-          <sourceRoot location="generator/template" />
-        </modelRoot>
-      </models>
-      <facets>
-        <facet type="java">
-          <classes generated="true" path="${module}/generator/classes_gen" />
-        </facet>
-      </facets>
-      <external-templates />
-      <languageVersions>
-        <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
-        <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
-        <language slang="l:b401a680-8325-4110-8fd3-84331ff25bef:jetbrains.mps.lang.generator" version="3" />
-        <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
-      </languageVersions>
-      <dependencyVersions>
-        <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
-        <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
-        <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
-        <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
-        <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
-        <module reference="9e98f4e2-decf-4e97-bf80-9109e8b759aa(jetbrains.mps.lang.feedback.context)" version="0" />
-        <module reference="aff569ad-098d-414a-aa23-96963959392c(test.de.itemis.mps.editor.diagram.lang)" version="0" />
-        <module reference="0ec087f2-d6a4-49c1-8bd8-7a06bc979430(test.de.itemis.mps.editor.diagram.lang#6137251545971652545)" version="0" />
-      </dependencyVersions>
-      <mapping-priorities />
-    </generator>
-  </generators>
   <sourcePath />
   <dependencies>
     <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells.runtimelang/com.mbeddr.mpsutil.grammarcells.runtimelang.mpl
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells.runtimelang/com.mbeddr.mpsutil.grammarcells.runtimelang.mpl
@@ -11,41 +11,6 @@
     </facet>
   </facets>
   <accessoryModels />
-  <generators>
-    <generator namespace="com.mbeddr.mpsutil.grammarcells.runtimelang#5083944728301309305" uuid="79e1a72a-662e-4384-882a-49dd59eb455c">
-      <models>
-        <modelRoot contentPath="${module}" type="default">
-          <sourceRoot location="generator/template" />
-        </modelRoot>
-      </models>
-      <facets>
-        <facet type="java">
-          <classes generated="true" path="${module}/generator/classes_gen" />
-        </facet>
-      </facets>
-      <external-templates />
-      <languageVersions>
-        <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
-        <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
-        <language slang="l:b401a680-8325-4110-8fd3-84331ff25bef:jetbrains.mps.lang.generator" version="3" />
-        <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
-      </languageVersions>
-      <dependencyVersions>
-        <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
-        <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
-        <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
-        <module reference="1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)" version="0" />
-        <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
-        <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
-        <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
-        <module reference="b4f35ed8-45af-4efa-abe4-00ac26956e69(com.mbeddr.mpsutil.grammarcells.runtimelang)" version="0" />
-        <module reference="79e1a72a-662e-4384-882a-49dd59eb455c(com.mbeddr.mpsutil.grammarcells.runtimelang#5083944728301309305)" version="0" />
-        <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
-        <module reference="9e98f4e2-decf-4e97-bf80-9109e8b759aa(jetbrains.mps.lang.feedback.context)" version="0" />
-      </dependencyVersions>
-      <mapping-priorities />
-    </generator>
-  </generators>
   <sourcePath />
   <dependencies>
     <dependency reexport="false">18bc6592-03a6-4e29-a83a-7ff23bde13ba(jetbrains.mps.lang.editor)</dependency>

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells.sandboxlang/com.mbeddr.mpsutil.grammarcells.sandboxlang.mpl
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells.sandboxlang/com.mbeddr.mpsutil.grammarcells.sandboxlang.mpl
@@ -11,38 +11,6 @@
     </facet>
   </facets>
   <accessoryModels />
-  <generators>
-    <generator namespace="com.mbeddr.mpsutil.grammarcells.sandboxlang#1749127723000259754" uuid="70c639aa-2028-47e9-88c9-7d69c9b405e3">
-      <models>
-        <modelRoot contentPath="${module}" type="default">
-          <sourceRoot location="generator/template" />
-        </modelRoot>
-      </models>
-      <facets>
-        <facet type="java">
-          <classes generated="true" path="${module}/generator/classes_gen" />
-        </facet>
-      </facets>
-      <external-templates />
-      <languageVersions>
-        <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
-        <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
-        <language slang="l:b401a680-8325-4110-8fd3-84331ff25bef:jetbrains.mps.lang.generator" version="3" />
-        <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
-      </languageVersions>
-      <dependencyVersions>
-        <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
-        <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
-        <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
-        <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
-        <module reference="a257f68c-93a3-47b0-838b-6905dd9c20f6(com.mbeddr.mpsutil.grammarcells.sandboxlang)" version="0" />
-        <module reference="70c639aa-2028-47e9-88c9-7d69c9b405e3(com.mbeddr.mpsutil.grammarcells.sandboxlang#1749127723000259754)" version="0" />
-        <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
-        <module reference="9e98f4e2-decf-4e97-bf80-9109e8b759aa(jetbrains.mps.lang.feedback.context)" version="0" />
-      </dependencyVersions>
-      <mapping-priorities />
-    </generator>
-  </generators>
   <sourcePath />
   <dependencies>
     <dependency reexport="false">7ac49bcb-77fb-4f0f-9036-e31b86b854b2(com.mbeddr.mpsutil.grammarcells.runtime)</dependency>

--- a/code/hacks/languages/de.slisson.mps.hacks.xmodelgen/de.slisson.mps.hacks.xmodelgen.mpl
+++ b/code/hacks/languages/de.slisson.mps.hacks.xmodelgen/de.slisson.mps.hacks.xmodelgen.mpl
@@ -11,67 +11,6 @@
     </facet>
   </facets>
   <accessoryModels />
-  <generators>
-    <generator namespace="de.slisson.mps.hacks.xmodelgen#961590472824343780" uuid="98b4b625-da69-443b-a553-2f746fe85c4a">
-      <models>
-        <modelRoot contentPath="${module}" type="default">
-          <sourceRoot location="generator/template" />
-        </modelRoot>
-      </models>
-      <facets>
-        <facet type="java">
-          <classes generated="true" path="${module}/generator/classes_gen" />
-        </facet>
-      </facets>
-      <external-templates />
-      <languageVersions>
-        <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
-        <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
-        <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
-        <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
-        <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
-        <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
-        <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
-        <language slang="l:b401a680-8325-4110-8fd3-84331ff25bef:jetbrains.mps.lang.generator" version="3" />
-        <language slang="l:d7706f63-9be2-479c-a3da-ae92af1e64d5:jetbrains.mps.lang.generator.generationContext" version="2" />
-        <language slang="l:289fcc83-6543-41e8-a5ca-768235715ce4:jetbrains.mps.lang.generator.generationParameters" version="0" />
-        <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
-        <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
-        <language slang="l:13744753-c81f-424a-9c1b-cf8943bf4e86:jetbrains.mps.lang.sharedConcepts" version="0" />
-        <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="17" />
-        <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
-        <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
-      </languageVersions>
-      <dependencyVersions>
-        <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
-        <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
-        <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
-        <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
-        <module reference="4c6a28d1-2c60-478d-b36e-db9b3cbb21fb(closures.runtime)" version="0" />
-        <module reference="9b80526e-f0bf-4992-bdf5-cee39c1833f3(collections.runtime)" version="0" />
-        <module reference="c5eeb6dc-2f3d-45ae-a7be-929daeb6bda1(de.slisson.mps.hacks.xmodelgen)" version="0" />
-        <module reference="98b4b625-da69-443b-a553-2f746fe85c4a(de.slisson.mps.hacks.xmodelgen#961590472824343780)" version="0" />
-        <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
-        <module reference="fd392034-7849-419d-9071-12563d152375(jetbrains.mps.baseLanguage.closures)" version="0" />
-        <module reference="83888646-71ce-4f1c-9c53-c54016f6ad4f(jetbrains.mps.baseLanguage.collections)" version="0" />
-        <module reference="52b81ac7-93fd-4e9e-b972-4995882da6d4(jetbrains.mps.baseLanguage.references.runtime)" version="0" />
-        <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
-        <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
-        <module reference="d936855b-48da-4812-a8a0-2bfddd633ac5(jetbrains.mps.lang.behavior.api)" version="0" />
-        <module reference="d936855b-48da-4812-a8a0-2bfddd633ac4(jetbrains.mps.lang.behavior.runtime)" version="0" />
-        <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
-        <module reference="9e98f4e2-decf-4e97-bf80-9109e8b759aa(jetbrains.mps.lang.feedback.context)" version="0" />
-        <module reference="7ab1a6fa-0a11-4b95-9e48-75f363d6cb00(jetbrains.mps.lang.generator.plan)" version="0" />
-        <module reference="446c26eb-2b7b-4bf0-9b35-f83fa582753e(jetbrains.mps.lang.modelapi)" version="0" />
-        <module reference="d7eb0a2a-bd50-4576-beae-e4a89db35f20(jetbrains.mps.lang.scopes.runtime)" version="0" />
-        <module reference="7866978e-a0f0-4cc7-81bc-4d213d9375e1(jetbrains.mps.lang.smodel)" version="1" />
-        <module reference="c72da2b9-7cce-4447-8389-f407dc1158b7(jetbrains.mps.lang.structure)" version="0" />
-        <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
-        <module reference="9a4afe51-f114-4595-b5df-048ce3c596be(jetbrains.mps.runtime)" version="0" />
-      </dependencyVersions>
-      <mapping-priorities />
-    </generator>
-  </generators>
   <sourcePath />
   <dependencies>
     <dependency reexport="false">7ab1a6fa-0a11-4b95-9e48-75f363d6cb00(jetbrains.mps.lang.generator.plan)</dependency>

--- a/code/langvis/languages/com.dslfoundry.langvis.demolang/com.dslfoundry.langvis.demolang.mpl
+++ b/code/langvis/languages/com.dslfoundry.langvis.demolang/com.dslfoundry.langvis.demolang.mpl
@@ -11,51 +11,6 @@
     </facet>
   </facets>
   <accessoryModels />
-  <generators>
-    <generator namespace="com.dslfoundry.langvis.demolang#4447146095239211315" uuid="2591ccb9-52a3-4aa7-baa6-be8fe64e93d9">
-      <models>
-        <modelRoot contentPath="${module}" type="default">
-          <sourceRoot location="generator/template" />
-        </modelRoot>
-      </models>
-      <facets>
-        <facet type="java">
-          <classes generated="true" path="${module}/generator/classes_gen" />
-        </facet>
-      </facets>
-      <external-templates />
-      <languageVersions>
-        <language slang="l:dc9d6b4e-4765-4436-8571-fc40ffa80f72:com.dslfoundry.langvis.demolang" version="-1" />
-        <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
-        <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
-        <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
-        <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
-        <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
-        <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
-        <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
-        <language slang="l:b401a680-8325-4110-8fd3-84331ff25bef:jetbrains.mps.lang.generator" version="3" />
-        <language slang="l:d7706f63-9be2-479c-a3da-ae92af1e64d5:jetbrains.mps.lang.generator.generationContext" version="2" />
-        <language slang="l:289fcc83-6543-41e8-a5ca-768235715ce4:jetbrains.mps.lang.generator.generationParameters" version="0" />
-        <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
-        <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
-        <language slang="l:13744753-c81f-424a-9c1b-cf8943bf4e86:jetbrains.mps.lang.sharedConcepts" version="0" />
-        <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="17" />
-        <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
-        <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
-      </languageVersions>
-      <dependencyVersions>
-        <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
-        <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
-        <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
-        <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
-        <module reference="dc9d6b4e-4765-4436-8571-fc40ffa80f72(com.dslfoundry.langvis.demolang)" version="0" />
-        <module reference="2591ccb9-52a3-4aa7-baa6-be8fe64e93d9(com.dslfoundry.langvis.demolang#4447146095239211315)" version="0" />
-        <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
-        <module reference="9e98f4e2-decf-4e97-bf80-9109e8b759aa(jetbrains.mps.lang.feedback.context)" version="0" />
-      </dependencyVersions>
-      <mapping-priorities />
-    </generator>
-  </generators>
   <sourcePath />
   <languageVersions>
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />

--- a/code/math/languages/de.itemis.mps.editor.math.demolang/de.itemis.mps.editor.math.demolang.mpl
+++ b/code/math/languages/de.itemis.mps.editor.math.demolang/de.itemis.mps.editor.math.demolang.mpl
@@ -11,43 +11,6 @@
     </facet>
   </facets>
   <accessoryModels />
-  <generators>
-    <generator namespace="de.itemis.mps.editor.math.demolang#175930839491777503" uuid="55125df6-64d8-46e2-b523-daf2c2e95338">
-      <models>
-        <modelRoot contentPath="${module}" type="default">
-          <sourceRoot location="generator/template" />
-        </modelRoot>
-      </models>
-      <facets>
-        <facet type="java">
-          <classes generated="true" path="${module}/generator/classes_gen" />
-        </facet>
-      </facets>
-      <external-templates />
-      <languageVersions>
-        <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
-        <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
-        <language slang="l:b401a680-8325-4110-8fd3-84331ff25bef:jetbrains.mps.lang.generator" version="3" />
-        <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
-      </languageVersions>
-      <dependencyVersions>
-        <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
-        <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
-        <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
-        <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
-        <module reference="76a53b21-d4a7-409f-93a2-e70951b4b3f9(de.itemis.mps.editor.math.demolang)" version="0" />
-        <module reference="55125df6-64d8-46e2-b523-daf2c2e95338(de.itemis.mps.editor.math.demolang#175930839491777503)" version="0" />
-        <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
-        <module reference="52b81ac7-93fd-4e9e-b972-4995882da6d4(jetbrains.mps.baseLanguage.references.runtime)" version="0" />
-        <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
-        <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
-        <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
-        <module reference="9e98f4e2-decf-4e97-bf80-9109e8b759aa(jetbrains.mps.lang.feedback.context)" version="0" />
-        <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
-      </dependencyVersions>
-      <mapping-priorities />
-    </generator>
-  </generators>
   <sourcePath />
   <dependencies>
     <dependency reexport="false">1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)</dependency>

--- a/code/model-api/org.modelix.model.repositoryconcepts/org.modelix.model.repositoryconcepts.mpl
+++ b/code/model-api/org.modelix.model.repositoryconcepts/org.modelix.model.repositoryconcepts.mpl
@@ -11,50 +11,6 @@
     </facet>
   </facets>
   <accessoryModels />
-  <generators>
-    <generator alias="main" namespace="org.modelix.model.repositoryconcepts.generator" uuid="51731586-2c9b-4758-912e-a0e5dfe2d6f2">
-      <models>
-        <modelRoot contentPath="${module}/generator" type="default">
-          <sourceRoot location="templates" />
-        </modelRoot>
-      </models>
-      <facets>
-        <facet type="java">
-          <classes generated="true" path="${module}/generator/classes_gen" />
-        </facet>
-      </facets>
-      <external-templates />
-      <languageVersions>
-        <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
-        <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
-        <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
-        <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
-        <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
-        <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
-        <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
-        <language slang="l:b401a680-8325-4110-8fd3-84331ff25bef:jetbrains.mps.lang.generator" version="3" />
-        <language slang="l:d7706f63-9be2-479c-a3da-ae92af1e64d5:jetbrains.mps.lang.generator.generationContext" version="2" />
-        <language slang="l:289fcc83-6543-41e8-a5ca-768235715ce4:jetbrains.mps.lang.generator.generationParameters" version="0" />
-        <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
-        <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
-        <language slang="l:13744753-c81f-424a-9c1b-cf8943bf4e86:jetbrains.mps.lang.sharedConcepts" version="0" />
-        <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="17" />
-        <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
-        <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
-      </languageVersions>
-      <dependencyVersions>
-        <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
-        <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
-        <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
-        <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
-        <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
-        <module reference="9e98f4e2-decf-4e97-bf80-9109e8b759aa(jetbrains.mps.lang.feedback.context)" version="0" />
-        <module reference="0a7577d1-d4e5-431d-98b1-fae38f9aee80(org.modelix.model.repositoryconcepts)" version="0" />
-        <module reference="51731586-2c9b-4758-912e-a0e5dfe2d6f2(org.modelix.model.repositoryconcepts.generator)" version="0" />
-      </dependencyVersions>
-      <mapping-priorities />
-    </generator>
-  </generators>
   <sourcePath />
   <languageVersions>
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />

--- a/code/modellisteners/com.mbeddr.mpsutil.modellisteners.sandboxlang/com.mbeddr.mpsutil.modellisteners.sandboxlang.mpl
+++ b/code/modellisteners/com.mbeddr.mpsutil.modellisteners.sandboxlang/com.mbeddr.mpsutil.modellisteners.sandboxlang.mpl
@@ -11,49 +11,6 @@
     </facet>
   </facets>
   <accessoryModels />
-  <generators>
-    <generator namespace="com.mbeddr.mpsutil.modellisteners.sandboxlang#5818559022137961742" uuid="749f46bd-91e8-4ec8-b9e6-82066aa0f940">
-      <models>
-        <modelRoot contentPath="${module}" type="default">
-          <sourceRoot location="generator/template" />
-        </modelRoot>
-      </models>
-      <facets>
-        <facet type="java">
-          <classes generated="true" path="${module}/generator/classes_gen" />
-        </facet>
-      </facets>
-      <external-templates />
-      <languageVersions>
-        <language slang="l:4cbe8d8b-9aa4-4342-8d1a-f3bcd858d0e8:com.mbeddr.mpsutil.modellisteners.sandboxlang" version="0" />
-        <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
-        <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
-        <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
-        <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
-        <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
-        <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
-        <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
-        <language slang="l:b401a680-8325-4110-8fd3-84331ff25bef:jetbrains.mps.lang.generator" version="3" />
-        <language slang="l:d7706f63-9be2-479c-a3da-ae92af1e64d5:jetbrains.mps.lang.generator.generationContext" version="2" />
-        <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
-        <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
-        <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="17" />
-        <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
-        <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
-      </languageVersions>
-      <dependencyVersions>
-        <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
-        <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
-        <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
-        <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
-        <module reference="4cbe8d8b-9aa4-4342-8d1a-f3bcd858d0e8(com.mbeddr.mpsutil.modellisteners.sandboxlang)" version="0" />
-        <module reference="749f46bd-91e8-4ec8-b9e6-82066aa0f940(com.mbeddr.mpsutil.modellisteners.sandboxlang#5818559022137961742)" version="0" />
-        <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
-        <module reference="9e98f4e2-decf-4e97-bf80-9109e8b759aa(jetbrains.mps.lang.feedback.context)" version="0" />
-      </dependencyVersions>
-      <mapping-priorities />
-    </generator>
-  </generators>
   <sourcePath />
   <dependencies>
     <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>

--- a/code/nodeversioning/languages/de.itemis.mps.nodeversioning/de.itemis.mps.nodeversioning.mpl
+++ b/code/nodeversioning/languages/de.itemis.mps.nodeversioning/de.itemis.mps.nodeversioning.mpl
@@ -11,50 +11,6 @@
     </facet>
   </facets>
   <accessoryModels />
-  <generators>
-    <generator alias="main" namespace="de.itemis.mps.nodeversioning#6525061419584643890" uuid="fd3d0e89-8881-49ed-815d-6fc731a8b022">
-      <models>
-        <modelRoot contentPath="${module}/generator/template" type="default">
-          <sourceRoot location="." />
-        </modelRoot>
-      </models>
-      <facets>
-        <facet type="java">
-          <classes generated="true" path="${module}/generator/classes_gen" />
-        </facet>
-      </facets>
-      <external-templates />
-      <languageVersions>
-        <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
-        <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
-        <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
-        <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
-        <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
-        <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
-        <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
-        <language slang="l:b401a680-8325-4110-8fd3-84331ff25bef:jetbrains.mps.lang.generator" version="3" />
-        <language slang="l:d7706f63-9be2-479c-a3da-ae92af1e64d5:jetbrains.mps.lang.generator.generationContext" version="2" />
-        <language slang="l:289fcc83-6543-41e8-a5ca-768235715ce4:jetbrains.mps.lang.generator.generationParameters" version="0" />
-        <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
-        <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
-        <language slang="l:13744753-c81f-424a-9c1b-cf8943bf4e86:jetbrains.mps.lang.sharedConcepts" version="0" />
-        <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="17" />
-        <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
-        <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
-      </languageVersions>
-      <dependencyVersions>
-        <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
-        <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
-        <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
-        <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
-        <module reference="93b43956-3552-4a1d-bf2a-f4d377edbed6(de.itemis.mps.nodeversioning)" version="0" />
-        <module reference="fd3d0e89-8881-49ed-815d-6fc731a8b022(de.itemis.mps.nodeversioning#6525061419584643890)" version="0" />
-        <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
-        <module reference="9e98f4e2-decf-4e97-bf80-9109e8b759aa(jetbrains.mps.lang.feedback.context)" version="0" />
-      </dependencyVersions>
-      <mapping-priorities />
-    </generator>
-  </generators>
   <sourcePath />
   <languageVersions>
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />

--- a/code/plaintextgen/languages/com.dslfoundry.plaintextgen/com.dslfoundry.plaintextgen.mpl
+++ b/code/plaintextgen/languages/com.dslfoundry.plaintextgen/com.dslfoundry.plaintextgen.mpl
@@ -11,38 +11,6 @@
     </facet>
   </facets>
   <accessoryModels />
-  <generators>
-    <generator namespace="com.dslfoundry.plaintextgen#5198309202559528987" uuid="ebbc2a81-6618-40a2-b3b8-997fd1520167">
-      <models>
-        <modelRoot contentPath="${module}" type="default">
-          <sourceRoot location="generator/template" />
-        </modelRoot>
-      </models>
-      <facets>
-        <facet type="java">
-          <classes generated="true" path="${module}/generator/classes_gen" />
-        </facet>
-      </facets>
-      <external-templates />
-      <languageVersions>
-        <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
-        <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
-        <language slang="l:b401a680-8325-4110-8fd3-84331ff25bef:jetbrains.mps.lang.generator" version="3" />
-        <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
-      </languageVersions>
-      <dependencyVersions>
-        <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
-        <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
-        <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
-        <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
-        <module reference="990507d3-3527-4c54-bfe9-0ca3c9c6247a(com.dslfoundry.plaintextgen)" version="0" />
-        <module reference="ebbc2a81-6618-40a2-b3b8-997fd1520167(com.dslfoundry.plaintextgen#5198309202559528987)" version="0" />
-        <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
-        <module reference="9e98f4e2-decf-4e97-bf80-9109e8b759aa(jetbrains.mps.lang.feedback.context)" version="0" />
-      </dependencyVersions>
-      <mapping-priorities />
-    </generator>
-  </generators>
   <sourcePath />
   <dependencies>
     <dependency reexport="false">498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)</dependency>

--- a/code/querylist/com.mbeddr.mpsutil.editor.querylist.demolang/com.mbeddr.mpsutil.editor.querylist.demolang.mpl
+++ b/code/querylist/com.mbeddr.mpsutil.editor.querylist.demolang/com.mbeddr.mpsutil.editor.querylist.demolang.mpl
@@ -11,49 +11,6 @@
     </facet>
   </facets>
   <accessoryModels />
-  <generators>
-    <generator namespace="com.mbeddr.mpsutil.editor.querylist.demolang#6202678563380233177" uuid="91208f02-68b6-4cfd-881a-12b7e34fa630">
-      <models>
-        <modelRoot contentPath="${module}" type="default">
-          <sourceRoot location="generator/template" />
-        </modelRoot>
-      </models>
-      <facets>
-        <facet type="java">
-          <classes generated="true" path="${module}/generator/classes_gen" />
-        </facet>
-      </facets>
-      <external-templates />
-      <languageVersions>
-        <language slang="l:9b71d0db-bcaf-4144-bb2e-1ddef2b249b9:com.mbeddr.mpsutil.editor.querylist.demolang" version="0" />
-        <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
-        <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
-        <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
-        <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
-        <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
-        <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
-        <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
-        <language slang="l:b401a680-8325-4110-8fd3-84331ff25bef:jetbrains.mps.lang.generator" version="3" />
-        <language slang="l:d7706f63-9be2-479c-a3da-ae92af1e64d5:jetbrains.mps.lang.generator.generationContext" version="2" />
-        <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
-        <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
-        <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="17" />
-        <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
-        <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
-      </languageVersions>
-      <dependencyVersions>
-        <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
-        <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
-        <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
-        <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
-        <module reference="9b71d0db-bcaf-4144-bb2e-1ddef2b249b9(com.mbeddr.mpsutil.editor.querylist.demolang)" version="0" />
-        <module reference="91208f02-68b6-4cfd-881a-12b7e34fa630(com.mbeddr.mpsutil.editor.querylist.demolang#6202678563380233177)" version="0" />
-        <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
-        <module reference="9e98f4e2-decf-4e97-bf80-9109e8b759aa(jetbrains.mps.lang.feedback.context)" version="0" />
-      </dependencyVersions>
-      <mapping-priorities />
-    </generator>
-  </generators>
   <sourcePath />
   <dependencies>
     <dependency reexport="false">120e1c9d-4e27-4478-b2af-b2c3bd3850b0(com.mbeddr.mpsutil.editor.querylist)</dependency>

--- a/code/shadowmodels/languages/de.q60.mps.incremental.sandboxlang/de.q60.mps.incremental.sandboxlang.mpl
+++ b/code/shadowmodels/languages/de.q60.mps.incremental.sandboxlang/de.q60.mps.incremental.sandboxlang.mpl
@@ -11,50 +11,6 @@
     </facet>
   </facets>
   <accessoryModels />
-  <generators>
-    <generator alias="main" namespace="de.q60.mps.incremental.sandboxlang#01" uuid="fc6e6a5a-6127-4948-95cb-49490a1a33d3">
-      <models>
-        <modelRoot contentPath="${module}/generator/template" type="default">
-          <sourceRoot location="." />
-        </modelRoot>
-      </models>
-      <facets>
-        <facet type="java">
-          <classes generated="true" path="${module}/generator/classes_gen" />
-        </facet>
-      </facets>
-      <external-templates />
-      <languageVersions>
-        <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
-        <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
-        <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
-        <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
-        <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
-        <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
-        <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
-        <language slang="l:b401a680-8325-4110-8fd3-84331ff25bef:jetbrains.mps.lang.generator" version="3" />
-        <language slang="l:d7706f63-9be2-479c-a3da-ae92af1e64d5:jetbrains.mps.lang.generator.generationContext" version="2" />
-        <language slang="l:289fcc83-6543-41e8-a5ca-768235715ce4:jetbrains.mps.lang.generator.generationParameters" version="0" />
-        <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
-        <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
-        <language slang="l:13744753-c81f-424a-9c1b-cf8943bf4e86:jetbrains.mps.lang.sharedConcepts" version="0" />
-        <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="17" />
-        <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
-        <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
-      </languageVersions>
-      <dependencyVersions>
-        <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
-        <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
-        <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
-        <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
-        <module reference="f81dfbf3-f833-402f-8a2a-c9613de9fb53(de.q60.mps.incremental.sandboxlang)" version="0" />
-        <module reference="fc6e6a5a-6127-4948-95cb-49490a1a33d3(de.q60.mps.incremental.sandboxlang#01)" version="0" />
-        <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
-        <module reference="9e98f4e2-decf-4e97-bf80-9109e8b759aa(jetbrains.mps.lang.feedback.context)" version="0" />
-      </dependencyVersions>
-      <mapping-priorities />
-    </generator>
-  </generators>
   <sourcePath />
   <languageVersions>
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />

--- a/code/shadowmodels/languages/de.q60.mps.polymorphicfunctions.sandboxlang/de.q60.mps.polymorphicfunctions.sandboxlang.mpl
+++ b/code/shadowmodels/languages/de.q60.mps.polymorphicfunctions.sandboxlang/de.q60.mps.polymorphicfunctions.sandboxlang.mpl
@@ -11,50 +11,6 @@
     </facet>
   </facets>
   <accessoryModels />
-  <generators>
-    <generator alias="main" namespace="de.q60.mps.polymorphicfunctions.sandboxlang#01" uuid="47ed4cac-d70e-4c6d-96dd-78ff5ca5b2e8">
-      <models>
-        <modelRoot contentPath="${module}/generator/template" type="default">
-          <sourceRoot location="." />
-        </modelRoot>
-      </models>
-      <facets>
-        <facet type="java">
-          <classes generated="true" path="${module}/generator/classes_gen" />
-        </facet>
-      </facets>
-      <external-templates />
-      <languageVersions>
-        <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
-        <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
-        <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
-        <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
-        <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
-        <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
-        <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
-        <language slang="l:b401a680-8325-4110-8fd3-84331ff25bef:jetbrains.mps.lang.generator" version="3" />
-        <language slang="l:d7706f63-9be2-479c-a3da-ae92af1e64d5:jetbrains.mps.lang.generator.generationContext" version="2" />
-        <language slang="l:289fcc83-6543-41e8-a5ca-768235715ce4:jetbrains.mps.lang.generator.generationParameters" version="0" />
-        <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
-        <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
-        <language slang="l:13744753-c81f-424a-9c1b-cf8943bf4e86:jetbrains.mps.lang.sharedConcepts" version="0" />
-        <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="17" />
-        <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
-        <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
-      </languageVersions>
-      <dependencyVersions>
-        <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
-        <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
-        <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
-        <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
-        <module reference="0c63e607-c09d-40e3-861a-c65c3ca2eabb(de.q60.mps.polymorphicfunctions.sandboxlang)" version="0" />
-        <module reference="47ed4cac-d70e-4c6d-96dd-78ff5ca5b2e8(de.q60.mps.polymorphicfunctions.sandboxlang#01)" version="0" />
-        <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
-        <module reference="9e98f4e2-decf-4e97-bf80-9109e8b759aa(jetbrains.mps.lang.feedback.context)" version="0" />
-      </dependencyVersions>
-      <mapping-priorities />
-    </generator>
-  </generators>
   <sourcePath />
   <languageVersions>
     <language slang="l:bc963c22-d419-49b6-8543-ea411eb9d3a1:de.q60.mps.polymorphicfunctions" version="0" />

--- a/code/shadowmodels/languages/de.q60.mps.shadowmodels.examples.blext/de.q60.mps.shadowmodels.examples.blext.mpl
+++ b/code/shadowmodels/languages/de.q60.mps.shadowmodels.examples.blext/de.q60.mps.shadowmodels.examples.blext.mpl
@@ -11,55 +11,6 @@
     </facet>
   </facets>
   <accessoryModels />
-  <generators>
-    <generator alias="main" namespace="de.q60.mps.shadowmodels.examples.blext#01" uuid="e89c1be2-df3a-444d-9766-b255bcee5e73">
-      <models>
-        <modelRoot contentPath="${module}/generator/template" type="default">
-          <sourceRoot location="." />
-        </modelRoot>
-      </models>
-      <facets>
-        <facet type="java">
-          <classes generated="true" path="${module}/generator/classes_gen" />
-        </facet>
-      </facets>
-      <external-templates />
-      <languageVersions>
-        <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
-        <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
-        <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
-        <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
-        <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
-        <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
-        <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
-        <language slang="l:b401a680-8325-4110-8fd3-84331ff25bef:jetbrains.mps.lang.generator" version="3" />
-        <language slang="l:d7706f63-9be2-479c-a3da-ae92af1e64d5:jetbrains.mps.lang.generator.generationContext" version="2" />
-        <language slang="l:289fcc83-6543-41e8-a5ca-768235715ce4:jetbrains.mps.lang.generator.generationParameters" version="0" />
-        <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
-        <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
-        <language slang="l:13744753-c81f-424a-9c1b-cf8943bf4e86:jetbrains.mps.lang.sharedConcepts" version="0" />
-        <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="17" />
-        <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
-        <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
-      </languageVersions>
-      <dependencyVersions>
-        <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
-        <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
-        <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
-        <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
-        <module reference="bbb5f4e2-794a-4b91-bd27-caf7d437ac9e(de.q60.mps.shadowmodels.examples.blext)" version="0" />
-        <module reference="e89c1be2-df3a-444d-9766-b255bcee5e73(de.q60.mps.shadowmodels.examples.blext#01)" version="0" />
-        <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
-        <module reference="52b81ac7-93fd-4e9e-b972-4995882da6d4(jetbrains.mps.baseLanguage.references.runtime)" version="0" />
-        <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
-        <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
-        <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
-        <module reference="9e98f4e2-decf-4e97-bf80-9109e8b759aa(jetbrains.mps.lang.feedback.context)" version="0" />
-        <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
-      </dependencyVersions>
-      <mapping-priorities />
-    </generator>
-  </generators>
   <sourcePath />
   <dependencies>
     <dependency reexport="false">f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)</dependency>

--- a/code/shadowmodels/languages/de.q60.mps.shadowmodels.examples.editor/de.q60.mps.shadowmodels.examples.editor.mpl
+++ b/code/shadowmodels/languages/de.q60.mps.shadowmodels.examples.editor/de.q60.mps.shadowmodels.examples.editor.mpl
@@ -11,50 +11,6 @@
     </facet>
   </facets>
   <accessoryModels />
-  <generators>
-    <generator alias="main" namespace="de.q60.mps.shadowmodels.examples.editor#01" uuid="303f2251-227c-4ccc-aad1-6231491124aa">
-      <models>
-        <modelRoot contentPath="${module}/generator/template" type="default">
-          <sourceRoot location="." />
-        </modelRoot>
-      </models>
-      <facets>
-        <facet type="java">
-          <classes generated="true" path="${module}/generator/classes_gen" />
-        </facet>
-      </facets>
-      <external-templates />
-      <languageVersions>
-        <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
-        <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
-        <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
-        <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
-        <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
-        <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
-        <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
-        <language slang="l:b401a680-8325-4110-8fd3-84331ff25bef:jetbrains.mps.lang.generator" version="3" />
-        <language slang="l:d7706f63-9be2-479c-a3da-ae92af1e64d5:jetbrains.mps.lang.generator.generationContext" version="2" />
-        <language slang="l:289fcc83-6543-41e8-a5ca-768235715ce4:jetbrains.mps.lang.generator.generationParameters" version="0" />
-        <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
-        <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
-        <language slang="l:13744753-c81f-424a-9c1b-cf8943bf4e86:jetbrains.mps.lang.sharedConcepts" version="0" />
-        <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="17" />
-        <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
-        <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
-      </languageVersions>
-      <dependencyVersions>
-        <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
-        <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
-        <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
-        <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
-        <module reference="fc86eb59-1aa6-4c55-87af-07be910a1eb2(de.q60.mps.shadowmodels.examples.editor)" version="0" />
-        <module reference="303f2251-227c-4ccc-aad1-6231491124aa(de.q60.mps.shadowmodels.examples.editor#01)" version="0" />
-        <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
-        <module reference="9e98f4e2-decf-4e97-bf80-9109e8b759aa(jetbrains.mps.lang.feedback.context)" version="0" />
-      </dependencyVersions>
-      <mapping-priorities />
-    </generator>
-  </generators>
   <sourcePath />
   <dependencies>
     <dependency reexport="false">94b64715-a263-4c36-a138-8da14705ffa7(de.q60.mps.shadowmodels.transformation)</dependency>
@@ -126,6 +82,7 @@
     <module reference="a9e4c532-c5f5-4bb7-99ef-42abb73bbb70(jetbrains.mps.lang.descriptor.aspects)" version="0" />
     <module reference="9e98f4e2-decf-4e97-bf80-9109e8b759aa(jetbrains.mps.lang.feedback.context)" version="0" />
     <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
+    <module reference="cc99dce1-49f3-4392-8dbf-e22ca47bd0af(org.modelix.model.api)" version="0" />
   </dependencyVersions>
   <extendedLanguages />
 </language>

--- a/code/shadowmodels/languages/de.q60.mps.shadowmodels.examples.entities/de.q60.mps.shadowmodels.examples.entities.mpl
+++ b/code/shadowmodels/languages/de.q60.mps.shadowmodels.examples.entities/de.q60.mps.shadowmodels.examples.entities.mpl
@@ -11,50 +11,6 @@
     </facet>
   </facets>
   <accessoryModels />
-  <generators>
-    <generator alias="main" namespace="de.q60.mps.shadowmodels.examples.entities#01" uuid="4b81b271-0a0f-4f4b-9d1b-c2c6711961a5">
-      <models>
-        <modelRoot contentPath="${module}/generator/template" type="default">
-          <sourceRoot location="." />
-        </modelRoot>
-      </models>
-      <facets>
-        <facet type="java">
-          <classes generated="true" path="${module}/generator/classes_gen" />
-        </facet>
-      </facets>
-      <external-templates />
-      <languageVersions>
-        <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
-        <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
-        <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
-        <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
-        <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
-        <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
-        <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
-        <language slang="l:b401a680-8325-4110-8fd3-84331ff25bef:jetbrains.mps.lang.generator" version="3" />
-        <language slang="l:d7706f63-9be2-479c-a3da-ae92af1e64d5:jetbrains.mps.lang.generator.generationContext" version="2" />
-        <language slang="l:289fcc83-6543-41e8-a5ca-768235715ce4:jetbrains.mps.lang.generator.generationParameters" version="0" />
-        <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
-        <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
-        <language slang="l:13744753-c81f-424a-9c1b-cf8943bf4e86:jetbrains.mps.lang.sharedConcepts" version="0" />
-        <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="17" />
-        <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
-        <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
-      </languageVersions>
-      <dependencyVersions>
-        <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
-        <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
-        <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
-        <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
-        <module reference="ca32b5fa-caea-4f97-9686-6f60d4d677d4(de.q60.mps.shadowmodels.examples.entities)" version="0" />
-        <module reference="4b81b271-0a0f-4f4b-9d1b-c2c6711961a5(de.q60.mps.shadowmodels.examples.entities#01)" version="0" />
-        <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
-        <module reference="9e98f4e2-decf-4e97-bf80-9109e8b759aa(jetbrains.mps.lang.feedback.context)" version="0" />
-      </dependencyVersions>
-      <mapping-priorities />
-    </generator>
-  </generators>
   <sourcePath />
   <dependencies>
     <dependency reexport="false">a7322769-ef64-4daa-a2f4-fd4228fb713e(de.q60.mps.shadowmodels.target.text)</dependency>

--- a/code/shadowmodels/languages/de.q60.mps.shadowmodels.examples.statemachine/de.q60.mps.shadowmodels.examples.statemachine.mpl
+++ b/code/shadowmodels/languages/de.q60.mps.shadowmodels.examples.statemachine/de.q60.mps.shadowmodels.examples.statemachine.mpl
@@ -11,50 +11,6 @@
     </facet>
   </facets>
   <accessoryModels />
-  <generators>
-    <generator alias="main" namespace="de.q60.mps.shadowmodels.examples.statemachine#6069004802152564660" uuid="f48d6c1a-9b4c-4196-ab78-21a90a729163">
-      <models>
-        <modelRoot contentPath="${module}/generator/template" type="default">
-          <sourceRoot location="." />
-        </modelRoot>
-      </models>
-      <facets>
-        <facet type="java">
-          <classes generated="true" path="${module}/generator/classes_gen" />
-        </facet>
-      </facets>
-      <external-templates />
-      <languageVersions>
-        <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
-        <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
-        <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
-        <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
-        <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
-        <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
-        <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
-        <language slang="l:b401a680-8325-4110-8fd3-84331ff25bef:jetbrains.mps.lang.generator" version="3" />
-        <language slang="l:d7706f63-9be2-479c-a3da-ae92af1e64d5:jetbrains.mps.lang.generator.generationContext" version="2" />
-        <language slang="l:289fcc83-6543-41e8-a5ca-768235715ce4:jetbrains.mps.lang.generator.generationParameters" version="0" />
-        <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
-        <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
-        <language slang="l:13744753-c81f-424a-9c1b-cf8943bf4e86:jetbrains.mps.lang.sharedConcepts" version="0" />
-        <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="17" />
-        <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
-        <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
-      </languageVersions>
-      <dependencyVersions>
-        <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
-        <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
-        <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
-        <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
-        <module reference="ebb56408-a287-44ca-ab2d-1b6ee6850446(de.q60.mps.shadowmodels.examples.statemachine)" version="0" />
-        <module reference="f48d6c1a-9b4c-4196-ab78-21a90a729163(de.q60.mps.shadowmodels.examples.statemachine#6069004802152564660)" version="0" />
-        <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
-        <module reference="9e98f4e2-decf-4e97-bf80-9109e8b759aa(jetbrains.mps.lang.feedback.context)" version="0" />
-      </dependencyVersions>
-      <mapping-priorities />
-    </generator>
-  </generators>
   <sourcePath />
   <dependencies>
     <dependency reexport="false">f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)</dependency>
@@ -147,7 +103,6 @@
     <module reference="9e98f4e2-decf-4e97-bf80-9109e8b759aa(jetbrains.mps.lang.feedback.context)" version="0" />
     <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
     <module reference="cc99dce1-49f3-4392-8dbf-e22ca47bd0af(org.modelix.model.api)" version="0" />
-    <module reference="0a2651ab-f212-45c2-a2f0-343e76cbc26b(org.modelix.model.client)" version="0" />
     <module reference="5622e615-959d-4843-9df6-ef04ee578c18(org.modelix.model.mpsadapters)" version="0" />
     <module reference="0a7577d1-d4e5-431d-98b1-fae38f9aee80(org.modelix.model.repositoryconcepts)" version="0" />
   </dependencyVersions>

--- a/code/shadowmodels/languages/de.q60.mps.shadowmodels.repository/de.q60.mps.shadowmodels.repository.mpl
+++ b/code/shadowmodels/languages/de.q60.mps.shadowmodels.repository/de.q60.mps.shadowmodels.repository.mpl
@@ -11,50 +11,6 @@
     </facet>
   </facets>
   <accessoryModels />
-  <generators>
-    <generator alias="main" namespace="de.q60.mps.shadowmodels.repository#01" uuid="3047c9fb-b7ce-45c0-b3d9-a11e5bde9906">
-      <models>
-        <modelRoot contentPath="${module}/generator/template" type="default">
-          <sourceRoot location="." />
-        </modelRoot>
-      </models>
-      <facets>
-        <facet type="java">
-          <classes generated="true" path="${module}/generator/classes_gen" />
-        </facet>
-      </facets>
-      <external-templates />
-      <languageVersions>
-        <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
-        <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
-        <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
-        <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
-        <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
-        <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
-        <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
-        <language slang="l:b401a680-8325-4110-8fd3-84331ff25bef:jetbrains.mps.lang.generator" version="3" />
-        <language slang="l:d7706f63-9be2-479c-a3da-ae92af1e64d5:jetbrains.mps.lang.generator.generationContext" version="2" />
-        <language slang="l:289fcc83-6543-41e8-a5ca-768235715ce4:jetbrains.mps.lang.generator.generationParameters" version="0" />
-        <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
-        <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
-        <language slang="l:13744753-c81f-424a-9c1b-cf8943bf4e86:jetbrains.mps.lang.sharedConcepts" version="0" />
-        <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="17" />
-        <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
-        <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
-      </languageVersions>
-      <dependencyVersions>
-        <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
-        <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
-        <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
-        <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
-        <module reference="fdda8484-fc57-4faa-9059-032e2b8b648f(de.q60.mps.shadowmodels.repository)" version="0" />
-        <module reference="3047c9fb-b7ce-45c0-b3d9-a11e5bde9906(de.q60.mps.shadowmodels.repository#01)" version="0" />
-        <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
-        <module reference="9e98f4e2-decf-4e97-bf80-9109e8b759aa(jetbrains.mps.lang.feedback.context)" version="0" />
-      </dependencyVersions>
-      <mapping-priorities />
-    </generator>
-  </generators>
   <sourcePath />
   <dependencies>
     <dependency reexport="false">0bf7bc3b-b11d-42e4-b160-93d72af96397(de.q60.mps.shadowmodels.runtimelang)</dependency>

--- a/code/shadowmodels/languages/de.q60.mps.shadowmodels.runtimelang/de.q60.mps.shadowmodels.runtimelang.mpl
+++ b/code/shadowmodels/languages/de.q60.mps.shadowmodels.runtimelang/de.q60.mps.shadowmodels.runtimelang.mpl
@@ -11,50 +11,6 @@
     </facet>
   </facets>
   <accessoryModels />
-  <generators>
-    <generator alias="main" namespace="de.q60.mps.shadowmodels.runtimelang#01" uuid="d81a5946-dea0-44cd-93bb-ab50632b69c4">
-      <models>
-        <modelRoot contentPath="${module}/generator/template" type="default">
-          <sourceRoot location="." />
-        </modelRoot>
-      </models>
-      <facets>
-        <facet type="java">
-          <classes generated="true" path="${module}/generator/classes_gen" />
-        </facet>
-      </facets>
-      <external-templates />
-      <languageVersions>
-        <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
-        <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
-        <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
-        <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
-        <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
-        <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
-        <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
-        <language slang="l:b401a680-8325-4110-8fd3-84331ff25bef:jetbrains.mps.lang.generator" version="3" />
-        <language slang="l:d7706f63-9be2-479c-a3da-ae92af1e64d5:jetbrains.mps.lang.generator.generationContext" version="2" />
-        <language slang="l:289fcc83-6543-41e8-a5ca-768235715ce4:jetbrains.mps.lang.generator.generationParameters" version="0" />
-        <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
-        <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
-        <language slang="l:13744753-c81f-424a-9c1b-cf8943bf4e86:jetbrains.mps.lang.sharedConcepts" version="0" />
-        <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="17" />
-        <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
-        <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
-      </languageVersions>
-      <dependencyVersions>
-        <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
-        <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
-        <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
-        <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
-        <module reference="0bf7bc3b-b11d-42e4-b160-93d72af96397(de.q60.mps.shadowmodels.runtimelang)" version="0" />
-        <module reference="d81a5946-dea0-44cd-93bb-ab50632b69c4(de.q60.mps.shadowmodels.runtimelang#01)" version="0" />
-        <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
-        <module reference="9e98f4e2-decf-4e97-bf80-9109e8b759aa(jetbrains.mps.lang.feedback.context)" version="0" />
-      </dependencyVersions>
-      <mapping-priorities />
-    </generator>
-  </generators>
   <sourcePath />
   <dependencies>
     <dependency reexport="false">498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)</dependency>

--- a/code/shadowmodels/languages/de.q60.mps.shadowmodels.target.editor/de.q60.mps.shadowmodels.target.editor.mpl
+++ b/code/shadowmodels/languages/de.q60.mps.shadowmodels.target.editor/de.q60.mps.shadowmodels.target.editor.mpl
@@ -11,50 +11,6 @@
     </facet>
   </facets>
   <accessoryModels />
-  <generators>
-    <generator alias="main" namespace="de.q60.mps.shadowmodels.target.editor#01" uuid="28036230-ca8e-4a87-ba2b-7d1c304f9681">
-      <models>
-        <modelRoot contentPath="${module}/generator/template" type="default">
-          <sourceRoot location="." />
-        </modelRoot>
-      </models>
-      <facets>
-        <facet type="java">
-          <classes generated="true" path="${module}/generator/classes_gen" />
-        </facet>
-      </facets>
-      <external-templates />
-      <languageVersions>
-        <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
-        <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
-        <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
-        <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
-        <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
-        <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
-        <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
-        <language slang="l:b401a680-8325-4110-8fd3-84331ff25bef:jetbrains.mps.lang.generator" version="3" />
-        <language slang="l:d7706f63-9be2-479c-a3da-ae92af1e64d5:jetbrains.mps.lang.generator.generationContext" version="2" />
-        <language slang="l:289fcc83-6543-41e8-a5ca-768235715ce4:jetbrains.mps.lang.generator.generationParameters" version="0" />
-        <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
-        <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
-        <language slang="l:13744753-c81f-424a-9c1b-cf8943bf4e86:jetbrains.mps.lang.sharedConcepts" version="0" />
-        <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="17" />
-        <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
-        <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
-      </languageVersions>
-      <dependencyVersions>
-        <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
-        <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
-        <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
-        <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
-        <module reference="9826ee01-d0ba-4048-a622-61eda9424397(de.q60.mps.shadowmodels.target.editor)" version="0" />
-        <module reference="28036230-ca8e-4a87-ba2b-7d1c304f9681(de.q60.mps.shadowmodels.target.editor#01)" version="0" />
-        <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
-        <module reference="9e98f4e2-decf-4e97-bf80-9109e8b759aa(jetbrains.mps.lang.feedback.context)" version="0" />
-      </dependencyVersions>
-      <mapping-priorities />
-    </generator>
-  </generators>
   <sourcePath />
   <dependencies>
     <dependency reexport="false">1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)</dependency>
@@ -120,6 +76,7 @@
     <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
     <module reference="a9e4c532-c5f5-4bb7-99ef-42abb73bbb70(jetbrains.mps.lang.descriptor.aspects)" version="0" />
     <module reference="9e98f4e2-decf-4e97-bf80-9109e8b759aa(jetbrains.mps.lang.feedback.context)" version="0" />
+    <module reference="cc99dce1-49f3-4392-8dbf-e22ca47bd0af(org.modelix.model.api)" version="0" />
   </dependencyVersions>
   <extendedLanguages />
 </language>

--- a/code/shadowmodels/languages/de.q60.mps.shadowmodels.target.text/de.q60.mps.shadowmodels.target.text.mpl
+++ b/code/shadowmodels/languages/de.q60.mps.shadowmodels.target.text/de.q60.mps.shadowmodels.target.text.mpl
@@ -11,50 +11,6 @@
     </facet>
   </facets>
   <accessoryModels />
-  <generators>
-    <generator alias="main" namespace="de.q60.mps.shadowmodels.target.text#01" uuid="ecc7bf4b-c8ec-4b14-87e5-e9f512860567">
-      <models>
-        <modelRoot contentPath="${module}/generator/template" type="default">
-          <sourceRoot location="." />
-        </modelRoot>
-      </models>
-      <facets>
-        <facet type="java">
-          <classes generated="true" path="${module}/generator/classes_gen" />
-        </facet>
-      </facets>
-      <external-templates />
-      <languageVersions>
-        <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
-        <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
-        <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
-        <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
-        <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
-        <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
-        <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
-        <language slang="l:b401a680-8325-4110-8fd3-84331ff25bef:jetbrains.mps.lang.generator" version="3" />
-        <language slang="l:d7706f63-9be2-479c-a3da-ae92af1e64d5:jetbrains.mps.lang.generator.generationContext" version="2" />
-        <language slang="l:289fcc83-6543-41e8-a5ca-768235715ce4:jetbrains.mps.lang.generator.generationParameters" version="0" />
-        <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
-        <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
-        <language slang="l:13744753-c81f-424a-9c1b-cf8943bf4e86:jetbrains.mps.lang.sharedConcepts" version="0" />
-        <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="17" />
-        <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
-        <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
-      </languageVersions>
-      <dependencyVersions>
-        <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
-        <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
-        <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
-        <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
-        <module reference="a7322769-ef64-4daa-a2f4-fd4228fb713e(de.q60.mps.shadowmodels.target.text)" version="0" />
-        <module reference="ecc7bf4b-c8ec-4b14-87e5-e9f512860567(de.q60.mps.shadowmodels.target.text#01)" version="0" />
-        <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
-        <module reference="9e98f4e2-decf-4e97-bf80-9109e8b759aa(jetbrains.mps.lang.feedback.context)" version="0" />
-      </dependencyVersions>
-      <mapping-priorities />
-    </generator>
-  </generators>
   <sourcePath />
   <languageVersions>
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />

--- a/code/shadowmodels/languages/de.q60.mps.virtualinterfaces.sandboxlang/de.q60.mps.virtualinterfaces.sandboxlang.mpl
+++ b/code/shadowmodels/languages/de.q60.mps.virtualinterfaces.sandboxlang/de.q60.mps.virtualinterfaces.sandboxlang.mpl
@@ -11,50 +11,6 @@
     </facet>
   </facets>
   <accessoryModels />
-  <generators>
-    <generator alias="main" namespace="de.q60.mps.virtualinterfaces.sandboxlang#01" uuid="41238e41-1ebc-4450-9ec6-78ff2769eec0">
-      <models>
-        <modelRoot contentPath="${module}/generator/template" type="default">
-          <sourceRoot location="." />
-        </modelRoot>
-      </models>
-      <facets>
-        <facet type="java">
-          <classes generated="true" path="${module}/generator/classes_gen" />
-        </facet>
-      </facets>
-      <external-templates />
-      <languageVersions>
-        <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
-        <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
-        <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
-        <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
-        <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
-        <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
-        <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
-        <language slang="l:b401a680-8325-4110-8fd3-84331ff25bef:jetbrains.mps.lang.generator" version="3" />
-        <language slang="l:d7706f63-9be2-479c-a3da-ae92af1e64d5:jetbrains.mps.lang.generator.generationContext" version="2" />
-        <language slang="l:289fcc83-6543-41e8-a5ca-768235715ce4:jetbrains.mps.lang.generator.generationParameters" version="0" />
-        <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
-        <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
-        <language slang="l:13744753-c81f-424a-9c1b-cf8943bf4e86:jetbrains.mps.lang.sharedConcepts" version="0" />
-        <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="17" />
-        <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
-        <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
-      </languageVersions>
-      <dependencyVersions>
-        <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
-        <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
-        <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
-        <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
-        <module reference="0d105493-edc0-4e24-a961-f655cb10ee48(de.q60.mps.virtualinterfaces.sandboxlang)" version="0" />
-        <module reference="41238e41-1ebc-4450-9ec6-78ff2769eec0(de.q60.mps.virtualinterfaces.sandboxlang#01)" version="0" />
-        <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
-        <module reference="9e98f4e2-decf-4e97-bf80-9109e8b759aa(jetbrains.mps.lang.feedback.context)" version="0" />
-      </dependencyVersions>
-      <mapping-priorities />
-    </generator>
-  </generators>
   <sourcePath />
   <languageVersions>
     <language slang="l:bc963c22-d419-49b6-8543-ea411eb9d3a1:de.q60.mps.polymorphicfunctions" version="0" />

--- a/code/tables/languages/de.slisson.mps.tables.demolang/de.slisson.mps.tables.demolang.mpl
+++ b/code/tables/languages/de.slisson.mps.tables.demolang/de.slisson.mps.tables.demolang.mpl
@@ -11,51 +11,6 @@
     </facet>
   </facets>
   <accessoryModels />
-  <generators>
-    <generator namespace="de.slisson.mps.tables.demolang#1397920687865224039" uuid="20b297e4-a2b3-4766-b3b4-d8e7046ea638">
-      <models>
-        <modelRoot contentPath="${module}" type="default">
-          <sourceRoot location="generator/template" />
-        </modelRoot>
-      </models>
-      <facets>
-        <facet type="java">
-          <classes generated="true" path="${module}/generator/classes_gen" />
-        </facet>
-      </facets>
-      <external-templates />
-      <languageVersions>
-        <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
-        <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
-        <language slang="l:b401a680-8325-4110-8fd3-84331ff25bef:jetbrains.mps.lang.generator" version="3" />
-        <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
-      </languageVersions>
-      <dependencyVersions>
-        <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
-        <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
-        <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
-        <module reference="1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)" version="0" />
-        <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
-        <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
-        <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
-        <module reference="848ef45d-e560-4e35-853c-f35a64cc135c(de.itemis.mps.editor.celllayout.runtime)" version="0" />
-        <module reference="24c96a96-b7a1-4f30-82da-0f8e279a2661(de.itemis.mps.editor.celllayout.styles)" version="0" />
-        <module reference="cce85e64-7b37-4ad5-b0e6-9d18324cdfb3(de.itemis.mps.selection.runtime)" version="0" />
-        <module reference="f0fff802-6d26-4d2e-b89d-391357265626(de.slisson.mps.hacks.editor)" version="0" />
-        <module reference="2d56439e-634d-4d25-9d30-963e89ecda48(de.slisson.mps.tables.demolang)" version="0" />
-        <module reference="20b297e4-a2b3-4766-b3b4-d8e7046ea638(de.slisson.mps.tables.demolang#1397920687865224039)" version="0" />
-        <module reference="da21218f-a674-474d-8b4e-d59e33007003(de.slisson.mps.tables.runtime)" version="0" />
-        <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
-        <module reference="52b81ac7-93fd-4e9e-b972-4995882da6d4(jetbrains.mps.baseLanguage.references.runtime)" version="0" />
-        <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
-        <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
-        <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
-        <module reference="9e98f4e2-decf-4e97-bf80-9109e8b759aa(jetbrains.mps.lang.feedback.context)" version="0" />
-        <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
-      </dependencyVersions>
-      <mapping-priorities />
-    </generator>
-  </generators>
   <sourcePath />
   <dependencies>
     <dependency reexport="false">7e450f4e-1ac3-41ef-a851-4598161bdb94(de.slisson.mps.tables)</dependency>

--- a/code/widgets/languages/de.itemis.mps.editor.bool.demolang/de.itemis.mps.editor.bool.demolang.mpl
+++ b/code/widgets/languages/de.itemis.mps.editor.bool.demolang/de.itemis.mps.editor.bool.demolang.mpl
@@ -11,38 +11,6 @@
     </facet>
   </facets>
   <accessoryModels />
-  <generators>
-    <generator namespace="de.itemis.mps.editor.bool.demolang#4900677560560046179" uuid="1f538166-ed71-448e-98a4-258176a5d557">
-      <models>
-        <modelRoot contentPath="${module}" type="default">
-          <sourceRoot location="generator/template" />
-        </modelRoot>
-      </models>
-      <facets>
-        <facet type="java">
-          <classes generated="true" path="${module}/generator/classes_gen" />
-        </facet>
-      </facets>
-      <external-templates />
-      <languageVersions>
-        <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
-        <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
-        <language slang="l:b401a680-8325-4110-8fd3-84331ff25bef:jetbrains.mps.lang.generator" version="3" />
-        <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
-      </languageVersions>
-      <dependencyVersions>
-        <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
-        <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
-        <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
-        <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
-        <module reference="8eb39fd6-60ad-48f0-8c8e-0ea1c36c2d65(de.itemis.mps.editor.bool.demolang)" version="0" />
-        <module reference="1f538166-ed71-448e-98a4-258176a5d557(de.itemis.mps.editor.bool.demolang#4900677560560046179)" version="0" />
-        <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
-        <module reference="9e98f4e2-decf-4e97-bf80-9109e8b759aa(jetbrains.mps.lang.feedback.context)" version="0" />
-      </dependencyVersions>
-      <mapping-priorities />
-    </generator>
-  </generators>
   <sourcePath />
   <languageVersions>
     <language slang="l:f89904fb-9486-43a1-865e-5ad0375a8a88:de.itemis.mps.editor.bool" version="0" />

--- a/code/widgets/languages/de.itemis.mps.editor.collapsible.testlang/de.itemis.mps.editor.collapsible.testlang.mpl
+++ b/code/widgets/languages/de.itemis.mps.editor.collapsible.testlang/de.itemis.mps.editor.collapsible.testlang.mpl
@@ -11,50 +11,6 @@
     </facet>
   </facets>
   <accessoryModels />
-  <generators>
-    <generator alias="main" namespace="de.itemis.mps.editor.collapsible.testlang#01" uuid="7f15d063-5431-4c8f-819e-740eb30699a2">
-      <models>
-        <modelRoot contentPath="${module}/generator/template" type="default">
-          <sourceRoot location="." />
-        </modelRoot>
-      </models>
-      <facets>
-        <facet type="java">
-          <classes generated="true" path="${module}/generator/classes_gen" />
-        </facet>
-      </facets>
-      <external-templates />
-      <languageVersions>
-        <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
-        <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
-        <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
-        <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
-        <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
-        <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
-        <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
-        <language slang="l:b401a680-8325-4110-8fd3-84331ff25bef:jetbrains.mps.lang.generator" version="3" />
-        <language slang="l:d7706f63-9be2-479c-a3da-ae92af1e64d5:jetbrains.mps.lang.generator.generationContext" version="2" />
-        <language slang="l:289fcc83-6543-41e8-a5ca-768235715ce4:jetbrains.mps.lang.generator.generationParameters" version="0" />
-        <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
-        <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
-        <language slang="l:13744753-c81f-424a-9c1b-cf8943bf4e86:jetbrains.mps.lang.sharedConcepts" version="0" />
-        <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="17" />
-        <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
-        <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
-      </languageVersions>
-      <dependencyVersions>
-        <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
-        <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
-        <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
-        <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
-        <module reference="d92a0cd8-920d-42ea-923c-f8c68d0a9444(de.itemis.mps.editor.collapsible.testlang)" version="0" />
-        <module reference="7f15d063-5431-4c8f-819e-740eb30699a2(de.itemis.mps.editor.collapsible.testlang#01)" version="0" />
-        <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
-        <module reference="9e98f4e2-decf-4e97-bf80-9109e8b759aa(jetbrains.mps.lang.feedback.context)" version="0" />
-      </dependencyVersions>
-      <mapping-priorities />
-    </generator>
-  </generators>
   <sourcePath />
   <languageVersions>
     <language slang="l:3bdedd09-792a-4e15-a4db-83970df3ee86:de.itemis.mps.editor.collapsible" version="0" />

--- a/code/widgets/languages/de.itemis.mps.editor.dropdown.demolang/de.itemis.mps.editor.dropdown.demolang.mpl
+++ b/code/widgets/languages/de.itemis.mps.editor.dropdown.demolang/de.itemis.mps.editor.dropdown.demolang.mpl
@@ -11,38 +11,6 @@
     </facet>
   </facets>
   <accessoryModels />
-  <generators>
-    <generator namespace="de.itemis.mps.editor.dropdown.demolang#671762723175673162" uuid="11a6287a-f1ce-468e-bcad-0ac609eb39af">
-      <models>
-        <modelRoot contentPath="${module}" type="default">
-          <sourceRoot location="generator/template" />
-        </modelRoot>
-      </models>
-      <facets>
-        <facet type="java">
-          <classes generated="true" path="${module}/generator/classes_gen" />
-        </facet>
-      </facets>
-      <external-templates />
-      <languageVersions>
-        <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
-        <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
-        <language slang="l:b401a680-8325-4110-8fd3-84331ff25bef:jetbrains.mps.lang.generator" version="3" />
-        <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
-      </languageVersions>
-      <dependencyVersions>
-        <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
-        <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
-        <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
-        <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
-        <module reference="6b5dd191-3c21-47c5-a7d3-c6e1f7c7cbd0(de.itemis.mps.editor.dropdown.demolang)" version="0" />
-        <module reference="11a6287a-f1ce-468e-bcad-0ac609eb39af(de.itemis.mps.editor.dropdown.demolang#671762723175673162)" version="0" />
-        <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
-        <module reference="9e98f4e2-decf-4e97-bf80-9109e8b759aa(jetbrains.mps.lang.feedback.context)" version="0" />
-      </dependencyVersions>
-      <mapping-priorities />
-    </generator>
-  </generators>
   <sourcePath />
   <dependencies>
     <dependency reexport="false">f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)</dependency>

--- a/code/widgets/languages/de.itemis.mps.editor.enumeration.demolang/de.itemis.mps.editor.enumeration.demolang.mpl
+++ b/code/widgets/languages/de.itemis.mps.editor.enumeration.demolang/de.itemis.mps.editor.enumeration.demolang.mpl
@@ -11,50 +11,6 @@
     </facet>
   </facets>
   <accessoryModels />
-  <generators>
-    <generator alias="main" namespace="de.itemis.mps.editor.enumeration.demolang#2135528801629813660" uuid="0d5cbe1a-9a43-4d2f-9d53-60f15cd45fd3">
-      <models>
-        <modelRoot contentPath="${module}/generator/template" type="default">
-          <sourceRoot location="." />
-        </modelRoot>
-      </models>
-      <facets>
-        <facet type="java">
-          <classes generated="true" path="${module}/generator/classes_gen" />
-        </facet>
-      </facets>
-      <external-templates />
-      <languageVersions>
-        <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
-        <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
-        <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
-        <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
-        <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
-        <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
-        <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
-        <language slang="l:b401a680-8325-4110-8fd3-84331ff25bef:jetbrains.mps.lang.generator" version="3" />
-        <language slang="l:d7706f63-9be2-479c-a3da-ae92af1e64d5:jetbrains.mps.lang.generator.generationContext" version="2" />
-        <language slang="l:289fcc83-6543-41e8-a5ca-768235715ce4:jetbrains.mps.lang.generator.generationParameters" version="0" />
-        <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
-        <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
-        <language slang="l:13744753-c81f-424a-9c1b-cf8943bf4e86:jetbrains.mps.lang.sharedConcepts" version="0" />
-        <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="17" />
-        <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
-        <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
-      </languageVersions>
-      <dependencyVersions>
-        <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
-        <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
-        <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
-        <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
-        <module reference="724a3ff4-f161-46ae-b766-26b81317341a(de.itemis.mps.editor.enumeration.demolang)" version="0" />
-        <module reference="0d5cbe1a-9a43-4d2f-9d53-60f15cd45fd3(de.itemis.mps.editor.enumeration.demolang#2135528801629813660)" version="0" />
-        <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
-        <module reference="9e98f4e2-decf-4e97-bf80-9109e8b759aa(jetbrains.mps.lang.feedback.context)" version="0" />
-      </dependencyVersions>
-      <mapping-priorities />
-    </generator>
-  </generators>
   <sourcePath />
   <languageVersions>
     <language slang="l:eef1aa08-6b84-4194-90d9-ff3e9d6b4505:de.itemis.mps.editor.enumeration" version="1" />


### PR DESCRIPTION
When a custom generation plan is defined the model checker shows the error
'model uses language X with 1 generator(s), none of which is engaged with the active generation plan'.

A workaround would be to just include these languages in the generation
plan, but since they don't do anything it's unnecessary noise.