### PR TITLE
Diagrams: give the option to save the layout data of subdiagrams in the main diagram

### DIFF
--- a/code/diagram/languages/de.itemis.mps.editor.diagram.demolang/languageModels/editor.mps
+++ b/code/diagram/languages/de.itemis.mps.editor.diagram.demolang/languageModels/editor.mps
@@ -38,6 +38,7 @@
       <concept id="1237307900041" name="jetbrains.mps.lang.editor.structure.IndentLayoutIndentStyleClassItem" flags="ln" index="lj46D" />
       <concept id="1237308012275" name="jetbrains.mps.lang.editor.structure.IndentLayoutNewLineStyleClassItem" flags="ln" index="ljvvj" />
       <concept id="1237375020029" name="jetbrains.mps.lang.editor.structure.IndentLayoutNewLineChildrenStyleClassItem" flags="ln" index="pj6Ft" />
+      <concept id="1142886221719" name="jetbrains.mps.lang.editor.structure.QueryFunction_NodeCondition" flags="in" index="pkWqt" />
       <concept id="1142886811589" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameter_node" flags="nn" index="pncrf" />
       <concept id="1237385578942" name="jetbrains.mps.lang.editor.structure.IndentLayoutOnNewLineStyleClassItem" flags="ln" index="pVoyu" />
       <concept id="1080736578640" name="jetbrains.mps.lang.editor.structure.BaseEditorComponent" flags="ig" index="2wURMF">
@@ -70,6 +71,9 @@
       <concept id="1139848536355" name="jetbrains.mps.lang.editor.structure.CellModel_WithRole" flags="ng" index="1$h60E">
         <property id="1140017977771" name="readOnly" index="1Intyy" />
         <reference id="1140103550593" name="relationDeclaration" index="1NtTu8" />
+      </concept>
+      <concept id="1073389214265" name="jetbrains.mps.lang.editor.structure.EditorCellModel" flags="ng" index="3EYTF0">
+        <child id="1142887637401" name="renderingCondition" index="pqm2j" />
       </concept>
       <concept id="1073389446423" name="jetbrains.mps.lang.editor.structure.CellModel_Collection" flags="sn" stub="3013115976261988961" index="3EZMnI">
         <child id="1106270802874" name="cellLayout" index="2iSdaV" />
@@ -439,6 +443,7 @@
       <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
         <child id="1177027386292" name="conceptArgument" index="cj9EA" />
       </concept>
+      <concept id="1172008320231" name="jetbrains.mps.lang.smodel.structure.Node_IsNotNullOperation" flags="nn" index="3x8VRR" />
       <concept id="1144101972840" name="jetbrains.mps.lang.smodel.structure.OperationParm_Concept" flags="ng" index="1xMEDy">
         <child id="1207343664468" name="conceptArgument" index="ri$Ld" />
       </concept>
@@ -491,6 +496,10 @@
       </concept>
     </language>
     <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="1235573135402" name="jetbrains.mps.baseLanguage.collections.structure.SingletonSequenceCreator" flags="nn" index="2HTt$P">
+        <child id="1235573175711" name="elementType" index="2HTBi0" />
+        <child id="1235573187520" name="singletonValue" index="2HTEbv" />
+      </concept>
       <concept id="1237721394592" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerCreator" flags="nn" index="HWqM0">
         <child id="1237721435808" name="initValue" index="HW$Y0" />
         <child id="1237721435807" name="elementType" index="HW$YZ" />
@@ -717,6 +726,40 @@
             <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
           </node>
           <node concept="2iRfu4" id="190K99KdUE_" role="2iSdaV" />
