### PR TITLE
GrammarCells: Add support for descriptions in more cells.

### DIFF
--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/generator/template/main@generator.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/generator/template/main@generator.mps
@@ -2491,34 +2491,39 @@
                                           <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
                                         </node>
                                         <node concept="3clFbS" id="J6gp_6LHFf" role="3clF47">
-                                          <node concept="3cpWs8" id="J6gp_6LHFg" role="3cqZAp">
-                                            <node concept="3cpWsn" id="J6gp_6LHFh" role="3cpWs9">
+                                          <node concept="3cpWs8" id="7PVnOXzMUlG" role="3cqZAp">
+                                            <node concept="3cpWsn" id="7PVnOXzMUlH" role="3cpWs9">
+                                              <property role="TrG5h" value="node" />
+                                              <node concept="3Tqbb2" id="7PVnOXzMUlI" role="1tU5fm" />
+                                              <node concept="2OqwBi" id="7PVnOXzMUlJ" role="33vP2m">
+                                                <node concept="2Mo9yH" id="7PVnOXzMUlK" role="2Oq$k0" />
+                                                <node concept="liA8E" id="7PVnOXzMUlL" role="2OqNvi">
+                                                  <ref role="37wK5l" to="uddc:~TransformationMenuContext.getNode()" resolve="getNode" />
+                                                </node>
+                                              </node>
+                                            </node>
+                                          </node>
+                                          <node concept="3cpWs8" id="7PVnOXzMUlM" role="3cqZAp">
+                                            <node concept="3cpWsn" id="7PVnOXzMUlN" role="3cpWs9">
                                               <property role="TrG5h" value="originalText" />
-                                              <node concept="17QB3L" id="J6gp_6LHFi" role="1tU5fm" />
-                                              <node concept="3nyPlj" id="J6gp_6LHFj" role="33vP2m">
+                                              <node concept="17QB3L" id="7PVnOXzMUlO" role="1tU5fm" />
+                                              <node concept="3nyPlj" id="7PVnOXzMUlP" role="33vP2m">
                                                 <ref role="37wK5l" to="gdpt:1YKLYyyGCB0" resolve="getShortDescriptionText" />
-                                                <node concept="37vLTw" id="J6gp_6LHFk" role="37wK5m">
+                                                <node concept="37vLTw" id="7PVnOXzMUlQ" role="37wK5m">
                                                   <ref role="3cqZAo" node="J6gp_6LHFb" resolve="pattern" />
                                                 </node>
                                               </node>
                                             </node>
                                           </node>
-                                          <node concept="3cpWs8" id="J6gp_6LHFl" role="3cqZAp">
-                                            <node concept="3cpWsn" id="J6gp_6LHFm" role="3cpWs9">
-                                              <property role="TrG5h" value="wrappedNode" />
-                                              <node concept="3Tqbb2" id="J6gp_6LHFn" role="1tU5fm" />
-                                              <node concept="10Nm6u" id="J6gp_6LHFo" role="33vP2m" />
-                                            </node>
-                                          </node>
-                                          <node concept="3cpWs8" id="J6gp_6LHFp" role="3cqZAp">
-                                            <node concept="3cpWsn" id="J6gp_6LHFq" role="3cpWs9">
+                                          <node concept="3cpWs8" id="7PVnOXzMUlR" role="3cqZAp">
+                                            <node concept="3cpWsn" id="7PVnOXzMUlS" role="3cpWs9">
                                               <property role="TrG5h" value="editorContext" />
-                                              <node concept="3uibUv" id="J6gp_6LHFr" role="1tU5fm">
+                                              <node concept="3uibUv" id="7PVnOXzMUlT" role="1tU5fm">
                                                 <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
                                               </node>
-                                              <node concept="2OqwBi" id="J6gp_6LHFs" role="33vP2m">
-                                                <node concept="2Mo9yH" id="J6gp_6LHFt" role="2Oq$k0" />
-                                                <node concept="liA8E" id="J6gp_6LHFu" role="2OqNvi">
+                                              <node concept="2OqwBi" id="7PVnOXzMUlU" role="33vP2m">
+                                                <node concept="2Mo9yH" id="7PVnOXzMUlV" role="2Oq$k0" />
+                                                <node concept="liA8E" id="7PVnOXzMUlW" role="2OqNvi">
                                                   <ref role="37wK5l" to="uddc:~TransformationMenuContext.getEditorContext()" resolve="getEditorContext" />
                                                 </node>
                                               </node>
@@ -2526,7 +2531,7 @@
                                           </node>
                                           <node concept="3cpWs6" id="J6gp_6LHFv" role="3cqZAp">
                                             <node concept="37vLTw" id="J6gp_6LHFw" role="3cqZAk">
-                                              <ref role="3cqZAo" node="J6gp_6LHFh" resolve="originalText" />
+                                              <ref role="3cqZAo" node="7PVnOXzMUlN" resolve="originalText" />
                                             </node>
                                             <node concept="2b32R4" id="J6gp_6LHFx" role="lGtFl">
                                               <node concept="3JmXsc" id="J6gp_6LHFy" role="2P8S$">
@@ -3333,6 +3338,18 @@
                                           <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
                                         </node>
                                         <node concept="3clFbS" id="4xgCL2SOjW_" role="3clF47">
+                                          <node concept="3cpWs8" id="7PVnOXzM__o" role="3cqZAp">
+                                            <node concept="3cpWsn" id="7PVnOXzM__r" role="3cpWs9">
+                                              <property role="TrG5h" value="node" />
+                                              <node concept="3Tqbb2" id="7PVnOXzM__m" role="1tU5fm" />
+                                              <node concept="2OqwBi" id="7PVnOXzMDvN" role="33vP2m">
+                                                <node concept="2Mo9yH" id="7PVnOXzMC2y" role="2Oq$k0" />
+                                                <node concept="liA8E" id="7PVnOXzMEdp" role="2OqNvi">
+                                                  <ref role="37wK5l" to="uddc:~TransformationMenuContext.getNode()" resolve="getNode" />
+                                                </node>
+                                              </node>
+                                            </node>
+                                          </node>
                                           <node concept="3cpWs8" id="4xgCL2SOjWA" role="3cqZAp">
                                             <node concept="3cpWsn" id="4xgCL2SOjWB" role="3cpWs9">
                                               <property role="TrG5h" value="originalText" />
@@ -3343,13 +3360,6 @@
                                                   <ref role="3cqZAo" node="4xgCL2SOjWx" resolve="pattern" />
                                                 </node>
                                               </node>
-                                            </node>
-                                          </node>
-                                          <node concept="3cpWs8" id="4xgCL2SOjWF" role="3cqZAp">
-                                            <node concept="3cpWsn" id="4xgCL2SOjWG" role="3cpWs9">
-                                              <property role="TrG5h" value="wrappedNode" />
-                                              <node concept="3Tqbb2" id="4xgCL2SOjWH" role="1tU5fm" />
-                                              <node concept="10Nm6u" id="4xgCL2SOjWI" role="33vP2m" />
                                             </node>
                                           </node>
                                           <node concept="3cpWs8" id="4xgCL2SOjWJ" role="3cqZAp">
@@ -6010,34 +6020,39 @@
                                         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
                                       </node>
                                       <node concept="3clFbS" id="J6gp_6z5bZ" role="3clF47">
-                                        <node concept="3cpWs8" id="J6gp_6z5c0" role="3cqZAp">
-                                          <node concept="3cpWsn" id="J6gp_6z5c1" role="3cpWs9">
+                                        <node concept="3cpWs8" id="7PVnOXzMOnz" role="3cqZAp">
+                                          <node concept="3cpWsn" id="7PVnOXzMOn$" role="3cpWs9">
+                                            <property role="TrG5h" value="node" />
+                                            <node concept="3Tqbb2" id="7PVnOXzMOn_" role="1tU5fm" />
+                                            <node concept="2OqwBi" id="7PVnOXzMOnA" role="33vP2m">
+                                              <node concept="2Mo9yH" id="7PVnOXzMOnB" role="2Oq$k0" />
+                                              <node concept="liA8E" id="7PVnOXzMOnC" role="2OqNvi">
+                                                <ref role="37wK5l" to="uddc:~TransformationMenuContext.getNode()" resolve="getNode" />
+                                              </node>
+                                            </node>
+                                          </node>
+                                        </node>
+                                        <node concept="3cpWs8" id="7PVnOXzMOnD" role="3cqZAp">
+                                          <node concept="3cpWsn" id="7PVnOXzMOnE" role="3cpWs9">
                                             <property role="TrG5h" value="originalText" />
-                                            <node concept="17QB3L" id="J6gp_6z5c2" role="1tU5fm" />
-                                            <node concept="3nyPlj" id="J6gp_6z5c3" role="33vP2m">
+                                            <node concept="17QB3L" id="7PVnOXzMOnF" role="1tU5fm" />
+                                            <node concept="3nyPlj" id="7PVnOXzMOnG" role="33vP2m">
                                               <ref role="37wK5l" to="czm:325OF_Mo$mK" resolve="getShortDescriptionText" />
-                                              <node concept="37vLTw" id="J6gp_6z5c4" role="37wK5m">
+                                              <node concept="37vLTw" id="7PVnOXzMOnH" role="37wK5m">
                                                 <ref role="3cqZAo" node="J6gp_6z5bV" resolve="pattern" />
                                               </node>
                                             </node>
                                           </node>
                                         </node>
-                                        <node concept="3cpWs8" id="J6gp_6z5c5" role="3cqZAp">
-                                          <node concept="3cpWsn" id="J6gp_6z5c6" role="3cpWs9">
-                                            <property role="TrG5h" value="wrappedNode" />
-                                            <node concept="3Tqbb2" id="J6gp_6z5c7" role="1tU5fm" />
-                                            <node concept="10Nm6u" id="J6gp_6z5c8" role="33vP2m" />
-                                          </node>
-                                        </node>
-                                        <node concept="3cpWs8" id="J6gp_6z5c9" role="3cqZAp">
-                                          <node concept="3cpWsn" id="J6gp_6z5ca" role="3cpWs9">
+                                        <node concept="3cpWs8" id="7PVnOXzMOnI" role="3cqZAp">
+                                          <node concept="3cpWsn" id="7PVnOXzMOnJ" role="3cpWs9">
                                             <property role="TrG5h" value="editorContext" />
-                                            <node concept="3uibUv" id="J6gp_6z5cb" role="1tU5fm">
+                                            <node concept="3uibUv" id="7PVnOXzMOnK" role="1tU5fm">
                                               <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
                                             </node>
