### PR TITLE
Intentions: Trim group name from grouped entries without submenu

### DIFF
--- a/code/.mps/modules.xml
+++ b/code/.mps/modules.xml
@@ -58,6 +58,7 @@
       <modulePath path="$PROJECT_DIR$/intentionsmenu/com.mbeddr.mpsutil.intentions.runtime/com.mbeddr.mpsutil.intentions.runtime.msd" folder="intentionsmenu" />
       <modulePath path="$PROJECT_DIR$/intentionsmenu/com.mbeddr.mpsutil.intentions/com.mbeddr.mpsutil.intentions.mpl" folder="intentionsmenu" />
       <modulePath path="$PROJECT_DIR$/jackson/solutions/com.fasterxml.jackson/com.fasterxml.jackson.msd" folder="jackson" />
+      <modulePath path="$PROJECT_DIR$/languages/com.mbeddr.mpsutil.intentions.sandboxlang/com.mbeddr.mpsutil.intentions.sandboxlang.mpl" folder="intentionsmenu" />
       <modulePath path="$PROJECT_DIR$/languages/de.itemis.model.merge.baselang/de.itemis.model.merge.baselang.mpl" folder="modelmerger2" />
       <modulePath path="$PROJECT_DIR$/languages/de.itemis.model.merge.baselang/sandbox/de.itemis.model.merge.baselang.sandbox.msd" folder="modelmerger2" />
       <modulePath path="$PROJECT_DIR$/languages/de.itemis.model.merge.diamond/de.itemis.model.merge.diamond.mpl" folder="modelmerger2.test.language" />
@@ -163,6 +164,7 @@
       <modulePath path="$PROJECT_DIR$/shadowmodels/solutions/test.de.q60.mps.incremental.runtime/test.de.q60.mps.incremental.runtime.msd" folder="shadowmodels.tests" />
       <modulePath path="$PROJECT_DIR$/shadowmodels/solutions/test.de.q60.mps.shadowmodels.examples/test.de.q60.mps.shadowmodels.examples.msd" folder="shadowmodels.tests" />
       <modulePath path="$PROJECT_DIR$/shadowmodels/solutions/test.de.q60.mps.shadowmodels.runtime/test.de.q60.mps.shadowmodels.runtime.msd" folder="shadowmodels.tests" />
+      <modulePath path="$PROJECT_DIR$/solutions/com.mbeddr.mpsutil.intentions.sandbox/com.mbeddr.mpsutil.intentions.sandbox.msd" folder="intentionsmenu" />
       <modulePath path="$PROJECT_DIR$/solutions/de.itemis.model.merge.runtime/de.itemis.model.merge.runtime.msd" folder="modelmerger2" />
       <modulePath path="$PROJECT_DIR$/solutions/de.itemis.model.merge.simple.demo/de.itemis.model.merge.simple.demo.msd" folder="modelmerger2" />
       <modulePath path="$PROJECT_DIR$/solutions/de.itemis.model.merge.test.integration/de.itemis.model.merge.test.integration.msd" folder="modelmerger2" />

--- a/code/intentionsmenu/com.mbeddr.mpsutil.intentions.runtime/models/com/mbeddr/mpsutil/intentions/runtime.mps
+++ b/code/intentionsmenu/com.mbeddr.mpsutil.intentions.runtime/models/com/mbeddr/mpsutil/intentions/runtime.mps
@@ -2578,6 +2578,100 @@
                 </node>
               </node>
             </node>
