### PR TITLE
Grammarcells: fix some concept function parameters

### DIFF
--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells.sandboxlang/models/com/mbeddr/mpsutil/grammarcells/sandboxlang/editor.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells.sandboxlang/models/com/mbeddr/mpsutil/grammarcells/sandboxlang/editor.mps
@@ -193,6 +193,7 @@
         <child id="5083944728300220903" name="wrapped" index="yw3OG" />
       </concept>
       <concept id="5083944728298846680" name="com.mbeddr.mpsutil.grammarcells.structure.OptionalCell" flags="ng" index="_tjkj">
+        <child id="7011566904921631440" name="postprocess" index="vWNKz" />
         <child id="5083944728298846681" name="option" index="_tjki" />
         <child id="8945098465480008160" name="transformationText" index="ZWbT9" />
       </concept>
@@ -202,12 +203,14 @@
         <child id="8207263695491670784" name="priority" index="2EmURo" />
       </concept>
       <concept id="8207263695491691232" name="com.mbeddr.mpsutil.grammarcells.structure.SubconceptExpression" flags="ng" index="2EmZKS" />
+      <concept id="2489050352088028316" name="com.mbeddr.mpsutil.grammarcells.structure.Parameter_editorContext" flags="ng" index="2MNBq7" />
       <concept id="8945098465480383073" name="com.mbeddr.mpsutil.grammarcells.structure.OptionalCell_TransformationText" flags="ig" index="ZYGn8" />
       <concept id="7363578995839203705" name="com.mbeddr.mpsutil.grammarcells.structure.FlagCell" flags="sg" stub="1984422498400729024" index="1kHk_G" />
       <concept id="7363578995839435357" name="com.mbeddr.mpsutil.grammarcells.structure.WrapperCell" flags="ng" index="1kIj98">
         <child id="1954385921685817931" name="postprocessSideTransform" index="31dnJ" />
         <child id="7363578995839435358" name="wrapped" index="1kIj9b" />
       </concept>
+      <concept id="904978958140335648" name="com.mbeddr.mpsutil.grammarcells.structure.Parameter_parentNode" flags="ng" index="1tDOuL" />
       <concept id="2862331529394479412" name="com.mbeddr.mpsutil.grammarcells.structure.GrammarConstantQuery" flags="ig" index="1Lj6DC" />
       <concept id="2862331529394479405" name="com.mbeddr.mpsutil.grammarcells.structure.GrammarConstantQueryCell" flags="ng" index="1Lj6DL">
         <child id="2862331529394487726" name="query" index="1Lj8FM" />
@@ -216,6 +219,11 @@
       <concept id="3011849438420226693" name="com.mbeddr.mpsutil.grammarcells.structure.GrammarInfoCell" flags="ng" index="1WcQYu">
         <child id="8207263695490916687" name="rules" index="2El2Yn" />
         <child id="2862331529394260612" name="projection" index="1LiK7o" />
+      </concept>
+    </language>
+    <language id="760a0a8c-eabb-4521-8bfd-65db761a9ba3" name="jetbrains.mps.baseLanguage.logging">
+      <concept id="6332851714983831325" name="jetbrains.mps.baseLanguage.logging.structure.MsgStatement" flags="ng" index="2xdQw9">
+        <child id="5721587534047265374" name="message" index="9lYJi" />
       </concept>
     </language>
     <language id="e359e0a2-368a-4c40-ae2a-e5a09f9cfd58" name="de.itemis.mps.editor.math.notations">
@@ -1016,6 +1024,34 @@
             <property role="VOm3f" value="false" />
           </node>
         </node>
+        <node concept="315t4" id="6gjbwaaGgIl" role="vWNKz">
+          <node concept="3clFbS" id="6gjbwaaGgIm" role="2VODD2">
+            <node concept="2xdQw9" id="6gjbwaaGgIn" role="3cqZAp">
+              <node concept="3cpWs3" id="6gjbwaaGgIo" role="9lYJi">
+                <node concept="313q4" id="6gjbwaaGgIp" role="3uHU7w" />
+                <node concept="Xl_RD" id="6gjbwaaGgIq" role="3uHU7B">
+                  <property role="Xl_RC" value="Node:" />
+                </node>
+              </node>
+            </node>
+            <node concept="2xdQw9" id="6gjbwaaGgIr" role="3cqZAp">
+              <node concept="3cpWs3" id="6gjbwaaGgIs" role="9lYJi">
+                <node concept="Xl_RD" id="6gjbwaaGgIt" role="3uHU7B">
+                  <property role="Xl_RC" value="EditorContext:" />
+                </node>
+                <node concept="2MNBq7" id="6gjbwaaGgIu" role="3uHU7w" />
+              </node>
+            </node>
+            <node concept="2xdQw9" id="6gjbwaaGgIv" role="3cqZAp">
+              <node concept="3cpWs3" id="6gjbwaaGgIw" role="9lYJi">
+                <node concept="1tDOuL" id="6gjbwaaGgIx" role="3uHU7w" />
+                <node concept="Xl_RD" id="6gjbwaaGgIy" role="3uHU7B">
+                  <property role="Xl_RC" value="ParentNode:" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
       </node>
       <node concept="l2Vlx" id="3efHud92zmh" role="2iSdaV" />
     </node>
@@ -1357,6 +1393,34 @@
         <node concept="3F1sOY" id="5ycts4RUtC3" role="_tjki">
           <ref role="1NtTu8" to="ibwz:5ycts4RUtB8" resolve="child" />
         </node>
+        <node concept="315t4" id="6gjbwaaGgMP" role="vWNKz">
+          <node concept="3clFbS" id="6gjbwaaGgMQ" role="2VODD2">
+            <node concept="2xdQw9" id="6gjbwaaGgMR" role="3cqZAp">
+              <node concept="3cpWs3" id="6gjbwaaGgMS" role="9lYJi">
+                <node concept="313q4" id="6gjbwaaGgMT" role="3uHU7w" />
+                <node concept="Xl_RD" id="6gjbwaaGgMU" role="3uHU7B">
+                  <property role="Xl_RC" value="Node:" />
+                </node>
+              </node>
+            </node>
+            <node concept="2xdQw9" id="6gjbwaaGgMV" role="3cqZAp">
+              <node concept="3cpWs3" id="6gjbwaaGgMW" role="9lYJi">
+                <node concept="Xl_RD" id="6gjbwaaGgMX" role="3uHU7B">
+                  <property role="Xl_RC" value="EditorContext:" />
+                </node>
+                <node concept="2MNBq7" id="6gjbwaaGgMY" role="3uHU7w" />
+              </node>
+            </node>
+            <node concept="2xdQw9" id="6gjbwaaGgMZ" role="3cqZAp">
+              <node concept="3cpWs3" id="6gjbwaaGgN0" role="9lYJi">
+                <node concept="1tDOuL" id="6gjbwaaGgN1" role="3uHU7w" />
+                <node concept="Xl_RD" id="6gjbwaaGgN2" role="3uHU7B">
+                  <property role="Xl_RC" value="ParentNode:" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
       </node>
       <node concept="3F0ifn" id="5ycts4RUtBN" role="3EZMnx">
         <property role="3F0ifm" value=";" />
@@ -1377,6 +1441,34 @@
         <node concept="3F2HdR" id="5ycts4RWGCe" role="_tjki">
           <property role="2czwfO" value="," />
           <ref role="1NtTu8" to="ibwz:5ycts4RWGBy" resolve="child" />
+        </node>
+        <node concept="315t4" id="6gjbwaaGgJP" role="vWNKz">
+          <node concept="3clFbS" id="6gjbwaaGgJQ" role="2VODD2">
+            <node concept="2xdQw9" id="6gjbwaaGgJR" role="3cqZAp">
+              <node concept="3cpWs3" id="6gjbwaaGgJS" role="9lYJi">
+                <node concept="313q4" id="6gjbwaaGgJT" role="3uHU7w" />
+                <node concept="Xl_RD" id="6gjbwaaGgJU" role="3uHU7B">
+                  <property role="Xl_RC" value="Node:" />
+                </node>
+              </node>
+            </node>
+            <node concept="2xdQw9" id="6gjbwaaGgJV" role="3cqZAp">
+              <node concept="3cpWs3" id="6gjbwaaGgJW" role="9lYJi">
+                <node concept="Xl_RD" id="6gjbwaaGgJX" role="3uHU7B">
+                  <property role="Xl_RC" value="EditorContext:" />
+                </node>
+                <node concept="2MNBq7" id="6gjbwaaGgJY" role="3uHU7w" />
+              </node>
+            </node>
+            <node concept="2xdQw9" id="6gjbwaaGgJZ" role="3cqZAp">
+              <node concept="3cpWs3" id="6gjbwaaGgK0" role="9lYJi">
+                <node concept="1tDOuL" id="6gjbwaaGgK1" role="3uHU7w" />
+                <node concept="Xl_RD" id="6gjbwaaGgK2" role="3uHU7B">
+                  <property role="Xl_RC" value="ParentNode:" />
+                </node>
+              </node>
+            </node>
+          </node>
         </node>
       </node>
       <node concept="3F0ifn" id="5ycts4RWGC4" role="3EZMnx">