-                                            <node concept="2OqwBi" id="J6gp_6z5cc" role="33vP2m">
-                                              <node concept="2Mo9yH" id="J6gp_6z5cd" role="2Oq$k0" />
-                                              <node concept="liA8E" id="J6gp_6z5ce" role="2OqNvi">
+                                            <node concept="2OqwBi" id="7PVnOXzMOnL" role="33vP2m">
+                                              <node concept="2Mo9yH" id="7PVnOXzMOnM" role="2Oq$k0" />
+                                              <node concept="liA8E" id="7PVnOXzMOnN" role="2OqNvi">
                                                 <ref role="37wK5l" to="uddc:~TransformationMenuContext.getEditorContext()" resolve="getEditorContext" />
                                               </node>
                                             </node>
@@ -6045,7 +6060,7 @@
                                         </node>
                                         <node concept="3cpWs6" id="J6gp_6z5cf" role="3cqZAp">
                                           <node concept="37vLTw" id="J6gp_6z5cg" role="3cqZAk">
-                                            <ref role="3cqZAo" node="J6gp_6z5c1" resolve="originalText" />
+                                            <ref role="3cqZAo" node="7PVnOXzMOnE" resolve="originalText" />
                                           </node>
                                           <node concept="2b32R4" id="J6gp_6z5ch" role="lGtFl">
                                             <node concept="3JmXsc" id="J6gp_6z5ci" role="2P8S$">

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/generator/template/main@generator.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/generator/template/main@generator.mps
@@ -2365,22 +2365,127 @@
                                       <property role="2bfB8j" value="true" />
                                       <ref role="1Y3XeK" to="gdpt:1YKLYyyGBzT" resolve="GrammarCellsSideTransformTransformationMenuItem" />
                                       <ref role="37wK5l" to="gdpt:My09KinEek" resolve="GrammarCellsSideTransformTransformationMenuItem" />
+                                      <node concept="2tJIrI" id="J6gp_6LQnM" role="jymVt" />
                                       <node concept="2Mo9yH" id="DnjeumzccK" role="37wK5m" />
                                       <node concept="3Tm1VV" id="DnjeumzccL" role="1B3o_S" />
-                                      <node concept="3clFb_" id="DnjeumzccM" role="jymVt">
+                                      <node concept="3clFb_" id="J6gp_6LHF8" role="jymVt">
                                         <property role="1EzhhJ" value="false" />
-                                        <property role="TrG5h" value="getDescriptionText" />
+                                        <property role="TrG5h" value="getShortDescriptionText" />
                                         <property role="DiZV1" value="false" />
                                         <property role="od$2w" value="false" />
-                                        <node concept="3Tm1VV" id="DnjeumzccN" role="1B3o_S" />
-                                        <node concept="17QB3L" id="DnjeumzccO" role="3clF45" />
-                                        <node concept="37vLTG" id="DnjeumzccP" role="3clF46">
+                                        <node concept="3Tm1VV" id="J6gp_6LHF9" role="1B3o_S" />
+                                        <node concept="17QB3L" id="J6gp_6LHFa" role="3clF45" />
+                                        <node concept="37vLTG" id="J6gp_6LHFb" role="3clF46">
                                           <property role="TrG5h" value="pattern" />
-                                          <node concept="17QB3L" id="DnjeumzccQ" role="1tU5fm" />
+                                          <node concept="17QB3L" id="J6gp_6LHFc" role="1tU5fm" />
                                         </node>
-                                        <node concept="3clFbS" id="DnjeumzccR" role="3clF47">
-                                          <node concept="3clFbF" id="DnjeumzccS" role="3cqZAp">
-                                            <node concept="10Nm6u" id="DnjeumzccT" role="3clFbG" />
+                                        <node concept="2AHcQZ" id="J6gp_6LHFe" role="2AJF6D">
+                                          <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                                        </node>
+                                        <node concept="3clFbS" id="J6gp_6LHFf" role="3clF47">
+                                          <node concept="3cpWs8" id="J6gp_6LHFg" role="3cqZAp">
+                                            <node concept="3cpWsn" id="J6gp_6LHFh" role="3cpWs9">
+                                              <property role="TrG5h" value="originalText" />
+                                              <node concept="17QB3L" id="J6gp_6LHFi" role="1tU5fm" />
+                                              <node concept="3nyPlj" id="J6gp_6LHFj" role="33vP2m">
+                                                <ref role="37wK5l" to="gdpt:1YKLYyyGCB0" resolve="getShortDescriptionText" />
+                                                <node concept="37vLTw" id="J6gp_6LHFk" role="37wK5m">
+                                                  <ref role="3cqZAo" node="J6gp_6LHFb" resolve="pattern" />
+                                                </node>
+                                              </node>
+                                            </node>
+                                          </node>
+                                          <node concept="3cpWs8" id="J6gp_6LHFl" role="3cqZAp">
+                                            <node concept="3cpWsn" id="J6gp_6LHFm" role="3cpWs9">
+                                              <property role="TrG5h" value="wrappedNode" />
+                                              <node concept="3Tqbb2" id="J6gp_6LHFn" role="1tU5fm" />
+                                              <node concept="10Nm6u" id="J6gp_6LHFo" role="33vP2m" />
+                                            </node>
+                                          </node>
+                                          <node concept="3cpWs8" id="J6gp_6LHFp" role="3cqZAp">
+                                            <node concept="3cpWsn" id="J6gp_6LHFq" role="3cpWs9">
+                                              <property role="TrG5h" value="editorContext" />
+                                              <node concept="3uibUv" id="J6gp_6LHFr" role="1tU5fm">
+                                                <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+                                              </node>
+                                              <node concept="2OqwBi" id="J6gp_6LHFs" role="33vP2m">
+                                                <node concept="2Mo9yH" id="J6gp_6LHFt" role="2Oq$k0" />
+                                                <node concept="liA8E" id="J6gp_6LHFu" role="2OqNvi">
+                                                  <ref role="37wK5l" to="uddc:~TransformationMenuContext.getEditorContext()" resolve="getEditorContext" />
+                                                </node>
+                                              </node>
+                                            </node>
+                                          </node>
+                                          <node concept="3cpWs6" id="J6gp_6LHFv" role="3cqZAp">
+                                            <node concept="37vLTw" id="J6gp_6LHFw" role="3cqZAk">
+                                              <ref role="3cqZAo" node="J6gp_6LHFh" resolve="originalText" />
+                                            </node>
+                                            <node concept="2b32R4" id="J6gp_6LHFx" role="lGtFl">
+                                              <node concept="3JmXsc" id="J6gp_6LHFy" role="2P8S$">
+                                                <node concept="3clFbS" id="J6gp_6LHFz" role="2VODD2">
+                                                  <node concept="3clFbF" id="J6gp_6LHF$" role="3cqZAp">
+                                                    <node concept="2OqwBi" id="J6gp_6LHF_" role="3clFbG">
+                                                      <node concept="2OqwBi" id="J6gp_6LHFA" role="2Oq$k0">
+                                                        <node concept="2OqwBi" id="J6gp_6LHFB" role="2Oq$k0">
+                                                          <node concept="30H73N" id="J6gp_6LHFC" role="2Oq$k0" />
+                                                          <node concept="3TrEf2" id="J6gp_6LHFD" role="2OqNvi">
+                                                            <ref role="3Tt5mk" to="teg0:J6gp_6ycpL" resolve="descriptionText" />
+                                                          </node>
+                                                        </node>
+                                                        <node concept="3TrEf2" id="J6gp_6LHFE" role="2OqNvi">
+                                                          <ref role="3Tt5mk" to="tpee:gyVODHa" resolve="body" />
+                                                        </node>
+                                                      </node>
+                                                      <node concept="3Tsc0h" id="J6gp_6LHFF" role="2OqNvi">
+                                                        <ref role="3TtcxE" to="tpee:fzcqZ_x" resolve="statement" />
+                                                      </node>
+                                                    </node>
+                                                  </node>
+                                                </node>
+                                              </node>
+                                            </node>
+                                          </node>
+                                        </node>
+                                        <node concept="1W57fq" id="J6gp_6LHFG" role="lGtFl">
+                                          <node concept="3IZrLx" id="J6gp_6LHFH" role="3IZSJc">
+                                            <node concept="3clFbS" id="J6gp_6LHFI" role="2VODD2">
+                                              <node concept="3clFbF" id="J6gp_6LHFJ" role="3cqZAp">
+                                                <node concept="2OqwBi" id="J6gp_6LHFK" role="3clFbG">
+                                                  <node concept="2OqwBi" id="J6gp_6LHFL" role="2Oq$k0">
+                                                    <node concept="30H73N" id="J6gp_6LHFM" role="2Oq$k0" />
+                                                    <node concept="3TrEf2" id="J6gp_6LHFN" role="2OqNvi">
+                                                      <ref role="3Tt5mk" to="teg0:J6gp_6ycpL" resolve="descriptionText" />
+                                                    </node>
+                                                  </node>
+                                                  <node concept="3x8VRR" id="J6gp_6LHFO" role="2OqNvi" />
+                                                </node>
+                                              </node>
+                                            </node>
+                                          </node>
+                                          <node concept="gft3U" id="4owkxKUwVWz" role="UU_$l">
+                                            <node concept="3clFb_" id="4owkxKUwVW$" role="gfFT$">
+                                              <property role="1EzhhJ" value="false" />
+                                              <property role="TrG5h" value="getDescriptionText" />
+                                              <property role="DiZV1" value="false" />
+                                              <property role="od$2w" value="false" />
+                                              <node concept="3Tm1VV" id="4owkxKUwVW_" role="1B3o_S" />
+                                              <node concept="17QB3L" id="4owkxKUwVWA" role="3clF45" />
+                                              <node concept="37vLTG" id="4owkxKUwVWB" role="3clF46">
+                                                <property role="TrG5h" value="string" />
+                                                <node concept="17QB3L" id="4owkxKUwVWC" role="1tU5fm" />
+                                              </node>
+                                              <node concept="3clFbS" id="4owkxKUwVWD" role="3clF47">
+                                                <node concept="3clFbF" id="4owkxKUwVWE" role="3cqZAp">
+                                                  <node concept="2YIFZM" id="4owkxKUwVWF" role="3clFbG">
+                                                    <ref role="1Pybhc" to="5b0:~NodePresentationUtil" resolve="NodePresentationUtil" />
+                                                    <ref role="37wK5l" to="5b0:~NodePresentationUtil.descriptionText(org.jetbrains.mps.openapi.language.SAbstractConcept)" resolve="descriptionText" />
+                                                    <node concept="1rXfSq" id="4owkxKUwVWG" role="37wK5m">
+                                                      <ref role="37wK5l" node="Dnjeumzces" resolve="getOutputConcept" />
+                                                    </node>
+                                                  </node>
+                                                </node>
+                                              </node>
+                                            </node>
                                           </node>
                                         </node>
                                       </node>
@@ -3101,6 +3206,132 @@
                                           <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
                                         </node>
                                       </node>
