### PR TITLE
GrammarCells: Add support for descriptions in more cells

### DIFF
--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells.sandboxlang/com.mbeddr.mpsutil.grammarcells.sandboxlang.mpl
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells.sandboxlang/com.mbeddr.mpsutil.grammarcells.sandboxlang.mpl
@@ -19,7 +19,7 @@
     <dependency reexport="false">2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)</dependency>
   </dependencies>
   <languageVersions>
-    <language slang="l:9d69e719-78c8-4286-90db-fb19c107d049:com.mbeddr.mpsutil.grammarcells" version="1" />
+    <language slang="l:9d69e719-78c8-4286-90db-fb19c107d049:com.mbeddr.mpsutil.grammarcells" version="2" />
     <language slang="l:b4f35ed8-45af-4efa-abe4-00ac26956e69:com.mbeddr.mpsutil.grammarcells.runtimelang" version="0" />
     <language slang="l:e359e0a2-368a-4c40-ae2a-e5a09f9cfd58:de.itemis.mps.editor.math.notations" version="0" />
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells.sandboxlang/models/com/mbeddr/mpsutil/grammarcells/sandboxlang/editor.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells.sandboxlang/models/com/mbeddr/mpsutil/grammarcells/sandboxlang/editor.mps
@@ -2,7 +2,7 @@
 <model ref="r:3eda9818-abb7-42b4-a347-71b6a5e2c7c7(com.mbeddr.mpsutil.grammarcells.sandboxlang.editor)">
   <persistence version="9" />
   <languages>
-    <use id="9d69e719-78c8-4286-90db-fb19c107d049" name="com.mbeddr.mpsutil.grammarcells" version="1" />
+    <use id="9d69e719-78c8-4286-90db-fb19c107d049" name="com.mbeddr.mpsutil.grammarcells" version="2" />
     <use id="e359e0a2-368a-4c40-ae2a-e5a09f9cfd58" name="de.itemis.mps.editor.math.notations" version="0" />
     <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="14" />
     <use id="b1ab8c10-c118-4755-bf2a-cebab35cf533" name="jetbrains.mps.lang.editor.tooltips" version="0" />

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/com.mbeddr.mpsutil.grammarcells.mpl
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/com.mbeddr.mpsutil.grammarcells.mpl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<language namespace="com.mbeddr.mpsutil.grammarcells" uuid="9d69e719-78c8-4286-90db-fb19c107d049" languageVersion="1" moduleVersion="0">
+<language namespace="com.mbeddr.mpsutil.grammarcells" uuid="9d69e719-78c8-4286-90db-fb19c107d049" languageVersion="2" moduleVersion="0">
   <models>
     <modelRoot contentPath="${module}" type="default">
       <sourceRoot location="models" />
@@ -42,7 +42,7 @@
         <dependency reexport="false">2e24a298-44d1-4697-baec-5c424fed3a3b(jetbrains.mps.editorlang.runtime)</dependency>
       </dependencies>
       <languageVersions>
-        <language slang="l:9d69e719-78c8-4286-90db-fb19c107d049:com.mbeddr.mpsutil.grammarcells" version="1" />
+        <language slang="l:9d69e719-78c8-4286-90db-fb19c107d049:com.mbeddr.mpsutil.grammarcells" version="2" />
         <language slang="l:b4f35ed8-45af-4efa-abe4-00ac26956e69:com.mbeddr.mpsutil.grammarcells.runtimelang" version="0" />
         <language slang="l:654422bf-e75f-44dc-936d-188890a746ce:de.slisson.mps.reflection" version="0" />
         <language slang="l:52733268-be24-4f5f-ab84-a73b7c0c03b0:de.slisson.mps.richtext.customcell" version="0" />

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/generator/template/main@generator.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/generator/template/main@generator.mps
@@ -1649,47 +1649,193 @@
                                     </node>
                                     <node concept="TSZUe" id="qT5MFmnLil" role="2OqNvi">
                                       <node concept="2ShNRf" id="qT5MFmnLim" role="25WWJ7">
-                                        <node concept="1pGfFk" id="qT5MFmnLin" role="2ShVmc">
-                                          <ref role="37wK5l" to="czm:4AuGfbNRh27" resolve="FlagSubstituteMenuItem" />
-                                          <node concept="37vLTw" id="2c4RKQNyRNx" role="37wK5m">
-                                            <ref role="3cqZAo" node="2c4RKQNyRNs" resolve="parentNode" />
-                                          </node>
-                                          <node concept="2OqwBi" id="qT5MFmnLir" role="37wK5m">
-                                            <node concept="2kYc5w" id="qT5MFmnMhf" role="2Oq$k0" />
-                                            <node concept="liA8E" id="qT5MFmnLit" role="2OqNvi">
-                                              <ref role="37wK5l" to="78sh:~SubstituteMenuContext.getCurrentTargetNode()" resolve="getCurrentTargetNode" />
+                                        <node concept="YeOm9" id="4owkxKW9yrk" role="2ShVmc">
+                                          <node concept="1Y3b0j" id="4owkxKW9yrn" role="YeSDq">
+                                            <property role="2bfB8j" value="true" />
+                                            <ref role="37wK5l" to="czm:4AuGfbNRh27" resolve="FlagSubstituteMenuItem" />
+                                            <ref role="1Y3XeK" to="czm:7NlRaxAJR0G" resolve="FlagSubstituteMenuItem" />
+                                            <node concept="3Tm1VV" id="4owkxKW9yro" role="1B3o_S" />
+                                            <node concept="37vLTw" id="2c4RKQNyRNx" role="37wK5m">
+                                              <ref role="3cqZAo" node="2c4RKQNyRNs" resolve="parentNode" />
                                             </node>
-                                          </node>
-                                          <node concept="37vLTw" id="qT5MFmto$a" role="37wK5m">
-                                            <ref role="3cqZAo" node="qT5MFmsSRB" resolve="subconcept" />
-                                          </node>
-                                          <node concept="Xl_RD" id="qT5MFmnLiX" role="37wK5m">
-                                            <property role="Xl_RC" value="flagText" />
-                                            <node concept="17Uvod" id="qT5MFmnLiY" role="lGtFl">
-                                              <property role="P4ACc" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1070475926800/1070475926801" />
-                                              <property role="2qtEX9" value="value" />
-                                              <node concept="3zFVjK" id="qT5MFmnLiZ" role="3zH0cK">
-                                                <node concept="3clFbS" id="qT5MFmnLj0" role="2VODD2">
-                                                  <node concept="3clFbF" id="qT5MFmnLj1" role="3cqZAp">
-                                                    <node concept="2OqwBi" id="qT5MFmnLj2" role="3clFbG">
-                                                      <node concept="30H73N" id="qT5MFmnLj3" role="2Oq$k0" />
-                                                      <node concept="2qgKlT" id="qT5MFmnLj4" role="2OqNvi">
-                                                        <ref role="37wK5l" to="karh:6ASs6LmXZEr" resolve="getFlagText" />
+                                            <node concept="2OqwBi" id="qT5MFmnLir" role="37wK5m">
+                                              <node concept="2kYc5w" id="qT5MFmnMhf" role="2Oq$k0" />
+                                              <node concept="liA8E" id="qT5MFmnLit" role="2OqNvi">
+                                                <ref role="37wK5l" to="78sh:~SubstituteMenuContext.getCurrentTargetNode()" resolve="getCurrentTargetNode" />
+                                              </node>
+                                            </node>
+                                            <node concept="37vLTw" id="qT5MFmto$a" role="37wK5m">
+                                              <ref role="3cqZAo" node="qT5MFmsSRB" resolve="subconcept" />
+                                            </node>
+                                            <node concept="Xl_RD" id="qT5MFmnLiX" role="37wK5m">
+                                              <property role="Xl_RC" value="flagText" />
+                                              <node concept="17Uvod" id="qT5MFmnLiY" role="lGtFl">
+                                                <property role="P4ACc" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1070475926800/1070475926801" />
+                                                <property role="2qtEX9" value="value" />
+                                                <node concept="3zFVjK" id="qT5MFmnLiZ" role="3zH0cK">
+                                                  <node concept="3clFbS" id="qT5MFmnLj0" role="2VODD2">
+                                                    <node concept="3clFbF" id="qT5MFmnLj1" role="3cqZAp">
+                                                      <node concept="2OqwBi" id="qT5MFmnLj2" role="3clFbG">
+                                                        <node concept="30H73N" id="qT5MFmnLj3" role="2Oq$k0" />
+                                                        <node concept="2qgKlT" id="qT5MFmnLj4" role="2OqNvi">
+                                                          <ref role="37wK5l" to="karh:6ASs6LmXZEr" resolve="getFlagText" />
+                                                        </node>
                                                       </node>
                                                     </node>
                                                   </node>
                                                 </node>
                                               </node>
                                             </node>
-                                          </node>
-                                          <node concept="2kYc5w" id="7NlRaxAKsc0" role="37wK5m" />
-                                          <node concept="2ShNRf" id="4AuGfbNTpCy" role="37wK5m">
-                                            <node concept="1pGfFk" id="4AuGfbNTsfe" role="2ShVmc">
-                                              <ref role="37wK5l" to="czm:4AuGfbNRor$" resolve="DefaultFlagModelAccess" />
-                                              <node concept="10Nm6u" id="4AuGfbNTu1_" role="37wK5m" />
+                                            <node concept="2kYc5w" id="7NlRaxAKsc0" role="37wK5m" />
+                                            <node concept="2ShNRf" id="4AuGfbNTpCy" role="37wK5m">
+                                              <node concept="1pGfFk" id="4AuGfbNTsfe" role="2ShVmc">
+                                                <ref role="37wK5l" to="czm:4AuGfbNRor$" resolve="DefaultFlagModelAccess" />
+                                                <node concept="10Nm6u" id="4AuGfbNTu1_" role="37wK5m" />
+                                              </node>
+                                              <node concept="5jKBG" id="4AuGfbNTFhH" role="lGtFl">
+                                                <ref role="v9R2y" node="4AuGfbNTl2e" resolve="template_FlagCell_ModelAccess" />
+                                              </node>
                                             </node>
-                                            <node concept="5jKBG" id="4AuGfbNTFhH" role="lGtFl">
-                                              <ref role="v9R2y" node="4AuGfbNTl2e" resolve="template_FlagCell_ModelAccess" />
+                                            <node concept="3clFb_" id="4owkxKW9$h2" role="jymVt">
+                                              <property role="TrG5h" value="getDescriptionText" />
+                                              <property role="DiZV1" value="false" />
+                                              <property role="od$2w" value="false" />
+                                              <node concept="3Tm1VV" id="4owkxKW9$h3" role="1B3o_S" />
+                                              <node concept="2AHcQZ" id="4owkxKW9$h4" role="2AJF6D">
+                                                <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+                                              </node>
+                                              <node concept="17QB3L" id="4owkxKW9$h5" role="3clF45" />
+                                              <node concept="37vLTG" id="4owkxKW9$h6" role="3clF46">
+                                                <property role="TrG5h" value="pattern" />
+                                                <node concept="3uibUv" id="4owkxKW9$h7" role="1tU5fm">
+                                                  <ref role="3uigEE" to="wyt6:~String" resolve="String" />
+                                                </node>
+                                                <node concept="2AHcQZ" id="4owkxKW9$h8" role="2AJF6D">
+                                                  <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+                                                </node>
+                                              </node>
+                                              <node concept="2AHcQZ" id="4owkxKW9$hq" role="2AJF6D">
+                                                <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                                              </node>
+                                              <node concept="3clFbS" id="4owkxKW9$hs" role="3clF47">
+                                                <node concept="3cpWs8" id="1ZlHRbfJYbY" role="3cqZAp">
+                                                  <node concept="3cpWsn" id="1ZlHRbfJYbZ" role="3cpWs9">
+                                                    <property role="TrG5h" value="node" />
+                                                    <node concept="3Tqbb2" id="1ZlHRbfJYc0" role="1tU5fm" />
+                                                    <node concept="2OqwBi" id="1ZlHRbfJYc1" role="33vP2m">
+                                                      <node concept="2kYc5w" id="1ZlHRbfK2sJ" role="2Oq$k0" />
+                                                      <node concept="liA8E" id="1ZlHRbfJYc3" role="2OqNvi">
+                                                        <ref role="37wK5l" to="78sh:~SubstituteMenuContext.getCurrentTargetNode()" resolve="getCurrentTargetNode" />
+                                                      </node>
+                                                    </node>
+                                                  </node>
+                                                </node>
+                                                <node concept="3cpWs8" id="1ZlHRbfJYc4" role="3cqZAp">
+                                                  <node concept="3cpWsn" id="1ZlHRbfJYc5" role="3cpWs9">
+                                                    <property role="TrG5h" value="originalText" />
+                                                    <node concept="17QB3L" id="1ZlHRbfJYc6" role="1tU5fm" />
+                                                    <node concept="2YIFZM" id="1ZlHRbfJYc7" role="33vP2m">
+                                                      <ref role="37wK5l" to="5b0:~NodePresentationUtil.descriptionText(org.jetbrains.mps.openapi.language.SAbstractConcept)" resolve="descriptionText" />
+                                                      <ref role="1Pybhc" to="5b0:~NodePresentationUtil" resolve="NodePresentationUtil" />
+                                                      <node concept="1rXfSq" id="1ZlHRbfJYc8" role="37wK5m">
+                                                        <ref role="37wK5l" to="qtqj:~DefaultSubstituteMenuItem.getOutputConcept()" resolve="getOutputConcept" />
+                                                      </node>
+                                                    </node>
+                                                  </node>
+                                                </node>
+                                                <node concept="3cpWs8" id="1ZlHRbfJYc9" role="3cqZAp">
+                                                  <node concept="3cpWsn" id="1ZlHRbfJYca" role="3cpWs9">
+                                                    <property role="TrG5h" value="editorContext" />
+                                                    <node concept="3uibUv" id="1ZlHRbfJYcb" role="1tU5fm">
+                                                      <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+                                                    </node>
+                                                    <node concept="2OqwBi" id="1ZlHRbfJYcc" role="33vP2m">
+                                                      <node concept="2kYc5w" id="1ZlHRbfK4nA" role="2Oq$k0" />
+                                                      <node concept="liA8E" id="1ZlHRbfJYce" role="2OqNvi">
+                                                        <ref role="37wK5l" to="78sh:~SubstituteMenuContext.getEditorContext()" resolve="getEditorContext" />
+                                                      </node>
+                                                    </node>
+                                                  </node>
+                                                </node>
+                                                <node concept="3clFbH" id="1ZlHRbfTfDW" role="3cqZAp" />
+                                                <node concept="3cpWs6" id="4owkxKWaPbm" role="3cqZAp">
+                                                  <node concept="37vLTw" id="4owkxKWaPbn" role="3cqZAk">
+                                                    <ref role="3cqZAo" node="1ZlHRbfJYc5" resolve="originalText" />
+                                                  </node>
+                                                  <node concept="2b32R4" id="4owkxKWaPbo" role="lGtFl">
+                                                    <node concept="3JmXsc" id="4owkxKWaPbp" role="2P8S$">
+                                                      <node concept="3clFbS" id="4owkxKWaPbq" role="2VODD2">
+                                                        <node concept="3clFbF" id="4owkxKWaPbr" role="3cqZAp">
+                                                          <node concept="2OqwBi" id="4owkxKWaPbs" role="3clFbG">
+                                                            <node concept="2OqwBi" id="4owkxKWaPbt" role="2Oq$k0">
+                                                              <node concept="2OqwBi" id="4owkxKWaPbu" role="2Oq$k0">
+                                                                <node concept="30H73N" id="4owkxKWaPbv" role="2Oq$k0" />
+                                                                <node concept="3TrEf2" id="4owkxKWaPbw" role="2OqNvi">
+                                                                  <ref role="3Tt5mk" to="teg0:J6gp_6ycpL" resolve="descriptionText" />
+                                                                </node>
+                                                              </node>
+                                                              <node concept="3TrEf2" id="4owkxKWaPbx" role="2OqNvi">
+                                                                <ref role="3Tt5mk" to="tpee:gyVODHa" resolve="body" />
+                                                              </node>
+                                                            </node>
+                                                            <node concept="3Tsc0h" id="4owkxKWaPby" role="2OqNvi">
+                                                              <ref role="3TtcxE" to="tpee:fzcqZ_x" resolve="statement" />
+                                                            </node>
+                                                          </node>
+                                                        </node>
+                                                      </node>
+                                                    </node>
+                                                  </node>
+                                                </node>
+                                              </node>
+                                              <node concept="1W57fq" id="4owkxKWaeWa" role="lGtFl">
+                                                <node concept="3IZrLx" id="4owkxKWaeWb" role="3IZSJc">
+                                                  <node concept="3clFbS" id="4owkxKWaeWc" role="2VODD2">
+                                                    <node concept="3clFbF" id="4owkxKWas81" role="3cqZAp">
+                                                      <node concept="2OqwBi" id="4owkxKWatx$" role="3clFbG">
+                                                        <node concept="2OqwBi" id="4owkxKWaszj" role="2Oq$k0">
+                                                          <node concept="30H73N" id="4owkxKWas80" role="2Oq$k0" />
+                                                          <node concept="3TrEf2" id="4owkxKWatgb" role="2OqNvi">
+                                                            <ref role="3Tt5mk" to="teg0:J6gp_6ycpL" resolve="descriptionText" />
+                                                          </node>
+                                                        </node>
+                                                        <node concept="3x8VRR" id="4owkxKWaubq" role="2OqNvi" />
+                                                      </node>
+                                                    </node>
+                                                  </node>
+                                                </node>
+                                                <node concept="gft3U" id="1ZlHRbfK8yi" role="UU_$l">
+                                                  <node concept="3clFb_" id="1ZlHRbfK8yj" role="gfFT$">
+                                                    <property role="1EzhhJ" value="false" />
+                                                    <property role="TrG5h" value="getDescriptionText" />
+                                                    <property role="DiZV1" value="false" />
+                                                    <property role="od$2w" value="false" />
+                                                    <node concept="3Tm1VV" id="1ZlHRbfK8yk" role="1B3o_S" />
+                                                    <node concept="17QB3L" id="1ZlHRbfK8yl" role="3clF45" />
+                                                    <node concept="37vLTG" id="1ZlHRbfK8ym" role="3clF46">
+                                                      <property role="TrG5h" value="string" />
+                                                      <node concept="17QB3L" id="1ZlHRbfK8yn" role="1tU5fm" />
+                                                    </node>
+                                                    <node concept="3clFbS" id="1ZlHRbfK8yo" role="3clF47">
+                                                      <node concept="3clFbF" id="1ZlHRbfK8yp" role="3cqZAp">
+                                                        <node concept="2YIFZM" id="1ZlHRbfK8yq" role="3clFbG">
+                                                          <ref role="37wK5l" to="5b0:~NodePresentationUtil.descriptionText(org.jetbrains.mps.openapi.language.SAbstractConcept)" resolve="descriptionText" />
+                                                          <ref role="1Pybhc" to="5b0:~NodePresentationUtil" resolve="NodePresentationUtil" />
+                                                          <node concept="1rXfSq" id="1ZlHRbfK8yr" role="37wK5m">
+                                                            <ref role="37wK5l" to="qtqj:~DefaultSubstituteMenuItem.getOutputConcept()" resolve="getOutputConcept" />
+                                                          </node>
+                                                        </node>
+                                                      </node>
+                                                    </node>
+                                                    <node concept="2AHcQZ" id="1ZlHRbfYJQ9" role="2AJF6D">
+                                                      <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+                                                    </node>
+                                                    <node concept="2AHcQZ" id="1ZlHRbfYJnU" role="2AJF6D">
+                                                      <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                                                    </node>
+                                                  </node>
+                                                </node>
+                                              </node>
                                             </node>
                                           </node>
                                         </node>
@@ -2365,22 +2511,142 @@
                                       <property role="2bfB8j" value="true" />
                                       <ref role="1Y3XeK" to="gdpt:1YKLYyyGBzT" resolve="GrammarCellsSideTransformTransformationMenuItem" />
                                       <ref role="37wK5l" to="gdpt:My09KinEek" resolve="GrammarCellsSideTransformTransformationMenuItem" />
+                                      <node concept="2tJIrI" id="J6gp_6LQnM" role="jymVt" />
                                       <node concept="2Mo9yH" id="DnjeumzccK" role="37wK5m" />
                                       <node concept="3Tm1VV" id="DnjeumzccL" role="1B3o_S" />
-                                      <node concept="3clFb_" id="DnjeumzccM" role="jymVt">
+                                      <node concept="3clFb_" id="J6gp_6LHF8" role="jymVt">
                                         <property role="1EzhhJ" value="false" />
-                                        <property role="TrG5h" value="getDescriptionText" />
+                                        <property role="TrG5h" value="getShortDescriptionText" />
                                         <property role="DiZV1" value="false" />
                                         <property role="od$2w" value="false" />
-                                        <node concept="3Tm1VV" id="DnjeumzccN" role="1B3o_S" />
-                                        <node concept="17QB3L" id="DnjeumzccO" role="3clF45" />
-                                        <node concept="37vLTG" id="DnjeumzccP" role="3clF46">
+                                        <node concept="3Tm1VV" id="J6gp_6LHF9" role="1B3o_S" />
+                                        <node concept="17QB3L" id="J6gp_6LHFa" role="3clF45" />
+                                        <node concept="37vLTG" id="J6gp_6LHFb" role="3clF46">
                                           <property role="TrG5h" value="pattern" />
-                                          <node concept="17QB3L" id="DnjeumzccQ" role="1tU5fm" />
+                                          <node concept="17QB3L" id="J6gp_6LHFc" role="1tU5fm" />
                                         </node>
-                                        <node concept="3clFbS" id="DnjeumzccR" role="3clF47">
-                                          <node concept="3clFbF" id="DnjeumzccS" role="3cqZAp">
-                                            <node concept="10Nm6u" id="DnjeumzccT" role="3clFbG" />
+                                        <node concept="2AHcQZ" id="1ZlHRbfYT83" role="2AJF6D">
+                                          <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+                                        </node>
+                                        <node concept="2AHcQZ" id="J6gp_6LHFe" role="2AJF6D">
+                                          <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                                        </node>
+                                        <node concept="3clFbS" id="J6gp_6LHFf" role="3clF47">
+                                          <node concept="3cpWs8" id="7PVnOXzMUlG" role="3cqZAp">
+                                            <node concept="3cpWsn" id="7PVnOXzMUlH" role="3cpWs9">
+                                              <property role="TrG5h" value="node" />
+                                              <node concept="3Tqbb2" id="7PVnOXzMUlI" role="1tU5fm" />
+                                              <node concept="2OqwBi" id="7PVnOXzMUlJ" role="33vP2m">
+                                                <node concept="2Mo9yH" id="7PVnOXzMUlK" role="2Oq$k0" />
+                                                <node concept="liA8E" id="7PVnOXzMUlL" role="2OqNvi">
+                                                  <ref role="37wK5l" to="uddc:~TransformationMenuContext.getNode()" resolve="getNode" />
+                                                </node>
+                                              </node>
+                                            </node>
+                                          </node>
+                                          <node concept="3cpWs8" id="7PVnOXzMUlM" role="3cqZAp">
+                                            <node concept="3cpWsn" id="7PVnOXzMUlN" role="3cpWs9">
+                                              <property role="TrG5h" value="originalText" />
+                                              <node concept="17QB3L" id="7PVnOXzMUlO" role="1tU5fm" />
+                                              <node concept="2YIFZM" id="1ZlHRbfEQxu" role="33vP2m">
+                                                <ref role="1Pybhc" to="5b0:~NodePresentationUtil" resolve="NodePresentationUtil" />
+                                                <ref role="37wK5l" to="5b0:~NodePresentationUtil.descriptionText(org.jetbrains.mps.openapi.language.SAbstractConcept)" resolve="descriptionText" />
+                                                <node concept="1rXfSq" id="1ZlHRbfEQxv" role="37wK5m">
+                                                  <ref role="37wK5l" node="Dnjeumzces" resolve="getOutputConcept" />
+                                                </node>
+                                              </node>
+                                            </node>
+                                          </node>
+                                          <node concept="3cpWs8" id="7PVnOXzMUlR" role="3cqZAp">
+                                            <node concept="3cpWsn" id="7PVnOXzMUlS" role="3cpWs9">
+                                              <property role="TrG5h" value="editorContext" />
+                                              <node concept="3uibUv" id="7PVnOXzMUlT" role="1tU5fm">
+                                                <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+                                              </node>
+                                              <node concept="2OqwBi" id="7PVnOXzMUlU" role="33vP2m">
+                                                <node concept="2Mo9yH" id="7PVnOXzMUlV" role="2Oq$k0" />
+                                                <node concept="liA8E" id="7PVnOXzMUlW" role="2OqNvi">
+                                                  <ref role="37wK5l" to="uddc:~TransformationMenuContext.getEditorContext()" resolve="getEditorContext" />
+                                                </node>
+                                              </node>
+                                            </node>
+                                          </node>
+                                          <node concept="3cpWs6" id="J6gp_6LHFv" role="3cqZAp">
+                                            <node concept="37vLTw" id="J6gp_6LHFw" role="3cqZAk">
+                                              <ref role="3cqZAo" node="7PVnOXzMUlN" resolve="originalText" />
+                                            </node>
+                                            <node concept="2b32R4" id="J6gp_6LHFx" role="lGtFl">
+                                              <node concept="3JmXsc" id="J6gp_6LHFy" role="2P8S$">
+                                                <node concept="3clFbS" id="J6gp_6LHFz" role="2VODD2">
+                                                  <node concept="3clFbF" id="J6gp_6LHF$" role="3cqZAp">
+                                                    <node concept="2OqwBi" id="J6gp_6LHF_" role="3clFbG">
+                                                      <node concept="2OqwBi" id="J6gp_6LHFA" role="2Oq$k0">
+                                                        <node concept="2OqwBi" id="J6gp_6LHFB" role="2Oq$k0">
+                                                          <node concept="30H73N" id="J6gp_6LHFC" role="2Oq$k0" />
+                                                          <node concept="3TrEf2" id="J6gp_6LHFD" role="2OqNvi">
+                                                            <ref role="3Tt5mk" to="teg0:J6gp_6ycpL" resolve="descriptionText" />
+                                                          </node>
+                                                        </node>
+                                                        <node concept="3TrEf2" id="J6gp_6LHFE" role="2OqNvi">
+                                                          <ref role="3Tt5mk" to="tpee:gyVODHa" resolve="body" />
+                                                        </node>
+                                                      </node>
+                                                      <node concept="3Tsc0h" id="J6gp_6LHFF" role="2OqNvi">
+                                                        <ref role="3TtcxE" to="tpee:fzcqZ_x" resolve="statement" />
+                                                      </node>
+                                                    </node>
+                                                  </node>
+                                                </node>
+                                              </node>
+                                            </node>
+                                          </node>
+                                        </node>
+                                        <node concept="1W57fq" id="J6gp_6LHFG" role="lGtFl">
+                                          <node concept="3IZrLx" id="J6gp_6LHFH" role="3IZSJc">
+                                            <node concept="3clFbS" id="J6gp_6LHFI" role="2VODD2">
+                                              <node concept="3clFbF" id="J6gp_6LHFJ" role="3cqZAp">
+                                                <node concept="2OqwBi" id="J6gp_6LHFK" role="3clFbG">
+                                                  <node concept="2OqwBi" id="J6gp_6LHFL" role="2Oq$k0">
+                                                    <node concept="30H73N" id="J6gp_6LHFM" role="2Oq$k0" />
+                                                    <node concept="3TrEf2" id="J6gp_6LHFN" role="2OqNvi">
+                                                      <ref role="3Tt5mk" to="teg0:J6gp_6ycpL" resolve="descriptionText" />
+                                                    </node>
+                                                  </node>
+                                                  <node concept="3x8VRR" id="J6gp_6LHFO" role="2OqNvi" />
+                                                </node>
+                                              </node>
+                                            </node>
+                                          </node>
+                                          <node concept="gft3U" id="4owkxKUwVWz" role="UU_$l">
+                                            <node concept="3clFb_" id="4owkxKUwVW$" role="gfFT$">
+                                              <property role="1EzhhJ" value="false" />
+                                              <property role="TrG5h" value="getShortDescriptionText" />
+                                              <property role="DiZV1" value="false" />
+                                              <property role="od$2w" value="false" />
+                                              <node concept="3Tm1VV" id="4owkxKUwVW_" role="1B3o_S" />
+                                              <node concept="17QB3L" id="4owkxKUwVWA" role="3clF45" />
+                                              <node concept="37vLTG" id="4owkxKUwVWB" role="3clF46">
+                                                <property role="TrG5h" value="string" />
+                                                <node concept="17QB3L" id="4owkxKUwVWC" role="1tU5fm" />
+                                              </node>
+                                              <node concept="3clFbS" id="4owkxKUwVWD" role="3clF47">
+                                                <node concept="3clFbF" id="4owkxKUwVWE" role="3cqZAp">
+                                                  <node concept="2YIFZM" id="4owkxKUwVWF" role="3clFbG">
+                                                    <ref role="1Pybhc" to="5b0:~NodePresentationUtil" resolve="NodePresentationUtil" />
+                                                    <ref role="37wK5l" to="5b0:~NodePresentationUtil.descriptionText(org.jetbrains.mps.openapi.language.SAbstractConcept)" resolve="descriptionText" />
+                                                    <node concept="1rXfSq" id="4owkxKUwVWG" role="37wK5m">
+                                                      <ref role="37wK5l" node="Dnjeumzces" resolve="getOutputConcept" />
+                                                    </node>
+                                                  </node>
+                                                </node>
+                                              </node>
+                                              <node concept="2AHcQZ" id="1ZlHRbfYXgG" role="2AJF6D">
+                                                <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+                                              </node>
+                                              <node concept="2AHcQZ" id="1ZlHRbfYWL8" role="2AJF6D">
+                                                <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                                              </node>
+                                            </node>
                                           </node>
                                         </node>
                                       </node>
@@ -3101,6 +3367,147 @@
                                           <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
                                         </node>
                                       </node>