+        </node>
+        <node concept="27vDVx" id="2YJ6Svp5y5V" role="3EZMnx">
+          <node concept="2ZMM4L" id="2YJ6Svp5SIR" role="aCds2">
+            <node concept="3clFbS" id="2YJ6Svp5SIT" role="2VODD2">
+              <node concept="3clFbF" id="2YJ6Svp5SJu" role="3cqZAp">
+                <node concept="2ShNRf" id="2YJ6Svp5SJs" role="3clFbG">
+                  <node concept="2HTt$P" id="2YJ6Svp5TYw" role="2ShVmc">
+                    <node concept="3Tqbb2" id="2YJ6Svp5U4p" role="2HTBi0" />
+                    <node concept="2OqwBi" id="2YJ6Svp5RsO" role="2HTEbv">
+                      <node concept="2ZN8Hh" id="2YJ6Svp5RgI" role="2Oq$k0" />
+                      <node concept="3TrEf2" id="2YJ6Svp5SDb" role="2OqNvi">
+                        <ref role="3Tt5mk" to="7fae:2YJ6Svp5RPD" resolve="subComponent" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="pkWqt" id="2YJ6Svp6dvI" role="pqm2j">
+            <node concept="3clFbS" id="2YJ6Svp6dvJ" role="2VODD2">
+              <node concept="3clFbF" id="2YJ6Svp6dJj" role="3cqZAp">
+                <node concept="2OqwBi" id="2YJ6Svp6ena" role="3clFbG">
+                  <node concept="2OqwBi" id="2YJ6Svp6dV2" role="2Oq$k0">
+                    <node concept="pncrf" id="2YJ6Svp6dJi" role="2Oq$k0" />
+                    <node concept="3TrEf2" id="2YJ6Svp6ebG" role="2OqNvi">
+                      <ref role="3Tt5mk" to="7fae:2YJ6Svp5RPD" resolve="subComponent" />
+                    </node>
+                  </node>
+                  <node concept="3x8VRR" id="2YJ6Svp6eC5" role="2OqNvi" />
+                </node>
+              </node>
+            </node>
+          </node>
         </node>
         <node concept="3uPbVW" id="48DYfEt4OuY" role="3EZMnx">
           <property role="3vvbre" value="true" />
@@ -3397,6 +3440,20 @@
       </node>
       <node concept="2SsqMj" id="6OhZPz3aZm_" role="3EZMnx" />
       <node concept="2iRkQZ" id="6OhZPz3aZmA" role="2iSdaV" />
+    </node>
+  </node>
+  <node concept="24kQdi" id="2YJ6Svp5Qpb">
+    <ref role="1XX52x" to="7fae:2YJ6Svp5Qp3" resolve="SubComponent" />
+    <node concept="2ZK4vF" id="2YJ6Svp6Gpj" role="2wV5jI">
+      <node concept="3EZMnI" id="2YJ6Svp5Qpg" role="1ytjkN">
+        <node concept="2iRfu4" id="2YJ6Svp5Qph" role="2iSdaV" />
+        <node concept="3F0ifn" id="2YJ6Svp5Qpd" role="3EZMnx">
+          <property role="3F0ifm" value="subcomponent" />
+        </node>
+        <node concept="3F0A7n" id="2YJ6Svp5Qpr" role="3EZMnx">
+          <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
+        </node>
+      </node>
     </node>
   </node>
 </model>

--- a/code/diagram/languages/de.itemis.mps.editor.diagram.demolang/languageModels/structure.mps
+++ b/code/diagram/languages/de.itemis.mps.editor.diagram.demolang/languageModels/structure.mps
@@ -81,6 +81,11 @@
     <property role="34LRSv" value="component" />
     <property role="EcuMT" value="6237710625713136478" />
     <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+    <node concept="1TJgyj" id="2YJ6Svp5RPD" role="1TKVEi">
+      <property role="IQ2ns" value="3435995310983708009" />
+      <property role="20kJfa" value="subComponent" />
+      <ref role="20lvS9" node="2YJ6Svp5Qp3" resolve="SubComponent" />
+    </node>
     <node concept="1TJgyj" id="3P47XPYx5Nb" role="1TKVEi">
       <property role="20lmBu" value="fLJjDmT/aggregation" />
       <property role="20kJfa" value="expr" />
@@ -222,6 +227,15 @@
       <node concept="trNpa" id="6OhZPz3aZ5_" role="EQaZv">
         <ref role="trN6q" to="tpck:gw2VY9q" resolve="BaseConcept" />
       </node>
+    </node>
+  </node>
+  <node concept="1TIwiD" id="2YJ6Svp5Qp3">
+    <property role="EcuMT" value="3435995310983702083" />
+    <property role="TrG5h" value="SubComponent" />
+    <property role="19KtqR" value="true" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+    <node concept="PrWs8" id="2YJ6Svp5Qpp" role="PzmwI">
+      <ref role="PrY4T" to="tpck:h0TrEE$" resolve="INamedConcept" />
     </node>
   </node>
 </model>

--- a/code/diagram/languages/de.itemis.mps.editor.diagram/generator/template/main@generator.mps
+++ b/code/diagram/languages/de.itemis.mps.editor.diagram/generator/template/main@generator.mps
@@ -5042,6 +5042,37 @@
                                                     </node>
                                                   </node>
                                                 </node>