+                                      <node concept="2tJIrI" id="4xgCL2SNMHz" role="jymVt" />
+                                      <node concept="3clFb_" id="4xgCL2SOjWu" role="jymVt">
+                                        <property role="1EzhhJ" value="false" />
+                                        <property role="TrG5h" value="getShortDescriptionText" />
+                                        <property role="DiZV1" value="false" />
+                                        <property role="od$2w" value="false" />
+                                        <node concept="3Tm1VV" id="4xgCL2SOjWv" role="1B3o_S" />
+                                        <node concept="17QB3L" id="4xgCL2SOjWw" role="3clF45" />
+                                        <node concept="37vLTG" id="4xgCL2SOjWx" role="3clF46">
+                                          <property role="TrG5h" value="pattern" />
+                                          <node concept="17QB3L" id="4xgCL2SOjWy" role="1tU5fm" />
+                                          <node concept="2AHcQZ" id="4xgCL2SOjWz" role="2AJF6D">
+                                            <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+                                          </node>
+                                        </node>
+                                        <node concept="2AHcQZ" id="4xgCL2SOjW$" role="2AJF6D">
+                                          <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                                        </node>
+                                        <node concept="3clFbS" id="4xgCL2SOjW_" role="3clF47">
+                                          <node concept="3cpWs8" id="4xgCL2SOjWA" role="3cqZAp">
+                                            <node concept="3cpWsn" id="4xgCL2SOjWB" role="3cpWs9">
+                                              <property role="TrG5h" value="originalText" />
+                                              <node concept="17QB3L" id="4xgCL2SOjWC" role="1tU5fm" />
+                                              <node concept="3nyPlj" id="4xgCL2SOjWD" role="33vP2m">
+                                                <ref role="37wK5l" to="czm:325OF_Mo$mK" resolve="getShortDescriptionText" />
+                                                <node concept="37vLTw" id="4xgCL2SOjWE" role="37wK5m">
+                                                  <ref role="3cqZAo" node="4xgCL2SOjWx" resolve="pattern" />
+                                                </node>
+                                              </node>
+                                            </node>
+                                          </node>
+                                          <node concept="3cpWs8" id="4xgCL2SOjWF" role="3cqZAp">
+                                            <node concept="3cpWsn" id="4xgCL2SOjWG" role="3cpWs9">
+                                              <property role="TrG5h" value="wrappedNode" />
+                                              <node concept="3Tqbb2" id="4xgCL2SOjWH" role="1tU5fm" />
+                                              <node concept="10Nm6u" id="4xgCL2SOjWI" role="33vP2m" />
+                                            </node>
+                                          </node>
+                                          <node concept="3cpWs8" id="4xgCL2SOjWJ" role="3cqZAp">
+                                            <node concept="3cpWsn" id="4xgCL2SOjWK" role="3cpWs9">
+                                              <property role="TrG5h" value="editorContext" />
+                                              <node concept="3uibUv" id="4xgCL2SOjWL" role="1tU5fm">
+                                                <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+                                              </node>
+                                              <node concept="2OqwBi" id="4xgCL2SOjWM" role="33vP2m">
+                                                <node concept="2Mo9yH" id="4xgCL2SOpbr" role="2Oq$k0" />
+                                                <node concept="liA8E" id="4xgCL2SOjWO" role="2OqNvi">
+                                                  <ref role="37wK5l" to="uddc:~TransformationMenuContext.getEditorContext()" resolve="getEditorContext" />
+                                                </node>
+                                              </node>
+                                            </node>
+                                          </node>
+                                          <node concept="3cpWs6" id="4xgCL2SOjWP" role="3cqZAp">
+                                            <node concept="37vLTw" id="4xgCL2SOjWQ" role="3cqZAk">
+                                              <ref role="3cqZAo" node="4xgCL2SOjWB" resolve="originalText" />
+                                            </node>
+                                            <node concept="2b32R4" id="4xgCL2SOjWR" role="lGtFl">
+                                              <node concept="3JmXsc" id="4xgCL2SOjWS" role="2P8S$">
+                                                <node concept="3clFbS" id="4xgCL2SOjWT" role="2VODD2">
+                                                  <node concept="3clFbF" id="4xgCL2SOjWU" role="3cqZAp">
+                                                    <node concept="2OqwBi" id="4xgCL2SOjWV" role="3clFbG">
+                                                      <node concept="2OqwBi" id="4xgCL2SOjWW" role="2Oq$k0">
+                                                        <node concept="2OqwBi" id="4xgCL2SOjWX" role="2Oq$k0">
+                                                          <node concept="30H73N" id="4xgCL2SOjWY" role="2Oq$k0" />
+                                                          <node concept="3TrEf2" id="4xgCL2SOjWZ" role="2OqNvi">
+                                                            <ref role="3Tt5mk" to="teg0:J6gp_6ycpL" resolve="descriptionText" />
+                                                          </node>
+                                                        </node>
+                                                        <node concept="3TrEf2" id="4xgCL2SOjX0" role="2OqNvi">
+                                                          <ref role="3Tt5mk" to="tpee:gyVODHa" resolve="body" />
+                                                        </node>
+                                                      </node>
+                                                      <node concept="3Tsc0h" id="4xgCL2SOjX1" role="2OqNvi">
+                                                        <ref role="3TtcxE" to="tpee:fzcqZ_x" resolve="statement" />
+                                                      </node>
+                                                    </node>
+                                                  </node>
+                                                </node>
+                                              </node>
+                                            </node>
+                                          </node>
+                                        </node>
+                                        <node concept="1W57fq" id="4owkxKUw_Ol" role="lGtFl">
+                                          <node concept="3IZrLx" id="4owkxKUw_Om" role="3IZSJc">
+                                            <node concept="3clFbS" id="4owkxKUw_On" role="2VODD2">
+                                              <node concept="3clFbF" id="4owkxKUwBvO" role="3cqZAp">
+                                                <node concept="2OqwBi" id="4owkxKUwCGq" role="3clFbG">
+                                                  <node concept="2OqwBi" id="4owkxKUwBP6" role="2Oq$k0">
+                                                    <node concept="30H73N" id="4owkxKUwBvN" role="2Oq$k0" />
+                                                    <node concept="3TrEf2" id="4owkxKUwCnl" role="2OqNvi">
+                                                      <ref role="3Tt5mk" to="teg0:J6gp_6ycpL" resolve="descriptionText" />
+                                                    </node>
+                                                  </node>
+                                                  <node concept="3x8VRR" id="4owkxKUwDbH" role="2OqNvi" />
+                                                </node>
+                                              </node>
+                                            </node>
+                                          </node>
+                                          <node concept="gft3U" id="4owkxKUwNet" role="UU_$l">
+                                            <node concept="3clFb_" id="4owkxKUwNeu" role="gfFT$">
+                                              <property role="1EzhhJ" value="false" />
+                                              <property role="TrG5h" value="getDescriptionText" />
+                                              <property role="DiZV1" value="false" />
+                                              <property role="od$2w" value="false" />
+                                              <node concept="3Tm1VV" id="4owkxKUwNev" role="1B3o_S" />
+                                              <node concept="17QB3L" id="4owkxKUwNew" role="3clF45" />
+                                              <node concept="37vLTG" id="4owkxKUwNex" role="3clF46">
+                                                <property role="TrG5h" value="string" />
+                                                <node concept="17QB3L" id="4owkxKUwNey" role="1tU5fm" />
+                                              </node>
+                                              <node concept="3clFbS" id="4owkxKUwNez" role="3clF47">
+                                                <node concept="3clFbF" id="4owkxKUwNe$" role="3cqZAp">
+                                                  <node concept="2YIFZM" id="4owkxKUwNe_" role="3clFbG">
+                                                    <ref role="1Pybhc" to="5b0:~NodePresentationUtil" resolve="NodePresentationUtil" />
+                                                    <ref role="37wK5l" to="5b0:~NodePresentationUtil.descriptionText(org.jetbrains.mps.openapi.language.SAbstractConcept)" resolve="descriptionText" />
+                                                    <node concept="1rXfSq" id="4owkxKUwRGM" role="37wK5m">
+                                                      <ref role="37wK5l" node="5fS8LroEqAw" resolve="getOutputConcept" />
+                                                    </node>
+                                                  </node>
+                                                </node>
+                                              </node>
+                                            </node>
+                                          </node>
+                                        </node>
+                                      </node>
+                                      <node concept="2tJIrI" id="4xgCL2SOi7W" role="jymVt" />
                                       <node concept="3Tm1VV" id="5fS8LroEqAM" role="1B3o_S" />
                                       <node concept="37vLTw" id="5fS8LroEqAN" role="37wK5m">
                                         <ref role="3cqZAo" node="5fS8LroEq_3" resolve="matchingTexts" />
@@ -5652,6 +5883,132 @@
                                         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
                                       </node>
                                     </node>