+                                      <node concept="2tJIrI" id="4xgCL2SNMHz" role="jymVt" />
+                                      <node concept="3clFb_" id="4xgCL2SOjWu" role="jymVt">
+                                        <property role="1EzhhJ" value="false" />
+                                        <property role="TrG5h" value="getShortDescriptionText" />
+                                        <property role="DiZV1" value="false" />
+                                        <property role="od$2w" value="false" />
+                                        <node concept="3Tm1VV" id="4xgCL2SOjWv" role="1B3o_S" />
+                                        <node concept="17QB3L" id="4xgCL2SOjWw" role="3clF45" />
+                                        <node concept="37vLTG" id="4xgCL2SOjWx" role="3clF46">
+                                          <property role="TrG5h" value="pattern" />
+                                          <node concept="17QB3L" id="4xgCL2SOjWy" role="1tU5fm" />
+                                          <node concept="2AHcQZ" id="4xgCL2SOjWz" role="2AJF6D">
+                                            <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+                                          </node>
+                                        </node>
+                                        <node concept="2AHcQZ" id="1ZlHRbfZ09J" role="2AJF6D">
+                                          <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+                                        </node>
+                                        <node concept="2AHcQZ" id="4xgCL2SOjW$" role="2AJF6D">
+                                          <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                                        </node>
+                                        <node concept="3clFbS" id="4xgCL2SOjW_" role="3clF47">
+                                          <node concept="3cpWs8" id="7PVnOXzM__o" role="3cqZAp">
+                                            <node concept="3cpWsn" id="7PVnOXzM__r" role="3cpWs9">
+                                              <property role="TrG5h" value="node" />
+                                              <node concept="3Tqbb2" id="7PVnOXzM__m" role="1tU5fm" />
+                                              <node concept="2OqwBi" id="7PVnOXzMDvN" role="33vP2m">
+                                                <node concept="2Mo9yH" id="7PVnOXzMC2y" role="2Oq$k0" />
+                                                <node concept="liA8E" id="7PVnOXzMEdp" role="2OqNvi">
+                                                  <ref role="37wK5l" to="uddc:~TransformationMenuContext.getNode()" resolve="getNode" />
+                                                </node>
+                                              </node>
+                                            </node>
+                                          </node>
+                                          <node concept="3cpWs8" id="4xgCL2SOjWA" role="3cqZAp">
+                                            <node concept="3cpWsn" id="4xgCL2SOjWB" role="3cpWs9">
+                                              <property role="TrG5h" value="originalText" />
+                                              <node concept="17QB3L" id="4xgCL2SOjWC" role="1tU5fm" />
+                                              <node concept="2YIFZM" id="1ZlHRbfEEDL" role="33vP2m">
+                                                <ref role="37wK5l" to="5b0:~NodePresentationUtil.descriptionText(org.jetbrains.mps.openapi.language.SAbstractConcept)" resolve="descriptionText" />
+                                                <ref role="1Pybhc" to="5b0:~NodePresentationUtil" resolve="NodePresentationUtil" />
+                                                <node concept="1rXfSq" id="1ZlHRbfEEDM" role="37wK5m">
+                                                  <ref role="37wK5l" node="5fS8LroEqAw" resolve="getOutputConcept" />
+                                                </node>
+                                              </node>
+                                            </node>
+                                          </node>
+                                          <node concept="3cpWs8" id="4xgCL2SOjWJ" role="3cqZAp">
+                                            <node concept="3cpWsn" id="4xgCL2SOjWK" role="3cpWs9">
+                                              <property role="TrG5h" value="editorContext" />
+                                              <node concept="3uibUv" id="4xgCL2SOjWL" role="1tU5fm">
+                                                <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+                                              </node>
+                                              <node concept="2OqwBi" id="4xgCL2SOjWM" role="33vP2m">
+                                                <node concept="2Mo9yH" id="4xgCL2SOpbr" role="2Oq$k0" />
+                                                <node concept="liA8E" id="4xgCL2SOjWO" role="2OqNvi">
+                                                  <ref role="37wK5l" to="uddc:~TransformationMenuContext.getEditorContext()" resolve="getEditorContext" />
+                                                </node>
+                                              </node>
+                                            </node>
+                                          </node>
+                                          <node concept="3cpWs6" id="4xgCL2SOjWP" role="3cqZAp">
+                                            <node concept="37vLTw" id="4xgCL2SOjWQ" role="3cqZAk">
+                                              <ref role="3cqZAo" node="4xgCL2SOjWB" resolve="originalText" />
+                                            </node>
+                                            <node concept="2b32R4" id="4xgCL2SOjWR" role="lGtFl">
+                                              <node concept="3JmXsc" id="4xgCL2SOjWS" role="2P8S$">
+                                                <node concept="3clFbS" id="4xgCL2SOjWT" role="2VODD2">
+                                                  <node concept="3clFbF" id="4xgCL2SOjWU" role="3cqZAp">
+                                                    <node concept="2OqwBi" id="4xgCL2SOjWV" role="3clFbG">
+                                                      <node concept="2OqwBi" id="4xgCL2SOjWW" role="2Oq$k0">
+                                                        <node concept="2OqwBi" id="4xgCL2SOjWX" role="2Oq$k0">
+                                                          <node concept="30H73N" id="4xgCL2SOjWY" role="2Oq$k0" />
+                                                          <node concept="3TrEf2" id="4xgCL2SOjWZ" role="2OqNvi">
+                                                            <ref role="3Tt5mk" to="teg0:J6gp_6ycpL" resolve="descriptionText" />
+                                                          </node>
+                                                        </node>
+                                                        <node concept="3TrEf2" id="4xgCL2SOjX0" role="2OqNvi">
+                                                          <ref role="3Tt5mk" to="tpee:gyVODHa" resolve="body" />
+                                                        </node>
+                                                      </node>
+                                                      <node concept="3Tsc0h" id="4xgCL2SOjX1" role="2OqNvi">
+                                                        <ref role="3TtcxE" to="tpee:fzcqZ_x" resolve="statement" />
+                                                      </node>
+                                                    </node>
+                                                  </node>
+                                                </node>
+                                              </node>
+                                            </node>
+                                          </node>
+                                        </node>
+                                        <node concept="1W57fq" id="4owkxKUw_Ol" role="lGtFl">
+                                          <node concept="3IZrLx" id="4owkxKUw_Om" role="3IZSJc">
+                                            <node concept="3clFbS" id="4owkxKUw_On" role="2VODD2">
+                                              <node concept="3clFbF" id="4owkxKUwBvO" role="3cqZAp">
+                                                <node concept="2OqwBi" id="4owkxKUwCGq" role="3clFbG">
+                                                  <node concept="2OqwBi" id="4owkxKUwBP6" role="2Oq$k0">
+                                                    <node concept="30H73N" id="4owkxKUwBvN" role="2Oq$k0" />
+                                                    <node concept="3TrEf2" id="4owkxKUwCnl" role="2OqNvi">
+                                                      <ref role="3Tt5mk" to="teg0:J6gp_6ycpL" resolve="descriptionText" />
+                                                    </node>
+                                                  </node>
+                                                  <node concept="3x8VRR" id="4owkxKUwDbH" role="2OqNvi" />
+                                                </node>
+                                              </node>
+                                            </node>
+                                          </node>
+                                          <node concept="gft3U" id="4owkxKUwNet" role="UU_$l">
+                                            <node concept="3clFb_" id="4owkxKUwNeu" role="gfFT$">
+                                              <property role="1EzhhJ" value="false" />
+                                              <property role="TrG5h" value="getShortDescriptionText" />
+                                              <property role="DiZV1" value="false" />
+                                              <property role="od$2w" value="false" />
+                                              <node concept="3Tm1VV" id="4owkxKUwNev" role="1B3o_S" />
+                                              <node concept="17QB3L" id="4owkxKUwNew" role="3clF45" />
+                                              <node concept="37vLTG" id="4owkxKUwNex" role="3clF46">
+                                                <property role="TrG5h" value="string" />
+                                                <node concept="17QB3L" id="4owkxKUwNey" role="1tU5fm" />
+                                              </node>
+                                              <node concept="3clFbS" id="4owkxKUwNez" role="3clF47">
+                                                <node concept="3clFbF" id="4owkxKUwNe$" role="3cqZAp">
+                                                  <node concept="2YIFZM" id="4owkxKUwNe_" role="3clFbG">
+                                                    <ref role="1Pybhc" to="5b0:~NodePresentationUtil" resolve="NodePresentationUtil" />
+                                                    <ref role="37wK5l" to="5b0:~NodePresentationUtil.descriptionText(org.jetbrains.mps.openapi.language.SAbstractConcept)" resolve="descriptionText" />
+                                                    <node concept="1rXfSq" id="4owkxKUwRGM" role="37wK5m">
+                                                      <ref role="37wK5l" node="5fS8LroEqAw" resolve="getOutputConcept" />
+                                                    </node>
+                                                  </node>
+                                                </node>
+                                              </node>
+                                              <node concept="2AHcQZ" id="1ZlHRbfZ2Kr" role="2AJF6D">
+                                                <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+                                              </node>
+                                              <node concept="2AHcQZ" id="1ZlHRbfZ2gx" role="2AJF6D">
+                                                <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                                              </node>
+                                            </node>
+                                          </node>
+                                        </node>
+                                      </node>
+                                      <node concept="2tJIrI" id="4xgCL2SOi7W" role="jymVt" />
                                       <node concept="3Tm1VV" id="5fS8LroEqAM" role="1B3o_S" />
                                       <node concept="37vLTw" id="5fS8LroEqAN" role="37wK5m">
                                         <ref role="3cqZAo" node="5fS8LroEq_3" resolve="matchingTexts" />
@@ -5652,6 +6059,147 @@
                                         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
                                       </node>
                                     </node>
+                                    <node concept="2tJIrI" id="J6gp_6z2Mm" role="jymVt" />
+                                    <node concept="3clFb_" id="J6gp_6z5bS" role="jymVt">
+                                      <property role="1EzhhJ" value="false" />
+                                      <property role="TrG5h" value="getShortDescriptionText" />
+                                      <property role="DiZV1" value="false" />
+                                      <property role="od$2w" value="false" />
+                                      <node concept="3Tm1VV" id="J6gp_6z5bT" role="1B3o_S" />
+                                      <node concept="17QB3L" id="J6gp_6z5bU" role="3clF45" />
+                                      <node concept="37vLTG" id="J6gp_6z5bV" role="3clF46">
+                                        <property role="TrG5h" value="pattern" />
+                                        <node concept="17QB3L" id="J6gp_6z5bW" role="1tU5fm" />
+                                        <node concept="2AHcQZ" id="J6gp_6z5bX" role="2AJF6D">
+                                          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+                                        </node>
+                                      </node>
+                                      <node concept="2AHcQZ" id="1ZlHRbfZ3tH" role="2AJF6D">
+                                        <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+                                      </node>
+                                      <node concept="2AHcQZ" id="J6gp_6z5bY" role="2AJF6D">
+                                        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                                      </node>
+                                      <node concept="3clFbS" id="J6gp_6z5bZ" role="3clF47">
+                                        <node concept="3cpWs8" id="7PVnOXzMOnz" role="3cqZAp">
+                                          <node concept="3cpWsn" id="7PVnOXzMOn$" role="3cpWs9">
+                                            <property role="TrG5h" value="node" />
+                                            <node concept="3Tqbb2" id="7PVnOXzMOn_" role="1tU5fm" />
+                                            <node concept="2OqwBi" id="7PVnOXzMOnA" role="33vP2m">
+                                              <node concept="2Mo9yH" id="7PVnOXzMOnB" role="2Oq$k0" />
+                                              <node concept="liA8E" id="7PVnOXzMOnC" role="2OqNvi">
+                                                <ref role="37wK5l" to="uddc:~TransformationMenuContext.getNode()" resolve="getNode" />
+                                              </node>
+                                            </node>
+                                          </node>
+                                        </node>
+                                        <node concept="3cpWs8" id="7PVnOXzMOnD" role="3cqZAp">
+                                          <node concept="3cpWsn" id="7PVnOXzMOnE" role="3cpWs9">
+                                            <property role="TrG5h" value="originalText" />
+                                            <node concept="17QB3L" id="7PVnOXzMOnF" role="1tU5fm" />
+                                            <node concept="2YIFZM" id="1ZlHRbfEKNr" role="33vP2m">
+                                              <ref role="1Pybhc" to="5b0:~NodePresentationUtil" resolve="NodePresentationUtil" />
+                                              <ref role="37wK5l" to="5b0:~NodePresentationUtil.descriptionText(org.jetbrains.mps.openapi.language.SAbstractConcept)" resolve="descriptionText" />
+                                              <node concept="1rXfSq" id="1ZlHRbfEKNs" role="37wK5m">
+                                                <ref role="37wK5l" node="15DZatORrHk" resolve="getOutputConcept" />
+                                              </node>
+                                            </node>
+                                          </node>
+                                        </node>
+                                        <node concept="3cpWs8" id="7PVnOXzMOnI" role="3cqZAp">
+                                          <node concept="3cpWsn" id="7PVnOXzMOnJ" role="3cpWs9">
+                                            <property role="TrG5h" value="editorContext" />
+                                            <node concept="3uibUv" id="7PVnOXzMOnK" role="1tU5fm">
+                                              <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+                                            </node>
+                                            <node concept="2OqwBi" id="7PVnOXzMOnL" role="33vP2m">
+                                              <node concept="2Mo9yH" id="7PVnOXzMOnM" role="2Oq$k0" />
+                                              <node concept="liA8E" id="7PVnOXzMOnN" role="2OqNvi">
+                                                <ref role="37wK5l" to="uddc:~TransformationMenuContext.getEditorContext()" resolve="getEditorContext" />
+                                              </node>
+                                            </node>
+                                          </node>
+                                        </node>
+                                        <node concept="3cpWs6" id="J6gp_6z5cf" role="3cqZAp">
+                                          <node concept="37vLTw" id="J6gp_6z5cg" role="3cqZAk">
+                                            <ref role="3cqZAo" node="7PVnOXzMOnE" resolve="originalText" />
+                                          </node>
+                                          <node concept="2b32R4" id="J6gp_6z5ch" role="lGtFl">
+                                            <node concept="3JmXsc" id="J6gp_6z5ci" role="2P8S$">
+                                              <node concept="3clFbS" id="J6gp_6z5cj" role="2VODD2">
+                                                <node concept="3clFbF" id="J6gp_6z5ck" role="3cqZAp">
+                                                  <node concept="2OqwBi" id="J6gp_6z5cl" role="3clFbG">
+                                                    <node concept="2OqwBi" id="J6gp_6z5cm" role="2Oq$k0">
+                                                      <node concept="2OqwBi" id="J6gp_6z5cn" role="2Oq$k0">
+                                                        <node concept="30H73N" id="J6gp_6z5co" role="2Oq$k0" />
+                                                        <node concept="3TrEf2" id="J6gp_6z5cp" role="2OqNvi">
+                                                          <ref role="3Tt5mk" to="teg0:J6gp_6ycpL" resolve="descriptionText" />
+                                                        </node>
+                                                      </node>
+                                                      <node concept="3TrEf2" id="J6gp_6z5cq" role="2OqNvi">
+                                                        <ref role="3Tt5mk" to="tpee:gyVODHa" resolve="body" />
+                                                      </node>
+                                                    </node>
+                                                    <node concept="3Tsc0h" id="J6gp_6z5cr" role="2OqNvi">
+                                                      <ref role="3TtcxE" to="tpee:fzcqZ_x" resolve="statement" />
+                                                    </node>
+                                                  </node>
+                                                </node>
+                                              </node>
+                                            </node>
+                                          </node>
+                                        </node>
+                                      </node>
+                                      <node concept="1W57fq" id="J6gp_6z5cs" role="lGtFl">
+                                        <node concept="3IZrLx" id="J6gp_6z5ct" role="3IZSJc">
+                                          <node concept="3clFbS" id="J6gp_6z5cu" role="2VODD2">
+                                            <node concept="3clFbF" id="J6gp_6z5cv" role="3cqZAp">
+                                              <node concept="2OqwBi" id="J6gp_6z5cw" role="3clFbG">
+                                                <node concept="2OqwBi" id="J6gp_6z5cx" role="2Oq$k0">
+                                                  <node concept="30H73N" id="J6gp_6z5cy" role="2Oq$k0" />
+                                                  <node concept="3TrEf2" id="J6gp_6z5cz" role="2OqNvi">
+                                                    <ref role="3Tt5mk" to="teg0:J6gp_6ycpL" resolve="descriptionText" />
+                                                  </node>
+                                                </node>
+                                                <node concept="3x8VRR" id="J6gp_6z5c$" role="2OqNvi" />
+                                              </node>
+                                            </node>
+                                          </node>
+                                        </node>
+                                        <node concept="gft3U" id="4owkxKUwSb2" role="UU_$l">
+                                          <node concept="3clFb_" id="4owkxKUwSb3" role="gfFT$">
+                                            <property role="1EzhhJ" value="false" />
+                                            <property role="TrG5h" value="getShortDescriptionText" />
+                                            <property role="DiZV1" value="false" />
+                                            <property role="od$2w" value="false" />
+                                            <node concept="3Tm1VV" id="4owkxKUwSb4" role="1B3o_S" />
+                                            <node concept="17QB3L" id="4owkxKUwSb5" role="3clF45" />
+                                            <node concept="37vLTG" id="4owkxKUwSb6" role="3clF46">
+                                              <property role="TrG5h" value="string" />
+                                              <node concept="17QB3L" id="4owkxKUwSb7" role="1tU5fm" />
+                                            </node>
+                                            <node concept="3clFbS" id="4owkxKUwSb8" role="3clF47">
+                                              <node concept="3clFbF" id="4owkxKUwSb9" role="3cqZAp">
+                                                <node concept="2YIFZM" id="4owkxKUwSba" role="3clFbG">
+                                                  <ref role="1Pybhc" to="5b0:~NodePresentationUtil" resolve="NodePresentationUtil" />
+                                                  <ref role="37wK5l" to="5b0:~NodePresentationUtil.descriptionText(org.jetbrains.mps.openapi.language.SAbstractConcept)" resolve="descriptionText" />
+                                                  <node concept="1rXfSq" id="4owkxKUwSbb" role="37wK5m">
+                                                    <ref role="37wK5l" node="15DZatORrHk" resolve="getOutputConcept" />
+                                                  </node>
+                                                </node>
+                                              </node>
+                                            </node>
+                                            <node concept="2AHcQZ" id="1ZlHRbfZ9Pr" role="2AJF6D">
+                                              <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+                                            </node>
+                                            <node concept="2AHcQZ" id="1ZlHRbfZ9ok" role="2AJF6D">
+                                              <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                                            </node>
+                                          </node>
+                                        </node>
+                                      </node>
+                                    </node>
+                                    <node concept="2tJIrI" id="J6gp_6z2Oo" role="jymVt" />
                                     <node concept="3Tm1VV" id="15DZatORrHA" role="1B3o_S" />
                                     <node concept="37vLTw" id="15DZatORrHB" role="37wK5m">
                                       <ref role="3cqZAo" node="15DZatORrFR" resolve="matchingTexts" />
@@ -12919,21 +13467,142 @@
                                       <ref role="3cqZAo" node="RbLMy69QlL" resolve="_context" />
                                     </node>
                                     <node concept="3Tm1VV" id="RbLMy69Znm" role="1B3o_S" />
-                                    <node concept="3clFb_" id="RbLMy69Zpw" role="jymVt">
-                                      <property role="1EzhhJ" value="false" />
-                                      <property role="TrG5h" value="getDescriptionText" />
+                                    <node concept="3clFb_" id="1ZlHRbfYgLu" role="jymVt">
+                                      <property role="TrG5h" value="getShortDescriptionText" />
                                       <property role="DiZV1" value="false" />
                                       <property role="od$2w" value="false" />
-                                      <node concept="3Tm1VV" id="RbLMy69Zpx" role="1B3o_S" />
-                                      <node concept="17QB3L" id="RbLMy69Zvr" role="3clF45" />
-                                      <node concept="37vLTG" id="RbLMy69Zp$" role="3clF46">
-                                        <property role="TrG5h" value="string" />
-                                        <node concept="17QB3L" id="RbLMy69ZDb" role="1tU5fm" />
+                                      <node concept="3Tm1VV" id="1ZlHRbfYgLv" role="1B3o_S" />
+                                      <node concept="2AHcQZ" id="1ZlHRbfYgLw" role="2AJF6D">
+                                        <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
                                       </node>
-                                      <node concept="3clFbS" id="RbLMy69ZpD" role="3clF47">
-                                        <node concept="3clFbF" id="RbLMy6a1DJ" role="3cqZAp">
-                                          <node concept="Xl_RD" id="RbLMy6a1DI" role="3clFbG">
-                                            <property role="Xl_RC" value="" />
+                                      <node concept="17QB3L" id="1ZlHRbfYgLx" role="3clF45" />
+                                      <node concept="37vLTG" id="1ZlHRbfYgLy" role="3clF46">
+                                        <property role="TrG5h" value="pattern" />
+                                        <node concept="3uibUv" id="1ZlHRbfYgLz" role="1tU5fm">
+                                          <ref role="3uigEE" to="wyt6:~String" resolve="String" />
+                                        </node>
+                                        <node concept="2AHcQZ" id="1ZlHRbfYgL$" role="2AJF6D">
+                                          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+                                        </node>
+                                      </node>
+                                      <node concept="2AHcQZ" id="1ZlHRbfYgL_" role="2AJF6D">
+                                        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                                      </node>
+                                      <node concept="3clFbS" id="1ZlHRbfYgLA" role="3clF47">
+                                        <node concept="3cpWs8" id="1ZlHRbfYgLB" role="3cqZAp">
+                                          <node concept="3cpWsn" id="1ZlHRbfYgLC" role="3cpWs9">
+                                            <property role="TrG5h" value="node" />
+                                            <node concept="3Tqbb2" id="1ZlHRbfYgLD" role="1tU5fm" />
+                                            <node concept="37vLTw" id="1ZlHRbfYtUD" role="33vP2m">
+                                              <ref role="3cqZAo" node="RbLMy6c0kw" resolve="sourceNode" />
+                                            </node>
+                                          </node>
+                                        </node>
+                                        <node concept="3cpWs8" id="1ZlHRbfYgLH" role="3cqZAp">
+                                          <node concept="3cpWsn" id="1ZlHRbfYgLI" role="3cpWs9">
+                                            <property role="TrG5h" value="originalText" />
+                                            <node concept="17QB3L" id="1ZlHRbfYgLJ" role="1tU5fm" />
+                                            <node concept="2YIFZM" id="1ZlHRbfYgLK" role="33vP2m">
+                                              <ref role="37wK5l" to="5b0:~NodePresentationUtil.descriptionText(org.jetbrains.mps.openapi.language.SAbstractConcept)" resolve="descriptionText" />
+                                              <ref role="1Pybhc" to="5b0:~NodePresentationUtil" resolve="NodePresentationUtil" />
+                                              <node concept="1rXfSq" id="1ZlHRbfYgLL" role="37wK5m">
+                                                <ref role="37wK5l" node="2c84p9PulRA" resolve="getOutputConcept" />
+                                              </node>
+                                            </node>
+                                          </node>
+                                        </node>
+                                        <node concept="3cpWs8" id="1ZlHRbfYgLM" role="3cqZAp">
+                                          <node concept="3cpWsn" id="1ZlHRbfYgLN" role="3cpWs9">
+                                            <property role="TrG5h" value="editorContext" />
+                                            <node concept="3uibUv" id="1ZlHRbfYgLO" role="1tU5fm">
+                                              <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+                                            </node>
+                                            <node concept="2OqwBi" id="1ZlHRbfYgLP" role="33vP2m">
+                                              <node concept="37vLTw" id="1ZlHRbfYwu1" role="2Oq$k0">
+                                                <ref role="3cqZAo" node="RbLMy69QlL" resolve="_context" />
+                                              </node>
+                                              <node concept="liA8E" id="1ZlHRbfYgLR" role="2OqNvi">
+                                                <ref role="37wK5l" to="uddc:~TransformationMenuContext.getEditorContext()" resolve="getEditorContext" />
+                                              </node>
+                                            </node>
+                                          </node>
+                                        </node>
+                                        <node concept="3clFbH" id="1ZlHRbfYgLU" role="3cqZAp" />
+                                        <node concept="3cpWs6" id="1ZlHRbfYgLV" role="3cqZAp">
+                                          <node concept="37vLTw" id="1ZlHRbfYgLW" role="3cqZAk">
+                                            <ref role="3cqZAo" node="1ZlHRbfYgLI" resolve="originalText" />
+                                          </node>
+                                          <node concept="2b32R4" id="1ZlHRbfYgLX" role="lGtFl">
+                                            <node concept="3JmXsc" id="1ZlHRbfYgLY" role="2P8S$">
+                                              <node concept="3clFbS" id="1ZlHRbfYgLZ" role="2VODD2">
+                                                <node concept="3clFbF" id="1ZlHRbfYgM0" role="3cqZAp">
+                                                  <node concept="2OqwBi" id="1ZlHRbfYgM1" role="3clFbG">
+                                                    <node concept="2OqwBi" id="1ZlHRbfYgM2" role="2Oq$k0">
+                                                      <node concept="2OqwBi" id="1ZlHRbfYgM3" role="2Oq$k0">
+                                                        <node concept="30H73N" id="1ZlHRbfYgM4" role="2Oq$k0" />
+                                                        <node concept="3TrEf2" id="1ZlHRbfYgM5" role="2OqNvi">
+                                                          <ref role="3Tt5mk" to="teg0:J6gp_6ycpL" resolve="descriptionText" />
+                                                        </node>
+                                                      </node>
+                                                      <node concept="3TrEf2" id="1ZlHRbfYgM6" role="2OqNvi">
+                                                        <ref role="3Tt5mk" to="tpee:gyVODHa" resolve="body" />
+                                                      </node>
+                                                    </node>
+                                                    <node concept="3Tsc0h" id="1ZlHRbfYgM7" role="2OqNvi">
+                                                      <ref role="3TtcxE" to="tpee:fzcqZ_x" resolve="statement" />
+                                                    </node>
+                                                  </node>
+                                                </node>
+                                              </node>
+                                            </node>
+                                          </node>
+                                        </node>
+                                      </node>
+                                      <node concept="1W57fq" id="1ZlHRbfYgM8" role="lGtFl">
+                                        <node concept="3IZrLx" id="1ZlHRbfYgM9" role="3IZSJc">
+                                          <node concept="3clFbS" id="1ZlHRbfYgMa" role="2VODD2">
+                                            <node concept="3clFbF" id="1ZlHRbfYgMb" role="3cqZAp">
+                                              <node concept="2OqwBi" id="1ZlHRbfYgMc" role="3clFbG">
+                                                <node concept="2OqwBi" id="1ZlHRbfYgMd" role="2Oq$k0">
+                                                  <node concept="30H73N" id="1ZlHRbfYgMe" role="2Oq$k0" />
+                                                  <node concept="3TrEf2" id="1ZlHRbfYgMf" role="2OqNvi">
+                                                    <ref role="3Tt5mk" to="teg0:J6gp_6ycpL" resolve="descriptionText" />
+                                                  </node>
+                                                </node>
+                                                <node concept="3x8VRR" id="1ZlHRbfYgMg" role="2OqNvi" />
+                                              </node>
+                                            </node>
+                                          </node>
+                                        </node>
+                                        <node concept="gft3U" id="1ZlHRbfYgMh" role="UU_$l">
+                                          <node concept="3clFb_" id="1ZlHRbfYgMi" role="gfFT$">
+                                            <property role="1EzhhJ" value="false" />
+                                            <property role="TrG5h" value="getShortDescriptionText" />
+                                            <property role="DiZV1" value="false" />
+                                            <property role="od$2w" value="false" />
+                                            <node concept="3Tm1VV" id="1ZlHRbfYgMj" role="1B3o_S" />
+                                            <node concept="17QB3L" id="1ZlHRbfYgMk" role="3clF45" />
+                                            <node concept="37vLTG" id="1ZlHRbfYgMl" role="3clF46">
+                                              <property role="TrG5h" value="string" />
+                                              <node concept="17QB3L" id="1ZlHRbfYgMm" role="1tU5fm" />
+                                            </node>
+                                            <node concept="3clFbS" id="1ZlHRbfYgMn" role="3clF47">
+                                              <node concept="3clFbF" id="1ZlHRbfYgMs" role="3cqZAp">
+                                                <node concept="2YIFZM" id="1ZlHRbfYgMt" role="3clFbG">
+                                                  <ref role="37wK5l" to="5b0:~NodePresentationUtil.descriptionText(org.jetbrains.mps.openapi.language.SAbstractConcept)" resolve="descriptionText" />
+                                                  <ref role="1Pybhc" to="5b0:~NodePresentationUtil" resolve="NodePresentationUtil" />
+                                                  <node concept="1rXfSq" id="1ZlHRbfYgMu" role="37wK5m">
+                                                    <ref role="37wK5l" node="2c84p9PulRA" resolve="getOutputConcept" />
+                                                  </node>
+                                                </node>
+                                              </node>
+                                            </node>
+                                            <node concept="2AHcQZ" id="1ZlHRbfYHe2" role="2AJF6D">
+                                              <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+                                            </node>
+                                            <node concept="2AHcQZ" id="1ZlHRbfYF01" role="2AJF6D">
+                                              <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                                            </node>
                                           </node>
                                         </node>
                                       </node>
@@ -14797,7 +15466,7 @@
                                 </node>
                                 <node concept="3clFb_" id="7KznU_45jk1" role="jymVt">
                                   <property role="1EzhhJ" value="false" />
-                                  <property role="TrG5h" value="getDescriptionText" />
+                                  <property role="TrG5h" value="getShortDescriptionText" />
                                   <property role="DiZV1" value="false" />
                                   <property role="od$2w" value="false" />
                                   <node concept="3Tm1VV" id="7KznU_45jk2" role="1B3o_S" />
@@ -15381,7 +16050,7 @@
                                             </node>
                                             <node concept="3clFb_" id="4qdNcHzZSh5" role="jymVt">
                                               <property role="1EzhhJ" value="false" />
-                                              <property role="TrG5h" value="getDescriptionText" />
+                                              <property role="TrG5h" value="getShortDescriptionText" />
                                               <property role="DiZV1" value="false" />
                                               <property role="od$2w" value="false" />
                                               <node concept="3Tm1VV" id="4qdNcHzZSh6" role="1B3o_S" />
@@ -20304,7 +20973,7 @@
                                                             <node concept="2tJIrI" id="6uixmKZ43qj" role="jymVt" />
                                                             <node concept="3clFb_" id="6uixmKZ3UtU" role="jymVt">
                                                               <property role="1EzhhJ" value="false" />
-                                                              <property role="TrG5h" value="getDescriptionText" />
+                                                              <property role="TrG5h" value="getShortDescriptionText" />
                                                               <property role="DiZV1" value="false" />
                                                               <property role="od$2w" value="false" />
                                                               <node concept="3Tm1VV" id="6uixmKZ3UtV" role="1B3o_S" />
@@ -20325,7 +20994,7 @@
                                                                     <property role="TrG5h" value="originalText" />
                                                                     <node concept="17QB3L" id="6uixmKZ3Uu4" role="1tU5fm" />
                                                                     <node concept="3nyPlj" id="6uixmKZ3Uu5" role="33vP2m">
-                                                                      <ref role="37wK5l" to="czm:1YKLYyyOIGd" resolve="getDescriptionText" />
+                                                                      <ref role="37wK5l" to="czm:325OF_Mo$mK" resolve="getShortDescriptionText" />
                                                                       <node concept="37vLTw" id="6uixmKZ3Uu6" role="37wK5m">
                                                                         <ref role="3cqZAo" node="6uixmKZ3UtX" resolve="pattern" />
                                                                       </node>

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/generator/template/main@generator.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/generator/template/main@generator.mps
@@ -19534,6 +19534,99 @@
                                             <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
                                           </node>
                                         </node>
+                                        <node concept="3clFb_" id="dN43cd3U1V" role="jymVt">
+                                          <property role="1EzhhJ" value="false" />
+                                          <property role="TrG5h" value="getDescriptionText" />
+                                          <property role="DiZV1" value="false" />
+                                          <property role="od$2w" value="false" />
+                                          <node concept="3Tm1VV" id="dN43cd3U1W" role="1B3o_S" />
+                                          <node concept="17QB3L" id="dN43cd3U1X" role="3clF45" />
+                                          <node concept="37vLTG" id="dN43cd3U1Y" role="3clF46">
+                                            <property role="TrG5h" value="pattern" />
+                                            <node concept="17QB3L" id="dN43cd3U1Z" role="1tU5fm" />
+                                            <node concept="2AHcQZ" id="dN43cd3U20" role="2AJF6D">
+                                              <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+                                            </node>
+                                          </node>
+                                          <node concept="2AHcQZ" id="dN43cd3U21" role="2AJF6D">
+                                            <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                                          </node>
+                                          <node concept="3clFbS" id="dN43cd3U22" role="3clF47">
+                                            <node concept="3cpWs8" id="dN43cd3U23" role="3cqZAp">
+                                              <node concept="3cpWsn" id="dN43cd3U24" role="3cpWs9">
+                                                <property role="TrG5h" value="originalText" />
+                                                <node concept="17QB3L" id="dN43cd3U25" role="1tU5fm" />
+                                                <node concept="3nyPlj" id="dN43cd3U26" role="33vP2m">
+                                                  <ref role="37wK5l" to="czm:mEdliw$MP4" resolve="getDescriptionText" />
+                                                  <node concept="37vLTw" id="dN43cd3U27" role="37wK5m">
+                                                    <ref role="3cqZAo" node="dN43cd3U1Y" resolve="pattern" />
+                                                  </node>
+                                                </node>
+                                              </node>
+                                            </node>
+                                            <node concept="3cpWs8" id="dN43cd3U28" role="3cqZAp">
+                                              <node concept="3cpWsn" id="dN43cd3U29" role="3cpWs9">
+                                                <property role="TrG5h" value="node" />
+                                                <node concept="3Tqbb2" id="dN43cd3U2a" role="1tU5fm" />
+                                                <node concept="2OqwBi" id="dN43cd3U2b" role="33vP2m">
+                                                  <node concept="37vLTw" id="dN43cd3U2c" role="2Oq$k0">
+                                                    <ref role="3cqZAo" node="4qdNcH$47TU" resolve="_context" />
+                                                  </node>
+                                                  <node concept="liA8E" id="dN43cd3U2d" role="2OqNvi">
+                                                    <ref role="37wK5l" to="zce0:~NodeSubstituteActionsFactoryContext.getCurrentTargetNode()" resolve="getCurrentTargetNode" />
+                                                  </node>
+                                                </node>
+                                              </node>
+                                            </node>
+                                            <node concept="3cpWs6" id="dN43cd3U2k" role="3cqZAp">
+                                              <node concept="37vLTw" id="dN43cd3U2l" role="3cqZAk">
+                                                <ref role="3cqZAo" node="dN43cd3U24" resolve="originalText" />
+                                              </node>
+                                              <node concept="2b32R4" id="dN43cd3U2m" role="lGtFl">
+                                                <node concept="3JmXsc" id="dN43cd3U2n" role="2P8S$">
+                                                  <node concept="3clFbS" id="dN43cd3U2o" role="2VODD2">
+                                                    <node concept="3clFbF" id="dN43cd3U2p" role="3cqZAp">
+                                                      <node concept="2OqwBi" id="dN43cd3U2q" role="3clFbG">
+                                                        <node concept="2OqwBi" id="dN43cd3U2r" role="2Oq$k0">
+                                                          <node concept="2OqwBi" id="dN43cd3U2s" role="2Oq$k0">
+                                                            <node concept="30H73N" id="dN43cd3U2t" role="2Oq$k0" />
+                                                            <node concept="3TrEf2" id="dN43cd3U2u" role="2OqNvi">
+                                                              <ref role="3Tt5mk" to="teg0:J6gp_6ycpL" resolve="descriptionText" />
+                                                            </node>
+                                                          </node>
+                                                          <node concept="3TrEf2" id="dN43cd3U2v" role="2OqNvi">
+                                                            <ref role="3Tt5mk" to="tpee:gyVODHa" resolve="body" />
+                                                          </node>
+                                                        </node>
+                                                        <node concept="3Tsc0h" id="dN43cd3U2w" role="2OqNvi">
+                                                          <ref role="3TtcxE" to="tpee:fzcqZ_x" resolve="statement" />
+                                                        </node>
+                                                      </node>
+                                                    </node>
+                                                  </node>
+                                                </node>
+                                              </node>
+                                            </node>
+                                          </node>
+                                          <node concept="1W57fq" id="dN43cd3U2x" role="lGtFl">
+                                            <node concept="3IZrLx" id="dN43cd3U2y" role="3IZSJc">
+                                              <node concept="3clFbS" id="dN43cd3U2z" role="2VODD2">
+                                                <node concept="3clFbF" id="dN43cd3U2$" role="3cqZAp">
+                                                  <node concept="2OqwBi" id="dN43cd3U2_" role="3clFbG">
+                                                    <node concept="2OqwBi" id="dN43cd3U2A" role="2Oq$k0">
+                                                      <node concept="30H73N" id="dN43cd3U2B" role="2Oq$k0" />
+                                                      <node concept="3TrEf2" id="dN43cd3U2C" role="2OqNvi">
+                                                        <ref role="3Tt5mk" to="teg0:J6gp_6ycpL" resolve="descriptionText" />
+                                                      </node>
+                                                    </node>
+                                                    <node concept="3x8VRR" id="dN43cd3U2D" role="2OqNvi" />
+                                                  </node>
+                                                </node>
+                                              </node>
+                                            </node>
+                                          </node>
+                                        </node>
+                                        <node concept="2tJIrI" id="dN43cd3S0$" role="jymVt" />
                                       </node>
                                     </node>
                                   </node>

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/generator/template/main@generator.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/generator/template/main@generator.mps
@@ -2,7 +2,7 @@
 <model ref="r:0e2d0780-27a1-4dda-a429-65b192261fcc(com.mbeddr.mpsutil.grammarcells.generator.template.main@generator)">
   <persistence version="9" />
   <languages>
