### PR TITLE
Feature: HTML Swing-Component

### DIFF
--- a/code/.mps/modules.xml
+++ b/code/.mps/modules.xml
@@ -55,6 +55,10 @@
       <modulePath path="$PROJECT_DIR$/hacks/solutions/de.itemis.mps.nativelibs.loader/de.itemis.mps.nativelibs.loader.msd" folder="hacks" />
       <modulePath path="$PROJECT_DIR$/hacks/solutions/de.slisson.mps.hacks.editor/de.slisson.mps.hacks.editor.msd" folder="hacks" />
       <modulePath path="$PROJECT_DIR$/hacks/solutions/de.slisson.mps.reflection.runtime/de.slisson.mps.reflection.runtime.msd" folder="hacks" />
+      <modulePath path="$PROJECT_DIR$/htmlcell/languages/de.itemis.mps.editor.htmlcell.demolang/de.itemis.mps.editor.htmlcell.demolang.mpl" folder="widgets" />
+      <modulePath path="$PROJECT_DIR$/htmlcell/languages/de.itemis.mps.editor.htmlcell/de.itemis.mps.editor.htmlcell.mpl" folder="widgets" />
+      <modulePath path="$PROJECT_DIR$/htmlcell/languages/de.itemis.mps.editor.htmlcell/sandbox/de.itemis.mps.editor.htmlcell.sandbox.msd" folder="widgets" />
+      <modulePath path="$PROJECT_DIR$/htmlcell/solutions/de.itemis.mps.editor.htmlcell.runtime/de.itemis.mps.editor.htmlcell.runtime.msd" folder="widgets" />
       <modulePath path="$PROJECT_DIR$/intentionsmenu/com.mbeddr.mpsutil.intentions.runtime/com.mbeddr.mpsutil.intentions.runtime.msd" folder="intentionsmenu" />
       <modulePath path="$PROJECT_DIR$/intentionsmenu/com.mbeddr.mpsutil.intentions/com.mbeddr.mpsutil.intentions.mpl" folder="intentionsmenu" />
       <modulePath path="$PROJECT_DIR$/jackson/solutions/com.fasterxml.jackson/com.fasterxml.jackson.msd" folder="jackson" />
@@ -71,6 +75,7 @@
       <modulePath path="$PROJECT_DIR$/langvis/languages/com.dslfoundry.langvis.demolang/com.dslfoundry.langvis.demolang.mpl" folder="langvis" />
       <modulePath path="$PROJECT_DIR$/langvis/solutions/com.dslfoundry.langvis.demo/com.dslfoundry.langvis.demo.msd" folder="langvis" />
       <modulePath path="$PROJECT_DIR$/langvis/solutions/com.dslfoundry.langvis.plugin/com.dslfoundry.langvis.plugin.msd" folder="langvis" />
+      <modulePath path="$PROJECT_DIR$/linenumbers/de.itemis.mps.linenumbers/de.itemis.mps.linenumbers.msd" folder="linenumbers" />
       <modulePath path="$PROJECT_DIR$/math/languages/de.itemis.mps.editor.math.demolang/de.itemis.mps.editor.math.demolang.mpl" folder="math" />
       <modulePath path="$PROJECT_DIR$/math/languages/de.itemis.mps.editor.math.java/de.itemis.mps.editor.math.java.mpl" folder="math" />
       <modulePath path="$PROJECT_DIR$/math/languages/de.itemis.mps.editor.math.notations/de.itemis.mps.editor.math.notations.mpl" folder="math" />
@@ -167,7 +172,6 @@
       <modulePath path="$PROJECT_DIR$/solutions/de.itemis.model.merge.simple.demo/de.itemis.model.merge.simple.demo.msd" folder="modelmerger2" />
       <modulePath path="$PROJECT_DIR$/solutions/de.itemis.model.merge.test.integration/de.itemis.model.merge.test.integration.msd" folder="modelmerger2" />
       <modulePath path="$PROJECT_DIR$/solutions/de.itemis.model.merge.test/de.itemis.model.merge.test.msd" folder="modelmerger2" />
-      <modulePath path="$PROJECT_DIR$/linenumbers/de.itemis.mps.linenumbers/de.itemis.mps.linenumbers.msd" folder="linenumbers" />
       <modulePath path="$PROJECT_DIR$/structurecheck/languages/de.slisson.mps.structurecheck/de.slisson.mps.structurecheck.mpl" folder="structurecheck" />
       <modulePath path="$PROJECT_DIR$/structurecheck/solutions/de.slisson.mps.structurecheck.runtime/de.slisson.mps.structurecheck.runtime.msd" folder="structurecheck" />
       <modulePath path="$PROJECT_DIR$/structurecheck/solutions/de.slisson.mps.structurecheck.sandbox/de.slisson.mps.structurecheck.sandbox.msd" folder="structurecheck" />

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells.sandboxlang/models/com/mbeddr/mpsutil/grammarcells/sandboxlang/editor.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells.sandboxlang/models/com/mbeddr/mpsutil/grammarcells/sandboxlang/editor.mps
@@ -1731,10 +1731,6 @@
         </node>
       </node>
       <node concept="_tjkj" id="5ycts4RWGC2" role="3EZMnx">
-        <node concept="3F2HdR" id="5ycts4RWGCe" role="_tjki">
-          <property role="2czwfO" value="," />
-          <ref role="1NtTu8" to="ibwz:5ycts4RWGBy" resolve="child" />
-        </node>
         <node concept="315t4" id="6gjbwaaGgJP" role="vWNKz">
           <node concept="3clFbS" id="6gjbwaaGgJQ" role="2VODD2">
             <node concept="2xdQw9" id="6gjbwaaGgJR" role="3cqZAp">
@@ -1787,6 +1783,10 @@
               </node>
             </node>
           </node>
+        </node>
+        <node concept="3F2HdR" id="5ycts4RWGCe" role="_tjki">
+          <property role="2czwfO" value="," />
+          <ref role="1NtTu8" to="ibwz:5ycts4RWGBy" resolve="child" />
         </node>
       </node>
       <node concept="3F0ifn" id="5ycts4RWGC4" role="3EZMnx">

--- a/code/htmlcell/languages/de.itemis.mps.editor.htmlcell.demolang/de.itemis.mps.editor.htmlcell.demolang.mpl
+++ b/code/htmlcell/languages/de.itemis.mps.editor.htmlcell.demolang/de.itemis.mps.editor.htmlcell.demolang.mpl
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<language namespace="de.itemis.mps.editor.htmlcell.demolang" uuid="4f348220-8c30-49ab-b23f-98fdc5c19b18" languageVersion="0" moduleVersion="0">
+  <models>
+    <modelRoot contentPath="${module}" type="default">
+      <sourceRoot location="models" />
+    </modelRoot>
+  </models>
+  <facets>
+    <facet type="java">
+      <classes generated="true" path="${module}/classes_gen" />
+    </facet>
+  </facets>
+  <accessoryModels />
+  <stubModelEntries>
+    <stubModelEntry path="${module}/resources" />
+  </stubModelEntries>
+  <sourcePath />
+  <languageVersions>
+    <language slang="l:1919c723-b60b-4592-9318-9ce96d91da44:de.itemis.mps.editor.celllayout" version="0" />
+    <language slang="l:a46e4f41-529c-4c2e-bf93-818590da160d:de.itemis.mps.editor.htmlcell" version="0" />
+    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
+    <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />
+    <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
+    <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
+    <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
+    <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
+    <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
+    <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
+    <language slang="l:f4ad079d-bc71-4ffb-9600-9328705cf998:jetbrains.mps.lang.descriptor" version="0" />
+    <language slang="l:18bc6592-03a6-4e29-a83a-7ff23bde13ba:jetbrains.mps.lang.editor" version="14" />
+    <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
+    <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
+    <language slang="l:982eb8df-2c96-4bd7-9963-11712ea622e5:jetbrains.mps.lang.resources" version="2" />
+    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="18" />
+    <language slang="l:c72da2b9-7cce-4447-8389-f407dc1158b7:jetbrains.mps.lang.structure" version="9" />
+    <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
+    <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
+  </languageVersions>
+  <dependencyVersions>
+    <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
+    <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
+    <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
+    <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+    <module reference="4f348220-8c30-49ab-b23f-98fdc5c19b18(de.itemis.mps.editor.htmlcell.demolang)" version="0" />
+    <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
+    <module reference="a9e4c532-c5f5-4bb7-99ef-42abb73bbb70(jetbrains.mps.lang.descriptor.aspects)" version="0" />
+  </dependencyVersions>
+  <extendedLanguages />
+</language>
+