@@ -1404,6 +1496,34 @@
             </node>
           </node>
         </node>
+        <node concept="315t4" id="6gjbwaaGgLl" role="vWNKz">
+          <node concept="3clFbS" id="6gjbwaaGgLm" role="2VODD2">
+            <node concept="2xdQw9" id="6gjbwaaGgLn" role="3cqZAp">
+              <node concept="3cpWs3" id="6gjbwaaGgLo" role="9lYJi">
+                <node concept="313q4" id="6gjbwaaGgLp" role="3uHU7w" />
+                <node concept="Xl_RD" id="6gjbwaaGgLq" role="3uHU7B">
+                  <property role="Xl_RC" value="Node:" />
+                </node>
+              </node>
+            </node>
+            <node concept="2xdQw9" id="6gjbwaaGgLr" role="3cqZAp">
+              <node concept="3cpWs3" id="6gjbwaaGgLs" role="9lYJi">
+                <node concept="Xl_RD" id="6gjbwaaGgLt" role="3uHU7B">
+                  <property role="Xl_RC" value="EditorContext:" />
+                </node>
+                <node concept="2MNBq7" id="6gjbwaaGgLu" role="3uHU7w" />
+              </node>
+            </node>
+            <node concept="2xdQw9" id="6gjbwaaGgLv" role="3cqZAp">
+              <node concept="3cpWs3" id="6gjbwaaGgLw" role="9lYJi">
+                <node concept="1tDOuL" id="6gjbwaaGgLx" role="3uHU7w" />
+                <node concept="Xl_RD" id="6gjbwaaGgLy" role="3uHU7B">
+                  <property role="Xl_RC" value="ParentNode:" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
       </node>
       <node concept="l2Vlx" id="5ycts4Sb$sV" role="2iSdaV" />
     </node>
@@ -1424,6 +1544,34 @@
         </node>
         <node concept="3F2HdR" id="7uEwlsAbcOt" role="_tjki">
           <ref role="1NtTu8" to="ibwz:7uEwlsA7N2F" resolve="optionalChildren" />
+        </node>
+        <node concept="315t4" id="6gjbwaaGfTY" role="vWNKz">
+          <node concept="3clFbS" id="6gjbwaaGfTZ" role="2VODD2">
+            <node concept="2xdQw9" id="6gjbwaaGfUa" role="3cqZAp">
+              <node concept="3cpWs3" id="6gjbwaaGgcS" role="9lYJi">
+                <node concept="313q4" id="6gjbwaaGgdm" role="3uHU7w" />
+                <node concept="Xl_RD" id="6gjbwaaGfUc" role="3uHU7B">
+                  <property role="Xl_RC" value="Node:" />
+                </node>
+              </node>
+            </node>
+            <node concept="2xdQw9" id="6gjbwaaGgiz" role="3cqZAp">
+              <node concept="3cpWs3" id="6gjbwaaGgi$" role="9lYJi">
+                <node concept="Xl_RD" id="6gjbwaaGgiA" role="3uHU7B">
+                  <property role="Xl_RC" value="EditorContext:" />
+                </node>
+                <node concept="2MNBq7" id="6gjbwaaGgld" role="3uHU7w" />
+              </node>
+            </node>
+            <node concept="2xdQw9" id="6gjbwaaGgq2" role="3cqZAp">
+              <node concept="3cpWs3" id="6gjbwaaGgq3" role="9lYJi">
+                <node concept="1tDOuL" id="6gjbwaaGgsF" role="3uHU7w" />
+                <node concept="Xl_RD" id="6gjbwaaGgq5" role="3uHU7B">
+                  <property role="Xl_RC" value="ParentNode:" />
+                </node>
+              </node>
+            </node>
+          </node>
         </node>
       </node>
       <node concept="2iRfu4" id="7uEwlsAbFZ_" role="2iSdaV" />

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells.sandboxlang/models/com/mbeddr/mpsutil/grammarcells/sandboxlang/editor.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells.sandboxlang/models/com/mbeddr/mpsutil/grammarcells/sandboxlang/editor.mps
@@ -187,6 +187,7 @@
       <concept id="3921456275302774825" name="com.mbeddr.mpsutil.grammarcells.structure.SplittableCell" flags="sg" stub="3921456275302774831" index="2lNzut">
         <child id="3921456275305506525" name="tokenizer" index="2lD6_D" />
       </concept>
+      <concept id="9041925471455857605" name="com.mbeddr.mpsutil.grammarcells.structure.Cell_DescriptionText" flags="ig" index="uPpia" />
       <concept id="1997572252229165641" name="com.mbeddr.mpsutil.grammarcells.structure.TransformationLocation_Before" flags="ng" index="wWMWC" />
       <concept id="1997572252229165700" name="com.mbeddr.mpsutil.grammarcells.structure.TransformationLocation_After" flags="ng" index="wWMZ_" />
       <concept id="5083944728300220902" name="com.mbeddr.mpsutil.grammarcells.structure.SubstituteCell" flags="ng" index="yw3OH">
@@ -205,11 +206,15 @@
       <concept id="8207263695491691232" name="com.mbeddr.mpsutil.grammarcells.structure.SubconceptExpression" flags="ng" index="2EmZKS" />
       <concept id="2489050352088028316" name="com.mbeddr.mpsutil.grammarcells.structure.Parameter_editorContext" flags="ng" index="2MNBq7" />
       <concept id="8945098465480383073" name="com.mbeddr.mpsutil.grammarcells.structure.OptionalCell_TransformationText" flags="ig" index="ZYGn8" />
+      <concept id="848437706375087728" name="com.mbeddr.mpsutil.grammarcells.structure.ICanHaveDescriptionText" flags="ng" index="1djCvD">
+        <child id="848437706375087729" name="descriptionText" index="1djCvC" />
+      </concept>
       <concept id="7363578995839203705" name="com.mbeddr.mpsutil.grammarcells.structure.FlagCell" flags="sg" stub="1984422498400729024" index="1kHk_G" />
       <concept id="7363578995839435357" name="com.mbeddr.mpsutil.grammarcells.structure.WrapperCell" flags="ng" index="1kIj98">
         <child id="1954385921685817931" name="postprocessSideTransform" index="31dnJ" />
         <child id="7363578995839435358" name="wrapped" index="1kIj9b" />
       </concept>
+      <concept id="7463174232466930070" name="com.mbeddr.mpsutil.grammarcells.structure.Parameter_OriginalText" flags="ng" index="1oAbNU" />
       <concept id="2862331529394479412" name="com.mbeddr.mpsutil.grammarcells.structure.GrammarConstantQuery" flags="ig" index="1Lj6DC" />
       <concept id="2862331529394479405" name="com.mbeddr.mpsutil.grammarcells.structure.GrammarConstantQueryCell" flags="ng" index="1Lj6DL">
         <child id="2862331529394487726" name="query" index="1Lj8FM" />
@@ -1043,6 +1048,39 @@
             </node>
           </node>
         </node>