-    <use id="9d69e719-78c8-4286-90db-fb19c107d049" name="com.mbeddr.mpsutil.grammarcells" version="-1" />
+    <use id="9d69e719-78c8-4286-90db-fb19c107d049" name="com.mbeddr.mpsutil.grammarcells" version="2" />
     <use id="d7706f63-9be2-479c-a3da-ae92af1e64d5" name="jetbrains.mps.lang.generator.generationContext" version="-1" />
     <use id="b401a680-8325-4110-8fd3-84331ff25bef" name="jetbrains.mps.lang.generator" version="4" />
     <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="18" />
@@ -9686,7 +9686,7 @@
                                                                           <node concept="2OqwBi" id="6uixmKZ3tky" role="2Oq$k0">
                                                                             <node concept="30H73N" id="6uixmKZ3tkz" role="2Oq$k0" />
                                                                             <node concept="3TrEf2" id="6uixmKZ3tk$" role="2OqNvi">
-                                                                              <ref role="3Tt5mk" to="teg0:6uixmKZ2FIJ" resolve="descriptionText" />
+                                                                              <ref role="3Tt5mk" to="teg0:J6gp_6ycpL" resolve="descriptionText" />
                                                                             </node>
                                                                           </node>
                                                                           <node concept="3TrEf2" id="6uixmKZ3tk_" role="2OqNvi">
@@ -9711,7 +9711,7 @@
                                                                     <node concept="2OqwBi" id="6uixmKZ3tkG" role="2Oq$k0">
                                                                       <node concept="30H73N" id="6uixmKZ3tkH" role="2Oq$k0" />
                                                                       <node concept="3TrEf2" id="6uixmKZ3tkI" role="2OqNvi">
-                                                                        <ref role="3Tt5mk" to="teg0:6uixmKZ2FIJ" resolve="descriptionText" />
+                                                                        <ref role="3Tt5mk" to="teg0:J6gp_6ycpL" resolve="descriptionText" />
                                                                       </node>
                                                                     </node>
                                                                     <node concept="3x8VRR" id="6uixmKZ3tkJ" role="2OqNvi" />
@@ -10472,7 +10472,7 @@
                                                                   <node concept="2OqwBi" id="6uixmKZ39tf" role="2Oq$k0">
                                                                     <node concept="30H73N" id="6uixmKZ39tg" role="2Oq$k0" />
                                                                     <node concept="3TrEf2" id="6uixmKZ39th" role="2OqNvi">
-                                                                      <ref role="3Tt5mk" to="teg0:6uixmKZ2FIJ" resolve="descriptionText" />
+                                                                      <ref role="3Tt5mk" to="teg0:J6gp_6ycpL" resolve="descriptionText" />
                                                                     </node>
                                                                   </node>
                                                                   <node concept="3TrEf2" id="6uixmKZ39ti" role="2OqNvi">
@@ -10497,7 +10497,7 @@
                                                             <node concept="2OqwBi" id="6uixmKZ3ix5" role="2Oq$k0">
                                                               <node concept="30H73N" id="6uixmKZ3ifr" role="2Oq$k0" />
                                                               <node concept="3TrEf2" id="6uixmKZ3iUe" role="2OqNvi">
-                                                                <ref role="3Tt5mk" to="teg0:6uixmKZ2FIJ" resolve="descriptionText" />
+                                                                <ref role="3Tt5mk" to="teg0:J6gp_6ycpL" resolve="descriptionText" />
                                                               </node>
                                                             </node>
                                                             <node concept="3x8VRR" id="6uixmKZ3kkk" role="2OqNvi" />
@@ -11576,7 +11576,7 @@
                                                               <node concept="2OqwBi" id="6uixmKZ3lSe" role="2Oq$k0">
                                                                 <node concept="30H73N" id="6uixmKZ3lSf" role="2Oq$k0" />
                                                                 <node concept="3TrEf2" id="6uixmKZ3lSg" role="2OqNvi">
-                                                                  <ref role="3Tt5mk" to="teg0:6uixmKZ2FIJ" resolve="descriptionText" />
+                                                                  <ref role="3Tt5mk" to="teg0:J6gp_6ycpL" resolve="descriptionText" />
                                                                 </node>
                                                               </node>
                                                               <node concept="3TrEf2" id="6uixmKZ3lSh" role="2OqNvi">
@@ -11601,7 +11601,7 @@
                                                         <node concept="2OqwBi" id="6uixmKZ3lSo" role="2Oq$k0">
                                                           <node concept="30H73N" id="6uixmKZ3lSp" role="2Oq$k0" />
                                                           <node concept="3TrEf2" id="6uixmKZ3s_n" role="2OqNvi">
-                                                            <ref role="3Tt5mk" to="teg0:6uixmKZ2FIJ" resolve="descriptionText" />
+                                                            <ref role="3Tt5mk" to="teg0:J6gp_6ycpL" resolve="descriptionText" />
                                                           </node>
                                                         </node>
                                                         <node concept="3x8VRR" id="6uixmKZ3lSr" role="2OqNvi" />
@@ -21068,7 +21068,7 @@
                                                                               <node concept="2OqwBi" id="6uixmKZ3Uuf" role="2Oq$k0">
                                                                                 <node concept="30H73N" id="6uixmKZ3Uug" role="2Oq$k0" />
                                                                                 <node concept="3TrEf2" id="6uixmKZ3Uuh" role="2OqNvi">
-                                                                                  <ref role="3Tt5mk" to="teg0:6uixmKZ2FIJ" resolve="descriptionText" />
+                                                                                  <ref role="3Tt5mk" to="teg0:J6gp_6ycpL" resolve="descriptionText" />
                                                                                 </node>
                                                                               </node>
                                                                               <node concept="3TrEf2" id="6uixmKZ3Uui" role="2OqNvi">
@@ -21095,7 +21095,7 @@
                                                                             <node concept="2OqwBi" id="2q0cFwFI$l_" role="2Oq$k0">
                                                                               <node concept="30H73N" id="2q0cFwFI$0Z" role="2Oq$k0" />
                                                                               <node concept="3TrEf2" id="2q0cFwFI_17" role="2OqNvi">
-                                                                                <ref role="3Tt5mk" to="teg0:6uixmKZ2FIJ" resolve="descriptionText" />
+                                                                                <ref role="3Tt5mk" to="teg0:J6gp_6ycpL" resolve="descriptionText" />
                                                                               </node>
                                                                             </node>
                                                                             <node concept="2Rf3mk" id="2q0cFwFIAaL" role="2OqNvi">
@@ -21112,7 +21112,7 @@
                                                                           <node concept="2OqwBi" id="6uixmKZ3Uup" role="2Oq$k0">
                                                                             <node concept="30H73N" id="6uixmKZ3Uuq" role="2Oq$k0" />
                                                                             <node concept="3TrEf2" id="6uixmKZ3Uur" role="2OqNvi">
-                                                                              <ref role="3Tt5mk" to="teg0:6uixmKZ2FIJ" resolve="descriptionText" />
+                                                                              <ref role="3Tt5mk" to="teg0:J6gp_6ycpL" resolve="descriptionText" />
                                                                             </node>
                                                                           </node>
                                                                           <node concept="3x8VRR" id="6uixmKZ3Uus" role="2OqNvi" />

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/generator/template/main@generator.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/generator/template/main@generator.mps
@@ -9505,11 +9505,49 @@
                                                               <node concept="3cpWsn" id="6uixmKZ3tkm" role="3cpWs9">
                                                                 <property role="TrG5h" value="originalText" />
                                                                 <node concept="17QB3L" id="6uixmKZ3tkn" role="1tU5fm" />
-                                                                <node concept="3nyPlj" id="6uixmKZ3tko" role="33vP2m">
-                                                                  <ref role="37wK5l" to="qtqj:~SubstituteMenuItemWrapper.getDescriptionText(java.lang.String)" resolve="getDescriptionText" />
-                                                                  <node concept="37vLTw" id="6uixmKZ3tkp" role="37wK5m">
-                                                                    <ref role="3cqZAo" node="6uixmKZ3tkg" resolve="pattern" />
+                                                                <node concept="2OqwBi" id="dN43ccHFTe" role="33vP2m">
+                                                                  <node concept="1bVj0M" id="dN43ccHDVL" role="2Oq$k0">
+                                                                    <node concept="3clFbS" id="dN43ccHDVN" role="1bW5cS">
+                                                                      <node concept="3cpWs8" id="dN43ccHKe3" role="3cqZAp">
+                                                                        <node concept="3cpWsn" id="dN43ccHKe4" role="3cpWs9">
+                                                                          <property role="TrG5h" value="description" />
+                                                                          <node concept="3uibUv" id="dN43ccHKe5" role="1tU5fm">
+                                                                            <ref role="3uigEE" to="wyt6:~String" resolve="String" />
+                                                                          </node>
+                                                                          <node concept="2OqwBi" id="dN43ccHKe6" role="33vP2m">
+                                                                            <node concept="1rXfSq" id="dN43ccHKe7" role="2Oq$k0">
+                                                                              <ref role="37wK5l" node="7NlRaxBn2jp" resolve="getOutputConcept" />
+                                                                            </node>
+                                                                            <node concept="liA8E" id="dN43ccHKe8" role="2OqNvi">
+                                                                              <ref role="37wK5l" to="c17a:~SAbstractConcept.getShortDescription()" resolve="getShortDescription" />
+                                                                            </node>
+                                                                          </node>
+                                                                        </node>
+                                                                      </node>
+                                                                      <node concept="3clFbF" id="dN43ccHKe9" role="3cqZAp">
+                                                                        <node concept="3K4zz7" id="dN43ccHKea" role="3clFbG">
+                                                                          <node concept="37vLTw" id="dN43ccHKeb" role="3K4E3e">
+                                                                            <ref role="3cqZAo" node="dN43ccHKe4" resolve="description" />
+                                                                          </node>
+                                                                          <node concept="2OqwBi" id="dN43ccHKec" role="3K4GZi">
+                                                                            <node concept="1rXfSq" id="dN43ccHKed" role="2Oq$k0">
+                                                                              <ref role="37wK5l" node="7NlRaxBn2jp" resolve="getOutputConcept" />
+                                                                            </node>
+                                                                            <node concept="liA8E" id="dN43ccHKee" role="2OqNvi">
+                                                                              <ref role="37wK5l" to="c17a:~SAbstractConcept.getName()" resolve="getName" />
+                                                                            </node>
+                                                                          </node>
+                                                                          <node concept="2OqwBi" id="dN43ccHKef" role="3K4Cdx">
+                                                                            <node concept="37vLTw" id="dN43ccHKeg" role="2Oq$k0">
+                                                                              <ref role="3cqZAo" node="dN43ccHKe4" resolve="description" />
+                                                                            </node>
+                                                                            <node concept="17RvpY" id="dN43ccHKeh" role="2OqNvi" />
+                                                                          </node>
+                                                                        </node>
+                                                                      </node>
+                                                                    </node>
                                                                   </node>
+                                                                  <node concept="1Bd96e" id="dN43ccHIg0" role="2OqNvi" />
                                                                 </node>
                                                               </node>
                                                             </node>
@@ -11473,8 +11511,8 @@
                                                   <node concept="3cpWsn" id="1ZlHRbiA73S" role="3cpWs9">
                                                     <property role="TrG5h" value="wrappedConcept" />
                                                     <node concept="3bZ5Sz" id="1ZlHRbiA73N" role="1tU5fm" />
-                                                    <node concept="2GrUjf" id="1ZlHRbjygSk" role="33vP2m">
-                                                      <ref role="2Gs0qQ" node="5AkACHrYHAX" resolve="subconcept" />
+                                                    <node concept="1rXfSq" id="dN43cczSwb" role="33vP2m">
+                                                      <ref role="37wK5l" node="7NlRaxB407M" resolve="getOutputConcept" />
                                                     </node>
                                                   </node>
                                                 </node>

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/generator/template/main@generator.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/generator/template/main@generator.mps
@@ -1723,11 +1723,10 @@
                                                   <node concept="3cpWsn" id="1ZlHRbfJYc5" role="3cpWs9">
                                                     <property role="TrG5h" value="originalText" />
                                                     <node concept="17QB3L" id="1ZlHRbfJYc6" role="1tU5fm" />
-                                                    <node concept="2YIFZM" id="1ZlHRbfJYc7" role="33vP2m">
-                                                      <ref role="37wK5l" to="5b0:~NodePresentationUtil.descriptionText(org.jetbrains.mps.openapi.language.SAbstractConcept)" resolve="descriptionText" />
-                                                      <ref role="1Pybhc" to="5b0:~NodePresentationUtil" resolve="NodePresentationUtil" />
-                                                      <node concept="1rXfSq" id="1ZlHRbfJYc8" role="37wK5m">
-                                                        <ref role="37wK5l" to="qtqj:~DefaultSubstituteMenuItem.getOutputConcept()" resolve="getOutputConcept" />
+                                                    <node concept="3nyPlj" id="dN43caGbWa" role="33vP2m">
+                                                      <ref role="37wK5l" to="czm:3uJMZ8xGyln" resolve="getDescriptionText" />
+                                                      <node concept="37vLTw" id="dN43caGeNX" role="37wK5m">
+                                                        <ref role="3cqZAo" node="4owkxKW9$h6" resolve="pattern" />
                                                       </node>
                                                     </node>
                                                   </node>
@@ -1790,37 +1789,6 @@
                                                         </node>
                                                         <node concept="3x8VRR" id="4owkxKWaubq" role="2OqNvi" />
                                                       </node>
-                                                    </node>
-                                                  </node>
-                                                </node>
-                                                <node concept="gft3U" id="1ZlHRbfK8yi" role="UU_$l">
-                                                  <node concept="3clFb_" id="1ZlHRbfK8yj" role="gfFT$">
-                                                    <property role="1EzhhJ" value="false" />
-                                                    <property role="TrG5h" value="getDescriptionText" />
-                                                    <property role="DiZV1" value="false" />
-                                                    <property role="od$2w" value="false" />
-                                                    <node concept="3Tm1VV" id="1ZlHRbfK8yk" role="1B3o_S" />
-                                                    <node concept="17QB3L" id="1ZlHRbfK8yl" role="3clF45" />
-                                                    <node concept="37vLTG" id="1ZlHRbfK8ym" role="3clF46">
-                                                      <property role="TrG5h" value="string" />
-                                                      <node concept="17QB3L" id="1ZlHRbfK8yn" role="1tU5fm" />
-                                                    </node>
-                                                    <node concept="3clFbS" id="1ZlHRbfK8yo" role="3clF47">
-                                                      <node concept="3clFbF" id="1ZlHRbfK8yp" role="3cqZAp">
-                                                        <node concept="2YIFZM" id="1ZlHRbfK8yq" role="3clFbG">
-                                                          <ref role="37wK5l" to="5b0:~NodePresentationUtil.descriptionText(org.jetbrains.mps.openapi.language.SAbstractConcept)" resolve="descriptionText" />
-                                                          <ref role="1Pybhc" to="5b0:~NodePresentationUtil" resolve="NodePresentationUtil" />
-                                                          <node concept="1rXfSq" id="1ZlHRbfK8yr" role="37wK5m">
-                                                            <ref role="37wK5l" to="qtqj:~DefaultSubstituteMenuItem.getOutputConcept()" resolve="getOutputConcept" />
-                                                          </node>
-                                                        </node>
-                                                      </node>
-                                                    </node>
-                                                    <node concept="2AHcQZ" id="1ZlHRbfYJQ9" role="2AJF6D">
-                                                      <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
-                                                    </node>
-                                                    <node concept="2AHcQZ" id="1ZlHRbfYJnU" role="2AJF6D">
-                                                      <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
                                                     </node>
                                                   </node>
                                                 </node>
@@ -2537,11 +2505,10 @@
                                             <node concept="3cpWsn" id="7PVnOXzMUlN" role="3cpWs9">
                                               <property role="TrG5h" value="originalText" />
                                               <node concept="17QB3L" id="7PVnOXzMUlO" role="1tU5fm" />
-                                              <node concept="2YIFZM" id="1ZlHRbfEQxu" role="33vP2m">
-                                                <ref role="1Pybhc" to="5b0:~NodePresentationUtil" resolve="NodePresentationUtil" />
-                                                <ref role="37wK5l" to="5b0:~NodePresentationUtil.descriptionText(org.jetbrains.mps.openapi.language.SAbstractConcept)" resolve="descriptionText" />
-                                                <node concept="1rXfSq" id="1ZlHRbfEQxv" role="37wK5m">
-                                                  <ref role="37wK5l" node="Dnjeumzces" resolve="getOutputConcept" />
+                                              <node concept="3nyPlj" id="dN43caGk6h" role="33vP2m">
+                                                <ref role="37wK5l" to="gdpt:1YKLYyyGCB0" resolve="getShortDescriptionText" />
+                                                <node concept="37vLTw" id="dN43caGmPr" role="37wK5m">
+                                                  <ref role="3cqZAo" node="J6gp_6LHFb" resolve="pattern" />
                                                 </node>
                                               </node>
                                             </node>
@@ -2603,37 +2570,6 @@
                                                   </node>
                                                   <node concept="3x8VRR" id="J6gp_6LHFO" role="2OqNvi" />
                                                 </node>
-                                              </node>
-                                            </node>
-                                          </node>
-                                          <node concept="gft3U" id="4owkxKUwVWz" role="UU_$l">
-                                            <node concept="3clFb_" id="4owkxKUwVW$" role="gfFT$">
-                                              <property role="1EzhhJ" value="false" />
-                                              <property role="TrG5h" value="getShortDescriptionText" />
-                                              <property role="DiZV1" value="false" />
-                                              <property role="od$2w" value="false" />
-                                              <node concept="3Tm1VV" id="4owkxKUwVW_" role="1B3o_S" />
-                                              <node concept="17QB3L" id="4owkxKUwVWA" role="3clF45" />
-                                              <node concept="37vLTG" id="4owkxKUwVWB" role="3clF46">
-                                                <property role="TrG5h" value="string" />
-                                                <node concept="17QB3L" id="4owkxKUwVWC" role="1tU5fm" />
-                                              </node>
-                                              <node concept="3clFbS" id="4owkxKUwVWD" role="3clF47">
-                                                <node concept="3clFbF" id="4owkxKUwVWE" role="3cqZAp">
-                                                  <node concept="2YIFZM" id="4owkxKUwVWF" role="3clFbG">
-                                                    <ref role="1Pybhc" to="5b0:~NodePresentationUtil" resolve="NodePresentationUtil" />
-                                                    <ref role="37wK5l" to="5b0:~NodePresentationUtil.descriptionText(org.jetbrains.mps.openapi.language.SAbstractConcept)" resolve="descriptionText" />
-                                                    <node concept="1rXfSq" id="4owkxKUwVWG" role="37wK5m">
-                                                      <ref role="37wK5l" node="Dnjeumzces" resolve="getOutputConcept" />
-                                                    </node>
-                                                  </node>
-                                                </node>
-                                              </node>
-                                              <node concept="2AHcQZ" id="1ZlHRbfYXgG" role="2AJF6D">
-                                                <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
-                                              </node>
-                                              <node concept="2AHcQZ" id="1ZlHRbfYWL8" role="2AJF6D">
-                                                <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
                                               </node>
                                             </node>
                                           </node>
@@ -3394,11 +3330,10 @@
                                             <node concept="3cpWsn" id="4xgCL2SOjWB" role="3cpWs9">
                                               <property role="TrG5h" value="originalText" />
                                               <node concept="17QB3L" id="4xgCL2SOjWC" role="1tU5fm" />
-                                              <node concept="2YIFZM" id="1ZlHRbfEEDL" role="33vP2m">
-                                                <ref role="37wK5l" to="5b0:~NodePresentationUtil.descriptionText(org.jetbrains.mps.openapi.language.SAbstractConcept)" resolve="descriptionText" />
-                                                <ref role="1Pybhc" to="5b0:~NodePresentationUtil" resolve="NodePresentationUtil" />
-                                                <node concept="1rXfSq" id="1ZlHRbfEEDM" role="37wK5m">
-                                                  <ref role="37wK5l" node="5fS8LroEqAw" resolve="getOutputConcept" />
+                                              <node concept="3nyPlj" id="dN43caGpW3" role="33vP2m">
+                                                <ref role="37wK5l" to="czm:325OF_Mo$mK" resolve="getShortDescriptionText" />
+                                                <node concept="37vLTw" id="dN43caGsYt" role="37wK5m">
+                                                  <ref role="3cqZAo" node="4xgCL2SOjWx" resolve="pattern" />
                                                 </node>
                                               </node>
                                             </node>
@@ -3460,37 +3395,6 @@
                                                   </node>
                                                   <node concept="3x8VRR" id="4owkxKUwDbH" role="2OqNvi" />
                                                 </node>
-                                              </node>
-                                            </node>
-                                          </node>
-                                          <node concept="gft3U" id="4owkxKUwNet" role="UU_$l">
-                                            <node concept="3clFb_" id="4owkxKUwNeu" role="gfFT$">
-                                              <property role="1EzhhJ" value="false" />
-                                              <property role="TrG5h" value="getShortDescriptionText" />
-                                              <property role="DiZV1" value="false" />
-                                              <property role="od$2w" value="false" />
-                                              <node concept="3Tm1VV" id="4owkxKUwNev" role="1B3o_S" />
-                                              <node concept="17QB3L" id="4owkxKUwNew" role="3clF45" />
-                                              <node concept="37vLTG" id="4owkxKUwNex" role="3clF46">
-                                                <property role="TrG5h" value="string" />
-                                                <node concept="17QB3L" id="4owkxKUwNey" role="1tU5fm" />
-                                              </node>
-                                              <node concept="3clFbS" id="4owkxKUwNez" role="3clF47">
-                                                <node concept="3clFbF" id="4owkxKUwNe$" role="3cqZAp">
-                                                  <node concept="2YIFZM" id="4owkxKUwNe_" role="3clFbG">
-                                                    <ref role="1Pybhc" to="5b0:~NodePresentationUtil" resolve="NodePresentationUtil" />
-                                                    <ref role="37wK5l" to="5b0:~NodePresentationUtil.descriptionText(org.jetbrains.mps.openapi.language.SAbstractConcept)" resolve="descriptionText" />
-                                                    <node concept="1rXfSq" id="4owkxKUwRGM" role="37wK5m">
-                                                      <ref role="37wK5l" node="5fS8LroEqAw" resolve="getOutputConcept" />
-                                                    </node>
-                                                  </node>
-                                                </node>
-                                              </node>
-                                              <node concept="2AHcQZ" id="1ZlHRbfZ2Kr" role="2AJF6D">
-                                                <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
-                                              </node>
-                                              <node concept="2AHcQZ" id="1ZlHRbfZ2gx" role="2AJF6D">
-                                                <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
                                               </node>
                                             </node>
                                           </node>
@@ -6086,11 +5990,10 @@
                                           <node concept="3cpWsn" id="7PVnOXzMOnE" role="3cpWs9">
                                             <property role="TrG5h" value="originalText" />
                                             <node concept="17QB3L" id="7PVnOXzMOnF" role="1tU5fm" />
-                                            <node concept="2YIFZM" id="1ZlHRbfEKNr" role="33vP2m">
-                                              <ref role="1Pybhc" to="5b0:~NodePresentationUtil" resolve="NodePresentationUtil" />
-                                              <ref role="37wK5l" to="5b0:~NodePresentationUtil.descriptionText(org.jetbrains.mps.openapi.language.SAbstractConcept)" resolve="descriptionText" />
-                                              <node concept="1rXfSq" id="1ZlHRbfEKNs" role="37wK5m">
-                                                <ref role="37wK5l" node="15DZatORrHk" resolve="getOutputConcept" />
+                                            <node concept="3nyPlj" id="dN43caH41S" role="33vP2m">
+                                              <ref role="37wK5l" to="czm:325OF_Mo$mK" resolve="getShortDescriptionText" />
+                                              <node concept="37vLTw" id="dN43caH9Oa" role="37wK5m">
+                                                <ref role="3cqZAo" node="J6gp_6z5bV" resolve="pattern" />
                                               </node>
                                             </node>
                                           </node>
@@ -6152,37 +6055,6 @@
                                                 </node>
                                                 <node concept="3x8VRR" id="J6gp_6z5c$" role="2OqNvi" />
                                               </node>
-                                            </node>
-                                          </node>
-                                        </node>
-                                        <node concept="gft3U" id="4owkxKUwSb2" role="UU_$l">
-                                          <node concept="3clFb_" id="4owkxKUwSb3" role="gfFT$">
-                                            <property role="1EzhhJ" value="false" />
-                                            <property role="TrG5h" value="getShortDescriptionText" />
-                                            <property role="DiZV1" value="false" />
-                                            <property role="od$2w" value="false" />
-                                            <node concept="3Tm1VV" id="4owkxKUwSb4" role="1B3o_S" />
-                                            <node concept="17QB3L" id="4owkxKUwSb5" role="3clF45" />
-                                            <node concept="37vLTG" id="4owkxKUwSb6" role="3clF46">
-                                              <property role="TrG5h" value="string" />
-                                              <node concept="17QB3L" id="4owkxKUwSb7" role="1tU5fm" />
-                                            </node>
-                                            <node concept="3clFbS" id="4owkxKUwSb8" role="3clF47">
-                                              <node concept="3clFbF" id="4owkxKUwSb9" role="3cqZAp">
-                                                <node concept="2YIFZM" id="4owkxKUwSba" role="3clFbG">
-                                                  <ref role="1Pybhc" to="5b0:~NodePresentationUtil" resolve="NodePresentationUtil" />
-                                                  <ref role="37wK5l" to="5b0:~NodePresentationUtil.descriptionText(org.jetbrains.mps.openapi.language.SAbstractConcept)" resolve="descriptionText" />
-                                                  <node concept="1rXfSq" id="4owkxKUwSbb" role="37wK5m">
-                                                    <ref role="37wK5l" node="15DZatORrHk" resolve="getOutputConcept" />
-                                                  </node>
-                                                </node>
-                                              </node>
-                                            </node>
-                                            <node concept="2AHcQZ" id="1ZlHRbfZ9Pr" role="2AJF6D">
-                                              <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
-                                            </node>
-                                            <node concept="2AHcQZ" id="1ZlHRbfZ9ok" role="2AJF6D">
-                                              <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
                                             </node>
                                           </node>
                                         </node>
@@ -9715,6 +9587,65 @@
                                                                       </node>
                                                                     </node>
                                                                     <node concept="3x8VRR" id="6uixmKZ3tkJ" role="2OqNvi" />
+                                                                  </node>
+                                                                </node>
+                                                              </node>
+                                                            </node>
+                                                            <node concept="gft3U" id="dN43caW6vW" role="UU_$l">
+                                                              <node concept="3clFb_" id="dN43caW98X" role="gfFT$">
+                                                                <property role="1EzhhJ" value="false" />
+                                                                <property role="TrG5h" value="getDescriptionText" />
+                                                                <property role="DiZV1" value="false" />
+                                                                <property role="od$2w" value="false" />
+                                                                <node concept="3Tm1VV" id="dN43caW98Y" role="1B3o_S" />
+                                                                <node concept="17QB3L" id="dN43caW98Z" role="3clF45" />
+                                                                <node concept="37vLTG" id="dN43caW990" role="3clF46">
+                                                                  <property role="TrG5h" value="pattern" />
+                                                                  <node concept="17QB3L" id="dN43caW991" role="1tU5fm" />
+                                                                  <node concept="2AHcQZ" id="dN43caW992" role="2AJF6D">
+                                                                    <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+                                                                  </node>
+                                                                </node>
+                                                                <node concept="2AHcQZ" id="dN43caW993" role="2AJF6D">
+                                                                  <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                                                                </node>
+                                                                <node concept="3clFbS" id="dN43caW994" role="3clF47">
+                                                                  <node concept="3cpWs8" id="dN43cbhgzl" role="3cqZAp">
+                                                                    <node concept="3cpWsn" id="dN43cbhgzm" role="3cpWs9">
+                                                                      <property role="TrG5h" value="description" />
+                                                                      <node concept="3uibUv" id="dN43cbhgzn" role="1tU5fm">
+                                                                        <ref role="3uigEE" to="wyt6:~String" resolve="String" />
+                                                                      </node>
+                                                                      <node concept="2OqwBi" id="dN43cbh1cb" role="33vP2m">
+                                                                        <node concept="1rXfSq" id="dN43cbhgzo" role="2Oq$k0">
+                                                                          <ref role="37wK5l" node="7NlRaxBn2jp" resolve="getOutputConcept" />
+                                                                        </node>
+                                                                        <node concept="liA8E" id="dN43cbh1UR" role="2OqNvi">
+                                                                          <ref role="37wK5l" to="c17a:~SAbstractConcept.getShortDescription()" resolve="getShortDescription" />
+                                                                        </node>
+                                                                      </node>
+                                                                    </node>
+                                                                  </node>
+                                                                  <node concept="3clFbF" id="dN43caGy86" role="3cqZAp">
+                                                                    <node concept="3K4zz7" id="dN43cbhgzp" role="3clFbG">
+                                                                      <node concept="37vLTw" id="dN43cbhgzq" role="3K4E3e">
+                                                                        <ref role="3cqZAo" node="dN43cbhgzm" resolve="description" />
+                                                                      </node>
+                                                                      <node concept="2OqwBi" id="dN43cbhgzr" role="3K4GZi">
+                                                                        <node concept="1rXfSq" id="dN43cbhgzs" role="2Oq$k0">
+                                                                          <ref role="37wK5l" node="7NlRaxBn2jp" resolve="getOutputConcept" />
+                                                                        </node>
+                                                                        <node concept="liA8E" id="dN43cbhgzt" role="2OqNvi">
+                                                                          <ref role="37wK5l" to="c17a:~SAbstractConcept.getName()" resolve="getName" />
+                                                                        </node>
+                                                                      </node>
+                                                                      <node concept="2OqwBi" id="dN43cbh4eU" role="3K4Cdx">
+                                                                        <node concept="37vLTw" id="dN43cbhgzu" role="2Oq$k0">
+                                                                          <ref role="3cqZAo" node="dN43cbhgzm" resolve="description" />
+                                                                        </node>
+                                                                        <node concept="17RvpY" id="dN43cbh5g4" role="2OqNvi" />
+                                                                      </node>
+                                                                    </node>
                                                                   </node>
                                                                 </node>
                                                               </node>
@@ -13513,11 +13444,10 @@
                                           <node concept="3cpWsn" id="1ZlHRbfYgLI" role="3cpWs9">
                                             <property role="TrG5h" value="originalText" />
                                             <node concept="17QB3L" id="1ZlHRbfYgLJ" role="1tU5fm" />
-                                            <node concept="2YIFZM" id="1ZlHRbfYgLK" role="33vP2m">
-                                              <ref role="37wK5l" to="5b0:~NodePresentationUtil.descriptionText(org.jetbrains.mps.openapi.language.SAbstractConcept)" resolve="descriptionText" />
-                                              <ref role="1Pybhc" to="5b0:~NodePresentationUtil" resolve="NodePresentationUtil" />
-                                              <node concept="1rXfSq" id="1ZlHRbfYgLL" role="37wK5m">
-                                                <ref role="37wK5l" node="2c84p9PulRA" resolve="getOutputConcept" />
+                                            <node concept="3nyPlj" id="dN43caHHnt" role="33vP2m">
+                                              <ref role="37wK5l" to="gdpt:1YKLYyyGCB0" resolve="getShortDescriptionText" />
+                                              <node concept="37vLTw" id="dN43caHLlP" role="37wK5m">
+                                                <ref role="3cqZAo" node="1ZlHRbfYgLy" resolve="pattern" />
                                               </node>
                                             </node>
                                           </node>
@@ -13582,37 +13512,6 @@
                                                 </node>
                                                 <node concept="3x8VRR" id="1ZlHRbfYgMg" role="2OqNvi" />
                                               </node>
-                                            </node>
-                                          </node>
-                                        </node>
-                                        <node concept="gft3U" id="1ZlHRbfYgMh" role="UU_$l">
-                                          <node concept="3clFb_" id="1ZlHRbfYgMi" role="gfFT$">
-                                            <property role="1EzhhJ" value="false" />
-                                            <property role="TrG5h" value="getShortDescriptionText" />
-                                            <property role="DiZV1" value="false" />
-                                            <property role="od$2w" value="false" />
-                                            <node concept="3Tm1VV" id="1ZlHRbfYgMj" role="1B3o_S" />
-                                            <node concept="17QB3L" id="1ZlHRbfYgMk" role="3clF45" />
-                                            <node concept="37vLTG" id="1ZlHRbfYgMl" role="3clF46">
-                                              <property role="TrG5h" value="string" />
-                                              <node concept="17QB3L" id="1ZlHRbfYgMm" role="1tU5fm" />
-                                            </node>
-                                            <node concept="3clFbS" id="1ZlHRbfYgMn" role="3clF47">
-                                              <node concept="3clFbF" id="1ZlHRbfYgMs" role="3cqZAp">
-                                                <node concept="2YIFZM" id="1ZlHRbfYgMt" role="3clFbG">
-                                                  <ref role="37wK5l" to="5b0:~NodePresentationUtil.descriptionText(org.jetbrains.mps.openapi.language.SAbstractConcept)" resolve="descriptionText" />
-                                                  <ref role="1Pybhc" to="5b0:~NodePresentationUtil" resolve="NodePresentationUtil" />
-                                                  <node concept="1rXfSq" id="1ZlHRbfYgMu" role="37wK5m">
-                                                    <ref role="37wK5l" node="2c84p9PulRA" resolve="getOutputConcept" />
-                                                  </node>
-                                                </node>
-                                              </node>
-                                            </node>
-                                            <node concept="2AHcQZ" id="1ZlHRbfYHe2" role="2AJF6D">
-                                              <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
-                                            </node>
-                                            <node concept="2AHcQZ" id="1ZlHRbfYF01" role="2AJF6D">
-                                              <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
                                             </node>
                                           </node>
                                         </node>
