### PR TITLE
Implement generic insert handler for treenotation

### DIFF
--- a/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
+++ b/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
@@ -10590,6 +10590,9 @@
         <node concept="3LEDTy" id="7q24334ZzZk" role="3LEDUa">
           <ref role="3LEDTV" to="ffeo:7Kfy9QB6KZc" resolve="jetbrains.mps.baseLanguage.checkedDots" />
         </node>
+        <node concept="3LEDTy" id="7fqbBL2CM4m" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L2l" resolve="jetbrains.mps.baseLanguage.logging" />
+        </node>
       </node>
       <node concept="1E1JtA" id="4hqUO9aIeR_" role="2G$12L">
         <property role="BnDLt" value="true" />
@@ -10816,6 +10819,12 @@
         </node>
         <node concept="3LEDTy" id="4CvHZ0pb1br" role="3LEDUa">
           <ref role="3LEDTV" to="ffeo:7Kfy9QB6KZ0" resolve="jetbrains.mps.baseLanguageInternal" />
+        </node>
+        <node concept="3LEDTy" id="7fqbBL2CM4U" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L2F" resolve="jetbrains.mps.baseLanguage.tuples" />
+        </node>
+        <node concept="3LEDTy" id="7fqbBL2CM4V" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L2l" resolve="jetbrains.mps.baseLanguage.logging" />
         </node>
       </node>
     </node>
@@ -13075,6 +13084,16 @@
             </node>
           </node>
         </node>
+        <node concept="1SiIV0" id="7fqbBL2CMaw" role="3bR37C">
+          <node concept="3bR9La" id="7fqbBL2CMax" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1H905DlDUSw" resolve="MPS.OpenAPI" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="7fqbBL2CMay" role="3bR37C">
+          <node concept="3bR9La" id="7fqbBL2CMaz" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1TaHNgiIbJt" resolve="jetbrains.mps.ide.platform" />
+          </node>
+        </node>
       </node>
       <node concept="1E1JtD" id="2jlBy7bQtz0" role="2G$12L">
         <property role="BnDLt" value="true" />
@@ -13290,6 +13309,16 @@
             <node concept="3qWCbU" id="4PRpvcZJO62" role="3LXTna">
               <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
             </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="7fqbBL2CMaQ" role="3bR37C">
+          <node concept="3bR9La" id="7fqbBL2CMaR" role="1SiIV1">
+            <ref role="3bR37D" node="2jlBy7bQp6P" resolve="com.mbeddr.mpsutil.treenotation.runtime" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="7fqbBL2CMaS" role="3bR37C">
+          <node concept="3bR9La" id="7fqbBL2CMaT" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
           </node>
         </node>
       </node>

--- a/code/treenotation/com.mbeddr.mpsutil.treenotation.runtime/com.mbeddr.mpsutil.treenotation.runtime.msd
+++ b/code/treenotation/com.mbeddr.mpsutil.treenotation.runtime/com.mbeddr.mpsutil.treenotation.runtime.msd
@@ -17,6 +17,8 @@
     <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
     <dependency reexport="false">6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)</dependency>
     <dependency reexport="false">498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)</dependency>
+    <dependency reexport="false">8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)</dependency>
+    <dependency reexport="false">8d29d73f-ed99-4652-ae0a-083cdfe53c34(jetbrains.mps.ide.platform)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
@@ -48,6 +50,8 @@
     <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
     <module reference="e9d9e7bc-3ca3-4ef7-8aa7-316a55bcc1ab(com.mbeddr.mpsutil.treenotation.runtime)" version="0" />
     <module reference="bda054c4-5d71-46ca-aba0-7104e3070b5a(com.mbeddr.mpsutil.treenotation.styles)" version="0" />
+    <module reference="fdaaf35f-8ee3-4c37-b09d-9efaeaaa7a41(jetbrains.mps.core.tool.environment)" version="0" />
+    <module reference="8d29d73f-ed99-4652-ae0a-083cdfe53c34(jetbrains.mps.ide.platform)" version="0" />
     <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
     <module reference="9e98f4e2-decf-4e97-bf80-9109e8b759aa(jetbrains.mps.lang.feedback.context)" version="0" />
   </dependencyVersions>

--- a/code/treenotation/com.mbeddr.mpsutil.treenotation.runtime/models/com/mbeddr/mpsutil/treenotation/runtime.mps
+++ b/code/treenotation/com.mbeddr.mpsutil.treenotation.runtime/models/com/mbeddr/mpsutil/treenotation/runtime.mps
@@ -7,12 +7,12 @@
     <use id="5dc5fc0d-37ef-4782-8192-8b5ce1f69f80" name="jetbrains.mps.baseLanguage.extensionMethods" version="0" />
     <use id="774bf8a0-62e5-41e1-af63-f4812e60e48b" name="jetbrains.mps.baseLanguage.checkedDots" version="0" />
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="11" />
+    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="17" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
     <import index="g51k" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor.cells(MPS.Editor/)" />
     <import index="kcid" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor.cellLayout(MPS.Editor/)" />
-    <import index="eh3q" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor.text(MPS.Editor/)" />
     <import index="cj4x" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor(MPS.Editor/)" />
     <import index="f4zo" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.cells(MPS.Editor/)" />
     <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" />
@@ -33,6 +33,9 @@
     <import index="zj86" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.ui.popup.util(MPS.IDEA/)" />
     <import index="hhnx" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.editor.runtime(MPS.Editor/)" />
     <import index="nlpl" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.editor.runtime.commands(MPS.Editor/)" />
+    <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" />
+    <import index="zce0" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.smodel.action(MPS.Editor/)" />
+    <import index="sn11" ref="r:836426ab-a6f4-4fa3-9a9c-34c02ed6ab5d(jetbrains.mps.ide.icons)" />
     <import index="lui2" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.module(MPS.OpenAPI/)" implicit="true" />
   </imports>
   <registry>
@@ -173,6 +176,7 @@
       <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
       <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
       <concept id="1225271283259" name="jetbrains.mps.baseLanguage.structure.NPEEqualsExpression" flags="nn" index="17R0WA" />
+      <concept id="1225271369338" name="jetbrains.mps.baseLanguage.structure.IsEmptyOperation" flags="nn" index="17RlXB" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
@@ -321,6 +325,7 @@
         <child id="1423104411234567454" name="repo" index="ukAjM" />
         <child id="8974276187400348171" name="commandClosureLiteral" index="1QHqEI" />
       </concept>
+      <concept id="8974276187400348181" name="jetbrains.mps.lang.access.structure.ExecuteLightweightCommandStatement" flags="nn" index="1QHqEK" />
       <concept id="8974276187400348177" name="jetbrains.mps.lang.access.structure.ExecuteCommandStatement" flags="nn" index="1QHqEO" />
     </language>
     <language id="774bf8a0-62e5-41e1-af63-f4812e60e48b" name="jetbrains.mps.baseLanguage.checkedDots">
@@ -343,6 +348,17 @@
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1204834851141" name="jetbrains.mps.lang.smodel.structure.PoundExpression" flags="ng" index="25Kdxt">
+        <child id="1204834868751" name="expression" index="25KhWn" />
+      </concept>
+      <concept id="1138411891628" name="jetbrains.mps.lang.smodel.structure.SNodeOperation" flags="nn" index="eCIE_">
+        <child id="1144104376918" name="parameter" index="1xVPHs" />
+      </concept>
+      <concept id="1171500988903" name="jetbrains.mps.lang.smodel.structure.Node_GetChildrenOperation" flags="nn" index="32TBzR" />
+      <concept id="5168775467716640652" name="jetbrains.mps.lang.smodel.structure.OperationParm_LinkQualifier" flags="ng" index="1aIX9F">
+        <child id="5168775467716640653" name="linkQualifier" index="1aIX9E" />
+      </concept>
+      <concept id="6677504323281689838" name="jetbrains.mps.lang.smodel.structure.SConceptType" flags="in" index="3bZ5Sz" />
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2" />
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
@@ -17226,6 +17242,305 @@
       </node>
     </node>
     <node concept="2tJIrI" id="148yUDVm1Mp" role="jymVt" />
+  </node>
+  <node concept="312cEu" id="7fqbBL2vauY">
+    <property role="3GE5qa" value="" />
+    <property role="TrG5h" value="DefaultInsertHandler" />
+    <node concept="312cEg" id="7fqbBL2vcFz" role="jymVt">
+      <property role="TrG5h" value="koncept" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="7fqbBL2vcF$" role="1B3o_S" />
+      <node concept="3bZ5Sz" id="7fqbBL2vcF_" role="1tU5fm" />
+    </node>
+    <node concept="312cEg" id="7fqbBL2vpGU" role="jymVt">
+      <property role="TrG5h" value="targetLink" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="7fqbBL2vp2Y" role="1B3o_S" />
+      <node concept="3uibUv" id="7fqbBL2vpCN" role="1tU5fm">
+        <ref role="3uigEE" to="c17a:~SContainmentLink" resolve="SContainmentLink" />
+      </node>
+    </node>
+    <node concept="312cEg" id="7fqbBL2vhaA" role="jymVt">
+      <property role="TrG5h" value="editorContext" />
+      <node concept="3Tm6S6" id="7fqbBL2vgGl" role="1B3o_S" />
+      <node concept="3uibUv" id="7fqbBL2vhA_" role="1tU5fm">
+        <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="7fqbBL2vcjl" role="jymVt" />
+    <node concept="3clFbW" id="7fqbBL2vcd$" role="jymVt">
+      <node concept="37vLTG" id="7fqbBL2vg58" role="3clF46">
+        <property role="TrG5h" value="editorContext" />
+        <node concept="3uibUv" id="7fqbBL2vg59" role="1tU5fm">
+          <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="7fqbBL2vcPa" role="3clF46">
+        <property role="TrG5h" value="koncept" />
+        <node concept="3bZ5Sz" id="7fqbBL2vd0a" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="7fqbBL2vnJD" role="3clF46">
+        <property role="TrG5h" value="targetLink" />
+        <node concept="3uibUv" id="7fqbBL2voqY" role="1tU5fm">
+          <ref role="3uigEE" to="c17a:~SContainmentLink" resolve="SContainmentLink" />
+        </node>
+      </node>
+      <node concept="3cqZAl" id="7fqbBL2vcdA" role="3clF45" />
+      <node concept="3Tm1VV" id="7fqbBL2vcdB" role="1B3o_S" />
+      <node concept="3clFbS" id="7fqbBL2vcdC" role="3clF47">
+        <node concept="3clFbF" id="7fqbBL2vdaU" role="3cqZAp">
+          <node concept="37vLTI" id="7fqbBL2ve1O" role="3clFbG">
+            <node concept="37vLTw" id="7fqbBL2vesy" role="37vLTx">
+              <ref role="3cqZAo" node="7fqbBL2vcPa" resolve="koncept" />
+            </node>
+            <node concept="2OqwBi" id="7fqbBL2vdlU" role="37vLTJ">
+              <node concept="Xjq3P" id="7fqbBL2vdaT" role="2Oq$k0" />
+              <node concept="2OwXpG" id="7fqbBL2vdIS" role="2OqNvi">
+                <ref role="2Oxat5" node="7fqbBL2vcFz" resolve="koncept" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7fqbBL2vqpb" role="3cqZAp">
+          <node concept="37vLTI" id="7fqbBL2vrgJ" role="3clFbG">
+            <node concept="37vLTw" id="7fqbBL2vrGT" role="37vLTx">
+              <ref role="3cqZAo" node="7fqbBL2vnJD" resolve="targetLink" />
+            </node>
+            <node concept="2OqwBi" id="7fqbBL2vqCh" role="37vLTJ">
+              <node concept="Xjq3P" id="7fqbBL2vqp9" role="2Oq$k0" />
+              <node concept="2OwXpG" id="7fqbBL2vqRg" role="2OqNvi">
+                <ref role="2Oxat5" node="7fqbBL2vpGU" resolve="targetLink" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7fqbBL2vhRw" role="3cqZAp">
+          <node concept="37vLTI" id="7fqbBL2viz6" role="3clFbG">
+            <node concept="37vLTw" id="7fqbBL2viXc" role="37vLTx">
+              <ref role="3cqZAo" node="7fqbBL2vg58" resolve="editorContext" />
+            </node>
+            <node concept="2OqwBi" id="7fqbBL2vi4T" role="37vLTJ">
+              <node concept="Xjq3P" id="7fqbBL2vhRu" role="2Oq$k0" />
+              <node concept="2OwXpG" id="7fqbBL2vijM" role="2OqNvi">
+                <ref role="2Oxat5" node="7fqbBL2vhaA" resolve="editorContext" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="7fqbBL2vkoY" role="jymVt" />
+    <node concept="3clFb_" id="7fqbBL2vlc2" role="jymVt">
+      <property role="TrG5h" value="getConcept" />
+      <node concept="3clFbS" id="7fqbBL2vlc5" role="3clF47">
+        <node concept="3clFbF" id="7fqbBL2vlHh" role="3cqZAp">
+          <node concept="2OqwBi" id="7fqbBL2vm4X" role="3clFbG">
+            <node concept="Xjq3P" id="7fqbBL2vlHg" role="2Oq$k0" />
+            <node concept="2OwXpG" id="7fqbBL2vmjG" role="2OqNvi">
+              <ref role="2Oxat5" node="7fqbBL2vcFz" resolve="koncept" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tmbuc" id="7fqbBL2vkRv" role="1B3o_S" />
+      <node concept="3bZ5Sz" id="7fqbBL2vl7Z" role="3clF45" />
+    </node>
+    <node concept="2tJIrI" id="7fqbBL2vev6" role="jymVt" />
+    <node concept="3Tm1VV" id="7fqbBL2vauZ" role="1B3o_S" />
+    <node concept="3uibUv" id="7fqbBL2va$u" role="1zkMxy">
+      <ref role="3uigEE" node="4Q9g1gQNj1I" resolve="AbstractInsertHandler" />
+    </node>
+    <node concept="3clFb_" id="7fqbBL2va_$" role="jymVt">
+      <property role="TrG5h" value="insert" />
+      <node concept="37vLTG" id="7fqbBL2va__" role="3clF46">
+        <property role="TrG5h" value="editorContext" />
+        <node concept="3uibUv" id="7fqbBL2va_A" role="1tU5fm">
+          <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="7fqbBL2va_B" role="3clF46">
+        <property role="TrG5h" value="node" />
+        <node concept="3Tqbb2" id="7fqbBL2va_C" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="7fqbBL2va_D" role="3clF46">
+        <property role="TrG5h" value="index" />
+        <node concept="10Oyi0" id="7fqbBL2va_E" role="1tU5fm" />
+      </node>
+      <node concept="3cqZAl" id="7fqbBL2va_F" role="3clF45" />
+      <node concept="3Tm1VV" id="7fqbBL2va_G" role="1B3o_S" />
+      <node concept="3clFbS" id="7fqbBL2va_J" role="3clF47">
+        <node concept="3cpWs8" id="7fqbBL2vnbj" role="3cqZAp">
+          <node concept="3cpWsn" id="7fqbBL2vnbk" role="3cpWs9">
+            <property role="TrG5h" value="newChild" />
+            <node concept="3Tqbb2" id="7fqbBL2vnbl" role="1tU5fm" />
+            <node concept="2YIFZM" id="7fqbBL2vnbm" role="33vP2m">
+              <ref role="37wK5l" to="zce0:~NodeFactoryManager.createNode(org.jetbrains.mps.openapi.language.SAbstractConcept,org.jetbrains.mps.openapi.model.SNode,org.jetbrains.mps.openapi.model.SNode,org.jetbrains.mps.openapi.model.SModel)" resolve="createNode" />
+              <ref role="1Pybhc" to="zce0:~NodeFactoryManager" resolve="NodeFactoryManager" />
+              <node concept="37vLTw" id="7fqbBL2vnbn" role="37wK5m">
+                <ref role="3cqZAo" node="7fqbBL2vcFz" resolve="koncept" />
+              </node>
+              <node concept="10Nm6u" id="7fqbBL2vnbo" role="37wK5m" />
+              <node concept="37vLTw" id="7fqbBL2vnbp" role="37wK5m">
+                <ref role="3cqZAo" node="7fqbBL2va_B" resolve="node" />
+              </node>
+              <node concept="2OqwBi" id="7fqbBL2vnbq" role="37wK5m">
+                <node concept="37vLTw" id="7fqbBL2vnbr" role="2Oq$k0">
+                  <ref role="3cqZAo" node="7fqbBL2va__" resolve="editorContext" />
+                </node>
+                <node concept="liA8E" id="7fqbBL2vnbs" role="2OqNvi">
+                  <ref role="37wK5l" to="cj4x:~EditorContext.getModel()" resolve="getModel" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7fqbBL2vnbt" role="3cqZAp">
+          <node concept="2OqwBi" id="7fqbBL2vnbu" role="3clFbG">
+            <node concept="2OqwBi" id="7fqbBL2vnbv" role="2Oq$k0">
+              <node concept="37vLTw" id="7fqbBL2vnbw" role="2Oq$k0">
+                <ref role="3cqZAo" node="7fqbBL2va_B" resolve="node" />
+              </node>
+              <node concept="32TBzR" id="7fqbBL2vnbx" role="2OqNvi">
+                <node concept="1aIX9F" id="7fqbBL2vnby" role="1xVPHs">
+                  <node concept="25Kdxt" id="7fqbBL2vnbz" role="1aIX9E">
+                    <node concept="37vLTw" id="7fqbBL2vrUG" role="25KhWn">
+                      <ref role="3cqZAo" node="7fqbBL2vpGU" resolve="targetLink" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="liA8E" id="7fqbBL2vnb_" role="2OqNvi">
+              <ref role="37wK5l" to="33ny:~List.add(int,java.lang.Object)" resolve="add" />
+              <node concept="37vLTw" id="7fqbBL2vnbA" role="37wK5m">
+                <ref role="3cqZAo" node="7fqbBL2va_D" resolve="index" />
+              </node>
+              <node concept="37vLTw" id="7fqbBL2vnbB" role="37wK5m">
+                <ref role="3cqZAo" node="7fqbBL2vnbk" resolve="newChild" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7fqbBL2va_K" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="7fqbBL2vaFB" role="jymVt" />
+    <node concept="3clFb_" id="7fqbBL2vaLl" role="jymVt">
+      <property role="TrG5h" value="getDescription" />
+      <node concept="17QB3L" id="7fqbBL2vaLm" role="3clF45" />
+      <node concept="3Tm1VV" id="7fqbBL2vaLn" role="1B3o_S" />
+      <node concept="3clFbS" id="7fqbBL2vaLr" role="3clF47">
+        <node concept="3cpWs8" id="7fqbBL2vjU$" role="3cqZAp">
+          <node concept="3cpWsn" id="7fqbBL2vjU_" role="3cpWs9">
+            <property role="TrG5h" value="description" />
+            <node concept="17QB3L" id="7fqbBL2vjUA" role="1tU5fm" />
+            <node concept="2OqwBi" id="7fqbBL2vjUB" role="33vP2m">
+              <node concept="37vLTw" id="7fqbBL2vjUC" role="2Oq$k0">
+                <ref role="3cqZAo" node="7fqbBL2vcFz" resolve="koncept" />
+              </node>
+              <node concept="liA8E" id="7fqbBL2vjUD" role="2OqNvi">
+                <ref role="37wK5l" to="c17a:~SAbstractConcept.getConceptAlias()" resolve="getConceptAlias" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="7fqbBL2vjUE" role="3cqZAp">
+          <node concept="3clFbS" id="7fqbBL2vjUF" role="3clFbx">
+            <node concept="3clFbF" id="7fqbBL2vjUG" role="3cqZAp">
+              <node concept="37vLTI" id="7fqbBL2vjUH" role="3clFbG">
+                <node concept="2OqwBi" id="7fqbBL2vjUI" role="37vLTx">
+                  <node concept="37vLTw" id="7fqbBL2vjUJ" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7fqbBL2vcFz" resolve="koncept" />
+                  </node>
+                  <node concept="liA8E" id="7fqbBL2vjUK" role="2OqNvi">
+                    <ref role="37wK5l" to="c17a:~SAbstractConcept.getName()" resolve="getName" />
+                  </node>
+                </node>
+                <node concept="37vLTw" id="7fqbBL2vjUL" role="37vLTJ">
+                  <ref role="3cqZAo" node="7fqbBL2vjU_" resolve="description" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="7fqbBL2vjUM" role="3clFbw">
+            <node concept="37vLTw" id="7fqbBL2vjUN" role="2Oq$k0">
+              <ref role="3cqZAo" node="7fqbBL2vjU_" resolve="description" />
+            </node>
+            <node concept="17RlXB" id="7fqbBL2vjUO" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="3clFbF" id="7fqbBL2vjUP" role="3cqZAp">
+          <node concept="37vLTw" id="7fqbBL2vjUQ" role="3clFbG">
+            <ref role="3cqZAo" node="7fqbBL2vjU_" resolve="description" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7fqbBL2vaLs" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="7fqbBL2vfau" role="jymVt" />
+    <node concept="3clFb_" id="7fqbBL2vaLv" role="jymVt">
+      <property role="TrG5h" value="getIcon" />
+      <node concept="3uibUv" id="7fqbBL2vaLw" role="3clF45">
+        <ref role="3uigEE" to="dxuu:~Icon" resolve="Icon" />
+      </node>
+      <node concept="3Tm1VV" id="7fqbBL2vaLx" role="1B3o_S" />
+      <node concept="3clFbS" id="7fqbBL2vaL_" role="3clF47">
+        <node concept="3cpWs8" id="7fqbBL2veS6" role="3cqZAp">
+          <node concept="3cpWsn" id="7fqbBL2veS7" role="3cpWs9">
+            <property role="TrG5h" value="icon" />
+            <node concept="3uibUv" id="7fqbBL2veS8" role="1tU5fm">
+              <ref role="3uigEE" to="dxuu:~Icon" resolve="Icon" />
+            </node>
+            <node concept="10Nm6u" id="7fqbBL2veS9" role="33vP2m" />
+          </node>
+        </node>
+        <node concept="1QHqEK" id="7fqbBL2veSa" role="3cqZAp">
+          <node concept="1QHqEC" id="7fqbBL2veSb" role="1QHqEI">
+            <node concept="3clFbS" id="7fqbBL2veSc" role="1bW5cS">
+              <node concept="3clFbF" id="7fqbBL2veSd" role="3cqZAp">
+                <node concept="37vLTI" id="7fqbBL2veSe" role="3clFbG">
+                  <node concept="2OqwBi" id="7fqbBL2veSf" role="37vLTx">
+                    <node concept="2YIFZM" id="7fqbBL2veSg" role="2Oq$k0">
+                      <ref role="1Pybhc" to="sn11:192HKKPMXeL" resolve="GlobalIconManager" />
+                      <ref role="37wK5l" to="sn11:5UC$YgehaLf" resolve="getInstance" />
+                    </node>
+                    <node concept="liA8E" id="7fqbBL2veSh" role="2OqNvi">
+                      <ref role="37wK5l" to="sn11:192HKKPOcza" resolve="getIconFor" />
+                      <node concept="37vLTw" id="7fqbBL2veSi" role="37wK5m">
+                        <ref role="3cqZAo" node="7fqbBL2vcFz" resolve="koncept" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="37vLTw" id="7fqbBL2veSj" role="37vLTJ">
+                    <ref role="3cqZAo" node="7fqbBL2veS7" resolve="icon" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="7fqbBL2veSk" role="ukAjM">
+            <node concept="37vLTw" id="7fqbBL2vj96" role="2Oq$k0">
+              <ref role="3cqZAo" node="7fqbBL2vhaA" resolve="editorContext" />
+            </node>
+            <node concept="liA8E" id="7fqbBL2veSm" role="2OqNvi">
+              <ref role="37wK5l" to="cj4x:~EditorContext.getRepository()" resolve="getRepository" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7fqbBL2veSn" role="3cqZAp">
+          <node concept="37vLTw" id="7fqbBL2veSo" role="3clFbG">
+            <ref role="3cqZAo" node="7fqbBL2veS7" resolve="icon" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7fqbBL2vaLA" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
   </node>
 </model>
 