+                                    <node concept="2tJIrI" id="J6gp_6z2Mm" role="jymVt" />
+                                    <node concept="3clFb_" id="J6gp_6z5bS" role="jymVt">
+                                      <property role="1EzhhJ" value="false" />
+                                      <property role="TrG5h" value="getShortDescriptionText" />
+                                      <property role="DiZV1" value="false" />
+                                      <property role="od$2w" value="false" />
+                                      <node concept="3Tm1VV" id="J6gp_6z5bT" role="1B3o_S" />
+                                      <node concept="17QB3L" id="J6gp_6z5bU" role="3clF45" />
+                                      <node concept="37vLTG" id="J6gp_6z5bV" role="3clF46">
+                                        <property role="TrG5h" value="pattern" />
+                                        <node concept="17QB3L" id="J6gp_6z5bW" role="1tU5fm" />
+                                        <node concept="2AHcQZ" id="J6gp_6z5bX" role="2AJF6D">
+                                          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+                                        </node>
+                                      </node>
+                                      <node concept="2AHcQZ" id="J6gp_6z5bY" role="2AJF6D">
+                                        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                                      </node>
+                                      <node concept="3clFbS" id="J6gp_6z5bZ" role="3clF47">
+                                        <node concept="3cpWs8" id="J6gp_6z5c0" role="3cqZAp">
+                                          <node concept="3cpWsn" id="J6gp_6z5c1" role="3cpWs9">
+                                            <property role="TrG5h" value="originalText" />
+                                            <node concept="17QB3L" id="J6gp_6z5c2" role="1tU5fm" />
+                                            <node concept="3nyPlj" id="J6gp_6z5c3" role="33vP2m">
+                                              <ref role="37wK5l" to="czm:325OF_Mo$mK" resolve="getShortDescriptionText" />
+                                              <node concept="37vLTw" id="J6gp_6z5c4" role="37wK5m">
+                                                <ref role="3cqZAo" node="J6gp_6z5bV" resolve="pattern" />
+                                              </node>
+                                            </node>
+                                          </node>
+                                        </node>
+                                        <node concept="3cpWs8" id="J6gp_6z5c5" role="3cqZAp">
+                                          <node concept="3cpWsn" id="J6gp_6z5c6" role="3cpWs9">
+                                            <property role="TrG5h" value="wrappedNode" />
+                                            <node concept="3Tqbb2" id="J6gp_6z5c7" role="1tU5fm" />
+                                            <node concept="10Nm6u" id="J6gp_6z5c8" role="33vP2m" />
+                                          </node>
+                                        </node>
+                                        <node concept="3cpWs8" id="J6gp_6z5c9" role="3cqZAp">
+                                          <node concept="3cpWsn" id="J6gp_6z5ca" role="3cpWs9">
+                                            <property role="TrG5h" value="editorContext" />
+                                            <node concept="3uibUv" id="J6gp_6z5cb" role="1tU5fm">
+                                              <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+                                            </node>
+                                            <node concept="2OqwBi" id="J6gp_6z5cc" role="33vP2m">
+                                              <node concept="2Mo9yH" id="J6gp_6z5cd" role="2Oq$k0" />
+                                              <node concept="liA8E" id="J6gp_6z5ce" role="2OqNvi">
+                                                <ref role="37wK5l" to="uddc:~TransformationMenuContext.getEditorContext()" resolve="getEditorContext" />
+                                              </node>
+                                            </node>
+                                          </node>
+                                        </node>
+                                        <node concept="3cpWs6" id="J6gp_6z5cf" role="3cqZAp">
+                                          <node concept="37vLTw" id="J6gp_6z5cg" role="3cqZAk">
+                                            <ref role="3cqZAo" node="J6gp_6z5c1" resolve="originalText" />
+                                          </node>
+                                          <node concept="2b32R4" id="J6gp_6z5ch" role="lGtFl">
+                                            <node concept="3JmXsc" id="J6gp_6z5ci" role="2P8S$">
+                                              <node concept="3clFbS" id="J6gp_6z5cj" role="2VODD2">
+                                                <node concept="3clFbF" id="J6gp_6z5ck" role="3cqZAp">
+                                                  <node concept="2OqwBi" id="J6gp_6z5cl" role="3clFbG">
+                                                    <node concept="2OqwBi" id="J6gp_6z5cm" role="2Oq$k0">
+                                                      <node concept="2OqwBi" id="J6gp_6z5cn" role="2Oq$k0">
+                                                        <node concept="30H73N" id="J6gp_6z5co" role="2Oq$k0" />
+                                                        <node concept="3TrEf2" id="J6gp_6z5cp" role="2OqNvi">
+                                                          <ref role="3Tt5mk" to="teg0:J6gp_6ycpL" resolve="descriptionText" />
+                                                        </node>
+                                                      </node>
+                                                      <node concept="3TrEf2" id="J6gp_6z5cq" role="2OqNvi">
+                                                        <ref role="3Tt5mk" to="tpee:gyVODHa" resolve="body" />
+                                                      </node>
+                                                    </node>
+                                                    <node concept="3Tsc0h" id="J6gp_6z5cr" role="2OqNvi">
+                                                      <ref role="3TtcxE" to="tpee:fzcqZ_x" resolve="statement" />
+                                                    </node>
+                                                  </node>
+                                                </node>
+                                              </node>
+                                            </node>
+                                          </node>
+                                        </node>
+                                      </node>
+                                      <node concept="1W57fq" id="J6gp_6z5cs" role="lGtFl">
+                                        <node concept="3IZrLx" id="J6gp_6z5ct" role="3IZSJc">
+                                          <node concept="3clFbS" id="J6gp_6z5cu" role="2VODD2">
+                                            <node concept="3clFbF" id="J6gp_6z5cv" role="3cqZAp">
+                                              <node concept="2OqwBi" id="J6gp_6z5cw" role="3clFbG">
+                                                <node concept="2OqwBi" id="J6gp_6z5cx" role="2Oq$k0">
+                                                  <node concept="30H73N" id="J6gp_6z5cy" role="2Oq$k0" />
+                                                  <node concept="3TrEf2" id="J6gp_6z5cz" role="2OqNvi">
+                                                    <ref role="3Tt5mk" to="teg0:J6gp_6ycpL" resolve="descriptionText" />
+                                                  </node>
+                                                </node>
+                                                <node concept="3x8VRR" id="J6gp_6z5c$" role="2OqNvi" />
+                                              </node>
+                                            </node>
+                                          </node>
+                                        </node>
+                                        <node concept="gft3U" id="4owkxKUwSb2" role="UU_$l">
+                                          <node concept="3clFb_" id="4owkxKUwSb3" role="gfFT$">
+                                            <property role="1EzhhJ" value="false" />
+                                            <property role="TrG5h" value="getDescriptionText" />
+                                            <property role="DiZV1" value="false" />
+                                            <property role="od$2w" value="false" />
+                                            <node concept="3Tm1VV" id="4owkxKUwSb4" role="1B3o_S" />
+                                            <node concept="17QB3L" id="4owkxKUwSb5" role="3clF45" />
+                                            <node concept="37vLTG" id="4owkxKUwSb6" role="3clF46">
+                                              <property role="TrG5h" value="string" />
+                                              <node concept="17QB3L" id="4owkxKUwSb7" role="1tU5fm" />
+                                            </node>
+                                            <node concept="3clFbS" id="4owkxKUwSb8" role="3clF47">
+                                              <node concept="3clFbF" id="4owkxKUwSb9" role="3cqZAp">
+                                                <node concept="2YIFZM" id="4owkxKUwSba" role="3clFbG">
+                                                  <ref role="1Pybhc" to="5b0:~NodePresentationUtil" resolve="NodePresentationUtil" />
+                                                  <ref role="37wK5l" to="5b0:~NodePresentationUtil.descriptionText(org.jetbrains.mps.openapi.language.SAbstractConcept)" resolve="descriptionText" />
+                                                  <node concept="1rXfSq" id="4owkxKUwSbb" role="37wK5m">
+                                                    <ref role="37wK5l" node="15DZatORrHk" resolve="getOutputConcept" />
+                                                  </node>
+                                                </node>
+                                              </node>
+                                            </node>
+                                          </node>
+                                        </node>
+                                      </node>
+                                    </node>
+                                    <node concept="2tJIrI" id="J6gp_6z2Oo" role="jymVt" />
                                     <node concept="3Tm1VV" id="15DZatORrHA" role="1B3o_S" />
                                     <node concept="37vLTw" id="15DZatORrHB" role="37wK5m">
                                       <ref role="3cqZAo" node="15DZatORrFR" resolve="matchingTexts" />
@@ -9140,7 +9497,7 @@
                                                                           <node concept="2OqwBi" id="6uixmKZ3tky" role="2Oq$k0">
                                                                             <node concept="30H73N" id="6uixmKZ3tkz" role="2Oq$k0" />
                                                                             <node concept="3TrEf2" id="6uixmKZ3tk$" role="2OqNvi">
-                                                                              <ref role="3Tt5mk" to="teg0:6uixmKZ2FIJ" resolve="descriptionText" />
+                                                                              <ref role="3Tt5mk" to="teg0:J6gp_6ycpL" resolve="descriptionText" />
                                                                             </node>
                                                                           </node>
                                                                           <node concept="3TrEf2" id="6uixmKZ3tk_" role="2OqNvi">
@@ -9165,7 +9522,7 @@
                                                                     <node concept="2OqwBi" id="6uixmKZ3tkG" role="2Oq$k0">
                                                                       <node concept="30H73N" id="6uixmKZ3tkH" role="2Oq$k0" />
                                                                       <node concept="3TrEf2" id="6uixmKZ3tkI" role="2OqNvi">
-                                                                        <ref role="3Tt5mk" to="teg0:6uixmKZ2FIJ" resolve="descriptionText" />
+                                                                        <ref role="3Tt5mk" to="teg0:J6gp_6ycpL" resolve="descriptionText" />
                                                                       </node>
                                                                     </node>
                                                                     <node concept="3x8VRR" id="6uixmKZ3tkJ" role="2OqNvi" />
@@ -9913,7 +10270,7 @@
                                                                   <node concept="2OqwBi" id="6uixmKZ39tf" role="2Oq$k0">
                                                                     <node concept="30H73N" id="6uixmKZ39tg" role="2Oq$k0" />
                                                                     <node concept="3TrEf2" id="6uixmKZ39th" role="2OqNvi">
-                                                                      <ref role="3Tt5mk" to="teg0:6uixmKZ2FIJ" resolve="descriptionText" />
+                                                                      <ref role="3Tt5mk" to="teg0:J6gp_6ycpL" resolve="descriptionText" />
                                                                     </node>
                                                                   </node>
                                                                   <node concept="3TrEf2" id="6uixmKZ39ti" role="2OqNvi">
@@ -9938,7 +10295,7 @@
                                                             <node concept="2OqwBi" id="6uixmKZ3ix5" role="2Oq$k0">
                                                               <node concept="30H73N" id="6uixmKZ3ifr" role="2Oq$k0" />
                                                               <node concept="3TrEf2" id="6uixmKZ3iUe" role="2OqNvi">
-                                                                <ref role="3Tt5mk" to="teg0:6uixmKZ2FIJ" resolve="descriptionText" />
+                                                                <ref role="3Tt5mk" to="teg0:J6gp_6ycpL" resolve="descriptionText" />
                                                               </node>
                                                             </node>
                                                             <node concept="3x8VRR" id="6uixmKZ3kkk" role="2OqNvi" />
@@ -11008,7 +11365,7 @@
                                                               <node concept="2OqwBi" id="6uixmKZ3lSe" role="2Oq$k0">
                                                                 <node concept="30H73N" id="6uixmKZ3lSf" role="2Oq$k0" />
                                                                 <node concept="3TrEf2" id="6uixmKZ3lSg" role="2OqNvi">
-                                                                  <ref role="3Tt5mk" to="teg0:6uixmKZ2FIJ" resolve="descriptionText" />
+                                                                  <ref role="3Tt5mk" to="teg0:J6gp_6ycpL" resolve="descriptionText" />
                                                                 </node>
                                                               </node>
                                                               <node concept="3TrEf2" id="6uixmKZ3lSh" role="2OqNvi">
@@ -11033,7 +11390,7 @@
                                                         <node concept="2OqwBi" id="6uixmKZ3lSo" role="2Oq$k0">
                                                           <node concept="30H73N" id="6uixmKZ3lSp" role="2Oq$k0" />
                                                           <node concept="3TrEf2" id="6uixmKZ3s_n" role="2OqNvi">