+                                                <node concept="2tJIrI" id="2YJ6SvpdKMa" role="jymVt" />
+                                                <node concept="2tJIrI" id="2YJ6SvpdKSv" role="jymVt" />
+                                                <node concept="3clFb_" id="2YJ6SvpdLQ5" role="jymVt">
+                                                  <property role="TrG5h" value="saveSubDiagramLayoutInDiagram" />
+                                                  <node concept="3Tm1VV" id="2YJ6SvpdLQ9" role="1B3o_S" />
+                                                  <node concept="10P_77" id="2YJ6SvpdLQa" role="3clF45" />
+                                                  <node concept="3clFbS" id="2YJ6SvpdLQc" role="3clF47">
+                                                    <node concept="3clFbF" id="2YJ6SvpdQp1" role="3cqZAp">
+                                                      <node concept="3clFbT" id="2YJ6SvpdQp0" role="3clFbG">
+                                                        <property role="3clFbU" value="true" />
+                                                      </node>
+                                                    </node>
+                                                  </node>
+                                                  <node concept="2AHcQZ" id="2YJ6SvpdLQd" role="2AJF6D">
+                                                    <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                                                  </node>
+                                                  <node concept="1W57fq" id="2YJ6SvpdRkp" role="lGtFl">
+                                                    <node concept="3IZrLx" id="2YJ6SvpdRks" role="3IZSJc">
+                                                      <node concept="3clFbS" id="2YJ6SvpdRkt" role="2VODD2">
+                                                        <node concept="3clFbF" id="2YJ6SvpdRkz" role="3cqZAp">
+                                                          <node concept="2OqwBi" id="2YJ6SvpdRku" role="3clFbG">
+                                                            <node concept="3TrcHB" id="2YJ6SvpdRkx" role="2OqNvi">
+                                                              <ref role="3TsBF5" to="2qld:2YJ6Svp2O0G" resolve="saveSubdiagramLayoutInDiagram" />
+                                                            </node>
+                                                            <node concept="30H73N" id="2YJ6SvpdRky" role="2Oq$k0" />
+                                                          </node>
+                                                        </node>
+                                                      </node>
+                                                    </node>
+                                                  </node>
+                                                </node>
                                               </node>
                                             </node>
                                           </node>

--- a/code/diagram/languages/de.itemis.mps.editor.diagram/languageModels/editor.mps
+++ b/code/diagram/languages/de.itemis.mps.editor.diagram/languageModels/editor.mps
@@ -713,6 +713,24 @@
             </node>
             <node concept="2iRfu4" id="45g3j8ia4Dw" role="2iSdaV" />
           </node>
+          <node concept="3EZMnI" id="2YJ6Svp2Ooy" role="3EZMnx">
+            <node concept="VPM3Z" id="2YJ6Svp2Ooz" role="3F10Kt">
+              <property role="VOm3f" value="false" />
+            </node>
+            <node concept="VPXOz" id="2YJ6Svp2Oo$" role="3F10Kt">
+              <property role="VOm3f" value="true" />
+            </node>
+            <node concept="3F0ifn" id="2YJ6Svp2Oo_" role="3EZMnx">
+              <property role="3F0ifm" value="save subdiagram layout in this diagram" />
+            </node>
+            <node concept="3F0A7n" id="2YJ6Svp2OoA" role="3EZMnx">
+              <ref role="1NtTu8" to="2qld:2YJ6Svp2O0G" resolve="saveSubDiagramLayoutInDiagram" />
+              <node concept="VPXOz" id="2YJ6Svp2OoB" role="3F10Kt">
+                <property role="VOm3f" value="true" />
+              </node>
+            </node>
+            <node concept="2iRfu4" id="2YJ6Svp2OoC" role="2iSdaV" />
+          </node>
         </node>
         <node concept="2iRfu4" id="5qgNcfDnGw9" role="2iSdaV" />
         <node concept="3F0ifn" id="5qgNcfDnGxf" role="3EZMnx" />

--- a/code/diagram/languages/de.itemis.mps.editor.diagram/languageModels/structure.mps
+++ b/code/diagram/languages/de.itemis.mps.editor.diagram/languageModels/structure.mps
@@ -105,6 +105,11 @@
       <property role="TrG5h" value="runAutoLayoutOnInit" />
       <ref role="AX2Wp" to="tpck:fKAQMTB" resolve="boolean" />
     </node>