--- a/code/treenotation/com.mbeddr.mpsutil.treenotation.sandbox/models/com/mbeddr/mpsutil/treenotation/sandbox.mps
+++ b/code/treenotation/com.mbeddr.mpsutil.treenotation.sandbox/models/com/mbeddr/mpsutil/treenotation/sandbox.mps
@@ -7,10 +7,14 @@
   <imports />
   <registry>
     <language id="ce6e35ab-eb16-4223-b8fd-cd565ab8b2fb" name="com.mbeddr.mpsutil.treenotation.sandboxlang">
+      <concept id="8348035970508746634" name="com.mbeddr.mpsutil.treenotation.sandboxlang.structure.AnotherTreeNode" flags="ng" index="Lwk7Q">
+        <child id="8348035970508746640" name="childTreeNodes" index="Lwk7G" />
+      </concept>
       <concept id="134774857085152567" name="com.mbeddr.mpsutil.treenotation.sandboxlang.structure.TreeNode" flags="ng" index="2SU3KN">
         <child id="134774857085152568" name="childTreeNodes" index="2SU3KW" />
       </concept>
       <concept id="134774857084560974" name="com.mbeddr.mpsutil.treenotation.sandboxlang.structure.RootConcept" flags="ng" index="2SWNta">
+        <child id="8348035970509311074" name="tree3" index="LJy8u" />
         <child id="134774857085152597" name="tree" index="2SU3Lh" />
         <child id="857420770335041366" name="tree2" index="3teCNN" />
       </concept>
@@ -80,6 +84,27 @@
       <node concept="2SU3KN" id="JAaUnmT2h7" role="2SU3KW" />
       <node concept="2SU3KN" id="JAaUnmT2hn" role="2SU3KW" />
       <node concept="2SU3KN" id="JAaUnmT2gP" role="2SU3KW" />
+    </node>
+    <node concept="Lwk7Q" id="7fqbBL2pclN" role="LJy8u">
+      <property role="TrG5h" value="xx" />
+      <node concept="Lwk7Q" id="7fqbBL2pArB" role="Lwk7G">
+        <property role="TrG5h" value="c1" />
+        <node concept="Lwk7Q" id="7fqbBL2q952" role="Lwk7G">
+          <property role="TrG5h" value="c1x" />
+        </node>
+      </node>
+      <node concept="Lwk7Q" id="7fqbBL2pArD" role="Lwk7G">
+        <property role="TrG5h" value="c2" />
+      </node>
+      <node concept="Lwk7Q" id="7fqbBL2pArG" role="Lwk7G">
+        <property role="TrG5h" value="c3" />
+        <node concept="Lwk7Q" id="7fqbBL2pArK" role="Lwk7G">
+          <property role="TrG5h" value="c3x" />
+        </node>
+        <node concept="Lwk7Q" id="7fqbBL2pArM" role="Lwk7G">
+          <property role="TrG5h" value="c3y" />
+        </node>
+      </node>
     </node>
   </node>
 </model>

--- a/code/treenotation/com.mbeddr.mpsutil.treenotation.sandbox/models/com/mbeddr/mpsutil/treenotation/sandbox.mps
+++ b/code/treenotation/com.mbeddr.mpsutil.treenotation.sandbox/models/com/mbeddr/mpsutil/treenotation/sandbox.mps
@@ -10,6 +10,7 @@
       <concept id="8348035970508746634" name="com.mbeddr.mpsutil.treenotation.sandboxlang.structure.AnotherTreeNode" flags="ng" index="Lwk7Q">
         <child id="8348035970508746640" name="childTreeNodes" index="Lwk7G" />
       </concept>
+      <concept id="8348035970510806568" name="com.mbeddr.mpsutil.treenotation.sandboxlang.structure.TreeNode2" flags="ng" index="LCf1k" />
       <concept id="134774857085152567" name="com.mbeddr.mpsutil.treenotation.sandboxlang.structure.TreeNode" flags="ng" index="2SU3KN">
         <child id="134774857085152568" name="childTreeNodes" index="2SU3KW" />
       </concept>
@@ -37,7 +38,9 @@
           <property role="TrG5h" value="dfghj" />
         </node>
       </node>
-      <node concept="2SU3KN" id="JAaUnmTYz2" role="2SU3KW" />
+      <node concept="2SU3KN" id="JAaUnmTYz2" role="2SU3KW">
+        <property role="TrG5h" value="d1" />
+      </node>
       <node concept="2SU3KN" id="7uOgiTdJDz" role="2SU3KW">
         <property role="TrG5h" value="dfghj" />
         <node concept="2SU3KN" id="7GMtHW6DEbi" role="2SU3KW">
@@ -57,6 +60,12 @@
           <node concept="2SU3KN" id="3aGR_qcunhG" role="2SU3KW">
             <property role="TrG5h" value="b" />
           </node>
+          <node concept="LCf1k" id="7fqbBL2CFMa" role="2SU3KW">
+            <property role="TrG5h" value="tn2a" />
+          </node>
+          <node concept="LCf1k" id="7fqbBL2CFMm" role="2SU3KW">
+            <property role="TrG5h" value="tn2b" />
+          </node>
         </node>
         <node concept="2SU3KN" id="JAaUnmT17S" role="2SU3KW">
           <property role="TrG5h" value="b" />
@@ -64,10 +73,15 @@
         <node concept="2SU3KN" id="7GMtHW6DEbk" role="2SU3KW">
           <property role="TrG5h" value="w4ttgfg" />
         </node>
-        <node concept="2SU3KN" id="7CiTYi$vRBm" role="2SU3KW" />
+        <node concept="2SU3KN" id="7CiTYi$vRBm" role="2SU3KW">
+          <property role="TrG5h" value="d4" />
+        </node>
       </node>
       <node concept="2SU3KN" id="7CiTYi$vRB5" role="2SU3KW">
-        <node concept="2SU3KN" id="7CiTYi$wuO8" role="2SU3KW" />
+        <property role="TrG5h" value="d2" />
+        <node concept="2SU3KN" id="7CiTYi$wuO8" role="2SU3KW">
+          <property role="TrG5h" value="d3" />
+        </node>
       </node>
       <node concept="2SU3KN" id="7uOgiTdJuT" role="2SU3KW">
         <property role="TrG5h" value="ghi" />
@@ -75,15 +89,27 @@
     </node>
     <node concept="2SU3KN" id="JAaUnmT2gH" role="3teCNN">
       <property role="TrG5h" value="abc" />
-      <node concept="2SU3KN" id="JAaUnmUPNK" role="2SU3KW" />
+      <node concept="2SU3KN" id="JAaUnmUPNK" role="2SU3KW">
+        <property role="TrG5h" value="f1" />
+      </node>
       <node concept="2SU3KN" id="JAaUnmT2gL" role="2SU3KW">
         <property role="TrG5h" value="def" />
-        <node concept="2SU3KN" id="JAaUnmT2gW" role="2SU3KW" />
-        <node concept="2SU3KN" id="JAaUnmT2h0" role="2SU3KW" />
+        <node concept="2SU3KN" id="JAaUnmT2gW" role="2SU3KW">
+          <property role="TrG5h" value="f2" />
+        </node>
+        <node concept="2SU3KN" id="JAaUnmT2h0" role="2SU3KW">
+          <property role="TrG5h" value="f3" />
+        </node>
       </node>
-      <node concept="2SU3KN" id="JAaUnmT2h7" role="2SU3KW" />
-      <node concept="2SU3KN" id="JAaUnmT2hn" role="2SU3KW" />
-      <node concept="2SU3KN" id="JAaUnmT2gP" role="2SU3KW" />
+      <node concept="2SU3KN" id="JAaUnmT2h7" role="2SU3KW">
+        <property role="TrG5h" value="f4" />
+      </node>
+      <node concept="2SU3KN" id="JAaUnmT2hn" role="2SU3KW">
+        <property role="TrG5h" value="f5" />
+      </node>
+      <node concept="2SU3KN" id="JAaUnmT2gP" role="2SU3KW">
+        <property role="TrG5h" value="f5" />
+      </node>
     </node>
     <node concept="Lwk7Q" id="7fqbBL2pclN" role="LJy8u">
       <property role="TrG5h" value="xx" />

--- a/code/treenotation/com.mbeddr.mpsutil.treenotation.sandboxlang/com.mbeddr.mpsutil.treenotation.sandboxlang.mpl
+++ b/code/treenotation/com.mbeddr.mpsutil.treenotation.sandboxlang/com.mbeddr.mpsutil.treenotation.sandboxlang.mpl
@@ -16,6 +16,7 @@
     <dependency reexport="false">bda054c4-5d71-46ca-aba0-7104e3070b5a(com.mbeddr.mpsutil.treenotation.styles)</dependency>
     <dependency reexport="false">b0f8641f-bd77-4421-8425-30d9088a82f7(org.apache.commons)</dependency>
     <dependency reexport="false">e9d9e7bc-3ca3-4ef7-8aa7-316a55bcc1ab(com.mbeddr.mpsutil.treenotation.runtime)</dependency>
+    <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:c73b17af-16a1-4490-8072-8a84937c5206:com.mbeddr.mpsutil.treenotation" version="0" />

--- a/code/treenotation/com.mbeddr.mpsutil.treenotation.sandboxlang/models/editor.mps
+++ b/code/treenotation/com.mbeddr.mpsutil.treenotation.sandboxlang/models/editor.mps
@@ -84,6 +84,7 @@
       </concept>
       <concept id="1073389882823" name="jetbrains.mps.lang.editor.structure.CellModel_RefNode" flags="sg" stub="730538219795960754" index="3F1sOY" />
       <concept id="1073390211982" name="jetbrains.mps.lang.editor.structure.CellModel_RefNodeList" flags="sg" stub="2794558372793454595" index="3F2HdR" />
+      <concept id="1161622981231" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameter_editorContext" flags="nn" index="1Q80Hx" />
       <concept id="1950447826681509042" name="jetbrains.mps.lang.editor.structure.ApplyStyleClass" flags="lg" index="3Xmtl4">
         <child id="1950447826683828796" name="target" index="3XvnJa" />
       </concept>
@@ -165,6 +166,7 @@
       <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
         <property id="1068580320021" name="value" index="3cmrfH" />
       </concept>
+      <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
       <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
         <child id="1068581517676" name="expression" index="3cqZAk" />
       </concept>
@@ -183,6 +185,7 @@
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
+      <concept id="1073063089578" name="jetbrains.mps.baseLanguage.structure.SuperMethodCall" flags="nn" index="3nyPlj" />
       <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
       <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
         <property id="521412098689998745" name="nonStatic" index="2bfB8j" />
@@ -216,6 +219,7 @@
       </concept>
     </language>
     <language id="c73b17af-16a1-4490-8072-8a84937c5206" name="com.mbeddr.mpsutil.treenotation">
+      <concept id="8348035970511374774" name="com.mbeddr.mpsutil.treenotation.structure.Parameter_subconcepts" flags="ng" index="Lmqva" />
       <concept id="8348035970508546380" name="com.mbeddr.mpsutil.treenotation.structure.GenericInsertFunction" flags="ig" index="Lw$WK" />
       <concept id="8348035970508542281" name="com.mbeddr.mpsutil.treenotation.structure.GenericInsertHandler" flags="ng" index="LwBWP">
         <child id="8348035970508665694" name="insertFunction" index="Lw1Oy" />
@@ -277,6 +281,10 @@
       </concept>
       <concept id="1883223317721008713" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfVariable" flags="ng" index="JncvC" />
       <concept id="1883223317721107059" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfVarReference" flags="nn" index="Jnkvi" />
+      <concept id="2644386474301421077" name="jetbrains.mps.lang.smodel.structure.LinkIdRefExpression" flags="nn" index="359W_D">
+        <reference id="2644386474301421078" name="conceptDeclaration" index="359W_E" />
+        <reference id="2644386474301421079" name="linkDeclaration" index="359W_F" />
+      </concept>
       <concept id="1180636770613" name="jetbrains.mps.lang.smodel.structure.SNodeCreator" flags="nn" index="3zrR0B">
         <child id="1180636770616" name="createdType" index="3zrR0E" />
       </concept>
@@ -305,6 +313,9 @@
       </concept>
     </language>
     <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
+        <child id="1204796294226" name="closure" index="23t8la" />
+      </concept>
       <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="nn" index="25WWJ4">
         <child id="540871147943773366" name="argument" index="25WWJ7" />
       </concept>
@@ -322,8 +333,10 @@
       <concept id="1237721394592" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerCreator" flags="nn" index="HWqM0">
         <child id="1237721435807" name="elementType" index="HW$YZ" />
       </concept>
+      <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
       <concept id="1160600644654" name="jetbrains.mps.baseLanguage.collections.structure.ListCreatorWithInit" flags="nn" index="Tc6Ow" />
       <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
+      <concept id="1160666733551" name="jetbrains.mps.baseLanguage.collections.structure.AddAllElementsOperation" flags="nn" index="X8dFx" />
       <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
       <concept id="1225621920911" name="jetbrains.mps.baseLanguage.collections.structure.InsertElementOperation" flags="nn" index="1sK_Qi">
         <child id="1225621943565" name="element" index="1sKFgg" />
@@ -331,6 +344,7 @@
       </concept>
       <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
       <concept id="1165595910856" name="jetbrains.mps.baseLanguage.collections.structure.GetLastOperation" flags="nn" index="1yVyf7" />
+      <concept id="1202128969694" name="jetbrains.mps.baseLanguage.collections.structure.SelectOperation" flags="nn" index="3$u5V9" />
       <concept id="1176501494711" name="jetbrains.mps.baseLanguage.collections.structure.IsNotEmptyOperation" flags="nn" index="3GX2aA" />
     </language>
   </registry>
@@ -1092,7 +1106,6 @@
           <node concept="3clFbS" id="4Q9g1gQNey5" role="2VODD2" />
         </node>
       </node>
-      <node concept="1VmSv7" id="4Q9g1gQPDVP" role="1Vhs_Z" />
       <node concept="37fpnD" id="2rPTijxUTCd" role="37fetC" />
       <node concept="1uO$qF" id="3aGR_qctW6b" role="3F10Kt">
         <node concept="3nzxsE" id="3aGR_qctW6c" role="1uO$qD">
@@ -1128,6 +1141,7 @@
           <ref role="1wgcnl" node="3aGR_qctVBV" resolve="topToBottom" />
         </node>
       </node>
+      <node concept="1VmSv7" id="4Q9g1gQPDVP" role="1Vhs_Z" />
     </node>
     <node concept="3EZMnI" id="3aGR_qcudGb" role="6VMZX">
       <node concept="2iRkQZ" id="3aGR_qcudGc" role="2iSdaV" />
@@ -1677,97 +1691,29 @@
                 </node>
               </node>
             </node>
-            <node concept="3clFbF" id="7fqbBL2mWBP" role="3cqZAp">
-              <node concept="2OqwBi" id="7fqbBL2mYc9" role="3clFbG">
-                <node concept="37vLTw" id="7fqbBL2mXke" role="2Oq$k0">
-                  <ref role="3cqZAo" node="7fqbBL2mXka" resolve="handlers" />
+            <node concept="3clFbH" id="7fqbBL2$jmQ" role="3cqZAp" />
+            <node concept="3SKdUt" id="7fqbBL2$kgf" role="3cqZAp">
+              <node concept="1PaTwC" id="7fqbBL2$kgg" role="1aUNEU">
+                <node concept="3oM_SD" id="7fqbBL2$kgh" role="1PaTwD">
+                  <property role="3oM_SC" value="register" />
                 </node>
-                <node concept="TSZUe" id="7fqbBL2mZt2" role="2OqNvi">
-                  <node concept="2ShNRf" id="7fqbBL2mW6k" role="25WWJ7">
-                    <node concept="YeOm9" id="7fqbBL2mWpu" role="2ShVmc">
-                      <node concept="1Y3b0j" id="7fqbBL2mWpx" role="YeSDq">
-                        <property role="2bfB8j" value="true" />
-                        <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
-                        <ref role="1Y3XeK" to="4hco:4Q9g1gQNj1I" resolve="AbstractInsertHandler" />
-                        <node concept="3Tm1VV" id="7fqbBL2mWpy" role="1B3o_S" />
-                        <node concept="3clFb_" id="7fqbBL2mWpE" role="jymVt">
-                          <property role="TrG5h" value="insert" />
-                          <node concept="37vLTG" id="7fqbBL2mWpF" role="3clF46">
-                            <property role="TrG5h" value="editorContext" />
-                            <node concept="3uibUv" id="7fqbBL2mWpG" role="1tU5fm">
-                              <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
-                            </node>
-                          </node>
-                          <node concept="37vLTG" id="7fqbBL2mWpH" role="3clF46">
-                            <property role="TrG5h" value="node" />
-                            <node concept="3Tqbb2" id="7fqbBL2mWpI" role="1tU5fm" />
-                          </node>
-                          <node concept="37vLTG" id="7fqbBL2mWpJ" role="3clF46">
-                            <property role="TrG5h" value="index" />
-                            <node concept="10Oyi0" id="7fqbBL2mWpK" role="1tU5fm" />
-                          </node>
-                          <node concept="3cqZAl" id="7fqbBL2mWpL" role="3clF45" />
-                          <node concept="3Tm1VV" id="7fqbBL2mWpM" role="1B3o_S" />
-                          <node concept="3clFbS" id="7fqbBL2mWpO" role="3clF47">
-                            <node concept="Jncv_" id="7fqbBL2pjG7" role="3cqZAp">
-                              <ref role="JncvD" to="uin2:7fqbBL2mQYa" resolve="AnotherTreeNode" />
-                              <node concept="37vLTw" id="7fqbBL2pjTm" role="JncvB">
-                                <ref role="3cqZAo" node="7fqbBL2mWpH" resolve="node" />
-                              </node>
-                              <node concept="3clFbS" id="7fqbBL2pjGb" role="Jncv$">
-                                <node concept="3clFbF" id="7fqbBL2pkhj" role="3cqZAp">
-                                  <node concept="2OqwBi" id="7fqbBL2pmBm" role="3clFbG">
-                                    <node concept="2OqwBi" id="7fqbBL2pkum" role="2Oq$k0">
-                                      <node concept="Jnkvi" id="7fqbBL2pkhi" role="2Oq$k0">
-                                        <ref role="1M0zk5" node="7fqbBL2pjGd" resolve="tn" />
-                                      </node>
-                                      <node concept="3Tsc0h" id="7fqbBL2pkH_" role="2OqNvi">
-                                        <ref role="3TtcxE" to="uin2:7fqbBL2mQYg" resolve="childTreeNodes" />
-                                      </node>
-                                    </node>
-                                    <node concept="1sK_Qi" id="7fqbBL2pqeg" role="2OqNvi">
-                                      <node concept="37vLTw" id="7fqbBL2pqmg" role="1sKJu8">
-                                        <ref role="3cqZAo" node="7fqbBL2mWpJ" resolve="index" />
-                                      </node>
-                                      <node concept="2ShNRf" id="7fqbBL2pqE9" role="1sKFgg">
-                                        <node concept="2fJWfE" id="7fqbBL2prdC" role="2ShVmc">
-                                          <node concept="3Tqbb2" id="7fqbBL2prdE" role="3zrR0E">
-                                            <ref role="ehGHo" to="uin2:7fqbBL2mQYa" resolve="AnotherTreeNode" />
-                                          </node>
-                                        </node>
-                                      </node>
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                              <node concept="JncvC" id="7fqbBL2pjGd" role="JncvA">
-                                <property role="TrG5h" value="tn" />
-                                <node concept="2jxLKc" id="7fqbBL2pjGe" role="1tU5fm" />
-                              </node>
-                            </node>
-                          </node>
-                          <node concept="2AHcQZ" id="7fqbBL2mWpQ" role="2AJF6D">
-                            <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-                          </node>
-                        </node>
-                        <node concept="3clFb_" id="7fqbBL2n1zE" role="jymVt">
-                          <property role="TrG5h" value="getDescription" />
-                          <node concept="17QB3L" id="7fqbBL2n1zF" role="3clF45" />
-                          <node concept="3Tm1VV" id="7fqbBL2n1zG" role="1B3o_S" />
-                          <node concept="3clFbS" id="7fqbBL2n1zL" role="3clF47">
-                            <node concept="3clFbF" id="7fqbBL2n1zO" role="3cqZAp">
-                              <node concept="Xl_RD" id="7fqbBL2onbx" role="3clFbG">
-                                <property role="Xl_RC" value="Some child" />
-                              </node>
-                            </node>
-                          </node>
-                          <node concept="2AHcQZ" id="7fqbBL2n1zM" role="2AJF6D">
-                            <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
+                <node concept="3oM_SD" id="7fqbBL2$kF8" role="1PaTwD">
+                  <property role="3oM_SC" value="insert" />
+                </node>
+                <node concept="3oM_SD" id="7fqbBL2$kH1" role="1PaTwD">
+                  <property role="3oM_SC" value="handler" />
+                </node>
+                <node concept="3oM_SD" id="7fqbBL2$kH7" role="1PaTwD">
+                  <property role="3oM_SC" value="for" />
+                </node>
+                <node concept="3oM_SD" id="7fqbBL2$kJO" role="1PaTwD">
+                  <property role="3oM_SC" value="a" />
+                </node>
+                <node concept="3oM_SD" id="7fqbBL2$kL$" role="1PaTwD">
+                  <property role="3oM_SC" value="specific" />
+                </node>
+                <node concept="3oM_SD" id="7fqbBL2$kMB" role="1PaTwD">
+                  <property role="3oM_SC" value="item" />
                 </node>
               </node>
             </node>
@@ -1851,7 +1797,7 @@
                           <node concept="3clFbS" id="7fqbBL2qkbO" role="3clF47">
                             <node concept="3clFbF" id="7fqbBL2qkbP" role="3cqZAp">
                               <node concept="Xl_RD" id="7fqbBL2qkbQ" role="3clFbG">
-                                <property role="Xl_RC" value="Another child" />
+                                <property role="Xl_RC" value="Yet another child" />
                               </node>
                             </node>
                           </node>
@@ -1865,6 +1811,97 @@
                 </node>
               </node>
             </node>