--- a/code/htmlcell/languages/de.itemis.mps.editor.htmlcell.demolang/models/de.itemis.mps.editor.htmlcell.demolang.editor.mps
+++ b/code/htmlcell/languages/de.itemis.mps.editor.htmlcell.demolang/models/de.itemis.mps.editor.htmlcell.demolang.editor.mps
@@ -1,0 +1,1363 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:9bf12b1d-2184-4816-b9eb-2a9803f288f2(de.itemis.mps.editor.htmlcell.demolang.editor)">
+  <persistence version="9" />
+  <languages>
+    <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="14" />
+    <use id="a46e4f41-529c-4c2e-bf93-818590da160d" name="de.itemis.mps.editor.htmlcell" version="0" />
+    <use id="1919c723-b60b-4592-9318-9ce96d91da44" name="de.itemis.mps.editor.celllayout" version="0" />
+    <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
+  </languages>
+  <imports>
+    <import index="j8aq" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.module(MPS.Core/)" />
+    <import index="3qmy" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.classloading(MPS.Core/)" />
+    <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" />
+    <import index="guwi" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.io(JDK/)" />
+    <import index="7x5y" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.nio.charset(JDK/)" />
+    <import index="42d5" ref="r:68925bf2-3e62-43f2-9686-5a115c3ac2e8(de.itemis.mps.editor.htmlcell.demolang.structure)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor">
+      <concept id="1071666914219" name="jetbrains.mps.lang.editor.structure.ConceptEditorDeclaration" flags="ig" index="24kQdi" />
+      <concept id="1106270549637" name="jetbrains.mps.lang.editor.structure.CellLayout_Horizontal" flags="nn" index="2iRfu4" />
+      <concept id="1106270571710" name="jetbrains.mps.lang.editor.structure.CellLayout_Vertical" flags="nn" index="2iRkQZ" />
+      <concept id="1106270637846" name="jetbrains.mps.lang.editor.structure.CellLayout_Flow" flags="nn" index="2iR$Sn" />
+      <concept id="1237303669825" name="jetbrains.mps.lang.editor.structure.CellLayout_Indent" flags="nn" index="l2Vlx" />
+      <concept id="1142886811589" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameter_node" flags="nn" index="pncrf" />
+      <concept id="1080736578640" name="jetbrains.mps.lang.editor.structure.BaseEditorComponent" flags="ig" index="2wURMF">
+        <child id="1080736633877" name="cellModel" index="2wV5jI" />
+      </concept>
+      <concept id="1215007762405" name="jetbrains.mps.lang.editor.structure.FloatStyleClassItem" flags="ln" index="3$6MrZ">
+        <property id="1215007802031" name="value" index="3$6WeP" />
+      </concept>
+      <concept id="1215007883204" name="jetbrains.mps.lang.editor.structure.PaddingLeftStyleClassItem" flags="ln" index="3$7fVu" />
+      <concept id="1215007897487" name="jetbrains.mps.lang.editor.structure.PaddingRightStyleClassItem" flags="ln" index="3$7jql" />
+      <concept id="1139848536355" name="jetbrains.mps.lang.editor.structure.CellModel_WithRole" flags="ng" index="1$h60E">
+        <reference id="1140103550593" name="relationDeclaration" index="1NtTu8" />
+      </concept>
+      <concept id="1073389446423" name="jetbrains.mps.lang.editor.structure.CellModel_Collection" flags="sn" stub="3013115976261988961" index="3EZMnI">
+        <child id="1106270802874" name="cellLayout" index="2iSdaV" />
+        <child id="1073389446424" name="childCellModel" index="3EZMnx" />
+      </concept>
+      <concept id="1073389577006" name="jetbrains.mps.lang.editor.structure.CellModel_Constant" flags="sn" stub="3610246225209162225" index="3F0ifn">
+        <property id="1073389577007" name="text" index="3F0ifm" />
+      </concept>
+      <concept id="1073389658414" name="jetbrains.mps.lang.editor.structure.CellModel_Property" flags="sg" stub="730538219796134133" index="3F0A7n" />
+      <concept id="1219418625346" name="jetbrains.mps.lang.editor.structure.IStyleContainer" flags="ng" index="3F0Thp">
+        <child id="1219418656006" name="styleItem" index="3F10Kt" />
+      </concept>
+      <concept id="1166049232041" name="jetbrains.mps.lang.editor.structure.AbstractComponent" flags="ng" index="1XWOmA">
+        <reference id="1166049300910" name="conceptDeclaration" index="1XX52x" />
+      </concept>
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
+        <child id="1068498886297" name="rValue" index="37vLTx" />
+        <child id="1068498886295" name="lValue" index="37vLTJ" />
+      </concept>
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="8118189177080264853" name="jetbrains.mps.baseLanguage.structure.AlternativeType" flags="ig" index="nSUau">
+        <child id="8118189177080264854" name="alternative" index="nSUat" />
+      </concept>
+      <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
+        <child id="1154032183016" name="body" index="2LFqv$" />
+      </concept>
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
+        <child id="1145553007750" name="creator" index="2ShVmc" />
+      </concept>
+      <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
+        <child id="1137022507850" name="body" index="2VODD2" />
+      </concept>
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="4952749571008284462" name="jetbrains.mps.baseLanguage.structure.CatchVariable" flags="ng" index="XOnhg" />
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
+      </concept>
+      <concept id="1070533707846" name="jetbrains.mps.baseLanguage.structure.StaticFieldReference" flags="nn" index="10M0yZ">
+        <reference id="1144433057691" name="classifier" index="1PxDUh" />
+      </concept>
+      <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
+      <concept id="1070534555686" name="jetbrains.mps.baseLanguage.structure.CharType" flags="in" index="10Pfzv" />
+      <concept id="1070534760951" name="jetbrains.mps.baseLanguage.structure.ArrayType" flags="in" index="10Q1$e">
+        <child id="1070534760952" name="componentType" index="10Q1$1" />
+      </concept>
+      <concept id="1070534934090" name="jetbrains.mps.baseLanguage.structure.CastExpression" flags="nn" index="10QFUN">
+        <child id="1070534934091" name="type" index="10QFUM" />
+        <child id="1070534934092" name="expression" index="10QFUP" />
+      </concept>
+      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
+        <property id="1068580320021" name="value" index="3cmrfH" />
+      </concept>
+      <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
+      <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
+        <child id="1068581517676" name="expression" index="3cqZAk" />
+      </concept>
+      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
+        <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
+      </concept>
+      <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1079359253375" name="jetbrains.mps.baseLanguage.structure.ParenthesizedExpression" flags="nn" index="1eOMI4">
+        <child id="1079359253376" name="expression" index="1eOMHV" />
+      </concept>
+      <concept id="1081506762703" name="jetbrains.mps.baseLanguage.structure.GreaterThanExpression" flags="nn" index="3eOSWO" />
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+        <reference id="1107535924139" name="classifier" index="3uigEE" />
+      </concept>
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
+        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
+        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
+      </concept>
+      <concept id="3093926081414150598" name="jetbrains.mps.baseLanguage.structure.MultipleCatchClause" flags="ng" index="3uVAMA">
+        <child id="8276990574895933173" name="catchBody" index="1zc67A" />
+        <child id="8276990574895933172" name="throwable" index="1zc67B" />
+      </concept>
+      <concept id="1184950988562" name="jetbrains.mps.baseLanguage.structure.ArrayCreator" flags="nn" index="3$_iS1">
+        <child id="1184951007469" name="componentType" index="3$_nBY" />
+        <child id="1184952969026" name="dimensionExpression" index="3$GQph" />
+      </concept>
+      <concept id="1184952934362" name="jetbrains.mps.baseLanguage.structure.DimensionExpression" flags="nn" index="3$GHV9">
+        <child id="1184953288404" name="expression" index="3$I4v7" />
+      </concept>
+      <concept id="1144230876926" name="jetbrains.mps.baseLanguage.structure.AbstractForStatement" flags="nn" index="1DupvO">
+        <child id="1144230900587" name="variable" index="1Duv9x" />
+      </concept>
+      <concept id="1144231330558" name="jetbrains.mps.baseLanguage.structure.ForStatement" flags="nn" index="1Dw8fO">
+        <child id="1144231399730" name="condition" index="1Dwp0S" />
+      </concept>
+      <concept id="5351203823916750322" name="jetbrains.mps.baseLanguage.structure.TryUniversalStatement" flags="nn" index="3J1_TO">
+        <child id="8276990574886367510" name="catchClause" index="1zxBo5" />
+        <child id="8276990574886367508" name="body" index="1zxBo7" />
+      </concept>
+      <concept id="1208890769693" name="jetbrains.mps.baseLanguage.structure.ArrayLengthOperation" flags="nn" index="1Rwk04" />
+    </language>
+    <language id="1919c723-b60b-4592-9318-9ce96d91da44" name="de.itemis.mps.editor.celllayout">
+      <concept id="4682418030828725523" name="de.itemis.mps.editor.celllayout.structure.HorizontalLineCell" flags="ng" index="2T_mXK" />
+    </language>
+    <language id="a46e4f41-529c-4c2e-bf93-818590da160d" name="de.itemis.mps.editor.htmlcell">
+      <concept id="9175692738071681118" name="de.itemis.mps.editor.htmlcell.structure.CellModel_HTML" flags="ng" index="1jG$eK">
+        <child id="9175692738071697533" name="contentProvider" index="1jGSej" />
+      </concept>
+      <concept id="9175692738071695071" name="de.itemis.mps.editor.htmlcell.structure.QueryFunction_Content" flags="ig" index="1jGTkL" />
+    </language>
+    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="4040588429969021681" name="jetbrains.mps.lang.smodel.structure.ModuleReferenceExpression" flags="nn" index="3rM5sP">
+        <property id="4040588429969021683" name="moduleId" index="3rM5sR" />
+      </concept>
+      <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
+        <reference id="1138056395725" name="property" index="3TsBF5" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="24kQdi" id="7XmAYSGGXp2">
+    <ref role="1XX52x" to="42d5:7XmAYSGGXoU" resolve="Root" />
+    <node concept="3EZMnI" id="7XmAYSGN80H" role="2wV5jI">
+      <node concept="3EZMnI" id="3X4py5opbop" role="3EZMnx">
+        <node concept="l2Vlx" id="3X4py5opboq" role="2iSdaV" />
+        <node concept="3EZMnI" id="DlTQZmdX6P" role="3EZMnx">
+          <node concept="2iR$Sn" id="DlTQZmdX6Q" role="2iSdaV" />
+          <node concept="3F0ifn" id="DlTQZmdX6R" role="3EZMnx">
+            <property role="3F0ifm" value="Lorem" />
+            <node concept="3$7fVu" id="DlTQZmdX6S" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdX6T" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdX6U" role="3EZMnx">
+            <property role="3F0ifm" value="ipsum" />
+            <node concept="3$7fVu" id="DlTQZmdX6V" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdX6W" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdX6X" role="3EZMnx">
+            <property role="3F0ifm" value="dolor" />
+            <node concept="3$7fVu" id="DlTQZmdX6Y" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdX6Z" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdX70" role="3EZMnx">
+            <property role="3F0ifm" value="sit" />
+            <node concept="3$7fVu" id="DlTQZmdX71" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdX72" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdX73" role="3EZMnx">
+            <property role="3F0ifm" value="amet," />
+            <node concept="3$7fVu" id="DlTQZmdX74" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdX75" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdX76" role="3EZMnx">
+            <property role="3F0ifm" value="consetetur" />
+            <node concept="3$7fVu" id="DlTQZmdX77" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdX78" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdX79" role="3EZMnx">
+            <property role="3F0ifm" value="sadipscing" />
+            <node concept="3$7fVu" id="DlTQZmdX7a" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdX7b" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdX7c" role="3EZMnx">
+            <property role="3F0ifm" value="elitr," />
+            <node concept="3$7fVu" id="DlTQZmdX7d" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdX7e" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdX7f" role="3EZMnx">
+            <property role="3F0ifm" value="sed" />
+            <node concept="3$7fVu" id="DlTQZmdX7g" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdX7h" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdX7i" role="3EZMnx">
+            <property role="3F0ifm" value="diam" />
+            <node concept="3$7fVu" id="DlTQZmdX7j" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdX7k" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdX7l" role="3EZMnx">
+            <property role="3F0ifm" value="nonumy" />
+            <node concept="3$7fVu" id="DlTQZmdX7m" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdX7n" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdX7o" role="3EZMnx">
+            <property role="3F0ifm" value="eirmod" />
+            <node concept="3$7fVu" id="DlTQZmdX7p" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdX7q" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdX7r" role="3EZMnx">
+            <property role="3F0ifm" value="tempor" />
+            <node concept="3$7fVu" id="DlTQZmdX7s" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdX7t" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdX7u" role="3EZMnx">
+            <property role="3F0ifm" value="invidunt" />
+            <node concept="3$7fVu" id="DlTQZmdX7v" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdX7w" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdX7x" role="3EZMnx">
+            <property role="3F0ifm" value="ut" />
+            <node concept="3$7fVu" id="DlTQZmdX7y" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdX7z" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdX7$" role="3EZMnx">
+            <property role="3F0ifm" value="labore" />
+            <node concept="3$7fVu" id="DlTQZmdX7_" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdX7A" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdX7B" role="3EZMnx">
+            <property role="3F0ifm" value="et" />
+            <node concept="3$7fVu" id="DlTQZmdX7C" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdX7D" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdX7E" role="3EZMnx">
+            <property role="3F0ifm" value="dolore" />
+            <node concept="3$7fVu" id="DlTQZmdX7F" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdX7G" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdX7H" role="3EZMnx">
+            <property role="3F0ifm" value="magna" />
+            <node concept="3$7fVu" id="DlTQZmdX7I" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdX7J" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdX7K" role="3EZMnx">
+            <property role="3F0ifm" value="aliquyam" />
+            <node concept="3$7fVu" id="DlTQZmdX7L" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdX7M" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdX7N" role="3EZMnx">
+            <property role="3F0ifm" value="erat," />
+            <node concept="3$7fVu" id="DlTQZmdX7O" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdX7P" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdX7Q" role="3EZMnx">
+            <property role="3F0ifm" value="sed" />
+            <node concept="3$7fVu" id="DlTQZmdX7R" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdX7S" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdX7T" role="3EZMnx">
+            <property role="3F0ifm" value="diam" />
+            <node concept="3$7fVu" id="DlTQZmdX7U" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdX7V" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdX7W" role="3EZMnx">
+            <property role="3F0ifm" value="voluptua." />
+            <node concept="3$7fVu" id="DlTQZmdX7X" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdX7Y" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdX7Z" role="3EZMnx">
+            <property role="3F0ifm" value="At" />
+            <node concept="3$7fVu" id="DlTQZmdX80" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdX81" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdX82" role="3EZMnx">
+            <property role="3F0ifm" value="vero" />
+            <node concept="3$7fVu" id="DlTQZmdX83" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdX84" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdX85" role="3EZMnx">
+            <property role="3F0ifm" value="eos" />
+            <node concept="3$7fVu" id="DlTQZmdX86" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdX87" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdX88" role="3EZMnx">
+            <property role="3F0ifm" value="et" />
+            <node concept="3$7fVu" id="DlTQZmdX89" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdX8a" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdX8b" role="3EZMnx">
+            <property role="3F0ifm" value="accusam" />
+            <node concept="3$7fVu" id="DlTQZmdX8c" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdX8d" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdX8e" role="3EZMnx">
+            <property role="3F0ifm" value="et" />
+            <node concept="3$7fVu" id="DlTQZmdX8f" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdX8g" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdX8h" role="3EZMnx">
+            <property role="3F0ifm" value="justo" />
+            <node concept="3$7fVu" id="DlTQZmdX8i" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdX8j" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdX8k" role="3EZMnx">
+            <property role="3F0ifm" value="duo" />
+            <node concept="3$7fVu" id="DlTQZmdX8l" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdX8m" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdX8n" role="3EZMnx">
+            <property role="3F0ifm" value="dolores" />
+            <node concept="3$7fVu" id="DlTQZmdX8o" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdX8p" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdX8q" role="3EZMnx">
+            <property role="3F0ifm" value="et" />
+            <node concept="3$7fVu" id="DlTQZmdX8r" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdX8s" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdX8t" role="3EZMnx">
+            <property role="3F0ifm" value="ea" />
+            <node concept="3$7fVu" id="DlTQZmdX8u" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdX8v" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdX8w" role="3EZMnx">
+            <property role="3F0ifm" value="rebum." />
+            <node concept="3$7fVu" id="DlTQZmdX8x" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdX8y" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdX8z" role="3EZMnx">
+            <property role="3F0ifm" value="Stet" />
+            <node concept="3$7fVu" id="DlTQZmdX8$" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdX8_" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdX8A" role="3EZMnx">
+            <property role="3F0ifm" value="clita" />
+            <node concept="3$7fVu" id="DlTQZmdX8B" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdX8C" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdX8D" role="3EZMnx">
+            <property role="3F0ifm" value="kasd" />
+            <node concept="3$7fVu" id="DlTQZmdX8E" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdX8F" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdX8G" role="3EZMnx">
+            <property role="3F0ifm" value="gubergren," />
+            <node concept="3$7fVu" id="DlTQZmdX8H" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdX8I" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdX8J" role="3EZMnx">
+            <property role="3F0ifm" value="no" />
+            <node concept="3$7fVu" id="DlTQZmdX8K" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdX8L" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdX8M" role="3EZMnx">
+            <property role="3F0ifm" value="sea" />
+            <node concept="3$7fVu" id="DlTQZmdX8N" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdX8O" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdX8P" role="3EZMnx">
+            <property role="3F0ifm" value="takimata" />
+            <node concept="3$7fVu" id="DlTQZmdX8Q" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdX8R" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdX8S" role="3EZMnx">
+            <property role="3F0ifm" value="sanctus" />
+            <node concept="3$7fVu" id="DlTQZmdX8T" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdX8U" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdX8V" role="3EZMnx">
+            <property role="3F0ifm" value="est" />
+            <node concept="3$7fVu" id="DlTQZmdX8W" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdX8X" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdX8Y" role="3EZMnx">
+            <property role="3F0ifm" value="Lorem" />
+            <node concept="3$7fVu" id="DlTQZmdX8Z" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdX90" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdX91" role="3EZMnx">
+            <property role="3F0ifm" value="ipsum" />
+            <node concept="3$7fVu" id="DlTQZmdX92" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdX93" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdX94" role="3EZMnx">
+            <property role="3F0ifm" value="dolor" />
+            <node concept="3$7fVu" id="DlTQZmdX95" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdX96" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdX97" role="3EZMnx">
+            <property role="3F0ifm" value="sit" />
+            <node concept="3$7fVu" id="DlTQZmdX98" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdX99" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdX9a" role="3EZMnx">
+            <property role="3F0ifm" value="amet." />
+            <node concept="3$7fVu" id="DlTQZmdX9b" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdX9c" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdX9d" role="3EZMnx">
+            <property role="3F0ifm" value="Lorem" />
+            <node concept="3$7fVu" id="DlTQZmdX9e" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdX9f" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdX9g" role="3EZMnx">
+            <property role="3F0ifm" value="ipsum" />
+            <node concept="3$7fVu" id="DlTQZmdX9h" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdX9i" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdX9j" role="3EZMnx">
+            <property role="3F0ifm" value="dolor" />
+            <node concept="3$7fVu" id="DlTQZmdX9k" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdX9l" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdX9m" role="3EZMnx">
+            <property role="3F0ifm" value="sit" />
+            <node concept="3$7fVu" id="DlTQZmdX9n" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdX9o" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdX9p" role="3EZMnx">
+            <property role="3F0ifm" value="amet," />
+            <node concept="3$7fVu" id="DlTQZmdX9q" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdX9r" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdX9s" role="3EZMnx">
+            <property role="3F0ifm" value="consetetur" />
+            <node concept="3$7fVu" id="DlTQZmdX9t" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdX9u" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdX9v" role="3EZMnx">
+            <property role="3F0ifm" value="sadipscing" />
+            <node concept="3$7fVu" id="DlTQZmdX9w" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdX9x" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdX9y" role="3EZMnx">
+            <property role="3F0ifm" value="elitr," />
+            <node concept="3$7fVu" id="DlTQZmdX9z" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdX9$" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdX9_" role="3EZMnx">
+            <property role="3F0ifm" value="sed" />
+            <node concept="3$7fVu" id="DlTQZmdX9A" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdX9B" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdX9C" role="3EZMnx">
+            <property role="3F0ifm" value="diam" />
+            <node concept="3$7fVu" id="DlTQZmdX9D" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdX9E" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdX9F" role="3EZMnx">
+            <property role="3F0ifm" value="nonumy" />
+            <node concept="3$7fVu" id="DlTQZmdX9G" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdX9H" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdX9I" role="3EZMnx">
+            <property role="3F0ifm" value="eirmod" />
+            <node concept="3$7fVu" id="DlTQZmdX9J" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdX9K" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdX9L" role="3EZMnx">
+            <property role="3F0ifm" value="tempor" />
+            <node concept="3$7fVu" id="DlTQZmdX9M" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdX9N" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdX9O" role="3EZMnx">
+            <property role="3F0ifm" value="invidunt" />
+            <node concept="3$7fVu" id="DlTQZmdX9P" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdX9Q" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdX9R" role="3EZMnx">
+            <property role="3F0ifm" value="ut" />
+            <node concept="3$7fVu" id="DlTQZmdX9S" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdX9T" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdX9U" role="3EZMnx">
+            <property role="3F0ifm" value="labore" />
+            <node concept="3$7fVu" id="DlTQZmdX9V" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdX9W" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdX9X" role="3EZMnx">
+            <property role="3F0ifm" value="et" />
+            <node concept="3$7fVu" id="DlTQZmdX9Y" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdX9Z" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdXa0" role="3EZMnx">
+            <property role="3F0ifm" value="dolore" />
+            <node concept="3$7fVu" id="DlTQZmdXa1" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdXa2" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdXa3" role="3EZMnx">
+            <property role="3F0ifm" value="magna" />
+            <node concept="3$7fVu" id="DlTQZmdXa4" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdXa5" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdXa6" role="3EZMnx">
+            <property role="3F0ifm" value="aliquyam" />
+            <node concept="3$7fVu" id="DlTQZmdXa7" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdXa8" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdXa9" role="3EZMnx">
+            <property role="3F0ifm" value="erat," />
+            <node concept="3$7fVu" id="DlTQZmdXaa" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdXab" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdXac" role="3EZMnx">
+            <property role="3F0ifm" value="sed" />
+            <node concept="3$7fVu" id="DlTQZmdXad" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdXae" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdXaf" role="3EZMnx">
+            <property role="3F0ifm" value="diam" />
+            <node concept="3$7fVu" id="DlTQZmdXag" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdXah" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdXai" role="3EZMnx">
+            <property role="3F0ifm" value="voluptua." />
+            <node concept="3$7fVu" id="DlTQZmdXaj" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdXak" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdXal" role="3EZMnx">
+            <property role="3F0ifm" value="At" />
+            <node concept="3$7fVu" id="DlTQZmdXam" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdXan" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdXao" role="3EZMnx">
+            <property role="3F0ifm" value="vero" />
+            <node concept="3$7fVu" id="DlTQZmdXap" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdXaq" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdXar" role="3EZMnx">
+            <property role="3F0ifm" value="eos" />
+            <node concept="3$7fVu" id="DlTQZmdXas" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdXat" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdXau" role="3EZMnx">
+            <property role="3F0ifm" value="et" />
+            <node concept="3$7fVu" id="DlTQZmdXav" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdXaw" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdXax" role="3EZMnx">
+            <property role="3F0ifm" value="accusam" />
+            <node concept="3$7fVu" id="DlTQZmdXay" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdXaz" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdXa$" role="3EZMnx">
+            <property role="3F0ifm" value="et" />
+            <node concept="3$7fVu" id="DlTQZmdXa_" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdXaA" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdXaB" role="3EZMnx">
+            <property role="3F0ifm" value="justo" />
+            <node concept="3$7fVu" id="DlTQZmdXaC" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdXaD" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdXaE" role="3EZMnx">
+            <property role="3F0ifm" value="duo" />
+            <node concept="3$7fVu" id="DlTQZmdXaF" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdXaG" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdXaH" role="3EZMnx">
+            <property role="3F0ifm" value="dolores" />
+            <node concept="3$7fVu" id="DlTQZmdXaI" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdXaJ" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdXaK" role="3EZMnx">
+            <property role="3F0ifm" value="et" />
+            <node concept="3$7fVu" id="DlTQZmdXaL" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdXaM" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdXaN" role="3EZMnx">
+            <property role="3F0ifm" value="ea" />
+            <node concept="3$7fVu" id="DlTQZmdXaO" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdXaP" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdXaQ" role="3EZMnx">
+            <property role="3F0ifm" value="rebum." />
+            <node concept="3$7fVu" id="DlTQZmdXaR" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdXaS" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdXaT" role="3EZMnx">
+            <property role="3F0ifm" value="Stet" />
+            <node concept="3$7fVu" id="DlTQZmdXaU" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdXaV" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdXaW" role="3EZMnx">
+            <property role="3F0ifm" value="clita" />
+            <node concept="3$7fVu" id="DlTQZmdXaX" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdXaY" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdXaZ" role="3EZMnx">
+            <property role="3F0ifm" value="kasd" />
+            <node concept="3$7fVu" id="DlTQZmdXb0" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdXb1" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdXb2" role="3EZMnx">
+            <property role="3F0ifm" value="gubergren," />
+            <node concept="3$7fVu" id="DlTQZmdXb3" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdXb4" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdXb5" role="3EZMnx">
+            <property role="3F0ifm" value="no" />
+            <node concept="3$7fVu" id="DlTQZmdXb6" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdXb7" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdXb8" role="3EZMnx">
+            <property role="3F0ifm" value="sea" />
+            <node concept="3$7fVu" id="DlTQZmdXb9" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdXba" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdXbb" role="3EZMnx">
+            <property role="3F0ifm" value="takimata" />
+            <node concept="3$7fVu" id="DlTQZmdXbc" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdXbd" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdXbe" role="3EZMnx">
+            <property role="3F0ifm" value="sanctus" />
+            <node concept="3$7fVu" id="DlTQZmdXbf" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdXbg" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdXbh" role="3EZMnx">
+            <property role="3F0ifm" value="est" />
+            <node concept="3$7fVu" id="DlTQZmdXbi" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdXbj" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdXbk" role="3EZMnx">
+            <property role="3F0ifm" value="Lorem" />
+            <node concept="3$7fVu" id="DlTQZmdXbl" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdXbm" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdXbn" role="3EZMnx">
+            <property role="3F0ifm" value="ipsum" />
+            <node concept="3$7fVu" id="DlTQZmdXbo" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdXbp" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdXbq" role="3EZMnx">
+            <property role="3F0ifm" value="dolor" />
+            <node concept="3$7fVu" id="DlTQZmdXbr" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdXbs" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdXbt" role="3EZMnx">
+            <property role="3F0ifm" value="sit" />
+            <node concept="3$7fVu" id="DlTQZmdXbu" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdXbv" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="DlTQZmdXbw" role="3EZMnx">
+            <property role="3F0ifm" value="amet." />
+            <node concept="3$7fVu" id="DlTQZmdXbx" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="DlTQZmdXby" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2T_mXK" id="3X4py5ooyqT" role="3EZMnx" />
+      <node concept="3EZMnI" id="7XmAYSGXbiz" role="3EZMnx">
+        <node concept="2iRfu4" id="7XmAYSGXbi$" role="2iSdaV" />
+        <node concept="3F0ifn" id="7XmAYSGXbkr" role="3EZMnx">
+          <property role="3F0ifm" value="text" />
+        </node>
+        <node concept="3F0A7n" id="7XmAYSGXbgP" role="3EZMnx">
+          <ref role="1NtTu8" to="42d5:7XmAYSGWVzr" resolve="text" />
+        </node>
+      </node>
+      <node concept="1jG$eK" id="7XmAYSGWWA7" role="3EZMnx">
+        <node concept="1jGTkL" id="7XmAYSGWWDv" role="1jGSej">
+          <node concept="3clFbS" id="7XmAYSGWWDw" role="2VODD2">
+            <node concept="3clFbF" id="7XmAYSGWWI4" role="3cqZAp">
+              <node concept="3cpWs3" id="7XmAYSGX033" role="3clFbG">
+                <node concept="Xl_RD" id="7XmAYSGX0Lr" role="3uHU7w">
+                  <property role="Xl_RC" value="&lt;/font&gt;" />
+                </node>
+                <node concept="3cpWs3" id="7XmAYSGWYVp" role="3uHU7B">
+                  <node concept="Xl_RD" id="7XmAYSGWZDv" role="3uHU7B">
+                    <property role="Xl_RC" value="&lt;font color=blue size=15&gt;" />
+                  </node>
+                  <node concept="2YIFZM" id="7XmAYSGWXtm" role="3uHU7w">
+                    <ref role="1Pybhc" to="wyt6:~String" resolve="String" />
+                    <ref role="37wK5l" to="wyt6:~String.valueOf(java.lang.Object)" resolve="valueOf" />
+                    <node concept="2OqwBi" id="7XmAYSGWWTA" role="37wK5m">
+                      <node concept="pncrf" id="7XmAYSGWWI3" role="2Oq$k0" />
+                      <node concept="3TrcHB" id="7XmAYSGWX4C" role="2OqNvi">
+                        <ref role="3TsBF5" to="42d5:7XmAYSGWVzr" resolve="text" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1jG$eK" id="7XmAYSGU5a3" role="3EZMnx">
+        <node concept="1jGTkL" id="7XmAYSGU5ad" role="1jGSej">
+          <node concept="3clFbS" id="7XmAYSGU5ae" role="2VODD2">
+            <node concept="3clFbF" id="7XmAYSGU5aj" role="3cqZAp">
+              <node concept="Xl_RD" id="7XmAYSGU5ai" role="3clFbG">
+                <property role="Xl_RC" value="The HTML cell supports part of the &lt;a href=\&quot;https://www.w3.org/TR/2018/SPSD-html32-20180315/\&quot;&gt;HTML 3.2 standard&lt;/a&gt;" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2iRkQZ" id="7XmAYSGN80I" role="2iSdaV" />
+      <node concept="3EZMnI" id="fKKzZrdunn" role="3EZMnx">
+        <node concept="2iRfu4" id="fKKzZrduno" role="2iSdaV" />
+        <node concept="3F0ifn" id="fKKzZrduFF" role="3EZMnx">
+          <property role="3F0ifm" value="VERY WIDE LEFT CONTENT" />
+        </node>
+        <node concept="1jG$eK" id="7XmAYSGTLzY" role="3EZMnx">
+          <node concept="1jGTkL" id="7XmAYSGTMzH" role="1jGSej">
+            <node concept="3clFbS" id="7XmAYSGTMzI" role="2VODD2">
+              <node concept="3cpWs8" id="7XmAYSGVg6m" role="3cqZAp">
+                <node concept="3cpWsn" id="7XmAYSGVg6n" role="3cpWs9">
+                  <property role="TrG5h" value="module" />
+                  <node concept="3uibUv" id="7XmAYSGVg6o" role="1tU5fm">
+                    <ref role="3uigEE" to="j8aq:~ReloadableModule" resolve="ReloadableModule" />
+                  </node>
+                  <node concept="1eOMI4" id="7XmAYSGVgfX" role="33vP2m">
+                    <node concept="10QFUN" id="7XmAYSGVgfU" role="1eOMHV">
+                      <node concept="3uibUv" id="7XmAYSGVgfZ" role="10QFUM">
+                        <ref role="3uigEE" to="j8aq:~ReloadableModule" resolve="ReloadableModule" />
+                      </node>
+                      <node concept="3rM5sP" id="7XmAYSGVfV$" role="10QFUP">
+                        <property role="3rM5sR" value="4f348220-8c30-49ab-b23f-98fdc5c19b18" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3cpWs8" id="7XmAYSGVgqw" role="3cqZAp">
+                <node concept="3cpWsn" id="7XmAYSGVgqx" role="3cpWs9">
+                  <property role="TrG5h" value="loader" />
+                  <node concept="3uibUv" id="7XmAYSGVgqy" role="1tU5fm">
+                    <ref role="3uigEE" to="3qmy:~ModuleClassLoader" resolve="ModuleClassLoader" />
+                  </node>
+                  <node concept="10QFUN" id="7XmAYSGVfVC" role="33vP2m">
+                    <node concept="3uibUv" id="7XmAYSGVfVD" role="10QFUM">
+                      <ref role="3uigEE" to="3qmy:~ModuleClassLoader" resolve="ModuleClassLoader" />
+                    </node>
+                    <node concept="2OqwBi" id="7XmAYSGVfVE" role="10QFUP">
+                      <node concept="37vLTw" id="7XmAYSGVfVF" role="2Oq$k0">
+                        <ref role="3cqZAo" node="7XmAYSGVg6n" resolve="module" />
+                      </node>
+                      <node concept="liA8E" id="7XmAYSGVfVG" role="2OqNvi">
+                        <ref role="37wK5l" to="j8aq:~ReloadableModule.getClassLoader0()" resolve="getClassLoader0" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3cpWs8" id="7XmAYSGVkCp" role="3cqZAp">
+                <node concept="3cpWsn" id="7XmAYSGVkCq" role="3cpWs9">
+                  <property role="TrG5h" value="inputStream" />
+                  <node concept="3uibUv" id="7XmAYSGVkAw" role="1tU5fm">
+                    <ref role="3uigEE" to="guwi:~InputStream" resolve="InputStream" />
+                  </node>
+                  <node concept="2OqwBi" id="7XmAYSGVkCr" role="33vP2m">
+                    <node concept="37vLTw" id="7XmAYSGVkCs" role="2Oq$k0">
+                      <ref role="3cqZAo" node="7XmAYSGVgqx" resolve="loader" />
+                    </node>
+                    <node concept="liA8E" id="7XmAYSGVkCt" role="2OqNvi">
+                      <ref role="37wK5l" to="wyt6:~ClassLoader.getResourceAsStream(java.lang.String)" resolve="getResourceAsStream" />
+                      <node concept="Xl_RD" id="7XmAYSGVkCu" role="37wK5m">
+                        <property role="Xl_RC" value="html_3.2_demo.html" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3cpWs8" id="7XmAYSGViRC" role="3cqZAp">
+                <node concept="3cpWsn" id="7XmAYSGViRB" role="3cpWs9">
+                  <property role="TrG5h" value="bufferSize" />
+                  <node concept="10Oyi0" id="7XmAYSGViRD" role="1tU5fm" />
+                  <node concept="3cmrfG" id="7XmAYSGViRE" role="33vP2m">
+                    <property role="3cmrfH" value="1024" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3cpWs8" id="7XmAYSGViRG" role="3cqZAp">
+                <node concept="3cpWsn" id="7XmAYSGViRF" role="3cpWs9">
+                  <property role="TrG5h" value="buffer" />
+                  <node concept="10Q1$e" id="7XmAYSGViRI" role="1tU5fm">
+                    <node concept="10Pfzv" id="7XmAYSGViRH" role="10Q1$1" />
+                  </node>
+                  <node concept="2ShNRf" id="7XmAYSGViRN" role="33vP2m">
+                    <node concept="3$_iS1" id="7XmAYSGViRL" role="2ShVmc">
+                      <node concept="3$GHV9" id="7XmAYSGViRM" role="3$GQph">
+                        <node concept="37vLTw" id="7XmAYSGViRK" role="3$I4v7">
+                          <ref role="3cqZAo" node="7XmAYSGViRB" resolve="bufferSize" />
+                        </node>
+                      </node>
+                      <node concept="10Pfzv" id="7XmAYSGViRJ" role="3$_nBY" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3cpWs8" id="7XmAYSGViRP" role="3cqZAp">
+                <node concept="3cpWsn" id="7XmAYSGViRO" role="3cpWs9">
+                  <property role="TrG5h" value="out" />
+                  <node concept="3uibUv" id="7XmAYSGViRQ" role="1tU5fm">
+                    <ref role="3uigEE" to="wyt6:~StringBuilder" resolve="StringBuilder" />
+                  </node>
+                  <node concept="2ShNRf" id="7XmAYSGVj4X" role="33vP2m">
+                    <node concept="1pGfFk" id="7XmAYSGVj52" role="2ShVmc">
+                      <ref role="37wK5l" to="wyt6:~StringBuilder.&lt;init&gt;()" resolve="StringBuilder" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3cpWs8" id="7XmAYSGViRT" role="3cqZAp">
+                <node concept="3cpWsn" id="7XmAYSGViRS" role="3cpWs9">
+                  <property role="TrG5h" value="in" />
+                  <node concept="3uibUv" id="7XmAYSGViRU" role="1tU5fm">
+                    <ref role="3uigEE" to="guwi:~Reader" resolve="Reader" />
+                  </node>
+                  <node concept="2ShNRf" id="7XmAYSGVky6" role="33vP2m">
+                    <node concept="1pGfFk" id="7XmAYSGVkyq" role="2ShVmc">
+                      <ref role="37wK5l" to="guwi:~InputStreamReader.&lt;init&gt;(java.io.InputStream,java.nio.charset.Charset)" resolve="InputStreamReader" />
+                      <node concept="37vLTw" id="7XmAYSGVkyr" role="37wK5m">
+                        <ref role="3cqZAo" node="7XmAYSGVkCq" resolve="inputStream" />
+                      </node>
+                      <node concept="10M0yZ" id="7XmAYSGVm5a" role="37wK5m">
+                        <ref role="1PxDUh" to="7x5y:~StandardCharsets" resolve="StandardCharsets" />
+                        <ref role="3cqZAo" to="7x5y:~StandardCharsets.UTF_8" resolve="UTF_8" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3J1_TO" id="7XmAYSGVmBB" role="3cqZAp">
+                <node concept="3uVAMA" id="7XmAYSGVn0L" role="1zxBo5">
+                  <node concept="XOnhg" id="7XmAYSGVn0M" role="1zc67B">
+                    <property role="TrG5h" value="io" />
+                    <node concept="nSUau" id="7XmAYSGVn0N" role="1tU5fm">
+                      <node concept="3uibUv" id="7XmAYSGVn9T" role="nSUat">
+                        <ref role="3uigEE" to="guwi:~IOException" resolve="IOException" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbS" id="7XmAYSGVn0O" role="1zc67A" />
+                </node>
+                <node concept="3clFbS" id="7XmAYSGVmBD" role="1zxBo7">
+                  <node concept="1Dw8fO" id="7XmAYSGViRY" role="3cqZAp">
+                    <node concept="3cpWsn" id="7XmAYSGViRZ" role="1Duv9x">
+                      <property role="TrG5h" value="numRead" />
+                      <node concept="10Oyi0" id="7XmAYSGViS1" role="1tU5fm" />
+                    </node>
+                    <node concept="3eOSWO" id="7XmAYSGViS2" role="1Dwp0S">
+                      <node concept="1eOMI4" id="7XmAYSGViS9" role="3uHU7B">
+                        <node concept="37vLTI" id="7XmAYSGViS3" role="1eOMHV">
+                          <node concept="37vLTw" id="7XmAYSGViS4" role="37vLTJ">
+                            <ref role="3cqZAo" node="7XmAYSGViRZ" resolve="numRead" />
+                          </node>
+                          <node concept="2OqwBi" id="7XmAYSGVj4h" role="37vLTx">
+                            <node concept="37vLTw" id="7XmAYSGVj4g" role="2Oq$k0">
+                              <ref role="3cqZAo" node="7XmAYSGViRS" resolve="in" />
+                            </node>
+                            <node concept="liA8E" id="7XmAYSGVj4i" role="2OqNvi">
+                              <ref role="37wK5l" to="guwi:~Reader.read(char[],int,int)" resolve="read" />
+                              <node concept="37vLTw" id="7XmAYSGVj4j" role="37wK5m">
+                                <ref role="3cqZAo" node="7XmAYSGViRF" resolve="buffer" />
+                              </node>
+                              <node concept="3cmrfG" id="7XmAYSGVj4k" role="37wK5m">
+                                <property role="3cmrfH" value="0" />
+                              </node>
+                              <node concept="2OqwBi" id="7XmAYSGVjy9" role="37wK5m">
+                                <node concept="37vLTw" id="7XmAYSGVjy8" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="7XmAYSGViRF" resolve="buffer" />
+                                </node>
+                                <node concept="1Rwk04" id="7XmAYSGVk0Y" role="2OqNvi" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3cmrfG" id="7XmAYSGViSa" role="3uHU7w">
+                        <property role="3cmrfH" value="0" />
+                      </node>
+                    </node>
+                    <node concept="3clFbS" id="7XmAYSGViSc" role="2LFqv$">
+                      <node concept="3clFbF" id="7XmAYSGViSd" role="3cqZAp">
+                        <node concept="2OqwBi" id="7XmAYSGVj5v" role="3clFbG">
+                          <node concept="37vLTw" id="7XmAYSGVj5u" role="2Oq$k0">
+                            <ref role="3cqZAo" node="7XmAYSGViRO" resolve="out" />
+                          </node>
+                          <node concept="liA8E" id="7XmAYSGVj5w" role="2OqNvi">
+                            <ref role="37wK5l" to="wyt6:~StringBuilder.append(char[],int,int)" resolve="append" />
+                            <node concept="37vLTw" id="7XmAYSGVj5x" role="37wK5m">
+                              <ref role="3cqZAo" node="7XmAYSGViRF" resolve="buffer" />
+                            </node>
+                            <node concept="3cmrfG" id="7XmAYSGVj5y" role="37wK5m">
+                              <property role="3cmrfH" value="0" />
+                            </node>
+                            <node concept="37vLTw" id="7XmAYSGVj5z" role="37wK5m">
+                              <ref role="3cqZAo" node="7XmAYSGViRZ" resolve="numRead" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3cpWs6" id="7XmAYSGViSi" role="3cqZAp">
+                <node concept="2OqwBi" id="7XmAYSGVjbd" role="3cqZAk">
+                  <node concept="37vLTw" id="7XmAYSGVjbc" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7XmAYSGViRO" resolve="out" />
+                  </node>
+                  <node concept="liA8E" id="7XmAYSGVjbe" role="2OqNvi">
+                    <ref role="37wK5l" to="wyt6:~StringBuilder.toString()" resolve="toString" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbH" id="7XmAYSGViLS" role="3cqZAp" />
+            </node>
+          </node>
+        </node>
+        <node concept="3F0ifn" id="fKKzZrduOd" role="3EZMnx">
+          <property role="3F0ifm" value="RIGHT CONTENT" />
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/code/htmlcell/languages/de.itemis.mps.editor.htmlcell.demolang/models/de.itemis.mps.editor.htmlcell.demolang.structure.mps
+++ b/code/htmlcell/languages/de.itemis.mps.editor.htmlcell.demolang/models/de.itemis.mps.editor.htmlcell.demolang.structure.mps
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:68925bf2-3e62-43f2-9686-5a115c3ac2e8(de.itemis.mps.editor.htmlcell.demolang.structure)">
+  <persistence version="9" />
+  <languages>
+    <use id="c72da2b9-7cce-4447-8389-f407dc1158b7" name="jetbrains.mps.lang.structure" version="9" />
+    <devkit ref="78434eb8-b0e5-444b-850d-e7c4ad2da9ab(jetbrains.mps.devkit.aspect.structure)" />
+  </languages>
+  <imports>
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="c72da2b9-7cce-4447-8389-f407dc1158b7" name="jetbrains.mps.lang.structure">
+      <concept id="1169125787135" name="jetbrains.mps.lang.structure.structure.AbstractConceptDeclaration" flags="ig" index="PkWjJ">
+        <property id="6714410169261853888" name="conceptId" index="EcuMT" />
+        <child id="1071489727084" name="propertyDeclaration" index="1TKVEl" />
+      </concept>
+      <concept id="1071489090640" name="jetbrains.mps.lang.structure.structure.ConceptDeclaration" flags="ig" index="1TIwiD">
+        <property id="1096454100552" name="rootable" index="19KtqR" />
+        <reference id="1071489389519" name="extends" index="1TJDcQ" />
+      </concept>
+      <concept id="1071489288299" name="jetbrains.mps.lang.structure.structure.PropertyDeclaration" flags="ig" index="1TJgyi">
+        <property id="241647608299431129" name="propertyId" index="IQ2nx" />
+        <reference id="1082985295845" name="dataType" index="AX2Wp" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="1TIwiD" id="7XmAYSGGXoU">
+    <property role="EcuMT" value="9175692738068469306" />
+    <property role="TrG5h" value="Root" />
+    <property role="19KtqR" value="true" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+    <node concept="1TJgyi" id="7XmAYSGWVzr" role="1TKVEl">
+      <property role="IQ2nx" value="9175692738072656091" />
+      <property role="TrG5h" value="text" />
+      <ref role="AX2Wp" to="tpck:fKAOsGN" resolve="string" />
+    </node>
+  </node>
+</model>
+