+    <node concept="1TJgyi" id="2YJ6Svp2O0G" role="1TKVEl">
+      <property role="IQ2nx" value="3435995310982905900" />
+      <property role="TrG5h" value="saveSubDiagramLayoutInDiagram" />
+      <ref role="AX2Wp" to="tpck:fKAQMTB" resolve="boolean" />
+    </node>
     <node concept="1TJgyj" id="7vufT$lixNl" role="1TKVEi">
       <property role="20lmBu" value="fLJjDmT/aggregation" />
       <property role="20kJfa" value="paletteFolder" />

--- a/code/diagram/solutions/de.itemis.mps.editor.diagram.runtime/models/de/itemis/mps/editor/diagram/runtime/model.mps
+++ b/code/diagram/solutions/de.itemis.mps.editor.diagram.runtime/models/de/itemis/mps/editor/diagram/runtime/model.mps
@@ -27755,13 +27755,56 @@
             </node>
           </node>
         </node>
+        <node concept="3cpWs8" id="2YJ6Svp9IP6" role="3cqZAp">
+          <node concept="3cpWsn" id="2YJ6Svp9IP9" role="3cpWs9">
+            <property role="TrG5h" value="layoutMapLocation" />
+            <node concept="3Tqbb2" id="2YJ6Svp9IP4" role="1tU5fm" />
+            <node concept="37vLTw" id="2YJ6Svp9JXK" role="33vP2m">
+              <ref role="3cqZAo" node="7L$rKAVfKt6" resolve="snode" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="2YJ6Svp9GNC" role="3cqZAp">
+          <node concept="3clFbS" id="2YJ6Svp9GNE" role="3clFbx">
+            <node concept="3clFbF" id="2YJ6Svp9KIJ" role="3cqZAp">
+              <node concept="37vLTI" id="2YJ6Svp9L3P" role="3clFbG">
+                <node concept="37vLTw" id="2YJ6Svp9KIH" role="37vLTJ">
+                  <ref role="3cqZAo" node="2YJ6Svp9IP9" resolve="layoutMapLocation" />
+                </node>
+                <node concept="2OqwBi" id="2YJ6Svp7w0C" role="37vLTx">
+                  <node concept="2OqwBi" id="2YJ6Svp7vqL" role="2Oq$k0">
+                    <node concept="2YIFZM" id="2YJ6Svp7vaZ" role="2Oq$k0">
+                      <ref role="37wK5l" to="r3rm:5S8_I2GP_o0" resolve="getRootGraph" />
+                      <ref role="1Pybhc" to="r3rm:5S8_I2FYVEf" resolve="DiagramCreationContext" />
+                    </node>
+                    <node concept="liA8E" id="2YJ6Svp7vSU" role="2OqNvi">
+                      <ref role="37wK5l" to="r3rm:zdi$i4F31o" resolve="getRootDiagramModel" />
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="2YJ6Svp7wor" role="2OqNvi">
+                    <ref role="37wK5l" node="4KemxTdSKHW" resolve="getSNode" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1Wc70l" id="2YJ6SvpdI6F" role="3clFbw">
+            <node concept="1rXfSq" id="2YJ6SvpdIv9" role="3uHU7w">
+              <ref role="37wK5l" node="2YJ6SvpdGYk" resolve="saveSubDiagramLayoutInDiagram" />
+            </node>
+            <node concept="2YIFZM" id="2YJ6Svp9H_H" role="3uHU7B">
+              <ref role="37wK5l" to="r3rm:5S8_I2FYWDU" resolve="isSubdiagram" />
+              <ref role="1Pybhc" to="r3rm:5S8_I2FYVEf" resolve="DiagramCreationContext" />
+            </node>
+          </node>
+        </node>
         <node concept="3clFbF" id="7L$rKAVgS4D" role="3cqZAp">
           <node concept="37vLTI" id="7L$rKAVgScC" role="3clFbG">
             <node concept="2YIFZM" id="7L$rKAVgU50" role="37vLTx">
               <ref role="37wK5l" node="7L$rKAVgSYS" resolve="getInstance" />
               <ref role="1Pybhc" node="7L$rKAVfOqc" resolve="LayoutMap" />
-              <node concept="37vLTw" id="7L$rKAVgU70" role="37wK5m">
-                <ref role="3cqZAo" node="7L$rKAVfKt6" resolve="snode" />
+              <node concept="37vLTw" id="2YJ6Svp7zLf" role="37wK5m">
+                <ref role="3cqZAo" node="2YJ6Svp9IP9" resolve="layoutMapLocation" />
               </node>
             </node>
             <node concept="37vLTw" id="7L$rKAVgS4B" role="37vLTJ">