+            <node concept="3clFbH" id="7fqbBL2$kOp" role="3cqZAp" />
+            <node concept="3SKdUt" id="7fqbBL2$ldw" role="3cqZAp">
+              <node concept="1PaTwC" id="7fqbBL2$ldx" role="1aUNEU">
+                <node concept="3oM_SD" id="7fqbBL2$ldy" role="1PaTwD">
+                  <property role="3oM_SC" value="register" />
+                </node>
+                <node concept="3oM_SD" id="7fqbBL2$lHs" role="1PaTwD">
+                  <property role="3oM_SC" value="insert" />
+                </node>
+                <node concept="3oM_SD" id="7fqbBL2$lIr" role="1PaTwD">
+                  <property role="3oM_SC" value="handlers" />
+                </node>
+                <node concept="3oM_SD" id="7fqbBL2$lIx" role="1PaTwD">
+                  <property role="3oM_SC" value="for" />
+                </node>
+                <node concept="3oM_SD" id="7fqbBL2$lJy" role="1PaTwD">
+                  <property role="3oM_SC" value="all" />
+                </node>
+                <node concept="3oM_SD" id="7fqbBL2$Rm2" role="1PaTwD">
+                  <property role="3oM_SC" value="subconcepts" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="7fqbBL2zDkq" role="3cqZAp">
+              <node concept="2OqwBi" id="7fqbBL2zFmn" role="3clFbG">
+                <node concept="37vLTw" id="7fqbBL2zE$a" role="2Oq$k0">
+                  <ref role="3cqZAo" node="7fqbBL2mXka" resolve="handlers" />
+                </node>
+                <node concept="X8dFx" id="7fqbBL2zGfx" role="2OqNvi">
+                  <node concept="2OqwBi" id="7fqbBL2zH4Y" role="25WWJ7">
+                    <node concept="Lmqva" id="7fqbBL2zGDa" role="2Oq$k0" />
+                    <node concept="3$u5V9" id="7fqbBL2zHPj" role="2OqNvi">
+                      <node concept="1bVj0M" id="7fqbBL2zHPl" role="23t8la">
+                        <node concept="3clFbS" id="7fqbBL2zHPm" role="1bW5cS">
+                          <node concept="3clFbF" id="7fqbBL2zJQQ" role="3cqZAp">
+                            <node concept="2ShNRf" id="7fqbBL2zJQO" role="3clFbG">
+                              <node concept="YeOm9" id="7fqbBL2zNfO" role="2ShVmc">
+                                <node concept="1Y3b0j" id="7fqbBL2zNfR" role="YeSDq">
+                                  <property role="2bfB8j" value="true" />
+                                  <ref role="37wK5l" to="4hco:7fqbBL2vcd$" resolve="DefaultInsertHandler" />
+                                  <ref role="1Y3XeK" to="4hco:7fqbBL2vauY" resolve="DefaultInsertHandler" />
+                                  <node concept="3Tm1VV" id="7fqbBL2zNfS" role="1B3o_S" />
+                                  <node concept="1Q80Hx" id="7fqbBL2zL15" role="37wK5m" />
+                                  <node concept="37vLTw" id="7fqbBL2zLrD" role="37wK5m">
+                                    <ref role="3cqZAo" node="7fqbBL2zHPn" resolve="subconcept" />
+                                  </node>
+                                  <node concept="359W_D" id="7fqbBL2zM3B" role="37wK5m">
+                                    <ref role="359W_E" to="uin2:7fqbBL2mQYa" resolve="AnotherTreeNode" />
+                                    <ref role="359W_F" to="uin2:7fqbBL2mQYg" resolve="childTreeNodes" />
+                                  </node>
+                                  <node concept="3clFb_" id="7fqbBL2zNR3" role="jymVt">
+                                    <property role="TrG5h" value="getDescription" />
+                                    <node concept="17QB3L" id="7fqbBL2zNR4" role="3clF45" />
+                                    <node concept="3Tm1VV" id="7fqbBL2zNR5" role="1B3o_S" />
+                                    <node concept="2AHcQZ" id="7fqbBL2zNRq" role="2AJF6D">
+                                      <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                                    </node>
+                                    <node concept="3clFbS" id="7fqbBL2zNRs" role="3clF47">
+                                      <node concept="3clFbF" id="7fqbBL2zNRu" role="3cqZAp">
+                                        <node concept="3cpWs3" id="7fqbBL2zPqX" role="3clFbG">
+                                          <node concept="Xl_RD" id="7fqbBL2zPvq" role="3uHU7w">
+                                            <property role="Xl_RC" value=" &lt;&lt;&lt;" />
+                                          </node>
+                                          <node concept="3cpWs3" id="7fqbBL2zOQX" role="3uHU7B">
+                                            <node concept="Xl_RD" id="7fqbBL2zOZy" role="3uHU7B">
+                                              <property role="Xl_RC" value="&gt;&gt;&gt; " />
+                                            </node>
+                                            <node concept="3nyPlj" id="7fqbBL2zNRt" role="3uHU7w">
+                                              <ref role="37wK5l" to="4hco:7fqbBL2vaLl" resolve="getDescription" />
+                                            </node>
+                                          </node>
+                                        </node>
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="Rh6nW" id="7fqbBL2zHPn" role="1bW2Oz">
+                          <property role="TrG5h" value="subconcept" />
+                          <node concept="2jxLKc" id="7fqbBL2zHPo" role="1tU5fm" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbH" id="7fqbBL2zJu5" role="3cqZAp" />
             <node concept="3cpWs6" id="7fqbBL2mZQO" role="3cqZAp">
               <node concept="37vLTw" id="7fqbBL2mZWh" role="3cqZAk">
                 <ref role="3cqZAo" node="7fqbBL2mXka" resolve="handlers" />
@@ -1874,6 +1911,15 @@
         </node>
       </node>
       <node concept="37fpnD" id="7fqbBL2mR9o" role="37fetC" />
+    </node>
+  </node>
+  <node concept="24kQdi" id="7fqbBL2uI3n">
+    <ref role="1XX52x" to="uin2:7fqbBL2uHSC" resolve="TreeNode2" />
+    <node concept="3F0A7n" id="7fqbBL2uIdD" role="2wV5jI">
+      <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
+      <node concept="VechU" id="7fqbBL2uIdG" role="3F10Kt">
+        <property role="Vb096" value="fLwANPs/magenta" />
+      </node>
     </node>
   </node>
 </model>

--- a/code/treenotation/com.mbeddr.mpsutil.treenotation.sandboxlang/models/editor.mps
+++ b/code/treenotation/com.mbeddr.mpsutil.treenotation.sandboxlang/models/editor.mps
@@ -14,8 +14,10 @@
     <import index="fbzs" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt.geom(JDK/)" />
     <import index="4io5" ref="b0f8641f-bd77-4421-8425-30d9088a82f7/java:org.apache.commons.math3.geometry.euclidean.twod(org.apache.commons/)" />
     <import index="4hco" ref="r:55549eb8-b827-44b3-bd84-ef3114bd2fe2(com.mbeddr.mpsutil.treenotation.runtime)" />
+    <import index="cj4x" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor(MPS.Editor/)" />
     <import index="uin2" ref="r:74912edc-30f3-44ff-8b9f-c9c8b1fb4035(com.mbeddr.mpsutil.treenotation.sandboxlang.structure)" implicit="true" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
+    <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
   </imports>
   <registry>
     <language id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor">
@@ -90,9 +92,16 @@
       </concept>
     </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
       <concept id="5279705229678483897" name="jetbrains.mps.baseLanguage.structure.FloatingPointFloatConstant" flags="nn" index="2$xPTn">
         <property id="5279705229678483899" name="value" index="2$xPTl" />
+      </concept>
+      <concept id="1188207840427" name="jetbrains.mps.baseLanguage.structure.AnnotationInstance" flags="nn" index="2AHcQZ">
+        <reference id="1188208074048" name="annotation" index="2AI5Lk" />
+      </concept>
+      <concept id="1188208481402" name="jetbrains.mps.baseLanguage.structure.HasAnnotation" flags="ng" index="2AJDlI">
+        <child id="1188208488637" name="annotation" index="2AJF6D" />
       </concept>
       <concept id="1095950406618" name="jetbrains.mps.baseLanguage.structure.DivExpression" flags="nn" index="FJ1c_" />
       <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
@@ -108,9 +117,16 @@
       <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
         <child id="1137022507850" name="body" index="2VODD2" />
       </concept>
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="1182160077978" name="jetbrains.mps.baseLanguage.structure.AnonymousClassCreator" flags="nn" index="YeOm9">
+        <child id="1182160096073" name="cls" index="YeSDq" />
+      </concept>
       <concept id="1070533707846" name="jetbrains.mps.baseLanguage.structure.StaticFieldReference" flags="nn" index="10M0yZ">
         <reference id="1144433057691" name="classifier" index="1PxDUh" />
       </concept>
+      <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
       <concept id="1070534513062" name="jetbrains.mps.baseLanguage.structure.DoubleType" flags="in" index="10P55v" />
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <child id="1068431790190" name="initializer" index="33vP2m" />
@@ -119,12 +135,19 @@
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
       <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
+      <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
       <concept id="1111509017652" name="jetbrains.mps.baseLanguage.structure.FloatingPointConstant" flags="nn" index="3b6qkQ">
         <property id="1113006610751" name="value" index="$nhwW" />
       </concept>
+      <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123134" name="parameter" index="3clF46" />
+        <child id="1068580123135" name="body" index="3clF47" />
+      </concept>
+      <concept id="1068580123165" name="jetbrains.mps.baseLanguage.structure.InstanceMethodDeclaration" flags="ig" index="3clFb_" />
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
@@ -142,12 +165,15 @@
       <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
         <property id="1068580320021" name="value" index="3cmrfH" />
       </concept>
-      <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6" />
+      <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
+        <child id="1068581517676" name="expression" index="3cqZAk" />
+      </concept>
       <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
         <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
       </concept>
       <concept id="1068581242869" name="jetbrains.mps.baseLanguage.structure.MinusExpression" flags="nn" index="3cpWsd" />
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
       <concept id="1079359253375" name="jetbrains.mps.baseLanguage.structure.ParenthesizedExpression" flags="nn" index="1eOMI4">
         <child id="1079359253376" name="expression" index="1eOMHV" />
       </concept>
@@ -158,6 +184,10 @@
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
       <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
+      <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
+        <property id="521412098689998745" name="nonStatic" index="2bfB8j" />
+        <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
+      </concept>
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
       </concept>
@@ -165,8 +195,18 @@
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
+        <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="5497648299878491908" name="jetbrains.mps.baseLanguage.structure.BaseVariableReference" flags="nn" index="1M0zk4">
+        <reference id="5497648299878491909" name="baseVariableDeclaration" index="1M0zk5" />
+      </concept>
       <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
         <child id="8356039341262087992" name="line" index="1aUNEU" />
+      </concept>
+      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+      <concept id="1170345865475" name="jetbrains.mps.baseLanguage.structure.AnonymousClass" flags="ig" index="1Y3b0j">
+        <reference id="1170346070688" name="classifier" index="1Y3XeK" />
       </concept>
     </language>
     <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
@@ -176,6 +216,10 @@
       </concept>
     </language>
     <language id="c73b17af-16a1-4490-8072-8a84937c5206" name="com.mbeddr.mpsutil.treenotation">
+      <concept id="8348035970508546380" name="com.mbeddr.mpsutil.treenotation.structure.GenericInsertFunction" flags="ig" index="Lw$WK" />
+      <concept id="8348035970508542281" name="com.mbeddr.mpsutil.treenotation.structure.GenericInsertHandler" flags="ng" index="LwBWP">
+        <child id="8348035970508665694" name="insertFunction" index="Lw1Oy" />
+      </concept>
       <concept id="134774857084556552" name="com.mbeddr.mpsutil.treenotation.structure.TreeCell" flags="ng" index="2SWKgc">
         <child id="134774857084558327" name="treeRoot" index="2SWKFN" />
         <child id="134774857084558329" name="treeChildren" index="2SWKFX" />
@@ -219,9 +263,26 @@
         <child id="8877288515762039491" name="paintFunction" index="1X_dKs" />
       </concept>
       <concept id="8877288515759654453" name="com.mbeddr.mpsutil.treenotation.structure.DeleteHandler" flags="ig" index="1XG33E" />
-      <concept id="8877288515760224194" name="com.mbeddr.mpsutil.treenotation.structure.InserHandler" flags="ig" index="1XI84t" />
+      <concept id="8877288515760224194" name="com.mbeddr.mpsutil.treenotation.structure.SimpleInsertFunction" flags="ig" index="1XI84t" />
+    </language>
+    <language id="aee9cad2-acd4-4608-aef2-0004f6a1cdbd" name="jetbrains.mps.lang.actions">
+      <concept id="5979988948250981289" name="jetbrains.mps.lang.actions.structure.SNodeCreatorAndInitializer" flags="nn" index="2fJWfE" />
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1883223317721008708" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfStatement" flags="nn" index="Jncv_">
+        <reference id="1883223317721008712" name="nodeConcept" index="JncvD" />
+        <child id="1883223317721008709" name="body" index="Jncv$" />
+        <child id="1883223317721008711" name="variable" index="JncvA" />
+        <child id="1883223317721008710" name="nodeExpression" index="JncvB" />
+      </concept>
+      <concept id="1883223317721008713" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfVariable" flags="ng" index="JncvC" />
+      <concept id="1883223317721107059" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfVarReference" flags="nn" index="Jnkvi" />
+      <concept id="1180636770613" name="jetbrains.mps.lang.smodel.structure.SNodeCreator" flags="nn" index="3zrR0B">
+        <child id="1180636770616" name="createdType" index="3zrR0E" />
+      </concept>
+      <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
+        <reference id="1138405853777" name="concept" index="ehGHo" />
+      </concept>
       <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
         <reference id="1138056395725" name="property" index="3TsBF5" />
       </concept>
@@ -244,6 +305,12 @@
       </concept>
     </language>
     <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="nn" index="25WWJ4">
+        <child id="540871147943773366" name="argument" index="25WWJ7" />
+      </concept>
+      <concept id="1151688443754" name="jetbrains.mps.baseLanguage.collections.structure.ListType" flags="in" index="_YKpA">
+        <child id="1151688676805" name="elementType" index="_ZDj9" />
+      </concept>
       <concept id="1153943597977" name="jetbrains.mps.baseLanguage.collections.structure.ForEachStatement" flags="nn" index="2Gpval">
         <child id="1153944400369" name="variable" index="2Gsz3X" />
         <child id="1153944424730" name="inputSequence" index="2GsD0m" />
@@ -252,7 +319,16 @@
       <concept id="1153944233411" name="jetbrains.mps.baseLanguage.collections.structure.ForEachVariableReference" flags="nn" index="2GrUjf">
         <reference id="1153944258490" name="variable" index="2Gs0qQ" />
       </concept>
+      <concept id="1237721394592" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerCreator" flags="nn" index="HWqM0">
+        <child id="1237721435807" name="elementType" index="HW$YZ" />
+      </concept>
+      <concept id="1160600644654" name="jetbrains.mps.baseLanguage.collections.structure.ListCreatorWithInit" flags="nn" index="Tc6Ow" />
+      <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
       <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
+      <concept id="1225621920911" name="jetbrains.mps.baseLanguage.collections.structure.InsertElementOperation" flags="nn" index="1sK_Qi">
+        <child id="1225621943565" name="element" index="1sKFgg" />
+        <child id="1225621960341" name="index" index="1sKJu8" />
+      </concept>
       <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
       <concept id="1165595910856" name="jetbrains.mps.baseLanguage.collections.structure.GetLastOperation" flags="nn" index="1yVyf7" />
       <concept id="1176501494711" name="jetbrains.mps.baseLanguage.collections.structure.IsNotEmptyOperation" flags="nn" index="3GX2aA" />
@@ -296,6 +372,10 @@
                 <node concept="3cmrfG" id="7CiTYi$AiL9" role="15NUvb">
                   <property role="3cmrfH" value="13" />
                 </node>
+                <node concept="10M0yZ" id="7fqbBL2pY_o" role="15NUvb">
+                  <ref role="3cqZAo" to="z60i:~Color.MAGENTA" resolve="MAGENTA" />
+                  <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                </node>
               </node>
             </node>
           </node>
@@ -311,6 +391,10 @@
                     <ref role="1X_clt" node="7k8R9gKN2ah" resolve="Circle" />
                     <node concept="3cmrfG" id="JAaUnmRv94" role="15NUvb">
                       <property role="3cmrfH" value="10" />
+                    </node>
+                    <node concept="10M0yZ" id="7fqbBL2pY_P" role="15NUvb">
+                      <ref role="3cqZAo" to="z60i:~Color.CYAN" resolve="CYAN" />
+                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
                     </node>
                   </node>
                 </node>
@@ -366,6 +450,10 @@
               <ref role="1X_clt" node="7k8R9gKN2ah" resolve="Circle" />
               <node concept="3b6qkQ" id="2rPTijxvbum" role="15NUvb">
                 <property role="$nhwW" value="10.0" />
+              </node>
+              <node concept="10M0yZ" id="7fqbBL2pYlN" role="15NUvb">
+                <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
+                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
               </node>
             </node>
           </node>
@@ -446,6 +534,10 @@
                 <ref role="1X_clt" node="7k8R9gKN2ah" resolve="Circle" />
                 <node concept="3b6qkQ" id="7k8R9gKOYiq" role="15NUvb">
                   <property role="$nhwW" value="20.0" />
+                </node>
+                <node concept="10M0yZ" id="7fqbBL2pYmt" role="15NUvb">
+                  <ref role="3cqZAo" to="z60i:~Color.green" resolve="green" />
+                  <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
                 </node>
               </node>
               <node concept="37fpnE" id="2rPTijxRT8h" role="37fetC" />
@@ -893,6 +985,10 @@
           </node>
         </node>
       </node>
+      <node concept="3F0ifn" id="7fqbBL2p1uJ" role="3EZMnx" />
+      <node concept="3F1sOY" id="7fqbBL2p1BE" role="3EZMnx">
+        <ref role="1NtTu8" to="uin2:7fqbBL2p0Ly" resolve="tree3" />
+      </node>
       <node concept="2iRkQZ" id="7uOgiTdmmh" role="2iSdaV" />
       <node concept="3tD6jV" id="7uOgiTdGUP" role="3F10Kt">
         <ref role="3tD7wE" to="5un2:7uOgiTdCky" resolve="tree-level-spacing" />
@@ -945,7 +1041,11 @@
       <node concept="1X_cmw" id="7k8R9gKNv2u" role="15K7xk">
         <ref role="1X_clt" node="7k8R9gKN2ah" resolve="Circle" />
         <node concept="3b6qkQ" id="7k8R9gKN_MB" role="15NUvb">
-          <property role="$nhwW" value="7.0" />
+          <property role="$nhwW" value="6.0" />
+        </node>
+        <node concept="10M0yZ" id="7fqbBL2pN8s" role="15NUvb">
+          <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
+          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
         </node>
       </node>
       <node concept="3u$I1K" id="7CiTYi$wnL6" role="15K7wI">
@@ -973,6 +1073,10 @@
           <ref role="1X_clt" node="7k8R9gKN2ah" resolve="Circle" />
           <node concept="3b6qkQ" id="7CiTYi$wp79" role="15NUvb">
             <property role="$nhwW" value="10.0" />
+          </node>
+          <node concept="10M0yZ" id="7fqbBL2pN7D" role="15NUvb">
+            <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
+            <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
           </node>
         </node>
       </node>
@@ -1058,6 +1162,12 @@
     <node concept="15NUNA" id="7k8R9gKNzLG" role="15NUdi">
       <property role="TrG5h" value="size" />
       <node concept="10P55v" id="7k8R9gKNzLN" role="15NUNB" />
+    </node>
+    <node concept="15NUNA" id="7fqbBL2pMRr" role="15NUdi">
+      <property role="TrG5h" value="col" />
+      <node concept="3uibUv" id="7fqbBL2pMTZ" role="15NUNB">
+        <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
+      </node>
     </node>
     <node concept="1X_dKt" id="7k8R9gKN2ai" role="1X_dKs">
       <node concept="3clFbS" id="7k8R9gKN2aj" role="2VODD2">
@@ -1206,6 +1316,17 @@
                         <ref role="37wK5l" to="4io5:~Vector2D.normalize()" resolve="normalize" />
                       </node>
                     </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="7fqbBL2pB_E" role="3cqZAp">
+              <node concept="2OqwBi" id="7fqbBL2pC3T" role="3clFbG">
+                <node concept="1X_dKq" id="7fqbBL2pB_D" role="2Oq$k0" />
+                <node concept="liA8E" id="7fqbBL2pChC" role="2OqNvi">
+                  <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
+                  <node concept="15NUKc" id="7fqbBL2pMV3" role="37wK5m">
+                    <ref role="15NUKd" node="7fqbBL2pMRr" resolve="col" />
                   </node>
                 </node>
               </node>
@@ -1458,6 +1579,301 @@
           </node>
         </node>
       </node>