@@ -17115,6 +17014,115 @@
                                                       </node>
                                                     </node>
                                                   </node>
+                                                  <node concept="3clFb_" id="dN43cc7214" role="jymVt">
+                                                    <property role="1EzhhJ" value="false" />
+                                                    <property role="TrG5h" value="getShortDescriptionText" />
+                                                    <property role="DiZV1" value="false" />
+                                                    <property role="od$2w" value="false" />
+                                                    <node concept="3Tm1VV" id="dN43cc7215" role="1B3o_S" />
+                                                    <node concept="17QB3L" id="dN43cc7216" role="3clF45" />
+                                                    <node concept="37vLTG" id="dN43cc7217" role="3clF46">
+                                                      <property role="TrG5h" value="pattern" />
+                                                      <node concept="17QB3L" id="dN43cc7218" role="1tU5fm" />
+                                                      <node concept="2AHcQZ" id="dN43cc7219" role="2AJF6D">
+                                                        <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+                                                      </node>
+                                                    </node>
+                                                    <node concept="2AHcQZ" id="dN43cc721a" role="2AJF6D">
+                                                      <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                                                    </node>
+                                                    <node concept="3clFbS" id="dN43cc721b" role="3clF47">
+                                                      <node concept="3cpWs8" id="dN43cc721c" role="3cqZAp">
+                                                        <node concept="3cpWsn" id="dN43cc721d" role="3cpWs9">
+                                                          <property role="TrG5h" value="originalText" />
+                                                          <node concept="17QB3L" id="dN43cc721e" role="1tU5fm" />
+                                                          <node concept="3nyPlj" id="dN43cc721f" role="33vP2m">
+                                                            <ref role="37wK5l" to="czm:325OF_Mo$mK" resolve="getShortDescriptionText" />
+                                                            <node concept="37vLTw" id="dN43cc721g" role="37wK5m">
+                                                              <ref role="3cqZAo" node="dN43cc7217" resolve="pattern" />
+                                                            </node>
+                                                          </node>
+                                                        </node>
+                                                      </node>
+                                                      <node concept="3cpWs8" id="dN43cc721h" role="3cqZAp">
+                                                        <node concept="3cpWsn" id="dN43cc721i" role="3cpWs9">
+                                                          <property role="TrG5h" value="node" />
+                                                          <node concept="3Tqbb2" id="dN43cc721j" role="1tU5fm" />
+                                                          <node concept="2OqwBi" id="dN43cc721k" role="33vP2m">
+                                                            <node concept="37vLTw" id="dN43cc721l" role="2Oq$k0">
+                                                              <ref role="3cqZAo" node="4eBi5gdtxpN" resolve="_context" />
+                                                            </node>
+                                                            <node concept="liA8E" id="dN43cc721m" role="2OqNvi">
+                                                              <ref role="37wK5l" to="uddc:~TransformationMenuContext.getNode()" resolve="getNode" />
+                                                            </node>
+                                                          </node>
+                                                        </node>
+                                                      </node>
+                                                      <node concept="3cpWs8" id="dN43cc721n" role="3cqZAp">
+                                                        <node concept="3cpWsn" id="dN43cc721o" role="3cpWs9">
+                                                          <property role="TrG5h" value="editorContext" />
+                                                          <node concept="3uibUv" id="dN43cc721p" role="1tU5fm">
+                                                            <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+                                                          </node>
+                                                          <node concept="2OqwBi" id="dN43cc721q" role="33vP2m">
+                                                            <node concept="37vLTw" id="dN43cc721r" role="2Oq$k0">
+                                                              <ref role="3cqZAo" node="4eBi5gdtxpN" resolve="_context" />
+                                                            </node>
+                                                            <node concept="liA8E" id="dN43cc721s" role="2OqNvi">
+                                                              <ref role="37wK5l" to="uddc:~TransformationMenuContext.getEditorContext()" resolve="getEditorContext" />
+                                                            </node>
+                                                          </node>
+                                                        </node>
+                                                      </node>
+                                                      <node concept="3cpWs6" id="dN43cc721t" role="3cqZAp">
+                                                        <node concept="37vLTw" id="dN43cc721u" role="3cqZAk">
+                                                          <ref role="3cqZAo" node="dN43cc721d" resolve="originalText" />
+                                                        </node>
+                                                        <node concept="2b32R4" id="dN43cc721v" role="lGtFl">
+                                                          <node concept="3JmXsc" id="dN43cc721w" role="2P8S$">
+                                                            <node concept="3clFbS" id="dN43cc721x" role="2VODD2">
+                                                              <node concept="3clFbF" id="dN43cc721y" role="3cqZAp">
+                                                                <node concept="2OqwBi" id="dN43cc721z" role="3clFbG">
+                                                                  <node concept="2OqwBi" id="dN43cc721$" role="2Oq$k0">
+                                                                    <node concept="2OqwBi" id="dN43cc721_" role="2Oq$k0">
+                                                                      <node concept="30H73N" id="dN43cc721A" role="2Oq$k0" />
+                                                                      <node concept="3TrEf2" id="dN43cc721B" role="2OqNvi">
+                                                                        <ref role="3Tt5mk" to="teg0:J6gp_6ycpL" resolve="descriptionText" />
+                                                                      </node>
+                                                                    </node>
+                                                                    <node concept="3TrEf2" id="dN43cc721C" role="2OqNvi">
+                                                                      <ref role="3Tt5mk" to="tpee:gyVODHa" resolve="body" />
+                                                                    </node>
+                                                                  </node>
+                                                                  <node concept="3Tsc0h" id="dN43cc721D" role="2OqNvi">
+                                                                    <ref role="3TtcxE" to="tpee:fzcqZ_x" resolve="statement" />
+                                                                  </node>
+                                                                </node>
+                                                              </node>
+                                                            </node>
+                                                          </node>
+                                                        </node>
+                                                      </node>
+                                                    </node>
+                                                    <node concept="1W57fq" id="dN43cc721E" role="lGtFl">
+                                                      <node concept="3IZrLx" id="dN43cc721F" role="3IZSJc">
+                                                        <node concept="3clFbS" id="dN43cc721G" role="2VODD2">
+                                                          <node concept="3clFbF" id="dN43cc721H" role="3cqZAp">
+                                                            <node concept="2OqwBi" id="dN43cc721I" role="3clFbG">
+                                                              <node concept="2OqwBi" id="dN43cc721J" role="2Oq$k0">
+                                                                <node concept="30H73N" id="dN43cc721K" role="2Oq$k0" />
+                                                                <node concept="3TrEf2" id="dN43cc721L" role="2OqNvi">
+                                                                  <ref role="3Tt5mk" to="teg0:J6gp_6ycpL" resolve="descriptionText" />
+                                                                </node>
+                                                              </node>
+                                                              <node concept="3x8VRR" id="dN43cc721M" role="2OqNvi" />
+                                                            </node>
+                                                          </node>
+                                                        </node>
+                                                      </node>
+                                                    </node>
+                                                  </node>
+                                                  <node concept="2tJIrI" id="dN43cc708x" role="jymVt" />
                                                   <node concept="3clFb_" id="My09KinYdE" role="jymVt">
                                                     <property role="1EzhhJ" value="false" />
                                                     <property role="TrG5h" value="getOutputConcept" />
@@ -17207,20 +17215,111 @@
                                                         <ref role="3cqZAo" node="4eBi5gdtxpN" resolve="_context" />
                                                       </node>
                                                       <node concept="3Tm1VV" id="5$jJV5e8FKQ" role="1B3o_S" />
-                                                      <node concept="3clFb_" id="5$jJV5e8FKS" role="jymVt">
+                                                      <node concept="3clFb_" id="dN43caI7aM" role="jymVt">
                                                         <property role="1EzhhJ" value="false" />
-                                                        <property role="TrG5h" value="getDescriptionText" />
+                                                        <property role="TrG5h" value="getShortDescriptionText" />
                                                         <property role="DiZV1" value="false" />
                                                         <property role="od$2w" value="false" />
-                                                        <node concept="3Tm1VV" id="5$jJV5e8FKT" role="1B3o_S" />
-                                                        <node concept="17QB3L" id="5$jJV5e8FKU" role="3clF45" />
-                                                        <node concept="37vLTG" id="5$jJV5e8FKV" role="3clF46">
+                                                        <node concept="3Tm1VV" id="dN43caI7aN" role="1B3o_S" />
+                                                        <node concept="17QB3L" id="dN43caI7aO" role="3clF45" />
+                                                        <node concept="37vLTG" id="dN43caI7aP" role="3clF46">
                                                           <property role="TrG5h" value="pattern" />
-                                                          <node concept="17QB3L" id="5$jJV5e8FKW" role="1tU5fm" />
+                                                          <node concept="17QB3L" id="dN43caI7aQ" role="1tU5fm" />
+                                                          <node concept="2AHcQZ" id="dN43caI7aR" role="2AJF6D">
+                                                            <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+                                                          </node>
                                                         </node>
-                                                        <node concept="3clFbS" id="5$jJV5e8FKX" role="3clF47">
-                                                          <node concept="3clFbF" id="5$jJV5e8FKY" role="3cqZAp">
-                                                            <node concept="10Nm6u" id="5$jJV5e8FKZ" role="3clFbG" />
+                                                        <node concept="2AHcQZ" id="dN43caI7aS" role="2AJF6D">
+                                                          <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                                                        </node>
+                                                        <node concept="3clFbS" id="dN43caI7aT" role="3clF47">
+                                                          <node concept="3cpWs8" id="dN43caI7aU" role="3cqZAp">
+                                                            <node concept="3cpWsn" id="dN43caI7aV" role="3cpWs9">
+                                                              <property role="TrG5h" value="originalText" />
+                                                              <node concept="17QB3L" id="dN43caI7aW" role="1tU5fm" />
+                                                              <node concept="3nyPlj" id="dN43caI7aX" role="33vP2m">
+                                                                <ref role="37wK5l" to="gdpt:1YKLYyyGCB0" resolve="getShortDescriptionText" />
+                                                                <node concept="37vLTw" id="dN43caI7aY" role="37wK5m">
+                                                                  <ref role="3cqZAo" node="dN43caI7aP" resolve="pattern" />
+                                                                </node>
+                                                              </node>
+                                                            </node>
+                                                          </node>
+                                                          <node concept="3cpWs8" id="dN43caI7aZ" role="3cqZAp">
+                                                            <node concept="3cpWsn" id="dN43caI7b0" role="3cpWs9">
+                                                              <property role="TrG5h" value="node" />
+                                                              <node concept="3Tqbb2" id="dN43caI7b1" role="1tU5fm" />
+                                                              <node concept="2OqwBi" id="dN43caIBmu" role="33vP2m">
+                                                                <node concept="37vLTw" id="dN43caIBmv" role="2Oq$k0">
+                                                                  <ref role="3cqZAo" node="4eBi5gdtxpN" resolve="_context" />
+                                                                </node>
+                                                                <node concept="liA8E" id="dN43caIBmw" role="2OqNvi">
+                                                                  <ref role="37wK5l" to="uddc:~TransformationMenuContext.getNode()" resolve="getNode" />
+                                                                </node>
+                                                              </node>
+                                                            </node>
+                                                          </node>
+                                                          <node concept="3cpWs8" id="dN43caI7b7" role="3cqZAp">
+                                                            <node concept="3cpWsn" id="dN43caI7b8" role="3cpWs9">
+                                                              <property role="TrG5h" value="editorContext" />
+                                                              <node concept="3uibUv" id="dN43caI7b9" role="1tU5fm">
+                                                                <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+                                                              </node>
+                                                              <node concept="2OqwBi" id="dN43caI7ba" role="33vP2m">
+                                                                <node concept="37vLTw" id="dN43caI7bb" role="2Oq$k0">
+                                                                  <ref role="3cqZAo" node="4eBi5gdtxpN" resolve="_context" />
+                                                                </node>
+                                                                <node concept="liA8E" id="dN43caI7bc" role="2OqNvi">
+                                                                  <ref role="37wK5l" to="uddc:~TransformationMenuContext.getEditorContext()" resolve="getEditorContext" />
+                                                                </node>
+                                                              </node>
+                                                            </node>
+                                                          </node>
+                                                          <node concept="3cpWs6" id="dN43caI7bd" role="3cqZAp">
+                                                            <node concept="37vLTw" id="dN43caI7be" role="3cqZAk">
+                                                              <ref role="3cqZAo" node="dN43caI7aV" resolve="originalText" />
+                                                            </node>
+                                                            <node concept="2b32R4" id="dN43caI7bf" role="lGtFl">
+                                                              <node concept="3JmXsc" id="dN43caI7bg" role="2P8S$">
+                                                                <node concept="3clFbS" id="dN43caI7bh" role="2VODD2">
+                                                                  <node concept="3clFbF" id="dN43caI7bi" role="3cqZAp">
+                                                                    <node concept="2OqwBi" id="dN43caI7bj" role="3clFbG">
+                                                                      <node concept="2OqwBi" id="dN43caI7bk" role="2Oq$k0">
+                                                                        <node concept="2OqwBi" id="dN43caI7bl" role="2Oq$k0">
+                                                                          <node concept="30H73N" id="dN43caI7bm" role="2Oq$k0" />
+                                                                          <node concept="3TrEf2" id="dN43caI7bn" role="2OqNvi">
+                                                                            <ref role="3Tt5mk" to="teg0:J6gp_6ycpL" resolve="descriptionText" />
+                                                                          </node>
+                                                                        </node>
+                                                                        <node concept="3TrEf2" id="dN43caI7bo" role="2OqNvi">
+                                                                          <ref role="3Tt5mk" to="tpee:gyVODHa" resolve="body" />
+                                                                        </node>
+                                                                      </node>
+                                                                      <node concept="3Tsc0h" id="dN43caI7bp" role="2OqNvi">
+                                                                        <ref role="3TtcxE" to="tpee:fzcqZ_x" resolve="statement" />
+                                                                      </node>
+                                                                    </node>
+                                                                  </node>
+                                                                </node>
+                                                              </node>
+                                                            </node>
+                                                          </node>
+                                                        </node>
+                                                        <node concept="1W57fq" id="dN43caI7bq" role="lGtFl">
+                                                          <node concept="3IZrLx" id="dN43caI7br" role="3IZSJc">
+                                                            <node concept="3clFbS" id="dN43caI7bs" role="2VODD2">
+                                                              <node concept="3clFbF" id="dN43caI7bt" role="3cqZAp">
+                                                                <node concept="2OqwBi" id="dN43caI7bu" role="3clFbG">
+                                                                  <node concept="2OqwBi" id="dN43caI7bv" role="2Oq$k0">
+                                                                    <node concept="30H73N" id="dN43caI7bw" role="2Oq$k0" />
+                                                                    <node concept="3TrEf2" id="dN43caI7bx" role="2OqNvi">
+                                                                      <ref role="3Tt5mk" to="teg0:J6gp_6ycpL" resolve="descriptionText" />
+                                                                    </node>
+                                                                  </node>
+                                                                  <node concept="3x8VRR" id="dN43caI7by" role="2OqNvi" />
+                                                                </node>
+                                                              </node>
+                                                            </node>
                                                           </node>
                                                         </node>
                                                       </node>
@@ -18091,6 +18190,135 @@
                                     </node>
                                   </node>
                                 </node>
+                                <node concept="2tJIrI" id="2l$VAMFeGyK" role="jymVt" />
+                                <node concept="3clFb_" id="2l$VAMFeUMw" role="jymVt">
+                                  <property role="1EzhhJ" value="false" />
+                                  <property role="TrG5h" value="getShortDescriptionText" />
+                                  <property role="DiZV1" value="false" />
+                                  <property role="od$2w" value="false" />
+                                  <node concept="3Tm1VV" id="2l$VAMFeUMx" role="1B3o_S" />
+                                  <node concept="17QB3L" id="2l$VAMFeUMy" role="3clF45" />
+                                  <node concept="37vLTG" id="2l$VAMFeUMz" role="3clF46">
+                                    <property role="TrG5h" value="pattern" />
+                                    <node concept="17QB3L" id="2l$VAMFeUM$" role="1tU5fm" />
+                                    <node concept="2AHcQZ" id="2l$VAMFeUM_" role="2AJF6D">
+                                      <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+                                    </node>
+                                  </node>
+                                  <node concept="2AHcQZ" id="2l$VAMFeUMA" role="2AJF6D">
+                                    <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                                  </node>
+                                  <node concept="3clFbS" id="2l$VAMFeUMB" role="3clF47">
+                                    <node concept="3cpWs8" id="2l$VAMFeUMC" role="3cqZAp">
+                                      <node concept="3cpWsn" id="2l$VAMFeUMD" role="3cpWs9">
+                                        <property role="TrG5h" value="originalText" />
+                                        <node concept="17QB3L" id="2l$VAMFeUME" role="1tU5fm" />
+                                        <node concept="3nyPlj" id="2l$VAMFeUMF" role="33vP2m">
+                                          <ref role="37wK5l" to="czm:325OF_Mo$mK" resolve="getShortDescriptionText" />
+                                          <node concept="37vLTw" id="2l$VAMFeUMG" role="37wK5m">
+                                            <ref role="3cqZAo" node="2l$VAMFeUMz" resolve="pattern" />
+                                          </node>
+                                        </node>
+                                      </node>
+                                    </node>
+                                    <node concept="3cpWs8" id="2l$VAMFeUMH" role="3cqZAp">
+                                      <node concept="3cpWsn" id="2l$VAMFeUMI" role="3cpWs9">
+                                        <property role="TrG5h" value="node" />
+                                        <node concept="3Tqbb2" id="2l$VAMFeUMJ" role="1tU5fm" />
+                                        <node concept="2OqwBi" id="2l$VAMFeUMK" role="33vP2m">
+                                          <node concept="37vLTw" id="2l$VAMFeUML" role="2Oq$k0">
+                                            <ref role="3cqZAo" node="6rhOS_xwLRq" resolve="_context" />
+                                          </node>
+                                          <node concept="liA8E" id="2l$VAMFeUMM" role="2OqNvi">
+                                            <ref role="37wK5l" to="uddc:~TransformationMenuContext.getNode()" resolve="getNode" />
+                                          </node>
+                                        </node>
+                                      </node>
+                                    </node>
+                                    <node concept="3cpWs8" id="2l$VAMFeUMT" role="3cqZAp">
+                                      <node concept="3cpWsn" id="2l$VAMFeUMU" role="3cpWs9">
+                                        <property role="TrG5h" value="editorContext" />
+                                        <node concept="3uibUv" id="2l$VAMFeUMV" role="1tU5fm">
+                                          <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+                                        </node>
+                                        <node concept="2OqwBi" id="2l$VAMFeUMW" role="33vP2m">
+                                          <node concept="37vLTw" id="2l$VAMFeUMX" role="2Oq$k0">
+                                            <ref role="3cqZAo" node="6rhOS_xwLRq" resolve="_context" />
+                                          </node>
+                                          <node concept="liA8E" id="2l$VAMFeUMY" role="2OqNvi">
+                                            <ref role="37wK5l" to="uddc:~TransformationMenuContext.getEditorContext()" resolve="getEditorContext" />
+                                          </node>
+                                        </node>
+                                      </node>
+                                    </node>
+                                    <node concept="3cpWs6" id="2l$VAMFeUMZ" role="3cqZAp">
+                                      <node concept="37vLTw" id="2l$VAMFeUN0" role="3cqZAk">
+                                        <ref role="3cqZAo" node="2l$VAMFeUMD" resolve="originalText" />
+                                      </node>
+                                      <node concept="2b32R4" id="2l$VAMFeUN1" role="lGtFl">
+                                        <node concept="3JmXsc" id="2l$VAMFeUN2" role="2P8S$">
+                                          <node concept="3clFbS" id="2l$VAMFeUN3" role="2VODD2">
+                                            <node concept="3clFbF" id="2l$VAMFeUN4" role="3cqZAp">
+                                              <node concept="2OqwBi" id="2l$VAMFeUN5" role="3clFbG">
+                                                <node concept="2OqwBi" id="2l$VAMFeUN6" role="2Oq$k0">
+                                                  <node concept="2OqwBi" id="2l$VAMFeUN7" role="2Oq$k0">
+                                                    <node concept="30H73N" id="2l$VAMFeUN8" role="2Oq$k0" />
+                                                    <node concept="3TrEf2" id="2l$VAMFeUN9" role="2OqNvi">
+                                                      <ref role="3Tt5mk" to="teg0:J6gp_6ycpL" resolve="descriptionText" />
+                                                    </node>
+                                                  </node>
+                                                  <node concept="3TrEf2" id="2l$VAMFeUNa" role="2OqNvi">
+                                                    <ref role="3Tt5mk" to="tpee:gyVODHa" resolve="body" />
+                                                  </node>
+                                                </node>
+                                                <node concept="3Tsc0h" id="2l$VAMFeUNb" role="2OqNvi">
+                                                  <ref role="3TtcxE" to="tpee:fzcqZ_x" resolve="statement" />
+                                                </node>
+                                              </node>
+                                            </node>
+                                          </node>
+                                        </node>
+                                      </node>
+                                    </node>
+                                  </node>
+                                  <node concept="1W57fq" id="2l$VAMFeUNc" role="lGtFl">
+                                    <node concept="3IZrLx" id="2l$VAMFeUNd" role="3IZSJc">
+                                      <node concept="3clFbS" id="2l$VAMFeUNe" role="2VODD2">
+                                        <node concept="3clFbF" id="2l$VAMFeUNf" role="3cqZAp">
+                                          <node concept="1Wc70l" id="2l$VAMFeUNg" role="3clFbG">
+                                            <node concept="2OqwBi" id="2l$VAMFeUNh" role="3uHU7w">
+                                              <node concept="2OqwBi" id="2l$VAMFeUNi" role="2Oq$k0">
+                                                <node concept="2OqwBi" id="2l$VAMFeUNj" role="2Oq$k0">
+                                                  <node concept="30H73N" id="2l$VAMFeUNk" role="2Oq$k0" />
+                                                  <node concept="3TrEf2" id="2l$VAMFeUNl" role="2OqNvi">
+                                                    <ref role="3Tt5mk" to="teg0:J6gp_6ycpL" resolve="descriptionText" />
+                                                  </node>
+                                                </node>
+                                                <node concept="2Rf3mk" id="2l$VAMFeUNm" role="2OqNvi">
+                                                  <node concept="1xMEDy" id="2l$VAMFeUNn" role="1xVPHs">
+                                                    <node concept="chp4Y" id="2l$VAMFeUNo" role="ri$Ld">
+                                                      <ref role="cht4Q" to="teg0:2q0cFwEBOkL" resolve="Parameter_smartReferent" />
+                                                    </node>
+                                                  </node>
+                                                </node>
+                                              </node>
+                                              <node concept="1v1jN8" id="2l$VAMFeUNp" role="2OqNvi" />
+                                            </node>
+                                            <node concept="2OqwBi" id="2l$VAMFeUNq" role="3uHU7B">
+                                              <node concept="2OqwBi" id="2l$VAMFeUNr" role="2Oq$k0">
+                                                <node concept="30H73N" id="2l$VAMFeUNs" role="2Oq$k0" />
+                                                <node concept="3TrEf2" id="2l$VAMFeUNt" role="2OqNvi">
+                                                  <ref role="3Tt5mk" to="teg0:J6gp_6ycpL" resolve="descriptionText" />
+                                                </node>
+                                              </node>
+                                              <node concept="3x8VRR" id="2l$VAMFeUNu" role="2OqNvi" />
+                                            </node>
+                                          </node>
+                                        </node>
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
                               </node>
                             </node>
                           </node>
@@ -18131,20 +18359,131 @@
                                       <ref role="3cqZAo" node="6rhOS_xwLRq" resolve="_context" />
                                     </node>
                                     <node concept="3Tm1VV" id="5$jJV5e8NtP" role="1B3o_S" />
-                                    <node concept="3clFb_" id="5$jJV5e8NtT" role="jymVt">
+                                    <node concept="3clFb_" id="2l$VAMF3Ca7" role="jymVt">
                                       <property role="1EzhhJ" value="false" />
-                                      <property role="TrG5h" value="getDescriptionText" />
+                                      <property role="TrG5h" value="getShortDescriptionText" />
                                       <property role="DiZV1" value="false" />
                                       <property role="od$2w" value="false" />
-                                      <node concept="3Tm1VV" id="5$jJV5e8NtU" role="1B3o_S" />
-                                      <node concept="17QB3L" id="5$jJV5e8NtV" role="3clF45" />
-                                      <node concept="37vLTG" id="5$jJV5e8NtW" role="3clF46">
+                                      <node concept="3Tm1VV" id="2l$VAMF3Ca8" role="1B3o_S" />
+                                      <node concept="17QB3L" id="2l$VAMF3Ca9" role="3clF45" />
+                                      <node concept="37vLTG" id="2l$VAMF3Caa" role="3clF46">
                                         <property role="TrG5h" value="pattern" />
-                                        <node concept="17QB3L" id="5$jJV5e8NtX" role="1tU5fm" />
+                                        <node concept="17QB3L" id="2l$VAMF3Cab" role="1tU5fm" />
+                                        <node concept="2AHcQZ" id="2l$VAMF3Cac" role="2AJF6D">
+                                          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+                                        </node>
                                       </node>
-                                      <node concept="3clFbS" id="5$jJV5e8NtY" role="3clF47">
-                                        <node concept="3clFbF" id="5$jJV5e8NtZ" role="3cqZAp">
-                                          <node concept="10Nm6u" id="5$jJV5e8Nu0" role="3clFbG" />
+                                      <node concept="2AHcQZ" id="2l$VAMF3Cad" role="2AJF6D">
+                                        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                                      </node>
+                                      <node concept="3clFbS" id="2l$VAMF3Cae" role="3clF47">
+                                        <node concept="3cpWs8" id="2l$VAMF3Caf" role="3cqZAp">
+                                          <node concept="3cpWsn" id="2l$VAMF3Cag" role="3cpWs9">
+                                            <property role="TrG5h" value="originalText" />
+                                            <node concept="17QB3L" id="2l$VAMF3Cah" role="1tU5fm" />
+                                            <node concept="3nyPlj" id="2l$VAMF3Cai" role="33vP2m">
+                                              <ref role="37wK5l" to="gdpt:1YKLYyyGCB0" resolve="getShortDescriptionText" />
+                                              <node concept="37vLTw" id="2l$VAMF3Caj" role="37wK5m">
+                                                <ref role="3cqZAo" node="2l$VAMF3Caa" resolve="pattern" />
+                                              </node>
+                                            </node>
+                                          </node>
+                                        </node>
+                                        <node concept="3cpWs8" id="2l$VAMF3Cak" role="3cqZAp">
+                                          <node concept="3cpWsn" id="2l$VAMF3Cal" role="3cpWs9">
+                                            <property role="TrG5h" value="node" />
+                                            <node concept="3Tqbb2" id="2l$VAMF3Cam" role="1tU5fm" />
+                                            <node concept="2OqwBi" id="2l$VAMF3Can" role="33vP2m">
+                                              <node concept="37vLTw" id="2l$VAMF3Cao" role="2Oq$k0">
+                                                <ref role="3cqZAo" node="6rhOS_xwLRq" resolve="_context" />
+                                              </node>
+                                              <node concept="liA8E" id="2l$VAMF3Cap" role="2OqNvi">
+                                                <ref role="37wK5l" to="uddc:~TransformationMenuContext.getNode()" resolve="getNode" />
+                                              </node>
+                                            </node>
+                                          </node>
+                                        </node>
+                                        <node concept="3cpWs8" id="2l$VAMF3Caw" role="3cqZAp">
+                                          <node concept="3cpWsn" id="2l$VAMF3Cax" role="3cpWs9">
+                                            <property role="TrG5h" value="editorContext" />
+                                            <node concept="3uibUv" id="2l$VAMF3Cay" role="1tU5fm">
+                                              <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+                                            </node>
+                                            <node concept="2OqwBi" id="2l$VAMF3Caz" role="33vP2m">
+                                              <node concept="37vLTw" id="2l$VAMF3Ca$" role="2Oq$k0">
+                                                <ref role="3cqZAo" node="6rhOS_xwLRq" resolve="_context" />
+                                              </node>
+                                              <node concept="liA8E" id="2l$VAMF3Ca_" role="2OqNvi">
+                                                <ref role="37wK5l" to="uddc:~TransformationMenuContext.getEditorContext()" resolve="getEditorContext" />
+                                              </node>
+                                            </node>
+                                          </node>
+                                        </node>
+                                        <node concept="3cpWs6" id="2l$VAMF3CaA" role="3cqZAp">
+                                          <node concept="37vLTw" id="2l$VAMF3CaB" role="3cqZAk">
+                                            <ref role="3cqZAo" node="2l$VAMF3Cag" resolve="originalText" />
+                                          </node>
+                                          <node concept="2b32R4" id="2l$VAMF3CaC" role="lGtFl">
+                                            <node concept="3JmXsc" id="2l$VAMF3CaD" role="2P8S$">
+                                              <node concept="3clFbS" id="2l$VAMF3CaE" role="2VODD2">
+                                                <node concept="3clFbF" id="2l$VAMF3CaF" role="3cqZAp">
+                                                  <node concept="2OqwBi" id="2l$VAMF3CaG" role="3clFbG">
+                                                    <node concept="2OqwBi" id="2l$VAMF3CaH" role="2Oq$k0">
+                                                      <node concept="2OqwBi" id="2l$VAMF3CaI" role="2Oq$k0">
+                                                        <node concept="30H73N" id="2l$VAMF3CaJ" role="2Oq$k0" />
+                                                        <node concept="3TrEf2" id="2l$VAMF3CaK" role="2OqNvi">
+                                                          <ref role="3Tt5mk" to="teg0:J6gp_6ycpL" resolve="descriptionText" />
+                                                        </node>
+                                                      </node>
+                                                      <node concept="3TrEf2" id="2l$VAMF3CaL" role="2OqNvi">
+                                                        <ref role="3Tt5mk" to="tpee:gyVODHa" resolve="body" />
+                                                      </node>
+                                                    </node>
+                                                    <node concept="3Tsc0h" id="2l$VAMF3CaM" role="2OqNvi">
+                                                      <ref role="3TtcxE" to="tpee:fzcqZ_x" resolve="statement" />
+                                                    </node>
+                                                  </node>
+                                                </node>
+                                              </node>
+                                            </node>
+                                          </node>
+                                        </node>
+                                      </node>
+                                      <node concept="1W57fq" id="2l$VAMF3CaN" role="lGtFl">
+                                        <node concept="3IZrLx" id="2l$VAMF3CaO" role="3IZSJc">
+                                          <node concept="3clFbS" id="2l$VAMF3CaP" role="2VODD2">
+                                            <node concept="3clFbF" id="2l$VAMF3CaQ" role="3cqZAp">
+                                              <node concept="1Wc70l" id="2l$VAMF3CaR" role="3clFbG">
+                                                <node concept="2OqwBi" id="2l$VAMF3CaS" role="3uHU7w">
+                                                  <node concept="2OqwBi" id="2l$VAMF3CaT" role="2Oq$k0">
+                                                    <node concept="2OqwBi" id="2l$VAMF3CaU" role="2Oq$k0">
+                                                      <node concept="30H73N" id="2l$VAMF3CaV" role="2Oq$k0" />
+                                                      <node concept="3TrEf2" id="2l$VAMF3CaW" role="2OqNvi">
+                                                        <ref role="3Tt5mk" to="teg0:J6gp_6ycpL" resolve="descriptionText" />
+                                                      </node>
+                                                    </node>
+                                                    <node concept="2Rf3mk" id="2l$VAMF3CaX" role="2OqNvi">
+                                                      <node concept="1xMEDy" id="2l$VAMF3CaY" role="1xVPHs">
+                                                        <node concept="chp4Y" id="2l$VAMF3CaZ" role="ri$Ld">
+                                                          <ref role="cht4Q" to="teg0:2q0cFwEBOkL" resolve="Parameter_smartReferent" />
+                                                        </node>
+                                                      </node>
+                                                    </node>
+                                                  </node>
+                                                  <node concept="1v1jN8" id="2l$VAMF3Cb0" role="2OqNvi" />
+                                                </node>
+                                                <node concept="2OqwBi" id="2l$VAMF3Cb1" role="3uHU7B">
+                                                  <node concept="2OqwBi" id="2l$VAMF3Cb2" role="2Oq$k0">
+                                                    <node concept="30H73N" id="2l$VAMF3Cb3" role="2Oq$k0" />
+                                                    <node concept="3TrEf2" id="2l$VAMF3Cb4" role="2OqNvi">
+                                                      <ref role="3Tt5mk" to="teg0:J6gp_6ycpL" resolve="descriptionText" />
+                                                    </node>
+                                                  </node>
+                                                  <node concept="3x8VRR" id="2l$VAMF3Cb5" role="2OqNvi" />
+                                                </node>
+                                              </node>
+                                            </node>
+                                          </node>
                                         </node>
                                       </node>
                                     </node>
@@ -18167,6 +18506,7 @@
                                         </node>
                                       </node>
                                     </node>
+                                    <node concept="2tJIrI" id="dN43c9PrXq" role="jymVt" />
                                     <node concept="3clFb_" id="1YKLYyyRBli" role="jymVt">
                                       <property role="1EzhhJ" value="false" />
                                       <property role="TrG5h" value="execute" />