+            <node concept="3SKdUt" id="3pZvzolt2Zu" role="3cqZAp">
+              <node concept="1PaTwC" id="3pZvzolt2Zv" role="1aUNEU">
+                <node concept="3oM_SD" id="3pZvzolt7BI" role="1PaTwD">
+                  <property role="3oM_SC" value="cut" />
+                </node>
+                <node concept="3oM_SD" id="3pZvzolt7BK" role="1PaTwD">
+                  <property role="3oM_SC" value="off" />
+                </node>
+                <node concept="3oM_SD" id="3pZvzolt7BN" role="1PaTwD">
+                  <property role="3oM_SC" value="the" />
+                </node>
+                <node concept="3oM_SD" id="3pZvzolt7BR" role="1PaTwD">
+                  <property role="3oM_SC" value="groupName" />
+                </node>
+                <node concept="3oM_SD" id="3pZvzolt7BW" role="1PaTwD">
+                  <property role="3oM_SC" value="from" />
+                </node>
+                <node concept="3oM_SD" id="3pZvzolt7C2" role="1PaTwD">
+                  <property role="3oM_SC" value="the" />
+                </node>
+                <node concept="3oM_SD" id="3pZvzolt7C9" role="1PaTwD">
+                  <property role="3oM_SC" value="action," />
+                </node>
+                <node concept="3oM_SD" id="3pZvzolt7Ch" role="1PaTwD">
+                  <property role="3oM_SC" value="if" />
+                </node>
+                <node concept="3oM_SD" id="3pZvzolt7Cq" role="1PaTwD">
+                  <property role="3oM_SC" value="action" />
+                </node>
+                <node concept="3oM_SD" id="3pZvzolt7C$" role="1PaTwD">
+                  <property role="3oM_SC" value="is" />
+                </node>
+                <node concept="3oM_SD" id="3pZvzolt7CJ" role="1PaTwD">
+                  <property role="3oM_SC" value="not" />
+                </node>
+                <node concept="3oM_SD" id="3pZvzolt7CV" role="1PaTwD">
+                  <property role="3oM_SC" value="a" />
+                </node>
+                <node concept="3oM_SD" id="3pZvzolt7D8" role="1PaTwD">
+                  <property role="3oM_SC" value="group," />
+                </node>
+                <node concept="3oM_SD" id="3pZvzolt7Dm" role="1PaTwD">
+                  <property role="3oM_SC" value="i.e." />
+                </node>
+                <node concept="3oM_SD" id="3pZvzolt7D_" role="1PaTwD">
+                  <property role="3oM_SC" value="has" />
+                </node>
+                <node concept="3oM_SD" id="3pZvzolt7DP" role="1PaTwD">
+                  <property role="3oM_SC" value="no" />
+                </node>
+                <node concept="3oM_SD" id="3pZvzolt7E6" role="1PaTwD">
+                  <property role="3oM_SC" value="submenu," />
+                </node>
+                <node concept="3oM_SD" id="3pZvzolt8Rv" role="1PaTwD">
+                  <property role="3oM_SC" value="" />
+                </node>
+              </node>
+            </node>
+            <node concept="3SKdUt" id="3pZvzoltfB5" role="3cqZAp">
+              <node concept="1PaTwC" id="3pZvzoltfAI" role="1aUNEU">
+                <node concept="3oM_SD" id="3pZvzoltfAH" role="1PaTwD">
+                  <property role="3oM_SC" value="and" />
+                </node>
+                <node concept="3oM_SD" id="3pZvzolt8RM" role="1PaTwD">
+                  <property role="3oM_SC" value="the" />
+                </node>
+                <node concept="3oM_SD" id="3pZvzolt8S6" role="1PaTwD">
+                  <property role="3oM_SC" value="intention" />
+                </node>
+                <node concept="3oM_SD" id="3pZvzolt8Sr" role="1PaTwD">
+                  <property role="3oM_SC" value="annotation" />
+                </node>
+                <node concept="3oM_SD" id="3pZvzoltipc" role="1PaTwD">
+                  <property role="3oM_SC" value="was" />
+                </node>
+                <node concept="3oM_SD" id="3pZvzoltipq" role="1PaTwD">
+                  <property role="3oM_SC" value="not" />
+                </node>
+                <node concept="3oM_SD" id="3pZvzoltipx" role="1PaTwD">
+                  <property role="3oM_SC" value="used." />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="3pZvzols0Bn" role="3cqZAp">
+              <node concept="1rXfSq" id="3pZvzols0Bl" role="3clFbG">
+                <ref role="37wK5l" node="3pZvzolpwf_" resolve="trimGroupNameFromActionText" />
+                <node concept="37vLTw" id="3pZvzols489" role="37wK5m">
+                  <ref role="3cqZAo" node="3pwG8PSq661" resolve="intentionEntry" />
+                </node>
+                <node concept="37vLTw" id="3pZvzolsaBu" role="37wK5m">
+                  <ref role="3cqZAo" node="3pwG8PSq6Q3" resolve="groupName" />
+                </node>
+              </node>
+            </node>
             <node concept="3cpWs8" id="6d0zIQxdhDi" role="3cqZAp">
               <node concept="3cpWsn" id="6d0zIQxdhDj" role="3cpWs9">
                 <property role="TrG5h" value="c" />
@@ -3032,6 +3126,167 @@
       </node>
     </node>
     <node concept="2tJIrI" id="2xgTENkRhXD" role="jymVt" />