+    </node>
+  </node>
+  <node concept="24kQdi" id="7fqbBL2mR8G">
+    <ref role="1XX52x" to="uin2:7fqbBL2mQYa" resolve="AnotherTreeNode" />
+    <node concept="2SWKgc" id="7fqbBL2mR8M" role="2wV5jI">
+      <node concept="1XG33E" id="7fqbBL2mR8N" role="1XG3MI">
+        <node concept="3clFbS" id="7fqbBL2mR8O" role="2VODD2">
+          <node concept="3clFbF" id="7fqbBL2mR8P" role="3cqZAp">
+            <node concept="2OqwBi" id="7fqbBL2mR8Q" role="3clFbG">
+              <node concept="pncrf" id="7fqbBL2mR8R" role="2Oq$k0" />
+              <node concept="3YRAZt" id="7fqbBL2mR8S" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3F2HdR" id="7fqbBL2mR8T" role="2SWKFX">
+        <ref role="1NtTu8" to="uin2:7fqbBL2mQYg" resolve="childTreeNodes" />
+        <node concept="pkWqt" id="7fqbBL2mR8U" role="pqm2j">
+          <node concept="3clFbS" id="7fqbBL2mR8V" role="2VODD2">
+            <node concept="3clFbF" id="7fqbBL2mR8W" role="3cqZAp">
+              <node concept="2OqwBi" id="7fqbBL2mR8X" role="3clFbG">
+                <node concept="2OqwBi" id="7fqbBL2mR8Y" role="2Oq$k0">
+                  <node concept="pncrf" id="7fqbBL2mR8Z" role="2Oq$k0" />
+                  <node concept="3Tsc0h" id="7fqbBL2mR90" role="2OqNvi">
+                    <ref role="3TtcxE" to="uin2:7fqbBL2mQYg" resolve="childTreeNodes" />
+                  </node>
+                </node>
+                <node concept="3GX2aA" id="7fqbBL2mR91" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3F0A7n" id="7fqbBL2mR92" role="2SWKFN">
+        <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
+      </node>
+      <node concept="1X_cmw" id="7fqbBL2mR93" role="15K7xk">
+        <ref role="1X_clt" node="7k8R9gKN2ah" resolve="Circle" />
+        <node concept="3b6qkQ" id="7fqbBL2mR94" role="15NUvb">
+          <property role="$nhwW" value="7.0" />
+        </node>
+        <node concept="10M0yZ" id="7fqbBL2pNMF" role="15NUvb">
+          <ref role="3cqZAo" to="z60i:~Color.orange" resolve="orange" />
+          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+        </node>
+      </node>
+      <node concept="3u$I1K" id="7fqbBL2mR95" role="15K7wI">
+        <node concept="3eOSWO" id="7fqbBL2mR96" role="3u$JiU">
+          <node concept="3cmrfG" id="7fqbBL2mR97" role="3uHU7w">
+            <property role="3cmrfH" value="1" />
+          </node>
+          <node concept="2OqwBi" id="7fqbBL2mR98" role="3uHU7B">
+            <node concept="2OqwBi" id="7fqbBL2mR99" role="2Oq$k0">
+              <node concept="3u$I0N" id="7fqbBL2mR9a" role="2Oq$k0" />
+              <node concept="3Tsc0h" id="7fqbBL2mR9b" role="2OqNvi">
+                <ref role="3TtcxE" to="uin2:7fqbBL2mQYg" resolve="childTreeNodes" />
+              </node>
+            </node>
+            <node concept="34oBXx" id="7fqbBL2mR9c" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="1X_cmw" id="7fqbBL2mR9d" role="3u$Jl3">
+          <ref role="1X_clt" node="7k8R9gKOHrW" resolve="Arc" />
+          <node concept="3b6qkQ" id="7fqbBL2mR9e" role="15NUvb">
+            <property role="$nhwW" value="6.0" />
+          </node>
+        </node>
+        <node concept="1X_cmw" id="7fqbBL2mR9f" role="3u$Jle">
+          <ref role="1X_clt" node="7k8R9gKN2ah" resolve="Circle" />
+          <node concept="3b6qkQ" id="7fqbBL2mR9g" role="15NUvb">
+            <property role="$nhwW" value="7.0" />
+          </node>
+          <node concept="10M0yZ" id="7fqbBL2pNKI" role="15NUvb">
+            <ref role="3cqZAo" to="z60i:~Color.blue" resolve="blue" />
+            <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+          </node>
+        </node>
+      </node>
+      <node concept="LwBWP" id="7fqbBL2mRSO" role="1Vhs_Z">
+        <node concept="Lw$WK" id="7fqbBL2mRSQ" role="Lw1Oy">
+          <node concept="3clFbS" id="7fqbBL2mRSS" role="2VODD2">
+            <node concept="3cpWs8" id="7fqbBL2mXk9" role="3cqZAp">
+              <node concept="3cpWsn" id="7fqbBL2mXka" role="3cpWs9">
+                <property role="TrG5h" value="handlers" />
+                <node concept="_YKpA" id="7fqbBL2mXff" role="1tU5fm">
+                  <node concept="3uibUv" id="7fqbBL2mXfi" role="_ZDj9">
+                    <ref role="3uigEE" to="4hco:7GMtHW6y0BZ" resolve="IInsertHandler" />
+                  </node>
+                </node>
+                <node concept="2ShNRf" id="7fqbBL2mXkb" role="33vP2m">
+                  <node concept="Tc6Ow" id="7fqbBL2mXkc" role="2ShVmc">
+                    <node concept="3uibUv" id="7fqbBL2mXkd" role="HW$YZ">
+                      <ref role="3uigEE" to="4hco:7GMtHW6y0BZ" resolve="IInsertHandler" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="7fqbBL2mWBP" role="3cqZAp">
+              <node concept="2OqwBi" id="7fqbBL2mYc9" role="3clFbG">
+                <node concept="37vLTw" id="7fqbBL2mXke" role="2Oq$k0">
+                  <ref role="3cqZAo" node="7fqbBL2mXka" resolve="handlers" />
+                </node>
+                <node concept="TSZUe" id="7fqbBL2mZt2" role="2OqNvi">
+                  <node concept="2ShNRf" id="7fqbBL2mW6k" role="25WWJ7">
+                    <node concept="YeOm9" id="7fqbBL2mWpu" role="2ShVmc">
+                      <node concept="1Y3b0j" id="7fqbBL2mWpx" role="YeSDq">
+                        <property role="2bfB8j" value="true" />
+                        <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
+                        <ref role="1Y3XeK" to="4hco:4Q9g1gQNj1I" resolve="AbstractInsertHandler" />
+                        <node concept="3Tm1VV" id="7fqbBL2mWpy" role="1B3o_S" />
+                        <node concept="3clFb_" id="7fqbBL2mWpE" role="jymVt">
+                          <property role="TrG5h" value="insert" />
+                          <node concept="37vLTG" id="7fqbBL2mWpF" role="3clF46">
+                            <property role="TrG5h" value="editorContext" />
+                            <node concept="3uibUv" id="7fqbBL2mWpG" role="1tU5fm">
+                              <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+                            </node>
+                          </node>
+                          <node concept="37vLTG" id="7fqbBL2mWpH" role="3clF46">
+                            <property role="TrG5h" value="node" />
+                            <node concept="3Tqbb2" id="7fqbBL2mWpI" role="1tU5fm" />
+                          </node>
+                          <node concept="37vLTG" id="7fqbBL2mWpJ" role="3clF46">
+                            <property role="TrG5h" value="index" />
+                            <node concept="10Oyi0" id="7fqbBL2mWpK" role="1tU5fm" />
+                          </node>
+                          <node concept="3cqZAl" id="7fqbBL2mWpL" role="3clF45" />
+                          <node concept="3Tm1VV" id="7fqbBL2mWpM" role="1B3o_S" />
+                          <node concept="3clFbS" id="7fqbBL2mWpO" role="3clF47">
+                            <node concept="Jncv_" id="7fqbBL2pjG7" role="3cqZAp">
+                              <ref role="JncvD" to="uin2:7fqbBL2mQYa" resolve="AnotherTreeNode" />
+                              <node concept="37vLTw" id="7fqbBL2pjTm" role="JncvB">
+                                <ref role="3cqZAo" node="7fqbBL2mWpH" resolve="node" />
+                              </node>
+                              <node concept="3clFbS" id="7fqbBL2pjGb" role="Jncv$">
+                                <node concept="3clFbF" id="7fqbBL2pkhj" role="3cqZAp">
+                                  <node concept="2OqwBi" id="7fqbBL2pmBm" role="3clFbG">
+                                    <node concept="2OqwBi" id="7fqbBL2pkum" role="2Oq$k0">
+                                      <node concept="Jnkvi" id="7fqbBL2pkhi" role="2Oq$k0">
+                                        <ref role="1M0zk5" node="7fqbBL2pjGd" resolve="tn" />
+                                      </node>
+                                      <node concept="3Tsc0h" id="7fqbBL2pkH_" role="2OqNvi">
+                                        <ref role="3TtcxE" to="uin2:7fqbBL2mQYg" resolve="childTreeNodes" />
+                                      </node>
+                                    </node>
+                                    <node concept="1sK_Qi" id="7fqbBL2pqeg" role="2OqNvi">
+                                      <node concept="37vLTw" id="7fqbBL2pqmg" role="1sKJu8">
+                                        <ref role="3cqZAo" node="7fqbBL2mWpJ" resolve="index" />
+                                      </node>
+                                      <node concept="2ShNRf" id="7fqbBL2pqE9" role="1sKFgg">
+                                        <node concept="2fJWfE" id="7fqbBL2prdC" role="2ShVmc">
+                                          <node concept="3Tqbb2" id="7fqbBL2prdE" role="3zrR0E">
+                                            <ref role="ehGHo" to="uin2:7fqbBL2mQYa" resolve="AnotherTreeNode" />
+                                          </node>
+                                        </node>
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                              <node concept="JncvC" id="7fqbBL2pjGd" role="JncvA">
+                                <property role="TrG5h" value="tn" />
+                                <node concept="2jxLKc" id="7fqbBL2pjGe" role="1tU5fm" />
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="2AHcQZ" id="7fqbBL2mWpQ" role="2AJF6D">
+                            <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                          </node>
+                        </node>
+                        <node concept="3clFb_" id="7fqbBL2n1zE" role="jymVt">
+                          <property role="TrG5h" value="getDescription" />
+                          <node concept="17QB3L" id="7fqbBL2n1zF" role="3clF45" />
+                          <node concept="3Tm1VV" id="7fqbBL2n1zG" role="1B3o_S" />
+                          <node concept="3clFbS" id="7fqbBL2n1zL" role="3clF47">
+                            <node concept="3clFbF" id="7fqbBL2n1zO" role="3cqZAp">
+                              <node concept="Xl_RD" id="7fqbBL2onbx" role="3clFbG">
+                                <property role="Xl_RC" value="Some child" />
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="2AHcQZ" id="7fqbBL2n1zM" role="2AJF6D">
+                            <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="7fqbBL2qkb8" role="3cqZAp">
+              <node concept="2OqwBi" id="7fqbBL2qkb9" role="3clFbG">
+                <node concept="37vLTw" id="7fqbBL2qkba" role="2Oq$k0">
+                  <ref role="3cqZAo" node="7fqbBL2mXka" resolve="handlers" />
+                </node>
+                <node concept="TSZUe" id="7fqbBL2qkbb" role="2OqNvi">
+                  <node concept="2ShNRf" id="7fqbBL2qkbc" role="25WWJ7">
+                    <node concept="YeOm9" id="7fqbBL2qkbd" role="2ShVmc">
+                      <node concept="1Y3b0j" id="7fqbBL2qkbe" role="YeSDq">
+                        <property role="2bfB8j" value="true" />
+                        <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
+                        <ref role="1Y3XeK" to="4hco:4Q9g1gQNj1I" resolve="AbstractInsertHandler" />
+                        <node concept="3Tm1VV" id="7fqbBL2qkbf" role="1B3o_S" />
+                        <node concept="3clFb_" id="7fqbBL2qkbg" role="jymVt">
+                          <property role="TrG5h" value="insert" />
+                          <node concept="37vLTG" id="7fqbBL2qkbh" role="3clF46">
+                            <property role="TrG5h" value="editorContext" />
+                            <node concept="3uibUv" id="7fqbBL2qkbi" role="1tU5fm">
+                              <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+                            </node>
+                          </node>
+                          <node concept="37vLTG" id="7fqbBL2qkbj" role="3clF46">
+                            <property role="TrG5h" value="node" />
+                            <node concept="3Tqbb2" id="7fqbBL2qkbk" role="1tU5fm" />
+                          </node>
+                          <node concept="37vLTG" id="7fqbBL2qkbl" role="3clF46">
+                            <property role="TrG5h" value="index" />
+                            <node concept="10Oyi0" id="7fqbBL2qkbm" role="1tU5fm" />
+                          </node>
+                          <node concept="3cqZAl" id="7fqbBL2qkbn" role="3clF45" />
+                          <node concept="3Tm1VV" id="7fqbBL2qkbo" role="1B3o_S" />
+                          <node concept="3clFbS" id="7fqbBL2qkbp" role="3clF47">
+                            <node concept="Jncv_" id="7fqbBL2qkbx" role="3cqZAp">
+                              <ref role="JncvD" to="uin2:7fqbBL2mQYa" resolve="AnotherTreeNode" />
+                              <node concept="37vLTw" id="7fqbBL2qkby" role="JncvB">
+                                <ref role="3cqZAo" node="7fqbBL2qkbj" resolve="node" />
+                              </node>
+                              <node concept="3clFbS" id="7fqbBL2qkbz" role="Jncv$">
+                                <node concept="3clFbF" id="7fqbBL2qkb$" role="3cqZAp">
+                                  <node concept="2OqwBi" id="7fqbBL2qkb_" role="3clFbG">
+                                    <node concept="2OqwBi" id="7fqbBL2qkbA" role="2Oq$k0">
+                                      <node concept="Jnkvi" id="7fqbBL2qkbB" role="2Oq$k0">
+                                        <ref role="1M0zk5" node="7fqbBL2qkbI" resolve="tn" />
+                                      </node>
+                                      <node concept="3Tsc0h" id="7fqbBL2qkbC" role="2OqNvi">
+                                        <ref role="3TtcxE" to="uin2:7fqbBL2mQYg" resolve="childTreeNodes" />
+                                      </node>
+                                    </node>
+                                    <node concept="1sK_Qi" id="7fqbBL2qkbD" role="2OqNvi">
+                                      <node concept="37vLTw" id="7fqbBL2qkbE" role="1sKJu8">
+                                        <ref role="3cqZAo" node="7fqbBL2qkbl" resolve="index" />
+                                      </node>
+                                      <node concept="2ShNRf" id="7fqbBL2qkbF" role="1sKFgg">
+                                        <node concept="2fJWfE" id="7fqbBL2qkbG" role="2ShVmc">
+                                          <node concept="3Tqbb2" id="7fqbBL2qkbH" role="3zrR0E">
+                                            <ref role="ehGHo" to="uin2:7fqbBL2mQYa" resolve="AnotherTreeNode" />
+                                          </node>
+                                        </node>
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                              <node concept="JncvC" id="7fqbBL2qkbI" role="JncvA">
+                                <property role="TrG5h" value="tn" />
+                                <node concept="2jxLKc" id="7fqbBL2qkbJ" role="1tU5fm" />
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="2AHcQZ" id="7fqbBL2qkbK" role="2AJF6D">
+                            <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                          </node>
+                        </node>
+                        <node concept="3clFb_" id="7fqbBL2qkbL" role="jymVt">
+                          <property role="TrG5h" value="getDescription" />
+                          <node concept="17QB3L" id="7fqbBL2qkbM" role="3clF45" />
+                          <node concept="3Tm1VV" id="7fqbBL2qkbN" role="1B3o_S" />
+                          <node concept="3clFbS" id="7fqbBL2qkbO" role="3clF47">
+                            <node concept="3clFbF" id="7fqbBL2qkbP" role="3cqZAp">
+                              <node concept="Xl_RD" id="7fqbBL2qkbQ" role="3clFbG">
+                                <property role="Xl_RC" value="Another child" />
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="2AHcQZ" id="7fqbBL2qkbR" role="2AJF6D">
+                            <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs6" id="7fqbBL2mZQO" role="3cqZAp">
+              <node concept="37vLTw" id="7fqbBL2mZWh" role="3cqZAk">
+                <ref role="3cqZAo" node="7fqbBL2mXka" resolve="handlers" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37fpnD" id="7fqbBL2mR9o" role="37fetC" />
     </node>
   </node>
 </model>

--- a/code/treenotation/com.mbeddr.mpsutil.treenotation.sandboxlang/models/structure.mps
+++ b/code/treenotation/com.mbeddr.mpsutil.treenotation.sandboxlang/models/structure.mps
@@ -9,6 +9,24 @@
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
   </imports>
   <registry>
+    <language id="982eb8df-2c96-4bd7-9963-11712ea622e5" name="jetbrains.mps.lang.resources">
+      <concept id="2756621024541681841" name="jetbrains.mps.lang.resources.structure.Primitive" flags="ng" index="1irPi6">
+        <child id="1860120738943552529" name="fillColor" index="3PKjn_" />
+        <child id="1860120738943552531" name="borderColor" index="3PKjnB" />
+      </concept>
+      <concept id="2756621024541681849" name="jetbrains.mps.lang.resources.structure.Text" flags="ng" index="1irPie">
+        <property id="2756621024541681854" name="text" index="1irPi9" />
+        <child id="1860120738943552534" name="color" index="3PKjny" />
+      </concept>
+      <concept id="2756621024541674821" name="jetbrains.mps.lang.resources.structure.TextIcon" flags="ng" index="1irR5M">
+        <property id="1358878980655415353" name="iconId" index="2$rrk2" />
+        <child id="2756621024541675110" name="layers" index="1irR9h" />
+      </concept>
+      <concept id="2756621024541675104" name="jetbrains.mps.lang.resources.structure.Circle" flags="ng" index="1irR9n" />
+      <concept id="1860120738943552477" name="jetbrains.mps.lang.resources.structure.ColorLiteral" flags="ng" index="3PKj8D">
+        <property id="1860120738943552481" name="val" index="3PKj8l" />
+      </concept>
+    </language>
     <language id="c72da2b9-7cce-4447-8389-f407dc1158b7" name="jetbrains.mps.lang.structure">
       <concept id="1169125787135" name="jetbrains.mps.lang.structure.structure.AbstractConceptDeclaration" flags="ig" index="PkWjJ">
         <property id="6714410169261853888" name="conceptId" index="EcuMT" />
@@ -21,6 +39,7 @@
       <concept id="1071489090640" name="jetbrains.mps.lang.structure.structure.ConceptDeclaration" flags="ig" index="1TIwiD">
         <property id="1096454100552" name="rootable" index="19KtqR" />
         <reference id="1071489389519" name="extends" index="1TJDcQ" />
+        <child id="6327362524875300597" name="icon" index="rwd14" />
         <child id="1169129564478" name="implements" index="PzmwI" />
       </concept>
       <concept id="1071489288299" name="jetbrains.mps.lang.structure.structure.PropertyDeclaration" flags="ig" index="1TJgyi">
@@ -111,6 +130,28 @@
       <property role="20kJfa" value="childTreeNodes" />
       <property role="20lbJX" value="fLJekj5/_0__n" />
       <ref role="20lvS9" node="7fqbBL2mQYa" resolve="AnotherTreeNode" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="7fqbBL2uHSC">
+    <property role="EcuMT" value="8348035970510806568" />
+    <property role="TrG5h" value="TreeNode2" />
+    <ref role="1TJDcQ" node="7uOgiTdIOR" resolve="TreeNode" />
+    <node concept="1irR5M" id="7fqbBL2ytPD" role="rwd14">
+      <property role="2$rrk2" value="1" />
+      <node concept="1irR9n" id="7fqbBL2ytPH" role="1irR9h">
+        <node concept="3PKj8D" id="7fqbBL2ytPM" role="3PKjn_">
+          <property role="3PKj8l" value="f0f0f0" />
+        </node>
+        <node concept="3PKj8D" id="7fqbBL2ytPR" role="3PKjnB">
+          <property role="3PKj8l" value="d0d0d0" />
+        </node>
+      </node>
+      <node concept="1irPie" id="7fqbBL2ytPZ" role="1irR9h">
+        <property role="1irPi9" value="2" />
+        <node concept="3PKj8D" id="7fqbBL2ytQ7" role="3PKjny">
+          <property role="3PKj8l" value="ff8080" />
+        </node>
+      </node>
     </node>
   </node>
 </model>

--- a/code/treenotation/com.mbeddr.mpsutil.treenotation.sandboxlang/models/structure.mps
+++ b/code/treenotation/com.mbeddr.mpsutil.treenotation.sandboxlang/models/structure.mps
@@ -60,6 +60,13 @@
       <property role="IQ2ns" value="857420770335041366" />
       <ref role="20lvS9" node="7uOgiTdIOR" resolve="TreeNode" />
     </node>
+    <node concept="1TJgyj" id="7fqbBL2p0Ly" role="1TKVEi">
+      <property role="IQ2ns" value="8348035970509311074" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="tree3" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <ref role="20lvS9" node="7fqbBL2mQYa" resolve="AnotherTreeNode" />
+    </node>
   </node>
   <node concept="1TIwiD" id="7uOgiTdIOR">
     <property role="TrG5h" value="TreeNode" />
@@ -90,6 +97,21 @@
     <property role="EcuMT" value="3301624890555901394" />
     <property role="TrG5h" value="DisallowedChildConcept" />
     <ref role="1TJDcQ" node="7uOgiTdIOR" resolve="TreeNode" />
+  </node>
+  <node concept="1TIwiD" id="7fqbBL2mQYa">
+    <property role="EcuMT" value="8348035970508746634" />
+    <property role="TrG5h" value="AnotherTreeNode" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+    <node concept="PrWs8" id="7fqbBL2mQYe" role="PzmwI">
+      <ref role="PrY4T" to="tpck:h0TrEE$" resolve="INamedConcept" />
+    </node>
+    <node concept="1TJgyj" id="7fqbBL2mQYg" role="1TKVEi">
+      <property role="IQ2ns" value="8348035970508746640" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="childTreeNodes" />
+      <property role="20lbJX" value="fLJekj5/_0__n" />
+      <ref role="20lvS9" node="7fqbBL2mQYa" resolve="AnotherTreeNode" />
+    </node>
   </node>
 </model>
 

--- a/code/treenotation/com.mbeddr.mpsutil.treenotation/com.mbeddr.mpsutil.treenotation.mpl
+++ b/code/treenotation/com.mbeddr.mpsutil.treenotation/com.mbeddr.mpsutil.treenotation.mpl
@@ -49,7 +49,6 @@
         <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
         <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
         <language slang="l:df345b11-b8c7-4213-ac66-48d2a9b75d88:jetbrains.mps.baseLanguageInternal" version="0" />
-        <language slang="l:63650c59-16c8-498a-99c8-005c7ee9515d:jetbrains.mps.lang.access" version="0" />
         <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
         <language slang="l:18bc6592-03a6-4e29-a83a-7ff23bde13ba:jetbrains.mps.lang.editor" version="14" />
         <language slang="l:b401a680-8325-4110-8fd3-84331ff25bef:jetbrains.mps.lang.generator" version="3" />
@@ -113,6 +112,20 @@
             <generator generatorUID="0647eca7-da98-422a-8a8b-6ebc0bd014ea(jetbrains.mps.lang.editor#1129914002149)" />
             <external-mapping>
               <mapping-node modelUID="r:00000000-0000-4000-0000-011c8959029f(jetbrains.mps.lang.editor.generator.baseLanguage.template.main@generator)" nodeID="1096629760203" />
+            </external-mapping>
+          </lesser-priority-mapping>
+        </mapping-priority-rule>
+        <mapping-priority-rule kind="strictly_before">
+          <greater-priority-mapping>
+            <generator generatorUID="54c59793-411e-455f-9eb0-b4f7c3d2e9e0(com.mbeddr.mpsutil.treenotation#134774857084556400)" />
+            <external-mapping>
+              <mapping-node modelUID="r:28e6f353-faeb-45c3-85c1-f10c8ed0603c(com.mbeddr.mpsutil.treenotation.generator.template.main@generator)" nodeID="8348035970513117141" />
+            </external-mapping>
+          </greater-priority-mapping>
+          <lesser-priority-mapping>
+            <generator generatorUID="54c59793-411e-455f-9eb0-b4f7c3d2e9e0(com.mbeddr.mpsutil.treenotation#134774857084556400)" />
+            <external-mapping>
+              <mapping-node modelUID="r:28e6f353-faeb-45c3-85c1-f10c8ed0603c(com.mbeddr.mpsutil.treenotation.generator.template.main@generator)" nodeID="134774857084556401" />
             </external-mapping>
           </lesser-priority-mapping>
         </mapping-priority-rule>

--- a/code/treenotation/com.mbeddr.mpsutil.treenotation/com.mbeddr.mpsutil.treenotation.mpl
+++ b/code/treenotation/com.mbeddr.mpsutil.treenotation/com.mbeddr.mpsutil.treenotation.mpl
@@ -124,6 +124,7 @@
     <dependency reexport="false">f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)</dependency>
     <dependency reexport="false">c72da2b9-7cce-4447-8389-f407dc1158b7(jetbrains.mps.lang.structure)</dependency>
     <dependency reexport="false">e9d9e7bc-3ca3-4ef7-8aa7-316a55bcc1ab(com.mbeddr.mpsutil.treenotation.runtime)</dependency>
+    <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />

--- a/code/treenotation/com.mbeddr.mpsutil.treenotation/com.mbeddr.mpsutil.treenotation.mpl
+++ b/code/treenotation/com.mbeddr.mpsutil.treenotation/com.mbeddr.mpsutil.treenotation.mpl
@@ -123,6 +123,7 @@
   <dependencies>
     <dependency reexport="false">f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)</dependency>
     <dependency reexport="false">c72da2b9-7cce-4447-8389-f407dc1158b7(jetbrains.mps.lang.structure)</dependency>
+    <dependency reexport="false">e9d9e7bc-3ca3-4ef7-8aa7-316a55bcc1ab(com.mbeddr.mpsutil.treenotation.runtime)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
@@ -162,8 +163,12 @@
     <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
     <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
     <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
+    <module reference="1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)" version="0" />
+    <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+    <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
     <module reference="c73b17af-16a1-4490-8072-8a84937c5206(com.mbeddr.mpsutil.treenotation)" version="0" />
+    <module reference="e9d9e7bc-3ca3-4ef7-8aa7-316a55bcc1ab(com.mbeddr.mpsutil.treenotation.runtime)" version="0" />
     <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
     <module reference="443f4c36-fcf5-4eb6-9500-8d06ed259e3e(jetbrains.mps.baseLanguage.classifiers)" version="0" />
     <module reference="fd392034-7849-419d-9071-12563d152375(jetbrains.mps.baseLanguage.closures)" version="0" />

--- a/code/treenotation/com.mbeddr.mpsutil.treenotation/generator/template/main@generator.mps
+++ b/code/treenotation/com.mbeddr.mpsutil.treenotation/generator/template/main@generator.mps
@@ -276,6 +276,7 @@
         <child id="1199569906740" name="parameter" index="1bW2Oz" />
         <child id="1199569916463" name="body" index="1bW5cS" />
       </concept>
+      <concept id="1225797177491" name="jetbrains.mps.baseLanguage.closures.structure.InvokeFunctionOperation" flags="nn" index="1Bd96e" />
     </language>
     <language id="d7706f63-9be2-479c-a3da-ae92af1e64d5" name="jetbrains.mps.lang.generator.generationContext">
       <concept id="1216860049627" name="jetbrains.mps.lang.generator.generationContext.structure.GenerationContextOp_GetOutputByLabelAndInput" flags="nn" index="1iwH70">