@@ -27777,6 +27820,17 @@
           <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
         </node>
       </node>
+    </node>
+    <node concept="2tJIrI" id="2YJ6SvpdDyA" role="jymVt" />
+    <node concept="3clFb_" id="2YJ6SvpdGYk" role="jymVt">
+      <property role="TrG5h" value="saveSubDiagramLayoutInDiagram" />
+      <node concept="3clFbS" id="2YJ6SvpdGYn" role="3clF47">
+        <node concept="3clFbF" id="2YJ6SvpdHvx" role="3cqZAp">
+          <node concept="3clFbT" id="2YJ6SvpdHvw" role="3clFbG" />
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="2YJ6SvpdEfA" role="1B3o_S" />
+      <node concept="10P_77" id="2YJ6SvpdEB5" role="3clF45" />
     </node>
     <node concept="2tJIrI" id="7L$rKAVfJg9" role="jymVt" />
     <node concept="3clFb_" id="63AkbuOFrVG" role="jymVt">

--- a/code/diagram/solutions/de.itemis.mps.editor.diagram.sandbox/models/de/itemis/mps/editor/diagram/sandbox.mps
+++ b/code/diagram/solutions/de.itemis.mps.editor.diagram.sandbox/models/de/itemis/mps/editor/diagram/sandbox.mps
@@ -66,8 +66,11 @@
         <child id="6237710625714092846" name="nodes" index="2ZNJvH" />
         <child id="6237710625714092848" name="connections" index="2ZNJvN" />
       </concept>
-      <concept id="6237710625713136478" name="de.itemis.mps.editor.diagram.demolang.structure.Component" flags="ng" index="2ZRQYt" />
+      <concept id="6237710625713136478" name="de.itemis.mps.editor.diagram.demolang.structure.Component" flags="ng" index="2ZRQYt">
+        <reference id="3435995310983708009" name="subComponent" index="3QI6rI" />
+      </concept>
       <concept id="3469399874292359781" name="de.itemis.mps.editor.diagram.demolang.structure.ComponentAnnotation" flags="ng" index="3yRIEC" />
+      <concept id="3435995310983702083" name="de.itemis.mps.editor.diagram.demolang.structure.SubComponent" flags="ng" index="3QI7R4" />
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
@@ -84,6 +87,7 @@
         <property id="6720495385597071503" name="bounds_width" index="gqqTX" />
         <property id="6720495385597071501" name="bounds_x" index="gqqTZ" />
         <property id="4583510071007917016" name="transform" index="TgtnS" />
+        <child id="738815095926774816" name="portLayouts" index="1pap1a" />
       </concept>
       <concept id="2319506556913310852" name="de.itemis.mps.editor.diagram.layout.structure.Layout_Connection" flags="ng" index="2VclpC">
         <child id="2319506556913311101" name="anchors" index="2Vcluh" />
@@ -100,6 +104,10 @@
       <concept id="8963411245960991903" name="de.itemis.mps.editor.diagram.layout.structure.LayoutMapEntry" flags="ng" index="37mRIm">
         <property id="8963411245960998400" name="key" index="37mO49" />
         <child id="8963411245960998404" name="value" index="37mO4d" />
+      </concept>
+      <concept id="738815095926749345" name="de.itemis.mps.editor.diagram.layout.structure.Layout_Port" flags="ng" index="1pa3jb">
+        <property id="7964702570467115501" name="ordinal" index="2gRgW$" />
+        <property id="738815095926749379" name="portName" index="1pa3iD" />
       </concept>
       <concept id="4767615435799372731" name="de.itemis.mps.editor.diagram.layout.structure.Layout_EdgeLabel" flags="ng" index="3ul5H1">
         <property id="4767615435799372759" name="type" index="3ul5GH" />
@@ -766,8 +774,8 @@
               <property role="3ul5GH" value="label" />
               <node concept="3wpmZ1" id="6OhZPz40CYU" role="3ul5Gz">
                 <node concept="2VclrF" id="6OhZPz40CYV" role="3wpmZR">