+    <node concept="3clFb_" id="3pZvzolpwf_" role="jymVt">
+      <property role="TrG5h" value="trimGroupNameFromActionText" />
+      <node concept="3clFbS" id="3pZvzolpwfC" role="3clF47">
+        <node concept="3clFbJ" id="3pZvzolpEqJ" role="3cqZAp">
+          <node concept="3fqX7Q" id="3pZvzolpP1r" role="3clFbw">
+            <node concept="2ZW3vV" id="3pZvzolpP1t" role="3fr31v">
+              <node concept="3uibUv" id="3pZvzolpP1u" role="2ZW6by">
+                <ref role="3uigEE" node="2xgTENkSGPx" resolve="IntentionsMenuWithGroups.IntentionActionGroup" />
+              </node>
+              <node concept="37vLTw" id="3pZvzolpP1v" role="2ZW6bz">
+                <ref role="3cqZAo" node="3pZvzolpzLz" resolve="action" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbS" id="3pZvzolpEqL" role="3clFbx">
+            <node concept="3cpWs8" id="3pZvzolqck1" role="3cqZAp">
+              <node concept="3cpWsn" id="3pZvzolqck2" role="3cpWs9">
+                <property role="TrG5h" value="text" />
+                <node concept="17QB3L" id="3pZvzolqck3" role="1tU5fm" />
+                <node concept="2OqwBi" id="3pZvzolqck4" role="33vP2m">
+                  <node concept="2OqwBi" id="3pZvzolqck5" role="2Oq$k0">
+                    <node concept="37vLTw" id="3pZvzolqck6" role="2Oq$k0">
+                      <ref role="3cqZAo" node="3pZvzolpzLz" resolve="action" />
+                    </node>
+                    <node concept="liA8E" id="3pZvzolqck7" role="2OqNvi">
+                      <ref role="37wK5l" to="qkt:~AnAction.getTemplatePresentation()" resolve="getTemplatePresentation" />
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="3pZvzolqck8" role="2OqNvi">
+                    <ref role="37wK5l" to="qkt:~Presentation.getText()" resolve="getText" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbJ" id="3pZvzolq8Yp" role="3cqZAp">
+              <node concept="3clFbS" id="3pZvzolq8Yr" role="3clFbx">
+                <node concept="3SKdUt" id="3pZvzolsS9j" role="3cqZAp">
+                  <node concept="1PaTwC" id="3pZvzolsS9k" role="1aUNEU">
+                    <node concept="3oM_SD" id="3pZvzolsV8k" role="1PaTwD">
+                      <property role="3oM_SC" value="add" />
+                    </node>
+                    <node concept="3oM_SD" id="3pZvzolsV8m" role="1PaTwD">
+                      <property role="3oM_SC" value="+1" />
+                    </node>
+                    <node concept="3oM_SD" id="3pZvzolsV8p" role="1PaTwD">
+                      <property role="3oM_SC" value="in" />
+                    </node>
+                    <node concept="3oM_SD" id="3pZvzolsV8C" role="1PaTwD">
+                      <property role="3oM_SC" value="substring" />
+                    </node>
+                    <node concept="3oM_SD" id="3pZvzolsV8H" role="1PaTwD">
+                      <property role="3oM_SC" value="to" />
+                    </node>
+                    <node concept="3oM_SD" id="3pZvzolsV8N" role="1PaTwD">
+                      <property role="3oM_SC" value="cut" />
+                    </node>
+                    <node concept="3oM_SD" id="3pZvzolsV8U" role="1PaTwD">
+                      <property role="3oM_SC" value="off" />
+                    </node>
+                    <node concept="3oM_SD" id="3pZvzolsV92" role="1PaTwD">
+                      <property role="3oM_SC" value="the" />
+                    </node>
+                    <node concept="3oM_SD" id="3pZvzolsV9b" role="1PaTwD">
+                      <property role="3oM_SC" value="colon" />
+                    </node>
+                    <node concept="3oM_SD" id="3pZvzolsV9l" role="1PaTwD">
+                      <property role="3oM_SC" value="after" />
+                    </node>
+                    <node concept="3oM_SD" id="3pZvzolsV9w" role="1PaTwD">
+                      <property role="3oM_SC" value="the" />
+                    </node>
+                    <node concept="3oM_SD" id="3pZvzolsV9G" role="1PaTwD">
+                      <property role="3oM_SC" value="groupName" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbF" id="3pZvzolm1oQ" role="3cqZAp">
+                  <node concept="2OqwBi" id="3pZvzolmb07" role="3clFbG">
+                    <node concept="2OqwBi" id="3pZvzolm59K" role="2Oq$k0">
+                      <node concept="37vLTw" id="3pZvzolm1oO" role="2Oq$k0">
+                        <ref role="3cqZAo" node="3pZvzolpzLz" resolve="action" />
+                      </node>
+                      <node concept="liA8E" id="3pZvzolm8FW" role="2OqNvi">
+                        <ref role="37wK5l" to="qkt:~AnAction.getTemplatePresentation()" resolve="getTemplatePresentation" />
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="3pZvzolmeOD" role="2OqNvi">
+                      <ref role="37wK5l" to="qkt:~Presentation.setText(java.lang.String)" resolve="setText" />
+                      <node concept="2OqwBi" id="3pZvzolmzk3" role="37wK5m">
+                        <node concept="2OqwBi" id="3pZvzolmjWV" role="2Oq$k0">
+                          <node concept="37vLTw" id="3pZvzolmhSV" role="2Oq$k0">
+                            <ref role="3cqZAo" node="3pZvzolqck2" resolve="text" />
+                          </node>
+                          <node concept="liA8E" id="3pZvzolmnyg" role="2OqNvi">
+                            <ref role="37wK5l" to="wyt6:~String.substring(int)" resolve="substring" />
+                            <node concept="3cpWs3" id="3pZvzolsEDU" role="37wK5m">
+                              <node concept="3cmrfG" id="3pZvzolsEJo" role="3uHU7w">
+                                <property role="3cmrfH" value="1" />
+                              </node>
+                              <node concept="2OqwBi" id="3pZvzolreqn" role="3uHU7B">
+                                <node concept="37vLTw" id="3pZvzolraE$" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="3pZvzolpBeb" resolve="groupName" />
+                                </node>
+                                <node concept="liA8E" id="3pZvzolrhFo" role="2OqNvi">
+                                  <ref role="37wK5l" to="wyt6:~String.length()" resolve="length" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="17S1cR" id="3pZvzolmHIg" role="2OqNvi" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="1Wc70l" id="3pZvzolqK4g" role="3clFbw">
+                <node concept="2OqwBi" id="3pZvzolqQ0G" role="3uHU7w">
+                  <node concept="37vLTw" id="3pZvzolqMhi" role="2Oq$k0">
+                    <ref role="3cqZAo" node="3pZvzolqck2" resolve="text" />
+                  </node>
+                  <node concept="liA8E" id="3pZvzolqSjV" role="2OqNvi">
+                    <ref role="37wK5l" to="wyt6:~String.startsWith(java.lang.String)" resolve="startsWith" />
+                    <node concept="37vLTw" id="3pZvzolqVNv" role="37wK5m">
+                      <ref role="3cqZAo" node="3pZvzolpBeb" resolve="groupName" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="1Wc70l" id="3pZvzolqyGY" role="3uHU7B">
+                  <node concept="3y3z36" id="3pZvzolqs4n" role="3uHU7B">
+                    <node concept="37vLTw" id="3pZvzolqidM" role="3uHU7B">
+                      <ref role="3cqZAo" node="3pZvzolqck2" resolve="text" />
+                    </node>
+                    <node concept="10Nm6u" id="3pZvzolqvEd" role="3uHU7w" />
+                  </node>
+                  <node concept="3y3z36" id="3pZvzolqD4$" role="3uHU7w">
+                    <node concept="37vLTw" id="3pZvzolq_lp" role="3uHU7B">
+                      <ref role="3cqZAo" node="3pZvzolpBeb" resolve="groupName" />
+                    </node>
+                    <node concept="10Nm6u" id="3pZvzolqGEH" role="3uHU7w" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tmbuc" id="3pZvzolps_O" role="1B3o_S" />
+      <node concept="37vLTG" id="3pZvzolpzLz" role="3clF46">
+        <property role="TrG5h" value="action" />
+        <node concept="3uibUv" id="3pZvzolpzLy" role="1tU5fm">
+          <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="3pZvzolpBeb" role="3clF46">
+        <property role="TrG5h" value="groupName" />
+        <node concept="17QB3L" id="3pZvzolpE5e" role="1tU5fm" />
+      </node>
+      <node concept="3cqZAl" id="3pZvzolpUMR" role="3clF45" />
+    </node>
+    <node concept="2tJIrI" id="3pZvzolpp4b" role="jymVt" />
     <node concept="3clFb_" id="2xgTENkWOsD" role="jymVt">
       <property role="TrG5h" value="createIntentionActionGroup" />
       <property role="1EzhhJ" value="false" />