-                                                            <ref role="3Tt5mk" to="teg0:6uixmKZ2FIJ" resolve="descriptionText" />
+                                                            <ref role="3Tt5mk" to="teg0:J6gp_6ycpL" resolve="descriptionText" />
                                                           </node>
                                                         </node>
                                                         <node concept="3x8VRR" id="6uixmKZ3lSr" role="2OqNvi" />
@@ -14797,7 +15154,7 @@
                                 </node>
                                 <node concept="3clFb_" id="7KznU_45jk1" role="jymVt">
                                   <property role="1EzhhJ" value="false" />
-                                  <property role="TrG5h" value="getDescriptionText" />
+                                  <property role="TrG5h" value="getShortDescriptionText" />
                                   <property role="DiZV1" value="false" />
                                   <property role="od$2w" value="false" />
                                   <node concept="3Tm1VV" id="7KznU_45jk2" role="1B3o_S" />
@@ -15381,7 +15738,7 @@
                                             </node>
                                             <node concept="3clFb_" id="4qdNcHzZSh5" role="jymVt">
                                               <property role="1EzhhJ" value="false" />
-                                              <property role="TrG5h" value="getDescriptionText" />
+                                              <property role="TrG5h" value="getShortDescriptionText" />
                                               <property role="DiZV1" value="false" />
                                               <property role="od$2w" value="false" />
                                               <node concept="3Tm1VV" id="4qdNcHzZSh6" role="1B3o_S" />
@@ -20304,7 +20661,7 @@
                                                             <node concept="2tJIrI" id="6uixmKZ43qj" role="jymVt" />
                                                             <node concept="3clFb_" id="6uixmKZ3UtU" role="jymVt">
                                                               <property role="1EzhhJ" value="false" />
-                                                              <property role="TrG5h" value="getDescriptionText" />
+                                                              <property role="TrG5h" value="getShortDescriptionText" />
                                                               <property role="DiZV1" value="false" />
                                                               <property role="od$2w" value="false" />
                                                               <node concept="3Tm1VV" id="6uixmKZ3UtV" role="1B3o_S" />
@@ -20325,7 +20682,7 @@
                                                                     <property role="TrG5h" value="originalText" />
                                                                     <node concept="17QB3L" id="6uixmKZ3Uu4" role="1tU5fm" />
                                                                     <node concept="3nyPlj" id="6uixmKZ3Uu5" role="33vP2m">
-                                                                      <ref role="37wK5l" to="czm:1YKLYyyOIGd" resolve="getDescriptionText" />
+                                                                      <ref role="37wK5l" to="czm:325OF_Mo$mK" resolve="getShortDescriptionText" />
                                                                       <node concept="37vLTw" id="6uixmKZ3Uu6" role="37wK5m">
                                                                         <ref role="3cqZAo" node="6uixmKZ3UtX" resolve="pattern" />
                                                                       </node>
@@ -20375,7 +20732,7 @@
                                                                               <node concept="2OqwBi" id="6uixmKZ3Uuf" role="2Oq$k0">
                                                                                 <node concept="30H73N" id="6uixmKZ3Uug" role="2Oq$k0" />
                                                                                 <node concept="3TrEf2" id="6uixmKZ3Uuh" role="2OqNvi">
-                                                                                  <ref role="3Tt5mk" to="teg0:6uixmKZ2FIJ" resolve="descriptionText" />
+                                                                                  <ref role="3Tt5mk" to="teg0:J6gp_6ycpL" resolve="descriptionText" />
                                                                                 </node>
                                                                               </node>
                                                                               <node concept="3TrEf2" id="6uixmKZ3Uui" role="2OqNvi">
@@ -20402,7 +20759,7 @@
                                                                             <node concept="2OqwBi" id="2q0cFwFI$l_" role="2Oq$k0">
                                                                               <node concept="30H73N" id="2q0cFwFI$0Z" role="2Oq$k0" />
                                                                               <node concept="3TrEf2" id="2q0cFwFI_17" role="2OqNvi">
-                                                                                <ref role="3Tt5mk" to="teg0:6uixmKZ2FIJ" resolve="descriptionText" />
+                                                                                <ref role="3Tt5mk" to="teg0:J6gp_6ycpL" resolve="descriptionText" />
                                                                               </node>
                                                                             </node>
                                                                             <node concept="2Rf3mk" id="2q0cFwFIAaL" role="2OqNvi">
@@ -20419,7 +20776,7 @@
                                                                           <node concept="2OqwBi" id="6uixmKZ3Uup" role="2Oq$k0">
                                                                             <node concept="30H73N" id="6uixmKZ3Uuq" role="2Oq$k0" />
                                                                             <node concept="3TrEf2" id="6uixmKZ3Uur" role="2OqNvi">
-                                                                              <ref role="3Tt5mk" to="teg0:6uixmKZ2FIJ" resolve="descriptionText" />
+                                                                              <ref role="3Tt5mk" to="teg0:J6gp_6ycpL" resolve="descriptionText" />
                                                                             </node>
                                                                           </node>
                                                                           <node concept="3x8VRR" id="6uixmKZ3Uus" role="2OqNvi" />

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/generator/template/main@generator.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/generator/template/main@generator.mps
@@ -1649,47 +1649,155 @@
                                     </node>
                                     <node concept="TSZUe" id="qT5MFmnLil" role="2OqNvi">
                                       <node concept="2ShNRf" id="qT5MFmnLim" role="25WWJ7">
-                                        <node concept="1pGfFk" id="qT5MFmnLin" role="2ShVmc">
-                                          <ref role="37wK5l" to="czm:4AuGfbNRh27" resolve="FlagSubstituteMenuItem" />
-                                          <node concept="37vLTw" id="2c4RKQNyRNx" role="37wK5m">
-                                            <ref role="3cqZAo" node="2c4RKQNyRNs" resolve="parentNode" />
-                                          </node>
-                                          <node concept="2OqwBi" id="qT5MFmnLir" role="37wK5m">
-                                            <node concept="2kYc5w" id="qT5MFmnMhf" role="2Oq$k0" />
-                                            <node concept="liA8E" id="qT5MFmnLit" role="2OqNvi">
-                                              <ref role="37wK5l" to="78sh:~SubstituteMenuContext.getCurrentTargetNode()" resolve="getCurrentTargetNode" />
+                                        <node concept="YeOm9" id="4owkxKW9yrk" role="2ShVmc">
+                                          <node concept="1Y3b0j" id="4owkxKW9yrn" role="YeSDq">
+                                            <property role="2bfB8j" value="true" />
+                                            <ref role="37wK5l" to="czm:4AuGfbNRh27" resolve="FlagSubstituteMenuItem" />
+                                            <ref role="1Y3XeK" to="czm:7NlRaxAJR0G" resolve="FlagSubstituteMenuItem" />
+                                            <node concept="3Tm1VV" id="4owkxKW9yro" role="1B3o_S" />
+                                            <node concept="37vLTw" id="2c4RKQNyRNx" role="37wK5m">
+                                              <ref role="3cqZAo" node="2c4RKQNyRNs" resolve="parentNode" />
                                             </node>
-                                          </node>
-                                          <node concept="37vLTw" id="qT5MFmto$a" role="37wK5m">
-                                            <ref role="3cqZAo" node="qT5MFmsSRB" resolve="subconcept" />
-                                          </node>
-                                          <node concept="Xl_RD" id="qT5MFmnLiX" role="37wK5m">
-                                            <property role="Xl_RC" value="flagText" />
-                                            <node concept="17Uvod" id="qT5MFmnLiY" role="lGtFl">
-                                              <property role="P4ACc" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1070475926800/1070475926801" />
-                                              <property role="2qtEX9" value="value" />
-                                              <node concept="3zFVjK" id="qT5MFmnLiZ" role="3zH0cK">
-                                                <node concept="3clFbS" id="qT5MFmnLj0" role="2VODD2">
-                                                  <node concept="3clFbF" id="qT5MFmnLj1" role="3cqZAp">
-                                                    <node concept="2OqwBi" id="qT5MFmnLj2" role="3clFbG">
-                                                      <node concept="30H73N" id="qT5MFmnLj3" role="2Oq$k0" />
-                                                      <node concept="2qgKlT" id="qT5MFmnLj4" role="2OqNvi">
-                                                        <ref role="37wK5l" to="karh:6ASs6LmXZEr" resolve="getFlagText" />
+                                            <node concept="2OqwBi" id="qT5MFmnLir" role="37wK5m">
+                                              <node concept="2kYc5w" id="qT5MFmnMhf" role="2Oq$k0" />
+                                              <node concept="liA8E" id="qT5MFmnLit" role="2OqNvi">
+                                                <ref role="37wK5l" to="78sh:~SubstituteMenuContext.getCurrentTargetNode()" resolve="getCurrentTargetNode" />
+                                              </node>
+                                            </node>
+                                            <node concept="37vLTw" id="qT5MFmto$a" role="37wK5m">
+                                              <ref role="3cqZAo" node="qT5MFmsSRB" resolve="subconcept" />
+                                            </node>
+                                            <node concept="Xl_RD" id="qT5MFmnLiX" role="37wK5m">
+                                              <property role="Xl_RC" value="flagText" />
+                                              <node concept="17Uvod" id="qT5MFmnLiY" role="lGtFl">
+                                                <property role="P4ACc" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1070475926800/1070475926801" />
+                                                <property role="2qtEX9" value="value" />
+                                                <node concept="3zFVjK" id="qT5MFmnLiZ" role="3zH0cK">
+                                                  <node concept="3clFbS" id="qT5MFmnLj0" role="2VODD2">
+                                                    <node concept="3clFbF" id="qT5MFmnLj1" role="3cqZAp">
+                                                      <node concept="2OqwBi" id="qT5MFmnLj2" role="3clFbG">
+                                                        <node concept="30H73N" id="qT5MFmnLj3" role="2Oq$k0" />
+                                                        <node concept="2qgKlT" id="qT5MFmnLj4" role="2OqNvi">
+                                                          <ref role="37wK5l" to="karh:6ASs6LmXZEr" resolve="getFlagText" />
+                                                        </node>
                                                       </node>
                                                     </node>
                                                   </node>
                                                 </node>
                                               </node>
                                             </node>
-                                          </node>
-                                          <node concept="2kYc5w" id="7NlRaxAKsc0" role="37wK5m" />
-                                          <node concept="2ShNRf" id="4AuGfbNTpCy" role="37wK5m">
-                                            <node concept="1pGfFk" id="4AuGfbNTsfe" role="2ShVmc">
-                                              <ref role="37wK5l" to="czm:4AuGfbNRor$" resolve="DefaultFlagModelAccess" />
-                                              <node concept="10Nm6u" id="4AuGfbNTu1_" role="37wK5m" />
+                                            <node concept="2kYc5w" id="7NlRaxAKsc0" role="37wK5m" />
+                                            <node concept="2ShNRf" id="4AuGfbNTpCy" role="37wK5m">
+                                              <node concept="1pGfFk" id="4AuGfbNTsfe" role="2ShVmc">
+                                                <ref role="37wK5l" to="czm:4AuGfbNRor$" resolve="DefaultFlagModelAccess" />
+                                                <node concept="10Nm6u" id="4AuGfbNTu1_" role="37wK5m" />
+                                              </node>
+                                              <node concept="5jKBG" id="4AuGfbNTFhH" role="lGtFl">
+                                                <ref role="v9R2y" node="4AuGfbNTl2e" resolve="template_FlagCell_ModelAccess" />
+                                              </node>
                                             </node>