+        <node concept="uPpia" id="6gjbwab2h_K" role="1djCvC">
+          <node concept="3clFbS" id="6gjbwab2h_L" role="2VODD2">
+            <node concept="2xdQw9" id="6gjbwab2hEU" role="3cqZAp">
+              <node concept="3cpWs3" id="6gjbwab2hEV" role="9lYJi">
+                <node concept="313q4" id="6gjbwab2hEW" role="3uHU7w" />
+                <node concept="Xl_RD" id="6gjbwab2hEX" role="3uHU7B">
+                  <property role="Xl_RC" value="Node:" />
+                </node>
+              </node>
+            </node>
+            <node concept="2xdQw9" id="6gjbwab2hEY" role="3cqZAp">
+              <node concept="3cpWs3" id="6gjbwab2hEZ" role="9lYJi">
+                <node concept="Xl_RD" id="6gjbwab2hF0" role="3uHU7B">
+                  <property role="Xl_RC" value="Original text" />
+                </node>
+                <node concept="1oAbNU" id="6gjbwab2hF1" role="3uHU7w" />
+              </node>
+            </node>
+            <node concept="2xdQw9" id="6gjbwab2hF2" role="3cqZAp">
+              <node concept="3cpWs3" id="6gjbwab2hF3" role="9lYJi">
+                <node concept="Xl_RD" id="6gjbwab2hF4" role="3uHU7B">
+                  <property role="Xl_RC" value="EditorContext:" />
+                </node>
+                <node concept="2MNBq7" id="6gjbwab2hF5" role="3uHU7w" />
+              </node>
+            </node>
+            <node concept="3clFbF" id="6gjbwab2hF6" role="3cqZAp">
+              <node concept="Xl_RD" id="6gjbwab2hF7" role="3clFbG">
+                <property role="Xl_RC" value="add optional expression" />
+              </node>
+            </node>
+          </node>
+        </node>
       </node>
       <node concept="l2Vlx" id="3efHud92zmh" role="2iSdaV" />
     </node>
@@ -1177,6 +1215,39 @@
                   <property role="Xl_RC" value="EditorContext:" />
                 </node>
                 <node concept="2MNBq7" id="6gjbwaaLzan" role="3uHU7w" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="uPpia" id="6gjbwab2irO" role="1djCvC">
+          <node concept="3clFbS" id="6gjbwab2irP" role="2VODD2">
+            <node concept="2xdQw9" id="6gjbwab2isB" role="3cqZAp">
+              <node concept="3cpWs3" id="6gjbwab2isC" role="9lYJi">
+                <node concept="313q4" id="6gjbwab2isD" role="3uHU7w" />
+                <node concept="Xl_RD" id="6gjbwab2isE" role="3uHU7B">
+                  <property role="Xl_RC" value="Node:" />
+                </node>
+              </node>
+            </node>
+            <node concept="2xdQw9" id="6gjbwab2isF" role="3cqZAp">
+              <node concept="3cpWs3" id="6gjbwab2isG" role="9lYJi">
+                <node concept="Xl_RD" id="6gjbwab2isH" role="3uHU7B">
+                  <property role="Xl_RC" value="Original text" />
+                </node>
+                <node concept="1oAbNU" id="6gjbwab2isI" role="3uHU7w" />
+              </node>
+            </node>
+            <node concept="2xdQw9" id="6gjbwab2isJ" role="3cqZAp">
+              <node concept="3cpWs3" id="6gjbwab2isK" role="9lYJi">
+                <node concept="Xl_RD" id="6gjbwab2isL" role="3uHU7B">
+                  <property role="Xl_RC" value="EditorContext:" />
+                </node>
+                <node concept="2MNBq7" id="6gjbwab2isM" role="3uHU7w" />
+              </node>
+            </node>
+            <node concept="3clFbF" id="6gjbwab2isN" role="3cqZAp">
+              <node concept="Xl_RD" id="6gjbwab2isO" role="3clFbG">
+                <property role="Xl_RC" value="add optional expression" />
               </node>
             </node>
           </node>
@@ -1424,6 +1495,39 @@
             </node>
           </node>
         </node>
+        <node concept="uPpia" id="6gjbwab2icL" role="1djCvC">
+          <node concept="3clFbS" id="6gjbwab2icM" role="2VODD2">
+            <node concept="2xdQw9" id="6gjbwab2ihL" role="3cqZAp">
+              <node concept="3cpWs3" id="6gjbwab2ihM" role="9lYJi">
+                <node concept="313q4" id="6gjbwab2ihN" role="3uHU7w" />
+                <node concept="Xl_RD" id="6gjbwab2ihO" role="3uHU7B">
+                  <property role="Xl_RC" value="Node:" />
+                </node>
+              </node>
+            </node>
+            <node concept="2xdQw9" id="6gjbwab2ihP" role="3cqZAp">
+              <node concept="3cpWs3" id="6gjbwab2ihQ" role="9lYJi">
+                <node concept="Xl_RD" id="6gjbwab2ihR" role="3uHU7B">
+                  <property role="Xl_RC" value="Original text" />
+                </node>
+                <node concept="1oAbNU" id="6gjbwab2ihS" role="3uHU7w" />
+              </node>
+            </node>
+            <node concept="2xdQw9" id="6gjbwab2ihT" role="3cqZAp">
+              <node concept="3cpWs3" id="6gjbwab2ihU" role="9lYJi">
+                <node concept="Xl_RD" id="6gjbwab2ihV" role="3uHU7B">
+                  <property role="Xl_RC" value="EditorContext:" />
+                </node>
+                <node concept="2MNBq7" id="6gjbwab2ihW" role="3uHU7w" />
+              </node>
+            </node>
+            <node concept="3clFbF" id="6gjbwab2ihX" role="3cqZAp">
+              <node concept="Xl_RD" id="6gjbwab2ihY" role="3clFbG">
+                <property role="Xl_RC" value="add optional single child" />
+              </node>
+            </node>
+          </node>
+        </node>
       </node>
       <node concept="3F0ifn" id="5ycts4RUtBN" role="3EZMnx">
         <property role="3F0ifm" value=";" />
@@ -1461,6 +1565,39 @@
                   <property role="Xl_RC" value="EditorContext:" />
                 </node>
                 <node concept="2MNBq7" id="6gjbwaaGgJY" role="3uHU7w" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="uPpia" id="6gjbwab2hPI" role="1djCvC">
+          <node concept="3clFbS" id="6gjbwab2hPJ" role="2VODD2">
+            <node concept="2xdQw9" id="6gjbwab2hUS" role="3cqZAp">
+              <node concept="3cpWs3" id="6gjbwab2hUT" role="9lYJi">
+                <node concept="313q4" id="6gjbwab2hUU" role="3uHU7w" />
+                <node concept="Xl_RD" id="6gjbwab2hUV" role="3uHU7B">
+                  <property role="Xl_RC" value="Node:" />
+                </node>
+              </node>
+            </node>
+            <node concept="2xdQw9" id="6gjbwab2hUW" role="3cqZAp">
+              <node concept="3cpWs3" id="6gjbwab2hUX" role="9lYJi">
+                <node concept="Xl_RD" id="6gjbwab2hUY" role="3uHU7B">
+                  <property role="Xl_RC" value="Original text" />
+                </node>
+                <node concept="1oAbNU" id="6gjbwab2hUZ" role="3uHU7w" />
+              </node>
+            </node>
+            <node concept="2xdQw9" id="6gjbwab2hV0" role="3cqZAp">
+              <node concept="3cpWs3" id="6gjbwab2hV1" role="9lYJi">
+                <node concept="Xl_RD" id="6gjbwab2hV2" role="3uHU7B">
+                  <property role="Xl_RC" value="EditorContext:" />
+                </node>
+                <node concept="2MNBq7" id="6gjbwab2hV3" role="3uHU7w" />
+              </node>
+            </node>
+            <node concept="3clFbF" id="6gjbwab2hV4" role="3cqZAp">
+              <node concept="Xl_RD" id="6gjbwab2hV5" role="3clFbG">
+                <property role="Xl_RC" value="add optional children" />
               </node>
             </node>
           </node>
@@ -1507,6 +1644,39 @@
                   <property role="Xl_RC" value="EditorContext:" />
                 </node>
                 <node concept="2MNBq7" id="6gjbwaaGgLu" role="3uHU7w" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="uPpia" id="6gjbwab2i2z" role="1djCvC">