--- a/code/languages/com.mbeddr.mpsutil.intentions.sandboxlang/com.mbeddr.mpsutil.intentions.sandboxlang.mpl
+++ b/code/languages/com.mbeddr.mpsutil.intentions.sandboxlang/com.mbeddr.mpsutil.intentions.sandboxlang.mpl
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<language namespace="com.mbeddr.mpsutil.intentions.sandboxlang" uuid="4972ae94-72e7-499b-8766-0d6acffdb4f2" languageVersion="0" moduleVersion="0">
+  <models>
+    <modelRoot contentPath="${module}" type="default">
+      <sourceRoot location="models" />
+    </modelRoot>
+  </models>
+  <facets>
+    <facet type="java">
+      <classes generated="true" path="${module}/classes_gen" />
+    </facet>
+  </facets>
+  <accessoryModels />
+  <generators>
+    <generator alias="main" namespace="com.mbeddr.mpsutil.intentions.sandboxlang" uuid="80dab4d6-7c88-4760-9a42-0338421bd077">
+      <models>
+        <modelRoot contentPath="${module}/generator" type="default">
+          <sourceRoot location="templates" />
+        </modelRoot>
+      </models>
+      <facets>
+        <facet type="java">
+          <classes generated="true" path="${module}/generator/classes_gen" />
+        </facet>
+      </facets>
+      <external-templates />
+      <languageVersions>
+        <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
+        <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
+        <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
+        <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
+        <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
+        <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
+        <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
+        <language slang="l:b401a680-8325-4110-8fd3-84331ff25bef:jetbrains.mps.lang.generator" version="4" />
+        <language slang="l:d7706f63-9be2-479c-a3da-ae92af1e64d5:jetbrains.mps.lang.generator.generationContext" version="2" />
+        <language slang="l:289fcc83-6543-41e8-a5ca-768235715ce4:jetbrains.mps.lang.generator.generationParameters" version="0" />
+        <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
+        <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
+        <language slang="l:13744753-c81f-424a-9c1b-cf8943bf4e86:jetbrains.mps.lang.sharedConcepts" version="0" />
+        <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="18" />
+        <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
+        <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
+      </languageVersions>
+      <dependencyVersions>
+        <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
+        <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
+        <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
+        <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+        <module reference="4972ae94-72e7-499b-8766-0d6acffdb4f2(com.mbeddr.mpsutil.intentions.sandboxlang)" version="0" />
+        <module reference="80dab4d6-7c88-4760-9a42-0338421bd077(com.mbeddr.mpsutil.intentions.sandboxlang)" version="0" />
+        <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
+      </dependencyVersions>
+      <mapping-priorities />
+    </generator>
+  </generators>
+  <sourcePath />
+  <languageVersions>
+    <language slang="l:b92f861d-0184-446d-b88b-6dcf0e070241:com.mbeddr.mpsutil.intentions" version="0" />
+    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
+    <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />
+    <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
+    <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
+    <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
+    <language slang="l:c7d5b9dd-a05f-4be2-bc73-f2e16994cc67:jetbrains.mps.baseLanguage.lightweightdsl" version="1" />
+    <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
+    <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
+    <language slang="l:aee9cad2-acd4-4608-aef2-0004f6a1cdbd:jetbrains.mps.lang.actions" version="4" />
+    <language slang="l:af65afd8-f0dd-4942-87d9-63a55f2a9db1:jetbrains.mps.lang.behavior" version="2" />
+    <language slang="l:fe9d76d7-5809-45c9-ae28-a40915b4d6ff:jetbrains.mps.lang.checkedName" version="1" />
+    <language slang="l:3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1:jetbrains.mps.lang.constraints" version="6" />
+    <language slang="l:e51810c5-7308-4642-bcb6-469e61b5dd18:jetbrains.mps.lang.constraints.msg.specification" version="0" />
+    <language slang="l:47257bf3-78d3-470b-89d9-8c3261a61d15:jetbrains.mps.lang.constraints.rules" version="0" />
+    <language slang="l:5dae8159-ab99-46bb-a40d-0cee30ee7018:jetbrains.mps.lang.constraints.rules.kinds" version="0" />
+    <language slang="l:134c38d4-e3af-4d9e-b069-1c7df0a4005d:jetbrains.mps.lang.constraints.rules.skeleton" version="0" />
+    <language slang="l:3ad5badc-1d9c-461c-b7b1-fa2fcd0a0ae7:jetbrains.mps.lang.context" version="0" />
+    <language slang="l:ea3159bf-f48e-4720-bde2-86dba75f0d34:jetbrains.mps.lang.context.defs" version="0" />
+    <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
+    <language slang="l:f4ad079d-bc71-4ffb-9600-9328705cf998:jetbrains.mps.lang.descriptor" version="0" />
+    <language slang="l:18bc6592-03a6-4e29-a83a-7ff23bde13ba:jetbrains.mps.lang.editor" version="14" />
+    <language slang="l:d7a92d38-f7db-40d0-8431-763b0c3c9f20:jetbrains.mps.lang.intentions" version="1" />
+    <language slang="l:ad93155d-79b2-4759-b10c-55123e763903:jetbrains.mps.lang.messages" version="0" />
+    <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
+    <language slang="l:d4615e3b-d671-4ba9-af01-2b78369b0ba7:jetbrains.mps.lang.pattern" version="2" />
+    <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
+    <language slang="l:982eb8df-2c96-4bd7-9963-11712ea622e5:jetbrains.mps.lang.resources" version="2" />
+    <language slang="l:b3551702-269c-4f05-ba61-58060cef4292:jetbrains.mps.lang.rulesAndMessages" version="0" />
+    <language slang="l:d8f591ec-4d86-4af2-9f92-a9e93c803ffa:jetbrains.mps.lang.scopes" version="0" />
+    <language slang="l:13744753-c81f-424a-9c1b-cf8943bf4e86:jetbrains.mps.lang.sharedConcepts" version="0" />
+    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="18" />
+    <language slang="l:c72da2b9-7cce-4447-8389-f407dc1158b7:jetbrains.mps.lang.structure" version="9" />
+    <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
+    <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
+    <language slang="l:7a5dda62-9140-4668-ab76-d5ed1746f2b2:jetbrains.mps.lang.typesystem" version="5" />
+  </languageVersions>
+  <dependencyVersions>
+    <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
+    <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
+    <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
+    <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+    <module reference="4972ae94-72e7-499b-8766-0d6acffdb4f2(com.mbeddr.mpsutil.intentions.sandboxlang)" version="0" />
+    <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
+    <module reference="a9e4c532-c5f5-4bb7-99ef-42abb73bbb70(jetbrains.mps.lang.descriptor.aspects)" version="0" />
+  </dependencyVersions>
+  <extendedLanguages />
+</language>
+