-                                            <node concept="5jKBG" id="4AuGfbNTFhH" role="lGtFl">
-                                              <ref role="v9R2y" node="4AuGfbNTl2e" resolve="template_FlagCell_ModelAccess" />
+                                            <node concept="3clFb_" id="4owkxKW9$h2" role="jymVt">
+                                              <property role="TrG5h" value="getDescriptionText" />
+                                              <property role="DiZV1" value="false" />
+                                              <property role="od$2w" value="false" />
+                                              <node concept="3Tm1VV" id="4owkxKW9$h3" role="1B3o_S" />
+                                              <node concept="2AHcQZ" id="4owkxKW9$h4" role="2AJF6D">
+                                                <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+                                              </node>
+                                              <node concept="17QB3L" id="4owkxKW9$h5" role="3clF45" />
+                                              <node concept="37vLTG" id="4owkxKW9$h6" role="3clF46">
+                                                <property role="TrG5h" value="pattern" />
+                                                <node concept="3uibUv" id="4owkxKW9$h7" role="1tU5fm">
+                                                  <ref role="3uigEE" to="wyt6:~String" resolve="String" />
+                                                </node>
+                                                <node concept="2AHcQZ" id="4owkxKW9$h8" role="2AJF6D">
+                                                  <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+                                                </node>
+                                              </node>
+                                              <node concept="2AHcQZ" id="4owkxKW9$hq" role="2AJF6D">
+                                                <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                                              </node>
+                                              <node concept="3clFbS" id="4owkxKW9$hs" role="3clF47">
+                                                <node concept="3cpWs8" id="4owkxKWaPb7" role="3cqZAp">
+                                                  <node concept="3cpWsn" id="4owkxKWaPb8" role="3cpWs9">
+                                                    <property role="TrG5h" value="originalText" />
+                                                    <node concept="17QB3L" id="4owkxKWaPb9" role="1tU5fm" />
+                                                    <node concept="3nyPlj" id="4owkxKWaPba" role="33vP2m">
+                                                      <ref role="37wK5l" to="czm:3uJMZ8xGyln" resolve="getDescriptionText" />
+                                                      <node concept="37vLTw" id="4owkxKWaPbb" role="37wK5m">
+                                                        <ref role="3cqZAo" node="4owkxKW9$h6" resolve="pattern" />
+                                                      </node>
+                                                    </node>
+                                                  </node>
+                                                </node>
+                                                <node concept="3cpWs8" id="4owkxKWaPbc" role="3cqZAp">
+                                                  <node concept="3cpWsn" id="4owkxKWaPbd" role="3cpWs9">
+                                                    <property role="TrG5h" value="wrappedNode" />
+                                                    <node concept="3Tqbb2" id="4owkxKWaPbe" role="1tU5fm" />
+                                                    <node concept="10Nm6u" id="4owkxKWaPbf" role="33vP2m" />
+                                                  </node>
+                                                </node>
+                                                <node concept="3cpWs8" id="4owkxKWaPbg" role="3cqZAp">
+                                                  <node concept="3cpWsn" id="4owkxKWaPbh" role="3cpWs9">
+                                                    <property role="TrG5h" value="editorContext" />
+                                                    <node concept="3uibUv" id="4owkxKWaPbi" role="1tU5fm">
+                                                      <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+                                                    </node>
+                                                    <node concept="2OqwBi" id="4owkxKWbEYh" role="33vP2m">
+                                                      <node concept="2kYc5w" id="4owkxKWbDDc" role="2Oq$k0" />
+                                                      <node concept="liA8E" id="4owkxKWbHAY" role="2OqNvi">
+                                                        <ref role="37wK5l" to="78sh:~SubstituteMenuContext.getEditorContext()" resolve="getEditorContext" />
+                                                      </node>
+                                                    </node>
+                                                  </node>
+                                                </node>
+                                                <node concept="3cpWs6" id="4owkxKWaPbm" role="3cqZAp">
+                                                  <node concept="37vLTw" id="4owkxKWaPbn" role="3cqZAk">
+                                                    <ref role="3cqZAo" node="4owkxKWaPb8" resolve="originalText" />
+                                                  </node>
+                                                  <node concept="2b32R4" id="4owkxKWaPbo" role="lGtFl">
+                                                    <node concept="3JmXsc" id="4owkxKWaPbp" role="2P8S$">
+                                                      <node concept="3clFbS" id="4owkxKWaPbq" role="2VODD2">
+                                                        <node concept="3clFbF" id="4owkxKWaPbr" role="3cqZAp">
+                                                          <node concept="2OqwBi" id="4owkxKWaPbs" role="3clFbG">
+                                                            <node concept="2OqwBi" id="4owkxKWaPbt" role="2Oq$k0">
+                                                              <node concept="2OqwBi" id="4owkxKWaPbu" role="2Oq$k0">
+                                                                <node concept="30H73N" id="4owkxKWaPbv" role="2Oq$k0" />
+                                                                <node concept="3TrEf2" id="4owkxKWaPbw" role="2OqNvi">
+                                                                  <ref role="3Tt5mk" to="teg0:J6gp_6ycpL" resolve="descriptionText" />
+                                                                </node>
+                                                              </node>
+                                                              <node concept="3TrEf2" id="4owkxKWaPbx" role="2OqNvi">
+                                                                <ref role="3Tt5mk" to="tpee:gyVODHa" resolve="body" />
+                                                              </node>
+                                                            </node>
+                                                            <node concept="3Tsc0h" id="4owkxKWaPby" role="2OqNvi">
+                                                              <ref role="3TtcxE" to="tpee:fzcqZ_x" resolve="statement" />
+                                                            </node>
+                                                          </node>
+                                                        </node>
+                                                      </node>
+                                                    </node>
+                                                  </node>
+                                                </node>
+                                              </node>
+                                              <node concept="1W57fq" id="4owkxKWaeWa" role="lGtFl">
+                                                <node concept="3IZrLx" id="4owkxKWaeWb" role="3IZSJc">
+                                                  <node concept="3clFbS" id="4owkxKWaeWc" role="2VODD2">
+                                                    <node concept="3clFbF" id="4owkxKWas81" role="3cqZAp">
+                                                      <node concept="2OqwBi" id="4owkxKWatx$" role="3clFbG">
+                                                        <node concept="2OqwBi" id="4owkxKWaszj" role="2Oq$k0">
+                                                          <node concept="30H73N" id="4owkxKWas80" role="2Oq$k0" />
+                                                          <node concept="3TrEf2" id="4owkxKWatgb" role="2OqNvi">
+                                                            <ref role="3Tt5mk" to="teg0:J6gp_6ycpL" resolve="descriptionText" />
+                                                          </node>
+                                                        </node>
+                                                        <node concept="3x8VRR" id="4owkxKWaubq" role="2OqNvi" />
+                                                      </node>
+                                                    </node>
+                                                  </node>
+                                                </node>
+                                              </node>
                                             </node>
                                           </node>
                                         </node>

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/generator/template/main@generator.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/generator/template/main@generator.mps
@@ -2507,10 +2507,11 @@
                                             <node concept="3cpWsn" id="7PVnOXzMUlN" role="3cpWs9">
                                               <property role="TrG5h" value="originalText" />
                                               <node concept="17QB3L" id="7PVnOXzMUlO" role="1tU5fm" />
-                                              <node concept="3nyPlj" id="7PVnOXzMUlP" role="33vP2m">
-                                                <ref role="37wK5l" to="gdpt:1YKLYyyGCB0" resolve="getShortDescriptionText" />
-                                                <node concept="37vLTw" id="7PVnOXzMUlQ" role="37wK5m">
-                                                  <ref role="3cqZAo" node="J6gp_6LHFb" resolve="pattern" />
+                                              <node concept="2YIFZM" id="1ZlHRbfEQxu" role="33vP2m">
+                                                <ref role="1Pybhc" to="5b0:~NodePresentationUtil" resolve="NodePresentationUtil" />
+                                                <ref role="37wK5l" to="5b0:~NodePresentationUtil.descriptionText(org.jetbrains.mps.openapi.language.SAbstractConcept)" resolve="descriptionText" />
+                                                <node concept="1rXfSq" id="1ZlHRbfEQxv" role="37wK5m">
+                                                  <ref role="37wK5l" node="Dnjeumzces" resolve="getOutputConcept" />
                                                 </node>
                                               </node>
                                             </node>
@@ -3354,10 +3355,11 @@
                                             <node concept="3cpWsn" id="4xgCL2SOjWB" role="3cpWs9">
                                               <property role="TrG5h" value="originalText" />
                                               <node concept="17QB3L" id="4xgCL2SOjWC" role="1tU5fm" />
-                                              <node concept="3nyPlj" id="4xgCL2SOjWD" role="33vP2m">
-                                                <ref role="37wK5l" to="czm:325OF_Mo$mK" resolve="getShortDescriptionText" />
-                                                <node concept="37vLTw" id="4xgCL2SOjWE" role="37wK5m">
-                                                  <ref role="3cqZAo" node="4xgCL2SOjWx" resolve="pattern" />
+                                              <node concept="2YIFZM" id="1ZlHRbfEEDL" role="33vP2m">
+                                                <ref role="37wK5l" to="5b0:~NodePresentationUtil.descriptionText(org.jetbrains.mps.openapi.language.SAbstractConcept)" resolve="descriptionText" />
+                                                <ref role="1Pybhc" to="5b0:~NodePresentationUtil" resolve="NodePresentationUtil" />
+                                                <node concept="1rXfSq" id="1ZlHRbfEEDM" role="37wK5m">
+                                                  <ref role="37wK5l" node="5fS8LroEqAw" resolve="getOutputConcept" />
                                                 </node>
                                               </node>
                                             </node>
@@ -6036,10 +6038,11 @@
                                           <node concept="3cpWsn" id="7PVnOXzMOnE" role="3cpWs9">
                                             <property role="TrG5h" value="originalText" />
                                             <node concept="17QB3L" id="7PVnOXzMOnF" role="1tU5fm" />
