### PR TITLE
Fix jackson stubs

### DIFF
--- a/code/.mps/modules.xml
+++ b/code/.mps/modules.xml
@@ -158,7 +158,7 @@
       <modulePath path="$PROJECT_DIR$/shadowmodels/solutions/test.de.q60.mps.incremental.runtime/test.de.q60.mps.incremental.runtime.msd" folder="shadowmodels.tests" />
       <modulePath path="$PROJECT_DIR$/shadowmodels/solutions/test.de.q60.mps.shadowmodels.examples/test.de.q60.mps.shadowmodels.examples.msd" folder="shadowmodels.tests" />
       <modulePath path="$PROJECT_DIR$/shadowmodels/solutions/test.de.q60.mps.shadowmodels.runtime/test.de.q60.mps.shadowmodels.runtime.msd" folder="shadowmodels.tests" />
-      <modulePath path="$PROJECT_DIR$/solutions/com.fasterxml.jackson/com.fasterxml.jackson.msd" folder="jackson" />
+      <modulePath path="$PROJECT_DIR$/jackson/solutions/com.fasterxml.jackson/com.fasterxml.jackson.msd" folder="jackson" />
       <modulePath path="$PROJECT_DIR$/solutions/de.itemis.model.merge.runtime/de.itemis.model.merge.runtime.msd" folder="modelmerger2" />
       <modulePath path="$PROJECT_DIR$/solutions/de.itemis.model.merge.simple.demo/de.itemis.model.merge.simple.demo.msd" folder="modelmerger2" />
       <modulePath path="$PROJECT_DIR$/solutions/de.itemis.model.merge.test/de.itemis.model.merge.test.msd" folder="modelmerger2" />

--- a/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
+++ b/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
@@ -13832,19 +13832,11 @@
               <property role="3MwjfP" value="lib" />
             </node>
           </node>
-          <node concept="28jJK3" id="36BYqFT0Neh" role="39821P">
-            <node concept="398BVA" id="36BYqFT0Nlx" role="28jJRO">
-              <ref role="398BVh" node="5Ngh5kRcxhz" resolve="platform_lib" />
-              <node concept="2Ry0Ak" id="1YKRxVzEZVi" role="iGT6I">
-                <property role="2Ry0Am" value="jackson-annotations-2.11.0.jar" />
-              </node>
-            </node>
-          </node>
           <node concept="28jJK3" id="36BYqFT0N$6" role="39821P">
             <node concept="398BVA" id="36BYqFT0NFr" role="28jJRO">
               <ref role="398BVh" node="5Ngh5kRcxhz" resolve="platform_lib" />
               <node concept="2Ry0Ak" id="1YKRxVzF01Q" role="iGT6I">
-                <property role="2Ry0Am" value="jackson-core-2.11.0.jar" />
+                <property role="2Ry0Am" value="jackson-core-2.12.0.jar" />
               </node>
             </node>
           </node>
@@ -13852,7 +13844,7 @@
             <node concept="398BVA" id="36BYqFT0O1r" role="28jJRO">
               <ref role="398BVh" node="5Ngh5kRcxhz" resolve="platform_lib" />
               <node concept="2Ry0Ak" id="1YKRxVzF08q" role="iGT6I">
-                <property role="2Ry0Am" value="jackson-databind-2.11.0.jar" />
+                <property role="2Ry0Am" value="jackson-databind.jar" />
               </node>
             </node>
           </node>

--- a/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
+++ b/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
@@ -947,32 +947,22 @@
             <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
           </node>
         </node>
-        <node concept="1SiIV0" id="36BYqFT0t_z" role="3bR37C">
-          <node concept="1BurEX" id="36BYqFT0t_$" role="1SiIV1">
-            <node concept="398BVA" id="36BYqFT0t_u" role="1BurEY">
+        <node concept="1SiIV0" id="7UObDbYKXm" role="3bR37C">
+          <node concept="1BurEX" id="7UObDbYKXn" role="1SiIV1">
+            <node concept="398BVA" id="7UObDbYKX8" role="1BurEY">
               <ref role="398BVh" node="5Ngh5kRcxhz" resolve="platform_lib" />
-              <node concept="2Ry0Ak" id="1YKRxVzEZk0" role="iGT6I">
-                <property role="2Ry0Am" value="jackson-annotations-2.11.0.jar" />
+              <node concept="2Ry0Ak" id="7UObDbYKX9" role="iGT6I">
+                <property role="2Ry0Am" value="jackson-core-2.12.0.jar" />
               </node>
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="36BYqFT0t_E" role="3bR37C">
-          <node concept="1BurEX" id="36BYqFT0t_F" role="1SiIV1">
-            <node concept="398BVA" id="36BYqFT0t__" role="1BurEY">
+        <node concept="1SiIV0" id="7UObDbYKXA" role="3bR37C">
+          <node concept="1BurEX" id="7UObDbYKXB" role="1SiIV1">
+            <node concept="398BVA" id="7UObDbYKXo" role="1BurEY">
               <ref role="398BVh" node="5Ngh5kRcxhz" resolve="platform_lib" />