--- a/code/htmlcell/languages/de.itemis.mps.editor.htmlcell.demolang/resources/html_3.2_demo.html
+++ b/code/htmlcell/languages/de.itemis.mps.editor.htmlcell.demolang/resources/html_3.2_demo.html
@@ -1,0 +1,602 @@
+ These tags imply some meaning and structure to the document.
+  The appearance they are given is controlled by the browser and its preferences.
+  <P>
+  <table COLS=2 border=0 cellspacing=0 cellpadding=0 width="100%">
+    <tr>
+      <td>
+        <a name="Presentation"></a>
+        <H2><font color=RED> Presentation Formatting </font></H2>
+      </td>
+    </tr>
+  </table>
+
+  These tags allow the document's author to control the appearance of the document.
+  <P>
+
+  <table border=0 cellspacing=0 cellpadding=0 bgcolor="white"smoke width="100%">
+    <th align=LEFT width=111> TAG </th>
+    <th align=LEFT width=98> Name </th>
+    <th align=LEFT> Example </th>
+
+    <tr valign=top>
+      <TD width=111>
+        <b>B</b> 
+      </td>
+      <TD width=98> Bold </td>
+      <td><b> Bold </b></td>
+    </tr>
+    <tr valign=top>
+      <td> <b>I</b> </td>
+      <td> Italic </td>
+      <td><i> Italic </i></td>
+    </tr>
+    <tr valign=top>
+      <td><b>STRIKE</b> </td>
+      <td> Strikeout </td>
+      <td><STRIKE> Strikeout </STRIKE></td>
+    <tr valign=top>
+    </tr>
+      <td> <b>SUB</b> </td>
+      <td> Subscript </td>
+      <td> Sub<SUB>script </SUB></td>
+    </tr>
+    <tr valign=top>
+      <td> <b>SUP</b> </td>
+      <td> Superscript </td>
+      <td> Super<SUP>script </SUP></td>
+    </tr>
+    <tr valign=top>
+      <td> <b>SMALL</b> </td>
+      <td> Small Font Size </td>
+      <td><small> Small Font Size </small></td>
+    </tr>
+    <tr valign=top>
+      <td> <b>U</b> </td>
+      <td> Underline </td>
+      <td><U> Underline </U></td>
+    </tr>
+    <tr valign=top>
+      <td> <b>WBR</b> </td>
+      <td> Word Break </td>
+      <td> Word <WBR> Break </WBR> exhibit </td>
+    </tr>
+  </table>
+
+  <table border=0 cellspacing=0 cellpadding=0 bgcolor="white"smoke width="100%">
+    <tr valign=top>
+      <TD width=111> <b>NOBR</b> </td>
+      <TD width=98> No Break </td>   
+      <td>
+        <NOBR> If this line disappears off the right hand side of the page, window, or frame, you are seeing this tag in action. 
+        </NOBR>
+      </td>
+    </tr>
+  </table>
+
+  <P>
+  <a name="Block"></a>
+  <table COLS=2 border=0 cellspacing=0 cellpadding=0 width="100%">
+    <tr>
+      <td>
+        <H2><font color=RED> Block elements </font></H2>
+      </td>
+      <TD align=right Valign=TOP>
+        <font size="1">
+        <FORM>
+          <INPUT TYPE=button Value="^top^" onClick="window.open('#top', window.name)" align=right>
+        </FORM>
+        </font>
+      </td>
+    </tr>
+  </table>
+
+  These tags cause paragraph breaks.
+  <P>
+
+  <table border=0 cellspacing=0 cellpadding=0 bgcolor=oldlace width="100%">
+    <th align=LEFT width=111> TAG </th>
+    <th align=LEFT width=98> Name </th>
+    <th align=LEFT> Attributes </th>
+    <th align=LEFT> Example </th>
+
+    <tr valign=top>
+      <TD width=111>
+        <a name="Blockquote"><b>BLOCKQUOTE</b> 
+      </td>
+      <TD width=98> Block&nbsp;Quote </td>
+      <td><small><b>ALIGN</b> = {left center right justify}</small>
+      <td>
+        Science Fiction has some memorable prose
+        <BLOCKQUOTE align=justify>
+          In this Universe the night was falling: the shadows were lengthening toward an east that would not know another dawn.
+          But elsewhere the stars were still young and the light of morning lingered: and along the path he had once followed, Man would one day go again.
+        </BLOCKQUOTE>
+          as exemplified in the justified quote above.
+      </td>
+    </tr>
+    <tr valign=top>
+      <td> <b>PRE</b> </td>
+      <td> Preformatted </td>
+      <td> <small> <b>WIDTH</b> =&nbsp;#  </small> </td>
+      <td>
+        <PRE width=30> Preformatted text with line
+              breaks, and a maximum line width of 30 characters.
+        </PRE>
+      </td>
+    </tr>
+    <tr valign=top>
+      <td> <b>P</b> </td>
+      <td> Paragraph </td>
+      <td> <small> <b>ALIGN</b> = {left center right justify} </small> </td>
+      <td> 
+        Paragraph one. 
+        <P align=justify> Paragraph two. 
+          This paragraph has alignment set to "justify".
+          Not all browsers support justified alignment.
+        </P> After closing tag. Closing tag is optional. 
+      </td>
+    </tr>
+    <tr valign=top>
+      <td> <b>BR</b> </td>
+      <td> Line Break </td>
+      <td> CLEAR = {left right all} </td>
+      <td> Line <br> break </BR> exhibit. 
+           CLEAR moves vertically down until left, right, or all margins are clear of images.
+      </td>
+    </tr>
+    <tr valign=top>
+      <td> <b>HR</b> </td>
+      <td> Horizontal Rule </td>
+      <td> <small> 
+            <b>ALIGN</b> = {left right center} 
+        <br><b>NOSHADE</b>
+        <br><b>SIZE</b> =&nbsp;#  
+        <br><b>WIDTH</b> = {% #} 
+        </small></td>
+      <td> Horizontal <HR> rule. </HR> No end tag.
+           <br> Size = 10 <HR size=10>
+           <br> No shade <HR NOSHADE>
+           <br> Width = 50% <HR width=50%>
+           <br> Width = 100 <HR width=100>
+      </td>
+    </tr>
+  </table>
+
+  <P>
+  <a name="List"></a>
+  <table COLS=2 border=0 cellspacing=0 cellpadding=0 width="100%">
+    <tr>
+      <td>
+        <H2><font color=RED> Lists </font></H2>
+      </td>
+      <TD align=right Valign=TOP>
+        <font size="1"> &nbsp;
+        <FORM>
+          <INPUT TYPE=button Value="^top^" onClick="window.open('#top', window.name)">
+        </FORM> &nbsp;
+        </font>
+      </td>
+    </tr>
+  </table>
+
+  Lists provide a means of tabulating data. They provide structure to a document.
+  Formatting is controlled by the browser, paragraph breaks are implied by the tags.
+  Lists can be nested.
+  <P>
+
+  <table COLS=5 border=0 cellspacing=0 cellpadding=0 bgcolor=mintcream width="100%">
+    <th align=LEFT width=111> TAG </th>
+    <th align=LEFT width=98> Name </th>
+    <th align=LEFT> Attributes </th>
+    <th align=LEFT> Example </th>
+    <th align=LEFT> Compact Example </th>
+
+    <tr valign=top>
+      <TD width=111>
+        <b>UL 
+        <br> LI</b> 
+      </td>
+      <TD width=98> Unordered List <br> List item </td>
+      <td> 
+        <small>
+             <b>COMPACT</b> 
+        <br> <b>TYPE</b> = 
+        <br> {disk circle square}
+        </small>
+      </td>
+      <td>
+        <UL> Unordered list
+          <LI> Unordered list item 
+          <LI> Second unordered list item, Bullet type default 
+          <LI TYPE=DISC>   Bullet Type = Disc
+          <LI TYPE=CIRCLE> Bullet Type = Circle
+          <LI TYPE=SQUARE> Bullet Type = Square
+          <LI> Last unordered list item 
+        </UL>   
+      </td>
+      <td>
+        <UL COMPACT> Unordered compact list
+          <LI> Unordered list item 
+          <LI> Second unordered list item 
+          <LI> Last unordered list item 
+        </UL>   
+      </td>
+    </tr>
+
+    <tr valign=top>
+      <td> <b>OL <br> LI</b> </td>
+      <td> Ordered List <br> List item </td>
+      <td> <a name="start"></a>
+           <small>
+                <b>COMPACT</b>
+           <br> <b>START</b> =&nbsp;#  
+           <br> <b>TYPE</b> = {A a I i 1} 
+           <br> <b>VALUE</b> =&nbsp;# 
+        </small>
+      </td>
+      <td>
+        <OL> Ordered list
+          <LI> Ordered list item 
+          <LI> Second ordered list item 
+          <LI TYPE=A> Ordinal Type = A
+          <LI TYPE=a> Ordinal Type = a
+          <LI TYPE=I> Ordinal Type = I
+          <LI TYPE=i> Ordinal Type = i
+          <LI TYPE=1> Ordinal Type = 1
+          <LI VALUE=10> Value = 10
+          <LI> Last ordered list item 
+        </OL>   
+      </td>
+      <td>
+        <OL COMPACT START=4> Ordered compact list Start = 4
+          <LI> Ordered list item 
+          <LI> Second ordered list item 
+          <LI> Last ordered list item 
+        </OL>   
+      </td>
+    </tr>
+    <tr valign=top>
+      <td> <b>FONT</b> </td>
+      <td> Font </td>
+      <td> 
+        <small><b>SIZE</b> = "size" 
+        <br><b>COLOR</b> = "colour" 
+        <br>   FACE = "font&nbsp;names list in order of preference"
+        </small>
+      </td>
+      <td> Size from 1 to 7, or relative, eg +1, -2. Face is not part of HTML 3.2
+      </td>
+    </tr>
+      <TD COLSPAN=2><PRE> </PRE></td>
+      <TD COLSPAN=2>
+         <font SIZE =1> 1Aa# </font>
+         <font SIZE =2> 2Aa# </font>
+         <font SIZE =3> 3Aa# </font>
+         <font SIZE =4> 4Aa# </font>
+         <font SIZE =5> 5Aa# </font>
+         <font SIZE =6> 6Aa# </font>
+         <font SIZE =7> 7Aa# </font>
+      </td> 
+    </tr>
+  </table>
+
+  <table COLS=6 border=2 cellspacing=0 cellpadding=0 bgcolor="white" width="100%">
+    <th align=LEFT width=17%> Alignment </th>
+    <th align=LEFT width=17%> Default </th>
+    <th align=LEFT width=17%> Baseline </th>
+    <th align=LEFT width=17%> Top </th>
+    <th align=LEFT width=17%> Center </th>
+    <th align=LEFT width=17%> Bottom </th>
+    <TR HEIGHT=50>
+      <td HEIGHT=50 Valign=baseline> <b> Default </td>
+      <td> <font size=1> Rows show ALIGN,<br>Columns show VALIGN </td>
+      <td Valign=baseline> <font size=1> Rows show ALIGN,<br>Columns show VALIGN </td>
+      <td Valign=top> <font size=1> Rows show ALIGN,<br>Columns show VALIGN </td>
+      <td Valign=center> <font size=1> Rows show ALIGN,<br>Columns show VALIGN </td>
+      <td Valign=bottom> <font size=1> Rows show ALIGN,<br>Columns show VALIGN </td>
+    </tr>
+    <TR HEIGHT=50>
+      <td HEIGHT=50 valign=top> <b> Left </td>
+      <td align=left> <font size=1> Rows show ALIGN,<br>Columns show VALIGN </td>
+      <td align=left Valign=baseline> <font size=1> Rows show ALIGN,<br>Columns show VALIGN </td>
+      <td align=left Valign=top> <font size=1> Rows show ALIGN,<br>Columns show VALIGN </td>
+      <td align=left Valign=center> <font size=1> Rows show ALIGN,<br>Columns show VALIGN </td>
+      <td align=left Valign=bottom> <font size=1> Rows show ALIGN,<br>Columns show VALIGN </td>
+    </tr>
+    <TR HEIGHT=50>
+      <td HEIGHT=50 Valign=center> <b> Center </td>
+      <td align=center> <font size=1> Rows show ALIGN,<br>Columns show VALIGN </td>
+      <td align=center Valign=baseline> <font size=1> Rows show ALIGN,<br>Columns show VALIGN </td>
+      <td align=center Valign=top> <font size=1> Rows show ALIGN,<br>Columns show VALIGN </td>
+      <td align=center Valign=center> <font size=1> Rows show ALIGN,<br>Columns show VALIGN </td>
+      <td align=center Valign=bottom> <font size=1> Rows show ALIGN,<br>Columns show VALIGN </td>
+    </tr>
+    <TR HEIGHT=50>
+      <td HEIGHT=50 Valign=bottom> <b> Right </td>
+      <td align=right> <font size=1> Rows show ALIGN,<br>Columns show VALIGN </td>
+      <td align=right Valign=baseline> <font size=1> Rows show ALIGN,<br>Columns show VALIGN </td>
+      <td align=right Valign=top> <font size=1> Rows show ALIGN,<br>Columns show VALIGN </td>
+      <td align=right Valign=center> <font size=1> Rows show ALIGN,<br>Columns show VALIGN </td>
+      <td align=right Valign=bottom> <font size=1> Rows show ALIGN,<br>Columns show VALIGN </td>
+    </tr>
+  </table>
+
+        <P>
+  <a name="Chars"></a>
+  <table COLS=2 border=0 cellspacing=0 cellpadding=0 width="100%">
+    <tr>
+      <td>
+        <H2><font color=RED> Character Sets </font></H2>
+      </td>
+      <td align=right Valign=TOP>
+        <font size=1>
+        <FORM>
+          <INPUT TYPE=button Value="^top^" onClick="window.open('#top', window.name)">
+        </FORM>
+        </font>
+      </td>
+    </tr>
+  </table>
+
+  Characters and special symbols can be inserted in text and HTML, 
+  either as a <i>numeric character reference</i> 
+  (&amp;&#35;nnnn&#59;&nbsp;where <i>nnnn</i> is a number corresponding to a character in a character set),
+  or as a <i>named entity reference</i> (&amp;&#35;mnem&#59;&nbsp;where <i>mnem</i> is the mnemonic for the character).
+  These are described in a number of places, and a include only a few of the more common and useful ones.
+  <br>
+  There are also some circumstances, particularly in URIs where you can use %##, eg %20 for space, 
+  to represent characters that otherwise wouldn't be parsed by the browser.
+  <table border=0 cellspacing=1 cellpadding=1 bgcolor=papayawhip width="100%">
+    <tr valign=top>
+      <td><small>%20</td><td><small>space &nbsp;</td>
+      <td><small>%21</td><td><small>! &nbsp;</td>
+      <td><small>%22</td><td><small>"&nbsp;</td>
+      <td><small>%23</td><td><small># &nbsp;</td>
+      <td><small>%24</td><td><small>$ &nbsp;</td>
+      <td><small>%25</td><td><small>% &nbsp;</td>
+      <td><small>%26</td><td><small>&amp; &nbsp;</td>
+      <td><small>%27</td><td><small>' &nbsp;</td>
+      <td><small>%28</td><td><small>( &nbsp;</td>
+      <td><small>%29</td><td><small>) &nbsp;</td>
+      <td><small>%2a</td><td><small>* &nbsp;</td>
+      <td><small>%2b</td><td><small>+ &nbsp;</td>
+      <td><small>%2c</td><td><small>, &nbsp;</td>
+      <td><small>%2d</td><td><small>- &nbsp;</td>
+      <td><small>%2e</td><td><small>. &nbsp;</td>
+      <td><small>%2f</td><td><small>/ &nbsp;</td>
+      <td><small>%3a</td><td><small>: &nbsp;</td>
+      <td><small>%3b</td><td><small>; &nbsp;</td>
+      <td><small>%3c</td><td><small>&lt; &nbsp;</td>
+      <td><small>%3d</td><td><small>= &nbsp;</td>
+      <td><small>%3e</td><td><small>&gt; &nbsp;</td>
+      <td><small>%3f</td><td><small>? &nbsp;</td>
+      <td><small>%40</td><td><small>@ &nbsp;</td>
+    </tr>
+  </table>
+        <P>
+
+  <table border=0 cellspacing=1 cellpadding=1 bgcolor=papayawhip width="100%">
+    <tr valign=top>
+      <th align=right><small><font color="darkblue">C</th><th align=center><small>h</th><th align=LEFT><small><font color="darkred">r</th>
+      <th align=LEFT><small>Name</th>
+      <th align=LEFT><small><font color="darkred">#</th>
+      <th align=LEFT><small><small>Description</th>
+      <th align=right><small><font color="darkblue">C</th><th align=center><small>h</th><th align=LEFT><small><font color="darkred">r</th>
+      <th align=LEFT><small>Name</th>
+      <th align=LEFT><small><font color="darkred">#</th>
+      <th align=LEFT><small><small>Description</th>
+      <th align=right><small><font color="darkblue">C</th><th align=center><small>h</th><th align=LEFT><small><font color="darkred">r</th>
+      <th align=LEFT><small>Name</th>
+      <th align=LEFT><small><font color="darkred">#</th>
+      <th align=LEFT><small><small>Description</th>
+    </tr>
+
+    <tr valign=top>
+      <td><small><font color="darkblue">   </td><td><small></td><td><small><font color="darkred">&#09;</td>
+      <td><small>&nbsp;</td>
+      <td><small><font color="darkred">&amp;#09;</td>
+      <td><small><small>Horizontal Tab</td>
+      <td><small><font color="darkblue">&nbsp;</td><td><small></td><td><small><font color="darkred">&#32;</td>
+      <td><small>&nbsp;</td>
+      <td><small><font color="darkred">&amp;#32;</td>
+      <td><small><small>Space</td>
+      <td><small><font color="darkblue">!</td><td><small></td><td><small><font color="darkred">&#33;</td>
+      <td><small>&nbsp;</td>
+      <td><small><font color="darkred">&amp;#33;</td>
+      <td><small><small>Exclamation Mark</td>
+    </tr>
+
+    <tr valign=top>
+      <td><small><font color="darkblue">"</td><td><small>&quot;</td><td><small><font color="darkred">&#34;</td>
+      <td><small>&amp;quot;</td>
+      <td><small><font color="darkred">&amp;#34;</td>
+      <td><small><small>Double quotation mark</td>
+      <td><small><font color="darkblue">&</td><td><small>&amp;</td><td><small><font color="darkred">&#38;</td>
+      <td><small>&amp;amp;</td>
+      <td><small><font color="darkred">&amp;#38;</td>
+      <td><small><small>Ampersand</td>
+      <td><small><font color="darkblue">.</td><td><small>&nbsp;</td><td><small><font color="darkred">&#46;</td>
+      <td><small><font color="darkred">&nbsp;</td>
+      <td><small>&amp;#46;</td>
+      <td><small><small>Full stop (period)</td>
+    </tr>
+
+    <tr valign=top>
+      <td><small><font color="darkblue">&nbsp;</td><td><small>&lt;</td><td><small><font color="darkred">&#60;</td>
+      <td><small>&amp;lt;</td>
+      <td><small><font color="darkred">&amp;#60;</td>
+      <td><small><small>Less than</td>
+      <td><small><font color="darkblue">&nbsp;</td><td><small>&gt;</td><td><small><font color="darkred">&#62;</td>
+      <td><small>&amp;gt;</td>
+      <td><small><font color="darkred">&amp;#62;</td>
+      <td><small><small>Greater than</td>
+      <td><small><font color="darkblue">@</td><td><small>&nbsp;</td><td><small><font color="darkred">&#64;</td>
+      <td><small>&nbsp;</td>
+      <td><small><font color="darkred">&amp;#64;</td>
+      <td><small><small>Commercial at</td>
+    </tr>
+
+    <tr valign=top>
+      <td><small><font color="darkblue">&nbsp;</td><td><small>&nbsp;</td><td><small><font color="darkred">&#160;</td>
+      <td><small>&amp;nbsp;</td>
+      <td><small><font color="darkred">&amp;#160;</td>
+      <td><small><small>Non breaking space</td>
+      <td><small><font color="darkblue">&nbsp;</td><td><small>&iexcl;</td><td><small><font color="darkred">&#161;</td>
+      <td><small>&amp;iexcl;</td>
+      <td><small><font color="darkred">&amp;#161;</td>
+      <td><small><small>Inverted exclamation</td>
+      <td><small><font color="darkblue">&nbsp;</td><td><small>&cent;</td><td><small><font color="darkred">&#162;</td>
+      <td><small>&amp;cent;</td>
+      <td><small><font color="darkred">&amp;#162;</td>
+      <td><small><small>Cent</td>
+    </tr>
+    <tr valign=top>
+      <td><small><font color="darkblue">&nbsp;</td><td><small>&pound;</td><td><small><font color="darkred">&#163;</td>
+      <td><small>&amp;pound;</td>
+      <td><small><font color="darkred">&amp;#163;</td>
+      <td><small><small>Pound sign</td>
+      <td><small><font color="darkblue">&nbsp;</td><td><small>&curren;</td><td><small><font color="darkred">&#164;</td>
+      <td><small>&amp;curren;</td>
+      <td><small><font color="darkred">&amp;#164;</td>
+      <td><small><small>Currency sign</td>
+      <td><small><font color="darkblue">&nbsp;</td><td><small>&yen;</td><td><small><font color="darkred">&#165;</td>
+      <td><small>&amp;yen;</td>
+      <td><small><font color="darkred">&amp;#165;</td>
+      <td><small><small>Yen sign</td>
+    </tr>
+
+    <tr valign=top>
+      <td><small><font color="darkblue">&nbsp;</td><td><small>&brvbar;</td><td><small><font color="darkred">&#166;</td>
+      <td><small>&amp;brvbar;</td>
+      <td><small><font color="darkred">&amp;#166;</td>
+      <td><small><small>Broken Vertical Bar</td>
+      <td><small><font color="darkblue">&nbsp;</td><td><small>&sect;</td><td><small><font color="darkred">&#167;</td>
+      <td><small>&amp;sect;</td>
+      <td><small><font color="darkred">&amp;#167;</td>
+      <td><small><small>Section sign</td>
+      <td><small><font color="darkblue">&nbsp;</td><td><small>&copy;</td><td><small><font color="darkred">&#169;</td>
+      <td><small>&amp;copy;</td>
+      <td><small><font color="darkred">&amp;#169;</td>
+      <td><small><small>Copyright</td>
+    </tr>
+
+    <tr valign=top>
+      <td><small><font color="darkblue">&nbsp;</td><td><small>&laquo;</td><td><small><font color="darkred">&#171;</td>
+      <td><small>&amp;laquo;</td>
+      <td><small><font color="darkred">&amp;#171;</td>
+      <td><small><small>Left angle quote, guillemot left</td>
+      <td><small><font color="darkblue">&nbsp;</td><td><small>&not;</td><td><small><font color="darkred">&#172;</td>
+      <td><small>&amp;not;</td>
+      <td><small><font color="darkred">&amp;#172;</td>
+      <td><small><small>Not</td>
+      <td><small><font color="darkblue">&nbsp;</td><td><small>&reg;</td><td><small><font color="darkred">&#174;</td>
+      <td><small>&amp;reg;</td>
+      <td><small><font color="darkred">&amp;#174;</td>
+      <td><small><small>Registered sign</td>
+    </tr>
+
+    <tr valign=top>
+      <td><small><font color="darkblue">&nbsp;</td><td><small>&plusmn;</td><td><small><font color="darkred">&#177;</td>
+      <td><small>&amp;plusmn;</td>
+      <td><small><font color="darkred">&amp;#177;</td>
+      <td><small><small>Plus minus sign</td>
+      <td><small><font color="darkblue">&nbsp;</td><td><small>&para;</td><td><small><font color="darkred">&#182;</td>
+      <td><small>&amp;para;</td>
+      <td><small><font color="darkred">&amp;#182;</td>
+      <td><small><small>Paragraph sign</td>
+      <td><small><font color="darkblue">&nbsp;</td><td><small>&raquo;</td><td><small><font color="darkred">&#187;</td>
+      <td><small>&amp;raquo;</td>
+      <td><small><font color="darkred">&amp;#187;</td>
+      <td><small><small>Right angle quote, guillemot right</td>
+    </tr>
+
+    <tr valign=top>
+      <td><small><font color="darkblue">&nbsp;</td><td><small>&frac14;</td><td><small><font color="darkred">&#188;</td>
+      <td><small>&amp;frac14;</td>
+      <td><small><font color="darkred">&amp;#188;</td>
+      <td><small><small>One quarter fraction</td>
+      <td><small><font color="darkblue">&nbsp;</td><td><small>&frac12;</td><td><small><font color="darkred">&#189;</td>
+      <td><small>&amp;frac12;</td>
+      <td><small><font color="darkred">&amp;#189;</td>
+      <td><small><small>One half fraction</td>
+      <td><small><font color="darkblue">&nbsp;</td><td><small>&frac34;</td><td><small><font color="darkred">&#190;</td>
+      <td><small>&amp;frac34;</td>
+      <td><small><font color="darkred">&amp;#190;</td>
+      <td><small><small>Three quarters fraction</td>
+    </tr>
+
+    <tr valign=top>
+      <td><small><font color="darkblue">&nbsp;</td><td><small>&iquest;</td><td><small><font color="darkred">&#191;</td>
+      <td><small>&amp;iquest;</td>
+      <td><small><font color="darkred">&amp;#191;</td>
+      <td><small><small>Inverted question mark</td>
+      <td><small><font color="darkblue">&nbsp;</td><td><small>&times;</td><td><small><font color="darkred">&#215;</td>
+      <td><small>&amp;times;</td>
+      <td><small><font color="darkred">&amp;#215;</td>
+      <td><small><small>Times</td>
+      <td><small><font color="darkblue">&nbsp;</td><td><small>&divide;</td><td><small><font color="darkred">&#247;</td>
+      <td><small>&amp;divide;</td>
+      <td><small><font color="darkred">&amp;#247;</td>
+      <td><small><small>Division sign</td>
+    </tr>
+
+    <tr valign=top>
+      <td><small><font color="darkblue">&nbsp;</td><td><small>&bull;</td><td><small>&#8226;</td>
+      <td><small>&amp;bull;</td>
+      <td><small>&amp;#8226;</td>
+      <td><small><small>bullet</td>
+      <td><small><font color="darkblue">&nbsp;</td><td><small>&hellip;</td><td><small>&#8230;</td>
+      <td><small>&amp;hellip;</td>
+      <td><small>&amp;#8230;</td>
+      <td><small><small>horizontal ellipsis</td>
+      <td><small><font color="darkblue">&nbsp;</td><td><small>&prime;</td><td><small>&#8242;</td>
+      <td><small>&amp;prime;</td>
+      <td><small>&amp;#8242;</td>
+      <td><small><small>prime = minutes = feet</td>
+    </tr>
+
+    <tr valign=top>
+      <td><small><font color="darkblue">&nbsp;</td><td><small>&Primt;</td><td><small><font color="darkred">&#8243;</td>
+      <td><small>&amp;Prime;</td>
+      <td><small><font color="darkred">&amp;#8243;</td>
+      <td><small><small>double prime = seconds = inches</td>
+      <td><small><font color="darkblue">&nbsp;</td><td><small>&oline;</td><td><small><font color="darkred">&#8254;</td>
+      <td><small>&amp;oline;</td>
+      <td><small><font color="darkred">&amp;#8254;</td>
+      <td><small><small>overline</td>
+      <td><small><font color="darkblue">&nbsp;</td><td><small>&frasl;</td><td><small><font color="darkred">&#8260;</td>
+      <td><small>&amp;frasl;</td>
+      <td><small><font color="darkred">&amp;#8260;</td>
+      <td><small><small>fraction slash</td>
+    </tr>
+
+    <tr valign=top>
+      <td><small><font color="darkblue">&nbsp;</td><td><small>&larr;</td><td><small><font color="darkred">&#8592;</td>
+      <td><small>&amp;larr;</td>
+      <td><small><font color="darkred">&amp;#8592;</td>
+      <td><small><small>leftwards arrow</td>
+      <td><small><font color="darkblue">&nbsp;</td><td><small>&uarr;</td><td><small><font color="darkred">&#8593;</td>
+      <td><small>&amp;uarr;</td>
+      <td><small><font color="darkred">&amp;#8593;</td>
+      <td><small><small>upwards arrow</td>
+      <td><small><font color="darkblue">&nbsp;</td><td><small>&rarr;</td><td><small><font color="darkred">&#8594;</td>
+      <td><small>&amp;rarr;</td>
+      <td><small><font color="darkred">&amp;#8594;</td>
+      <td><small><small>right arrow</td>
+    </tr>
+
+    <tr valign=top>
+      <td><small><font color="darkblue">&nbsp;</td><td><small>&darr;</td><td><small><font color="darkred">&#8595;</td>
+      <td><small>&amp;darr;</td>
+      <td><small><font color="darkred">&amp;#8595;</td>
+      <td><small><small>downwards arrow</td>
+      <td><small><font color="darkblue">&nbsp;</td><td><small>&harr;</td><td><small><font color="darkred">&#8596;</td>
+      <td><small>&amp;harr;</td>
+      <td><small>&amp;#8596;</td>
+      <td><small><small>left right arrow</td>
+      <td><small><font color="darkblue">&nbsp;</td><td><small>&crarr;</td><td><small><font color="darkred">&#8629;</td>
+      <td><small>&amp;crarr;</td>
+      <td><small><font color="darkred"><font color="darkred">&amp;#8629;</td>
+      <td><small><small>downwards arrow with corner leftwards</td>
+    </tr>
+  </table>

--- a/code/htmlcell/languages/de.itemis.mps.editor.htmlcell/de.itemis.mps.editor.htmlcell.mpl
+++ b/code/htmlcell/languages/de.itemis.mps.editor.htmlcell/de.itemis.mps.editor.htmlcell.mpl
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<language namespace="de.itemis.mps.editor.htmlcell" uuid="a46e4f41-529c-4c2e-bf93-818590da160d" languageVersion="0" moduleVersion="0">
+  <models>
+    <modelRoot contentPath="${module}" type="default">
+      <sourceRoot location="models" />
+    </modelRoot>
+  </models>
+  <facets>
+    <facet type="java">
+      <classes generated="true" path="${module}/classes_gen" />
+    </facet>
+  </facets>
+  <accessoryModels />
+  <generators>
+    <generator alias="main" namespace="de.itemis.mps.editor.htmlcell.generator" uuid="8bc2c756-c8be-4af8-a74e-4b8bbda72bb5">
+      <models>
+        <modelRoot contentPath="${module}/generator" type="default">
+          <sourceRoot location="templates" />
+        </modelRoot>
+      </models>
+      <facets>
+        <facet type="java">
+          <classes generated="true" path="${module}/generator/classes_gen" />
+        </facet>
+      </facets>
+      <external-templates />
+      <dependencies>
+        <dependency reexport="false">18bc6592-03a6-4e29-a83a-7ff23bde13ba(jetbrains.mps.lang.editor)</dependency>
+        <dependency reexport="false">1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)</dependency>
+        <dependency reexport="false">0647eca7-da98-422a-8a8b-6ebc0bd014ea(jetbrains.mps.lang.editor#1129914002149)</dependency>
+        <dependency reexport="false">5af3b4c1-0c4a-4bb7-9e0d-df3c07ff6b84(de.itemis.mps.editor.htmlcell.runtime)</dependency>
+        <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
+        <dependency reexport="false">2e24a298-44d1-4697-baec-5c424fed3a3b(jetbrains.mps.editorlang.runtime)</dependency>
+      </dependencies>
+      <languageVersions>
+        <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
+        <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
+        <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
+        <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
+        <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
+        <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
+        <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
+        <language slang="l:b401a680-8325-4110-8fd3-84331ff25bef:jetbrains.mps.lang.generator" version="4" />
+        <language slang="l:d7706f63-9be2-479c-a3da-ae92af1e64d5:jetbrains.mps.lang.generator.generationContext" version="2" />
+        <language slang="l:289fcc83-6543-41e8-a5ca-768235715ce4:jetbrains.mps.lang.generator.generationParameters" version="0" />
+        <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
+        <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
+        <language slang="l:13744753-c81f-424a-9c1b-cf8943bf4e86:jetbrains.mps.lang.sharedConcepts" version="0" />
+        <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="18" />
+        <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
+        <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
+      </languageVersions>
+      <dependencyVersions>
+        <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
+        <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
+        <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
+        <module reference="1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)" version="0" />
+        <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
+        <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+        <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
+        <module reference="4c6a28d1-2c60-478d-b36e-db9b3cbb21fb(closures.runtime)" version="0" />
+        <module reference="9b80526e-f0bf-4992-bdf5-cee39c1833f3(collections.runtime)" version="0" />
+        <module reference="a46e4f41-529c-4c2e-bf93-818590da160d(de.itemis.mps.editor.htmlcell)" version="0" />
+        <module reference="8bc2c756-c8be-4af8-a74e-4b8bbda72bb5(de.itemis.mps.editor.htmlcell.generator)" version="0" />
+        <module reference="5af3b4c1-0c4a-4bb7-9e0d-df3c07ff6b84(de.itemis.mps.editor.htmlcell.runtime)" version="0" />
+        <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
+        <module reference="443f4c36-fcf5-4eb6-9500-8d06ed259e3e(jetbrains.mps.baseLanguage.classifiers)" version="0" />
+        <module reference="fd392034-7849-419d-9071-12563d152375(jetbrains.mps.baseLanguage.closures)" version="0" />
+        <module reference="83888646-71ce-4f1c-9c53-c54016f6ad4f(jetbrains.mps.baseLanguage.collections)" version="0" />
+        <module reference="52b81ac7-93fd-4e9e-b972-4995882da6d4(jetbrains.mps.baseLanguage.references.runtime)" version="0" />
+        <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
+        <module reference="d44dab97-aaac-44cb-9745-8a14db674c03(jetbrains.mps.baseLanguage.tuples.runtime)" version="0" />
+        <module reference="2e24a298-44d1-4697-baec-5c424fed3a3b(jetbrains.mps.editorlang.runtime)" version="0" />
+        <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
+        <module reference="d936855b-48da-4812-a8a0-2bfddd633ac5(jetbrains.mps.lang.behavior.api)" version="0" />
+        <module reference="d936855b-48da-4812-a8a0-2bfddd633ac4(jetbrains.mps.lang.behavior.runtime)" version="0" />
+        <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
+        <module reference="3ac18869-0828-4401-abad-822a47bf83f1(jetbrains.mps.lang.descriptor#9020561928507175817)" version="0" />
+        <module reference="18bc6592-03a6-4e29-a83a-7ff23bde13ba(jetbrains.mps.lang.editor)" version="0" />
+        <module reference="0647eca7-da98-422a-8a8b-6ebc0bd014ea(jetbrains.mps.lang.editor#1129914002149)" version="0" />
+        <module reference="446c26eb-2b7b-4bf0-9b35-f83fa582753e(jetbrains.mps.lang.modelapi)" version="0" />
+        <module reference="d7eb0a2a-bd50-4576-beae-e4a89db35f20(jetbrains.mps.lang.scopes.runtime)" version="0" />
+        <module reference="7866978e-a0f0-4cc7-81bc-4d213d9375e1(jetbrains.mps.lang.smodel)" version="1" />
+        <module reference="c72da2b9-7cce-4447-8389-f407dc1158b7(jetbrains.mps.lang.structure)" version="0" />
+        <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
+        <module reference="9a4afe51-f114-4595-b5df-048ce3c596be(jetbrains.mps.runtime)" version="0" />
+      </dependencyVersions>
+      <mapping-priorities>
+        <mapping-priority-rule kind="strictly_together">
+          <greater-priority-mapping>
+            <generator generatorUID="8bc2c756-c8be-4af8-a74e-4b8bbda72bb5(de.itemis.mps.editor.htmlcell.generator)" />
+            <external-mapping>
+              <mapping-node modelUID="r:408cde72-0749-4804-bf93-e49982ad34dd(de.itemis.mps.editor.htmlcell.generator.templates@generator)" nodeID="7222428958171432427" />
+            </external-mapping>
+          </greater-priority-mapping>
+          <lesser-priority-mapping>
+            <generator generatorUID="0647eca7-da98-422a-8a8b-6ebc0bd014ea(jetbrains.mps.lang.editor#1129914002149)" />
+            <external-mapping>
+              <mapping-node modelUID="r:00000000-0000-4000-0000-011c8959029f(jetbrains.mps.lang.editor.generator.baseLanguage.template.main@generator)" nodeID="1096629760203" />
+            </external-mapping>
+          </lesser-priority-mapping>
+        </mapping-priority-rule>
+      </mapping-priorities>
+    </generator>
+  </generators>
+  <sourcePath />
+  <dependencies>
+    <dependency reexport="false">18bc6592-03a6-4e29-a83a-7ff23bde13ba(jetbrains.mps.lang.editor)</dependency>
+  </dependencies>
+  <languageVersions>
+    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
+    <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />
+    <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
+    <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
+    <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
+    <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
+    <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
+    <language slang="l:af65afd8-f0dd-4942-87d9-63a55f2a9db1:jetbrains.mps.lang.behavior" version="2" />
+    <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
+    <language slang="l:f4ad079d-bc71-4ffb-9600-9328705cf998:jetbrains.mps.lang.descriptor" version="0" />
+    <language slang="l:18bc6592-03a6-4e29-a83a-7ff23bde13ba:jetbrains.mps.lang.editor" version="14" />
+    <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
+    <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
+    <language slang="l:982eb8df-2c96-4bd7-9963-11712ea622e5:jetbrains.mps.lang.resources" version="2" />
+    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="18" />
+    <language slang="l:c72da2b9-7cce-4447-8389-f407dc1158b7:jetbrains.mps.lang.structure" version="9" />
+    <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
+    <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
+  </languageVersions>
+  <dependencyVersions>
+    <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
+    <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
+    <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
+    <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+    <module reference="a46e4f41-529c-4c2e-bf93-818590da160d(de.itemis.mps.editor.htmlcell)" version="0" />
+    <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
+    <module reference="443f4c36-fcf5-4eb6-9500-8d06ed259e3e(jetbrains.mps.baseLanguage.classifiers)" version="0" />
+    <module reference="fd392034-7849-419d-9071-12563d152375(jetbrains.mps.baseLanguage.closures)" version="0" />
+    <module reference="83888646-71ce-4f1c-9c53-c54016f6ad4f(jetbrains.mps.baseLanguage.collections)" version="0" />
+    <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
+    <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
+    <module reference="d936855b-48da-4812-a8a0-2bfddd633ac5(jetbrains.mps.lang.behavior.api)" version="0" />
+    <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
+    <module reference="a9e4c532-c5f5-4bb7-99ef-42abb73bbb70(jetbrains.mps.lang.descriptor.aspects)" version="0" />
+    <module reference="18bc6592-03a6-4e29-a83a-7ff23bde13ba(jetbrains.mps.lang.editor)" version="0" />
+    <module reference="446c26eb-2b7b-4bf0-9b35-f83fa582753e(jetbrains.mps.lang.modelapi)" version="0" />
+    <module reference="d7eb0a2a-bd50-4576-beae-e4a89db35f20(jetbrains.mps.lang.scopes.runtime)" version="0" />
+    <module reference="7866978e-a0f0-4cc7-81bc-4d213d9375e1(jetbrains.mps.lang.smodel)" version="1" />
+    <module reference="c72da2b9-7cce-4447-8389-f407dc1158b7(jetbrains.mps.lang.structure)" version="0" />
+    <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
+  </dependencyVersions>
+  <runtime>
+    <dependency reexport="false">5af3b4c1-0c4a-4bb7-9e0d-df3c07ff6b84(de.itemis.mps.editor.htmlcell.runtime)</dependency>
+  </runtime>
+  <extendedLanguages>
+    <extendedLanguage>18bc6592-03a6-4e29-a83a-7ff23bde13ba(jetbrains.mps.lang.editor)</extendedLanguage>
+  </extendedLanguages>
+</language>
+

--- a/code/htmlcell/languages/de.itemis.mps.editor.htmlcell/de.itemis.mps.editor.htmlcell.mpl
+++ b/code/htmlcell/languages/de.itemis.mps.editor.htmlcell/de.itemis.mps.editor.htmlcell.mpl
@@ -60,9 +60,12 @@
         <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
         <module reference="4c6a28d1-2c60-478d-b36e-db9b3cbb21fb(closures.runtime)" version="0" />
         <module reference="9b80526e-f0bf-4992-bdf5-cee39c1833f3(collections.runtime)" version="0" />
+        <module reference="848ef45d-e560-4e35-853c-f35a64cc135c(de.itemis.mps.editor.celllayout.runtime)" version="0" />
+        <module reference="24c96a96-b7a1-4f30-82da-0f8e279a2661(de.itemis.mps.editor.celllayout.styles)" version="0" />
         <module reference="a46e4f41-529c-4c2e-bf93-818590da160d(de.itemis.mps.editor.htmlcell)" version="0" />
         <module reference="8bc2c756-c8be-4af8-a74e-4b8bbda72bb5(de.itemis.mps.editor.htmlcell.generator)" version="0" />
         <module reference="5af3b4c1-0c4a-4bb7-9e0d-df3c07ff6b84(de.itemis.mps.editor.htmlcell.runtime)" version="0" />
+        <module reference="f0fff802-6d26-4d2e-b89d-391357265626(de.slisson.mps.hacks.editor)" version="0" />
         <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
         <module reference="443f4c36-fcf5-4eb6-9500-8d06ed259e3e(jetbrains.mps.baseLanguage.classifiers)" version="0" />
         <module reference="fd392034-7849-419d-9071-12563d152375(jetbrains.mps.baseLanguage.closures)" version="0" />

--- a/code/htmlcell/languages/de.itemis.mps.editor.htmlcell/generator/templates/de.itemis.mps.editor.htmlcell.generator.templates@generator.mps
+++ b/code/htmlcell/languages/de.itemis.mps.editor.htmlcell/generator/templates/de.itemis.mps.editor.htmlcell.generator.templates@generator.mps
@@ -1,0 +1,434 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:408cde72-0749-4804-bf93-e49982ad34dd(de.itemis.mps.editor.htmlcell.generator.templates@generator)">
+  <persistence version="9" />
+  <languages>
+    <devkit ref="a2eb3a43-fcc2-4200-80dc-c60110c4862d(jetbrains.mps.devkit.templates)" />
+  </languages>
+  <imports>
+    <import index="kl84" ref="r:04146354-a55e-4279-a2c9-199d983d46c4(de.itemis.mps.editor.htmlcell.structure)" />
+    <import index="tpcb" ref="r:00000000-0000-4000-0000-011c89590297(jetbrains.mps.lang.editor.behavior)" />
+    <import index="cj4x" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor(MPS.Editor/)" />
+    <import index="f4zo" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.cells(MPS.Editor/)" />
+    <import index="tpc3" ref="r:00000000-0000-4000-0000-011c8959029f(jetbrains.mps.lang.editor.generator.baseLanguage.template.main@generator)" />
+    <import index="6708" ref="r:bdf0ce56-0540-4970-ba23-53f0c7ca0a2e(de.itemis.mps.editor.htmlcell.runtime.runtime)" />
+    <import index="dxuu" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:javax.swing(JDK/)" />
+    <import index="qvne" ref="r:8ff33705-85bf-4855-805c-06d68fbe233c(jetbrains.mps.editor.runtime.descriptor)" />
+    <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1082485599095" name="jetbrains.mps.baseLanguage.structure.BlockStatement" flags="nn" index="9aQIb">
+        <child id="1082485599096" name="statements" index="9aQI4" />
+      </concept>
+      <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
+        <child id="1145553007750" name="creator" index="2ShVmc" />
+      </concept>
+      <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
+        <child id="1137022507850" name="body" index="2VODD2" />
+      </concept>
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
+      <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
+      <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu">
+        <property id="1075300953594" name="abstractClass" index="1sVAO0" />
+        <child id="1165602531693" name="superclass" index="1zkMxy" />
+      </concept>
+      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <property id="4276006055363816570" name="isSynchronized" index="od$2w" />
+        <property id="1181808852946" name="isFinal" index="DiZV1" />
+        <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123135" name="body" index="3clF47" />
+      </concept>
+      <concept id="1068580123165" name="jetbrains.mps.baseLanguage.structure.InstanceMethodDeclaration" flags="ig" index="3clFb_" />
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068580123140" name="jetbrains.mps.baseLanguage.structure.ConstructorDeclaration" flags="ig" index="3clFbW" />
+      <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
+        <child id="1068581517676" name="expression" index="3cqZAk" />
+      </concept>
+      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
+        <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
+      </concept>
+      <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
+      <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
+        <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
+      </concept>
+      <concept id="7812454656619025416" name="jetbrains.mps.baseLanguage.structure.MethodDeclaration" flags="ng" index="1rXfSm">
+        <property id="8355037393041754995" name="isNative" index="2aFKle" />
+      </concept>
+      <concept id="7812454656619025412" name="jetbrains.mps.baseLanguage.structure.LocalMethodCall" flags="nn" index="1rXfSq" />
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+        <reference id="1107535924139" name="classifier" index="3uigEE" />
+      </concept>
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
+        <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
+        <child id="8356039341262087992" name="line" index="1aUNEU" />
+      </concept>
+      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+      <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
+    </language>
+    <language id="b401a680-8325-4110-8fd3-84331ff25bef" name="jetbrains.mps.lang.generator">
+      <concept id="1510949579266781519" name="jetbrains.mps.lang.generator.structure.TemplateCallMacro" flags="ln" index="5jKBG" />
+      <concept id="1114706874351" name="jetbrains.mps.lang.generator.structure.CopySrcNodeMacro" flags="ln" index="29HgVG">
+        <child id="1168024447342" name="sourceNodeQuery" index="3NFExx" />
+      </concept>
+      <concept id="1095416546421" name="jetbrains.mps.lang.generator.structure.MappingConfiguration" flags="ig" index="bUwia">
+        <child id="1200911492601" name="mappingLabel" index="2rTMjI" />
+        <child id="1167328349397" name="reductionMappingRule" index="3acgRq" />
+      </concept>
+      <concept id="1168559333462" name="jetbrains.mps.lang.generator.structure.TemplateDeclarationReference" flags="ln" index="j$656" />
+      <concept id="1095672379244" name="jetbrains.mps.lang.generator.structure.TemplateFragment" flags="ng" index="raruj">
+        <reference id="1200916687663" name="labelDeclaration" index="2sdACS" />
+      </concept>
+      <concept id="1200911316486" name="jetbrains.mps.lang.generator.structure.MappingLabelDeclaration" flags="lg" index="2rT7sh">
+        <reference id="1200911342686" name="sourceConcept" index="2rTdP9" />
+        <reference id="1200913004646" name="targetConcept" index="2rZz_L" />
+      </concept>
+      <concept id="1722980698497626400" name="jetbrains.mps.lang.generator.structure.ITemplateCall" flags="ng" index="v9R3L">
+        <reference id="1722980698497626483" name="template" index="v9R2y" />
+      </concept>
+      <concept id="1167169188348" name="jetbrains.mps.lang.generator.structure.TemplateFunctionParameter_sourceNode" flags="nn" index="30H73N" />
+      <concept id="1167169308231" name="jetbrains.mps.lang.generator.structure.BaseMappingRule" flags="ng" index="30H$t8">
+        <reference id="1167169349424" name="applicableConcept" index="30HIoZ" />
+      </concept>
+      <concept id="1092059087312" name="jetbrains.mps.lang.generator.structure.TemplateDeclaration" flags="ig" index="13MO4I">
+        <reference id="1168285871518" name="applicableConcept" index="3gUMe" />
+        <child id="1092060348987" name="contentNode" index="13RCb5" />
+      </concept>
+      <concept id="1087833241328" name="jetbrains.mps.lang.generator.structure.PropertyMacro" flags="ln" index="17Uvod">
+        <child id="1167756362303" name="propertyValueFunction" index="3zH0cK" />
+      </concept>
+      <concept id="1167327847730" name="jetbrains.mps.lang.generator.structure.Reduction_MappingRule" flags="lg" index="3aamgX">
+        <child id="1169672767469" name="ruleConsequence" index="1lVwrX" />
+      </concept>
+      <concept id="1167756080639" name="jetbrains.mps.lang.generator.structure.PropertyMacro_GetPropertyValue" flags="in" index="3zFVjK" />
+      <concept id="1167770111131" name="jetbrains.mps.lang.generator.structure.ReferenceMacro_GetReferent" flags="in" index="3$xsQk" />
+      <concept id="8900764248744213868" name="jetbrains.mps.lang.generator.structure.InlineTemplateWithContext_RuleConsequence" flags="lg" index="1Koe21">
+        <child id="8900764248744213871" name="contentNode" index="1Koe22" />
+      </concept>
+      <concept id="1168024337012" name="jetbrains.mps.lang.generator.structure.SourceSubstituteMacro_SourceNodeQuery" flags="in" index="3NFfHV" />
+      <concept id="1088761943574" name="jetbrains.mps.lang.generator.structure.ReferenceMacro" flags="ln" index="1ZhdrF">
+        <child id="1167770376702" name="referentFunction" index="3$ytzL" />
+      </concept>
+    </language>
+    <language id="d7706f63-9be2-479c-a3da-ae92af1e64d5" name="jetbrains.mps.lang.generator.generationContext">
+      <concept id="1218047638031" name="jetbrains.mps.lang.generator.generationContext.structure.GenerationContextOp_CreateUniqueName" flags="nn" index="2piZGk">
+        <child id="1218047638032" name="baseName" index="2piZGb" />
+        <child id="1218049772449" name="contextNode" index="2pr8EU" />
+      </concept>
+      <concept id="1216860049627" name="jetbrains.mps.lang.generator.generationContext.structure.GenerationContextOp_GetOutputByLabelAndInput" flags="nn" index="1iwH70">
+        <reference id="1216860049628" name="label" index="1iwH77" />
+        <child id="1216860049632" name="inputNode" index="1iwH7V" />
+      </concept>
+      <concept id="1216860049635" name="jetbrains.mps.lang.generator.generationContext.structure.TemplateFunctionParameter_generationContext" flags="nn" index="1iwH7S" />
+    </language>
+    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
+      <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="nn" index="3TrEf2">
+        <reference id="1138056516764" name="link" index="3Tt5mk" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="3364660638048049750" name="jetbrains.mps.lang.core.structure.PropertyAttribute" flags="ng" index="A9Btg">
+        <property id="1757699476691236117" name="name_DebugInfo" index="2qtEX9" />
+        <property id="1341860900487648621" name="propertyId" index="P4ACc" />
+      </concept>
+      <concept id="3364660638048049745" name="jetbrains.mps.lang.core.structure.LinkAttribute" flags="ng" index="A9Btn">
+        <property id="1757699476691236116" name="role_DebugInfo" index="2qtEX8" />
+        <property id="1341860900488019036" name="linkId" index="P3scX" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+    <language id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text">
+      <concept id="155656958578482948" name="jetbrains.mps.lang.text.structure.Word" flags="nn" index="3oM_SD">
+        <property id="155656958578482949" name="value" index="3oM_SC" />
+      </concept>
+      <concept id="2535923850359271782" name="jetbrains.mps.lang.text.structure.Line" flags="nn" index="1PaTwC">
+        <child id="2535923850359271783" name="elements" index="1PaTwD" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="bUwia" id="6gVedWjjonF">
+    <property role="TrG5h" value="main" />
+    <node concept="3aamgX" id="48TKAW3Vg3I" role="3acgRq">
+      <ref role="30HIoZ" to="kl84:7XmAYSGTdxu" resolve="CellModel_HTML" />
+      <node concept="1Koe21" id="48TKAW3Vg3J" role="1lVwrX">
+        <node concept="9aQIb" id="48TKAW3Vg3K" role="1Koe22">
+          <node concept="3clFbS" id="48TKAW3Vg3L" role="9aQI4">
+            <node concept="3clFbH" id="48TKAW3Vg3M" role="3cqZAp">
+              <node concept="raruj" id="48TKAW3Vg3N" role="lGtFl" />
+              <node concept="5jKBG" id="48TKAW3Vg3O" role="lGtFl">
+                <ref role="v9R2y" node="g_$xCuf" resolve="reduce_CellModel_HTML" />
+              </node>
+            </node>
+            <node concept="3clFbH" id="48TKAW3Vg3P" role="3cqZAp">
+              <node concept="raruj" id="48TKAW3Vg3Q" role="lGtFl" />
+              <node concept="29HgVG" id="48TKAW3Vg3R" role="lGtFl">
+                <node concept="3NFfHV" id="48TKAW3Vg3S" role="3NFExx">
+                  <node concept="3clFbS" id="48TKAW3Vg3T" role="2VODD2">
+                    <node concept="3clFbF" id="48TKAW3Vg3U" role="3cqZAp">
+                      <node concept="2OqwBi" id="48TKAW3Vg3V" role="3clFbG">
+                        <node concept="3TrEf2" id="48TKAW3Vg3W" role="2OqNvi">
+                          <ref role="3Tt5mk" to="kl84:7XmAYSGThxX" resolve="contentProvider" />
+                        </node>
+                        <node concept="30H73N" id="48TKAW3Vg3X" role="2Oq$k0" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbH" id="48TKAW3Vg3Y" role="3cqZAp">
+              <node concept="raruj" id="48TKAW3Vg3Z" role="lGtFl" />
+              <node concept="5jKBG" id="48TKAW3Vg40" role="lGtFl">
+                <ref role="v9R2y" to="tpc3:2dv1ickkgDx" resolve="template_EditorCellModel_CommonMethods" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3aamgX" id="7XmAYSGU3kq" role="3acgRq">
+      <ref role="30HIoZ" to="kl84:7XmAYSGTgVv" resolve="QueryFunction_Content" />
+      <node concept="j$656" id="7XmAYSGU3kw" role="1lVwrX">
+        <ref role="v9R2y" node="h7FsCx7" resolve="reduce_QueryFunction_Content" />
+      </node>
+    </node>
+    <node concept="2rT7sh" id="hG092Bk" role="2rTMjI">
+      <property role="TrG5h" value="content_query_method" />
+      <ref role="2rZz_L" to="tpee:fIYIFWa" resolve="StaticMethodDeclaration" />
+      <ref role="2rTdP9" to="kl84:7XmAYSGTgVv" resolve="QueryFunction_Content" />
+    </node>
+  </node>
+  <node concept="13MO4I" id="g_$xCuf">
+    <property role="TrG5h" value="reduce_CellModel_HTML" />
+    <ref role="3gUMe" to="kl84:7XmAYSGTdxu" resolve="CellModel_HTML" />
+    <node concept="312cEu" id="g_$xYfi" role="13RCb5">
+      <property role="TrG5h" value="_context_class_" />
+      <property role="1sVAO0" value="true" />
+      <node concept="3clFbW" id="3NbAIGiCiLd" role="jymVt">
+        <node concept="3clFbS" id="3NbAIGiCiLg" role="3clF47" />
+        <node concept="3cqZAl" id="3NbAIGiCiLe" role="3clF45" />
+        <node concept="3Tm1VV" id="3NbAIGiCiLf" role="1B3o_S" />
+      </node>
+      <node concept="3clFb_" id="g_CeiMb" role="jymVt">
+        <property role="TrG5h" value="_cell_factory_method_" />
+        <node concept="3uibUv" id="5Hr2i_R23Rv" role="3clF45">
+          <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+        </node>
+        <node concept="raruj" id="g_CeiMW" role="lGtFl">
+          <ref role="2sdACS" to="tpc3:2dNBF9rpTiT" resolve="cellFactory.factoryMethod" />
+        </node>
+        <node concept="3clFbS" id="g_CeiMh" role="3clF47">
+          <node concept="3cpWs8" id="7XmAYSGTmGA" role="3cqZAp">
+            <node concept="3cpWsn" id="7XmAYSGTmGB" role="3cpWs9">
+              <property role="TrG5h" value="editorCell" />
+              <node concept="3uibUv" id="7XmAYSGTmGC" role="1tU5fm">
+                <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+              </node>
+              <node concept="2ShNRf" id="7XmAYSGToQi" role="33vP2m">
+                <node concept="1pGfFk" id="7XmAYSGTtMl" role="2ShVmc">
+                  <ref role="37wK5l" to="6708:7XmAYSGN9qp" resolve="EditorCell_HTML" />
+                  <node concept="1rXfSq" id="7XmAYSGTQ83" role="37wK5m">
+                    <ref role="37wK5l" to="qvne:6OQfiPCHBdf" resolve="getEditorContext" />
+                  </node>
+                  <node concept="37vLTw" id="7XmAYSGTuJa" role="37wK5m">
+                    <ref role="3cqZAo" to="tpc3:7GOmDNDA2zg" resolve="myNode" />
+                  </node>
+                  <node concept="1rXfSq" id="7XmAYSGTx6P" role="37wK5m">
+                    <ref role="37wK5l" node="5_YqJ2SkYPJ" resolve="getContent" />
+                    <node concept="1ZhdrF" id="7XmAYSGTxxI" role="lGtFl">
+                      <property role="2qtEX8" value="baseMethodDeclaration" />
+                      <property role="P3scX" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1204053956946/1068499141037" />
+                      <node concept="3$xsQk" id="7XmAYSGTxxJ" role="3$ytzL">
+                        <node concept="3clFbS" id="7XmAYSGTxxK" role="2VODD2">
+                          <node concept="3cpWs6" id="5_YqJ2Sl1G6" role="3cqZAp">
+                            <node concept="2OqwBi" id="5_YqJ2Sl1G7" role="3cqZAk">
+                              <node concept="1iwH70" id="5_YqJ2Sl1G8" role="2OqNvi">
+                                <ref role="1iwH77" node="hG092Bk" resolve="content_query_method" />
+                                <node concept="2OqwBi" id="5_YqJ2Sl1G9" role="1iwH7V">
+                                  <node concept="3TrEf2" id="5_YqJ2Sl1Ga" role="2OqNvi">
+                                    <ref role="3Tt5mk" to="kl84:7XmAYSGThxX" resolve="contentProvider" />
+                                  </node>
+                                  <node concept="30H73N" id="5_YqJ2Sl1Gb" role="2Oq$k0" />
+                                </node>
+                              </node>
+                              <node concept="1iwH7S" id="5_YqJ2Sl1Gc" role="2Oq$k0" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="3dYY$_sKB13" role="3cqZAp">
+            <node concept="3cpWsn" id="3dYY$_sKB14" role="3cpWs9">
+              <property role="TrG5h" value="i" />
+              <node concept="10Oyi0" id="3dYY$_sKB15" role="1tU5fm" />
+            </node>
+            <node concept="5jKBG" id="6hpM9fmFEc4" role="lGtFl">
+              <ref role="v9R2y" to="tpc3:4v1iCryNDHi" resolve="template_cellSetupBlock" />
+            </node>
+          </node>
+          <node concept="3cpWs6" id="3_TG3j97Dvo" role="3cqZAp">
+            <node concept="37vLTw" id="3_TG3j97DEO" role="3cqZAk">
+              <ref role="3cqZAo" node="7XmAYSGTmGB" resolve="editorCell" />
+            </node>
+          </node>
+        </node>
+        <node concept="3Tm6S6" id="1y7DiaVv33d" role="1B3o_S" />
+        <node concept="17Uvod" id="g_CeiMX" role="lGtFl">
+          <property role="2qtEX9" value="name" />
+          <property role="P4ACc" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c/1169194658468/1169194664001" />
+          <node concept="3zFVjK" id="hBfjNCh" role="3zH0cK">
+            <node concept="3clFbS" id="hBfjNCi" role="2VODD2">
+              <node concept="3clFbF" id="hBfjPju" role="3cqZAp">
+                <node concept="2OqwBi" id="hHfEEhU" role="3clFbG">
+                  <node concept="2qgKlT" id="hHfEExm" role="2OqNvi">
+                    <ref role="37wK5l" to="tpcb:hHfE2BD" resolve="getFactoryMethodName" />
+                    <node concept="1iwH7S" id="hT7EuZ9" role="37wK5m" />
+                  </node>
+                  <node concept="30H73N" id="hHfEEbM" role="2Oq$k0" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2tJIrI" id="7XmAYSGTvef" role="jymVt" />
+      <node concept="3clFb_" id="5_YqJ2SkYPJ" role="jymVt">
+        <property role="TrG5h" value="getContent" />
+        <property role="DiZV1" value="false" />
+        <property role="od$2w" value="false" />
+        <property role="2aFKle" value="false" />
+        <node concept="3clFbS" id="5_YqJ2SkYPM" role="3clF47">
+          <node concept="3cpWs6" id="5_YqJ2SkYPN" role="3cqZAp">
+            <node concept="10Nm6u" id="5_YqJ2SkYPO" role="3cqZAk" />
+          </node>
+        </node>
+        <node concept="17QB3L" id="7XmAYSGTwgd" role="3clF45" />
+        <node concept="3Tm1VV" id="5_YqJ2SkYPL" role="1B3o_S" />
+      </node>
+      <node concept="2tJIrI" id="7XmAYSGTvvi" role="jymVt" />
+      <node concept="3Tm1VV" id="h9B3LuZ" role="1B3o_S" />
+      <node concept="3uibUv" id="7XmAYSGTBUX" role="1zkMxy">
+        <ref role="3uigEE" to="tpc3:7GOmDNDyRby" resolve="CellFactoryContextClass" />
+      </node>
+    </node>
+  </node>
+  <node concept="13MO4I" id="h7FsCx7">
+    <property role="TrG5h" value="reduce_QueryFunction_Content" />
+    <ref role="3gUMe" to="kl84:7XmAYSGTgVv" resolve="QueryFunction_Content" />
+    <node concept="312cEu" id="h7FsCx8" role="13RCb5">
+      <property role="TrG5h" value="_context_class_" />
+      <node concept="3clFb_" id="5_YqJ2SkpPB" role="jymVt">
+        <property role="TrG5h" value="_query_method" />
+        <property role="DiZV1" value="false" />
+        <property role="od$2w" value="false" />
+        <property role="2aFKle" value="false" />
+        <node concept="3clFbS" id="5_YqJ2SkpPD" role="3clF47">
+          <node concept="3SKdUt" id="5_YqJ2SkpPE" role="3cqZAp">
+            <node concept="1PaTwC" id="ATZLwXnUUU" role="1aUNEU">
+              <node concept="3oM_SD" id="ATZLwXnUUV" role="1PaTwD">
+                <property role="3oM_SC" value="note:" />
+              </node>
+              <node concept="3oM_SD" id="ATZLwXnUUW" role="1PaTwD">
+                <property role="3oM_SC" value="macro" />
+              </node>
+              <node concept="3oM_SD" id="ATZLwXnUUX" role="1PaTwD">
+                <property role="3oM_SC" value="is" />
+              </node>
+              <node concept="3oM_SD" id="ATZLwXnUUY" role="1PaTwD">
+                <property role="3oM_SC" value="on" />
+              </node>
+              <node concept="3oM_SD" id="ATZLwXnUUZ" role="1PaTwD">
+                <property role="3oM_SC" value="StatementList" />
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs6" id="5_YqJ2SkpPG" role="3cqZAp">
+            <node concept="10Nm6u" id="5_YqJ2SkpPH" role="3cqZAk" />
+          </node>
+          <node concept="29HgVG" id="5_YqJ2SkpPI" role="lGtFl">
+            <node concept="3NFfHV" id="5_YqJ2SkpPJ" role="3NFExx">
+              <node concept="3clFbS" id="5_YqJ2SkpPK" role="2VODD2">
+                <node concept="3cpWs6" id="5_YqJ2SkpPL" role="3cqZAp">
+                  <node concept="2OqwBi" id="5_YqJ2SkpPM" role="3cqZAk">
+                    <node concept="3TrEf2" id="5_YqJ2SkpPN" role="2OqNvi">
+                      <ref role="3Tt5mk" to="tpee:gyVODHa" resolve="body" />
+                    </node>
+                    <node concept="30H73N" id="5_YqJ2SkpPO" role="2Oq$k0" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="17QB3L" id="7XmAYSGTlTK" role="3clF45" />
+        <node concept="3Tm6S6" id="5_YqJ2SkpPP" role="1B3o_S" />
+        <node concept="raruj" id="5_YqJ2SkpQ6" role="lGtFl">
+          <ref role="2sdACS" node="hG092Bk" resolve="content_query_method" />
+        </node>
+        <node concept="17Uvod" id="5_YqJ2SkpQ7" role="lGtFl">
+          <property role="2qtEX9" value="name" />
+          <property role="P4ACc" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c/1169194658468/1169194664001" />
+          <node concept="3zFVjK" id="5_YqJ2SkpQ8" role="3zH0cK">
+            <node concept="3clFbS" id="5_YqJ2SkpQ9" role="2VODD2">
+              <node concept="3clFbF" id="5_YqJ2SkpQa" role="3cqZAp">
+                <node concept="2OqwBi" id="5_YqJ2SkpQb" role="3clFbG">
+                  <node concept="2piZGk" id="5_YqJ2SkpQc" role="2OqNvi">
+                    <node concept="30H73N" id="5_YqJ2SkpQd" role="2pr8EU" />
+                    <node concept="Xl_RD" id="5_YqJ2SkpQe" role="2piZGb">
+                      <property role="Xl_RC" value="_QueryFunction_JComponent_" />
+                    </node>
+                  </node>
+                  <node concept="1iwH7S" id="5_YqJ2SkpQf" role="2Oq$k0" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="h9B3LwM" role="1B3o_S" />
+    </node>
+  </node>
+</model>
+

--- a/code/htmlcell/languages/de.itemis.mps.editor.htmlcell/models/de.itemis.mps.editor.htmlcell.behavior.mps
+++ b/code/htmlcell/languages/de.itemis.mps.editor.htmlcell/models/de.itemis.mps.editor.htmlcell.behavior.mps
@@ -1,0 +1,189 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:166b8e18-e09d-457c-a682-a73ebad515da(de.itemis.mps.editor.htmlcell.behavior)">
+  <persistence version="9" />
+  <languages>
+    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="18" />
+    <use id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior" version="2" />
+    <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
+  </languages>
+  <imports>
+    <import index="tpc2" ref="r:00000000-0000-4000-0000-011c8959029e(jetbrains.mps.lang.editor.structure)" />
+    <import index="kl84" ref="r:04146354-a55e-4279-a2c9-199d983d46c4(de.itemis.mps.editor.htmlcell.structure)" implicit="true" />
+    <import index="tpek" ref="r:00000000-0000-4000-0000-011c895902c0(jetbrains.mps.baseLanguage.behavior)" implicit="true" />
+    <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior">
+      <concept id="1225194240794" name="jetbrains.mps.lang.behavior.structure.ConceptBehavior" flags="ng" index="13h7C7">
+        <reference id="1225194240799" name="concept" index="13h7C2" />
+        <child id="1225194240805" name="method" index="13h7CS" />
+        <child id="1225194240801" name="constructor" index="13h7CW" />
+      </concept>
+      <concept id="1225194413805" name="jetbrains.mps.lang.behavior.structure.ConceptConstructorDeclaration" flags="in" index="13hLZK" />
+      <concept id="1225194472830" name="jetbrains.mps.lang.behavior.structure.ConceptMethodDeclaration" flags="ng" index="13i0hz">
+        <property id="5864038008284099149" name="isStatic" index="2Ki8OM" />
+        <property id="1225194472832" name="isVirtual" index="13i0it" />
+        <property id="1225194472834" name="isAbstract" index="13i0iv" />
+        <reference id="1225194472831" name="overriddenMethod" index="13i0hy" />
+      </concept>
+      <concept id="1225194628440" name="jetbrains.mps.lang.behavior.structure.SuperNodeExpression" flags="nn" index="13iAh5">
+        <reference id="5299096511375896640" name="superConcept" index="3eA5LN" />
+      </concept>
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
+        <child id="1137022507850" name="body" index="2VODD2" />
+      </concept>
+      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123135" name="body" index="3clF47" />
+      </concept>
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
+        <child id="1068581517676" name="expression" index="3cqZAk" />
+      </concept>
+      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
+        <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
+      </concept>
+      <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+      </concept>
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
+        <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+    </language>
+    <language id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation">
+      <concept id="1196350785113" name="jetbrains.mps.lang.quotation.structure.Quotation" flags="nn" index="2c44tf">
+        <child id="1196350785114" name="quotedNode" index="2c44tc" />
+      </concept>
+    </language>
+    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
+      <concept id="2644386474300074836" name="jetbrains.mps.lang.smodel.structure.ConceptIdRefExpression" flags="nn" index="35c_gC">
+        <reference id="2644386474300074837" name="conceptDeclaration" index="35c_gD" />
+      </concept>
+      <concept id="6677504323281689838" name="jetbrains.mps.lang.smodel.structure.SConceptType" flags="in" index="3bZ5Sz">
+        <reference id="6677504323281689839" name="conceptDeclaraton" index="3bZ5Sy" />
+      </concept>
+      <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2" />
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+    <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="nn" index="25WWJ4">
+        <child id="540871147943773366" name="argument" index="25WWJ7" />
+      </concept>
+      <concept id="1151688443754" name="jetbrains.mps.baseLanguage.collections.structure.ListType" flags="in" index="_YKpA">
+        <child id="1151688676805" name="elementType" index="_ZDj9" />
+      </concept>
+      <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
+    </language>
+  </registry>
+  <node concept="13h7C7" id="7XmAYSGTgVw">
+    <ref role="13h7C2" to="kl84:7XmAYSGTgVv" resolve="QueryFunction_Content" />
+    <node concept="13i0hz" id="2D1PBM_bzmv" role="13h7CS">
+      <property role="2Ki8OM" value="false" />
+      <property role="TrG5h" value="getParameterConcepts" />
+      <property role="13i0it" value="false" />
+      <ref role="13i0hy" to="tpek:2xELmDxyi2v" resolve="getParameterConcepts" />
+      <node concept="_YKpA" id="2xELmDxRnSw" role="3clF45">
+        <node concept="3bZ5Sz" id="2xELmDxRnSx" role="_ZDj9">
+          <ref role="3bZ5Sy" to="tpee:g76ryKb" resolve="ConceptFunctionParameter" />
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="2D1PBM_bzmw" role="1B3o_S" />
+      <node concept="3clFbS" id="2D1PBM_bzmx" role="3clF47">
+        <node concept="3cpWs8" id="2D1PBM_bzmy" role="3cqZAp">
+          <node concept="3cpWsn" id="2D1PBM_bzmz" role="3cpWs9">
+            <property role="TrG5h" value="result" />
+            <node concept="_YKpA" id="2D1PBM_bzmB" role="1tU5fm">
+              <node concept="3bZ5Sz" id="2xELmDxRnS$" role="_ZDj9">
+                <ref role="3bZ5Sy" to="tpee:g76ryKb" resolve="ConceptFunctionParameter" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="2D1PBM_bzmJ" role="33vP2m">
+              <node concept="13iAh5" id="2D1PBM_bzmF" role="2Oq$k0">
+                <ref role="3eA5LN" to="tpee:gyVMwX8" resolve="ConceptFunction" />
+              </node>
+              <node concept="2qgKlT" id="2D1PBM_bzmE" role="2OqNvi">
+                <ref role="37wK5l" to="tpek:2xELmDxyi2v" resolve="getParameterConcepts" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="2D1PBM_bzmL" role="3cqZAp">
+          <node concept="2OqwBi" id="2D1PBM_bzmM" role="3clFbG">
+            <node concept="37vLTw" id="2D1PBM_bzmN" role="2Oq$k0">
+              <ref role="3cqZAo" node="2D1PBM_bzmz" resolve="result" />
+            </node>
+            <node concept="TSZUe" id="2D1PBM_bzmO" role="2OqNvi">
+              <node concept="35c_gC" id="2xELmDxRnSy" role="25WWJ7">
+                <ref role="35c_gD" to="tpc2:gTQ80DJ" resolve="ConceptFunctionParameter_editorContext" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="2D1PBM_bzmQ" role="3cqZAp">
+          <node concept="2OqwBi" id="2D1PBM_bzmR" role="3clFbG">
+            <node concept="37vLTw" id="2D1PBM_bzmS" role="2Oq$k0">
+              <ref role="3cqZAo" node="2D1PBM_bzmz" resolve="result" />
+            </node>
+            <node concept="TSZUe" id="2D1PBM_bzmT" role="2OqNvi">
+              <node concept="35c_gC" id="2xELmDxRnSz" role="25WWJ7">
+                <ref role="35c_gD" to="tpc2:gCpncv5" resolve="ConceptFunctionParameter_node" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="2D1PBM_bzmU" role="3cqZAp">
+          <node concept="37vLTw" id="2D1PBM_bzmV" role="3cqZAk">
+            <ref role="3cqZAo" node="2D1PBM_bzmz" resolve="result" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="13i0hz" id="2wC_gGKEiZd" role="13h7CS">
+      <property role="13i0iv" value="false" />
+      <property role="TrG5h" value="getExpectedReturnType" />
+      <property role="13i0it" value="false" />
+      <ref role="13i0hy" to="tpek:hEwIGRD" resolve="getExpectedReturnType" />
+      <node concept="3Tm1VV" id="2wC_gGKEiZl" role="1B3o_S" />
+      <node concept="3Tqbb2" id="2wC_gGKEiZm" role="3clF45" />
+      <node concept="3clFbS" id="2wC_gGKEiZn" role="3clF47">
+        <node concept="3cpWs6" id="2wC_gGKEjcc" role="3cqZAp">
+          <node concept="2c44tf" id="2wC_gGKEjcd" role="3cqZAk">
+            <node concept="17QB3L" id="2wC_gGKEjiw" role="2c44tc" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="13hLZK" id="7XmAYSGTgVx" role="13h7CW">
+      <node concept="3clFbS" id="7XmAYSGTgVy" role="2VODD2" />
+    </node>
+  </node>
+</model>
+

--- a/code/htmlcell/languages/de.itemis.mps.editor.htmlcell/models/de.itemis.mps.editor.htmlcell.editor.mps
+++ b/code/htmlcell/languages/de.itemis.mps.editor.htmlcell/models/de.itemis.mps.editor.htmlcell.editor.mps
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:9c3762e4-b489-45f0-9711-2124493e5d11(de.itemis.mps.editor.htmlcell.editor)">
+  <persistence version="9" />
+  <languages>
+    <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="14" />
+  </languages>
+  <imports>
+    <import index="kl84" ref="r:04146354-a55e-4279-a2c9-199d983d46c4(de.itemis.mps.editor.htmlcell.structure)" implicit="true" />
+    <import index="tpco" ref="r:00000000-0000-4000-0000-011c89590284(jetbrains.mps.lang.core.editor)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor">
+      <concept id="1071666914219" name="jetbrains.mps.lang.editor.structure.ConceptEditorDeclaration" flags="ig" index="24kQdi">
+        <child id="1078153129734" name="inspectedCellModel" index="6VMZX" />
+      </concept>
+      <concept id="1106270549637" name="jetbrains.mps.lang.editor.structure.CellLayout_Horizontal" flags="nn" index="2iRfu4" />
+      <concept id="1106270571710" name="jetbrains.mps.lang.editor.structure.CellLayout_Vertical" flags="nn" index="2iRkQZ" />
+      <concept id="1080736578640" name="jetbrains.mps.lang.editor.structure.BaseEditorComponent" flags="ig" index="2wURMF">
+        <child id="1080736633877" name="cellModel" index="2wV5jI" />
+      </concept>
+      <concept id="1078939183254" name="jetbrains.mps.lang.editor.structure.CellModel_Component" flags="sg" stub="3162947552742194261" index="PMmxH">
+        <reference id="1078939183255" name="editorComponent" index="PMmxG" />
+      </concept>
+      <concept id="1139848536355" name="jetbrains.mps.lang.editor.structure.CellModel_WithRole" flags="ng" index="1$h60E">
+        <reference id="1140103550593" name="relationDeclaration" index="1NtTu8" />
+      </concept>
+      <concept id="1073389446423" name="jetbrains.mps.lang.editor.structure.CellModel_Collection" flags="sn" stub="3013115976261988961" index="3EZMnI">
+        <child id="1106270802874" name="cellLayout" index="2iSdaV" />
+        <child id="1073389446424" name="childCellModel" index="3EZMnx" />
+      </concept>
+      <concept id="1073389577006" name="jetbrains.mps.lang.editor.structure.CellModel_Constant" flags="sn" stub="3610246225209162225" index="3F0ifn">
+        <property id="1073389577007" name="text" index="3F0ifm" />
+      </concept>
+      <concept id="1073389882823" name="jetbrains.mps.lang.editor.structure.CellModel_RefNode" flags="sg" stub="730538219795960754" index="3F1sOY" />
+      <concept id="1166049232041" name="jetbrains.mps.lang.editor.structure.AbstractComponent" flags="ng" index="1XWOmA">
+        <reference id="1166049300910" name="conceptDeclaration" index="1XX52x" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="24kQdi" id="7XmAYSGThy5">
+    <ref role="1XX52x" to="kl84:7XmAYSGTdxu" resolve="CellModel_HTML" />
+    <node concept="PMmxH" id="7XmAYSGThy7" role="2wV5jI">
+      <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
+    </node>
+    <node concept="3EZMnI" id="g3gUIcH" role="6VMZX">
+      <node concept="3EZMnI" id="hF4vBE0" role="3EZMnx">
+        <node concept="3F0ifn" id="h7FoCa2" role="3EZMnx">
+          <property role="3F0ifm" value="content provider:" />
+        </node>
+        <node concept="3F1sOY" id="7XmAYSGThy9" role="3EZMnx">
+          <ref role="1NtTu8" to="kl84:7XmAYSGThxX" resolve="contentProvider" />
+        </node>
+        <node concept="2iRfu4" id="i2IxuTT" role="2iSdaV" />
+      </node>
+      <node concept="2iRkQZ" id="i2IxuOH" role="2iSdaV" />
+    </node>
+  </node>
+</model>
+

--- a/code/htmlcell/languages/de.itemis.mps.editor.htmlcell/models/de.itemis.mps.editor.htmlcell.structure.mps
+++ b/code/htmlcell/languages/de.itemis.mps.editor.htmlcell/models/de.itemis.mps.editor.htmlcell.structure.mps
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:04146354-a55e-4279-a2c9-199d983d46c4(de.itemis.mps.editor.htmlcell.structure)">
+  <persistence version="9" />
+  <languages>
+    <use id="c72da2b9-7cce-4447-8389-f407dc1158b7" name="jetbrains.mps.lang.structure" version="9" />
+    <devkit ref="78434eb8-b0e5-444b-850d-e7c4ad2da9ab(jetbrains.mps.devkit.aspect.structure)" />
+  </languages>
+  <imports>
+    <import index="tpc2" ref="r:00000000-0000-4000-0000-011c8959029e(jetbrains.mps.lang.editor.structure)" />
+    <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" />
+  </imports>
+  <registry>
+    <language id="c72da2b9-7cce-4447-8389-f407dc1158b7" name="jetbrains.mps.lang.structure">
+      <concept id="1169125787135" name="jetbrains.mps.lang.structure.structure.AbstractConceptDeclaration" flags="ig" index="PkWjJ">
+        <property id="6714410169261853888" name="conceptId" index="EcuMT" />
+        <property id="4628067390765907488" name="conceptShortDescription" index="R4oN_" />
+        <property id="5092175715804935370" name="conceptAlias" index="34LRSv" />
+        <child id="1071489727083" name="linkDeclaration" index="1TKVEi" />
+      </concept>
+      <concept id="1071489090640" name="jetbrains.mps.lang.structure.structure.ConceptDeclaration" flags="ig" index="1TIwiD">
+        <reference id="1071489389519" name="extends" index="1TJDcQ" />
+      </concept>
+      <concept id="1071489288298" name="jetbrains.mps.lang.structure.structure.LinkDeclaration" flags="ig" index="1TJgyj">
+        <property id="1071599776563" name="role" index="20kJfa" />
+        <property id="1071599937831" name="metaClass" index="20lmBu" />
+        <property id="241647608299431140" name="linkId" index="IQ2ns" />
+        <reference id="1071599976176" name="target" index="20lvS9" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="1TIwiD" id="7XmAYSGTdxu">
+    <property role="EcuMT" value="9175692738071681118" />
+    <property role="TrG5h" value="CellModel_HTML" />
+    <property role="34LRSv" value="html" />
+    <property role="R4oN_" value="a readonly cell that supports HTML" />
+    <ref role="1TJDcQ" to="tpc2:fBEYTCT" resolve="EditorCellModel" />
+    <node concept="1TJgyj" id="7XmAYSGThxX" role="1TKVEi">
+      <property role="IQ2ns" value="9175692738071697533" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="contentProvider" />
+      <ref role="20lvS9" node="7XmAYSGTgVv" resolve="QueryFunction_Content" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="7XmAYSGTgVv">
+    <property role="EcuMT" value="9175692738071695071" />
+    <property role="TrG5h" value="QueryFunction_Content" />
+    <property role="34LRSv" value="content" />
+    <property role="R4oN_" value="embedded block of code" />
+    <ref role="1TJDcQ" to="tpee:gyVMwX8" resolve="ConceptFunction" />
+  </node>
+</model>
+

--- a/code/htmlcell/languages/de.itemis.mps.editor.htmlcell/sandbox/de.itemis.mps.editor.htmlcell.sandbox.msd
+++ b/code/htmlcell/languages/de.itemis.mps.editor.htmlcell/sandbox/de.itemis.mps.editor.htmlcell.sandbox.msd
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<solution name="de.itemis.mps.editor.htmlcell.sandbox" uuid="3116b37b-a6ce-4aa2-bfb6-f1989be3b96a" moduleVersion="0" compileInMPS="true">
+  <models>
+    <modelRoot contentPath="${module}" type="default">
+      <sourceRoot location="models" />
+    </modelRoot>
+  </models>
+  <facets>
+    <facet type="java">
+      <classes generated="true" path="${module}/classes_gen" />
+    </facet>
+  </facets>
+  <sourcePath />
+  <languageVersions>
+    <language slang="l:4f348220-8c30-49ab-b23f-98fdc5c19b18:de.itemis.mps.editor.htmlcell.demolang" version="0" />
+    <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
+  </languageVersions>
+  <dependencyVersions>
+    <module reference="3116b37b-a6ce-4aa2-bfb6-f1989be3b96a(de.itemis.mps.editor.htmlcell.sandbox)" version="0" />
+  </dependencyVersions>
+</solution>
+

--- a/code/htmlcell/languages/de.itemis.mps.editor.htmlcell/sandbox/models/de.itemis.mps.editor.htmlcell.sandbox.mps
+++ b/code/htmlcell/languages/de.itemis.mps.editor.htmlcell/sandbox/models/de.itemis.mps.editor.htmlcell.sandbox.mps
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:ea5a180b-eeb1-4b59-93b8-b6547f0f7210(de.itemis.mps.editor.htmlcell.sandbox)">
+  <persistence version="9" />
+  <languages>
+    <use id="4f348220-8c30-49ab-b23f-98fdc5c19b18" name="de.itemis.mps.editor.htmlcell.demolang" version="0" />
+  </languages>
+  <imports />
+  <registry>
+    <language id="4f348220-8c30-49ab-b23f-98fdc5c19b18" name="de.itemis.mps.editor.htmlcell.demolang">
+      <concept id="9175692738068469306" name="de.itemis.mps.editor.htmlcell.demolang.structure.Root" flags="ng" index="1jTkRk">
+        <property id="9175692738072656091" name="text" index="1jDicP" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="1jTkRk" id="7XmAYSGXahl">
+    <property role="1jDicP" value="HTML CELL" />
+  </node>
+</model>
+

--- a/code/htmlcell/solutions/de.itemis.mps.editor.htmlcell.runtime/de.itemis.mps.editor.htmlcell.runtime.msd
+++ b/code/htmlcell/solutions/de.itemis.mps.editor.htmlcell.runtime/de.itemis.mps.editor.htmlcell.runtime.msd
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<solution name="de.itemis.mps.editor.htmlcell.runtime" uuid="5af3b4c1-0c4a-4bb7-9e0d-df3c07ff6b84" moduleVersion="0" compileInMPS="true">
+  <models>
+    <modelRoot contentPath="${module}" type="default">
+      <sourceRoot location="models" />
+    </modelRoot>
+  </models>
+  <facets>
+    <facet type="java">
+      <classes generated="true" path="${module}/classes_gen" />
+    </facet>
+  </facets>
+  <sourcePath />
+  <dependencies>
+    <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
+    <dependency reexport="false">498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)</dependency>
+    <dependency reexport="true">1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)</dependency>
+    <dependency reexport="false">24c96a96-b7a1-4f30-82da-0f8e279a2661(de.itemis.mps.editor.celllayout.styles)</dependency>
+    <dependency reexport="true">848ef45d-e560-4e35-853c-f35a64cc135c(de.itemis.mps.editor.celllayout.runtime)</dependency>
+  </dependencies>
+  <languageVersions>
+    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
+    <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />
+    <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
+    <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
+    <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
+    <language slang="l:18bc6592-03a6-4e29-a83a-7ff23bde13ba:jetbrains.mps.lang.editor" version="14" />
+    <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
+    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="18" />
+    <language slang="l:c72da2b9-7cce-4447-8389-f407dc1158b7:jetbrains.mps.lang.structure" version="9" />
+    <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
+  </languageVersions>
+  <dependencyVersions>
+    <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
+    <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
+    <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
+    <module reference="1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)" version="0" />
+    <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
+    <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+    <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
+    <module reference="848ef45d-e560-4e35-853c-f35a64cc135c(de.itemis.mps.editor.celllayout.runtime)" version="0" />
+    <module reference="24c96a96-b7a1-4f30-82da-0f8e279a2661(de.itemis.mps.editor.celllayout.styles)" version="0" />
+    <module reference="5af3b4c1-0c4a-4bb7-9e0d-df3c07ff6b84(de.itemis.mps.editor.htmlcell.runtime)" version="0" />
+    <module reference="f0fff802-6d26-4d2e-b89d-391357265626(de.slisson.mps.hacks.editor)" version="0" />
+    <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
+  </dependencyVersions>
+</solution>
+

--- a/code/htmlcell/solutions/de.itemis.mps.editor.htmlcell.runtime/de.itemis.mps.editor.htmlcell.runtime.msd
+++ b/code/htmlcell/solutions/de.itemis.mps.editor.htmlcell.runtime/de.itemis.mps.editor.htmlcell.runtime.msd
@@ -17,6 +17,7 @@
     <dependency reexport="true">1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)</dependency>
     <dependency reexport="false">24c96a96-b7a1-4f30-82da-0f8e279a2661(de.itemis.mps.editor.celllayout.styles)</dependency>
     <dependency reexport="true">848ef45d-e560-4e35-853c-f35a64cc135c(de.itemis.mps.editor.celllayout.runtime)</dependency>