@@ -1212,6 +1213,76 @@
           <node concept="37vLTG" id="2RhI_xvat27" role="3clF46">
             <property role="TrG5h" value="node" />
             <node concept="3Tqbb2" id="2RhI_xvat28" role="1tU5fm" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3aamgX" id="7fqbBL2nkEq" role="3acgRq">
+      <ref role="30HIoZ" to="hfvq:7fqbBL2m559" resolve="GenericInsertHandler" />
+      <node concept="1Koe21" id="7fqbBL2nnrb" role="1lVwrX">
+        <node concept="3clFb_" id="7fqbBL2nnrh" role="1Koe22">
+          <property role="TrG5h" value="m" />
+          <node concept="A3Dl8" id="7fqbBL2nnri" role="3clF45">
+            <node concept="3uibUv" id="7fqbBL2nnrj" role="A3Ik2">
+              <ref role="3uigEE" to="4hco:7GMtHW6y0BZ" resolve="IInsertHandler" />
+            </node>
+          </node>
+          <node concept="3Tm1VV" id="7fqbBL2nnrk" role="1B3o_S" />
+          <node concept="3clFbS" id="7fqbBL2nnrl" role="3clF47">
+            <node concept="3clFbF" id="7fqbBL2nYax" role="3cqZAp">
+              <node concept="2OqwBi" id="7fqbBL2nYly" role="3clFbG">
+                <node concept="1bVj0M" id="7fqbBL2nYat" role="2Oq$k0">
+                  <node concept="3clFbS" id="7fqbBL2nYav" role="1bW5cS">
+                    <node concept="3cpWs6" id="7fqbBL2oC6B" role="3cqZAp">
+                      <node concept="2ShNRf" id="7fqbBL2oBIk" role="3cqZAk">
+                        <node concept="Tc6Ow" id="7fqbBL2oBIl" role="2ShVmc">
+                          <node concept="3uibUv" id="7fqbBL2oBIm" role="HW$YZ">
+                            <ref role="3uigEE" to="4hco:7GMtHW6y0BZ" resolve="IInsertHandler" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="2b32R4" id="7fqbBL2oCZr" role="lGtFl">
+                        <node concept="3JmXsc" id="7fqbBL2oCZu" role="2P8S$">
+                          <node concept="3clFbS" id="7fqbBL2oCZv" role="2VODD2">
+                            <node concept="3clFbF" id="7fqbBL2oCZ_" role="3cqZAp">
+                              <node concept="2OqwBi" id="7fqbBL2oENa" role="3clFbG">
+                                <node concept="2OqwBi" id="7fqbBL2oDOa" role="2Oq$k0">
+                                  <node concept="2OqwBi" id="7fqbBL2oCZw" role="2Oq$k0">
+                                    <node concept="3TrEf2" id="7fqbBL2oDuM" role="2OqNvi">
+                                      <ref role="3Tt5mk" to="hfvq:7fqbBL2mzdu" resolve="insertFunction" />
+                                    </node>
+                                    <node concept="30H73N" id="7fqbBL2oCZ$" role="2Oq$k0" />
+                                  </node>
+                                  <node concept="3TrEf2" id="7fqbBL2oEmF" role="2OqNvi">
+                                    <ref role="3Tt5mk" to="tpee:gyVODHa" resolve="body" />
+                                  </node>
+                                </node>
+                                <node concept="3Tsc0h" id="7fqbBL2oGej" role="2OqNvi">
+                                  <ref role="3TtcxE" to="tpee:fzcqZ_x" resolve="statement" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="1Bd96e" id="7fqbBL2nYuz" role="2OqNvi" />
+                <node concept="raruj" id="7fqbBL2o2lN" role="lGtFl" />
+              </node>
+            </node>
+          </node>
+          <node concept="37vLTG" id="7fqbBL2nntZ" role="3clF46">
+            <property role="TrG5h" value="editorContext" />
+            <property role="3TUv4t" value="true" />
+            <node concept="3uibUv" id="7fqbBL2nnu0" role="1tU5fm">
+              <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+            </node>
+          </node>
+          <node concept="37vLTG" id="7fqbBL2nnu1" role="3clF46">
+            <property role="TrG5h" value="node" />
+            <node concept="3Tqbb2" id="7fqbBL2nnu2" role="1tU5fm" />
           </node>
         </node>
       </node>

--- a/code/treenotation/com.mbeddr.mpsutil.treenotation/generator/template/main@generator.mps
+++ b/code/treenotation/com.mbeddr.mpsutil.treenotation/generator/template/main@generator.mps
@@ -308,6 +308,7 @@
       <concept id="2644386474300074836" name="jetbrains.mps.lang.smodel.structure.ConceptIdRefExpression" flags="nn" index="35c_gC">
         <reference id="2644386474300074837" name="conceptDeclaration" index="35c_gD" />
       </concept>
+      <concept id="6677504323281689838" name="jetbrains.mps.lang.smodel.structure.SConceptType" flags="in" index="3bZ5Sz" />
       <concept id="1171999116870" name="jetbrains.mps.lang.smodel.structure.Node_IsNullOperation" flags="nn" index="3w_OXm" />
       <concept id="1172008320231" name="jetbrains.mps.lang.smodel.structure.Node_IsNotNullOperation" flags="nn" index="3x8VRR" />
       <concept id="1140137987495" name="jetbrains.mps.lang.smodel.structure.SNodeTypeCastExpression" flags="nn" index="1PxgMI" />
@@ -1233,6 +1234,178 @@
               <node concept="2OqwBi" id="7fqbBL2nYly" role="3clFbG">
                 <node concept="1bVj0M" id="7fqbBL2nYat" role="2Oq$k0">
                   <node concept="3clFbS" id="7fqbBL2nYav" role="1bW5cS">
+                    <node concept="3cpWs8" id="7fqbBL2xDeP" role="3cqZAp">
+                      <node concept="3cpWsn" id="7fqbBL2xDeS" role="3cpWs9">
+                        <property role="TrG5h" value="subconcepts" />
+                        <node concept="2OqwBi" id="7fqbBL2xDME" role="33vP2m">
+                          <node concept="2OqwBi" id="7fqbBL2xDMF" role="2Oq$k0">
+                            <node concept="1eOMI4" id="7fqbBL2xDMG" role="2Oq$k0">
+                              <node concept="10QFUN" id="7fqbBL2xDMH" role="1eOMHV">
+                                <node concept="2YIFZM" id="7fqbBL2xDMI" role="10QFUP">
+                                  <ref role="37wK5l" to="i8bi:1EtdPNufFQS" resolve="getAllSubConcepts" />
+                                  <ref role="1Pybhc" to="i8bi:5IkW5anF8_6" resolve="SConceptOperations" />
+                                  <node concept="35c_gC" id="7fqbBL2xDMJ" role="37wK5m">
+                                    <ref role="35c_gD" to="tpck:gw2VY9q" resolve="BaseConcept" />
+                                    <node concept="1ZhdrF" id="7fqbBL2xDMK" role="lGtFl">
+                                      <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/2644386474300074836/2644386474300074837" />
+                                      <property role="2qtEX8" value="conceptDeclaration" />
+                                      <node concept="3$xsQk" id="7fqbBL2xDML" role="3$ytzL">
+                                        <node concept="3clFbS" id="7fqbBL2xDMM" role="2VODD2">
+                                          <node concept="3clFbF" id="7fqbBL2xDMN" role="3cqZAp">
+                                            <node concept="2OqwBi" id="7fqbBL2xDMO" role="3clFbG">
+                                              <node concept="2OqwBi" id="7fqbBL2xDMP" role="2Oq$k0">
+                                                <node concept="30H73N" id="7fqbBL2xDMQ" role="2Oq$k0" />
+                                                <node concept="2qgKlT" id="7fqbBL2xDMR" role="2OqNvi">
+                                                  <ref role="37wK5l" to="wvyf:4Q9g1gQP3R9" resolve="getTargetLink" />
+                                                </node>
+                                              </node>
+                                              <node concept="3TrEf2" id="7fqbBL2xDMS" role="2OqNvi">
+                                                <ref role="3Tt5mk" to="tpce:fA0lvVK" resolve="target" />
+                                              </node>
+                                            </node>
+                                          </node>
+                                        </node>
+                                      </node>
+                                    </node>
+                                  </node>
+                                  <node concept="2OqwBi" id="7fqbBL2xDMT" role="37wK5m">
+                                    <node concept="37vLTw" id="7fqbBL2xDMU" role="2Oq$k0">
+                                      <ref role="3cqZAo" node="7fqbBL2nntZ" resolve="editorContext" />
+                                    </node>
+                                    <node concept="liA8E" id="7fqbBL2xDMV" role="2OqNvi">
+                                      <ref role="37wK5l" to="cj4x:~EditorContext.getModel()" resolve="getModel" />
+                                    </node>
+                                  </node>
+                                </node>
+                                <node concept="_YKpA" id="7fqbBL2xDMW" role="10QFUM">
+                                  <node concept="3uibUv" id="7fqbBL2xDMX" role="_ZDj9">
+                                    <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="3zZkjj" id="7fqbBL2xDMY" role="2OqNvi">
+                              <node concept="1bVj0M" id="7fqbBL2xDMZ" role="23t8la">
+                                <node concept="3clFbS" id="7fqbBL2xDN0" role="1bW5cS">
+                                  <node concept="3clFbF" id="7fqbBL2xDN1" role="3cqZAp">
+                                    <node concept="3fqX7Q" id="7fqbBL2xDN2" role="3clFbG">
+                                      <node concept="2OqwBi" id="7fqbBL2xDN3" role="3fr31v">
+                                        <node concept="37vLTw" id="7fqbBL2xDN4" role="2Oq$k0">
+                                          <ref role="3cqZAo" node="7fqbBL2xDN6" resolve="it" />
+                                        </node>
+                                        <node concept="liA8E" id="7fqbBL2xDN5" role="2OqNvi">
+                                          <ref role="37wK5l" to="c17a:~SAbstractConcept.isAbstract()" resolve="isAbstract" />
+                                        </node>
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                                <node concept="Rh6nW" id="7fqbBL2xDN6" role="1bW2Oz">
+                                  <property role="TrG5h" value="it" />
+                                  <node concept="2jxLKc" id="7fqbBL2xDN7" role="1tU5fm" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="3zZkjj" id="7fqbBL2xDN8" role="2OqNvi">
+                            <node concept="1bVj0M" id="7fqbBL2xDN9" role="23t8la">
+                              <node concept="3clFbS" id="7fqbBL2xDNa" role="1bW5cS">
+                                <node concept="3clFbF" id="7fqbBL2xDNb" role="3cqZAp">
+                                  <node concept="2OqwBi" id="7fqbBL2xDNc" role="3clFbG">
+                                    <node concept="2YIFZM" id="7fqbBL2xDNd" role="2Oq$k0">
+                                      <ref role="37wK5l" to="ykok:~ConstraintsCanBeFacade.checkCanBeChild(jetbrains.mps.core.aspects.constraints.rules.kinds.ContainmentContext)" resolve="checkCanBeChild" />
+                                      <ref role="1Pybhc" to="ykok:~ConstraintsCanBeFacade" resolve="ConstraintsCanBeFacade" />
+                                      <node concept="2OqwBi" id="7fqbBL2xDNe" role="37wK5m">
+                                        <node concept="2OqwBi" id="7fqbBL2xDNf" role="2Oq$k0">
+                                          <node concept="2OqwBi" id="7fqbBL2xDNg" role="2Oq$k0">
+                                            <node concept="2OqwBi" id="7fqbBL2xDNh" role="2Oq$k0">
+                                              <node concept="2ShNRf" id="7fqbBL2xDNi" role="2Oq$k0">
+                                                <node concept="1pGfFk" id="7fqbBL2xDNj" role="2ShVmc">
+                                                  <ref role="37wK5l" to="pdwk:~ContainmentContext$Builder.&lt;init&gt;()" resolve="ContainmentContext.Builder" />
+                                                </node>
+                                              </node>
+                                              <node concept="liA8E" id="7fqbBL2xDNk" role="2OqNvi">
+                                                <ref role="37wK5l" to="pdwk:~ContainmentContext$Builder.childConcept(org.jetbrains.mps.openapi.language.SAbstractConcept)" resolve="childConcept" />
+                                                <node concept="37vLTw" id="7fqbBL2xDNl" role="37wK5m">
+                                                  <ref role="3cqZAo" node="7fqbBL2xDNG" resolve="it" />
+                                                </node>
+                                              </node>
+                                            </node>
+                                            <node concept="liA8E" id="7fqbBL2xDNm" role="2OqNvi">
+                                              <ref role="37wK5l" to="pdwk:~ContainmentContext$Builder.parentNode(org.jetbrains.mps.openapi.model.SNode)" resolve="parentNode" />
+                                              <node concept="37vLTw" id="7fqbBL2xDNn" role="37wK5m">
+                                                <ref role="3cqZAo" node="7fqbBL2nnu1" resolve="node" />
+                                              </node>
+                                            </node>
+                                          </node>
+                                          <node concept="liA8E" id="7fqbBL2xDNo" role="2OqNvi">
+                                            <ref role="37wK5l" to="pdwk:~ContainmentContext$Builder.link(org.jetbrains.mps.openapi.language.SContainmentLink)" resolve="link" />
+                                            <node concept="359W_D" id="7fqbBL2xDNp" role="37wK5m">
+                                              <ref role="359W_E" to="tpck:gw2VY9q" resolve="BaseConcept" />
+                                              <ref role="359W_F" to="tpck:4uZwTti3__2" resolve="smodelAttribute" />
+                                              <node concept="1ZhdrF" id="7fqbBL2xDNq" role="lGtFl">
+                                                <property role="2qtEX8" value="conceptDeclaration" />
+                                                <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/2644386474301421077/2644386474301421078" />
+                                                <node concept="3$xsQk" id="7fqbBL2xDNr" role="3$ytzL">
+                                                  <node concept="3clFbS" id="7fqbBL2xDNs" role="2VODD2">
+                                                    <node concept="3clFbF" id="7fqbBL2xDNt" role="3cqZAp">
+                                                      <node concept="2OqwBi" id="7fqbBL2xDNu" role="3clFbG">
+                                                        <node concept="2OqwBi" id="7fqbBL2xDNv" role="2Oq$k0">
+                                                          <node concept="30H73N" id="7fqbBL2xDNw" role="2Oq$k0" />
+                                                          <node concept="2qgKlT" id="7fqbBL2xDNx" role="2OqNvi">
+                                                            <ref role="37wK5l" to="wvyf:4Q9g1gQP3R9" resolve="getTargetLink" />
+                                                          </node>
+                                                        </node>
+                                                        <node concept="2qgKlT" id="7fqbBL2xDNy" role="2OqNvi">
+                                                          <ref role="37wK5l" to="tpcn:7jb4LXpbWaP" resolve="getConceptDeclaration" />
+                                                        </node>
+                                                      </node>
+                                                    </node>
+                                                  </node>
+                                                </node>
+                                              </node>
+                                              <node concept="1ZhdrF" id="7fqbBL2xDNz" role="lGtFl">
+                                                <property role="2qtEX8" value="linkDeclaration" />
+                                                <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/2644386474301421077/2644386474301421079" />
+                                                <node concept="3$xsQk" id="7fqbBL2xDN$" role="3$ytzL">
+                                                  <node concept="3clFbS" id="7fqbBL2xDN_" role="2VODD2">
+                                                    <node concept="3clFbF" id="7fqbBL2xDNA" role="3cqZAp">
+                                                      <node concept="2OqwBi" id="7fqbBL2xDNB" role="3clFbG">
+                                                        <node concept="30H73N" id="7fqbBL2xDNC" role="2Oq$k0" />
+                                                        <node concept="2qgKlT" id="7fqbBL2xDND" role="2OqNvi">
+                                                          <ref role="37wK5l" to="wvyf:4Q9g1gQP3R9" resolve="getTargetLink" />
+                                                        </node>
+                                                      </node>
+                                                    </node>
+                                                  </node>
+                                                </node>
+                                              </node>
+                                            </node>
+                                          </node>
+                                        </node>
+                                        <node concept="liA8E" id="7fqbBL2xDNE" role="2OqNvi">
+                                          <ref role="37wK5l" to="pdwk:~ContainmentContext$Builder.build()" resolve="build" />
+                                        </node>
+                                      </node>
+                                    </node>
+                                    <node concept="liA8E" id="7fqbBL2xDNF" role="2OqNvi">
+                                      <ref role="37wK5l" to="33ny:~List.isEmpty()" resolve="isEmpty" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                              <node concept="Rh6nW" id="7fqbBL2xDNG" role="1bW2Oz">
+                                <property role="TrG5h" value="it" />
+                                <node concept="2jxLKc" id="7fqbBL2xDNH" role="1tU5fm" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="A3Dl8" id="7fqbBL2vCV9" role="1tU5fm">
+                          <node concept="3bZ5Sz" id="7fqbBL2vCVa" role="A3Ik2" />
+                        </node>
+                      </node>
+                    </node>
                     <node concept="3cpWs6" id="7fqbBL2oC6B" role="3cqZAp">
                       <node concept="2ShNRf" id="7fqbBL2oBIk" role="3cqZAk">
                         <node concept="Tc6Ow" id="7fqbBL2oBIl" role="2ShVmc">
@@ -1283,6 +1456,21 @@
           <node concept="37vLTG" id="7fqbBL2nnu1" role="3clF46">
             <property role="TrG5h" value="node" />
             <node concept="3Tqbb2" id="7fqbBL2nnu2" role="1tU5fm" />
+          </node>
+        </node>
+      </node>
+      <node concept="30G5F_" id="7fqbBL2xOjH" role="30HLyM">
+        <node concept="3clFbS" id="7fqbBL2xOjI" role="2VODD2">
+          <node concept="3clFbF" id="7fqbBL2xOjJ" role="3cqZAp">
+            <node concept="2OqwBi" id="7fqbBL2xOjK" role="3clFbG">
+              <node concept="2OqwBi" id="7fqbBL2xOjL" role="2Oq$k0">
+                <node concept="30H73N" id="7fqbBL2xOjM" role="2Oq$k0" />
+                <node concept="2qgKlT" id="7fqbBL2xOjN" role="2OqNvi">
+                  <ref role="37wK5l" to="wvyf:4Q9g1gQP3R9" resolve="getTargetLink" />
+                </node>
+              </node>
+              <node concept="3x8VRR" id="7fqbBL2xOjO" role="2OqNvi" />
+            </node>
           </node>
         </node>
       </node>

--- a/code/treenotation/com.mbeddr.mpsutil.treenotation/generator/template/main@generator.mps
+++ b/code/treenotation/com.mbeddr.mpsutil.treenotation/generator/template/main@generator.mps
@@ -7,7 +7,7 @@
     <use id="c73b17af-16a1-4490-8072-8a84937c5206" name="com.mbeddr.mpsutil.treenotation" version="0" />
     <use id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core" version="2" />
     <use id="df345b11-b8c7-4213-ac66-48d2a9b75d88" name="jetbrains.mps.baseLanguageInternal" version="0" />
-    <use id="63650c59-16c8-498a-99c8-005c7ee9515d" name="jetbrains.mps.lang.access" version="0" />
+    <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="14" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -40,6 +40,7 @@
   </imports>
   <registry>
     <language id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor">
+      <concept id="1161622981231" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameter_editorContext" flags="nn" index="1Q80Hx" />
       <concept id="6029276237631252951" name="jetbrains.mps.lang.editor.structure.StyleAttributeReferenceExpression" flags="ng" index="1Z6Ecs">
         <reference id="6029276237631253682" name="attributeDeclaration" index="1Z6EpT" />
       </concept>
@@ -109,7 +110,6 @@
       <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
       <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
       <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
-      <concept id="1225271369338" name="jetbrains.mps.baseLanguage.structure.IsEmptyOperation" flags="nn" index="17RlXB" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
@@ -185,14 +185,6 @@
       <concept id="1170345865475" name="jetbrains.mps.baseLanguage.structure.AnonymousClass" flags="ig" index="1Y3b0j">
         <reference id="1170346070688" name="classifier" index="1Y3XeK" />
       </concept>
-    </language>
-    <language id="63650c59-16c8-498a-99c8-005c7ee9515d" name="jetbrains.mps.lang.access">
-      <concept id="8974276187400348173" name="jetbrains.mps.lang.access.structure.CommandClosureLiteral" flags="nn" index="1QHqEC" />
-      <concept id="8974276187400348170" name="jetbrains.mps.lang.access.structure.BaseExecuteCommandStatement" flags="nn" index="1QHqEJ">
-        <child id="1423104411234567454" name="repo" index="ukAjM" />
-        <child id="8974276187400348171" name="commandClosureLiteral" index="1QHqEI" />
-      </concept>
-      <concept id="8974276187400348181" name="jetbrains.mps.lang.access.structure.ExecuteLightweightCommandStatement" flags="nn" index="1QHqEK" />
     </language>
     <language id="b401a680-8325-4110-8fd3-84331ff25bef" name="jetbrains.mps.lang.generator">
       <concept id="1510949579266781519" name="jetbrains.mps.lang.generator.structure.TemplateCallMacro" flags="ln" index="5jKBG">
@@ -285,6 +277,13 @@
       </concept>
       <concept id="1216860049635" name="jetbrains.mps.lang.generator.generationContext.structure.TemplateFunctionParameter_generationContext" flags="nn" index="1iwH7S" />
     </language>
+    <language id="c73b17af-16a1-4490-8072-8a84937c5206" name="com.mbeddr.mpsutil.treenotation">
+      <concept id="8348035970511374774" name="com.mbeddr.mpsutil.treenotation.structure.Parameter_subconcepts" flags="ng" index="Lmqva" />
+      <concept id="8348035970508546380" name="com.mbeddr.mpsutil.treenotation.structure.GenericInsertFunction" flags="ig" index="Lw$WK" />
+      <concept id="8348035970508542281" name="com.mbeddr.mpsutil.treenotation.structure.GenericInsertHandler" flags="ng" index="LwBWP">
+        <child id="8348035970508665694" name="insertFunction" index="Lw1Oy" />
+      </concept>
+    </language>
     <language id="df345b11-b8c7-4213-ac66-48d2a9b75d88" name="jetbrains.mps.baseLanguageInternal">
       <concept id="1173996401517" name="jetbrains.mps.baseLanguageInternal.structure.InternalNewExpression" flags="nn" index="1nCR9W">
         <property id="1173996588177" name="fqClassName" index="1nD$Q0" />
@@ -293,14 +292,7 @@
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
-      <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
-        <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
-      </concept>
       <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
-      <concept id="2396822768958367367" name="jetbrains.mps.lang.smodel.structure.AbstractTypeCastExpression" flags="nn" index="$5XWr">
-        <child id="6733348108486823193" name="leftExpression" index="1m5AlR" />
-        <child id="3906496115198199033" name="conceptArgument" index="3oSUPX" />
-      </concept>
       <concept id="2644386474301421077" name="jetbrains.mps.lang.smodel.structure.LinkIdRefExpression" flags="nn" index="359W_D">
         <reference id="2644386474301421078" name="conceptDeclaration" index="359W_E" />
         <reference id="2644386474301421079" name="linkDeclaration" index="359W_F" />
@@ -311,7 +303,6 @@
       <concept id="6677504323281689838" name="jetbrains.mps.lang.smodel.structure.SConceptType" flags="in" index="3bZ5Sz" />
       <concept id="1171999116870" name="jetbrains.mps.lang.smodel.structure.Node_IsNullOperation" flags="nn" index="3w_OXm" />
       <concept id="1172008320231" name="jetbrains.mps.lang.smodel.structure.Node_IsNotNullOperation" flags="nn" index="3x8VRR" />