-                                            <node concept="3nyPlj" id="7PVnOXzMOnG" role="33vP2m">
-                                              <ref role="37wK5l" to="czm:325OF_Mo$mK" resolve="getShortDescriptionText" />
-                                              <node concept="37vLTw" id="7PVnOXzMOnH" role="37wK5m">
-                                                <ref role="3cqZAo" node="J6gp_6z5bV" resolve="pattern" />
+                                            <node concept="2YIFZM" id="1ZlHRbfEKNr" role="33vP2m">
+                                              <ref role="1Pybhc" to="5b0:~NodePresentationUtil" resolve="NodePresentationUtil" />
+                                              <ref role="37wK5l" to="5b0:~NodePresentationUtil.descriptionText(org.jetbrains.mps.openapi.language.SAbstractConcept)" resolve="descriptionText" />
+                                              <node concept="1rXfSq" id="1ZlHRbfEKNs" role="37wK5m">
+                                                <ref role="37wK5l" node="15DZatORrHk" resolve="getOutputConcept" />
                                               </node>
                                             </node>
                                           </node>

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/models/com/mbeddr/mpsutil/grammarcells/behavior.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/models/com/mbeddr/mpsutil/grammarcells/behavior.mps
@@ -3660,7 +3660,7 @@
   </node>
   <node concept="13h7C7" id="6uixmKZ2zv0">
     <property role="3GE5qa" value="cells" />
-    <ref role="13h7C2" to="teg0:6uixmKZ2zuG" resolve="WrapperCell_DescriptionText" />
+    <ref role="13h7C2" to="teg0:6uixmKZ2zuG" resolve="Cell_DescriptionText" />
     <node concept="13i0hz" id="6uixmKZ2zvb" role="13h7CS">
       <property role="TrG5h" value="getParameterConcepts" />
       <property role="13i0it" value="false" />

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/models/com/mbeddr/mpsutil/grammarcells/behavior.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/models/com/mbeddr/mpsutil/grammarcells/behavior.mps
@@ -3660,7 +3660,7 @@
   </node>
   <node concept="13h7C7" id="6uixmKZ2zv0">
     <property role="3GE5qa" value="cells" />
-    <ref role="13h7C2" to="teg0:6uixmKZ2zuG" resolve="Cell_DescriptionText" />
+    <ref role="13h7C2" to="teg0:6uixmKZ2zuG" resolve="WrapperCell_DescriptionText" />
     <node concept="13i0hz" id="6uixmKZ2zvb" role="13h7CS">
       <property role="TrG5h" value="getParameterConcepts" />
       <property role="13i0it" value="false" />
@@ -4330,6 +4330,100 @@
         </node>
       </node>
       <node concept="10P_77" id="2EPKBwvmwCx" role="3clF45" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="7PVnOXzIrnD">
+    <property role="3GE5qa" value="cells" />
+    <ref role="13h7C2" to="teg0:7PVnOXzFGJ5" resolve="Cell_DescriptionText" />
+    <node concept="13i0hz" id="7PVnOXzIrnO" role="13h7CS">
+      <property role="TrG5h" value="getParameterConcepts" />
+      <property role="13i0it" value="false" />
+      <property role="13i0iv" value="false" />
+      <ref role="13i0hy" to="tpek:2xELmDxyi2v" resolve="getParameterConcepts" />
+      <node concept="3Tm1VV" id="7PVnOXzIrnP" role="1B3o_S" />
+      <node concept="3clFbS" id="7PVnOXzIrnQ" role="3clF47">
+        <node concept="3cpWs8" id="7PVnOXzIrnR" role="3cqZAp">
+          <node concept="3cpWsn" id="7PVnOXzIrnS" role="3cpWs9">
+            <property role="TrG5h" value="params" />
+            <node concept="_YKpA" id="7PVnOXzIrnT" role="1tU5fm">
+              <node concept="3bZ5Sz" id="7PVnOXzIrnU" role="_ZDj9">
+                <ref role="3bZ5Sy" to="tpee:g76ryKb" resolve="ConceptFunctionParameter" />
+              </node>
+            </node>
+            <node concept="2ShNRf" id="7PVnOXzIrnV" role="33vP2m">
+              <node concept="Tc6Ow" id="7PVnOXzIrnW" role="2ShVmc">
+                <node concept="3bZ5Sz" id="7PVnOXzIrnX" role="HW$YZ">
+                  <ref role="3bZ5Sy" to="tpee:g76ryKb" resolve="ConceptFunctionParameter" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7PVnOXzIs9U" role="3cqZAp">
+          <node concept="2OqwBi" id="7PVnOXzIs9V" role="3clFbG">
+            <node concept="37vLTw" id="7PVnOXzIs9W" role="2Oq$k0">
+              <ref role="3cqZAo" node="7PVnOXzIrnS" resolve="params" />
+            </node>
+            <node concept="TSZUe" id="7PVnOXzIs9X" role="2OqNvi">
+              <node concept="35c_gC" id="7PVnOXzIs9Y" role="25WWJ7">
+                <ref role="35c_gD" to="teg0:1GvnUgo6Q$w" resolve="Parameter_node" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7PVnOXzMKbe" role="3cqZAp">
+          <node concept="2OqwBi" id="7PVnOXzMKbf" role="3clFbG">
+            <node concept="37vLTw" id="7PVnOXzMKbg" role="2Oq$k0">
+              <ref role="3cqZAo" node="7PVnOXzIrnS" resolve="params" />
+            </node>
+            <node concept="TSZUe" id="7PVnOXzMKbh" role="2OqNvi">
+              <node concept="35c_gC" id="7PVnOXzMKbi" role="25WWJ7">
+                <ref role="35c_gD" to="teg0:6uixmKZ2zAm" resolve="Parameter_OriginalText" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7PVnOXzIroY" role="3cqZAp">
+          <node concept="2OqwBi" id="7PVnOXzIroZ" role="3clFbG">
+            <node concept="37vLTw" id="7PVnOXzIrp0" role="2Oq$k0">
+              <ref role="3cqZAo" node="7PVnOXzIrnS" resolve="params" />
+            </node>
+            <node concept="TSZUe" id="7PVnOXzIrp1" role="2OqNvi">
+              <node concept="35c_gC" id="7PVnOXzIrp2" role="25WWJ7">
+                <ref role="35c_gD" to="teg0:2aaSxIgh9is" resolve="Parameter_editorContext" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7PVnOXzIrp3" role="3cqZAp">
+          <node concept="37vLTw" id="7PVnOXzIrp4" role="3clFbG">
+            <ref role="3cqZAo" node="7PVnOXzIrnS" resolve="params" />
+          </node>
+        </node>
+      </node>
+      <node concept="_YKpA" id="7PVnOXzIrp5" role="3clF45">
+        <node concept="3bZ5Sz" id="7PVnOXzIrp6" role="_ZDj9">
+          <ref role="3bZ5Sy" to="tpee:g76ryKb" resolve="ConceptFunctionParameter" />
+        </node>
+      </node>
+    </node>
+    <node concept="13i0hz" id="1ZlHRbfyFea" role="13h7CS">
+      <property role="TrG5h" value="getExpectedReturnType" />
+      <property role="13i0it" value="false" />
+      <property role="13i0iv" value="false" />
+      <ref role="13i0hy" to="tpek:hEwIGRD" resolve="getExpectedReturnType" />
+      <node concept="3Tm1VV" id="1ZlHRbfyFeb" role="1B3o_S" />
+      <node concept="3clFbS" id="1ZlHRbfyFec" role="3clF47">
+        <node concept="3clFbF" id="1ZlHRbfyFed" role="3cqZAp">
+          <node concept="2c44tf" id="1ZlHRbfyFee" role="3clFbG">
+            <node concept="17QB3L" id="1ZlHRbfyFef" role="2c44tc" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tqbb2" id="1ZlHRbfyFeg" role="3clF45" />
+    </node>
+    <node concept="13hLZK" id="7PVnOXzIrnE" role="13h7CW">
+      <node concept="3clFbS" id="7PVnOXzIrnF" role="2VODD2" />
     </node>
   </node>
 </model>

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/models/com/mbeddr/mpsutil/grammarcells/editor.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/models/com/mbeddr/mpsutil/grammarcells/editor.mps
@@ -41,6 +41,7 @@
         <child id="1080736633877" name="cellModel" index="2wV5jI" />
       </concept>
       <concept id="1239814640496" name="jetbrains.mps.lang.editor.structure.CellLayout_VerticalGrid" flags="nn" index="2EHx9g" />
+      <concept id="1078938745671" name="jetbrains.mps.lang.editor.structure.EditorComponentDeclaration" flags="ig" index="PKFIW" />
       <concept id="1078939183254" name="jetbrains.mps.lang.editor.structure.CellModel_Component" flags="sg" stub="3162947552742194261" index="PMmxH">
         <reference id="1078939183255" name="editorComponent" index="PMmxG" />
       </concept>
@@ -457,20 +458,10 @@
       </node>
       <node concept="3F0ifn" id="6uixmKZ2$eH" role="3EZMnx" />
       <node concept="3EZMnI" id="6uixmKZ2EVK" role="3EZMnx">
-        <node concept="3EZMnI" id="6uixmKZ2EVL" role="3EZMnx">
-          <node concept="3F0ifn" id="6uixmKZ2EVM" role="3EZMnx">
-            <property role="3F0ifm" value="description:" />
-            <ref role="1k5W1q" to="tpc5:hF4H1c8" resolve="property" />
-          </node>
-          <node concept="3F1sOY" id="6uixmKZ2EVN" role="3EZMnx">
-            <ref role="1NtTu8" to="teg0:6uixmKZ2FIJ" resolve="descriptionText" />
-          </node>
-          <node concept="VPXOz" id="6uixmKZ2EVO" role="3F10Kt">
-            <property role="VOm3f" value="true" />
-          </node>
-          <node concept="2iRfu4" id="6uixmKZ2EVP" role="2iSdaV" />
-        </node>
         <node concept="2EHx9g" id="6uixmKZ2EW0" role="2iSdaV" />
+        <node concept="PMmxH" id="J6gp_6ycMC" role="3EZMnx">
+          <ref role="PMmxG" node="J6gp_6ycIY" resolve="DescriptionText" />
+        </node>
       </node>
       <node concept="2iRkQZ" id="3h9t8JnexrD" role="2iSdaV" />
     </node>
@@ -880,6 +871,9 @@
           </node>
           <node concept="2iRfu4" id="78yXNxdi31c" role="2iSdaV" />
         </node>
+        <node concept="PMmxH" id="J6gp_6LEHF" role="3EZMnx">
+          <ref role="PMmxG" node="J6gp_6ycIY" resolve="DescriptionText" />
+        </node>
         <node concept="VPXOz" id="6ASs6LmXZ4T" role="3F10Kt">
           <property role="VOm3f" value="true" />
         </node>
@@ -1034,6 +1028,9 @@
             <property role="VOm3f" value="true" />
           </node>
           <node concept="2iRfu4" id="65e5JdYJiFH" role="2iSdaV" />