+    <dependency reexport="false">3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />

--- a/code/htmlcell/solutions/de.itemis.mps.editor.htmlcell.runtime/models/de.itemis.mps.editor.htmlcell.runtime.runtime.mps
+++ b/code/htmlcell/solutions/de.itemis.mps.editor.htmlcell.runtime/models/de.itemis.mps.editor.htmlcell.runtime.runtime.mps
@@ -19,6 +19,8 @@
     <import index="z0fb" ref="r:0b928dd6-dd7e-45a8-b309-a2e315b7877a(de.itemis.mps.editor.celllayout.styles.editor)" />
     <import index="hox0" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.style(MPS.Editor/)" />
     <import index="qxi4" ref="r:45c19b6d-dd9a-4f15-973f-0267c5e76303(de.itemis.mps.editor.celllayout.runtime)" />
+    <import index="rtot" ref="r:6107a535-c9ce-47d9-a4cd-4df6fd2db517(de.itemis.mps.editor.celllayout.boxmodel)" />
+    <import index="mhfm" ref="3f233e7f-b8a6-46d2-a57f-795d56775243/java:org.jetbrains.annotations(Annotations/)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
   </imports>
   <registry>
@@ -55,6 +57,9 @@
       <concept id="1070475587102" name="jetbrains.mps.baseLanguage.structure.SuperConstructorInvocation" flags="nn" index="XkiVB" />
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="1182160077978" name="jetbrains.mps.baseLanguage.structure.AnonymousClassCreator" flags="nn" index="YeOm9">
+        <child id="1182160096073" name="cls" index="YeSDq" />
       </concept>
       <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