-      <concept id="1140137987495" name="jetbrains.mps.lang.smodel.structure.SNodeTypeCastExpression" flags="nn" index="1PxgMI" />
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2" />
       <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
         <reference id="1138056395725" name="property" index="3TsBF5" />
@@ -770,450 +761,6 @@
                 </node>
               </node>
             </node>
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="3aamgX" id="4Q9g1gQP3vs" role="3acgRq">
-      <ref role="30HIoZ" to="hfvq:4Q9g1gQOGvj" resolve="SubconceptsInsertHandler" />
-      <node concept="30G5F_" id="4Q9g1gQP4Yg" role="30HLyM">
-        <node concept="3clFbS" id="4Q9g1gQP4Yh" role="2VODD2">
-          <node concept="3clFbF" id="4Q9g1gQP4Zq" role="3cqZAp">
-            <node concept="2OqwBi" id="4Q9g1gQP5gw" role="3clFbG">
-              <node concept="2OqwBi" id="4Q9g1gQP521" role="2Oq$k0">
-                <node concept="30H73N" id="4Q9g1gQP4Zp" role="2Oq$k0" />
-                <node concept="2qgKlT" id="4Q9g1gQP5b7" role="2OqNvi">
-                  <ref role="37wK5l" to="wvyf:4Q9g1gQP3R9" resolve="getTargetLink" />
-                </node>
-              </node>
-              <node concept="3x8VRR" id="4Q9g1gQP5vz" role="2OqNvi" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="1Koe21" id="4Q9g1gQP9nT" role="1lVwrX">
-        <node concept="3clFb_" id="4Q9g1gQP9qS" role="1Koe22">
-          <property role="TrG5h" value="m" />
-          <node concept="A3Dl8" id="4Q9g1gQP9El" role="3clF45">
-            <node concept="3uibUv" id="4Q9g1gQP9Ii" role="A3Ik2">
-              <ref role="3uigEE" to="4hco:7GMtHW6y0BZ" resolve="IInsertHandler" />
-            </node>
-          </node>
-          <node concept="3Tm1VV" id="4Q9g1gQP9qV" role="1B3o_S" />
-          <node concept="3clFbS" id="4Q9g1gQP9qW" role="3clF47">
-            <node concept="3clFbF" id="4Q9g1gQPdhO" role="3cqZAp">
-              <node concept="2OqwBi" id="4Q9g1gQPdvd" role="3clFbG">
-                <node concept="2OqwBi" id="2RhI_xva3yP" role="2Oq$k0">
-                  <node concept="2OqwBi" id="231TZAqpebX" role="2Oq$k0">
-                    <node concept="1eOMI4" id="4Q9g1gQPd9F" role="2Oq$k0">
-                      <node concept="10QFUN" id="4Q9g1gQPd9G" role="1eOMHV">
-                        <node concept="2YIFZM" id="4Q9g1gQPd9A" role="10QFUP">
-                          <ref role="37wK5l" to="i8bi:1EtdPNufFQS" resolve="getAllSubConcepts" />
-                          <ref role="1Pybhc" to="i8bi:5IkW5anF8_6" resolve="SConceptOperations" />
-                          <node concept="35c_gC" id="4Q9g1gQPd9B" role="37wK5m">
-                            <ref role="35c_gD" to="tpck:gw2VY9q" resolve="BaseConcept" />
-                            <node concept="1ZhdrF" id="4Q9g1gQPslQ" role="lGtFl">
-                              <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/2644386474300074836/2644386474300074837" />
-                              <property role="2qtEX8" value="conceptDeclaration" />
-                              <node concept="3$xsQk" id="4Q9g1gQPslR" role="3$ytzL">
-                                <node concept="3clFbS" id="4Q9g1gQPslS" role="2VODD2">
-                                  <node concept="3clFbF" id="4Q9g1gQPsM9" role="3cqZAp">
-                                    <node concept="2OqwBi" id="4Q9g1gQPt8u" role="3clFbG">
-                                      <node concept="2OqwBi" id="4Q9g1gQPsPh" role="2Oq$k0">
-                                        <node concept="30H73N" id="4Q9g1gQPsM8" role="2Oq$k0" />
-                                        <node concept="2qgKlT" id="4Q9g1gQPsYo" role="2OqNvi">
-                                          <ref role="37wK5l" to="wvyf:4Q9g1gQP3R9" resolve="getTargetLink" />
-                                        </node>
-                                      </node>
-                                      <node concept="3TrEf2" id="4Q9g1gQPtiP" role="2OqNvi">
-                                        <ref role="3Tt5mk" to="tpce:fA0lvVK" resolve="target" />
-                                      </node>
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                          <node concept="2OqwBi" id="4Q9g1gQPd9C" role="37wK5m">
-                            <node concept="37vLTw" id="4Q9g1gQPd9D" role="2Oq$k0">
-                              <ref role="3cqZAo" node="4Q9g1gQP9rw" resolve="editorContext" />
-                            </node>
-                            <node concept="liA8E" id="4Q9g1gQPd9E" role="2OqNvi">
-                              <ref role="37wK5l" to="cj4x:~EditorContext.getModel()" resolve="getModel" />
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="_YKpA" id="4Q9g1gQPd9$" role="10QFUM">
-                          <node concept="3uibUv" id="4Q9g1gQPd9_" role="_ZDj9">
-                            <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="3zZkjj" id="231TZAqpeUL" role="2OqNvi">
-                      <node concept="1bVj0M" id="231TZAqpeUN" role="23t8la">
-                        <node concept="3clFbS" id="231TZAqpeUO" role="1bW5cS">
-                          <node concept="3clFbF" id="231TZAqphvO" role="3cqZAp">
-                            <node concept="3fqX7Q" id="231TZAqpij8" role="3clFbG">
-                              <node concept="2OqwBi" id="231TZAqpija" role="3fr31v">
-                                <node concept="37vLTw" id="231TZAqpijb" role="2Oq$k0">
-                                  <ref role="3cqZAo" node="231TZAqpeUP" resolve="it" />
-                                </node>
-                                <node concept="liA8E" id="231TZAqpijc" role="2OqNvi">
-                                  <ref role="37wK5l" to="c17a:~SAbstractConcept.isAbstract()" resolve="isAbstract" />
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="Rh6nW" id="231TZAqpeUP" role="1bW2Oz">
-                          <property role="TrG5h" value="it" />
-                          <node concept="2jxLKc" id="231TZAqpeUQ" role="1tU5fm" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3zZkjj" id="2RhI_xva4_4" role="2OqNvi">
-                    <node concept="1bVj0M" id="2RhI_xva4_6" role="23t8la">
-                      <node concept="3clFbS" id="2RhI_xva4_7" role="1bW5cS">
-                        <node concept="3clFbF" id="2RhI_xva5vo" role="3cqZAp">
-                          <node concept="2OqwBi" id="2RhI_xvbd1U" role="3clFbG">
-                            <node concept="2YIFZM" id="2RhI_xva6QX" role="2Oq$k0">
-                              <ref role="37wK5l" to="ykok:~ConstraintsCanBeFacade.checkCanBeChild(jetbrains.mps.core.aspects.constraints.rules.kinds.ContainmentContext)" resolve="checkCanBeChild" />
-                              <ref role="1Pybhc" to="ykok:~ConstraintsCanBeFacade" resolve="ConstraintsCanBeFacade" />
-                              <node concept="2OqwBi" id="2RhI_xvaK9M" role="37wK5m">
-                                <node concept="2OqwBi" id="2RhI_xvauIh" role="2Oq$k0">
-                                  <node concept="2OqwBi" id="2RhI_xvamYs" role="2Oq$k0">
-                                    <node concept="2OqwBi" id="2RhI_xvakAt" role="2Oq$k0">
-                                      <node concept="2ShNRf" id="2RhI_xva7HK" role="2Oq$k0">
-                                        <node concept="1pGfFk" id="2RhI_xvaiAm" role="2ShVmc">
-                                          <ref role="37wK5l" to="pdwk:~ContainmentContext$Builder.&lt;init&gt;()" resolve="ContainmentContext.Builder" />
-                                        </node>
-                                      </node>
-                                      <node concept="liA8E" id="2RhI_xvals5" role="2OqNvi">
-                                        <ref role="37wK5l" to="pdwk:~ContainmentContext$Builder.childConcept(org.jetbrains.mps.openapi.language.SAbstractConcept)" resolve="childConcept" />
-                                        <node concept="37vLTw" id="2RhI_xvamb6" role="37wK5m">
-                                          <ref role="3cqZAo" node="2RhI_xva4_8" resolve="it" />
-                                        </node>
-                                      </node>
-                                    </node>
-                                    <node concept="liA8E" id="2RhI_xvanAN" role="2OqNvi">
-                                      <ref role="37wK5l" to="pdwk:~ContainmentContext$Builder.parentNode(org.jetbrains.mps.openapi.model.SNode)" resolve="parentNode" />
-                                      <node concept="37vLTw" id="2RhI_xvatv8" role="37wK5m">
-                                        <ref role="3cqZAo" node="2RhI_xvat27" resolve="node" />
-                                      </node>
-                                    </node>
-                                  </node>
-                                  <node concept="liA8E" id="2RhI_xvavHj" role="2OqNvi">
-                                    <ref role="37wK5l" to="pdwk:~ContainmentContext$Builder.link(org.jetbrains.mps.openapi.language.SContainmentLink)" resolve="link" />
-                                    <node concept="359W_D" id="2RhI_xvawSH" role="37wK5m">
-                                      <ref role="359W_E" to="tpck:gw2VY9q" resolve="BaseConcept" />
-                                      <ref role="359W_F" to="tpck:4uZwTti3__2" resolve="smodelAttribute" />
-                                      <node concept="1ZhdrF" id="2RhI_xva_uk" role="lGtFl">
-                                        <property role="2qtEX8" value="conceptDeclaration" />
-                                        <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/2644386474301421077/2644386474301421078" />
-                                        <node concept="3$xsQk" id="2RhI_xva_ul" role="3$ytzL">
-                                          <node concept="3clFbS" id="2RhI_xva_um" role="2VODD2">
-                                            <node concept="3clFbF" id="2RhI_xvaAem" role="3cqZAp">
-                                              <node concept="2OqwBi" id="2RhI_xvaCxi" role="3clFbG">
-                                                <node concept="2OqwBi" id="2RhI_xvaAMo" role="2Oq$k0">
-                                                  <node concept="30H73N" id="2RhI_xvaAel" role="2Oq$k0" />
-                                                  <node concept="2qgKlT" id="2RhI_xvaBQc" role="2OqNvi">
-                                                    <ref role="37wK5l" to="wvyf:4Q9g1gQP3R9" resolve="getTargetLink" />
-                                                  </node>
-                                                </node>
-                                                <node concept="2qgKlT" id="2RhI_xvaDWS" role="2OqNvi">
-                                                  <ref role="37wK5l" to="tpcn:7jb4LXpbWaP" resolve="getConceptDeclaration" />
-                                                </node>
-                                              </node>
-                                            </node>
-                                          </node>
-                                        </node>
-                                      </node>
-                                      <node concept="1ZhdrF" id="2RhI_xvaENJ" role="lGtFl">
-                                        <property role="2qtEX8" value="linkDeclaration" />
-                                        <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/2644386474301421077/2644386474301421079" />
-                                        <node concept="3$xsQk" id="2RhI_xvaENK" role="3$ytzL">
-                                          <node concept="3clFbS" id="2RhI_xvaENL" role="2VODD2">
-                                            <node concept="3clFbF" id="2RhI_xvaFC0" role="3cqZAp">
-                                              <node concept="2OqwBi" id="2RhI_xvaGcO" role="3clFbG">
-                                                <node concept="30H73N" id="2RhI_xvaFBZ" role="2Oq$k0" />
-                                                <node concept="2qgKlT" id="2RhI_xvaGS_" role="2OqNvi">
-                                                  <ref role="37wK5l" to="wvyf:4Q9g1gQP3R9" resolve="getTargetLink" />
-                                                </node>
-                                              </node>
-                                            </node>
-                                          </node>
-                                        </node>
-                                      </node>
-                                    </node>
-                                  </node>
-                                </node>
-                                <node concept="liA8E" id="2RhI_xvaLey" role="2OqNvi">
-                                  <ref role="37wK5l" to="pdwk:~ContainmentContext$Builder.build()" resolve="build" />
-                                </node>
-                              </node>
-                            </node>
-                            <node concept="liA8E" id="2RhI_xvbf36" role="2OqNvi">
-                              <ref role="37wK5l" to="33ny:~List.isEmpty()" resolve="isEmpty" />
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="Rh6nW" id="2RhI_xva4_8" role="1bW2Oz">
-                        <property role="TrG5h" value="it" />
-                        <node concept="2jxLKc" id="2RhI_xva4_9" role="1tU5fm" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="3$u5V9" id="4Q9g1gQPe8H" role="2OqNvi">
-                  <node concept="1bVj0M" id="4Q9g1gQPe8J" role="23t8la">
-                    <node concept="3clFbS" id="4Q9g1gQPe8K" role="1bW5cS">
-                      <node concept="3clFbF" id="4Q9g1gQPf1N" role="3cqZAp">
-                        <node concept="2ShNRf" id="4Q9g1gQPf1L" role="3clFbG">
-                          <node concept="YeOm9" id="4Q9g1gQPfvm" role="2ShVmc">
-                            <node concept="1Y3b0j" id="4Q9g1gQPfvp" role="YeSDq">
-                              <property role="2bfB8j" value="true" />
-                              <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
-                              <ref role="1Y3XeK" to="4hco:4Q9g1gQNj1I" resolve="AbstractInsertHandler" />
-                              <node concept="3Tm1VV" id="4Q9g1gQPfvq" role="1B3o_S" />
-                              <node concept="3clFb_" id="4Q9g1gQPfvr" role="jymVt">
-                                <property role="1EzhhJ" value="false" />
-                                <property role="TrG5h" value="insert" />
-                                <node concept="37vLTG" id="4Q9g1gQPfvs" role="3clF46">
-                                  <property role="TrG5h" value="editorContext" />
-                                  <node concept="3uibUv" id="4Q9g1gQPfvt" role="1tU5fm">
-                                    <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
-                                  </node>
-                                </node>
-                                <node concept="37vLTG" id="4Q9g1gQPfvu" role="3clF46">
-                                  <property role="TrG5h" value="node" />
-                                  <node concept="3Tqbb2" id="4Q9g1gQPfvv" role="1tU5fm" />
-                                </node>
-                                <node concept="37vLTG" id="4Q9g1gQPfvw" role="3clF46">
-                                  <property role="TrG5h" value="index" />
-                                  <node concept="10Oyi0" id="4Q9g1gQPfvx" role="1tU5fm" />
-                                </node>
-                                <node concept="3cqZAl" id="4Q9g1gQPfvy" role="3clF45" />
-                                <node concept="3Tm1VV" id="4Q9g1gQPfvz" role="1B3o_S" />
-                                <node concept="3clFbS" id="4Q9g1gQPfv_" role="3clF47">
-                                  <node concept="3clFbF" id="4Q9g1gQPgdc" role="3cqZAp">
-                                    <node concept="2OqwBi" id="4Q9g1gQPgI9" role="3clFbG">
-                                      <node concept="liA8E" id="7n5r_AQRXFR" role="2OqNvi">
-                                        <ref role="37wK5l" to="33ny:~List.add(int,java.lang.Object)" resolve="add" />
-                                        <node concept="37vLTw" id="7n5r_AQRY8B" role="37wK5m">
-                                          <ref role="3cqZAo" node="4Q9g1gQPfvw" resolve="index" />
-                                        </node>
-                                        <node concept="1PxgMI" id="4Q9g1gQPrRC" role="37wK5m">
-                                          <node concept="2YIFZM" id="4Q9g1gQPpQt" role="1m5AlR">
-                                            <ref role="37wK5l" to="zce0:~NodeFactoryManager.createNode(org.jetbrains.mps.openapi.language.SAbstractConcept,org.jetbrains.mps.openapi.model.SNode,org.jetbrains.mps.openapi.model.SNode,org.jetbrains.mps.openapi.model.SModel)" resolve="createNode" />
-                                            <ref role="1Pybhc" to="zce0:~NodeFactoryManager" resolve="NodeFactoryManager" />
-                                            <node concept="37vLTw" id="4Q9g1gQPq6g" role="37wK5m">
-                                              <ref role="3cqZAo" node="4Q9g1gQPe8L" resolve="subconcept" />
-                                            </node>
-                                            <node concept="10Nm6u" id="4Q9g1gQPqrh" role="37wK5m" />
-                                            <node concept="37vLTw" id="4Q9g1gQPqNV" role="37wK5m">
-                                              <ref role="3cqZAo" node="4Q9g1gQPfvu" resolve="node" />
-                                            </node>
-                                            <node concept="2OqwBi" id="4Q9g1gQPruW" role="37wK5m">
-                                              <node concept="37vLTw" id="4Q9g1gQPrjF" role="2Oq$k0">
-                                                <ref role="3cqZAo" node="4Q9g1gQPfvs" resolve="editorContext" />
-                                              </node>
-                                              <node concept="liA8E" id="4Q9g1gQPrHS" role="2OqNvi">
-                                                <ref role="37wK5l" to="cj4x:~EditorContext.getModel()" resolve="getModel" />
-                                              </node>
-                                            </node>
-                                          </node>
-                                          <node concept="chp4Y" id="1SbcsM_ISe8" role="3oSUPX">
-                                            <ref role="cht4Q" to="tpck:4uZwTti3_$T" resolve="Attribute" />
-                                            <node concept="1ZhdrF" id="4Q9g1gQPtpY" role="lGtFl">
-                                              <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/1177026924588/1177026940964" />
-                                              <property role="2qtEX8" value="conceptDeclaration" />
-                                              <node concept="3$xsQk" id="4Q9g1gQPtpZ" role="3$ytzL">
-                                                <node concept="3clFbS" id="4Q9g1gQPtq0" role="2VODD2">
-                                                  <node concept="3clFbF" id="4Q9g1gQPtx5" role="3cqZAp">
-                                                    <node concept="2OqwBi" id="4Q9g1gQPtx7" role="3clFbG">
-                                                      <node concept="2OqwBi" id="4Q9g1gQPtx8" role="2Oq$k0">
-                                                        <node concept="30H73N" id="4Q9g1gQPtx9" role="2Oq$k0" />
-                                                        <node concept="2qgKlT" id="4Q9g1gQPtxa" role="2OqNvi">
-                                                          <ref role="37wK5l" to="wvyf:4Q9g1gQP3R9" resolve="getTargetLink" />
-                                                        </node>
-                                                      </node>
-                                                      <node concept="3TrEf2" id="4Q9g1gQPtxb" role="2OqNvi">
-                                                        <ref role="3Tt5mk" to="tpce:fA0lvVK" resolve="target" />
-                                                      </node>
-                                                    </node>
-                                                  </node>
-                                                </node>
-                                              </node>
-                                            </node>
-                                          </node>
-                                        </node>
-                                      </node>
-                                      <node concept="2OqwBi" id="4Q9g1gQPgjQ" role="2Oq$k0">
-                                        <node concept="37vLTw" id="4Q9g1gQPgdb" role="2Oq$k0">
-                                          <ref role="3cqZAo" node="4Q9g1gQPfvu" resolve="node" />
-                                        </node>
-                                        <node concept="3Tsc0h" id="4Q9g1gQPgnX" role="2OqNvi">
-                                          <ref role="3TtcxE" to="tpck:4uZwTti3__2" resolve="smodelAttribute" />
-                                          <node concept="1ZhdrF" id="4Q9g1gQPios" role="lGtFl">
-                                            <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/1138056282393/1138056546658" />
-                                            <property role="2qtEX8" value="link" />
-                                            <node concept="3$xsQk" id="4Q9g1gQPiot" role="3$ytzL">
-                                              <node concept="3clFbS" id="4Q9g1gQPiou" role="2VODD2">
-                                                <node concept="3clFbF" id="4Q9g1gQPjQW" role="3cqZAp">
-                                                  <node concept="2OqwBi" id="4Q9g1gQPjTI" role="3clFbG">
-                                                    <node concept="30H73N" id="4Q9g1gQPjQV" role="2Oq$k0" />
-                                                    <node concept="2qgKlT" id="4Q9g1gQPk2T" role="2OqNvi">
-                                                      <ref role="37wK5l" to="wvyf:4Q9g1gQP3R9" resolve="getTargetLink" />
-                                                    </node>
-                                                  </node>
-                                                </node>
-                                              </node>
-                                            </node>
-                                          </node>
-                                        </node>
-                                      </node>
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                              <node concept="3clFb_" id="4Q9g1gQPfvB" role="jymVt">
-                                <property role="1EzhhJ" value="false" />
-                                <property role="TrG5h" value="getDescription" />
-                                <node concept="17QB3L" id="4Q9g1gQPfvC" role="3clF45" />
-                                <node concept="3Tm1VV" id="4Q9g1gQPfvD" role="1B3o_S" />
-                                <node concept="3clFbS" id="4Q9g1gQPfvF" role="3clF47">
-                                  <node concept="3cpWs8" id="4Q9g1gQPy$H" role="3cqZAp">
-                                    <node concept="3cpWsn" id="4Q9g1gQPy$K" role="3cpWs9">
-                                      <property role="TrG5h" value="description" />
-                                      <node concept="17QB3L" id="4Q9g1gQPy$F" role="1tU5fm" />
-                                      <node concept="2OqwBi" id="4Q9g1gQPAE3" role="33vP2m">
-                                        <node concept="37vLTw" id="4Q9g1gQPAE4" role="2Oq$k0">
-                                          <ref role="3cqZAo" node="4Q9g1gQPe8L" resolve="subconcept" />
-                                        </node>
-                                        <node concept="liA8E" id="4Q9g1gQPAE5" role="2OqNvi">
-                                          <ref role="37wK5l" to="c17a:~SAbstractConcept.getConceptAlias()" resolve="getConceptAlias" />
-                                        </node>
-                                      </node>
-                                    </node>
-                                  </node>
-                                  <node concept="3clFbJ" id="4Q9g1gQP_7J" role="3cqZAp">
-                                    <node concept="3clFbS" id="4Q9g1gQP_7L" role="3clFbx">
-                                      <node concept="3clFbF" id="4Q9g1gQPyRr" role="3cqZAp">
-                                        <node concept="37vLTI" id="4Q9g1gQPyXw" role="3clFbG">
-                                          <node concept="2OqwBi" id="4Q9g1gQP$Bd" role="37vLTx">
-                                            <node concept="37vLTw" id="4Q9g1gQP$y8" role="2Oq$k0">
-                                              <ref role="3cqZAo" node="4Q9g1gQPe8L" resolve="subconcept" />
-                                            </node>
-                                            <node concept="liA8E" id="4Q9g1gQP$FS" role="2OqNvi">
-                                              <ref role="37wK5l" to="c17a:~SAbstractConcept.getName()" resolve="getName" />
-                                            </node>
-                                          </node>
-                                          <node concept="37vLTw" id="4Q9g1gQPyRq" role="37vLTJ">
-                                            <ref role="3cqZAo" node="4Q9g1gQPy$K" resolve="description" />
-                                          </node>
-                                        </node>
-                                      </node>
-                                    </node>
-                                    <node concept="2OqwBi" id="4Q9g1gQPAOS" role="3clFbw">
-                                      <node concept="37vLTw" id="4Q9g1gQP_hj" role="2Oq$k0">
-                                        <ref role="3cqZAo" node="4Q9g1gQPy$K" resolve="description" />
-                                      </node>
-                                      <node concept="17RlXB" id="4Q9g1gQPB1$" role="2OqNvi" />
-                                    </node>
-                                  </node>
-                                  <node concept="3clFbF" id="4Q9g1gQP_Kw" role="3cqZAp">
-                                    <node concept="37vLTw" id="4Q9g1gQP_Ku" role="3clFbG">
-                                      <ref role="3cqZAo" node="4Q9g1gQPy$K" resolve="description" />
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                              <node concept="3clFb_" id="4Q9g1gQPfvH" role="jymVt">
-                                <property role="1EzhhJ" value="false" />
-                                <property role="TrG5h" value="getIcon" />
-                                <node concept="3uibUv" id="4Q9g1gQPfvI" role="3clF45">
-                                  <ref role="3uigEE" to="dxuu:~Icon" resolve="Icon" />
-                                </node>
-                                <node concept="3Tm1VV" id="4Q9g1gQPfvJ" role="1B3o_S" />
-                                <node concept="3clFbS" id="4Q9g1gQPfvL" role="3clF47">
-                                  <node concept="3cpWs8" id="4Q9g1gQPW7u" role="3cqZAp">
-                                    <node concept="3cpWsn" id="4Q9g1gQPW7v" role="3cpWs9">
-                                      <property role="TrG5h" value="icon" />
-                                      <node concept="3uibUv" id="4Q9g1gQPW7c" role="1tU5fm">
-                                        <ref role="3uigEE" to="dxuu:~Icon" resolve="Icon" />
-                                      </node>
-                                      <node concept="10Nm6u" id="4Q9g1gQPWoY" role="33vP2m" />
-                                    </node>
-                                  </node>
-                                  <node concept="1QHqEK" id="4Q9g1gQPVon" role="3cqZAp">
-                                    <node concept="1QHqEC" id="4Q9g1gQPVop" role="1QHqEI">
-                                      <node concept="3clFbS" id="4Q9g1gQPVor" role="1bW5cS">
-                                        <node concept="3clFbF" id="4Q9g1gQPWaW" role="3cqZAp">
-                                          <node concept="37vLTI" id="4Q9g1gQPWaY" role="3clFbG">
-                                            <node concept="2OqwBi" id="VuyCfHHek7" role="37vLTx">
-                                              <node concept="2YIFZM" id="VuyCfHHe19" role="2Oq$k0">
-                                                <ref role="37wK5l" to="sn11:5UC$YgehaLf" resolve="getInstance" />
-                                                <ref role="1Pybhc" to="sn11:192HKKPMXeL" resolve="GlobalIconManager" />
-                                              </node>
-                                              <node concept="liA8E" id="VuyCfHHeWP" role="2OqNvi">
-                                                <ref role="37wK5l" to="sn11:192HKKPOcza" resolve="getIconFor" />
-                                                <node concept="37vLTw" id="VuyCfHHfdx" role="37wK5m">
-                                                  <ref role="3cqZAo" node="4Q9g1gQPe8L" resolve="subconcept" />
-                                                </node>
-                                              </node>
-                                            </node>
-                                            <node concept="37vLTw" id="4Q9g1gQPWb2" role="37vLTJ">
-                                              <ref role="3cqZAo" node="4Q9g1gQPW7v" resolve="icon" />
-                                            </node>
-                                          </node>
-                                        </node>
-                                      </node>
-                                    </node>
-                                    <node concept="2OqwBi" id="4Q9g1gQPW0T" role="ukAjM">
-                                      <node concept="37vLTw" id="4Q9g1gQPVOb" role="2Oq$k0">
-                                        <ref role="3cqZAo" node="4Q9g1gQP9rw" resolve="editorContext" />
-                                      </node>
-                                      <node concept="liA8E" id="4Q9g1gQPW4l" role="2OqNvi">
-                                        <ref role="37wK5l" to="cj4x:~EditorContext.getRepository()" resolve="getRepository" />
-                                      </node>
-                                    </node>
-                                  </node>
-                                  <node concept="3clFbF" id="4Q9g1gQPBll" role="3cqZAp">
-                                    <node concept="37vLTw" id="4Q9g1gQPW7y" role="3clFbG">
-                                      <ref role="3cqZAo" node="4Q9g1gQPW7v" resolve="icon" />
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="Rh6nW" id="4Q9g1gQPe8L" role="1bW2Oz">
-                      <property role="TrG5h" value="subconcept" />
-                      <property role="3TUv4t" value="true" />
-                      <node concept="2jxLKc" id="4Q9g1gQPe8M" role="1tU5fm" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="raruj" id="4Q9g1gQPjyC" role="lGtFl" />
-              </node>
-            </node>
-          </node>
-          <node concept="37vLTG" id="4Q9g1gQP9rw" role="3clF46">
-            <property role="TrG5h" value="editorContext" />
-            <property role="3TUv4t" value="true" />
-            <node concept="3uibUv" id="4Q9g1gQP9rv" role="1tU5fm">
-              <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
-            </node>
-          </node>
-          <node concept="37vLTG" id="2RhI_xvat27" role="3clF46">
-            <property role="TrG5h" value="node" />
-            <node concept="3Tqbb2" id="2RhI_xvat28" role="1tU5fm" />
           </node>
         </node>
       </node>