+          <node concept="3clFbS" id="6gjbwab2i2$" role="2VODD2">
+            <node concept="2xdQw9" id="6gjbwab2i3m" role="3cqZAp">
+              <node concept="3cpWs3" id="6gjbwab2i3n" role="9lYJi">
+                <node concept="313q4" id="6gjbwab2i3o" role="3uHU7w" />
+                <node concept="Xl_RD" id="6gjbwab2i3p" role="3uHU7B">
+                  <property role="Xl_RC" value="Node:" />
+                </node>
+              </node>
+            </node>
+            <node concept="2xdQw9" id="6gjbwab2i3q" role="3cqZAp">
+              <node concept="3cpWs3" id="6gjbwab2i3r" role="9lYJi">
+                <node concept="Xl_RD" id="6gjbwab2i3s" role="3uHU7B">
+                  <property role="Xl_RC" value="Original text" />
+                </node>
+                <node concept="1oAbNU" id="6gjbwab2i3t" role="3uHU7w" />
+              </node>
+            </node>
+            <node concept="2xdQw9" id="6gjbwab2i3u" role="3cqZAp">
+              <node concept="3cpWs3" id="6gjbwab2i3v" role="9lYJi">
+                <node concept="Xl_RD" id="6gjbwab2i3w" role="3uHU7B">
+                  <property role="Xl_RC" value="EditorContext:" />
+                </node>
+                <node concept="2MNBq7" id="6gjbwab2i3x" role="3uHU7w" />
+              </node>
+            </node>
+            <node concept="3clFbF" id="6gjbwab2i3y" role="3cqZAp">
+              <node concept="Xl_RD" id="6gjbwab2i3z" role="3clFbG">
+                <property role="Xl_RC" value="add optional reference" />
               </node>
             </node>
           </node>
@@ -1564,6 +1734,39 @@
                   <property role="Xl_RC" value="EditorContext:" />
                 </node>
                 <node concept="2MNBq7" id="6gjbwaaGgld" role="3uHU7w" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="uPpia" id="6gjbwab0EZE" role="1djCvC">
+          <node concept="3clFbS" id="6gjbwab0EZF" role="2VODD2">
+            <node concept="2xdQw9" id="6gjbwab0FbE" role="3cqZAp">
+              <node concept="3cpWs3" id="6gjbwab0FbF" role="9lYJi">
+                <node concept="313q4" id="6gjbwab0FbG" role="3uHU7w" />
+                <node concept="Xl_RD" id="6gjbwab0FbH" role="3uHU7B">
+                  <property role="Xl_RC" value="Node:" />
+                </node>
+              </node>
+            </node>
+            <node concept="2xdQw9" id="6gjbwab0FbI" role="3cqZAp">
+              <node concept="3cpWs3" id="6gjbwab0FbJ" role="9lYJi">
+                <node concept="Xl_RD" id="6gjbwab0FbK" role="3uHU7B">
+                  <property role="Xl_RC" value="Original text" />
+                </node>
+                <node concept="1oAbNU" id="6gjbwab0Fg5" role="3uHU7w" />
+              </node>
+            </node>
+            <node concept="2xdQw9" id="6gjbwab0Fhf" role="3cqZAp">
+              <node concept="3cpWs3" id="6gjbwab0Fhg" role="9lYJi">
+                <node concept="Xl_RD" id="6gjbwab0Fhh" role="3uHU7B">
+                  <property role="Xl_RC" value="EditorContext:" />
+                </node>
+                <node concept="2MNBq7" id="6gjbwab0Fhi" role="3uHU7w" />
+              </node>
+            </node>
+            <node concept="3clFbF" id="6gjbwab0FaB" role="3cqZAp">
+              <node concept="Xl_RD" id="6gjbwab0FaA" role="3clFbG">
+                <property role="Xl_RC" value="add optional children" />
               </node>
             </node>
           </node>

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells.sandboxlang/models/com/mbeddr/mpsutil/grammarcells/sandboxlang/editor.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells.sandboxlang/models/com/mbeddr/mpsutil/grammarcells/sandboxlang/editor.mps
@@ -160,6 +160,9 @@
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
+      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
+        <property id="1068580123138" name="value" index="3clFbU" />
+      </concept>
       <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
         <property id="1068580320021" name="value" index="3cmrfH" />
       </concept>
@@ -184,6 +187,8 @@
         <child id="1716599163375643746" name="inner" index="drBAU" />
         <child id="1716599163375643751" name="right" index="drBAZ" />
       </concept>
+      <concept id="1984422498402698431" name="com.mbeddr.mpsutil.grammarcells.structure.WrapperCell_Condition" flags="ig" index="2e7140" />
+      <concept id="1984422498402709328" name="com.mbeddr.mpsutil.grammarcells.structure.WrapperCell_Condition_wrappedNode" flags="ng" index="2e73FJ" />
       <concept id="3921456275302774825" name="com.mbeddr.mpsutil.grammarcells.structure.SplittableCell" flags="sg" stub="3921456275302774831" index="2lNzut">
         <child id="3921456275305506525" name="tokenizer" index="2lD6_D" />
       </concept>
@@ -212,6 +217,8 @@
       <concept id="7363578995839203705" name="com.mbeddr.mpsutil.grammarcells.structure.FlagCell" flags="sg" stub="1984422498400729024" index="1kHk_G" />
       <concept id="7363578995839435357" name="com.mbeddr.mpsutil.grammarcells.structure.WrapperCell" flags="ng" index="1kIj98">
         <child id="1954385921685817931" name="postprocessSideTransform" index="31dnJ" />
+        <child id="1954385921685817946" name="postprocessNodeSubstitute" index="31dnY" />
+        <child id="1984422498402083610" name="sideTransformationCondition" index="2e1Fq_" />
         <child id="7363578995839435358" name="wrapped" index="1kIj9b" />
       </concept>
       <concept id="7463174232466930070" name="com.mbeddr.mpsutil.grammarcells.structure.Parameter_OriginalText" flags="ng" index="1oAbNU" />
@@ -564,6 +571,79 @@
         <node concept="1kIj98" id="RbLMy6d8Zw" role="3EZMnx">
           <node concept="3F1sOY" id="RbLMy6d8Zy" role="1kIj9b">
             <ref role="1NtTu8" to="ibwz:RbLMy6d5VU" resolve="type" />
+          </node>
+          <node concept="315t4" id="6gjbwab3Srs" role="31dnY">
+            <node concept="3clFbS" id="6gjbwab3Srt" role="2VODD2">
+              <node concept="2xdQw9" id="6gjbwab3S$R" role="3cqZAp">
+                <node concept="3cpWs3" id="6gjbwab3S$S" role="9lYJi">
+                  <node concept="313q4" id="6gjbwab3S$T" role="3uHU7w" />
+                  <node concept="Xl_RD" id="6gjbwab3S$U" role="3uHU7B">
+                    <property role="Xl_RC" value="Node:" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2xdQw9" id="6gjbwab3S$V" role="3cqZAp">
+                <node concept="3cpWs3" id="6gjbwab3S$W" role="9lYJi">
+                  <node concept="Xl_RD" id="6gjbwab3S$X" role="3uHU7B">
+                    <property role="Xl_RC" value="EditorContext:" />
+                  </node>
+                  <node concept="2MNBq7" id="6gjbwab3S$Y" role="3uHU7w" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="315t4" id="6gjbwab3S_R" role="31dnJ">
+            <node concept="3clFbS" id="6gjbwab3S_S" role="2VODD2">
+              <node concept="2xdQw9" id="6gjbwab3SAv" role="3cqZAp">
+                <node concept="3cpWs3" id="6gjbwab3SAw" role="9lYJi">
+                  <node concept="313q4" id="6gjbwab3SAx" role="3uHU7w" />
+                  <node concept="Xl_RD" id="6gjbwab3SAy" role="3uHU7B">
+                    <property role="Xl_RC" value="Node:" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2xdQw9" id="6gjbwab3SAz" role="3cqZAp">
+                <node concept="3cpWs3" id="6gjbwab3SA$" role="9lYJi">
+                  <node concept="Xl_RD" id="6gjbwab3SA_" role="3uHU7B">
+                    <property role="Xl_RC" value="EditorContext:" />
+                  </node>
+                  <node concept="2MNBq7" id="6gjbwab3SAA" role="3uHU7w" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2e7140" id="6gjbwab5uMO" role="2e1Fq_">
+            <node concept="3clFbS" id="6gjbwab5uMP" role="2VODD2">
+              <node concept="2xdQw9" id="6gjbwab5uW0" role="3cqZAp">
+                <node concept="3cpWs3" id="6gjbwab5uW1" role="9lYJi">
+                  <node concept="2e73FJ" id="6gjbwab5v0B" role="3uHU7w" />
+                  <node concept="Xl_RD" id="6gjbwab5uW3" role="3uHU7B">
+                    <property role="Xl_RC" value="WrappedNode:" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2xdQw9" id="6gjbwab5v5a" role="3cqZAp">
+                <node concept="3cpWs3" id="6gjbwab5v5b" role="9lYJi">
+                  <node concept="1Lj6YZ" id="6gjbwab5vkI" role="3uHU7w" />
+                  <node concept="Xl_RD" id="6gjbwab5v5d" role="3uHU7B">
+                    <property role="Xl_RC" value="Subconcept:" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2xdQw9" id="6gjbwab5v6x" role="3cqZAp">
+                <node concept="3cpWs3" id="6gjbwab5v6y" role="9lYJi">
+                  <node concept="2MNBq7" id="6gjbwab5vmc" role="3uHU7w" />
+                  <node concept="Xl_RD" id="6gjbwab5v6$" role="3uHU7B">
+                    <property role="Xl_RC" value="EditorContext:" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbF" id="6gjbwab5uRL" role="3cqZAp">
+                <node concept="3clFbT" id="6gjbwab5uRK" role="3clFbG">
+                  <property role="3clFbU" value="true" />
+                </node>
+              </node>
+            </node>
           </node>
         </node>
         <node concept="3F0ifn" id="RbLMy6d5WL" role="3EZMnx">

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells.sandboxlang/models/com/mbeddr/mpsutil/grammarcells/sandboxlang/editor.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells.sandboxlang/models/com/mbeddr/mpsutil/grammarcells/sandboxlang/editor.mps
@@ -210,7 +210,6 @@
         <child id="1954385921685817931" name="postprocessSideTransform" index="31dnJ" />
         <child id="7363578995839435358" name="wrapped" index="1kIj9b" />
       </concept>