@@ -110,6 +115,7 @@
       </concept>
       <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
       <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
+        <property id="521412098689998745" name="nonStatic" index="2bfB8j" />
         <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
       </concept>
       <concept id="7812454656619025412" name="jetbrains.mps.baseLanguage.structure.LocalMethodCall" flags="nn" index="1rXfSq" />
@@ -129,6 +135,9 @@
       </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
       <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
+      <concept id="1170345865475" name="jetbrains.mps.baseLanguage.structure.AnonymousClass" flags="ig" index="1Y3b0j">
+        <reference id="1170346070688" name="classifier" index="1Y3XeK" />
+      </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2" />
@@ -576,9 +585,203 @@
       <node concept="3clFbS" id="fKKzZraI8U" role="3clF47">
         <node concept="3clFbF" id="fKKzZraSEa" role="3cqZAp">
           <node concept="2ShNRf" id="fKKzZraSE8" role="3clFbG">
-            <node concept="1pGfFk" id="fKKzZrb3LF" role="2ShVmc">
-              <ref role="37wK5l" to="qxi4:6aN_eBIZw$g" resolve="LayoutableAdapter" />
-              <node concept="Xjq3P" id="fKKzZrb4_B" role="37wK5m" />
+            <node concept="YeOm9" id="3apKh7j24T1" role="2ShVmc">
+              <node concept="1Y3b0j" id="3apKh7j24T4" role="YeSDq">
+                <property role="2bfB8j" value="true" />
+                <ref role="37wK5l" to="qxi4:6aN_eBIZw$g" resolve="LayoutableAdapter" />
+                <ref role="1Y3XeK" to="qxi4:6aN_eBIZww6" resolve="LayoutableAdapter" />
+                <node concept="3Tm1VV" id="3apKh7j24T5" role="1B3o_S" />
+                <node concept="Xjq3P" id="fKKzZrb4_B" role="37wK5m" />
+                <node concept="3clFb_" id="3apKh7j25$u" role="jymVt">
+                  <property role="TrG5h" value="getMaxSize" />
+                  <node concept="37vLTG" id="3apKh7j25$v" role="3clF46">
+                    <property role="TrG5h" value="sizeConstraint" />
+                    <node concept="3uibUv" id="3apKh7j25$w" role="1tU5fm">
+                      <ref role="3uigEE" to="rtot:ZjQ6tpoDFn" resolve="Size" />
+                    </node>
+                    <node concept="2AHcQZ" id="3apKh7j25$x" role="2AJF6D">
+                      <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+                    </node>
+                  </node>
+                  <node concept="3uibUv" id="3apKh7j25$y" role="3clF45">
+                    <ref role="3uigEE" to="rtot:ZjQ6tpoDFn" resolve="Size" />
+                  </node>
+                  <node concept="3Tm1VV" id="3apKh7j25$z" role="1B3o_S" />
+                  <node concept="2AHcQZ" id="3apKh7j25$$" role="2AJF6D">
+                    <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+                  </node>
+                  <node concept="2AHcQZ" id="3apKh7j25_d" role="2AJF6D">
+                    <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                  </node>
+                  <node concept="3clFbS" id="3apKh7j25_f" role="3clF47">
+                    <node concept="3cpWs8" id="3apKh7j2mWc" role="3cqZAp">
+                      <node concept="3cpWsn" id="3apKh7j2mWd" role="3cpWs9">
+                        <property role="TrG5h" value="size" />
+                        <node concept="3uibUv" id="3apKh7j2dEq" role="1tU5fm">
+                          <ref role="3uigEE" to="z60i:~Dimension" resolve="Dimension" />
+                        </node>
+                        <node concept="2OqwBi" id="3apKh7j2mWe" role="33vP2m">
+                          <node concept="1rXfSq" id="3apKh7j2mWf" role="2Oq$k0">
+                            <ref role="37wK5l" to="g51k:~EditorCell_Component.getComponent()" resolve="getComponent" />
+                          </node>
+                          <node concept="liA8E" id="3apKh7j2mWg" role="2OqNvi">
+                            <ref role="37wK5l" to="dxuu:~JComponent.getMaximumSize()" resolve="getMaximumSize" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbF" id="3apKh7j2oIO" role="3cqZAp">
+                      <node concept="2ShNRf" id="3apKh7j2oII" role="3clFbG">
+                        <node concept="1pGfFk" id="3apKh7j2WwK" role="2ShVmc">
+                          <ref role="37wK5l" to="rtot:ZjQ6tpoDHS" resolve="Size" />
+                          <node concept="2OqwBi" id="3apKh7j2Y44" role="37wK5m">
+                            <node concept="37vLTw" id="3apKh7j2XzS" role="2Oq$k0">
+                              <ref role="3cqZAo" node="3apKh7j2mWd" resolve="size" />
+                            </node>
+                            <node concept="2OwXpG" id="3apKh7j2ZdS" role="2OqNvi">
+                              <ref role="2Oxat5" to="z60i:~Dimension.width" resolve="width" />
+                            </node>
+                          </node>
+                          <node concept="2OqwBi" id="3apKh7j31k_" role="37wK5m">
+                            <node concept="37vLTw" id="3apKh7j30Oo" role="2Oq$k0">
+                              <ref role="3cqZAo" node="3apKh7j2mWd" resolve="size" />
+                            </node>
+                            <node concept="2OwXpG" id="3apKh7j32ja" role="2OqNvi">
+                              <ref role="2Oxat5" to="z60i:~Dimension.height" resolve="height" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFb_" id="3apKh7j25_j" role="jymVt">
+                  <property role="TrG5h" value="getMinSize" />
+                  <node concept="37vLTG" id="3apKh7j25_k" role="3clF46">
+                    <property role="TrG5h" value="sizeConstraint" />
+                    <node concept="3uibUv" id="3apKh7j25_l" role="1tU5fm">
+                      <ref role="3uigEE" to="rtot:ZjQ6tpoDFn" resolve="Size" />
+                    </node>
+                    <node concept="2AHcQZ" id="3apKh7j25_m" role="2AJF6D">
+                      <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+                    </node>
+                  </node>
+                  <node concept="3uibUv" id="3apKh7j25_n" role="3clF45">
+                    <ref role="3uigEE" to="rtot:ZjQ6tpoDFn" resolve="Size" />
+                  </node>
+                  <node concept="3Tm1VV" id="3apKh7j25_o" role="1B3o_S" />
+                  <node concept="2AHcQZ" id="3apKh7j25_p" role="2AJF6D">
+                    <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+                  </node>
+                  <node concept="2AHcQZ" id="3apKh7j25_u" role="2AJF6D">
+                    <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                  </node>
+                  <node concept="3clFbS" id="3apKh7j25_w" role="3clF47">
+                    <node concept="3cpWs8" id="3apKh7j32Qq" role="3cqZAp">
+                      <node concept="3cpWsn" id="3apKh7j32Qr" role="3cpWs9">
+                        <property role="TrG5h" value="size" />
+                        <node concept="3uibUv" id="3apKh7j32Qs" role="1tU5fm">
+                          <ref role="3uigEE" to="z60i:~Dimension" resolve="Dimension" />
+                        </node>
+                        <node concept="2OqwBi" id="3apKh7j32Qt" role="33vP2m">
+                          <node concept="1rXfSq" id="3apKh7j32Qu" role="2Oq$k0">
+                            <ref role="37wK5l" to="g51k:~EditorCell_Component.getComponent()" resolve="getComponent" />
+                          </node>
+                          <node concept="liA8E" id="3apKh7j32Qv" role="2OqNvi">
+                            <ref role="37wK5l" to="dxuu:~JComponent.getMinimumSize()" resolve="getMinimumSize" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbF" id="3apKh7j32Qw" role="3cqZAp">
+                      <node concept="2ShNRf" id="3apKh7j32Qx" role="3clFbG">
+                        <node concept="1pGfFk" id="3apKh7j32Qy" role="2ShVmc">
+                          <ref role="37wK5l" to="rtot:ZjQ6tpoDHS" resolve="Size" />
+                          <node concept="2OqwBi" id="3apKh7j32Qz" role="37wK5m">
+                            <node concept="37vLTw" id="3apKh7j32Q$" role="2Oq$k0">
+                              <ref role="3cqZAo" node="3apKh7j32Qr" resolve="size" />
+                            </node>
+                            <node concept="2OwXpG" id="3apKh7j32Q_" role="2OqNvi">
+                              <ref role="2Oxat5" to="z60i:~Dimension.width" resolve="width" />
+                            </node>
+                          </node>
+                          <node concept="2OqwBi" id="3apKh7j32QA" role="37wK5m">
+                            <node concept="37vLTw" id="3apKh7j32QB" role="2Oq$k0">
+                              <ref role="3cqZAo" node="3apKh7j32Qr" resolve="size" />
+                            </node>
+                            <node concept="2OwXpG" id="3apKh7j32QC" role="2OqNvi">
+                              <ref role="2Oxat5" to="z60i:~Dimension.height" resolve="height" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFb_" id="3apKh7j25_$" role="jymVt">
+                  <property role="TrG5h" value="getPreferredSize" />
+                  <node concept="37vLTG" id="3apKh7j25__" role="3clF46">
+                    <property role="TrG5h" value="sizeConstraint" />
+                    <node concept="3uibUv" id="3apKh7j25_A" role="1tU5fm">
+                      <ref role="3uigEE" to="rtot:ZjQ6tpoDFn" resolve="Size" />
+                    </node>
+                    <node concept="2AHcQZ" id="3apKh7j25_B" role="2AJF6D">
+                      <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+                    </node>
+                  </node>
+                  <node concept="3uibUv" id="3apKh7j25_C" role="3clF45">
+                    <ref role="3uigEE" to="rtot:ZjQ6tpoDFn" resolve="Size" />
+                  </node>
+                  <node concept="3Tm1VV" id="3apKh7j25_D" role="1B3o_S" />
+                  <node concept="2AHcQZ" id="3apKh7j25_E" role="2AJF6D">
+                    <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+                  </node>
+                  <node concept="2AHcQZ" id="3apKh7j25Ax" role="2AJF6D">
+                    <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                  </node>
+                  <node concept="3clFbS" id="3apKh7j25Az" role="3clF47">
+                    <node concept="3cpWs8" id="3apKh7j33$G" role="3cqZAp">
+                      <node concept="3cpWsn" id="3apKh7j33$H" role="3cpWs9">
+                        <property role="TrG5h" value="size" />
+                        <node concept="3uibUv" id="3apKh7j33$I" role="1tU5fm">
+                          <ref role="3uigEE" to="z60i:~Dimension" resolve="Dimension" />
+                        </node>
+                        <node concept="2OqwBi" id="3apKh7j33$J" role="33vP2m">
+                          <node concept="1rXfSq" id="3apKh7j33$K" role="2Oq$k0">
+                            <ref role="37wK5l" to="g51k:~EditorCell_Component.getComponent()" resolve="getComponent" />
+                          </node>
+                          <node concept="liA8E" id="3apKh7j33$L" role="2OqNvi">
+                            <ref role="37wK5l" to="dxuu:~JComponent.getPreferredSize()" resolve="getPreferredSize" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbF" id="3apKh7j33$M" role="3cqZAp">
+                      <node concept="2ShNRf" id="3apKh7j33$N" role="3clFbG">
+                        <node concept="1pGfFk" id="3apKh7j33$O" role="2ShVmc">
+                          <ref role="37wK5l" to="rtot:ZjQ6tpoDHS" resolve="Size" />
+                          <node concept="2OqwBi" id="3apKh7j33$P" role="37wK5m">
+                            <node concept="37vLTw" id="3apKh7j33$Q" role="2Oq$k0">
+                              <ref role="3cqZAo" node="3apKh7j33$H" resolve="size" />
+                            </node>
+                            <node concept="2OwXpG" id="3apKh7j33$R" role="2OqNvi">
+                              <ref role="2Oxat5" to="z60i:~Dimension.width" resolve="width" />
+                            </node>
+                          </node>
+                          <node concept="2OqwBi" id="3apKh7j33$S" role="37wK5m">
+                            <node concept="37vLTw" id="3apKh7j33$T" role="2Oq$k0">
+                              <ref role="3cqZAo" node="3apKh7j33$H" resolve="size" />
+                            </node>
+                            <node concept="2OwXpG" id="3apKh7j33$U" role="2OqNvi">
+                              <ref role="2Oxat5" to="z60i:~Dimension.height" resolve="height" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>