@@ -18869,55 +19209,6 @@
                                         </node>
                                         <node concept="37vLTw" id="mEdliwCg3I" role="37wK5m">
                                           <ref role="3cqZAo" node="19dgrWhDrIl" resolve="matchingText" />
-                                        </node>
-                                        <node concept="3clFb_" id="4qdNcH$4uFw" role="jymVt">
-                                          <property role="1EzhhJ" value="false" />
-                                          <property role="TrG5h" value="getDescriptionText" />
-                                          <property role="DiZV1" value="false" />
-                                          <property role="od$2w" value="false" />
-                                          <node concept="3Tm1VV" id="4qdNcH$4uFx" role="1B3o_S" />
-                                          <node concept="17QB3L" id="4qdNcH$4uMn" role="3clF45" />
-                                          <node concept="37vLTG" id="4qdNcH$4uF$" role="3clF46">
-                                            <property role="TrG5h" value="pattern" />
-                                            <node concept="17QB3L" id="4qdNcH$4uW8" role="1tU5fm" />
-                                          </node>
-                                          <node concept="3clFbS" id="4qdNcH$4uFD" role="3clF47">
-                                            <node concept="3cpWs8" id="19dgrWhDrgt" role="3cqZAp">
-                                              <node concept="3cpWsn" id="19dgrWhDrgu" role="3cpWs9">
-                                                <property role="TrG5h" value="shortDescription" />
-                                                <node concept="17QB3L" id="19dgrWhDrll" role="1tU5fm" />
-                                                <node concept="2OqwBi" id="19dgrWhDrgv" role="33vP2m">
-                                                  <node concept="37vLTw" id="19dgrWhDrgw" role="2Oq$k0">
-                                                    <ref role="3cqZAo" node="19dgrWh_gjE" resolve="subconcept" />
-                                                  </node>
-                                                  <node concept="liA8E" id="19dgrWhDrgx" role="2OqNvi">
-                                                    <ref role="37wK5l" to="c17a:~SAbstractConcept.getShortDescription()" resolve="getShortDescription" />
-                                                  </node>
-                                                </node>
-                                              </node>
-                                            </node>
-                                            <node concept="3clFbF" id="19dgrWhDr7J" role="3cqZAp">
-                                              <node concept="3K4zz7" id="19dgrWhDruG" role="3clFbG">
-                                                <node concept="2OqwBi" id="19dgrWhDrAS" role="3K4GZi">
-                                                  <node concept="37vLTw" id="19dgrWhDryv" role="2Oq$k0">
-                                                    <ref role="3cqZAo" node="19dgrWh_gjE" resolve="subconcept" />
-                                                  </node>
-                                                  <node concept="liA8E" id="19dgrWhDrFH" role="2OqNvi">
-                                                    <ref role="37wK5l" to="c17a:~SAbstractConcept.getName()" resolve="getName" />
-                                                  </node>
-                                                </node>
-                                                <node concept="37vLTw" id="19dgrWhDrwQ" role="3K4E3e">
-                                                  <ref role="3cqZAo" node="19dgrWhDrgu" resolve="shortDescription" />
-                                                </node>
-                                                <node concept="3y3z36" id="19dgrWhDrrQ" role="3K4Cdx">
-                                                  <node concept="10Nm6u" id="19dgrWhDrti" role="3uHU7w" />
-                                                  <node concept="37vLTw" id="19dgrWhDrgy" role="3uHU7B">
-                                                    <ref role="3cqZAo" node="19dgrWhDrgu" resolve="shortDescription" />
-                                                  </node>
-                                                </node>
-                                              </node>
-                                            </node>
-                                          </node>
                                         </node>
                                         <node concept="3clFb_" id="4qdNcH$4wrn" role="jymVt">
                                           <property role="1EzhhJ" value="false" />
@@ -21116,31 +21407,6 @@
                                                                             </node>
                                                                           </node>
                                                                           <node concept="3x8VRR" id="6uixmKZ3Uus" role="2OqNvi" />
-                                                                        </node>
-                                                                      </node>
-                                                                    </node>
-                                                                  </node>
-                                                                </node>
-                                                                <node concept="gft3U" id="6uixmKZ42U3" role="UU_$l">
-                                                                  <node concept="3clFb_" id="6uixmKZ43hp" role="gfFT$">
-                                                                    <property role="1EzhhJ" value="false" />
-                                                                    <property role="TrG5h" value="getDescriptionText" />
-                                                                    <property role="DiZV1" value="false" />
-                                                                    <property role="od$2w" value="false" />
-                                                                    <node concept="3Tm1VV" id="6uixmKZ43hq" role="1B3o_S" />
-                                                                    <node concept="17QB3L" id="6uixmKZ43hr" role="3clF45" />
-                                                                    <node concept="37vLTG" id="6uixmKZ43hs" role="3clF46">
-                                                                      <property role="TrG5h" value="string" />
-                                                                      <node concept="17QB3L" id="6uixmKZ43ht" role="1tU5fm" />
-                                                                    </node>
-                                                                    <node concept="3clFbS" id="6uixmKZ43hu" role="3clF47">
-                                                                      <node concept="3clFbF" id="6uixmKZ43hv" role="3cqZAp">
-                                                                        <node concept="2YIFZM" id="6uixmKZ43hw" role="3clFbG">
-                                                                          <ref role="1Pybhc" to="5b0:~NodePresentationUtil" resolve="NodePresentationUtil" />
-                                                                          <ref role="37wK5l" to="5b0:~NodePresentationUtil.descriptionText(org.jetbrains.mps.openapi.language.SAbstractConcept)" resolve="descriptionText" />
-                                                                          <node concept="37vLTw" id="6uixmKZ43hx" role="37wK5m">
-                                                                            <ref role="3cqZAo" node="5n4nn1a7a1f" resolve="subconcept" />
-                                                                          </node>
                                                                         </node>
                                                                       </node>
                                                                     </node>

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/generator/template/main@generator.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/generator/template/main@generator.mps
@@ -240,6 +240,7 @@
         <child id="1137022507850" name="body" index="2VODD2" />
       </concept>
       <concept id="1070462154015" name="jetbrains.mps.baseLanguage.structure.StaticFieldDeclaration" flags="ig" index="Wx3nA" />
+      <concept id="1070475354124" name="jetbrains.mps.baseLanguage.structure.ThisExpression" flags="nn" index="Xjq3P" />
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
       </concept>
@@ -9659,6 +9660,15 @@
                                                                 <node concept="10Nm6u" id="6uixmKZ4uso" role="33vP2m" />
                                                               </node>
                                                             </node>
+                                                            <node concept="3cpWs8" id="1ZlHRbiQw1o" role="3cqZAp">
+                                                              <node concept="3cpWsn" id="1ZlHRbiQw1r" role="3cpWs9">
+                                                                <property role="TrG5h" value="wrappedConcept" />
+                                                                <node concept="3bZ5Sz" id="1ZlHRbiQw1m" role="1tU5fm" />
+                                                                <node concept="3nyPlj" id="1ZlHRbjybAX" role="33vP2m">
+                                                                  <ref role="37wK5l" to="qtqj:~SubstituteMenuItemWrapper.getOutputConcept()" resolve="getOutputConcept" />
+                                                                </node>
+                                                              </node>
+                                                            </node>
                                                             <node concept="3cpWs8" id="6uixmKZ4usp" role="3cqZAp">
                                                               <node concept="3cpWsn" id="6uixmKZ4usq" role="3cpWs9">
                                                                 <property role="TrG5h" value="editorContext" />
@@ -10430,6 +10440,19 @@
                                                         <property role="TrG5h" value="wrappedNode" />
                                                         <node concept="3Tqbb2" id="6uixmKZ4suX" role="1tU5fm" />
                                                         <node concept="10Nm6u" id="6uixmKZ4suY" role="33vP2m" />
+                                                      </node>
+                                                    </node>
+                                                    <node concept="3clFbH" id="1ZlHRbjybBn" role="3cqZAp" />
+                                                    <node concept="3cpWs8" id="1ZlHRbi_Q7L" role="3cqZAp">
+                                                      <node concept="3cpWsn" id="1ZlHRbi_Q7O" role="3cpWs9">
+                                                        <property role="TrG5h" value="wrappedConcept" />
+                                                        <node concept="3bZ5Sz" id="1ZlHRbi_Q7J" role="1tU5fm" />
+                                                        <node concept="2OqwBi" id="1ZlHRbjg$N7" role="33vP2m">
+                                                          <node concept="Xjq3P" id="1ZlHRbjgygJ" role="2Oq$k0" />
+                                                          <node concept="liA8E" id="1ZlHRbjgCHb" role="2OqNvi">
+                                                            <ref role="37wK5l" node="2c84p9Pu6j2" resolve="getOutputConcept" />
+                                                          </node>
+                                                        </node>
                                                       </node>
                                                     </node>
                                                     <node concept="3cpWs8" id="6uixmKZ4suZ" role="3cqZAp">
@@ -11525,6 +11548,15 @@
                                                     <property role="TrG5h" value="wrappedNode" />
                                                     <node concept="3Tqbb2" id="6uixmKZ4ezu" role="1tU5fm" />
                                                     <node concept="10Nm6u" id="6uixmKZ4g8k" role="33vP2m" />
+                                                  </node>
+                                                </node>
+                                                <node concept="3cpWs8" id="1ZlHRbiA73P" role="3cqZAp">
+                                                  <node concept="3cpWsn" id="1ZlHRbiA73S" role="3cpWs9">
+                                                    <property role="TrG5h" value="wrappedConcept" />
+                                                    <node concept="3bZ5Sz" id="1ZlHRbiA73N" role="1tU5fm" />
+                                                    <node concept="2GrUjf" id="1ZlHRbjygSk" role="33vP2m">
+                                                      <ref role="2Gs0qQ" node="5AkACHrYHAX" resolve="subconcept" />
+                                                    </node>
                                                   </node>
                                                 </node>
                                                 <node concept="3cpWs8" id="6uixmKZ4p9c" role="3cqZAp">
@@ -20601,6 +20633,7 @@
                               <node concept="3cpWs8" id="6B579NGr$GM" role="3cqZAp">
                                 <node concept="3cpWsn" id="6B579NGr$GN" role="3cpWs9">
                                   <property role="TrG5h" value="expectedConcept" />
+                                  <property role="3TUv4t" value="true" />
                                   <node concept="3bZ5Sz" id="6B579NGr$GO" role="1tU5fm" />
                                   <node concept="3K4zz7" id="6B579NGr$GP" role="33vP2m">
                                     <node concept="10Nm6u" id="6B579NGr$GQ" role="3K4E3e" />
@@ -21011,6 +21044,18 @@
                                                                       </node>
                                                                       <node concept="liA8E" id="6uixmKZ4$6T" role="2OqNvi">
                                                                         <ref role="37wK5l" to="uddc:~TransformationMenuContext.getNode()" resolve="getNode" />
+                                                                      </node>
+                                                                    </node>
+                                                                  </node>
+                                                                </node>
+                                                                <node concept="3cpWs8" id="1ZlHRbintLf" role="3cqZAp">
+                                                                  <node concept="3cpWsn" id="1ZlHRbintLg" role="3cpWs9">
+                                                                    <property role="TrG5h" value="wrappedConcept" />
+                                                                    <node concept="3bZ5Sz" id="1ZlHRbintLh" role="1tU5fm" />
+                                                                    <node concept="2OqwBi" id="2Zbcfw$rtYi" role="33vP2m">
+                                                                      <node concept="Xjq3P" id="2Zbcfw$rr6x" role="2Oq$k0" />
+                                                                      <node concept="liA8E" id="2Zbcfw$rx$x" role="2OqNvi">
+                                                                        <ref role="37wK5l" node="2c84p9PGgPo" resolve="getOutputConcept" />
                                                                       </node>
                                                                     </node>
                                                                   </node>

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/generator/template/main@generator.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/generator/template/main@generator.mps
@@ -1719,18 +1719,6 @@
                                                 <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
                                               </node>
                                               <node concept="3clFbS" id="4owkxKW9$hs" role="3clF47">
-                                                <node concept="3cpWs8" id="1ZlHRbfJYbY" role="3cqZAp">
-                                                  <node concept="3cpWsn" id="1ZlHRbfJYbZ" role="3cpWs9">
-                                                    <property role="TrG5h" value="node" />
-                                                    <node concept="3Tqbb2" id="1ZlHRbfJYc0" role="1tU5fm" />
-                                                    <node concept="2OqwBi" id="1ZlHRbfJYc1" role="33vP2m">
-                                                      <node concept="2kYc5w" id="1ZlHRbfK2sJ" role="2Oq$k0" />
-                                                      <node concept="liA8E" id="1ZlHRbfJYc3" role="2OqNvi">
-                                                        <ref role="37wK5l" to="78sh:~SubstituteMenuContext.getCurrentTargetNode()" resolve="getCurrentTargetNode" />
-                                                      </node>
-                                                    </node>
-                                                  </node>
-                                                </node>
                                                 <node concept="3cpWs8" id="1ZlHRbfJYc4" role="3cqZAp">
                                                   <node concept="3cpWsn" id="1ZlHRbfJYc5" role="3cpWs9">
                                                     <property role="TrG5h" value="originalText" />
@@ -13521,15 +13509,6 @@
                                         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
                                       </node>
                                       <node concept="3clFbS" id="1ZlHRbfYgLA" role="3clF47">
-                                        <node concept="3cpWs8" id="1ZlHRbfYgLB" role="3cqZAp">
-                                          <node concept="3cpWsn" id="1ZlHRbfYgLC" role="3cpWs9">
-                                            <property role="TrG5h" value="node" />
-                                            <node concept="3Tqbb2" id="1ZlHRbfYgLD" role="1tU5fm" />
-                                            <node concept="37vLTw" id="1ZlHRbfYtUD" role="33vP2m">
-                                              <ref role="3cqZAo" node="RbLMy6c0kw" resolve="sourceNode" />
-                                            </node>
-                                          </node>
-                                        </node>
                                         <node concept="3cpWs8" id="1ZlHRbfYgLH" role="3cqZAp">
                                           <node concept="3cpWsn" id="1ZlHRbfYgLI" role="3cpWs9">
                                             <property role="TrG5h" value="originalText" />

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/models/com.mbeddr.mpsutil.grammarcells.migration.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/models/com.mbeddr.mpsutil.grammarcells.migration.mps
@@ -19,9 +19,14 @@
     <import index="tpc2" ref="r:00000000-0000-4000-0000-011c8959029e(jetbrains.mps.lang.editor.structure)" />
     <import index="teg0" ref="r:96165ed2-ef22-48c7-bfe5-8fce083cbabb(com.mbeddr.mpsutil.grammarcells.structure)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
+    <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" implicit="true" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
+        <child id="1068498886297" name="rValue" index="37vLTx" />
+        <child id="1068498886295" name="lValue" index="37vLTJ" />
+      </concept>
       <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
       <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
@@ -48,6 +53,7 @@
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
+      <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
       <concept id="1225271283259" name="jetbrains.mps.baseLanguage.structure.NPEEqualsExpression" flags="nn" index="17R0WA" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
@@ -153,6 +159,9 @@
       <concept id="6985522012210254362" name="jetbrains.mps.lang.quotation.structure.NodeBuilderPropertyExpression" flags="nn" index="WxPPo">
         <child id="6985522012210254363" name="expression" index="WxPPp" />
       </concept>
+      <concept id="8182547171709752110" name="jetbrains.mps.lang.quotation.structure.NodeBuilderExpression" flags="nn" index="36biLy">
+        <child id="8182547171709752112" name="expression" index="36biLW" />
+      </concept>
       <concept id="8182547171709614739" name="jetbrains.mps.lang.quotation.structure.NodeBuilderRef" flags="nn" index="36bGnv">
         <reference id="8182547171709614741" name="target" index="36bGnp" />
       </concept>
@@ -174,9 +183,15 @@
       <concept id="1678062499342629858" name="jetbrains.mps.lang.smodel.structure.ModuleRefExpression" flags="ng" index="37shsh">
         <child id="1678062499342629861" name="moduleId" index="37shsm" />
       </concept>
+      <concept id="1171999116870" name="jetbrains.mps.lang.smodel.structure.Node_IsNullOperation" flags="nn" index="3w_OXm" />
+      <concept id="1172008320231" name="jetbrains.mps.lang.smodel.structure.Node_IsNotNullOperation" flags="nn" index="3x8VRR" />
       <concept id="1206482823744" name="jetbrains.mps.lang.smodel.structure.Model_AddRootOperation" flags="nn" index="3BYIHo">
         <child id="1206482823746" name="nodeArgument" index="3BYIHq" />
       </concept>
+      <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="nn" index="3TrEf2">
+        <reference id="1138056516764" name="link" index="3Tt5mk" />
+      </concept>
+      <concept id="1228341669568" name="jetbrains.mps.lang.smodel.structure.Node_DetachOperation" flags="nn" index="3YRAZt" />
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
@@ -192,6 +207,7 @@
       <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
         <child id="1204796294226" name="closure" index="23t8la" />
       </concept>
+      <concept id="1204980550705" name="jetbrains.mps.baseLanguage.collections.structure.VisitAllOperation" flags="nn" index="2es0OD" />
       <concept id="1226511727824" name="jetbrains.mps.baseLanguage.collections.structure.SetType" flags="in" index="2hMVRd">
         <child id="1226511765987" name="elementType" index="2hN53Y" />
       </concept>
@@ -408,6 +424,176 @@
       <ref role="3tTeZr" to="slm6:1JWcQ2VeXpD" resolve="check" />
     </node>
     <node concept="3uibUv" id="2izAb4rOmcL" role="1zkMxy">
+      <ref role="3uigEE" to="slm6:5TUCQr2ybBO" resolve="HasMigrationScriptReference" />
+    </node>
+  </node>
+  <node concept="3SyAh_" id="2l$VAMETgoY">
+    <property role="qMTe8" value="1" />
+    <property role="TrG5h" value="ChangeWrapperCell_DescriptionTextToGenericVersion" />
+    <node concept="3Tm1VV" id="2l$VAMETgoZ" role="1B3o_S" />
+    <node concept="3tTeZs" id="2l$VAMETgp0" role="jymVt">
+      <property role="3tTeZt" value="&lt;no execute after&gt;" />
+      <ref role="3tTeZr" to="slm6:7ay_HjIMt1a" resolve="execute after" />
+    </node>
+    <node concept="3tTeZs" id="2l$VAMETgp1" role="jymVt">
+      <property role="3tTeZt" value="&lt;no required data&gt;" />
+      <ref role="3tTeZr" to="slm6:5TUCQr2FPTh" resolve="requires annotation data" />
+    </node>
+    <node concept="3tTeZs" id="2l$VAMETgp2" role="jymVt">
+      <property role="3tTeZt" value="&lt;no produced data&gt;" />
+      <ref role="3tTeZr" to="slm6:5TUCQr2C271" resolve="produces annotation data" />
+    </node>
+    <node concept="2tJIrI" id="2l$VAMETgp3" role="jymVt" />
+    <node concept="3tYpMH" id="2l$VAMETgp4" role="jymVt">
+      <property role="TrG5h" value="isRerunnable" />
+      <property role="3tYpME" value="true" />
+      <ref role="25KYV2" to="slm6:1JWcQ2VeWIs" resolve="isRerunnable" />
+      <node concept="3Tm1VV" id="2l$VAMETgp5" role="1B3o_S" />
+      <node concept="10P_77" id="2l$VAMETgp6" role="1tU5fm" />
+    </node>
+    <node concept="3tTeZs" id="2l$VAMETgp7" role="jymVt">
+      <property role="3tTeZt" value="&lt;description&gt;" />
+      <ref role="3tTeZr" to="slm6:1_lSsE3RFpE" resolve="description" />
+    </node>
+    <node concept="q3mfD" id="2l$VAMETgp8" role="jymVt">
+      <property role="TrG5h" value="execute" />
+      <ref role="2VtyIY" to="slm6:4ubqdNOF9cA" resolve="execute" />
+      <node concept="3Tm1VV" id="2l$VAMETgpa" role="1B3o_S" />
+      <node concept="3clFbS" id="2l$VAMETgpc" role="3clF47">
+        <node concept="1DcWWT" id="2l$VAMETih3" role="3cqZAp">
+          <node concept="3clFbS" id="2l$VAMETih5" role="2LFqv$">
+            <node concept="3clFbF" id="2l$VAMETjpT" role="3cqZAp">
+              <node concept="2OqwBi" id="2l$VAMETn2N" role="3clFbG">
+                <node concept="2OqwBi" id="2l$VAMETjyF" role="2Oq$k0">
+                  <node concept="37vLTw" id="2l$VAMETjpR" role="2Oq$k0">
+                    <ref role="3cqZAo" node="2l$VAMETih6" resolve="model" />
+                  </node>
+                  <node concept="2SmgA7" id="2l$VAMETjHg" role="2OqNvi">
+                    <node concept="chp4Y" id="2l$VAMETjO_" role="1dBWTz">
+                      <ref role="cht4Q" to="teg0:6oKG1kMyo9t" resolve="WrapperCell" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2es0OD" id="2l$VAMETrai" role="2OqNvi">
+                  <node concept="1bVj0M" id="2l$VAMETrak" role="23t8la">
+                    <node concept="3clFbS" id="2l$VAMETral" role="1bW5cS">
+                      <node concept="3clFbJ" id="2l$VAMETtFZ" role="3cqZAp">
+                        <node concept="1Wc70l" id="2l$VAMETw8h" role="3clFbw">
+                          <node concept="2OqwBi" id="2l$VAMETwIp" role="3uHU7w">
+                            <node concept="2OqwBi" id="2l$VAMETwgz" role="2Oq$k0">
+                              <node concept="37vLTw" id="2l$VAMETwdd" role="2Oq$k0">
+                                <ref role="3cqZAo" node="2l$VAMETram" resolve="it" />
+                              </node>
+                              <node concept="3TrEf2" id="2l$VAMETwnj" role="2OqNvi">
+                                <ref role="3Tt5mk" to="teg0:J6gp_6ycpL" resolve="descriptionText" />
+                              </node>
+                            </node>
+                            <node concept="3w_OXm" id="2l$VAMETxhR" role="2OqNvi" />
+                          </node>
+                          <node concept="2OqwBi" id="2l$VAMETv6k" role="3uHU7B">
+                            <node concept="2OqwBi" id="2l$VAMETu68" role="2Oq$k0">
+                              <node concept="37vLTw" id="2l$VAMETtKo" role="2Oq$k0">
+                                <ref role="3cqZAo" node="2l$VAMETram" resolve="it" />
+                              </node>
+                              <node concept="3TrEf2" id="2l$VAMETuGp" role="2OqNvi">
+                                <ref role="3Tt5mk" to="teg0:6uixmKZ2FIJ" resolve="descriptionText_old" />
+                              </node>
+                            </node>
+                            <node concept="3x8VRR" id="2l$VAMETvDu" role="2OqNvi" />
+                          </node>
+                        </node>
+                        <node concept="3clFbS" id="2l$VAMETtG1" role="3clFbx">
+                          <node concept="3clFbF" id="2l$VAMETxwZ" role="3cqZAp">
+                            <node concept="37vLTI" id="2l$VAMET_Hu" role="3clFbG">
+                              <node concept="2pJPEk" id="2l$VAMET_Rw" role="37vLTx">
+                                <node concept="2pJPED" id="2l$VAMET_Ry" role="2pJPEn">
+                                  <ref role="2pJxaS" to="teg0:7PVnOXzFGJ5" resolve="Cell_DescriptionText" />
+                                  <node concept="2pIpSj" id="2l$VAMETAje" role="2pJxcM">
+                                    <ref role="2pIpSl" to="tpee:gyVODHa" resolve="body" />
+                                    <node concept="36biLy" id="2l$VAMETAol" role="28nt2d">
+                                      <node concept="2OqwBi" id="2l$VAMETBPZ" role="36biLW">
+                                        <node concept="2OqwBi" id="2l$VAMETAR4" role="2Oq$k0">
+                                          <node concept="37vLTw" id="2l$VAMETAw$" role="2Oq$k0">
+                                            <ref role="3cqZAo" node="2l$VAMETram" resolve="it" />
+                                          </node>
+                                          <node concept="3TrEf2" id="2l$VAMETBvQ" role="2OqNvi">
+                                            <ref role="3Tt5mk" to="teg0:6uixmKZ2FIJ" resolve="descriptionText_old" />
+                                          </node>
+                                        </node>
+                                        <node concept="3TrEf2" id="2l$VAMETCsZ" role="2OqNvi">
+                                          <ref role="3Tt5mk" to="tpee:gyVODHa" resolve="body" />
+                                        </node>
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                              <node concept="2OqwBi" id="2l$VAMETx$f" role="37vLTJ">
+                                <node concept="37vLTw" id="2l$VAMETxwY" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="2l$VAMETram" resolve="it" />
+                                </node>
+                                <node concept="3TrEf2" id="2l$VAMETytg" role="2OqNvi">
+                                  <ref role="3Tt5mk" to="teg0:J6gp_6ycpL" resolve="descriptionText" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="3clFbF" id="2l$VAMETzyU" role="3cqZAp">
+                            <node concept="2OqwBi" id="2l$VAMETCUs" role="3clFbG">
+                              <node concept="2OqwBi" id="2l$VAMETzPe" role="2Oq$k0">
+                                <node concept="37vLTw" id="2l$VAMETzyS" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="2l$VAMETram" resolve="it" />
+                                </node>
+                                <node concept="3TrEf2" id="2l$VAMET$cb" role="2OqNvi">
+                                  <ref role="3Tt5mk" to="teg0:6uixmKZ2FIJ" resolve="descriptionText_old" />
+                                </node>
+                              </node>
+                              <node concept="3YRAZt" id="2l$VAMETD0H" role="2OqNvi" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="Rh6nW" id="2l$VAMETram" role="1bW2Oz">
+                      <property role="TrG5h" value="it" />
+                      <node concept="2jxLKc" id="2l$VAMETran" role="1tU5fm" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWsn" id="2l$VAMETih6" role="1Duv9x">
+            <property role="TrG5h" value="model" />
+            <node concept="H_c77" id="2l$VAMETith" role="1tU5fm" />
+          </node>
+          <node concept="2OqwBi" id="2l$VAMETiZC" role="1DdaDG">
+            <node concept="37vLTw" id="2l$VAMETiSe" role="2Oq$k0">
+              <ref role="3cqZAo" node="2l$VAMETgpe" resolve="m" />
+            </node>
+            <node concept="liA8E" id="2l$VAMETjg4" role="2OqNvi">
+              <ref role="37wK5l" to="lui2:~SModule.getModels()" resolve="getModels" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="ffn8J" id="2l$VAMETgpe" role="3clF46">
+        <property role="TrG5h" value="m" />
+        <ref role="ffrpq" to="slm6:7fCCGqboj9J" resolve="m" />
+        <node concept="3uibUv" id="2l$VAMETgpd" role="1tU5fm">
+          <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
+        </node>
+      </node>
+      <node concept="q3mfm" id="2l$VAMETgpf" role="3clF45">
+        <ref role="q3mfh" to="slm6:4F5w8gPXEEe" />
+        <ref role="1QQUv3" node="2l$VAMETgp8" resolve="execute" />
+      </node>
+    </node>
+    <node concept="3tTeZs" id="2l$VAMETgpg" role="jymVt">
+      <property role="3tTeZt" value="&lt;no result checking&gt;" />
+      <ref role="3tTeZr" to="slm6:1JWcQ2VeXpD" resolve="check" />
+    </node>
+    <node concept="3uibUv" id="2l$VAMETgph" role="1zkMxy">
       <ref role="3uigEE" to="slm6:5TUCQr2ybBO" resolve="HasMigrationScriptReference" />
     </node>
   </node>

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/models/com/mbeddr/mpsutil/grammarcells/behavior.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/models/com/mbeddr/mpsutil/grammarcells/behavior.mps
@@ -3698,6 +3698,18 @@
             </node>
           </node>
         </node>
+        <node concept="3clFbF" id="1ZlHRbimin7" role="3cqZAp">
+          <node concept="2OqwBi" id="1ZlHRbimin8" role="3clFbG">
+            <node concept="37vLTw" id="1ZlHRbimin9" role="2Oq$k0">
+              <ref role="3cqZAo" node="2q0cFwFbS2K" resolve="params" />
+            </node>
+            <node concept="TSZUe" id="1ZlHRbimina" role="2OqNvi">
+              <node concept="35c_gC" id="1ZlHRbiminb" role="25WWJ7">
+                <ref role="35c_gD" to="teg0:1ZlHRbijA01" resolve="WrapperCell_Condition_wrappedConcept" />
+              </node>
+            </node>
+          </node>
+        </node>
         <node concept="3clFbF" id="2q0cFwFbTTm" role="3cqZAp">
           <node concept="2OqwBi" id="2q0cFwFbUzm" role="3clFbG">
             <node concept="37vLTw" id="2q0cFwFbTTk" role="2Oq$k0">
@@ -4424,6 +4436,30 @@
     </node>
     <node concept="13hLZK" id="7PVnOXzIrnE" role="13h7CW">
       <node concept="3clFbS" id="7PVnOXzIrnF" role="2VODD2" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="1ZlHRbijAaT">
+    <property role="3GE5qa" value="cells" />
+    <ref role="13h7C2" to="teg0:1ZlHRbijA01" resolve="WrapperCell_Condition_wrappedConcept" />
+    <node concept="13i0hz" id="1ZlHRbijAb4" role="13h7CS">
+      <property role="TrG5h" value="getType" />
+      <property role="13i0it" value="false" />
+      <property role="13i0iv" value="false" />
+      <ref role="13i0hy" to="tpek:27DJnJtIQ9C" resolve="getType" />
+      <node concept="3Tm1VV" id="1ZlHRbijAb5" role="1B3o_S" />
+      <node concept="3clFbS" id="1ZlHRbijAb6" role="3clF47">
+        <node concept="3clFbF" id="1ZlHRbimhIi" role="3cqZAp">
+          <node concept="2c44tf" id="1ZlHRbimhIg" role="3clFbG">
+            <node concept="3bZ5Sz" id="1ZlHRbimhL9" role="2c44tc" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tqbb2" id="1ZlHRbijAbk" role="3clF45">
+        <ref role="ehGHo" to="tpee:fz3vP1H" resolve="Type" />
+      </node>
+    </node>
+    <node concept="13hLZK" id="1ZlHRbijAaU" role="13h7CW">
+      <node concept="3clFbS" id="1ZlHRbijAaV" role="2VODD2" />
     </node>
   </node>
 </model>

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/models/com/mbeddr/mpsutil/grammarcells/behavior.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/models/com/mbeddr/mpsutil/grammarcells/behavior.mps
@@ -4332,5 +4332,99 @@
       <node concept="10P_77" id="2EPKBwvmwCx" role="3clF45" />
     </node>
   </node>
+  <node concept="13h7C7" id="7PVnOXzIrnD">
+    <property role="3GE5qa" value="cells" />
+    <ref role="13h7C2" to="teg0:7PVnOXzFGJ5" resolve="Cell_DescriptionText" />
+    <node concept="13i0hz" id="7PVnOXzIrnO" role="13h7CS">
+      <property role="TrG5h" value="getParameterConcepts" />
+      <property role="13i0it" value="false" />
+      <property role="13i0iv" value="false" />
+      <ref role="13i0hy" to="tpek:2xELmDxyi2v" resolve="getParameterConcepts" />
+      <node concept="3Tm1VV" id="7PVnOXzIrnP" role="1B3o_S" />
+      <node concept="3clFbS" id="7PVnOXzIrnQ" role="3clF47">
+        <node concept="3cpWs8" id="7PVnOXzIrnR" role="3cqZAp">
+          <node concept="3cpWsn" id="7PVnOXzIrnS" role="3cpWs9">
+            <property role="TrG5h" value="params" />
+            <node concept="_YKpA" id="7PVnOXzIrnT" role="1tU5fm">
+              <node concept="3bZ5Sz" id="7PVnOXzIrnU" role="_ZDj9">
+                <ref role="3bZ5Sy" to="tpee:g76ryKb" resolve="ConceptFunctionParameter" />
+              </node>
+            </node>
+            <node concept="2ShNRf" id="7PVnOXzIrnV" role="33vP2m">
+              <node concept="Tc6Ow" id="7PVnOXzIrnW" role="2ShVmc">
+                <node concept="3bZ5Sz" id="7PVnOXzIrnX" role="HW$YZ">
+                  <ref role="3bZ5Sy" to="tpee:g76ryKb" resolve="ConceptFunctionParameter" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7PVnOXzIs9U" role="3cqZAp">
+          <node concept="2OqwBi" id="7PVnOXzIs9V" role="3clFbG">
+            <node concept="37vLTw" id="7PVnOXzIs9W" role="2Oq$k0">
+              <ref role="3cqZAo" node="7PVnOXzIrnS" resolve="params" />
+            </node>
+            <node concept="TSZUe" id="7PVnOXzIs9X" role="2OqNvi">
+              <node concept="35c_gC" id="7PVnOXzIs9Y" role="25WWJ7">
+                <ref role="35c_gD" to="teg0:1GvnUgo6Q$w" resolve="Parameter_node" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7PVnOXzMKbe" role="3cqZAp">
+          <node concept="2OqwBi" id="7PVnOXzMKbf" role="3clFbG">
+            <node concept="37vLTw" id="7PVnOXzMKbg" role="2Oq$k0">
+              <ref role="3cqZAo" node="7PVnOXzIrnS" resolve="params" />
+            </node>
+            <node concept="TSZUe" id="7PVnOXzMKbh" role="2OqNvi">
+              <node concept="35c_gC" id="7PVnOXzMKbi" role="25WWJ7">
+                <ref role="35c_gD" to="teg0:6uixmKZ2zAm" resolve="Parameter_OriginalText" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7PVnOXzIroY" role="3cqZAp">
+          <node concept="2OqwBi" id="7PVnOXzIroZ" role="3clFbG">
+            <node concept="37vLTw" id="7PVnOXzIrp0" role="2Oq$k0">
+              <ref role="3cqZAo" node="7PVnOXzIrnS" resolve="params" />
+            </node>
+            <node concept="TSZUe" id="7PVnOXzIrp1" role="2OqNvi">
+              <node concept="35c_gC" id="7PVnOXzIrp2" role="25WWJ7">
+                <ref role="35c_gD" to="teg0:2aaSxIgh9is" resolve="Parameter_editorContext" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7PVnOXzIrp3" role="3cqZAp">
+          <node concept="37vLTw" id="7PVnOXzIrp4" role="3clFbG">
+            <ref role="3cqZAo" node="7PVnOXzIrnS" resolve="params" />
+          </node>
+        </node>
+      </node>
+      <node concept="_YKpA" id="7PVnOXzIrp5" role="3clF45">
+        <node concept="3bZ5Sz" id="7PVnOXzIrp6" role="_ZDj9">
+          <ref role="3bZ5Sy" to="tpee:g76ryKb" resolve="ConceptFunctionParameter" />
+        </node>
+      </node>
+    </node>
+    <node concept="13i0hz" id="1ZlHRbfyFea" role="13h7CS">
+      <property role="TrG5h" value="getExpectedReturnType" />
+      <property role="13i0it" value="false" />
+      <property role="13i0iv" value="false" />
+      <ref role="13i0hy" to="tpek:hEwIGRD" resolve="getExpectedReturnType" />
+      <node concept="3Tm1VV" id="1ZlHRbfyFeb" role="1B3o_S" />
+      <node concept="3clFbS" id="1ZlHRbfyFec" role="3clF47">
+        <node concept="3clFbF" id="1ZlHRbfyFed" role="3cqZAp">
+          <node concept="2c44tf" id="1ZlHRbfyFee" role="3clFbG">
+            <node concept="17QB3L" id="1ZlHRbfyFef" role="2c44tc" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tqbb2" id="1ZlHRbfyFeg" role="3clF45" />
+    </node>
+    <node concept="13hLZK" id="7PVnOXzIrnE" role="13h7CW">
+      <node concept="3clFbS" id="7PVnOXzIrnF" role="2VODD2" />
+    </node>
+  </node>
 </model>
 

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/models/com/mbeddr/mpsutil/grammarcells/behavior.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/models/com/mbeddr/mpsutil/grammarcells/behavior.mps
@@ -2255,6 +2255,64 @@
         <ref role="ehGHo" to="tpc2:fBEYTCT" resolve="EditorCellModel" />
       </node>
     </node>