-      <concept id="904978958140335648" name="com.mbeddr.mpsutil.grammarcells.structure.Parameter_parentNode" flags="ng" index="1tDOuL" />
       <concept id="2862331529394479412" name="com.mbeddr.mpsutil.grammarcells.structure.GrammarConstantQuery" flags="ig" index="1Lj6DC" />
       <concept id="2862331529394479405" name="com.mbeddr.mpsutil.grammarcells.structure.GrammarConstantQueryCell" flags="ng" index="1Lj6DL">
         <child id="2862331529394487726" name="query" index="1Lj8FM" />
@@ -1042,14 +1041,6 @@
                 <node concept="2MNBq7" id="6gjbwaaGgIu" role="3uHU7w" />
               </node>
             </node>
-            <node concept="2xdQw9" id="6gjbwaaGgIv" role="3cqZAp">
-              <node concept="3cpWs3" id="6gjbwaaGgIw" role="9lYJi">
-                <node concept="1tDOuL" id="6gjbwaaGgIx" role="3uHU7w" />
-                <node concept="Xl_RD" id="6gjbwaaGgIy" role="3uHU7B">
-                  <property role="Xl_RC" value="ParentNode:" />
-                </node>
-              </node>
-            </node>
           </node>
         </node>
       </node>
@@ -1168,6 +1159,26 @@
           <node concept="l2Vlx" id="24ObHxTtaD5" role="2iSdaV" />
           <node concept="VPM3Z" id="24ObHxTtaD6" role="3F10Kt">
             <property role="VOm3f" value="false" />
+          </node>
+        </node>
+        <node concept="315t4" id="6gjbwaaLza4" role="vWNKz">
+          <node concept="3clFbS" id="6gjbwaaLza5" role="2VODD2">
+            <node concept="2xdQw9" id="6gjbwaaLzag" role="3cqZAp">
+              <node concept="3cpWs3" id="6gjbwaaLzah" role="9lYJi">
+                <node concept="313q4" id="6gjbwaaLzai" role="3uHU7w" />
+                <node concept="Xl_RD" id="6gjbwaaLzaj" role="3uHU7B">
+                  <property role="Xl_RC" value="Node:" />
+                </node>
+              </node>
+            </node>
+            <node concept="2xdQw9" id="6gjbwaaLzak" role="3cqZAp">
+              <node concept="3cpWs3" id="6gjbwaaLzal" role="9lYJi">
+                <node concept="Xl_RD" id="6gjbwaaLzam" role="3uHU7B">
+                  <property role="Xl_RC" value="EditorContext:" />
+                </node>
+                <node concept="2MNBq7" id="6gjbwaaLzan" role="3uHU7w" />
+              </node>
+            </node>
           </node>
         </node>
       </node>
@@ -1411,14 +1422,6 @@
                 <node concept="2MNBq7" id="6gjbwaaGgMY" role="3uHU7w" />
               </node>
             </node>
-            <node concept="2xdQw9" id="6gjbwaaGgMZ" role="3cqZAp">
-              <node concept="3cpWs3" id="6gjbwaaGgN0" role="9lYJi">
-                <node concept="1tDOuL" id="6gjbwaaGgN1" role="3uHU7w" />
-                <node concept="Xl_RD" id="6gjbwaaGgN2" role="3uHU7B">
-                  <property role="Xl_RC" value="ParentNode:" />
-                </node>
-              </node>
-            </node>
           </node>
         </node>
       </node>
@@ -1458,14 +1461,6 @@
                   <property role="Xl_RC" value="EditorContext:" />
                 </node>
                 <node concept="2MNBq7" id="6gjbwaaGgJY" role="3uHU7w" />
-              </node>
-            </node>
-            <node concept="2xdQw9" id="6gjbwaaGgJZ" role="3cqZAp">
-              <node concept="3cpWs3" id="6gjbwaaGgK0" role="9lYJi">
-                <node concept="1tDOuL" id="6gjbwaaGgK1" role="3uHU7w" />
-                <node concept="Xl_RD" id="6gjbwaaGgK2" role="3uHU7B">
-                  <property role="Xl_RC" value="ParentNode:" />
-                </node>
               </node>
             </node>
           </node>
@@ -1514,14 +1509,6 @@
                 <node concept="2MNBq7" id="6gjbwaaGgLu" role="3uHU7w" />
               </node>
             </node>
-            <node concept="2xdQw9" id="6gjbwaaGgLv" role="3cqZAp">
-              <node concept="3cpWs3" id="6gjbwaaGgLw" role="9lYJi">
-                <node concept="1tDOuL" id="6gjbwaaGgLx" role="3uHU7w" />
-                <node concept="Xl_RD" id="6gjbwaaGgLy" role="3uHU7B">
-                  <property role="Xl_RC" value="ParentNode:" />
-                </node>
-              </node>
-            </node>
           </node>
         </node>
       </node>
@@ -1561,14 +1548,6 @@
                   <property role="Xl_RC" value="EditorContext:" />
                 </node>
                 <node concept="2MNBq7" id="6gjbwaaGgld" role="3uHU7w" />
-              </node>
-            </node>
-            <node concept="2xdQw9" id="6gjbwaaGgq2" role="3cqZAp">
-              <node concept="3cpWs3" id="6gjbwaaGgq3" role="9lYJi">
-                <node concept="1tDOuL" id="6gjbwaaGgsF" role="3uHU7w" />
-                <node concept="Xl_RD" id="6gjbwaaGgq5" role="3uHU7B">
-                  <property role="Xl_RC" value="ParentNode:" />
-                </node>
               </node>
             </node>
           </node>

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells.sandboxlang/models/com/mbeddr/mpsutil/grammarcells/sandboxlang/editor.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells.sandboxlang/models/com/mbeddr/mpsutil/grammarcells/sandboxlang/editor.mps
@@ -1522,6 +1522,22 @@
       <node concept="_tjkj" id="7uEwlsA7BRu" role="3EZMnx">
         <node concept="ZYGn8" id="7uEwlsA7G6U" role="ZWbT9">
           <node concept="3clFbS" id="7uEwlsA7G6V" role="2VODD2">