@@ -2604,6 +2151,102 @@
                   </node>
                 </node>
               </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="bUwia" id="7fqbBL2BxZl">
+    <property role="TrG5h" value="pre_main" />
+    <node concept="3aamgX" id="7fqbBL2A0pd" role="3acgRq">
+      <ref role="30HIoZ" to="hfvq:4Q9g1gQOGvj" resolve="SubconceptsInsertHandler" />
+      <node concept="gft3U" id="7fqbBL2A3ny" role="1lVwrX">
+        <node concept="LwBWP" id="7fqbBL2A3nC" role="gfFT$">
+          <node concept="Lw$WK" id="7fqbBL2A3nD" role="Lw1Oy">
+            <node concept="3clFbS" id="7fqbBL2A3nE" role="2VODD2">
+              <node concept="3clFbF" id="7fqbBL2A3qm" role="3cqZAp">
+                <node concept="2OqwBi" id="7fqbBL2A3FK" role="3clFbG">
+                  <node concept="Lmqva" id="7fqbBL2A3ql" role="2Oq$k0" />
+                  <node concept="3$u5V9" id="7fqbBL2A4hE" role="2OqNvi">
+                    <node concept="1bVj0M" id="7fqbBL2A4hG" role="23t8la">
+                      <node concept="3clFbS" id="7fqbBL2A4hH" role="1bW5cS">
+                        <node concept="3clFbF" id="7fqbBL2A4oS" role="3cqZAp">
+                          <node concept="2ShNRf" id="7fqbBL2A4oQ" role="3clFbG">
+                            <node concept="1pGfFk" id="7fqbBL2A6hG" role="2ShVmc">
+                              <ref role="37wK5l" to="4hco:7fqbBL2vcd$" resolve="DefaultInsertHandler" />
+                              <node concept="1Q80Hx" id="7fqbBL2A6on" role="37wK5m" />
+                              <node concept="37vLTw" id="7fqbBL2A6yt" role="37wK5m">
+                                <ref role="3cqZAo" node="7fqbBL2A4hI" resolve="subconcept" />
+                              </node>
+                              <node concept="359W_D" id="7fqbBL2A6D9" role="37wK5m">
+                                <ref role="359W_E" to="tpck:gw2VY9q" resolve="BaseConcept" />
+                                <ref role="359W_F" to="tpck:4uZwTti3__2" resolve="smodelAttribute" />
+                                <node concept="1ZhdrF" id="7fqbBL2A6Da" role="lGtFl">
+                                  <property role="2qtEX8" value="conceptDeclaration" />
+                                  <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/2644386474301421077/2644386474301421078" />
+                                  <node concept="3$xsQk" id="7fqbBL2A6Db" role="3$ytzL">
+                                    <node concept="3clFbS" id="7fqbBL2A6Dc" role="2VODD2">
+                                      <node concept="3clFbF" id="7fqbBL2A6Dd" role="3cqZAp">
+                                        <node concept="2OqwBi" id="7fqbBL2A6De" role="3clFbG">
+                                          <node concept="2OqwBi" id="7fqbBL2A6Df" role="2Oq$k0">
+                                            <node concept="30H73N" id="7fqbBL2A6Dg" role="2Oq$k0" />
+                                            <node concept="2qgKlT" id="7fqbBL2A6Dh" role="2OqNvi">
+                                              <ref role="37wK5l" to="wvyf:4Q9g1gQP3R9" resolve="getTargetLink" />
+                                            </node>
+                                          </node>
+                                          <node concept="2qgKlT" id="7fqbBL2A6Di" role="2OqNvi">
+                                            <ref role="37wK5l" to="tpcn:7jb4LXpbWaP" resolve="getConceptDeclaration" />
+                                          </node>
+                                        </node>
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                                <node concept="1ZhdrF" id="7fqbBL2A6Dj" role="lGtFl">
+                                  <property role="2qtEX8" value="linkDeclaration" />
+                                  <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/2644386474301421077/2644386474301421079" />
+                                  <node concept="3$xsQk" id="7fqbBL2A6Dk" role="3$ytzL">
+                                    <node concept="3clFbS" id="7fqbBL2A6Dl" role="2VODD2">
+                                      <node concept="3clFbF" id="7fqbBL2A6Dm" role="3cqZAp">
+                                        <node concept="2OqwBi" id="7fqbBL2A6Dn" role="3clFbG">
+                                          <node concept="30H73N" id="7fqbBL2A6Do" role="2Oq$k0" />
+                                          <node concept="2qgKlT" id="7fqbBL2A6Dp" role="2OqNvi">
+                                            <ref role="37wK5l" to="wvyf:4Q9g1gQP3R9" resolve="getTargetLink" />
+                                          </node>
+                                        </node>
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="Rh6nW" id="7fqbBL2A4hI" role="1bW2Oz">
+                        <property role="TrG5h" value="subconcept" />
+                        <node concept="2jxLKc" id="7fqbBL2A4hJ" role="1tU5fm" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="30G5F_" id="7fqbBL2A7do" role="30HLyM">
+        <node concept="3clFbS" id="7fqbBL2A7dp" role="2VODD2">
+          <node concept="3clFbF" id="7fqbBL2A7dq" role="3cqZAp">
+            <node concept="2OqwBi" id="7fqbBL2A7dr" role="3clFbG">
+              <node concept="2OqwBi" id="7fqbBL2A7ds" role="2Oq$k0">
+                <node concept="30H73N" id="7fqbBL2A7dt" role="2Oq$k0" />
+                <node concept="2qgKlT" id="7fqbBL2A7du" role="2OqNvi">
+                  <ref role="37wK5l" to="wvyf:4Q9g1gQP3R9" resolve="getTargetLink" />
+                </node>
+              </node>
+              <node concept="3x8VRR" id="7fqbBL2A7dv" role="2OqNvi" />
             </node>
           </node>
         </node>

--- a/code/treenotation/com.mbeddr.mpsutil.treenotation/models/behavior.mps
+++ b/code/treenotation/com.mbeddr.mpsutil.treenotation/models/behavior.mps
@@ -321,50 +321,6 @@
       </node>
     </node>
   </node>
-  <node concept="13h7C7" id="4Q9g1gQOGvo">
-    <property role="3GE5qa" value="handler" />
-    <ref role="13h7C2" to="hfvq:4Q9g1gQOGvj" resolve="SubconceptsInsertHandler" />
-    <node concept="13hLZK" id="4Q9g1gQOGvp" role="13h7CW">
-      <node concept="3clFbS" id="4Q9g1gQOGvq" role="2VODD2" />
-    </node>
-    <node concept="13i0hz" id="4Q9g1gQP3R9" role="13h7CS">
-      <property role="TrG5h" value="getTargetLink" />
-      <node concept="3Tm1VV" id="4Q9g1gQP3Ra" role="1B3o_S" />
-      <node concept="3clFbS" id="4Q9g1gQP3Rb" role="3clF47">
-        <node concept="3clFbF" id="4Q9g1gQP3Rv" role="3cqZAp">
-          <node concept="2OqwBi" id="4Q9g1gQP4Dx" role="3clFbG">
-            <node concept="1PxgMI" id="4Q9g1gQP4rY" role="2Oq$k0">
-              <property role="1BlNFB" value="true" />
-              <node concept="2OqwBi" id="4Q9g1gQP41D" role="1m5AlR">
-                <node concept="2OqwBi" id="4Q9g1gQP3Tx" role="2Oq$k0">
-                  <node concept="13iPFW" id="4Q9g1gQP3Ru" role="2Oq$k0" />
-                  <node concept="2Xjw5R" id="4Q9g1gQP3Xl" role="2OqNvi">
-                    <node concept="1xMEDy" id="4Q9g1gQP3Xn" role="1xVPHs">
-                      <node concept="chp4Y" id="4Q9g1gQP3XX" role="ri$Ld">
-                        <ref role="cht4Q" to="hfvq:7uOgiTbtk8" resolve="TreeCell" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="3TrEf2" id="4Q9g1gQP48e" role="2OqNvi">
-                  <ref role="3Tt5mk" to="hfvq:7uOgiTbtJT" resolve="treeChildren" />
-                </node>
-              </node>
-              <node concept="chp4Y" id="5RIakkDJ3RW" role="3oSUPX">
-                <ref role="cht4Q" to="tpc2:fBF2Hee" resolve="CellModel_RefNodeList" />
-              </node>
-            </node>
-            <node concept="3TrEf2" id="4Q9g1gQP4Sa" role="2OqNvi">
-              <ref role="3Tt5mk" to="tpc2:fBF2Hej" resolve="linkDeclaration" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tqbb2" id="4Q9g1gQP3Rp" role="3clF45">
-        <ref role="ehGHo" to="tpce:f_TJgxE" resolve="LinkDeclaration" />
-      </node>
-    </node>
-  </node>
   <node concept="13h7C7" id="7fqbBL2m65B">
     <property role="3GE5qa" value="handler" />
     <ref role="13h7C2" to="hfvq:7fqbBL2m65c" resolve="GenericInsertFunction" />
@@ -378,9 +334,34 @@
       <ref role="13i0hy" to="tpek:2xELmDxyi2v" resolve="getParameterConcepts" />
       <node concept="3Tm1VV" id="7fqbBL2oiPj" role="1B3o_S" />
       <node concept="3clFbS" id="7fqbBL2oiPk" role="3clF47">
+        <node concept="3cpWs8" id="7fqbBL2wT7f" role="3cqZAp">
+          <node concept="3cpWsn" id="7fqbBL2wT7g" role="3cpWs9">
+            <property role="TrG5h" value="params" />
+            <node concept="_YKpA" id="7fqbBL2wT6M" role="1tU5fm">
+              <node concept="3bZ5Sz" id="7fqbBL2wT6P" role="_ZDj9">
+                <ref role="3bZ5Sy" to="tpee:g76ryKb" resolve="ConceptFunctionParameter" />
+              </node>
+            </node>
+            <node concept="BsUDl" id="7fqbBL2wT7h" role="33vP2m">
+              <ref role="37wK5l" node="7fqbBL2oi0G" resolve="getStandardParameters" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7fqbBL2wTa5" role="3cqZAp">
+          <node concept="2OqwBi" id="7fqbBL2wTNV" role="3clFbG">
+            <node concept="37vLTw" id="7fqbBL2wTa3" role="2Oq$k0">
+              <ref role="3cqZAo" node="7fqbBL2wT7g" resolve="params" />
+            </node>
+            <node concept="TSZUe" id="7fqbBL2wUBz" role="2OqNvi">
+              <node concept="35c_gC" id="7fqbBL2wUNM" role="25WWJ7">
+                <ref role="35c_gD" to="hfvq:7fqbBL2wSAQ" resolve="Parameter_subconcepts" />
+              </node>
+            </node>
+          </node>
+        </node>
         <node concept="3clFbF" id="7fqbBL2oiXz" role="3cqZAp">
-          <node concept="BsUDl" id="7fqbBL2oiXy" role="3clFbG">
-            <ref role="37wK5l" node="7fqbBL2oi0G" resolve="getStandardParameters" />
+          <node concept="37vLTw" id="7fqbBL2wT7i" role="3clFbG">
+            <ref role="3cqZAo" node="7fqbBL2wT7g" resolve="params" />
           </node>
         </node>
       </node>
@@ -521,6 +502,76 @@
     </node>
     <node concept="13hLZK" id="7fqbBL2oirM" role="13h7CW">
       <node concept="3clFbS" id="7fqbBL2oirN" role="2VODD2" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="7fqbBL2wSD$">
+    <property role="3GE5qa" value="handler" />
+    <ref role="13h7C2" to="hfvq:7fqbBL2wSAQ" resolve="Parameter_subconcepts" />
+    <node concept="13i0hz" id="7fqbBL2wSDJ" role="13h7CS">
+      <property role="TrG5h" value="getType" />
+      <property role="13i0it" value="false" />
+      <property role="13i0iv" value="false" />
+      <ref role="13i0hy" to="tpek:27DJnJtIQ9C" resolve="getType" />
+      <node concept="3Tm1VV" id="7fqbBL2wSDK" role="1B3o_S" />
+      <node concept="3clFbS" id="7fqbBL2wSDL" role="3clF47">
+        <node concept="3clFbF" id="7fqbBL2wSDM" role="3cqZAp">
+          <node concept="2c44tf" id="7fqbBL2wSDN" role="3clFbG">
+            <node concept="A3Dl8" id="7fqbBL2vCV9" role="2c44tc">
+              <node concept="3bZ5Sz" id="7fqbBL2vCVa" role="A3Ik2" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tqbb2" id="7fqbBL2wSDP" role="3clF45">
+        <ref role="ehGHo" to="tpee:fz3vP1H" resolve="Type" />
+      </node>
+    </node>
+    <node concept="13hLZK" id="7fqbBL2wSD_" role="13h7CW">
+      <node concept="3clFbS" id="7fqbBL2wSDA" role="2VODD2" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="7fqbBL2xGmc">
+    <property role="3GE5qa" value="handler" />
+    <ref role="13h7C2" to="hfvq:4Q9g1gQN5nv" resolve="IInsertHandler" />
+    <node concept="13i0hz" id="4Q9g1gQP3R9" role="13h7CS">
+      <property role="TrG5h" value="getTargetLink" />
+      <node concept="3Tm1VV" id="4Q9g1gQP3Ra" role="1B3o_S" />
+      <node concept="3clFbS" id="4Q9g1gQP3Rb" role="3clF47">
+        <node concept="3clFbF" id="4Q9g1gQP3Rv" role="3cqZAp">
+          <node concept="2OqwBi" id="4Q9g1gQP4Dx" role="3clFbG">
+            <node concept="1PxgMI" id="4Q9g1gQP4rY" role="2Oq$k0">
+              <property role="1BlNFB" value="true" />
+              <node concept="2OqwBi" id="4Q9g1gQP41D" role="1m5AlR">
+                <node concept="2OqwBi" id="4Q9g1gQP3Tx" role="2Oq$k0">
+                  <node concept="13iPFW" id="4Q9g1gQP3Ru" role="2Oq$k0" />
+                  <node concept="2Xjw5R" id="4Q9g1gQP3Xl" role="2OqNvi">
+                    <node concept="1xMEDy" id="4Q9g1gQP3Xn" role="1xVPHs">
+                      <node concept="chp4Y" id="4Q9g1gQP3XX" role="ri$Ld">
+                        <ref role="cht4Q" to="hfvq:7uOgiTbtk8" resolve="TreeCell" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3TrEf2" id="4Q9g1gQP48e" role="2OqNvi">
+                  <ref role="3Tt5mk" to="hfvq:7uOgiTbtJT" resolve="treeChildren" />
+                </node>
+              </node>
+              <node concept="chp4Y" id="5RIakkDJ3RW" role="3oSUPX">
+                <ref role="cht4Q" to="tpc2:fBF2Hee" resolve="CellModel_RefNodeList" />
+              </node>
+            </node>
+            <node concept="3TrEf2" id="4Q9g1gQP4Sa" role="2OqNvi">
+              <ref role="3Tt5mk" to="tpc2:fBF2Hej" resolve="linkDeclaration" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tqbb2" id="4Q9g1gQP3Rp" role="3clF45">
+        <ref role="ehGHo" to="tpce:f_TJgxE" resolve="LinkDeclaration" />
+      </node>
+    </node>
+    <node concept="13hLZK" id="7fqbBL2xGmd" role="13h7CW">
+      <node concept="3clFbS" id="7fqbBL2xGme" role="2VODD2" />
     </node>
   </node>
 </model>

--- a/code/treenotation/com.mbeddr.mpsutil.treenotation/models/behavior.mps
+++ b/code/treenotation/com.mbeddr.mpsutil.treenotation/models/behavior.mps
@@ -12,10 +12,12 @@
     <import index="fbzs" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt.geom(JDK/)" />
     <import index="hfvq" ref="r:0eb4b752-afe1-4ade-9bab-3975c6c0405f(com.mbeddr.mpsutil.treenotation.structure)" />
     <import index="tpce" ref="r:00000000-0000-4000-0000-011c89590292(jetbrains.mps.lang.structure.structure)" />
+    <import index="4hco" ref="r:55549eb8-b827-44b3-bd84-ef3114bd2fe2(com.mbeddr.mpsutil.treenotation.runtime)" />
     <import index="tpc2" ref="r:00000000-0000-4000-0000-011c8959029e(jetbrains.mps.lang.editor.structure)" implicit="true" />
   </imports>
   <registry>
     <language id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior">
+      <concept id="6496299201655527393" name="jetbrains.mps.lang.behavior.structure.LocalBehaviorMethodCall" flags="nn" index="BsUDl" />
       <concept id="1225194240794" name="jetbrains.mps.lang.behavior.structure.ConceptBehavior" flags="ng" index="13h7C7">
         <reference id="1225194240799" name="concept" index="13h7C2" />
         <child id="1225194240805" name="method" index="13h7CS" />
@@ -67,6 +69,9 @@
         <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
       </concept>
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+      </concept>
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
       </concept>
@@ -74,6 +79,7 @@
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+      <concept id="1146644641414" name="jetbrains.mps.baseLanguage.structure.ProtectedVisibility" flags="nn" index="3Tmbuc" />
     </language>
     <language id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation">
       <concept id="1196350785113" name="jetbrains.mps.lang.quotation.structure.Quotation" flags="nn" index="2c44tf">
@@ -112,6 +118,9 @@
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+      </concept>
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
@@ -123,6 +132,9 @@
       <concept id="1151688443754" name="jetbrains.mps.baseLanguage.collections.structure.ListType" flags="in" index="_YKpA">
         <child id="1151688676805" name="elementType" index="_ZDj9" />
       </concept>
+      <concept id="1151689724996" name="jetbrains.mps.baseLanguage.collections.structure.SequenceType" flags="in" index="A3Dl8">
+        <child id="1151689745422" name="elementType" index="A3Ik2" />
+      </concept>
       <concept id="1237721394592" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerCreator" flags="nn" index="HWqM0">
         <child id="1237721435808" name="initValue" index="HW$Y0" />
         <child id="1237721435807" name="elementType" index="HW$YZ" />
@@ -132,6 +144,7 @@
     </language>
   </registry>
   <node concept="13h7C7" id="7GMtHW6w$oQ">
+    <property role="3GE5qa" value="handler" />
     <ref role="13h7C2" to="hfvq:7GMtHW6w$oP" resolve="DeleteHandler" />
     <node concept="13hLZK" id="7GMtHW6w$oR" role="13h7CW">
       <node concept="3clFbS" id="7GMtHW6w$oS" role="2VODD2" />
@@ -197,85 +210,8 @@
       </node>
     </node>
   </node>