--- a/code/htmlcell/solutions/de.itemis.mps.editor.htmlcell.runtime/models/de.itemis.mps.editor.htmlcell.runtime.runtime.mps
+++ b/code/htmlcell/solutions/de.itemis.mps.editor.htmlcell.runtime/models/de.itemis.mps.editor.htmlcell.runtime.runtime.mps
@@ -1,0 +1,592 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:bdf0ce56-0540-4970-ba23-53f0c7ca0a2e(de.itemis.mps.editor.htmlcell.runtime.runtime)">
+  <persistence version="9" />
+  <languages>
+    <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="11" />
+    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="18" />
+    <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="14" />
+  </languages>
+  <imports>
+    <import index="dxuu" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:javax.swing(JDK/)" />
+    <import index="g1qu" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.util.ui(MPS.IDEA/)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
+    <import index="j936" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ide.ui(MPS.IDEA/)" />
+    <import index="exr9" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor(MPS.Editor/)" />
+    <import index="g51k" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor.cells(MPS.Editor/)" />
+    <import index="cj4x" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor(MPS.Editor/)" />
+    <import index="z60i" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt(JDK/)" />
+    <import index="r791" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:javax.swing.text(JDK/)" />
+    <import index="z0fb" ref="r:0b928dd6-dd7e-45a8-b309-a2e315b7877a(de.itemis.mps.editor.celllayout.styles.editor)" />
+    <import index="hox0" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.style(MPS.Editor/)" />
+    <import index="qxi4" ref="r:45c19b6d-dd9a-4f15-973f-0267c5e76303(de.itemis.mps.editor.celllayout.runtime)" />
+    <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor">
+      <concept id="6029276237631252951" name="jetbrains.mps.lang.editor.structure.StyleAttributeReferenceExpression" flags="ng" index="1Z6Ecs">
+        <reference id="6029276237631253682" name="attributeDeclaration" index="1Z6EpT" />
+      </concept>
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
+        <child id="1068498886297" name="rValue" index="37vLTx" />
+        <child id="1068498886295" name="lValue" index="37vLTJ" />
+      </concept>
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
+      <concept id="1188207840427" name="jetbrains.mps.baseLanguage.structure.AnnotationInstance" flags="nn" index="2AHcQZ">
+        <reference id="1188208074048" name="annotation" index="2AI5Lk" />
+      </concept>
+      <concept id="1188208481402" name="jetbrains.mps.baseLanguage.structure.HasAnnotation" flags="ng" index="2AJDlI">
+        <child id="1188208488637" name="annotation" index="2AJF6D" />
+      </concept>
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1197029447546" name="jetbrains.mps.baseLanguage.structure.FieldReferenceOperation" flags="nn" index="2OwXpG">
+        <reference id="1197029500499" name="fieldDeclaration" index="2Oxat5" />
+      </concept>
+      <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
+        <child id="1145553007750" name="creator" index="2ShVmc" />
+      </concept>
+      <concept id="1070462154015" name="jetbrains.mps.baseLanguage.structure.StaticFieldDeclaration" flags="ig" index="Wx3nA" />
+      <concept id="1070475354124" name="jetbrains.mps.baseLanguage.structure.ThisExpression" flags="nn" index="Xjq3P" />
+      <concept id="1070475587102" name="jetbrains.mps.baseLanguage.structure.SuperConstructorInvocation" flags="nn" index="XkiVB" />
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
+      </concept>
+      <concept id="1070533707846" name="jetbrains.mps.baseLanguage.structure.StaticFieldReference" flags="nn" index="10M0yZ">
+        <reference id="1144433057691" name="classifier" index="1PxDUh" />
+      </concept>
+      <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu">
+        <child id="1095933932569" name="implementedInterface" index="EKbjA" />
+        <child id="1165602531693" name="superclass" index="1zkMxy" />
+      </concept>
+      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <property id="1176718929932" name="isFinal" index="3TUv4t" />
+        <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
+      <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
+      <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123134" name="parameter" index="3clF46" />
+        <child id="1068580123135" name="body" index="3clF47" />
+      </concept>
+      <concept id="1068580123165" name="jetbrains.mps.baseLanguage.structure.InstanceMethodDeclaration" flags="ig" index="3clFb_" />
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
+        <property id="1068580123138" name="value" index="3clFbU" />
+      </concept>
+      <concept id="1068580123140" name="jetbrains.mps.baseLanguage.structure.ConstructorDeclaration" flags="ig" index="3clFbW" />
+      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
+        <property id="1068580320021" name="value" index="3cmrfH" />
+      </concept>
+      <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
+      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
+        <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
+      </concept>
+      <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
+      <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
+        <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
+      </concept>
+      <concept id="7812454656619025412" name="jetbrains.mps.baseLanguage.structure.LocalMethodCall" flags="nn" index="1rXfSq" />
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+        <reference id="1107535924139" name="classifier" index="3uigEE" />
+        <child id="1109201940907" name="parameter" index="11_B2D" />
+      </concept>
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
+        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
+        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
+      </concept>
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
+        <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
+        <child id="8356039341262087992" name="line" index="1aUNEU" />
+      </concept>
+      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+      <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
+    </language>
+    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2" />
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+    <language id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text">
+      <concept id="155656958578482948" name="jetbrains.mps.lang.text.structure.Word" flags="nn" index="3oM_SD">
+        <property id="155656958578482949" name="value" index="3oM_SC" />
+      </concept>
+      <concept id="2535923850359271782" name="jetbrains.mps.lang.text.structure.Line" flags="nn" index="1PaTwC">
+        <child id="2535923850359271783" name="elements" index="1PaTwD" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="312cEu" id="7XmAYSGHmpV">
+    <property role="TrG5h" value="HTMLCellEditorPane" />
+    <node concept="2tJIrI" id="7XmAYSGNoyw" role="jymVt" />
+    <node concept="3clFbW" id="7XmAYSGHCKB" role="jymVt">
+      <node concept="3cqZAl" id="7XmAYSGHCKC" role="3clF45" />
+      <node concept="3clFbS" id="7XmAYSGHCKE" role="3clF47">
+        <node concept="3cpWs8" id="7XmAYSGRA_p" role="3cqZAp">
+          <node concept="3cpWsn" id="7XmAYSGRA_q" role="3cpWs9">
+            <property role="TrG5h" value="editorKit" />
+            <node concept="3uibUv" id="7XmAYSGMEbe" role="1tU5fm">
+              <ref role="3uigEE" to="g1qu:~JBHtmlEditorKit" resolve="JBHtmlEditorKit" />
+            </node>
+          </node>
+        </node>
+        <node concept="3SKdUt" id="7XmAYSGIr9O" role="3cqZAp">
+          <node concept="1PaTwC" id="7XmAYSGIr9P" role="1aUNEU">
+            <node concept="3oM_SD" id="7XmAYSGIrab" role="1PaTwD">
+              <property role="3oM_SC" value="JBHTMLEditorKit" />
+            </node>
+            <node concept="3oM_SD" id="7XmAYSGIrad" role="1PaTwD">
+              <property role="3oM_SC" value="is" />
+            </node>
+            <node concept="3oM_SD" id="7XmAYSGIrag" role="1PaTwD">
+              <property role="3oM_SC" value="deprecated" />
+            </node>
+            <node concept="3oM_SD" id="7XmAYSGIv7y" role="1PaTwD">
+              <property role="3oM_SC" value="but" />
+            </node>
+            <node concept="3oM_SD" id="7XmAYSGIv7B" role="1PaTwD">
+              <property role="3oM_SC" value="for" />
+            </node>
+            <node concept="3oM_SD" id="7XmAYSGIv7W" role="1PaTwD">
+              <property role="3oM_SC" value="compatibility" />
+            </node>
+            <node concept="3oM_SD" id="7XmAYSGIv83" role="1PaTwD">
+              <property role="3oM_SC" value="reasons" />
+            </node>
+            <node concept="3oM_SD" id="7XmAYSGIv8b" role="1PaTwD">
+              <property role="3oM_SC" value="let" />
+            </node>
+            <node concept="3oM_SD" id="7XmAYSGIv8k" role="1PaTwD">
+              <property role="3oM_SC" value="use" />
+            </node>
+            <node concept="3oM_SD" id="7XmAYSGIv8u" role="1PaTwD">
+              <property role="3oM_SC" value="this" />
+            </node>
+            <node concept="3oM_SD" id="7XmAYSGIv8D" role="1PaTwD">
+              <property role="3oM_SC" value="class." />
+            </node>
+            <node concept="3oM_SD" id="7XmAYSGIv8P" role="1PaTwD">
+              <property role="3oM_SC" value="This" />
+            </node>
+            <node concept="3oM_SD" id="7XmAYSGIv92" role="1PaTwD">
+              <property role="3oM_SC" value="should" />
+            </node>
+            <node concept="3oM_SD" id="7XmAYSGIv9g" role="1PaTwD">
+              <property role="3oM_SC" value="be" />
+            </node>
+            <node concept="3oM_SD" id="7XmAYSGIv9v" role="1PaTwD">
+              <property role="3oM_SC" value="replaced" />
+            </node>
+            <node concept="3oM_SD" id="7XmAYSGIv9J" role="1PaTwD">
+              <property role="3oM_SC" value="by" />
+            </node>
+            <node concept="3oM_SD" id="7XmAYSGIvai" role="1PaTwD">
+              <property role="3oM_SC" value="HTMLEditorKitBuilder" />
+            </node>
+            <node concept="3oM_SD" id="7XmAYSGIva$" role="1PaTwD">
+              <property role="3oM_SC" value="in" />
+            </node>
+            <node concept="3oM_SD" id="7XmAYSGIvaR" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="7XmAYSGIvbb" role="1PaTwD">
+              <property role="3oM_SC" value="future" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7XmAYSGNz2j" role="3cqZAp">
+          <node concept="37vLTI" id="7XmAYSGNz2l" role="3clFbG">
+            <node concept="2ShNRf" id="7XmAYSGMEbz" role="37vLTx">
+              <node concept="1pGfFk" id="7XmAYSGMEb$" role="2ShVmc">
+                <ref role="37wK5l" to="g1qu:~JBHtmlEditorKit.&lt;init&gt;(boolean)" resolve="JBHtmlEditorKit" />
+                <node concept="3clFbT" id="7XmAYSGMEb_" role="37wK5m">
+                  <property role="3clFbU" value="true" />
+                </node>
+              </node>
+            </node>
+            <node concept="37vLTw" id="7XmAYSGRA_r" role="37vLTJ">
+              <ref role="3cqZAo" node="7XmAYSGRA_q" resolve="editorKit" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7XmAYSGHD$N" role="3cqZAp">
+          <node concept="2OqwBi" id="7XmAYSGHDRH" role="3clFbG">
+            <node concept="Xjq3P" id="7XmAYSGHD$M" role="2Oq$k0" />
+            <node concept="liA8E" id="7XmAYSGHEaC" role="2OqNvi">
+              <ref role="37wK5l" to="dxuu:~JEditorPane.setEditorKit(javax.swing.text.EditorKit)" resolve="setEditorKit" />
+              <node concept="37vLTw" id="7XmAYSGRA_s" role="37wK5m">
+                <ref role="3cqZAo" node="7XmAYSGRA_q" resolve="editorKit" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7XmAYSGIp6q" role="3cqZAp">
+          <node concept="2OqwBi" id="7XmAYSGIpsW" role="3clFbG">
+            <node concept="Xjq3P" id="7XmAYSGIp6o" role="2Oq$k0" />
+            <node concept="liA8E" id="7XmAYSGIpKr" role="2OqNvi">
+              <ref role="37wK5l" to="r791:~JTextComponent.setEditable(boolean)" resolve="setEditable" />
+              <node concept="3clFbT" id="7XmAYSGIq4e" role="37wK5m" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7XmAYSGIqnY" role="3cqZAp">
+          <node concept="2OqwBi" id="7XmAYSGIqoW" role="3clFbG">
+            <node concept="Xjq3P" id="7XmAYSGIqnW" role="2Oq$k0" />
+            <node concept="liA8E" id="7XmAYSGIqzT" role="2OqNvi">
+              <ref role="37wK5l" to="dxuu:~JComponent.setOpaque(boolean)" resolve="setOpaque" />
+              <node concept="3clFbT" id="7XmAYSGIqMU" role="37wK5m" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7XmAYSGICSB" role="3cqZAp">
+          <node concept="1rXfSq" id="7XmAYSGICS_" role="3clFbG">
+            <ref role="37wK5l" to="dxuu:~JEditorPane.addHyperlinkListener(javax.swing.event.HyperlinkListener)" resolve="addHyperlinkListener" />
+            <node concept="10M0yZ" id="7XmAYSGIEiX" role="37wK5m">
+              <ref role="3cqZAo" to="lzb2:~BrowserHyperlinkListener.INSTANCE" resolve="INSTANCE" />
+              <ref role="1PxDUh" to="lzb2:~BrowserHyperlinkListener" resolve="BrowserHyperlinkListener" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7XmAYSGIEKP" role="3cqZAp">
+          <node concept="1rXfSq" id="7XmAYSGIEKN" role="3clFbG">
+            <ref role="37wK5l" to="r791:~JTextComponent.setMargin(java.awt.Insets)" resolve="setMargin" />
+            <node concept="2YIFZM" id="7XmAYSGIFqx" role="37wK5m">
+              <ref role="37wK5l" to="g1qu:~JBUI.emptyInsets()" resolve="emptyInsets" />
+              <ref role="1Pybhc" to="g1qu:~JBUI" resolve="JBUI" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7XmAYSGIFRe" role="3cqZAp">
+          <node concept="2YIFZM" id="7XmAYSGIG0w" role="3clFbG">
+            <ref role="37wK5l" to="g1qu:~GraphicsUtil.setAntialiasingType(javax.swing.JComponent,java.lang.Object)" resolve="setAntialiasingType" />
+            <ref role="1Pybhc" to="g1qu:~GraphicsUtil" resolve="GraphicsUtil" />
+            <node concept="Xjq3P" id="7XmAYSGIGiG" role="37wK5m" />
+            <node concept="2YIFZM" id="7XmAYSGWKN7" role="37wK5m">
+              <ref role="37wK5l" to="j936:~AntialiasingType.getAAHintForSwingComponent()" resolve="getAAHintForSwingComponent" />
+              <ref role="1Pybhc" to="j936:~AntialiasingType" resolve="AntialiasingType" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7XmAYSGWpzf" role="3cqZAp">
+          <node concept="1rXfSq" id="7XmAYSGWpzd" role="3clFbG">
+            <ref role="37wK5l" to="dxuu:~JComponent.putClientProperty(java.lang.Object,java.lang.Object)" resolve="putClientProperty" />
+            <node concept="10M0yZ" id="7XmAYSGWqOP" role="37wK5m">
+              <ref role="3cqZAo" to="dxuu:~JEditorPane.HONOR_DISPLAY_PROPERTIES" resolve="HONOR_DISPLAY_PROPERTIES" />
+              <ref role="1PxDUh" to="dxuu:~JEditorPane" resolve="JEditorPane" />
+            </node>
+            <node concept="3clFbT" id="7XmAYSGWrY5" role="37wK5m">
+              <property role="3clFbU" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7XmAYSGPc6l" role="3cqZAp">
+          <node concept="2OqwBi" id="7XmAYSGPcIH" role="3clFbG">
+            <node concept="Xjq3P" id="7XmAYSGPc6j" role="2Oq$k0" />
+            <node concept="liA8E" id="7XmAYSGPdHg" role="2OqNvi">
+              <ref role="37wK5l" node="7XmAYSGIVd5" resolve="setBody" />
+              <node concept="37vLTw" id="7XmAYSGPeq0" role="37wK5m">
+                <ref role="3cqZAo" node="7XmAYSGPbmQ" resolve="content" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7XmAYSGWzld" role="3cqZAp">
+          <node concept="2OqwBi" id="7XmAYSGWzVv" role="3clFbG">
+            <node concept="Xjq3P" id="7XmAYSGWzlb" role="2Oq$k0" />
+            <node concept="liA8E" id="7XmAYSGW$UV" role="2OqNvi">
+              <ref role="37wK5l" to="dxuu:~JComponent.setFont(java.awt.Font)" resolve="setFont" />
+              <node concept="2OqwBi" id="7XmAYSGWBE6" role="37wK5m">
+                <node concept="2YIFZM" id="7XmAYSGWBup" role="2Oq$k0">
+                  <ref role="37wK5l" to="exr9:~EditorSettings.getInstance()" resolve="getInstance" />
+                  <ref role="1Pybhc" to="exr9:~EditorSettings" resolve="EditorSettings" />
+                </node>
+                <node concept="liA8E" id="7XmAYSGWCj4" role="2OqNvi">
+                  <ref role="37wK5l" to="exr9:~EditorSettings.getDefaultEditorFont()" resolve="getDefaultEditorFont" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="7XmAYSGHCKF" role="1B3o_S" />
+      <node concept="37vLTG" id="7XmAYSGPbmQ" role="3clF46">
+        <property role="TrG5h" value="content" />
+        <node concept="17QB3L" id="7XmAYSGPbmP" role="1tU5fm" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="7XmAYSGIUSm" role="jymVt" />
+    <node concept="3clFb_" id="7XmAYSGIVd5" role="jymVt">
+      <property role="TrG5h" value="setBody" />
+      <node concept="3clFbS" id="7XmAYSGIVd8" role="3clF47">
+        <node concept="3clFbF" id="7XmAYSGIVDn" role="3cqZAp">
+          <node concept="1rXfSq" id="7XmAYSGIVDm" role="3clFbG">
+            <ref role="37wK5l" to="dxuu:~JEditorPane.setText(java.lang.String)" resolve="setText" />
+            <node concept="3cpWs3" id="7XmAYSGIX0j" role="37wK5m">
+              <node concept="Xl_RD" id="7XmAYSGIXiG" role="3uHU7w">
+                <property role="Xl_RC" value="&lt;/body&gt;&lt;/html" />
+              </node>
+              <node concept="3cpWs3" id="7XmAYSGIWdi" role="3uHU7B">
+                <node concept="Xl_RD" id="7XmAYSGIVVC" role="3uHU7B">
+                  <property role="Xl_RC" value="&lt;html&gt;&lt;body&gt;" />
+                </node>
+                <node concept="37vLTw" id="7XmAYSGIWvA" role="3uHU7w">
+                  <ref role="3cqZAo" node="7XmAYSGIVn5" resolve="body" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="7XmAYSGIV37" role="1B3o_S" />
+      <node concept="3cqZAl" id="7XmAYSGIVd3" role="3clF45" />
+      <node concept="37vLTG" id="7XmAYSGIVn5" role="3clF46">
+        <property role="TrG5h" value="body" />
+        <node concept="17QB3L" id="7XmAYSGIVn4" role="1tU5fm" />
+      </node>
+    </node>
+    <node concept="3Tm1VV" id="7XmAYSGHmpW" role="1B3o_S" />
+    <node concept="3uibUv" id="7XmAYSGHtOG" role="1zkMxy">
+      <ref role="3uigEE" to="dxuu:~JEditorPane" resolve="JEditorPane" />
+    </node>
+  </node>
+  <node concept="312cEu" id="7XmAYSGN9iw">
+    <property role="TrG5h" value="EditorCell_HTML" />
+    <node concept="Wx3nA" id="2iZPrFZnMN9" role="jymVt">
+      <property role="3TUv4t" value="true" />
+      <property role="TrG5h" value="GROW_X" />
+      <node concept="3Tm6S6" id="2iZPrFZnMN5" role="1B3o_S" />
+      <node concept="3uibUv" id="2iZPrFZnMN6" role="1tU5fm">
+        <ref role="3uigEE" to="hox0:~StyleAttribute" resolve="StyleAttribute" />
+        <node concept="3uibUv" id="2iZPrFZnMN7" role="11_B2D">
+          <ref role="3uigEE" to="wyt6:~Boolean" resolve="Boolean" />
+        </node>
+      </node>
+      <node concept="1Z6Ecs" id="2iZPrFZnMN8" role="33vP2m">
+        <ref role="1Z6EpT" to="z0fb:7lS0O5066sF" resolve="_grow-x" />
+      </node>
+    </node>
+    <node concept="Wx3nA" id="2iZPrFZnNch" role="jymVt">
+      <property role="3TUv4t" value="true" />
+      <property role="TrG5h" value="PUSH_X" />
+      <node concept="3Tm6S6" id="2iZPrFZnNcd" role="1B3o_S" />
+      <node concept="3uibUv" id="2iZPrFZnNce" role="1tU5fm">
+        <ref role="3uigEE" to="hox0:~StyleAttribute" resolve="StyleAttribute" />
+        <node concept="3uibUv" id="2iZPrFZnNcf" role="11_B2D">
+          <ref role="3uigEE" to="wyt6:~Boolean" resolve="Boolean" />
+        </node>
+      </node>
+      <node concept="1Z6Ecs" id="2iZPrFZnNcg" role="33vP2m">
+        <ref role="1Z6EpT" to="z0fb:7lS0O5066tP" resolve="_push-x" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="fKKzZr7sOR" role="jymVt" />
+    <node concept="3clFbW" id="7XmAYSGN9qp" role="jymVt">
+      <node concept="3cqZAl" id="7XmAYSGN9qq" role="3clF45" />
+      <node concept="3clFbS" id="7XmAYSGN9qs" role="3clF47">
+        <node concept="XkiVB" id="7XmAYSGNiF8" role="3cqZAp">
+          <ref role="37wK5l" to="g51k:~EditorCell_Component.&lt;init&gt;(jetbrains.mps.openapi.editor.EditorContext,org.jetbrains.mps.openapi.model.SNode,javax.swing.JComponent)" resolve="EditorCell_Component" />
+          <node concept="37vLTw" id="7XmAYSGNiOJ" role="37wK5m">
+            <ref role="3cqZAo" node="7XmAYSGNij7" resolve="editorContext" />
+          </node>
+          <node concept="37vLTw" id="7XmAYSGNkw9" role="37wK5m">
+            <ref role="3cqZAo" node="7XmAYSGNjp3" resolve="node" />
+          </node>
+          <node concept="2ShNRf" id="7XmAYSGNaAX" role="37wK5m">
+            <node concept="1pGfFk" id="7XmAYSGNh71" role="2ShVmc">
+              <ref role="37wK5l" node="7XmAYSGHCKB" resolve="HTMLCellEditorPane" />
+              <node concept="37vLTw" id="7XmAYSGPfIE" role="37wK5m">
+                <ref role="3cqZAo" node="7XmAYSGN9v9" resolve="content" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4U82Y3yZNF5" role="3cqZAp">
+          <node concept="2OqwBi" id="4U82Y3yZNGL" role="3clFbG">
+            <node concept="1rXfSq" id="4U82Y3yZNF3" role="2Oq$k0">
+              <ref role="37wK5l" to="g51k:~EditorCell_Basic.getStyle()" resolve="getStyle" />
+            </node>
+            <node concept="liA8E" id="4U82Y3yZNKx" role="2OqNvi">
+              <ref role="37wK5l" to="hox0:~Style.set(jetbrains.mps.openapi.editor.style.StyleAttribute,java.lang.Object)" resolve="set" />
+              <node concept="37vLTw" id="fKKzZr7wgZ" role="37wK5m">
+                <ref role="3cqZAo" node="2iZPrFZnNch" resolve="PUSH_X" />
+              </node>
+              <node concept="3clFbT" id="4U82Y3yZOyR" role="37wK5m">
+                <property role="3clFbU" value="true" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4U82Y3yZOUF" role="3cqZAp">
+          <node concept="2OqwBi" id="4U82Y3yZOUG" role="3clFbG">
+            <node concept="1rXfSq" id="4U82Y3yZOUH" role="2Oq$k0">
+              <ref role="37wK5l" to="g51k:~EditorCell_Basic.getStyle()" resolve="getStyle" />
+            </node>
+            <node concept="liA8E" id="4U82Y3yZOUI" role="2OqNvi">
+              <ref role="37wK5l" to="hox0:~Style.set(jetbrains.mps.openapi.editor.style.StyleAttribute,java.lang.Object)" resolve="set" />
+              <node concept="37vLTw" id="fKKzZr7wT4" role="37wK5m">
+                <ref role="3cqZAo" node="2iZPrFZnMN9" resolve="GROW_X" />
+              </node>
+              <node concept="3clFbT" id="4U82Y3yZOUK" role="37wK5m">
+                <property role="3clFbU" value="true" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="7XmAYSGN9qt" role="1B3o_S" />
+      <node concept="37vLTG" id="7XmAYSGNij7" role="3clF46">
+        <property role="TrG5h" value="editorContext" />
+        <node concept="3uibUv" id="7XmAYSGNinN" role="1tU5fm">
+          <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="7XmAYSGNjp3" role="3clF46">
+        <property role="TrG5h" value="node" />
+        <node concept="3Tqbb2" id="7XmAYSGNk0Q" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="7XmAYSGN9v9" role="3clF46">
+        <property role="TrG5h" value="content" />
+        <node concept="17QB3L" id="7XmAYSGN9v8" role="1tU5fm" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="3X4py5omcvF" role="jymVt" />
+    <node concept="3clFb_" id="3X4py5ooAhx" role="jymVt">
+      <property role="TrG5h" value="relayoutImpl" />
+      <node concept="3Tm1VV" id="3X4py5ooAhy" role="1B3o_S" />
+      <node concept="3cqZAl" id="3X4py5ooAh$" role="3clF45" />
+      <node concept="3clFbS" id="3X4py5ooAhB" role="3clF47">
+        <node concept="3clFbF" id="3X4py5ooCeV" role="3cqZAp">
+          <node concept="1rXfSq" id="3X4py5ooCeU" role="3clFbG">
+            <ref role="37wK5l" to="g51k:~EditorCell_Basic.setWidth(int)" resolve="setWidth" />
+            <node concept="3cmrfG" id="3X4py5ooCFN" role="37wK5m">
+              <property role="3cmrfH" value="1" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="3X4py5orh6n" role="3cqZAp">
+          <node concept="1rXfSq" id="3X4py5orh6l" role="3clFbG">
+            <ref role="37wK5l" to="g51k:~EditorCell_Basic.setHeight(int)" resolve="setHeight" />
+            <node concept="2OqwBi" id="3X4py5ork96" role="37wK5m">
+              <node concept="2OqwBi" id="3X4py5ork97" role="2Oq$k0">
+                <node concept="1rXfSq" id="3X4py5ork98" role="2Oq$k0">
+                  <ref role="37wK5l" to="g51k:~EditorCell_Component.getComponent()" resolve="getComponent" />
+                </node>
+                <node concept="liA8E" id="3X4py5ork99" role="2OqNvi">
+                  <ref role="37wK5l" to="dxuu:~JComponent.getPreferredSize()" resolve="getPreferredSize" />
+                </node>
+              </node>
+              <node concept="2OwXpG" id="3X4py5ork9a" role="2OqNvi">
+                <ref role="2Oxat5" to="z60i:~Dimension.height" resolve="height" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="3X4py5ooAhC" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="3X4py5oo_KA" role="jymVt" />
+    <node concept="3clFb_" id="3X4py5oo$V1" role="jymVt">
+      <property role="TrG5h" value="layoutComponent" />
+      <node concept="3Tm1VV" id="3X4py5oo$V3" role="1B3o_S" />
+      <node concept="3cqZAl" id="3X4py5oo$V5" role="3clF45" />
+      <node concept="3clFbS" id="3X4py5oo$Ve" role="3clF47">
+        <node concept="3clFbF" id="3X4py5ooVYu" role="3cqZAp">
+          <node concept="2OqwBi" id="3X4py5ooWvi" role="3clFbG">
+            <node concept="1rXfSq" id="3X4py5ooVYt" role="2Oq$k0">
+              <ref role="37wK5l" to="g51k:~EditorCell_Component.getComponent()" resolve="getComponent" />
+            </node>
+            <node concept="liA8E" id="3X4py5ooXlE" role="2OqNvi">
+              <ref role="37wK5l" to="z60i:~Component.setSize(int,int)" resolve="setSize" />
+              <node concept="1rXfSq" id="3X4py5or8oF" role="37wK5m">
+                <ref role="37wK5l" to="g51k:~EditorCell_Basic.getWidth()" resolve="getWidth" />
+              </node>
+              <node concept="2OqwBi" id="3X4py5op3fL" role="37wK5m">
+                <node concept="2OqwBi" id="3X4py5op1uQ" role="2Oq$k0">
+                  <node concept="1rXfSq" id="3X4py5op0RY" role="2Oq$k0">
+                    <ref role="37wK5l" to="g51k:~EditorCell_Component.getComponent()" resolve="getComponent" />
+                  </node>
+                  <node concept="liA8E" id="3X4py5op2Db" role="2OqNvi">
+                    <ref role="37wK5l" to="dxuu:~JComponent.getPreferredSize()" resolve="getPreferredSize" />
+                  </node>
+                </node>
+                <node concept="2OwXpG" id="3X4py5op40K" role="2OqNvi">
+                  <ref role="2Oxat5" to="z60i:~Dimension.height" resolve="height" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="3X4py5oqoJS" role="3cqZAp">
+          <node concept="1rXfSq" id="3X4py5oqoJQ" role="3clFbG">
+            <ref role="37wK5l" to="g51k:~EditorCell_Basic.requestRelayout()" resolve="requestRelayout" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="3X4py5oo$Vf" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="fKKzZrcUlV" role="jymVt" />
+    <node concept="3Tm1VV" id="7XmAYSGN9ix" role="1B3o_S" />
+    <node concept="3uibUv" id="7XmAYSGN9lJ" role="1zkMxy">
+      <ref role="3uigEE" to="g51k:~EditorCell_Component" resolve="EditorCell_Component" />
+    </node>
+    <node concept="3uibUv" id="fKKzZraH8c" role="EKbjA">
+      <ref role="3uigEE" to="qxi4:3bNiYZ6RRgk" resolve="ISupportsTopDownLayout" />
+    </node>
+    <node concept="3clFb_" id="fKKzZraI8P" role="jymVt">
+      <property role="TrG5h" value="getTopDownLayoutable" />
+      <node concept="3uibUv" id="fKKzZraI8Q" role="3clF45">
+        <ref role="3uigEE" to="qxi4:3bNiYZ6RRTc" resolve="IEditorCellBasedLayoutable" />
+      </node>
+      <node concept="3Tm1VV" id="fKKzZraI8R" role="1B3o_S" />
+      <node concept="3clFbS" id="fKKzZraI8U" role="3clF47">
+        <node concept="3clFbF" id="fKKzZraSEa" role="3cqZAp">
+          <node concept="2ShNRf" id="fKKzZraSE8" role="3clFbG">
+            <node concept="1pGfFk" id="fKKzZrb3LF" role="2ShVmc">
+              <ref role="37wK5l" to="qxi4:6aN_eBIZw$g" resolve="LayoutableAdapter" />
+              <node concept="Xjq3P" id="fKKzZrb4_B" role="37wK5m" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="fKKzZraI8V" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+  </node>
+</model>
+


### PR DESCRIPTION
![Screenshot 2023-02-07 at 13 36 26](https://user-images.githubusercontent.com/88385944/217246756-7e8f3d69-db18-4277-875d-133c5b074c3c.png)

![Screenshot 2023-02-07 at 13 40 44](https://user-images.githubusercontent.com/88385944/217247584-936803d1-86f2-4ae7-a456-a25acf4bb6e0.png)

As part of a performance investigation, I've created this experimental custom swing component that supports a small subset of HTML. With a few additional lines there could also be rudimentary support for [RTF](https://en.wikipedia.org/wiki/Rich_Text_Format) in case anybody needs that. This cell can be used, for example, for long read-only explanations instead of using many single MSP editor cells.

Unfortunately,I couldn't quite figure out the correct relayouting of the cell. I think there might still be issues where the content of the JComponent gets cuts off on the right side, that's why the PR is still in draft mode.

Not sure if we really need it, as it doesn't integrate that nicely with other editor cells and using some old HTML standard for writing messages is also not that great. At last, the approach is more lightweight than my full [JCEF integration](https://github.com/alexanderpann/mps_jcef_minimal).