+            <node concept="2xdQw9" id="6gjbwaaQn9E" role="3cqZAp">
+              <node concept="3cpWs3" id="6gjbwaaQn9F" role="9lYJi">
+                <node concept="pncrf" id="6gjbwaaQni4" role="3uHU7w" />
+                <node concept="Xl_RD" id="6gjbwaaQn9H" role="3uHU7B">
+                  <property role="Xl_RC" value="Node:" />
+                </node>
+              </node>
+            </node>
+            <node concept="2xdQw9" id="6gjbwaaQn9I" role="3cqZAp">
+              <node concept="3cpWs3" id="6gjbwaaQn9J" role="9lYJi">
+                <node concept="Xl_RD" id="6gjbwaaQn9K" role="3uHU7B">
+                  <property role="Xl_RC" value="EditorContext:" />
+                </node>
+                <node concept="2MNBq7" id="6gjbwaaQnjJ" role="3uHU7w" />
+              </node>
+            </node>
             <node concept="3clFbF" id="7uEwlsA7G7A" role="3cqZAp">
               <node concept="Xl_RD" id="7uEwlsA7G7_" role="3clFbG">
                 <property role="Xl_RC" value="abc" />

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells.sandboxlang/models/com/mbeddr/mpsutil/grammarcells/sandboxlang/editor.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells.sandboxlang/models/com/mbeddr/mpsutil/grammarcells/sandboxlang/editor.mps
@@ -189,6 +189,7 @@
       </concept>
       <concept id="1984422498402698431" name="com.mbeddr.mpsutil.grammarcells.structure.WrapperCell_Condition" flags="ig" index="2e7140" />
       <concept id="1984422498402709328" name="com.mbeddr.mpsutil.grammarcells.structure.WrapperCell_Condition_wrappedNode" flags="ng" index="2e73FJ" />
+      <concept id="2523386941174202656" name="com.mbeddr.mpsutil.grammarcells.structure.FlagCell_SubstituteCondition_parentNode" flags="ng" index="2gy9SH" />
       <concept id="3921456275302774825" name="com.mbeddr.mpsutil.grammarcells.structure.SplittableCell" flags="sg" stub="3921456275302774831" index="2lNzut">
         <child id="3921456275305506525" name="tokenizer" index="2lD6_D" />
       </concept>
@@ -214,13 +215,19 @@
       <concept id="848437706375087728" name="com.mbeddr.mpsutil.grammarcells.structure.ICanHaveDescriptionText" flags="ng" index="1djCvD">
         <child id="848437706375087729" name="descriptionText" index="1djCvC" />
       </concept>
-      <concept id="7363578995839203705" name="com.mbeddr.mpsutil.grammarcells.structure.FlagCell" flags="sg" stub="1984422498400729024" index="1kHk_G" />
+      <concept id="484443907672824414" name="com.mbeddr.mpsutil.grammarcells.structure.FlagCell_SubstituteCondition" flags="ig" index="3gMsPO" />
+      <concept id="484443907672900465" name="com.mbeddr.mpsutil.grammarcells.structure.FlagCell_SubstituteCondition_substitutedNode" flags="ng" index="3gMLhr" />
+      <concept id="7363578995839203705" name="com.mbeddr.mpsutil.grammarcells.structure.FlagCell" flags="sg" stub="1984422498400729024" index="1kHk_G">
+        <child id="484443907672828832" name="substituteCondition" index="3gMvMa" />
+        <child id="621193272061064649" name="sideTransformCondition" index="1m$hSO" />
+      </concept>
       <concept id="7363578995839435357" name="com.mbeddr.mpsutil.grammarcells.structure.WrapperCell" flags="ng" index="1kIj98">
         <child id="1954385921685817931" name="postprocessSideTransform" index="31dnJ" />
         <child id="1954385921685817946" name="postprocessNodeSubstitute" index="31dnY" />
         <child id="1984422498402083610" name="sideTransformationCondition" index="2e1Fq_" />
         <child id="7363578995839435358" name="wrapped" index="1kIj9b" />
       </concept>
+      <concept id="621193272061064420" name="com.mbeddr.mpsutil.grammarcells.structure.FlagCell_SideTransformationCondition" flags="ig" index="1m$hWp" />
       <concept id="7463174232466930070" name="com.mbeddr.mpsutil.grammarcells.structure.Parameter_OriginalText" flags="ng" index="1oAbNU" />
       <concept id="2862331529394479412" name="com.mbeddr.mpsutil.grammarcells.structure.GrammarConstantQuery" flags="ig" index="1Lj6DC" />
       <concept id="2862331529394479405" name="com.mbeddr.mpsutil.grammarcells.structure.GrammarConstantQueryCell" flags="ng" index="1Lj6DL">
@@ -521,6 +528,105 @@
       <node concept="3EZMnI" id="RbLMy68PdP" role="1LiK7o">
         <node concept="1kHk_G" id="qT5MFml3J9" role="3EZMnx">
           <ref role="1NtTu8" to="ibwz:qT5MFml3Gb" resolve="static" />
+          <node concept="3gMsPO" id="6gjbwab9PEO" role="3gMvMa">
+            <node concept="3clFbS" id="6gjbwab9PEP" role="2VODD2">
+              <node concept="2xdQw9" id="6gjbwab9PJU" role="3cqZAp">
+                <node concept="3cpWs3" id="6gjbwab9Q38" role="9lYJi">
+                  <node concept="1Lj6YZ" id="6gjbwab9Q7x" role="3uHU7w" />
+                  <node concept="Xl_RD" id="6gjbwab9PJW" role="3uHU7B">
+                    <property role="Xl_RC" value="Subconcept:" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2xdQw9" id="6gjbwab9Q8x" role="3cqZAp">
+                <node concept="3cpWs3" id="6gjbwab9Q8y" role="9lYJi">
+                  <node concept="3gMLhr" id="6gjbwab9Qdc" role="3uHU7w" />
+                  <node concept="Xl_RD" id="6gjbwab9Q8$" role="3uHU7B">
+                    <property role="Xl_RC" value="SubstitutedNode:" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2xdQw9" id="6gjbwab9Qem" role="3cqZAp">
+                <node concept="3cpWs3" id="6gjbwab9Qen" role="9lYJi">
+                  <node concept="Xl_RD" id="6gjbwab9Qep" role="3uHU7B">
+                    <property role="Xl_RC" value="ParentNode:" />
+                  </node>
+                  <node concept="2gy9SH" id="6gjbwab9Qvc" role="3uHU7w" />
+                </node>
+              </node>
+              <node concept="2xdQw9" id="6gjbwab9QwE" role="3cqZAp">
+                <node concept="3cpWs3" id="6gjbwab9QwF" role="9lYJi">
+                  <node concept="Xl_RD" id="6gjbwab9QwG" role="3uHU7B">
+                    <property role="Xl_RC" value="EditorContext:" />
+                  </node>
+                  <node concept="2MNBq7" id="6gjbwab9QFp" role="3uHU7w" />
+                </node>
+              </node>
+              <node concept="3clFbF" id="6gjbwab9PFc" role="3cqZAp">
+                <node concept="3clFbT" id="6gjbwab9PFb" role="3clFbG">
+                  <property role="3clFbU" value="true" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1m$hWp" id="6gjbwab9QHb" role="1m$hSO">
+            <node concept="3clFbS" id="6gjbwab9QHc" role="2VODD2">
+              <node concept="2xdQw9" id="6gjbwab9QMQ" role="3cqZAp">
+                <node concept="3cpWs3" id="6gjbwab9QMR" role="9lYJi">
+                  <node concept="1Lj6YZ" id="6gjbwab9QMS" role="3uHU7w" />
+                  <node concept="Xl_RD" id="6gjbwab9QMT" role="3uHU7B">
+                    <property role="Xl_RC" value="Subconcept:" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2xdQw9" id="6gjbwab9QSt" role="3cqZAp">
+                <node concept="3cpWs3" id="6gjbwab9QSu" role="9lYJi">
+                  <node concept="313q4" id="6gjbwab9QW2" role="3uHU7w" />
+                  <node concept="Xl_RD" id="6gjbwab9QSw" role="3uHU7B">
+                    <property role="Xl_RC" value="Node:" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2xdQw9" id="6gjbwab9QXc" role="3cqZAp">
+                <node concept="3cpWs3" id="6gjbwab9QXd" role="9lYJi">
+                  <node concept="Xl_RD" id="6gjbwab9QXe" role="3uHU7B">
+                    <property role="Xl_RC" value="EditorContext:" />
+                  </node>
+                  <node concept="2MNBq7" id="6gjbwab9QXf" role="3uHU7w" />
+                </node>
+              </node>
+              <node concept="3clFbF" id="6gjbwab9QHh" role="3cqZAp">
+                <node concept="3clFbT" id="6gjbwab9QHg" role="3clFbG">
+                  <property role="3clFbU" value="true" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="uPpia" id="6gjbwabl$Xu" role="1djCvC">
+            <node concept="3clFbS" id="6gjbwabl$Xv" role="2VODD2">
+              <node concept="2xdQw9" id="6gjbwabl_9O" role="3cqZAp">
+                <node concept="3cpWs3" id="6gjbwabl_9P" role="9lYJi">
+                  <node concept="Xl_RD" id="6gjbwabl_9Q" role="3uHU7B">
+                    <property role="Xl_RC" value="OriginalText:" />
+                  </node>
+                  <node concept="1oAbNU" id="6gjbwabl_kn" role="3uHU7w" />
+                </node>
+              </node>
+              <node concept="2xdQw9" id="6gjbwabl_9S" role="3cqZAp">
+                <node concept="3cpWs3" id="6gjbwabl_9T" role="9lYJi">
+                  <node concept="Xl_RD" id="6gjbwabl_9U" role="3uHU7B">
+                    <property role="Xl_RC" value="EditorContext:" />
+                  </node>
+                  <node concept="2MNBq7" id="6gjbwabl_9V" role="3uHU7w" />
+                </node>
+              </node>
+              <node concept="3clFbF" id="6gjbwabl_8i" role="3cqZAp">
+                <node concept="Xl_RD" id="6gjbwabl_8h" role="3clFbG">
+                  <property role="Xl_RC" value="add static flag" />
+                </node>
+              </node>
+            </node>
+          </node>
         </node>
         <node concept="1kIj98" id="RbLMy68PdQ" role="3EZMnx">
           <node concept="3F1sOY" id="RbLMy68PdR" role="1kIj9b">

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/generator/template/main@generator.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/generator/template/main@generator.mps
@@ -21085,7 +21085,6 @@
                               </node>
                             </node>
                           </node>