--- a/code/languages/com.mbeddr.mpsutil.intentions.sandboxlang/generator/templates/com.mbeddr.mpsutil.intentions.sandboxlang.templates@generator.mps
+++ b/code/languages/com.mbeddr.mpsutil.intentions.sandboxlang/generator/templates/com.mbeddr.mpsutil.intentions.sandboxlang.templates@generator.mps
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:92df4366-26f3-462f-8611-8e215c7f3049(com.mbeddr.mpsutil.intentions.sandboxlang.templates@generator)">
+  <persistence version="9" />
+  <languages>
+    <devkit ref="a2eb3a43-fcc2-4200-80dc-c60110c4862d(jetbrains.mps.devkit.templates)" />
+  </languages>
+  <imports>
+    <import index="iikq" ref="r:7a511fd5-d829-4752-8daa-0ca5c0705ea8(com.mbeddr.mpsutil.intentions.sandboxlang.structure)" />
+  </imports>
+  <registry>
+    <language id="b401a680-8325-4110-8fd3-84331ff25bef" name="jetbrains.mps.lang.generator">
+      <concept id="1095416546421" name="jetbrains.mps.lang.generator.structure.MappingConfiguration" flags="ig" index="bUwia" />
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="bUwia" id="197NvysMw7I">
+    <property role="TrG5h" value="main" />
+  </node>
+</model>
+

--- a/code/languages/com.mbeddr.mpsutil.intentions.sandboxlang/models/com.mbeddr.mpsutil.intentions.sandboxlang.behavior.mps
+++ b/code/languages/com.mbeddr.mpsutil.intentions.sandboxlang/models/com.mbeddr.mpsutil.intentions.sandboxlang.behavior.mps
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:e3199048-e152-4209-b3b8-04a81268755d(com.mbeddr.mpsutil.intentions.sandboxlang.behavior)">
+  <persistence version="9" />
+  <languages>
+    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="18" />
+    <use id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior" version="2" />
+    <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
+  </languages>
+  <imports />
+  <registry />
+</model>
+