+        </node>
+        <node concept="PMmxH" id="J6gp_6ydEK" role="3EZMnx">
+          <ref role="PMmxG" node="J6gp_6ycIY" resolve="DescriptionText" />
         </node>
         <node concept="2EHx9g" id="7KznU_3P5iA" role="2iSdaV" />
       </node>
@@ -1850,6 +1847,9 @@
         </node>
         <node concept="2iRfu4" id="6rhOS_xv$_b" role="2iSdaV" />
       </node>
+      <node concept="PMmxH" id="J6gp_6zbfd" role="3EZMnx">
+        <ref role="PMmxG" node="J6gp_6ycIY" resolve="DescriptionText" />
+      </node>
     </node>
   </node>
   <node concept="24kQdi" id="7Q6ZOiKJNMi">
@@ -2424,6 +2424,24 @@
       </node>
       <node concept="2SsqMj" id="2cruuiKBFCz" role="3EZMnx" />
       <node concept="2iRfu4" id="2cruuiKBFCv" role="2iSdaV" />
+    </node>
+  </node>
+  <node concept="PKFIW" id="J6gp_6ycIY">
+    <property role="3GE5qa" value="cells" />
+    <property role="TrG5h" value="DescriptionText" />
+    <ref role="1XX52x" to="teg0:J6gp_6ycpK" resolve="IOptionalDescriptionText" />
+    <node concept="3EZMnI" id="J6gp_6ycJ0" role="2wV5jI">
+      <node concept="3F0ifn" id="J6gp_6ycJ1" role="3EZMnx">
+        <property role="3F0ifm" value="description:" />
+        <ref role="1k5W1q" to="tpc5:hF4H1c8" resolve="property" />
+      </node>
+      <node concept="3F1sOY" id="J6gp_6ycJ2" role="3EZMnx">
+        <ref role="1NtTu8" to="teg0:J6gp_6ycpL" resolve="descriptionText" />
+      </node>
+      <node concept="VPXOz" id="J6gp_6ycJ3" role="3F10Kt">
+        <property role="VOm3f" value="true" />
+      </node>
+      <node concept="2iRfu4" id="J6gp_6ycJ4" role="2iSdaV" />
     </node>
   </node>
 </model>

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/models/com/mbeddr/mpsutil/grammarcells/editor.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/models/com/mbeddr/mpsutil/grammarcells/editor.mps
@@ -2436,6 +2436,7 @@
         <ref role="1k5W1q" to="tpc5:hF4H1c8" resolve="property" />
       </node>
       <node concept="3F1sOY" id="J6gp_6ycJ2" role="3EZMnx">
+        <property role="1$x2rV" value="concept description" />
         <ref role="1NtTu8" to="teg0:J6gp_6ycpL" resolve="descriptionText" />
       </node>
       <node concept="VPXOz" id="J6gp_6ycJ3" role="3F10Kt">

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/models/com/mbeddr/mpsutil/grammarcells/structure.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/models/com/mbeddr/mpsutil/grammarcells/structure.mps
@@ -103,6 +103,9 @@
     <node concept="PrWs8" id="RbLMy6aM8Q" role="PzmwI">
       <ref role="PrY4T" node="6oKG1kMyAVO" resolve="IActionGeneratingCell" />
     </node>
+    <node concept="PrWs8" id="J6gp_6LEaU" role="PzmwI">
+      <ref role="PrY4T" node="J6gp_6ycpK" resolve="IOptionalDescriptionText" />
+    </node>
   </node>
   <node concept="1TIwiD" id="6oKG1kMxvFA">
     <property role="TrG5h" value="UnorderedCollection" />
@@ -181,17 +184,14 @@
       <property role="IQ2ns" value="1954385921685817946" />
       <ref role="20lvS9" node="1GvnUgo6Kzw" resolve="PostprocessFunction" />
     </node>
-    <node concept="1TJgyj" id="6uixmKZ2FIJ" role="1TKVEi">
-      <property role="IQ2ns" value="7463174232466963375" />
-      <property role="20lmBu" value="fLJjDmT/aggregation" />
-      <property role="20kJfa" value="descriptionText" />
-      <ref role="20lvS9" node="6uixmKZ2zuG" resolve="WrapperCell_DescriptionText" />
-    </node>
     <node concept="PrWs8" id="6oKG1kMyAVP" role="PzmwI">
       <ref role="PrY4T" node="6oKG1kMyAVO" resolve="IActionGeneratingCell" />
     </node>
     <node concept="PrWs8" id="3O7ZvCZLRkq" role="PzmwI">
       <ref role="PrY4T" node="3O7ZvCZLPYU" resolve="ICellWrapper" />
+    </node>
+    <node concept="PrWs8" id="J6gp_6ycpV" role="PzmwI">
+      <ref role="PrY4T" node="J6gp_6ycpK" resolve="IOptionalDescriptionText" />
     </node>
   </node>
   <node concept="PlHQZ" id="6oKG1kMyAVO">
@@ -232,6 +232,9 @@
     </node>
     <node concept="PrWs8" id="7KznU_45d0Q" role="PzmwI">
       <ref role="PrY4T" node="3O7ZvCZLPYU" resolve="ICellWrapper" />
+    </node>
+    <node concept="PrWs8" id="J6gp_6ydlP" role="PzmwI">
+      <ref role="PrY4T" node="J6gp_6ycpK" resolve="IOptionalDescriptionText" />
     </node>
     <node concept="1TJgyj" id="2EPKBwvgsS2" role="1TKVEi">
       <property role="IQ2ns" value="3077579741553872386" />
@@ -984,7 +987,7 @@
   </node>
   <node concept="1TIwiD" id="6uixmKZ2zuG">
     <property role="3GE5qa" value="cells" />
-    <property role="TrG5h" value="WrapperCell_DescriptionText" />
+    <property role="TrG5h" value="Cell_DescriptionText" />
     <property role="EcuMT" value="7463174232466929580" />
     <ref role="1TJDcQ" to="tpee:gyVMwX8" resolve="ConceptFunction" />
   </node>
@@ -1157,6 +1160,17 @@
     <property role="TrG5h" value="TransformationLocation_ContributionsToSideTranformation" />
     <property role="R5$K7" value="true" />
     <ref role="1TJDcQ" to="tpc2:7L5lpRJH$EA" resolve="TransformationLocation" />
+  </node>
+  <node concept="PlHQZ" id="J6gp_6ycpK">
+    <property role="EcuMT" value="848437706375087728" />
+    <property role="3GE5qa" value="cells" />
+    <property role="TrG5h" value="IOptionalDescriptionText" />
+    <node concept="1TJgyj" id="J6gp_6ycpL" role="1TKVEi">
+      <property role="IQ2ns" value="848437706375087729" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="descriptionText" />
+      <ref role="20lvS9" node="6uixmKZ2zuG" resolve="Cell_DescriptionText" />
+    </node>
   </node>
 </model>
 

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/models/com/mbeddr/mpsutil/grammarcells/structure.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/models/com/mbeddr/mpsutil/grammarcells/structure.mps
@@ -987,7 +987,7 @@
   </node>
   <node concept="1TIwiD" id="6uixmKZ2zuG">
     <property role="3GE5qa" value="cells" />
-    <property role="TrG5h" value="Cell_DescriptionText" />
+    <property role="TrG5h" value="WrapperCell_DescriptionText" />
     <property role="EcuMT" value="7463174232466929580" />
     <ref role="1TJDcQ" to="tpee:gyVMwX8" resolve="ConceptFunction" />
   </node>
@@ -1169,8 +1169,14 @@
       <property role="IQ2ns" value="848437706375087729" />
       <property role="20lmBu" value="fLJjDmT/aggregation" />
       <property role="20kJfa" value="descriptionText" />
-      <ref role="20lvS9" node="6uixmKZ2zuG" resolve="Cell_DescriptionText" />
+      <ref role="20lvS9" node="7PVnOXzFGJ5" resolve="Cell_DescriptionText" />
     </node>
+  </node>
+  <node concept="1TIwiD" id="7PVnOXzFGJ5">
+    <property role="3GE5qa" value="cells" />
+    <property role="TrG5h" value="Cell_DescriptionText" />
+    <property role="EcuMT" value="9041925471455857605" />
+    <ref role="1TJDcQ" to="tpee:gyVMwX8" resolve="ConceptFunction" />
   </node>
 </model>
 

--- a/code/grammarcells/solutions/com.mbeddr.mpsutil.grammarcells.runtime/models/com/mbeddr/mpsutil/grammarcells/runtime.mps
+++ b/code/grammarcells/solutions/com.mbeddr.mpsutil.grammarcells.runtime/models/com/mbeddr/mpsutil/grammarcells/runtime.mps
@@ -32792,12 +32792,9 @@
         <ref role="3uigEE" node="1YKLYyyOIFO" resolve="MultiTextActionItem" />
       </node>
       <node concept="3clFb_" id="15DZatP$kWG" role="jymVt">
-        <property role="TrG5h" value="getDescriptionText" />
+        <property role="TrG5h" value="getShortDescriptionText" />
         <property role="DiZV1" value="false" />
         <property role="od$2w" value="false" />
-        <node concept="2AHcQZ" id="15DZatP$kWH" role="2AJF6D">
-          <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-        </node>
         <node concept="3Tm1VV" id="15DZatP$kWM" role="1B3o_S" />
         <node concept="17QB3L" id="15DZatP$kWN" role="3clF45" />
         <node concept="37vLTG" id="15DZatP$kWO" role="3clF46">

--- a/code/querylist/com.mbeddr.mpsutil.editor.querylist.demolang/languageModels/editor.mps
+++ b/code/querylist/com.mbeddr.mpsutil.editor.querylist.demolang/languageModels/editor.mps
@@ -778,7 +778,7 @@
               <node concept="2OqwBi" id="lPJxik9iuv" role="3cqZAk">
                 <node concept="2hkjam" id="lPJxik9il1" role="2Oq$k0" />
                 <node concept="liA8E" id="lPJxik9iXI" role="2OqNvi">
-                  <ref role="37wK5l" to="d2zl:lPJxik8Xgp" resolve="forChild" />
+                  <ref role="37wK5l" to="d2zl:2Fugwv5Fpi_" resolve="forChild" />
                   <node concept="37vLTw" id="3jHPIDngupV" role="37wK5m">
                     <ref role="3cqZAo" node="lPJxik8ump" resolve="body" />
                   </node>


### PR DESCRIPTION
This PR add support for description texts for optional and flags cells in grammar cells.
When a description is provided in the inspector, the description is used. Otherwise, the description of concept is used.

The old behavior was no description at all for these two cells. The wrap cell already had support for description texts.

I am not sure if this is the best default behavior. What do you all think?