-                          <node concept="3clFbH" id="6B579NGr3Hh" role="3cqZAp" />
                           <node concept="3clFbJ" id="6B579NGqSU5" role="3cqZAp">
                             <node concept="3clFbS" id="6B579NGqSU7" role="3clFbx">
                               <node concept="3cpWs8" id="6B579NGr$G_" role="3cqZAp">
@@ -21201,6 +21200,22 @@
                                       </node>
                                       <node concept="3clFbJ" id="5n4nn1a79Z$" role="3cqZAp">
                                         <node concept="3clFbS" id="5n4nn1a79Z_" role="3clFbx">
+                                          <node concept="3cpWs8" id="6gjbwab7wAw" role="3cqZAp">
+                                            <node concept="3cpWsn" id="6gjbwab7wAx" role="3cpWs9">
+                                              <property role="TrG5h" value="editorContext" />
+                                              <node concept="3uibUv" id="6gjbwab7uyf" role="1tU5fm">
+                                                <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+                                              </node>
+                                              <node concept="2OqwBi" id="6gjbwab7wAy" role="33vP2m">
+                                                <node concept="37vLTw" id="6gjbwab7wAz" role="2Oq$k0">
+                                                  <ref role="3cqZAo" node="5n4nn1a79YN" resolve="_context" />
+                                                </node>
+                                                <node concept="liA8E" id="6gjbwab7wA$" role="2OqNvi">
+                                                  <ref role="37wK5l" to="uddc:~TransformationMenuContext.getEditorContext()" resolve="getEditorContext" />
+                                                </node>
+                                              </node>
+                                            </node>
+                                          </node>
                                           <node concept="3cpWs8" id="49FqtR5VyJX" role="3cqZAp">
                                             <node concept="3cpWsn" id="49FqtR5VyJY" role="3cpWs9">
                                               <property role="TrG5h" value="sideTransformationEnabled" />

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/generator/template/main@generator.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/generator/template/main@generator.mps
@@ -3093,6 +3093,20 @@
                                               </node>
                                             </node>
                                           </node>
+                                          <node concept="3cpWs8" id="6gjbwaaIhPI" role="3cqZAp">
+                                            <node concept="3cpWsn" id="6gjbwaaIhPJ" role="3cpWs9">
+                                              <property role="TrG5h" value="editorContext" />
+                                              <node concept="3uibUv" id="6gjbwaaIh3e" role="1tU5fm">
+                                                <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+                                              </node>
+                                              <node concept="2OqwBi" id="6gjbwaaIhPK" role="33vP2m">
+                                                <node concept="2Mo9yH" id="6gjbwaaIhPL" role="2Oq$k0" />
+                                                <node concept="liA8E" id="6gjbwaaIhPM" role="2OqNvi">
+                                                  <ref role="37wK5l" to="uddc:~TransformationMenuContext.getEditorContext()" resolve="getEditorContext" />
+                                                </node>
+                                              </node>
+                                            </node>
+                                          </node>
                                           <node concept="3cpWs8" id="5fS8LroEMHn" role="3cqZAp">
                                             <node concept="3cpWsn" id="5fS8LroEMHo" role="3cpWs9">
                                               <property role="TrG5h" value="newNode" />
@@ -5818,6 +5832,20 @@
                                                     </node>
                                                   </node>
                                                 </node>
+                                              </node>
+                                            </node>
+                                          </node>
+                                        </node>
+                                        <node concept="3cpWs8" id="6gjbwaaIuGL" role="3cqZAp">
+                                          <node concept="3cpWsn" id="6gjbwaaIuGM" role="3cpWs9">
+                                            <property role="TrG5h" value="editorContext" />
+                                            <node concept="3uibUv" id="6gjbwaaIuG9" role="1tU5fm">
+                                              <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+                                            </node>
+                                            <node concept="2OqwBi" id="6gjbwaaIuGN" role="33vP2m">
+                                              <node concept="2Mo9yH" id="6gjbwaaIuGO" role="2Oq$k0" />
+                                              <node concept="liA8E" id="6gjbwaaIuGP" role="2OqNvi">
+                                                <ref role="37wK5l" to="uddc:~TransformationMenuContext.getEditorContext()" resolve="getEditorContext" />
                                               </node>
                                             </node>
                                           </node>

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/generator/template/main@generator.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/generator/template/main@generator.mps
@@ -1552,6 +1552,20 @@
                         </node>
                         <node concept="1DcWWT" id="qT5MFmsSR$" role="3cqZAp">
                           <node concept="3clFbS" id="qT5MFmsSRA" role="2LFqv$">
+                            <node concept="3cpWs8" id="6gjbwabe73F" role="3cqZAp">
+                              <node concept="3cpWsn" id="6gjbwabe73G" role="3cpWs9">
+                                <property role="TrG5h" value="editorContext" />
+                                <node concept="3uibUv" id="6gjbwabe73H" role="1tU5fm">
+                                  <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+                                </node>
+                                <node concept="2OqwBi" id="6gjbwabe73I" role="33vP2m">
+                                  <node concept="2kYc5w" id="6gjbwabe73J" role="2Oq$k0" />
+                                  <node concept="liA8E" id="6gjbwabe73K" role="2OqNvi">
+                                    <ref role="37wK5l" to="78sh:~SubstituteMenuContext.getEditorContext()" resolve="getEditorContext" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
                             <node concept="3cpWs8" id="qT5MFmt1j6" role="3cqZAp">
                               <node concept="3cpWsn" id="qT5MFmt1j9" role="3cpWs9">
                                 <property role="TrG5h" value="applicable" />
@@ -1745,7 +1759,6 @@
                                                     </node>
                                                   </node>
                                                 </node>
-                                                <node concept="3clFbH" id="1ZlHRbfTfDW" role="3cqZAp" />
                                                 <node concept="3cpWs6" id="4owkxKWaPbm" role="3cqZAp">
                                                   <node concept="37vLTw" id="4owkxKWaPbn" role="3cqZAk">
                                                     <ref role="3cqZAo" node="1ZlHRbfJYc5" resolve="originalText" />
@@ -2285,6 +2298,32 @@
                                               <node concept="2Mo9yH" id="Dnjeumzcbx" role="2Oq$k0" />
                                               <node concept="liA8E" id="Dnjeumzcby" role="2OqNvi">
                                                 <ref role="37wK5l" to="uddc:~TransformationMenuContext.getNode()" resolve="getNode" />