--- a/code/languages/com.mbeddr.mpsutil.intentions.sandboxlang/models/com.mbeddr.mpsutil.intentions.sandboxlang.constraints.mps
+++ b/code/languages/com.mbeddr.mpsutil.intentions.sandboxlang/models/com.mbeddr.mpsutil.intentions.sandboxlang.constraints.mps
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:f8439381-6239-448e-88ca-ea7a9c854100(com.mbeddr.mpsutil.intentions.sandboxlang.constraints)">
+  <persistence version="9" />
+  <languages>
+    <use id="5dae8159-ab99-46bb-a40d-0cee30ee7018" name="jetbrains.mps.lang.constraints.rules.kinds" version="0" />
+    <use id="ea3159bf-f48e-4720-bde2-86dba75f0d34" name="jetbrains.mps.lang.context.defs" version="0" />
+    <use id="e51810c5-7308-4642-bcb6-469e61b5dd18" name="jetbrains.mps.lang.constraints.msg.specification" version="0" />
+    <use id="134c38d4-e3af-4d9e-b069-1c7df0a4005d" name="jetbrains.mps.lang.constraints.rules.skeleton" version="0" />
+    <use id="b3551702-269c-4f05-ba61-58060cef4292" name="jetbrains.mps.lang.rulesAndMessages" version="0" />
+    <use id="3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1" name="jetbrains.mps.lang.constraints" version="6" />
+    <use id="13744753-c81f-424a-9c1b-cf8943bf4e86" name="jetbrains.mps.lang.sharedConcepts" version="0" />
+    <use id="3ad5badc-1d9c-461c-b7b1-fa2fcd0a0ae7" name="jetbrains.mps.lang.context" version="0" />
+    <use id="ad93155d-79b2-4759-b10c-55123e763903" name="jetbrains.mps.lang.messages" version="0" />
+    <devkit ref="00000000-0000-4000-0000-5604ebd4f22c(jetbrains.mps.devkit.aspect.constraints)" />
+  </languages>
+  <imports />
+  <registry />
+</model>
+

--- a/code/languages/com.mbeddr.mpsutil.intentions.sandboxlang/models/com.mbeddr.mpsutil.intentions.sandboxlang.editor.mps
+++ b/code/languages/com.mbeddr.mpsutil.intentions.sandboxlang/models/com.mbeddr.mpsutil.intentions.sandboxlang.editor.mps
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:fa9fd341-fc8d-4ee7-97a7-1fb6c0106fec(com.mbeddr.mpsutil.intentions.sandboxlang.editor)">
+  <persistence version="9" />
+  <languages>
+    <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="14" />
+    <use id="aee9cad2-acd4-4608-aef2-0004f6a1cdbd" name="jetbrains.mps.lang.actions" version="4" />
+    <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
+  </languages>
+  <imports>
+    <import index="iikq" ref="r:7a511fd5-d829-4752-8daa-0ca5c0705ea8(com.mbeddr.mpsutil.intentions.sandboxlang.structure)" implicit="true" />
+    <import index="tpco" ref="r:00000000-0000-4000-0000-011c89590284(jetbrains.mps.lang.core.editor)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor">
+      <concept id="1071666914219" name="jetbrains.mps.lang.editor.structure.ConceptEditorDeclaration" flags="ig" index="24kQdi" />
+      <concept id="1080736578640" name="jetbrains.mps.lang.editor.structure.BaseEditorComponent" flags="ig" index="2wURMF">
+        <child id="1080736633877" name="cellModel" index="2wV5jI" />
+      </concept>
+      <concept id="1078939183254" name="jetbrains.mps.lang.editor.structure.CellModel_Component" flags="sg" stub="3162947552742194261" index="PMmxH">
+        <reference id="1078939183255" name="editorComponent" index="PMmxG" />
+      </concept>
+      <concept id="1166049232041" name="jetbrains.mps.lang.editor.structure.AbstractComponent" flags="ng" index="1XWOmA">
+        <reference id="1166049300910" name="conceptDeclaration" index="1XX52x" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="24kQdi" id="197NvysMAmf">
+    <ref role="1XX52x" to="iikq:197NvysM_3t" resolve="DemoNodeWithIntentions" />
+    <node concept="PMmxH" id="3pZvzolnXtY" role="2wV5jI">
+      <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
+    </node>
+  </node>
+</model>
+

