### PR TITLE
model client use ir compiler

### DIFF
--- a/model-api/build.gradle
+++ b/model-api/build.gradle
@@ -73,7 +73,7 @@ kotlin {
         }
         jsMain {
             dependencies {
-                implementation kotlin('stdlib-js:1.4.31')
+                implementation kotlin('stdlib-js')
             }
         }
         jsTest {

--- a/model-api/build.gradle
+++ b/model-api/build.gradle
@@ -118,7 +118,7 @@ spotless {
 }
 
 task copyJarsToMps(type: Sync) {
-    from jvmJar
+    from configurations.jvmRuntimeClasspath
     from "$buildDir/libs"
     into "$projectDir/../code/model-api/org.modelix.model.api/lib"
     rename { fileName ->
@@ -131,6 +131,11 @@ task copyJarsToMps(type: Sync) {
 // Workaround for M1 macs. Remove after kotlin 1.6.20 is released.
 rootProject.plugins.withType(Class.forName("org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootPlugin")) {
     rootProject.extensions.getByType(org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension.class).nodeVersion = "16.0.0"
+}
+
+configurations.each {
+    println(it)
+    println(it.canBeResolved)
 }
 
 

--- a/model-api/build.gradle
+++ b/model-api/build.gradle
@@ -1,7 +1,7 @@
 
 plugins {
     id 'maven-publish'
-    id 'org.jetbrains.kotlin.multiplatform' version '1.4.31'
+    id 'org.jetbrains.kotlin.multiplatform' version '1.6.10'
     id 'com.diffplug.gradle.spotless' version '4.5.1'
     id 'org.jlleitschuh.gradle.ktlint' version '9.3.0'
     id 'java-library'
@@ -36,7 +36,7 @@ check.dependsOn ktlintCheck
 
 kotlin {
     jvm()
-    js {
+    js(IR) {
         //browser {}
         nodejs {
             testTask {
@@ -45,11 +45,12 @@ kotlin {
                 }
             }
         }
+        binaries.executable()
     }
     sourceSets {
         commonMain {
             dependencies {
-                implementation kotlin('stdlib-common')
+                implementation kotlin('stdlib-common:1.4.31')
             }
         }
         commonTest {
@@ -60,7 +61,7 @@ kotlin {
         }
         jvmMain {
             dependencies {
-                implementation kotlin('stdlib-jdk8')
+                implementation kotlin('stdlib-jdk8:1.4.31')
                 implementation group: 'log4j', name: 'log4j', version:'1.2.17'
             }
         }
@@ -72,7 +73,7 @@ kotlin {
         }
         jsMain {
             dependencies {
-                implementation kotlin('stdlib-js')
+                implementation kotlin('stdlib-js:1.4.31')
             }
         }
         jsTest {
@@ -117,7 +118,7 @@ spotless {
 }
 
 task copyJarsToMps(type: Sync) {
-    from configurations.jvmDefault
+    from jvmJar
     from "$buildDir/libs"
     into "$projectDir/../code/model-api/org.modelix.model.api/lib"
     rename { fileName ->
@@ -126,6 +127,12 @@ task copyJarsToMps(type: Sync) {
     exclude 'log4j*.jar'
     exclude 'annotations*.jar'
 }
+
+// Workaround for M1 macs. Remove after kotlin 1.6.20 is released.
+rootProject.plugins.withType(Class.forName("org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootPlugin")) {
+    rootProject.extensions.getByType(org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension.class).nodeVersion = "16.0.0"
+}
+
 
 assemble.finalizedBy(copyJarsToMps)
 


### PR DESCRIPTION
I changed the JavaScript compiler for the model-api to use the new `IR` [compiler backend](https://kotlinlang.org/docs/js-ir-compiler.html). The IR compiler can produce better code for interoperability with TypeScript and JavaScript. We are creating an implementation for the INode interface that is consumed from TypeScript. (Not using the modelix model server as a storage backend but a custom implementation.)
Or implementation is a kotlin multiplatform project targeting the JVM and JS. Since we would like to provide our implementation to teams using type script we want to export richt type information for type script tooling, hence are planning to use the IR compiler backend. Unfortunately all dependencies are required to use the IR backend as well otherwise the dependency is rejected during resolving. The `IR` backend is still beta but seems quite stable from our testing.

To be able to use the `IR` backend I upgraded to the latest kotlin multiplatform plugin `1.6.10`. To prevent problem at runtime on the JVM the jvm std-lib is use with the version `1.4.31` the same as before as the kotlin plugin defaults to the same version of std-lib as the kotlin plugin when no version number is set. 
The JS implementation uses the std-lib from 1.6.10 because the `IR` backend isn't compatible with older versions of the js-std-lib. 
I'm not aware of any consumers of the model-api that are actually using JS as a target that used in production. Modelix has the model-client implementation but afaik there are no users. 
Consumers of the model-api in a muliplatform target JS would also need to switch to the IR backend after this change. I will create a PR in modelix with the required changes after this has been merged.