-  <node concept="13h7C7" id="7GMtHW6yJv3">
-    <ref role="13h7C2" to="hfvq:7GMtHW6yJv2" resolve="InserHandler" />
-    <node concept="13i0hz" id="7GMtHW6yJv6" role="13h7CS">
-      <property role="13i0iv" value="false" />
-      <property role="TrG5h" value="getParameterConcepts" />
-      <property role="13i0it" value="false" />
-      <ref role="13i0hy" to="tpek:2xELmDxyi2v" resolve="getParameterConcepts" />
-      <node concept="3Tm1VV" id="7GMtHW6yJv9" role="1B3o_S" />
-      <node concept="3clFbS" id="7GMtHW6yJva" role="3clF47">
-        <node concept="3cpWs8" id="7GMtHW6yJvb" role="3cqZAp">
-          <node concept="3cpWsn" id="7GMtHW6yJvc" role="3cpWs9">
-            <property role="TrG5h" value="result" />
-            <node concept="2ShNRf" id="7GMtHW6yJvd" role="33vP2m">
-              <node concept="Tc6Ow" id="7GMtHW6yJve" role="2ShVmc">
-                <node concept="3bZ5Sz" id="1zqEQG3WoIb" role="HW$YZ">
-                  <ref role="3bZ5Sy" to="tpee:g76ryKb" resolve="ConceptFunctionParameter" />
-                </node>
-              </node>
-            </node>
-            <node concept="_YKpA" id="7GMtHW6yJvg" role="1tU5fm">
-              <node concept="3bZ5Sz" id="1zqEQG3WoIc" role="_ZDj9">
-                <ref role="3bZ5Sy" to="tpee:g76ryKb" resolve="ConceptFunctionParameter" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="7GMtHW6yJvi" role="3cqZAp">
-          <node concept="2OqwBi" id="7GMtHW6yJvj" role="3clFbG">
-            <node concept="TSZUe" id="7GMtHW6yJvk" role="2OqNvi">
-              <node concept="35c_gC" id="1zqEQG3WoI8" role="25WWJ7">
-                <ref role="35c_gD" to="tpc2:gTQ80DJ" resolve="ConceptFunctionParameter_editorContext" />
-              </node>
-            </node>
-            <node concept="37vLTw" id="7GMtHW6yJvm" role="2Oq$k0">
-              <ref role="3cqZAo" node="7GMtHW6yJvc" resolve="result" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="7GMtHW6yJvn" role="3cqZAp">
-          <node concept="2OqwBi" id="7GMtHW6yJvo" role="3clFbG">
-            <node concept="TSZUe" id="7GMtHW6yJvp" role="2OqNvi">
-              <node concept="35c_gC" id="1zqEQG3WoI9" role="25WWJ7">
-                <ref role="35c_gD" to="tpc2:gCpncv5" resolve="ConceptFunctionParameter_node" />
-              </node>
-            </node>
-            <node concept="37vLTw" id="7GMtHW6yJvr" role="2Oq$k0">
-              <ref role="3cqZAo" node="7GMtHW6yJvc" resolve="result" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="7GMtHW6yJyV" role="3cqZAp">
-          <node concept="2OqwBi" id="7GMtHW6yJyW" role="3clFbG">
-            <node concept="TSZUe" id="7GMtHW6yJyX" role="2OqNvi">
-              <node concept="35c_gC" id="1zqEQG3WoIa" role="25WWJ7">
-                <ref role="35c_gD" to="hfvq:7GMtHW6yJ$P" resolve="Parameter_index" />
-              </node>
-            </node>
-            <node concept="37vLTw" id="7GMtHW6yJyZ" role="2Oq$k0">
-              <ref role="3cqZAo" node="7GMtHW6yJvc" resolve="result" />
-            </node>
-          </node>
-        </node>
-        <node concept="3cpWs6" id="7GMtHW6yJvs" role="3cqZAp">
-          <node concept="37vLTw" id="7GMtHW6yJvt" role="3cqZAk">
-            <ref role="3cqZAo" node="7GMtHW6yJvc" resolve="result" />
-          </node>
-        </node>
-      </node>
-      <node concept="_YKpA" id="1zqEQG3WoI6" role="3clF45">
-        <node concept="3bZ5Sz" id="1zqEQG3WoI7" role="_ZDj9">
-          <ref role="3bZ5Sy" to="tpee:g76ryKb" resolve="ConceptFunctionParameter" />
-        </node>
-      </node>
-    </node>
-    <node concept="13hLZK" id="7GMtHW6yJv4" role="13h7CW">
-      <node concept="3clFbS" id="7GMtHW6yJv5" role="2VODD2" />
-    </node>
-  </node>
   <node concept="13h7C7" id="7GMtHW6yJ$Q">
+    <property role="3GE5qa" value="handler" />
     <ref role="13h7C2" to="hfvq:7GMtHW6yJ$P" resolve="Parameter_index" />
     <node concept="13hLZK" id="7GMtHW6yJ$R" role="13h7CW">
       <node concept="3clFbS" id="7GMtHW6yJ$S" role="2VODD2" />
@@ -386,6 +322,7 @@
     </node>
   </node>
   <node concept="13h7C7" id="4Q9g1gQOGvo">
+    <property role="3GE5qa" value="handler" />
     <ref role="13h7C2" to="hfvq:4Q9g1gQOGvj" resolve="SubconceptsInsertHandler" />
     <node concept="13hLZK" id="4Q9g1gQOGvp" role="13h7CW">
       <node concept="3clFbS" id="4Q9g1gQOGvq" role="2VODD2" />
@@ -426,6 +363,164 @@
       <node concept="3Tqbb2" id="4Q9g1gQP3Rp" role="3clF45">
         <ref role="ehGHo" to="tpce:f_TJgxE" resolve="LinkDeclaration" />
       </node>
+    </node>
+  </node>
+  <node concept="13h7C7" id="7fqbBL2m65B">
+    <property role="3GE5qa" value="handler" />
+    <ref role="13h7C2" to="hfvq:7fqbBL2m65c" resolve="GenericInsertFunction" />
+    <node concept="13hLZK" id="7fqbBL2m65C" role="13h7CW">
+      <node concept="3clFbS" id="7fqbBL2m65D" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="7fqbBL2oiPi" role="13h7CS">
+      <property role="13i0iv" value="false" />
+      <property role="TrG5h" value="getParameterConcepts" />
+      <property role="13i0it" value="false" />
+      <ref role="13i0hy" to="tpek:2xELmDxyi2v" resolve="getParameterConcepts" />
+      <node concept="3Tm1VV" id="7fqbBL2oiPj" role="1B3o_S" />
+      <node concept="3clFbS" id="7fqbBL2oiPk" role="3clF47">
+        <node concept="3clFbF" id="7fqbBL2oiXz" role="3cqZAp">
+          <node concept="BsUDl" id="7fqbBL2oiXy" role="3clFbG">
+            <ref role="37wK5l" node="7fqbBL2oi0G" resolve="getStandardParameters" />
+          </node>
+        </node>
+      </node>
+      <node concept="_YKpA" id="7fqbBL2oiPx" role="3clF45">
+        <node concept="3bZ5Sz" id="7fqbBL2oiPy" role="_ZDj9">
+          <ref role="3bZ5Sy" to="tpee:g76ryKb" resolve="ConceptFunctionParameter" />
+        </node>
+      </node>
+    </node>
+    <node concept="13i0hz" id="7fqbBL2myQ8" role="13h7CS">
+      <property role="TrG5h" value="getExpectedReturnType" />
+      <ref role="13i0hy" to="tpek:hEwIGRD" resolve="getExpectedReturnType" />
+      <node concept="3Tm1VV" id="7fqbBL2myQc" role="1B3o_S" />
+      <node concept="3clFbS" id="7fqbBL2myQe" role="3clF47">
+        <node concept="3clFbF" id="7fqbBL2mz1_" role="3cqZAp">
+          <node concept="2c44tf" id="7fqbBL2mz1z" role="3clFbG">
+            <node concept="A3Dl8" id="7fqbBL2mz24" role="2c44tc">
+              <node concept="3uibUv" id="7fqbBL2mz31" role="A3Ik2">
+                <ref role="3uigEE" to="4hco:7GMtHW6y0BZ" resolve="IInsertHandler" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tqbb2" id="7fqbBL2myQf" role="3clF45" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="7fqbBL2myeS">
+    <property role="3GE5qa" value="handler" />
+    <ref role="13h7C2" to="hfvq:7fqbBL2mxWc" resolve="AbstractInsertFunction" />
+    <node concept="13i0hz" id="7fqbBL2oi0G" role="13h7CS">
+      <property role="TrG5h" value="getStandardParameters" />
+      <node concept="3Tmbuc" id="7fqbBL2oi1p" role="1B3o_S" />
+      <node concept="_YKpA" id="7fqbBL2oi1$" role="3clF45">
+        <node concept="3bZ5Sz" id="7fqbBL2oi1K" role="_ZDj9">
+          <ref role="3bZ5Sy" to="tpee:g76ryKb" resolve="ConceptFunctionParameter" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="7fqbBL2oi0J" role="3clF47">
+        <node concept="3cpWs8" id="7fqbBL2oi2r" role="3cqZAp">
+          <node concept="3cpWsn" id="7fqbBL2oi2s" role="3cpWs9">
+            <property role="TrG5h" value="result" />
+            <node concept="2ShNRf" id="7fqbBL2oi2t" role="33vP2m">
+              <node concept="Tc6Ow" id="7fqbBL2oi2u" role="2ShVmc">
+                <node concept="3bZ5Sz" id="7fqbBL2oi2v" role="HW$YZ">
+                  <ref role="3bZ5Sy" to="tpee:g76ryKb" resolve="ConceptFunctionParameter" />
+                </node>
+              </node>
+            </node>
+            <node concept="_YKpA" id="7fqbBL2oi2w" role="1tU5fm">
+              <node concept="3bZ5Sz" id="7fqbBL2oi2x" role="_ZDj9">
+                <ref role="3bZ5Sy" to="tpee:g76ryKb" resolve="ConceptFunctionParameter" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7fqbBL2oi2y" role="3cqZAp">
+          <node concept="2OqwBi" id="7fqbBL2oi2z" role="3clFbG">
+            <node concept="TSZUe" id="7fqbBL2oi2$" role="2OqNvi">
+              <node concept="35c_gC" id="7fqbBL2oi2_" role="25WWJ7">
+                <ref role="35c_gD" to="tpc2:gTQ80DJ" resolve="ConceptFunctionParameter_editorContext" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="7fqbBL2oi2A" role="2Oq$k0">
+              <ref role="3cqZAo" node="7fqbBL2oi2s" resolve="result" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7fqbBL2oi2B" role="3cqZAp">
+          <node concept="2OqwBi" id="7fqbBL2oi2C" role="3clFbG">
+            <node concept="TSZUe" id="7fqbBL2oi2D" role="2OqNvi">
+              <node concept="35c_gC" id="7fqbBL2oi2E" role="25WWJ7">
+                <ref role="35c_gD" to="tpc2:gCpncv5" resolve="ConceptFunctionParameter_node" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="7fqbBL2oi2F" role="2Oq$k0">
+              <ref role="3cqZAo" node="7fqbBL2oi2s" resolve="result" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="7fqbBL2oiko" role="3cqZAp">
+          <node concept="37vLTw" id="7fqbBL2oinQ" role="3cqZAk">
+            <ref role="3cqZAo" node="7fqbBL2oi2s" resolve="result" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="13hLZK" id="7fqbBL2myeT" role="13h7CW">
+      <node concept="3clFbS" id="7fqbBL2myeU" role="2VODD2" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="7fqbBL2oirL">
+    <property role="3GE5qa" value="handler" />
+    <ref role="13h7C2" to="hfvq:7GMtHW6yJv2" resolve="SimpleInsertFunction" />
+    <node concept="13i0hz" id="7fqbBL2myf3" role="13h7CS">
+      <property role="13i0iv" value="false" />
+      <property role="TrG5h" value="getParameterConcepts" />
+      <property role="13i0it" value="false" />
+      <ref role="13i0hy" to="tpek:2xELmDxyi2v" resolve="getParameterConcepts" />
+      <node concept="3Tm1VV" id="7fqbBL2myf4" role="1B3o_S" />
+      <node concept="3clFbS" id="7fqbBL2myf5" role="3clF47">
+        <node concept="3cpWs8" id="7fqbBL2myf6" role="3cqZAp">
+          <node concept="3cpWsn" id="7fqbBL2myf7" role="3cpWs9">
+            <property role="TrG5h" value="result" />
+            <node concept="BsUDl" id="7fqbBL2oiIe" role="33vP2m">
+              <ref role="37wK5l" node="7fqbBL2oi0G" resolve="getStandardParameters" />
+            </node>
+            <node concept="_YKpA" id="7fqbBL2myfb" role="1tU5fm">
+              <node concept="3bZ5Sz" id="7fqbBL2myfc" role="_ZDj9">
+                <ref role="3bZ5Sy" to="tpee:g76ryKb" resolve="ConceptFunctionParameter" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7fqbBL2myfn" role="3cqZAp">
+          <node concept="2OqwBi" id="7fqbBL2myfo" role="3clFbG">
+            <node concept="TSZUe" id="7fqbBL2myfp" role="2OqNvi">
+              <node concept="35c_gC" id="7fqbBL2myfq" role="25WWJ7">
+                <ref role="35c_gD" to="hfvq:7GMtHW6yJ$P" resolve="Parameter_index" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="7fqbBL2myfr" role="2Oq$k0">
+              <ref role="3cqZAo" node="7fqbBL2myf7" resolve="result" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="7fqbBL2myfs" role="3cqZAp">
+          <node concept="37vLTw" id="7fqbBL2myft" role="3cqZAk">
+            <ref role="3cqZAo" node="7fqbBL2myf7" resolve="result" />
+          </node>
+        </node>
+      </node>
+      <node concept="_YKpA" id="7fqbBL2myfu" role="3clF45">
+        <node concept="3bZ5Sz" id="7fqbBL2myfv" role="_ZDj9">
+          <ref role="3bZ5Sy" to="tpee:g76ryKb" resolve="ConceptFunctionParameter" />
+        </node>
+      </node>
+    </node>
+    <node concept="13hLZK" id="7fqbBL2oirM" role="13h7CW">
+      <node concept="3clFbS" id="7fqbBL2oirN" role="2VODD2" />
     </node>
   </node>
 </model>

--- a/code/treenotation/com.mbeddr.mpsutil.treenotation/models/editor.mps
+++ b/code/treenotation/com.mbeddr.mpsutil.treenotation/models/editor.mps
@@ -520,6 +520,7 @@
     </node>
   </node>
   <node concept="24kQdi" id="4Q9g1gQN5nT">
+    <property role="3GE5qa" value="handler" />
     <ref role="1XX52x" to="hfvq:4Q9g1gQN5nw" resolve="SimpleInsertHandler" />
     <node concept="3EZMnI" id="4Q9g1gQN5o2" role="2wV5jI">
       <node concept="l2Vlx" id="4Q9g1gQN5o3" role="2iSdaV" />
@@ -544,6 +545,7 @@
     </node>
   </node>
   <node concept="24kQdi" id="4Q9g1gQQ0Yr">
+    <property role="3GE5qa" value="handler" />
     <ref role="1XX52x" to="hfvq:4Q9g1gQOGvj" resolve="SubconceptsInsertHandler" />
     <node concept="PMmxH" id="4Q9g1gQQ0Yt" role="2wV5jI">
       <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
@@ -554,6 +556,25 @@
     <ref role="1XX52x" to="hfvq:2rPTijxM72O" resolve="AbstractTreeLayout" />
     <node concept="PMmxH" id="2rPTijxM738" role="2wV5jI">
       <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
+    </node>
+  </node>
+  <node concept="24kQdi" id="7fqbBL2mzdU">
+    <property role="3GE5qa" value="handler" />
+    <ref role="1XX52x" to="hfvq:7fqbBL2m559" resolve="GenericInsertHandler" />
+    <node concept="3EZMnI" id="7fqbBL2mzdW" role="2wV5jI">
+      <node concept="l2Vlx" id="7fqbBL2mzdX" role="2iSdaV" />
+      <node concept="PMmxH" id="7fqbBL2mzdY" role="3EZMnx">
+        <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
+      </node>
+      <node concept="3F1sOY" id="7fqbBL2mze1" role="3EZMnx">
+        <ref role="1NtTu8" to="hfvq:7fqbBL2mzdu" resolve="insertFunction" />
+        <node concept="lj46D" id="7fqbBL2mze2" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+        <node concept="ljvvj" id="7fqbBL2mze3" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
     </node>
   </node>
 </model>

--- a/code/treenotation/com.mbeddr.mpsutil.treenotation/models/structure.mps
+++ b/code/treenotation/com.mbeddr.mpsutil.treenotation/models/structure.mps
@@ -383,5 +383,12 @@
     <property role="R5$K7" value="true" />
     <ref role="1TJDcQ" to="tpee:gyVMwX8" resolve="ConceptFunction" />
   </node>
+  <node concept="1TIwiD" id="7fqbBL2wSAQ">
+    <property role="TrG5h" value="Parameter_subconcepts" />
+    <property role="34LRSv" value="subconcepts" />
+    <property role="EcuMT" value="8348035970511374774" />
+    <property role="3GE5qa" value="handler" />
+    <ref role="1TJDcQ" to="tpee:g76ryKb" resolve="ConceptFunctionParameter" />
+  </node>
 </model>
 

--- a/code/treenotation/com.mbeddr.mpsutil.treenotation/models/structure.mps
+++ b/code/treenotation/com.mbeddr.mpsutil.treenotation/models/structure.mps
@@ -7,7 +7,7 @@
   </languages>
   <imports>
     <import index="tpc2" ref="r:00000000-0000-4000-0000-011c8959029e(jetbrains.mps.lang.editor.structure)" />
-    <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" implicit="true" />
+    <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
   </imports>
   <registry>
@@ -82,7 +82,7 @@
       <property role="20lmBu" value="fLJjDmT/aggregation" />
       <property role="20kJfa" value="insertHandler" />
       <property role="IQ2ns" value="8877288515760225002" />
-      <ref role="20lvS9" node="7GMtHW6yJv2" resolve="InserHandler" />
+      <ref role="20lvS9" node="7GMtHW6yJv2" resolve="SimpleInsertFunction" />
       <node concept="asaX9" id="4Q9g1gQNbx6" role="lGtFl" />
     </node>
     <node concept="1TJgyj" id="4Q9g1gQN8_F" role="1TKVEi">
@@ -123,17 +123,20 @@
   <node concept="1TIwiD" id="7GMtHW6w$oP">
     <property role="TrG5h" value="DeleteHandler" />
     <property role="EcuMT" value="8877288515759654453" />
+    <property role="3GE5qa" value="handler" />
     <ref role="1TJDcQ" to="tpee:gyVMwX8" resolve="ConceptFunction" />
   </node>
   <node concept="1TIwiD" id="7GMtHW6yJv2">
-    <property role="TrG5h" value="InserHandler" />
+    <property role="TrG5h" value="SimpleInsertFunction" />
     <property role="EcuMT" value="8877288515760224194" />
-    <ref role="1TJDcQ" to="tpee:gyVMwX8" resolve="ConceptFunction" />
+    <property role="3GE5qa" value="handler" />
+    <ref role="1TJDcQ" node="7fqbBL2mxWc" resolve="AbstractInsertFunction" />
   </node>
   <node concept="1TIwiD" id="7GMtHW6yJ$P">
     <property role="TrG5h" value="Parameter_index" />
     <property role="34LRSv" value="index" />
     <property role="EcuMT" value="8877288515760224565" />
+    <property role="3GE5qa" value="handler" />
     <ref role="1TJDcQ" to="tpee:g76ryKb" resolve="ConceptFunctionParameter" />
   </node>
   <node concept="1TIwiD" id="7GMtHW6DEF1">
@@ -278,18 +281,20 @@
   <node concept="PlHQZ" id="4Q9g1gQN5nv">
     <property role="TrG5h" value="IInsertHandler" />
     <property role="EcuMT" value="5587067268292695519" />
+    <property role="3GE5qa" value="handler" />
   </node>
   <node concept="1TIwiD" id="4Q9g1gQN5nw">
     <property role="TrG5h" value="SimpleInsertHandler" />
     <property role="34LRSv" value="simple" />
     <property role="EcuMT" value="5587067268292695520" />
+    <property role="3GE5qa" value="handler" />
     <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
     <node concept="1TJgyj" id="4Q9g1gQN5n_" role="1TKVEi">
       <property role="20lmBu" value="fLJjDmT/aggregation" />
       <property role="20kJfa" value="insertFunction" />
       <property role="20lbJX" value="fLJekj4/_1" />
       <property role="IQ2ns" value="5587067268292695525" />
-      <ref role="20lvS9" node="7GMtHW6yJv2" resolve="InserHandler" />
+      <ref role="20lvS9" node="7GMtHW6yJv2" resolve="SimpleInsertFunction" />
     </node>
     <node concept="PrWs8" id="4Q9g1gQN5nx" role="PzmwI">
       <ref role="PrY4T" node="4Q9g1gQN5nv" resolve="IInsertHandler" />
@@ -304,6 +309,7 @@
     <property role="TrG5h" value="SubconceptsInsertHandler" />
     <property role="34LRSv" value="subconcepts" />
     <property role="EcuMT" value="5587067268293117907" />
+    <property role="3GE5qa" value="handler" />
     <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
     <node concept="PrWs8" id="4Q9g1gQOGvk" role="PzmwI">
       <ref role="PrY4T" node="4Q9g1gQN5nv" resolve="IInsertHandler" />
@@ -345,6 +351,37 @@
     <property role="TrG5h" value="CompactTreeLayout" />
     <property role="34LRSv" value="compact" />
     <ref role="1TJDcQ" node="2rPTijxM72O" resolve="AbstractTreeLayout" />
+  </node>
+  <node concept="1TIwiD" id="7fqbBL2m559">
+    <property role="EcuMT" value="8348035970508542281" />
+    <property role="TrG5h" value="GenericInsertHandler" />
+    <property role="34LRSv" value="generic" />
+    <property role="3GE5qa" value="handler" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+    <node concept="1TJgyj" id="7fqbBL2mzdu" role="1TKVEi">
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="insertFunction" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <property role="IQ2ns" value="8348035970508665694" />
+      <ref role="20lvS9" node="7fqbBL2m65c" resolve="GenericInsertFunction" />
+    </node>
+    <node concept="PrWs8" id="7fqbBL2m55a" role="PzmwI">
+      <ref role="PrY4T" node="4Q9g1gQN5nv" resolve="IInsertHandler" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="7fqbBL2m65c">
+    <property role="EcuMT" value="8348035970508546380" />
+    <property role="3GE5qa" value="handler" />
+    <property role="TrG5h" value="GenericInsertFunction" />
+    <property role="34LRSv" value="generic" />
+    <ref role="1TJDcQ" node="7fqbBL2mxWc" resolve="AbstractInsertFunction" />
+  </node>
+  <node concept="1TIwiD" id="7fqbBL2mxWc">
+    <property role="EcuMT" value="8348035970508660492" />
+    <property role="3GE5qa" value="handler" />
+    <property role="TrG5h" value="AbstractInsertFunction" />
+    <property role="R5$K7" value="true" />
+    <ref role="1TJDcQ" to="tpee:gyVMwX8" resolve="ConceptFunction" />
   </node>
 </model>
 


### PR DESCRIPTION
This solves issue #481. It consists of the following extensions / changes:

- a new insert handler for treenotation editors named `generic` which allows adding arbitrary runtime `IInsertHandler` instances
- a new runtime class `DefaultInsertHandler` which can be used or adapted
- the `subconcepts` insert handler has been implemented as special case of `generic`
- extended examples to show and test the new features

Here is an example of `generic` usage which behaves like `subconcepts`, but only allows to insert concepts which have an alias:

<img width="1002" alt="image" src="https://user-images.githubusercontent.com/1193045/146382705-aa530857-83e9-41c1-891b-b750de5c8ac7.png">