--- a/code/languages/com.mbeddr.mpsutil.intentions.sandboxlang/models/com.mbeddr.mpsutil.intentions.sandboxlang.intentions.mps
+++ b/code/languages/com.mbeddr.mpsutil.intentions.sandboxlang/models/com.mbeddr.mpsutil.intentions.sandboxlang.intentions.mps
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:f1d822a2-1f43-4b14-8097-de7e855e6079(com.mbeddr.mpsutil.intentions.sandboxlang.intentions)">
+  <persistence version="9" />
+  <languages>
+    <use id="d7a92d38-f7db-40d0-8431-763b0c3c9f20" name="jetbrains.mps.lang.intentions" version="1" />
+    <use id="b92f861d-0184-446d-b88b-6dcf0e070241" name="com.mbeddr.mpsutil.intentions" version="0" />
+    <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
+  </languages>
+  <imports>
+    <import index="iikq" ref="r:7a511fd5-d829-4752-8daa-0ca5c0705ea8(com.mbeddr.mpsutil.intentions.sandboxlang.structure)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
+        <child id="1137022507850" name="body" index="2VODD2" />
+      </concept>
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
+        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
+        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
+      </concept>
+    </language>
+    <language id="b92f861d-0184-446d-b88b-6dcf0e070241" name="com.mbeddr.mpsutil.intentions">
+      <concept id="5846558918537398687" name="com.mbeddr.mpsutil.intentions.structure.IntentionGroupAnnotation" flags="ng" index="1SWQZ3">
+        <property id="5846558918537400330" name="label" index="1SWRpm" />
+      </concept>
+    </language>
+    <language id="d7a92d38-f7db-40d0-8431-763b0c3c9f20" name="jetbrains.mps.lang.intentions">
+      <concept id="1192794744107" name="jetbrains.mps.lang.intentions.structure.IntentionDeclaration" flags="ig" index="2S6QgY" />
+      <concept id="1192794782375" name="jetbrains.mps.lang.intentions.structure.DescriptionBlock" flags="in" index="2S6ZIM" />
+      <concept id="1192795911897" name="jetbrains.mps.lang.intentions.structure.ExecuteBlock" flags="in" index="2Sbjvc" />
+      <concept id="2522969319638091381" name="jetbrains.mps.lang.intentions.structure.BaseIntentionDeclaration" flags="ig" index="2ZfUlf">
+        <reference id="2522969319638198290" name="forConcept" index="2ZfgGC" />
+        <child id="2522969319638198291" name="executeFunction" index="2ZfgGD" />
+        <child id="2522969319638093993" name="descriptionFunction" index="2ZfVej" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="2S6QgY" id="197NvysM_J3">
+    <property role="TrG5h" value="DemoIntention_1" />
+    <ref role="2ZfgGC" to="iikq:197NvysM_3t" resolve="DemoNodeWithIntentions" />
+    <node concept="2S6ZIM" id="197NvysM_J4" role="2ZfVej">
+      <node concept="3clFbS" id="197NvysM_J5" role="2VODD2">
+        <node concept="3clFbF" id="197NvysM_La" role="3cqZAp">
+          <node concept="3cpWs3" id="197NvysM_Lc" role="3clFbG">
+            <node concept="Xl_RD" id="197NvysM_Ld" role="3uHU7w">
+              <property role="Xl_RC" value=" DemoIntention_1" />
+            </node>
+            <node concept="Xl_RD" id="197NvysM_Le" role="3uHU7B">
+              <property role="Xl_RC" value="Some Group:" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2Sbjvc" id="197NvysM_J6" role="2ZfgGD">
+      <node concept="3clFbS" id="197NvysM_J7" role="2VODD2" />
+    </node>
+  </node>
+  <node concept="2S6QgY" id="3pZvzolkwO8">
+    <property role="TrG5h" value="DemoIntention_2" />
+    <ref role="2ZfgGC" to="iikq:197NvysM_3t" resolve="DemoNodeWithIntentions" />
+    <node concept="2S6ZIM" id="3pZvzolkwO9" role="2ZfVej">
+      <node concept="3clFbS" id="3pZvzolkwOa" role="2VODD2">
+        <node concept="3clFbF" id="3pZvzolkwOb" role="3cqZAp">
+          <node concept="Xl_RD" id="3pZvzolkwOd" role="3clFbG">
+            <property role="Xl_RC" value="DemoIntention_2" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2Sbjvc" id="3pZvzolkwOf" role="2ZfgGD">
+      <node concept="3clFbS" id="3pZvzolkwOg" role="2VODD2" />
+    </node>
+    <node concept="1SWQZ3" id="3pZvzolkKrc" role="lGtFl">
+      <property role="1SWRpm" value="Some Group" />
+    </node>
+  </node>
+</model>
+

--- a/code/languages/com.mbeddr.mpsutil.intentions.sandboxlang/models/com.mbeddr.mpsutil.intentions.sandboxlang.structure.mps
+++ b/code/languages/com.mbeddr.mpsutil.intentions.sandboxlang/models/com.mbeddr.mpsutil.intentions.sandboxlang.structure.mps
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:7a511fd5-d829-4752-8daa-0ca5c0705ea8(com.mbeddr.mpsutil.intentions.sandboxlang.structure)">
+  <persistence version="9" />
+  <languages>
+    <use id="c72da2b9-7cce-4447-8389-f407dc1158b7" name="jetbrains.mps.lang.structure" version="9" />
+    <devkit ref="78434eb8-b0e5-444b-850d-e7c4ad2da9ab(jetbrains.mps.devkit.aspect.structure)" />
+  </languages>
+  <imports>
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="c72da2b9-7cce-4447-8389-f407dc1158b7" name="jetbrains.mps.lang.structure">
+      <concept id="1169125787135" name="jetbrains.mps.lang.structure.structure.AbstractConceptDeclaration" flags="ig" index="PkWjJ">
+        <property id="6714410169261853888" name="conceptId" index="EcuMT" />
+        <property id="5092175715804935370" name="conceptAlias" index="34LRSv" />
+      </concept>
+      <concept id="1071489090640" name="jetbrains.mps.lang.structure.structure.ConceptDeclaration" flags="ig" index="1TIwiD">
+        <property id="1096454100552" name="rootable" index="19KtqR" />
+        <reference id="1071489389519" name="extends" index="1TJDcQ" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="1TIwiD" id="197NvysM_3t">
+    <property role="EcuMT" value="1317247883695247581" />
+    <property role="TrG5h" value="DemoNodeWithIntentions" />
+    <property role="19KtqR" value="true" />
+    <property role="34LRSv" value="DemoNodeWithIntentions" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+  </node>
+</model>
+