-                  <property role="2Vclpx" value="0.0" />
-                  <property role="2Vclpz" value="0.0" />
+                  <property role="2Vclpx" value="-128.5" />
+                  <property role="2Vclpz" value="-31.887611083984325" />
                 </node>
                 <node concept="2VclrF" id="6OhZPz40CYW" role="3wpmZP">
                   <property role="2Vclpx" value="393.5" />
@@ -779,8 +787,8 @@
               <property role="3ul5GH" value="startRole" />
               <node concept="3wpmZ1" id="6OhZPz40CYY" role="3ul5Gz">
                 <node concept="2VclrF" id="6OhZPz40CYZ" role="3wpmZR">
-                  <property role="2Vclpx" value="0.5189673776000063" />
-                  <property role="2Vclpz" value="-22.157416254893093" />
+                  <property role="2Vclpx" value="-72.96631399663858" />
+                  <property role="2Vclpz" value="25.162583745106957" />
                 </node>
                 <node concept="2VclrF" id="6OhZPz40CZ0" role="3wpmZP">
                   <property role="2Vclpx" value="312.9663139966386" />
@@ -792,22 +800,14 @@
               <property role="3ul5GH" value="endRole" />
               <node concept="3wpmZ1" id="6OhZPz40CZ2" role="3ul5Gz">
                 <node concept="2VclrF" id="6OhZPz40CZ3" role="3wpmZR">
-                  <property role="2Vclpx" value="-3.1379099219844875" />
-                  <property role="2Vclpz" value="-13.849986121137874" />
+                  <property role="2Vclpx" value="-184.0336858735826" />
+                  <property role="2Vclpz" value="-133.25263546133039" />
                 </node>
                 <node concept="2VclrF" id="6OhZPz40CZ4" role="3wpmZP">
                   <property role="2Vclpx" value="474.0336858735826" />
                   <property role="2Vclpz" value="393.57263546133044" />
                 </node>
               </node>
-            </node>
-            <node concept="2VclrF" id="1EGRR3nyuGh" role="2Vcluh">
-              <property role="2Vclpx" value="393.5" />
-              <property role="2Vclpz" value="213.0" />
-            </node>
-            <node concept="2VclrF" id="1EGRR3nyuGi" role="2Vcluh">
-              <property role="2Vclpx" value="393.5" />
-              <property role="2Vclpz" value="371.41522216796875" />
             </node>
           </node>
         </node>
@@ -850,31 +850,153 @@
         <node concept="37mRIm" id="1EGRR3nyuj4" role="37mRID">
           <property role="37mO49" value="7464726264121402820" />
           <node concept="gqqVs" id="1EGRR3nyuj3" role="37mO4d">
-            <property role="gqqTZ" value="78.0" />
-            <property role="gqqTW" value="142.0" />
-            <property role="gqqTX" value="209.0" />
-            <property role="gqqTy" value="142.0" />
+            <property role="gqqTZ" value="24.0" />
+            <property role="gqqTW" value="176.61" />
+            <property role="gqqTX" value="196.0" />
+            <property role="gqqTy" value="146.87800000000001" />
             <property role="TgtnS" value="1.0;0.0;0.0;1.0;0.0;0.0" />
+            <node concept="1pa3jb" id="2YJ6Svp6Aq9" role="1pap1a">
+              <property role="1pa3iD" value="in1" />
+              <property role="2gRgW$" value="494709820" />
+            </node>
+            <node concept="1pa3jb" id="2YJ6Svp6Aqa" role="1pap1a">
+              <property role="1pa3iD" value="in1a" />
+              <property role="2gRgW$" value="730989138" />
+            </node>
+            <node concept="1pa3jb" id="2YJ6Svp6Aqb" role="1pap1a">
+              <property role="1pa3iD" value="in1b" />
+              <property role="2gRgW$" value="967268455" />
+            </node>
+            <node concept="1pa3jb" id="2YJ6Svp6Aqc" role="1pap1a">
+              <property role="1pa3iD" value="in2" />
+              <property role="2gRgW$" value="1073741823" />
+            </node>
+            <node concept="1pa3jb" id="2YJ6Svp6Aqd" role="1pap1a">
+              <property role="1pa3iD" value="in3" />
+              <property role="2gRgW$" value="258430503" />
+            </node>
+            <node concept="1pa3jb" id="2YJ6Svp6Aqe" role="1pap1a">
+              <property role="1pa3iD" value="out1" />
+              <property role="2gRgW$" value="2041010278" />
+            </node>
+            <node concept="1pa3jb" id="2YJ6Svp6Aqf" role="1pap1a">
+              <property role="1pa3iD" value="out2" />
+              <property role="2gRgW$" value="1568451643" />
+            </node>
           </node>
         </node>
         <node concept="37mRIm" id="1EGRR3nyuj6" role="37mRID">
           <property role="37mO49" value="7859343581448602163" />
           <node concept="gqqVs" id="1EGRR3nyuj5" role="37mO4d">