+    <node concept="13i0hz" id="dN43cd4jlu" role="13h7CS">
+      <property role="TrG5h" value="getDescriptionFunctionParameters" />
+      <ref role="13i0hy" node="2l$VAMESpmP" resolve="getDescriptionFunctionParameters" />
+      <node concept="3Tm1VV" id="dN43cd4jlv" role="1B3o_S" />
+      <node concept="3clFbS" id="dN43cd4jlV" role="3clF47">
+        <node concept="3cpWs8" id="dN43cd4jr2" role="3cqZAp">
+          <node concept="3cpWsn" id="dN43cd4jr3" role="3cpWs9">
+            <property role="TrG5h" value="params" />
+            <node concept="_YKpA" id="dN43cd4jr4" role="1tU5fm">
+              <node concept="3bZ5Sz" id="dN43cd4jr5" role="_ZDj9">
+                <ref role="3bZ5Sy" to="tpee:g76ryKb" resolve="ConceptFunctionParameter" />
+              </node>
+            </node>
+            <node concept="2ShNRf" id="dN43cd4jr6" role="33vP2m">
+              <node concept="Tc6Ow" id="dN43cd4jr7" role="2ShVmc">
+                <node concept="3bZ5Sz" id="dN43cd4jr8" role="HW$YZ">
+                  <ref role="3bZ5Sy" to="tpee:g76ryKb" resolve="ConceptFunctionParameter" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="dN43cd4jr9" role="3cqZAp">
+          <node concept="2OqwBi" id="dN43cd4jra" role="3clFbG">
+            <node concept="37vLTw" id="dN43cd4jrb" role="2Oq$k0">
+              <ref role="3cqZAo" node="dN43cd4jr3" resolve="params" />
+            </node>
+            <node concept="TSZUe" id="dN43cd4jrc" role="2OqNvi">
+              <node concept="35c_gC" id="dN43cd4jrd" role="25WWJ7">
+                <ref role="35c_gD" to="teg0:1GvnUgo6Q$w" resolve="Parameter_node" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="dN43cd4jre" role="3cqZAp">
+          <node concept="2OqwBi" id="dN43cd4jrf" role="3clFbG">
+            <node concept="37vLTw" id="dN43cd4jrg" role="2Oq$k0">
+              <ref role="3cqZAo" node="dN43cd4jr3" resolve="params" />
+            </node>
+            <node concept="TSZUe" id="dN43cd4jrh" role="2OqNvi">
+              <node concept="35c_gC" id="dN43cd4jri" role="25WWJ7">
+                <ref role="35c_gD" to="teg0:6uixmKZ2zAm" resolve="Parameter_OriginalText" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="dN43cd4jro" role="3cqZAp">
+          <node concept="37vLTw" id="dN43cd4jrp" role="3clFbG">
+            <ref role="3cqZAo" node="dN43cd4jr3" resolve="params" />
+          </node>
+        </node>
+      </node>
+      <node concept="_YKpA" id="dN43cd4jlW" role="3clF45">
+        <node concept="3bZ5Sz" id="dN43cd4jlX" role="_ZDj9">
+          <ref role="3bZ5Sy" to="tpee:g76ryKb" resolve="ConceptFunctionParameter" />
+        </node>
+      </node>
+    </node>
   </node>
   <node concept="13h7C7" id="3O7ZvCZLSPE">
     <property role="3GE5qa" value="inlineActions" />

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/models/com/mbeddr/mpsutil/grammarcells/behavior.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/models/com/mbeddr/mpsutil/grammarcells/behavior.mps
@@ -1053,6 +1053,218 @@
         <ref role="ehGHo" to="tpc2:fBEYTCT" resolve="EditorCellModel" />
       </node>
     </node>
+    <node concept="13i0hz" id="2l$VAMEXUZ3" role="13h7CS">
+      <property role="TrG5h" value="getDescriptionFunctionParameters" />
+      <ref role="13i0hy" node="2l$VAMESpmP" resolve="getDescriptionFunctionParameters" />
+      <node concept="3Tm1VV" id="2l$VAMEXUZ4" role="1B3o_S" />
+      <node concept="3clFbS" id="2l$VAMEXUZw" role="3clF47">
+        <node concept="3cpWs8" id="2l$VAMEXVf7" role="3cqZAp">
+          <node concept="3cpWsn" id="2l$VAMEXVf8" role="3cpWs9">
+            <property role="TrG5h" value="params" />
+            <node concept="_YKpA" id="2l$VAMEXVf9" role="1tU5fm">
+              <node concept="3bZ5Sz" id="2l$VAMEXVfa" role="_ZDj9">
+                <ref role="3bZ5Sy" to="tpee:g76ryKb" resolve="ConceptFunctionParameter" />
+              </node>
+            </node>
+            <node concept="2ShNRf" id="2l$VAMEXVfb" role="33vP2m">
+              <node concept="Tc6Ow" id="2l$VAMEXVfc" role="2ShVmc">
+                <node concept="3bZ5Sz" id="2l$VAMEXVfd" role="HW$YZ">
+                  <ref role="3bZ5Sy" to="tpee:g76ryKb" resolve="ConceptFunctionParameter" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="2l$VAMEXVfe" role="3cqZAp" />
+        <node concept="3clFbF" id="2l$VAMEXVff" role="3cqZAp">
+          <node concept="2OqwBi" id="2l$VAMEXVfg" role="3clFbG">
+            <node concept="37vLTw" id="2l$VAMEXVfh" role="2Oq$k0">
+              <ref role="3cqZAo" node="2l$VAMEXVf8" resolve="params" />
+            </node>
+            <node concept="TSZUe" id="2l$VAMEXVfi" role="2OqNvi">
+              <node concept="35c_gC" id="2l$VAMEXVfj" role="25WWJ7">
+                <ref role="35c_gD" to="teg0:1Ia5rYl_yXg" resolve="WrapperCell_Condition_wrappedNode" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="2l$VAMEXVfk" role="3cqZAp">
+          <node concept="2OqwBi" id="2l$VAMEXVfl" role="3clFbG">
+            <node concept="37vLTw" id="2l$VAMEXVfm" role="2Oq$k0">
+              <ref role="3cqZAo" node="2l$VAMEXVf8" resolve="params" />
+            </node>
+            <node concept="TSZUe" id="2l$VAMEXVfn" role="2OqNvi">
+              <node concept="35c_gC" id="2l$VAMEXVfo" role="25WWJ7">
+                <ref role="35c_gD" to="teg0:1ZlHRbijA01" resolve="WrapperCell_Condition_wrappedConcept" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="2l$VAMEXVfp" role="3cqZAp">
+          <node concept="2OqwBi" id="2l$VAMEXVfq" role="3clFbG">
+            <node concept="37vLTw" id="2l$VAMEXVfr" role="2Oq$k0">
+              <ref role="3cqZAo" node="2l$VAMEXVf8" resolve="params" />
+            </node>
+            <node concept="TSZUe" id="2l$VAMEXVfs" role="2OqNvi">
+              <node concept="35c_gC" id="2l$VAMEXVft" role="25WWJ7">
+                <ref role="35c_gD" to="teg0:2uT2PLmXmjz" resolve="Parameter_SubConcept" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="2l$VAMEXVfu" role="3cqZAp">
+          <node concept="2OqwBi" id="2l$VAMEXVfv" role="3clFbG">
+            <node concept="37vLTw" id="2l$VAMEXVfw" role="2Oq$k0">
+              <ref role="3cqZAo" node="2l$VAMEXVf8" resolve="params" />
+            </node>
+            <node concept="TSZUe" id="2l$VAMEXVfx" role="2OqNvi">
+              <node concept="35c_gC" id="2l$VAMEXVfy" role="25WWJ7">
+                <ref role="35c_gD" to="teg0:6uixmKZ2zAm" resolve="Parameter_OriginalText" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="2l$VAMEXVfz" role="3cqZAp" />
+        <node concept="3SKdUt" id="2l$VAMEXVf$" role="3cqZAp">
+          <node concept="1PaTwC" id="2l$VAMEXVf_" role="1aUNEU">
+            <node concept="3oM_SD" id="2l$VAMEXVfA" role="1PaTwD">
+              <property role="3oM_SC" value="add" />
+            </node>
+            <node concept="3oM_SD" id="2l$VAMEXVfB" role="1PaTwD">
+              <property role="3oM_SC" value="smartRef" />
+            </node>
+            <node concept="3oM_SD" id="2l$VAMEXVfC" role="1PaTwD">
+              <property role="3oM_SC" value="parameter" />
+            </node>
+            <node concept="3oM_SD" id="2l$VAMEXVfD" role="1PaTwD">
+              <property role="3oM_SC" value="only" />
+            </node>
+            <node concept="3oM_SD" id="2l$VAMEXVfE" role="1PaTwD">
+              <property role="3oM_SC" value="if" />
+            </node>
+            <node concept="3oM_SD" id="2l$VAMEXVfF" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="2l$VAMEXVfG" role="1PaTwD">
+              <property role="3oM_SC" value="wrapped" />
+            </node>
+            <node concept="3oM_SD" id="2l$VAMEXVfH" role="1PaTwD">
+              <property role="3oM_SC" value="concept" />
+            </node>
+            <node concept="3oM_SD" id="2l$VAMEXVfI" role="1PaTwD">
+              <property role="3oM_SC" value="has" />
+            </node>
+            <node concept="3oM_SD" id="2l$VAMEXVfJ" role="1PaTwD">
+              <property role="3oM_SC" value="a" />
+            </node>
+            <node concept="3oM_SD" id="2l$VAMEXVfK" role="1PaTwD">
+              <property role="3oM_SC" value="smart" />
+            </node>
+            <node concept="3oM_SD" id="2l$VAMEXVfL" role="1PaTwD">
+              <property role="3oM_SC" value="reference" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="2l$VAMEXVfM" role="3cqZAp">
+          <node concept="3cpWsn" id="2l$VAMEXVfN" role="3cpWs9">
+            <property role="TrG5h" value="wrappedConcept" />
+            <node concept="3Tqbb2" id="2l$VAMEXVfO" role="1tU5fm">
+              <ref role="ehGHo" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
+            </node>
+            <node concept="2OqwBi" id="2l$VAMEXVfP" role="33vP2m">
+              <node concept="FGMqu" id="2l$VAMEXVfQ" role="2OqNvi" />
+              <node concept="2OqwBi" id="2l$VAMEXVfR" role="2Oq$k0">
+                <node concept="2OqwBi" id="2l$VAMEXVfS" role="2Oq$k0">
+                  <node concept="13iPFW" id="2l$VAMEXVfT" role="2Oq$k0" />
+                  <node concept="2Xjw5R" id="2l$VAMEXVfU" role="2OqNvi">
+                    <node concept="1xMEDy" id="2l$VAMEXVfV" role="1xVPHs">
+                      <node concept="chp4Y" id="2l$VAMEXVfW" role="ri$Ld">
+                        <ref role="cht4Q" to="teg0:6oKG1kMyo9t" resolve="WrapperCell" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="2qgKlT" id="2l$VAMEXVfX" role="2OqNvi">
+                  <ref role="37wK5l" node="3O7ZvCZLQaC" resolve="getWrappedConcept" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="Jncv_" id="2l$VAMEXVfY" role="3cqZAp">
+          <ref role="JncvD" to="tpce:f_TIwhg" resolve="ConceptDeclaration" />
+          <node concept="37vLTw" id="2l$VAMEXVfZ" role="JncvB">
+            <ref role="3cqZAo" node="2l$VAMEXVfN" resolve="wrappedConcept" />
+          </node>
+          <node concept="3clFbS" id="2l$VAMEXVg0" role="Jncv$">
+            <node concept="3cpWs8" id="2l$VAMEXVg1" role="3cqZAp">
+              <node concept="3cpWsn" id="2l$VAMEXVg2" role="3cpWs9">
+                <property role="TrG5h" value="smartRefLink" />
+                <node concept="3Tqbb2" id="2l$VAMEXVg3" role="1tU5fm">
+                  <ref role="ehGHo" to="tpce:f_TJgxE" resolve="LinkDeclaration" />
+                </node>
+                <node concept="2YIFZM" id="2l$VAMEXVg4" role="33vP2m">
+                  <ref role="1Pybhc" to="twe9:1yWNr0biLwW" resolve="SmartRefAttributeUtil" />
+                  <ref role="37wK5l" to="twe9:6vCx0seF9Xh" resolve="getCharacteristicLinkDeclaration" />
+                  <node concept="Jnkvi" id="2l$VAMEXVg5" role="37wK5m">
+                    <ref role="1M0zk5" node="2l$VAMEXVgg" resolve="conceptDecl" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbJ" id="2l$VAMEXVg6" role="3cqZAp">
+              <node concept="3clFbS" id="2l$VAMEXVg7" role="3clFbx">
+                <node concept="3clFbF" id="2l$VAMEXVg8" role="3cqZAp">
+                  <node concept="2OqwBi" id="2l$VAMEXVg9" role="3clFbG">
+                    <node concept="37vLTw" id="2l$VAMEXVga" role="2Oq$k0">
+                      <ref role="3cqZAo" node="2l$VAMEXVf8" resolve="params" />
+                    </node>
+                    <node concept="TSZUe" id="2l$VAMEXVgb" role="2OqNvi">
+                      <node concept="35c_gC" id="2l$VAMEXVgc" role="25WWJ7">
+                        <ref role="35c_gD" to="teg0:2q0cFwEBOkL" resolve="Parameter_smartReferent" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="2OqwBi" id="2l$VAMEXVgd" role="3clFbw">
+                <node concept="37vLTw" id="2l$VAMEXVge" role="2Oq$k0">
+                  <ref role="3cqZAo" node="2l$VAMEXVg2" resolve="smartRefLink" />
+                </node>
+                <node concept="3x8VRR" id="2l$VAMEXVgf" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
+          <node concept="JncvC" id="2l$VAMEXVgg" role="JncvA">
+            <property role="TrG5h" value="conceptDecl" />
+            <node concept="2jxLKc" id="2l$VAMEXVgh" role="1tU5fm" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="2l$VAMEXVgi" role="3cqZAp" />
+        <node concept="3clFbF" id="2l$VAMEXVgj" role="3cqZAp">
+          <node concept="2OqwBi" id="2l$VAMEXVgk" role="3clFbG">
+            <node concept="37vLTw" id="2l$VAMEXVgl" role="2Oq$k0">
+              <ref role="3cqZAo" node="2l$VAMEXVf8" resolve="params" />
+            </node>
+            <node concept="TSZUe" id="2l$VAMEXVgm" role="2OqNvi">
+              <node concept="35c_gC" id="2l$VAMEXVgn" role="25WWJ7">
+                <ref role="35c_gD" to="teg0:2aaSxIgh9is" resolve="Parameter_editorContext" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="2l$VAMEXVgo" role="3cqZAp">
+          <node concept="37vLTw" id="2l$VAMEXVgp" role="3clFbG">
+            <ref role="3cqZAo" node="2l$VAMEXVf8" resolve="params" />
+          </node>
+        </node>
+      </node>
+      <node concept="_YKpA" id="2l$VAMEXUZx" role="3clF45">
+        <node concept="3bZ5Sz" id="2l$VAMEXUZy" role="_ZDj9">
+          <ref role="3bZ5Sy" to="tpee:g76ryKb" resolve="ConceptFunctionParameter" />
+        </node>
+      </node>
+    </node>
   </node>
   <node concept="13h7C7" id="1Ia5rYl_Jpd">
     <property role="3GE5qa" value="cells" />

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/models/com/mbeddr/mpsutil/grammarcells/behavior.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/models/com/mbeddr/mpsutil/grammarcells/behavior.mps
@@ -25,7 +25,7 @@
     <import index="twe9" ref="r:28e6d713-c3c3-493e-8d97-e9a2c49f28ce(jetbrains.mps.lang.structure.util)" />
     <import index="v95p" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.lang.editor.menus(MPS.Editor/)" />
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
-    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" />
     <import index="tpdg" ref="r:00000000-0000-4000-0000-011c895902a8(jetbrains.mps.lang.actions.structure)" implicit="true" />
     <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" implicit="true" />
   </imports>
@@ -306,6 +306,7 @@
       <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
       <concept id="1160600644654" name="jetbrains.mps.baseLanguage.collections.structure.ListCreatorWithInit" flags="nn" index="Tc6Ow" />
       <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
+      <concept id="1160666733551" name="jetbrains.mps.baseLanguage.collections.structure.AddAllElementsOperation" flags="nn" index="X8dFx" />
       <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
       <concept id="1240687580870" name="jetbrains.mps.baseLanguage.collections.structure.JoinOperation" flags="nn" index="3uJxvA">
         <child id="1240687658305" name="delimiter" index="3uJOhx" />
@@ -427,6 +428,64 @@
               <node concept="17RvpY" id="6ASs6LmY0Do" role="2OqNvi" />
             </node>
           </node>
+        </node>
+      </node>
+    </node>
+    <node concept="13i0hz" id="2l$VAMESzLz" role="13h7CS">
+      <property role="TrG5h" value="getDescriptionFunctionParameters" />
+      <ref role="13i0hy" node="2l$VAMESpmP" resolve="getDescriptionFunctionParameters" />
+      <node concept="3Tm1VV" id="2l$VAMESzL$" role="1B3o_S" />
+      <node concept="3clFbS" id="2l$VAMESzM0" role="3clF47">
+        <node concept="3cpWs8" id="2l$VAMES$8P" role="3cqZAp">
+          <node concept="3cpWsn" id="2l$VAMES$8Q" role="3cpWs9">
+            <property role="TrG5h" value="params" />
+            <node concept="_YKpA" id="2l$VAMES$8R" role="1tU5fm">
+              <node concept="3bZ5Sz" id="2l$VAMES$8S" role="_ZDj9">
+                <ref role="3bZ5Sy" to="tpee:g76ryKb" resolve="ConceptFunctionParameter" />
+              </node>
+            </node>
+            <node concept="2ShNRf" id="2l$VAMES$8T" role="33vP2m">
+              <node concept="Tc6Ow" id="2l$VAMES$8U" role="2ShVmc">
+                <node concept="3bZ5Sz" id="2l$VAMES$8V" role="HW$YZ">
+                  <ref role="3bZ5Sy" to="tpee:g76ryKb" resolve="ConceptFunctionParameter" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="2l$VAMES$91" role="3cqZAp">
+          <node concept="2OqwBi" id="2l$VAMES$92" role="3clFbG">
+            <node concept="37vLTw" id="2l$VAMES$93" role="2Oq$k0">
+              <ref role="3cqZAo" node="2l$VAMES$8Q" resolve="params" />
+            </node>
+            <node concept="TSZUe" id="2l$VAMES$94" role="2OqNvi">
+              <node concept="35c_gC" id="2l$VAMES$95" role="25WWJ7">
+                <ref role="35c_gD" to="teg0:6uixmKZ2zAm" resolve="Parameter_OriginalText" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="2l$VAMES$96" role="3cqZAp">
+          <node concept="2OqwBi" id="2l$VAMES$97" role="3clFbG">
+            <node concept="37vLTw" id="2l$VAMES$98" role="2Oq$k0">
+              <ref role="3cqZAo" node="2l$VAMES$8Q" resolve="params" />
+            </node>
+            <node concept="TSZUe" id="2l$VAMES$99" role="2OqNvi">
+              <node concept="35c_gC" id="2l$VAMES$9a" role="25WWJ7">
+                <ref role="35c_gD" to="teg0:2aaSxIgh9is" resolve="Parameter_editorContext" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="2l$VAMES$9b" role="3cqZAp">
+          <node concept="37vLTw" id="2l$VAMES$9c" role="3clFbG">
+            <ref role="3cqZAo" node="2l$VAMES$8Q" resolve="params" />
+          </node>
+        </node>
+      </node>
+      <node concept="_YKpA" id="2l$VAMESzM1" role="3clF45">
+        <node concept="3bZ5Sz" id="2l$VAMESzM2" role="_ZDj9">
+          <ref role="3bZ5Sy" to="tpee:g76ryKb" resolve="ConceptFunctionParameter" />
         </node>
       </node>
     </node>
@@ -4371,57 +4430,45 @@
             </node>
           </node>
         </node>
-        <node concept="3clFbJ" id="2Zbcfw_ckXj" role="3cqZAp">
-          <node concept="3clFbS" id="2Zbcfw_ckXl" role="3clFbx">
-            <node concept="3clFbF" id="7PVnOXzIs9U" role="3cqZAp">
-              <node concept="2OqwBi" id="7PVnOXzIs9V" role="3clFbG">
-                <node concept="37vLTw" id="7PVnOXzIs9W" role="2Oq$k0">
+        <node concept="3clFbJ" id="2l$VAMESpVM" role="3cqZAp">
+          <node concept="3clFbS" id="2l$VAMESpVO" role="3clFbx">
+            <node concept="3clFbF" id="2l$VAMESs4M" role="3cqZAp">
+              <node concept="2OqwBi" id="2l$VAMESsRB" role="3clFbG">
+                <node concept="37vLTw" id="2l$VAMESs4K" role="2Oq$k0">
                   <ref role="3cqZAo" node="7PVnOXzIrnS" resolve="params" />
                 </node>
-                <node concept="TSZUe" id="7PVnOXzIs9X" role="2OqNvi">
-                  <node concept="35c_gC" id="7PVnOXzIs9Y" role="25WWJ7">
-                    <ref role="35c_gD" to="teg0:1GvnUgo6Q$w" resolve="Parameter_node" />
+                <node concept="X8dFx" id="2l$VAMESv9$" role="2OqNvi">
+                  <node concept="2OqwBi" id="2l$VAMESv9A" role="25WWJ7">
+                    <node concept="2OqwBi" id="2l$VAMESv9B" role="2Oq$k0">
+                      <node concept="13iPFW" id="2l$VAMESv9C" role="2Oq$k0" />
+                      <node concept="2Xjw5R" id="2l$VAMESv9D" role="2OqNvi">
+                        <node concept="1xMEDy" id="2l$VAMESv9E" role="1xVPHs">
+                          <node concept="chp4Y" id="2l$VAMESv9F" role="ri$Ld">
+                            <ref role="cht4Q" to="teg0:J6gp_6ycpK" resolve="ICanHaveDescriptionText" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2qgKlT" id="2l$VAMESv9G" role="2OqNvi">
+                      <ref role="37wK5l" node="2l$VAMESpmP" resolve="getDescriptionFunctionParameters" />
+                    </node>
                   </node>
                 </node>
               </node>
             </node>
           </node>
-          <node concept="2OqwBi" id="2Zbcfw_cmzq" role="3clFbw">
-            <node concept="2OqwBi" id="2Zbcfw_clw3" role="2Oq$k0">
-              <node concept="13iPFW" id="2Zbcfw_cl7c" role="2Oq$k0" />
-              <node concept="2Xjw5R" id="2Zbcfw_clV2" role="2OqNvi">
-                <node concept="1xMEDy" id="2Zbcfw_clV4" role="1xVPHs">
-                  <node concept="chp4Y" id="2Zbcfw_cm1J" role="ri$Ld">
-                    <ref role="cht4Q" to="teg0:6oKG1kMxv_T" resolve="FlagCell" />
+          <node concept="2OqwBi" id="2l$VAMESrtf" role="3clFbw">
+            <node concept="2OqwBi" id="2l$VAMESqoG" role="2Oq$k0">
+              <node concept="13iPFW" id="2l$VAMESq0q" role="2Oq$k0" />
+              <node concept="2Xjw5R" id="2l$VAMESqOM" role="2OqNvi">
+                <node concept="1xMEDy" id="2l$VAMESqOO" role="1xVPHs">
+                  <node concept="chp4Y" id="2l$VAMESrcZ" role="ri$Ld">
+                    <ref role="cht4Q" to="teg0:J6gp_6ycpK" resolve="ICanHaveDescriptionText" />
                   </node>
                 </node>
               </node>
             </node>
-            <node concept="3w_OXm" id="2Zbcfw_cncb" role="2OqNvi" />
-          </node>
-        </node>
-        <node concept="3clFbF" id="7PVnOXzMKbe" role="3cqZAp">
-          <node concept="2OqwBi" id="7PVnOXzMKbf" role="3clFbG">
-            <node concept="37vLTw" id="7PVnOXzMKbg" role="2Oq$k0">
-              <ref role="3cqZAo" node="7PVnOXzIrnS" resolve="params" />
-            </node>
-            <node concept="TSZUe" id="7PVnOXzMKbh" role="2OqNvi">
-              <node concept="35c_gC" id="7PVnOXzMKbi" role="25WWJ7">
-                <ref role="35c_gD" to="teg0:6uixmKZ2zAm" resolve="Parameter_OriginalText" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="7PVnOXzIroY" role="3cqZAp">
-          <node concept="2OqwBi" id="7PVnOXzIroZ" role="3clFbG">
-            <node concept="37vLTw" id="7PVnOXzIrp0" role="2Oq$k0">
-              <ref role="3cqZAo" node="7PVnOXzIrnS" resolve="params" />
-            </node>
-            <node concept="TSZUe" id="7PVnOXzIrp1" role="2OqNvi">
-              <node concept="35c_gC" id="7PVnOXzIrp2" role="25WWJ7">
-                <ref role="35c_gD" to="teg0:2aaSxIgh9is" resolve="Parameter_editorContext" />
-              </node>
-            </node>
+            <node concept="3x8VRR" id="2l$VAMESrHT" role="2OqNvi" />
           </node>
         </node>
         <node concept="3clFbF" id="7PVnOXzIrp3" role="3cqZAp">
@@ -4477,6 +4524,83 @@
     </node>
     <node concept="13hLZK" id="1ZlHRbijAaU" role="13h7CW">
       <node concept="3clFbS" id="1ZlHRbijAaV" role="2VODD2" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="2l$VAMESp03">
+    <property role="3GE5qa" value="cells" />
+    <ref role="13h7C2" to="teg0:J6gp_6ycpK" resolve="ICanHaveDescriptionText" />
+    <node concept="13i0hz" id="2l$VAMESpmP" role="13h7CS">
+      <property role="TrG5h" value="getDescriptionFunctionParameters" />
+      <property role="13i0it" value="true" />
+      <node concept="3Tm1VV" id="2l$VAMESpmQ" role="1B3o_S" />
+      <node concept="3clFbS" id="2l$VAMESpmS" role="3clF47">
+        <node concept="3cpWs8" id="2l$VAMESz24" role="3cqZAp">
+          <node concept="3cpWsn" id="2l$VAMESz25" role="3cpWs9">
+            <property role="TrG5h" value="params" />
+            <node concept="_YKpA" id="2l$VAMESz26" role="1tU5fm">
+              <node concept="3bZ5Sz" id="2l$VAMESz27" role="_ZDj9">
+                <ref role="3bZ5Sy" to="tpee:g76ryKb" resolve="ConceptFunctionParameter" />
+              </node>
+            </node>
+            <node concept="2ShNRf" id="2l$VAMESz28" role="33vP2m">
+              <node concept="Tc6Ow" id="2l$VAMESz29" role="2ShVmc">
+                <node concept="3bZ5Sz" id="2l$VAMESz2a" role="HW$YZ">
+                  <ref role="3bZ5Sy" to="tpee:g76ryKb" resolve="ConceptFunctionParameter" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7PVnOXzIs9U" role="3cqZAp">
+          <node concept="2OqwBi" id="7PVnOXzIs9V" role="3clFbG">
+            <node concept="37vLTw" id="7PVnOXzIs9W" role="2Oq$k0">
+              <ref role="3cqZAo" node="2l$VAMESz25" resolve="params" />
+            </node>
+            <node concept="TSZUe" id="7PVnOXzIs9X" role="2OqNvi">
+              <node concept="35c_gC" id="7PVnOXzIs9Y" role="25WWJ7">
+                <ref role="35c_gD" to="teg0:1GvnUgo6Q$w" resolve="Parameter_node" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7PVnOXzMKbe" role="3cqZAp">
+          <node concept="2OqwBi" id="7PVnOXzMKbf" role="3clFbG">
+            <node concept="37vLTw" id="7PVnOXzMKbg" role="2Oq$k0">
+              <ref role="3cqZAo" node="2l$VAMESz25" resolve="params" />
+            </node>
+            <node concept="TSZUe" id="7PVnOXzMKbh" role="2OqNvi">
+              <node concept="35c_gC" id="7PVnOXzMKbi" role="25WWJ7">
+                <ref role="35c_gD" to="teg0:6uixmKZ2zAm" resolve="Parameter_OriginalText" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7PVnOXzIroY" role="3cqZAp">
+          <node concept="2OqwBi" id="7PVnOXzIroZ" role="3clFbG">
+            <node concept="37vLTw" id="7PVnOXzIrp0" role="2Oq$k0">
+              <ref role="3cqZAo" node="2l$VAMESz25" resolve="params" />
+            </node>
+            <node concept="TSZUe" id="7PVnOXzIrp1" role="2OqNvi">
+              <node concept="35c_gC" id="7PVnOXzIrp2" role="25WWJ7">
+                <ref role="35c_gD" to="teg0:2aaSxIgh9is" resolve="Parameter_editorContext" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="2l$VAMESzgT" role="3cqZAp">
+          <node concept="37vLTw" id="2l$VAMESzgR" role="3clFbG">
+            <ref role="3cqZAo" node="2l$VAMESz25" resolve="params" />
+          </node>
+        </node>
+      </node>
+      <node concept="_YKpA" id="2l$VAMESpn5" role="3clF45">
+        <node concept="3bZ5Sz" id="2l$VAMESpn6" role="_ZDj9">
+          <ref role="3bZ5Sy" to="tpee:g76ryKb" resolve="ConceptFunctionParameter" />
+        </node>
+      </node>
+    </node>
+    <node concept="13hLZK" id="2l$VAMESp04" role="13h7CW">
+      <node concept="3clFbS" id="2l$VAMESp05" role="2VODD2" />
     </node>
   </node>
 </model>

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/models/com/mbeddr/mpsutil/grammarcells/behavior.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/models/com/mbeddr/mpsutil/grammarcells/behavior.mps
@@ -4371,16 +4371,33 @@
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="7PVnOXzIs9U" role="3cqZAp">
-          <node concept="2OqwBi" id="7PVnOXzIs9V" role="3clFbG">
-            <node concept="37vLTw" id="7PVnOXzIs9W" role="2Oq$k0">
-              <ref role="3cqZAo" node="7PVnOXzIrnS" resolve="params" />
-            </node>
-            <node concept="TSZUe" id="7PVnOXzIs9X" role="2OqNvi">
-              <node concept="35c_gC" id="7PVnOXzIs9Y" role="25WWJ7">
-                <ref role="35c_gD" to="teg0:1GvnUgo6Q$w" resolve="Parameter_node" />
+        <node concept="3clFbJ" id="2Zbcfw_ckXj" role="3cqZAp">
+          <node concept="3clFbS" id="2Zbcfw_ckXl" role="3clFbx">
+            <node concept="3clFbF" id="7PVnOXzIs9U" role="3cqZAp">
+              <node concept="2OqwBi" id="7PVnOXzIs9V" role="3clFbG">
+                <node concept="37vLTw" id="7PVnOXzIs9W" role="2Oq$k0">
+                  <ref role="3cqZAo" node="7PVnOXzIrnS" resolve="params" />
+                </node>
+                <node concept="TSZUe" id="7PVnOXzIs9X" role="2OqNvi">
+                  <node concept="35c_gC" id="7PVnOXzIs9Y" role="25WWJ7">
+                    <ref role="35c_gD" to="teg0:1GvnUgo6Q$w" resolve="Parameter_node" />
+                  </node>
+                </node>
               </node>
             </node>