--- a/code/languages/com.mbeddr.mpsutil.intentions.sandboxlang/models/com.mbeddr.mpsutil.intentions.sandboxlang.typesystem.mps
+++ b/code/languages/com.mbeddr.mpsutil.intentions.sandboxlang/models/com.mbeddr.mpsutil.intentions.sandboxlang.typesystem.mps
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:6f5819ed-04b9-4e1c-9e2c-a054dea031f2(com.mbeddr.mpsutil.intentions.sandboxlang.typesystem)">
+  <persistence version="9" />
+  <languages>
+    <use id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem" version="5" />
+    <devkit ref="00000000-0000-4000-0000-1de82b3a4936(jetbrains.mps.devkit.aspect.typesystem)" />
+  </languages>
+  <imports />
+  <registry />
+</model>
+

--- a/code/solutions/com.mbeddr.mpsutil.intentions.sandbox/com.mbeddr.mpsutil.intentions.sandbox.msd
+++ b/code/solutions/com.mbeddr.mpsutil.intentions.sandbox/com.mbeddr.mpsutil.intentions.sandbox.msd
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<solution name="com.mbeddr.mpsutil.intentions.sandbox" uuid="0d2a7b00-efef-4261-a99e-3b2b1397083e" moduleVersion="0" compileInMPS="true">
+  <models>
+    <modelRoot contentPath="${module}" type="default">
+      <sourceRoot location="models" />
+    </modelRoot>
+  </models>
+  <facets>
+    <facet type="java">
+      <classes generated="true" path="${module}/classes_gen" />
+    </facet>
+  </facets>
+  <sourcePath />
+  <languageVersions>
+    <language slang="l:4972ae94-72e7-499b-8766-0d6acffdb4f2:com.mbeddr.mpsutil.intentions.sandboxlang" version="0" />
+    <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
+  </languageVersions>
+  <dependencyVersions>
+    <module reference="0d2a7b00-efef-4261-a99e-3b2b1397083e(com.mbeddr.mpsutil.intentions.sandbox)" version="0" />
+  </dependencyVersions>
+</solution>
+

--- a/code/solutions/com.mbeddr.mpsutil.intentions.sandbox/models/com.mbeddr.mpsutil.intentions.sandbox.sandbox.mps
+++ b/code/solutions/com.mbeddr.mpsutil.intentions.sandbox/models/com.mbeddr.mpsutil.intentions.sandbox.sandbox.mps
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:90799386-115c-4e10-a0db-87f6760b8627(com.mbeddr.mpsutil.intentions.sandbox.sandbox)">
+  <persistence version="9" />
+  <languages>
+    <use id="4972ae94-72e7-499b-8766-0d6acffdb4f2" name="com.mbeddr.mpsutil.intentions.sandboxlang" version="0" />
+  </languages>
+  <imports />
+  <registry>
+    <language id="4972ae94-72e7-499b-8766-0d6acffdb4f2" name="com.mbeddr.mpsutil.intentions.sandboxlang">
+      <concept id="1317247883695247581" name="com.mbeddr.mpsutil.intentions.sandboxlang.structure.DemoNodeWithIntentions" flags="ng" index="2ezpO_" />
+    </language>
+  </registry>
+  <node concept="2ezpO_" id="197NvysMAlM" />
+</model>
+


### PR DESCRIPTION
This PR trims the group name from grouped entries without submenu

# Bug Description
When intention groups are used, the groupname is derived from the intention-names group-name-prefix (e.g. `"Some Group:" + " DemoIntention_1"`) or the intention-group annotation. Furthermore the intention is transformed to contain submenus. During this process the group-name-prefix is trimmed from the intention-name. 
<img src="https://user-images.githubusercontent.com/5792623/214069375-f6118db1-f554-44b8-9c93-2b24282f833c.png" width="450">

If an intention doesn't contain a submenu, this trimming is missed, thus the group-name-prefix is shown on each intention in the group.
<img src="https://user-images.githubusercontent.com/5792623/214069439-6e9778e0-acb0-414e-bb51-1933b00da00f.png" width="350">

# Bug Fix
After the groupname was derived from the intention-name, in the case where the intention doesn't contain a submenu, the groupname and the `:` is trimmed from that intentions name.
<img src="https://user-images.githubusercontent.com/5792623/214070225-6610eefe-b80d-4c79-941e-97452592b7b3.png" width="250">
For easier testing, I've created the branch `bugfix/trim-groupname-from-grouped-intentions_test-helper` with a project-plugin that deactivates (the default) submenus for intentions. Just build the solution to unregister the IntentionActionsProviderImpl extension, or register the extension and rebuild the solution to restore the submenus again.

# Further Changes
- Added a demo language with intentions, with group-name prefix and intention-group-annotation
- Added a sandbox for intentions