-            <property role="gqqTZ" value="500.0" />
-            <property role="gqqTW" value="365.0" />
-            <property role="gqqTX" value="182.0" />
-            <property role="gqqTy" value="61.0" />
+            <property role="gqqTZ" value="317.0" />
+            <property role="gqqTW" value="236.19634765625003" />
+            <property role="gqqTX" value="124.0" />
+            <property role="gqqTy" value="112.61500000000001" />
             <property role="TgtnS" value="1.0;0.0;0.0;1.0;0.0;0.0" />
+            <node concept="1pa3jb" id="2YJ6Svp6Aqg" role="1pap1a">
+              <property role="1pa3iD" value="in1" />
+              <property role="2gRgW$" value="350078843" />
+            </node>
+            <node concept="1pa3jb" id="2YJ6Svp6Aqh" role="1pap1a">
+              <property role="1pa3iD" value="in1a" />
+              <property role="2gRgW$" value="990223013" />
+            </node>
+            <node concept="1pa3jb" id="2YJ6Svp6Aqi" role="1pap1a">
+              <property role="1pa3iD" value="in1b" />
+              <property role="2gRgW$" value="1073741823" />
+            </node>
+            <node concept="1pa3jb" id="2YJ6Svp6Aqj" role="1pap1a">
+              <property role="1pa3iD" value="in2" />
+              <property role="2gRgW$" value="1073741823" />
+            </node>
+            <node concept="1pa3jb" id="2YJ6Svp6Aqk" role="1pap1a">
+              <property role="1pa3iD" value="in3" />
+              <property role="2gRgW$" value="670150928" />
+            </node>
+            <node concept="1pa3jb" id="2YJ6Svp6Aql" role="1pap1a">
+              <property role="1pa3iD" value="out1" />
+              <property role="2gRgW$" value="1743892751" />
+            </node>
+            <node concept="1pa3jb" id="2YJ6Svp6Aqm" role="1pap1a">
+              <property role="1pa3iD" value="out2" />
+              <property role="2gRgW$" value="2147483646" />
+            </node>
           </node>
         </node>
         <node concept="37mRIm" id="4uAxemPynDh" role="37mRID">
           <property role="37mO49" value="5162960144954915327" />
           <node concept="gqqVs" id="4uAxemPynDg" role="37mO4d">
-            <property role="gqqTZ" value="390.0" />
-            <property role="gqqTW" value="43.0" />
-            <property role="gqqTX" value="158.0" />
-            <property role="gqqTy" value="52.0" />
+            <property role="gqqTZ" value="192.0001" />
+            <property role="gqqTW" value="12.0" />
+            <property role="gqqTX" value="300.0003950927735" />
+            <property role="gqqTy" value="145.0" />
             <property role="TgtnS" value="1.0;0.0;0.0;1.0;0.0;0.0" />