+          </node>
+          <node concept="2OqwBi" id="2Zbcfw_cmzq" role="3clFbw">
+            <node concept="2OqwBi" id="2Zbcfw_clw3" role="2Oq$k0">
+              <node concept="13iPFW" id="2Zbcfw_cl7c" role="2Oq$k0" />
+              <node concept="2Xjw5R" id="2Zbcfw_clV2" role="2OqNvi">
+                <node concept="1xMEDy" id="2Zbcfw_clV4" role="1xVPHs">
+                  <node concept="chp4Y" id="2Zbcfw_cm1J" role="ri$Ld">
+                    <ref role="cht4Q" to="teg0:6oKG1kMxv_T" resolve="FlagCell" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3w_OXm" id="2Zbcfw_cncb" role="2OqNvi" />
           </node>
         </node>
         <node concept="3clFbF" id="7PVnOXzMKbe" role="3cqZAp">

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/models/com/mbeddr/mpsutil/grammarcells/editor.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/models/com/mbeddr/mpsutil/grammarcells/editor.mps
@@ -2440,7 +2440,7 @@
   <node concept="PKFIW" id="J6gp_6ycIY">
     <property role="3GE5qa" value="cells" />
     <property role="TrG5h" value="DescriptionText" />
-    <ref role="1XX52x" to="teg0:J6gp_6ycpK" resolve="IOptionalDescriptionText" />
+    <ref role="1XX52x" to="teg0:J6gp_6ycpK" resolve="ICanHaveDescriptionText" />
     <node concept="3EZMnI" id="J6gp_6ycJ0" role="2wV5jI">
       <node concept="3F0ifn" id="J6gp_6ycJ1" role="3EZMnx">
         <property role="3F0ifm" value="description:" />

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/models/com/mbeddr/mpsutil/grammarcells/editor.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/models/com/mbeddr/mpsutil/grammarcells/editor.mps
@@ -1079,6 +1079,19 @@
         </node>
       </node>
     </node>
+    <node concept="3EZMnI" id="dN43cd3wZ8" role="6VMZX">
+      <node concept="2iRkQZ" id="dN43cd3wZ9" role="2iSdaV" />
+      <node concept="3F0ifn" id="dN43cd3wZ5" role="3EZMnx">
+        <property role="3F0ifm" value="Substitute cell:" />
+        <ref role="1k5W1q" to="tpc5:hF4yUZ8" resolve="header" />
+      </node>
+      <node concept="3EZMnI" id="dN43cd3wZi" role="3EZMnx">
+        <node concept="2EHx9g" id="dN43cd3wZp" role="2iSdaV" />
+        <node concept="PMmxH" id="dN43cd3wZs" role="3EZMnx">
+          <ref role="PMmxG" node="J6gp_6ycIY" resolve="DescriptionText" />
+        </node>
+      </node>
+    </node>
   </node>
   <node concept="24kQdi" id="1vi_twqJeMu">
     <property role="3GE5qa" value="cells" />

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/models/com/mbeddr/mpsutil/grammarcells/editor.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/models/com/mbeddr/mpsutil/grammarcells/editor.mps
@@ -41,6 +41,7 @@
         <child id="1080736633877" name="cellModel" index="2wV5jI" />
       </concept>
       <concept id="1239814640496" name="jetbrains.mps.lang.editor.structure.CellLayout_VerticalGrid" flags="nn" index="2EHx9g" />
+      <concept id="1078938745671" name="jetbrains.mps.lang.editor.structure.EditorComponentDeclaration" flags="ig" index="PKFIW" />
       <concept id="1078939183254" name="jetbrains.mps.lang.editor.structure.CellModel_Component" flags="sg" stub="3162947552742194261" index="PMmxH">
         <reference id="1078939183255" name="editorComponent" index="PMmxG" />
       </concept>
@@ -457,20 +458,21 @@
       </node>
       <node concept="3F0ifn" id="6uixmKZ2$eH" role="3EZMnx" />
       <node concept="3EZMnI" id="6uixmKZ2EVK" role="3EZMnx">
-        <node concept="3EZMnI" id="6uixmKZ2EVL" role="3EZMnx">
-          <node concept="3F0ifn" id="6uixmKZ2EVM" role="3EZMnx">
+        <node concept="2EHx9g" id="6uixmKZ2EW0" role="2iSdaV" />
+        <node concept="3EZMnI" id="1ZlHRbhokpL" role="3EZMnx">
+          <node concept="3F0ifn" id="1ZlHRbhokpM" role="3EZMnx">
             <property role="3F0ifm" value="description:" />
             <ref role="1k5W1q" to="tpc5:hF4H1c8" resolve="property" />
           </node>
-          <node concept="3F1sOY" id="6uixmKZ2EVN" role="3EZMnx">
+          <node concept="3F1sOY" id="1ZlHRbhokpN" role="3EZMnx">
+            <property role="1$x2rV" value="concept description" />
             <ref role="1NtTu8" to="teg0:6uixmKZ2FIJ" resolve="descriptionText" />
           </node>
-          <node concept="VPXOz" id="6uixmKZ2EVO" role="3F10Kt">
+          <node concept="VPXOz" id="1ZlHRbhokpO" role="3F10Kt">
             <property role="VOm3f" value="true" />
           </node>
-          <node concept="2iRfu4" id="6uixmKZ2EVP" role="2iSdaV" />
+          <node concept="2iRfu4" id="1ZlHRbhokpP" role="2iSdaV" />
         </node>
-        <node concept="2EHx9g" id="6uixmKZ2EW0" role="2iSdaV" />
       </node>
       <node concept="2iRkQZ" id="3h9t8JnexrD" role="2iSdaV" />
     </node>
@@ -880,6 +882,9 @@
           </node>
           <node concept="2iRfu4" id="78yXNxdi31c" role="2iSdaV" />
         </node>
+        <node concept="PMmxH" id="J6gp_6LEHF" role="3EZMnx">
+          <ref role="PMmxG" node="J6gp_6ycIY" resolve="DescriptionText" />
+        </node>
         <node concept="VPXOz" id="6ASs6LmXZ4T" role="3F10Kt">
           <property role="VOm3f" value="true" />
         </node>
@@ -1034,6 +1039,9 @@
             <property role="VOm3f" value="true" />
           </node>
           <node concept="2iRfu4" id="65e5JdYJiFH" role="2iSdaV" />
+        </node>
+        <node concept="PMmxH" id="J6gp_6ydEK" role="3EZMnx">
+          <ref role="PMmxG" node="J6gp_6ycIY" resolve="DescriptionText" />
         </node>
         <node concept="2EHx9g" id="7KznU_3P5iA" role="2iSdaV" />
       </node>
@@ -1850,6 +1858,9 @@
         </node>
         <node concept="2iRfu4" id="6rhOS_xv$_b" role="2iSdaV" />
       </node>
+      <node concept="PMmxH" id="J6gp_6zbfd" role="3EZMnx">
+        <ref role="PMmxG" node="J6gp_6ycIY" resolve="DescriptionText" />
+      </node>
     </node>
   </node>
   <node concept="24kQdi" id="7Q6ZOiKJNMi">
@@ -2424,6 +2435,25 @@
       </node>
       <node concept="2SsqMj" id="2cruuiKBFCz" role="3EZMnx" />
       <node concept="2iRfu4" id="2cruuiKBFCv" role="2iSdaV" />
+    </node>
+  </node>
+  <node concept="PKFIW" id="J6gp_6ycIY">
+    <property role="3GE5qa" value="cells" />
+    <property role="TrG5h" value="DescriptionText" />
+    <ref role="1XX52x" to="teg0:J6gp_6ycpK" resolve="IOptionalDescriptionText" />
+    <node concept="3EZMnI" id="J6gp_6ycJ0" role="2wV5jI">
+      <node concept="3F0ifn" id="J6gp_6ycJ1" role="3EZMnx">
+        <property role="3F0ifm" value="description:" />
+        <ref role="1k5W1q" to="tpc5:hF4H1c8" resolve="property" />
+      </node>
+      <node concept="3F1sOY" id="J6gp_6ycJ2" role="3EZMnx">
+        <property role="1$x2rV" value="concept description" />
+        <ref role="1NtTu8" to="teg0:J6gp_6ycpL" resolve="descriptionText" />
+      </node>
+      <node concept="VPXOz" id="J6gp_6ycJ3" role="3F10Kt">
+        <property role="VOm3f" value="true" />
+      </node>
+      <node concept="2iRfu4" id="J6gp_6ycJ4" role="2iSdaV" />
     </node>
   </node>
 </model>

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/models/com/mbeddr/mpsutil/grammarcells/editor.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/models/com/mbeddr/mpsutil/grammarcells/editor.mps
@@ -454,11 +454,10 @@
           </node>
           <node concept="2iRfu4" id="1GvnUgo6SJE" role="2iSdaV" />
         </node>
+        <node concept="PMmxH" id="2l$VAMEYyz3" role="3EZMnx">
+          <ref role="PMmxG" node="J6gp_6ycIY" resolve="DescriptionText" />
+        </node>
         <node concept="2EHx9g" id="6rhOS_xTjX$" role="2iSdaV" />
-      </node>
-      <node concept="3F0ifn" id="6uixmKZ2$eH" role="3EZMnx" />
-      <node concept="PMmxH" id="2l$VAMEYyz3" role="3EZMnx">
-        <ref role="PMmxG" node="J6gp_6ycIY" resolve="DescriptionText" />
       </node>
       <node concept="2iRkQZ" id="3h9t8JnexrD" role="2iSdaV" />
     </node>
@@ -1113,15 +1112,23 @@
       <node concept="3EZMnI" id="2uT2PLmWyH2" role="3EZMnx">
         <node concept="3F0ifn" id="2uT2PLmWyH3" role="3EZMnx">
           <property role="3F0ifm" value="projection:" />
+          <ref role="1k5W1q" to="tpc5:hF4H1c8" resolve="property" />
         </node>
         <node concept="3F1sOY" id="2uT2PLmWyH4" role="3EZMnx">
           <ref role="1NtTu8" to="teg0:2uT2PLmWwE4" resolve="projection" />
+          <node concept="VPXOz" id="dN43ccfaqS" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
         </node>
         <node concept="2iRfu4" id="2uT2PLmWyH5" role="2iSdaV" />
+        <node concept="VPXOz" id="dN43ccfaqQ" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
       </node>
       <node concept="3EZMnI" id="77A3HzrGy4w" role="3EZMnx">
         <node concept="3F0ifn" id="77A3HzrGy4x" role="3EZMnx">
           <property role="3F0ifm" value="grammar:" />
+          <ref role="1k5W1q" to="tpc5:hF4H1c8" resolve="property" />
         </node>
         <node concept="3F2HdR" id="77A3HzrGy4y" role="3EZMnx">
           <ref role="1NtTu8" to="teg0:77A3HzrGy5f" resolve="rules" />
@@ -1129,8 +1136,14 @@
           <node concept="3F0ifn" id="4mHeUYNeBq7" role="2czzBI">
             <property role="ilYzB" value="&lt;disabled&gt;" />
           </node>
+          <node concept="VPXOz" id="dN43ccfaqW" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
         </node>
         <node concept="2iRfu4" id="77A3HzrGy4$" role="2iSdaV" />
+        <node concept="VPXOz" id="dN43ccfaqU" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
       </node>
       <node concept="2EHx9g" id="2uT2PLmWyHu" role="2iSdaV" />
     </node>
@@ -1331,30 +1344,45 @@
       </node>
       <node concept="l2Vlx" id="77A3HzrGswe" role="2iSdaV" />
     </node>
-    <node concept="3EZMnI" id="77A3HzrGFAX" role="6VMZX">
-      <node concept="2EHx9g" id="77A3HzrGFBh" role="2iSdaV" />
-      <node concept="3EZMnI" id="77A3HzrGFB5" role="3EZMnx">
-        <node concept="2iRfu4" id="77A3HzrGFBm" role="2iSdaV" />
-        <node concept="VPM3Z" id="77A3HzrGFB7" role="3F10Kt">
-          <property role="VOm3f" value="false" />
-        </node>
-        <node concept="3F0ifn" id="77A3HzrGFBr" role="3EZMnx">
-          <property role="3F0ifm" value="left associative (concept&lt;&gt; subconcept):" />
-        </node>
-        <node concept="3F1sOY" id="77A3HzrJqx8" role="3EZMnx">
-          <ref role="1NtTu8" to="teg0:77A3HzrJpWi" resolve="leftAssociative" />
-        </node>
+    <node concept="3EZMnI" id="dN43ccfCUW" role="6VMZX">
+      <node concept="3F0ifn" id="dN43ccfCWl" role="3EZMnx">
+        <property role="3F0ifm" value="Cell based rule:" />
+        <ref role="1k5W1q" to="tpc5:hF4yUZ8" resolve="header" />
       </node>
-      <node concept="3EZMnI" id="77A3HzrGFBP" role="3EZMnx">
-        <node concept="2iRfu4" id="77A3HzrGFBQ" role="2iSdaV" />
-        <node concept="VPM3Z" id="77A3HzrGFBR" role="3F10Kt">
-          <property role="VOm3f" value="false" />
+      <node concept="2iRkQZ" id="dN43ccfCUX" role="2iSdaV" />
+      <node concept="3EZMnI" id="77A3HzrGFAX" role="3EZMnx">
+        <node concept="2EHx9g" id="77A3HzrGFBh" role="2iSdaV" />
+        <node concept="3EZMnI" id="77A3HzrGFB5" role="3EZMnx">
+          <node concept="2iRfu4" id="77A3HzrGFBm" role="2iSdaV" />
+          <node concept="VPM3Z" id="77A3HzrGFB7" role="3F10Kt">
+            <property role="VOm3f" value="false" />
+          </node>
+          <node concept="VPXOz" id="dN43cceIhb" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+          <node concept="3F0ifn" id="77A3HzrGFBr" role="3EZMnx">
+            <property role="3F0ifm" value="left associative (concept&lt;&gt; subconcept):" />
+            <ref role="1k5W1q" to="tpc5:hF4H1c8" resolve="property" />
+          </node>
+          <node concept="3F1sOY" id="77A3HzrJqx8" role="3EZMnx">
+            <ref role="1NtTu8" to="teg0:77A3HzrJpWi" resolve="leftAssociative" />
+          </node>
         </node>
-        <node concept="3F0ifn" id="77A3HzrGFBS" role="3EZMnx">
-          <property role="3F0ifm" value="priority (concept&lt;&gt; subconcept):" />
-        </node>
-        <node concept="3F1sOY" id="77A3HzrJqxq" role="3EZMnx">
-          <ref role="1NtTu8" to="teg0:77A3HzrJqc0" resolve="priority" />
+        <node concept="3EZMnI" id="77A3HzrGFBP" role="3EZMnx">
+          <node concept="2iRfu4" id="77A3HzrGFBQ" role="2iSdaV" />
+          <node concept="VPM3Z" id="77A3HzrGFBR" role="3F10Kt">
+            <property role="VOm3f" value="false" />
+          </node>
+          <node concept="VPXOz" id="dN43cceIhk" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+          <node concept="3F0ifn" id="77A3HzrGFBS" role="3EZMnx">
+            <property role="3F0ifm" value="priority (concept&lt;&gt; subconcept):" />
+            <ref role="1k5W1q" to="tpc5:hF4H1c8" resolve="property" />
+          </node>
+          <node concept="3F1sOY" id="77A3HzrJqxq" role="3EZMnx">
+            <ref role="1NtTu8" to="teg0:77A3HzrJqc0" resolve="priority" />
+          </node>
         </node>
       </node>
     </node>
@@ -1640,14 +1668,22 @@
       </node>
     </node>
     <node concept="3EZMnI" id="6jH9yJK3gIA" role="6VMZX">
+      <node concept="3F0ifn" id="dN43ccfaYG" role="3EZMnx">
+        <property role="3F0ifm" value="Side transformation cell:" />
+        <ref role="1k5W1q" to="tpc5:hF4yUZ8" resolve="header" />
+      </node>
       <node concept="2EHx9g" id="6jH9yJK3rcY" role="2iSdaV" />
       <node concept="3EZMnI" id="6jH9yJK3gLR" role="3EZMnx">
         <node concept="2iRfu4" id="6jH9yJK3gLS" role="2iSdaV" />
         <node concept="VPM3Z" id="6jH9yJK3gLT" role="3F10Kt">
           <property role="VOm3f" value="false" />
         </node>
+        <node concept="VPXOz" id="dN43ccfaYS" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
         <node concept="3F0ifn" id="6jH9yJK3gM6" role="3EZMnx">
           <property role="3F0ifm" value="side:" />
+          <ref role="1k5W1q" to="tpc5:hF4H1c8" resolve="property" />
         </node>
         <node concept="3F0A7n" id="6jH9yJK3gMk" role="3EZMnx">
           <ref role="1NtTu8" to="teg0:7WTFIQIcYwe" resolve="side" />
@@ -1657,8 +1693,12 @@
         <node concept="VPM3Z" id="6jH9yJK3rc3" role="3F10Kt">
           <property role="VOm3f" value="false" />
         </node>
+        <node concept="VPXOz" id="dN43ccfaYV" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
         <node concept="3F0ifn" id="6jH9yJK3rc5" role="3EZMnx">
           <property role="3F0ifm" value="factory:" />
+          <ref role="1k5W1q" to="tpc5:hF4H1c8" resolve="property" />
         </node>
         <node concept="3F1sOY" id="6jH9yJK3rcO" role="3EZMnx">
           <ref role="1NtTu8" to="teg0:6jH9yJK3r7v" resolve="factory" />
@@ -1691,16 +1731,27 @@
       </node>
     </node>
     <node concept="3EZMnI" id="6jH9yJK5uWv" role="6VMZX">
+      <node concept="3F0ifn" id="dN43ccf9qb" role="3EZMnx">
+        <property role="3F0ifm" value="Node substitute cell:" />
+        <ref role="1k5W1q" to="tpc5:hF4yUZ8" resolve="header" />
+      </node>
       <node concept="2EHx9g" id="6jH9yJK5uWw" role="2iSdaV" />
       <node concept="3EZMnI" id="6jH9yJK5uWA" role="3EZMnx">
         <node concept="VPM3Z" id="6jH9yJK5uWB" role="3F10Kt">
           <property role="VOm3f" value="false" />
         </node>
+        <node concept="VPXOz" id="dN43ccf9_J" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
         <node concept="3F0ifn" id="6jH9yJK5uWC" role="3EZMnx">
           <property role="3F0ifm" value="factory:" />
+          <ref role="1k5W1q" to="tpc5:hF4H1c8" resolve="property" />
         </node>
         <node concept="3F1sOY" id="6jH9yJK5uWD" role="3EZMnx">
           <ref role="1NtTu8" to="teg0:6jH9yJK5ut2" resolve="factory" />
+          <node concept="VPXOz" id="dN43ccf9_N" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
         </node>
         <node concept="2iRfu4" id="6jH9yJK5uWE" role="2iSdaV" />
       </node>
@@ -1721,14 +1772,22 @@
       </node>
     </node>
     <node concept="3EZMnI" id="4eBi5gdnlmA" role="6VMZX">
+      <node concept="3F0ifn" id="dN43ccfaXg" role="3EZMnx">
+        <property role="3F0ifm" value="Side transformation cell 2:" />
+        <ref role="1k5W1q" to="tpc5:hF4yUZ8" resolve="header" />
+      </node>
       <node concept="2EHx9g" id="4eBi5gdnEZU" role="2iSdaV" />
       <node concept="3EZMnI" id="4eBi5gdnlmK" role="3EZMnx">
         <node concept="2iRfu4" id="4eBi5gdnlmL" role="2iSdaV" />
         <node concept="VPM3Z" id="4eBi5gdnlmM" role="3F10Kt">
           <property role="VOm3f" value="false" />
         </node>
+        <node concept="VPXOz" id="dN43ccfaWV" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
         <node concept="3F0ifn" id="4eBi5gdnlmZ" role="3EZMnx">
           <property role="3F0ifm" value="matching text:" />
+          <ref role="1k5W1q" to="tpc5:hF4H1c8" resolve="property" />
         </node>
         <node concept="3F1sOY" id="4eBi5gdnlnd" role="3EZMnx">
           <ref role="1NtTu8" to="teg0:4eBi5gdnl37" resolve="matchingText" />
@@ -1739,8 +1798,12 @@
         <node concept="VPM3Z" id="5$jJV5dZWGH" role="3F10Kt">
           <property role="VOm3f" value="false" />
         </node>
+        <node concept="VPXOz" id="dN43ccfaWZ" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
         <node concept="3F0ifn" id="5$jJV5dZWGI" role="3EZMnx">
           <property role="3F0ifm" value="show multiple entries:" />
+          <ref role="1k5W1q" to="tpc5:hF4H1c8" resolve="property" />
         </node>
         <node concept="3F0A7n" id="5$jJV5dZWIV" role="3EZMnx">
           <property role="1$x2rV" value="&lt;best match only&gt;" />
@@ -1752,8 +1815,12 @@
         <node concept="VPM3Z" id="4eBi5gdnlnp" role="3F10Kt">
           <property role="VOm3f" value="false" />
         </node>
+        <node concept="VPXOz" id="dN43ccfaX2" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
         <node concept="3F0ifn" id="4eBi5gdnlnq" role="3EZMnx">
           <property role="3F0ifm" value="is applicable:" />
+          <ref role="1k5W1q" to="tpc5:hF4H1c8" resolve="property" />
         </node>
         <node concept="3F1sOY" id="4eBi5gdnlnr" role="3EZMnx">
           <ref role="1NtTu8" to="teg0:4eBi5gdnl32" resolve="isApplicable" />
@@ -1763,8 +1830,12 @@
         <node concept="VPM3Z" id="4eBi5gdnlp1" role="3F10Kt">
           <property role="VOm3f" value="false" />
         </node>
+        <node concept="VPXOz" id="dN43ccfaX5" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
         <node concept="3F0ifn" id="4eBi5gdnlp3" role="3EZMnx">
           <property role="3F0ifm" value="execute:" />
+          <ref role="1k5W1q" to="tpc5:hF4H1c8" resolve="property" />
         </node>
         <node concept="3F1sOY" id="4eBi5gdnlq6" role="3EZMnx">
           <ref role="1NtTu8" to="teg0:4eBi5gdnlo5" resolve="execute" />
@@ -1797,14 +1868,22 @@
       </node>
     </node>
     <node concept="3EZMnI" id="6rhOS_xv$$V" role="6VMZX">
+      <node concept="3F0ifn" id="dN43ccfaXP" role="3EZMnx">
+        <property role="3F0ifm" value="Side transformation cell 3:" />
+        <ref role="1k5W1q" to="tpc5:hF4yUZ8" resolve="header" />
+      </node>
       <node concept="2EHx9g" id="6rhOS_xv$$W" role="2iSdaV" />
       <node concept="3EZMnI" id="6rhOS_xv$$X" role="3EZMnx">
         <node concept="2iRfu4" id="6rhOS_xv$$Y" role="2iSdaV" />
         <node concept="VPM3Z" id="6rhOS_xv$$Z" role="3F10Kt">
           <property role="VOm3f" value="false" />
         </node>
+        <node concept="VPXOz" id="dN43ccfaYc" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
         <node concept="3F0ifn" id="6rhOS_xv$_0" role="3EZMnx">
           <property role="3F0ifm" value="matching text:" />
+          <ref role="1k5W1q" to="tpc5:hF4H1c8" resolve="property" />
         </node>
         <node concept="3F1sOY" id="6rhOS_xv$_1" role="3EZMnx">
           <ref role="1NtTu8" to="teg0:6rhOS_xvr8s" resolve="matchingText" />
@@ -1815,8 +1894,12 @@
         <node concept="VPM3Z" id="5$jJV5e0$ZG" role="3F10Kt">
           <property role="VOm3f" value="false" />
         </node>
+        <node concept="VPXOz" id="dN43ccfaYf" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
         <node concept="3F0ifn" id="5$jJV5e0$ZH" role="3EZMnx">
           <property role="3F0ifm" value="show multiple entries:" />
+          <ref role="1k5W1q" to="tpc5:hF4H1c8" resolve="property" />
         </node>
         <node concept="3F0A7n" id="5$jJV5e0_1U" role="3EZMnx">
           <property role="1$x2rV" value="&lt;best match only&gt;" />
@@ -1828,8 +1911,12 @@
         <node concept="VPM3Z" id="6rhOS_xv$_4" role="3F10Kt">
           <property role="VOm3f" value="false" />
         </node>
+        <node concept="VPXOz" id="dN43ccfaYi" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
         <node concept="3F0ifn" id="6rhOS_xv$_5" role="3EZMnx">
-          <property role="3F0ifm" value="is appicable:" />
+          <property role="3F0ifm" value="is applicable:" />
+          <ref role="1k5W1q" to="tpc5:hF4H1c8" resolve="property" />
         </node>
         <node concept="3F1sOY" id="6rhOS_xv$_6" role="3EZMnx">
           <ref role="1NtTu8" to="teg0:6rhOS_xvr8r" resolve="isApplicable" />
@@ -1839,8 +1926,12 @@
         <node concept="VPM3Z" id="6rhOS_xv$_8" role="3F10Kt">
           <property role="VOm3f" value="false" />
         </node>
+        <node concept="VPXOz" id="dN43ccfaYl" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
         <node concept="3F0ifn" id="6rhOS_xv$_9" role="3EZMnx">
           <property role="3F0ifm" value="execute:" />
+          <ref role="1k5W1q" to="tpc5:hF4H1c8" resolve="property" />
         </node>
         <node concept="3F1sOY" id="6rhOS_xv$_a" role="3EZMnx">
           <ref role="1NtTu8" to="teg0:6rhOS_xvr8t" resolve="execute" />
@@ -2360,14 +2451,22 @@
       </node>
     </node>
     <node concept="3EZMnI" id="Dnjeun4pIE" role="6VMZX">
+      <node concept="3F0ifn" id="dN43ccfaYw" role="3EZMnx">
+        <property role="3F0ifm" value="Side transformation cell 4:" />
+        <ref role="1k5W1q" to="tpc5:hF4yUZ8" resolve="header" />
+      </node>
       <node concept="3F1sOY" id="Dnjeul18aU" role="3EZMnx">
         <ref role="1NtTu8" to="teg0:Dnjeul188y" resolve="section" />
       </node>
       <node concept="3F0ifn" id="Dnjeun4pIM" role="3EZMnx" />
       <node concept="3EZMnI" id="Dnjeun4pKL" role="3EZMnx">
+        <node concept="VPXOz" id="dN43ccfaYC" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
         <node concept="2iRfu4" id="Dnjeun4pKM" role="2iSdaV" />
         <node concept="3F0ifn" id="Dnjeun4pIP" role="3EZMnx">
           <property role="3F0ifm" value="description for trace:" />
+          <ref role="1k5W1q" to="tpc5:hF4H1c8" resolve="property" />
         </node>
         <node concept="3F0A7n" id="Dnjeun4pOG" role="3EZMnx">
           <ref role="1NtTu8" to="teg0:Dnjeun4iHs" resolve="description" />

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/models/com/mbeddr/mpsutil/grammarcells/editor.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/models/com/mbeddr/mpsutil/grammarcells/editor.mps
@@ -1771,6 +1771,9 @@
         </node>
         <node concept="2iRfu4" id="4eBi5gdnlp4" role="2iSdaV" />
       </node>
+      <node concept="PMmxH" id="dN43cafnhZ" role="3EZMnx">
+        <ref role="PMmxG" node="J6gp_6ycIY" resolve="DescriptionText" />
+      </node>
     </node>
   </node>
   <node concept="24kQdi" id="6rhOS_xvraI">

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/models/com/mbeddr/mpsutil/grammarcells/editor.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/models/com/mbeddr/mpsutil/grammarcells/editor.mps
@@ -457,22 +457,8 @@
         <node concept="2EHx9g" id="6rhOS_xTjX$" role="2iSdaV" />
       </node>
       <node concept="3F0ifn" id="6uixmKZ2$eH" role="3EZMnx" />
-      <node concept="3EZMnI" id="6uixmKZ2EVK" role="3EZMnx">
-        <node concept="2EHx9g" id="6uixmKZ2EW0" role="2iSdaV" />
-        <node concept="3EZMnI" id="1ZlHRbhokpL" role="3EZMnx">
-          <node concept="3F0ifn" id="1ZlHRbhokpM" role="3EZMnx">
-            <property role="3F0ifm" value="description:" />
-            <ref role="1k5W1q" to="tpc5:hF4H1c8" resolve="property" />
-          </node>
-          <node concept="3F1sOY" id="1ZlHRbhokpN" role="3EZMnx">
-            <property role="1$x2rV" value="concept description" />
-            <ref role="1NtTu8" to="teg0:6uixmKZ2FIJ" resolve="descriptionText" />
-          </node>
-          <node concept="VPXOz" id="1ZlHRbhokpO" role="3F10Kt">
-            <property role="VOm3f" value="true" />
-          </node>
-          <node concept="2iRfu4" id="1ZlHRbhokpP" role="2iSdaV" />
-        </node>
+      <node concept="PMmxH" id="2l$VAMEYyz3" role="3EZMnx">
+        <ref role="PMmxG" node="J6gp_6ycIY" resolve="DescriptionText" />
       </node>
       <node concept="2iRkQZ" id="3h9t8JnexrD" role="2iSdaV" />
     </node>

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/models/com/mbeddr/mpsutil/grammarcells/structure.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/models/com/mbeddr/mpsutil/grammarcells/structure.mps
@@ -1181,5 +1181,12 @@
     <property role="EcuMT" value="9041925471455857605" />
     <ref role="1TJDcQ" to="tpee:gyVMwX8" resolve="ConceptFunction" />
   </node>
+  <node concept="1TIwiD" id="1ZlHRbijA01">
+    <property role="3GE5qa" value="cells" />
+    <property role="TrG5h" value="WrapperCell_Condition_wrappedConcept" />
+    <property role="34LRSv" value="wrappedConcept" />
+    <property role="EcuMT" value="2293941288997642241" />
+    <ref role="1TJDcQ" to="tpee:g76ryKb" resolve="ConceptFunctionParameter" />
+  </node>
 </model>
 

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/models/com/mbeddr/mpsutil/grammarcells/structure.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/models/com/mbeddr/mpsutil/grammarcells/structure.mps
@@ -104,7 +104,7 @@
       <ref role="PrY4T" node="6oKG1kMyAVO" resolve="IActionGeneratingCell" />
     </node>
     <node concept="PrWs8" id="J6gp_6LEaU" role="PzmwI">
-      <ref role="PrY4T" node="J6gp_6ycpK" resolve="IOptionalDescriptionText" />
+      <ref role="PrY4T" node="J6gp_6ycpK" resolve="ICanHaveDescriptionText" />
     </node>
   </node>
   <node concept="1TIwiD" id="6oKG1kMxvFA">
@@ -237,7 +237,7 @@
       <ref role="PrY4T" node="3O7ZvCZLPYU" resolve="ICellWrapper" />
     </node>
     <node concept="PrWs8" id="J6gp_6ydlP" role="PzmwI">
-      <ref role="PrY4T" node="J6gp_6ycpK" resolve="IOptionalDescriptionText" />
+      <ref role="PrY4T" node="J6gp_6ycpK" resolve="ICanHaveDescriptionText" />
     </node>
     <node concept="1TJgyj" id="2EPKBwvgsS2" role="1TKVEi">
       <property role="IQ2ns" value="3077579741553872386" />
@@ -1167,7 +1167,7 @@
   <node concept="PlHQZ" id="J6gp_6ycpK">
     <property role="EcuMT" value="848437706375087728" />
     <property role="3GE5qa" value="cells" />
-    <property role="TrG5h" value="IOptionalDescriptionText" />
+    <property role="TrG5h" value="ICanHaveDescriptionText" />
     <node concept="1TJgyj" id="J6gp_6ycpL" role="1TKVEi">
       <property role="IQ2ns" value="848437706375087729" />
       <property role="20lmBu" value="fLJjDmT/aggregation" />

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/models/com/mbeddr/mpsutil/grammarcells/structure.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/models/com/mbeddr/mpsutil/grammarcells/structure.mps
@@ -271,6 +271,9 @@
     <node concept="PrWs8" id="3O7ZvCZLSwp" role="PzmwI">
       <ref role="PrY4T" node="3O7ZvCZLPYU" resolve="ICellWrapper" />
     </node>
+    <node concept="PrWs8" id="dN43cd3wQB" role="PzmwI">
+      <ref role="PrY4T" node="J6gp_6ycpK" resolve="ICanHaveDescriptionText" />
+    </node>
   </node>
   <node concept="1TIwiD" id="1vi_twqJeLl">
     <property role="3GE5qa" value="cells" />

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/models/com/mbeddr/mpsutil/grammarcells/structure.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/models/com/mbeddr/mpsutil/grammarcells/structure.mps
@@ -722,6 +722,9 @@
     <node concept="PrWs8" id="4eBi5gdBmA1" role="PzmwI">
       <ref role="PrY4T" node="4eBi5gdADMe" resolve="INotALeaf" />
     </node>
+    <node concept="PrWs8" id="dN43cafnh_" role="PzmwI">
+      <ref role="PrY4T" node="J6gp_6ycpK" resolve="ICanHaveDescriptionText" />
+    </node>
   </node>
   <node concept="1TIwiD" id="4eBi5gdn8p_">
     <property role="3GE5qa" value="cells" />
