### PR TITLE
Setting the BOTH flag for the Kotlin JS compiler

### DIFF
--- a/model-api/build.gradle
+++ b/model-api/build.gradle
@@ -36,8 +36,7 @@ check.dependsOn ktlintCheck
 
 kotlin {
     jvm()
-    js(IR) {
-        //browser {}
+    js(BOTH) {
         nodejs {
             testTask {
                 useMocha {
@@ -45,7 +44,6 @@ kotlin {
                 }
             }
         }
-        binaries.executable()
     }
     sourceSets {
         commonMain {


### PR DESCRIPTION
Given Modelix is using the legacy JS compiler it is useful to have support in model-api both for the IR and the legacy Kotlin compiler.

Also, we do not need to generate executables for the model-api, only a library.