+                                              </node>
+                                            </node>
+                                          </node>
+                                        </node>
+                                        <node concept="3cpWs8" id="6gjbwabktJ9" role="3cqZAp">
+                                          <node concept="3cpWsn" id="6gjbwabktJc" role="3cpWs9">
+                                            <property role="TrG5h" value="subconcept" />
+                                            <node concept="3bZ5Sz" id="6gjbwabktJ7" role="1tU5fm" />
+                                            <node concept="2OqwBi" id="6gjbwabnJWn" role="33vP2m">
+                                              <node concept="37vLTw" id="6gjbwabnITE" role="2Oq$k0">
+                                                <ref role="3cqZAo" node="Dnjeumzcbu" resolve="node" />
+                                              </node>
+                                              <node concept="2yIwOk" id="6gjbwabnKYu" role="2OqNvi" />
+                                            </node>
+                                          </node>
+                                        </node>
+                                        <node concept="3cpWs8" id="6gjbwabe15C" role="3cqZAp">
+                                          <node concept="3cpWsn" id="6gjbwabe15D" role="3cpWs9">
+                                            <property role="TrG5h" value="editorContext" />
+                                            <node concept="3uibUv" id="6gjbwabe15E" role="1tU5fm">
+                                              <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+                                            </node>
+                                            <node concept="2OqwBi" id="6gjbwabe15F" role="33vP2m">
+                                              <node concept="2Mo9yH" id="6gjbwabe15G" role="2Oq$k0" />
+                                              <node concept="liA8E" id="6gjbwabe15H" role="2OqNvi">
+                                                <ref role="37wK5l" to="uddc:~TransformationMenuContext.getEditorContext()" resolve="getEditorContext" />
                                               </node>
                                             </node>
                                           </node>
@@ -13725,6 +13764,22 @@
                                               </node>
                                               <node concept="37vLTw" id="RbLMy6c0kA" role="1m5AlR">
                                                 <ref role="3cqZAo" node="RbLMy6c0kw" resolve="sourceNode" />
+                                              </node>
+                                            </node>
+                                          </node>
+                                        </node>
+                                        <node concept="3cpWs8" id="6gjbwabbKDB" role="3cqZAp">
+                                          <node concept="3cpWsn" id="6gjbwabbKDC" role="3cpWs9">
+                                            <property role="TrG5h" value="editorContext" />
+                                            <node concept="3uibUv" id="6gjbwabbK9K" role="1tU5fm">
+                                              <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+                                            </node>
+                                            <node concept="2OqwBi" id="6gjbwabbKDD" role="33vP2m">
+                                              <node concept="37vLTw" id="6gjbwabbKDE" role="2Oq$k0">
+                                                <ref role="3cqZAo" node="RbLMy69QlL" resolve="_context" />
+                                              </node>
+                                              <node concept="liA8E" id="6gjbwabbKDF" role="2OqNvi">
+                                                <ref role="37wK5l" to="uddc:~TransformationMenuContext.getEditorContext()" resolve="getEditorContext" />
                                               </node>
                                             </node>
                                           </node>

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/generator/template/main@generator.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/generator/template/main@generator.mps
@@ -2996,6 +2996,20 @@
                           </node>
                         </node>
                       </node>
+                      <node concept="3cpWs8" id="6gjbwaaS$le" role="3cqZAp">
+                        <node concept="3cpWsn" id="6gjbwaaS$lf" role="3cpWs9">
+                          <property role="TrG5h" value="editorContext" />
+                          <node concept="3uibUv" id="6gjbwaaSzXy" role="1tU5fm">
+                            <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+                          </node>
+                          <node concept="2OqwBi" id="6gjbwaaS$lg" role="33vP2m">
+                            <node concept="2Mo9yH" id="6gjbwaaS$lh" role="2Oq$k0" />
+                            <node concept="liA8E" id="6gjbwaaS$li" role="2OqNvi">
+                              <ref role="37wK5l" to="uddc:~TransformationMenuContext.getEditorContext()" resolve="getEditorContext" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
                       <node concept="3cpWs8" id="5fS8LroEq_2" role="3cqZAp">
                         <node concept="3cpWsn" id="5fS8LroEq_3" role="3cpWs9">
                           <property role="TrG5h" value="matchingTexts" />
@@ -5526,6 +5540,20 @@
                           <node concept="2Mo9yH" id="15DZatPfj7O" role="2Oq$k0" />
                           <node concept="liA8E" id="15DZatPfj7P" role="2OqNvi">
                             <ref role="37wK5l" to="uddc:~TransformationMenuContext.getNode()" resolve="getNode" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3cpWs8" id="6gjbwaaXK63" role="3cqZAp">
+                      <node concept="3cpWsn" id="6gjbwaaXK64" role="3cpWs9">
+                        <property role="TrG5h" value="editorContext" />
+                        <node concept="3uibUv" id="6gjbwaaXJ3n" role="1tU5fm">
+                          <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+                        </node>
+                        <node concept="2OqwBi" id="6gjbwaaXK65" role="33vP2m">
+                          <node concept="2Mo9yH" id="6gjbwaaXK66" role="2Oq$k0" />
+                          <node concept="liA8E" id="6gjbwaaXK67" role="2OqNvi">
+                            <ref role="37wK5l" to="uddc:~TransformationMenuContext.getEditorContext()" resolve="getEditorContext" />
                           </node>
                         </node>
                       </node>
@@ -16870,6 +16898,22 @@
                                   </node>
                                 </node>
                               </node>
+                              <node concept="3cpWs8" id="6gjbwaaSSid" role="3cqZAp">
+                                <node concept="3cpWsn" id="6gjbwaaSSie" role="3cpWs9">
+                                  <property role="TrG5h" value="editorContext" />
+                                  <node concept="3uibUv" id="6gjbwaaSQui" role="1tU5fm">
+                                    <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+                                  </node>
+                                  <node concept="2OqwBi" id="6gjbwaaSSif" role="33vP2m">
+                                    <node concept="37vLTw" id="6gjbwaaSSig" role="2Oq$k0">
+                                      <ref role="3cqZAo" node="4eBi5gdtxpN" resolve="_context" />
+                                    </node>
+                                    <node concept="liA8E" id="6gjbwaaSSih" role="2OqNvi">
+                                      <ref role="37wK5l" to="uddc:~TransformationMenuContext.getEditorContext()" resolve="getEditorContext" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
                               <node concept="3clFbJ" id="4eBi5gdpjoK" role="3cqZAp">
                                 <node concept="3clFbS" id="4eBi5gdpjoL" role="3clFbx">
                                   <node concept="3cpWs8" id="4eBi5gdpvff" role="3cqZAp">
@@ -18001,6 +18045,22 @@
                       </node>
                       <node concept="liA8E" id="6rhOS_xAibE" role="2OqNvi">
                         <ref role="37wK5l" to="uddc:~TransformationMenuContext.getNode()" resolve="getNode" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3cpWs8" id="6gjbwaaSGom" role="3cqZAp">
+                  <node concept="3cpWsn" id="6gjbwaaSGon" role="3cpWs9">
+                    <property role="TrG5h" value="editorContext" />
+                    <node concept="3uibUv" id="6gjbwaaSFTo" role="1tU5fm">
+                      <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+                    </node>
+                    <node concept="2OqwBi" id="6gjbwaaSGoo" role="33vP2m">
+                      <node concept="37vLTw" id="6gjbwaaSGop" role="2Oq$k0">
+                        <ref role="3cqZAo" node="6rhOS_xwLRq" resolve="_context" />
+                      </node>
+                      <node concept="liA8E" id="6gjbwaaSGoq" role="2OqNvi">
+                        <ref role="37wK5l" to="uddc:~TransformationMenuContext.getEditorContext()" resolve="getEditorContext" />
                       </node>
                     </node>
                   </node>

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/models/com/mbeddr/mpsutil/grammarcells/behavior.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/models/com/mbeddr/mpsutil/grammarcells/behavior.mps
@@ -3781,9 +3781,6 @@
               <node concept="35c_gC" id="1L96m4u4nK4" role="HW$Y0">
                 <ref role="35c_gD" to="teg0:2aaSxIgh9is" resolve="Parameter_editorContext" />
               </node>
-              <node concept="35c_gC" id="Mf8p5ha7fB" role="HW$Y0">
-                <ref role="35c_gD" to="teg0:Mf8p5ha6ow" resolve="Parameter_parentNode" />
-              </node>
             </node>
           </node>
         </node>


### PR DESCRIPTION
This PR fixes #559 and some other cases where concept function parameters such as `editorContext` were not correctly generated. I've also removed the `parentNode` parameter from the postprocess function as there was no code generated for it.