@@ -797,6 +800,9 @@
     </node>
     <node concept="PrWs8" id="6rhOS_xwHOh" role="PzmwI">
       <ref role="PrY4T" node="6oKG1kMyAVO" resolve="IActionGeneratingCell" />
+    </node>
+    <node concept="PrWs8" id="2l$VAMF302A" role="PzmwI">
+      <ref role="PrY4T" node="J6gp_6ycpK" resolve="ICanHaveDescriptionText" />
     </node>
   </node>
   <node concept="1TIwiD" id="6rhOS_xT3yl">

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/models/com/mbeddr/mpsutil/grammarcells/structure.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/models/com/mbeddr/mpsutil/grammarcells/structure.mps
@@ -187,14 +187,20 @@
     <node concept="1TJgyj" id="6uixmKZ2FIJ" role="1TKVEi">
       <property role="IQ2ns" value="7463174232466963375" />
       <property role="20lmBu" value="fLJjDmT/aggregation" />
-      <property role="20kJfa" value="descriptionText" />
+      <property role="20kJfa" value="descriptionText_old" />
       <ref role="20lvS9" node="6uixmKZ2zuG" resolve="WrapperCell_DescriptionText" />
+      <node concept="asaX9" id="2l$VAMETgoS" role="lGtFl">
+        <property role="YLQ7P" value="Use descriptionText from ICanHaveDescriptionText" />
+      </node>
     </node>
     <node concept="PrWs8" id="6oKG1kMyAVP" role="PzmwI">
       <ref role="PrY4T" node="6oKG1kMyAVO" resolve="IActionGeneratingCell" />
     </node>
     <node concept="PrWs8" id="3O7ZvCZLRkq" role="PzmwI">
       <ref role="PrY4T" node="3O7ZvCZLPYU" resolve="ICellWrapper" />
+    </node>
+    <node concept="PrWs8" id="2l$VAMETgoU" role="PzmwI">
+      <ref role="PrY4T" node="J6gp_6ycpK" resolve="ICanHaveDescriptionText" />
     </node>
   </node>
   <node concept="PlHQZ" id="6oKG1kMyAVO">
@@ -993,6 +999,9 @@
     <property role="TrG5h" value="WrapperCell_DescriptionText" />
     <property role="EcuMT" value="7463174232466929580" />
     <ref role="1TJDcQ" to="tpee:gyVMwX8" resolve="ConceptFunction" />
+    <node concept="asaX9" id="2l$VAMF1BI2" role="lGtFl">
+      <property role="YLQ7P" value="Use IHaveHaveDescription instead" />
+    </node>
   </node>
   <node concept="1TIwiD" id="6uixmKZ2zAm">
     <property role="3GE5qa" value="cells" />

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/models/com/mbeddr/mpsutil/grammarcells/structure.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/models/com/mbeddr/mpsutil/grammarcells/structure.mps
@@ -103,6 +103,9 @@
     <node concept="PrWs8" id="RbLMy6aM8Q" role="PzmwI">
       <ref role="PrY4T" node="6oKG1kMyAVO" resolve="IActionGeneratingCell" />
     </node>
+    <node concept="PrWs8" id="J6gp_6LEaU" role="PzmwI">
+      <ref role="PrY4T" node="J6gp_6ycpK" resolve="IOptionalDescriptionText" />
+    </node>
   </node>
   <node concept="1TIwiD" id="6oKG1kMxvFA">
     <property role="TrG5h" value="UnorderedCollection" />
@@ -232,6 +235,9 @@
     </node>
     <node concept="PrWs8" id="7KznU_45d0Q" role="PzmwI">
       <ref role="PrY4T" node="3O7ZvCZLPYU" resolve="ICellWrapper" />
+    </node>
+    <node concept="PrWs8" id="J6gp_6ydlP" role="PzmwI">
+      <ref role="PrY4T" node="J6gp_6ycpK" resolve="IOptionalDescriptionText" />
     </node>
     <node concept="1TJgyj" id="2EPKBwvgsS2" role="1TKVEi">
       <property role="IQ2ns" value="3077579741553872386" />
@@ -1157,6 +1163,23 @@
     <property role="TrG5h" value="TransformationLocation_ContributionsToSideTranformation" />
     <property role="R5$K7" value="true" />
     <ref role="1TJDcQ" to="tpc2:7L5lpRJH$EA" resolve="TransformationLocation" />
+  </node>
+  <node concept="PlHQZ" id="J6gp_6ycpK">
+    <property role="EcuMT" value="848437706375087728" />
+    <property role="3GE5qa" value="cells" />
+    <property role="TrG5h" value="IOptionalDescriptionText" />
+    <node concept="1TJgyj" id="J6gp_6ycpL" role="1TKVEi">
+      <property role="IQ2ns" value="848437706375087729" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="descriptionText" />
+      <ref role="20lvS9" node="7PVnOXzFGJ5" resolve="Cell_DescriptionText" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="7PVnOXzFGJ5">
+    <property role="3GE5qa" value="cells" />
+    <property role="TrG5h" value="Cell_DescriptionText" />
+    <property role="EcuMT" value="9041925471455857605" />
+    <ref role="1TJDcQ" to="tpee:gyVMwX8" resolve="ConceptFunction" />
   </node>
 </model>
 

--- a/code/grammarcells/solutions/com.mbeddr.mpsutil.grammarcells.runtime/models/com/mbeddr/mpsutil/grammarcells/runtime.mps
+++ b/code/grammarcells/solutions/com.mbeddr.mpsutil.grammarcells.runtime/models/com/mbeddr/mpsutil/grammarcells/runtime.mps
@@ -29563,42 +29563,40 @@
         </node>
       </node>
       <node concept="3clFbS" id="3uJMZ8xGylv" role="3clF47">
-        <node concept="3cpWs8" id="3uJMZ8xG$wF" role="3cqZAp">
-          <node concept="3cpWsn" id="3uJMZ8xG$wG" role="3cpWs9">
-            <property role="TrG5h" value="outputConcept" />
-            <node concept="3bZ5Sz" id="3uJMZ8xG$BS" role="1tU5fm" />
-            <node concept="1rXfSq" id="3uJMZ8xG$wH" role="33vP2m">
-              <ref role="37wK5l" to="qtqj:~DefaultSubstituteMenuItem.getOutputConcept()" resolve="getOutputConcept" />
+        <node concept="3cpWs8" id="dN43cci3aw" role="3cqZAp">
+          <node concept="3cpWsn" id="dN43cci3ax" role="3cpWs9">
+            <property role="TrG5h" value="description" />
+            <node concept="3uibUv" id="dN43cci3ay" role="1tU5fm">
+              <ref role="3uigEE" to="wyt6:~String" resolve="String" />
+            </node>
+            <node concept="2OqwBi" id="dN43cci3az" role="33vP2m">
+              <node concept="1rXfSq" id="dN43cci3a$" role="2Oq$k0">
+                <ref role="37wK5l" to="qtqj:~DefaultSubstituteMenuItem.getOutputConcept()" resolve="getOutputConcept" />
+              </node>
+              <node concept="liA8E" id="dN43cci3a_" role="2OqNvi">
+                <ref role="37wK5l" to="c17a:~SAbstractConcept.getShortDescription()" resolve="getShortDescription" />
+              </node>
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="3uJMZ8xGzVz" role="3cqZAp">
-          <node concept="3cpWs3" id="3uJMZ8xGD3G" role="3clFbG">
-            <node concept="Xl_RD" id="3uJMZ8xGD4e" role="3uHU7w">
-              <property role="Xl_RC" value=")" />
+        <node concept="3clFbF" id="dN43cci3aA" role="3cqZAp">
+          <node concept="3K4zz7" id="dN43cci3aB" role="3clFbG">
+            <node concept="37vLTw" id="dN43cci3aC" role="3K4E3e">
+              <ref role="3cqZAo" node="dN43cci3ax" resolve="description" />
             </node>
-            <node concept="3cpWs3" id="3uJMZ8xGB7w" role="3uHU7B">
-              <node concept="3cpWs3" id="3uJMZ8xG_Wp" role="3uHU7B">
-                <node concept="2OqwBi" id="3uJMZ8xG$Oa" role="3uHU7B">
-                  <node concept="37vLTw" id="3uJMZ8xG$wI" role="2Oq$k0">
-                    <ref role="3cqZAo" node="3uJMZ8xG$wG" resolve="outputConcept" />
-                  </node>
-                  <node concept="liA8E" id="3uJMZ8xG$YA" role="2OqNvi">
-                    <ref role="37wK5l" to="c17a:~SAbstractConcept.getShortDescription()" resolve="getShortDescription" />
-                  </node>
-                </node>
-                <node concept="Xl_RD" id="3uJMZ8xG_WV" role="3uHU7w">
-                  <property role="Xl_RC" value=" (" />
-                </node>
+            <node concept="2OqwBi" id="dN43cci3aD" role="3K4GZi">
+              <node concept="1rXfSq" id="dN43cci3aE" role="2Oq$k0">
+                <ref role="37wK5l" to="qtqj:~DefaultSubstituteMenuItem.getOutputConcept()" resolve="getOutputConcept" />
               </node>
-              <node concept="2OqwBi" id="3uJMZ8xGC14" role="3uHU7w">
-                <node concept="37vLTw" id="3uJMZ8xGBIi" role="2Oq$k0">
-                  <ref role="3cqZAo" node="3uJMZ8xG$wG" resolve="outputConcept" />
-                </node>
-                <node concept="liA8E" id="3uJMZ8xGCv9" role="2OqNvi">
-                  <ref role="37wK5l" to="c17a:~SAbstractConcept.getName()" resolve="getName" />
-                </node>
+              <node concept="liA8E" id="dN43cci3aF" role="2OqNvi">
+                <ref role="37wK5l" to="c17a:~SAbstractConcept.getName()" resolve="getName" />
               </node>
+            </node>
+            <node concept="2OqwBi" id="dN43cci3aG" role="3K4Cdx">
+              <node concept="37vLTw" id="dN43cci3aH" role="2Oq$k0">
+                <ref role="3cqZAo" node="dN43cci3ax" resolve="description" />
+              </node>
+              <node concept="17RvpY" id="dN43cci3aI" role="2OqNvi" />
             </node>
           </node>
         </node>

--- a/code/grammarcells/solutions/com.mbeddr.mpsutil.grammarcells.runtime/models/com/mbeddr/mpsutil/grammarcells/runtime.mps
+++ b/code/grammarcells/solutions/com.mbeddr.mpsutil.grammarcells.runtime/models/com/mbeddr/mpsutil/grammarcells/runtime.mps
@@ -20339,8 +20339,14 @@
         <node concept="17QB3L" id="mEdliw$NFW" role="1tU5fm" />
       </node>
       <node concept="3clFbS" id="mEdliw$MPc" role="3clF47">
-        <node concept="3clFbF" id="mEdliw$MPe" role="3cqZAp">
-          <node concept="10Nm6u" id="mEdliw$MPd" role="3clFbG" />
+        <node concept="3clFbF" id="dN43caHsY2" role="3cqZAp">
+          <node concept="2YIFZM" id="dN43caHsY4" role="3clFbG">
+            <ref role="1Pybhc" to="5b0:~NodePresentationUtil" resolve="NodePresentationUtil" />
+            <ref role="37wK5l" to="5b0:~NodePresentationUtil.descriptionText(org.jetbrains.mps.openapi.model.SNode)" resolve="descriptionText" />
+            <node concept="1rXfSq" id="dN43caHsY5" role="37wK5m">
+              <ref role="37wK5l" to="zce0:~AbstractSubstituteAction.getOutputConcept()" resolve="getOutputConcept" />
+            </node>
+          </node>
         </node>
       </node>
     </node>
@@ -29749,8 +29755,42 @@
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
       <node concept="3clFbS" id="325OF_Mo$mV" role="3clF47">
-        <node concept="3clFbF" id="2l$VAMEScCi" role="3cqZAp">
-          <node concept="10Nm6u" id="2l$VAMEScCh" role="3clFbG" />
+        <node concept="3cpWs8" id="dN43cbh6lL" role="3cqZAp">
+          <node concept="3cpWsn" id="dN43cbh6lM" role="3cpWs9">
+            <property role="TrG5h" value="description" />
+            <node concept="3uibUv" id="dN43cbh6lN" role="1tU5fm">
+              <ref role="3uigEE" to="wyt6:~String" resolve="String" />
+            </node>
+            <node concept="2OqwBi" id="dN43cbh1cb" role="33vP2m">
+              <node concept="1rXfSq" id="dN43cbh6lO" role="2Oq$k0">
+                <ref role="37wK5l" to="uddc:~ConstraintsVerifiableActionItem.getOutputConcept()" resolve="getOutputConcept" />
+              </node>
+              <node concept="liA8E" id="dN43cbh1UR" role="2OqNvi">
+                <ref role="37wK5l" to="c17a:~SAbstractConcept.getShortDescription()" resolve="getShortDescription" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="dN43cbh6lP" role="3cqZAp">
+          <node concept="3K4zz7" id="dN43cbh6lQ" role="3clFbG">
+            <node concept="37vLTw" id="dN43cbh6lR" role="3K4E3e">
+              <ref role="3cqZAo" node="dN43cbh6lM" resolve="description" />
+            </node>
+            <node concept="2OqwBi" id="dN43cbh6lS" role="3K4GZi">
+              <node concept="1rXfSq" id="dN43cbh6lT" role="2Oq$k0">
+                <ref role="37wK5l" to="uddc:~ConstraintsVerifiableActionItem.getOutputConcept()" resolve="getOutputConcept" />
+              </node>
+              <node concept="liA8E" id="dN43cbh6lU" role="2OqNvi">
+                <ref role="37wK5l" to="c17a:~SAbstractConcept.getName()" resolve="getName" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="dN43cbh4eU" role="3K4Cdx">
+              <node concept="37vLTw" id="dN43cbh6lV" role="2Oq$k0">
+                <ref role="3cqZAo" node="dN43cbh6lM" resolve="description" />
+              </node>
+              <node concept="17RvpY" id="dN43cbh5g4" role="2OqNvi" />
+            </node>
+          </node>
         </node>
       </node>
     </node>

--- a/code/grammarcells/solutions/com.mbeddr.mpsutil.grammarcells.runtime/models/com/mbeddr/mpsutil/grammarcells/runtime.mps
+++ b/code/grammarcells/solutions/com.mbeddr.mpsutil.grammarcells.runtime/models/com/mbeddr/mpsutil/grammarcells/runtime.mps
@@ -438,6 +438,10 @@
       <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
       <concept id="7453996997717780434" name="jetbrains.mps.lang.smodel.structure.Node_GetSConceptOperation" flags="nn" index="2yIwOk" />
       <concept id="1173122760281" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorsOperation" flags="nn" index="z$bX8" />
+      <concept id="2396822768958367367" name="jetbrains.mps.lang.smodel.structure.AbstractTypeCastExpression" flags="nn" index="$5XWr">
+        <child id="6733348108486823193" name="leftExpression" index="1m5AlR" />
+        <child id="3906496115198199033" name="conceptArgument" index="3oSUPX" />
+      </concept>
       <concept id="8866923313515890008" name="jetbrains.mps.lang.smodel.structure.AsNodeOperation" flags="nn" index="FGMqu" />
       <concept id="1143226024141" name="jetbrains.mps.lang.smodel.structure.SModelType" flags="in" index="H_c77" />
       <concept id="1143234257716" name="jetbrains.mps.lang.smodel.structure.Node_GetModelOperation" flags="nn" index="I4A8Y" />
@@ -492,6 +496,9 @@
       </concept>
       <concept id="1140131837776" name="jetbrains.mps.lang.smodel.structure.Node_ReplaceWithAnotherOperation" flags="nn" index="1P9Npp">
         <child id="1140131861877" name="replacementNode" index="1P9ThW" />
+      </concept>
+      <concept id="1140137987495" name="jetbrains.mps.lang.smodel.structure.SNodeTypeCastExpression" flags="nn" index="1PxgMI">
+        <property id="1238684351431" name="asCast" index="1BlNFB" />
       </concept>
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
         <reference id="1138405853777" name="concept" index="ehGHo" />
@@ -20339,12 +20346,46 @@
         <node concept="17QB3L" id="mEdliw$NFW" role="1tU5fm" />
       </node>
       <node concept="3clFbS" id="mEdliw$MPc" role="3clF47">
-        <node concept="3clFbF" id="dN43caHsY2" role="3cqZAp">
-          <node concept="2YIFZM" id="dN43caHsY4" role="3clFbG">
-            <ref role="1Pybhc" to="5b0:~NodePresentationUtil" resolve="NodePresentationUtil" />
-            <ref role="37wK5l" to="5b0:~NodePresentationUtil.descriptionText(org.jetbrains.mps.openapi.model.SNode)" resolve="descriptionText" />
-            <node concept="1rXfSq" id="dN43caHsY5" role="37wK5m">
-              <ref role="37wK5l" to="zce0:~AbstractSubstituteAction.getOutputConcept()" resolve="getOutputConcept" />
+        <node concept="3cpWs8" id="dN43ccT$_9" role="3cqZAp">
+          <node concept="3cpWsn" id="dN43ccT$_a" role="3cpWs9">
+            <property role="TrG5h" value="description" />
+            <node concept="3uibUv" id="dN43ccT$_b" role="1tU5fm">
+              <ref role="3uigEE" to="wyt6:~String" resolve="String" />
+            </node>
+            <node concept="2OqwBi" id="dN43ccY_UM" role="33vP2m">
+              <node concept="1PxgMI" id="dN43ccY$Yg" role="2Oq$k0">
+                <property role="1BlNFB" value="true" />
+                <node concept="chp4Y" id="dN43ccY_m0" role="3oSUPX">
+                  <ref role="cht4Q" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
+                </node>
+                <node concept="1rXfSq" id="dN43ccT$_d" role="1m5AlR">
+                  <ref role="37wK5l" to="zce0:~AbstractSubstituteAction.getOutputConcept()" resolve="getOutputConcept" />
+                </node>
+              </node>
+              <node concept="3TrcHB" id="dN43ccYADG" role="2OqNvi">
+                <ref role="3TsBF5" to="tpce:40UcGlRaVSw" resolve="conceptShortDescription" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="dN43ccT$_f" role="3cqZAp">
+          <node concept="3K4zz7" id="dN43ccT$_g" role="3clFbG">
+            <node concept="37vLTw" id="dN43ccT$_h" role="3K4E3e">
+              <ref role="3cqZAo" node="dN43ccT$_a" resolve="description" />
+            </node>
+            <node concept="2OqwBi" id="dN43ccT$_i" role="3K4GZi">
+              <node concept="1rXfSq" id="dN43ccT$_j" role="2Oq$k0">
+                <ref role="37wK5l" to="zce0:~AbstractSubstituteAction.getOutputConcept()" resolve="getOutputConcept" />
+              </node>
+              <node concept="liA8E" id="dN43ccT$_k" role="2OqNvi">
+                <ref role="37wK5l" to="mhbf:~SNode.getName()" resolve="getName" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="dN43ccT$_l" role="3K4Cdx">
+              <node concept="37vLTw" id="dN43ccT$_m" role="2Oq$k0">
+                <ref role="3cqZAo" node="dN43ccT$_a" resolve="description" />
+              </node>
+              <node concept="17RvpY" id="dN43ccT$_n" role="2OqNvi" />
             </node>
           </node>
         </node>

--- a/code/grammarcells/solutions/com.mbeddr.mpsutil.grammarcells.runtime/models/com/mbeddr/mpsutil/grammarcells/runtime.mps
+++ b/code/grammarcells/solutions/com.mbeddr.mpsutil.grammarcells.runtime/models/com/mbeddr/mpsutil/grammarcells/runtime.mps
@@ -32792,12 +32792,9 @@
         <ref role="3uigEE" node="1YKLYyyOIFO" resolve="MultiTextActionItem" />
       </node>
       <node concept="3clFb_" id="15DZatP$kWG" role="jymVt">
-        <property role="TrG5h" value="getDescriptionText" />
+        <property role="TrG5h" value="getShortDescriptionText" />
         <property role="DiZV1" value="false" />
         <property role="od$2w" value="false" />
-        <node concept="2AHcQZ" id="15DZatP$kWH" role="2AJF6D">
-          <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-        </node>
         <node concept="3Tm1VV" id="15DZatP$kWM" role="1B3o_S" />
         <node concept="17QB3L" id="15DZatP$kWN" role="3clF45" />
         <node concept="37vLTG" id="15DZatP$kWO" role="3clF46">

--- a/code/grammarcells/solutions/com.mbeddr.mpsutil.grammarcells.runtime/models/com/mbeddr/mpsutil/grammarcells/runtime.mps
+++ b/code/grammarcells/solutions/com.mbeddr.mpsutil.grammarcells.runtime/models/com/mbeddr/mpsutil/grammarcells/runtime.mps
@@ -29727,36 +29727,6 @@
         </node>
       </node>
     </node>
-    <node concept="2tJIrI" id="1YKLYyyOIGc" role="jymVt" />
-    <node concept="3clFb_" id="1YKLYyyOIGd" role="jymVt">
-      <property role="1EzhhJ" value="false" />
-      <property role="TrG5h" value="getDescriptionText" />
-      <property role="DiZV1" value="false" />
-      <property role="od$2w" value="false" />
-      <node concept="2AHcQZ" id="325OF_MqRIl" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-      <node concept="P$JXv" id="325OF_MqRIi" role="lGtFl">
-        <node concept="TZ5HI" id="325OF_MqRIj" role="3nqlJM">
-          <node concept="TZ5HA" id="325OF_MqRIk" role="3HnX3l">
-            <node concept="1dT_AC" id="325OF_MqSNX" role="1dT_Ay">
-              <property role="1dT_AB" value=" Use getShortDescriptionText" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="1YKLYyyOIGe" role="1B3o_S" />
-      <node concept="17QB3L" id="1YKLYyyOIGf" role="3clF45" />
-      <node concept="37vLTG" id="1YKLYyyOIGg" role="3clF46">
-        <property role="TrG5h" value="pattern" />
-        <node concept="17QB3L" id="1YKLYyyOIGh" role="1tU5fm" />
-      </node>
-      <node concept="3clFbS" id="1YKLYyyOIGi" role="3clF47">
-        <node concept="3clFbF" id="1YKLYyyOIGj" role="3cqZAp">
-          <node concept="10Nm6u" id="1YKLYyyOIGk" role="3clFbG" />
-        </node>
-      </node>
-    </node>
     <node concept="2tJIrI" id="325OF_Moz8e" role="jymVt" />
     <node concept="3clFb_" id="325OF_Mo$mK" role="jymVt">
       <property role="1EzhhJ" value="false" />
@@ -29779,16 +29749,8 @@
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
       <node concept="3clFbS" id="325OF_Mo$mV" role="3clF47">
-        <node concept="3clFbF" id="325OF_MoRXq" role="3cqZAp">
-          <node concept="2OqwBi" id="325OF_MoSsj" role="3clFbG">
-            <node concept="Xjq3P" id="325OF_MoRXm" role="2Oq$k0" />
-            <node concept="liA8E" id="325OF_MoTCx" role="2OqNvi">
-              <ref role="37wK5l" node="1YKLYyyOIGd" resolve="getDescriptionText" />
-              <node concept="37vLTw" id="325OF_MoTKM" role="37wK5m">
-                <ref role="3cqZAo" node="325OF_Mo$mO" resolve="pattern" />
-              </node>
-            </node>
-          </node>
+        <node concept="3clFbF" id="2l$VAMEScCi" role="3cqZAp">
+          <node concept="10Nm6u" id="2l$VAMEScCh" role="3clFbG" />
         </node>
       </node>
     </node>
@@ -30139,7 +30101,7 @@
                 <ref role="1HBi2w" node="1YKLYyyOIFO" resolve="MultiTextActionItem" />
               </node>
               <node concept="liA8E" id="1YKLYyyOIIP" role="2OqNvi">
-                <ref role="37wK5l" node="1YKLYyyOIGd" resolve="getDescriptionText" />
+                <ref role="37wK5l" node="325OF_Mo$mK" resolve="getShortDescriptionText" />
                 <node concept="37vLTw" id="1YKLYyyOIIQ" role="37wK5m">
                   <ref role="3cqZAo" node="1YKLYyyOIIh" resolve="myMatchingText" />
                 </node>

--- a/code/grammarcells/solutions/com.mbeddr.mpsutil.grammarcells.runtime/models/com/mbeddr/mpsutil/grammarcells/runtime/menu.mps
+++ b/code/grammarcells/solutions/com.mbeddr.mpsutil.grammarcells.runtime/models/com/mbeddr/mpsutil/grammarcells/runtime/menu.mps
@@ -37,6 +37,7 @@
     <import index="y49u" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.util(MPS.OpenAPI/)" />
     <import index="9eyi" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.lang.editor.menus.transformation(MPS.Editor/)" />
     <import index="vndm" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel.language(MPS.Core/)" />
+    <import index="qtqj" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.lang.editor.menus.substitute(MPS.Editor/)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
     <import index="878o" ref="r:46fddec3-0db9-4b86-8274-957463dd4499(com.mbeddr.mpsutil.grammarcells.runtimelang.structure)" implicit="true" />
   </imports>
@@ -163,6 +164,7 @@
       <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
       <concept id="1225271221393" name="jetbrains.mps.baseLanguage.structure.NPENotEqualsExpression" flags="nn" index="17QLQc" />
       <concept id="1225271283259" name="jetbrains.mps.baseLanguage.structure.NPEEqualsExpression" flags="nn" index="17R0WA" />
+      <concept id="1225271408483" name="jetbrains.mps.baseLanguage.structure.IsNotEmptyOperation" flags="nn" index="17RvpY" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
@@ -856,8 +858,42 @@
         </node>
       </node>
       <node concept="3clFbS" id="1YKLYyyGCBc" role="3clF47">
+        <node concept="3cpWs8" id="dN43caQj_w" role="3cqZAp">
+          <node concept="3cpWsn" id="dN43caQj_x" role="3cpWs9">
+            <property role="TrG5h" value="description" />
+            <node concept="3uibUv" id="dN43caQ0qP" role="1tU5fm">
+              <ref role="3uigEE" to="wyt6:~String" resolve="String" />
+            </node>
+            <node concept="2OqwBi" id="dN43cbh1cb" role="33vP2m">
+              <node concept="1rXfSq" id="dN43caQj_z" role="2Oq$k0">
+                <ref role="37wK5l" to="uddc:~ConstraintsVerifiableActionItem.getOutputConcept()" resolve="getOutputConcept" />
+              </node>
+              <node concept="liA8E" id="dN43cbh1UR" role="2OqNvi">
+                <ref role="37wK5l" to="c17a:~SAbstractConcept.getShortDescription()" resolve="getShortDescription" />
+              </node>
+            </node>
+          </node>
+        </node>
         <node concept="3clFbF" id="1YKLYyyGCBf" role="3cqZAp">
-          <node concept="10Nm6u" id="1YKLYyyGCBe" role="3clFbG" />
+          <node concept="3K4zz7" id="dN43caQo4K" role="3clFbG">
+            <node concept="37vLTw" id="dN43caQp85" role="3K4E3e">
+              <ref role="3cqZAo" node="dN43caQj_x" resolve="description" />
+            </node>
+            <node concept="2OqwBi" id="dN43caQrlx" role="3K4GZi">
+              <node concept="1rXfSq" id="dN43caQqwC" role="2Oq$k0">
+                <ref role="37wK5l" to="uddc:~ConstraintsVerifiableActionItem.getOutputConcept()" resolve="getOutputConcept" />
+              </node>
+              <node concept="liA8E" id="dN43caQrY8" role="2OqNvi">
+                <ref role="37wK5l" to="c17a:~SAbstractConcept.getName()" resolve="getName" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="dN43cbh4eU" role="3K4Cdx">
+              <node concept="37vLTw" id="dN43caQj_$" role="2Oq$k0">
+                <ref role="3cqZAo" node="dN43caQj_x" resolve="description" />
+              </node>
+              <node concept="17RvpY" id="dN43cbh5g4" role="2OqNvi" />
+            </node>
+          </node>
         </node>
       </node>
       <node concept="2AHcQZ" id="1YKLYyyGCBd" role="2AJF6D">
@@ -1054,44 +1090,41 @@
         </node>
       </node>
       <node concept="3clFbS" id="2mvFNoUAyzP" role="3clF47">
-        <node concept="3cpWs8" id="2mvFNoUAFIL" role="3cqZAp">
-          <node concept="3cpWsn" id="2mvFNoUAFIM" role="3cpWs9">
-            <property role="TrG5h" value="concept" />
-            <node concept="3uibUv" id="2mvFNoUAFIK" role="1tU5fm">
-              <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
+        <node concept="3cpWs8" id="dN43cbhijJ" role="3cqZAp">
+          <node concept="3cpWsn" id="dN43cbhijK" role="3cpWs9">
+            <property role="TrG5h" value="description" />
+            <node concept="3uibUv" id="dN43cbhijL" role="1tU5fm">
+              <ref role="3uigEE" to="wyt6:~String" resolve="String" />
             </node>
-            <node concept="1rXfSq" id="2mvFNoUAFIN" role="33vP2m">
-              <ref role="37wK5l" to="78sh:~SubstituteMenuItem.getOutputConcept()" resolve="getOutputConcept" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbJ" id="2mvFNoUAFV7" role="3cqZAp">
-          <node concept="3clFbS" id="2mvFNoUAFV9" role="3clFbx">
-            <node concept="3cpWs6" id="2mvFNoUAGt0" role="3cqZAp">
-              <node concept="2YIFZM" id="2mvFNoUAGXd" role="3cqZAk">
-                <ref role="1Pybhc" to="5b0:~NodePresentationUtil" resolve="NodePresentationUtil" />
-                <ref role="37wK5l" to="5b0:~NodePresentationUtil.descriptionText(org.jetbrains.mps.openapi.language.SAbstractConcept,boolean)" resolve="descriptionText" />
-                <node concept="37vLTw" id="2mvFNoUAH7K" role="37wK5m">
-                  <ref role="3cqZAo" node="2mvFNoUAFIM" resolve="concept" />
-                </node>
-                <node concept="3clFbT" id="2mvFNoUAHGX" role="37wK5m">
-                  <property role="3clFbU" value="false" />
-                </node>
+            <node concept="2OqwBi" id="dN43cbhijM" role="33vP2m">
+              <node concept="1rXfSq" id="dN43cbhijN" role="2Oq$k0">
+                <ref role="37wK5l" to="uddc:~ConstraintsVerifiableActionItem.getOutputConcept()" resolve="getOutputConcept" />
+              </node>
+              <node concept="liA8E" id="dN43cbhijO" role="2OqNvi">
+                <ref role="37wK5l" to="c17a:~SAbstractConcept.getShortDescription()" resolve="getShortDescription" />
               </node>
             </node>
           </node>
-          <node concept="2ZW3vV" id="2mvFNoUAGn0" role="3clFbw">
-            <node concept="3uibUv" id="2mvFNoUAGrH" role="2ZW6by">
-              <ref role="3uigEE" to="c17a:~SConcept" resolve="SConcept" />
-            </node>
-            <node concept="37vLTw" id="2mvFNoUAFYc" role="2ZW6bz">
-              <ref role="3cqZAo" node="2mvFNoUAFIM" resolve="concept" />
-            </node>
-          </node>
         </node>
-        <node concept="3clFbF" id="2mvFNoUAFsW" role="3cqZAp">
-          <node concept="Xl_RD" id="2mvFNoUAFsV" role="3clFbG">
-            <property role="Xl_RC" value="" />
+        <node concept="3clFbF" id="dN43cbhijP" role="3cqZAp">
+          <node concept="3K4zz7" id="dN43cbhijQ" role="3clFbG">
+            <node concept="37vLTw" id="dN43cbhijR" role="3K4E3e">
+              <ref role="3cqZAo" node="dN43cbhijK" resolve="description" />
+            </node>
+            <node concept="2OqwBi" id="dN43cbhijS" role="3K4GZi">
+              <node concept="1rXfSq" id="dN43cbhijT" role="2Oq$k0">
+                <ref role="37wK5l" to="uddc:~ConstraintsVerifiableActionItem.getOutputConcept()" resolve="getOutputConcept" />
+              </node>
+              <node concept="liA8E" id="dN43cbhijU" role="2OqNvi">
+                <ref role="37wK5l" to="c17a:~SAbstractConcept.getName()" resolve="getName" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="dN43cbhijV" role="3K4Cdx">
+              <node concept="37vLTw" id="dN43cbhijW" role="2Oq$k0">
+                <ref role="3cqZAo" node="dN43cbhijK" resolve="description" />
+              </node>
+              <node concept="17RvpY" id="dN43cbhijX" role="2OqNvi" />
+            </node>
           </node>
         </node>
       </node>

--- a/code/querylist/com.mbeddr.mpsutil.editor.querylist.demolang/languageModels/editor.mps
+++ b/code/querylist/com.mbeddr.mpsutil.editor.querylist.demolang/languageModels/editor.mps
@@ -778,7 +778,7 @@
               <node concept="2OqwBi" id="lPJxik9iuv" role="3cqZAk">
                 <node concept="2hkjam" id="lPJxik9il1" role="2Oq$k0" />
                 <node concept="liA8E" id="lPJxik9iXI" role="2OqNvi">
-                  <ref role="37wK5l" to="d2zl:lPJxik8Xgp" resolve="forChild" />
+                  <ref role="37wK5l" to="d2zl:2Fugwv5Fpi_" resolve="forChild" />
                   <node concept="37vLTw" id="3jHPIDngupV" role="37wK5m">
                     <ref role="3cqZAo" node="lPJxik8ump" resolve="body" />
                   </node>


### PR DESCRIPTION
This PR adds support for an optional description in flag, substitute cells and some other cells such as side transformation cells. When no description is provided, the concept description is used. If the description is empty, the name of the concept is used. Additionally, a wrapped concept parameter for the optional description of the wrapper cell was added.