-              <node concept="2Ry0Ak" id="1YKRxVzEZx6" role="iGT6I">
-                <property role="2Ry0Am" value="jackson-core-2.11.0.jar" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="36BYqFT0t_L" role="3bR37C">
-          <node concept="1BurEX" id="36BYqFT0t_M" role="1SiIV1">
-            <node concept="398BVA" id="36BYqFT0t_G" role="1BurEY">
-              <ref role="398BVh" node="5Ngh5kRcxhz" resolve="platform_lib" />
-              <node concept="2Ry0Ak" id="1YKRxVzEZOI" role="iGT6I">
-                <property role="2Ry0Am" value="jackson-databind-2.11.0.jar" />
+              <node concept="2Ry0Ak" id="7UObDbYKXp" role="iGT6I">
+                <property role="2Ry0Am" value="jackson-databind.jar" />
               </node>
             </node>
           </node>
@@ -6979,26 +6969,6 @@
           <property role="3ZfqAx" value="models" />
           <property role="1Hdu6h" value="true" />
           <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="5zr7Q_1BFGe" role="1HemKq">
-            <node concept="398BVA" id="5zr7Q_1BFG2" role="3LXTmr">
-              <ref role="398BVh" node="2fo8bJE$D4t" resolve="extensions.code" />
-              <node concept="2Ry0Ak" id="5zr7Q_1BFG3" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="5zr7Q_1BFG4" role="2Ry0An">
-                  <property role="2Ry0Am" value="de.itemis.model.merge" />
-                  <node concept="2Ry0Ak" id="5zr7Q_1BFG5" role="2Ry0An">
-                    <property role="2Ry0Am" value="runtime" />
-                    <node concept="2Ry0Ak" id="5zr7Q_1BFG6" role="2Ry0An">
-                      <property role="2Ry0Am" value="models" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="5zr7Q_1BFGf" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
           <node concept="3LXTmp" id="5RxOLvL3ALq" role="1HemKq">
             <node concept="398BVA" id="5RxOLvL3ALh" role="3LXTmr">
               <ref role="398BVh" node="2fo8bJE$D4t" resolve="extensions.code" />
@@ -10873,6 +10843,9 @@
         <node concept="3LEDTy" id="7q24334ZzZk" role="3LEDUa">
           <ref role="3LEDTV" to="ffeo:7Kfy9QB6KZc" resolve="jetbrains.mps.baseLanguage.checkedDots" />
         </node>
+        <node concept="3LEDTy" id="7UObDbYLjt" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L2l" resolve="jetbrains.mps.baseLanguage.logging" />
+        </node>
       </node>
       <node concept="1E1JtA" id="4hqUO9aIeR_" role="2G$12L">
         <property role="BnDLt" value="true" />
@@ -11099,6 +11072,12 @@
         </node>
         <node concept="3LEDTy" id="4CvHZ0pb1br" role="3LEDUa">
           <ref role="3LEDTV" to="ffeo:7Kfy9QB6KZ0" resolve="jetbrains.mps.baseLanguageInternal" />
+        </node>
+        <node concept="3LEDTy" id="7UObDbYLk1" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L2F" resolve="jetbrains.mps.baseLanguage.tuples" />
+        </node>
+        <node concept="3LEDTy" id="7UObDbYLk2" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L2l" resolve="jetbrains.mps.baseLanguage.logging" />
         </node>
       </node>
     </node>

--- a/code/jackson/solutions/com.fasterxml.jackson/com.fasterxml.jackson.msd
+++ b/code/jackson/solutions/com.fasterxml.jackson/com.fasterxml.jackson.msd
@@ -3,9 +3,8 @@
   <models>
     <modelRoot contentPath="${module}" type="default" />
     <modelRoot contentPath="${platform_lib}" type="java_classes">
-      <sourceRoot location="jackson-annotations-2.11.0.jar" />
-      <sourceRoot location="jackson-core-2.11.0.jar" />
-      <sourceRoot location="jackson-databind-2.11.0.jar" />
+      <sourceRoot location="jackson-core-2.12.0.jar" />
+      <sourceRoot location="jackson-databind.jar" />
     </modelRoot>
   </models>
   <facets>
@@ -14,15 +13,19 @@
     </facet>
   </facets>
   <stubModelEntries>
-    <stubModelEntry path="${platform_lib}/jackson-core-2.11.0.jar" />
-    <stubModelEntry path="${platform_lib}/jackson-databind-2.11.0.jar" />
-    <stubModelEntry path="${platform_lib}/jackson-annotations-2.11.0.jar" />
+    <stubModelEntry path="${platform_lib}/jackson-core-2.12.0.jar" />
+    <stubModelEntry path="${platform_lib}/jackson-databind.jar" />
   </stubModelEntries>
   <sourcePath />
   <dependencies>
     <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
   </dependencies>
-  <languageVersions />
+  <languageVersions>
+    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
+    <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
+    <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
+    <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
+  </languageVersions>
   <dependencyVersions>
     <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
     <module reference="39983771-4e9b-401b-a1a9-1da6c777c843(com.fasterxml.jackson)" version="0" />


### PR DESCRIPTION
The stubs were not working anymore since probably 2021.1.4. Note: The paths change again in 2021.1.5.