### PR TITLE
Support for dark theme

### DIFF
--- a/code/blutil/languages/com.mbeddr.mpsutil.blutil/languageModels/editor.mps
+++ b/code/blutil/languages/com.mbeddr.mpsutil.blutil/languageModels/editor.mps
@@ -20,6 +20,7 @@
     <import index="f4zo" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.cells(MPS.Editor/)" />
     <import index="cj4x" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor(MPS.Editor/)" />
     <import index="g51k" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor.cells(MPS.Editor/)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="tpce" ref="r:00000000-0000-4000-0000-011c89590292(jetbrains.mps.lang.structure.structure)" implicit="true" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
     <import index="tp25" ref="r:00000000-0000-4000-0000-011c89590301(jetbrains.mps.lang.smodel.structure)" implicit="true" />
@@ -1901,8 +1902,8 @@
                   <node concept="3clFbS" id="4kSfyefw5ru" role="3clFbx">
                     <node concept="3cpWs6" id="2$_w8oMzGER" role="3cqZAp">
                       <node concept="10M0yZ" id="2$_w8oM$egS" role="3cqZAk">
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                        <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
+                        <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                        <ref role="3cqZAo" to="lzb2:~JBColor.lightGray" resolve="lightGray" />
                       </node>
                     </node>
                   </node>
@@ -1921,8 +1922,8 @@
                     <node concept="3clFbS" id="2$_w8oM$eUs" role="9aQI4">
                       <node concept="3cpWs6" id="2$_w8oM$f$e" role="3cqZAp">
                         <node concept="10M0yZ" id="2$_w8oM$ge6" role="3cqZAk">
-                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                          <ref role="3cqZAo" to="z60i:~Color.red" resolve="red" />
+                          <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                          <ref role="3cqZAo" to="lzb2:~JBColor.red" resolve="red" />
                         </node>
                       </node>
                     </node>
@@ -1940,8 +1941,8 @@
             </node>
             <node concept="3cpWs6" id="2$_w8oM$CAj" role="3cqZAp">
               <node concept="10M0yZ" id="2$_w8oM$Dhu" role="3cqZAk">
-                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                <ref role="3cqZAo" to="z60i:~Color.red" resolve="red" />
+                <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                <ref role="3cqZAo" to="lzb2:~JBColor.red" resolve="red" />
               </node>
             </node>
           </node>
@@ -2162,8 +2163,8 @@
                     <ref role="37wK5l" node="3d2YJYTUz8q" resolve="OpeningBracketCell" />
                     <node concept="pncrf" id="3d2YJYTUdjI" role="37wK5m" />
                     <node concept="10M0yZ" id="3d2YJYTUdjJ" role="37wK5m">
-                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                      <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
+                      <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                      <ref role="3cqZAo" to="lzb2:~JBColor.gray" resolve="gray" />
                     </node>
                   </node>
                 </node>
@@ -2190,8 +2191,8 @@
                     <ref role="37wK5l" node="3d2YJYTUz5N" resolve="ClosingBracketCell" />
                     <node concept="pncrf" id="3d2YJYTUdjU" role="37wK5m" />
                     <node concept="10M0yZ" id="3d2YJYTUdjV" role="37wK5m">
-                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                      <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
+                      <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                      <ref role="3cqZAo" to="lzb2:~JBColor.gray" resolve="gray" />
                     </node>
                   </node>
                 </node>
@@ -2353,8 +2354,8 @@
                                 <node concept="liA8E" id="3d2YJYTUz6J" role="2OqNvi">
                                   <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
                                   <node concept="10M0yZ" id="3d2YJYTUz6K" role="37wK5m">
-                                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                                    <ref role="3cqZAo" to="z60i:~Color.GRAY" resolve="GRAY" />
+                                    <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                                    <ref role="3cqZAo" to="lzb2:~JBColor.GRAY" resolve="GRAY" />
                                   </node>
                                 </node>
                               </node>
@@ -2721,8 +2722,8 @@
                                 <node concept="liA8E" id="3d2YJYTUz9m" role="2OqNvi">
                                   <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
                                   <node concept="10M0yZ" id="3d2YJYTUz9n" role="37wK5m">
-                                    <ref role="3cqZAo" to="z60i:~Color.GRAY" resolve="GRAY" />
-                                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                                    <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                                    <ref role="3cqZAo" to="lzb2:~JBColor.GRAY" resolve="GRAY" />
                                   </node>
                                 </node>
                               </node>

--- a/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
+++ b/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
@@ -227,6 +227,4885 @@
       </concept>
     </language>
   </registry>
+  <node concept="1l3spW" id="6$6tsX_CERA">
+    <property role="2DA0ip" value="../../../../build/generated/tests" />
+    <property role="turDy" value="build.xml" />
+    <property role="TrG5h" value="tests" />
+    <node concept="2_Ic$z" id="6$6tsX_CF79" role="3989C9">
+      <property role="2_Ic$$" value="true" />
+      <property role="TZNOO" value="1.8" />
+    </node>
+    <node concept="1wNqPr" id="6$6tsX_CF7a" role="3989C9">
+      <property role="1wNuhc" value="true" />
+      <property role="1wNuhe" value="true" />
+      <property role="1wNuhh" value="16" />
+      <property role="1wOHq$" value="true" />
+    </node>
+    <node concept="2G$12M" id="6$6tsX_CIRQ" role="3989C9">
+      <property role="TrG5h" value="de.slisson.mps.all.tests" />
+      <node concept="1E1JtD" id="F1NWDqweoc" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="com.mbeddr.mpsutil.grammarcells.sandboxlang" />
+        <property role="3LESm3" value="a257f68c-93a3-47b0-838b-6905dd9c20f6" />
+        <node concept="398BVA" id="F1NWDqwfmr" role="3LF7KH">
+          <ref role="398BVh" node="F1NWDquQCJ" resolve="grammarcells.home" />
+          <node concept="2Ry0Ak" id="F1NWDqwfFz" role="iGT6I">
+            <property role="2Ry0Am" value="languages" />
+            <node concept="2Ry0Ak" id="F1NWDqwg0E" role="2Ry0An">
+              <property role="2Ry0Am" value="com.mbeddr.mpsutil.grammarcells.sandboxlang" />
+              <node concept="2Ry0Ak" id="F1NWDqwgeL" role="2Ry0An">
+                <property role="2Ry0Am" value="com.mbeddr.mpsutil.grammarcells.sandboxlang.mpl" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="F1NWDqwgsO" role="3bR37C">
+          <node concept="3bR9La" id="F1NWDqwgsP" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="F1NWDqwgsQ" role="3bR37C">
+          <node concept="3bR9La" id="F1NWDqwgsR" role="1SiIV1">
+            <ref role="3bR37D" node="F1NWDqq_DA" resolve="com.mbeddr.mpsutil.grammarcells.runtime" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="F1NWDqwgsS" role="3bR37C">
+          <node concept="3bR9La" id="F1NWDqwgsT" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1TaHNgiIbIZ" resolve="MPS.Editor" />
+          </node>
+        </node>
+        <node concept="3rtmxn" id="5py4VqXmLNU" role="3bR31x">
+          <node concept="3LXTmp" id="5py4VqXmLNV" role="3rtmxm">
+            <node concept="3qWCbU" id="5py4VqXmLNW" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="5py4VqXmLNX" role="3LXTmr">
+              <ref role="398BVh" node="F1NWDquQCJ" resolve="grammarcells.home" />
+              <node concept="2Ry0Ak" id="5py4VqXmLNY" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="5py4VqXmLNZ" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mbeddr.mpsutil.grammarcells.sandboxlang" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1BupzO" id="7q24334ZKzB" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="7q24334ZKzC" role="1HemKq">
+            <node concept="398BVA" id="7q24334ZKzi" role="3LXTmr">
+              <ref role="398BVh" node="F1NWDquQCJ" resolve="grammarcells.home" />
+              <node concept="2Ry0Ak" id="7q24334ZKzj" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="7q24334ZKzk" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mbeddr.mpsutil.grammarcells.sandboxlang" />
+                  <node concept="2Ry0Ak" id="7q24334ZKzl" role="2Ry0An">
+                    <property role="2Ry0Am" value="models" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="7q24334ZKzD" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="5ycts4SlSD6" role="3bR37C">
+          <node concept="3bR9La" id="5ycts4SlSD7" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:7Kfy9QB6LfQ" resolve="jetbrains.mps.kernel" />
+          </node>
+        </node>
+      </node>
+      <node concept="1E1JtA" id="F1NWDqwbth" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="com.mbeddr.mpsutil.grammarcells.tests" />
+        <property role="3LESm3" value="c24d4a42-505e-4ffb-a24c-28919615a5bc" />
+        <property role="aoJFB" value="eYcmk9QOlj/sources_and_tests" />
+        <node concept="398BVA" id="F1NWDqwbKR" role="3LF7KH">
+          <ref role="398BVh" node="F1NWDquQCJ" resolve="grammarcells.home" />
+          <node concept="2Ry0Ak" id="F1NWDqwcbM" role="iGT6I">
+            <property role="2Ry0Am" value="solutions" />
+            <node concept="2Ry0Ak" id="F1NWDqwcvU" role="2Ry0An">
+              <property role="2Ry0Am" value="com.mbeddr.mpsutil.grammarcells.tests" />
+              <node concept="2Ry0Ak" id="F1NWDqy369" role="2Ry0An">
+                <property role="2Ry0Am" value="com.mbeddr.mpsutil.grammarcells.tests.msd" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="F1NWDqwd86" role="3bR37C">
+          <node concept="3bR9La" id="F1NWDqwd87" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="F1NWDqwd88" role="3bR37C">
+          <node concept="3bR9La" id="F1NWDqwd89" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1TaHNgiIbJ$" resolve="jetbrains.mps.ide.editor" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="F1NWDqwd8a" role="3bR37C">
+          <node concept="3bR9La" id="F1NWDqwd8b" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1TaHNgiIbIZ" resolve="MPS.Editor" />
+          </node>
+        </node>
+        <node concept="3rtmxn" id="5py4VqXmLK$" role="3bR31x">
+          <node concept="3LXTmp" id="5py4VqXmLK_" role="3rtmxm">
+            <node concept="3qWCbU" id="5py4VqXmLKA" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="5py4VqXmLKB" role="3LXTmr">
+              <ref role="398BVh" node="F1NWDquQCJ" resolve="grammarcells.home" />
+              <node concept="2Ry0Ak" id="5py4VqXmLKC" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="5py4VqXmLKD" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mbeddr.mpsutil.grammarcells.tests" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1BupzO" id="7q24334ZK$r" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="7q24334ZK$s" role="1HemKq">
+            <node concept="398BVA" id="7q24334ZK$6" role="3LXTmr">
+              <ref role="398BVh" node="F1NWDquQCJ" resolve="grammarcells.home" />
+              <node concept="2Ry0Ak" id="7q24334ZK$7" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="7q24334ZK$8" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mbeddr.mpsutil.grammarcells.tests" />
+                  <node concept="2Ry0Ak" id="7q24334ZK$9" role="2Ry0An">
+                    <property role="2Ry0Am" value="models" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="7q24334ZK$t" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1E1JtA" id="6$6tsX_CURF" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="de.slisson.mps.structurecheck.runtime" />
+        <property role="3LESm3" value="6f14e29b-9796-426f-ae46-86ea46d4d320" />
+        <property role="aoJFB" value="eYcmk9QOlj/sources_and_tests" />
+        <node concept="398BVA" id="3vzyAKEK04f" role="3LF7KH">
+          <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+          <node concept="2Ry0Ak" id="3vzyAKEK04k" role="iGT6I">
+            <property role="2Ry0Am" value="structurecheck" />
+            <node concept="2Ry0Ak" id="3vzyAKEK04l" role="2Ry0An">
+              <property role="2Ry0Am" value="solutions" />
+              <node concept="2Ry0Ak" id="1QLFoGOMUbK" role="2Ry0An">
+                <property role="2Ry0Am" value="de.slisson.mps.structurecheck.runtime" />
+                <node concept="2Ry0Ak" id="1QLFoGOMUoj" role="2Ry0An">
+                  <property role="2Ry0Am" value="de.slisson.mps.structurecheck.runtime.msd" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="6$6tsX_CV2i" role="3bR37C">
+          <node concept="3bR9La" id="6$6tsX_CV2j" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:44LXwdzyvTi" resolve="Annotations" />
+          </node>
+        </node>
+        <node concept="3rtmxn" id="3xFG3bj5MpX" role="3bR31x">
+          <node concept="3LXTmp" id="3xFG3bj5MpY" role="3rtmxm">
+            <node concept="3qWCbU" id="3xFG3bj5MpZ" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="nsMIIcsJ47" role="3LXTmr">
+              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="nsMIIcsJ48" role="iGT6I">
+                <property role="2Ry0Am" value="structurecheck" />
+                <node concept="2Ry0Ak" id="nsMIIcsJ49" role="2Ry0An">
+                  <property role="2Ry0Am" value="solutions" />
+                  <node concept="2Ry0Ak" id="nsMIIcsJ4a" role="2Ry0An">
+                    <property role="2Ry0Am" value="de.slisson.mps.structurecheck.runtime" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1BupzO" id="7q24334ZK$J" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="7q24334ZK$K" role="1HemKq">
+            <node concept="398BVA" id="7q24334ZK$u" role="3LXTmr">
+              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="7q24334ZK$v" role="iGT6I">
+                <property role="2Ry0Am" value="structurecheck" />
+                <node concept="2Ry0Ak" id="7q24334ZK$w" role="2Ry0An">
+                  <property role="2Ry0Am" value="solutions" />
+                  <node concept="2Ry0Ak" id="7q24334ZK$x" role="2Ry0An">
+                    <property role="2Ry0Am" value="de.slisson.mps.structurecheck.runtime" />
+                    <node concept="2Ry0Ak" id="7q24334ZK$y" role="2Ry0An">
+                      <property role="2Ry0Am" value="models" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="7q24334ZK$L" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1E1JtD" id="6$6tsX_CUvL" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="de.slisson.mps.structurecheck" />
+        <property role="3LESm3" value="c6cfed73-685b-4891-8bdd-b38a1dcb107a" />
+        <node concept="398BVA" id="3vzyAKEJZkI" role="3LF7KH">
+          <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+          <node concept="2Ry0Ak" id="3vzyAKEJZkN" role="iGT6I">
+            <property role="2Ry0Am" value="structurecheck" />
+            <node concept="2Ry0Ak" id="3vzyAKEJZkO" role="2Ry0An">
+              <property role="2Ry0Am" value="languages" />
+              <node concept="2Ry0Ak" id="1QLFoGOMUL_" role="2Ry0An">
+                <property role="2Ry0Am" value="de.slisson.mps.structurecheck" />
+                <node concept="2Ry0Ak" id="1QLFoGOMUYi" role="2Ry0An">
+                  <property role="2Ry0Am" value="de.slisson.mps.structurecheck.mpl" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1E0d5M" id="6$6tsX_CV3t" role="1E1XAP">
+          <ref role="1E0d5P" node="6$6tsX_CURF" resolve="de.slisson.mps.structurecheck.runtime" />
+        </node>
+        <node concept="1SiIV0" id="6$6tsX_CV3u" role="3bR37C">
+          <node concept="1Busua" id="6$6tsX_CV3v" role="1SiIV1">
+            <ref role="1Busuk" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
+          </node>
+        </node>
+        <node concept="1yeLz9" id="6$6tsX_CV3w" role="1TViLv">
+          <property role="TrG5h" value="de.slisson.mps.structurecheck#380240910834170735" />
+          <property role="3LESm3" value="ce4c3eb8-9598-4a3c-a7c0-46a16d2333d9" />
+          <node concept="1SiIV0" id="6$6tsX_CV3x" role="3bR37C">
+            <node concept="3bR9La" id="6$6tsX_CV3y" role="1SiIV1">
+              <ref role="3bR37D" node="6$6tsX_CURF" resolve="de.slisson.mps.structurecheck.runtime" />
+            </node>
+          </node>
+          <node concept="1SiIV0" id="6yXTMcTUXML" role="3bR37C">
+            <node concept="3bR9La" id="6yXTMcTUXMM" role="1SiIV1">
+              <ref role="3bR37D" to="ffeo:7Kfy9QB6KZG" resolve="jetbrains.mps.baseLanguage.closures" />
+            </node>
+          </node>
+          <node concept="1BupzO" id="7q24334ZK_q" role="3bR31x">
+            <property role="3ZfqAx" value="generator/template" />
+            <property role="1Hdu6h" value="true" />
+            <property role="1HemKv" value="true" />
+            <node concept="3LXTmp" id="7q24334ZK_r" role="1HemKq">
+              <node concept="398BVA" id="7q24334ZK_6" role="3LXTmr">
+                <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+                <node concept="2Ry0Ak" id="7q24334ZK_7" role="iGT6I">
+                  <property role="2Ry0Am" value="structurecheck" />
+                  <node concept="2Ry0Ak" id="7q24334ZK_8" role="2Ry0An">
+                    <property role="2Ry0Am" value="languages" />
+                    <node concept="2Ry0Ak" id="7q24334ZK_9" role="2Ry0An">
+                      <property role="2Ry0Am" value="de.slisson.mps.structurecheck" />
+                      <node concept="2Ry0Ak" id="7q24334ZK_a" role="2Ry0An">
+                        <property role="2Ry0Am" value="generator" />
+                        <node concept="2Ry0Ak" id="7q24334ZK_b" role="2Ry0An">
+                          <property role="2Ry0Am" value="template" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3qWCbU" id="7q24334ZK_s" role="3LXTna">
+                <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3rtmxn" id="3xFG3bj5Moz" role="3bR31x">
+          <node concept="3LXTmp" id="3xFG3bj5Mo$" role="3rtmxm">
+            <node concept="3qWCbU" id="3xFG3bj5Mo_" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="PE3B26qlU$" role="3LXTmr">
+              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="PE3B26qlU_" role="iGT6I">
+                <property role="2Ry0Am" value="structurecheck" />
+                <node concept="2Ry0Ak" id="PE3B26qlUA" role="2Ry0An">
+                  <property role="2Ry0Am" value="languages" />
+                  <node concept="2Ry0Ak" id="PE3B26qlUB" role="2Ry0An">
+                    <property role="2Ry0Am" value="de.slisson.mps.structurecheck" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1BupzO" id="7q24334ZK_3" role="3bR31x">
+          <property role="3ZfqAx" value="languageModels" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="7q24334ZK_4" role="1HemKq">
+            <node concept="398BVA" id="7q24334ZK$M" role="3LXTmr">
+              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="7q24334ZK$N" role="iGT6I">
+                <property role="2Ry0Am" value="structurecheck" />
+                <node concept="2Ry0Ak" id="7q24334ZK$O" role="2Ry0An">
+                  <property role="2Ry0Am" value="languages" />
+                  <node concept="2Ry0Ak" id="7q24334ZK$P" role="2Ry0An">
+                    <property role="2Ry0Am" value="de.slisson.mps.structurecheck" />
+                    <node concept="2Ry0Ak" id="7q24334ZK$Q" role="2Ry0An">
+                      <property role="2Ry0Am" value="languageModels" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="7q24334ZK_5" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1E1JtA" id="5mH$9t6e_Fl" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="test.de.slisson.mps.tables" />
+        <property role="3LESm3" value="2b62b482-becb-4b5e-9543-c5cf37553cb6" />
+        <property role="aoJFB" value="eYcmk9QOlj/sources_and_tests" />
+        <node concept="398BVA" id="5mH$9t6e_Fm" role="3LF7KH">
+          <ref role="398BVh" node="5mH$9t6e_IG" resolve="tables.home" />
+          <node concept="2Ry0Ak" id="5mH$9t6e_Fn" role="iGT6I">
+            <property role="2Ry0Am" value="solutions" />
+            <node concept="2Ry0Ak" id="5mH$9t6e_Fo" role="2Ry0An">
+              <property role="2Ry0Am" value="test.de.slisson.mps.tables" />
+              <node concept="2Ry0Ak" id="5mH$9t6e_QZ" role="2Ry0An">
+                <property role="2Ry0Am" value="test.de.slisson.mps.tables.msd" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="5mH$9t6e_Fs" role="3bR37C">
+          <node concept="3bR9La" id="5mH$9t6e_Ft" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1TaHNgiIbIZ" resolve="MPS.Editor" />
+          </node>
+        </node>
+        <node concept="3rtmxn" id="5mH$9t6e_F$" role="3bR31x">
+          <node concept="3LXTmp" id="5mH$9t6e_F_" role="3rtmxm">
+            <node concept="3qWCbU" id="5mH$9t6e_FA" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="PE3B26qlKu" role="3LXTmr">
+              <ref role="398BVh" node="5mH$9t6e_IG" resolve="tables.home" />
+              <node concept="2Ry0Ak" id="PE3B26qlKv" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="PE3B26qlKw" role="2Ry0An">
+                  <property role="2Ry0Am" value="test.de.slisson.mps.tables" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="5mH$9t6e_SN" role="3bR37C">
+          <node concept="3bR9La" id="5mH$9t6e_SO" role="1SiIV1">
+            <ref role="3bR37D" node="29so9Vb$6T5" resolve="de.slisson.mps.tables.runtime" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="5mH$9t6e_SP" role="3bR37C">
+          <node concept="3bR9La" id="5mH$9t6e_SQ" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1TaHNgiIbJ$" resolve="jetbrains.mps.ide.editor" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="5mH$9t6eBLv" role="3bR37C">
+          <node concept="3bR9La" id="5mH$9t6eBLw" role="1SiIV1">
+            <ref role="3bR37D" node="5mH$9t6eA1O" resolve="de.slisson.mps.tables.demolang" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="D0xzCAzUZQ" role="3bR37C">
+          <node concept="3bR9La" id="D0xzCAzUZR" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
+          </node>
+        </node>
+        <node concept="1BupzO" id="7q24334ZK_M" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="7q24334ZK_N" role="1HemKq">
+            <node concept="398BVA" id="7q24334ZK_t" role="3LXTmr">
+              <ref role="398BVh" node="5mH$9t6e_IG" resolve="tables.home" />
+              <node concept="2Ry0Ak" id="7q24334ZK_u" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="7q24334ZK_v" role="2Ry0An">
+                  <property role="2Ry0Am" value="test.de.slisson.mps.tables" />
+                  <node concept="2Ry0Ak" id="7q24334ZK_w" role="2Ry0An">
+                    <property role="2Ry0Am" value="models" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="7q24334ZK_O" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1E1JtD" id="5mH$9t6eA1O" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="de.slisson.mps.tables.demolang" />
+        <property role="3LESm3" value="2d56439e-634d-4d25-9d30-963e89ecda48" />
+        <node concept="398BVA" id="5mH$9t6eA1P" role="3LF7KH">
+          <ref role="398BVh" node="5mH$9t6e_IG" resolve="tables.home" />
+          <node concept="2Ry0Ak" id="5mH$9t6eA1Q" role="iGT6I">
+            <property role="2Ry0Am" value="languages" />
+            <node concept="2Ry0Ak" id="5mH$9t6eA1R" role="2Ry0An">
+              <property role="2Ry0Am" value="de.slisson.mps.tables.demolang" />
+              <node concept="2Ry0Ak" id="5mH$9t6eA1S" role="2Ry0An">
+                <property role="2Ry0Am" value="de.slisson.mps.tables.demolang.mpl" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1E0d5M" id="5mH$9t6eA1U" role="1E1XAP">
+          <ref role="1E0d5P" node="6$6tsX_CURF" resolve="de.slisson.mps.structurecheck.runtime" />
+        </node>
+        <node concept="1SiIV0" id="5mH$9t6eA1V" role="3bR37C">
+          <node concept="1Busua" id="5mH$9t6eA1W" role="1SiIV1">
+            <ref role="1Busuk" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
+          </node>
+        </node>
+        <node concept="3rtmxn" id="5mH$9t6eA22" role="3bR31x">
+          <node concept="3LXTmp" id="5mH$9t6eA23" role="3rtmxm">
+            <node concept="3qWCbU" id="5mH$9t6eA24" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="PE3B26qlDI" role="3LXTmr">
+              <ref role="398BVh" node="5mH$9t6e_IG" resolve="tables.home" />
+              <node concept="2Ry0Ak" id="PE3B26qlDJ" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="PE3B26qlDK" role="2Ry0An">
+                  <property role="2Ry0Am" value="de.slisson.mps.tables.demolang" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="5mH$9t6eAhj" role="3bR37C">
+          <node concept="3bR9La" id="5mH$9t6eAhk" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="5mH$9t6eAhl" role="3bR37C">
+          <node concept="3bR9La" id="5mH$9t6eAhm" role="1SiIV1">
+            <ref role="3bR37D" node="29so9Vb$6T5" resolve="de.slisson.mps.tables.runtime" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="5mH$9t6eAhp" role="3bR37C">
+          <node concept="3bR9La" id="5mH$9t6eAhq" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="5mH$9t6eAhr" role="3bR37C">
+          <node concept="3bR9La" id="5mH$9t6eAhs" role="1SiIV1">
+            <ref role="3bR37D" node="29so9Vb$6Th" resolve="de.slisson.mps.tables" />
+          </node>
+        </node>
+        <node concept="1E0d5M" id="5mH$9t6eAht" role="1E1XAP">
+          <ref role="1E0d5P" node="29so9Vb$6T5" resolve="de.slisson.mps.tables.runtime" />
+        </node>
+        <node concept="1BupzO" id="7q24334ZKAa" role="3bR31x">
+          <property role="3ZfqAx" value="languageModels" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="7q24334ZKAb" role="1HemKq">
+            <node concept="398BVA" id="7q24334ZK_P" role="3LXTmr">
+              <ref role="398BVh" node="5mH$9t6e_IG" resolve="tables.home" />
+              <node concept="2Ry0Ak" id="7q24334ZK_Q" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="7q24334ZK_R" role="2Ry0An">
+                  <property role="2Ry0Am" value="de.slisson.mps.tables.demolang" />
+                  <node concept="2Ry0Ak" id="7q24334ZK_S" role="2Ry0An">
+                    <property role="2Ry0Am" value="languageModels" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="7q24334ZKAc" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1E1JtA" id="7i5Cc6LxCew" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="de.slisson.mps.testutils" />
+        <property role="3LESm3" value="3395a7d2-abac-467d-b35d-0e747a00a60e" />
+        <property role="aoJFB" value="eYcmk9QOlj/sources_and_tests" />
+        <node concept="3rtmxn" id="1bWvPKNGzHM" role="3bR31x">
+          <node concept="3LXTmp" id="1bWvPKNGzHN" role="3rtmxm">
+            <node concept="3qWCbU" id="1bWvPKNGzHO" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="1bWvPKNGzHP" role="3LXTmr">
+              <ref role="398BVh" node="5mH$9t6e_IG" resolve="tables.home" />
+              <node concept="2Ry0Ak" id="1bWvPKNGzHQ" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="1bWvPKNGzHR" role="2Ry0An">
+                  <property role="2Ry0Am" value="de.slisson.mps.testutils" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="398BVA" id="7i5Cc6LxCp3" role="3LF7KH">
+          <ref role="398BVh" node="5mH$9t6e_IG" resolve="tables.home" />
+          <node concept="2Ry0Ak" id="7i5Cc6LxCBi" role="iGT6I">
+            <property role="2Ry0Am" value="solutions" />
+            <node concept="2Ry0Ak" id="7i5Cc6LxCKN" role="2Ry0An">
+              <property role="2Ry0Am" value="de.slisson.mps.testutils" />
+              <node concept="2Ry0Ak" id="7i5Cc6LxCUk" role="2Ry0An">
+                <property role="2Ry0Am" value="de.slisson.mps.testutils.msd" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="7i5Cc6LxD3L" role="3bR37C">
+          <node concept="3bR9La" id="7i5Cc6LxD3M" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1TaHNgiIbIZ" resolve="MPS.Editor" />
+          </node>
+        </node>
+        <node concept="1BupzO" id="7q24334ZKAY" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="7q24334ZKAZ" role="1HemKq">
+            <node concept="398BVA" id="7q24334ZKAD" role="3LXTmr">
+              <ref role="398BVh" node="5mH$9t6e_IG" resolve="tables.home" />
+              <node concept="2Ry0Ak" id="7q24334ZKAE" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="7q24334ZKAF" role="2Ry0An">
+                  <property role="2Ry0Am" value="de.slisson.mps.testutils" />
+                  <node concept="2Ry0Ak" id="7q24334ZKAG" role="2Ry0An">
+                    <property role="2Ry0Am" value="models" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="7q24334ZKB0" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2G$12M" id="2NyZxKpX5XT" role="3989C9">
+      <property role="TrG5h" value="mps-blutil-test" />
+      <node concept="1E1JtD" id="2NyZxKpX6$b" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="test.com.mbeddr.mpsutil.blutil.genutil.lang" />
+        <property role="3LESm3" value="2980eccb-8de2-4e74-96a0-1908c0172899" />
+        <node concept="3rtmxn" id="1bWvPKNGzHj" role="3bR31x">
+          <node concept="3LXTmp" id="1bWvPKNGzHk" role="3rtmxm">
+            <node concept="3qWCbU" id="1bWvPKNGzHl" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="1bWvPKNGzHm" role="3LXTmr">
+              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="1bWvPKNGzHn" role="iGT6I">
+                <property role="2Ry0Am" value="blutil" />
+                <node concept="2Ry0Ak" id="1bWvPKNGzHo" role="2Ry0An">
+                  <property role="2Ry0Am" value="tests" />
+                  <node concept="2Ry0Ak" id="1bWvPKNGzHp" role="2Ry0An">
+                    <property role="2Ry0Am" value="test.com.mbeddr.mpsutil.blutil.genutil.lang" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="398BVA" id="2NyZxKpX6Dh" role="3LF7KH">
+          <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+          <node concept="2Ry0Ak" id="2NyZxKpX6Xv" role="iGT6I">
+            <property role="2Ry0Am" value="blutil" />
+            <node concept="2Ry0Ak" id="2NyZxKpX77C" role="2Ry0An">
+              <property role="2Ry0Am" value="tests" />
+              <node concept="2Ry0Ak" id="2NyZxKpX7rR" role="2Ry0An">
+                <property role="2Ry0Am" value="test.com.mbeddr.mpsutil.blutil.genutil.lang" />
+                <node concept="2Ry0Ak" id="2NyZxKpX7A0" role="2Ry0An">
+                  <property role="2Ry0Am" value="test.com.mbeddr.mpsutil.blutil.genutil.lang.mpl" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1yeLz9" id="2NyZxKpX7K6" role="1TViLv">
+          <property role="TrG5h" value="test.com.mbeddr.mpsutil.blutil.genutil.lang#4213334375079416143" />
+          <property role="3LESm3" value="b174e65b-8333-4361-ae60-201190bf7c0a" />
+          <node concept="1SiIV0" id="2NyZxKpX7K7" role="3bR37C">
+            <node concept="3bR9La" id="2NyZxKpX7K8" role="1SiIV1">
+              <ref role="3bR37D" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
+            </node>
+          </node>
+          <node concept="1BupzO" id="7q24334ZKBD" role="3bR31x">
+            <property role="3ZfqAx" value="generator/template" />
+            <property role="1Hdu6h" value="true" />
+            <property role="1HemKv" value="true" />
+            <node concept="3LXTmp" id="7q24334ZKBE" role="1HemKq">
+              <node concept="398BVA" id="7q24334ZKBl" role="3LXTmr">
+                <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+                <node concept="2Ry0Ak" id="7q24334ZKBm" role="iGT6I">
+                  <property role="2Ry0Am" value="blutil" />
+                  <node concept="2Ry0Ak" id="7q24334ZKBn" role="2Ry0An">
+                    <property role="2Ry0Am" value="tests" />
+                    <node concept="2Ry0Ak" id="7q24334ZKBo" role="2Ry0An">
+                      <property role="2Ry0Am" value="test.com.mbeddr.mpsutil.blutil.genutil.lang" />
+                      <node concept="2Ry0Ak" id="7q24334ZKBp" role="2Ry0An">
+                        <property role="2Ry0Am" value="generator" />
+                        <node concept="2Ry0Ak" id="7q24334ZKBq" role="2Ry0An">
+                          <property role="2Ry0Am" value="template" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3qWCbU" id="7q24334ZKBF" role="3LXTna">
+                <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1BupzO" id="7q24334ZKBi" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="7q24334ZKBj" role="1HemKq">
+            <node concept="398BVA" id="7q24334ZKB1" role="3LXTmr">
+              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="7q24334ZKB2" role="iGT6I">
+                <property role="2Ry0Am" value="blutil" />
+                <node concept="2Ry0Ak" id="7q24334ZKB3" role="2Ry0An">
+                  <property role="2Ry0Am" value="tests" />
+                  <node concept="2Ry0Ak" id="7q24334ZKB4" role="2Ry0An">
+                    <property role="2Ry0Am" value="test.com.mbeddr.mpsutil.blutil.genutil.lang" />
+                    <node concept="2Ry0Ak" id="7q24334ZKB5" role="2Ry0An">
+                      <property role="2Ry0Am" value="models" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="7q24334ZKBk" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1E1JtA" id="2NyZxKpX7We" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="test.com.mbeddr.mpsutil.blutil.genutil" />
+        <property role="3LESm3" value="990da2f9-03a7-461e-90ee-1e2c77962d6b" />
+        <property role="aoJFB" value="eYcmk9QOlj/sources_and_tests" />
+        <node concept="3rtmxn" id="1bWvPKNGzGN" role="3bR31x">
+          <node concept="3LXTmp" id="1bWvPKNGzGO" role="3rtmxm">
+            <node concept="3qWCbU" id="1bWvPKNGzGP" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="1bWvPKNGzGQ" role="3LXTmr">
+              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="1bWvPKNGzGR" role="iGT6I">
+                <property role="2Ry0Am" value="blutil" />
+                <node concept="2Ry0Ak" id="1bWvPKNGzGS" role="2Ry0An">
+                  <property role="2Ry0Am" value="tests" />
+                  <node concept="2Ry0Ak" id="1bWvPKNGzGT" role="2Ry0An">
+                    <property role="2Ry0Am" value="test.com.mbeddr.mpsutil.blutil.genutil" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="398BVA" id="2NyZxKpX824" role="3LF7KH">
+          <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+          <node concept="2Ry0Ak" id="2NyZxKpX8do" role="iGT6I">
+            <property role="2Ry0Am" value="blutil" />
+            <node concept="2Ry0Ak" id="2NyZxKpX8oF" role="2Ry0An">
+              <property role="2Ry0Am" value="tests" />
+              <node concept="2Ry0Ak" id="2NyZxKpX8zY" role="2Ry0An">
+                <property role="2Ry0Am" value="test.com.mbeddr.mpsutil.blutil.genutil" />
+                <node concept="2Ry0Ak" id="2NyZxKpX8Jh" role="2Ry0An">
+                  <property role="2Ry0Am" value="test.com.mbeddr.mpsutil.blutil.genutil.msd" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1BupzO" id="7q24334ZKBX" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="7q24334ZKBY" role="1HemKq">
+            <node concept="398BVA" id="7q24334ZKBG" role="3LXTmr">
+              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="7q24334ZKBH" role="iGT6I">
+                <property role="2Ry0Am" value="blutil" />
+                <node concept="2Ry0Ak" id="7q24334ZKBI" role="2Ry0An">
+                  <property role="2Ry0Am" value="tests" />
+                  <node concept="2Ry0Ak" id="7q24334ZKBJ" role="2Ry0An">
+                    <property role="2Ry0Am" value="test.com.mbeddr.mpsutil.blutil.genutil" />
+                    <node concept="2Ry0Ak" id="7q24334ZKBK" role="2Ry0An">
+                      <property role="2Ry0Am" value="models" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="7q24334ZKBZ" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1E1JtA" id="2NyZxKpX96P" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="test.ts.conceptswitch" />
+        <property role="3LESm3" value="ac7d22d0-cbff-4ae0-aed8-fde151aacde1" />
+        <property role="aoJFB" value="eYcmk9QOlj/sources_and_tests" />
+        <node concept="3rtmxn" id="1bWvPKNGzIi" role="3bR31x">
+          <node concept="3LXTmp" id="1bWvPKNGzIj" role="3rtmxm">
+            <node concept="3qWCbU" id="1bWvPKNGzIk" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="1bWvPKNGzIl" role="3LXTmr">
+              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="1bWvPKNGzIm" role="iGT6I">
+                <property role="2Ry0Am" value="blutil" />
+                <node concept="2Ry0Ak" id="1bWvPKNGzIn" role="2Ry0An">
+                  <property role="2Ry0Am" value="tests" />
+                  <node concept="2Ry0Ak" id="1bWvPKNGzIo" role="2Ry0An">
+                    <property role="2Ry0Am" value="test.ts.conceptswitch" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="398BVA" id="2NyZxKpX9d2" role="3LF7KH">
+          <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+          <node concept="2Ry0Ak" id="2NyZxKpX9oS" role="iGT6I">
+            <property role="2Ry0Am" value="blutil" />
+            <node concept="2Ry0Ak" id="2NyZxKpX9$H" role="2Ry0An">
+              <property role="2Ry0Am" value="tests" />
+              <node concept="2Ry0Ak" id="2NyZxKpX9Ky" role="2Ry0An">
+                <property role="2Ry0Am" value="test.ts.conceptswitch" />
+                <node concept="2Ry0Ak" id="2NyZxKpX9Wn" role="2Ry0An">
+                  <property role="2Ry0Am" value="test.ts.conceptswitch.msd" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2NyZxKpXa89" role="3bR37C">
+          <node concept="3bR9La" id="2NyZxKpXa8a" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2NyZxKpXa8b" role="3bR37C">
+          <node concept="3bR9La" id="2NyZxKpXa8c" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:7Kfy9QB6LaO" resolve="jetbrains.mps.lang.structure" />
+          </node>
+        </node>
+        <node concept="1BupzO" id="7q24334ZKCh" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="7q24334ZKCi" role="1HemKq">
+            <node concept="398BVA" id="7q24334ZKC0" role="3LXTmr">
+              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="7q24334ZKC1" role="iGT6I">
+                <property role="2Ry0Am" value="blutil" />
+                <node concept="2Ry0Ak" id="7q24334ZKC2" role="2Ry0An">
+                  <property role="2Ry0Am" value="tests" />
+                  <node concept="2Ry0Ak" id="7q24334ZKC3" role="2Ry0An">
+                    <property role="2Ry0Am" value="test.ts.conceptswitch" />
+                    <node concept="2Ry0Ak" id="7q24334ZKC4" role="2Ry0An">
+                      <property role="2Ry0Am" value="models" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="7q24334ZKCj" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1E1JtA" id="2NyZxKpXalh" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="test.ex.match" />
+        <property role="3LESm3" value="bb2d89dd-a4c7-4821-a0c8-7437446fd8d3" />
+        <property role="aoJFB" value="eYcmk9QOlj/sources_and_tests" />
+        <node concept="3rtmxn" id="1bWvPKNGzH3" role="3bR31x">
+          <node concept="3LXTmp" id="1bWvPKNGzH4" role="3rtmxm">
+            <node concept="3qWCbU" id="1bWvPKNGzH5" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="1bWvPKNGzH6" role="3LXTmr">
+              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="1bWvPKNGzH7" role="iGT6I">
+                <property role="2Ry0Am" value="blutil" />
+                <node concept="2Ry0Ak" id="1bWvPKNGzH8" role="2Ry0An">
+                  <property role="2Ry0Am" value="tests" />
+                  <node concept="2Ry0Ak" id="1bWvPKNGzH9" role="2Ry0An">
+                    <property role="2Ry0Am" value="test.ts.match" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="398BVA" id="2NyZxKpXarT" role="3LF7KH">
+          <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+          <node concept="2Ry0Ak" id="2NyZxKpXaOz" role="iGT6I">
+            <property role="2Ry0Am" value="blutil" />
+            <node concept="2Ry0Ak" id="2NyZxKpXb0U" role="2Ry0An">
+              <property role="2Ry0Am" value="tests" />
+              <node concept="2Ry0Ak" id="2NyZxKpXbdh" role="2Ry0An">
+                <property role="2Ry0Am" value="test.ts.match" />
+                <node concept="2Ry0Ak" id="2NyZxKpXbpC" role="2Ry0An">
+                  <property role="2Ry0Am" value="match.msd" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2NyZxKpXb_W" role="3bR37C">
+          <node concept="3bR9La" id="2NyZxKpXb_X" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
+          </node>
+        </node>
+        <node concept="1BupzO" id="7q24334ZKC_" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="7q24334ZKCA" role="1HemKq">
+            <node concept="398BVA" id="7q24334ZKCk" role="3LXTmr">
+              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="7q24334ZKCl" role="iGT6I">
+                <property role="2Ry0Am" value="blutil" />
+                <node concept="2Ry0Ak" id="7q24334ZKCm" role="2Ry0An">
+                  <property role="2Ry0Am" value="tests" />
+                  <node concept="2Ry0Ak" id="7q24334ZKCn" role="2Ry0An">
+                    <property role="2Ry0Am" value="test.ts.match" />
+                    <node concept="2Ry0Ak" id="7q24334ZKCo" role="2Ry0An">
+                      <property role="2Ry0Am" value="models" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="7q24334ZKCB" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2G$12M" id="7XTah2ufRUJ" role="3989C9">
+      <property role="TrG5h" value="mps-nodeVersioningTest" />
+      <node concept="1E1JtA" id="7XTah2ufTo1" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="de.itemis.mps.nodeversioning.test" />
+        <property role="3LESm3" value="92dbf947-9ad7-4892-925f-1183ba0104c5" />
+        <property role="aoJFB" value="eYcmk9QOlj/sources_and_tests" />
+        <node concept="3rtmxn" id="1bWvPKNGzGV" role="3bR31x">
+          <node concept="3LXTmp" id="1bWvPKNGzGW" role="3rtmxm">
+            <node concept="3qWCbU" id="1bWvPKNGzGX" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="1bWvPKNGzGY" role="3LXTmr">
+              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="1bWvPKNGzGZ" role="iGT6I">
+                <property role="2Ry0Am" value="nodeversioning" />
+                <node concept="2Ry0Ak" id="1bWvPKNGzH0" role="2Ry0An">
+                  <property role="2Ry0Am" value="tests" />
+                  <node concept="2Ry0Ak" id="1bWvPKNGzH1" role="2Ry0An">
+                    <property role="2Ry0Am" value="de.itemis.mps.nodeversioning.test" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="398BVA" id="7XTah2ufTuv" role="3LF7KH">
+          <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+          <node concept="2Ry0Ak" id="7XTah2ufUhZ" role="iGT6I">
+            <property role="2Ry0Am" value="nodeversioning" />
+            <node concept="2Ry0Ak" id="7XTah2ufUuS" role="2Ry0An">
+              <property role="2Ry0Am" value="tests" />
+              <node concept="2Ry0Ak" id="7XTah2ufUFL" role="2Ry0An">
+                <property role="2Ry0Am" value="de.itemis.mps.nodeversioning.test" />
+                <node concept="2Ry0Ak" id="7XTah2ufUSE" role="2Ry0An">
+                  <property role="2Ry0Am" value="de.itemis.mps.nodeversioning.test.msd" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="7XTah2ufV5w" role="3bR37C">
+          <node concept="3bR9La" id="7XTah2ufV5x" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="7XTah2ufV5y" role="3bR37C">
+          <node concept="3bR9La" id="7XTah2ufV5z" role="1SiIV1">
+            <ref role="3bR37D" node="457TI2XWgk_" resolve="de.itemis.mps.nodeversioning" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="7XTah2ufV5A" role="3bR37C">
+          <node concept="3bR9La" id="7XTah2ufV5B" role="1SiIV1">
+            <ref role="3bR37D" node="457TI2XWdaZ" resolve="de.itemis.mps.nodeversioning.runtime" />
+          </node>
+        </node>
+        <node concept="1BupzO" id="7q24334ZKCT" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="7q24334ZKCU" role="1HemKq">
+            <node concept="398BVA" id="7q24334ZKCC" role="3LXTmr">
+              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="7q24334ZKCD" role="iGT6I">
+                <property role="2Ry0Am" value="nodeversioning" />
+                <node concept="2Ry0Ak" id="7q24334ZKCE" role="2Ry0An">
+                  <property role="2Ry0Am" value="tests" />
+                  <node concept="2Ry0Ak" id="7q24334ZKCF" role="2Ry0An">
+                    <property role="2Ry0Am" value="de.itemis.mps.nodeversioning.test" />
+                    <node concept="2Ry0Ak" id="7q24334ZKCG" role="2Ry0An">
+                      <property role="2Ry0Am" value="models" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="7q24334ZKCV" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2G$12M" id="GuygFg7$fH" role="3989C9">
+      <property role="TrG5h" value="mps-modelmergerTest" />
+      <node concept="1E1JtD" id="3aF8hCvy3sT" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="de.itemis.model.merge.diamond" />
+        <property role="3LESm3" value="0ef84c01-bf36-41ed-9882-d7b70a4a4eba" />
+        <node concept="398BVA" id="3aF8hCvy3vF" role="3LF7KH">
+          <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+          <node concept="2Ry0Ak" id="3aF8hCvy3vL" role="iGT6I">
+            <property role="2Ry0Am" value="languages" />
+            <node concept="2Ry0Ak" id="3aF8hCvy3vQ" role="2Ry0An">
+              <property role="2Ry0Am" value="de.itemis.model.merge.diamond" />
+              <node concept="2Ry0Ak" id="3aF8hCvy3vV" role="2Ry0An">
+                <property role="2Ry0Am" value="de.itemis.model.merge.diamond.mpl" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1BupzO" id="3aF8hCvy3_p" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="3aF8hCvy3_q" role="1HemKq">
+            <node concept="398BVA" id="3aF8hCvy3_b" role="3LXTmr">
+              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="3aF8hCvy3_c" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="3aF8hCvy3_d" role="2Ry0An">
+                  <property role="2Ry0Am" value="de.itemis.model.merge.diamond" />
+                  <node concept="2Ry0Ak" id="3aF8hCvy3_e" role="2Ry0An">
+                    <property role="2Ry0Am" value="models" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="3aF8hCvy3_r" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+        <node concept="3rtmxn" id="3M9VIK_gQAK" role="3bR31x">
+          <node concept="3LXTmp" id="3M9VIK_gQAL" role="3rtmxm">
+            <node concept="398BVA" id="3M9VIK_gQAM" role="3LXTmr">
+              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="3M9VIK_gQAN" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="3M9VIK_gQAO" role="2Ry0An">
+                  <property role="2Ry0Am" value="de.itemis.model.merge.diamond" />
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="3M9VIK_gQAQ" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1E1JtD" id="2UnEDPCh8Ac" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="de.itemis.model.simple.demo.property" />
+        <property role="3LESm3" value="e50b0500-6fd7-4c7f-a730-9d841358ca2b" />
+        <node concept="398BVA" id="2UnEDPCh8C2" role="3LF7KH">
+          <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+          <node concept="2Ry0Ak" id="2UnEDPCh8C8" role="iGT6I">
+            <property role="2Ry0Am" value="languages" />
+            <node concept="2Ry0Ak" id="2UnEDPCh8Cd" role="2Ry0An">
+              <property role="2Ry0Am" value="de.itemis.model.simple.demo.property" />
+              <node concept="2Ry0Ak" id="2UnEDPCh8Ci" role="2Ry0An">
+                <property role="2Ry0Am" value="de.itemis.model.simple.demo.property.mpl" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1BupzO" id="2UnEDPCh8GS" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="2UnEDPCh8GT" role="1HemKq">
+            <node concept="398BVA" id="2UnEDPCh8GE" role="3LXTmr">
+              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="2UnEDPCh8GF" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="2UnEDPCh8GG" role="2Ry0An">
+                  <property role="2Ry0Am" value="de.itemis.model.simple.demo.property" />
+                  <node concept="2Ry0Ak" id="2UnEDPCh8GH" role="2Ry0An">
+                    <property role="2Ry0Am" value="models" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="2UnEDPCh8GU" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+        <node concept="3rtmxn" id="3M9VIK_gQBd" role="3bR31x">
+          <node concept="3LXTmp" id="3M9VIK_gQBe" role="3rtmxm">
+            <node concept="398BVA" id="3M9VIK_gQBf" role="3LXTmr">
+              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="3M9VIK_gQBg" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="3M9VIK_gQBh" role="2Ry0An">
+                  <property role="2Ry0Am" value="de.itemis.model.simple.demo.property" />
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="3M9VIK_gQBj" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1E1JtD" id="2UnEDPClLCV" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="de.itemis.model.simple.demo.children" />
+        <property role="3LESm3" value="8688ed72-e0ba-44cb-9688-5c8397cb5bbb" />
+        <node concept="398BVA" id="2UnEDPClLEX" role="3LF7KH">
+          <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+          <node concept="2Ry0Ak" id="2UnEDPClLF3" role="iGT6I">
+            <property role="2Ry0Am" value="languages" />
+            <node concept="2Ry0Ak" id="2UnEDPClLF8" role="2Ry0An">
+              <property role="2Ry0Am" value="de.itemis.model.simple.demo.children" />
+              <node concept="2Ry0Ak" id="2UnEDPClLFd" role="2Ry0An">
+                <property role="2Ry0Am" value="de.itemis.model.simple.demo.children.mpl" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2UnEDPClLXF" role="3bR37C">
+          <node concept="3bR9La" id="2UnEDPClLXG" role="1SiIV1">
+            <ref role="3bR37D" node="2UnEDPCh8Ac" resolve="de.itemis.model.simple.demo.property" />
+          </node>
+        </node>
+        <node concept="1BupzO" id="2UnEDPClLXV" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="2UnEDPClLXW" role="1HemKq">
+            <node concept="398BVA" id="2UnEDPClLXH" role="3LXTmr">
+              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="2UnEDPClLXI" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="2UnEDPClLXJ" role="2Ry0An">
+                  <property role="2Ry0Am" value="de.itemis.model.simple.demo.children" />
+                  <node concept="2Ry0Ak" id="2UnEDPClLXK" role="2Ry0An">
+                    <property role="2Ry0Am" value="models" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="2UnEDPClLXX" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1E1JtD" id="2UnEDPClLHk" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="de.itemis.model.simple.demo.collection" />
+        <property role="3LESm3" value="e50b0500-6fd7-4c7f-a730-9d841358ce8b" />
+        <node concept="398BVA" id="2UnEDPClLJr" role="3LF7KH">
+          <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+          <node concept="2Ry0Ak" id="2UnEDPClLJx" role="iGT6I">
+            <property role="2Ry0Am" value="languages" />
+            <node concept="2Ry0Ak" id="2UnEDPClLJA" role="2Ry0An">
+              <property role="2Ry0Am" value="de.itemis.model.simple.demo.collection" />
+              <node concept="2Ry0Ak" id="2UnEDPClLJF" role="2Ry0An">
+                <property role="2Ry0Am" value="de.itemis.model.simple.demo.collection.mpl" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1BupzO" id="2UnEDPClLYc" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="2UnEDPClLYd" role="1HemKq">
+            <node concept="398BVA" id="2UnEDPClLXY" role="3LXTmr">
+              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="2UnEDPClLXZ" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="2UnEDPClLY0" role="2Ry0An">
+                  <property role="2Ry0Am" value="de.itemis.model.simple.demo.collection" />
+                  <node concept="2Ry0Ak" id="2UnEDPClLY1" role="2Ry0An">
+                    <property role="2Ry0Am" value="models" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="2UnEDPClLYe" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2UnEDPClLYf" role="3bR37C">
+          <node concept="1Busua" id="2UnEDPClLYg" role="1SiIV1">
+            <ref role="1Busuk" node="2UnEDPCh8Ac" resolve="de.itemis.model.simple.demo.property" />
+          </node>
+        </node>
+      </node>
+      <node concept="1E1JtD" id="2UnEDPClLLR" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="de.itemis.model.simple.demo.collection.keeper" />
+        <property role="3LESm3" value="36ead753-43ea-471e-bcb9-d4fb1e637bbc" />
+        <node concept="398BVA" id="2UnEDPClLO3" role="3LF7KH">
+          <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+          <node concept="2Ry0Ak" id="2UnEDPClLO9" role="iGT6I">
+            <property role="2Ry0Am" value="languages" />
+            <node concept="2Ry0Ak" id="2UnEDPClLOe" role="2Ry0An">
+              <property role="2Ry0Am" value="de.itemis.model.simple.demo.collection.keeper" />
+              <node concept="2Ry0Ak" id="2UnEDPClLOj" role="2Ry0An">
+                <property role="2Ry0Am" value="de.itemis.model.simple.demo.collection.keeper.mpl" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1BupzO" id="2UnEDPClLYv" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="2UnEDPClLYw" role="1HemKq">
+            <node concept="398BVA" id="2UnEDPClLYh" role="3LXTmr">
+              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="2UnEDPClLYi" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="2UnEDPClLYj" role="2Ry0An">
+                  <property role="2Ry0Am" value="de.itemis.model.simple.demo.collection.keeper" />
+                  <node concept="2Ry0Ak" id="2UnEDPClLYk" role="2Ry0An">
+                    <property role="2Ry0Am" value="models" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="2UnEDPClLYx" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2UnEDPClLYy" role="3bR37C">
+          <node concept="1Busua" id="2UnEDPClLYz" role="1SiIV1">
+            <ref role="1Busuk" node="2UnEDPCh8Ac" resolve="de.itemis.model.simple.demo.property" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2UnEDPClMjG" role="3bR37C">
+          <node concept="1Busua" id="2UnEDPClMjH" role="1SiIV1">
+            <ref role="1Busuk" node="2UnEDPClLHk" resolve="de.itemis.model.simple.demo.collection" />
+          </node>
+        </node>
+      </node>
+      <node concept="1E1JtD" id="2UnEDPClLQ$" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="de.itemis.model.simple.demo.reference" />
+        <property role="3LESm3" value="6001215c-aa6e-4f9f-bfc2-f22e3c7250b2" />
+        <node concept="398BVA" id="2UnEDPClLSP" role="3LF7KH">
+          <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+          <node concept="2Ry0Ak" id="2UnEDPClLSV" role="iGT6I">
+            <property role="2Ry0Am" value="languages" />
+            <node concept="2Ry0Ak" id="2UnEDPClLT0" role="2Ry0An">
+              <property role="2Ry0Am" value="de.itemis.model.simple.demo.reference" />
+              <node concept="2Ry0Ak" id="2UnEDPClLT5" role="2Ry0An">
+                <property role="2Ry0Am" value="de.itemis.model.simple.demo.reference.mpl" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1BupzO" id="2UnEDPClLYM" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="2UnEDPClLYN" role="1HemKq">
+            <node concept="398BVA" id="2UnEDPClLY$" role="3LXTmr">
+              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="2UnEDPClLY_" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="2UnEDPClLYA" role="2Ry0An">
+                  <property role="2Ry0Am" value="de.itemis.model.simple.demo.reference" />
+                  <node concept="2Ry0Ak" id="2UnEDPClLYB" role="2Ry0An">
+                    <property role="2Ry0Am" value="models" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="2UnEDPClLYO" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2UnEDPClLYP" role="3bR37C">
+          <node concept="1Busua" id="2UnEDPClLYQ" role="1SiIV1">
+            <ref role="1Busuk" node="2UnEDPCh8Ac" resolve="de.itemis.model.simple.demo.property" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2UnEDPClMjW" role="3bR37C">
+          <node concept="1Busua" id="2UnEDPClMjX" role="1SiIV1">
+            <ref role="1Busuk" node="2UnEDPClLHk" resolve="de.itemis.model.simple.demo.collection" />
+          </node>
+        </node>
+      </node>
+      <node concept="1E1JtA" id="5RxOLvLcQHZ" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="de.itemis.model.merge.test" />
+        <property role="3LESm3" value="cb29f2d3-8375-4a4d-bc96-278c6b7ca172" />
+        <property role="aoJFB" value="eYcmk9QOlj/sources_and_tests" />
+        <node concept="398BVA" id="5RxOLvLcQJ$" role="3LF7KH">
+          <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+          <node concept="2Ry0Ak" id="5RxOLvLcQJE" role="iGT6I">
+            <property role="2Ry0Am" value="solutions" />
+            <node concept="2Ry0Ak" id="5RxOLvLcQJJ" role="2Ry0An">
+              <property role="2Ry0Am" value="de.itemis.model.merge.test" />
+              <node concept="2Ry0Ak" id="5RxOLvLcQJO" role="2Ry0An">
+                <property role="2Ry0Am" value="de.itemis.model.merge.test.msd" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="5RxOLvLcQPf" role="3bR37C">
+          <node concept="3bR9La" id="5RxOLvLcQPg" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1H905DlDUSw" resolve="MPS.OpenAPI" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="5RxOLvLcQPh" role="3bR37C">
+          <node concept="3bR9La" id="5RxOLvLcQPi" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="5RxOLvLcQPj" role="3bR37C">
+          <node concept="3bR9La" id="5RxOLvLcQPk" role="1SiIV1">
+            <ref role="3bR37D" node="5zr7Q_1BAoJ" resolve="de.itemis.model.merge" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="5RxOLvLcQPl" role="3bR37C">
+          <node concept="3bR9La" id="5RxOLvLcQPm" role="1SiIV1">
+            <ref role="3bR37D" node="6fQhGuklQWU" resolve="de.q60.mps.collections.libs" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="5RxOLvLcQPn" role="3bR37C">
+          <node concept="3bR9La" id="5RxOLvLcQPo" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:7Kfy9QB6LaO" resolve="jetbrains.mps.lang.structure" />
+          </node>
+        </node>
+        <node concept="1BupzO" id="5RxOLvLcQPD" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="5RxOLvLcQPE" role="1HemKq">
+            <node concept="398BVA" id="5RxOLvLcQPr" role="3LXTmr">
+              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="5RxOLvLcQPs" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="5RxOLvLcQPt" role="2Ry0An">
+                  <property role="2Ry0Am" value="de.itemis.model.merge.test" />
+                  <node concept="2Ry0Ak" id="5RxOLvLcQPu" role="2Ry0An">
+                    <property role="2Ry0Am" value="models" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="5RxOLvLcQPF" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2C9csoiagDt" role="3bR37C">
+          <node concept="3bR9La" id="2C9csoiagDu" role="1SiIV1">
+            <ref role="3bR37D" node="5zr7Q_1BD5a" resolve="de.itemis.model.merge.runtime" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="3aF8hCvy3TH" role="3bR37C">
+          <node concept="3bR9La" id="3aF8hCvy3TI" role="1SiIV1">
+            <ref role="3bR37D" node="3aF8hCvy3sT" resolve="de.itemis.model.merge.diamond" />
+          </node>
+        </node>
+        <node concept="3rtmxn" id="3aF8hCw9tVs" role="3bR31x">
+          <node concept="3LXTmp" id="3aF8hCw9tVt" role="3rtmxm">
+            <node concept="398BVA" id="3aF8hCw9tVu" role="3LXTmr">
+              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="3aF8hCw9tVv" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="3aF8hCw9tVw" role="2Ry0An">
+                  <property role="2Ry0Am" value="de.itemis.model.merge.test" />
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="3aF8hCw9tVy" role="3LXTna">
+              <property role="3qWCbO" value="icons/**" />
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="6CwG2k7MRyq" role="3bR37C">
+          <node concept="3bR9La" id="6CwG2k7MRyr" role="1SiIV1">
+            <ref role="3bR37D" node="2UnEDPCh8Ac" resolve="de.itemis.model.simple.demo.property" />
+          </node>
+        </node>
+      </node>
+      <node concept="1E1JtA" id="2UnEDPCpnjG" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="de.itemis.model.merge.simple.demo" />
+        <property role="3LESm3" value="3bfac093-0c90-42c7-87af-7dbe19b8f3e0" />
+        <property role="aoJFB" value="eYcmk9QOlj/sources_and_tests" />
+        <node concept="398BVA" id="2UnEDPCpnmE" role="3LF7KH">
+          <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+          <node concept="2Ry0Ak" id="2UnEDPCpnmK" role="iGT6I">
+            <property role="2Ry0Am" value="solutions" />
+            <node concept="2Ry0Ak" id="2UnEDPCpnmP" role="2Ry0An">
+              <property role="2Ry0Am" value="de.itemis.model.merge.simple.demo" />
+              <node concept="2Ry0Ak" id="2UnEDPCpnmU" role="2Ry0An">
+                <property role="2Ry0Am" value="de.itemis.model.merge.simple.demo.msd" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2UnEDPCpnsA" role="3bR37C">
+          <node concept="3bR9La" id="2UnEDPCpnsB" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1H905DlDUSw" resolve="MPS.OpenAPI" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2UnEDPCpnsC" role="3bR37C">
+          <node concept="3bR9La" id="2UnEDPCpnsD" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2UnEDPCpnsE" role="3bR37C">
+          <node concept="3bR9La" id="2UnEDPCpnsF" role="1SiIV1">
+            <ref role="3bR37D" node="5zr7Q_1BAoJ" resolve="de.itemis.model.merge" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2UnEDPCpnsG" role="3bR37C">
+          <node concept="3bR9La" id="2UnEDPCpnsH" role="1SiIV1">
+            <ref role="3bR37D" node="2UnEDPClLCV" resolve="de.itemis.model.simple.demo.children" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2UnEDPCpnsI" role="3bR37C">
+          <node concept="3bR9La" id="2UnEDPCpnsJ" role="1SiIV1">
+            <ref role="3bR37D" node="2UnEDPClLQ$" resolve="de.itemis.model.simple.demo.reference" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2UnEDPCpnsK" role="3bR37C">
+          <node concept="3bR9La" id="2UnEDPCpnsL" role="1SiIV1">
+            <ref role="3bR37D" node="2UnEDPClLLR" resolve="de.itemis.model.simple.demo.collection.keeper" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2UnEDPCpnsM" role="3bR37C">
+          <node concept="3bR9La" id="2UnEDPCpnsN" role="1SiIV1">
+            <ref role="3bR37D" node="6fQhGuklQWU" resolve="de.q60.mps.collections.libs" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2UnEDPCpnsO" role="3bR37C">
+          <node concept="3bR9La" id="2UnEDPCpnsP" role="1SiIV1">
+            <ref role="3bR37D" node="2UnEDPClLHk" resolve="de.itemis.model.simple.demo.collection" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2UnEDPCpnsQ" role="3bR37C">
+          <node concept="3bR9La" id="2UnEDPCpnsR" role="1SiIV1">
+            <ref role="3bR37D" node="2UnEDPCh8Ac" resolve="de.itemis.model.simple.demo.property" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2UnEDPCpnsS" role="3bR37C">
+          <node concept="3bR9La" id="2UnEDPCpnsT" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1xb0AuwN7WS" resolve="JUnit" />
+          </node>
+        </node>
+        <node concept="1BupzO" id="2UnEDPCpnt8" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="2UnEDPCpnt9" role="1HemKq">
+            <node concept="398BVA" id="2UnEDPCpnsU" role="3LXTmr">
+              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="2UnEDPCpnsV" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="2UnEDPCpnsW" role="2Ry0An">
+                  <property role="2Ry0Am" value="de.itemis.model.merge.simple.demo" />
+                  <node concept="2Ry0Ak" id="2UnEDPCpnsX" role="2Ry0An">
+                    <property role="2Ry0Am" value="models" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="2UnEDPCpnta" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="6QQNrZyfqj" role="3bR37C">
+          <node concept="3bR9La" id="6QQNrZyfqk" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1TaHNgiIbIQ" resolve="MPS.Core" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="6QQNrZIiQM" role="3bR37C">
+          <node concept="3bR9La" id="6QQNrZIiQN" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:4SM2EuqHUPF" resolve="jetbrains.mps.lang.modelapi" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="6QQNrZIiQO" role="3bR37C">
+          <node concept="3bR9La" id="6QQNrZIiQP" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:7Kfy9QB6L9O" resolve="jetbrains.mps.lang.smodel" />
+          </node>
+        </node>
+      </node>
+      <node concept="1E1JtA" id="5Jy3PcPRnpY" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="de.itemis.model.merge.baselang.sandbox" />
+        <property role="3LESm3" value="17d34773-aaeb-4315-92e6-9e0314373a68" />
+        <node concept="398BVA" id="5Jy3PcPRntS" role="3LF7KH">
+          <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+          <node concept="2Ry0Ak" id="5Jy3PcPRnu3" role="iGT6I">
+            <property role="2Ry0Am" value="languages" />
+            <node concept="2Ry0Ak" id="5Jy3PcPRnu8" role="2Ry0An">
+              <property role="2Ry0Am" value="de.itemis.model.merge.baselang" />
+              <node concept="2Ry0Ak" id="5Jy3PcPRnud" role="2Ry0An">
+                <property role="2Ry0Am" value="sandbox" />
+                <node concept="2Ry0Ak" id="5Jy3PcPRnui" role="2Ry0An">
+                  <property role="2Ry0Am" value="de.itemis.model.merge.baselang.sandbox.msd" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="5Jy3PcPRn$c" role="3bR37C">
+          <node concept="3bR9La" id="5Jy3PcPRn$d" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1H905DlDUSw" resolve="MPS.OpenAPI" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="5Jy3PcPRn$e" role="3bR37C">
+          <node concept="3bR9La" id="5Jy3PcPRn$f" role="1SiIV1">
+            <ref role="3bR37D" node="6XR_ZZHk3hx" resolve="de.itemis.model.merge.baselang" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="5Jy3PcPRn$g" role="3bR37C">
+          <node concept="3bR9La" id="5Jy3PcPRn$h" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1ia2VB5guYy" resolve="MPS.IDEA" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="5Jy3PcPRn$i" role="3bR37C">
+          <node concept="3bR9La" id="5Jy3PcPRn$j" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="5Jy3PcPRn$k" role="3bR37C">
+          <node concept="3bR9La" id="5Jy3PcPRn$l" role="1SiIV1">
+            <ref role="3bR37D" node="5zr7Q_1BAoJ" resolve="de.itemis.model.merge" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="5Jy3PcPRn$m" role="3bR37C">
+          <node concept="3bR9La" id="5Jy3PcPRn$n" role="1SiIV1">
+            <ref role="3bR37D" node="2UnEDPCh8Ac" resolve="de.itemis.model.simple.demo.property" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="5Jy3PcPRn$o" role="3bR37C">
+          <node concept="3bR9La" id="5Jy3PcPRn$p" role="1SiIV1">
+            <ref role="3bR37D" node="2UnEDPCpnjG" resolve="de.itemis.model.merge.simple.demo" />
+          </node>
+        </node>
+        <node concept="1BupzO" id="5Jy3PcPRn$F" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="5Jy3PcPRn$G" role="1HemKq">
+            <node concept="398BVA" id="5Jy3PcPRn$q" role="3LXTmr">
+              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="5Jy3PcPRn$r" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="5Jy3PcPRn$s" role="2Ry0An">
+                  <property role="2Ry0Am" value="de.itemis.model.merge.baselang" />
+                  <node concept="2Ry0Ak" id="5Jy3PcPRn$t" role="2Ry0An">
+                    <property role="2Ry0Am" value="sandbox" />
+                    <node concept="2Ry0Ak" id="5Jy3PcPRn$u" role="2Ry0An">
+                      <property role="2Ry0Am" value="models" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="5Jy3PcPRn$H" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1E1JtA" id="3Afi$YnEYQQ" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="de.itemis.mps.modelmerger.testhelper" />
+        <property role="3LESm3" value="be1bf59c-934a-4cee-8859-a8bde460b96f" />
+        <node concept="398BVA" id="3Afi$YnEYYs" role="3LF7KH">
+          <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+          <node concept="2Ry0Ak" id="3Afi$YnEZDh" role="iGT6I">
+            <property role="2Ry0Am" value="modelmerger" />
+            <node concept="2Ry0Ak" id="1RcjJjMqUWR" role="2Ry0An">
+              <property role="2Ry0Am" value="languages" />
+              <node concept="2Ry0Ak" id="1RcjJjMqUWS" role="2Ry0An">
+                <property role="2Ry0Am" value="de.itemis.mps.modelmerger" />
+                <node concept="2Ry0Ak" id="1RcjJjMqUWT" role="2Ry0An">
+                  <property role="2Ry0Am" value="sandbox" />
+                  <node concept="2Ry0Ak" id="1RcjJjMqUWU" role="2Ry0An">
+                    <property role="2Ry0Am" value="de.itemis.mps.modelmerger.testhelper.msd" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="3Afi$YnF0y2" role="3bR37C">
+          <node concept="3bR9La" id="3Afi$YnF0y3" role="1SiIV1">
+            <ref role="3bR37D" node="GuygFg7AfB" resolve="test.de.itemis.mps.modelmerger.testlanguage" />
+          </node>
+        </node>
+        <node concept="3rtmxn" id="5py4VqXmLKF" role="3bR31x">
+          <node concept="3LXTmp" id="5py4VqXmLKG" role="3rtmxm">
+            <node concept="3qWCbU" id="5py4VqXmLKH" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="5py4VqXmLKI" role="3LXTmr">
+              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="5py4VqXmLKJ" role="iGT6I">
+                <property role="2Ry0Am" value="modelmerger" />
+                <node concept="2Ry0Ak" id="67K7yGVZou4" role="2Ry0An">
+                  <property role="2Ry0Am" value="languages" />
+                  <node concept="2Ry0Ak" id="67K7yGVZou5" role="2Ry0An">
+                    <property role="2Ry0Am" value="de.itemis.mps.modelmerger" />
+                    <node concept="2Ry0Ak" id="67K7yGVZou6" role="2Ry0An">
+                      <property role="2Ry0Am" value="sandbox" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1BupzO" id="7q24334ZKDd" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="1RcjJjMqV2r" role="1HemKq">
+            <node concept="398BVA" id="1RcjJjMqV27" role="3LXTmr">
+              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="1RcjJjMqV28" role="iGT6I">
+                <property role="2Ry0Am" value="modelmerger" />
+                <node concept="2Ry0Ak" id="1RcjJjMqV29" role="2Ry0An">
+                  <property role="2Ry0Am" value="languages" />
+                  <node concept="2Ry0Ak" id="1RcjJjMqV2a" role="2Ry0An">
+                    <property role="2Ry0Am" value="de.itemis.mps.modelmerger" />
+                    <node concept="2Ry0Ak" id="1RcjJjMqV2b" role="2Ry0An">
+                      <property role="2Ry0Am" value="sandbox" />
+                      <node concept="2Ry0Ak" id="1RcjJjMqV2c" role="2Ry0An">
+                        <property role="2Ry0Am" value="models" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="1RcjJjMqV2s" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1E1JtA" id="GuygFg7$fI" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="tests.de.itemis.mps.modelmerger" />
+        <property role="3LESm3" value="92726818-95f2-4d46-96d1-aacb660cb63a" />
+        <property role="aoJFB" value="eYcmk9QOlj/sources_and_tests" />
+        <node concept="3rtmxn" id="GuygFg7$fJ" role="3bR31x">
+          <node concept="3LXTmp" id="GuygFg7$fK" role="3rtmxm">
+            <node concept="3qWCbU" id="GuygFg7$fL" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="GuygFg7$fM" role="3LXTmr">
+              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="GuygFg7$fN" role="iGT6I">
+                <property role="2Ry0Am" value="modelmerger" />
+                <node concept="2Ry0Ak" id="67K7yGVZoub" role="2Ry0An">
+                  <property role="2Ry0Am" value="solutions" />
+                  <node concept="2Ry0Ak" id="67K7yGVZouc" role="2Ry0An">
+                    <property role="2Ry0Am" value="tests.de.itemis.mps.modelmerger" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="398BVA" id="GuygFg7$fQ" role="3LF7KH">
+          <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+          <node concept="2Ry0Ak" id="GuygFg7_oX" role="iGT6I">
+            <property role="2Ry0Am" value="modelmerger" />
+            <node concept="2Ry0Ak" id="1RcjJjMqUX0" role="2Ry0An">
+              <property role="2Ry0Am" value="solutions" />
+              <node concept="2Ry0Ak" id="1RcjJjMqUX1" role="2Ry0An">
+                <property role="2Ry0Am" value="tests.de.itemis.mps.modelmerger" />
+                <node concept="2Ry0Ak" id="1RcjJjMqUX2" role="2Ry0An">
+                  <property role="2Ry0Am" value="tests.de.itemis.mps.modelmerger.msd" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="GuygFg7A1b" role="3bR37C">
+          <node concept="3bR9La" id="GuygFg7A1c" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1TaHNgiIbIQ" resolve="MPS.Core" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="GuygFg7A1d" role="3bR37C">
+          <node concept="3bR9La" id="GuygFg7A1e" role="1SiIV1">
+            <ref role="3bR37D" node="GuygFg6VEV" resolve="de.itemis.mps.modelmerger.runtime" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="GuygFg7BEG" role="3bR37C">
+          <node concept="3bR9La" id="GuygFg7BEH" role="1SiIV1">
+            <ref role="3bR37D" node="GuygFg7AfB" resolve="test.de.itemis.mps.modelmerger.testlanguage" />
+          </node>
+        </node>
+        <node concept="1BupzO" id="7q24334ZKDu" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="1RcjJjMqV2I" role="1HemKq">
+            <node concept="398BVA" id="1RcjJjMqV2t" role="3LXTmr">
+              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="1RcjJjMqV2u" role="iGT6I">
+                <property role="2Ry0Am" value="modelmerger" />
+                <node concept="2Ry0Ak" id="1RcjJjMqV2v" role="2Ry0An">
+                  <property role="2Ry0Am" value="solutions" />
+                  <node concept="2Ry0Ak" id="1RcjJjMqV2w" role="2Ry0An">
+                    <property role="2Ry0Am" value="tests.de.itemis.mps.modelmerger" />
+                    <node concept="2Ry0Ak" id="1RcjJjMqV2x" role="2Ry0An">
+                      <property role="2Ry0Am" value="models" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="1RcjJjMqV2J" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="59_ttdjbdCz" role="3bR37C">
+          <node concept="3bR9La" id="59_ttdjbdC$" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:7Kfy9QB6KXW" resolve="jetbrains.mps.lang.core" />
+          </node>
+        </node>
+      </node>
+      <node concept="1E1JtD" id="GuygFg7AfB" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="test.de.itemis.mps.modelmerger.testlanguage" />
+        <property role="3LESm3" value="d119cd03-ed7e-477f-adb6-22a3d2e6ea77" />
+        <node concept="398BVA" id="GuygFg7AmQ" role="3LF7KH">
+          <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+          <node concept="2Ry0Ak" id="GuygFg7AtP" role="iGT6I">
+            <property role="2Ry0Am" value="modelmerger" />
+            <node concept="2Ry0Ak" id="1RcjJjMqUX7" role="2Ry0An">
+              <property role="2Ry0Am" value="languages" />
+              <node concept="2Ry0Ak" id="1RcjJjMqUX8" role="2Ry0An">
+                <property role="2Ry0Am" value="test.de.itemis.mps.modelmerger.testlanguage" />
+                <node concept="2Ry0Ak" id="1RcjJjMqUX9" role="2Ry0An">
+                  <property role="2Ry0Am" value="test.de.itemis.mps.modelmerger.testlanguage.mpl" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3rtmxn" id="5py4VqXmLO1" role="3bR31x">
+          <node concept="3LXTmp" id="5py4VqXmLO2" role="3rtmxm">
+            <node concept="3qWCbU" id="5py4VqXmLO3" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="5py4VqXmLO4" role="3LXTmr">
+              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="5py4VqXmLO5" role="iGT6I">
+                <property role="2Ry0Am" value="modelmerger" />
+                <node concept="2Ry0Ak" id="67K7yGVZotZ" role="2Ry0An">
+                  <property role="2Ry0Am" value="languages" />
+                  <node concept="2Ry0Ak" id="67K7yGVZou0" role="2Ry0An">
+                    <property role="2Ry0Am" value="test.de.itemis.mps.modelmerger.testlanguage" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1BupzO" id="7q24334ZKDJ" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="1RcjJjMqV31" role="1HemKq">
+            <node concept="398BVA" id="1RcjJjMqV2K" role="3LXTmr">
+              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="1RcjJjMqV2L" role="iGT6I">
+                <property role="2Ry0Am" value="modelmerger" />
+                <node concept="2Ry0Ak" id="1RcjJjMqV2M" role="2Ry0An">
+                  <property role="2Ry0Am" value="languages" />
+                  <node concept="2Ry0Ak" id="1RcjJjMqV2N" role="2Ry0An">
+                    <property role="2Ry0Am" value="test.de.itemis.mps.modelmerger.testlanguage" />
+                    <node concept="2Ry0Ak" id="1RcjJjMqV2O" role="2Ry0An">
+                      <property role="2Ry0Am" value="models" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="1RcjJjMqV32" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2G$12M" id="T8sXq9o52B" role="3989C9">
+      <property role="TrG5h" value="plaintextgen-tests" />
+      <node concept="1E1JtD" id="T8sXq9o58u" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="com.dslfoundry.plaintextgen.example.nestedlist" />
+        <property role="3LESm3" value="a50fc719-4261-4a46-8e65-d98071469ff6" />
+        <node concept="398BVA" id="T8sXq9o58y" role="3LF7KH">
+          <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+          <node concept="2Ry0Ak" id="T8sXq9o58C" role="iGT6I">
+            <property role="2Ry0Am" value="plaintextgen" />
+            <node concept="2Ry0Ak" id="T8sXq9o58H" role="2Ry0An">
+              <property role="2Ry0Am" value="languages" />
+              <node concept="2Ry0Ak" id="T8sXq9o58M" role="2Ry0An">
+                <property role="2Ry0Am" value="com.dslfoundry.plaintextgen.example.nestedlist" />
+                <node concept="2Ry0Ak" id="T8sXq9o58R" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.dslfoundry.plaintextgen.example.nestedlist.mpl" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1yeLz9" id="T8sXq9o5cP" role="1TViLv">
+          <property role="TrG5h" value="com.dslfoundry.plaintextgen.example.nestedlist#7022720084780710580" />
+          <property role="3LESm3" value="516b4c2f-de92-4b35-b9ea-223ab1ed88d9" />
+          <node concept="1BupzO" id="7q24334ZKEq" role="3bR31x">
+            <property role="3ZfqAx" value="generator/template" />
+            <property role="1Hdu6h" value="true" />
+            <property role="1HemKv" value="true" />
+            <node concept="3LXTmp" id="7q24334ZKEr" role="1HemKq">
+              <node concept="398BVA" id="7q24334ZKE6" role="3LXTmr">
+                <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+                <node concept="2Ry0Ak" id="7q24334ZKE7" role="iGT6I">
+                  <property role="2Ry0Am" value="plaintextgen" />
+                  <node concept="2Ry0Ak" id="7q24334ZKE8" role="2Ry0An">
+                    <property role="2Ry0Am" value="languages" />
+                    <node concept="2Ry0Ak" id="7q24334ZKE9" role="2Ry0An">
+                      <property role="2Ry0Am" value="com.dslfoundry.plaintextgen.example.nestedlist" />
+                      <node concept="2Ry0Ak" id="7q24334ZKEa" role="2Ry0An">
+                        <property role="2Ry0Am" value="generator" />
+                        <node concept="2Ry0Ak" id="7q24334ZKEb" role="2Ry0An">
+                          <property role="2Ry0Am" value="template" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3qWCbU" id="7q24334ZKEs" role="3LXTna">
+                <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3rtmxn" id="5py4VqXmLO8" role="3bR31x">
+          <node concept="3LXTmp" id="5py4VqXmLO9" role="3rtmxm">
+            <node concept="3qWCbU" id="5py4VqXmLOa" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="5py4VqXmLOb" role="3LXTmr">
+              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="5py4VqXmLOc" role="iGT6I">
+                <property role="2Ry0Am" value="plaintextgen" />
+                <node concept="2Ry0Ak" id="5py4VqXmLOd" role="2Ry0An">
+                  <property role="2Ry0Am" value="languages" />
+                  <node concept="2Ry0Ak" id="5py4VqXmLOe" role="2Ry0An">
+                    <property role="2Ry0Am" value="com.dslfoundry.plaintextgen.example.nestedlist" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1BupzO" id="7q24334ZKE3" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="7q24334ZKE4" role="1HemKq">
+            <node concept="398BVA" id="7q24334ZKDM" role="3LXTmr">
+              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="7q24334ZKDN" role="iGT6I">
+                <property role="2Ry0Am" value="plaintextgen" />
+                <node concept="2Ry0Ak" id="7q24334ZKDO" role="2Ry0An">
+                  <property role="2Ry0Am" value="languages" />
+                  <node concept="2Ry0Ak" id="7q24334ZKDP" role="2Ry0An">
+                    <property role="2Ry0Am" value="com.dslfoundry.plaintextgen.example.nestedlist" />
+                    <node concept="2Ry0Ak" id="7q24334ZKDQ" role="2Ry0An">
+                      <property role="2Ry0Am" value="models" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="7q24334ZKE5" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1E1JtD" id="T8sXq9o593" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="com.dslfoundry.plaintextgen.example.testlang" />
+        <property role="3LESm3" value="90aa1f1b-f65c-4e9a-99b4-4030e09d0bb2" />
+        <node concept="398BVA" id="T8sXq9o59f" role="3LF7KH">
+          <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+          <node concept="2Ry0Ak" id="T8sXq9o59l" role="iGT6I">
+            <property role="2Ry0Am" value="plaintextgen" />
+            <node concept="2Ry0Ak" id="T8sXq9o59q" role="2Ry0An">
+              <property role="2Ry0Am" value="languages" />
+              <node concept="2Ry0Ak" id="T8sXq9o59v" role="2Ry0An">
+                <property role="2Ry0Am" value="com.dslfoundry.plaintextgen.example.testlang" />
+                <node concept="2Ry0Ak" id="T8sXq9o59$" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.dslfoundry.plaintextgen.example.testlang.mpl" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1yeLz9" id="T8sXq9o5cQ" role="1TViLv">
+          <property role="TrG5h" value="com.dslfoundry.plaintextgen.example.testlang#3661149507326583883" />
+          <property role="3LESm3" value="ccd826e7-e85c-4fb5-8a54-657940fd9fa7" />
+          <node concept="1BupzO" id="7q24334ZKF5" role="3bR31x">
+            <property role="3ZfqAx" value="generator/template" />
+            <property role="1Hdu6h" value="true" />
+            <property role="1HemKv" value="true" />
+            <node concept="3LXTmp" id="7q24334ZKF6" role="1HemKq">
+              <node concept="398BVA" id="7q24334ZKEL" role="3LXTmr">
+                <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+                <node concept="2Ry0Ak" id="7q24334ZKEM" role="iGT6I">
+                  <property role="2Ry0Am" value="plaintextgen" />
+                  <node concept="2Ry0Ak" id="7q24334ZKEN" role="2Ry0An">
+                    <property role="2Ry0Am" value="languages" />
+                    <node concept="2Ry0Ak" id="7q24334ZKEO" role="2Ry0An">
+                      <property role="2Ry0Am" value="com.dslfoundry.plaintextgen.example.testlang" />
+                      <node concept="2Ry0Ak" id="7q24334ZKEP" role="2Ry0An">
+                        <property role="2Ry0Am" value="generator" />
+                        <node concept="2Ry0Ak" id="7q24334ZKEQ" role="2Ry0An">
+                          <property role="2Ry0Am" value="template" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3qWCbU" id="7q24334ZKF7" role="3LXTna">
+                <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3rtmxn" id="5py4VqXmLOg" role="3bR31x">
+          <node concept="3LXTmp" id="5py4VqXmLOh" role="3rtmxm">
+            <node concept="3qWCbU" id="5py4VqXmLOi" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="5py4VqXmLOj" role="3LXTmr">
+              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="5py4VqXmLOk" role="iGT6I">
+                <property role="2Ry0Am" value="plaintextgen" />
+                <node concept="2Ry0Ak" id="5py4VqXmLOl" role="2Ry0An">
+                  <property role="2Ry0Am" value="languages" />
+                  <node concept="2Ry0Ak" id="5py4VqXmLOm" role="2Ry0An">
+                    <property role="2Ry0Am" value="com.dslfoundry.plaintextgen.example.testlang" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1BupzO" id="7q24334ZKEI" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="7q24334ZKEJ" role="1HemKq">
+            <node concept="398BVA" id="7q24334ZKEt" role="3LXTmr">
+              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="7q24334ZKEu" role="iGT6I">
+                <property role="2Ry0Am" value="plaintextgen" />
+                <node concept="2Ry0Ak" id="7q24334ZKEv" role="2Ry0An">
+                  <property role="2Ry0Am" value="languages" />
+                  <node concept="2Ry0Ak" id="7q24334ZKEw" role="2Ry0An">
+                    <property role="2Ry0Am" value="com.dslfoundry.plaintextgen.example.testlang" />
+                    <node concept="2Ry0Ak" id="7q24334ZKEx" role="2Ry0An">
+                      <property role="2Ry0Am" value="models" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="7q24334ZKEK" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1E1JtA" id="T8sXq9o59Q" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="com.dslfoundry.plaintextgen.example.nestedlist.sandbox" />
+        <property role="3LESm3" value="ba03a5e3-c9b5-466f-83a9-e2775cc47038" />
+        <node concept="398BVA" id="T8sXq9o5a8" role="3LF7KH">
+          <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+          <node concept="2Ry0Ak" id="T8sXq9o5ae" role="iGT6I">
+            <property role="2Ry0Am" value="plaintextgen" />
+            <node concept="2Ry0Ak" id="T8sXq9o5aj" role="2Ry0An">
+              <property role="2Ry0Am" value="solutions" />
+              <node concept="2Ry0Ak" id="T8sXq9o5ao" role="2Ry0An">
+                <property role="2Ry0Am" value="com.dslfoundry.plaintextgen.example.nestedlist.sandbox" />
+                <node concept="2Ry0Ak" id="T8sXq9o5at" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.dslfoundry.plaintextgen.example.nestedlist.sandbox.msd" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3rtmxn" id="5py4VqXmLKN" role="3bR31x">
+          <node concept="3LXTmp" id="5py4VqXmLKO" role="3rtmxm">
+            <node concept="3qWCbU" id="5py4VqXmLKP" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="5py4VqXmLKQ" role="3LXTmr">
+              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="5py4VqXmLKR" role="iGT6I">
+                <property role="2Ry0Am" value="plaintextgen" />
+                <node concept="2Ry0Ak" id="5py4VqXmLKS" role="2Ry0An">
+                  <property role="2Ry0Am" value="solutions" />
+                  <node concept="2Ry0Ak" id="5py4VqXmLKT" role="2Ry0An">
+                    <property role="2Ry0Am" value="com.dslfoundry.plaintextgen.example.nestedlist.sandbox" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1BupzO" id="7q24334ZKFp" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="7q24334ZKFq" role="1HemKq">
+            <node concept="398BVA" id="7q24334ZKF8" role="3LXTmr">
+              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="7q24334ZKF9" role="iGT6I">
+                <property role="2Ry0Am" value="plaintextgen" />
+                <node concept="2Ry0Ak" id="7q24334ZKFa" role="2Ry0An">
+                  <property role="2Ry0Am" value="solutions" />
+                  <node concept="2Ry0Ak" id="7q24334ZKFb" role="2Ry0An">
+                    <property role="2Ry0Am" value="com.dslfoundry.plaintextgen.example.nestedlist.sandbox" />
+                    <node concept="2Ry0Ak" id="7q24334ZKFc" role="2Ry0An">
+                      <property role="2Ry0Am" value="models" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="7q24334ZKFr" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1E1JtA" id="T8sXq9o5aP" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="com.dslfoundry.plaintextgen.example.plaintextflow" />
+        <property role="3LESm3" value="98b33244-af76-406c-b3fd-e713f69cf5b8" />
+        <node concept="398BVA" id="T8sXq9o5bd" role="3LF7KH">
+          <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+          <node concept="2Ry0Ak" id="T8sXq9o5bj" role="iGT6I">
+            <property role="2Ry0Am" value="plaintextgen" />
+            <node concept="2Ry0Ak" id="T8sXq9o5bo" role="2Ry0An">
+              <property role="2Ry0Am" value="solutions" />
+              <node concept="2Ry0Ak" id="T8sXq9o5bt" role="2Ry0An">
+                <property role="2Ry0Am" value="com.dslfoundry.plaintextgen.example.plaintextflow" />
+                <node concept="2Ry0Ak" id="T8sXq9o5by" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.dslfoundry.plaintextgen.example.plaintextflow.msd" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3rtmxn" id="5py4VqXmLKV" role="3bR31x">
+          <node concept="3LXTmp" id="5py4VqXmLKW" role="3rtmxm">
+            <node concept="3qWCbU" id="5py4VqXmLKX" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="5py4VqXmLKY" role="3LXTmr">
+              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="5py4VqXmLKZ" role="iGT6I">
+                <property role="2Ry0Am" value="plaintextgen" />
+                <node concept="2Ry0Ak" id="5py4VqXmLL0" role="2Ry0An">
+                  <property role="2Ry0Am" value="solutions" />
+                  <node concept="2Ry0Ak" id="5py4VqXmLL1" role="2Ry0An">
+                    <property role="2Ry0Am" value="com.dslfoundry.plaintextgen.example.plaintextflow" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1BupzO" id="7q24334ZKFH" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="7q24334ZKFI" role="1HemKq">
+            <node concept="398BVA" id="7q24334ZKFs" role="3LXTmr">
+              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="7q24334ZKFt" role="iGT6I">
+                <property role="2Ry0Am" value="plaintextgen" />
+                <node concept="2Ry0Ak" id="7q24334ZKFu" role="2Ry0An">
+                  <property role="2Ry0Am" value="solutions" />
+                  <node concept="2Ry0Ak" id="7q24334ZKFv" role="2Ry0An">
+                    <property role="2Ry0Am" value="com.dslfoundry.plaintextgen.example.plaintextflow" />
+                    <node concept="2Ry0Ak" id="7q24334ZKFw" role="2Ry0An">
+                      <property role="2Ry0Am" value="models" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="7q24334ZKFJ" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1E1JtA" id="T8sXq9o5c0" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="com.dslfoundry.plaintextgen.example.testlang.sandbox" />
+        <property role="3LESm3" value="656d5e8d-33ef-4f6c-b197-7fbc05468208" />
+        <node concept="398BVA" id="T8sXq9o5cu" role="3LF7KH">
+          <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+          <node concept="2Ry0Ak" id="T8sXq9o5c$" role="iGT6I">
+            <property role="2Ry0Am" value="plaintextgen" />
+            <node concept="2Ry0Ak" id="T8sXq9o5cD" role="2Ry0An">
+              <property role="2Ry0Am" value="solutions" />
+              <node concept="2Ry0Ak" id="T8sXq9o5cI" role="2Ry0An">
+                <property role="2Ry0Am" value="com.dslfoundry.plaintextgen.example.testlang.sandbox" />
+                <node concept="2Ry0Ak" id="T8sXq9o5cN" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.dslfoundry.plaintextgen.example.testlang.sandbox.msd" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3rtmxn" id="5py4VqXmLL3" role="3bR31x">
+          <node concept="3LXTmp" id="5py4VqXmLL4" role="3rtmxm">
+            <node concept="3qWCbU" id="5py4VqXmLL5" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="5py4VqXmLL6" role="3LXTmr">
+              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="5py4VqXmLL7" role="iGT6I">
+                <property role="2Ry0Am" value="plaintextgen" />
+                <node concept="2Ry0Ak" id="5py4VqXmLL8" role="2Ry0An">
+                  <property role="2Ry0Am" value="solutions" />
+                  <node concept="2Ry0Ak" id="5py4VqXmLL9" role="2Ry0An">
+                    <property role="2Ry0Am" value="com.dslfoundry.plaintextgen.example.testlang.sandbox" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1BupzO" id="7q24334ZKG1" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="7q24334ZKG2" role="1HemKq">
+            <node concept="398BVA" id="7q24334ZKFK" role="3LXTmr">
+              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="7q24334ZKFL" role="iGT6I">
+                <property role="2Ry0Am" value="plaintextgen" />
+                <node concept="2Ry0Ak" id="7q24334ZKFM" role="2Ry0An">
+                  <property role="2Ry0Am" value="solutions" />
+                  <node concept="2Ry0Ak" id="7q24334ZKFN" role="2Ry0An">
+                    <property role="2Ry0Am" value="com.dslfoundry.plaintextgen.example.testlang.sandbox" />
+                    <node concept="2Ry0Ak" id="7q24334ZKFO" role="2Ry0An">
+                      <property role="2Ry0Am" value="models" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="7q24334ZKG3" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2G$12M" id="7g5FWGK0Kfe" role="3989C9">
+      <property role="TrG5h" value="model-api-tests" />
+      <node concept="1E1JtA" id="7g5FWGK0Kzy" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="test.org.modelix.model.mpsadapters" />
+        <property role="3LESm3" value="133bdd06-b98b-47f5-8335-a48e447f9c41" />
+        <node concept="398BVA" id="7g5FWGK0KzA" role="3LF7KH">
+          <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+          <node concept="2Ry0Ak" id="7g5FWGK0KzG" role="iGT6I">
+            <property role="2Ry0Am" value="model-api" />
+            <node concept="2Ry0Ak" id="7g5FWGK12Ig" role="2Ry0An">
+              <property role="2Ry0Am" value="test.org.modelix.model.mpsadapters" />
+              <node concept="2Ry0Ak" id="7g5FWGK12Il" role="2Ry0An">
+                <property role="2Ry0Am" value="test.org.modelix.model.mpsadapters.msd" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1BupzO" id="7g5FWGK12Pw" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="7g5FWGK12Px" role="1HemKq">
+            <node concept="398BVA" id="7g5FWGK12Pi" role="3LXTmr">
+              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="7g5FWGK12Pj" role="iGT6I">
+                <property role="2Ry0Am" value="model-api" />
+                <node concept="2Ry0Ak" id="7g5FWGK12Pk" role="2Ry0An">
+                  <property role="2Ry0Am" value="test.org.modelix.model.mpsadapters" />
+                  <node concept="2Ry0Ak" id="7g5FWGK12Pl" role="2Ry0An">
+                    <property role="2Ry0Am" value="models" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="7g5FWGK12Py" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="7g5FWGK3ZSU" role="3bR37C">
+          <node concept="3bR9La" id="7g5FWGK3ZSV" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1H905DlDUSw" resolve="MPS.OpenAPI" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="7g5FWGK3ZSW" role="3bR37C">
+          <node concept="3bR9La" id="7g5FWGK3ZSX" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="7g5FWGK3ZSY" role="3bR37C">
+          <node concept="3bR9La" id="7g5FWGK3ZSZ" role="1SiIV1">
+            <ref role="3bR37D" node="5U8hsWC73Be" resolve="org.modelix.model.repositoryconcepts" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="7g5FWGK3ZT0" role="3bR37C">
+          <node concept="3bR9La" id="7g5FWGK3ZT1" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:7Kfy9QB6KXW" resolve="jetbrains.mps.lang.core" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="7g5FWGK3ZT2" role="3bR37C">
+          <node concept="3bR9La" id="7g5FWGK3ZT3" role="1SiIV1">
+            <ref role="3bR37D" node="5U8hsWC70jw" resolve="org.modelix.model.api" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="7g5FWGK3ZT4" role="3bR37C">
+          <node concept="3bR9La" id="7g5FWGK3ZT5" role="1SiIV1">
+            <ref role="3bR37D" node="4iIKqJTZ5Hm" resolve="de.q60.mps.shadowmodels.runtime" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="7g5FWGK3ZT6" role="3bR37C">
+          <node concept="3bR9La" id="7g5FWGK3ZT7" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="7g5FWGK3ZT8" role="3bR37C">
+          <node concept="3bR9La" id="7g5FWGK3ZT9" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1TaHNgiIbIQ" resolve="MPS.Core" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="7g5FWGK3ZTa" role="3bR37C">
+          <node concept="3bR9La" id="7g5FWGK3ZTb" role="1SiIV1">
+            <ref role="3bR37D" node="5U8hsWC71Xh" resolve="org.modelix.model.mpsadapters" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2G$12M" id="4JmkJs3GrYV" role="3989C9">
+      <property role="TrG5h" value="shadowmodels-tests" />
+      <node concept="1E1JtA" id="4JmkJs3Gs4u" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="test.de.q60.mps.shadowmodels.examples" />
+        <property role="3LESm3" value="4ab36e7c-b9ac-4947-9bb8-c3ed105e5fbe" />
+        <property role="aoJFB" value="eYcmk9QOlj/sources_and_tests" />
+        <node concept="398BVA" id="4JmkJs3Gs4y" role="3LF7KH">
+          <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+          <node concept="2Ry0Ak" id="4JmkJs3Gs4C" role="iGT6I">
+            <property role="2Ry0Am" value="shadowmodels" />
+            <node concept="2Ry0Ak" id="4wrAhqcwXxO" role="2Ry0An">
+              <property role="2Ry0Am" value="solutions" />
+              <node concept="2Ry0Ak" id="4wrAhqcwXxM" role="2Ry0An">
+                <property role="2Ry0Am" value="test.de.q60.mps.shadowmodels.examples" />
+                <node concept="2Ry0Ak" id="4wrAhqcwXxN" role="2Ry0An">
+                  <property role="2Ry0Am" value="test.de.q60.mps.shadowmodels.examples.msd" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="4JmkJs3Gs4O" role="3bR37C">
+          <node concept="3bR9La" id="4JmkJs3Gs4P" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1H905DlDUSw" resolve="MPS.OpenAPI" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="4JmkJs3Gs4Q" role="3bR37C">
+          <node concept="3bR9La" id="4JmkJs3Gs4R" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="4JmkJs3Gs4S" role="3bR37C">
+          <node concept="3bR9La" id="4JmkJs3Gs4T" role="1SiIV1">
+            <ref role="3bR37D" node="4iIKqJTZ5Hm" resolve="de.q60.mps.shadowmodels.runtime" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="4JmkJs3Gs4U" role="3bR37C">
+          <node concept="3bR9La" id="4JmkJs3Gs4V" role="1SiIV1">
+            <ref role="3bR37D" node="4iIKqJTZ5HO" resolve="de.q60.mps.shadowmodels.transformation" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="4JmkJs3Gs4W" role="3bR37C">
+          <node concept="3bR9La" id="4JmkJs3Gs4X" role="1SiIV1">
+            <ref role="3bR37D" node="BRK1N8p1ux" resolve="de.q60.mps.shadowmodels.examples.statemachine" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="4JmkJs3Gs4Y" role="3bR37C">
+          <node concept="3bR9La" id="4JmkJs3Gs4Z" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:6aIAM_Qd5ki" resolve="jetbrains.mps.lang.test.matcher" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="4JmkJs3KO_i" role="3bR37C">
+          <node concept="3bR9La" id="4JmkJs3KO_j" role="1SiIV1">
+            <ref role="3bR37D" node="BRK1N8p1qk" resolve="de.q60.mps.shadowmodels.examples.entities" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2qi4B7uvqM5" role="3bR37C">
+          <node concept="3bR9La" id="2qi4B7uvqM6" role="1SiIV1">
+            <ref role="3bR37D" node="BRK1N8p1tm" resolve="de.q60.mps.shadowmodels.examples.blext" />
+          </node>
+        </node>
+        <node concept="3rtmxn" id="5py4VqXmLLb" role="3bR31x">
+          <node concept="3LXTmp" id="5py4VqXmLLc" role="3rtmxm">
+            <node concept="3qWCbU" id="5py4VqXmLLd" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="5py4VqXmLLe" role="3LXTmr">
+              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="5py4VqXmLLf" role="iGT6I">
+                <property role="2Ry0Am" value="shadowmodels" />
+                <node concept="2Ry0Ak" id="5py4VqXmLLg" role="2Ry0An">
+                  <property role="2Ry0Am" value="solutions" />
+                  <node concept="2Ry0Ak" id="5py4VqXmLLh" role="2Ry0An">
+                    <property role="2Ry0Am" value="test.de.q60.mps.shadowmodels.examples" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1BupzO" id="7q24334ZKGl" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="7q24334ZKGm" role="1HemKq">
+            <node concept="398BVA" id="7q24334ZKG4" role="3LXTmr">
+              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="7q24334ZKG5" role="iGT6I">
+                <property role="2Ry0Am" value="shadowmodels" />
+                <node concept="2Ry0Ak" id="7q24334ZKG6" role="2Ry0An">
+                  <property role="2Ry0Am" value="solutions" />
+                  <node concept="2Ry0Ak" id="7q24334ZKG7" role="2Ry0An">
+                    <property role="2Ry0Am" value="test.de.q60.mps.shadowmodels.examples" />
+                    <node concept="2Ry0Ak" id="7q24334ZKG8" role="2Ry0An">
+                      <property role="2Ry0Am" value="models" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="7q24334ZKGn" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="3ofF9dt4hqS" role="3bR37C">
+          <node concept="3bR9La" id="3ofF9dt4hqT" role="1SiIV1">
+            <ref role="3bR37D" node="5U8hsWC70jw" resolve="org.modelix.model.api" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="3ofF9dt4hqU" role="3bR37C">
+          <node concept="3bR9La" id="3ofF9dt4hqV" role="1SiIV1">
+            <ref role="3bR37D" node="5U8hsWC71Xh" resolve="org.modelix.model.mpsadapters" />
+          </node>
+        </node>
+      </node>
+      <node concept="1E1JtA" id="5QP6xyk3oCB" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="test.de.q60.mps.shadowmodels.runtime" />
+        <property role="3LESm3" value="2df94ad8-121c-4ade-96b4-16b8cd29b0cc" />
+        <property role="aoJFB" value="eYcmk9QOlj/sources_and_tests" />
+        <node concept="398BVA" id="5QP6xyk3oCC" role="3LF7KH">
+          <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+          <node concept="2Ry0Ak" id="5QP6xyk3oCD" role="iGT6I">
+            <property role="2Ry0Am" value="shadowmodels" />
+            <node concept="2Ry0Ak" id="5QP6xyk3oCE" role="2Ry0An">
+              <property role="2Ry0Am" value="solutions" />
+              <node concept="2Ry0Ak" id="5QP6xyk3oCF" role="2Ry0An">
+                <property role="2Ry0Am" value="test.de.q60.mps.shadowmodels.runtime" />
+                <node concept="2Ry0Ak" id="5QP6xyk3oDJ" role="2Ry0An">
+                  <property role="2Ry0Am" value="test.de.q60.mps.shadowmodels.runtime.msd" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="5QP6xyk3oCJ" role="3bR37C">
+          <node concept="3bR9La" id="5QP6xyk3oCK" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="5QP6xyk3oCL" role="3bR37C">
+          <node concept="3bR9La" id="5QP6xyk3oCM" role="1SiIV1">
+            <ref role="3bR37D" node="4iIKqJTZ5Hm" resolve="de.q60.mps.shadowmodels.runtime" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="5QP6xyk3oDL" role="3bR37C">
+          <node concept="3bR9La" id="5QP6xyk3oDM" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:7Kfy9QB6KXW" resolve="jetbrains.mps.lang.core" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="5QP6xyk3oDN" role="3bR37C">
+          <node concept="3bR9La" id="5QP6xyk3oDO" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2fAW4lf42S" role="3bR37C">
+          <node concept="3bR9La" id="2fAW4lf42T" role="1SiIV1">
+            <ref role="3bR37D" node="4iIKqJTZ5HI" resolve="de.q60.mps.shadowmodels.runtimelang" />
+          </node>
+        </node>
+        <node concept="3rtmxn" id="5py4VqXmLLj" role="3bR31x">
+          <node concept="3LXTmp" id="5py4VqXmLLk" role="3rtmxm">
+            <node concept="3qWCbU" id="5py4VqXmLLl" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="5py4VqXmLLm" role="3LXTmr">
+              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="5py4VqXmLLn" role="iGT6I">
+                <property role="2Ry0Am" value="shadowmodels" />
+                <node concept="2Ry0Ak" id="5py4VqXmLLo" role="2Ry0An">
+                  <property role="2Ry0Am" value="solutions" />
+                  <node concept="2Ry0Ak" id="5py4VqXmLLp" role="2Ry0An">
+                    <property role="2Ry0Am" value="test.de.q60.mps.shadowmodels.runtime" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="7q24334ZKGo" role="3bR37C">
+          <node concept="3bR9La" id="7q24334ZKGp" role="1SiIV1">
+            <ref role="3bR37D" node="6fQhGuklQWU" resolve="de.q60.mps.collections.libs" />
+          </node>
+        </node>
+        <node concept="1BupzO" id="7q24334ZKGF" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="7q24334ZKGG" role="1HemKq">
+            <node concept="398BVA" id="7q24334ZKGq" role="3LXTmr">
+              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="7q24334ZKGr" role="iGT6I">
+                <property role="2Ry0Am" value="shadowmodels" />
+                <node concept="2Ry0Ak" id="7q24334ZKGs" role="2Ry0An">
+                  <property role="2Ry0Am" value="solutions" />
+                  <node concept="2Ry0Ak" id="7q24334ZKGt" role="2Ry0An">
+                    <property role="2Ry0Am" value="test.de.q60.mps.shadowmodels.runtime" />
+                    <node concept="2Ry0Ak" id="7q24334ZKGu" role="2Ry0An">
+                      <property role="2Ry0Am" value="models" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="7q24334ZKGH" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="3ofF9dt4hrd" role="3bR37C">
+          <node concept="3bR9La" id="3ofF9dt4hre" role="1SiIV1">
+            <ref role="3bR37D" node="5U8hsWC73Be" resolve="org.modelix.model.repositoryconcepts" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="3ofF9dt4hrf" role="3bR37C">
+          <node concept="3bR9La" id="3ofF9dt4hrg" role="1SiIV1">
+            <ref role="3bR37D" node="5U8hsWC70jw" resolve="org.modelix.model.api" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="3ofF9dt4hrh" role="3bR37C">
+          <node concept="3bR9La" id="3ofF9dt4hri" role="1SiIV1">
+            <ref role="3bR37D" node="5U8hsWC71Xh" resolve="org.modelix.model.mpsadapters" />
+          </node>
+        </node>
+      </node>
+      <node concept="1E1JtA" id="7qGGLAjNnEU" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="test.de.q60.mps.incremental.runtime" />
+        <property role="3LESm3" value="c443280a-473c-4861-88cd-473f004f383a" />
+        <property role="aoJFB" value="eYcmk9QOlj/sources_and_tests" />
+        <node concept="398BVA" id="7qGGLAjNnFA" role="3LF7KH">
+          <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+          <node concept="2Ry0Ak" id="7qGGLAjNnFG" role="iGT6I">
+            <property role="2Ry0Am" value="shadowmodels" />
+            <node concept="2Ry0Ak" id="7qGGLAjNnFL" role="2Ry0An">
+              <property role="2Ry0Am" value="solutions" />
+              <node concept="2Ry0Ak" id="7qGGLAjNnFQ" role="2Ry0An">
+                <property role="2Ry0Am" value="test.de.q60.mps.incremental.runtime" />
+                <node concept="2Ry0Ak" id="7qGGLAjNnFV" role="2Ry0An">
+                  <property role="2Ry0Am" value="test.de.q60.mps.incremental.runtime.msd" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="7qGGLAjNnFX" role="3bR37C">
+          <node concept="3bR9La" id="7qGGLAjNnFY" role="1SiIV1">
+            <property role="3bR36h" value="true" />
+            <ref role="3bR37D" node="6fQhGuklPrV" resolve="de.q60.mps.incremental.runtime" />
+          </node>
+        </node>
+        <node concept="3rtmxn" id="5py4VqXmLLr" role="3bR31x">
+          <node concept="3LXTmp" id="5py4VqXmLLs" role="3rtmxm">
+            <node concept="3qWCbU" id="5py4VqXmLLt" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="5py4VqXmLLu" role="3LXTmr">
+              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="5py4VqXmLLv" role="iGT6I">
+                <property role="2Ry0Am" value="shadowmodels" />
+                <node concept="2Ry0Ak" id="5py4VqXmLLw" role="2Ry0An">
+                  <property role="2Ry0Am" value="solutions" />
+                  <node concept="2Ry0Ak" id="5py4VqXmLLx" role="2Ry0An">
+                    <property role="2Ry0Am" value="test.de.q60.mps.incremental.runtime" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1BupzO" id="7q24334ZKGZ" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="7q24334ZKH0" role="1HemKq">
+            <node concept="398BVA" id="7q24334ZKGI" role="3LXTmr">
+              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="7q24334ZKGJ" role="iGT6I">
+                <property role="2Ry0Am" value="shadowmodels" />
+                <node concept="2Ry0Ak" id="7q24334ZKGK" role="2Ry0An">
+                  <property role="2Ry0Am" value="solutions" />
+                  <node concept="2Ry0Ak" id="7q24334ZKGL" role="2Ry0An">
+                    <property role="2Ry0Am" value="test.de.q60.mps.incremental.runtime" />
+                    <node concept="2Ry0Ak" id="7q24334ZKGM" role="2Ry0An">
+                      <property role="2Ry0Am" value="models" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="7q24334ZKH1" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2G$12M" id="3$$s$wOI$Vt" role="3989C9">
+      <property role="TrG5h" value="widgets-tests" />
+      <node concept="1E1JtD" id="3$$s$wOI_E$" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="de.itemis.mps.editor.collapsible.testlang" />
+        <property role="3LESm3" value="d92a0cd8-920d-42ea-923c-f8c68d0a9444" />
+        <node concept="398BVA" id="3$$s$wOI_H4" role="3LF7KH">
+          <ref role="398BVh" node="3$$s$wOI_hD" resolve="widgets.home" />
+          <node concept="2Ry0Ak" id="3$$s$wOI_He" role="iGT6I">
+            <property role="2Ry0Am" value="languages" />
+            <node concept="2Ry0Ak" id="3$$s$wOI_Hn" role="2Ry0An">
+              <property role="2Ry0Am" value="de.itemis.mps.editor.collapsible.testlang" />
+              <node concept="2Ry0Ak" id="3$$s$wOI_Hw" role="2Ry0An">
+                <property role="2Ry0Am" value="de.itemis.mps.editor.collapsible.testlang.mpl" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3rtmxn" id="3$$s$wOI_H$" role="3bR31x">
+          <node concept="3LXTmp" id="3$$s$wOI_H_" role="3rtmxm">
+            <node concept="398BVA" id="3$$s$wOI_HA" role="3LXTmr">
+              <ref role="398BVh" node="3$$s$wOI_hD" resolve="widgets.home" />
+              <node concept="2Ry0Ak" id="3$$s$wOI_HB" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="3$$s$wOI_HC" role="2Ry0An">
+                  <property role="2Ry0Am" value="de.itemis.mps.editor.collapsible.testlang" />
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="3$$s$wOI_HE" role="3LXTna">
+              <property role="3qWCbO" value="icons/**" />
+            </node>
+          </node>
+        </node>
+        <node concept="1BupzO" id="7q24334ZKHn" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="7q24334ZKHo" role="1HemKq">
+            <node concept="398BVA" id="7q24334ZKH2" role="3LXTmr">
+              <ref role="398BVh" node="3$$s$wOI_hD" resolve="widgets.home" />
+              <node concept="2Ry0Ak" id="7q24334ZKH3" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="7q24334ZKH4" role="2Ry0An">
+                  <property role="2Ry0Am" value="de.itemis.mps.editor.collapsible.testlang" />
+                  <node concept="2Ry0Ak" id="7q24334ZKH5" role="2Ry0An">
+                    <property role="2Ry0Am" value="models" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="7q24334ZKHp" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="6JDgK_ZoELK" role="3bR37C">
+          <node concept="3bR9La" id="6JDgK_ZoELL" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1ia2VB5guYy" resolve="MPS.IDEA" />
+          </node>
+        </node>
+      </node>
+      <node concept="1E1JtD" id="7CKpyI71cs0" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="de.itemis.mps.editor.enumeration.demolang" />
+        <property role="3LESm3" value="724a3ff4-f161-46ae-b766-26b81317341a" />
+        <node concept="398BVA" id="7CKpyI71cs1" role="3LF7KH">
+          <ref role="398BVh" node="3$$s$wOI_hD" resolve="widgets.home" />
+          <node concept="2Ry0Ak" id="7CKpyI71cs2" role="iGT6I">
+            <property role="2Ry0Am" value="languages" />
+            <node concept="2Ry0Ak" id="7CKpyI71cs3" role="2Ry0An">
+              <property role="2Ry0Am" value="de.itemis.mps.editor.enumeration.demolang" />
+              <node concept="2Ry0Ak" id="7CKpyI71ctb" role="2Ry0An">
+                <property role="2Ry0Am" value="de.itemis.mps.editor.enumeration.demolang.mpl" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3rtmxn" id="7CKpyI71cs5" role="3bR31x">
+          <node concept="3LXTmp" id="7CKpyI71cs6" role="3rtmxm">
+            <node concept="398BVA" id="7CKpyI71cs7" role="3LXTmr">
+              <ref role="398BVh" node="3$$s$wOI_hD" resolve="widgets.home" />
+              <node concept="2Ry0Ak" id="7CKpyI71cs8" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="7CKpyI71cs9" role="2Ry0An">
+                  <property role="2Ry0Am" value="de.itemis.mps.editor.collapsible.testlang" />
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="7CKpyI71csa" role="3LXTna">
+              <property role="3qWCbO" value="icons/**" />
+            </node>
+          </node>
+        </node>
+        <node concept="1BupzO" id="7q24334ZKIb" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="7q24334ZKIc" role="1HemKq">
+            <node concept="398BVA" id="7q24334ZKHQ" role="3LXTmr">
+              <ref role="398BVh" node="3$$s$wOI_hD" resolve="widgets.home" />
+              <node concept="2Ry0Ak" id="7q24334ZKHR" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="7q24334ZKHS" role="2Ry0An">
+                  <property role="2Ry0Am" value="de.itemis.mps.editor.enumeration.demolang" />
+                  <node concept="2Ry0Ak" id="7q24334ZKHT" role="2Ry0An">
+                    <property role="2Ry0Am" value="models" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="7q24334ZKId" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1E1JtD" id="7CKpyI71ctd" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="de.itemis.mps.editor.dropdown.demolang" />
+        <property role="3LESm3" value="6b5dd191-3c21-47c5-a7d3-c6e1f7c7cbd0" />
+        <node concept="398BVA" id="7CKpyI71cte" role="3LF7KH">
+          <ref role="398BVh" node="3$$s$wOI_hD" resolve="widgets.home" />
+          <node concept="2Ry0Ak" id="7CKpyI71ctf" role="iGT6I">
+            <property role="2Ry0Am" value="languages" />
+            <node concept="2Ry0Ak" id="7CKpyI71ctg" role="2Ry0An">
+              <property role="2Ry0Am" value="de.itemis.mps.editor.dropdown.demolang" />
+              <node concept="2Ry0Ak" id="7CKpyI71cuA" role="2Ry0An">
+                <property role="2Ry0Am" value="de.itemis.mps.editor.dropdown.demolang.mpl" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3rtmxn" id="7CKpyI71cti" role="3bR31x">
+          <node concept="3LXTmp" id="7CKpyI71ctj" role="3rtmxm">
+            <node concept="398BVA" id="7CKpyI71ctk" role="3LXTmr">
+              <ref role="398BVh" node="3$$s$wOI_hD" resolve="widgets.home" />
+              <node concept="2Ry0Ak" id="7CKpyI71ctl" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="7CKpyI71ctm" role="2Ry0An">
+                  <property role="2Ry0Am" value="de.itemis.mps.editor.collapsible.testlang" />
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="7CKpyI71ctn" role="3LXTna">
+              <property role="3qWCbO" value="icons/**" />
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="7CKpyI71cDi" role="3bR37C">
+          <node concept="3bR9La" id="7CKpyI71cDj" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
+          </node>
+        </node>
+        <node concept="1BupzO" id="7q24334ZKIZ" role="3bR31x">
+          <property role="3ZfqAx" value="languageModels" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="7q24334ZKJ0" role="1HemKq">
+            <node concept="398BVA" id="7q24334ZKIE" role="3LXTmr">
+              <ref role="398BVh" node="3$$s$wOI_hD" resolve="widgets.home" />
+              <node concept="2Ry0Ak" id="7q24334ZKIF" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="7q24334ZKIG" role="2Ry0An">
+                  <property role="2Ry0Am" value="de.itemis.mps.editor.dropdown.demolang" />
+                  <node concept="2Ry0Ak" id="7q24334ZKIH" role="2Ry0An">
+                    <property role="2Ry0Am" value="languageModels" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="7q24334ZKJ1" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1E1JtD" id="7CKpyI71cuC" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="de.itemis.mps.editor.bool.demolang" />
+        <property role="3LESm3" value="8eb39fd6-60ad-48f0-8c8e-0ea1c36c2d65" />
+        <node concept="398BVA" id="7CKpyI71cuD" role="3LF7KH">
+          <ref role="398BVh" node="3$$s$wOI_hD" resolve="widgets.home" />
+          <node concept="2Ry0Ak" id="7CKpyI71cuE" role="iGT6I">
+            <property role="2Ry0Am" value="languages" />
+            <node concept="2Ry0Ak" id="7CKpyI71cuF" role="2Ry0An">
+              <property role="2Ry0Am" value="de.itemis.mps.editor.bool.demolang" />
+              <node concept="2Ry0Ak" id="7CKpyI71cwf" role="2Ry0An">
+                <property role="2Ry0Am" value="de.itemis.mps.editor.bool.demolang.mpl" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3rtmxn" id="7CKpyI71cuH" role="3bR31x">
+          <node concept="3LXTmp" id="7CKpyI71cuI" role="3rtmxm">
+            <node concept="398BVA" id="7CKpyI71cuJ" role="3LXTmr">
+              <ref role="398BVh" node="3$$s$wOI_hD" resolve="widgets.home" />
+              <node concept="2Ry0Ak" id="7CKpyI71cuK" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="7CKpyI71cuL" role="2Ry0An">
+                  <property role="2Ry0Am" value="de.itemis.mps.editor.collapsible.testlang" />
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="7CKpyI71cuM" role="3LXTna">
+              <property role="3qWCbO" value="icons/**" />
+            </node>
+          </node>
+        </node>
+        <node concept="1BupzO" id="7q24334ZKJN" role="3bR31x">
+          <property role="3ZfqAx" value="languageModels" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="7q24334ZKJO" role="1HemKq">
+            <node concept="398BVA" id="7q24334ZKJu" role="3LXTmr">
+              <ref role="398BVh" node="3$$s$wOI_hD" resolve="widgets.home" />
+              <node concept="2Ry0Ak" id="7q24334ZKJv" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="7q24334ZKJw" role="2Ry0An">
+                  <property role="2Ry0Am" value="de.itemis.mps.editor.bool.demolang" />
+                  <node concept="2Ry0Ak" id="7q24334ZKJx" role="2Ry0An">
+                    <property role="2Ry0Am" value="languageModels" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="7q24334ZKJP" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1E1JtA" id="7CKpyI71cwh" role="2G$12L">
+        <property role="TrG5h" value="de.itemis.mps.editor.enumeration.sandbox" />
+        <property role="3LESm3" value="5ae18ad0-711b-4a36-b3e2-161124c395a2" />
+        <property role="aoJFB" value="eYcmk9QOli/sources" />
+        <property role="BnDLt" value="true" />
+        <node concept="398BVA" id="7CKpyI71cwi" role="3LF7KH">
+          <ref role="398BVh" node="3$$s$wOI_hD" resolve="widgets.home" />
+          <node concept="2Ry0Ak" id="7CKpyI71cwj" role="iGT6I">
+            <property role="2Ry0Am" value="languages" />
+            <node concept="2Ry0Ak" id="7CKpyI71cwk" role="2Ry0An">
+              <property role="2Ry0Am" value="de.itemis.mps.editor.enumeration" />
+              <node concept="2Ry0Ak" id="7CKpyI71cyG" role="2Ry0An">
+                <property role="2Ry0Am" value="sandbox" />
+                <node concept="2Ry0Ak" id="7CKpyI71cyL" role="2Ry0An">
+                  <property role="2Ry0Am" value="de.itemis.mps.editor.enumeration.sandbox.msd" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3rtmxn" id="7CKpyI71cwG" role="3bR31x">
+          <node concept="3LXTmp" id="7CKpyI71cwH" role="3rtmxm">
+            <node concept="398BVA" id="7CKpyI71cwI" role="3LXTmr">
+              <ref role="398BVh" node="3$$s$wOI_hD" resolve="widgets.home" />
+              <node concept="2Ry0Ak" id="7CKpyI71cwJ" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="7CKpyI71cwK" role="2Ry0An">
+                  <property role="2Ry0Am" value="de.itemis.mps.editor.collapsible.tests" />
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="7CKpyI71cwL" role="3LXTna">
+              <property role="3qWCbO" value="icons/**" />
+            </node>
+          </node>
+        </node>
+        <node concept="1BupzO" id="7q24334ZKL3" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="7q24334ZKL4" role="1HemKq">
+            <node concept="398BVA" id="7q24334ZKKE" role="3LXTmr">
+              <ref role="398BVh" node="3$$s$wOI_hD" resolve="widgets.home" />
+              <node concept="2Ry0Ak" id="7q24334ZKKF" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="7q24334ZKKG" role="2Ry0An">
+                  <property role="2Ry0Am" value="de.itemis.mps.editor.enumeration" />
+                  <node concept="2Ry0Ak" id="7q24334ZKKH" role="2Ry0An">
+                    <property role="2Ry0Am" value="sandbox" />
+                    <node concept="2Ry0Ak" id="7q24334ZKKI" role="2Ry0An">
+                      <property role="2Ry0Am" value="models" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="7q24334ZKL5" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1E1JtA" id="7CKpyI71cyN" role="2G$12L">
+        <property role="TrG5h" value="de.itemis.mps.editor.dropdown.sandbox" />
+        <property role="3LESm3" value="dba47e42-d4c1-4eae-bc35-556658c0dc1e" />
+        <property role="BnDLt" value="true" />
+        <property role="aoJFB" value="eYcmk9QOli/sources" />
+        <node concept="398BVA" id="7CKpyI71cyO" role="3LF7KH">
+          <ref role="398BVh" node="3$$s$wOI_hD" resolve="widgets.home" />
+          <node concept="2Ry0Ak" id="7CKpyI71cyP" role="iGT6I">
+            <property role="2Ry0Am" value="solutions" />
+            <node concept="2Ry0Ak" id="7CKpyI71cyQ" role="2Ry0An">
+              <property role="2Ry0Am" value="de.itemis.mps.editor.dropdown.sandbox" />
+              <node concept="2Ry0Ak" id="7CKpyI71cyR" role="2Ry0An">
+                <property role="2Ry0Am" value="de.itemis.mps.editor.dropdown.sandbox.msd" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3rtmxn" id="7CKpyI71czf" role="3bR31x">
+          <node concept="3LXTmp" id="7CKpyI71czg" role="3rtmxm">
+            <node concept="398BVA" id="7CKpyI71czh" role="3LXTmr">
+              <ref role="398BVh" node="3$$s$wOI_hD" resolve="widgets.home" />
+              <node concept="2Ry0Ak" id="7CKpyI71czi" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="7CKpyI71czj" role="2Ry0An">
+                  <property role="2Ry0Am" value="de.itemis.mps.editor.collapsible.tests" />
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="7CKpyI71czk" role="3LXTna">
+              <property role="3qWCbO" value="icons/**" />
+            </node>
+          </node>
+        </node>
+        <node concept="1BupzO" id="7q24334ZKLr" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="7q24334ZKLs" role="1HemKq">
+            <node concept="398BVA" id="7q24334ZKL6" role="3LXTmr">
+              <ref role="398BVh" node="3$$s$wOI_hD" resolve="widgets.home" />
+              <node concept="2Ry0Ak" id="7q24334ZKL7" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="7q24334ZKL8" role="2Ry0An">
+                  <property role="2Ry0Am" value="de.itemis.mps.editor.dropdown.sandbox" />
+                  <node concept="2Ry0Ak" id="7q24334ZKL9" role="2Ry0An">
+                    <property role="2Ry0Am" value="models" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="7q24334ZKLt" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1E1JtA" id="7CKpyI71c_M" role="2G$12L">
+        <property role="TrG5h" value="de.itemis.mps.editor.bool.sandbox" />
+        <property role="3LESm3" value="9820b889-0935-4e7a-92f1-44e7fd6edcc3" />
+        <property role="aoJFB" value="eYcmk9QOli/sources" />
+        <property role="BnDLt" value="true" />
+        <node concept="398BVA" id="7CKpyI71c_N" role="3LF7KH">
+          <ref role="398BVh" node="3$$s$wOI_hD" resolve="widgets.home" />
+          <node concept="2Ry0Ak" id="7CKpyI71c_O" role="iGT6I">
+            <property role="2Ry0Am" value="solutions" />
+            <node concept="2Ry0Ak" id="7CKpyI71c_P" role="2Ry0An">
+              <property role="2Ry0Am" value="de.itemis.mps.editor.bool.sandbox" />
+              <node concept="2Ry0Ak" id="7CKpyI71cDg" role="2Ry0An">
+                <property role="2Ry0Am" value="de.itemis.mps.editor.bool.sandbox.msd" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3rtmxn" id="7CKpyI71cAd" role="3bR31x">
+          <node concept="3LXTmp" id="7CKpyI71cAe" role="3rtmxm">
+            <node concept="398BVA" id="7CKpyI71cAf" role="3LXTmr">
+              <ref role="398BVh" node="3$$s$wOI_hD" resolve="widgets.home" />
+              <node concept="2Ry0Ak" id="7CKpyI71cAg" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="7CKpyI71cAh" role="2Ry0An">
+                  <property role="2Ry0Am" value="de.itemis.mps.editor.collapsible.tests" />
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="7CKpyI71cAi" role="3LXTna">
+              <property role="3qWCbO" value="icons/**" />
+            </node>
+          </node>
+        </node>
+        <node concept="1BupzO" id="7q24334ZKLN" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="7q24334ZKLO" role="1HemKq">
+            <node concept="398BVA" id="7q24334ZKLu" role="3LXTmr">
+              <ref role="398BVh" node="3$$s$wOI_hD" resolve="widgets.home" />
+              <node concept="2Ry0Ak" id="7q24334ZKLv" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="7q24334ZKLw" role="2Ry0An">
+                  <property role="2Ry0Am" value="de.itemis.mps.editor.bool.sandbox" />
+                  <node concept="2Ry0Ak" id="7q24334ZKLx" role="2Ry0An">
+                    <property role="2Ry0Am" value="models" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="7q24334ZKLP" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2G$12M" id="7qi8mU1OyZm" role="3989C9">
+      <property role="TrG5h" value="richtext-demo" />
+      <node concept="1E1JtD" id="7qi8mU1Oz8O" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="de.slisson.mps.javadoc" />
+        <property role="3LESm3" value="4e0df6bd-e265-4d63-9ca0-ca97e44cf841" />
+        <node concept="398BVA" id="7qi8mU1Oz8S" role="3LF7KH">
+          <ref role="398BVh" node="7qi8mU1Oz8V" resolve="richtext.home" />
+          <node concept="2Ry0Ak" id="7qi8mU1Oz9I" role="iGT6I">
+            <property role="2Ry0Am" value="languages" />
+            <node concept="2Ry0Ak" id="7qi8mU1Oz9N" role="2Ry0An">
+              <property role="2Ry0Am" value="javadoc" />
+              <node concept="2Ry0Ak" id="7qi8mU1Oz9S" role="2Ry0An">
+                <property role="2Ry0Am" value="javadoc.mpl" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="7qi8mU1Oz9U" role="3bR37C">
+          <node concept="3bR9La" id="7qi8mU1Oz9V" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="7qi8mU1Oz9W" role="3bR37C">
+          <node concept="3bR9La" id="7qi8mU1Oz9X" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1TaHNgiIbIZ" resolve="MPS.Editor" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="7qi8mU1Oz9Y" role="3bR37C">
+          <node concept="3bR9La" id="7qi8mU1Oz9Z" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="7qi8mU1Oza0" role="3bR37C">
+          <node concept="3bR9La" id="7qi8mU1Oza1" role="1SiIV1">
+            <ref role="3bR37D" node="1sO539bGQvB" resolve="de.slisson.mps.richtext" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="7qi8mU1Oza2" role="3bR37C">
+          <node concept="1Busua" id="7qi8mU1Oza3" role="1SiIV1">
+            <ref role="1Busuk" node="1sO539bGQvB" resolve="de.slisson.mps.richtext" />
+          </node>
+        </node>
+        <node concept="3rtmxn" id="3D0nl1ssJIG" role="3bR31x">
+          <node concept="3LXTmp" id="3D0nl1ssJIH" role="3rtmxm">
+            <node concept="3qWCbU" id="3D0nl1ssJII" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="3D0nl1ssJIJ" role="3LXTmr">
+              <ref role="398BVh" node="7qi8mU1Oz8V" resolve="richtext.home" />
+              <node concept="2Ry0Ak" id="3D0nl1ssJIK" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="3D0nl1ssJIL" role="2Ry0An">
+                  <property role="2Ry0Am" value="javadoc" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1BupzO" id="7q24334ZKMb" role="3bR31x">
+          <property role="3ZfqAx" value="languageModels" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="7q24334ZKMc" role="1HemKq">
+            <node concept="398BVA" id="7q24334ZKLQ" role="3LXTmr">
+              <ref role="398BVh" node="7qi8mU1Oz8V" resolve="richtext.home" />
+              <node concept="2Ry0Ak" id="7q24334ZKLR" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="7q24334ZKLS" role="2Ry0An">
+                  <property role="2Ry0Am" value="javadoc" />
+                  <node concept="2Ry0Ak" id="7q24334ZKLT" role="2Ry0An">
+                    <property role="2Ry0Am" value="languageModels" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="7q24334ZKMd" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1E1JtA" id="7qi8mU1Ozax" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="de.slisson.mps.richtext.sandbox" />
+        <property role="3LESm3" value="fdae84e9-f8df-4c2f-8de3-b45a7b6af77e" />
+        <node concept="398BVA" id="7qi8mU1OzaQ" role="3LF7KH">
+          <ref role="398BVh" node="7qi8mU1Oz8V" resolve="richtext.home" />
+          <node concept="2Ry0Ak" id="7qi8mU1OzaY" role="iGT6I">
+            <property role="2Ry0Am" value="solutions" />
+            <node concept="2Ry0Ak" id="7qi8mU1Ozb3" role="2Ry0An">
+              <property role="2Ry0Am" value="de.slisson.mps.richtext.sandbox" />
+              <node concept="2Ry0Ak" id="7qi8mU1Ozb8" role="2Ry0An">
+                <property role="2Ry0Am" value="de.slisson.mps.richtext.sandbox.msd" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="7qi8mU1Ozba" role="3bR37C">
+          <node concept="3bR9La" id="7qi8mU1Ozbb" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
+          </node>
+        </node>
+        <node concept="3rtmxn" id="3D0nl1ssJHO" role="3bR31x">
+          <node concept="3LXTmp" id="3D0nl1ssJHP" role="3rtmxm">
+            <node concept="3qWCbU" id="3D0nl1ssJHQ" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="3D0nl1ssJHR" role="3LXTmr">
+              <ref role="398BVh" node="7qi8mU1Oz8V" resolve="richtext.home" />
+              <node concept="2Ry0Ak" id="3D0nl1ssJHS" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="3D0nl1ssJHT" role="2Ry0An">
+                  <property role="2Ry0Am" value="de.slisson.mps.richtext.sandbox" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1BupzO" id="7q24334ZKMz" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="7q24334ZKM$" role="1HemKq">
+            <node concept="398BVA" id="7q24334ZKMe" role="3LXTmr">
+              <ref role="398BVh" node="7qi8mU1Oz8V" resolve="richtext.home" />
+              <node concept="2Ry0Ak" id="7q24334ZKMf" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="7q24334ZKMg" role="2Ry0An">
+                  <property role="2Ry0Am" value="de.slisson.mps.richtext.sandbox" />
+                  <node concept="2Ry0Ak" id="7q24334ZKMh" role="2Ry0An">
+                    <property role="2Ry0Am" value="models" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="7q24334ZKM_" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2G$12M" id="7qi8mU1Ozdr" role="3989C9">
+      <property role="TrG5h" value="multiline-demo" />
+      <node concept="1E1JtD" id="7qi8mU1Ozds" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="de.slisson.mps.editor.multiline.demolang" />
+        <property role="3LESm3" value="26a9201d-e70b-4755-acd6-40baf7a63b3a" />
+        <node concept="398BVA" id="7qi8mU1Ozdt" role="3LF7KH">
+          <ref role="398BVh" node="7qi8mU1OzcE" resolve="multiline.home" />
+          <node concept="2Ry0Ak" id="7qi8mU1Ozdu" role="iGT6I">
+            <property role="2Ry0Am" value="languages" />
+            <node concept="2Ry0Ak" id="7qi8mU1Ozdv" role="2Ry0An">
+              <property role="2Ry0Am" value="demolang" />
+              <node concept="2Ry0Ak" id="7qi8mU1OznV" role="2Ry0An">
+                <property role="2Ry0Am" value="demolang.mpl" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3rtmxn" id="3D0nl1ssJIN" role="3bR31x">
+          <node concept="3LXTmp" id="3D0nl1ssJIO" role="3rtmxm">
+            <node concept="3qWCbU" id="3D0nl1ssJIP" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="3D0nl1ssJIQ" role="3LXTmr">
+              <ref role="398BVh" node="7qi8mU1OzcE" resolve="multiline.home" />
+              <node concept="2Ry0Ak" id="3D0nl1ssJIR" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="3D0nl1ssJIS" role="2Ry0An">
+                  <property role="2Ry0Am" value="demolang" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1BupzO" id="7q24334ZKMV" role="3bR31x">
+          <property role="3ZfqAx" value="languageModels" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="7q24334ZKMW" role="1HemKq">
+            <node concept="398BVA" id="7q24334ZKMA" role="3LXTmr">
+              <ref role="398BVh" node="7qi8mU1OzcE" resolve="multiline.home" />
+              <node concept="2Ry0Ak" id="7q24334ZKMB" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="7q24334ZKMC" role="2Ry0An">
+                  <property role="2Ry0Am" value="demolang" />
+                  <node concept="2Ry0Ak" id="7q24334ZKMD" role="2Ry0An">
+                    <property role="2Ry0Am" value="languageModels" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="7q24334ZKMX" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1E1JtA" id="7qi8mU1OzdF" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="de.slisson.mps.editor.multiline.sandbox" />
+        <property role="3LESm3" value="12db307d-5ea6-49b9-a36a-cb1cde091436" />
+        <node concept="398BVA" id="7qi8mU1OzdG" role="3LF7KH">
+          <ref role="398BVh" node="7qi8mU1OzcE" resolve="multiline.home" />
+          <node concept="2Ry0Ak" id="7qi8mU1OzdH" role="iGT6I">
+            <property role="2Ry0Am" value="solutions" />
+            <node concept="2Ry0Ak" id="7qi8mU1OzdI" role="2Ry0An">
+              <property role="2Ry0Am" value="de.slisson.mps.editor.multiline.sandbox" />
+              <node concept="2Ry0Ak" id="7qi8mU1OznX" role="2Ry0An">
+                <property role="2Ry0Am" value="de.slisson.mps.editor.multiline.sandbox.msd" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3rtmxn" id="3D0nl1ssJHV" role="3bR31x">
+          <node concept="3LXTmp" id="3D0nl1ssJHW" role="3rtmxm">
+            <node concept="3qWCbU" id="3D0nl1ssJHX" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="3D0nl1ssJHY" role="3LXTmr">
+              <ref role="398BVh" node="7qi8mU1OzcE" resolve="multiline.home" />
+              <node concept="2Ry0Ak" id="3D0nl1ssJHZ" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="3D0nl1ssJI0" role="2Ry0An">
+                  <property role="2Ry0Am" value="de.slisson.mps.editor.multiline.sandbox" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1BupzO" id="7q24334ZKNj" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="7q24334ZKNk" role="1HemKq">
+            <node concept="398BVA" id="7q24334ZKMY" role="3LXTmr">
+              <ref role="398BVh" node="7qi8mU1OzcE" resolve="multiline.home" />
+              <node concept="2Ry0Ak" id="7q24334ZKMZ" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="7q24334ZKN0" role="2Ry0An">
+                  <property role="2Ry0Am" value="de.slisson.mps.editor.multiline.sandbox" />
+                  <node concept="2Ry0Ak" id="7q24334ZKN1" role="2Ry0An">
+                    <property role="2Ry0Am" value="models" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="7q24334ZKNl" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2G$12M" id="7qi8mU1OznZ" role="3989C9">
+      <property role="TrG5h" value="conitional-editor-demo" />
+      <node concept="1E1JtD" id="7qi8mU1Ozo0" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="de.slisson.mps.conditionalEditor.demolang" />
+        <property role="3LESm3" value="1831633c-aea1-4345-beff-4a6e7fb4f813" />
+        <node concept="398BVA" id="7qi8mU1Ozo1" role="3LF7KH">
+          <ref role="398BVh" node="7qi8mU1OzW7" resolve="conditionalEditor.home" />
+          <node concept="2Ry0Ak" id="7qi8mU1Ozo2" role="iGT6I">
+            <property role="2Ry0Am" value="languages" />
+            <node concept="2Ry0Ak" id="7qi8mU1Ozo3" role="2Ry0An">
+              <property role="2Ry0Am" value="de.slisson.mps.conditionalEditor.demolang" />
+              <node concept="2Ry0Ak" id="7qi8mU1OzWY" role="2Ry0An">
+                <property role="2Ry0Am" value="de.slisson.mps.conditionalEditor.demolang.mpl" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="7qi8mU1Ozzw" role="3bR37C">
+          <node concept="3bR9La" id="7qi8mU1Ozzx" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1TaHNgiIbIZ" resolve="MPS.Editor" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="7qi8mU1OzzA" role="3bR37C">
+          <node concept="1Busua" id="7qi8mU1OzzB" role="1SiIV1">
+            <ref role="1Busuk" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
+          </node>
+        </node>
+        <node concept="3rtmxn" id="3D0nl1ssJIU" role="3bR31x">
+          <node concept="3LXTmp" id="3D0nl1ssJIV" role="3rtmxm">
+            <node concept="3qWCbU" id="3D0nl1ssJIW" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="3D0nl1ssJIX" role="3LXTmr">
+              <ref role="398BVh" node="7qi8mU1OzW7" resolve="conditionalEditor.home" />
+              <node concept="2Ry0Ak" id="3D0nl1ssJIY" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="3D0nl1ssJIZ" role="2Ry0An">
+                  <property role="2Ry0Am" value="de.slisson.mps.conditionalEditor.demolang" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1BupzO" id="7q24334ZKNF" role="3bR31x">
+          <property role="3ZfqAx" value="languageModels" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="7q24334ZKNG" role="1HemKq">
+            <node concept="398BVA" id="7q24334ZKNm" role="3LXTmr">
+              <ref role="398BVh" node="7qi8mU1OzW7" resolve="conditionalEditor.home" />
+              <node concept="2Ry0Ak" id="7q24334ZKNn" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="7q24334ZKNo" role="2Ry0An">
+                  <property role="2Ry0Am" value="de.slisson.mps.conditionalEditor.demolang" />
+                  <node concept="2Ry0Ak" id="7q24334ZKNp" role="2Ry0An">
+                    <property role="2Ry0Am" value="languageModels" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="7q24334ZKNH" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1E1JtA" id="7qi8mU1Ozo5" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="de.slisson.mps.conditionalEditor.sandbox" />
+        <property role="3LESm3" value="be556ac6-a425-413a-a574-3c2d4910a432" />
+        <node concept="398BVA" id="7qi8mU1Ozo6" role="3LF7KH">
+          <ref role="398BVh" node="7qi8mU1OzW7" resolve="conditionalEditor.home" />
+          <node concept="2Ry0Ak" id="7qi8mU1Ozo7" role="iGT6I">
+            <property role="2Ry0Am" value="solutions" />
+            <node concept="2Ry0Ak" id="7qi8mU1Ozo8" role="2Ry0An">
+              <property role="2Ry0Am" value="de.slisson.mps.conditionalEditor.sandbox" />
+              <node concept="2Ry0Ak" id="7qi8mU1OzXl" role="2Ry0An">
+                <property role="2Ry0Am" value="de.slisson.mps.conditionalEditor.sandbox.msd" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="7qi8mU1OzzP" role="3bR37C">
+          <node concept="3bR9La" id="7qi8mU1OzzQ" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
+          </node>
+        </node>
+        <node concept="3rtmxn" id="3D0nl1ssJI2" role="3bR31x">
+          <node concept="3LXTmp" id="3D0nl1ssJI3" role="3rtmxm">
+            <node concept="3qWCbU" id="3D0nl1ssJI4" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="3D0nl1ssJI5" role="3LXTmr">
+              <ref role="398BVh" node="7qi8mU1OzW7" resolve="conditionalEditor.home" />
+              <node concept="2Ry0Ak" id="3D0nl1ssJI6" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="3D0nl1ssJI7" role="2Ry0An">
+                  <property role="2Ry0Am" value="de.slisson.mps.conditionalEditor.sandbox" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1BupzO" id="7q24334ZKOv" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="7q24334ZKOw" role="1HemKq">
+            <node concept="398BVA" id="7q24334ZKOa" role="3LXTmr">
+              <ref role="398BVh" node="7qi8mU1OzW7" resolve="conditionalEditor.home" />
+              <node concept="2Ry0Ak" id="7q24334ZKOb" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="7q24334ZKOc" role="2Ry0An">
+                  <property role="2Ry0Am" value="de.slisson.mps.conditionalEditor.sandbox" />
+                  <node concept="2Ry0Ak" id="7q24334ZKOd" role="2Ry0An">
+                    <property role="2Ry0Am" value="models" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="7q24334ZKOx" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2G$12M" id="34tM7SkU508" role="3989C9">
+      <property role="TrG5h" value="math-demo" />
+      <node concept="1E1JtD" id="34tM7SkU5c3" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="de.itemis.mps.editor.math.demolang" />
+        <property role="3LESm3" value="76a53b21-d4a7-409f-93a2-e70951b4b3f9" />
+        <node concept="398BVA" id="34tM7SkU5c4" role="3LF7KH">
+          <ref role="398BVh" node="7qi8mU1Ozyi" resolve="math.home" />
+          <node concept="2Ry0Ak" id="34tM7SkU5c5" role="iGT6I">
+            <property role="2Ry0Am" value="languages" />
+            <node concept="2Ry0Ak" id="34tM7SkU5c6" role="2Ry0An">
+              <property role="2Ry0Am" value="de.itemis.mps.editor.math.demolang" />
+              <node concept="2Ry0Ak" id="34tM7SkU5cT" role="2Ry0An">
+                <property role="2Ry0Am" value="de.itemis.mps.editor.math.demolang.mpl" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="34tM7SkU5c8" role="3bR37C">
+          <node concept="3bR9La" id="34tM7SkU5c9" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1TaHNgiIbIZ" resolve="MPS.Editor" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="34tM7SkU5ca" role="3bR37C">
+          <node concept="1Busua" id="34tM7SkU5cb" role="1SiIV1">
+            <ref role="1Busuk" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="34tM7SkU5d$" role="3bR37C">
+          <node concept="3bR9La" id="34tM7SkU5d_" role="1SiIV1">
+            <ref role="3bR37D" node="2Xjt3l57bIF" resolve="de.itemis.mps.editor.math" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="34tM7SkU5dA" role="3bR37C">
+          <node concept="3bR9La" id="34tM7SkU5dB" role="1SiIV1">
+            <ref role="3bR37D" node="6vUATgmxw8m" resolve="de.itemis.mps.editor.math.symbols" />
+          </node>
+        </node>
+        <node concept="3rtmxn" id="3D0nl1ssJJ1" role="3bR31x">
+          <node concept="3LXTmp" id="3D0nl1ssJJ2" role="3rtmxm">
+            <node concept="3qWCbU" id="3D0nl1ssJJ3" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="3D0nl1ssJJ4" role="3LXTmr">
+              <ref role="398BVh" node="7qi8mU1Ozyi" resolve="math.home" />
+              <node concept="2Ry0Ak" id="3D0nl1ssJJ5" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="3D0nl1ssJJ6" role="2Ry0An">
+                  <property role="2Ry0Am" value="de.itemis.mps.editor.math.demolang" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1BupzO" id="7q24334ZKOR" role="3bR31x">
+          <property role="3ZfqAx" value="languageModels" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="7q24334ZKOS" role="1HemKq">
+            <node concept="398BVA" id="7q24334ZKOy" role="3LXTmr">
+              <ref role="398BVh" node="7qi8mU1Ozyi" resolve="math.home" />
+              <node concept="2Ry0Ak" id="7q24334ZKOz" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="7q24334ZKO$" role="2Ry0An">
+                  <property role="2Ry0Am" value="de.itemis.mps.editor.math.demolang" />
+                  <node concept="2Ry0Ak" id="7q24334ZKO_" role="2Ry0An">
+                    <property role="2Ry0Am" value="languageModels" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="7q24334ZKOT" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1E1JtD" id="34tM7SkU5cV" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="de.itemis.mps.editor.math.java" />
+        <property role="3LESm3" value="6ce9daa6-c7bc-4847-a19c-5cd82a4a13fc" />
+        <node concept="398BVA" id="34tM7SkU5cW" role="3LF7KH">
+          <ref role="398BVh" node="7qi8mU1Ozyi" resolve="math.home" />
+          <node concept="2Ry0Ak" id="34tM7SkU5cX" role="iGT6I">
+            <property role="2Ry0Am" value="languages" />
+            <node concept="2Ry0Ak" id="34tM7SkU5cY" role="2Ry0An">
+              <property role="2Ry0Am" value="de.itemis.mps.editor.math.java" />
+              <node concept="2Ry0Ak" id="34tM7SkU5dw" role="2Ry0An">
+                <property role="2Ry0Am" value="de.itemis.mps.editor.math.java.mpl" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="34tM7SkU5d2" role="3bR37C">
+          <node concept="1Busua" id="34tM7SkU5d3" role="1SiIV1">
+            <ref role="1Busuk" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
+          </node>
+        </node>
+        <node concept="1yeLz9" id="34tM7SkU5d4" role="1TViLv">
+          <property role="TrG5h" value="de.itemis.mps.editor.math.java#9023431908320258336" />
+          <property role="3LESm3" value="33d5b2aa-14ef-412a-a0e9-88e04a210e22" />
+          <node concept="1SiIV0" id="34tM7SkU5dJ" role="3bR37C">
+            <node concept="3bR9La" id="34tM7SkU5dK" role="1SiIV1">
+              <ref role="3bR37D" node="PE3B26QCrP" resolve="org.apache.commons" />
+            </node>
+          </node>
+          <node concept="1BupzO" id="7q24334ZKQ7" role="3bR31x">
+            <property role="3ZfqAx" value="generator/template" />
+            <property role="1Hdu6h" value="true" />
+            <property role="1HemKv" value="true" />
+            <node concept="3LXTmp" id="7q24334ZKQ8" role="1HemKq">
+              <node concept="398BVA" id="7q24334ZKPI" role="3LXTmr">
+                <ref role="398BVh" node="7qi8mU1Ozyi" resolve="math.home" />
+                <node concept="2Ry0Ak" id="7q24334ZKPJ" role="iGT6I">
+                  <property role="2Ry0Am" value="languages" />
+                  <node concept="2Ry0Ak" id="7q24334ZKPK" role="2Ry0An">
+                    <property role="2Ry0Am" value="de.itemis.mps.editor.math.java" />
+                    <node concept="2Ry0Ak" id="7q24334ZKPL" role="2Ry0An">
+                      <property role="2Ry0Am" value="generator" />
+                      <node concept="2Ry0Ak" id="7q24334ZKPM" role="2Ry0An">
+                        <property role="2Ry0Am" value="template" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3qWCbU" id="7q24334ZKQ9" role="3LXTna">
+                <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="34tM7SkU5dC" role="3bR37C">
+          <node concept="3bR9La" id="34tM7SkU5dD" role="1SiIV1">
+            <ref role="3bR37D" node="2Xjt3l57bIF" resolve="de.itemis.mps.editor.math" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="34tM7SkU5dE" role="3bR37C">
+          <node concept="3bR9La" id="34tM7SkU5dF" role="1SiIV1">
+            <ref role="3bR37D" node="6vUATgmxw8m" resolve="de.itemis.mps.editor.math.symbols" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="34tM7SkU5dG" role="3bR37C">
+          <node concept="3bR9La" id="34tM7SkU5dH" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1d41uYMTVPB" resolve="jetbrains.mps.lang.scopes.runtime" />
+          </node>
+        </node>
+        <node concept="1E0d5M" id="34tM7SkU5dI" role="1E1XAP">
+          <ref role="1E0d5P" node="PE3B26QCrP" resolve="org.apache.commons" />
+        </node>
+        <node concept="3rtmxn" id="3D0nl1ssJJ8" role="3bR31x">
+          <node concept="3LXTmp" id="3D0nl1ssJJ9" role="3rtmxm">
+            <node concept="3qWCbU" id="3D0nl1ssJJa" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="3D0nl1ssJJb" role="3LXTmr">
+              <ref role="398BVh" node="7qi8mU1Ozyi" resolve="math.home" />
+              <node concept="2Ry0Ak" id="3D0nl1ssJJc" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="3D0nl1ssJJd" role="2Ry0An">
+                  <property role="2Ry0Am" value="de.itemis.mps.editor.math.java" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1BupzO" id="7q24334ZKPF" role="3bR31x">
+          <property role="3ZfqAx" value="languageModels" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="7q24334ZKPG" role="1HemKq">
+            <node concept="398BVA" id="7q24334ZKPm" role="3LXTmr">
+              <ref role="398BVh" node="7qi8mU1Ozyi" resolve="math.home" />
+              <node concept="2Ry0Ak" id="7q24334ZKPn" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="7q24334ZKPo" role="2Ry0An">
+                  <property role="2Ry0Am" value="de.itemis.mps.editor.math.java" />
+                  <node concept="2Ry0Ak" id="7q24334ZKPp" role="2Ry0An">
+                    <property role="2Ry0Am" value="languageModels" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="7q24334ZKPH" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2obP5Y848D_" role="3bR37C">
+          <node concept="Rbm2T" id="2obP5Y848DA" role="1SiIV1">
+            <ref role="1E1Vl2" to="ffeo:7Kfy9QB6KZG" resolve="jetbrains.mps.baseLanguage.closures" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="6JDgK_ZoEQs" role="3bR37C">
+          <node concept="3bR9La" id="6JDgK_ZoEQt" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1ia2VB5guYy" resolve="MPS.IDEA" />
+          </node>
+        </node>
+      </node>
+      <node concept="1E1JtA" id="34tM7SkU50j" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="de.itemis.mps.editor.math.sandbox" />
+        <property role="3LESm3" value="c189a833-e32c-49bf-b32e-a93144e7f4c2" />
+        <node concept="398BVA" id="34tM7SkU50k" role="3LF7KH">
+          <ref role="398BVh" node="7qi8mU1Ozyi" resolve="math.home" />
+          <node concept="2Ry0Ak" id="34tM7SkU50l" role="iGT6I">
+            <property role="2Ry0Am" value="solutions" />
+            <node concept="2Ry0Ak" id="34tM7SkU50m" role="2Ry0An">
+              <property role="2Ry0Am" value="de.itemis.mps.editor.math.sandbox" />
+              <node concept="2Ry0Ak" id="34tM7SkU5dy" role="2Ry0An">
+                <property role="2Ry0Am" value="de.itemis.mps.editor.math.sandbox.msd" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="34tM7SkU50o" role="3bR37C">
+          <node concept="3bR9La" id="34tM7SkU50p" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
+          </node>
+        </node>
+        <node concept="3rtmxn" id="3D0nl1ssJI9" role="3bR31x">
+          <node concept="3LXTmp" id="3D0nl1ssJIa" role="3rtmxm">
+            <node concept="3qWCbU" id="3D0nl1ssJIb" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="3D0nl1ssJIc" role="3LXTmr">
+              <ref role="398BVh" node="7qi8mU1Ozyi" resolve="math.home" />
+              <node concept="2Ry0Ak" id="3D0nl1ssJId" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="3D0nl1ssJIe" role="2Ry0An">
+                  <property role="2Ry0Am" value="de.itemis.mps.editor.math.sandbox" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1BupzO" id="7q24334ZKQv" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="7q24334ZKQw" role="1HemKq">
+            <node concept="398BVA" id="7q24334ZKQa" role="3LXTmr">
+              <ref role="398BVh" node="7qi8mU1Ozyi" resolve="math.home" />
+              <node concept="2Ry0Ak" id="7q24334ZKQb" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="7q24334ZKQc" role="2Ry0An">
+                  <property role="2Ry0Am" value="de.itemis.mps.editor.math.sandbox" />
+                  <node concept="2Ry0Ak" id="7q24334ZKQd" role="2Ry0An">
+                    <property role="2Ry0Am" value="models" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="7q24334ZKQx" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2G$12M" id="7qi8mU1OzZs" role="3989C9">
+      <property role="TrG5h" value="celllayout-demo" />
+      <node concept="1E1JtA" id="5mH$9t6eAsB" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="test.de.itemis.mps.editor.celllayout" />
+        <property role="3LESm3" value="980a0de7-66ea-4656-ae70-f553227d6102" />
+        <property role="aoJFB" value="eYcmk9QOlj/sources_and_tests" />
+        <node concept="398BVA" id="5mH$9t6eAsC" role="3LF7KH">
+          <ref role="398BVh" node="5mH$9t6eA_$" resolve="celllayout.home" />
+          <node concept="2Ry0Ak" id="5mH$9t6eAsD" role="iGT6I">
+            <property role="2Ry0Am" value="solutions" />
+            <node concept="2Ry0Ak" id="5mH$9t6eAsE" role="2Ry0An">
+              <property role="2Ry0Am" value="test.de.itemis.mps.editor.celllayout.runtime" />
+              <node concept="2Ry0Ak" id="5mH$9t6eAT_" role="2Ry0An">
+                <property role="2Ry0Am" value="test.de.itemis.mps.editor.celllayout.msd" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="5mH$9t6eAsI" role="3bR37C">
+          <node concept="3bR9La" id="5mH$9t6eAsJ" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
+          </node>
+        </node>
+        <node concept="3rtmxn" id="5mH$9t6eAsK" role="3bR31x">
+          <node concept="3LXTmp" id="5mH$9t6eAsL" role="3rtmxm">
+            <node concept="3qWCbU" id="5mH$9t6eAsM" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="PE3B26qlyY" role="3LXTmr">
+              <ref role="398BVh" node="5mH$9t6eA_$" resolve="celllayout.home" />
+              <node concept="2Ry0Ak" id="PE3B26qlyZ" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="PE3B26qlz0" role="2Ry0An">
+                  <property role="2Ry0Am" value="test.de.itemis.mps.editor.celllayout.runtime" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="5mH$9t6eAsS" role="3bR37C">
+          <node concept="3bR9La" id="5mH$9t6eAsT" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1TaHNgiIbJ$" resolve="jetbrains.mps.ide.editor" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="5mH$9t6eAW_" role="3bR37C">
+          <node concept="3bR9La" id="5mH$9t6eAWA" role="1SiIV1">
+            <property role="3bR36h" value="true" />
+            <ref role="3bR37D" node="6SVXTgIejl1" resolve="de.itemis.mps.editor.celllayout.runtime" />
+          </node>
+        </node>
+        <node concept="1BupzO" id="7q24334ZKQR" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="7q24334ZKQS" role="1HemKq">
+            <node concept="398BVA" id="7q24334ZKQy" role="3LXTmr">
+              <ref role="398BVh" node="5mH$9t6eA_$" resolve="celllayout.home" />
+              <node concept="2Ry0Ak" id="7q24334ZKQz" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="7q24334ZKQ$" role="2Ry0An">
+                  <property role="2Ry0Am" value="test.de.itemis.mps.editor.celllayout.runtime" />
+                  <node concept="2Ry0Ak" id="7q24334ZKQ_" role="2Ry0An">
+                    <property role="2Ry0Am" value="models" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="7q24334ZKQT" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1E1JtD" id="5mH$9t6eBsU" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="test.de.itemis.mps.editor.celllayout.lang" />
+        <property role="3LESm3" value="e0fad6e1-a8d0-4af5-9a40-01cc391c0908" />
+        <node concept="398BVA" id="5mH$9t6eBsV" role="3LF7KH">
+          <ref role="398BVh" node="5mH$9t6eA_$" resolve="celllayout.home" />
+          <node concept="2Ry0Ak" id="5mH$9t6eBsW" role="iGT6I">
+            <property role="2Ry0Am" value="languages" />
+            <node concept="2Ry0Ak" id="5mH$9t6eBsX" role="2Ry0An">
+              <property role="2Ry0Am" value="test.de.itemis.mps.editor.celllayout.lang" />
+              <node concept="2Ry0Ak" id="5mH$9t6eBEv" role="2Ry0An">
+                <property role="2Ry0Am" value="test.de.itemis.mps.editor.celllayout.lang.mpl" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1E0d5M" id="5mH$9t6eBsZ" role="1E1XAP">
+          <ref role="1E0d5P" node="6$6tsX_CURF" resolve="de.slisson.mps.structurecheck.runtime" />
+        </node>
+        <node concept="3rtmxn" id="5mH$9t6eBt3" role="3bR31x">
+          <node concept="3LXTmp" id="5mH$9t6eBt4" role="3rtmxm">
+            <node concept="3qWCbU" id="5mH$9t6eBt5" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="PE3B26qlse" role="3LXTmr">
+              <ref role="398BVh" node="5mH$9t6eA_$" resolve="celllayout.home" />
+              <node concept="2Ry0Ak" id="PE3B26qlsf" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="PE3B26qlsg" role="2Ry0An">
+                  <property role="2Ry0Am" value="test.de.itemis.mps.editor.celllayout.lang" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="5mH$9t6eBte" role="3bR37C">
+          <node concept="3bR9La" id="5mH$9t6eBtf" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1TaHNgiIbIZ" resolve="MPS.Editor" />
+          </node>
+        </node>
+        <node concept="1E0d5M" id="5mH$9t6eBtk" role="1E1XAP">
+          <ref role="1E0d5P" node="29so9Vb$6T5" resolve="de.slisson.mps.tables.runtime" />
+        </node>
+        <node concept="1SiIV0" id="5mH$9t6eBHL" role="3bR37C">
+          <node concept="3bR9La" id="5mH$9t6eBHM" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1H905DlDUSw" resolve="MPS.OpenAPI" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="5mH$9t6eBHN" role="3bR37C">
+          <node concept="3bR9La" id="5mH$9t6eBHO" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1TaHNgiIbJb" resolve="MPS.Platform" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="5mH$9t6eBHP" role="3bR37C">
+          <node concept="3bR9La" id="5mH$9t6eBHQ" role="1SiIV1">
+            <property role="3bR36h" value="true" />
+            <ref role="3bR37D" node="6SVXTgIejl1" resolve="de.itemis.mps.editor.celllayout.runtime" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="5mH$9t6eBHR" role="3bR37C">
+          <node concept="3bR9La" id="5mH$9t6eBHS" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:ymnOULAU0H" resolve="jetbrains.mps.lang.test" />
+          </node>
+        </node>
+        <node concept="1E0d5M" id="2fo8bJECGDq" role="1E1XAP">
+          <ref role="1E0d5P" node="6SVXTgIejl1" resolve="de.itemis.mps.editor.celllayout.runtime" />
+        </node>
+        <node concept="1BupzO" id="7q24334ZKRf" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="7q24334ZKRg" role="1HemKq">
+            <node concept="398BVA" id="7q24334ZKQU" role="3LXTmr">
+              <ref role="398BVh" node="5mH$9t6eA_$" resolve="celllayout.home" />
+              <node concept="2Ry0Ak" id="7q24334ZKQV" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="7q24334ZKQW" role="2Ry0An">
+                  <property role="2Ry0Am" value="test.de.itemis.mps.editor.celllayout.lang" />
+                  <node concept="2Ry0Ak" id="7q24334ZKQX" role="2Ry0An">
+                    <property role="2Ry0Am" value="models" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="7q24334ZKRh" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1E1JtD" id="7qi8mU1OzZt" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="de.itemis.mps.editor.celllayout.sandboxlang" />
+        <property role="3LESm3" value="a49c7665-6e20-479f-8483-903f65b74ed2" />
+        <node concept="398BVA" id="7qi8mU1OzZu" role="3LF7KH">
+          <ref role="398BVh" node="5mH$9t6eA_$" resolve="celllayout.home" />
+          <node concept="2Ry0Ak" id="7qi8mU1OzZv" role="iGT6I">
+            <property role="2Ry0Am" value="languages" />
+            <node concept="2Ry0Ak" id="7qi8mU1OzZw" role="2Ry0An">
+              <property role="2Ry0Am" value="de.itemis.mps.editor.celllayout.sandboxlang" />
+              <node concept="2Ry0Ak" id="7qi8mU1O$bJ" role="2Ry0An">
+                <property role="2Ry0Am" value="de.itemis.mps.editor.celllayout.sandboxlang.mpl" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3rtmxn" id="3D0nl1ssJJf" role="3bR31x">
+          <node concept="3LXTmp" id="3D0nl1ssJJg" role="3rtmxm">
+            <node concept="3qWCbU" id="3D0nl1ssJJh" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="3D0nl1ssJJi" role="3LXTmr">
+              <ref role="398BVh" node="5mH$9t6eA_$" resolve="celllayout.home" />
+              <node concept="2Ry0Ak" id="3D0nl1ssJJj" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="3D0nl1ssJJk" role="2Ry0An">
+                  <property role="2Ry0Am" value="de.itemis.mps.editor.celllayout.sandboxlang" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1BupzO" id="7q24334ZKS3" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="7q24334ZKS4" role="1HemKq">
+            <node concept="398BVA" id="7q24334ZKRI" role="3LXTmr">
+              <ref role="398BVh" node="5mH$9t6eA_$" resolve="celllayout.home" />
+              <node concept="2Ry0Ak" id="7q24334ZKRJ" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="7q24334ZKRK" role="2Ry0An">
+                  <property role="2Ry0Am" value="de.itemis.mps.editor.celllayout.sandboxlang" />
+                  <node concept="2Ry0Ak" id="7q24334ZKRL" role="2Ry0An">
+                    <property role="2Ry0Am" value="models" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="7q24334ZKS5" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1E1JtA" id="7qi8mU1OzZB" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="de.itemis.mps.editor.celllayout.sandbox" />
+        <property role="3LESm3" value="3d5ab66d-c2b3-48c1-883a-d9c0e3febd61" />
+        <node concept="398BVA" id="7qi8mU1OzZC" role="3LF7KH">
+          <ref role="398BVh" node="5mH$9t6eA_$" resolve="celllayout.home" />
+          <node concept="2Ry0Ak" id="7qi8mU1OzZD" role="iGT6I">
+            <property role="2Ry0Am" value="solutions" />
+            <node concept="2Ry0Ak" id="7qi8mU1OzZE" role="2Ry0An">
+              <property role="2Ry0Am" value="de.itemis.mps.editor.celllayout.sandbox" />
+              <node concept="2Ry0Ak" id="7qi8mU1O$bL" role="2Ry0An">
+                <property role="2Ry0Am" value="de.itemis.mps.editor.celllayout.sandbox.msd" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3rtmxn" id="3D0nl1ssJIg" role="3bR31x">
+          <node concept="3LXTmp" id="3D0nl1ssJIh" role="3rtmxm">
+            <node concept="3qWCbU" id="3D0nl1ssJIi" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="3D0nl1ssJIj" role="3LXTmr">
+              <ref role="398BVh" node="5mH$9t6eA_$" resolve="celllayout.home" />
+              <node concept="2Ry0Ak" id="3D0nl1ssJIk" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="3D0nl1ssJIl" role="2Ry0An">
+                  <property role="2Ry0Am" value="de.itemis.mps.editor.celllayout.sandbox" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1BupzO" id="7q24334ZKSR" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="7q24334ZKSS" role="1HemKq">
+            <node concept="398BVA" id="7q24334ZKSy" role="3LXTmr">
+              <ref role="398BVh" node="5mH$9t6eA_$" resolve="celllayout.home" />
+              <node concept="2Ry0Ak" id="7q24334ZKSz" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="7q24334ZKS$" role="2Ry0An">
+                  <property role="2Ry0Am" value="de.itemis.mps.editor.celllayout.sandbox" />
+                  <node concept="2Ry0Ak" id="7q24334ZKS_" role="2Ry0An">
+                    <property role="2Ry0Am" value="models" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="7q24334ZKST" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2G$12M" id="7qi8mU1Oz$g" role="3989C9">
+      <property role="TrG5h" value="diagrams" />
+      <node concept="1E1JtD" id="6$6tsX_CJi6" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="de.itemis.mps.editor.diagram.demo.activity" />
+        <property role="3LESm3" value="5a82b7b8-2303-45be-b960-4e3ff16e82ce" />
+        <node concept="398BVA" id="6$6tsX_CJj$" role="3LF7KH">
+          <ref role="398BVh" node="6$6tsX_CF7m" resolve="diagram.home" />
+          <node concept="2Ry0Ak" id="6$6tsX_CJko" role="iGT6I">
+            <property role="2Ry0Am" value="languages" />
+            <node concept="2Ry0Ak" id="6$6tsX_CJlb" role="2Ry0An">
+              <property role="2Ry0Am" value="de.itemis.mps.editor.diagram.demo.activity" />
+              <node concept="2Ry0Ak" id="6$6tsX_CJlY" role="2Ry0An">
+                <property role="2Ry0Am" value="de.itemis.mps.editor.diagram.demo.activity.mpl" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="6$6tsX_CJv4" role="3bR37C">
+          <node concept="3bR9La" id="6$6tsX_CJv5" role="1SiIV1">
+            <ref role="3bR37D" node="4be$WTb1AQa" resolve="de.itemis.mps.editor.diagram.runtime" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="6$6tsX_CJv6" role="3bR37C">
+          <node concept="3bR9La" id="6$6tsX_CJv7" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="6$6tsX_CJv8" role="3bR37C">
+          <node concept="3bR9La" id="6$6tsX_CJv9" role="1SiIV1">
+            <ref role="3bR37D" node="6wEeo$QJAsB" resolve="de.itemis.mps.editor.diagram.shapes" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="6$6tsX_CJva" role="3bR37C">
+          <node concept="1Busua" id="6$6tsX_CJvb" role="1SiIV1">
+            <ref role="1Busuk" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
+          </node>
+        </node>
+        <node concept="3rtmxn" id="3xFG3bj5MnI" role="3bR31x">
+          <node concept="3LXTmp" id="3xFG3bj5MnJ" role="3rtmxm">
+            <node concept="3qWCbU" id="3xFG3bj5MnK" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="3xFG3bj5MnL" role="3LXTmr">
+              <ref role="398BVh" node="6$6tsX_CF7m" resolve="diagram.home" />
+              <node concept="2Ry0Ak" id="3xFG3bj5MnM" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="3xFG3bj5MnN" role="2Ry0An">
+                  <property role="2Ry0Am" value="de.itemis.mps.editor.diagram.demo.activity" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1BupzO" id="7q24334ZKTf" role="3bR31x">
+          <property role="3ZfqAx" value="languageModels" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="7q24334ZKTg" role="1HemKq">
+            <node concept="398BVA" id="7q24334ZKSU" role="3LXTmr">
+              <ref role="398BVh" node="6$6tsX_CF7m" resolve="diagram.home" />
+              <node concept="2Ry0Ak" id="7q24334ZKSV" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="7q24334ZKSW" role="2Ry0An">
+                  <property role="2Ry0Am" value="de.itemis.mps.editor.diagram.demo.activity" />
+                  <node concept="2Ry0Ak" id="7q24334ZKSX" role="2Ry0An">
+                    <property role="2Ry0Am" value="languageModels" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="7q24334ZKTh" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1E1JtD" id="6$6tsX_CISo" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="test.de.itemis.mps.editor.diagram.lang" />
+        <property role="3LESm3" value="aff569ad-098d-414a-aa23-96963959392c" />
+        <node concept="398BVA" id="6$6tsX_CJbC" role="3LF7KH">
+          <ref role="398BVh" node="6$6tsX_CF7m" resolve="diagram.home" />
+          <node concept="2Ry0Ak" id="6$6tsX_CJbS" role="iGT6I">
+            <property role="2Ry0Am" value="languages" />
+            <node concept="2Ry0Ak" id="6$6tsX_CJc7" role="2Ry0An">
+              <property role="2Ry0Am" value="test.de.itemis.mps.editor.diagram.lang" />
+              <node concept="2Ry0Ak" id="6$6tsX_CJcm" role="2Ry0An">
+                <property role="2Ry0Am" value="test.de.itemis.mps.editor.diagram.lang.mpl" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="6$6tsX_CJt8" role="3bR37C">
+          <node concept="3bR9La" id="6$6tsX_CJt9" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:7Kfy9QB6L4X" resolve="jetbrains.mps.lang.editor" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="6$6tsX_CJta" role="3bR37C">
+          <node concept="3bR9La" id="6$6tsX_CJtb" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1H905DlDUSw" resolve="MPS.OpenAPI" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="6$6tsX_CJtc" role="3bR37C">
+          <node concept="3bR9La" id="6$6tsX_CJtd" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
+          </node>
+        </node>
+        <node concept="3rtmxn" id="3xFG3bj5Mlq" role="3bR31x">
+          <node concept="3LXTmp" id="3xFG3bj5Mlr" role="3rtmxm">
+            <node concept="3qWCbU" id="3xFG3bj5Mls" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="3xFG3bj5Mlt" role="3LXTmr">
+              <ref role="398BVh" node="6$6tsX_CF7m" resolve="diagram.home" />
+              <node concept="2Ry0Ak" id="3xFG3bj5Mlu" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="3xFG3bj5Mlv" role="2Ry0An">
+                  <property role="2Ry0Am" value="test.de.itemis.mps.editor.diagram.lang" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="PE3B26v8j3" role="3bR37C">
+          <node concept="3bR9La" id="PE3B26v8j4" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
+          </node>
+        </node>
+        <node concept="3bR9La" id="2fo8bJECyg7" role="3bR37C">
+          <ref role="3bR37D" node="4be$WTb1CbJ" resolve="de.itemis.mps.editor.diagram" />
+        </node>
+        <node concept="1BupzO" id="7q24334ZKU3" role="3bR31x">
+          <property role="3ZfqAx" value="languageModels" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="7q24334ZKU4" role="1HemKq">
+            <node concept="398BVA" id="7q24334ZKTI" role="3LXTmr">
+              <ref role="398BVh" node="6$6tsX_CF7m" resolve="diagram.home" />
+              <node concept="2Ry0Ak" id="7q24334ZKTJ" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="7q24334ZKTK" role="2Ry0An">
+                  <property role="2Ry0Am" value="test.de.itemis.mps.editor.diagram.lang" />
+                  <node concept="2Ry0Ak" id="7q24334ZKTL" role="2Ry0An">
+                    <property role="2Ry0Am" value="languageModels" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="7q24334ZKU5" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1E1JtA" id="6$6tsX_CJdr" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="test.de.itemis.mps.editor.diagram.solution" />
+        <property role="3LESm3" value="a47122e4-d14a-4912-90ff-6967ad1e3b02" />
+        <property role="aoJFB" value="eYcmk9QOlj/sources_and_tests" />
+        <node concept="398BVA" id="6$6tsX_CJei" role="3LF7KH">
+          <ref role="398BVh" node="6$6tsX_CF7m" resolve="diagram.home" />
+          <node concept="2Ry0Ak" id="6$6tsX_CJeO" role="iGT6I">
+            <property role="2Ry0Am" value="solutions" />
+            <node concept="2Ry0Ak" id="6$6tsX_CJfu" role="2Ry0An">
+              <property role="2Ry0Am" value="test.de.itemis.mps.editor.diagram.solution" />
+              <node concept="2Ry0Ak" id="6$6tsX_CJg8" role="2Ry0An">
+                <property role="2Ry0Am" value="test.de.itemis.mps.editor.diagram.solution.msd" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="6$6tsX_CJx8" role="3bR37C">
+          <node concept="3bR9La" id="6$6tsX_CJx9" role="1SiIV1">
+            <ref role="3bR37D" node="6$6tsX_CJi6" resolve="de.itemis.mps.editor.diagram.demo.activity" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="6$6tsX_CJxa" role="3bR37C">
+          <node concept="3bR9La" id="6$6tsX_CJxb" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1TaHNgiIbIZ" resolve="MPS.Editor" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="6$6tsX_CJxc" role="3bR37C">
+          <node concept="3bR9La" id="6$6tsX_CJxd" role="1SiIV1">
+            <ref role="3bR37D" node="6$6tsX_CISo" resolve="test.de.itemis.mps.editor.diagram.lang" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="6$6tsX_CJxe" role="3bR37C">
+          <node concept="3bR9La" id="6$6tsX_CJxf" role="1SiIV1">
+            <ref role="3bR37D" node="4be$WTb1AQa" resolve="de.itemis.mps.editor.diagram.runtime" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="6$6tsX_CJxg" role="3bR37C">
+          <node concept="3bR9La" id="6$6tsX_CJxh" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
+          </node>
+        </node>
+        <node concept="3rtmxn" id="3xFG3bj5MkV" role="3bR31x">
+          <node concept="3LXTmp" id="3xFG3bj5MkW" role="3rtmxm">
+            <node concept="3qWCbU" id="3xFG3bj5MkX" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="3xFG3bj5MkY" role="3LXTmr">
+              <ref role="398BVh" node="6$6tsX_CF7m" resolve="diagram.home" />
+              <node concept="2Ry0Ak" id="3xFG3bj5MkZ" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="3xFG3bj5Ml0" role="2Ry0An">
+                  <property role="2Ry0Am" value="test.de.itemis.mps.editor.diagram.solution" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1BupzO" id="7q24334ZKUR" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="7q24334ZKUS" role="1HemKq">
+            <node concept="398BVA" id="7q24334ZKUy" role="3LXTmr">
+              <ref role="398BVh" node="6$6tsX_CF7m" resolve="diagram.home" />
+              <node concept="2Ry0Ak" id="7q24334ZKUz" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="7q24334ZKU$" role="2Ry0An">
+                  <property role="2Ry0Am" value="test.de.itemis.mps.editor.diagram.solution" />
+                  <node concept="2Ry0Ak" id="7q24334ZKU_" role="2Ry0An">
+                    <property role="2Ry0Am" value="models" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="7q24334ZKUT" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1E1JtD" id="7qi8mU1Oz$h" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="de.itemis.mps.editor.diagram.demolang" />
+        <property role="3LESm3" value="7cf26568-7255-45b6-b975-a44162a7e7e2" />
+        <node concept="398BVA" id="7qi8mU1Oz$i" role="3LF7KH">
+          <ref role="398BVh" node="6$6tsX_CF7m" resolve="diagram.home" />
+          <node concept="2Ry0Ak" id="7qi8mU1Oz$j" role="iGT6I">
+            <property role="2Ry0Am" value="languages" />
+            <node concept="2Ry0Ak" id="7qi8mU1Oz$k" role="2Ry0An">
+              <property role="2Ry0Am" value="de.itemis.mps.editor.diagram.demolang" />
+              <node concept="2Ry0Ak" id="7qi8mU1OzOV" role="2Ry0An">
+                <property role="2Ry0Am" value="de.itemis.mps.editor.diagram.demolang.mpl" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1yeLz9" id="7qi8mU1Oz$u" role="1TViLv">
+          <property role="TrG5h" value="de.itemis.mps.editor.diagram.demolang#5806942359871451541" />
+          <property role="3LESm3" value="1b7d09f9-42ec-4a9d-90c4-e292e54e3358" />
+          <node concept="1BupzO" id="7q24334ZKW2" role="3bR31x">
+            <property role="3ZfqAx" value="generator/template" />
+            <property role="1Hdu6h" value="true" />
+            <property role="1HemKv" value="true" />
+            <node concept="3LXTmp" id="7q24334ZKW3" role="1HemKq">
+              <node concept="398BVA" id="7q24334ZKVD" role="3LXTmr">
+                <ref role="398BVh" node="6$6tsX_CF7m" resolve="diagram.home" />
+                <node concept="2Ry0Ak" id="7q24334ZKVE" role="iGT6I">
+                  <property role="2Ry0Am" value="languages" />
+                  <node concept="2Ry0Ak" id="7q24334ZKVF" role="2Ry0An">
+                    <property role="2Ry0Am" value="de.itemis.mps.editor.diagram.demolang" />
+                    <node concept="2Ry0Ak" id="7q24334ZKVG" role="2Ry0An">
+                      <property role="2Ry0Am" value="generator" />
+                      <node concept="2Ry0Ak" id="7q24334ZKVH" role="2Ry0An">
+                        <property role="2Ry0Am" value="template" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3qWCbU" id="7q24334ZKW4" role="3LXTna">
+                <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="7qi8mU1OzTe" role="3bR37C">
+          <node concept="3bR9La" id="7qi8mU1OzTf" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="7qi8mU1OzTg" role="3bR37C">
+          <node concept="3bR9La" id="7qi8mU1OzTh" role="1SiIV1">
+            <ref role="3bR37D" node="4be$WTb1AQa" resolve="de.itemis.mps.editor.diagram.runtime" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="7qi8mU1OzTi" role="3bR37C">
+          <node concept="3bR9La" id="7qi8mU1OzTj" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="7qi8mU1OzTk" role="3bR37C">
+          <node concept="3bR9La" id="7qi8mU1OzTl" role="1SiIV1">
+            <ref role="3bR37D" node="6wEeo$QJAsB" resolve="de.itemis.mps.editor.diagram.shapes" />
+          </node>
+        </node>
+        <node concept="3rtmxn" id="3D0nl1ssJJm" role="3bR31x">
+          <node concept="3LXTmp" id="3D0nl1ssJJn" role="3rtmxm">
+            <node concept="3qWCbU" id="3D0nl1ssJJo" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="3D0nl1ssJJp" role="3LXTmr">
+              <ref role="398BVh" node="6$6tsX_CF7m" resolve="diagram.home" />
+              <node concept="2Ry0Ak" id="3D0nl1ssJJq" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="3D0nl1ssJJr" role="2Ry0An">
+                  <property role="2Ry0Am" value="de.itemis.mps.editor.diagram.demolang" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1BupzO" id="7q24334ZKVf" role="3bR31x">
+          <property role="3ZfqAx" value="languageModels" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="7q24334ZKVg" role="1HemKq">
+            <node concept="398BVA" id="7q24334ZKUU" role="3LXTmr">
+              <ref role="398BVh" node="6$6tsX_CF7m" resolve="diagram.home" />
+              <node concept="2Ry0Ak" id="7q24334ZKUV" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="7q24334ZKUW" role="2Ry0An">
+                  <property role="2Ry0Am" value="de.itemis.mps.editor.diagram.demolang" />
+                  <node concept="2Ry0Ak" id="7q24334ZKUX" role="2Ry0An">
+                    <property role="2Ry0Am" value="languageModels" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="7q24334ZKVh" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+        <node concept="1BupzO" id="42yR2aTbA8V" role="3bR31x">
+          <property role="3ZfqAx" value="languageAccessories" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="42yR2aTbA8W" role="1HemKq">
+            <node concept="398BVA" id="42yR2aTbA8A" role="3LXTmr">
+              <ref role="398BVh" node="6$6tsX_CF7m" resolve="diagram.home" />
+              <node concept="2Ry0Ak" id="42yR2aTbA8B" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="42yR2aTbA8C" role="2Ry0An">
+                  <property role="2Ry0Am" value="de.itemis.mps.editor.diagram.demolang" />
+                  <node concept="2Ry0Ak" id="42yR2aTbA8D" role="2Ry0An">
+                    <property role="2Ry0Am" value="languageAccessories" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="42yR2aTbA8X" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1E1JtD" id="7qi8mU1Oz$v" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="de.itemis.mps.editor.diagram.demoentities" />
+        <property role="3LESm3" value="46b1f1f4-3955-4255-af94-7acb92d5711a" />
+        <node concept="398BVA" id="7qi8mU1Oz$w" role="3LF7KH">
+          <ref role="398BVh" node="6$6tsX_CF7m" resolve="diagram.home" />
+          <node concept="2Ry0Ak" id="7qi8mU1Oz$x" role="iGT6I">
+            <property role="2Ry0Am" value="languages" />
+            <node concept="2Ry0Ak" id="7qi8mU1Oz$y" role="2Ry0An">
+              <property role="2Ry0Am" value="de.itemis.mps.editor.diagram.demoentities" />
+              <node concept="2Ry0Ak" id="7qi8mU1OzOX" role="2Ry0An">
+                <property role="2Ry0Am" value="de.itemis.mps.editor.diagram.demoentities.mpl" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1E0d5M" id="7qi8mU1Oz$E" role="1E1XAP">
+          <ref role="1E0d5P" node="PE3B26QCrP" resolve="org.apache.commons" />
+        </node>
+        <node concept="1SiIV0" id="7qi8mU1OzTm" role="3bR37C">
+          <node concept="3bR9La" id="7qi8mU1OzTn" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="7qi8mU1OzTo" role="3bR37C">
+          <node concept="3bR9La" id="7qi8mU1OzTp" role="1SiIV1">
+            <ref role="3bR37D" node="4be$WTb1AQa" resolve="de.itemis.mps.editor.diagram.runtime" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="7qi8mU1OzTq" role="3bR37C">
+          <node concept="3bR9La" id="7qi8mU1OzTr" role="1SiIV1">
+            <ref role="3bR37D" node="6wEeo$QJAsB" resolve="de.itemis.mps.editor.diagram.shapes" />
+          </node>
+        </node>
+        <node concept="3rtmxn" id="3D0nl1ssJJt" role="3bR31x">
+          <node concept="3LXTmp" id="3D0nl1ssJJu" role="3rtmxm">
+            <node concept="3qWCbU" id="3D0nl1ssJJv" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="3D0nl1ssJJw" role="3LXTmr">
+              <ref role="398BVh" node="6$6tsX_CF7m" resolve="diagram.home" />
+              <node concept="2Ry0Ak" id="3D0nl1ssJJx" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="3D0nl1ssJJy" role="2Ry0An">
+                  <property role="2Ry0Am" value="de.itemis.mps.editor.diagram.demoentities" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1BupzO" id="7q24334ZKWq" role="3bR31x">
+          <property role="3ZfqAx" value="languageModels" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="7q24334ZKWr" role="1HemKq">
+            <node concept="398BVA" id="7q24334ZKW5" role="3LXTmr">
+              <ref role="398BVh" node="6$6tsX_CF7m" resolve="diagram.home" />
+              <node concept="2Ry0Ak" id="7q24334ZKW6" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="7q24334ZKW7" role="2Ry0An">
+                  <property role="2Ry0Am" value="de.itemis.mps.editor.diagram.demoentities" />
+                  <node concept="2Ry0Ak" id="7q24334ZKW8" role="2Ry0An">
+                    <property role="2Ry0Am" value="languageModels" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="7q24334ZKWs" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1E1JtD" id="7qi8mU1OzOZ" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="de.itemis.mps.editor.diagram.demo.callgraph" />
+        <property role="3LESm3" value="3ba72f2f-a5c2-46e4-8b7e-b7ef6fb0cfc7" />
+        <node concept="398BVA" id="7qi8mU1OzP0" role="3LF7KH">
+          <ref role="398BVh" node="6$6tsX_CF7m" resolve="diagram.home" />
+          <node concept="2Ry0Ak" id="7qi8mU1OzP1" role="iGT6I">
+            <property role="2Ry0Am" value="languages" />
+            <node concept="2Ry0Ak" id="7qi8mU1OzP2" role="2Ry0An">
+              <property role="2Ry0Am" value="de.itemis.mps.editor.diagram.demo.callgraph" />
+              <node concept="2Ry0Ak" id="7qi8mU1OzR5" role="2Ry0An">
+                <property role="2Ry0Am" value="de.itemis.mps.editor.diagram.demo.callgraph.mpl" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1E0d5M" id="7qi8mU1OzPa" role="1E1XAP">
+          <ref role="1E0d5P" node="PE3B26QCrP" resolve="org.apache.commons" />
+        </node>
+        <node concept="1SiIV0" id="7qi8mU1OzTs" role="3bR37C">
+          <node concept="3bR9La" id="7qi8mU1OzTt" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="7qi8mU1OzTu" role="3bR37C">
+          <node concept="3bR9La" id="7qi8mU1OzTv" role="1SiIV1">
+            <ref role="3bR37D" node="4be$WTb1AQa" resolve="de.itemis.mps.editor.diagram.runtime" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="7qi8mU1OzTw" role="3bR37C">
+          <node concept="3bR9La" id="7qi8mU1OzTx" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
+          </node>
+        </node>
+        <node concept="3rtmxn" id="3D0nl1ssJJ$" role="3bR31x">
+          <node concept="3LXTmp" id="3D0nl1ssJJ_" role="3rtmxm">
+            <node concept="3qWCbU" id="3D0nl1ssJJA" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="3D0nl1ssJJB" role="3LXTmr">
+              <ref role="398BVh" node="6$6tsX_CF7m" resolve="diagram.home" />
+              <node concept="2Ry0Ak" id="3D0nl1ssJJC" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="3D0nl1ssJJD" role="2Ry0An">
+                  <property role="2Ry0Am" value="de.itemis.mps.editor.diagram.demo.callgraph" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1BupzO" id="7q24334ZKXe" role="3bR31x">
+          <property role="3ZfqAx" value="languageModels" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="7q24334ZKXf" role="1HemKq">
+            <node concept="398BVA" id="7q24334ZKWT" role="3LXTmr">
+              <ref role="398BVh" node="6$6tsX_CF7m" resolve="diagram.home" />
+              <node concept="2Ry0Ak" id="7q24334ZKWU" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="7q24334ZKWV" role="2Ry0An">
+                  <property role="2Ry0Am" value="de.itemis.mps.editor.diagram.demo.callgraph" />
+                  <node concept="2Ry0Ak" id="7q24334ZKWW" role="2Ry0An">
+                    <property role="2Ry0Am" value="languageModels" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="7q24334ZKXg" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1E1JtA" id="7qi8mU1Oz$K" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="de.itemis.mps.editor.diagram.sandbox" />
+        <property role="3LESm3" value="249b0ecd-6945-42f0-b1b6-eb5c6f600cdc" />
+        <node concept="398BVA" id="7qi8mU1Oz$L" role="3LF7KH">
+          <ref role="398BVh" node="6$6tsX_CF7m" resolve="diagram.home" />
+          <node concept="2Ry0Ak" id="7qi8mU1Oz$M" role="iGT6I">
+            <property role="2Ry0Am" value="solutions" />
+            <node concept="2Ry0Ak" id="7qi8mU1Oz$N" role="2Ry0An">
+              <property role="2Ry0Am" value="de.itemis.mps.editor.diagram.sandbox" />
+              <node concept="2Ry0Ak" id="7qi8mU1OzR7" role="2Ry0An">
+                <property role="2Ry0Am" value="de.itemis.mps.editor.diagram.sandbox.msd" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3rtmxn" id="3D0nl1ssJIn" role="3bR31x">
+          <node concept="3LXTmp" id="3D0nl1ssJIo" role="3rtmxm">
+            <node concept="3qWCbU" id="3D0nl1ssJIp" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="3D0nl1ssJIq" role="3LXTmr">
+              <ref role="398BVh" node="6$6tsX_CF7m" resolve="diagram.home" />
+              <node concept="2Ry0Ak" id="3D0nl1ssJIr" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="3D0nl1ssJIs" role="2Ry0An">
+                  <property role="2Ry0Am" value="de.itemis.mps.editor.diagram.sandbox" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1BupzO" id="7q24334ZKY2" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="7q24334ZKY3" role="1HemKq">
+            <node concept="398BVA" id="7q24334ZKXH" role="3LXTmr">
+              <ref role="398BVh" node="6$6tsX_CF7m" resolve="diagram.home" />
+              <node concept="2Ry0Ak" id="7q24334ZKXI" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="7q24334ZKXJ" role="2Ry0An">
+                  <property role="2Ry0Am" value="de.itemis.mps.editor.diagram.sandbox" />
+                  <node concept="2Ry0Ak" id="7q24334ZKXK" role="2Ry0An">
+                    <property role="2Ry0Am" value="models" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="7q24334ZKY4" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1E1JtA" id="7qi8mU1OzR9" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="de.itemis.mps.editor.diagram.demoentities.sandbox" />
+        <property role="3LESm3" value="3ef43972-347f-437c-8a95-637327907e38" />
+        <node concept="398BVA" id="7qi8mU1OzRa" role="3LF7KH">
+          <ref role="398BVh" node="6$6tsX_CF7m" resolve="diagram.home" />
+          <node concept="2Ry0Ak" id="7qi8mU1OzRb" role="iGT6I">
+            <property role="2Ry0Am" value="solutions" />
+            <node concept="2Ry0Ak" id="7qi8mU1OzRc" role="2Ry0An">
+              <property role="2Ry0Am" value="de.itemis.mps.editor.diagram.demoentities.sandbox" />
+              <node concept="2Ry0Ak" id="7qi8mU1OzTc" role="2Ry0An">
+                <property role="2Ry0Am" value="de.itemis.mps.editor.diagram.demoentities.sandbox.msd" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3rtmxn" id="3D0nl1ssJIu" role="3bR31x">
+          <node concept="3LXTmp" id="3D0nl1ssJIv" role="3rtmxm">
+            <node concept="3qWCbU" id="3D0nl1ssJIw" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="3D0nl1ssJIx" role="3LXTmr">
+              <ref role="398BVh" node="6$6tsX_CF7m" resolve="diagram.home" />
+              <node concept="2Ry0Ak" id="3D0nl1ssJIy" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="3D0nl1ssJIz" role="2Ry0An">
+                  <property role="2Ry0Am" value="de.itemis.mps.editor.diagram.demoentities.sandbox" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1BupzO" id="7q24334ZKYq" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="7q24334ZKYr" role="1HemKq">
+            <node concept="398BVA" id="7q24334ZKY5" role="3LXTmr">
+              <ref role="398BVh" node="6$6tsX_CF7m" resolve="diagram.home" />
+              <node concept="2Ry0Ak" id="7q24334ZKY6" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="7q24334ZKY7" role="2Ry0An">
+                  <property role="2Ry0Am" value="de.itemis.mps.editor.diagram.demoentities.sandbox" />
+                  <node concept="2Ry0Ak" id="7q24334ZKY8" role="2Ry0An">
+                    <property role="2Ry0Am" value="models" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="7q24334ZKYs" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1E1JtA" id="7qi8mU1OzTQ" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="de.itemis.mps.editor.diagram.demo.activity.sandbox" />
+        <property role="3LESm3" value="32505440-8493-4ca5-a95b-0d257a22763e" />
+        <node concept="398BVA" id="7qi8mU1OzTR" role="3LF7KH">
+          <ref role="398BVh" node="6$6tsX_CF7m" resolve="diagram.home" />
+          <node concept="2Ry0Ak" id="7qi8mU1OzTS" role="iGT6I">
+            <property role="2Ry0Am" value="solutions" />
+            <node concept="2Ry0Ak" id="7qi8mU1OzTT" role="2Ry0An">
+              <property role="2Ry0Am" value="de.itemis.mps.editor.diagram.demo.activity.sandbox" />
+              <node concept="2Ry0Ak" id="7qi8mU1OzVK" role="2Ry0An">
+                <property role="2Ry0Am" value="de.itemis.mps.editor.diagram.demo.activity.sandbox.msd" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="7qi8mU1OzVM" role="3bR37C">
+          <node concept="3bR9La" id="7qi8mU1OzVN" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
+          </node>
+        </node>
+        <node concept="3rtmxn" id="3D0nl1ssJI_" role="3bR31x">
+          <node concept="3LXTmp" id="3D0nl1ssJIA" role="3rtmxm">
+            <node concept="3qWCbU" id="3D0nl1ssJIB" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="3D0nl1ssJIC" role="3LXTmr">
+              <ref role="398BVh" node="6$6tsX_CF7m" resolve="diagram.home" />
+              <node concept="2Ry0Ak" id="3D0nl1ssJID" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="3D0nl1ssJIE" role="2Ry0An">
+                  <property role="2Ry0Am" value="de.itemis.mps.editor.diagram.demo.activity.sandbox" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1BupzO" id="7q24334ZKYM" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="7q24334ZKYN" role="1HemKq">
+            <node concept="398BVA" id="7q24334ZKYt" role="3LXTmr">
+              <ref role="398BVh" node="6$6tsX_CF7m" resolve="diagram.home" />
+              <node concept="2Ry0Ak" id="7q24334ZKYu" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="7q24334ZKYv" role="2Ry0An">
+                  <property role="2Ry0Am" value="de.itemis.mps.editor.diagram.demo.activity.sandbox" />
+                  <node concept="2Ry0Ak" id="7q24334ZKYw" role="2Ry0An">
+                    <property role="2Ry0Am" value="models" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="7q24334ZKYO" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="10PD9b" id="6$6tsX_CF7b" role="10PD9s" />
+    <node concept="3b7kt6" id="6$6tsX_CF7c" role="10PD9s" />
+    <node concept="1gjT0q" id="6$6tsX_CKLI" role="10PD9s" />
+    <node concept="398rNT" id="6$6tsX_CF7d" role="1l3spd">
+      <property role="TrG5h" value="mps.home" />
+      <node concept="55IIr" id="1QLFoGON26t" role="398pKh" />
+    </node>
+    <node concept="398rNT" id="1QLFoGON23s" role="1l3spd">
+      <property role="TrG5h" value="extensions.home" />
+      <node concept="55IIr" id="1QLFoGON23t" role="398pKh">
+        <node concept="2Ry0Ak" id="1QLFoGON23u" role="iGT6I">
+          <property role="2Ry0Am" value=".." />
+          <node concept="2Ry0Ak" id="2IxvlKPaLFA" role="2Ry0An">
+            <property role="2Ry0Am" value=".." />
+            <node concept="2Ry0Ak" id="2fo8bJEzAKn" role="2Ry0An">
+              <property role="2Ry0Am" value=".." />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="398rNT" id="PE3B26neqW" role="1l3spd">
+      <property role="TrG5h" value="extensions.code" />
+      <node concept="398BVA" id="27epzEomQ$V" role="398pKh">
+        <ref role="398BVh" node="1QLFoGON23s" resolve="extensions.home" />
+        <node concept="2Ry0Ak" id="27epzEomQ$Y" role="iGT6I">
+          <property role="2Ry0Am" value="code" />
+        </node>
+      </node>
+    </node>
+    <node concept="398rNT" id="6$6tsX_CF7m" role="1l3spd">
+      <property role="TrG5h" value="diagram.home" />
+      <node concept="398BVA" id="1QLFoGON23R" role="398pKh">
+        <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+        <node concept="2Ry0Ak" id="1QLFoGON23X" role="iGT6I">
+          <property role="2Ry0Am" value="diagram" />
+        </node>
+      </node>
+    </node>
+    <node concept="398rNT" id="5mH$9t6e_IG" role="1l3spd">
+      <property role="TrG5h" value="tables.home" />
+      <node concept="398BVA" id="5mH$9t6e_IH" role="398pKh">
+        <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+        <node concept="2Ry0Ak" id="5mH$9t6e_NL" role="iGT6I">
+          <property role="2Ry0Am" value="tables" />
+        </node>
+      </node>
+    </node>
+    <node concept="398rNT" id="F1NWDquQCJ" role="1l3spd">
+      <property role="TrG5h" value="grammarcells.home" />
+      <node concept="398BVA" id="F1NWDqwaSJ" role="398pKh">
+        <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+        <node concept="2Ry0Ak" id="F1NWDqwb9E" role="iGT6I">
+          <property role="2Ry0Am" value="grammarcells" />
+        </node>
+      </node>
+    </node>
+    <node concept="398rNT" id="5mH$9t6eA_$" role="1l3spd">
+      <property role="TrG5h" value="celllayout.home" />
+      <node concept="398BVA" id="5mH$9t6eA__" role="398pKh">
+        <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+        <node concept="2Ry0Ak" id="5mH$9t6eAP0" role="iGT6I">
+          <property role="2Ry0Am" value="celllayout" />
+        </node>
+      </node>
+    </node>
+    <node concept="398rNT" id="7qi8mU1Oz8V" role="1l3spd">
+      <property role="TrG5h" value="richtext.home" />
+      <node concept="398BVA" id="7qi8mU1Oz8W" role="398pKh">
+        <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+        <node concept="2Ry0Ak" id="7qi8mU1Oz9B" role="iGT6I">
+          <property role="2Ry0Am" value="richtext" />
+        </node>
+      </node>
+    </node>
+    <node concept="398rNT" id="7qi8mU1OzcE" role="1l3spd">
+      <property role="TrG5h" value="multiline.home" />
+      <node concept="398BVA" id="7qi8mU1OzcF" role="398pKh">
+        <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+        <node concept="2Ry0Ak" id="7qi8mU1Ozdp" role="iGT6I">
+          <property role="2Ry0Am" value="multiline" />
+        </node>
+      </node>
+    </node>
+    <node concept="398rNT" id="7qi8mU1Ozyi" role="1l3spd">
+      <property role="TrG5h" value="math.home" />
+      <node concept="398BVA" id="7qi8mU1Ozyj" role="398pKh">
+        <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+        <node concept="2Ry0Ak" id="7qi8mU1Ozz4" role="iGT6I">
+          <property role="2Ry0Am" value="math" />
+        </node>
+      </node>
+    </node>
+    <node concept="398rNT" id="7qi8mU1OzW7" role="1l3spd">
+      <property role="TrG5h" value="conditionalEditor.home" />
+      <node concept="398BVA" id="7qi8mU1OzW8" role="398pKh">
+        <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+        <node concept="2Ry0Ak" id="7qi8mU1OzWW" role="iGT6I">
+          <property role="2Ry0Am" value="conditional-editor" />
+        </node>
+      </node>
+    </node>
+    <node concept="398rNT" id="3$$s$wOI_hD" role="1l3spd">
+      <property role="TrG5h" value="widgets.home" />
+      <node concept="398BVA" id="3$$s$wOI_jn" role="398pKh">
+        <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+        <node concept="2Ry0Ak" id="3$$s$wOI_js" role="iGT6I">
+          <property role="2Ry0Am" value="widgets" />
+        </node>
+      </node>
+    </node>
+    <node concept="398rNT" id="OJuIQq1NW4" role="1l3spd">
+      <property role="TrG5h" value="mps.macro.extensions.home" />
+      <node concept="398BVA" id="OJuIQq1NY5" role="398pKh">
+        <ref role="398BVh" node="1QLFoGON23s" resolve="extensions.home" />
+      </node>
+    </node>
+    <node concept="2sgV4H" id="6$6tsX_CF7p" role="1l3spa">
+      <ref role="1l3spb" to="ffeo:3IKDaVZmzS6" resolve="mps" />
+      <node concept="398BVA" id="6$6tsX_CF7q" role="2JcizS">
+        <ref role="398BVh" node="6$6tsX_CF7d" resolve="mps.home" />
+      </node>
+    </node>
+    <node concept="2sgV4H" id="6yXTMcTQu49" role="1l3spa">
+      <ref role="1l3spb" to="ffeo:ymnOULAEsd" resolve="mpsTesting" />
+      <node concept="398BVA" id="6yXTMcTQu6h" role="2JcizS">
+        <ref role="398BVh" node="6$6tsX_CF7d" resolve="mps.home" />
+      </node>
+    </node>
+    <node concept="13uUGR" id="6$6tsX_CF7r" role="1l3spa">
+      <ref role="13uUGO" to="ffeo:6eCuTcwOnJO" resolve="IDEA" />
+      <node concept="398BVA" id="6$6tsX_CF7s" role="13uUGP">
+        <ref role="398BVh" node="6$6tsX_CF7d" resolve="mps.home" />
+      </node>
+    </node>
+    <node concept="2sgV4H" id="6$6tsX_CF7t" role="1l3spa">
+      <ref role="1l3spb" to="ffeo:6S1jmf0xDFC" resolve="mpsBootstrapCore" />
+      <node concept="398BVA" id="6$6tsX_CF7u" role="2JcizS">
+        <ref role="398BVh" node="6$6tsX_CF7d" resolve="mps.home" />
+      </node>
+    </node>
+    <node concept="2sgV4H" id="6$6tsX_CIho" role="1l3spa">
+      <ref role="1l3spb" node="2Xjt3l56m0V" resolve="de.itemis.mps.extensions" />
+      <node concept="398BVA" id="2fo8bJECJBq" role="2JcizS">
+        <ref role="398BVh" node="1QLFoGON23s" resolve="extensions.home" />
+        <node concept="2Ry0Ak" id="2fo8bJECJDk" role="iGT6I">
+          <property role="2Ry0Am" value="artifacts" />
+          <node concept="2Ry0Ak" id="2fo8bJECJDp" role="2Ry0An">
+            <property role="2Ry0Am" value="de.itemis.mps.extensions" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1l3spV" id="6$6tsX_CF7v" role="1l3spN">
+      <node concept="L2wRC" id="F1NWDqwjRk" role="39821P">
+        <ref role="L2wRA" node="F1NWDqweoc" resolve="com.mbeddr.mpsutil.grammarcells.sandboxlang" />
+      </node>
+      <node concept="L2wRC" id="F1NWDqwi5m" role="39821P">
+        <ref role="L2wRA" node="F1NWDqwbth" resolve="com.mbeddr.mpsutil.grammarcells.tests" />
+      </node>
+      <node concept="L2wRC" id="6$6tsX_CJNu" role="39821P">
+        <ref role="L2wRA" node="6$6tsX_CJi6" resolve="de.itemis.mps.editor.diagram.demo.activity" />
+      </node>
+      <node concept="L2wRC" id="6$6tsX_CJQ5" role="39821P">
+        <ref role="L2wRA" node="6$6tsX_CISo" resolve="test.de.itemis.mps.editor.diagram.lang" />
+      </node>
+      <node concept="L2wRC" id="6$6tsX_CJST" role="39821P">
+        <ref role="L2wRA" node="6$6tsX_CJdr" resolve="test.de.itemis.mps.editor.diagram.solution" />
+      </node>
+      <node concept="L2wRC" id="1x_$NGQM_y3" role="39821P">
+        <ref role="L2wRA" node="6$6tsX_CUvL" resolve="de.slisson.mps.structurecheck" />
+      </node>
+      <node concept="L2wRC" id="1x_$NGQM_$b" role="39821P">
+        <ref role="L2wRA" node="6$6tsX_CURF" resolve="de.slisson.mps.structurecheck.runtime" />
+      </node>
+      <node concept="L2wRC" id="5mH$9t6eCBc" role="39821P">
+        <ref role="L2wRA" node="5mH$9t6e_Fl" resolve="test.de.slisson.mps.tables" />
+      </node>
+      <node concept="L2wRC" id="5mH$9t6eE6L" role="39821P">
+        <ref role="L2wRA" node="5mH$9t6eA1O" resolve="de.slisson.mps.tables.demolang" />
+      </node>
+      <node concept="L2wRC" id="7i5Cc6Lw5nc" role="39821P">
+        <ref role="L2wRA" node="5mH$9t6eAsB" resolve="test.de.itemis.mps.editor.celllayout" />
+      </node>
+      <node concept="L2wRC" id="7i5Cc6Lw73q" role="39821P">
+        <ref role="L2wRA" node="5mH$9t6eBsU" resolve="test.de.itemis.mps.editor.celllayout.lang" />
+      </node>
+      <node concept="L2wRC" id="7i5Cc6LxDjB" role="39821P">
+        <ref role="L2wRA" node="7i5Cc6LxCew" resolve="de.slisson.mps.testutils" />
+      </node>
+      <node concept="L2wRC" id="2NyZxKpXc6v" role="39821P">
+        <ref role="L2wRA" node="2NyZxKpXalh" resolve="test.ex.match" />
+      </node>
+      <node concept="L2wRC" id="2NyZxKpXcjH" role="39821P">
+        <ref role="L2wRA" node="2NyZxKpX96P" resolve="test.ts.conceptswitch" />
+      </node>
+      <node concept="L2wRC" id="2NyZxKpXcBn" role="39821P">
+        <ref role="L2wRA" node="2NyZxKpX6$b" resolve="test.com.mbeddr.mpsutil.blutil.genutil.lang" />
+      </node>
+      <node concept="L2wRC" id="2NyZxKpXd8z" role="39821P">
+        <ref role="L2wRA" node="2NyZxKpX7We" resolve="test.com.mbeddr.mpsutil.blutil.genutil" />
+      </node>
+      <node concept="L2wRC" id="7XTah2ufVqi" role="39821P">
+        <ref role="L2wRA" node="7XTah2ufTo1" resolve="de.itemis.mps.nodeversioning.test" />
+      </node>
+      <node concept="L2wRC" id="4c23MZqTKA2" role="39821P">
+        <ref role="L2wRA" node="3aF8hCvy3sT" resolve="de.itemis.model.merge.diamond" />
+      </node>
+      <node concept="L2wRC" id="4c23MZqXAyP" role="39821P">
+        <ref role="L2wRA" node="5RxOLvLcQHZ" resolve="de.itemis.model.merge.test" />
+      </node>
+      <node concept="L2wRC" id="GuygFg7CfC" role="39821P">
+        <ref role="L2wRA" node="GuygFg7AfB" resolve="test.de.itemis.mps.modelmerger.testlanguage" />
+      </node>
+      <node concept="L2wRC" id="T8sXq9o5df" role="39821P">
+        <ref role="L2wRA" node="T8sXq9o58u" resolve="com.dslfoundry.plaintextgen.example.nestedlist" />
+      </node>
+      <node concept="L2wRC" id="T8sXq9o5dX" role="39821P">
+        <ref role="L2wRA" node="T8sXq9o593" resolve="com.dslfoundry.plaintextgen.example.testlang" />
+      </node>
+      <node concept="L2wRC" id="T8sXq9o5eH" role="39821P">
+        <ref role="L2wRA" node="T8sXq9o59Q" resolve="com.dslfoundry.plaintextgen.example.nestedlist.sandbox" />
+      </node>
+      <node concept="L2wRC" id="T8sXq9o5fv" role="39821P">
+        <ref role="L2wRA" node="T8sXq9o5aP" resolve="com.dslfoundry.plaintextgen.example.plaintextflow" />
+      </node>
+      <node concept="L2wRC" id="T8sXq9o5gj" role="39821P">
+        <ref role="L2wRA" node="T8sXq9o5c0" resolve="com.dslfoundry.plaintextgen.example.testlang.sandbox" />
+      </node>
+      <node concept="L2wRC" id="4JmkJs3Gs5B" role="39821P">
+        <ref role="L2wRA" node="4JmkJs3Gs4u" resolve="test.de.q60.mps.shadowmodels.examples" />
+      </node>
+      <node concept="L2wRC" id="5QP6xyk3oCb" role="39821P">
+        <ref role="L2wRA" node="5QP6xyk3oCB" resolve="test.de.q60.mps.shadowmodels.runtime" />
+      </node>
+      <node concept="L2wRC" id="7qGGLAjNnDN" role="39821P">
+        <ref role="L2wRA" node="7qGGLAjNnEU" resolve="test.de.q60.mps.incremental.runtime" />
+      </node>
+      <node concept="L2wRC" id="3$$s$wOI_mD" role="39821P">
+        <ref role="L2wRA" node="3$$s$wOI_E$" resolve="de.itemis.mps.editor.collapsible.testlang" />
+      </node>
+      <node concept="L2wRC" id="3aF8hCv$ro3" role="39821P">
+        <ref role="L2wRA" node="GuygFg7$fI" resolve="tests.de.itemis.mps.modelmerger" />
+      </node>
+      <node concept="L2wRC" id="2UnEDPCihk6" role="39821P">
+        <ref role="L2wRA" node="2UnEDPCh8Ac" resolve="de.itemis.model.simple.demo.property" />
+      </node>
+      <node concept="L2wRC" id="2UnEDPClM$0" role="39821P">
+        <ref role="L2wRA" node="2UnEDPClLCV" resolve="de.itemis.model.simple.demo.children" />
+      </node>
+      <node concept="L2wRC" id="2UnEDPClM_4" role="39821P">
+        <ref role="L2wRA" node="2UnEDPClLHk" resolve="de.itemis.model.simple.demo.collection" />
+      </node>
+      <node concept="L2wRC" id="2UnEDPClMAa" role="39821P">
+        <ref role="L2wRA" node="2UnEDPClLLR" resolve="de.itemis.model.simple.demo.collection.keeper" />
+      </node>
+      <node concept="L2wRC" id="2UnEDPClMBi" role="39821P">
+        <ref role="L2wRA" node="2UnEDPClLQ$" resolve="de.itemis.model.simple.demo.reference" />
+      </node>
+      <node concept="L2wRC" id="2UnEDPCpnGv" role="39821P">
+        <ref role="L2wRA" node="2UnEDPCpnjG" resolve="de.itemis.model.merge.simple.demo" />
+      </node>
+      <node concept="L2wRC" id="7g5FWGK132j" role="39821P">
+        <ref role="L2wRA" node="7g5FWGK0Kzy" resolve="test.org.modelix.model.mpsadapters" />
+      </node>
+    </node>
+    <node concept="22LTRH" id="6yXTMcTWb7V" role="1hWBAP">
+      <property role="TrG5h" value="all" />
+      <node concept="22LTRM" id="F1NWDqzA2e" role="22LTRK">
+        <ref role="22LTRN" node="F1NWDqwbth" resolve="com.mbeddr.mpsutil.grammarcells.tests" />
+      </node>
+      <node concept="22LTRM" id="7qi8mU1OzVQ" role="22LTRK">
+        <ref role="22LTRN" node="6$6tsX_CJdr" resolve="test.de.itemis.mps.editor.diagram.solution" />
+      </node>
+      <node concept="22LTRM" id="5mH$9t6eAr5" role="22LTRK">
+        <ref role="22LTRN" node="5mH$9t6e_Fl" resolve="test.de.slisson.mps.tables" />
+      </node>
+      <node concept="22LTRM" id="7i5Cc6Lw3P$" role="22LTRK">
+        <ref role="22LTRN" node="5mH$9t6eAsB" resolve="test.de.itemis.mps.editor.celllayout" />
+      </node>
+      <node concept="22LTRF" id="7i5Cc6Lw48Y" role="22LTRK">
+        <ref role="22LTRG" node="6$6tsX_CIRQ" resolve="de.slisson.mps.all.tests" />
+      </node>
+      <node concept="22LTRM" id="7i5Cc6LxDze" role="22LTRK">
+        <ref role="22LTRN" node="7i5Cc6LxCew" resolve="de.slisson.mps.testutils" />
+      </node>
+      <node concept="22LTRM" id="2NyZxKpXdyy" role="22LTRK">
+        <ref role="22LTRN" node="2NyZxKpXalh" resolve="test.ex.match" />
+      </node>
+      <node concept="22LTRM" id="2NyZxKpXdDc" role="22LTRK">
+        <ref role="22LTRN" node="2NyZxKpX96P" resolve="test.ts.conceptswitch" />
+      </node>
+      <node concept="22LTRM" id="7XTah2ufVII" role="22LTRK">
+        <ref role="22LTRN" node="7XTah2ufTo1" resolve="de.itemis.mps.nodeversioning.test" />
+      </node>
+      <node concept="22LTRM" id="GuygFg7CGG" role="22LTRK">
+        <ref role="22LTRN" node="GuygFg7$fI" resolve="tests.de.itemis.mps.modelmerger" />
+      </node>
+      <node concept="22LTRM" id="1VujIMZIYK" role="22LTRK">
+        <ref role="22LTRN" node="2NyZxKpX7We" resolve="test.com.mbeddr.mpsutil.blutil.genutil" />
+      </node>
+      <node concept="22LTRM" id="4JmkJs3Gsci" role="22LTRK">
+        <ref role="22LTRN" node="4JmkJs3Gs4u" resolve="test.de.q60.mps.shadowmodels.examples" />
+      </node>
+      <node concept="24cAiW" id="6hpM9fmFEj0" role="24cAkG" />
+      <node concept="22LTRM" id="5QP6xyk3oDX" role="22LTRK">
+        <ref role="22LTRN" node="5QP6xyk3oCB" resolve="test.de.q60.mps.shadowmodels.runtime" />
+      </node>
+      <node concept="22LTRM" id="7qGGLAjNnMO" role="22LTRK">
+        <ref role="22LTRN" node="7qGGLAjNnEU" resolve="test.de.q60.mps.incremental.runtime" />
+      </node>
+      <node concept="22LTRM" id="3aF8hCw8Sce" role="22LTRK">
+        <ref role="22LTRN" node="5RxOLvLcQHZ" resolve="de.itemis.model.merge.test" />
+      </node>
+      <node concept="22LTRM" id="2UnEDPCpnHm" role="22LTRK">
+        <ref role="22LTRN" node="2UnEDPCpnjG" resolve="de.itemis.model.merge.simple.demo" />
+      </node>
+      <node concept="22LTRM" id="7g5FWGK131$" role="22LTRK">
+        <ref role="22LTRN" node="7g5FWGK0Kzy" resolve="test.org.modelix.model.mpsadapters" />
+      </node>
+    </node>
+  </node>
   <node concept="1l3spW" id="2Xjt3l56m0V">
     <property role="TrG5h" value="de.itemis.mps.extensions" />
     <property role="2DA0ip" value="../../../../build/generated/languages" />
@@ -1009,6 +5888,9 @@
       <node concept="m$_yC" id="7mDAtWA2dyF" role="m$_yJ">
         <ref role="m$_y1" node="6SVXTgIe8wD" resolve="de.itemis.mps.celllayout" />
       </node>
+      <node concept="m$_yC" id="6JDgK_ZoAgR" role="m$_yJ">
+        <ref role="m$_y1" to="ffeo:RJsmGEieyQ" resolve="jetbrains.mps.vcs" />
+      </node>
       <node concept="3_J27D" id="31bAEZ0srEi" role="m_cZH">
         <node concept="3Mxwew" id="31bAEZ0srEj" role="3MwsjC">
           <property role="3MwjfP" value="mps-multiline" />
@@ -1300,6 +6182,16 @@
             </node>
           </node>
         </node>
+        <node concept="1SiIV0" id="6JDgK_Zo_al" role="3bR37C">
+          <node concept="3bR9La" id="6JDgK_Zo_am" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:39HJr_hyEzS" resolve="jetbrains.mps.ide.vcs.platform" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="6JDgK_Zo_an" role="3bR37C">
+          <node concept="3bR9La" id="6JDgK_Zo_ao" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:39HJr_hyAl1" resolve="jetbrains.mps.ide.vcs.core" />
+          </node>
+        </node>
       </node>
     </node>
     <node concept="m$_wf" id="1sO539bGQvt" role="3989C9">
@@ -1331,6 +6223,9 @@
       </node>
       <node concept="m$_yC" id="7mDAtWA2d7X" role="m$_yJ">
         <ref role="m$_y1" node="6SVXTgIe8wD" resolve="de.itemis.mps.celllayout" />
+      </node>
+      <node concept="m$_yC" id="6JDgK_ZoA2Q" role="m$_yJ">
+        <ref role="m$_y1" to="ffeo:RJsmGEieyQ" resolve="jetbrains.mps.vcs" />
       </node>
       <node concept="3_J27D" id="1sO539bGQv$" role="m_cZH">
         <node concept="3Mxwew" id="1sO539bGQv_" role="3MwsjC">
@@ -5100,6 +9995,11 @@
             </node>
           </node>
         </node>
+        <node concept="1SiIV0" id="6JDgK_Zo_jH" role="3bR37C">
+          <node concept="3bR9La" id="6JDgK_Zo_jI" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1ia2VB5guYy" resolve="MPS.IDEA" />
+          </node>
+        </node>
       </node>
       <node concept="1E1JtD" id="4be$WTb1CbJ" role="2G$12L">
         <property role="BnDLt" value="true" />
@@ -6147,6 +11047,9 @@
       <node concept="m$_yC" id="2NyZxKpV2nh" role="m$_yJ">
         <ref role="m$_y1" node="1sO539bGQvt" resolve="de.slisson.mps.richtext" />
       </node>
+      <node concept="m$_yC" id="6JDgK_Zo_OR" role="m$_yJ">
+        <ref role="m$_y1" to="ffeo:RJsmGEieyQ" resolve="jetbrains.mps.vcs" />
+      </node>
       <node concept="2iUeEo" id="2QgPOUCDeur" role="2iVFfd">
         <property role="2iUeEt" value="Itemis" />
         <property role="2iUeEu" value="https://www.itemis.com/" />
@@ -7017,26 +11920,6 @@
           <property role="3ZfqAx" value="models" />
           <property role="1Hdu6h" value="true" />
           <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="5zr7Q_1BFGe" role="1HemKq">
-            <node concept="398BVA" id="5zr7Q_1BFG2" role="3LXTmr">
-              <ref role="398BVh" node="2fo8bJE$D4t" resolve="extensions.code" />
-              <node concept="2Ry0Ak" id="5zr7Q_1BFG3" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="5zr7Q_1BFG4" role="2Ry0An">
-                  <property role="2Ry0Am" value="de.itemis.model.merge" />
-                  <node concept="2Ry0Ak" id="5zr7Q_1BFG5" role="2Ry0An">
-                    <property role="2Ry0Am" value="runtime" />
-                    <node concept="2Ry0Ak" id="5zr7Q_1BFG6" role="2Ry0An">
-                      <property role="2Ry0Am" value="models" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="5zr7Q_1BFGf" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
           <node concept="3LXTmp" id="5RxOLvL3ALq" role="1HemKq">
             <node concept="398BVA" id="5RxOLvL3ALh" role="3LXTmr">
               <ref role="398BVh" node="2fo8bJE$D4t" resolve="extensions.code" />
@@ -13545,6 +18428,11 @@
             </node>
           </node>
         </node>
+        <node concept="1SiIV0" id="6JDgK_Zo__S" role="3bR37C">
+          <node concept="3bR9La" id="6JDgK_Zo__T" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1ia2VB5guYy" resolve="MPS.IDEA" />
+          </node>
+        </node>
       </node>
       <node concept="1E1JtD" id="2jlBy7bQx3n" role="2G$12L">
         <property role="BnDLt" value="true" />
@@ -14170,4875 +19058,6 @@
       <node concept="m$_wl" id="hCVXosGXXN" role="39821P">
         <ref role="m_rDy" node="hCVXosGNJH" resolve="com.mbeddr.mpsutil.modellisteners" />
         <node concept="pUk6x" id="76N1O$Kj6tP" role="pUk7w" />
-      </node>
-    </node>
-  </node>
-  <node concept="1l3spW" id="6$6tsX_CERA">
-    <property role="2DA0ip" value="../../../../build/generated/tests" />
-    <property role="turDy" value="build.xml" />
-    <property role="TrG5h" value="tests" />
-    <node concept="2_Ic$z" id="6$6tsX_CF79" role="3989C9">
-      <property role="2_Ic$$" value="true" />
-      <property role="TZNOO" value="1.8" />
-    </node>
-    <node concept="1wNqPr" id="6$6tsX_CF7a" role="3989C9">
-      <property role="1wNuhc" value="true" />
-      <property role="1wNuhe" value="true" />
-      <property role="1wNuhh" value="16" />
-      <property role="1wOHq$" value="true" />
-    </node>
-    <node concept="2G$12M" id="6$6tsX_CIRQ" role="3989C9">
-      <property role="TrG5h" value="de.slisson.mps.all.tests" />
-      <node concept="1E1JtD" id="F1NWDqweoc" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="com.mbeddr.mpsutil.grammarcells.sandboxlang" />
-        <property role="3LESm3" value="a257f68c-93a3-47b0-838b-6905dd9c20f6" />
-        <node concept="398BVA" id="F1NWDqwfmr" role="3LF7KH">
-          <ref role="398BVh" node="F1NWDquQCJ" resolve="grammarcells.home" />
-          <node concept="2Ry0Ak" id="F1NWDqwfFz" role="iGT6I">
-            <property role="2Ry0Am" value="languages" />
-            <node concept="2Ry0Ak" id="F1NWDqwg0E" role="2Ry0An">
-              <property role="2Ry0Am" value="com.mbeddr.mpsutil.grammarcells.sandboxlang" />
-              <node concept="2Ry0Ak" id="F1NWDqwgeL" role="2Ry0An">
-                <property role="2Ry0Am" value="com.mbeddr.mpsutil.grammarcells.sandboxlang.mpl" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="F1NWDqwgsO" role="3bR37C">
-          <node concept="3bR9La" id="F1NWDqwgsP" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="F1NWDqwgsQ" role="3bR37C">
-          <node concept="3bR9La" id="F1NWDqwgsR" role="1SiIV1">
-            <ref role="3bR37D" node="F1NWDqq_DA" resolve="com.mbeddr.mpsutil.grammarcells.runtime" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="F1NWDqwgsS" role="3bR37C">
-          <node concept="3bR9La" id="F1NWDqwgsT" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:1TaHNgiIbIZ" resolve="MPS.Editor" />
-          </node>
-        </node>
-        <node concept="3rtmxn" id="5py4VqXmLNU" role="3bR31x">
-          <node concept="3LXTmp" id="5py4VqXmLNV" role="3rtmxm">
-            <node concept="3qWCbU" id="5py4VqXmLNW" role="3LXTna">
-              <property role="3qWCbO" value="icons/**, resources/**" />
-            </node>
-            <node concept="398BVA" id="5py4VqXmLNX" role="3LXTmr">
-              <ref role="398BVh" node="F1NWDquQCJ" resolve="grammarcells.home" />
-              <node concept="2Ry0Ak" id="5py4VqXmLNY" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="5py4VqXmLNZ" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mbeddr.mpsutil.grammarcells.sandboxlang" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1BupzO" id="7q24334ZKzB" role="3bR31x">
-          <property role="3ZfqAx" value="models" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="7q24334ZKzC" role="1HemKq">
-            <node concept="398BVA" id="7q24334ZKzi" role="3LXTmr">
-              <ref role="398BVh" node="F1NWDquQCJ" resolve="grammarcells.home" />
-              <node concept="2Ry0Ak" id="7q24334ZKzj" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="7q24334ZKzk" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mbeddr.mpsutil.grammarcells.sandboxlang" />
-                  <node concept="2Ry0Ak" id="7q24334ZKzl" role="2Ry0An">
-                    <property role="2Ry0Am" value="models" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="7q24334ZKzD" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="5ycts4SlSD6" role="3bR37C">
-          <node concept="3bR9La" id="5ycts4SlSD7" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:7Kfy9QB6LfQ" resolve="jetbrains.mps.kernel" />
-          </node>
-        </node>
-      </node>
-      <node concept="1E1JtA" id="F1NWDqwbth" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="com.mbeddr.mpsutil.grammarcells.tests" />
-        <property role="3LESm3" value="c24d4a42-505e-4ffb-a24c-28919615a5bc" />
-        <property role="aoJFB" value="eYcmk9QOlj/sources_and_tests" />
-        <node concept="398BVA" id="F1NWDqwbKR" role="3LF7KH">
-          <ref role="398BVh" node="F1NWDquQCJ" resolve="grammarcells.home" />
-          <node concept="2Ry0Ak" id="F1NWDqwcbM" role="iGT6I">
-            <property role="2Ry0Am" value="solutions" />
-            <node concept="2Ry0Ak" id="F1NWDqwcvU" role="2Ry0An">
-              <property role="2Ry0Am" value="com.mbeddr.mpsutil.grammarcells.tests" />
-              <node concept="2Ry0Ak" id="F1NWDqy369" role="2Ry0An">
-                <property role="2Ry0Am" value="com.mbeddr.mpsutil.grammarcells.tests.msd" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="F1NWDqwd86" role="3bR37C">
-          <node concept="3bR9La" id="F1NWDqwd87" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="F1NWDqwd88" role="3bR37C">
-          <node concept="3bR9La" id="F1NWDqwd89" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:1TaHNgiIbJ$" resolve="jetbrains.mps.ide.editor" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="F1NWDqwd8a" role="3bR37C">
-          <node concept="3bR9La" id="F1NWDqwd8b" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:1TaHNgiIbIZ" resolve="MPS.Editor" />
-          </node>
-        </node>
-        <node concept="3rtmxn" id="5py4VqXmLK$" role="3bR31x">
-          <node concept="3LXTmp" id="5py4VqXmLK_" role="3rtmxm">
-            <node concept="3qWCbU" id="5py4VqXmLKA" role="3LXTna">
-              <property role="3qWCbO" value="icons/**, resources/**" />
-            </node>
-            <node concept="398BVA" id="5py4VqXmLKB" role="3LXTmr">
-              <ref role="398BVh" node="F1NWDquQCJ" resolve="grammarcells.home" />
-              <node concept="2Ry0Ak" id="5py4VqXmLKC" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="5py4VqXmLKD" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mbeddr.mpsutil.grammarcells.tests" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1BupzO" id="7q24334ZK$r" role="3bR31x">
-          <property role="3ZfqAx" value="models" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="7q24334ZK$s" role="1HemKq">
-            <node concept="398BVA" id="7q24334ZK$6" role="3LXTmr">
-              <ref role="398BVh" node="F1NWDquQCJ" resolve="grammarcells.home" />
-              <node concept="2Ry0Ak" id="7q24334ZK$7" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="7q24334ZK$8" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mbeddr.mpsutil.grammarcells.tests" />
-                  <node concept="2Ry0Ak" id="7q24334ZK$9" role="2Ry0An">
-                    <property role="2Ry0Am" value="models" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="7q24334ZK$t" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="1E1JtA" id="6$6tsX_CURF" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="de.slisson.mps.structurecheck.runtime" />
-        <property role="3LESm3" value="6f14e29b-9796-426f-ae46-86ea46d4d320" />
-        <property role="aoJFB" value="eYcmk9QOlj/sources_and_tests" />
-        <node concept="398BVA" id="3vzyAKEK04f" role="3LF7KH">
-          <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-          <node concept="2Ry0Ak" id="3vzyAKEK04k" role="iGT6I">
-            <property role="2Ry0Am" value="structurecheck" />
-            <node concept="2Ry0Ak" id="3vzyAKEK04l" role="2Ry0An">
-              <property role="2Ry0Am" value="solutions" />
-              <node concept="2Ry0Ak" id="1QLFoGOMUbK" role="2Ry0An">
-                <property role="2Ry0Am" value="de.slisson.mps.structurecheck.runtime" />
-                <node concept="2Ry0Ak" id="1QLFoGOMUoj" role="2Ry0An">
-                  <property role="2Ry0Am" value="de.slisson.mps.structurecheck.runtime.msd" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="6$6tsX_CV2i" role="3bR37C">
-          <node concept="3bR9La" id="6$6tsX_CV2j" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:44LXwdzyvTi" resolve="Annotations" />
-          </node>
-        </node>
-        <node concept="3rtmxn" id="3xFG3bj5MpX" role="3bR31x">
-          <node concept="3LXTmp" id="3xFG3bj5MpY" role="3rtmxm">
-            <node concept="3qWCbU" id="3xFG3bj5MpZ" role="3LXTna">
-              <property role="3qWCbO" value="icons/**, resources/**" />
-            </node>
-            <node concept="398BVA" id="nsMIIcsJ47" role="3LXTmr">
-              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-              <node concept="2Ry0Ak" id="nsMIIcsJ48" role="iGT6I">
-                <property role="2Ry0Am" value="structurecheck" />
-                <node concept="2Ry0Ak" id="nsMIIcsJ49" role="2Ry0An">
-                  <property role="2Ry0Am" value="solutions" />
-                  <node concept="2Ry0Ak" id="nsMIIcsJ4a" role="2Ry0An">
-                    <property role="2Ry0Am" value="de.slisson.mps.structurecheck.runtime" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1BupzO" id="7q24334ZK$J" role="3bR31x">
-          <property role="3ZfqAx" value="models" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="7q24334ZK$K" role="1HemKq">
-            <node concept="398BVA" id="7q24334ZK$u" role="3LXTmr">
-              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-              <node concept="2Ry0Ak" id="7q24334ZK$v" role="iGT6I">
-                <property role="2Ry0Am" value="structurecheck" />
-                <node concept="2Ry0Ak" id="7q24334ZK$w" role="2Ry0An">
-                  <property role="2Ry0Am" value="solutions" />
-                  <node concept="2Ry0Ak" id="7q24334ZK$x" role="2Ry0An">
-                    <property role="2Ry0Am" value="de.slisson.mps.structurecheck.runtime" />
-                    <node concept="2Ry0Ak" id="7q24334ZK$y" role="2Ry0An">
-                      <property role="2Ry0Am" value="models" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="7q24334ZK$L" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="1E1JtD" id="6$6tsX_CUvL" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="de.slisson.mps.structurecheck" />
-        <property role="3LESm3" value="c6cfed73-685b-4891-8bdd-b38a1dcb107a" />
-        <node concept="398BVA" id="3vzyAKEJZkI" role="3LF7KH">
-          <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-          <node concept="2Ry0Ak" id="3vzyAKEJZkN" role="iGT6I">
-            <property role="2Ry0Am" value="structurecheck" />
-            <node concept="2Ry0Ak" id="3vzyAKEJZkO" role="2Ry0An">
-              <property role="2Ry0Am" value="languages" />
-              <node concept="2Ry0Ak" id="1QLFoGOMUL_" role="2Ry0An">
-                <property role="2Ry0Am" value="de.slisson.mps.structurecheck" />
-                <node concept="2Ry0Ak" id="1QLFoGOMUYi" role="2Ry0An">
-                  <property role="2Ry0Am" value="de.slisson.mps.structurecheck.mpl" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1E0d5M" id="6$6tsX_CV3t" role="1E1XAP">
-          <ref role="1E0d5P" node="6$6tsX_CURF" resolve="de.slisson.mps.structurecheck.runtime" />
-        </node>
-        <node concept="1SiIV0" id="6$6tsX_CV3u" role="3bR37C">
-          <node concept="1Busua" id="6$6tsX_CV3v" role="1SiIV1">
-            <ref role="1Busuk" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
-          </node>
-        </node>
-        <node concept="1yeLz9" id="6$6tsX_CV3w" role="1TViLv">
-          <property role="TrG5h" value="de.slisson.mps.structurecheck#380240910834170735" />
-          <property role="3LESm3" value="ce4c3eb8-9598-4a3c-a7c0-46a16d2333d9" />
-          <node concept="1SiIV0" id="6$6tsX_CV3x" role="3bR37C">
-            <node concept="3bR9La" id="6$6tsX_CV3y" role="1SiIV1">
-              <ref role="3bR37D" node="6$6tsX_CURF" resolve="de.slisson.mps.structurecheck.runtime" />
-            </node>
-          </node>
-          <node concept="1SiIV0" id="6yXTMcTUXML" role="3bR37C">
-            <node concept="3bR9La" id="6yXTMcTUXMM" role="1SiIV1">
-              <ref role="3bR37D" to="ffeo:7Kfy9QB6KZG" resolve="jetbrains.mps.baseLanguage.closures" />
-            </node>
-          </node>
-          <node concept="1BupzO" id="7q24334ZK_q" role="3bR31x">
-            <property role="3ZfqAx" value="generator/template" />
-            <property role="1Hdu6h" value="true" />
-            <property role="1HemKv" value="true" />
-            <node concept="3LXTmp" id="7q24334ZK_r" role="1HemKq">
-              <node concept="398BVA" id="7q24334ZK_6" role="3LXTmr">
-                <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-                <node concept="2Ry0Ak" id="7q24334ZK_7" role="iGT6I">
-                  <property role="2Ry0Am" value="structurecheck" />
-                  <node concept="2Ry0Ak" id="7q24334ZK_8" role="2Ry0An">
-                    <property role="2Ry0Am" value="languages" />
-                    <node concept="2Ry0Ak" id="7q24334ZK_9" role="2Ry0An">
-                      <property role="2Ry0Am" value="de.slisson.mps.structurecheck" />
-                      <node concept="2Ry0Ak" id="7q24334ZK_a" role="2Ry0An">
-                        <property role="2Ry0Am" value="generator" />
-                        <node concept="2Ry0Ak" id="7q24334ZK_b" role="2Ry0An">
-                          <property role="2Ry0Am" value="template" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3qWCbU" id="7q24334ZK_s" role="3LXTna">
-                <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3rtmxn" id="3xFG3bj5Moz" role="3bR31x">
-          <node concept="3LXTmp" id="3xFG3bj5Mo$" role="3rtmxm">
-            <node concept="3qWCbU" id="3xFG3bj5Mo_" role="3LXTna">
-              <property role="3qWCbO" value="icons/**, resources/**" />
-            </node>
-            <node concept="398BVA" id="PE3B26qlU$" role="3LXTmr">
-              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-              <node concept="2Ry0Ak" id="PE3B26qlU_" role="iGT6I">
-                <property role="2Ry0Am" value="structurecheck" />
-                <node concept="2Ry0Ak" id="PE3B26qlUA" role="2Ry0An">
-                  <property role="2Ry0Am" value="languages" />
-                  <node concept="2Ry0Ak" id="PE3B26qlUB" role="2Ry0An">
-                    <property role="2Ry0Am" value="de.slisson.mps.structurecheck" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1BupzO" id="7q24334ZK_3" role="3bR31x">
-          <property role="3ZfqAx" value="languageModels" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="7q24334ZK_4" role="1HemKq">
-            <node concept="398BVA" id="7q24334ZK$M" role="3LXTmr">
-              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-              <node concept="2Ry0Ak" id="7q24334ZK$N" role="iGT6I">
-                <property role="2Ry0Am" value="structurecheck" />
-                <node concept="2Ry0Ak" id="7q24334ZK$O" role="2Ry0An">
-                  <property role="2Ry0Am" value="languages" />
-                  <node concept="2Ry0Ak" id="7q24334ZK$P" role="2Ry0An">
-                    <property role="2Ry0Am" value="de.slisson.mps.structurecheck" />
-                    <node concept="2Ry0Ak" id="7q24334ZK$Q" role="2Ry0An">
-                      <property role="2Ry0Am" value="languageModels" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="7q24334ZK_5" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="1E1JtA" id="5mH$9t6e_Fl" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="test.de.slisson.mps.tables" />
-        <property role="3LESm3" value="2b62b482-becb-4b5e-9543-c5cf37553cb6" />
-        <property role="aoJFB" value="eYcmk9QOlj/sources_and_tests" />
-        <node concept="398BVA" id="5mH$9t6e_Fm" role="3LF7KH">
-          <ref role="398BVh" node="5mH$9t6e_IG" resolve="tables.home" />
-          <node concept="2Ry0Ak" id="5mH$9t6e_Fn" role="iGT6I">
-            <property role="2Ry0Am" value="solutions" />
-            <node concept="2Ry0Ak" id="5mH$9t6e_Fo" role="2Ry0An">
-              <property role="2Ry0Am" value="test.de.slisson.mps.tables" />
-              <node concept="2Ry0Ak" id="5mH$9t6e_QZ" role="2Ry0An">
-                <property role="2Ry0Am" value="test.de.slisson.mps.tables.msd" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="5mH$9t6e_Fs" role="3bR37C">
-          <node concept="3bR9La" id="5mH$9t6e_Ft" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:1TaHNgiIbIZ" resolve="MPS.Editor" />
-          </node>
-        </node>
-        <node concept="3rtmxn" id="5mH$9t6e_F$" role="3bR31x">
-          <node concept="3LXTmp" id="5mH$9t6e_F_" role="3rtmxm">
-            <node concept="3qWCbU" id="5mH$9t6e_FA" role="3LXTna">
-              <property role="3qWCbO" value="icons/**, resources/**" />
-            </node>
-            <node concept="398BVA" id="PE3B26qlKu" role="3LXTmr">
-              <ref role="398BVh" node="5mH$9t6e_IG" resolve="tables.home" />
-              <node concept="2Ry0Ak" id="PE3B26qlKv" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="PE3B26qlKw" role="2Ry0An">
-                  <property role="2Ry0Am" value="test.de.slisson.mps.tables" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="5mH$9t6e_SN" role="3bR37C">
-          <node concept="3bR9La" id="5mH$9t6e_SO" role="1SiIV1">
-            <ref role="3bR37D" node="29so9Vb$6T5" resolve="de.slisson.mps.tables.runtime" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="5mH$9t6e_SP" role="3bR37C">
-          <node concept="3bR9La" id="5mH$9t6e_SQ" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:1TaHNgiIbJ$" resolve="jetbrains.mps.ide.editor" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="5mH$9t6eBLv" role="3bR37C">
-          <node concept="3bR9La" id="5mH$9t6eBLw" role="1SiIV1">
-            <ref role="3bR37D" node="5mH$9t6eA1O" resolve="de.slisson.mps.tables.demolang" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="D0xzCAzUZQ" role="3bR37C">
-          <node concept="3bR9La" id="D0xzCAzUZR" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
-          </node>
-        </node>
-        <node concept="1BupzO" id="7q24334ZK_M" role="3bR31x">
-          <property role="3ZfqAx" value="models" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="7q24334ZK_N" role="1HemKq">
-            <node concept="398BVA" id="7q24334ZK_t" role="3LXTmr">
-              <ref role="398BVh" node="5mH$9t6e_IG" resolve="tables.home" />
-              <node concept="2Ry0Ak" id="7q24334ZK_u" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="7q24334ZK_v" role="2Ry0An">
-                  <property role="2Ry0Am" value="test.de.slisson.mps.tables" />
-                  <node concept="2Ry0Ak" id="7q24334ZK_w" role="2Ry0An">
-                    <property role="2Ry0Am" value="models" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="7q24334ZK_O" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="1E1JtD" id="5mH$9t6eA1O" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="de.slisson.mps.tables.demolang" />
-        <property role="3LESm3" value="2d56439e-634d-4d25-9d30-963e89ecda48" />
-        <node concept="398BVA" id="5mH$9t6eA1P" role="3LF7KH">
-          <ref role="398BVh" node="5mH$9t6e_IG" resolve="tables.home" />
-          <node concept="2Ry0Ak" id="5mH$9t6eA1Q" role="iGT6I">
-            <property role="2Ry0Am" value="languages" />
-            <node concept="2Ry0Ak" id="5mH$9t6eA1R" role="2Ry0An">
-              <property role="2Ry0Am" value="de.slisson.mps.tables.demolang" />
-              <node concept="2Ry0Ak" id="5mH$9t6eA1S" role="2Ry0An">
-                <property role="2Ry0Am" value="de.slisson.mps.tables.demolang.mpl" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1E0d5M" id="5mH$9t6eA1U" role="1E1XAP">
-          <ref role="1E0d5P" node="6$6tsX_CURF" resolve="de.slisson.mps.structurecheck.runtime" />
-        </node>
-        <node concept="1SiIV0" id="5mH$9t6eA1V" role="3bR37C">
-          <node concept="1Busua" id="5mH$9t6eA1W" role="1SiIV1">
-            <ref role="1Busuk" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
-          </node>
-        </node>
-        <node concept="3rtmxn" id="5mH$9t6eA22" role="3bR31x">
-          <node concept="3LXTmp" id="5mH$9t6eA23" role="3rtmxm">
-            <node concept="3qWCbU" id="5mH$9t6eA24" role="3LXTna">
-              <property role="3qWCbO" value="icons/**, resources/**" />
-            </node>
-            <node concept="398BVA" id="PE3B26qlDI" role="3LXTmr">
-              <ref role="398BVh" node="5mH$9t6e_IG" resolve="tables.home" />
-              <node concept="2Ry0Ak" id="PE3B26qlDJ" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="PE3B26qlDK" role="2Ry0An">
-                  <property role="2Ry0Am" value="de.slisson.mps.tables.demolang" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="5mH$9t6eAhj" role="3bR37C">
-          <node concept="3bR9La" id="5mH$9t6eAhk" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="5mH$9t6eAhl" role="3bR37C">
-          <node concept="3bR9La" id="5mH$9t6eAhm" role="1SiIV1">
-            <ref role="3bR37D" node="29so9Vb$6T5" resolve="de.slisson.mps.tables.runtime" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="5mH$9t6eAhp" role="3bR37C">
-          <node concept="3bR9La" id="5mH$9t6eAhq" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="5mH$9t6eAhr" role="3bR37C">
-          <node concept="3bR9La" id="5mH$9t6eAhs" role="1SiIV1">
-            <ref role="3bR37D" node="29so9Vb$6Th" resolve="de.slisson.mps.tables" />
-          </node>
-        </node>
-        <node concept="1E0d5M" id="5mH$9t6eAht" role="1E1XAP">
-          <ref role="1E0d5P" node="29so9Vb$6T5" resolve="de.slisson.mps.tables.runtime" />
-        </node>
-        <node concept="1BupzO" id="7q24334ZKAa" role="3bR31x">
-          <property role="3ZfqAx" value="languageModels" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="7q24334ZKAb" role="1HemKq">
-            <node concept="398BVA" id="7q24334ZK_P" role="3LXTmr">
-              <ref role="398BVh" node="5mH$9t6e_IG" resolve="tables.home" />
-              <node concept="2Ry0Ak" id="7q24334ZK_Q" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="7q24334ZK_R" role="2Ry0An">
-                  <property role="2Ry0Am" value="de.slisson.mps.tables.demolang" />
-                  <node concept="2Ry0Ak" id="7q24334ZK_S" role="2Ry0An">
-                    <property role="2Ry0Am" value="languageModels" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="7q24334ZKAc" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="1E1JtA" id="7i5Cc6LxCew" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="de.slisson.mps.testutils" />
-        <property role="3LESm3" value="3395a7d2-abac-467d-b35d-0e747a00a60e" />
-        <property role="aoJFB" value="eYcmk9QOlj/sources_and_tests" />
-        <node concept="3rtmxn" id="1bWvPKNGzHM" role="3bR31x">
-          <node concept="3LXTmp" id="1bWvPKNGzHN" role="3rtmxm">
-            <node concept="3qWCbU" id="1bWvPKNGzHO" role="3LXTna">
-              <property role="3qWCbO" value="icons/**, resources/**" />
-            </node>
-            <node concept="398BVA" id="1bWvPKNGzHP" role="3LXTmr">
-              <ref role="398BVh" node="5mH$9t6e_IG" resolve="tables.home" />
-              <node concept="2Ry0Ak" id="1bWvPKNGzHQ" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="1bWvPKNGzHR" role="2Ry0An">
-                  <property role="2Ry0Am" value="de.slisson.mps.testutils" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="398BVA" id="7i5Cc6LxCp3" role="3LF7KH">
-          <ref role="398BVh" node="5mH$9t6e_IG" resolve="tables.home" />
-          <node concept="2Ry0Ak" id="7i5Cc6LxCBi" role="iGT6I">
-            <property role="2Ry0Am" value="solutions" />
-            <node concept="2Ry0Ak" id="7i5Cc6LxCKN" role="2Ry0An">
-              <property role="2Ry0Am" value="de.slisson.mps.testutils" />
-              <node concept="2Ry0Ak" id="7i5Cc6LxCUk" role="2Ry0An">
-                <property role="2Ry0Am" value="de.slisson.mps.testutils.msd" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="7i5Cc6LxD3L" role="3bR37C">
-          <node concept="3bR9La" id="7i5Cc6LxD3M" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:1TaHNgiIbIZ" resolve="MPS.Editor" />
-          </node>
-        </node>
-        <node concept="1BupzO" id="7q24334ZKAY" role="3bR31x">
-          <property role="3ZfqAx" value="models" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="7q24334ZKAZ" role="1HemKq">
-            <node concept="398BVA" id="7q24334ZKAD" role="3LXTmr">
-              <ref role="398BVh" node="5mH$9t6e_IG" resolve="tables.home" />
-              <node concept="2Ry0Ak" id="7q24334ZKAE" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="7q24334ZKAF" role="2Ry0An">
-                  <property role="2Ry0Am" value="de.slisson.mps.testutils" />
-                  <node concept="2Ry0Ak" id="7q24334ZKAG" role="2Ry0An">
-                    <property role="2Ry0Am" value="models" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="7q24334ZKB0" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="2G$12M" id="2NyZxKpX5XT" role="3989C9">
-      <property role="TrG5h" value="mps-blutil-test" />
-      <node concept="1E1JtD" id="2NyZxKpX6$b" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="test.com.mbeddr.mpsutil.blutil.genutil.lang" />
-        <property role="3LESm3" value="2980eccb-8de2-4e74-96a0-1908c0172899" />
-        <node concept="3rtmxn" id="1bWvPKNGzHj" role="3bR31x">
-          <node concept="3LXTmp" id="1bWvPKNGzHk" role="3rtmxm">
-            <node concept="3qWCbU" id="1bWvPKNGzHl" role="3LXTna">
-              <property role="3qWCbO" value="icons/**, resources/**" />
-            </node>
-            <node concept="398BVA" id="1bWvPKNGzHm" role="3LXTmr">
-              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-              <node concept="2Ry0Ak" id="1bWvPKNGzHn" role="iGT6I">
-                <property role="2Ry0Am" value="blutil" />
-                <node concept="2Ry0Ak" id="1bWvPKNGzHo" role="2Ry0An">
-                  <property role="2Ry0Am" value="tests" />
-                  <node concept="2Ry0Ak" id="1bWvPKNGzHp" role="2Ry0An">
-                    <property role="2Ry0Am" value="test.com.mbeddr.mpsutil.blutil.genutil.lang" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="398BVA" id="2NyZxKpX6Dh" role="3LF7KH">
-          <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-          <node concept="2Ry0Ak" id="2NyZxKpX6Xv" role="iGT6I">
-            <property role="2Ry0Am" value="blutil" />
-            <node concept="2Ry0Ak" id="2NyZxKpX77C" role="2Ry0An">
-              <property role="2Ry0Am" value="tests" />
-              <node concept="2Ry0Ak" id="2NyZxKpX7rR" role="2Ry0An">
-                <property role="2Ry0Am" value="test.com.mbeddr.mpsutil.blutil.genutil.lang" />
-                <node concept="2Ry0Ak" id="2NyZxKpX7A0" role="2Ry0An">
-                  <property role="2Ry0Am" value="test.com.mbeddr.mpsutil.blutil.genutil.lang.mpl" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1yeLz9" id="2NyZxKpX7K6" role="1TViLv">
-          <property role="TrG5h" value="test.com.mbeddr.mpsutil.blutil.genutil.lang#4213334375079416143" />
-          <property role="3LESm3" value="b174e65b-8333-4361-ae60-201190bf7c0a" />
-          <node concept="1SiIV0" id="2NyZxKpX7K7" role="3bR37C">
-            <node concept="3bR9La" id="2NyZxKpX7K8" role="1SiIV1">
-              <ref role="3bR37D" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
-            </node>
-          </node>
-          <node concept="1BupzO" id="7q24334ZKBD" role="3bR31x">
-            <property role="3ZfqAx" value="generator/template" />
-            <property role="1Hdu6h" value="true" />
-            <property role="1HemKv" value="true" />
-            <node concept="3LXTmp" id="7q24334ZKBE" role="1HemKq">
-              <node concept="398BVA" id="7q24334ZKBl" role="3LXTmr">
-                <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-                <node concept="2Ry0Ak" id="7q24334ZKBm" role="iGT6I">
-                  <property role="2Ry0Am" value="blutil" />
-                  <node concept="2Ry0Ak" id="7q24334ZKBn" role="2Ry0An">
-                    <property role="2Ry0Am" value="tests" />
-                    <node concept="2Ry0Ak" id="7q24334ZKBo" role="2Ry0An">
-                      <property role="2Ry0Am" value="test.com.mbeddr.mpsutil.blutil.genutil.lang" />
-                      <node concept="2Ry0Ak" id="7q24334ZKBp" role="2Ry0An">
-                        <property role="2Ry0Am" value="generator" />
-                        <node concept="2Ry0Ak" id="7q24334ZKBq" role="2Ry0An">
-                          <property role="2Ry0Am" value="template" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3qWCbU" id="7q24334ZKBF" role="3LXTna">
-                <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1BupzO" id="7q24334ZKBi" role="3bR31x">
-          <property role="3ZfqAx" value="models" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="7q24334ZKBj" role="1HemKq">
-            <node concept="398BVA" id="7q24334ZKB1" role="3LXTmr">
-              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-              <node concept="2Ry0Ak" id="7q24334ZKB2" role="iGT6I">
-                <property role="2Ry0Am" value="blutil" />
-                <node concept="2Ry0Ak" id="7q24334ZKB3" role="2Ry0An">
-                  <property role="2Ry0Am" value="tests" />
-                  <node concept="2Ry0Ak" id="7q24334ZKB4" role="2Ry0An">
-                    <property role="2Ry0Am" value="test.com.mbeddr.mpsutil.blutil.genutil.lang" />
-                    <node concept="2Ry0Ak" id="7q24334ZKB5" role="2Ry0An">
-                      <property role="2Ry0Am" value="models" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="7q24334ZKBk" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="1E1JtA" id="2NyZxKpX7We" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="test.com.mbeddr.mpsutil.blutil.genutil" />
-        <property role="3LESm3" value="990da2f9-03a7-461e-90ee-1e2c77962d6b" />
-        <property role="aoJFB" value="eYcmk9QOlj/sources_and_tests" />
-        <node concept="3rtmxn" id="1bWvPKNGzGN" role="3bR31x">
-          <node concept="3LXTmp" id="1bWvPKNGzGO" role="3rtmxm">
-            <node concept="3qWCbU" id="1bWvPKNGzGP" role="3LXTna">
-              <property role="3qWCbO" value="icons/**, resources/**" />
-            </node>
-            <node concept="398BVA" id="1bWvPKNGzGQ" role="3LXTmr">
-              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-              <node concept="2Ry0Ak" id="1bWvPKNGzGR" role="iGT6I">
-                <property role="2Ry0Am" value="blutil" />
-                <node concept="2Ry0Ak" id="1bWvPKNGzGS" role="2Ry0An">
-                  <property role="2Ry0Am" value="tests" />
-                  <node concept="2Ry0Ak" id="1bWvPKNGzGT" role="2Ry0An">
-                    <property role="2Ry0Am" value="test.com.mbeddr.mpsutil.blutil.genutil" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="398BVA" id="2NyZxKpX824" role="3LF7KH">
-          <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-          <node concept="2Ry0Ak" id="2NyZxKpX8do" role="iGT6I">
-            <property role="2Ry0Am" value="blutil" />
-            <node concept="2Ry0Ak" id="2NyZxKpX8oF" role="2Ry0An">
-              <property role="2Ry0Am" value="tests" />
-              <node concept="2Ry0Ak" id="2NyZxKpX8zY" role="2Ry0An">
-                <property role="2Ry0Am" value="test.com.mbeddr.mpsutil.blutil.genutil" />
-                <node concept="2Ry0Ak" id="2NyZxKpX8Jh" role="2Ry0An">
-                  <property role="2Ry0Am" value="test.com.mbeddr.mpsutil.blutil.genutil.msd" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1BupzO" id="7q24334ZKBX" role="3bR31x">
-          <property role="3ZfqAx" value="models" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="7q24334ZKBY" role="1HemKq">
-            <node concept="398BVA" id="7q24334ZKBG" role="3LXTmr">
-              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-              <node concept="2Ry0Ak" id="7q24334ZKBH" role="iGT6I">
-                <property role="2Ry0Am" value="blutil" />
-                <node concept="2Ry0Ak" id="7q24334ZKBI" role="2Ry0An">
-                  <property role="2Ry0Am" value="tests" />
-                  <node concept="2Ry0Ak" id="7q24334ZKBJ" role="2Ry0An">
-                    <property role="2Ry0Am" value="test.com.mbeddr.mpsutil.blutil.genutil" />
-                    <node concept="2Ry0Ak" id="7q24334ZKBK" role="2Ry0An">
-                      <property role="2Ry0Am" value="models" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="7q24334ZKBZ" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="1E1JtA" id="2NyZxKpX96P" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="test.ts.conceptswitch" />
-        <property role="3LESm3" value="ac7d22d0-cbff-4ae0-aed8-fde151aacde1" />
-        <property role="aoJFB" value="eYcmk9QOlj/sources_and_tests" />
-        <node concept="3rtmxn" id="1bWvPKNGzIi" role="3bR31x">
-          <node concept="3LXTmp" id="1bWvPKNGzIj" role="3rtmxm">
-            <node concept="3qWCbU" id="1bWvPKNGzIk" role="3LXTna">
-              <property role="3qWCbO" value="icons/**, resources/**" />
-            </node>
-            <node concept="398BVA" id="1bWvPKNGzIl" role="3LXTmr">
-              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-              <node concept="2Ry0Ak" id="1bWvPKNGzIm" role="iGT6I">
-                <property role="2Ry0Am" value="blutil" />
-                <node concept="2Ry0Ak" id="1bWvPKNGzIn" role="2Ry0An">
-                  <property role="2Ry0Am" value="tests" />
-                  <node concept="2Ry0Ak" id="1bWvPKNGzIo" role="2Ry0An">
-                    <property role="2Ry0Am" value="test.ts.conceptswitch" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="398BVA" id="2NyZxKpX9d2" role="3LF7KH">
-          <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-          <node concept="2Ry0Ak" id="2NyZxKpX9oS" role="iGT6I">
-            <property role="2Ry0Am" value="blutil" />
-            <node concept="2Ry0Ak" id="2NyZxKpX9$H" role="2Ry0An">
-              <property role="2Ry0Am" value="tests" />
-              <node concept="2Ry0Ak" id="2NyZxKpX9Ky" role="2Ry0An">
-                <property role="2Ry0Am" value="test.ts.conceptswitch" />
-                <node concept="2Ry0Ak" id="2NyZxKpX9Wn" role="2Ry0An">
-                  <property role="2Ry0Am" value="test.ts.conceptswitch.msd" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2NyZxKpXa89" role="3bR37C">
-          <node concept="3bR9La" id="2NyZxKpXa8a" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2NyZxKpXa8b" role="3bR37C">
-          <node concept="3bR9La" id="2NyZxKpXa8c" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:7Kfy9QB6LaO" resolve="jetbrains.mps.lang.structure" />
-          </node>
-        </node>
-        <node concept="1BupzO" id="7q24334ZKCh" role="3bR31x">
-          <property role="3ZfqAx" value="models" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="7q24334ZKCi" role="1HemKq">
-            <node concept="398BVA" id="7q24334ZKC0" role="3LXTmr">
-              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-              <node concept="2Ry0Ak" id="7q24334ZKC1" role="iGT6I">
-                <property role="2Ry0Am" value="blutil" />
-                <node concept="2Ry0Ak" id="7q24334ZKC2" role="2Ry0An">
-                  <property role="2Ry0Am" value="tests" />
-                  <node concept="2Ry0Ak" id="7q24334ZKC3" role="2Ry0An">
-                    <property role="2Ry0Am" value="test.ts.conceptswitch" />
-                    <node concept="2Ry0Ak" id="7q24334ZKC4" role="2Ry0An">
-                      <property role="2Ry0Am" value="models" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="7q24334ZKCj" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="1E1JtA" id="2NyZxKpXalh" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="test.ex.match" />
-        <property role="3LESm3" value="bb2d89dd-a4c7-4821-a0c8-7437446fd8d3" />
-        <property role="aoJFB" value="eYcmk9QOlj/sources_and_tests" />
-        <node concept="3rtmxn" id="1bWvPKNGzH3" role="3bR31x">
-          <node concept="3LXTmp" id="1bWvPKNGzH4" role="3rtmxm">
-            <node concept="3qWCbU" id="1bWvPKNGzH5" role="3LXTna">
-              <property role="3qWCbO" value="icons/**, resources/**" />
-            </node>
-            <node concept="398BVA" id="1bWvPKNGzH6" role="3LXTmr">
-              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-              <node concept="2Ry0Ak" id="1bWvPKNGzH7" role="iGT6I">
-                <property role="2Ry0Am" value="blutil" />
-                <node concept="2Ry0Ak" id="1bWvPKNGzH8" role="2Ry0An">
-                  <property role="2Ry0Am" value="tests" />
-                  <node concept="2Ry0Ak" id="1bWvPKNGzH9" role="2Ry0An">
-                    <property role="2Ry0Am" value="test.ts.match" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="398BVA" id="2NyZxKpXarT" role="3LF7KH">
-          <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-          <node concept="2Ry0Ak" id="2NyZxKpXaOz" role="iGT6I">
-            <property role="2Ry0Am" value="blutil" />
-            <node concept="2Ry0Ak" id="2NyZxKpXb0U" role="2Ry0An">
-              <property role="2Ry0Am" value="tests" />
-              <node concept="2Ry0Ak" id="2NyZxKpXbdh" role="2Ry0An">
-                <property role="2Ry0Am" value="test.ts.match" />
-                <node concept="2Ry0Ak" id="2NyZxKpXbpC" role="2Ry0An">
-                  <property role="2Ry0Am" value="match.msd" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2NyZxKpXb_W" role="3bR37C">
-          <node concept="3bR9La" id="2NyZxKpXb_X" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
-          </node>
-        </node>
-        <node concept="1BupzO" id="7q24334ZKC_" role="3bR31x">
-          <property role="3ZfqAx" value="models" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="7q24334ZKCA" role="1HemKq">
-            <node concept="398BVA" id="7q24334ZKCk" role="3LXTmr">
-              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-              <node concept="2Ry0Ak" id="7q24334ZKCl" role="iGT6I">
-                <property role="2Ry0Am" value="blutil" />
-                <node concept="2Ry0Ak" id="7q24334ZKCm" role="2Ry0An">
-                  <property role="2Ry0Am" value="tests" />
-                  <node concept="2Ry0Ak" id="7q24334ZKCn" role="2Ry0An">
-                    <property role="2Ry0Am" value="test.ts.match" />
-                    <node concept="2Ry0Ak" id="7q24334ZKCo" role="2Ry0An">
-                      <property role="2Ry0Am" value="models" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="7q24334ZKCB" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="2G$12M" id="7XTah2ufRUJ" role="3989C9">
-      <property role="TrG5h" value="mps-nodeVersioningTest" />
-      <node concept="1E1JtA" id="7XTah2ufTo1" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="de.itemis.mps.nodeversioning.test" />
-        <property role="3LESm3" value="92dbf947-9ad7-4892-925f-1183ba0104c5" />
-        <property role="aoJFB" value="eYcmk9QOlj/sources_and_tests" />
-        <node concept="3rtmxn" id="1bWvPKNGzGV" role="3bR31x">
-          <node concept="3LXTmp" id="1bWvPKNGzGW" role="3rtmxm">
-            <node concept="3qWCbU" id="1bWvPKNGzGX" role="3LXTna">
-              <property role="3qWCbO" value="icons/**, resources/**" />
-            </node>
-            <node concept="398BVA" id="1bWvPKNGzGY" role="3LXTmr">
-              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-              <node concept="2Ry0Ak" id="1bWvPKNGzGZ" role="iGT6I">
-                <property role="2Ry0Am" value="nodeversioning" />
-                <node concept="2Ry0Ak" id="1bWvPKNGzH0" role="2Ry0An">
-                  <property role="2Ry0Am" value="tests" />
-                  <node concept="2Ry0Ak" id="1bWvPKNGzH1" role="2Ry0An">
-                    <property role="2Ry0Am" value="de.itemis.mps.nodeversioning.test" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="398BVA" id="7XTah2ufTuv" role="3LF7KH">
-          <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-          <node concept="2Ry0Ak" id="7XTah2ufUhZ" role="iGT6I">
-            <property role="2Ry0Am" value="nodeversioning" />
-            <node concept="2Ry0Ak" id="7XTah2ufUuS" role="2Ry0An">
-              <property role="2Ry0Am" value="tests" />
-              <node concept="2Ry0Ak" id="7XTah2ufUFL" role="2Ry0An">
-                <property role="2Ry0Am" value="de.itemis.mps.nodeversioning.test" />
-                <node concept="2Ry0Ak" id="7XTah2ufUSE" role="2Ry0An">
-                  <property role="2Ry0Am" value="de.itemis.mps.nodeversioning.test.msd" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="7XTah2ufV5w" role="3bR37C">
-          <node concept="3bR9La" id="7XTah2ufV5x" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="7XTah2ufV5y" role="3bR37C">
-          <node concept="3bR9La" id="7XTah2ufV5z" role="1SiIV1">
-            <ref role="3bR37D" node="457TI2XWgk_" resolve="de.itemis.mps.nodeversioning" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="7XTah2ufV5A" role="3bR37C">
-          <node concept="3bR9La" id="7XTah2ufV5B" role="1SiIV1">
-            <ref role="3bR37D" node="457TI2XWdaZ" resolve="de.itemis.mps.nodeversioning.runtime" />
-          </node>
-        </node>
-        <node concept="1BupzO" id="7q24334ZKCT" role="3bR31x">
-          <property role="3ZfqAx" value="models" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="7q24334ZKCU" role="1HemKq">
-            <node concept="398BVA" id="7q24334ZKCC" role="3LXTmr">
-              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-              <node concept="2Ry0Ak" id="7q24334ZKCD" role="iGT6I">
-                <property role="2Ry0Am" value="nodeversioning" />
-                <node concept="2Ry0Ak" id="7q24334ZKCE" role="2Ry0An">
-                  <property role="2Ry0Am" value="tests" />
-                  <node concept="2Ry0Ak" id="7q24334ZKCF" role="2Ry0An">
-                    <property role="2Ry0Am" value="de.itemis.mps.nodeversioning.test" />
-                    <node concept="2Ry0Ak" id="7q24334ZKCG" role="2Ry0An">
-                      <property role="2Ry0Am" value="models" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="7q24334ZKCV" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="2G$12M" id="GuygFg7$fH" role="3989C9">
-      <property role="TrG5h" value="mps-modelmergerTest" />
-      <node concept="1E1JtD" id="3aF8hCvy3sT" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="de.itemis.model.merge.diamond" />
-        <property role="3LESm3" value="0ef84c01-bf36-41ed-9882-d7b70a4a4eba" />
-        <node concept="398BVA" id="3aF8hCvy3vF" role="3LF7KH">
-          <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-          <node concept="2Ry0Ak" id="3aF8hCvy3vL" role="iGT6I">
-            <property role="2Ry0Am" value="languages" />
-            <node concept="2Ry0Ak" id="3aF8hCvy3vQ" role="2Ry0An">
-              <property role="2Ry0Am" value="de.itemis.model.merge.diamond" />
-              <node concept="2Ry0Ak" id="3aF8hCvy3vV" role="2Ry0An">
-                <property role="2Ry0Am" value="de.itemis.model.merge.diamond.mpl" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1BupzO" id="3aF8hCvy3_p" role="3bR31x">
-          <property role="3ZfqAx" value="models" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="3aF8hCvy3_q" role="1HemKq">
-            <node concept="398BVA" id="3aF8hCvy3_b" role="3LXTmr">
-              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-              <node concept="2Ry0Ak" id="3aF8hCvy3_c" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="3aF8hCvy3_d" role="2Ry0An">
-                  <property role="2Ry0Am" value="de.itemis.model.merge.diamond" />
-                  <node concept="2Ry0Ak" id="3aF8hCvy3_e" role="2Ry0An">
-                    <property role="2Ry0Am" value="models" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="3aF8hCvy3_r" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-        <node concept="3rtmxn" id="3M9VIK_gQAK" role="3bR31x">
-          <node concept="3LXTmp" id="3M9VIK_gQAL" role="3rtmxm">
-            <node concept="398BVA" id="3M9VIK_gQAM" role="3LXTmr">
-              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-              <node concept="2Ry0Ak" id="3M9VIK_gQAN" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="3M9VIK_gQAO" role="2Ry0An">
-                  <property role="2Ry0Am" value="de.itemis.model.merge.diamond" />
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="3M9VIK_gQAQ" role="3LXTna">
-              <property role="3qWCbO" value="icons/**, resources/**" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="1E1JtD" id="2UnEDPCh8Ac" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="de.itemis.model.simple.demo.property" />
-        <property role="3LESm3" value="e50b0500-6fd7-4c7f-a730-9d841358ca2b" />
-        <node concept="398BVA" id="2UnEDPCh8C2" role="3LF7KH">
-          <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-          <node concept="2Ry0Ak" id="2UnEDPCh8C8" role="iGT6I">
-            <property role="2Ry0Am" value="languages" />
-            <node concept="2Ry0Ak" id="2UnEDPCh8Cd" role="2Ry0An">
-              <property role="2Ry0Am" value="de.itemis.model.simple.demo.property" />
-              <node concept="2Ry0Ak" id="2UnEDPCh8Ci" role="2Ry0An">
-                <property role="2Ry0Am" value="de.itemis.model.simple.demo.property.mpl" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1BupzO" id="2UnEDPCh8GS" role="3bR31x">
-          <property role="3ZfqAx" value="models" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="2UnEDPCh8GT" role="1HemKq">
-            <node concept="398BVA" id="2UnEDPCh8GE" role="3LXTmr">
-              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-              <node concept="2Ry0Ak" id="2UnEDPCh8GF" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="2UnEDPCh8GG" role="2Ry0An">
-                  <property role="2Ry0Am" value="de.itemis.model.simple.demo.property" />
-                  <node concept="2Ry0Ak" id="2UnEDPCh8GH" role="2Ry0An">
-                    <property role="2Ry0Am" value="models" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="2UnEDPCh8GU" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-        <node concept="3rtmxn" id="3M9VIK_gQBd" role="3bR31x">
-          <node concept="3LXTmp" id="3M9VIK_gQBe" role="3rtmxm">
-            <node concept="398BVA" id="3M9VIK_gQBf" role="3LXTmr">
-              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-              <node concept="2Ry0Ak" id="3M9VIK_gQBg" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="3M9VIK_gQBh" role="2Ry0An">
-                  <property role="2Ry0Am" value="de.itemis.model.simple.demo.property" />
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="3M9VIK_gQBj" role="3LXTna">
-              <property role="3qWCbO" value="icons/**, resources/**" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="1E1JtD" id="2UnEDPClLCV" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="de.itemis.model.simple.demo.children" />
-        <property role="3LESm3" value="8688ed72-e0ba-44cb-9688-5c8397cb5bbb" />
-        <node concept="398BVA" id="2UnEDPClLEX" role="3LF7KH">
-          <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-          <node concept="2Ry0Ak" id="2UnEDPClLF3" role="iGT6I">
-            <property role="2Ry0Am" value="languages" />
-            <node concept="2Ry0Ak" id="2UnEDPClLF8" role="2Ry0An">
-              <property role="2Ry0Am" value="de.itemis.model.simple.demo.children" />
-              <node concept="2Ry0Ak" id="2UnEDPClLFd" role="2Ry0An">
-                <property role="2Ry0Am" value="de.itemis.model.simple.demo.children.mpl" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2UnEDPClLXF" role="3bR37C">
-          <node concept="3bR9La" id="2UnEDPClLXG" role="1SiIV1">
-            <ref role="3bR37D" node="2UnEDPCh8Ac" resolve="de.itemis.model.simple.demo.property" />
-          </node>
-        </node>
-        <node concept="1BupzO" id="2UnEDPClLXV" role="3bR31x">
-          <property role="3ZfqAx" value="models" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="2UnEDPClLXW" role="1HemKq">
-            <node concept="398BVA" id="2UnEDPClLXH" role="3LXTmr">
-              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-              <node concept="2Ry0Ak" id="2UnEDPClLXI" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="2UnEDPClLXJ" role="2Ry0An">
-                  <property role="2Ry0Am" value="de.itemis.model.simple.demo.children" />
-                  <node concept="2Ry0Ak" id="2UnEDPClLXK" role="2Ry0An">
-                    <property role="2Ry0Am" value="models" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="2UnEDPClLXX" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="1E1JtD" id="2UnEDPClLHk" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="de.itemis.model.simple.demo.collection" />
-        <property role="3LESm3" value="e50b0500-6fd7-4c7f-a730-9d841358ce8b" />
-        <node concept="398BVA" id="2UnEDPClLJr" role="3LF7KH">
-          <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-          <node concept="2Ry0Ak" id="2UnEDPClLJx" role="iGT6I">
-            <property role="2Ry0Am" value="languages" />
-            <node concept="2Ry0Ak" id="2UnEDPClLJA" role="2Ry0An">
-              <property role="2Ry0Am" value="de.itemis.model.simple.demo.collection" />
-              <node concept="2Ry0Ak" id="2UnEDPClLJF" role="2Ry0An">
-                <property role="2Ry0Am" value="de.itemis.model.simple.demo.collection.mpl" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1BupzO" id="2UnEDPClLYc" role="3bR31x">
-          <property role="3ZfqAx" value="models" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="2UnEDPClLYd" role="1HemKq">
-            <node concept="398BVA" id="2UnEDPClLXY" role="3LXTmr">
-              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-              <node concept="2Ry0Ak" id="2UnEDPClLXZ" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="2UnEDPClLY0" role="2Ry0An">
-                  <property role="2Ry0Am" value="de.itemis.model.simple.demo.collection" />
-                  <node concept="2Ry0Ak" id="2UnEDPClLY1" role="2Ry0An">
-                    <property role="2Ry0Am" value="models" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="2UnEDPClLYe" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2UnEDPClLYf" role="3bR37C">
-          <node concept="1Busua" id="2UnEDPClLYg" role="1SiIV1">
-            <ref role="1Busuk" node="2UnEDPCh8Ac" resolve="de.itemis.model.simple.demo.property" />
-          </node>
-        </node>
-      </node>
-      <node concept="1E1JtD" id="2UnEDPClLLR" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="de.itemis.model.simple.demo.collection.keeper" />
-        <property role="3LESm3" value="36ead753-43ea-471e-bcb9-d4fb1e637bbc" />
-        <node concept="398BVA" id="2UnEDPClLO3" role="3LF7KH">
-          <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-          <node concept="2Ry0Ak" id="2UnEDPClLO9" role="iGT6I">
-            <property role="2Ry0Am" value="languages" />
-            <node concept="2Ry0Ak" id="2UnEDPClLOe" role="2Ry0An">
-              <property role="2Ry0Am" value="de.itemis.model.simple.demo.collection.keeper" />
-              <node concept="2Ry0Ak" id="2UnEDPClLOj" role="2Ry0An">
-                <property role="2Ry0Am" value="de.itemis.model.simple.demo.collection.keeper.mpl" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1BupzO" id="2UnEDPClLYv" role="3bR31x">
-          <property role="3ZfqAx" value="models" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="2UnEDPClLYw" role="1HemKq">
-            <node concept="398BVA" id="2UnEDPClLYh" role="3LXTmr">
-              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-              <node concept="2Ry0Ak" id="2UnEDPClLYi" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="2UnEDPClLYj" role="2Ry0An">
-                  <property role="2Ry0Am" value="de.itemis.model.simple.demo.collection.keeper" />
-                  <node concept="2Ry0Ak" id="2UnEDPClLYk" role="2Ry0An">
-                    <property role="2Ry0Am" value="models" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="2UnEDPClLYx" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2UnEDPClLYy" role="3bR37C">
-          <node concept="1Busua" id="2UnEDPClLYz" role="1SiIV1">
-            <ref role="1Busuk" node="2UnEDPCh8Ac" resolve="de.itemis.model.simple.demo.property" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2UnEDPClMjG" role="3bR37C">
-          <node concept="1Busua" id="2UnEDPClMjH" role="1SiIV1">
-            <ref role="1Busuk" node="2UnEDPClLHk" resolve="de.itemis.model.simple.demo.collection" />
-          </node>
-        </node>
-      </node>
-      <node concept="1E1JtD" id="2UnEDPClLQ$" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="de.itemis.model.simple.demo.reference" />
-        <property role="3LESm3" value="6001215c-aa6e-4f9f-bfc2-f22e3c7250b2" />
-        <node concept="398BVA" id="2UnEDPClLSP" role="3LF7KH">
-          <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-          <node concept="2Ry0Ak" id="2UnEDPClLSV" role="iGT6I">
-            <property role="2Ry0Am" value="languages" />
-            <node concept="2Ry0Ak" id="2UnEDPClLT0" role="2Ry0An">
-              <property role="2Ry0Am" value="de.itemis.model.simple.demo.reference" />
-              <node concept="2Ry0Ak" id="2UnEDPClLT5" role="2Ry0An">
-                <property role="2Ry0Am" value="de.itemis.model.simple.demo.reference.mpl" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1BupzO" id="2UnEDPClLYM" role="3bR31x">
-          <property role="3ZfqAx" value="models" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="2UnEDPClLYN" role="1HemKq">
-            <node concept="398BVA" id="2UnEDPClLY$" role="3LXTmr">
-              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-              <node concept="2Ry0Ak" id="2UnEDPClLY_" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="2UnEDPClLYA" role="2Ry0An">
-                  <property role="2Ry0Am" value="de.itemis.model.simple.demo.reference" />
-                  <node concept="2Ry0Ak" id="2UnEDPClLYB" role="2Ry0An">
-                    <property role="2Ry0Am" value="models" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="2UnEDPClLYO" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2UnEDPClLYP" role="3bR37C">
-          <node concept="1Busua" id="2UnEDPClLYQ" role="1SiIV1">
-            <ref role="1Busuk" node="2UnEDPCh8Ac" resolve="de.itemis.model.simple.demo.property" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2UnEDPClMjW" role="3bR37C">
-          <node concept="1Busua" id="2UnEDPClMjX" role="1SiIV1">
-            <ref role="1Busuk" node="2UnEDPClLHk" resolve="de.itemis.model.simple.demo.collection" />
-          </node>
-        </node>
-      </node>
-      <node concept="1E1JtA" id="5RxOLvLcQHZ" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="de.itemis.model.merge.test" />
-        <property role="3LESm3" value="cb29f2d3-8375-4a4d-bc96-278c6b7ca172" />
-        <property role="aoJFB" value="eYcmk9QOlj/sources_and_tests" />
-        <node concept="398BVA" id="5RxOLvLcQJ$" role="3LF7KH">
-          <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-          <node concept="2Ry0Ak" id="5RxOLvLcQJE" role="iGT6I">
-            <property role="2Ry0Am" value="solutions" />
-            <node concept="2Ry0Ak" id="5RxOLvLcQJJ" role="2Ry0An">
-              <property role="2Ry0Am" value="de.itemis.model.merge.test" />
-              <node concept="2Ry0Ak" id="5RxOLvLcQJO" role="2Ry0An">
-                <property role="2Ry0Am" value="de.itemis.model.merge.test.msd" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="5RxOLvLcQPf" role="3bR37C">
-          <node concept="3bR9La" id="5RxOLvLcQPg" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:1H905DlDUSw" resolve="MPS.OpenAPI" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="5RxOLvLcQPh" role="3bR37C">
-          <node concept="3bR9La" id="5RxOLvLcQPi" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="5RxOLvLcQPj" role="3bR37C">
-          <node concept="3bR9La" id="5RxOLvLcQPk" role="1SiIV1">
-            <ref role="3bR37D" node="5zr7Q_1BAoJ" resolve="de.itemis.model.merge" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="5RxOLvLcQPl" role="3bR37C">
-          <node concept="3bR9La" id="5RxOLvLcQPm" role="1SiIV1">
-            <ref role="3bR37D" node="6fQhGuklQWU" resolve="de.q60.mps.collections.libs" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="5RxOLvLcQPn" role="3bR37C">
-          <node concept="3bR9La" id="5RxOLvLcQPo" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:7Kfy9QB6LaO" resolve="jetbrains.mps.lang.structure" />
-          </node>
-        </node>
-        <node concept="1BupzO" id="5RxOLvLcQPD" role="3bR31x">
-          <property role="3ZfqAx" value="models" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="5RxOLvLcQPE" role="1HemKq">
-            <node concept="398BVA" id="5RxOLvLcQPr" role="3LXTmr">
-              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-              <node concept="2Ry0Ak" id="5RxOLvLcQPs" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="5RxOLvLcQPt" role="2Ry0An">
-                  <property role="2Ry0Am" value="de.itemis.model.merge.test" />
-                  <node concept="2Ry0Ak" id="5RxOLvLcQPu" role="2Ry0An">
-                    <property role="2Ry0Am" value="models" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="5RxOLvLcQPF" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2C9csoiagDt" role="3bR37C">
-          <node concept="3bR9La" id="2C9csoiagDu" role="1SiIV1">
-            <ref role="3bR37D" node="5zr7Q_1BD5a" resolve="de.itemis.model.merge.runtime" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="3aF8hCvy3TH" role="3bR37C">
-          <node concept="3bR9La" id="3aF8hCvy3TI" role="1SiIV1">
-            <ref role="3bR37D" node="3aF8hCvy3sT" resolve="de.itemis.model.merge.diamond" />
-          </node>
-        </node>
-        <node concept="3rtmxn" id="3aF8hCw9tVs" role="3bR31x">
-          <node concept="3LXTmp" id="3aF8hCw9tVt" role="3rtmxm">
-            <node concept="398BVA" id="3aF8hCw9tVu" role="3LXTmr">
-              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-              <node concept="2Ry0Ak" id="3aF8hCw9tVv" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="3aF8hCw9tVw" role="2Ry0An">
-                  <property role="2Ry0Am" value="de.itemis.model.merge.test" />
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="3aF8hCw9tVy" role="3LXTna">
-              <property role="3qWCbO" value="icons/**" />
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="6CwG2k7MRyq" role="3bR37C">
-          <node concept="3bR9La" id="6CwG2k7MRyr" role="1SiIV1">
-            <ref role="3bR37D" node="2UnEDPCh8Ac" resolve="de.itemis.model.simple.demo.property" />
-          </node>
-        </node>
-      </node>
-      <node concept="1E1JtA" id="2UnEDPCpnjG" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="de.itemis.model.merge.simple.demo" />
-        <property role="3LESm3" value="3bfac093-0c90-42c7-87af-7dbe19b8f3e0" />
-        <property role="aoJFB" value="eYcmk9QOlj/sources_and_tests" />
-        <node concept="398BVA" id="2UnEDPCpnmE" role="3LF7KH">
-          <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-          <node concept="2Ry0Ak" id="2UnEDPCpnmK" role="iGT6I">
-            <property role="2Ry0Am" value="solutions" />
-            <node concept="2Ry0Ak" id="2UnEDPCpnmP" role="2Ry0An">
-              <property role="2Ry0Am" value="de.itemis.model.merge.simple.demo" />
-              <node concept="2Ry0Ak" id="2UnEDPCpnmU" role="2Ry0An">
-                <property role="2Ry0Am" value="de.itemis.model.merge.simple.demo.msd" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2UnEDPCpnsA" role="3bR37C">
-          <node concept="3bR9La" id="2UnEDPCpnsB" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:1H905DlDUSw" resolve="MPS.OpenAPI" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2UnEDPCpnsC" role="3bR37C">
-          <node concept="3bR9La" id="2UnEDPCpnsD" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2UnEDPCpnsE" role="3bR37C">
-          <node concept="3bR9La" id="2UnEDPCpnsF" role="1SiIV1">
-            <ref role="3bR37D" node="5zr7Q_1BAoJ" resolve="de.itemis.model.merge" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2UnEDPCpnsG" role="3bR37C">
-          <node concept="3bR9La" id="2UnEDPCpnsH" role="1SiIV1">
-            <ref role="3bR37D" node="2UnEDPClLCV" resolve="de.itemis.model.simple.demo.children" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2UnEDPCpnsI" role="3bR37C">
-          <node concept="3bR9La" id="2UnEDPCpnsJ" role="1SiIV1">
-            <ref role="3bR37D" node="2UnEDPClLQ$" resolve="de.itemis.model.simple.demo.reference" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2UnEDPCpnsK" role="3bR37C">
-          <node concept="3bR9La" id="2UnEDPCpnsL" role="1SiIV1">
-            <ref role="3bR37D" node="2UnEDPClLLR" resolve="de.itemis.model.simple.demo.collection.keeper" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2UnEDPCpnsM" role="3bR37C">
-          <node concept="3bR9La" id="2UnEDPCpnsN" role="1SiIV1">
-            <ref role="3bR37D" node="6fQhGuklQWU" resolve="de.q60.mps.collections.libs" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2UnEDPCpnsO" role="3bR37C">
-          <node concept="3bR9La" id="2UnEDPCpnsP" role="1SiIV1">
-            <ref role="3bR37D" node="2UnEDPClLHk" resolve="de.itemis.model.simple.demo.collection" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2UnEDPCpnsQ" role="3bR37C">
-          <node concept="3bR9La" id="2UnEDPCpnsR" role="1SiIV1">
-            <ref role="3bR37D" node="2UnEDPCh8Ac" resolve="de.itemis.model.simple.demo.property" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2UnEDPCpnsS" role="3bR37C">
-          <node concept="3bR9La" id="2UnEDPCpnsT" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:1xb0AuwN7WS" resolve="JUnit" />
-          </node>
-        </node>
-        <node concept="1BupzO" id="2UnEDPCpnt8" role="3bR31x">
-          <property role="3ZfqAx" value="models" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="2UnEDPCpnt9" role="1HemKq">
-            <node concept="398BVA" id="2UnEDPCpnsU" role="3LXTmr">
-              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-              <node concept="2Ry0Ak" id="2UnEDPCpnsV" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2UnEDPCpnsW" role="2Ry0An">
-                  <property role="2Ry0Am" value="de.itemis.model.merge.simple.demo" />
-                  <node concept="2Ry0Ak" id="2UnEDPCpnsX" role="2Ry0An">
-                    <property role="2Ry0Am" value="models" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="2UnEDPCpnta" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="6QQNrZyfqj" role="3bR37C">
-          <node concept="3bR9La" id="6QQNrZyfqk" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:1TaHNgiIbIQ" resolve="MPS.Core" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="6QQNrZIiQM" role="3bR37C">
-          <node concept="3bR9La" id="6QQNrZIiQN" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:4SM2EuqHUPF" resolve="jetbrains.mps.lang.modelapi" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="6QQNrZIiQO" role="3bR37C">
-          <node concept="3bR9La" id="6QQNrZIiQP" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:7Kfy9QB6L9O" resolve="jetbrains.mps.lang.smodel" />
-          </node>
-        </node>
-      </node>
-      <node concept="1E1JtA" id="5Jy3PcPRnpY" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="de.itemis.model.merge.baselang.sandbox" />
-        <property role="3LESm3" value="17d34773-aaeb-4315-92e6-9e0314373a68" />
-        <node concept="398BVA" id="5Jy3PcPRntS" role="3LF7KH">
-          <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-          <node concept="2Ry0Ak" id="5Jy3PcPRnu3" role="iGT6I">
-            <property role="2Ry0Am" value="languages" />
-            <node concept="2Ry0Ak" id="5Jy3PcPRnu8" role="2Ry0An">
-              <property role="2Ry0Am" value="de.itemis.model.merge.baselang" />
-              <node concept="2Ry0Ak" id="5Jy3PcPRnud" role="2Ry0An">
-                <property role="2Ry0Am" value="sandbox" />
-                <node concept="2Ry0Ak" id="5Jy3PcPRnui" role="2Ry0An">
-                  <property role="2Ry0Am" value="de.itemis.model.merge.baselang.sandbox.msd" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="5Jy3PcPRn$c" role="3bR37C">
-          <node concept="3bR9La" id="5Jy3PcPRn$d" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:1H905DlDUSw" resolve="MPS.OpenAPI" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="5Jy3PcPRn$e" role="3bR37C">
-          <node concept="3bR9La" id="5Jy3PcPRn$f" role="1SiIV1">
-            <ref role="3bR37D" node="6XR_ZZHk3hx" resolve="de.itemis.model.merge.baselang" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="5Jy3PcPRn$g" role="3bR37C">
-          <node concept="3bR9La" id="5Jy3PcPRn$h" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:1ia2VB5guYy" resolve="MPS.IDEA" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="5Jy3PcPRn$i" role="3bR37C">
-          <node concept="3bR9La" id="5Jy3PcPRn$j" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="5Jy3PcPRn$k" role="3bR37C">
-          <node concept="3bR9La" id="5Jy3PcPRn$l" role="1SiIV1">
-            <ref role="3bR37D" node="5zr7Q_1BAoJ" resolve="de.itemis.model.merge" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="5Jy3PcPRn$m" role="3bR37C">
-          <node concept="3bR9La" id="5Jy3PcPRn$n" role="1SiIV1">
-            <ref role="3bR37D" node="2UnEDPCh8Ac" resolve="de.itemis.model.simple.demo.property" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="5Jy3PcPRn$o" role="3bR37C">
-          <node concept="3bR9La" id="5Jy3PcPRn$p" role="1SiIV1">
-            <ref role="3bR37D" node="2UnEDPCpnjG" resolve="de.itemis.model.merge.simple.demo" />
-          </node>
-        </node>
-        <node concept="1BupzO" id="5Jy3PcPRn$F" role="3bR31x">
-          <property role="3ZfqAx" value="models" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="5Jy3PcPRn$G" role="1HemKq">
-            <node concept="398BVA" id="5Jy3PcPRn$q" role="3LXTmr">
-              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-              <node concept="2Ry0Ak" id="5Jy3PcPRn$r" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="5Jy3PcPRn$s" role="2Ry0An">
-                  <property role="2Ry0Am" value="de.itemis.model.merge.baselang" />
-                  <node concept="2Ry0Ak" id="5Jy3PcPRn$t" role="2Ry0An">
-                    <property role="2Ry0Am" value="sandbox" />
-                    <node concept="2Ry0Ak" id="5Jy3PcPRn$u" role="2Ry0An">
-                      <property role="2Ry0Am" value="models" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="5Jy3PcPRn$H" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="1E1JtA" id="3Afi$YnEYQQ" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="de.itemis.mps.modelmerger.testhelper" />
-        <property role="3LESm3" value="be1bf59c-934a-4cee-8859-a8bde460b96f" />
-        <node concept="398BVA" id="3Afi$YnEYYs" role="3LF7KH">
-          <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-          <node concept="2Ry0Ak" id="3Afi$YnEZDh" role="iGT6I">
-            <property role="2Ry0Am" value="modelmerger" />
-            <node concept="2Ry0Ak" id="1RcjJjMqUWR" role="2Ry0An">
-              <property role="2Ry0Am" value="languages" />
-              <node concept="2Ry0Ak" id="1RcjJjMqUWS" role="2Ry0An">
-                <property role="2Ry0Am" value="de.itemis.mps.modelmerger" />
-                <node concept="2Ry0Ak" id="1RcjJjMqUWT" role="2Ry0An">
-                  <property role="2Ry0Am" value="sandbox" />
-                  <node concept="2Ry0Ak" id="1RcjJjMqUWU" role="2Ry0An">
-                    <property role="2Ry0Am" value="de.itemis.mps.modelmerger.testhelper.msd" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="3Afi$YnF0y2" role="3bR37C">
-          <node concept="3bR9La" id="3Afi$YnF0y3" role="1SiIV1">
-            <ref role="3bR37D" node="GuygFg7AfB" resolve="test.de.itemis.mps.modelmerger.testlanguage" />
-          </node>
-        </node>
-        <node concept="3rtmxn" id="5py4VqXmLKF" role="3bR31x">
-          <node concept="3LXTmp" id="5py4VqXmLKG" role="3rtmxm">
-            <node concept="3qWCbU" id="5py4VqXmLKH" role="3LXTna">
-              <property role="3qWCbO" value="icons/**, resources/**" />
-            </node>
-            <node concept="398BVA" id="5py4VqXmLKI" role="3LXTmr">
-              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-              <node concept="2Ry0Ak" id="5py4VqXmLKJ" role="iGT6I">
-                <property role="2Ry0Am" value="modelmerger" />
-                <node concept="2Ry0Ak" id="67K7yGVZou4" role="2Ry0An">
-                  <property role="2Ry0Am" value="languages" />
-                  <node concept="2Ry0Ak" id="67K7yGVZou5" role="2Ry0An">
-                    <property role="2Ry0Am" value="de.itemis.mps.modelmerger" />
-                    <node concept="2Ry0Ak" id="67K7yGVZou6" role="2Ry0An">
-                      <property role="2Ry0Am" value="sandbox" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1BupzO" id="7q24334ZKDd" role="3bR31x">
-          <property role="3ZfqAx" value="models" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="1RcjJjMqV2r" role="1HemKq">
-            <node concept="398BVA" id="1RcjJjMqV27" role="3LXTmr">
-              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-              <node concept="2Ry0Ak" id="1RcjJjMqV28" role="iGT6I">
-                <property role="2Ry0Am" value="modelmerger" />
-                <node concept="2Ry0Ak" id="1RcjJjMqV29" role="2Ry0An">
-                  <property role="2Ry0Am" value="languages" />
-                  <node concept="2Ry0Ak" id="1RcjJjMqV2a" role="2Ry0An">
-                    <property role="2Ry0Am" value="de.itemis.mps.modelmerger" />
-                    <node concept="2Ry0Ak" id="1RcjJjMqV2b" role="2Ry0An">
-                      <property role="2Ry0Am" value="sandbox" />
-                      <node concept="2Ry0Ak" id="1RcjJjMqV2c" role="2Ry0An">
-                        <property role="2Ry0Am" value="models" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="1RcjJjMqV2s" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="1E1JtA" id="GuygFg7$fI" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="tests.de.itemis.mps.modelmerger" />
-        <property role="3LESm3" value="92726818-95f2-4d46-96d1-aacb660cb63a" />
-        <property role="aoJFB" value="eYcmk9QOlj/sources_and_tests" />
-        <node concept="3rtmxn" id="GuygFg7$fJ" role="3bR31x">
-          <node concept="3LXTmp" id="GuygFg7$fK" role="3rtmxm">
-            <node concept="3qWCbU" id="GuygFg7$fL" role="3LXTna">
-              <property role="3qWCbO" value="icons/**, resources/**" />
-            </node>
-            <node concept="398BVA" id="GuygFg7$fM" role="3LXTmr">
-              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-              <node concept="2Ry0Ak" id="GuygFg7$fN" role="iGT6I">
-                <property role="2Ry0Am" value="modelmerger" />
-                <node concept="2Ry0Ak" id="67K7yGVZoub" role="2Ry0An">
-                  <property role="2Ry0Am" value="solutions" />
-                  <node concept="2Ry0Ak" id="67K7yGVZouc" role="2Ry0An">
-                    <property role="2Ry0Am" value="tests.de.itemis.mps.modelmerger" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="398BVA" id="GuygFg7$fQ" role="3LF7KH">
-          <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-          <node concept="2Ry0Ak" id="GuygFg7_oX" role="iGT6I">
-            <property role="2Ry0Am" value="modelmerger" />
-            <node concept="2Ry0Ak" id="1RcjJjMqUX0" role="2Ry0An">
-              <property role="2Ry0Am" value="solutions" />
-              <node concept="2Ry0Ak" id="1RcjJjMqUX1" role="2Ry0An">
-                <property role="2Ry0Am" value="tests.de.itemis.mps.modelmerger" />
-                <node concept="2Ry0Ak" id="1RcjJjMqUX2" role="2Ry0An">
-                  <property role="2Ry0Am" value="tests.de.itemis.mps.modelmerger.msd" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="GuygFg7A1b" role="3bR37C">
-          <node concept="3bR9La" id="GuygFg7A1c" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:1TaHNgiIbIQ" resolve="MPS.Core" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="GuygFg7A1d" role="3bR37C">
-          <node concept="3bR9La" id="GuygFg7A1e" role="1SiIV1">
-            <ref role="3bR37D" node="GuygFg6VEV" resolve="de.itemis.mps.modelmerger.runtime" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="GuygFg7BEG" role="3bR37C">
-          <node concept="3bR9La" id="GuygFg7BEH" role="1SiIV1">
-            <ref role="3bR37D" node="GuygFg7AfB" resolve="test.de.itemis.mps.modelmerger.testlanguage" />
-          </node>
-        </node>
-        <node concept="1BupzO" id="7q24334ZKDu" role="3bR31x">
-          <property role="3ZfqAx" value="models" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="1RcjJjMqV2I" role="1HemKq">
-            <node concept="398BVA" id="1RcjJjMqV2t" role="3LXTmr">
-              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-              <node concept="2Ry0Ak" id="1RcjJjMqV2u" role="iGT6I">
-                <property role="2Ry0Am" value="modelmerger" />
-                <node concept="2Ry0Ak" id="1RcjJjMqV2v" role="2Ry0An">
-                  <property role="2Ry0Am" value="solutions" />
-                  <node concept="2Ry0Ak" id="1RcjJjMqV2w" role="2Ry0An">
-                    <property role="2Ry0Am" value="tests.de.itemis.mps.modelmerger" />
-                    <node concept="2Ry0Ak" id="1RcjJjMqV2x" role="2Ry0An">
-                      <property role="2Ry0Am" value="models" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="1RcjJjMqV2J" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="59_ttdjbdCz" role="3bR37C">
-          <node concept="3bR9La" id="59_ttdjbdC$" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:7Kfy9QB6KXW" resolve="jetbrains.mps.lang.core" />
-          </node>
-        </node>
-      </node>
-      <node concept="1E1JtD" id="GuygFg7AfB" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="test.de.itemis.mps.modelmerger.testlanguage" />
-        <property role="3LESm3" value="d119cd03-ed7e-477f-adb6-22a3d2e6ea77" />
-        <node concept="398BVA" id="GuygFg7AmQ" role="3LF7KH">
-          <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-          <node concept="2Ry0Ak" id="GuygFg7AtP" role="iGT6I">
-            <property role="2Ry0Am" value="modelmerger" />
-            <node concept="2Ry0Ak" id="1RcjJjMqUX7" role="2Ry0An">
-              <property role="2Ry0Am" value="languages" />
-              <node concept="2Ry0Ak" id="1RcjJjMqUX8" role="2Ry0An">
-                <property role="2Ry0Am" value="test.de.itemis.mps.modelmerger.testlanguage" />
-                <node concept="2Ry0Ak" id="1RcjJjMqUX9" role="2Ry0An">
-                  <property role="2Ry0Am" value="test.de.itemis.mps.modelmerger.testlanguage.mpl" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3rtmxn" id="5py4VqXmLO1" role="3bR31x">
-          <node concept="3LXTmp" id="5py4VqXmLO2" role="3rtmxm">
-            <node concept="3qWCbU" id="5py4VqXmLO3" role="3LXTna">
-              <property role="3qWCbO" value="icons/**, resources/**" />
-            </node>
-            <node concept="398BVA" id="5py4VqXmLO4" role="3LXTmr">
-              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-              <node concept="2Ry0Ak" id="5py4VqXmLO5" role="iGT6I">
-                <property role="2Ry0Am" value="modelmerger" />
-                <node concept="2Ry0Ak" id="67K7yGVZotZ" role="2Ry0An">
-                  <property role="2Ry0Am" value="languages" />
-                  <node concept="2Ry0Ak" id="67K7yGVZou0" role="2Ry0An">
-                    <property role="2Ry0Am" value="test.de.itemis.mps.modelmerger.testlanguage" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1BupzO" id="7q24334ZKDJ" role="3bR31x">
-          <property role="3ZfqAx" value="models" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="1RcjJjMqV31" role="1HemKq">
-            <node concept="398BVA" id="1RcjJjMqV2K" role="3LXTmr">
-              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-              <node concept="2Ry0Ak" id="1RcjJjMqV2L" role="iGT6I">
-                <property role="2Ry0Am" value="modelmerger" />
-                <node concept="2Ry0Ak" id="1RcjJjMqV2M" role="2Ry0An">
-                  <property role="2Ry0Am" value="languages" />
-                  <node concept="2Ry0Ak" id="1RcjJjMqV2N" role="2Ry0An">
-                    <property role="2Ry0Am" value="test.de.itemis.mps.modelmerger.testlanguage" />
-                    <node concept="2Ry0Ak" id="1RcjJjMqV2O" role="2Ry0An">
-                      <property role="2Ry0Am" value="models" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="1RcjJjMqV32" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="2G$12M" id="T8sXq9o52B" role="3989C9">
-      <property role="TrG5h" value="plaintextgen-tests" />
-      <node concept="1E1JtD" id="T8sXq9o58u" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="com.dslfoundry.plaintextgen.example.nestedlist" />
-        <property role="3LESm3" value="a50fc719-4261-4a46-8e65-d98071469ff6" />
-        <node concept="398BVA" id="T8sXq9o58y" role="3LF7KH">
-          <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-          <node concept="2Ry0Ak" id="T8sXq9o58C" role="iGT6I">
-            <property role="2Ry0Am" value="plaintextgen" />
-            <node concept="2Ry0Ak" id="T8sXq9o58H" role="2Ry0An">
-              <property role="2Ry0Am" value="languages" />
-              <node concept="2Ry0Ak" id="T8sXq9o58M" role="2Ry0An">
-                <property role="2Ry0Am" value="com.dslfoundry.plaintextgen.example.nestedlist" />
-                <node concept="2Ry0Ak" id="T8sXq9o58R" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.dslfoundry.plaintextgen.example.nestedlist.mpl" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1yeLz9" id="T8sXq9o5cP" role="1TViLv">
-          <property role="TrG5h" value="com.dslfoundry.plaintextgen.example.nestedlist#7022720084780710580" />
-          <property role="3LESm3" value="516b4c2f-de92-4b35-b9ea-223ab1ed88d9" />
-          <node concept="1BupzO" id="7q24334ZKEq" role="3bR31x">
-            <property role="3ZfqAx" value="generator/template" />
-            <property role="1Hdu6h" value="true" />
-            <property role="1HemKv" value="true" />
-            <node concept="3LXTmp" id="7q24334ZKEr" role="1HemKq">
-              <node concept="398BVA" id="7q24334ZKE6" role="3LXTmr">
-                <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-                <node concept="2Ry0Ak" id="7q24334ZKE7" role="iGT6I">
-                  <property role="2Ry0Am" value="plaintextgen" />
-                  <node concept="2Ry0Ak" id="7q24334ZKE8" role="2Ry0An">
-                    <property role="2Ry0Am" value="languages" />
-                    <node concept="2Ry0Ak" id="7q24334ZKE9" role="2Ry0An">
-                      <property role="2Ry0Am" value="com.dslfoundry.plaintextgen.example.nestedlist" />
-                      <node concept="2Ry0Ak" id="7q24334ZKEa" role="2Ry0An">
-                        <property role="2Ry0Am" value="generator" />
-                        <node concept="2Ry0Ak" id="7q24334ZKEb" role="2Ry0An">
-                          <property role="2Ry0Am" value="template" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3qWCbU" id="7q24334ZKEs" role="3LXTna">
-                <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3rtmxn" id="5py4VqXmLO8" role="3bR31x">
-          <node concept="3LXTmp" id="5py4VqXmLO9" role="3rtmxm">
-            <node concept="3qWCbU" id="5py4VqXmLOa" role="3LXTna">
-              <property role="3qWCbO" value="icons/**, resources/**" />
-            </node>
-            <node concept="398BVA" id="5py4VqXmLOb" role="3LXTmr">
-              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-              <node concept="2Ry0Ak" id="5py4VqXmLOc" role="iGT6I">
-                <property role="2Ry0Am" value="plaintextgen" />
-                <node concept="2Ry0Ak" id="5py4VqXmLOd" role="2Ry0An">
-                  <property role="2Ry0Am" value="languages" />
-                  <node concept="2Ry0Ak" id="5py4VqXmLOe" role="2Ry0An">
-                    <property role="2Ry0Am" value="com.dslfoundry.plaintextgen.example.nestedlist" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1BupzO" id="7q24334ZKE3" role="3bR31x">
-          <property role="3ZfqAx" value="models" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="7q24334ZKE4" role="1HemKq">
-            <node concept="398BVA" id="7q24334ZKDM" role="3LXTmr">
-              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-              <node concept="2Ry0Ak" id="7q24334ZKDN" role="iGT6I">
-                <property role="2Ry0Am" value="plaintextgen" />
-                <node concept="2Ry0Ak" id="7q24334ZKDO" role="2Ry0An">
-                  <property role="2Ry0Am" value="languages" />
-                  <node concept="2Ry0Ak" id="7q24334ZKDP" role="2Ry0An">
-                    <property role="2Ry0Am" value="com.dslfoundry.plaintextgen.example.nestedlist" />
-                    <node concept="2Ry0Ak" id="7q24334ZKDQ" role="2Ry0An">
-                      <property role="2Ry0Am" value="models" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="7q24334ZKE5" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="1E1JtD" id="T8sXq9o593" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="com.dslfoundry.plaintextgen.example.testlang" />
-        <property role="3LESm3" value="90aa1f1b-f65c-4e9a-99b4-4030e09d0bb2" />
-        <node concept="398BVA" id="T8sXq9o59f" role="3LF7KH">
-          <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-          <node concept="2Ry0Ak" id="T8sXq9o59l" role="iGT6I">
-            <property role="2Ry0Am" value="plaintextgen" />
-            <node concept="2Ry0Ak" id="T8sXq9o59q" role="2Ry0An">
-              <property role="2Ry0Am" value="languages" />
-              <node concept="2Ry0Ak" id="T8sXq9o59v" role="2Ry0An">
-                <property role="2Ry0Am" value="com.dslfoundry.plaintextgen.example.testlang" />
-                <node concept="2Ry0Ak" id="T8sXq9o59$" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.dslfoundry.plaintextgen.example.testlang.mpl" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1yeLz9" id="T8sXq9o5cQ" role="1TViLv">
-          <property role="TrG5h" value="com.dslfoundry.plaintextgen.example.testlang#3661149507326583883" />
-          <property role="3LESm3" value="ccd826e7-e85c-4fb5-8a54-657940fd9fa7" />
-          <node concept="1BupzO" id="7q24334ZKF5" role="3bR31x">
-            <property role="3ZfqAx" value="generator/template" />
-            <property role="1Hdu6h" value="true" />
-            <property role="1HemKv" value="true" />
-            <node concept="3LXTmp" id="7q24334ZKF6" role="1HemKq">
-              <node concept="398BVA" id="7q24334ZKEL" role="3LXTmr">
-                <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-                <node concept="2Ry0Ak" id="7q24334ZKEM" role="iGT6I">
-                  <property role="2Ry0Am" value="plaintextgen" />
-                  <node concept="2Ry0Ak" id="7q24334ZKEN" role="2Ry0An">
-                    <property role="2Ry0Am" value="languages" />
-                    <node concept="2Ry0Ak" id="7q24334ZKEO" role="2Ry0An">
-                      <property role="2Ry0Am" value="com.dslfoundry.plaintextgen.example.testlang" />
-                      <node concept="2Ry0Ak" id="7q24334ZKEP" role="2Ry0An">
-                        <property role="2Ry0Am" value="generator" />
-                        <node concept="2Ry0Ak" id="7q24334ZKEQ" role="2Ry0An">
-                          <property role="2Ry0Am" value="template" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3qWCbU" id="7q24334ZKF7" role="3LXTna">
-                <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3rtmxn" id="5py4VqXmLOg" role="3bR31x">
-          <node concept="3LXTmp" id="5py4VqXmLOh" role="3rtmxm">
-            <node concept="3qWCbU" id="5py4VqXmLOi" role="3LXTna">
-              <property role="3qWCbO" value="icons/**, resources/**" />
-            </node>
-            <node concept="398BVA" id="5py4VqXmLOj" role="3LXTmr">
-              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-              <node concept="2Ry0Ak" id="5py4VqXmLOk" role="iGT6I">
-                <property role="2Ry0Am" value="plaintextgen" />
-                <node concept="2Ry0Ak" id="5py4VqXmLOl" role="2Ry0An">
-                  <property role="2Ry0Am" value="languages" />
-                  <node concept="2Ry0Ak" id="5py4VqXmLOm" role="2Ry0An">
-                    <property role="2Ry0Am" value="com.dslfoundry.plaintextgen.example.testlang" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1BupzO" id="7q24334ZKEI" role="3bR31x">
-          <property role="3ZfqAx" value="models" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="7q24334ZKEJ" role="1HemKq">
-            <node concept="398BVA" id="7q24334ZKEt" role="3LXTmr">
-              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-              <node concept="2Ry0Ak" id="7q24334ZKEu" role="iGT6I">
-                <property role="2Ry0Am" value="plaintextgen" />
-                <node concept="2Ry0Ak" id="7q24334ZKEv" role="2Ry0An">
-                  <property role="2Ry0Am" value="languages" />
-                  <node concept="2Ry0Ak" id="7q24334ZKEw" role="2Ry0An">
-                    <property role="2Ry0Am" value="com.dslfoundry.plaintextgen.example.testlang" />
-                    <node concept="2Ry0Ak" id="7q24334ZKEx" role="2Ry0An">
-                      <property role="2Ry0Am" value="models" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="7q24334ZKEK" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="1E1JtA" id="T8sXq9o59Q" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="com.dslfoundry.plaintextgen.example.nestedlist.sandbox" />
-        <property role="3LESm3" value="ba03a5e3-c9b5-466f-83a9-e2775cc47038" />
-        <node concept="398BVA" id="T8sXq9o5a8" role="3LF7KH">
-          <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-          <node concept="2Ry0Ak" id="T8sXq9o5ae" role="iGT6I">
-            <property role="2Ry0Am" value="plaintextgen" />
-            <node concept="2Ry0Ak" id="T8sXq9o5aj" role="2Ry0An">
-              <property role="2Ry0Am" value="solutions" />
-              <node concept="2Ry0Ak" id="T8sXq9o5ao" role="2Ry0An">
-                <property role="2Ry0Am" value="com.dslfoundry.plaintextgen.example.nestedlist.sandbox" />
-                <node concept="2Ry0Ak" id="T8sXq9o5at" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.dslfoundry.plaintextgen.example.nestedlist.sandbox.msd" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3rtmxn" id="5py4VqXmLKN" role="3bR31x">
-          <node concept="3LXTmp" id="5py4VqXmLKO" role="3rtmxm">
-            <node concept="3qWCbU" id="5py4VqXmLKP" role="3LXTna">
-              <property role="3qWCbO" value="icons/**, resources/**" />
-            </node>
-            <node concept="398BVA" id="5py4VqXmLKQ" role="3LXTmr">
-              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-              <node concept="2Ry0Ak" id="5py4VqXmLKR" role="iGT6I">
-                <property role="2Ry0Am" value="plaintextgen" />
-                <node concept="2Ry0Ak" id="5py4VqXmLKS" role="2Ry0An">
-                  <property role="2Ry0Am" value="solutions" />
-                  <node concept="2Ry0Ak" id="5py4VqXmLKT" role="2Ry0An">
-                    <property role="2Ry0Am" value="com.dslfoundry.plaintextgen.example.nestedlist.sandbox" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1BupzO" id="7q24334ZKFp" role="3bR31x">
-          <property role="3ZfqAx" value="models" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="7q24334ZKFq" role="1HemKq">
-            <node concept="398BVA" id="7q24334ZKF8" role="3LXTmr">
-              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-              <node concept="2Ry0Ak" id="7q24334ZKF9" role="iGT6I">
-                <property role="2Ry0Am" value="plaintextgen" />
-                <node concept="2Ry0Ak" id="7q24334ZKFa" role="2Ry0An">
-                  <property role="2Ry0Am" value="solutions" />
-                  <node concept="2Ry0Ak" id="7q24334ZKFb" role="2Ry0An">
-                    <property role="2Ry0Am" value="com.dslfoundry.plaintextgen.example.nestedlist.sandbox" />
-                    <node concept="2Ry0Ak" id="7q24334ZKFc" role="2Ry0An">
-                      <property role="2Ry0Am" value="models" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="7q24334ZKFr" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="1E1JtA" id="T8sXq9o5aP" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="com.dslfoundry.plaintextgen.example.plaintextflow" />
-        <property role="3LESm3" value="98b33244-af76-406c-b3fd-e713f69cf5b8" />
-        <node concept="398BVA" id="T8sXq9o5bd" role="3LF7KH">
-          <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-          <node concept="2Ry0Ak" id="T8sXq9o5bj" role="iGT6I">
-            <property role="2Ry0Am" value="plaintextgen" />
-            <node concept="2Ry0Ak" id="T8sXq9o5bo" role="2Ry0An">
-              <property role="2Ry0Am" value="solutions" />
-              <node concept="2Ry0Ak" id="T8sXq9o5bt" role="2Ry0An">
-                <property role="2Ry0Am" value="com.dslfoundry.plaintextgen.example.plaintextflow" />
-                <node concept="2Ry0Ak" id="T8sXq9o5by" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.dslfoundry.plaintextgen.example.plaintextflow.msd" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3rtmxn" id="5py4VqXmLKV" role="3bR31x">
-          <node concept="3LXTmp" id="5py4VqXmLKW" role="3rtmxm">
-            <node concept="3qWCbU" id="5py4VqXmLKX" role="3LXTna">
-              <property role="3qWCbO" value="icons/**, resources/**" />
-            </node>
-            <node concept="398BVA" id="5py4VqXmLKY" role="3LXTmr">
-              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-              <node concept="2Ry0Ak" id="5py4VqXmLKZ" role="iGT6I">
-                <property role="2Ry0Am" value="plaintextgen" />
-                <node concept="2Ry0Ak" id="5py4VqXmLL0" role="2Ry0An">
-                  <property role="2Ry0Am" value="solutions" />
-                  <node concept="2Ry0Ak" id="5py4VqXmLL1" role="2Ry0An">
-                    <property role="2Ry0Am" value="com.dslfoundry.plaintextgen.example.plaintextflow" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1BupzO" id="7q24334ZKFH" role="3bR31x">
-          <property role="3ZfqAx" value="models" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="7q24334ZKFI" role="1HemKq">
-            <node concept="398BVA" id="7q24334ZKFs" role="3LXTmr">
-              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-              <node concept="2Ry0Ak" id="7q24334ZKFt" role="iGT6I">
-                <property role="2Ry0Am" value="plaintextgen" />
-                <node concept="2Ry0Ak" id="7q24334ZKFu" role="2Ry0An">
-                  <property role="2Ry0Am" value="solutions" />
-                  <node concept="2Ry0Ak" id="7q24334ZKFv" role="2Ry0An">
-                    <property role="2Ry0Am" value="com.dslfoundry.plaintextgen.example.plaintextflow" />
-                    <node concept="2Ry0Ak" id="7q24334ZKFw" role="2Ry0An">
-                      <property role="2Ry0Am" value="models" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="7q24334ZKFJ" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="1E1JtA" id="T8sXq9o5c0" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="com.dslfoundry.plaintextgen.example.testlang.sandbox" />
-        <property role="3LESm3" value="656d5e8d-33ef-4f6c-b197-7fbc05468208" />
-        <node concept="398BVA" id="T8sXq9o5cu" role="3LF7KH">
-          <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-          <node concept="2Ry0Ak" id="T8sXq9o5c$" role="iGT6I">
-            <property role="2Ry0Am" value="plaintextgen" />
-            <node concept="2Ry0Ak" id="T8sXq9o5cD" role="2Ry0An">
-              <property role="2Ry0Am" value="solutions" />
-              <node concept="2Ry0Ak" id="T8sXq9o5cI" role="2Ry0An">
-                <property role="2Ry0Am" value="com.dslfoundry.plaintextgen.example.testlang.sandbox" />
-                <node concept="2Ry0Ak" id="T8sXq9o5cN" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.dslfoundry.plaintextgen.example.testlang.sandbox.msd" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3rtmxn" id="5py4VqXmLL3" role="3bR31x">
-          <node concept="3LXTmp" id="5py4VqXmLL4" role="3rtmxm">
-            <node concept="3qWCbU" id="5py4VqXmLL5" role="3LXTna">
-              <property role="3qWCbO" value="icons/**, resources/**" />
-            </node>
-            <node concept="398BVA" id="5py4VqXmLL6" role="3LXTmr">
-              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-              <node concept="2Ry0Ak" id="5py4VqXmLL7" role="iGT6I">
-                <property role="2Ry0Am" value="plaintextgen" />
-                <node concept="2Ry0Ak" id="5py4VqXmLL8" role="2Ry0An">
-                  <property role="2Ry0Am" value="solutions" />
-                  <node concept="2Ry0Ak" id="5py4VqXmLL9" role="2Ry0An">
-                    <property role="2Ry0Am" value="com.dslfoundry.plaintextgen.example.testlang.sandbox" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1BupzO" id="7q24334ZKG1" role="3bR31x">
-          <property role="3ZfqAx" value="models" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="7q24334ZKG2" role="1HemKq">
-            <node concept="398BVA" id="7q24334ZKFK" role="3LXTmr">
-              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-              <node concept="2Ry0Ak" id="7q24334ZKFL" role="iGT6I">
-                <property role="2Ry0Am" value="plaintextgen" />
-                <node concept="2Ry0Ak" id="7q24334ZKFM" role="2Ry0An">
-                  <property role="2Ry0Am" value="solutions" />
-                  <node concept="2Ry0Ak" id="7q24334ZKFN" role="2Ry0An">
-                    <property role="2Ry0Am" value="com.dslfoundry.plaintextgen.example.testlang.sandbox" />
-                    <node concept="2Ry0Ak" id="7q24334ZKFO" role="2Ry0An">
-                      <property role="2Ry0Am" value="models" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="7q24334ZKG3" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="2G$12M" id="7g5FWGK0Kfe" role="3989C9">
-      <property role="TrG5h" value="model-api-tests" />
-      <node concept="1E1JtA" id="7g5FWGK0Kzy" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="test.org.modelix.model.mpsadapters" />
-        <property role="3LESm3" value="133bdd06-b98b-47f5-8335-a48e447f9c41" />
-        <node concept="398BVA" id="7g5FWGK0KzA" role="3LF7KH">
-          <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-          <node concept="2Ry0Ak" id="7g5FWGK0KzG" role="iGT6I">
-            <property role="2Ry0Am" value="model-api" />
-            <node concept="2Ry0Ak" id="7g5FWGK12Ig" role="2Ry0An">
-              <property role="2Ry0Am" value="test.org.modelix.model.mpsadapters" />
-              <node concept="2Ry0Ak" id="7g5FWGK12Il" role="2Ry0An">
-                <property role="2Ry0Am" value="test.org.modelix.model.mpsadapters.msd" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1BupzO" id="7g5FWGK12Pw" role="3bR31x">
-          <property role="3ZfqAx" value="models" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="7g5FWGK12Px" role="1HemKq">
-            <node concept="398BVA" id="7g5FWGK12Pi" role="3LXTmr">
-              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-              <node concept="2Ry0Ak" id="7g5FWGK12Pj" role="iGT6I">
-                <property role="2Ry0Am" value="model-api" />
-                <node concept="2Ry0Ak" id="7g5FWGK12Pk" role="2Ry0An">
-                  <property role="2Ry0Am" value="test.org.modelix.model.mpsadapters" />
-                  <node concept="2Ry0Ak" id="7g5FWGK12Pl" role="2Ry0An">
-                    <property role="2Ry0Am" value="models" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="7g5FWGK12Py" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="7g5FWGK3ZSU" role="3bR37C">
-          <node concept="3bR9La" id="7g5FWGK3ZSV" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:1H905DlDUSw" resolve="MPS.OpenAPI" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="7g5FWGK3ZSW" role="3bR37C">
-          <node concept="3bR9La" id="7g5FWGK3ZSX" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="7g5FWGK3ZSY" role="3bR37C">
-          <node concept="3bR9La" id="7g5FWGK3ZSZ" role="1SiIV1">
-            <ref role="3bR37D" node="5U8hsWC73Be" resolve="org.modelix.model.repositoryconcepts" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="7g5FWGK3ZT0" role="3bR37C">
-          <node concept="3bR9La" id="7g5FWGK3ZT1" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:7Kfy9QB6KXW" resolve="jetbrains.mps.lang.core" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="7g5FWGK3ZT2" role="3bR37C">
-          <node concept="3bR9La" id="7g5FWGK3ZT3" role="1SiIV1">
-            <ref role="3bR37D" node="5U8hsWC70jw" resolve="org.modelix.model.api" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="7g5FWGK3ZT4" role="3bR37C">
-          <node concept="3bR9La" id="7g5FWGK3ZT5" role="1SiIV1">
-            <ref role="3bR37D" node="4iIKqJTZ5Hm" resolve="de.q60.mps.shadowmodels.runtime" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="7g5FWGK3ZT6" role="3bR37C">
-          <node concept="3bR9La" id="7g5FWGK3ZT7" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="7g5FWGK3ZT8" role="3bR37C">
-          <node concept="3bR9La" id="7g5FWGK3ZT9" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:1TaHNgiIbIQ" resolve="MPS.Core" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="7g5FWGK3ZTa" role="3bR37C">
-          <node concept="3bR9La" id="7g5FWGK3ZTb" role="1SiIV1">
-            <ref role="3bR37D" node="5U8hsWC71Xh" resolve="org.modelix.model.mpsadapters" />
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="2G$12M" id="4JmkJs3GrYV" role="3989C9">
-      <property role="TrG5h" value="shadowmodels-tests" />
-      <node concept="1E1JtA" id="4JmkJs3Gs4u" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="test.de.q60.mps.shadowmodels.examples" />
-        <property role="3LESm3" value="4ab36e7c-b9ac-4947-9bb8-c3ed105e5fbe" />
-        <property role="aoJFB" value="eYcmk9QOlj/sources_and_tests" />
-        <node concept="398BVA" id="4JmkJs3Gs4y" role="3LF7KH">
-          <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-          <node concept="2Ry0Ak" id="4JmkJs3Gs4C" role="iGT6I">
-            <property role="2Ry0Am" value="shadowmodels" />
-            <node concept="2Ry0Ak" id="4wrAhqcwXxO" role="2Ry0An">
-              <property role="2Ry0Am" value="solutions" />
-              <node concept="2Ry0Ak" id="4wrAhqcwXxM" role="2Ry0An">
-                <property role="2Ry0Am" value="test.de.q60.mps.shadowmodels.examples" />
-                <node concept="2Ry0Ak" id="4wrAhqcwXxN" role="2Ry0An">
-                  <property role="2Ry0Am" value="test.de.q60.mps.shadowmodels.examples.msd" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="4JmkJs3Gs4O" role="3bR37C">
-          <node concept="3bR9La" id="4JmkJs3Gs4P" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:1H905DlDUSw" resolve="MPS.OpenAPI" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="4JmkJs3Gs4Q" role="3bR37C">
-          <node concept="3bR9La" id="4JmkJs3Gs4R" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="4JmkJs3Gs4S" role="3bR37C">
-          <node concept="3bR9La" id="4JmkJs3Gs4T" role="1SiIV1">
-            <ref role="3bR37D" node="4iIKqJTZ5Hm" resolve="de.q60.mps.shadowmodels.runtime" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="4JmkJs3Gs4U" role="3bR37C">
-          <node concept="3bR9La" id="4JmkJs3Gs4V" role="1SiIV1">
-            <ref role="3bR37D" node="4iIKqJTZ5HO" resolve="de.q60.mps.shadowmodels.transformation" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="4JmkJs3Gs4W" role="3bR37C">
-          <node concept="3bR9La" id="4JmkJs3Gs4X" role="1SiIV1">
-            <ref role="3bR37D" node="BRK1N8p1ux" resolve="de.q60.mps.shadowmodels.examples.statemachine" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="4JmkJs3Gs4Y" role="3bR37C">
-          <node concept="3bR9La" id="4JmkJs3Gs4Z" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:6aIAM_Qd5ki" resolve="jetbrains.mps.lang.test.matcher" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="4JmkJs3KO_i" role="3bR37C">
-          <node concept="3bR9La" id="4JmkJs3KO_j" role="1SiIV1">
-            <ref role="3bR37D" node="BRK1N8p1qk" resolve="de.q60.mps.shadowmodels.examples.entities" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2qi4B7uvqM5" role="3bR37C">
-          <node concept="3bR9La" id="2qi4B7uvqM6" role="1SiIV1">
-            <ref role="3bR37D" node="BRK1N8p1tm" resolve="de.q60.mps.shadowmodels.examples.blext" />
-          </node>
-        </node>
-        <node concept="3rtmxn" id="5py4VqXmLLb" role="3bR31x">
-          <node concept="3LXTmp" id="5py4VqXmLLc" role="3rtmxm">
-            <node concept="3qWCbU" id="5py4VqXmLLd" role="3LXTna">
-              <property role="3qWCbO" value="icons/**, resources/**" />
-            </node>
-            <node concept="398BVA" id="5py4VqXmLLe" role="3LXTmr">
-              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-              <node concept="2Ry0Ak" id="5py4VqXmLLf" role="iGT6I">
-                <property role="2Ry0Am" value="shadowmodels" />
-                <node concept="2Ry0Ak" id="5py4VqXmLLg" role="2Ry0An">
-                  <property role="2Ry0Am" value="solutions" />
-                  <node concept="2Ry0Ak" id="5py4VqXmLLh" role="2Ry0An">
-                    <property role="2Ry0Am" value="test.de.q60.mps.shadowmodels.examples" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1BupzO" id="7q24334ZKGl" role="3bR31x">
-          <property role="3ZfqAx" value="models" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="7q24334ZKGm" role="1HemKq">
-            <node concept="398BVA" id="7q24334ZKG4" role="3LXTmr">
-              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-              <node concept="2Ry0Ak" id="7q24334ZKG5" role="iGT6I">
-                <property role="2Ry0Am" value="shadowmodels" />
-                <node concept="2Ry0Ak" id="7q24334ZKG6" role="2Ry0An">
-                  <property role="2Ry0Am" value="solutions" />
-                  <node concept="2Ry0Ak" id="7q24334ZKG7" role="2Ry0An">
-                    <property role="2Ry0Am" value="test.de.q60.mps.shadowmodels.examples" />
-                    <node concept="2Ry0Ak" id="7q24334ZKG8" role="2Ry0An">
-                      <property role="2Ry0Am" value="models" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="7q24334ZKGn" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="3ofF9dt4hqS" role="3bR37C">
-          <node concept="3bR9La" id="3ofF9dt4hqT" role="1SiIV1">
-            <ref role="3bR37D" node="5U8hsWC70jw" resolve="org.modelix.model.api" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="3ofF9dt4hqU" role="3bR37C">
-          <node concept="3bR9La" id="3ofF9dt4hqV" role="1SiIV1">
-            <ref role="3bR37D" node="5U8hsWC71Xh" resolve="org.modelix.model.mpsadapters" />
-          </node>
-        </node>
-      </node>
-      <node concept="1E1JtA" id="5QP6xyk3oCB" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="test.de.q60.mps.shadowmodels.runtime" />
-        <property role="3LESm3" value="2df94ad8-121c-4ade-96b4-16b8cd29b0cc" />
-        <property role="aoJFB" value="eYcmk9QOlj/sources_and_tests" />
-        <node concept="398BVA" id="5QP6xyk3oCC" role="3LF7KH">
-          <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-          <node concept="2Ry0Ak" id="5QP6xyk3oCD" role="iGT6I">
-            <property role="2Ry0Am" value="shadowmodels" />
-            <node concept="2Ry0Ak" id="5QP6xyk3oCE" role="2Ry0An">
-              <property role="2Ry0Am" value="solutions" />
-              <node concept="2Ry0Ak" id="5QP6xyk3oCF" role="2Ry0An">
-                <property role="2Ry0Am" value="test.de.q60.mps.shadowmodels.runtime" />
-                <node concept="2Ry0Ak" id="5QP6xyk3oDJ" role="2Ry0An">
-                  <property role="2Ry0Am" value="test.de.q60.mps.shadowmodels.runtime.msd" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="5QP6xyk3oCJ" role="3bR37C">
-          <node concept="3bR9La" id="5QP6xyk3oCK" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="5QP6xyk3oCL" role="3bR37C">
-          <node concept="3bR9La" id="5QP6xyk3oCM" role="1SiIV1">
-            <ref role="3bR37D" node="4iIKqJTZ5Hm" resolve="de.q60.mps.shadowmodels.runtime" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="5QP6xyk3oDL" role="3bR37C">
-          <node concept="3bR9La" id="5QP6xyk3oDM" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:7Kfy9QB6KXW" resolve="jetbrains.mps.lang.core" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="5QP6xyk3oDN" role="3bR37C">
-          <node concept="3bR9La" id="5QP6xyk3oDO" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2fAW4lf42S" role="3bR37C">
-          <node concept="3bR9La" id="2fAW4lf42T" role="1SiIV1">
-            <ref role="3bR37D" node="4iIKqJTZ5HI" resolve="de.q60.mps.shadowmodels.runtimelang" />
-          </node>
-        </node>
-        <node concept="3rtmxn" id="5py4VqXmLLj" role="3bR31x">
-          <node concept="3LXTmp" id="5py4VqXmLLk" role="3rtmxm">
-            <node concept="3qWCbU" id="5py4VqXmLLl" role="3LXTna">
-              <property role="3qWCbO" value="icons/**, resources/**" />
-            </node>
-            <node concept="398BVA" id="5py4VqXmLLm" role="3LXTmr">
-              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-              <node concept="2Ry0Ak" id="5py4VqXmLLn" role="iGT6I">
-                <property role="2Ry0Am" value="shadowmodels" />
-                <node concept="2Ry0Ak" id="5py4VqXmLLo" role="2Ry0An">
-                  <property role="2Ry0Am" value="solutions" />
-                  <node concept="2Ry0Ak" id="5py4VqXmLLp" role="2Ry0An">
-                    <property role="2Ry0Am" value="test.de.q60.mps.shadowmodels.runtime" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="7q24334ZKGo" role="3bR37C">
-          <node concept="3bR9La" id="7q24334ZKGp" role="1SiIV1">
-            <ref role="3bR37D" node="6fQhGuklQWU" resolve="de.q60.mps.collections.libs" />
-          </node>
-        </node>
-        <node concept="1BupzO" id="7q24334ZKGF" role="3bR31x">
-          <property role="3ZfqAx" value="models" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="7q24334ZKGG" role="1HemKq">
-            <node concept="398BVA" id="7q24334ZKGq" role="3LXTmr">
-              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-              <node concept="2Ry0Ak" id="7q24334ZKGr" role="iGT6I">
-                <property role="2Ry0Am" value="shadowmodels" />
-                <node concept="2Ry0Ak" id="7q24334ZKGs" role="2Ry0An">
-                  <property role="2Ry0Am" value="solutions" />
-                  <node concept="2Ry0Ak" id="7q24334ZKGt" role="2Ry0An">
-                    <property role="2Ry0Am" value="test.de.q60.mps.shadowmodels.runtime" />
-                    <node concept="2Ry0Ak" id="7q24334ZKGu" role="2Ry0An">
-                      <property role="2Ry0Am" value="models" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="7q24334ZKGH" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="3ofF9dt4hrd" role="3bR37C">
-          <node concept="3bR9La" id="3ofF9dt4hre" role="1SiIV1">
-            <ref role="3bR37D" node="5U8hsWC73Be" resolve="org.modelix.model.repositoryconcepts" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="3ofF9dt4hrf" role="3bR37C">
-          <node concept="3bR9La" id="3ofF9dt4hrg" role="1SiIV1">
-            <ref role="3bR37D" node="5U8hsWC70jw" resolve="org.modelix.model.api" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="3ofF9dt4hrh" role="3bR37C">
-          <node concept="3bR9La" id="3ofF9dt4hri" role="1SiIV1">
-            <ref role="3bR37D" node="5U8hsWC71Xh" resolve="org.modelix.model.mpsadapters" />
-          </node>
-        </node>
-      </node>
-      <node concept="1E1JtA" id="7qGGLAjNnEU" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="test.de.q60.mps.incremental.runtime" />
-        <property role="3LESm3" value="c443280a-473c-4861-88cd-473f004f383a" />
-        <property role="aoJFB" value="eYcmk9QOlj/sources_and_tests" />
-        <node concept="398BVA" id="7qGGLAjNnFA" role="3LF7KH">
-          <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-          <node concept="2Ry0Ak" id="7qGGLAjNnFG" role="iGT6I">
-            <property role="2Ry0Am" value="shadowmodels" />
-            <node concept="2Ry0Ak" id="7qGGLAjNnFL" role="2Ry0An">
-              <property role="2Ry0Am" value="solutions" />
-              <node concept="2Ry0Ak" id="7qGGLAjNnFQ" role="2Ry0An">
-                <property role="2Ry0Am" value="test.de.q60.mps.incremental.runtime" />
-                <node concept="2Ry0Ak" id="7qGGLAjNnFV" role="2Ry0An">
-                  <property role="2Ry0Am" value="test.de.q60.mps.incremental.runtime.msd" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="7qGGLAjNnFX" role="3bR37C">
-          <node concept="3bR9La" id="7qGGLAjNnFY" role="1SiIV1">
-            <property role="3bR36h" value="true" />
-            <ref role="3bR37D" node="6fQhGuklPrV" resolve="de.q60.mps.incremental.runtime" />
-          </node>
-        </node>
-        <node concept="3rtmxn" id="5py4VqXmLLr" role="3bR31x">
-          <node concept="3LXTmp" id="5py4VqXmLLs" role="3rtmxm">
-            <node concept="3qWCbU" id="5py4VqXmLLt" role="3LXTna">
-              <property role="3qWCbO" value="icons/**, resources/**" />
-            </node>
-            <node concept="398BVA" id="5py4VqXmLLu" role="3LXTmr">
-              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-              <node concept="2Ry0Ak" id="5py4VqXmLLv" role="iGT6I">
-                <property role="2Ry0Am" value="shadowmodels" />
-                <node concept="2Ry0Ak" id="5py4VqXmLLw" role="2Ry0An">
-                  <property role="2Ry0Am" value="solutions" />
-                  <node concept="2Ry0Ak" id="5py4VqXmLLx" role="2Ry0An">
-                    <property role="2Ry0Am" value="test.de.q60.mps.incremental.runtime" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1BupzO" id="7q24334ZKGZ" role="3bR31x">
-          <property role="3ZfqAx" value="models" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="7q24334ZKH0" role="1HemKq">
-            <node concept="398BVA" id="7q24334ZKGI" role="3LXTmr">
-              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-              <node concept="2Ry0Ak" id="7q24334ZKGJ" role="iGT6I">
-                <property role="2Ry0Am" value="shadowmodels" />
-                <node concept="2Ry0Ak" id="7q24334ZKGK" role="2Ry0An">
-                  <property role="2Ry0Am" value="solutions" />
-                  <node concept="2Ry0Ak" id="7q24334ZKGL" role="2Ry0An">
-                    <property role="2Ry0Am" value="test.de.q60.mps.incremental.runtime" />
-                    <node concept="2Ry0Ak" id="7q24334ZKGM" role="2Ry0An">
-                      <property role="2Ry0Am" value="models" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="7q24334ZKH1" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="2G$12M" id="3$$s$wOI$Vt" role="3989C9">
-      <property role="TrG5h" value="widgets-tests" />
-      <node concept="1E1JtD" id="3$$s$wOI_E$" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="de.itemis.mps.editor.collapsible.testlang" />
-        <property role="3LESm3" value="d92a0cd8-920d-42ea-923c-f8c68d0a9444" />
-        <node concept="398BVA" id="3$$s$wOI_H4" role="3LF7KH">
-          <ref role="398BVh" node="3$$s$wOI_hD" resolve="widgets.home" />
-          <node concept="2Ry0Ak" id="3$$s$wOI_He" role="iGT6I">
-            <property role="2Ry0Am" value="languages" />
-            <node concept="2Ry0Ak" id="3$$s$wOI_Hn" role="2Ry0An">
-              <property role="2Ry0Am" value="de.itemis.mps.editor.collapsible.testlang" />
-              <node concept="2Ry0Ak" id="3$$s$wOI_Hw" role="2Ry0An">
-                <property role="2Ry0Am" value="de.itemis.mps.editor.collapsible.testlang.mpl" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3rtmxn" id="3$$s$wOI_H$" role="3bR31x">
-          <node concept="3LXTmp" id="3$$s$wOI_H_" role="3rtmxm">
-            <node concept="398BVA" id="3$$s$wOI_HA" role="3LXTmr">
-              <ref role="398BVh" node="3$$s$wOI_hD" resolve="widgets.home" />
-              <node concept="2Ry0Ak" id="3$$s$wOI_HB" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="3$$s$wOI_HC" role="2Ry0An">
-                  <property role="2Ry0Am" value="de.itemis.mps.editor.collapsible.testlang" />
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="3$$s$wOI_HE" role="3LXTna">
-              <property role="3qWCbO" value="icons/**" />
-            </node>
-          </node>
-        </node>
-        <node concept="1BupzO" id="7q24334ZKHn" role="3bR31x">
-          <property role="3ZfqAx" value="models" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="7q24334ZKHo" role="1HemKq">
-            <node concept="398BVA" id="7q24334ZKH2" role="3LXTmr">
-              <ref role="398BVh" node="3$$s$wOI_hD" resolve="widgets.home" />
-              <node concept="2Ry0Ak" id="7q24334ZKH3" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="7q24334ZKH4" role="2Ry0An">
-                  <property role="2Ry0Am" value="de.itemis.mps.editor.collapsible.testlang" />
-                  <node concept="2Ry0Ak" id="7q24334ZKH5" role="2Ry0An">
-                    <property role="2Ry0Am" value="models" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="7q24334ZKHp" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="1E1JtD" id="7CKpyI71cs0" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="de.itemis.mps.editor.enumeration.demolang" />
-        <property role="3LESm3" value="724a3ff4-f161-46ae-b766-26b81317341a" />
-        <node concept="398BVA" id="7CKpyI71cs1" role="3LF7KH">
-          <ref role="398BVh" node="3$$s$wOI_hD" resolve="widgets.home" />
-          <node concept="2Ry0Ak" id="7CKpyI71cs2" role="iGT6I">
-            <property role="2Ry0Am" value="languages" />
-            <node concept="2Ry0Ak" id="7CKpyI71cs3" role="2Ry0An">
-              <property role="2Ry0Am" value="de.itemis.mps.editor.enumeration.demolang" />
-              <node concept="2Ry0Ak" id="7CKpyI71ctb" role="2Ry0An">
-                <property role="2Ry0Am" value="de.itemis.mps.editor.enumeration.demolang.mpl" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3rtmxn" id="7CKpyI71cs5" role="3bR31x">
-          <node concept="3LXTmp" id="7CKpyI71cs6" role="3rtmxm">
-            <node concept="398BVA" id="7CKpyI71cs7" role="3LXTmr">
-              <ref role="398BVh" node="3$$s$wOI_hD" resolve="widgets.home" />
-              <node concept="2Ry0Ak" id="7CKpyI71cs8" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="7CKpyI71cs9" role="2Ry0An">
-                  <property role="2Ry0Am" value="de.itemis.mps.editor.collapsible.testlang" />
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="7CKpyI71csa" role="3LXTna">
-              <property role="3qWCbO" value="icons/**" />
-            </node>
-          </node>
-        </node>
-        <node concept="1BupzO" id="7q24334ZKIb" role="3bR31x">
-          <property role="3ZfqAx" value="models" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="7q24334ZKIc" role="1HemKq">
-            <node concept="398BVA" id="7q24334ZKHQ" role="3LXTmr">
-              <ref role="398BVh" node="3$$s$wOI_hD" resolve="widgets.home" />
-              <node concept="2Ry0Ak" id="7q24334ZKHR" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="7q24334ZKHS" role="2Ry0An">
-                  <property role="2Ry0Am" value="de.itemis.mps.editor.enumeration.demolang" />
-                  <node concept="2Ry0Ak" id="7q24334ZKHT" role="2Ry0An">
-                    <property role="2Ry0Am" value="models" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="7q24334ZKId" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="1E1JtD" id="7CKpyI71ctd" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="de.itemis.mps.editor.dropdown.demolang" />
-        <property role="3LESm3" value="6b5dd191-3c21-47c5-a7d3-c6e1f7c7cbd0" />
-        <node concept="398BVA" id="7CKpyI71cte" role="3LF7KH">
-          <ref role="398BVh" node="3$$s$wOI_hD" resolve="widgets.home" />
-          <node concept="2Ry0Ak" id="7CKpyI71ctf" role="iGT6I">
-            <property role="2Ry0Am" value="languages" />
-            <node concept="2Ry0Ak" id="7CKpyI71ctg" role="2Ry0An">
-              <property role="2Ry0Am" value="de.itemis.mps.editor.dropdown.demolang" />
-              <node concept="2Ry0Ak" id="7CKpyI71cuA" role="2Ry0An">
-                <property role="2Ry0Am" value="de.itemis.mps.editor.dropdown.demolang.mpl" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3rtmxn" id="7CKpyI71cti" role="3bR31x">
-          <node concept="3LXTmp" id="7CKpyI71ctj" role="3rtmxm">
-            <node concept="398BVA" id="7CKpyI71ctk" role="3LXTmr">
-              <ref role="398BVh" node="3$$s$wOI_hD" resolve="widgets.home" />
-              <node concept="2Ry0Ak" id="7CKpyI71ctl" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="7CKpyI71ctm" role="2Ry0An">
-                  <property role="2Ry0Am" value="de.itemis.mps.editor.collapsible.testlang" />
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="7CKpyI71ctn" role="3LXTna">
-              <property role="3qWCbO" value="icons/**" />
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="7CKpyI71cDi" role="3bR37C">
-          <node concept="3bR9La" id="7CKpyI71cDj" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
-          </node>
-        </node>
-        <node concept="1BupzO" id="7q24334ZKIZ" role="3bR31x">
-          <property role="3ZfqAx" value="languageModels" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="7q24334ZKJ0" role="1HemKq">
-            <node concept="398BVA" id="7q24334ZKIE" role="3LXTmr">
-              <ref role="398BVh" node="3$$s$wOI_hD" resolve="widgets.home" />
-              <node concept="2Ry0Ak" id="7q24334ZKIF" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="7q24334ZKIG" role="2Ry0An">
-                  <property role="2Ry0Am" value="de.itemis.mps.editor.dropdown.demolang" />
-                  <node concept="2Ry0Ak" id="7q24334ZKIH" role="2Ry0An">
-                    <property role="2Ry0Am" value="languageModels" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="7q24334ZKJ1" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="1E1JtD" id="7CKpyI71cuC" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="de.itemis.mps.editor.bool.demolang" />
-        <property role="3LESm3" value="8eb39fd6-60ad-48f0-8c8e-0ea1c36c2d65" />
-        <node concept="398BVA" id="7CKpyI71cuD" role="3LF7KH">
-          <ref role="398BVh" node="3$$s$wOI_hD" resolve="widgets.home" />
-          <node concept="2Ry0Ak" id="7CKpyI71cuE" role="iGT6I">
-            <property role="2Ry0Am" value="languages" />
-            <node concept="2Ry0Ak" id="7CKpyI71cuF" role="2Ry0An">
-              <property role="2Ry0Am" value="de.itemis.mps.editor.bool.demolang" />
-              <node concept="2Ry0Ak" id="7CKpyI71cwf" role="2Ry0An">
-                <property role="2Ry0Am" value="de.itemis.mps.editor.bool.demolang.mpl" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3rtmxn" id="7CKpyI71cuH" role="3bR31x">
-          <node concept="3LXTmp" id="7CKpyI71cuI" role="3rtmxm">
-            <node concept="398BVA" id="7CKpyI71cuJ" role="3LXTmr">
-              <ref role="398BVh" node="3$$s$wOI_hD" resolve="widgets.home" />
-              <node concept="2Ry0Ak" id="7CKpyI71cuK" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="7CKpyI71cuL" role="2Ry0An">
-                  <property role="2Ry0Am" value="de.itemis.mps.editor.collapsible.testlang" />
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="7CKpyI71cuM" role="3LXTna">
-              <property role="3qWCbO" value="icons/**" />
-            </node>
-          </node>
-        </node>
-        <node concept="1BupzO" id="7q24334ZKJN" role="3bR31x">
-          <property role="3ZfqAx" value="languageModels" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="7q24334ZKJO" role="1HemKq">
-            <node concept="398BVA" id="7q24334ZKJu" role="3LXTmr">
-              <ref role="398BVh" node="3$$s$wOI_hD" resolve="widgets.home" />
-              <node concept="2Ry0Ak" id="7q24334ZKJv" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="7q24334ZKJw" role="2Ry0An">
-                  <property role="2Ry0Am" value="de.itemis.mps.editor.bool.demolang" />
-                  <node concept="2Ry0Ak" id="7q24334ZKJx" role="2Ry0An">
-                    <property role="2Ry0Am" value="languageModels" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="7q24334ZKJP" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="1E1JtA" id="7CKpyI71cwh" role="2G$12L">
-        <property role="TrG5h" value="de.itemis.mps.editor.enumeration.sandbox" />
-        <property role="3LESm3" value="5ae18ad0-711b-4a36-b3e2-161124c395a2" />
-        <property role="aoJFB" value="eYcmk9QOli/sources" />
-        <property role="BnDLt" value="true" />
-        <node concept="398BVA" id="7CKpyI71cwi" role="3LF7KH">
-          <ref role="398BVh" node="3$$s$wOI_hD" resolve="widgets.home" />
-          <node concept="2Ry0Ak" id="7CKpyI71cwj" role="iGT6I">
-            <property role="2Ry0Am" value="languages" />
-            <node concept="2Ry0Ak" id="7CKpyI71cwk" role="2Ry0An">
-              <property role="2Ry0Am" value="de.itemis.mps.editor.enumeration" />
-              <node concept="2Ry0Ak" id="7CKpyI71cyG" role="2Ry0An">
-                <property role="2Ry0Am" value="sandbox" />
-                <node concept="2Ry0Ak" id="7CKpyI71cyL" role="2Ry0An">
-                  <property role="2Ry0Am" value="de.itemis.mps.editor.enumeration.sandbox.msd" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3rtmxn" id="7CKpyI71cwG" role="3bR31x">
-          <node concept="3LXTmp" id="7CKpyI71cwH" role="3rtmxm">
-            <node concept="398BVA" id="7CKpyI71cwI" role="3LXTmr">
-              <ref role="398BVh" node="3$$s$wOI_hD" resolve="widgets.home" />
-              <node concept="2Ry0Ak" id="7CKpyI71cwJ" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="7CKpyI71cwK" role="2Ry0An">
-                  <property role="2Ry0Am" value="de.itemis.mps.editor.collapsible.tests" />
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="7CKpyI71cwL" role="3LXTna">
-              <property role="3qWCbO" value="icons/**" />
-            </node>
-          </node>
-        </node>
-        <node concept="1BupzO" id="7q24334ZKL3" role="3bR31x">
-          <property role="3ZfqAx" value="models" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="7q24334ZKL4" role="1HemKq">
-            <node concept="398BVA" id="7q24334ZKKE" role="3LXTmr">
-              <ref role="398BVh" node="3$$s$wOI_hD" resolve="widgets.home" />
-              <node concept="2Ry0Ak" id="7q24334ZKKF" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="7q24334ZKKG" role="2Ry0An">
-                  <property role="2Ry0Am" value="de.itemis.mps.editor.enumeration" />
-                  <node concept="2Ry0Ak" id="7q24334ZKKH" role="2Ry0An">
-                    <property role="2Ry0Am" value="sandbox" />
-                    <node concept="2Ry0Ak" id="7q24334ZKKI" role="2Ry0An">
-                      <property role="2Ry0Am" value="models" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="7q24334ZKL5" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="1E1JtA" id="7CKpyI71cyN" role="2G$12L">
-        <property role="TrG5h" value="de.itemis.mps.editor.dropdown.sandbox" />
-        <property role="3LESm3" value="dba47e42-d4c1-4eae-bc35-556658c0dc1e" />
-        <property role="BnDLt" value="true" />
-        <property role="aoJFB" value="eYcmk9QOli/sources" />
-        <node concept="398BVA" id="7CKpyI71cyO" role="3LF7KH">
-          <ref role="398BVh" node="3$$s$wOI_hD" resolve="widgets.home" />
-          <node concept="2Ry0Ak" id="7CKpyI71cyP" role="iGT6I">
-            <property role="2Ry0Am" value="solutions" />
-            <node concept="2Ry0Ak" id="7CKpyI71cyQ" role="2Ry0An">
-              <property role="2Ry0Am" value="de.itemis.mps.editor.dropdown.sandbox" />
-              <node concept="2Ry0Ak" id="7CKpyI71cyR" role="2Ry0An">
-                <property role="2Ry0Am" value="de.itemis.mps.editor.dropdown.sandbox.msd" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3rtmxn" id="7CKpyI71czf" role="3bR31x">
-          <node concept="3LXTmp" id="7CKpyI71czg" role="3rtmxm">
-            <node concept="398BVA" id="7CKpyI71czh" role="3LXTmr">
-              <ref role="398BVh" node="3$$s$wOI_hD" resolve="widgets.home" />
-              <node concept="2Ry0Ak" id="7CKpyI71czi" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="7CKpyI71czj" role="2Ry0An">
-                  <property role="2Ry0Am" value="de.itemis.mps.editor.collapsible.tests" />
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="7CKpyI71czk" role="3LXTna">
-              <property role="3qWCbO" value="icons/**" />
-            </node>
-          </node>
-        </node>
-        <node concept="1BupzO" id="7q24334ZKLr" role="3bR31x">
-          <property role="3ZfqAx" value="models" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="7q24334ZKLs" role="1HemKq">
-            <node concept="398BVA" id="7q24334ZKL6" role="3LXTmr">
-              <ref role="398BVh" node="3$$s$wOI_hD" resolve="widgets.home" />
-              <node concept="2Ry0Ak" id="7q24334ZKL7" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="7q24334ZKL8" role="2Ry0An">
-                  <property role="2Ry0Am" value="de.itemis.mps.editor.dropdown.sandbox" />
-                  <node concept="2Ry0Ak" id="7q24334ZKL9" role="2Ry0An">
-                    <property role="2Ry0Am" value="models" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="7q24334ZKLt" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="1E1JtA" id="7CKpyI71c_M" role="2G$12L">
-        <property role="TrG5h" value="de.itemis.mps.editor.bool.sandbox" />
-        <property role="3LESm3" value="9820b889-0935-4e7a-92f1-44e7fd6edcc3" />
-        <property role="aoJFB" value="eYcmk9QOli/sources" />
-        <property role="BnDLt" value="true" />
-        <node concept="398BVA" id="7CKpyI71c_N" role="3LF7KH">
-          <ref role="398BVh" node="3$$s$wOI_hD" resolve="widgets.home" />
-          <node concept="2Ry0Ak" id="7CKpyI71c_O" role="iGT6I">
-            <property role="2Ry0Am" value="solutions" />
-            <node concept="2Ry0Ak" id="7CKpyI71c_P" role="2Ry0An">
-              <property role="2Ry0Am" value="de.itemis.mps.editor.bool.sandbox" />
-              <node concept="2Ry0Ak" id="7CKpyI71cDg" role="2Ry0An">
-                <property role="2Ry0Am" value="de.itemis.mps.editor.bool.sandbox.msd" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3rtmxn" id="7CKpyI71cAd" role="3bR31x">
-          <node concept="3LXTmp" id="7CKpyI71cAe" role="3rtmxm">
-            <node concept="398BVA" id="7CKpyI71cAf" role="3LXTmr">
-              <ref role="398BVh" node="3$$s$wOI_hD" resolve="widgets.home" />
-              <node concept="2Ry0Ak" id="7CKpyI71cAg" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="7CKpyI71cAh" role="2Ry0An">
-                  <property role="2Ry0Am" value="de.itemis.mps.editor.collapsible.tests" />
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="7CKpyI71cAi" role="3LXTna">
-              <property role="3qWCbO" value="icons/**" />
-            </node>
-          </node>
-        </node>
-        <node concept="1BupzO" id="7q24334ZKLN" role="3bR31x">
-          <property role="3ZfqAx" value="models" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="7q24334ZKLO" role="1HemKq">
-            <node concept="398BVA" id="7q24334ZKLu" role="3LXTmr">
-              <ref role="398BVh" node="3$$s$wOI_hD" resolve="widgets.home" />
-              <node concept="2Ry0Ak" id="7q24334ZKLv" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="7q24334ZKLw" role="2Ry0An">
-                  <property role="2Ry0Am" value="de.itemis.mps.editor.bool.sandbox" />
-                  <node concept="2Ry0Ak" id="7q24334ZKLx" role="2Ry0An">
-                    <property role="2Ry0Am" value="models" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="7q24334ZKLP" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="2G$12M" id="7qi8mU1OyZm" role="3989C9">
-      <property role="TrG5h" value="richtext-demo" />
-      <node concept="1E1JtD" id="7qi8mU1Oz8O" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="de.slisson.mps.javadoc" />
-        <property role="3LESm3" value="4e0df6bd-e265-4d63-9ca0-ca97e44cf841" />
-        <node concept="398BVA" id="7qi8mU1Oz8S" role="3LF7KH">
-          <ref role="398BVh" node="7qi8mU1Oz8V" resolve="richtext.home" />
-          <node concept="2Ry0Ak" id="7qi8mU1Oz9I" role="iGT6I">
-            <property role="2Ry0Am" value="languages" />
-            <node concept="2Ry0Ak" id="7qi8mU1Oz9N" role="2Ry0An">
-              <property role="2Ry0Am" value="javadoc" />
-              <node concept="2Ry0Ak" id="7qi8mU1Oz9S" role="2Ry0An">
-                <property role="2Ry0Am" value="javadoc.mpl" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="7qi8mU1Oz9U" role="3bR37C">
-          <node concept="3bR9La" id="7qi8mU1Oz9V" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="7qi8mU1Oz9W" role="3bR37C">
-          <node concept="3bR9La" id="7qi8mU1Oz9X" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:1TaHNgiIbIZ" resolve="MPS.Editor" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="7qi8mU1Oz9Y" role="3bR37C">
-          <node concept="3bR9La" id="7qi8mU1Oz9Z" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="7qi8mU1Oza0" role="3bR37C">
-          <node concept="3bR9La" id="7qi8mU1Oza1" role="1SiIV1">
-            <ref role="3bR37D" node="1sO539bGQvB" resolve="de.slisson.mps.richtext" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="7qi8mU1Oza2" role="3bR37C">
-          <node concept="1Busua" id="7qi8mU1Oza3" role="1SiIV1">
-            <ref role="1Busuk" node="1sO539bGQvB" resolve="de.slisson.mps.richtext" />
-          </node>
-        </node>
-        <node concept="3rtmxn" id="3D0nl1ssJIG" role="3bR31x">
-          <node concept="3LXTmp" id="3D0nl1ssJIH" role="3rtmxm">
-            <node concept="3qWCbU" id="3D0nl1ssJII" role="3LXTna">
-              <property role="3qWCbO" value="icons/**, resources/**" />
-            </node>
-            <node concept="398BVA" id="3D0nl1ssJIJ" role="3LXTmr">
-              <ref role="398BVh" node="7qi8mU1Oz8V" resolve="richtext.home" />
-              <node concept="2Ry0Ak" id="3D0nl1ssJIK" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="3D0nl1ssJIL" role="2Ry0An">
-                  <property role="2Ry0Am" value="javadoc" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1BupzO" id="7q24334ZKMb" role="3bR31x">
-          <property role="3ZfqAx" value="languageModels" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="7q24334ZKMc" role="1HemKq">
-            <node concept="398BVA" id="7q24334ZKLQ" role="3LXTmr">
-              <ref role="398BVh" node="7qi8mU1Oz8V" resolve="richtext.home" />
-              <node concept="2Ry0Ak" id="7q24334ZKLR" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="7q24334ZKLS" role="2Ry0An">
-                  <property role="2Ry0Am" value="javadoc" />
-                  <node concept="2Ry0Ak" id="7q24334ZKLT" role="2Ry0An">
-                    <property role="2Ry0Am" value="languageModels" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="7q24334ZKMd" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="1E1JtA" id="7qi8mU1Ozax" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="de.slisson.mps.richtext.sandbox" />
-        <property role="3LESm3" value="fdae84e9-f8df-4c2f-8de3-b45a7b6af77e" />
-        <node concept="398BVA" id="7qi8mU1OzaQ" role="3LF7KH">
-          <ref role="398BVh" node="7qi8mU1Oz8V" resolve="richtext.home" />
-          <node concept="2Ry0Ak" id="7qi8mU1OzaY" role="iGT6I">
-            <property role="2Ry0Am" value="solutions" />
-            <node concept="2Ry0Ak" id="7qi8mU1Ozb3" role="2Ry0An">
-              <property role="2Ry0Am" value="de.slisson.mps.richtext.sandbox" />
-              <node concept="2Ry0Ak" id="7qi8mU1Ozb8" role="2Ry0An">
-                <property role="2Ry0Am" value="de.slisson.mps.richtext.sandbox.msd" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="7qi8mU1Ozba" role="3bR37C">
-          <node concept="3bR9La" id="7qi8mU1Ozbb" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
-          </node>
-        </node>
-        <node concept="3rtmxn" id="3D0nl1ssJHO" role="3bR31x">
-          <node concept="3LXTmp" id="3D0nl1ssJHP" role="3rtmxm">
-            <node concept="3qWCbU" id="3D0nl1ssJHQ" role="3LXTna">
-              <property role="3qWCbO" value="icons/**, resources/**" />
-            </node>
-            <node concept="398BVA" id="3D0nl1ssJHR" role="3LXTmr">
-              <ref role="398BVh" node="7qi8mU1Oz8V" resolve="richtext.home" />
-              <node concept="2Ry0Ak" id="3D0nl1ssJHS" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="3D0nl1ssJHT" role="2Ry0An">
-                  <property role="2Ry0Am" value="de.slisson.mps.richtext.sandbox" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1BupzO" id="7q24334ZKMz" role="3bR31x">
-          <property role="3ZfqAx" value="models" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="7q24334ZKM$" role="1HemKq">
-            <node concept="398BVA" id="7q24334ZKMe" role="3LXTmr">
-              <ref role="398BVh" node="7qi8mU1Oz8V" resolve="richtext.home" />
-              <node concept="2Ry0Ak" id="7q24334ZKMf" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="7q24334ZKMg" role="2Ry0An">
-                  <property role="2Ry0Am" value="de.slisson.mps.richtext.sandbox" />
-                  <node concept="2Ry0Ak" id="7q24334ZKMh" role="2Ry0An">
-                    <property role="2Ry0Am" value="models" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="7q24334ZKM_" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="2G$12M" id="7qi8mU1Ozdr" role="3989C9">
-      <property role="TrG5h" value="multiline-demo" />
-      <node concept="1E1JtD" id="7qi8mU1Ozds" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="de.slisson.mps.editor.multiline.demolang" />
-        <property role="3LESm3" value="26a9201d-e70b-4755-acd6-40baf7a63b3a" />
-        <node concept="398BVA" id="7qi8mU1Ozdt" role="3LF7KH">
-          <ref role="398BVh" node="7qi8mU1OzcE" resolve="multiline.home" />
-          <node concept="2Ry0Ak" id="7qi8mU1Ozdu" role="iGT6I">
-            <property role="2Ry0Am" value="languages" />
-            <node concept="2Ry0Ak" id="7qi8mU1Ozdv" role="2Ry0An">
-              <property role="2Ry0Am" value="demolang" />
-              <node concept="2Ry0Ak" id="7qi8mU1OznV" role="2Ry0An">
-                <property role="2Ry0Am" value="demolang.mpl" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3rtmxn" id="3D0nl1ssJIN" role="3bR31x">
-          <node concept="3LXTmp" id="3D0nl1ssJIO" role="3rtmxm">
-            <node concept="3qWCbU" id="3D0nl1ssJIP" role="3LXTna">
-              <property role="3qWCbO" value="icons/**, resources/**" />
-            </node>
-            <node concept="398BVA" id="3D0nl1ssJIQ" role="3LXTmr">
-              <ref role="398BVh" node="7qi8mU1OzcE" resolve="multiline.home" />
-              <node concept="2Ry0Ak" id="3D0nl1ssJIR" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="3D0nl1ssJIS" role="2Ry0An">
-                  <property role="2Ry0Am" value="demolang" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1BupzO" id="7q24334ZKMV" role="3bR31x">
-          <property role="3ZfqAx" value="languageModels" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="7q24334ZKMW" role="1HemKq">
-            <node concept="398BVA" id="7q24334ZKMA" role="3LXTmr">
-              <ref role="398BVh" node="7qi8mU1OzcE" resolve="multiline.home" />
-              <node concept="2Ry0Ak" id="7q24334ZKMB" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="7q24334ZKMC" role="2Ry0An">
-                  <property role="2Ry0Am" value="demolang" />
-                  <node concept="2Ry0Ak" id="7q24334ZKMD" role="2Ry0An">
-                    <property role="2Ry0Am" value="languageModels" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="7q24334ZKMX" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="1E1JtA" id="7qi8mU1OzdF" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="de.slisson.mps.editor.multiline.sandbox" />
-        <property role="3LESm3" value="12db307d-5ea6-49b9-a36a-cb1cde091436" />
-        <node concept="398BVA" id="7qi8mU1OzdG" role="3LF7KH">
-          <ref role="398BVh" node="7qi8mU1OzcE" resolve="multiline.home" />
-          <node concept="2Ry0Ak" id="7qi8mU1OzdH" role="iGT6I">
-            <property role="2Ry0Am" value="solutions" />
-            <node concept="2Ry0Ak" id="7qi8mU1OzdI" role="2Ry0An">
-              <property role="2Ry0Am" value="de.slisson.mps.editor.multiline.sandbox" />
-              <node concept="2Ry0Ak" id="7qi8mU1OznX" role="2Ry0An">
-                <property role="2Ry0Am" value="de.slisson.mps.editor.multiline.sandbox.msd" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3rtmxn" id="3D0nl1ssJHV" role="3bR31x">
-          <node concept="3LXTmp" id="3D0nl1ssJHW" role="3rtmxm">
-            <node concept="3qWCbU" id="3D0nl1ssJHX" role="3LXTna">
-              <property role="3qWCbO" value="icons/**, resources/**" />
-            </node>
-            <node concept="398BVA" id="3D0nl1ssJHY" role="3LXTmr">
-              <ref role="398BVh" node="7qi8mU1OzcE" resolve="multiline.home" />
-              <node concept="2Ry0Ak" id="3D0nl1ssJHZ" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="3D0nl1ssJI0" role="2Ry0An">
-                  <property role="2Ry0Am" value="de.slisson.mps.editor.multiline.sandbox" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1BupzO" id="7q24334ZKNj" role="3bR31x">
-          <property role="3ZfqAx" value="models" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="7q24334ZKNk" role="1HemKq">
-            <node concept="398BVA" id="7q24334ZKMY" role="3LXTmr">
-              <ref role="398BVh" node="7qi8mU1OzcE" resolve="multiline.home" />
-              <node concept="2Ry0Ak" id="7q24334ZKMZ" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="7q24334ZKN0" role="2Ry0An">
-                  <property role="2Ry0Am" value="de.slisson.mps.editor.multiline.sandbox" />
-                  <node concept="2Ry0Ak" id="7q24334ZKN1" role="2Ry0An">
-                    <property role="2Ry0Am" value="models" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="7q24334ZKNl" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="2G$12M" id="7qi8mU1OznZ" role="3989C9">
-      <property role="TrG5h" value="conitional-editor-demo" />
-      <node concept="1E1JtD" id="7qi8mU1Ozo0" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="de.slisson.mps.conditionalEditor.demolang" />
-        <property role="3LESm3" value="1831633c-aea1-4345-beff-4a6e7fb4f813" />
-        <node concept="398BVA" id="7qi8mU1Ozo1" role="3LF7KH">
-          <ref role="398BVh" node="7qi8mU1OzW7" resolve="conditionalEditor.home" />
-          <node concept="2Ry0Ak" id="7qi8mU1Ozo2" role="iGT6I">
-            <property role="2Ry0Am" value="languages" />
-            <node concept="2Ry0Ak" id="7qi8mU1Ozo3" role="2Ry0An">
-              <property role="2Ry0Am" value="de.slisson.mps.conditionalEditor.demolang" />
-              <node concept="2Ry0Ak" id="7qi8mU1OzWY" role="2Ry0An">
-                <property role="2Ry0Am" value="de.slisson.mps.conditionalEditor.demolang.mpl" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="7qi8mU1Ozzw" role="3bR37C">
-          <node concept="3bR9La" id="7qi8mU1Ozzx" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:1TaHNgiIbIZ" resolve="MPS.Editor" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="7qi8mU1OzzA" role="3bR37C">
-          <node concept="1Busua" id="7qi8mU1OzzB" role="1SiIV1">
-            <ref role="1Busuk" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
-          </node>
-        </node>
-        <node concept="3rtmxn" id="3D0nl1ssJIU" role="3bR31x">
-          <node concept="3LXTmp" id="3D0nl1ssJIV" role="3rtmxm">
-            <node concept="3qWCbU" id="3D0nl1ssJIW" role="3LXTna">
-              <property role="3qWCbO" value="icons/**, resources/**" />
-            </node>
-            <node concept="398BVA" id="3D0nl1ssJIX" role="3LXTmr">
-              <ref role="398BVh" node="7qi8mU1OzW7" resolve="conditionalEditor.home" />
-              <node concept="2Ry0Ak" id="3D0nl1ssJIY" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="3D0nl1ssJIZ" role="2Ry0An">
-                  <property role="2Ry0Am" value="de.slisson.mps.conditionalEditor.demolang" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1BupzO" id="7q24334ZKNF" role="3bR31x">
-          <property role="3ZfqAx" value="languageModels" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="7q24334ZKNG" role="1HemKq">
-            <node concept="398BVA" id="7q24334ZKNm" role="3LXTmr">
-              <ref role="398BVh" node="7qi8mU1OzW7" resolve="conditionalEditor.home" />
-              <node concept="2Ry0Ak" id="7q24334ZKNn" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="7q24334ZKNo" role="2Ry0An">
-                  <property role="2Ry0Am" value="de.slisson.mps.conditionalEditor.demolang" />
-                  <node concept="2Ry0Ak" id="7q24334ZKNp" role="2Ry0An">
-                    <property role="2Ry0Am" value="languageModels" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="7q24334ZKNH" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="1E1JtA" id="7qi8mU1Ozo5" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="de.slisson.mps.conditionalEditor.sandbox" />
-        <property role="3LESm3" value="be556ac6-a425-413a-a574-3c2d4910a432" />
-        <node concept="398BVA" id="7qi8mU1Ozo6" role="3LF7KH">
-          <ref role="398BVh" node="7qi8mU1OzW7" resolve="conditionalEditor.home" />
-          <node concept="2Ry0Ak" id="7qi8mU1Ozo7" role="iGT6I">
-            <property role="2Ry0Am" value="solutions" />
-            <node concept="2Ry0Ak" id="7qi8mU1Ozo8" role="2Ry0An">
-              <property role="2Ry0Am" value="de.slisson.mps.conditionalEditor.sandbox" />
-              <node concept="2Ry0Ak" id="7qi8mU1OzXl" role="2Ry0An">
-                <property role="2Ry0Am" value="de.slisson.mps.conditionalEditor.sandbox.msd" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="7qi8mU1OzzP" role="3bR37C">
-          <node concept="3bR9La" id="7qi8mU1OzzQ" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
-          </node>
-        </node>
-        <node concept="3rtmxn" id="3D0nl1ssJI2" role="3bR31x">
-          <node concept="3LXTmp" id="3D0nl1ssJI3" role="3rtmxm">
-            <node concept="3qWCbU" id="3D0nl1ssJI4" role="3LXTna">
-              <property role="3qWCbO" value="icons/**, resources/**" />
-            </node>
-            <node concept="398BVA" id="3D0nl1ssJI5" role="3LXTmr">
-              <ref role="398BVh" node="7qi8mU1OzW7" resolve="conditionalEditor.home" />
-              <node concept="2Ry0Ak" id="3D0nl1ssJI6" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="3D0nl1ssJI7" role="2Ry0An">
-                  <property role="2Ry0Am" value="de.slisson.mps.conditionalEditor.sandbox" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1BupzO" id="7q24334ZKOv" role="3bR31x">
-          <property role="3ZfqAx" value="models" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="7q24334ZKOw" role="1HemKq">
-            <node concept="398BVA" id="7q24334ZKOa" role="3LXTmr">
-              <ref role="398BVh" node="7qi8mU1OzW7" resolve="conditionalEditor.home" />
-              <node concept="2Ry0Ak" id="7q24334ZKOb" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="7q24334ZKOc" role="2Ry0An">
-                  <property role="2Ry0Am" value="de.slisson.mps.conditionalEditor.sandbox" />
-                  <node concept="2Ry0Ak" id="7q24334ZKOd" role="2Ry0An">
-                    <property role="2Ry0Am" value="models" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="7q24334ZKOx" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="2G$12M" id="34tM7SkU508" role="3989C9">
-      <property role="TrG5h" value="math-demo" />
-      <node concept="1E1JtD" id="34tM7SkU5c3" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="de.itemis.mps.editor.math.demolang" />
-        <property role="3LESm3" value="76a53b21-d4a7-409f-93a2-e70951b4b3f9" />
-        <node concept="398BVA" id="34tM7SkU5c4" role="3LF7KH">
-          <ref role="398BVh" node="7qi8mU1Ozyi" resolve="math.home" />
-          <node concept="2Ry0Ak" id="34tM7SkU5c5" role="iGT6I">
-            <property role="2Ry0Am" value="languages" />
-            <node concept="2Ry0Ak" id="34tM7SkU5c6" role="2Ry0An">
-              <property role="2Ry0Am" value="de.itemis.mps.editor.math.demolang" />
-              <node concept="2Ry0Ak" id="34tM7SkU5cT" role="2Ry0An">
-                <property role="2Ry0Am" value="de.itemis.mps.editor.math.demolang.mpl" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="34tM7SkU5c8" role="3bR37C">
-          <node concept="3bR9La" id="34tM7SkU5c9" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:1TaHNgiIbIZ" resolve="MPS.Editor" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="34tM7SkU5ca" role="3bR37C">
-          <node concept="1Busua" id="34tM7SkU5cb" role="1SiIV1">
-            <ref role="1Busuk" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="34tM7SkU5d$" role="3bR37C">
-          <node concept="3bR9La" id="34tM7SkU5d_" role="1SiIV1">
-            <ref role="3bR37D" node="2Xjt3l57bIF" resolve="de.itemis.mps.editor.math" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="34tM7SkU5dA" role="3bR37C">
-          <node concept="3bR9La" id="34tM7SkU5dB" role="1SiIV1">
-            <ref role="3bR37D" node="6vUATgmxw8m" resolve="de.itemis.mps.editor.math.symbols" />
-          </node>
-        </node>
-        <node concept="3rtmxn" id="3D0nl1ssJJ1" role="3bR31x">
-          <node concept="3LXTmp" id="3D0nl1ssJJ2" role="3rtmxm">
-            <node concept="3qWCbU" id="3D0nl1ssJJ3" role="3LXTna">
-              <property role="3qWCbO" value="icons/**, resources/**" />
-            </node>
-            <node concept="398BVA" id="3D0nl1ssJJ4" role="3LXTmr">
-              <ref role="398BVh" node="7qi8mU1Ozyi" resolve="math.home" />
-              <node concept="2Ry0Ak" id="3D0nl1ssJJ5" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="3D0nl1ssJJ6" role="2Ry0An">
-                  <property role="2Ry0Am" value="de.itemis.mps.editor.math.demolang" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1BupzO" id="7q24334ZKOR" role="3bR31x">
-          <property role="3ZfqAx" value="languageModels" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="7q24334ZKOS" role="1HemKq">
-            <node concept="398BVA" id="7q24334ZKOy" role="3LXTmr">
-              <ref role="398BVh" node="7qi8mU1Ozyi" resolve="math.home" />
-              <node concept="2Ry0Ak" id="7q24334ZKOz" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="7q24334ZKO$" role="2Ry0An">
-                  <property role="2Ry0Am" value="de.itemis.mps.editor.math.demolang" />
-                  <node concept="2Ry0Ak" id="7q24334ZKO_" role="2Ry0An">
-                    <property role="2Ry0Am" value="languageModels" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="7q24334ZKOT" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="1E1JtD" id="34tM7SkU5cV" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="de.itemis.mps.editor.math.java" />
-        <property role="3LESm3" value="6ce9daa6-c7bc-4847-a19c-5cd82a4a13fc" />
-        <node concept="398BVA" id="34tM7SkU5cW" role="3LF7KH">
-          <ref role="398BVh" node="7qi8mU1Ozyi" resolve="math.home" />
-          <node concept="2Ry0Ak" id="34tM7SkU5cX" role="iGT6I">
-            <property role="2Ry0Am" value="languages" />
-            <node concept="2Ry0Ak" id="34tM7SkU5cY" role="2Ry0An">
-              <property role="2Ry0Am" value="de.itemis.mps.editor.math.java" />
-              <node concept="2Ry0Ak" id="34tM7SkU5dw" role="2Ry0An">
-                <property role="2Ry0Am" value="de.itemis.mps.editor.math.java.mpl" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="34tM7SkU5d2" role="3bR37C">
-          <node concept="1Busua" id="34tM7SkU5d3" role="1SiIV1">
-            <ref role="1Busuk" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
-          </node>
-        </node>
-        <node concept="1yeLz9" id="34tM7SkU5d4" role="1TViLv">
-          <property role="TrG5h" value="de.itemis.mps.editor.math.java#9023431908320258336" />
-          <property role="3LESm3" value="33d5b2aa-14ef-412a-a0e9-88e04a210e22" />
-          <node concept="1SiIV0" id="34tM7SkU5dJ" role="3bR37C">
-            <node concept="3bR9La" id="34tM7SkU5dK" role="1SiIV1">
-              <ref role="3bR37D" node="PE3B26QCrP" resolve="org.apache.commons" />
-            </node>
-          </node>
-          <node concept="1BupzO" id="7q24334ZKQ7" role="3bR31x">
-            <property role="3ZfqAx" value="generator/template" />
-            <property role="1Hdu6h" value="true" />
-            <property role="1HemKv" value="true" />
-            <node concept="3LXTmp" id="7q24334ZKQ8" role="1HemKq">
-              <node concept="398BVA" id="7q24334ZKPI" role="3LXTmr">
-                <ref role="398BVh" node="7qi8mU1Ozyi" resolve="math.home" />
-                <node concept="2Ry0Ak" id="7q24334ZKPJ" role="iGT6I">
-                  <property role="2Ry0Am" value="languages" />
-                  <node concept="2Ry0Ak" id="7q24334ZKPK" role="2Ry0An">
-                    <property role="2Ry0Am" value="de.itemis.mps.editor.math.java" />
-                    <node concept="2Ry0Ak" id="7q24334ZKPL" role="2Ry0An">
-                      <property role="2Ry0Am" value="generator" />
-                      <node concept="2Ry0Ak" id="7q24334ZKPM" role="2Ry0An">
-                        <property role="2Ry0Am" value="template" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3qWCbU" id="7q24334ZKQ9" role="3LXTna">
-                <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="34tM7SkU5dC" role="3bR37C">
-          <node concept="3bR9La" id="34tM7SkU5dD" role="1SiIV1">
-            <ref role="3bR37D" node="2Xjt3l57bIF" resolve="de.itemis.mps.editor.math" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="34tM7SkU5dE" role="3bR37C">
-          <node concept="3bR9La" id="34tM7SkU5dF" role="1SiIV1">
-            <ref role="3bR37D" node="6vUATgmxw8m" resolve="de.itemis.mps.editor.math.symbols" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="34tM7SkU5dG" role="3bR37C">
-          <node concept="3bR9La" id="34tM7SkU5dH" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:1d41uYMTVPB" resolve="jetbrains.mps.lang.scopes.runtime" />
-          </node>
-        </node>
-        <node concept="1E0d5M" id="34tM7SkU5dI" role="1E1XAP">
-          <ref role="1E0d5P" node="PE3B26QCrP" resolve="org.apache.commons" />
-        </node>
-        <node concept="3rtmxn" id="3D0nl1ssJJ8" role="3bR31x">
-          <node concept="3LXTmp" id="3D0nl1ssJJ9" role="3rtmxm">
-            <node concept="3qWCbU" id="3D0nl1ssJJa" role="3LXTna">
-              <property role="3qWCbO" value="icons/**, resources/**" />
-            </node>
-            <node concept="398BVA" id="3D0nl1ssJJb" role="3LXTmr">
-              <ref role="398BVh" node="7qi8mU1Ozyi" resolve="math.home" />
-              <node concept="2Ry0Ak" id="3D0nl1ssJJc" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="3D0nl1ssJJd" role="2Ry0An">
-                  <property role="2Ry0Am" value="de.itemis.mps.editor.math.java" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1BupzO" id="7q24334ZKPF" role="3bR31x">
-          <property role="3ZfqAx" value="languageModels" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="7q24334ZKPG" role="1HemKq">
-            <node concept="398BVA" id="7q24334ZKPm" role="3LXTmr">
-              <ref role="398BVh" node="7qi8mU1Ozyi" resolve="math.home" />
-              <node concept="2Ry0Ak" id="7q24334ZKPn" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="7q24334ZKPo" role="2Ry0An">
-                  <property role="2Ry0Am" value="de.itemis.mps.editor.math.java" />
-                  <node concept="2Ry0Ak" id="7q24334ZKPp" role="2Ry0An">
-                    <property role="2Ry0Am" value="languageModels" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="7q24334ZKPH" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2obP5Y848D_" role="3bR37C">
-          <node concept="Rbm2T" id="2obP5Y848DA" role="1SiIV1">
-            <ref role="1E1Vl2" to="ffeo:7Kfy9QB6KZG" resolve="jetbrains.mps.baseLanguage.closures" />
-          </node>
-        </node>
-      </node>
-      <node concept="1E1JtA" id="34tM7SkU50j" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="de.itemis.mps.editor.math.sandbox" />
-        <property role="3LESm3" value="c189a833-e32c-49bf-b32e-a93144e7f4c2" />
-        <node concept="398BVA" id="34tM7SkU50k" role="3LF7KH">
-          <ref role="398BVh" node="7qi8mU1Ozyi" resolve="math.home" />
-          <node concept="2Ry0Ak" id="34tM7SkU50l" role="iGT6I">
-            <property role="2Ry0Am" value="solutions" />
-            <node concept="2Ry0Ak" id="34tM7SkU50m" role="2Ry0An">
-              <property role="2Ry0Am" value="de.itemis.mps.editor.math.sandbox" />
-              <node concept="2Ry0Ak" id="34tM7SkU5dy" role="2Ry0An">
-                <property role="2Ry0Am" value="de.itemis.mps.editor.math.sandbox.msd" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="34tM7SkU50o" role="3bR37C">
-          <node concept="3bR9La" id="34tM7SkU50p" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
-          </node>
-        </node>
-        <node concept="3rtmxn" id="3D0nl1ssJI9" role="3bR31x">
-          <node concept="3LXTmp" id="3D0nl1ssJIa" role="3rtmxm">
-            <node concept="3qWCbU" id="3D0nl1ssJIb" role="3LXTna">
-              <property role="3qWCbO" value="icons/**, resources/**" />
-            </node>
-            <node concept="398BVA" id="3D0nl1ssJIc" role="3LXTmr">
-              <ref role="398BVh" node="7qi8mU1Ozyi" resolve="math.home" />
-              <node concept="2Ry0Ak" id="3D0nl1ssJId" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="3D0nl1ssJIe" role="2Ry0An">
-                  <property role="2Ry0Am" value="de.itemis.mps.editor.math.sandbox" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1BupzO" id="7q24334ZKQv" role="3bR31x">
-          <property role="3ZfqAx" value="models" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="7q24334ZKQw" role="1HemKq">
-            <node concept="398BVA" id="7q24334ZKQa" role="3LXTmr">
-              <ref role="398BVh" node="7qi8mU1Ozyi" resolve="math.home" />
-              <node concept="2Ry0Ak" id="7q24334ZKQb" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="7q24334ZKQc" role="2Ry0An">
-                  <property role="2Ry0Am" value="de.itemis.mps.editor.math.sandbox" />
-                  <node concept="2Ry0Ak" id="7q24334ZKQd" role="2Ry0An">
-                    <property role="2Ry0Am" value="models" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="7q24334ZKQx" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="2G$12M" id="7qi8mU1OzZs" role="3989C9">
-      <property role="TrG5h" value="celllayout-demo" />
-      <node concept="1E1JtA" id="5mH$9t6eAsB" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="test.de.itemis.mps.editor.celllayout" />
-        <property role="3LESm3" value="980a0de7-66ea-4656-ae70-f553227d6102" />
-        <property role="aoJFB" value="eYcmk9QOlj/sources_and_tests" />
-        <node concept="398BVA" id="5mH$9t6eAsC" role="3LF7KH">
-          <ref role="398BVh" node="5mH$9t6eA_$" resolve="celllayout.home" />
-          <node concept="2Ry0Ak" id="5mH$9t6eAsD" role="iGT6I">
-            <property role="2Ry0Am" value="solutions" />
-            <node concept="2Ry0Ak" id="5mH$9t6eAsE" role="2Ry0An">
-              <property role="2Ry0Am" value="test.de.itemis.mps.editor.celllayout.runtime" />
-              <node concept="2Ry0Ak" id="5mH$9t6eAT_" role="2Ry0An">
-                <property role="2Ry0Am" value="test.de.itemis.mps.editor.celllayout.msd" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="5mH$9t6eAsI" role="3bR37C">
-          <node concept="3bR9La" id="5mH$9t6eAsJ" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
-          </node>
-        </node>
-        <node concept="3rtmxn" id="5mH$9t6eAsK" role="3bR31x">
-          <node concept="3LXTmp" id="5mH$9t6eAsL" role="3rtmxm">
-            <node concept="3qWCbU" id="5mH$9t6eAsM" role="3LXTna">
-              <property role="3qWCbO" value="icons/**, resources/**" />
-            </node>
-            <node concept="398BVA" id="PE3B26qlyY" role="3LXTmr">
-              <ref role="398BVh" node="5mH$9t6eA_$" resolve="celllayout.home" />
-              <node concept="2Ry0Ak" id="PE3B26qlyZ" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="PE3B26qlz0" role="2Ry0An">
-                  <property role="2Ry0Am" value="test.de.itemis.mps.editor.celllayout.runtime" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="5mH$9t6eAsS" role="3bR37C">
-          <node concept="3bR9La" id="5mH$9t6eAsT" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:1TaHNgiIbJ$" resolve="jetbrains.mps.ide.editor" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="5mH$9t6eAW_" role="3bR37C">
-          <node concept="3bR9La" id="5mH$9t6eAWA" role="1SiIV1">
-            <property role="3bR36h" value="true" />
-            <ref role="3bR37D" node="6SVXTgIejl1" resolve="de.itemis.mps.editor.celllayout.runtime" />
-          </node>
-        </node>
-        <node concept="1BupzO" id="7q24334ZKQR" role="3bR31x">
-          <property role="3ZfqAx" value="models" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="7q24334ZKQS" role="1HemKq">
-            <node concept="398BVA" id="7q24334ZKQy" role="3LXTmr">
-              <ref role="398BVh" node="5mH$9t6eA_$" resolve="celllayout.home" />
-              <node concept="2Ry0Ak" id="7q24334ZKQz" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="7q24334ZKQ$" role="2Ry0An">
-                  <property role="2Ry0Am" value="test.de.itemis.mps.editor.celllayout.runtime" />
-                  <node concept="2Ry0Ak" id="7q24334ZKQ_" role="2Ry0An">
-                    <property role="2Ry0Am" value="models" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="7q24334ZKQT" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="1E1JtD" id="5mH$9t6eBsU" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="test.de.itemis.mps.editor.celllayout.lang" />
-        <property role="3LESm3" value="e0fad6e1-a8d0-4af5-9a40-01cc391c0908" />
-        <node concept="398BVA" id="5mH$9t6eBsV" role="3LF7KH">
-          <ref role="398BVh" node="5mH$9t6eA_$" resolve="celllayout.home" />
-          <node concept="2Ry0Ak" id="5mH$9t6eBsW" role="iGT6I">
-            <property role="2Ry0Am" value="languages" />
-            <node concept="2Ry0Ak" id="5mH$9t6eBsX" role="2Ry0An">
-              <property role="2Ry0Am" value="test.de.itemis.mps.editor.celllayout.lang" />
-              <node concept="2Ry0Ak" id="5mH$9t6eBEv" role="2Ry0An">
-                <property role="2Ry0Am" value="test.de.itemis.mps.editor.celllayout.lang.mpl" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1E0d5M" id="5mH$9t6eBsZ" role="1E1XAP">
-          <ref role="1E0d5P" node="6$6tsX_CURF" resolve="de.slisson.mps.structurecheck.runtime" />
-        </node>
-        <node concept="3rtmxn" id="5mH$9t6eBt3" role="3bR31x">
-          <node concept="3LXTmp" id="5mH$9t6eBt4" role="3rtmxm">
-            <node concept="3qWCbU" id="5mH$9t6eBt5" role="3LXTna">
-              <property role="3qWCbO" value="icons/**, resources/**" />
-            </node>
-            <node concept="398BVA" id="PE3B26qlse" role="3LXTmr">
-              <ref role="398BVh" node="5mH$9t6eA_$" resolve="celllayout.home" />
-              <node concept="2Ry0Ak" id="PE3B26qlsf" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="PE3B26qlsg" role="2Ry0An">
-                  <property role="2Ry0Am" value="test.de.itemis.mps.editor.celllayout.lang" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="5mH$9t6eBte" role="3bR37C">
-          <node concept="3bR9La" id="5mH$9t6eBtf" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:1TaHNgiIbIZ" resolve="MPS.Editor" />
-          </node>
-        </node>
-        <node concept="1E0d5M" id="5mH$9t6eBtk" role="1E1XAP">
-          <ref role="1E0d5P" node="29so9Vb$6T5" resolve="de.slisson.mps.tables.runtime" />
-        </node>
-        <node concept="1SiIV0" id="5mH$9t6eBHL" role="3bR37C">
-          <node concept="3bR9La" id="5mH$9t6eBHM" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:1H905DlDUSw" resolve="MPS.OpenAPI" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="5mH$9t6eBHN" role="3bR37C">
-          <node concept="3bR9La" id="5mH$9t6eBHO" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:1TaHNgiIbJb" resolve="MPS.Platform" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="5mH$9t6eBHP" role="3bR37C">
-          <node concept="3bR9La" id="5mH$9t6eBHQ" role="1SiIV1">
-            <property role="3bR36h" value="true" />
-            <ref role="3bR37D" node="6SVXTgIejl1" resolve="de.itemis.mps.editor.celllayout.runtime" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="5mH$9t6eBHR" role="3bR37C">
-          <node concept="3bR9La" id="5mH$9t6eBHS" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:ymnOULAU0H" resolve="jetbrains.mps.lang.test" />
-          </node>
-        </node>
-        <node concept="1E0d5M" id="2fo8bJECGDq" role="1E1XAP">
-          <ref role="1E0d5P" node="6SVXTgIejl1" resolve="de.itemis.mps.editor.celllayout.runtime" />
-        </node>
-        <node concept="1BupzO" id="7q24334ZKRf" role="3bR31x">
-          <property role="3ZfqAx" value="models" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="7q24334ZKRg" role="1HemKq">
-            <node concept="398BVA" id="7q24334ZKQU" role="3LXTmr">
-              <ref role="398BVh" node="5mH$9t6eA_$" resolve="celllayout.home" />
-              <node concept="2Ry0Ak" id="7q24334ZKQV" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="7q24334ZKQW" role="2Ry0An">
-                  <property role="2Ry0Am" value="test.de.itemis.mps.editor.celllayout.lang" />
-                  <node concept="2Ry0Ak" id="7q24334ZKQX" role="2Ry0An">
-                    <property role="2Ry0Am" value="models" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="7q24334ZKRh" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="1E1JtD" id="7qi8mU1OzZt" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="de.itemis.mps.editor.celllayout.sandboxlang" />
-        <property role="3LESm3" value="a49c7665-6e20-479f-8483-903f65b74ed2" />
-        <node concept="398BVA" id="7qi8mU1OzZu" role="3LF7KH">
-          <ref role="398BVh" node="5mH$9t6eA_$" resolve="celllayout.home" />
-          <node concept="2Ry0Ak" id="7qi8mU1OzZv" role="iGT6I">
-            <property role="2Ry0Am" value="languages" />
-            <node concept="2Ry0Ak" id="7qi8mU1OzZw" role="2Ry0An">
-              <property role="2Ry0Am" value="de.itemis.mps.editor.celllayout.sandboxlang" />
-              <node concept="2Ry0Ak" id="7qi8mU1O$bJ" role="2Ry0An">
-                <property role="2Ry0Am" value="de.itemis.mps.editor.celllayout.sandboxlang.mpl" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3rtmxn" id="3D0nl1ssJJf" role="3bR31x">
-          <node concept="3LXTmp" id="3D0nl1ssJJg" role="3rtmxm">
-            <node concept="3qWCbU" id="3D0nl1ssJJh" role="3LXTna">
-              <property role="3qWCbO" value="icons/**, resources/**" />
-            </node>
-            <node concept="398BVA" id="3D0nl1ssJJi" role="3LXTmr">
-              <ref role="398BVh" node="5mH$9t6eA_$" resolve="celllayout.home" />
-              <node concept="2Ry0Ak" id="3D0nl1ssJJj" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="3D0nl1ssJJk" role="2Ry0An">
-                  <property role="2Ry0Am" value="de.itemis.mps.editor.celllayout.sandboxlang" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1BupzO" id="7q24334ZKS3" role="3bR31x">
-          <property role="3ZfqAx" value="models" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="7q24334ZKS4" role="1HemKq">
-            <node concept="398BVA" id="7q24334ZKRI" role="3LXTmr">
-              <ref role="398BVh" node="5mH$9t6eA_$" resolve="celllayout.home" />
-              <node concept="2Ry0Ak" id="7q24334ZKRJ" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="7q24334ZKRK" role="2Ry0An">
-                  <property role="2Ry0Am" value="de.itemis.mps.editor.celllayout.sandboxlang" />
-                  <node concept="2Ry0Ak" id="7q24334ZKRL" role="2Ry0An">
-                    <property role="2Ry0Am" value="models" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="7q24334ZKS5" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="1E1JtA" id="7qi8mU1OzZB" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="de.itemis.mps.editor.celllayout.sandbox" />
-        <property role="3LESm3" value="3d5ab66d-c2b3-48c1-883a-d9c0e3febd61" />
-        <node concept="398BVA" id="7qi8mU1OzZC" role="3LF7KH">
-          <ref role="398BVh" node="5mH$9t6eA_$" resolve="celllayout.home" />
-          <node concept="2Ry0Ak" id="7qi8mU1OzZD" role="iGT6I">
-            <property role="2Ry0Am" value="solutions" />
-            <node concept="2Ry0Ak" id="7qi8mU1OzZE" role="2Ry0An">
-              <property role="2Ry0Am" value="de.itemis.mps.editor.celllayout.sandbox" />
-              <node concept="2Ry0Ak" id="7qi8mU1O$bL" role="2Ry0An">
-                <property role="2Ry0Am" value="de.itemis.mps.editor.celllayout.sandbox.msd" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3rtmxn" id="3D0nl1ssJIg" role="3bR31x">
-          <node concept="3LXTmp" id="3D0nl1ssJIh" role="3rtmxm">
-            <node concept="3qWCbU" id="3D0nl1ssJIi" role="3LXTna">
-              <property role="3qWCbO" value="icons/**, resources/**" />
-            </node>
-            <node concept="398BVA" id="3D0nl1ssJIj" role="3LXTmr">
-              <ref role="398BVh" node="5mH$9t6eA_$" resolve="celllayout.home" />
-              <node concept="2Ry0Ak" id="3D0nl1ssJIk" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="3D0nl1ssJIl" role="2Ry0An">
-                  <property role="2Ry0Am" value="de.itemis.mps.editor.celllayout.sandbox" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1BupzO" id="7q24334ZKSR" role="3bR31x">
-          <property role="3ZfqAx" value="models" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="7q24334ZKSS" role="1HemKq">
-            <node concept="398BVA" id="7q24334ZKSy" role="3LXTmr">
-              <ref role="398BVh" node="5mH$9t6eA_$" resolve="celllayout.home" />
-              <node concept="2Ry0Ak" id="7q24334ZKSz" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="7q24334ZKS$" role="2Ry0An">
-                  <property role="2Ry0Am" value="de.itemis.mps.editor.celllayout.sandbox" />
-                  <node concept="2Ry0Ak" id="7q24334ZKS_" role="2Ry0An">
-                    <property role="2Ry0Am" value="models" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="7q24334ZKST" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="2G$12M" id="7qi8mU1Oz$g" role="3989C9">
-      <property role="TrG5h" value="diagrams" />
-      <node concept="1E1JtD" id="6$6tsX_CJi6" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="de.itemis.mps.editor.diagram.demo.activity" />
-        <property role="3LESm3" value="5a82b7b8-2303-45be-b960-4e3ff16e82ce" />
-        <node concept="398BVA" id="6$6tsX_CJj$" role="3LF7KH">
-          <ref role="398BVh" node="6$6tsX_CF7m" resolve="diagram.home" />
-          <node concept="2Ry0Ak" id="6$6tsX_CJko" role="iGT6I">
-            <property role="2Ry0Am" value="languages" />
-            <node concept="2Ry0Ak" id="6$6tsX_CJlb" role="2Ry0An">
-              <property role="2Ry0Am" value="de.itemis.mps.editor.diagram.demo.activity" />
-              <node concept="2Ry0Ak" id="6$6tsX_CJlY" role="2Ry0An">
-                <property role="2Ry0Am" value="de.itemis.mps.editor.diagram.demo.activity.mpl" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="6$6tsX_CJv4" role="3bR37C">
-          <node concept="3bR9La" id="6$6tsX_CJv5" role="1SiIV1">
-            <ref role="3bR37D" node="4be$WTb1AQa" resolve="de.itemis.mps.editor.diagram.runtime" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="6$6tsX_CJv6" role="3bR37C">
-          <node concept="3bR9La" id="6$6tsX_CJv7" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="6$6tsX_CJv8" role="3bR37C">
-          <node concept="3bR9La" id="6$6tsX_CJv9" role="1SiIV1">
-            <ref role="3bR37D" node="6wEeo$QJAsB" resolve="de.itemis.mps.editor.diagram.shapes" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="6$6tsX_CJva" role="3bR37C">
-          <node concept="1Busua" id="6$6tsX_CJvb" role="1SiIV1">
-            <ref role="1Busuk" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
-          </node>
-        </node>
-        <node concept="3rtmxn" id="3xFG3bj5MnI" role="3bR31x">
-          <node concept="3LXTmp" id="3xFG3bj5MnJ" role="3rtmxm">
-            <node concept="3qWCbU" id="3xFG3bj5MnK" role="3LXTna">
-              <property role="3qWCbO" value="icons/**, resources/**" />
-            </node>
-            <node concept="398BVA" id="3xFG3bj5MnL" role="3LXTmr">
-              <ref role="398BVh" node="6$6tsX_CF7m" resolve="diagram.home" />
-              <node concept="2Ry0Ak" id="3xFG3bj5MnM" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="3xFG3bj5MnN" role="2Ry0An">
-                  <property role="2Ry0Am" value="de.itemis.mps.editor.diagram.demo.activity" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1BupzO" id="7q24334ZKTf" role="3bR31x">
-          <property role="3ZfqAx" value="languageModels" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="7q24334ZKTg" role="1HemKq">
-            <node concept="398BVA" id="7q24334ZKSU" role="3LXTmr">
-              <ref role="398BVh" node="6$6tsX_CF7m" resolve="diagram.home" />
-              <node concept="2Ry0Ak" id="7q24334ZKSV" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="7q24334ZKSW" role="2Ry0An">
-                  <property role="2Ry0Am" value="de.itemis.mps.editor.diagram.demo.activity" />
-                  <node concept="2Ry0Ak" id="7q24334ZKSX" role="2Ry0An">
-                    <property role="2Ry0Am" value="languageModels" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="7q24334ZKTh" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="1E1JtD" id="6$6tsX_CISo" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="test.de.itemis.mps.editor.diagram.lang" />
-        <property role="3LESm3" value="aff569ad-098d-414a-aa23-96963959392c" />
-        <node concept="398BVA" id="6$6tsX_CJbC" role="3LF7KH">
-          <ref role="398BVh" node="6$6tsX_CF7m" resolve="diagram.home" />
-          <node concept="2Ry0Ak" id="6$6tsX_CJbS" role="iGT6I">
-            <property role="2Ry0Am" value="languages" />
-            <node concept="2Ry0Ak" id="6$6tsX_CJc7" role="2Ry0An">
-              <property role="2Ry0Am" value="test.de.itemis.mps.editor.diagram.lang" />
-              <node concept="2Ry0Ak" id="6$6tsX_CJcm" role="2Ry0An">
-                <property role="2Ry0Am" value="test.de.itemis.mps.editor.diagram.lang.mpl" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="6$6tsX_CJt8" role="3bR37C">
-          <node concept="3bR9La" id="6$6tsX_CJt9" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:7Kfy9QB6L4X" resolve="jetbrains.mps.lang.editor" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="6$6tsX_CJta" role="3bR37C">
-          <node concept="3bR9La" id="6$6tsX_CJtb" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:1H905DlDUSw" resolve="MPS.OpenAPI" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="6$6tsX_CJtc" role="3bR37C">
-          <node concept="3bR9La" id="6$6tsX_CJtd" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
-          </node>
-        </node>
-        <node concept="3rtmxn" id="3xFG3bj5Mlq" role="3bR31x">
-          <node concept="3LXTmp" id="3xFG3bj5Mlr" role="3rtmxm">
-            <node concept="3qWCbU" id="3xFG3bj5Mls" role="3LXTna">
-              <property role="3qWCbO" value="icons/**, resources/**" />
-            </node>
-            <node concept="398BVA" id="3xFG3bj5Mlt" role="3LXTmr">
-              <ref role="398BVh" node="6$6tsX_CF7m" resolve="diagram.home" />
-              <node concept="2Ry0Ak" id="3xFG3bj5Mlu" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="3xFG3bj5Mlv" role="2Ry0An">
-                  <property role="2Ry0Am" value="test.de.itemis.mps.editor.diagram.lang" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="PE3B26v8j3" role="3bR37C">
-          <node concept="3bR9La" id="PE3B26v8j4" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
-          </node>
-        </node>
-        <node concept="3bR9La" id="2fo8bJECyg7" role="3bR37C">
-          <ref role="3bR37D" node="4be$WTb1CbJ" resolve="de.itemis.mps.editor.diagram" />
-        </node>
-        <node concept="1BupzO" id="7q24334ZKU3" role="3bR31x">
-          <property role="3ZfqAx" value="languageModels" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="7q24334ZKU4" role="1HemKq">
-            <node concept="398BVA" id="7q24334ZKTI" role="3LXTmr">
-              <ref role="398BVh" node="6$6tsX_CF7m" resolve="diagram.home" />
-              <node concept="2Ry0Ak" id="7q24334ZKTJ" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="7q24334ZKTK" role="2Ry0An">
-                  <property role="2Ry0Am" value="test.de.itemis.mps.editor.diagram.lang" />
-                  <node concept="2Ry0Ak" id="7q24334ZKTL" role="2Ry0An">
-                    <property role="2Ry0Am" value="languageModels" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="7q24334ZKU5" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="1E1JtA" id="6$6tsX_CJdr" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="test.de.itemis.mps.editor.diagram.solution" />
-        <property role="3LESm3" value="a47122e4-d14a-4912-90ff-6967ad1e3b02" />
-        <property role="aoJFB" value="eYcmk9QOlj/sources_and_tests" />
-        <node concept="398BVA" id="6$6tsX_CJei" role="3LF7KH">
-          <ref role="398BVh" node="6$6tsX_CF7m" resolve="diagram.home" />
-          <node concept="2Ry0Ak" id="6$6tsX_CJeO" role="iGT6I">
-            <property role="2Ry0Am" value="solutions" />
-            <node concept="2Ry0Ak" id="6$6tsX_CJfu" role="2Ry0An">
-              <property role="2Ry0Am" value="test.de.itemis.mps.editor.diagram.solution" />
-              <node concept="2Ry0Ak" id="6$6tsX_CJg8" role="2Ry0An">
-                <property role="2Ry0Am" value="test.de.itemis.mps.editor.diagram.solution.msd" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="6$6tsX_CJx8" role="3bR37C">
-          <node concept="3bR9La" id="6$6tsX_CJx9" role="1SiIV1">
-            <ref role="3bR37D" node="6$6tsX_CJi6" resolve="de.itemis.mps.editor.diagram.demo.activity" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="6$6tsX_CJxa" role="3bR37C">
-          <node concept="3bR9La" id="6$6tsX_CJxb" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:1TaHNgiIbIZ" resolve="MPS.Editor" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="6$6tsX_CJxc" role="3bR37C">
-          <node concept="3bR9La" id="6$6tsX_CJxd" role="1SiIV1">
-            <ref role="3bR37D" node="6$6tsX_CISo" resolve="test.de.itemis.mps.editor.diagram.lang" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="6$6tsX_CJxe" role="3bR37C">
-          <node concept="3bR9La" id="6$6tsX_CJxf" role="1SiIV1">
-            <ref role="3bR37D" node="4be$WTb1AQa" resolve="de.itemis.mps.editor.diagram.runtime" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="6$6tsX_CJxg" role="3bR37C">
-          <node concept="3bR9La" id="6$6tsX_CJxh" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
-          </node>
-        </node>
-        <node concept="3rtmxn" id="3xFG3bj5MkV" role="3bR31x">
-          <node concept="3LXTmp" id="3xFG3bj5MkW" role="3rtmxm">
-            <node concept="3qWCbU" id="3xFG3bj5MkX" role="3LXTna">
-              <property role="3qWCbO" value="icons/**, resources/**" />
-            </node>
-            <node concept="398BVA" id="3xFG3bj5MkY" role="3LXTmr">
-              <ref role="398BVh" node="6$6tsX_CF7m" resolve="diagram.home" />
-              <node concept="2Ry0Ak" id="3xFG3bj5MkZ" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="3xFG3bj5Ml0" role="2Ry0An">
-                  <property role="2Ry0Am" value="test.de.itemis.mps.editor.diagram.solution" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1BupzO" id="7q24334ZKUR" role="3bR31x">
-          <property role="3ZfqAx" value="models" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="7q24334ZKUS" role="1HemKq">
-            <node concept="398BVA" id="7q24334ZKUy" role="3LXTmr">
-              <ref role="398BVh" node="6$6tsX_CF7m" resolve="diagram.home" />
-              <node concept="2Ry0Ak" id="7q24334ZKUz" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="7q24334ZKU$" role="2Ry0An">
-                  <property role="2Ry0Am" value="test.de.itemis.mps.editor.diagram.solution" />
-                  <node concept="2Ry0Ak" id="7q24334ZKU_" role="2Ry0An">
-                    <property role="2Ry0Am" value="models" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="7q24334ZKUT" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="1E1JtD" id="7qi8mU1Oz$h" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="de.itemis.mps.editor.diagram.demolang" />
-        <property role="3LESm3" value="7cf26568-7255-45b6-b975-a44162a7e7e2" />
-        <node concept="398BVA" id="7qi8mU1Oz$i" role="3LF7KH">
-          <ref role="398BVh" node="6$6tsX_CF7m" resolve="diagram.home" />
-          <node concept="2Ry0Ak" id="7qi8mU1Oz$j" role="iGT6I">
-            <property role="2Ry0Am" value="languages" />
-            <node concept="2Ry0Ak" id="7qi8mU1Oz$k" role="2Ry0An">
-              <property role="2Ry0Am" value="de.itemis.mps.editor.diagram.demolang" />
-              <node concept="2Ry0Ak" id="7qi8mU1OzOV" role="2Ry0An">
-                <property role="2Ry0Am" value="de.itemis.mps.editor.diagram.demolang.mpl" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1yeLz9" id="7qi8mU1Oz$u" role="1TViLv">
-          <property role="TrG5h" value="de.itemis.mps.editor.diagram.demolang#5806942359871451541" />
-          <property role="3LESm3" value="1b7d09f9-42ec-4a9d-90c4-e292e54e3358" />
-          <node concept="1BupzO" id="7q24334ZKW2" role="3bR31x">
-            <property role="3ZfqAx" value="generator/template" />
-            <property role="1Hdu6h" value="true" />
-            <property role="1HemKv" value="true" />
-            <node concept="3LXTmp" id="7q24334ZKW3" role="1HemKq">
-              <node concept="398BVA" id="7q24334ZKVD" role="3LXTmr">
-                <ref role="398BVh" node="6$6tsX_CF7m" resolve="diagram.home" />
-                <node concept="2Ry0Ak" id="7q24334ZKVE" role="iGT6I">
-                  <property role="2Ry0Am" value="languages" />
-                  <node concept="2Ry0Ak" id="7q24334ZKVF" role="2Ry0An">
-                    <property role="2Ry0Am" value="de.itemis.mps.editor.diagram.demolang" />
-                    <node concept="2Ry0Ak" id="7q24334ZKVG" role="2Ry0An">
-                      <property role="2Ry0Am" value="generator" />
-                      <node concept="2Ry0Ak" id="7q24334ZKVH" role="2Ry0An">
-                        <property role="2Ry0Am" value="template" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3qWCbU" id="7q24334ZKW4" role="3LXTna">
-                <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="7qi8mU1OzTe" role="3bR37C">
-          <node concept="3bR9La" id="7qi8mU1OzTf" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="7qi8mU1OzTg" role="3bR37C">
-          <node concept="3bR9La" id="7qi8mU1OzTh" role="1SiIV1">
-            <ref role="3bR37D" node="4be$WTb1AQa" resolve="de.itemis.mps.editor.diagram.runtime" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="7qi8mU1OzTi" role="3bR37C">
-          <node concept="3bR9La" id="7qi8mU1OzTj" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="7qi8mU1OzTk" role="3bR37C">
-          <node concept="3bR9La" id="7qi8mU1OzTl" role="1SiIV1">
-            <ref role="3bR37D" node="6wEeo$QJAsB" resolve="de.itemis.mps.editor.diagram.shapes" />
-          </node>
-        </node>
-        <node concept="3rtmxn" id="3D0nl1ssJJm" role="3bR31x">
-          <node concept="3LXTmp" id="3D0nl1ssJJn" role="3rtmxm">
-            <node concept="3qWCbU" id="3D0nl1ssJJo" role="3LXTna">
-              <property role="3qWCbO" value="icons/**, resources/**" />
-            </node>
-            <node concept="398BVA" id="3D0nl1ssJJp" role="3LXTmr">
-              <ref role="398BVh" node="6$6tsX_CF7m" resolve="diagram.home" />
-              <node concept="2Ry0Ak" id="3D0nl1ssJJq" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="3D0nl1ssJJr" role="2Ry0An">
-                  <property role="2Ry0Am" value="de.itemis.mps.editor.diagram.demolang" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1BupzO" id="7q24334ZKVf" role="3bR31x">
-          <property role="3ZfqAx" value="languageModels" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="7q24334ZKVg" role="1HemKq">
-            <node concept="398BVA" id="7q24334ZKUU" role="3LXTmr">
-              <ref role="398BVh" node="6$6tsX_CF7m" resolve="diagram.home" />
-              <node concept="2Ry0Ak" id="7q24334ZKUV" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="7q24334ZKUW" role="2Ry0An">
-                  <property role="2Ry0Am" value="de.itemis.mps.editor.diagram.demolang" />
-                  <node concept="2Ry0Ak" id="7q24334ZKUX" role="2Ry0An">
-                    <property role="2Ry0Am" value="languageModels" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="7q24334ZKVh" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-        <node concept="1BupzO" id="42yR2aTbA8V" role="3bR31x">
-          <property role="3ZfqAx" value="languageAccessories" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="42yR2aTbA8W" role="1HemKq">
-            <node concept="398BVA" id="42yR2aTbA8A" role="3LXTmr">
-              <ref role="398BVh" node="6$6tsX_CF7m" resolve="diagram.home" />
-              <node concept="2Ry0Ak" id="42yR2aTbA8B" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="42yR2aTbA8C" role="2Ry0An">
-                  <property role="2Ry0Am" value="de.itemis.mps.editor.diagram.demolang" />
-                  <node concept="2Ry0Ak" id="42yR2aTbA8D" role="2Ry0An">
-                    <property role="2Ry0Am" value="languageAccessories" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="42yR2aTbA8X" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="1E1JtD" id="7qi8mU1Oz$v" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="de.itemis.mps.editor.diagram.demoentities" />
-        <property role="3LESm3" value="46b1f1f4-3955-4255-af94-7acb92d5711a" />
-        <node concept="398BVA" id="7qi8mU1Oz$w" role="3LF7KH">
-          <ref role="398BVh" node="6$6tsX_CF7m" resolve="diagram.home" />
-          <node concept="2Ry0Ak" id="7qi8mU1Oz$x" role="iGT6I">
-            <property role="2Ry0Am" value="languages" />
-            <node concept="2Ry0Ak" id="7qi8mU1Oz$y" role="2Ry0An">
-              <property role="2Ry0Am" value="de.itemis.mps.editor.diagram.demoentities" />
-              <node concept="2Ry0Ak" id="7qi8mU1OzOX" role="2Ry0An">
-                <property role="2Ry0Am" value="de.itemis.mps.editor.diagram.demoentities.mpl" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1E0d5M" id="7qi8mU1Oz$E" role="1E1XAP">
-          <ref role="1E0d5P" node="PE3B26QCrP" resolve="org.apache.commons" />
-        </node>
-        <node concept="1SiIV0" id="7qi8mU1OzTm" role="3bR37C">
-          <node concept="3bR9La" id="7qi8mU1OzTn" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="7qi8mU1OzTo" role="3bR37C">
-          <node concept="3bR9La" id="7qi8mU1OzTp" role="1SiIV1">
-            <ref role="3bR37D" node="4be$WTb1AQa" resolve="de.itemis.mps.editor.diagram.runtime" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="7qi8mU1OzTq" role="3bR37C">
-          <node concept="3bR9La" id="7qi8mU1OzTr" role="1SiIV1">
-            <ref role="3bR37D" node="6wEeo$QJAsB" resolve="de.itemis.mps.editor.diagram.shapes" />
-          </node>
-        </node>
-        <node concept="3rtmxn" id="3D0nl1ssJJt" role="3bR31x">
-          <node concept="3LXTmp" id="3D0nl1ssJJu" role="3rtmxm">
-            <node concept="3qWCbU" id="3D0nl1ssJJv" role="3LXTna">
-              <property role="3qWCbO" value="icons/**, resources/**" />
-            </node>
-            <node concept="398BVA" id="3D0nl1ssJJw" role="3LXTmr">
-              <ref role="398BVh" node="6$6tsX_CF7m" resolve="diagram.home" />
-              <node concept="2Ry0Ak" id="3D0nl1ssJJx" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="3D0nl1ssJJy" role="2Ry0An">
-                  <property role="2Ry0Am" value="de.itemis.mps.editor.diagram.demoentities" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1BupzO" id="7q24334ZKWq" role="3bR31x">
-          <property role="3ZfqAx" value="languageModels" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="7q24334ZKWr" role="1HemKq">
-            <node concept="398BVA" id="7q24334ZKW5" role="3LXTmr">
-              <ref role="398BVh" node="6$6tsX_CF7m" resolve="diagram.home" />
-              <node concept="2Ry0Ak" id="7q24334ZKW6" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="7q24334ZKW7" role="2Ry0An">
-                  <property role="2Ry0Am" value="de.itemis.mps.editor.diagram.demoentities" />
-                  <node concept="2Ry0Ak" id="7q24334ZKW8" role="2Ry0An">
-                    <property role="2Ry0Am" value="languageModels" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="7q24334ZKWs" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="1E1JtD" id="7qi8mU1OzOZ" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="de.itemis.mps.editor.diagram.demo.callgraph" />
-        <property role="3LESm3" value="3ba72f2f-a5c2-46e4-8b7e-b7ef6fb0cfc7" />
-        <node concept="398BVA" id="7qi8mU1OzP0" role="3LF7KH">
-          <ref role="398BVh" node="6$6tsX_CF7m" resolve="diagram.home" />
-          <node concept="2Ry0Ak" id="7qi8mU1OzP1" role="iGT6I">
-            <property role="2Ry0Am" value="languages" />
-            <node concept="2Ry0Ak" id="7qi8mU1OzP2" role="2Ry0An">
-              <property role="2Ry0Am" value="de.itemis.mps.editor.diagram.demo.callgraph" />
-              <node concept="2Ry0Ak" id="7qi8mU1OzR5" role="2Ry0An">
-                <property role="2Ry0Am" value="de.itemis.mps.editor.diagram.demo.callgraph.mpl" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1E0d5M" id="7qi8mU1OzPa" role="1E1XAP">
-          <ref role="1E0d5P" node="PE3B26QCrP" resolve="org.apache.commons" />
-        </node>
-        <node concept="1SiIV0" id="7qi8mU1OzTs" role="3bR37C">
-          <node concept="3bR9La" id="7qi8mU1OzTt" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="7qi8mU1OzTu" role="3bR37C">
-          <node concept="3bR9La" id="7qi8mU1OzTv" role="1SiIV1">
-            <ref role="3bR37D" node="4be$WTb1AQa" resolve="de.itemis.mps.editor.diagram.runtime" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="7qi8mU1OzTw" role="3bR37C">
-          <node concept="3bR9La" id="7qi8mU1OzTx" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
-          </node>
-        </node>
-        <node concept="3rtmxn" id="3D0nl1ssJJ$" role="3bR31x">
-          <node concept="3LXTmp" id="3D0nl1ssJJ_" role="3rtmxm">
-            <node concept="3qWCbU" id="3D0nl1ssJJA" role="3LXTna">
-              <property role="3qWCbO" value="icons/**, resources/**" />
-            </node>
-            <node concept="398BVA" id="3D0nl1ssJJB" role="3LXTmr">
-              <ref role="398BVh" node="6$6tsX_CF7m" resolve="diagram.home" />
-              <node concept="2Ry0Ak" id="3D0nl1ssJJC" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="3D0nl1ssJJD" role="2Ry0An">
-                  <property role="2Ry0Am" value="de.itemis.mps.editor.diagram.demo.callgraph" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1BupzO" id="7q24334ZKXe" role="3bR31x">
-          <property role="3ZfqAx" value="languageModels" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="7q24334ZKXf" role="1HemKq">
-            <node concept="398BVA" id="7q24334ZKWT" role="3LXTmr">
-              <ref role="398BVh" node="6$6tsX_CF7m" resolve="diagram.home" />
-              <node concept="2Ry0Ak" id="7q24334ZKWU" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="7q24334ZKWV" role="2Ry0An">
-                  <property role="2Ry0Am" value="de.itemis.mps.editor.diagram.demo.callgraph" />
-                  <node concept="2Ry0Ak" id="7q24334ZKWW" role="2Ry0An">
-                    <property role="2Ry0Am" value="languageModels" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="7q24334ZKXg" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="1E1JtA" id="7qi8mU1Oz$K" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="de.itemis.mps.editor.diagram.sandbox" />
-        <property role="3LESm3" value="249b0ecd-6945-42f0-b1b6-eb5c6f600cdc" />
-        <node concept="398BVA" id="7qi8mU1Oz$L" role="3LF7KH">
-          <ref role="398BVh" node="6$6tsX_CF7m" resolve="diagram.home" />
-          <node concept="2Ry0Ak" id="7qi8mU1Oz$M" role="iGT6I">
-            <property role="2Ry0Am" value="solutions" />
-            <node concept="2Ry0Ak" id="7qi8mU1Oz$N" role="2Ry0An">
-              <property role="2Ry0Am" value="de.itemis.mps.editor.diagram.sandbox" />
-              <node concept="2Ry0Ak" id="7qi8mU1OzR7" role="2Ry0An">
-                <property role="2Ry0Am" value="de.itemis.mps.editor.diagram.sandbox.msd" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3rtmxn" id="3D0nl1ssJIn" role="3bR31x">
-          <node concept="3LXTmp" id="3D0nl1ssJIo" role="3rtmxm">
-            <node concept="3qWCbU" id="3D0nl1ssJIp" role="3LXTna">
-              <property role="3qWCbO" value="icons/**, resources/**" />
-            </node>
-            <node concept="398BVA" id="3D0nl1ssJIq" role="3LXTmr">
-              <ref role="398BVh" node="6$6tsX_CF7m" resolve="diagram.home" />
-              <node concept="2Ry0Ak" id="3D0nl1ssJIr" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="3D0nl1ssJIs" role="2Ry0An">
-                  <property role="2Ry0Am" value="de.itemis.mps.editor.diagram.sandbox" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1BupzO" id="7q24334ZKY2" role="3bR31x">
-          <property role="3ZfqAx" value="models" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="7q24334ZKY3" role="1HemKq">
-            <node concept="398BVA" id="7q24334ZKXH" role="3LXTmr">
-              <ref role="398BVh" node="6$6tsX_CF7m" resolve="diagram.home" />
-              <node concept="2Ry0Ak" id="7q24334ZKXI" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="7q24334ZKXJ" role="2Ry0An">
-                  <property role="2Ry0Am" value="de.itemis.mps.editor.diagram.sandbox" />
-                  <node concept="2Ry0Ak" id="7q24334ZKXK" role="2Ry0An">
-                    <property role="2Ry0Am" value="models" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="7q24334ZKY4" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="1E1JtA" id="7qi8mU1OzR9" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="de.itemis.mps.editor.diagram.demoentities.sandbox" />
-        <property role="3LESm3" value="3ef43972-347f-437c-8a95-637327907e38" />
-        <node concept="398BVA" id="7qi8mU1OzRa" role="3LF7KH">
-          <ref role="398BVh" node="6$6tsX_CF7m" resolve="diagram.home" />
-          <node concept="2Ry0Ak" id="7qi8mU1OzRb" role="iGT6I">
-            <property role="2Ry0Am" value="solutions" />
-            <node concept="2Ry0Ak" id="7qi8mU1OzRc" role="2Ry0An">
-              <property role="2Ry0Am" value="de.itemis.mps.editor.diagram.demoentities.sandbox" />
-              <node concept="2Ry0Ak" id="7qi8mU1OzTc" role="2Ry0An">
-                <property role="2Ry0Am" value="de.itemis.mps.editor.diagram.demoentities.sandbox.msd" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3rtmxn" id="3D0nl1ssJIu" role="3bR31x">
-          <node concept="3LXTmp" id="3D0nl1ssJIv" role="3rtmxm">
-            <node concept="3qWCbU" id="3D0nl1ssJIw" role="3LXTna">
-              <property role="3qWCbO" value="icons/**, resources/**" />
-            </node>
-            <node concept="398BVA" id="3D0nl1ssJIx" role="3LXTmr">
-              <ref role="398BVh" node="6$6tsX_CF7m" resolve="diagram.home" />
-              <node concept="2Ry0Ak" id="3D0nl1ssJIy" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="3D0nl1ssJIz" role="2Ry0An">
-                  <property role="2Ry0Am" value="de.itemis.mps.editor.diagram.demoentities.sandbox" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1BupzO" id="7q24334ZKYq" role="3bR31x">
-          <property role="3ZfqAx" value="models" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="7q24334ZKYr" role="1HemKq">
-            <node concept="398BVA" id="7q24334ZKY5" role="3LXTmr">
-              <ref role="398BVh" node="6$6tsX_CF7m" resolve="diagram.home" />
-              <node concept="2Ry0Ak" id="7q24334ZKY6" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="7q24334ZKY7" role="2Ry0An">
-                  <property role="2Ry0Am" value="de.itemis.mps.editor.diagram.demoentities.sandbox" />
-                  <node concept="2Ry0Ak" id="7q24334ZKY8" role="2Ry0An">
-                    <property role="2Ry0Am" value="models" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="7q24334ZKYs" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="1E1JtA" id="7qi8mU1OzTQ" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="de.itemis.mps.editor.diagram.demo.activity.sandbox" />
-        <property role="3LESm3" value="32505440-8493-4ca5-a95b-0d257a22763e" />
-        <node concept="398BVA" id="7qi8mU1OzTR" role="3LF7KH">
-          <ref role="398BVh" node="6$6tsX_CF7m" resolve="diagram.home" />
-          <node concept="2Ry0Ak" id="7qi8mU1OzTS" role="iGT6I">
-            <property role="2Ry0Am" value="solutions" />
-            <node concept="2Ry0Ak" id="7qi8mU1OzTT" role="2Ry0An">
-              <property role="2Ry0Am" value="de.itemis.mps.editor.diagram.demo.activity.sandbox" />
-              <node concept="2Ry0Ak" id="7qi8mU1OzVK" role="2Ry0An">
-                <property role="2Ry0Am" value="de.itemis.mps.editor.diagram.demo.activity.sandbox.msd" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="7qi8mU1OzVM" role="3bR37C">
-          <node concept="3bR9La" id="7qi8mU1OzVN" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
-          </node>
-        </node>
-        <node concept="3rtmxn" id="3D0nl1ssJI_" role="3bR31x">
-          <node concept="3LXTmp" id="3D0nl1ssJIA" role="3rtmxm">
-            <node concept="3qWCbU" id="3D0nl1ssJIB" role="3LXTna">
-              <property role="3qWCbO" value="icons/**, resources/**" />
-            </node>
-            <node concept="398BVA" id="3D0nl1ssJIC" role="3LXTmr">
-              <ref role="398BVh" node="6$6tsX_CF7m" resolve="diagram.home" />
-              <node concept="2Ry0Ak" id="3D0nl1ssJID" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="3D0nl1ssJIE" role="2Ry0An">
-                  <property role="2Ry0Am" value="de.itemis.mps.editor.diagram.demo.activity.sandbox" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1BupzO" id="7q24334ZKYM" role="3bR31x">
-          <property role="3ZfqAx" value="models" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="7q24334ZKYN" role="1HemKq">
-            <node concept="398BVA" id="7q24334ZKYt" role="3LXTmr">
-              <ref role="398BVh" node="6$6tsX_CF7m" resolve="diagram.home" />
-              <node concept="2Ry0Ak" id="7q24334ZKYu" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="7q24334ZKYv" role="2Ry0An">
-                  <property role="2Ry0Am" value="de.itemis.mps.editor.diagram.demo.activity.sandbox" />
-                  <node concept="2Ry0Ak" id="7q24334ZKYw" role="2Ry0An">
-                    <property role="2Ry0Am" value="models" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="7q24334ZKYO" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="10PD9b" id="6$6tsX_CF7b" role="10PD9s" />
-    <node concept="3b7kt6" id="6$6tsX_CF7c" role="10PD9s" />
-    <node concept="1gjT0q" id="6$6tsX_CKLI" role="10PD9s" />
-    <node concept="398rNT" id="6$6tsX_CF7d" role="1l3spd">
-      <property role="TrG5h" value="mps.home" />
-      <node concept="55IIr" id="1QLFoGON26t" role="398pKh" />
-    </node>
-    <node concept="398rNT" id="1QLFoGON23s" role="1l3spd">
-      <property role="TrG5h" value="extensions.home" />
-      <node concept="55IIr" id="1QLFoGON23t" role="398pKh">
-        <node concept="2Ry0Ak" id="1QLFoGON23u" role="iGT6I">
-          <property role="2Ry0Am" value=".." />
-          <node concept="2Ry0Ak" id="2IxvlKPaLFA" role="2Ry0An">
-            <property role="2Ry0Am" value=".." />
-            <node concept="2Ry0Ak" id="2fo8bJEzAKn" role="2Ry0An">
-              <property role="2Ry0Am" value=".." />
-            </node>
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="398rNT" id="PE3B26neqW" role="1l3spd">
-      <property role="TrG5h" value="extensions.code" />
-      <node concept="398BVA" id="27epzEomQ$V" role="398pKh">
-        <ref role="398BVh" node="1QLFoGON23s" resolve="extensions.home" />
-        <node concept="2Ry0Ak" id="27epzEomQ$Y" role="iGT6I">
-          <property role="2Ry0Am" value="code" />
-        </node>
-      </node>
-    </node>
-    <node concept="398rNT" id="6$6tsX_CF7m" role="1l3spd">
-      <property role="TrG5h" value="diagram.home" />
-      <node concept="398BVA" id="1QLFoGON23R" role="398pKh">
-        <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-        <node concept="2Ry0Ak" id="1QLFoGON23X" role="iGT6I">
-          <property role="2Ry0Am" value="diagram" />
-        </node>
-      </node>
-    </node>
-    <node concept="398rNT" id="5mH$9t6e_IG" role="1l3spd">
-      <property role="TrG5h" value="tables.home" />
-      <node concept="398BVA" id="5mH$9t6e_IH" role="398pKh">
-        <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-        <node concept="2Ry0Ak" id="5mH$9t6e_NL" role="iGT6I">
-          <property role="2Ry0Am" value="tables" />
-        </node>
-      </node>
-    </node>
-    <node concept="398rNT" id="F1NWDquQCJ" role="1l3spd">
-      <property role="TrG5h" value="grammarcells.home" />
-      <node concept="398BVA" id="F1NWDqwaSJ" role="398pKh">
-        <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-        <node concept="2Ry0Ak" id="F1NWDqwb9E" role="iGT6I">
-          <property role="2Ry0Am" value="grammarcells" />
-        </node>
-      </node>
-    </node>
-    <node concept="398rNT" id="5mH$9t6eA_$" role="1l3spd">
-      <property role="TrG5h" value="celllayout.home" />
-      <node concept="398BVA" id="5mH$9t6eA__" role="398pKh">
-        <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-        <node concept="2Ry0Ak" id="5mH$9t6eAP0" role="iGT6I">
-          <property role="2Ry0Am" value="celllayout" />
-        </node>
-      </node>
-    </node>
-    <node concept="398rNT" id="7qi8mU1Oz8V" role="1l3spd">
-      <property role="TrG5h" value="richtext.home" />
-      <node concept="398BVA" id="7qi8mU1Oz8W" role="398pKh">
-        <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-        <node concept="2Ry0Ak" id="7qi8mU1Oz9B" role="iGT6I">
-          <property role="2Ry0Am" value="richtext" />
-        </node>
-      </node>
-    </node>
-    <node concept="398rNT" id="7qi8mU1OzcE" role="1l3spd">
-      <property role="TrG5h" value="multiline.home" />
-      <node concept="398BVA" id="7qi8mU1OzcF" role="398pKh">
-        <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-        <node concept="2Ry0Ak" id="7qi8mU1Ozdp" role="iGT6I">
-          <property role="2Ry0Am" value="multiline" />
-        </node>
-      </node>
-    </node>
-    <node concept="398rNT" id="7qi8mU1Ozyi" role="1l3spd">
-      <property role="TrG5h" value="math.home" />
-      <node concept="398BVA" id="7qi8mU1Ozyj" role="398pKh">
-        <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-        <node concept="2Ry0Ak" id="7qi8mU1Ozz4" role="iGT6I">
-          <property role="2Ry0Am" value="math" />
-        </node>
-      </node>
-    </node>
-    <node concept="398rNT" id="7qi8mU1OzW7" role="1l3spd">
-      <property role="TrG5h" value="conditionalEditor.home" />
-      <node concept="398BVA" id="7qi8mU1OzW8" role="398pKh">
-        <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-        <node concept="2Ry0Ak" id="7qi8mU1OzWW" role="iGT6I">
-          <property role="2Ry0Am" value="conditional-editor" />
-        </node>
-      </node>
-    </node>
-    <node concept="398rNT" id="3$$s$wOI_hD" role="1l3spd">
-      <property role="TrG5h" value="widgets.home" />
-      <node concept="398BVA" id="3$$s$wOI_jn" role="398pKh">
-        <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
-        <node concept="2Ry0Ak" id="3$$s$wOI_js" role="iGT6I">
-          <property role="2Ry0Am" value="widgets" />
-        </node>
-      </node>
-    </node>
-    <node concept="398rNT" id="OJuIQq1NW4" role="1l3spd">
-      <property role="TrG5h" value="mps.macro.extensions.home" />
-      <node concept="398BVA" id="OJuIQq1NY5" role="398pKh">
-        <ref role="398BVh" node="1QLFoGON23s" resolve="extensions.home" />
-      </node>
-    </node>
-    <node concept="2sgV4H" id="6$6tsX_CF7p" role="1l3spa">
-      <ref role="1l3spb" to="ffeo:3IKDaVZmzS6" resolve="mps" />
-      <node concept="398BVA" id="6$6tsX_CF7q" role="2JcizS">
-        <ref role="398BVh" node="6$6tsX_CF7d" resolve="mps.home" />
-      </node>
-    </node>
-    <node concept="2sgV4H" id="6yXTMcTQu49" role="1l3spa">
-      <ref role="1l3spb" to="ffeo:ymnOULAEsd" resolve="mpsTesting" />
-      <node concept="398BVA" id="6yXTMcTQu6h" role="2JcizS">
-        <ref role="398BVh" node="6$6tsX_CF7d" resolve="mps.home" />
-      </node>
-    </node>
-    <node concept="13uUGR" id="6$6tsX_CF7r" role="1l3spa">
-      <ref role="13uUGO" to="ffeo:6eCuTcwOnJO" resolve="IDEA" />
-      <node concept="398BVA" id="6$6tsX_CF7s" role="13uUGP">
-        <ref role="398BVh" node="6$6tsX_CF7d" resolve="mps.home" />
-      </node>
-    </node>
-    <node concept="2sgV4H" id="6$6tsX_CF7t" role="1l3spa">
-      <ref role="1l3spb" to="ffeo:6S1jmf0xDFC" resolve="mpsBootstrapCore" />
-      <node concept="398BVA" id="6$6tsX_CF7u" role="2JcizS">
-        <ref role="398BVh" node="6$6tsX_CF7d" resolve="mps.home" />
-      </node>
-    </node>
-    <node concept="2sgV4H" id="6$6tsX_CIho" role="1l3spa">
-      <ref role="1l3spb" node="2Xjt3l56m0V" resolve="de.itemis.mps.extensions" />
-      <node concept="398BVA" id="2fo8bJECJBq" role="2JcizS">
-        <ref role="398BVh" node="1QLFoGON23s" resolve="extensions.home" />
-        <node concept="2Ry0Ak" id="2fo8bJECJDk" role="iGT6I">
-          <property role="2Ry0Am" value="artifacts" />
-          <node concept="2Ry0Ak" id="2fo8bJECJDp" role="2Ry0An">
-            <property role="2Ry0Am" value="de.itemis.mps.extensions" />
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="1l3spV" id="6$6tsX_CF7v" role="1l3spN">
-      <node concept="L2wRC" id="F1NWDqwjRk" role="39821P">
-        <ref role="L2wRA" node="F1NWDqweoc" resolve="com.mbeddr.mpsutil.grammarcells.sandboxlang" />
-      </node>
-      <node concept="L2wRC" id="F1NWDqwi5m" role="39821P">
-        <ref role="L2wRA" node="F1NWDqwbth" resolve="com.mbeddr.mpsutil.grammarcells.tests" />
-      </node>
-      <node concept="L2wRC" id="6$6tsX_CJNu" role="39821P">
-        <ref role="L2wRA" node="6$6tsX_CJi6" resolve="de.itemis.mps.editor.diagram.demo.activity" />
-      </node>
-      <node concept="L2wRC" id="6$6tsX_CJQ5" role="39821P">
-        <ref role="L2wRA" node="6$6tsX_CISo" resolve="test.de.itemis.mps.editor.diagram.lang" />
-      </node>
-      <node concept="L2wRC" id="6$6tsX_CJST" role="39821P">
-        <ref role="L2wRA" node="6$6tsX_CJdr" resolve="test.de.itemis.mps.editor.diagram.solution" />
-      </node>
-      <node concept="L2wRC" id="1x_$NGQM_y3" role="39821P">
-        <ref role="L2wRA" node="6$6tsX_CUvL" resolve="de.slisson.mps.structurecheck" />
-      </node>
-      <node concept="L2wRC" id="1x_$NGQM_$b" role="39821P">
-        <ref role="L2wRA" node="6$6tsX_CURF" resolve="de.slisson.mps.structurecheck.runtime" />
-      </node>
-      <node concept="L2wRC" id="5mH$9t6eCBc" role="39821P">
-        <ref role="L2wRA" node="5mH$9t6e_Fl" resolve="test.de.slisson.mps.tables" />
-      </node>
-      <node concept="L2wRC" id="5mH$9t6eE6L" role="39821P">
-        <ref role="L2wRA" node="5mH$9t6eA1O" resolve="de.slisson.mps.tables.demolang" />
-      </node>
-      <node concept="L2wRC" id="7i5Cc6Lw5nc" role="39821P">
-        <ref role="L2wRA" node="5mH$9t6eAsB" resolve="test.de.itemis.mps.editor.celllayout" />
-      </node>
-      <node concept="L2wRC" id="7i5Cc6Lw73q" role="39821P">
-        <ref role="L2wRA" node="5mH$9t6eBsU" resolve="test.de.itemis.mps.editor.celllayout.lang" />
-      </node>
-      <node concept="L2wRC" id="7i5Cc6LxDjB" role="39821P">
-        <ref role="L2wRA" node="7i5Cc6LxCew" resolve="de.slisson.mps.testutils" />
-      </node>
-      <node concept="L2wRC" id="2NyZxKpXc6v" role="39821P">
-        <ref role="L2wRA" node="2NyZxKpXalh" resolve="test.ex.match" />
-      </node>
-      <node concept="L2wRC" id="2NyZxKpXcjH" role="39821P">
-        <ref role="L2wRA" node="2NyZxKpX96P" resolve="test.ts.conceptswitch" />
-      </node>
-      <node concept="L2wRC" id="2NyZxKpXcBn" role="39821P">
-        <ref role="L2wRA" node="2NyZxKpX6$b" resolve="test.com.mbeddr.mpsutil.blutil.genutil.lang" />
-      </node>
-      <node concept="L2wRC" id="2NyZxKpXd8z" role="39821P">
-        <ref role="L2wRA" node="2NyZxKpX7We" resolve="test.com.mbeddr.mpsutil.blutil.genutil" />
-      </node>
-      <node concept="L2wRC" id="7XTah2ufVqi" role="39821P">
-        <ref role="L2wRA" node="7XTah2ufTo1" resolve="de.itemis.mps.nodeversioning.test" />
-      </node>
-      <node concept="L2wRC" id="4c23MZqTKA2" role="39821P">
-        <ref role="L2wRA" node="3aF8hCvy3sT" resolve="de.itemis.model.merge.diamond" />
-      </node>
-      <node concept="L2wRC" id="4c23MZqXAyP" role="39821P">
-        <ref role="L2wRA" node="5RxOLvLcQHZ" resolve="de.itemis.model.merge.test" />
-      </node>
-      <node concept="L2wRC" id="GuygFg7CfC" role="39821P">
-        <ref role="L2wRA" node="GuygFg7AfB" resolve="test.de.itemis.mps.modelmerger.testlanguage" />
-      </node>
-      <node concept="L2wRC" id="T8sXq9o5df" role="39821P">
-        <ref role="L2wRA" node="T8sXq9o58u" resolve="com.dslfoundry.plaintextgen.example.nestedlist" />
-      </node>
-      <node concept="L2wRC" id="T8sXq9o5dX" role="39821P">
-        <ref role="L2wRA" node="T8sXq9o593" resolve="com.dslfoundry.plaintextgen.example.testlang" />
-      </node>
-      <node concept="L2wRC" id="T8sXq9o5eH" role="39821P">
-        <ref role="L2wRA" node="T8sXq9o59Q" resolve="com.dslfoundry.plaintextgen.example.nestedlist.sandbox" />
-      </node>
-      <node concept="L2wRC" id="T8sXq9o5fv" role="39821P">
-        <ref role="L2wRA" node="T8sXq9o5aP" resolve="com.dslfoundry.plaintextgen.example.plaintextflow" />
-      </node>
-      <node concept="L2wRC" id="T8sXq9o5gj" role="39821P">
-        <ref role="L2wRA" node="T8sXq9o5c0" resolve="com.dslfoundry.plaintextgen.example.testlang.sandbox" />
-      </node>
-      <node concept="L2wRC" id="4JmkJs3Gs5B" role="39821P">
-        <ref role="L2wRA" node="4JmkJs3Gs4u" resolve="test.de.q60.mps.shadowmodels.examples" />
-      </node>
-      <node concept="L2wRC" id="5QP6xyk3oCb" role="39821P">
-        <ref role="L2wRA" node="5QP6xyk3oCB" resolve="test.de.q60.mps.shadowmodels.runtime" />
-      </node>
-      <node concept="L2wRC" id="7qGGLAjNnDN" role="39821P">
-        <ref role="L2wRA" node="7qGGLAjNnEU" resolve="test.de.q60.mps.incremental.runtime" />
-      </node>
-      <node concept="L2wRC" id="3$$s$wOI_mD" role="39821P">
-        <ref role="L2wRA" node="3$$s$wOI_E$" resolve="de.itemis.mps.editor.collapsible.testlang" />
-      </node>
-      <node concept="L2wRC" id="3aF8hCv$ro3" role="39821P">
-        <ref role="L2wRA" node="GuygFg7$fI" resolve="tests.de.itemis.mps.modelmerger" />
-      </node>
-      <node concept="L2wRC" id="2UnEDPCihk6" role="39821P">
-        <ref role="L2wRA" node="2UnEDPCh8Ac" resolve="de.itemis.model.simple.demo.property" />
-      </node>
-      <node concept="L2wRC" id="2UnEDPClM$0" role="39821P">
-        <ref role="L2wRA" node="2UnEDPClLCV" resolve="de.itemis.model.simple.demo.children" />
-      </node>
-      <node concept="L2wRC" id="2UnEDPClM_4" role="39821P">
-        <ref role="L2wRA" node="2UnEDPClLHk" resolve="de.itemis.model.simple.demo.collection" />
-      </node>
-      <node concept="L2wRC" id="2UnEDPClMAa" role="39821P">
-        <ref role="L2wRA" node="2UnEDPClLLR" resolve="de.itemis.model.simple.demo.collection.keeper" />
-      </node>
-      <node concept="L2wRC" id="2UnEDPClMBi" role="39821P">
-        <ref role="L2wRA" node="2UnEDPClLQ$" resolve="de.itemis.model.simple.demo.reference" />
-      </node>
-      <node concept="L2wRC" id="2UnEDPCpnGv" role="39821P">
-        <ref role="L2wRA" node="2UnEDPCpnjG" resolve="de.itemis.model.merge.simple.demo" />
-      </node>
-      <node concept="L2wRC" id="7g5FWGK132j" role="39821P">
-        <ref role="L2wRA" node="7g5FWGK0Kzy" resolve="test.org.modelix.model.mpsadapters" />
-      </node>
-    </node>
-    <node concept="22LTRH" id="6yXTMcTWb7V" role="1hWBAP">
-      <property role="TrG5h" value="all" />
-      <node concept="22LTRM" id="F1NWDqzA2e" role="22LTRK">
-        <ref role="22LTRN" node="F1NWDqwbth" resolve="com.mbeddr.mpsutil.grammarcells.tests" />
-      </node>
-      <node concept="22LTRM" id="7qi8mU1OzVQ" role="22LTRK">
-        <ref role="22LTRN" node="6$6tsX_CJdr" resolve="test.de.itemis.mps.editor.diagram.solution" />
-      </node>
-      <node concept="22LTRM" id="5mH$9t6eAr5" role="22LTRK">
-        <ref role="22LTRN" node="5mH$9t6e_Fl" resolve="test.de.slisson.mps.tables" />
-      </node>
-      <node concept="22LTRM" id="7i5Cc6Lw3P$" role="22LTRK">
-        <ref role="22LTRN" node="5mH$9t6eAsB" resolve="test.de.itemis.mps.editor.celllayout" />
-      </node>
-      <node concept="22LTRF" id="7i5Cc6Lw48Y" role="22LTRK">
-        <ref role="22LTRG" node="6$6tsX_CIRQ" resolve="de.slisson.mps.all.tests" />
-      </node>
-      <node concept="22LTRM" id="7i5Cc6LxDze" role="22LTRK">
-        <ref role="22LTRN" node="7i5Cc6LxCew" resolve="de.slisson.mps.testutils" />
-      </node>
-      <node concept="22LTRM" id="2NyZxKpXdyy" role="22LTRK">
-        <ref role="22LTRN" node="2NyZxKpXalh" resolve="test.ex.match" />
-      </node>
-      <node concept="22LTRM" id="2NyZxKpXdDc" role="22LTRK">
-        <ref role="22LTRN" node="2NyZxKpX96P" resolve="test.ts.conceptswitch" />
-      </node>
-      <node concept="22LTRM" id="7XTah2ufVII" role="22LTRK">
-        <ref role="22LTRN" node="7XTah2ufTo1" resolve="de.itemis.mps.nodeversioning.test" />
-      </node>
-      <node concept="22LTRM" id="GuygFg7CGG" role="22LTRK">
-        <ref role="22LTRN" node="GuygFg7$fI" resolve="tests.de.itemis.mps.modelmerger" />
-      </node>
-      <node concept="22LTRM" id="1VujIMZIYK" role="22LTRK">
-        <ref role="22LTRN" node="2NyZxKpX7We" resolve="test.com.mbeddr.mpsutil.blutil.genutil" />
-      </node>
-      <node concept="22LTRM" id="4JmkJs3Gsci" role="22LTRK">
-        <ref role="22LTRN" node="4JmkJs3Gs4u" resolve="test.de.q60.mps.shadowmodels.examples" />
-      </node>
-      <node concept="24cAiW" id="6hpM9fmFEj0" role="24cAkG" />
-      <node concept="22LTRM" id="5QP6xyk3oDX" role="22LTRK">
-        <ref role="22LTRN" node="5QP6xyk3oCB" resolve="test.de.q60.mps.shadowmodels.runtime" />
-      </node>
-      <node concept="22LTRM" id="7qGGLAjNnMO" role="22LTRK">
-        <ref role="22LTRN" node="7qGGLAjNnEU" resolve="test.de.q60.mps.incremental.runtime" />
-      </node>
-      <node concept="22LTRM" id="3aF8hCw8Sce" role="22LTRK">
-        <ref role="22LTRN" node="5RxOLvLcQHZ" resolve="de.itemis.model.merge.test" />
-      </node>
-      <node concept="22LTRM" id="2UnEDPCpnHm" role="22LTRK">
-        <ref role="22LTRN" node="2UnEDPCpnjG" resolve="de.itemis.model.merge.simple.demo" />
-      </node>
-      <node concept="22LTRM" id="7g5FWGK131$" role="22LTRK">
-        <ref role="22LTRN" node="7g5FWGK0Kzy" resolve="test.org.modelix.model.mpsadapters" />
       </node>
     </node>
   </node>

--- a/code/celllayout/languages/de.itemis.mps.celllayout/models/styles/editor.mps
+++ b/code/celllayout/languages/de.itemis.mps.celllayout/models/styles/editor.mps
@@ -11,6 +11,7 @@
     <import index="hox0" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.style(MPS.Editor/)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" />
     <import index="5ueo" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.editor.runtime.style(MPS.Editor/)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
   </imports>
   <registry>
@@ -162,8 +163,8 @@
         <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
       </node>
       <node concept="10M0yZ" id="6SVXTgIaQA2" role="3t49C2">
-        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-        <ref role="3cqZAo" to="z60i:~Color.LIGHT_GRAY" resolve="LIGHT_GRAY" />
+        <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+        <ref role="3cqZAo" to="lzb2:~JBColor.LIGHT_GRAY" resolve="LIGHT_GRAY" />
       </node>
     </node>
     <node concept="3t5Usi" id="2FAXvauFoRY" role="V601i">
@@ -173,8 +174,8 @@
         <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
       </node>
       <node concept="10M0yZ" id="2FAXvauFoS0" role="3t49C2">
-        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-        <ref role="3cqZAo" to="z60i:~Color.LIGHT_GRAY" resolve="LIGHT_GRAY" />
+        <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+        <ref role="3cqZAo" to="lzb2:~JBColor.LIGHT_GRAY" resolve="LIGHT_GRAY" />
       </node>
     </node>
     <node concept="3t5Usi" id="2FAXvauFoUY" role="V601i">
@@ -184,8 +185,8 @@
         <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
       </node>
       <node concept="10M0yZ" id="2FAXvauFoV0" role="3t49C2">
-        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-        <ref role="3cqZAo" to="z60i:~Color.LIGHT_GRAY" resolve="LIGHT_GRAY" />
+        <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+        <ref role="3cqZAo" to="lzb2:~JBColor.LIGHT_GRAY" resolve="LIGHT_GRAY" />
       </node>
     </node>
     <node concept="3t5Usi" id="2FAXvauFoXW" role="V601i">
@@ -195,8 +196,8 @@
         <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
       </node>
       <node concept="10M0yZ" id="2FAXvauFoXY" role="3t49C2">
-        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-        <ref role="3cqZAo" to="z60i:~Color.LIGHT_GRAY" resolve="LIGHT_GRAY" />
+        <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+        <ref role="3cqZAo" to="lzb2:~JBColor.LIGHT_GRAY" resolve="LIGHT_GRAY" />
       </node>
     </node>
     <node concept="3t5Usi" id="2FAXvauFp1a" role="V601i">
@@ -206,8 +207,8 @@
         <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
       </node>
       <node concept="10M0yZ" id="2FAXvauFp1c" role="3t49C2">
-        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-        <ref role="3cqZAo" to="z60i:~Color.LIGHT_GRAY" resolve="LIGHT_GRAY" />
+        <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+        <ref role="3cqZAo" to="lzb2:~JBColor.LIGHT_GRAY" resolve="LIGHT_GRAY" />
       </node>
     </node>
     <node concept="3t5Usi" id="6SVXTgI9G1E" role="V601i">
@@ -372,8 +373,8 @@
         <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
       </node>
       <node concept="10M0yZ" id="43ViAfTrUmL" role="3t49C2">
-        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-        <ref role="3cqZAo" to="z60i:~Color.BLACK" resolve="BLACK" />
+        <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+        <ref role="3cqZAo" to="lzb2:~JBColor.BLACK" resolve="BLACK" />
       </node>
     </node>
     <node concept="3t5Usi" id="43ViAfTrUko" role="V601i">
@@ -389,8 +390,8 @@
         <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
       </node>
       <node concept="10M0yZ" id="7d0q5VH9BqO" role="3t49C2">
-        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-        <ref role="3cqZAo" to="z60i:~Color.BLACK" resolve="BLACK" />
+        <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+        <ref role="3cqZAo" to="lzb2:~JBColor.BLACK" resolve="BLACK" />
       </node>
     </node>
     <node concept="3t5Usi" id="7d0q5VH9Btz" role="V601i">

--- a/code/celllayout/solutions/de.slisson.mps.editor.celllayout.runtime/models/de/itemis/mps/editor/celllayout/runtime.mps
+++ b/code/celllayout/solutions/de.slisson.mps.editor.celllayout.runtime/models/de/itemis/mps/editor/celllayout/runtime.mps
@@ -29,6 +29,7 @@
     <import index="q7tw" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:org.apache.log4j(MPS.Core/)" />
     <import index="t6h5" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang.reflect(JDK/)" />
     <import index="hhnx" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.editor.runtime(MPS.Editor/)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="guwi" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.io(JDK/)" implicit="true" />
     <import index="z8iw" ref="r:dfdf3542-dbcf-43df-870a-3c3504b3c840(jetbrains.mps.baseLanguage.collections.custom)" implicit="true" />
   </imports>
@@ -18016,13 +18017,26 @@
                   <ref role="37wK5l" node="6p1TdwlPQkC" resolve="getBrightness" />
                 </node>
               </node>
-              <node concept="17R0WA" id="6p1TdwlTKlv" role="3K4Cdx">
-                <node concept="10M0yZ" id="6p1TdwlTKpK" role="3uHU7w">
-                  <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                  <ref role="3cqZAo" to="z60i:~Color.LIGHT_GRAY" resolve="LIGHT_GRAY" />
-                </node>
-                <node concept="37vLTw" id="6p1TdwlTKg7" role="3uHU7B">
-                  <ref role="3cqZAo" node="6p1TdwlRAw1" resolve="myColor" />
+              <node concept="1eOMI4" id="2WI5qcPWII" role="3K4Cdx">
+                <node concept="22lmx$" id="2WI5qcPY4Y" role="1eOMHV">
+                  <node concept="17R0WA" id="2WI5qcQ1KM" role="3uHU7w">
+                    <node concept="10M0yZ" id="2WI5qcQ6ET" role="3uHU7w">
+                      <ref role="3cqZAo" to="lzb2:~JBColor.LIGHT_GRAY" resolve="LIGHT_GRAY" />
+                      <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                    </node>
+                    <node concept="37vLTw" id="2WI5qcPZx2" role="3uHU7B">
+                      <ref role="3cqZAo" node="6p1TdwlRAw1" resolve="myColor" />
+                    </node>
+                  </node>
+                  <node concept="17R0WA" id="6p1TdwlTKlv" role="3uHU7B">
+                    <node concept="37vLTw" id="6p1TdwlTKg7" role="3uHU7B">
+                      <ref role="3cqZAo" node="6p1TdwlRAw1" resolve="myColor" />
+                    </node>
+                    <node concept="10M0yZ" id="6p1TdwlTKpK" role="3uHU7w">
+                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                      <ref role="3cqZAo" to="z60i:~Color.LIGHT_GRAY" resolve="LIGHT_GRAY" />
+                    </node>
+                  </node>
                 </node>
               </node>
             </node>

--- a/code/conditional-editor/languages/de.slisson.mps.conditionalEditor.demolang/languageModels/editor.mps
+++ b/code/conditional-editor/languages/de.slisson.mps.conditionalEditor.demolang/languageModels/editor.mps
@@ -11,6 +11,7 @@
   </languages>
   <imports>
     <import index="z60i" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt(JDK/)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" implicit="true" />
     <import index="ye5w" ref="r:6c3a5ff5-b652-48a4-80a3-0e283d57df4d(de.slisson.mps.conditionalEditor.demolang.structure)" implicit="true" />
     <import index="tpco" ref="r:00000000-0000-4000-0000-011c89590284(jetbrains.mps.lang.core.editor)" implicit="true" />
@@ -89,15 +90,15 @@
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
       </concept>
-      <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
-        <child id="1145553007750" name="creator" index="2ShVmc" />
-      </concept>
       <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
         <child id="1137022507850" name="body" index="2VODD2" />
       </concept>
       <concept id="1070462154015" name="jetbrains.mps.baseLanguage.structure.StaticFieldDeclaration" flags="ig" index="Wx3nA" />
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
       </concept>
       <concept id="1070533707846" name="jetbrains.mps.baseLanguage.structure.StaticFieldReference" flags="nn" index="10M0yZ">
         <reference id="1144433057691" name="classifier" index="1PxDUh" />
@@ -115,6 +116,9 @@
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
+      <concept id="1111509017652" name="jetbrains.mps.baseLanguage.structure.FloatingPointConstant" flags="nn" index="3b6qkQ">
+        <property id="1113006610751" name="value" index="$nhwW" />
+      </concept>
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
@@ -124,15 +128,11 @@
       <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
         <property id="1068580123138" name="value" index="3clFbU" />
       </concept>
-      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
-        <property id="1068580320021" name="value" index="3cmrfH" />
-      </concept>
       <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
-      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
       <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
         <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
       </concept>
@@ -220,22 +220,16 @@
       <node concept="Veino" id="7klUZA6Y2R$" role="3F10Kt">
         <node concept="3ZlJ5R" id="7klUZA6Y2RB" role="VblUZ">
           <node concept="3clFbS" id="7klUZA6Y2RC" role="2VODD2">
-            <node concept="3clFbF" id="7klUZA6Y4DP" role="3cqZAp">
-              <node concept="2ShNRf" id="7klUZA6Y4DN" role="3clFbG">
-                <node concept="1pGfFk" id="7klUZA6Y5Rt" role="2ShVmc">
-                  <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int,int)" resolve="Color" />
-                  <node concept="3cmrfG" id="7klUZA6Y_XU" role="37wK5m">
-                    <property role="3cmrfH" value="0" />
-                  </node>
-                  <node concept="3cmrfG" id="7klUZA6Y6Qz" role="37wK5m">
-                    <property role="3cmrfH" value="0" />
-                  </node>
-                  <node concept="3cmrfG" id="7klUZA6Y7DS" role="37wK5m">
-                    <property role="3cmrfH" value="0" />
-                  </node>
-                  <node concept="3cmrfG" id="7klUZA6Y97e" role="37wK5m">
-                    <property role="3cmrfH" value="10" />
-                  </node>
+            <node concept="3clFbF" id="2WI5qdwHWK" role="3cqZAp">
+              <node concept="2YIFZM" id="2WI5qdwI2H" role="3clFbG">
+                <ref role="37wK5l" to="lzb2:~ColorUtil.withAlpha(java.awt.Color,double)" resolve="withAlpha" />
+                <ref role="1Pybhc" to="lzb2:~ColorUtil" resolve="ColorUtil" />
+                <node concept="10M0yZ" id="2WI5qdwIf_" role="37wK5m">
+                  <ref role="3cqZAo" to="lzb2:~JBColor.BLACK" resolve="BLACK" />
+                  <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                </node>
+                <node concept="3b6qkQ" id="2WI5qdwIjZ" role="37wK5m">
+                  <property role="$nhwW" value="0.039" />
                 </node>
               </node>
             </node>

--- a/code/diagram/languages/de.itemis.mps.editor.diagram.demo.activity/languageModels/editor.mps
+++ b/code/diagram/languages/de.itemis.mps.editor.diagram.demo.activity/languageModels/editor.mps
@@ -18,6 +18,7 @@
     <import index="tc27" ref="r:92d28f3c-6acc-431a-94ba-30cd184d2da4(de.itemis.mps.editor.diagram.runtime.substitute)" />
     <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" />
     <import index="mhfm" ref="3f233e7f-b8a6-46d2-a57f-795d56775243/java:org.jetbrains.annotations(Annotations/)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
     <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" implicit="true" />
@@ -1288,8 +1289,8 @@
             <node concept="liA8E" id="4XPshStkWNL" role="2OqNvi">
               <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
               <node concept="10M0yZ" id="4XPshStkWNM" role="37wK5m">
-                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                <ref role="3cqZAo" to="z60i:~Color.BLACK" resolve="BLACK" />
+                <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                <ref role="3cqZAo" to="lzb2:~JBColor.BLACK" resolve="BLACK" />
               </node>
             </node>
           </node>
@@ -1533,8 +1534,8 @@
             <node concept="liA8E" id="4XPshStkTtV" role="2OqNvi">
               <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
               <node concept="10M0yZ" id="4XPshStkTtW" role="37wK5m">
-                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                <ref role="3cqZAo" to="z60i:~Color.BLACK" resolve="BLACK" />
+                <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                <ref role="3cqZAo" to="lzb2:~JBColor.BLACK" resolve="BLACK" />
               </node>
             </node>
           </node>
@@ -2729,8 +2730,8 @@
             <node concept="liA8E" id="4EOrrTBL_L5" role="2OqNvi">
               <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
               <node concept="10M0yZ" id="4EOrrTBL_Wq" role="37wK5m">
-                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                <ref role="3cqZAo" to="z60i:~Color.BLACK" resolve="BLACK" />
+                <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                <ref role="3cqZAo" to="lzb2:~JBColor.BLACK" resolve="BLACK" />
               </node>
             </node>
           </node>

--- a/code/diagram/languages/de.itemis.mps.editor.diagram.demolang/languageModels/editor.mps
+++ b/code/diagram/languages/de.itemis.mps.editor.diagram.demolang/languageModels/editor.mps
@@ -20,6 +20,7 @@
     <import index="wo6c" ref="r:de91083f-90a8-4dd4-83b1-8a92d65ab81d(de.itemis.mps.editor.diagram.shapes)" />
     <import index="mhfm" ref="3f233e7f-b8a6-46d2-a57f-795d56775243/java:org.jetbrains.annotations(Annotations/)" />
     <import index="swi3" ref="r:5eabed4f-92f5-4459-b9b3-e2faa24f3467(de.itemis.mps.editor.diagram.styles.editor)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
     <import index="guwi" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.io(JDK/)" implicit="true" />
     <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" implicit="true" />
@@ -735,8 +736,8 @@
                   <node concept="3clFbS" id="7WiZGib9KZR" role="2VODD2">
                     <node concept="3clFbF" id="7WiZGib9Lfy" role="3cqZAp">
                       <node concept="10M0yZ" id="7WiZGib9Lfx" role="3clFbG">
-                        <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                        <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                        <ref role="3cqZAo" to="lzb2:~JBColor.lightGray" resolve="lightGray" />
                       </node>
                     </node>
                   </node>

--- a/code/diagram/languages/de.itemis.mps.editor.diagram.demolang/languageModels/editor.mps
+++ b/code/diagram/languages/de.itemis.mps.editor.diagram.demolang/languageModels/editor.mps
@@ -148,6 +148,9 @@
         <property id="1176718929932" name="isFinal" index="3TUv4t" />
         <child id="1068431790190" name="initializer" index="33vP2m" />
       </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ng" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
+      </concept>
       <concept id="1092119917967" name="jetbrains.mps.baseLanguage.structure.MulExpression" flags="nn" index="17qRlL" />
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
@@ -1576,18 +1579,28 @@
           <ref role="3tD7wE" to="swi3:5FmzNQoGJXe" resolve="diagram-background-color" />
           <node concept="3sjG9q" id="5FmzNQoJ3fy" role="3tD6jU">
             <node concept="3clFbS" id="5FmzNQoJ3f$" role="2VODD2">
-              <node concept="3clFbF" id="5FmzNQoJ3z6" role="3cqZAp">
-                <node concept="2ShNRf" id="5FmzNQoJ3S2" role="3clFbG">
-                  <node concept="1pGfFk" id="5FmzNQoJ5by" role="2ShVmc">
-                    <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
-                    <node concept="3cmrfG" id="5FmzNQoJ5c_" role="37wK5m">
-                      <property role="3cmrfH" value="240" />
+              <node concept="3clFbF" id="4w64dgpLe$m" role="3cqZAp">
+                <node concept="2ShNRf" id="4w64dgpL3mM" role="3clFbG">
+                  <node concept="1pGfFk" id="4w64dgpLaZ7" role="2ShVmc">
+                    <property role="373rjd" value="true" />
+                    <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                    <node concept="2ShNRf" id="21DGiA4IQGq" role="37wK5m">
+                      <node concept="1pGfFk" id="21DGiA4IQGr" role="2ShVmc">
+                        <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
+                        <node concept="3cmrfG" id="21DGiA4IQGs" role="37wK5m">
+                          <property role="3cmrfH" value="240" />
+                        </node>
+                        <node concept="3cmrfG" id="21DGiA4IQGt" role="37wK5m">
+                          <property role="3cmrfH" value="240" />
+                        </node>
+                        <node concept="3cmrfG" id="21DGiA4IQGu" role="37wK5m">
+                          <property role="3cmrfH" value="240" />
+                        </node>
+                      </node>
                     </node>
-                    <node concept="3cmrfG" id="5FmzNQoJ5fw" role="37wK5m">
-                      <property role="3cmrfH" value="240" />
-                    </node>
-                    <node concept="3cmrfG" id="5FmzNQoJ5kz" role="37wK5m">
-                      <property role="3cmrfH" value="255" />
+                    <node concept="10M0yZ" id="4w64dgpLe$o" role="37wK5m">
+                      <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                      <ref role="3cqZAo" to="lzb2:~JBColor.WHITE" resolve="WHITE" />
                     </node>
                   </node>
                 </node>

--- a/code/diagram/languages/de.itemis.mps.editor.diagram.styles/languageModels/editor.mps
+++ b/code/diagram/languages/de.itemis.mps.editor.diagram.styles/languageModels/editor.mps
@@ -9,6 +9,8 @@
     <import index="z60i" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt(JDK/)" />
     <import index="hox0" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.style(MPS.Editor/)" />
     <import index="mhfm" ref="3f233e7f-b8a6-46d2-a57f-795d56775243/java:org.jetbrains.annotations(Annotations/)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
+    <import index="exr9" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor(MPS.Editor/)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
     <import index="1y6f" ref="r:a425f003-07f2-4ded-ad56-54c06b501569(de.itemis.mps.editor.diagram.styles.structure)" implicit="true" />
   </imports>
@@ -42,9 +44,6 @@
         <child id="1068498886295" name="lValue" index="37vLTJ" />
       </concept>
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
-      <concept id="1179360813171" name="jetbrains.mps.baseLanguage.structure.HexIntegerLiteral" flags="nn" index="2nou5x">
-        <property id="1179360856892" name="value" index="2noCCI" />
-      </concept>
       <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
       <concept id="5279705229678483897" name="jetbrains.mps.baseLanguage.structure.FloatingPointFloatConstant" flags="nn" index="2$xPTn">
         <property id="5279705229678483899" name="value" index="2$xPTl" />
@@ -94,6 +93,9 @@
       <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu" />
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ng" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
       </concept>
       <concept id="1092119917967" name="jetbrains.mps.baseLanguage.structure.MulExpression" flags="nn" index="17qRlL" />
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
@@ -225,18 +227,13 @@
       <node concept="3uibUv" id="4mmPun56RuI" role="3t5Oan">
         <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
       </node>
-      <node concept="2ShNRf" id="4mmPun56RuJ" role="3t49C2">
-        <node concept="1pGfFk" id="4mmPun56RuK" role="2ShVmc">
-          <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
-          <node concept="2nou5x" id="4mmPun56RuL" role="37wK5m">
-            <property role="2noCCI" value="64" />
-          </node>
-          <node concept="2nou5x" id="4mmPun56RuM" role="37wK5m">
-            <property role="2noCCI" value="82" />
-          </node>
-          <node concept="2nou5x" id="4mmPun56RuN" role="37wK5m">
-            <property role="2noCCI" value="B9" />
-          </node>
+      <node concept="2OqwBi" id="4w64dgpT40q" role="3t49C2">
+        <node concept="10M0yZ" id="2WI5qekdZ2" role="2Oq$k0">
+          <ref role="1PxDUh" to="exr9:~MPSColors" resolve="MPSColors" />
+          <ref role="3cqZAo" to="exr9:~MPSColors.LIGHT_BLUE" resolve="LIGHT_BLUE" />
+        </node>
+        <node concept="liA8E" id="4w64dgpT4iy" role="2OqNvi">
+          <ref role="37wK5l" to="z60i:~Color.darker()" resolve="darker" />
         </node>
       </node>
     </node>
@@ -251,17 +248,32 @@
       <node concept="3uibUv" id="5FmzNQoGJYL" role="3t5Oan">
         <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
       </node>
-      <node concept="2ShNRf" id="21DGiA4IQGq" role="3t49C2">
-        <node concept="1pGfFk" id="21DGiA4IQGr" role="2ShVmc">
-          <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
-          <node concept="3cmrfG" id="21DGiA4IQGs" role="37wK5m">
-            <property role="3cmrfH" value="240" />
-          </node>
-          <node concept="3cmrfG" id="21DGiA4IQGt" role="37wK5m">
-            <property role="3cmrfH" value="240" />
-          </node>
-          <node concept="3cmrfG" id="21DGiA4IQGu" role="37wK5m">
-            <property role="3cmrfH" value="240" />
+      <node concept="10QFUN" id="4w64dgpLbxS" role="3t49C2">
+        <node concept="3uibUv" id="4w64dgpLbC_" role="10QFUM">
+          <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
+        </node>
+        <node concept="2ShNRf" id="4w64dgpL3mM" role="10QFUP">
+          <node concept="1pGfFk" id="4w64dgpLaZ7" role="2ShVmc">
+            <property role="373rjd" value="true" />
+            <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+            <node concept="2ShNRf" id="21DGiA4IQGq" role="37wK5m">
+              <node concept="1pGfFk" id="21DGiA4IQGr" role="2ShVmc">
+                <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
+                <node concept="3cmrfG" id="21DGiA4IQGs" role="37wK5m">
+                  <property role="3cmrfH" value="240" />
+                </node>
+                <node concept="3cmrfG" id="21DGiA4IQGt" role="37wK5m">
+                  <property role="3cmrfH" value="240" />
+                </node>
+                <node concept="3cmrfG" id="21DGiA4IQGu" role="37wK5m">
+                  <property role="3cmrfH" value="240" />
+                </node>
+              </node>
+            </node>
+            <node concept="10M0yZ" id="4w64dgpKIn8" role="37wK5m">
+              <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+              <ref role="3cqZAo" to="lzb2:~JBColor.WHITE" resolve="WHITE" />
+            </node>
           </node>
         </node>
       </node>

--- a/code/diagram/solutions/de.itemis.mps.editor.diagram.runtime/models/de/itemis/mps/editor/diagram/runtime/shape.mps
+++ b/code/diagram/solutions/de.itemis.mps.editor.diagram.runtime/models/de/itemis/mps/editor/diagram/runtime/shape.mps
@@ -17,6 +17,9 @@
     <import index="r3rm" ref="r:7fc96130-6279-4a55-aeeb-422a6879539d(de.itemis.mps.editor.diagram.runtime.jgraph)" />
     <import index="swi3" ref="r:5eabed4f-92f5-4459-b9b3-e2faa24f3467(de.itemis.mps.editor.diagram.styles.editor)" />
     <import index="hox0" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.style(MPS.Editor/)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
+    <import index="exr9" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor(MPS.Editor/)" />
+    <import index="g1qu" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.util.ui(MPS.IDEA/)" />
   </imports>
   <registry>
     <language id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor">
@@ -95,6 +98,9 @@
       </concept>
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ng" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
       </concept>
       <concept id="1092119917967" name="jetbrains.mps.baseLanguage.structure.MulExpression" flags="nn" index="17qRlL" />
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
@@ -1855,24 +1861,47 @@
       <node concept="3cqZAl" id="6uo2fN6yu8q" role="3clF45" />
       <node concept="3Tm1VV" id="6uo2fN6yu8r" role="1B3o_S" />
       <node concept="3clFbS" id="6uo2fN6yu8s" role="3clF47">
-        <node concept="3clFbF" id="6uo2fN6yu8t" role="3cqZAp">
-          <node concept="2OqwBi" id="6uo2fN6yu8u" role="3clFbG">
-            <node concept="37vLTw" id="6uo2fN6yu8v" role="2Oq$k0">
-              <ref role="3cqZAo" node="6uo2fN6yu8A" resolve="g" />
+        <node concept="3clFbJ" id="4w64dgq$SbD" role="3cqZAp">
+          <node concept="3clFbS" id="4w64dgq$SbF" role="3clFbx">
+            <node concept="3clFbF" id="4w64dgq$UrB" role="3cqZAp">
+              <node concept="2OqwBi" id="4w64dgq$UrC" role="3clFbG">
+                <node concept="37vLTw" id="4w64dgq$UrD" role="2Oq$k0">
+                  <ref role="3cqZAo" node="6uo2fN6yu8A" resolve="g" />
+                </node>
+                <node concept="liA8E" id="4w64dgq$UrE" role="2OqNvi">
+                  <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
+                  <node concept="2YIFZM" id="oUEeqEZPtu" role="37wK5m">
+                    <ref role="37wK5l" to="lzb2:~ColorUtil.darker(java.awt.Color,int)" resolve="darker" />
+                    <ref role="1Pybhc" to="lzb2:~ColorUtil" resolve="ColorUtil" />
+                    <node concept="10M0yZ" id="4w64dgq$UrF" role="37wK5m">
+                      <ref role="3cqZAo" to="exr9:~MPSColors.LIGHT_BLUE" resolve="LIGHT_BLUE" />
+                      <ref role="1PxDUh" to="exr9:~MPSColors" resolve="MPSColors" />
+                    </node>
+                    <node concept="3cmrfG" id="oUEeqEZQeT" role="37wK5m">
+                      <property role="3cmrfH" value="3" />
+                    </node>
+                  </node>
+                </node>
+              </node>
             </node>
-            <node concept="liA8E" id="6uo2fN6yu8w" role="2OqNvi">
-              <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
-              <node concept="2ShNRf" id="61ORDkd5BwF" role="37wK5m">
-                <node concept="1pGfFk" id="61ORDkd5BwG" role="2ShVmc">
-                  <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
-                  <node concept="2nou5x" id="61ORDkd5BwH" role="37wK5m">
-                    <property role="2noCCI" value="C3" />
+          </node>
+          <node concept="2YIFZM" id="4w64dgq$TL_" role="3clFbw">
+            <ref role="37wK5l" to="g1qu:~UIUtil.isUnderDarcula()" resolve="isUnderDarcula" />
+            <ref role="1Pybhc" to="g1qu:~UIUtil" resolve="UIUtil" />
+          </node>
+          <node concept="9aQIb" id="4w64dgq$TYx" role="9aQIa">
+            <node concept="3clFbS" id="4w64dgq$TYy" role="9aQI4">
+              <node concept="3clFbF" id="6uo2fN6yu8t" role="3cqZAp">
+                <node concept="2OqwBi" id="6uo2fN6yu8u" role="3clFbG">
+                  <node concept="37vLTw" id="6uo2fN6yu8v" role="2Oq$k0">
+                    <ref role="3cqZAo" node="6uo2fN6yu8A" resolve="g" />
                   </node>
-                  <node concept="2nou5x" id="61ORDkd5BwI" role="37wK5m">
-                    <property role="2noCCI" value="D9" />
-                  </node>
-                  <node concept="2nou5x" id="61ORDkd5BwJ" role="37wK5m">
-                    <property role="2noCCI" value="FF" />
+                  <node concept="liA8E" id="6uo2fN6yu8w" role="2OqNvi">
+                    <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
+                    <node concept="10M0yZ" id="2WI5qekdZ2" role="37wK5m">
+                      <ref role="1PxDUh" to="exr9:~MPSColors" resolve="MPSColors" />
+                      <ref role="3cqZAo" to="exr9:~MPSColors.LIGHT_BLUE" resolve="LIGHT_BLUE" />
+                    </node>
                   </node>
                 </node>
               </node>
@@ -1921,17 +1950,42 @@
             </node>
             <node concept="liA8E" id="6uo2fN6yu8N" role="2OqNvi">
               <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
-              <node concept="2ShNRf" id="61ORDkd5BFP" role="37wK5m">
-                <node concept="1pGfFk" id="61ORDkd5BFQ" role="2ShVmc">
-                  <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
-                  <node concept="2nou5x" id="61ORDkd5BFR" role="37wK5m">
-                    <property role="2noCCI" value="64" />
+              <node concept="2ShNRf" id="2WI5qekCVc" role="37wK5m">
+                <node concept="1pGfFk" id="2WI5qekDzX" role="2ShVmc">
+                  <property role="373rjd" value="true" />
+                  <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                  <node concept="2ShNRf" id="61ORDkd5BFP" role="37wK5m">
+                    <node concept="1pGfFk" id="61ORDkd5BFQ" role="2ShVmc">
+                      <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
+                      <node concept="2nou5x" id="61ORDkd5BFR" role="37wK5m">
+                        <property role="2noCCI" value="64" />
+                      </node>
+                      <node concept="2nou5x" id="61ORDkd5BFS" role="37wK5m">
+                        <property role="2noCCI" value="82" />
+                      </node>
+                      <node concept="2nou5x" id="61ORDkd5BFT" role="37wK5m">
+                        <property role="2noCCI" value="B9" />
+                      </node>
+                    </node>
                   </node>
-                  <node concept="2nou5x" id="61ORDkd5BFS" role="37wK5m">
-                    <property role="2noCCI" value="82" />
-                  </node>
-                  <node concept="2nou5x" id="61ORDkd5BFT" role="37wK5m">
-                    <property role="2noCCI" value="B9" />
+                  <node concept="2OqwBi" id="4w64dgpS8is" role="37wK5m">
+                    <node concept="2ShNRf" id="2WI5qekE7T" role="2Oq$k0">
+                      <node concept="1pGfFk" id="2WI5qekE7U" role="2ShVmc">
+                        <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
+                        <node concept="2nou5x" id="2WI5qekE7V" role="37wK5m">
+                          <property role="2noCCI" value="64" />
+                        </node>
+                        <node concept="2nou5x" id="2WI5qekE7W" role="37wK5m">
+                          <property role="2noCCI" value="82" />
+                        </node>
+                        <node concept="2nou5x" id="2WI5qekE7X" role="37wK5m">
+                          <property role="2noCCI" value="B9" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="4w64dgpS8MK" role="2OqNvi">
+                      <ref role="37wK5l" to="z60i:~Color.darker()" resolve="darker" />
+                    </node>
                   </node>
                 </node>
               </node>
@@ -1977,7 +2031,7 @@
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="6uo2fN6yu93" role="3cqZAp">
+        <node concept="3clFbF" id="2WI5qekEBX" role="3cqZAp">
           <node concept="2OqwBi" id="6uo2fN6yu94" role="3clFbG">
             <node concept="37vLTw" id="6uo2fN6yu95" role="2Oq$k0">
               <ref role="3cqZAo" node="6uo2fN6yu8Y" resolve="g" />

--- a/code/diagram/solutions/de.itemis.mps.editor.diagram.shapes/de.itemis.mps.editor.diagram.shapes.msd
+++ b/code/diagram/solutions/de.itemis.mps.editor.diagram.shapes/de.itemis.mps.editor.diagram.shapes.msd
@@ -13,6 +13,7 @@
   <sourcePath />
   <dependencies>
     <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
+    <dependency reexport="false">498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:fa13cc63-c476-4d46-9c96-d53670abe7bc:de.itemis.mps.editor.diagram" version="0" />
@@ -29,7 +30,9 @@
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
   </languageVersions>
   <dependencyVersions>
+    <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
     <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
+    <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
     <module reference="f7ad14aa-a3e2-4301-8822-d919845c8bcf(de.itemis.mps.editor.diagram.shapes)" version="0" />
   </dependencyVersions>
 </solution>

--- a/code/diagram/solutions/de.itemis.mps.editor.diagram.shapes/models/de/itemis/mps/editor/diagram/shapes.mps
+++ b/code/diagram/solutions/de.itemis.mps.editor.diagram.shapes/models/de/itemis/mps/editor/diagram/shapes.mps
@@ -8,6 +8,7 @@
   <imports>
     <import index="fbzs" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt.geom(JDK/)" />
     <import index="z60i" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt(JDK/)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
@@ -28,6 +29,9 @@
       </concept>
       <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
         <child id="1137022507850" name="body" index="2VODD2" />
+      </concept>
+      <concept id="1070533707846" name="jetbrains.mps.baseLanguage.structure.StaticFieldReference" flags="nn" index="10M0yZ">
+        <reference id="1144433057691" name="classifier" index="1PxDUh" />
       </concept>
       <concept id="1070534513062" name="jetbrains.mps.baseLanguage.structure.DoubleType" flags="in" index="10P55v" />
       <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
@@ -409,19 +413,9 @@
             <node concept="2xDIQ0" id="5WYUu8HgObu" role="2Oq$k0" />
             <node concept="liA8E" id="5WYUu8HgOtt" role="2OqNvi">
               <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
-              <node concept="2ShNRf" id="5WYUu8HgOui" role="37wK5m">
-                <node concept="1pGfFk" id="5WYUu8HgRG0" role="2ShVmc">
-                  <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
-                  <node concept="3cmrfG" id="5WYUu8HgRH8" role="37wK5m">
-                    <property role="3cmrfH" value="200" />
-                  </node>
-                  <node concept="3cmrfG" id="5WYUu8HgRKt" role="37wK5m">
-                    <property role="3cmrfH" value="200" />
-                  </node>
-                  <node concept="3cmrfG" id="5WYUu8HgSoC" role="37wK5m">
-                    <property role="3cmrfH" value="200" />
-                  </node>
-                </node>
+              <node concept="10M0yZ" id="2WI5qcR4Zz" role="37wK5m">
+                <ref role="3cqZAo" to="lzb2:~JBColor.LIGHT_GRAY" resolve="LIGHT_GRAY" />
+                <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
               </node>
             </node>
           </node>

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells.sandboxlang/models/com/mbeddr/mpsutil/grammarcells/sandboxlang/editor.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells.sandboxlang/models/com/mbeddr/mpsutil/grammarcells/sandboxlang/editor.mps
@@ -10,6 +10,7 @@
   </languages>
   <imports>
     <import index="z60i" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt(JDK/)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="ibwz" ref="r:ad27d4b4-fc2c-4b6d-9e22-455eb0ccf354(com.mbeddr.mpsutil.grammarcells.sandboxlang.structure)" implicit="true" />
     <import index="tpco" ref="r:00000000-0000-4000-0000-011c89590284(jetbrains.mps.lang.core.editor)" implicit="true" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
@@ -147,6 +148,9 @@
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
       </concept>
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
+      </concept>
       <concept id="1070533707846" name="jetbrains.mps.baseLanguage.structure.StaticFieldReference" flags="nn" index="10M0yZ">
         <reference id="1144433057691" name="classifier" index="1PxDUh" />
       </concept>
@@ -154,6 +158,9 @@
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
       <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
+      <concept id="1111509017652" name="jetbrains.mps.baseLanguage.structure.FloatingPointConstant" flags="nn" index="3b6qkQ">
+        <property id="1113006610751" name="value" index="$nhwW" />
+      </concept>
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
@@ -168,7 +175,6 @@
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
-      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
       <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
@@ -590,22 +596,16 @@
               <node concept="Veino" id="1PeMnANeHGL" role="3F10Kt">
                 <node concept="3ZlJ5R" id="1PeMnANeXlY" role="VblUZ">
                   <node concept="3clFbS" id="1PeMnANeXlZ" role="2VODD2">
-                    <node concept="3clFbF" id="1PeMnANeXn0" role="3cqZAp">
-                      <node concept="2ShNRf" id="1PeMnANeXmY" role="3clFbG">
-                        <node concept="1pGfFk" id="1PeMnANeX_f" role="2ShVmc">
-                          <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int,int)" resolve="Color" />
-                          <node concept="3cmrfG" id="1PeMnANeXAr" role="37wK5m">
-                            <property role="3cmrfH" value="0" />
-                          </node>
-                          <node concept="3cmrfG" id="1PeMnANeXIN" role="37wK5m">
-                            <property role="3cmrfH" value="0" />
-                          </node>
-                          <node concept="3cmrfG" id="1PeMnANeXMY" role="37wK5m">
-                            <property role="3cmrfH" value="0" />
-                          </node>
-                          <node concept="3cmrfG" id="1PeMnANeXTM" role="37wK5m">
-                            <property role="3cmrfH" value="0" />
-                          </node>
+                    <node concept="3clFbF" id="2WI5qdaB_S" role="3cqZAp">
+                      <node concept="2YIFZM" id="2WI5qdaB_U" role="3clFbG">
+                        <ref role="1Pybhc" to="lzb2:~ColorUtil" resolve="ColorUtil" />
+                        <ref role="37wK5l" to="lzb2:~ColorUtil.withAlpha(java.awt.Color,double)" resolve="withAlpha" />
+                        <node concept="10M0yZ" id="2WI5qdaB_V" role="37wK5m">
+                          <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                          <ref role="3cqZAo" to="lzb2:~JBColor.BLACK" resolve="BLACK" />
+                        </node>
+                        <node concept="3cmrfG" id="2WI5qdaBGx" role="37wK5m">
+                          <property role="3cmrfH" value="0" />
                         </node>
                       </node>
                     </node>
@@ -656,22 +656,16 @@
               <node concept="Veino" id="1PeMnANeXYx" role="3F10Kt">
                 <node concept="3ZlJ5R" id="1PeMnANeXYy" role="VblUZ">
                   <node concept="3clFbS" id="1PeMnANeXYz" role="2VODD2">
-                    <node concept="3clFbF" id="1PeMnANeXY$" role="3cqZAp">
-                      <node concept="2ShNRf" id="1PeMnANeXY_" role="3clFbG">
-                        <node concept="1pGfFk" id="1PeMnANeXYA" role="2ShVmc">
-                          <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int,int)" resolve="Color" />
-                          <node concept="3cmrfG" id="1PeMnANeXYB" role="37wK5m">
-                            <property role="3cmrfH" value="0" />
-                          </node>
-                          <node concept="3cmrfG" id="1PeMnANeXYC" role="37wK5m">
-                            <property role="3cmrfH" value="0" />
-                          </node>
-                          <node concept="3cmrfG" id="1PeMnANeXYD" role="37wK5m">
-                            <property role="3cmrfH" value="0" />
-                          </node>
-                          <node concept="3cmrfG" id="1PeMnANeXYE" role="37wK5m">
-                            <property role="3cmrfH" value="0" />
-                          </node>
+                    <node concept="3clFbF" id="2WI5qdaBUu" role="3cqZAp">
+                      <node concept="2YIFZM" id="2WI5qdaBUw" role="3clFbG">
+                        <ref role="1Pybhc" to="lzb2:~ColorUtil" resolve="ColorUtil" />
+                        <ref role="37wK5l" to="lzb2:~ColorUtil.withAlpha(java.awt.Color,double)" resolve="withAlpha" />
+                        <node concept="10M0yZ" id="2WI5qdaBUx" role="37wK5m">
+                          <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                          <ref role="3cqZAo" to="lzb2:~JBColor.BLACK" resolve="BLACK" />
+                        </node>
+                        <node concept="3cmrfG" id="2WI5qdaC0o" role="37wK5m">
+                          <property role="3cmrfH" value="0" />
                         </node>
                       </node>
                     </node>
@@ -686,22 +680,16 @@
               <node concept="Veino" id="1PeMnANeY2I" role="3F10Kt">
                 <node concept="3ZlJ5R" id="1PeMnANeY2J" role="VblUZ">
                   <node concept="3clFbS" id="1PeMnANeY2K" role="2VODD2">
-                    <node concept="3clFbF" id="1PeMnANeY2L" role="3cqZAp">
-                      <node concept="2ShNRf" id="1PeMnANeY2M" role="3clFbG">
-                        <node concept="1pGfFk" id="1PeMnANeY2N" role="2ShVmc">
-                          <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int,int)" resolve="Color" />
-                          <node concept="3cmrfG" id="1PeMnANeY2O" role="37wK5m">
-                            <property role="3cmrfH" value="0" />
-                          </node>
-                          <node concept="3cmrfG" id="1PeMnANeY2P" role="37wK5m">
-                            <property role="3cmrfH" value="0" />
-                          </node>
-                          <node concept="3cmrfG" id="1PeMnANeY2Q" role="37wK5m">
-                            <property role="3cmrfH" value="0" />
-                          </node>
-                          <node concept="3cmrfG" id="1PeMnANeY2R" role="37wK5m">
-                            <property role="3cmrfH" value="0" />
-                          </node>
+                    <node concept="3clFbF" id="2WI5qdaC4P" role="3cqZAp">
+                      <node concept="2YIFZM" id="2WI5qdaC4R" role="3clFbG">
+                        <ref role="1Pybhc" to="lzb2:~ColorUtil" resolve="ColorUtil" />
+                        <ref role="37wK5l" to="lzb2:~ColorUtil.withAlpha(java.awt.Color,double)" resolve="withAlpha" />
+                        <node concept="10M0yZ" id="2WI5qdaC4S" role="37wK5m">
+                          <ref role="3cqZAo" to="lzb2:~JBColor.BLACK" resolve="BLACK" />
+                          <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                        </node>
+                        <node concept="3cmrfG" id="2WI5qdaCem" role="37wK5m">
+                          <property role="3cmrfH" value="0" />
                         </node>
                       </node>
                     </node>
@@ -714,22 +702,16 @@
           <node concept="Veino" id="1PeMnANe9$0" role="3F10Kt">
             <node concept="3ZlJ5R" id="1PeMnANe9_y" role="VblUZ">
               <node concept="3clFbS" id="1PeMnANe9_z" role="2VODD2">
-                <node concept="3clFbF" id="1PeMnANecua" role="3cqZAp">
-                  <node concept="2ShNRf" id="1PeMnANecu8" role="3clFbG">
-                    <node concept="1pGfFk" id="1PeMnANedtB" role="2ShVmc">
-                      <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int,int)" resolve="Color" />
-                      <node concept="3cmrfG" id="1PeMnANeduN" role="37wK5m">
-                        <property role="3cmrfH" value="0" />
-                      </node>
-                      <node concept="3cmrfG" id="1PeMnANedCF" role="37wK5m">
-                        <property role="3cmrfH" value="0" />
-                      </node>
-                      <node concept="3cmrfG" id="1PeMnANedK2" role="37wK5m">
-                        <property role="3cmrfH" value="0" />
-                      </node>
-                      <node concept="3cmrfG" id="1PeMnANedQQ" role="37wK5m">
-                        <property role="3cmrfH" value="20" />
-                      </node>
+                <node concept="3clFbF" id="2WI5qdaB1q" role="3cqZAp">
+                  <node concept="2YIFZM" id="2WI5qd69dq" role="3clFbG">
+                    <ref role="1Pybhc" to="lzb2:~ColorUtil" resolve="ColorUtil" />
+                    <ref role="37wK5l" to="lzb2:~ColorUtil.withAlpha(java.awt.Color,double)" resolve="withAlpha" />
+                    <node concept="10M0yZ" id="2WI5qd69h0" role="37wK5m">
+                      <ref role="3cqZAo" to="lzb2:~JBColor.BLACK" resolve="BLACK" />
+                      <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                    </node>
+                    <node concept="3b6qkQ" id="2WI5qd69lt" role="37wK5m">
+                      <property role="$nhwW" value="0.1275" />
                     </node>
                   </node>
                 </node>

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/models/com/mbeddr/mpsutil/grammarcells/editor.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/models/com/mbeddr/mpsutil/grammarcells/editor.mps
@@ -7,6 +7,7 @@
   </languages>
   <imports>
     <import index="z60i" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt(JDK/)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="teg0" ref="r:96165ed2-ef22-48c7-bfe5-8fce083cbabb(com.mbeddr.mpsutil.grammarcells.structure)" implicit="true" />
     <import index="tpco" ref="r:00000000-0000-4000-0000-011c89590284(jetbrains.mps.lang.core.editor)" implicit="true" />
     <import index="tpc5" ref="r:00000000-0000-4000-0000-011c89590299(jetbrains.mps.lang.editor.editor)" implicit="true" />

--- a/code/languages/de.itemis.model.merge/models/de.itemis.model.merge.editor.mps
+++ b/code/languages/de.itemis.model.merge/models/de.itemis.model.merge.editor.mps
@@ -16,6 +16,7 @@
     <import index="av1m" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.menus.style(MPS.Editor/)" />
     <import index="rnx3" ref="r:424d540e-f1fc-49a5-b16d-3f9264b84dee(de.itemis.model.merge.behavior)" />
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
     <import index="tpco" ref="r:00000000-0000-4000-0000-011c89590284(jetbrains.mps.lang.core.editor)" implicit="true" />
     <import index="guwi" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.io(JDK/)" implicit="true" />
@@ -1370,8 +1371,8 @@
             <node concept="liA8E" id="1VmHfRxJ0pk" role="2OqNvi">
               <ref role="37wK5l" to="av1m:~EditorMenuItemStyle.setTextColor(java.awt.Color)" resolve="setTextColor" />
               <node concept="10M0yZ" id="1VmHfRxJ0pl" role="37wK5m">
-                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                <ref role="3cqZAo" to="z60i:~Color.LIGHT_GRAY" resolve="LIGHT_GRAY" />
+                <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                <ref role="3cqZAo" to="lzb2:~JBColor.LIGHT_GRAY" resolve="LIGHT_GRAY" />
               </node>
             </node>
           </node>
@@ -1394,8 +1395,8 @@
             <node concept="liA8E" id="1VmHfRxJ0pt" role="2OqNvi">
               <ref role="37wK5l" to="av1m:~EditorMenuItemStyle.setTextColor(java.awt.Color)" resolve="setTextColor" />
               <node concept="10M0yZ" id="1VmHfRxJ0pu" role="37wK5m">
-                <ref role="3cqZAo" to="z60i:~Color.RED" resolve="RED" />
-                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                <ref role="3cqZAo" to="lzb2:~JBColor.RED" resolve="RED" />
               </node>
             </node>
           </node>

--- a/code/math/languages/de.itemis.mps.editor.math.java/de.itemis.mps.editor.math.java.mpl
+++ b/code/math/languages/de.itemis.mps.editor.math.java/de.itemis.mps.editor.math.java.mpl
@@ -70,6 +70,7 @@
     <dependency reexport="false">0fcee1cf-8f59-441b-b9c7-7ff7bdd6bc97(de.itemis.mps.editor.math.symbols)</dependency>
     <dependency reexport="false">d7eb0a2a-bd50-4576-beae-e4a89db35f20(jetbrains.mps.lang.scopes.runtime)</dependency>
     <dependency reexport="false" scope="generate-into">fd392034-7849-419d-9071-12563d152375(jetbrains.mps.baseLanguage.closures)</dependency>
+    <dependency reexport="false">498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:766348f7-6a67-4b85-9323-384840132299:de.itemis.mps.editor.math" version="0" />
@@ -111,6 +112,7 @@
     <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
     <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
     <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
+    <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="766348f7-6a67-4b85-9323-384840132299(de.itemis.mps.editor.math)" version="0" />
     <module reference="6ce9daa6-c7bc-4847-a19c-5cd82a4a13fc(de.itemis.mps.editor.math.java)" version="0" />

--- a/code/math/languages/de.itemis.mps.editor.math.java/languageModels/editor.mps
+++ b/code/math/languages/de.itemis.mps.editor.math.java/languageModels/editor.mps
@@ -14,6 +14,7 @@
     <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" />
     <import index="z60i" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt(JDK/)" />
     <import index="19h7" ref="r:c367b380-739b-4331-a16f-a542455fc0c8(de.itemis.mps.editor.math.editor)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
   </imports>
   <registry>
@@ -389,8 +390,8 @@
           <node concept="3clFbS" id="7$IFRLylKCL" role="2VODD2">
             <node concept="3clFbF" id="7$IFRLylLoV" role="3cqZAp">
               <node concept="10M0yZ" id="7$IFRLylLCt" role="3clFbG">
-                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                <ref role="3cqZAo" to="z60i:~Color.YELLOW" resolve="YELLOW" />
+                <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                <ref role="3cqZAo" to="lzb2:~JBColor.YELLOW" resolve="YELLOW" />
               </node>
             </node>
           </node>

--- a/code/math/solutions/de.itemis.mps.editor.math.runtime/models/de/itemis/mps/editor/math/runtime.mps
+++ b/code/math/solutions/de.itemis.mps.editor.math.runtime/models/de/itemis/mps/editor/math/runtime.mps
@@ -6833,21 +6833,15 @@
                     </node>
                     <node concept="liA8E" id="CZjRlGePvT" role="2OqNvi">
                       <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
-                      <node concept="2ShNRf" id="CZjRlGePvU" role="37wK5m">
-                        <node concept="1pGfFk" id="CZjRlGePvV" role="2ShVmc">
-                          <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int,int)" resolve="Color" />
-                          <node concept="3cmrfG" id="CZjRlGePvW" role="37wK5m">
-                            <property role="3cmrfH" value="0" />
-                          </node>
-                          <node concept="3cmrfG" id="CZjRlGePvX" role="37wK5m">
-                            <property role="3cmrfH" value="0" />
-                          </node>
-                          <node concept="3cmrfG" id="CZjRlGePvY" role="37wK5m">
-                            <property role="3cmrfH" value="255" />
-                          </node>
-                          <node concept="3cmrfG" id="CZjRlGePvZ" role="37wK5m">
-                            <property role="3cmrfH" value="50" />
-                          </node>
+                      <node concept="2YIFZM" id="2WI5qdvsTJ" role="37wK5m">
+                        <ref role="1Pybhc" to="lzb2:~ColorUtil" resolve="ColorUtil" />
+                        <ref role="37wK5l" to="lzb2:~ColorUtil.withAlpha(java.awt.Color,double)" resolve="withAlpha" />
+                        <node concept="10M0yZ" id="2WI5qdvtAX" role="37wK5m">
+                          <ref role="3cqZAo" to="lzb2:~JBColor.BLUE" resolve="BLUE" />
+                          <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                        </node>
+                        <node concept="3b6qkQ" id="2WI5qdvsTL" role="37wK5m">
+                          <property role="$nhwW" value="0.196" />
                         </node>
                       </node>
                     </node>
@@ -6943,21 +6937,15 @@
                     </node>
                     <node concept="liA8E" id="CZjRlG4EvV" role="2OqNvi">
                       <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
-                      <node concept="2ShNRf" id="CZjRlG4EvW" role="37wK5m">
-                        <node concept="1pGfFk" id="CZjRlG4EvX" role="2ShVmc">
-                          <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int,int)" resolve="Color" />
-                          <node concept="3cmrfG" id="CZjRlG4EvY" role="37wK5m">
-                            <property role="3cmrfH" value="0" />
-                          </node>
-                          <node concept="3cmrfG" id="CZjRlG4EvZ" role="37wK5m">
-                            <property role="3cmrfH" value="0" />
-                          </node>
-                          <node concept="3cmrfG" id="CZjRlG4Ew0" role="37wK5m">
-                            <property role="3cmrfH" value="0" />
-                          </node>
-                          <node concept="3cmrfG" id="CZjRlG4Ew1" role="37wK5m">
-                            <property role="3cmrfH" value="30" />
-                          </node>
+                      <node concept="2YIFZM" id="2WI5qdvkkd" role="37wK5m">
+                        <ref role="1Pybhc" to="lzb2:~ColorUtil" resolve="ColorUtil" />
+                        <ref role="37wK5l" to="lzb2:~ColorUtil.withAlpha(java.awt.Color,double)" resolve="withAlpha" />
+                        <node concept="10M0yZ" id="2WI5qdvlEJ" role="37wK5m">
+                          <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                          <ref role="3cqZAo" to="lzb2:~JBColor.BLACK" resolve="BLACK" />
+                        </node>
+                        <node concept="3b6qkQ" id="2WI5qdvooX" role="37wK5m">
+                          <property role="$nhwW" value="0.117" />
                         </node>
                       </node>
                     </node>

--- a/code/math/solutions/de.itemis.mps.editor.math.runtime/models/de/itemis/mps/editor/math/runtime.mps
+++ b/code/math/solutions/de.itemis.mps.editor.math.runtime/models/de/itemis/mps/editor/math/runtime.mps
@@ -34,6 +34,7 @@
     <import index="kvq8" ref="r:2e938759-cfd0-47cd-9046-896d85204f59(de.slisson.mps.hacks.editor)" />
     <import index="9hsz" ref="r:16d53f5e-7835-4b72-9581-fafeae0db9b1(jetbrains.mps.lang.editor.enumMigration)" />
     <import index="nlpl" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.editor.runtime.commands(MPS.Editor/)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="lui2" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.module(MPS.OpenAPI/)" implicit="true" />
     <import index="tpc2" ref="r:00000000-0000-4000-0000-011c8959029e(jetbrains.mps.lang.editor.structure)" implicit="true" />
   </imports>
@@ -1445,8 +1446,8 @@
                   <ref role="3cqZAo" node="5PByBculMLL" resolve="foregroundColor" />
                 </node>
                 <node concept="10M0yZ" id="5PByBculO9b" role="3K4GZi">
-                  <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                  <ref role="3cqZAo" to="z60i:~Color.BLACK" resolve="BLACK" />
+                  <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                  <ref role="3cqZAo" to="lzb2:~JBColor.BLACK" resolve="BLACK" />
                 </node>
                 <node concept="3y3z36" id="5PByBculNzg" role="3K4Cdx">
                   <node concept="10Nm6u" id="5PByBculNNL" role="3uHU7w" />

--- a/code/mouseselection/solutions/de.itemis.mps.selection.runtime/models/de/itemis/mps/selection/runtime/linear.mps
+++ b/code/mouseselection/solutions/de.itemis.mps.selection.runtime/models/de/itemis/mps/selection/runtime/linear.mps
@@ -24,6 +24,7 @@
     <import index="b8lf" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor.selection(MPS.Editor/)" />
     <import index="4jas" ref="r:b1829bc1-5615-478b-87a3-55032e34acfd(de.itemis.mps.selection.runtime)" />
     <import index="6tp1" ref="r:5c0390a8-12e2-407a-ba93-793107153436(de.itemis.mps.selection.runtime.mouse)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" implicit="true" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
   </imports>
@@ -3176,8 +3177,8 @@
                 <node concept="liA8E" id="4ZiZg53HGXf" role="2OqNvi">
                   <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
                   <node concept="10M0yZ" id="4ZiZg53HHaG" role="37wK5m">
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                    <ref role="3cqZAo" to="z60i:~Color.BLACK" resolve="BLACK" />
+                    <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                    <ref role="3cqZAo" to="lzb2:~JBColor.BLACK" resolve="BLACK" />
                   </node>
                 </node>
               </node>

--- a/code/multiline/solutions/de.slisson.mps.editor.multiline.runtime/models/de/slisson/mps/editor/multiline/cells.mps
+++ b/code/multiline/solutions/de.slisson.mps.editor.multiline.runtime/models/de/slisson/mps/editor/multiline/cells.mps
@@ -42,6 +42,8 @@
     <import index="xggr" ref="r:12584d60-2d80-4ca9-9c6e-b79d499da0cf(de.itemis.mps.editor.celllayout.layout)" />
     <import index="kcid" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor.cellLayout(MPS.Editor/)" />
     <import index="y49u" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.util(MPS.OpenAPI/)" />
+    <import index="hdhb" ref="r:07568eb8-30c0-4bb3-9dcb-50ee4b8de59a(jetbrains.mps.vcs.diff.ui.common)" />
+    <import index="btf5" ref="r:9b4a89e1-ec38-42c4-b1bd-96ab47ffcb3f(jetbrains.mps.vcs.diff.changes)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
     <import index="22ra" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.update(MPS.Editor/)" implicit="true" />
   </imports>
@@ -4406,17 +4408,16 @@
             <node concept="3uibUv" id="3gBYXhg3xPC" role="1tU5fm">
               <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
             </node>
-            <node concept="2ShNRf" id="3gBYXhg3xPE" role="33vP2m">
-              <node concept="1pGfFk" id="3gBYXhg3xPF" role="2ShVmc">
-                <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
-                <node concept="3cmrfG" id="3gBYXhg3xPG" role="37wK5m">
-                  <property role="3cmrfH" value="214" />
-                </node>
-                <node concept="3cmrfG" id="3gBYXhg3xPH" role="37wK5m">
-                  <property role="3cmrfH" value="245" />
-                </node>
-                <node concept="3cmrfG" id="3gBYXhg3xPI" role="37wK5m">
-                  <property role="3cmrfH" value="214" />
+            <node concept="2OqwBi" id="2WI5qdzlvl" role="33vP2m">
+              <node concept="2YIFZM" id="2WI5qdyCLV" role="2Oq$k0">
+                <ref role="37wK5l" to="hdhb:3$C2wb7p0AM" resolve="getInstance" />
+                <ref role="1Pybhc" to="hdhb:42hl10VH9R2" resolve="ChangeColors" />
+              </node>
+              <node concept="liA8E" id="2WI5qdzwxO" role="2OqNvi">
+                <ref role="37wK5l" to="hdhb:3$C2wb7oVfi" resolve="getDiffColor" />
+                <node concept="Rm8GO" id="2WI5qd$hnA" role="37wK5m">
+                  <ref role="Rm8GQ" to="btf5:7inhnIFBpHO" resolve="ADD" />
+                  <ref role="1Px2BO" to="btf5:7inhnIFBpHM" resolve="ChangeType" />
                 </node>
               </node>
             </node>
@@ -4428,17 +4429,16 @@
             <node concept="3uibUv" id="3gBYXhg3xPR" role="1tU5fm">
               <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
             </node>
-            <node concept="2ShNRf" id="3gBYXhg3xPT" role="33vP2m">
-              <node concept="1pGfFk" id="3gBYXhg3xPU" role="2ShVmc">
-                <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
-                <node concept="3cmrfG" id="3gBYXhg3xPV" role="37wK5m">
-                  <property role="3cmrfH" value="203" />
-                </node>
-                <node concept="3cmrfG" id="3gBYXhg3xPW" role="37wK5m">
-                  <property role="3cmrfH" value="203" />
-                </node>
-                <node concept="3cmrfG" id="3gBYXhg3xPX" role="37wK5m">
-                  <property role="3cmrfH" value="203" />
+            <node concept="2OqwBi" id="2WI5qd$AkL" role="33vP2m">
+              <node concept="2YIFZM" id="2WI5qd$AkM" role="2Oq$k0">
+                <ref role="1Pybhc" to="hdhb:42hl10VH9R2" resolve="ChangeColors" />
+                <ref role="37wK5l" to="hdhb:3$C2wb7p0AM" resolve="getInstance" />
+              </node>
+              <node concept="liA8E" id="2WI5qd$AkN" role="2OqNvi">
+                <ref role="37wK5l" to="hdhb:3$C2wb7oVfi" resolve="getDiffColor" />
+                <node concept="Rm8GO" id="2WI5qd$Hk9" role="37wK5m">
+                  <ref role="Rm8GQ" to="btf5:7inhnIFBpHU" resolve="DELETE" />
+                  <ref role="1Px2BO" to="btf5:7inhnIFBpHM" resolve="ChangeType" />
                 </node>
               </node>
             </node>
@@ -4450,17 +4450,16 @@
             <node concept="3uibUv" id="6nUV0qFJ6Hj" role="1tU5fm">
               <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
             </node>
-            <node concept="2ShNRf" id="6nUV0qFJ6Hl" role="33vP2m">
-              <node concept="1pGfFk" id="6nUV0qFJeGJ" role="2ShVmc">
-                <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
-                <node concept="3cmrfG" id="6nUV0qFJeGK" role="37wK5m">
-                  <property role="3cmrfH" value="188" />
-                </node>
-                <node concept="3cmrfG" id="6nUV0qFJeGM" role="37wK5m">
-                  <property role="3cmrfH" value="207" />
-                </node>
-                <node concept="3cmrfG" id="6nUV0qFJeH4" role="37wK5m">
-                  <property role="3cmrfH" value="249" />
+            <node concept="2OqwBi" id="2WI5qd$Q_V" role="33vP2m">
+              <node concept="2YIFZM" id="2WI5qd$Q_W" role="2Oq$k0">
+                <ref role="1Pybhc" to="hdhb:42hl10VH9R2" resolve="ChangeColors" />
+                <ref role="37wK5l" to="hdhb:3$C2wb7p0AM" resolve="getInstance" />
+              </node>
+              <node concept="liA8E" id="2WI5qd$Q_X" role="2OqNvi">
+                <ref role="37wK5l" to="hdhb:3$C2wb7oVfi" resolve="getDiffColor" />
+                <node concept="Rm8GO" id="2WI5qd$Y2z" role="37wK5m">
+                  <ref role="Rm8GQ" to="btf5:7inhnIFBpI0" resolve="CHANGE" />
+                  <ref role="1Px2BO" to="btf5:7inhnIFBpHM" resolve="ChangeType" />
                 </node>
               </node>
             </node>

--- a/code/multiline/solutions/de.slisson.mps.editor.multiline.runtime/runtime.msd
+++ b/code/multiline/solutions/de.slisson.mps.editor.multiline.runtime/runtime.msd
@@ -25,6 +25,8 @@
     <dependency reexport="false">cce85e64-7b37-4ad5-b0e6-9d18324cdfb3(de.itemis.mps.selection.runtime)</dependency>
     <dependency reexport="false">6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)</dependency>
     <dependency reexport="true">848ef45d-e560-4e35-853c-f35a64cc135c(de.itemis.mps.editor.celllayout.runtime)</dependency>
+    <dependency reexport="false">6fd1293f-7f65-4ffd-99dc-4719eca7c171(jetbrains.mps.ide.vcs.platform)</dependency>
+    <dependency reexport="false">85836058-a162-41d7-bb1d-52e99d873f28(jetbrains.mps.ide.vcs.core)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
@@ -55,6 +57,8 @@
     <module reference="cce85e64-7b37-4ad5-b0e6-9d18324cdfb3(de.itemis.mps.selection.runtime)" version="0" />
     <module reference="dc038ceb-b7ea-4fea-ac12-55f7400e97ba(de.slisson.mps.editor.multiline.runtime)" version="0" />
     <module reference="f0fff802-6d26-4d2e-b89d-391357265626(de.slisson.mps.hacks.editor)" version="0" />
+    <module reference="85836058-a162-41d7-bb1d-52e99d873f28(jetbrains.mps.ide.vcs.core)" version="0" />
+    <module reference="6fd1293f-7f65-4ffd-99dc-4719eca7c171(jetbrains.mps.ide.vcs.platform)" version="0" />
     <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
   </dependencyVersions>
 </solution>

--- a/code/projectview/com.mbeddr.mpsutil.projectview.runtime/models/com/mbeddr/mpsutil/projectview/runtime/tree.mps
+++ b/code/projectview/com.mbeddr.mpsutil.projectview.runtime/models/com/mbeddr/mpsutil/projectview/runtime/tree.mps
@@ -80,6 +80,7 @@
     <import index="32g5" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.library(MPS.Core/)" />
     <import index="w0gx" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.project.structure.modules(MPS.Core/)" />
     <import index="ewej" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt.font(JDK/)" />
+    <import index="exr9" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor(MPS.Editor/)" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
@@ -200,6 +201,9 @@
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <property id="1176718929932" name="isFinal" index="3TUv4t" />
         <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ng" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
       </concept>
       <concept id="1109279763828" name="jetbrains.mps.baseLanguage.structure.TypeVariableDeclaration" flags="ng" index="16euLQ">
         <child id="1214996921760" name="bound" index="3ztrMU" />
@@ -17799,12 +17803,17 @@
                           </node>
                           <node concept="liA8E" id="4dJXybkiiQY" role="2OqNvi">
                             <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
-                            <node concept="2ShNRf" id="4dJXybkiiQZ" role="37wK5m">
-                              <node concept="1pGfFk" id="4dJXybkiiR0" role="2ShVmc">
-                                <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int)" resolve="Color" />
-                                <node concept="10M0yZ" id="4dJXybkil5E" role="37wK5m">
-                                  <ref role="1PxDUh" to="cj4x:~ColorConstants" resolve="ColorConstants" />
+                            <node concept="2ShNRf" id="2WI5qdjux1" role="37wK5m">
+                              <node concept="1pGfFk" id="2WI5qdj$RP" role="2ShVmc">
+                                <property role="373rjd" value="true" />
+                                <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(int,int)" resolve="JBColor" />
+                                <node concept="10M0yZ" id="2WI5qdjDDg" role="37wK5m">
                                   <ref role="3cqZAo" to="cj4x:~ColorConstants.WARNING" resolve="WARNING" />
+                                  <ref role="1PxDUh" to="cj4x:~ColorConstants" resolve="ColorConstants" />
+                                </node>
+                                <node concept="10M0yZ" id="2WI5qdjKuW" role="37wK5m">
+                                  <ref role="3cqZAo" to="cj4x:~ColorConstants.WARNING_DARK" resolve="WARNING_DARK" />
+                                  <ref role="1PxDUh" to="cj4x:~ColorConstants" resolve="ColorConstants" />
                                 </node>
                               </node>
                             </node>
@@ -17821,14 +17830,9 @@
                         </node>
                         <node concept="liA8E" id="4dJXybkiiUO" role="2OqNvi">
                           <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
-                          <node concept="2ShNRf" id="4dJXybkiiUP" role="37wK5m">
-                            <node concept="1pGfFk" id="4dJXybkiiUQ" role="2ShVmc">
-                              <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int)" resolve="Color" />
-                              <node concept="10M0yZ" id="4dJXybkil5F" role="37wK5m">
-                                <ref role="1PxDUh" to="cj4x:~ColorConstants" resolve="ColorConstants" />
-                                <ref role="3cqZAo" to="cj4x:~ColorConstants.ERROR" resolve="ERROR" />
-                              </node>
-                            </node>
+                          <node concept="10M0yZ" id="2WI5qdjoLC" role="37wK5m">
+                            <ref role="3cqZAo" to="exr9:~MPSColors.RED" resolve="RED" />
+                            <ref role="1PxDUh" to="exr9:~MPSColors" resolve="MPSColors" />
                           </node>
                         </node>
                       </node>

--- a/code/richtext/languages/richtext/models/de/slisson/mps/richtext/runtime/vcs.mps
+++ b/code/richtext/languages/richtext/models/de/slisson/mps/richtext/runtime/vcs.mps
@@ -20,6 +20,7 @@
     <import index="lui2" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.module(MPS.OpenAPI/)" />
     <import index="q7tw" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:org.apache.log4j(MPS.Core/)" />
     <import index="wtuq" ref="r:ebe120ba-74f3-4913-8ba8-dc7299e610f9(de.slisson.mps.richtext.util)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
     <import index="cj4x" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor(MPS.Editor/)" implicit="true" />
     <import index="tbr6" ref="r:6a005c26-87c0-43c4-8cf3-49ffba1099df(de.slisson.mps.richtext.behavior)" implicit="true" />
@@ -1209,8 +1210,8 @@
                                     </node>
                                   </node>
                                   <node concept="10M0yZ" id="6nUV0qFIOOe" role="37wK5m">
-                                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
                                     <ref role="3cqZAo" to="z60i:~Color.WHITE" resolve="WHITE" />
+                                    <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                                   </node>
                                   <node concept="3clFbT" id="6nUV0qFIOOf" role="37wK5m" />
                                 </node>
@@ -1781,8 +1782,8 @@
                                     </node>
                                   </node>
                                   <node concept="10M0yZ" id="6nUV0qFIONU" role="37wK5m">
-                                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
                                     <ref role="3cqZAo" to="z60i:~Color.WHITE" resolve="WHITE" />
+                                    <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                                   </node>
                                   <node concept="3clFbT" id="6nUV0qFIONZ" role="37wK5m" />
                                 </node>

--- a/code/shadowmodels/languages/de.q60.mps.incremental/models/editor.mps
+++ b/code/shadowmodels/languages/de.q60.mps.incremental/models/editor.mps
@@ -11,6 +11,7 @@
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" />
     <import index="g51k" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor.cells(MPS.Editor/)" />
     <import index="z60i" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt(JDK/)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="tpco" ref="r:00000000-0000-4000-0000-011c89590284(jetbrains.mps.lang.core.editor)" implicit="true" />
   </imports>
   <registry>
@@ -101,6 +102,12 @@
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
       </concept>
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
+      </concept>
+      <concept id="1070533707846" name="jetbrains.mps.baseLanguage.structure.StaticFieldReference" flags="nn" index="10M0yZ">
+        <reference id="1144433057691" name="classifier" index="1PxDUh" />
+      </concept>
       <concept id="1070534934090" name="jetbrains.mps.baseLanguage.structure.CastExpression" flags="nn" index="10QFUN">
         <child id="1070534934091" name="type" index="10QFUM" />
         <child id="1070534934092" name="expression" index="10QFUP" />
@@ -115,14 +122,14 @@
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
+      <concept id="1111509017652" name="jetbrains.mps.baseLanguage.structure.FloatingPointConstant" flags="nn" index="3b6qkQ">
+        <property id="1113006610751" name="value" index="$nhwW" />
+      </concept>
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
-      </concept>
-      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
-        <property id="1068580320021" name="value" index="3cmrfH" />
       </concept>
       <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
         <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
@@ -135,7 +142,6 @@
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
-      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
       </concept>
@@ -317,22 +323,16 @@
             <node concept="Veino" id="VwH9CcWICo" role="3F10Kt">
               <node concept="3ZlJ5R" id="VwH9CcWICp" role="VblUZ">
                 <node concept="3clFbS" id="VwH9CcWICq" role="2VODD2">
-                  <node concept="3clFbF" id="VwH9CcWICr" role="3cqZAp">
-                    <node concept="2ShNRf" id="VwH9CcWICs" role="3clFbG">
-                      <node concept="1pGfFk" id="VwH9CcWICt" role="2ShVmc">
-                        <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int,int)" resolve="Color" />
-                        <node concept="3cmrfG" id="VwH9CcWICu" role="37wK5m">
-                          <property role="3cmrfH" value="0" />
-                        </node>
-                        <node concept="3cmrfG" id="VwH9CcWICv" role="37wK5m">
-                          <property role="3cmrfH" value="0" />
-                        </node>
-                        <node concept="3cmrfG" id="VwH9CcWICw" role="37wK5m">
-                          <property role="3cmrfH" value="0" />
-                        </node>
-                        <node concept="3cmrfG" id="VwH9CcWICx" role="37wK5m">
-                          <property role="3cmrfH" value="20" />
-                        </node>
+                  <node concept="3clFbF" id="2WI5qdKV6l" role="3cqZAp">
+                    <node concept="2YIFZM" id="2WI5qdKV6m" role="3clFbG">
+                      <ref role="1Pybhc" to="lzb2:~ColorUtil" resolve="ColorUtil" />
+                      <ref role="37wK5l" to="lzb2:~ColorUtil.withAlpha(java.awt.Color,double)" resolve="withAlpha" />
+                      <node concept="10M0yZ" id="2WI5qdKV6n" role="37wK5m">
+                        <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                        <ref role="3cqZAo" to="lzb2:~JBColor.DARK_GRAY" resolve="DARK_GRAY" />
+                      </node>
+                      <node concept="3b6qkQ" id="2WI5qdKV6o" role="37wK5m">
+                        <property role="$nhwW" value="0.078" />
                       </node>
                     </node>
                   </node>
@@ -597,22 +597,16 @@
             <node concept="Veino" id="7qGGLAkSijr" role="3F10Kt">
               <node concept="3ZlJ5R" id="7qGGLAkSijs" role="VblUZ">
                 <node concept="3clFbS" id="7qGGLAkSijt" role="2VODD2">
-                  <node concept="3clFbF" id="7qGGLAkSiju" role="3cqZAp">
-                    <node concept="2ShNRf" id="7qGGLAkSijv" role="3clFbG">
-                      <node concept="1pGfFk" id="7qGGLAkSijw" role="2ShVmc">
-                        <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int,int)" resolve="Color" />
-                        <node concept="3cmrfG" id="7qGGLAkSijx" role="37wK5m">
-                          <property role="3cmrfH" value="0" />
-                        </node>
-                        <node concept="3cmrfG" id="7qGGLAkSijy" role="37wK5m">
-                          <property role="3cmrfH" value="0" />
-                        </node>
-                        <node concept="3cmrfG" id="7qGGLAkSijz" role="37wK5m">
-                          <property role="3cmrfH" value="0" />
-                        </node>
-                        <node concept="3cmrfG" id="7qGGLAkSij$" role="37wK5m">
-                          <property role="3cmrfH" value="20" />
-                        </node>
+                  <node concept="3clFbF" id="2WI5qdKdBQ" role="3cqZAp">
+                    <node concept="2YIFZM" id="2WI5qdKdJS" role="3clFbG">
+                      <ref role="37wK5l" to="lzb2:~ColorUtil.withAlpha(java.awt.Color,double)" resolve="withAlpha" />
+                      <ref role="1Pybhc" to="lzb2:~ColorUtil" resolve="ColorUtil" />
+                      <node concept="10M0yZ" id="2WI5qdKD_K" role="37wK5m">
+                        <ref role="3cqZAo" to="lzb2:~JBColor.DARK_GRAY" resolve="DARK_GRAY" />
+                        <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                      </node>
+                      <node concept="3b6qkQ" id="2WI5qdKiAa" role="37wK5m">
+                        <property role="$nhwW" value="0.078" />
                       </node>
                     </node>
                   </node>

--- a/code/shadowmodels/solutions/de.q60.mps.shadowmodels.debugview/models/pf.mps
+++ b/code/shadowmodels/solutions/de.q60.mps.shadowmodels.debugview/models/pf.mps
@@ -44,6 +44,7 @@
     <import index="e55s" ref="r:340cdae2-711c-4186-bc13-94d9832e5a1d(de.q60.mps.explorer)" />
     <import index="jks5" ref="cc99dce1-49f3-4392-8dbf-e22ca47bd0af/java:org.modelix.model.api(org.modelix.model.api/)" />
     <import index="xxte" ref="r:a79f28f8-6055-40c6-bc5e-47a42a3b97e8(org.modelix.model.mpsadapters.mps)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="1ctc" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util.stream(JDK/)" implicit="true" />
     <import index="oyp0" ref="r:ff4bc8f2-4e53-41b7-a27c-792a5dcc86cb(de.q60.mps.shadowmodels.transformation.structure)" implicit="true" />
     <import index="hm90" ref="r:61d96d59-75af-4854-9d37-c81762926dfe(de.q60.mps.shadowmodels.transformation.behavior)" implicit="true" />
@@ -7755,8 +7756,8 @@
                 <node concept="liA8E" id="7pNuz6_YGT6" role="2OqNvi">
                   <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
                   <node concept="10M0yZ" id="7pNuz6_YHnx" role="37wK5m">
-                    <ref role="3cqZAo" to="z60i:~Color.BLACK" resolve="BLACK" />
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                    <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                    <ref role="3cqZAo" to="lzb2:~JBColor.BLACK" resolve="BLACK" />
                   </node>
                 </node>
               </node>

--- a/code/shadowmodels/solutions/de.q60.mps.shadowmodels.runtime/models/plugin.mps
+++ b/code/shadowmodels/solutions/de.q60.mps.shadowmodels.runtime/models/plugin.mps
@@ -49,6 +49,7 @@
     <import index="y071" ref="r:57711a24-29ad-4bd9-8062-d4259c0a2ba5(de.q60.mps.logging.runtime)" />
     <import index="zy2h" ref="r:ec0fe8c4-38e5-4216-9425-8861454eaf8a(de.q60.mps.util.invalidation)" />
     <import index="xxte" ref="r:a79f28f8-6055-40c6-bc5e-47a42a3b97e8(org.modelix.model.mpsadapters.mps)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="1m72" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.components(MPS.IDEA/)" implicit="true" />
     <import index="tprs" ref="r:00000000-0000-4000-0000-011c895904a4(jetbrains.mps.ide.actions)" implicit="true" />
   </imports>
@@ -4183,22 +4184,12 @@
             <ref role="3cqZAo" node="4NO8rntV3yC" resolve="offsetY" />
           </node>
           <node concept="10M0yZ" id="5wnrAmTLGD$" role="37wK5m">
-            <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-            <ref role="3cqZAo" to="z60i:~Color.BLACK" resolve="BLACK" />
+            <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+            <ref role="3cqZAo" to="lzb2:~JBColor.BLACK" resolve="BLACK" />
           </node>
-          <node concept="2ShNRf" id="5wnrAmTLG_g" role="37wK5m">
-            <node concept="1pGfFk" id="5wnrAmTLG_h" role="2ShVmc">
-              <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
-              <node concept="3cmrfG" id="5wnrAmTLG_i" role="37wK5m">
-                <property role="3cmrfH" value="200" />
-              </node>
-              <node concept="3cmrfG" id="5wnrAmTLG_j" role="37wK5m">
-                <property role="3cmrfH" value="200" />
-              </node>
-              <node concept="3cmrfG" id="5wnrAmTLG_k" role="37wK5m">
-                <property role="3cmrfH" value="200" />
-              </node>
-            </node>
+          <node concept="10M0yZ" id="2WI5qcS8iM" role="37wK5m">
+            <ref role="3cqZAo" to="lzb2:~JBColor.LIGHT_GRAY" resolve="LIGHT_GRAY" />
+            <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
           </node>
         </node>
       </node>

--- a/code/tables/languages/de.slisson.mps.tables/languageModels/editor.mps
+++ b/code/tables/languages/de.slisson.mps.tables/languageModels/editor.mps
@@ -20,6 +20,7 @@
     <import index="z60i" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt(JDK/)" />
     <import index="oghc" ref="r:356c0504-b4a3-4458-9604-13fbb48838d7(de.slisson.mps.tables.runtime.style)" />
     <import index="cj4x" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor(MPS.Editor/)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="tpce" ref="r:00000000-0000-4000-0000-011c89590292(jetbrains.mps.lang.structure.structure)" implicit="true" />
   </imports>
   <registry>
@@ -3022,8 +3023,8 @@
         <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
       </node>
       <node concept="10M0yZ" id="5PDTdguqQlH" role="3t49C2">
-        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-        <ref role="3cqZAo" to="z60i:~Color.LIGHT_GRAY" resolve="LIGHT_GRAY" />
+        <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+        <ref role="3cqZAo" to="lzb2:~JBColor.LIGHT_GRAY" resolve="LIGHT_GRAY" />
       </node>
     </node>
     <node concept="3t5Usi" id="5PDTdguqQlI" role="V601i">
@@ -3033,8 +3034,8 @@
         <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
       </node>
       <node concept="10M0yZ" id="5PDTdguqQlK" role="3t49C2">
-        <ref role="3cqZAo" to="z60i:~Color.LIGHT_GRAY" resolve="LIGHT_GRAY" />
-        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+        <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+        <ref role="3cqZAo" to="lzb2:~JBColor.LIGHT_GRAY" resolve="LIGHT_GRAY" />
       </node>
     </node>
     <node concept="3t5Usi" id="5PDTdguqQlL" role="V601i">
@@ -3044,8 +3045,8 @@
         <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
       </node>
       <node concept="10M0yZ" id="5PDTdguqQlN" role="3t49C2">
-        <ref role="3cqZAo" to="z60i:~Color.LIGHT_GRAY" resolve="LIGHT_GRAY" />
-        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+        <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+        <ref role="3cqZAo" to="lzb2:~JBColor.LIGHT_GRAY" resolve="LIGHT_GRAY" />
       </node>
     </node>
     <node concept="3t5Usi" id="5PDTdguqQlO" role="V601i">
@@ -3055,8 +3056,8 @@
         <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
       </node>
       <node concept="10M0yZ" id="5PDTdguqQlQ" role="3t49C2">
-        <ref role="3cqZAo" to="z60i:~Color.LIGHT_GRAY" resolve="LIGHT_GRAY" />
-        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+        <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+        <ref role="3cqZAo" to="lzb2:~JBColor.LIGHT_GRAY" resolve="LIGHT_GRAY" />
       </node>
     </node>
     <node concept="3t5Usi" id="5PDTdguqQlR" role="V601i">
@@ -3098,8 +3099,8 @@
         <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
       </node>
       <node concept="10M0yZ" id="5PDTdguqQm5" role="3t49C2">
-        <ref role="3cqZAo" to="z60i:~Color.LIGHT_GRAY" resolve="LIGHT_GRAY" />
-        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+        <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+        <ref role="3cqZAo" to="lzb2:~JBColor.LIGHT_GRAY" resolve="LIGHT_GRAY" />
       </node>
     </node>
     <node concept="3t5Usi" id="5PDTdguqQm6" role="V601i">
@@ -3109,8 +3110,8 @@
         <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
       </node>
       <node concept="10M0yZ" id="5PDTdguqQm8" role="3t49C2">
-        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-        <ref role="3cqZAo" to="z60i:~Color.LIGHT_GRAY" resolve="LIGHT_GRAY" />
+        <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+        <ref role="3cqZAo" to="lzb2:~JBColor.LIGHT_GRAY" resolve="LIGHT_GRAY" />
       </node>
     </node>
     <node concept="3t5Usi" id="5PDTdguqQm9" role="V601i">
@@ -3120,8 +3121,8 @@
         <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
       </node>
       <node concept="10M0yZ" id="5PDTdguqQmb" role="3t49C2">
-        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-        <ref role="3cqZAo" to="z60i:~Color.LIGHT_GRAY" resolve="LIGHT_GRAY" />
+        <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+        <ref role="3cqZAo" to="lzb2:~JBColor.LIGHT_GRAY" resolve="LIGHT_GRAY" />
       </node>
     </node>
     <node concept="3t5Usi" id="5PDTdguqQmc" role="V601i">
@@ -3131,8 +3132,8 @@
         <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
       </node>
       <node concept="10M0yZ" id="5PDTdguqQme" role="3t49C2">
-        <ref role="3cqZAo" to="z60i:~Color.LIGHT_GRAY" resolve="LIGHT_GRAY" />
-        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+        <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+        <ref role="3cqZAo" to="lzb2:~JBColor.LIGHT_GRAY" resolve="LIGHT_GRAY" />
       </node>
     </node>
     <node concept="3t5Usi" id="5PDTdguqQmf" role="V601i">
@@ -3174,8 +3175,8 @@
         <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
       </node>
       <node concept="10M0yZ" id="5PDTdguqQmt" role="3t49C2">
-        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-        <ref role="3cqZAo" to="z60i:~Color.LIGHT_GRAY" resolve="LIGHT_GRAY" />
+        <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+        <ref role="3cqZAo" to="lzb2:~JBColor.LIGHT_GRAY" resolve="LIGHT_GRAY" />
       </node>
     </node>
     <node concept="3t5Usi" id="5PDTdguqQmu" role="V601i">
@@ -3185,8 +3186,8 @@
         <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
       </node>
       <node concept="10M0yZ" id="5PDTdguqQmw" role="3t49C2">
-        <ref role="3cqZAo" to="z60i:~Color.LIGHT_GRAY" resolve="LIGHT_GRAY" />
-        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+        <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+        <ref role="3cqZAo" to="lzb2:~JBColor.LIGHT_GRAY" resolve="LIGHT_GRAY" />
       </node>
     </node>
     <node concept="3t5Usi" id="5PDTdguqQmx" role="V601i">
@@ -3196,8 +3197,8 @@
         <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
       </node>
       <node concept="10M0yZ" id="5PDTdguqQmz" role="3t49C2">
-        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-        <ref role="3cqZAo" to="z60i:~Color.LIGHT_GRAY" resolve="LIGHT_GRAY" />
+        <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+        <ref role="3cqZAo" to="lzb2:~JBColor.LIGHT_GRAY" resolve="LIGHT_GRAY" />
       </node>
     </node>
     <node concept="3t5Usi" id="5PDTdguqQm$" role="V601i">
@@ -3207,8 +3208,8 @@
         <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
       </node>
       <node concept="10M0yZ" id="5PDTdguqQmA" role="3t49C2">
-        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-        <ref role="3cqZAo" to="z60i:~Color.LIGHT_GRAY" resolve="LIGHT_GRAY" />
+        <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+        <ref role="3cqZAo" to="lzb2:~JBColor.LIGHT_GRAY" resolve="LIGHT_GRAY" />
       </node>
     </node>
     <node concept="3t5Usi" id="5PDTdguqQmB" role="V601i">

--- a/code/tables/languages/de.slisson.mps.tables/runtime/models/de/slisson/mps/tables/runtime/cells.mps
+++ b/code/tables/languages/de.slisson.mps.tables/runtime/models/de/slisson/mps/tables/runtime/cells.mps
@@ -60,6 +60,7 @@
     <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" />
     <import index="kvq8" ref="r:2e938759-cfd0-47cd-9046-896d85204f59(de.slisson.mps.hacks.editor)" />
     <import index="9hsz" ref="r:16d53f5e-7835-4b72-9581-fafeae0db9b1(jetbrains.mps.lang.editor.enumMigration)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="z8iw" ref="r:dfdf3542-dbcf-43df-870a-3c3504b3c840(jetbrains.mps.baseLanguage.collections.custom)" implicit="true" />
     <import index="tpc2" ref="r:00000000-0000-4000-0000-011c8959029e(jetbrains.mps.lang.editor.structure)" implicit="true" />
     <import index="nivk" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.editor.runtime.descriptor(MPS.Editor/)" implicit="true" />
@@ -12268,8 +12269,8 @@
                         <node concept="liA8E" id="7VuKdVa5Us_" role="2OqNvi">
                           <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
                           <node concept="10M0yZ" id="7VuKdVa7FRR" role="37wK5m">
-                            <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
-                            <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                            <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                            <ref role="3cqZAo" to="lzb2:~JBColor.lightGray" resolve="lightGray" />
                           </node>
                         </node>
                       </node>

--- a/code/tables/languages/de.slisson.mps.tables/runtime/models/de/slisson/mps/tables/runtime/cells.mps
+++ b/code/tables/languages/de.slisson.mps.tables/runtime/models/de/slisson/mps/tables/runtime/cells.mps
@@ -212,6 +212,9 @@
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
+      <concept id="1111509017652" name="jetbrains.mps.baseLanguage.structure.FloatingPointConstant" flags="nn" index="3b6qkQ">
+        <property id="1113006610751" name="value" index="$nhwW" />
+      </concept>
       <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
         <property id="4276006055363816570" name="isSynchronized" index="od$2w" />
         <property id="1181808852946" name="isFinal" index="DiZV1" />
@@ -27846,21 +27849,15 @@
                 </node>
                 <node concept="liA8E" id="CZjRlG4EvV" role="2OqNvi">
                   <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
-                  <node concept="2ShNRf" id="CZjRlG4EvW" role="37wK5m">
-                    <node concept="1pGfFk" id="CZjRlG4EvX" role="2ShVmc">
-                      <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int,int)" resolve="Color" />
-                      <node concept="3cmrfG" id="CZjRlG4EvY" role="37wK5m">
-                        <property role="3cmrfH" value="0" />
-                      </node>
-                      <node concept="3cmrfG" id="CZjRlG4EvZ" role="37wK5m">
-                        <property role="3cmrfH" value="0" />
-                      </node>
-                      <node concept="3cmrfG" id="CZjRlG4Ew0" role="37wK5m">
-                        <property role="3cmrfH" value="0" />
-                      </node>
-                      <node concept="3cmrfG" id="CZjRlG4Ew1" role="37wK5m">
-                        <property role="3cmrfH" value="30" />
-                      </node>
+                  <node concept="2YIFZM" id="2WI5qdE8Sr" role="37wK5m">
+                    <ref role="1Pybhc" to="lzb2:~ColorUtil" resolve="ColorUtil" />
+                    <ref role="37wK5l" to="lzb2:~ColorUtil.withAlpha(java.awt.Color,double)" resolve="withAlpha" />
+                    <node concept="10M0yZ" id="2WI5qdEewK" role="37wK5m">
+                      <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                      <ref role="3cqZAo" to="lzb2:~JBColor.BLACK" resolve="BLACK" />
+                    </node>
+                    <node concept="3b6qkQ" id="2WI5qdEov9" role="37wK5m">
+                      <property role="$nhwW" value="0.117" />
                     </node>
                   </node>
                 </node>

--- a/code/tables/languages/de.slisson.mps.tables/runtime/models/de/slisson/mps/tables/runtime/gridmodel.mps
+++ b/code/tables/languages/de.slisson.mps.tables/runtime/models/de/slisson/mps/tables/runtime/gridmodel.mps
@@ -32,6 +32,7 @@
     <import index="tpce" ref="r:00000000-0000-4000-0000-011c89590292(jetbrains.mps.lang.structure.structure)" />
     <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" />
     <import index="zce0" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.smodel.action(MPS.Editor/)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="22ra" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.update(MPS.Editor/)" implicit="true" />
   </imports>
   <registry>
@@ -24671,8 +24672,8 @@
                             <ref role="37wK5l" node="2c3czgponU5" resolve="createConstant" />
                             <node concept="Xl_RD" id="RywcYwuy46" role="37wK5m" />
                             <node concept="10M0yZ" id="2c3czgpoEbP" role="37wK5m">
-                              <ref role="3cqZAo" to="z60i:~Color.LIGHT_GRAY" resolve="LIGHT_GRAY" />
-                              <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                              <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                              <ref role="3cqZAo" to="lzb2:~JBColor.LIGHT_GRAY" resolve="LIGHT_GRAY" />
                             </node>
                             <node concept="3clFbT" id="2c3czgpoEBA" role="37wK5m">
                               <property role="3clFbU" value="false" />
@@ -25547,8 +25548,8 @@
                         <ref role="3cqZAo" to="5ueo:~StyleAttributes.TEXT_COLOR" resolve="TEXT_COLOR" />
                       </node>
                       <node concept="10M0yZ" id="2c3czgpmthd" role="37wK5m">
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                        <ref role="3cqZAo" to="z60i:~Color.LIGHT_GRAY" resolve="LIGHT_GRAY" />
+                        <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                        <ref role="3cqZAo" to="lzb2:~JBColor.LIGHT_GRAY" resolve="LIGHT_GRAY" />
                       </node>
                     </node>
                   </node>

--- a/code/tooltips/solutions/de.itemis.mps.tooltips.runtime/models/de/itemis/mps/tooltips/runtime.mps
+++ b/code/tooltips/solutions/de.itemis.mps.tooltips.runtime/models/de/itemis/mps/tooltips/runtime.mps
@@ -28,6 +28,7 @@
     <import index="kcid" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor.cellLayout(MPS.Editor/)" />
     <import index="88dm" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.ide.tooltips(MPS.Platform/)" />
     <import index="3qmy" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.classloading(MPS.Core/)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="22ra" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.update(MPS.Editor/)" implicit="true" />
   </imports>
   <registry>
@@ -1392,8 +1393,8 @@
             <node concept="liA8E" id="2a194$K08vi" role="2OqNvi">
               <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
               <node concept="10M0yZ" id="7CEHNszDLZH" role="37wK5m">
-                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                <ref role="3cqZAo" to="z60i:~Color.BLUE" resolve="BLUE" />
+                <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                <ref role="3cqZAo" to="lzb2:~JBColor.BLUE" resolve="BLUE" />
               </node>
             </node>
           </node>

--- a/code/treenotation/com.mbeddr.mpsutil.treenotation.runtime/models/com/mbeddr/mpsutil/treenotation/runtime.mps
+++ b/code/treenotation/com.mbeddr.mpsutil.treenotation.runtime/models/com/mbeddr/mpsutil/treenotation/runtime.mps
@@ -7666,19 +7666,9 @@
             </node>
             <node concept="liA8E" id="JAaUnmWuzi" role="2OqNvi">
               <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
-              <node concept="2ShNRf" id="JAaUnmWuVB" role="37wK5m">
-                <node concept="1pGfFk" id="JAaUnmWuVA" role="2ShVmc">
-                  <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
-                  <node concept="3cmrfG" id="JAaUnmWv3e" role="37wK5m">
-                    <property role="3cmrfH" value="0" />
-                  </node>
-                  <node concept="3cmrfG" id="JAaUnmWvhh" role="37wK5m">
-                    <property role="3cmrfH" value="150" />
-                  </node>
-                  <node concept="3cmrfG" id="JAaUnmWvvW" role="37wK5m">
-                    <property role="3cmrfH" value="0" />
-                  </node>
-                </node>
+              <node concept="10M0yZ" id="2WI5qdmB0W" role="37wK5m">
+                <ref role="3cqZAo" to="exr9:~MPSColors.DARK_GREEN" resolve="DARK_GREEN" />
+                <ref role="1PxDUh" to="exr9:~MPSColors" resolve="MPSColors" />
               </node>
             </node>
           </node>

--- a/code/treenotation/com.mbeddr.mpsutil.treenotation.runtime/models/com/mbeddr/mpsutil/treenotation/runtime.mps
+++ b/code/treenotation/com.mbeddr.mpsutil.treenotation.runtime/models/com/mbeddr/mpsutil/treenotation/runtime.mps
@@ -36,6 +36,7 @@
     <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" />
     <import index="zce0" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.smodel.action(MPS.Editor/)" />
     <import index="sn11" ref="r:836426ab-a6f4-4fa3-9a9c-34c02ed6ab5d(jetbrains.mps.ide.icons)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="lui2" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.module(MPS.OpenAPI/)" implicit="true" />
   </imports>
   <registry>
@@ -4879,8 +4880,8 @@
                     <node concept="liA8E" id="7GMtHW6slpR" role="2OqNvi">
                       <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
                       <node concept="10M0yZ" id="7GMtHW6slxj" role="37wK5m">
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                        <ref role="3cqZAo" to="z60i:~Color.WHITE" resolve="WHITE" />
+                        <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                        <ref role="3cqZAo" to="lzb2:~JBColor.WHITE" resolve="WHITE" />
                       </node>
                     </node>
                   </node>
@@ -4907,8 +4908,8 @@
                     <node concept="liA8E" id="7GMtHW6sm6I" role="2OqNvi">
                       <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
                       <node concept="10M0yZ" id="7GMtHW6smec" role="37wK5m">
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                        <ref role="3cqZAo" to="z60i:~Color.BLACK" resolve="BLACK" />
+                        <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                        <ref role="3cqZAo" to="lzb2:~JBColor.BLACK" resolve="BLACK" />
                       </node>
                     </node>
                   </node>
@@ -7114,8 +7115,8 @@
             <node concept="liA8E" id="JAaUnmWmWq" role="2OqNvi">
               <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
               <node concept="10M0yZ" id="JAaUnmWn3Q" role="37wK5m">
-                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                <ref role="3cqZAo" to="z60i:~Color.RED" resolve="RED" />
+                <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                <ref role="3cqZAo" to="lzb2:~JBColor.RED" resolve="RED" />
               </node>
             </node>
           </node>
@@ -7658,7 +7659,6 @@
             </node>
           </node>
         </node>
-        <node concept="3clFbH" id="JAaUnmWtuF" role="3cqZAp" />
         <node concept="3clFbF" id="JAaUnmWu2M" role="3cqZAp">
           <node concept="2OqwBi" id="JAaUnmWufl" role="3clFbG">
             <node concept="37vLTw" id="JAaUnmWu2K" role="2Oq$k0">
@@ -8281,8 +8281,8 @@
                   <node concept="liA8E" id="21DGiA5nvsR" role="2OqNvi">
                     <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
                     <node concept="10M0yZ" id="4Q9g1gQHcBT" role="37wK5m">
-                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                      <ref role="3cqZAo" to="z60i:~Color.WHITE" resolve="WHITE" />
+                      <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                      <ref role="3cqZAo" to="lzb2:~JBColor.WHITE" resolve="WHITE" />
                     </node>
                   </node>
                 </node>
@@ -8308,8 +8308,8 @@
                   <node concept="liA8E" id="21DGiA5nvt4" role="2OqNvi">
                     <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
                     <node concept="10M0yZ" id="4Q9g1gQHF08" role="37wK5m">
-                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                      <ref role="3cqZAo" to="z60i:~Color.GRAY" resolve="GRAY" />
+                      <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                      <ref role="3cqZAo" to="lzb2:~JBColor.GRAY" resolve="GRAY" />
                     </node>
                   </node>
                 </node>
@@ -8353,8 +8353,8 @@
                   <node concept="liA8E" id="21DGiA5nvto" role="2OqNvi">
                     <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
                     <node concept="10M0yZ" id="21DGiA5nvtp" role="37wK5m">
-                      <ref role="3cqZAo" to="z60i:~Color.BLACK" resolve="BLACK" />
-                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                      <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                      <ref role="3cqZAo" to="lzb2:~JBColor.BLACK" resolve="BLACK" />
                     </node>
                   </node>
                 </node>
@@ -8906,8 +8906,8 @@
             <node concept="liA8E" id="JAaUnmWT8v" role="2OqNvi">
               <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
               <node concept="10M0yZ" id="JAaUnmWT8w" role="37wK5m">
-                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                <ref role="3cqZAo" to="z60i:~Color.BLUE" resolve="BLUE" />
+                <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                <ref role="3cqZAo" to="lzb2:~JBColor.BLUE" resolve="BLUE" />
               </node>
             </node>
           </node>

--- a/code/treenotation/com.mbeddr.mpsutil.treenotation.sandboxlang/models/editor.mps
+++ b/code/treenotation/com.mbeddr.mpsutil.treenotation.sandboxlang/models/editor.mps
@@ -15,6 +15,7 @@
     <import index="4io5" ref="b0f8641f-bd77-4421-8425-30d9088a82f7/java:org.apache.commons.math3.geometry.euclidean.twod(org.apache.commons/)" />
     <import index="4hco" ref="r:55549eb8-b827-44b3-bd84-ef3114bd2fe2(com.mbeddr.mpsutil.treenotation.runtime)" />
     <import index="cj4x" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor(MPS.Editor/)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="uin2" ref="r:74912edc-30f3-44ff-8b9f-c9c8b1fb4035(com.mbeddr.mpsutil.treenotation.sandboxlang.structure)" implicit="true" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
@@ -373,8 +374,8 @@
                 <node concept="3clFbS" id="7GMtHW6qOhv" role="2VODD2">
                   <node concept="3clFbF" id="7GMtHW6qPYg" role="3cqZAp">
                     <node concept="10M0yZ" id="7GMtHW6qQ3j" role="3clFbG">
-                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                      <ref role="3cqZAo" to="z60i:~Color.BLUE" resolve="BLUE" />
+                      <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                      <ref role="3cqZAo" to="lzb2:~JBColor.BLUE" resolve="BLUE" />
                     </node>
                   </node>
                 </node>
@@ -387,8 +388,8 @@
                   <property role="3cmrfH" value="13" />
                 </node>
                 <node concept="10M0yZ" id="7fqbBL2pY_o" role="15NUvb">
-                  <ref role="3cqZAo" to="z60i:~Color.MAGENTA" resolve="MAGENTA" />
-                  <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                  <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                  <ref role="3cqZAo" to="lzb2:~JBColor.MAGENTA" resolve="MAGENTA" />
                 </node>
               </node>
             </node>
@@ -407,8 +408,8 @@
                       <property role="3cmrfH" value="10" />
                     </node>
                     <node concept="10M0yZ" id="7fqbBL2pY_P" role="15NUvb">
-                      <ref role="3cqZAo" to="z60i:~Color.CYAN" resolve="CYAN" />
-                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                      <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                      <ref role="3cqZAo" to="lzb2:~JBColor.CYAN" resolve="CYAN" />
                     </node>
                   </node>
                 </node>
@@ -466,8 +467,8 @@
                 <property role="$nhwW" value="10.0" />
               </node>
               <node concept="10M0yZ" id="7fqbBL2pYlN" role="15NUvb">
-                <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
-                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                <ref role="3cqZAo" to="lzb2:~JBColor.black" resolve="black" />
               </node>
             </node>
           </node>
@@ -550,8 +551,8 @@
                   <property role="$nhwW" value="20.0" />
                 </node>
                 <node concept="10M0yZ" id="7fqbBL2pYmt" role="15NUvb">
-                  <ref role="3cqZAo" to="z60i:~Color.green" resolve="green" />
-                  <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                  <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                  <ref role="3cqZAo" to="lzb2:~JBColor.green" resolve="green" />
                 </node>
               </node>
               <node concept="37fpnE" id="2rPTijxRT8h" role="37fetC" />
@@ -1058,8 +1059,8 @@
           <property role="$nhwW" value="6.0" />
         </node>
         <node concept="10M0yZ" id="7fqbBL2pN8s" role="15NUvb">
-          <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
-          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+          <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+          <ref role="3cqZAo" to="lzb2:~JBColor.gray" resolve="gray" />
         </node>
       </node>
       <node concept="3u$I1K" id="7CiTYi$wnL6" role="15K7wI">
@@ -1089,8 +1090,8 @@
             <property role="$nhwW" value="10.0" />
           </node>
           <node concept="10M0yZ" id="7fqbBL2pN7D" role="15NUvb">
-            <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
-            <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+            <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+            <ref role="3cqZAo" to="lzb2:~JBColor.black" resolve="black" />
           </node>
         </node>
       </node>
@@ -1635,8 +1636,8 @@
           <property role="$nhwW" value="7.0" />
         </node>
         <node concept="10M0yZ" id="7fqbBL2pNMF" role="15NUvb">
-          <ref role="3cqZAo" to="z60i:~Color.orange" resolve="orange" />
-          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+          <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+          <ref role="3cqZAo" to="lzb2:~JBColor.orange" resolve="orange" />
         </node>
       </node>
       <node concept="3u$I1K" id="7fqbBL2mR95" role="15K7wI">
@@ -1666,8 +1667,8 @@
             <property role="$nhwW" value="7.0" />
           </node>
           <node concept="10M0yZ" id="7fqbBL2pNKI" role="15NUvb">
-            <ref role="3cqZAo" to="z60i:~Color.blue" resolve="blue" />
-            <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+            <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+            <ref role="3cqZAo" to="lzb2:~JBColor.blue" resolve="blue" />
           </node>
         </node>
       </node>

--- a/code/treenotation/com.mbeddr.mpsutil.treenotation.styles/com.mbeddr.mpsutil.treenotation.styles.mpl
+++ b/code/treenotation/com.mbeddr.mpsutil.treenotation.styles/com.mbeddr.mpsutil.treenotation.styles.mpl
@@ -12,6 +12,9 @@
   </facets>
   <accessoryModels />
   <sourcePath />
+  <dependencies>
+    <dependency reexport="false">498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)</dependency>
+  </dependencies>
   <languageVersions>
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
     <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />
@@ -48,6 +51,7 @@
     <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
     <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
     <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
+    <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="bda054c4-5d71-46ca-aba0-7104e3070b5a(com.mbeddr.mpsutil.treenotation.styles)" version="0" />
     <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />

--- a/code/treenotation/com.mbeddr.mpsutil.treenotation.styles/models/editor.mps
+++ b/code/treenotation/com.mbeddr.mpsutil.treenotation.styles/models/editor.mps
@@ -8,6 +8,7 @@
   </languages>
   <imports>
     <import index="z60i" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt(JDK/)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
   </imports>
@@ -123,8 +124,8 @@
         <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
       </node>
       <node concept="10M0yZ" id="7GMtHW6qHam" role="3t49C2">
-        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-        <ref role="3cqZAo" to="z60i:~Color.BLACK" resolve="BLACK" />
+        <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+        <ref role="3cqZAo" to="lzb2:~JBColor.BLACK" resolve="BLACK" />
       </node>
     </node>
     <node concept="3t5Usi" id="7GMtHW6qHaD" role="V601i">

--- a/code/widgets/languages/de.itemis.mps.editor.collapsible.testlang/de.itemis.mps.editor.collapsible.testlang.mpl
+++ b/code/widgets/languages/de.itemis.mps.editor.collapsible.testlang/de.itemis.mps.editor.collapsible.testlang.mpl
@@ -12,6 +12,9 @@
   </facets>
   <accessoryModels />
   <sourcePath />
+  <dependencies>
+    <dependency reexport="false">498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)</dependency>
+  </dependencies>
   <languageVersions>
     <language slang="l:3bdedd09-792a-4e15-a4db-83970df3ee86:de.itemis.mps.editor.collapsible" version="0" />
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
@@ -49,6 +52,7 @@
     <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
     <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
     <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
+    <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="d92a0cd8-920d-42ea-923c-f8c68d0a9444(de.itemis.mps.editor.collapsible.testlang)" version="0" />
     <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />

--- a/code/widgets/languages/de.itemis.mps.editor.collapsible.testlang/models/editor.mps
+++ b/code/widgets/languages/de.itemis.mps.editor.collapsible.testlang/models/editor.mps
@@ -8,6 +8,7 @@
   </languages>
   <imports>
     <import index="z60i" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt(JDK/)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="n12" ref="r:7e4984f5-9a8f-4f8b-a5ad-97797cae2191(de.itemis.mps.editor.collapsible.testlang.structure)" implicit="true" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
   </imports>
@@ -151,8 +152,8 @@
               <node concept="liA8E" id="7CjItjXtbK_" role="2OqNvi">
                 <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
                 <node concept="10M0yZ" id="7CjItjXtbNn" role="37wK5m">
-                  <ref role="3cqZAo" to="z60i:~Color.RED" resolve="RED" />
-                  <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                  <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                  <ref role="3cqZAo" to="lzb2:~JBColor.RED" resolve="RED" />
                 </node>
               </node>
             </node>
@@ -219,12 +220,12 @@
                 <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
                 <node concept="3K4zz7" id="7CjItjXudl$" role="37wK5m">
                   <node concept="10M0yZ" id="7CjItjXudnd" role="3K4E3e">
-                    <ref role="3cqZAo" to="z60i:~Color.GREEN" resolve="GREEN" />
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                    <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                    <ref role="3cqZAo" to="lzb2:~JBColor.GREEN" resolve="GREEN" />
                   </node>
                   <node concept="10M0yZ" id="7CjItjXudpo" role="3K4GZi">
-                    <ref role="3cqZAo" to="z60i:~Color.RED" resolve="RED" />
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                    <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                    <ref role="3cqZAo" to="lzb2:~JBColor.RED" resolve="RED" />
                   </node>
                   <node concept="2DP$1s" id="7CjItjXucZf" role="3K4Cdx" />
                 </node>
@@ -273,8 +274,8 @@
               <node concept="liA8E" id="7CjItjXunkV" role="2OqNvi">
                 <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
                 <node concept="10M0yZ" id="7CjItjXunJE" role="37wK5m">
-                  <ref role="3cqZAo" to="z60i:~Color.BLUE" resolve="BLUE" />
-                  <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                  <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                  <ref role="3cqZAo" to="lzb2:~JBColor.BLUE" resolve="BLUE" />
                 </node>
               </node>
             </node>
@@ -321,8 +322,8 @@
               <node concept="liA8E" id="7CjItjXunK$" role="2OqNvi">
                 <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
                 <node concept="10M0yZ" id="7CjItjXunZ6" role="37wK5m">
-                  <ref role="3cqZAo" to="z60i:~Color.MAGENTA" resolve="MAGENTA" />
-                  <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                  <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                  <ref role="3cqZAo" to="lzb2:~JBColor.MAGENTA" resolve="MAGENTA" />
                 </node>
               </node>
             </node>
@@ -394,12 +395,12 @@
                     <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
                     <node concept="3K4zz7" id="62nlqxEmoiq" role="37wK5m">
                       <node concept="10M0yZ" id="62nlqxEmoir" role="3K4E3e">
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                        <ref role="3cqZAo" to="z60i:~Color.GREEN" resolve="GREEN" />
+                        <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                        <ref role="3cqZAo" to="lzb2:~JBColor.GREEN" resolve="GREEN" />
                       </node>
                       <node concept="10M0yZ" id="62nlqxEmois" role="3K4GZi">
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                        <ref role="3cqZAo" to="z60i:~Color.RED" resolve="RED" />
+                        <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                        <ref role="3cqZAo" to="lzb2:~JBColor.RED" resolve="RED" />
                       </node>
                       <node concept="2DP$1s" id="62nlqxEmoit" role="3K4Cdx" />
                     </node>
@@ -448,8 +449,8 @@
                   <node concept="liA8E" id="62nlqxEmp0W" role="2OqNvi">
                     <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
                     <node concept="10M0yZ" id="62nlqxEmp0X" role="37wK5m">
-                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                      <ref role="3cqZAo" to="z60i:~Color.BLUE" resolve="BLUE" />
+                      <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                      <ref role="3cqZAo" to="lzb2:~JBColor.BLUE" resolve="BLUE" />
                     </node>
                   </node>
                 </node>
@@ -496,8 +497,8 @@
                   <node concept="liA8E" id="62nlqxEmpYB" role="2OqNvi">
                     <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
                     <node concept="10M0yZ" id="62nlqxEmpYC" role="37wK5m">
-                      <ref role="3cqZAo" to="z60i:~Color.MAGENTA" resolve="MAGENTA" />
-                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                      <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                      <ref role="3cqZAo" to="lzb2:~JBColor.MAGENTA" resolve="MAGENTA" />
                     </node>
                   </node>
                 </node>
@@ -550,12 +551,12 @@
                 <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
                 <node concept="3K4zz7" id="62nlqxEmo0h" role="37wK5m">
                   <node concept="10M0yZ" id="62nlqxEmo0i" role="3K4E3e">
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                    <ref role="3cqZAo" to="z60i:~Color.GREEN" resolve="GREEN" />
+                    <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                    <ref role="3cqZAo" to="lzb2:~JBColor.GREEN" resolve="GREEN" />
                   </node>
                   <node concept="10M0yZ" id="62nlqxEmo0j" role="3K4GZi">
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                    <ref role="3cqZAo" to="z60i:~Color.RED" resolve="RED" />
+                    <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                    <ref role="3cqZAo" to="lzb2:~JBColor.RED" resolve="RED" />
                   </node>
                   <node concept="2DP$1s" id="62nlqxEmo0k" role="3K4Cdx" />
                 </node>
@@ -604,8 +605,8 @@
               <node concept="liA8E" id="62nlqxEmoG3" role="2OqNvi">
                 <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
                 <node concept="10M0yZ" id="62nlqxEmoG4" role="37wK5m">
-                  <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                  <ref role="3cqZAo" to="z60i:~Color.BLUE" resolve="BLUE" />
+                  <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                  <ref role="3cqZAo" to="lzb2:~JBColor.BLUE" resolve="BLUE" />
                 </node>
               </node>
             </node>
@@ -652,8 +653,8 @@
               <node concept="liA8E" id="62nlqxEmpAI" role="2OqNvi">
                 <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
                 <node concept="10M0yZ" id="62nlqxEmpAJ" role="37wK5m">
-                  <ref role="3cqZAo" to="z60i:~Color.MAGENTA" resolve="MAGENTA" />
-                  <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                  <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                  <ref role="3cqZAo" to="lzb2:~JBColor.MAGENTA" resolve="MAGENTA" />
                 </node>
               </node>
             </node>
@@ -725,12 +726,12 @@
                     <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
                     <node concept="3K4zz7" id="62nlqxEmuXv" role="37wK5m">
                       <node concept="10M0yZ" id="62nlqxEmuXw" role="3K4E3e">
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                        <ref role="3cqZAo" to="z60i:~Color.GREEN" resolve="GREEN" />
+                        <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                        <ref role="3cqZAo" to="lzb2:~JBColor.GREEN" resolve="GREEN" />
                       </node>
                       <node concept="10M0yZ" id="62nlqxEmuXx" role="3K4GZi">
-                        <ref role="3cqZAo" to="z60i:~Color.RED" resolve="RED" />
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                        <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                        <ref role="3cqZAo" to="lzb2:~JBColor.RED" resolve="RED" />
                       </node>
                       <node concept="2DP$1s" id="62nlqxEmuXy" role="3K4Cdx" />
                     </node>
@@ -779,8 +780,8 @@
                   <node concept="liA8E" id="62nlqxEmuXS" role="2OqNvi">
                     <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
                     <node concept="10M0yZ" id="62nlqxEmuXT" role="37wK5m">
-                      <ref role="3cqZAo" to="z60i:~Color.BLUE" resolve="BLUE" />
-                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                      <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                      <ref role="3cqZAo" to="lzb2:~JBColor.BLUE" resolve="BLUE" />
                     </node>
                   </node>
                 </node>
@@ -827,8 +828,8 @@
                   <node concept="liA8E" id="62nlqxEmuYf" role="2OqNvi">
                     <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
                     <node concept="10M0yZ" id="62nlqxEmuYg" role="37wK5m">
-                      <ref role="3cqZAo" to="z60i:~Color.MAGENTA" resolve="MAGENTA" />
-                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                      <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                      <ref role="3cqZAo" to="lzb2:~JBColor.MAGENTA" resolve="MAGENTA" />
                     </node>
                   </node>
                 </node>
@@ -881,12 +882,12 @@
                 <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
                 <node concept="3K4zz7" id="62nlqxEmuYC" role="37wK5m">
                   <node concept="10M0yZ" id="62nlqxEmuYD" role="3K4E3e">
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                    <ref role="3cqZAo" to="z60i:~Color.GREEN" resolve="GREEN" />
+                    <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                    <ref role="3cqZAo" to="lzb2:~JBColor.GREEN" resolve="GREEN" />
                   </node>
                   <node concept="10M0yZ" id="62nlqxEmuYE" role="3K4GZi">
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                    <ref role="3cqZAo" to="z60i:~Color.RED" resolve="RED" />
+                    <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                    <ref role="3cqZAo" to="lzb2:~JBColor.RED" resolve="RED" />
                   </node>
                   <node concept="2DP$1s" id="62nlqxEmuYF" role="3K4Cdx" />
                 </node>
@@ -935,8 +936,8 @@
               <node concept="liA8E" id="62nlqxEmuZ1" role="2OqNvi">
                 <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
                 <node concept="10M0yZ" id="62nlqxEmuZ2" role="37wK5m">
-                  <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                  <ref role="3cqZAo" to="z60i:~Color.BLUE" resolve="BLUE" />
+                  <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                  <ref role="3cqZAo" to="lzb2:~JBColor.BLUE" resolve="BLUE" />
                 </node>
               </node>
             </node>
@@ -983,8 +984,8 @@
               <node concept="liA8E" id="62nlqxEmuZo" role="2OqNvi">
                 <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
                 <node concept="10M0yZ" id="62nlqxEmuZp" role="37wK5m">
-                  <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                  <ref role="3cqZAo" to="z60i:~Color.MAGENTA" resolve="MAGENTA" />
+                  <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                  <ref role="3cqZAo" to="lzb2:~JBColor.MAGENTA" resolve="MAGENTA" />
                 </node>
               </node>
             </node>

--- a/code/widgets/languages/de.itemis.mps.editor.enumeration/runtime/models/de.itemis.mps.editor.enumeration.runtime.mps
+++ b/code/widgets/languages/de.itemis.mps.editor.enumeration/runtime/models/de.itemis.mps.editor.enumeration.runtime.mps
@@ -29,6 +29,7 @@
     <import index="22ra" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.update(MPS.Editor/)" />
     <import index="zf81" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.net(JDK/)" />
     <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="hox0" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.style(MPS.Editor/)" implicit="true" />
   </imports>
   <registry>
@@ -2568,8 +2569,8 @@
                   <node concept="liA8E" id="4KKQOHJkK6R" role="2OqNvi">
                     <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
                     <node concept="10M0yZ" id="4KKQOHJkK7L" role="37wK5m">
-                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                      <ref role="3cqZAo" to="z60i:~Color.BLACK" resolve="BLACK" />
+                      <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                      <ref role="3cqZAo" to="lzb2:~JBColor.BLACK" resolve="BLACK" />
                     </node>
                   </node>
                 </node>

--- a/code/widgets/solutions/de.itemis.mps.editor.bool.runtime/models/de/itemis/mps/editor/bool/runtime.mps
+++ b/code/widgets/solutions/de.itemis.mps.editor.bool.runtime/models/de/itemis/mps/editor/bool/runtime.mps
@@ -4221,21 +4221,15 @@
                 </node>
                 <node concept="liA8E" id="QvUN5MZxF0" role="2OqNvi">
                   <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
-                  <node concept="2ShNRf" id="QvUN5MZxFU" role="37wK5m">
-                    <node concept="1pGfFk" id="QvUN5MZDQ1" role="2ShVmc">
-                      <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int,int)" resolve="Color" />
-                      <node concept="3cmrfG" id="QvUN5MZDRg" role="37wK5m">
-                        <property role="3cmrfH" value="0" />
-                      </node>
-                      <node concept="3cmrfG" id="QvUN5MZEaq" role="37wK5m">
-                        <property role="3cmrfH" value="0" />
-                      </node>
-                      <node concept="3cmrfG" id="QvUN5MZEE3" role="37wK5m">
-                        <property role="3cmrfH" value="0" />
-                      </node>
-                      <node concept="3cmrfG" id="QvUN5MZF1q" role="37wK5m">
-                        <property role="3cmrfH" value="30" />
-                      </node>
+                  <node concept="2YIFZM" id="2WI5qdoevw" role="37wK5m">
+                    <ref role="1Pybhc" to="lzb2:~ColorUtil" resolve="ColorUtil" />
+                    <ref role="37wK5l" to="lzb2:~ColorUtil.withAlpha(java.awt.Color,double)" resolve="withAlpha" />
+                    <node concept="10M0yZ" id="2WI5qdofkt" role="37wK5m">
+                      <ref role="3cqZAo" to="lzb2:~JBColor.BLACK" resolve="BLACK" />
+                      <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                    </node>
+                    <node concept="3b6qkQ" id="2WI5qdog7M" role="37wK5m">
+                      <property role="$nhwW" value="0.117" />
                     </node>
                   </node>
                 </node>

--- a/code/widgets/solutions/de.itemis.mps.editor.bool.runtime/models/de/itemis/mps/editor/bool/runtime.mps
+++ b/code/widgets/solutions/de.itemis.mps.editor.bool.runtime/models/de/itemis/mps/editor/bool/runtime.mps
@@ -33,6 +33,7 @@
     <import index="5ueo" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.editor.runtime.style(MPS.Editor/)" />
     <import index="zf81" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.net(JDK/)" />
     <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="hox0" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.style(MPS.Editor/)" implicit="true" />
     <import index="22ra" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.update(MPS.Editor/)" implicit="true" />
   </imports>
@@ -2506,8 +2507,8 @@
                   <node concept="liA8E" id="4KKQOHJkK6R" role="2OqNvi">
                     <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
                     <node concept="10M0yZ" id="4KKQOHJkK7L" role="37wK5m">
-                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                      <ref role="3cqZAo" to="z60i:~Color.BLACK" resolve="BLACK" />
+                      <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                      <ref role="3cqZAo" to="lzb2:~JBColor.BLACK" resolve="BLACK" />
                     </node>
                   </node>
                 </node>

--- a/code/widgets/solutions/de.itemis.mps.editor.collapsible.runtime/models/de/itemis/mps/editor/collapsible/runtime.mps
+++ b/code/widgets/solutions/de.itemis.mps.editor.collapsible.runtime/models/de/itemis/mps/editor/collapsible/runtime.mps
@@ -25,6 +25,7 @@
     <import index="5usg" ref="r:3838bb8b-fecd-4f7c-841e-325717a43980(de.itemis.mps.tooltips.runtime)" />
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
     <import index="lui2" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.module(MPS.OpenAPI/)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="z8iw" ref="r:dfdf3542-dbcf-43df-870a-3c3504b3c840(jetbrains.mps.baseLanguage.collections.custom)" implicit="true" />
     <import index="dxuu" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:javax.swing(JDK/)" implicit="true" />
   </imports>
@@ -1623,8 +1624,8 @@
                           <node concept="liA8E" id="48DYfEtnxur" role="2OqNvi">
                             <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
                             <node concept="10M0yZ" id="48DYfEtnxvl" role="37wK5m">
-                              <ref role="3cqZAo" to="z60i:~Color.GRAY" resolve="GRAY" />
-                              <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                              <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                              <ref role="3cqZAo" to="lzb2:~JBColor.GRAY" resolve="GRAY" />
                             </node>
                           </node>
                         </node>
@@ -3676,23 +3677,13 @@
                 <node concept="liA8E" id="48DYfEtwvVa" role="2OqNvi">
                   <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
                   <node concept="3K4zz7" id="48DYfEtwwmO" role="37wK5m">
-                    <node concept="2ShNRf" id="48DYfEtwwsj" role="3K4E3e">
-                      <node concept="1pGfFk" id="48DYfEtwwL5" role="2ShVmc">
-                        <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
-                        <node concept="3cmrfG" id="48DYfEtwwL$" role="37wK5m">
-                          <property role="3cmrfH" value="200" />
-                        </node>
-                        <node concept="3cmrfG" id="48DYfEtwwNB" role="37wK5m">
-                          <property role="3cmrfH" value="200" />
-                        </node>
-                        <node concept="3cmrfG" id="48DYfEtwxio" role="37wK5m">
-                          <property role="3cmrfH" value="200" />
-                        </node>
-                      </node>
+                    <node concept="10M0yZ" id="2WI5qcQkpk" role="3K4E3e">
+                      <ref role="3cqZAo" to="lzb2:~JBColor.LIGHT_GRAY" resolve="LIGHT_GRAY" />
+                      <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                     </node>
                     <node concept="10M0yZ" id="48DYfEtwxBB" role="3K4GZi">
-                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                      <ref role="3cqZAo" to="z60i:~Color.WHITE" resolve="WHITE" />
+                      <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                      <ref role="3cqZAo" to="lzb2:~JBColor.WHITE" resolve="WHITE" />
                     </node>
                     <node concept="37vLTw" id="48DYfEtwvW6" role="3K4Cdx">
                       <ref role="3cqZAo" node="48DYfEtb43H" resolve="myIsHighlighted" />
@@ -3741,8 +3732,8 @@
                 <node concept="liA8E" id="48DYfEt2xwu" role="2OqNvi">
                   <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
                   <node concept="10M0yZ" id="48DYfEt2xxq" role="37wK5m">
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                    <ref role="3cqZAo" to="z60i:~Color.GRAY" resolve="GRAY" />
+                    <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                    <ref role="3cqZAo" to="lzb2:~JBColor.GRAY" resolve="GRAY" />
                   </node>
                 </node>
               </node>

--- a/code/widgets/solutions/de.itemis.mps.editor.dropdown.runtime/models/de/itemis/mps/editor/dropdown/runtime.mps
+++ b/code/widgets/solutions/de.itemis.mps.editor.dropdown.runtime/models/de/itemis/mps/editor/dropdown/runtime.mps
@@ -16,6 +16,7 @@
     <import index="py4t" ref="r:4e973dcf-7005-4515-8904-9c030ef293d4(de.itemis.mps.mouselistener.runtime)" />
     <import index="hyam" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt.event(JDK/)" />
     <import index="exr9" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor(MPS.Editor/)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
   </imports>
   <registry>
@@ -49,6 +50,9 @@
       <concept id="1070462154015" name="jetbrains.mps.baseLanguage.structure.StaticFieldDeclaration" flags="ig" index="Wx3nA" />
       <concept id="1070475354124" name="jetbrains.mps.baseLanguage.structure.ThisExpression" flags="nn" index="Xjq3P" />
       <concept id="1070475587102" name="jetbrains.mps.baseLanguage.structure.SuperConstructorInvocation" flags="nn" index="XkiVB" />
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
       <concept id="1182160077978" name="jetbrains.mps.baseLanguage.structure.AnonymousClassCreator" flags="nn" index="YeOm9">
         <child id="1182160096073" name="cls" index="YeSDq" />
       </concept>
@@ -197,18 +201,11 @@
       <node concept="3uibUv" id="7szUFELGYVN" role="1tU5fm">
         <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
       </node>
-      <node concept="2ShNRf" id="7szUFELH2FG" role="33vP2m">
-        <node concept="1pGfFk" id="7szUFELH2FF" role="2ShVmc">
-          <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
-          <node concept="3cmrfG" id="7szUFELH2IR" role="37wK5m">
-            <property role="3cmrfH" value="150" />
-          </node>
-          <node concept="3cmrfG" id="7szUFELH2Pe" role="37wK5m">
-            <property role="3cmrfH" value="150" />
-          </node>
-          <node concept="3cmrfG" id="7szUFELH36o" role="37wK5m">
-            <property role="3cmrfH" value="150" />
-          </node>
+      <node concept="2YIFZM" id="2WI5qdsu9_" role="33vP2m">
+        <ref role="37wK5l" to="lzb2:~JBColor.namedColor(java.lang.String)" resolve="namedColor" />
+        <ref role="1Pybhc" to="lzb2:~JBColor" resolve="JBColor" />
+        <node concept="Xl_RD" id="2WI5qdswUT" role="37wK5m">
+          <property role="Xl_RC" value="Component.borderColor" />
         </node>
       </node>
     </node>

--- a/code/widgets/solutions/de.itemis.mps.editor.dropdown.runtime/models/de/itemis/mps/editor/dropdown/runtime.mps
+++ b/code/widgets/solutions/de.itemis.mps.editor.dropdown.runtime/models/de/itemis/mps/editor/dropdown/runtime.mps
@@ -953,21 +953,16 @@
                         <ref role="3cqZAo" node="3_TG3j996Nd" resolve="isHighlighted" />
                       </node>
                       <node concept="10M0yZ" id="7szUFELG2wb" role="3K4GZi">
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                        <ref role="3cqZAo" to="z60i:~Color.WHITE" resolve="WHITE" />
+                        <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                        <ref role="3cqZAo" to="lzb2:~JBColor.WHITE" resolve="WHITE" />
                       </node>
-                      <node concept="2ShNRf" id="7szUFELFPMr" role="3K4E3e">
-                        <node concept="1pGfFk" id="7szUFELFQ5Y" role="2ShVmc">
-                          <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
-                          <node concept="3cmrfG" id="7szUFELFQ7W" role="37wK5m">
-                            <property role="3cmrfH" value="200" />
-                          </node>
-                          <node concept="3cmrfG" id="7szUFELFQaG" role="37wK5m">
-                            <property role="3cmrfH" value="200" />
-                          </node>
-                          <node concept="3cmrfG" id="7szUFELFQqP" role="37wK5m">
-                            <property role="3cmrfH" value="255" />
-                          </node>
+                      <node concept="2OqwBi" id="2WI5qdtkSo" role="3K4E3e">
+                        <node concept="2YIFZM" id="2WI5qdtkqn" role="2Oq$k0">
+                          <ref role="1Pybhc" to="exr9:~EditorSettings" resolve="EditorSettings" />
+                          <ref role="37wK5l" to="exr9:~EditorSettings.getInstance()" resolve="getInstance" />
+                        </node>
+                        <node concept="liA8E" id="2WI5qdtnB1" role="2OqNvi">
+                          <ref role="37wK5l" to="exr9:~EditorSettings.getSelectionBackgroundColor()" resolve="getSelectionBackgroundColor" />
                         </node>
                       </node>
                     </node>


### PR DESCRIPTION
This is a first draft for supporting the darcula theme.
I used `JBColor` instead of `Color` because this class already supports dark themes. This has some side effects, e.g., when using the darcula theme the color BLACK is more grayish and white is also not a pure white. 

There are hundreds of colors instances in this repo and I didn't change all of them (I excluded for example grammar cells and shadow models), so further contributions are welcome. Please play around with it, there are some colors that I couldn't test because we don't have examples that use these colors. I also tried to not change the colors too much in the light theme.

For testing: Bind a shortcut to the Quick Switch Theme action and select your theme.


Some screenshots:

![Screenshot 2022-04-15 at 14 16 24](https://user-images.githubusercontent.com/88385944/163569848-df31b8b0-1178-435d-a8b7-72f8106e227d.png)

![Screenshot 2022-04-15 at 14 16 08](https://user-images.githubusercontent.com/88385944/163569871-07407e10-5acf-4bf9-9080-129666cc49df.png)

![Screenshot 2022-04-15 at 14 18 19](https://user-images.githubusercontent.com/88385944/163569948-d1bc3507-5354-4872-8642-1ff5cce1913e.png)

![Screenshot 2022-04-15 at 14 18 41](https://user-images.githubusercontent.com/88385944/163569910-44ea3a00-e415-4bb7-ab1e-7b541b951321.png)