+            <node concept="1pa3jb" id="2YJ6Svp6Aqn" role="1pap1a">
+              <property role="1pa3iD" value="in1" />
+              <property role="2gRgW$" value="503433884" />
+            </node>
+            <node concept="1pa3jb" id="2YJ6Svp6Aqo" role="1pap1a">
+              <property role="1pa3iD" value="in1a" />
+              <property role="2gRgW$" value="743879919" />
+            </node>
+            <node concept="1pa3jb" id="2YJ6Svp6Aqp" role="1pap1a">
+              <property role="1pa3iD" value="in1b" />
+              <property role="2gRgW$" value="984325953" />
+            </node>
+            <node concept="1pa3jb" id="2YJ6Svp6Aqq" role="1pap1a">
+              <property role="1pa3iD" value="in2" />
+              <property role="2gRgW$" value="1073741823" />
+            </node>
+            <node concept="1pa3jb" id="2YJ6Svp6Aqr" role="1pap1a">
+              <property role="1pa3iD" value="in3" />
+              <property role="2gRgW$" value="262987850" />
+            </node>
+            <node concept="1pa3jb" id="2YJ6Svp6Aqs" role="1pap1a">
+              <property role="1pa3iD" value="out1" />
+              <property role="2gRgW$" value="1577175707" />
+            </node>
+            <node concept="1pa3jb" id="2YJ6Svp6Aqt" role="1pap1a">
+              <property role="1pa3iD" value="out2" />
+              <property role="2gRgW$" value="2058067776" />
+            </node>
+          </node>
+        </node>
+        <node concept="37mRIm" id="2YJ6Svp6$oE" role="37mRID">
+          <property role="37mO49" value="5162960144954915410" />
+          <node concept="gqqVs" id="2YJ6Svp6$oD" role="37mO4d">
+            <property role="gqqTZ" value="24.0" />
+            <property role="gqqTW" value="12.0" />
+            <property role="gqqTX" value="164.0" />
+            <property role="gqqTy" value="112.61500000000001" />
+            <property role="TgtnS" value="1.0;0.0;0.0;1.0;0.0;0.0" />
+            <node concept="1pa3jb" id="2YJ6Svp6Aqu" role="1pap1a">
+              <property role="1pa3iD" value="in1" />
+              <property role="2gRgW$" value="670150928" />
+            </node>
+            <node concept="1pa3jb" id="2YJ6Svp6Aqv" role="1pap1a">
+              <property role="1pa3iD" value="in1a" />
+              <property role="2gRgW$" value="990223013" />
+            </node>
+            <node concept="1pa3jb" id="2YJ6Svp6Aqw" role="1pap1a">
+              <property role="1pa3iD" value="in1b" />
+              <property role="2gRgW$" value="1073741823" />
+            </node>
+            <node concept="1pa3jb" id="2YJ6Svp6Aqx" role="1pap1a">
+              <property role="1pa3iD" value="in2" />
+              <property role="2gRgW$" value="1073741823" />
+            </node>
+            <node concept="1pa3jb" id="2YJ6Svp6Aqy" role="1pap1a">
+              <property role="1pa3iD" value="in3" />
+              <property role="2gRgW$" value="350078843" />
+            </node>
+            <node concept="1pa3jb" id="2YJ6Svp6Aqz" role="1pap1a">
+              <property role="1pa3iD" value="out1" />
+              <property role="2gRgW$" value="1743892751" />
+            </node>
+            <node concept="1pa3jb" id="2YJ6Svp6Aq$" role="1pap1a">
+              <property role="1pa3iD" value="out2" />
+              <property role="2gRgW$" value="2147483646" />
+            </node>
           </node>
         </node>
       </node>
@@ -894,6 +1016,19 @@
       </node>
       <node concept="2ZRQYt" id="4uAxemPynBZ" role="2ZNJvH">
         <property role="TrG5h" value="asdfgfgf" />
+        <ref role="3QI6rI" node="2YJ6Svp6$rR" resolve="Mysubcomponent" />
+        <node concept="37mRI7" id="2YJ6Svp6_FY" role="lGtFl">
+          <node concept="37mRIm" id="2YJ6Svp6_FZ" role="37mRID">
+            <property role="37mO49" value="3435995310983890679" />
+            <node concept="gqqVs" id="2YJ6Svp6_FX" role="37mO4d">
+              <property role="gqqTZ" value="0.0" />
+              <property role="gqqTW" value="33.0" />
+              <property role="gqqTX" value="228.0" />
+              <property role="gqqTy" value="33.0" />
+              <property role="TgtnS" value="1.0;0.0;0.0;1.0;0.0;0.0" />
+            </node>
+          </node>
+        </node>
       </node>
       <node concept="2ZRQYt" id="4uAxemPynDi" role="2ZNJvH" />
     </node>
@@ -49245,6 +49380,9 @@
         </node>
       </node>
     </node>
+  </node>
+  <node concept="3QI7R4" id="2YJ6Svp6$rR">
+    <property role="TrG5h" value="Mysubcomponent" />
   </node>
 </model>
 


### PR DESCRIPTION
Original problem: When the layout data of a diagram with sub-diagrams is changed (e.g. auto-relayout), each diagram saves its own layout data, which means that multiple root nodes might be affected by a change. This PR adds a new option to save the layout data of sub-diagrams in the same location as the main diagram.

The option is not enabled by default. It can be enabled in the properties of the diagram cell:
![Screenshot 2023-02-27 at 08 56 57](https://user-images.githubusercontent.com/88385944/221506194-df06dc32-a726-46bb-a27d-2d2caa6ffe46.png)

 If there are multiple sub-diagram layers, this option has to be enabled for each sub-diagram.