### PR TITLE
mpsutil.blutil: deprecate MethodLineDoc + migrate BLDoc if possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,15 @@ All notable changes to this project are documented in this file.
 Format of the log is _loosely_ based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). 
 The project does _not_ follow Semantic Versioning and the changes are documented in reverse chronological order, grouped by calendar month.
 
-## Feburary 2024
+## February 2024
 
 ### Changed
 
 - com.mbeddr.mpsutil.editor.querylist: Dynamic generated nodes (without a model) can now be used in query lists if `read-only` is set to true.
+
+### Deprecated
+
+- MethodLineDoc is now deprecated and an automatic migration is provided to migrate to `jetbrains.mps.baseLanguage.javadoc`.
 
 ### Fixed
 

--- a/code/.mps/modules.xml
+++ b/code/.mps/modules.xml
@@ -7,6 +7,7 @@
       <modulePath path="$PROJECT_DIR$/blutil/languages/com.mbeddr.mpsutil.blutil/blutil.mpl" folder="blutil" />
       <modulePath path="$PROJECT_DIR$/blutil/languages/com.mbeddr.mpsutil.blutil/solutions/com.mbeddr.mpsutil.blutil.rt.msd" folder="blutil" />
       <modulePath path="$PROJECT_DIR$/blutil/solutions/com.mbeddr.mpsutil.blutil.genutil.rt/com.mbeddr.mpsutil.blutil.genutil.rt.msd" folder="blutil" />
+      <modulePath path="$PROJECT_DIR$/blutil/tests/test.com.mbeddr.mpsutil.blutil.doc/test.com.mbeddr.mpsutil.blutil.doc.msd" folder="blutil" />
       <modulePath path="$PROJECT_DIR$/blutil/tests/test.com.mbeddr.mpsutil.blutil.genutil.lang/test.com.mbeddr.mpsutil.blutil.genutil.lang.mpl" folder="blutil" />
       <modulePath path="$PROJECT_DIR$/blutil/tests/test.com.mbeddr.mpsutil.blutil.genutil/test.com.mbeddr.mpsutil.blutil.genutil.msd" folder="blutil" />
       <modulePath path="$PROJECT_DIR$/blutil/tests/test.ts.conceptswitch/test.ts.conceptswitch.msd" folder="blutil" />

--- a/code/blutil/languages/com.mbeddr.mpsutil.blutil/blutil.mpl
+++ b/code/blutil/languages/com.mbeddr.mpsutil.blutil/blutil.mpl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<language namespace="com.mbeddr.mpsutil.blutil" uuid="63e0e566-5131-447e-90e3-12ea330e1a00" languageVersion="1" moduleVersion="0">
+<language namespace="com.mbeddr.mpsutil.blutil" uuid="63e0e566-5131-447e-90e3-12ea330e1a00" languageVersion="3" moduleVersion="0">
   <models>
     <modelRoot contentPath="${module}" type="default">
       <sourceRoot location="languageModels" />
@@ -132,6 +132,7 @@
     <dependency reexport="false">8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)</dependency>
     <dependency reexport="false">92d2ea16-5a42-4fdf-a676-c7604efe3504(de.slisson.mps.richtext)</dependency>
     <dependency reexport="false">3a13115c-633c-4c5c-bbcc-75c4219e9555(jetbrains.mps.lang.quotation)</dependency>
+    <dependency reexport="false">f2801650-65d5-424e-bb1b-463a8781b786(jetbrains.mps.baseLanguage.javadoc)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
@@ -161,6 +162,7 @@
     <language slang="l:90746344-04fd-4286-97d5-b46ae6a81709:jetbrains.mps.lang.migration" version="2" />
     <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
     <language slang="l:d4615e3b-d671-4ba9-af01-2b78369b0ba7:jetbrains.mps.lang.pattern" version="2" />
+    <language slang="l:28f9e497-3b42-4291-aeba-0a1039153ab1:jetbrains.mps.lang.plugin" version="5" />
     <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
     <language slang="l:982eb8df-2c96-4bd7-9963-11712ea622e5:jetbrains.mps.lang.resources" version="2" />
     <language slang="l:b3551702-269c-4f05-ba61-58060cef4292:jetbrains.mps.lang.rulesAndMessages" version="0" />
@@ -190,6 +192,7 @@
     <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
     <module reference="fd392034-7849-419d-9071-12563d152375(jetbrains.mps.baseLanguage.closures)" version="0" />
     <module reference="83888646-71ce-4f1c-9c53-c54016f6ad4f(jetbrains.mps.baseLanguage.collections)" version="0" />
+    <module reference="f2801650-65d5-424e-bb1b-463a8781b786(jetbrains.mps.baseLanguage.javadoc)" version="0" />
     <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
     <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
     <module reference="63650c59-16c8-498a-99c8-005c7ee9515d(jetbrains.mps.lang.access)" version="0" />

--- a/code/blutil/languages/com.mbeddr.mpsutil.blutil/languageModels/migration.mps
+++ b/code/blutil/languages/com.mbeddr.mpsutil.blutil/languageModels/migration.mps
@@ -4,6 +4,10 @@
   <languages>
     <use id="90746344-04fd-4286-97d5-b46ae6a81709" name="jetbrains.mps.lang.migration" version="2" />
     <use id="c7d5b9dd-a05f-4be2-bc73-f2e16994cc67" name="jetbrains.mps.baseLanguage.lightweightdsl" version="1" />
+    <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="11" />
+    <use id="28f9e497-3b42-4291-aeba-0a1039153ab1" name="jetbrains.mps.lang.plugin" version="5" />
+    <use id="d4615e3b-d671-4ba9-af01-2b78369b0ba7" name="jetbrains.mps.lang.pattern" version="2" />
+    <use id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections" version="1" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -11,8 +15,13 @@
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" />
     <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" />
     <import index="tp25" ref="r:00000000-0000-4000-0000-011c89590301(jetbrains.mps.lang.smodel.structure)" />
-    <import index="slm6" ref="90746344-04fd-4286-97d5-b46ae6a81709/r:52a3d974-bd4f-4651-ba6e-a2de5e336d95(jetbrains.mps.lang.migration/jetbrains.mps.lang.migration.methods)" implicit="true" />
+    <import index="slm6" ref="90746344-04fd-4286-97d5-b46ae6a81709/r:52a3d974-bd4f-4651-ba6e-a2de5e336d95(jetbrains.mps.lang.migration/jetbrains.mps.lang.migration.methods)" />
+    <import index="m373" ref="r:4095af4f-a097-4799-aaa9-03df087ddfa6(jetbrains.mps.baseLanguage.javadoc.structure)" />
+    <import index="w1kc" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel(MPS.Core/)" />
     <import index="hba4" ref="63e0e566-5131-447e-90e3-12ea330e1a00/r:f5bd2ad9-cd54-4408-b815-07f9f306f074(com.mbeddr.mpsutil.blutil/com.mbeddr.mpsutil.blutil.structure)" implicit="true" />
+    <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" implicit="true" />
+    <import index="87nw" ref="r:ca2ab6bb-f6e7-4c0f-a88c-b78b9b31fff3(de.slisson.mps.richtext.structure)" implicit="true" />
+    <import index="tbr6" ref="r:6a005c26-87c0-43c4-8cf3-49ffba1099df(de.slisson.mps.richtext.behavior)" implicit="true" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
@@ -26,8 +35,18 @@
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
       </concept>
+      <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
+        <child id="1145553007750" name="creator" index="2ShVmc" />
+      </concept>
+      <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
+      <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu">
+        <child id="1165602531693" name="superclass" index="1zkMxy" />
+      </concept>
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ng" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
       </concept>
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
@@ -42,22 +61,29 @@
         <child id="1068580123134" name="parameter" index="3clF46" />
         <child id="1068580123135" name="body" index="3clF47" />
       </concept>
+      <concept id="1068580123165" name="jetbrains.mps.baseLanguage.structure.InstanceMethodDeclaration" flags="ig" index="3clFb_" />
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
+      <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6" />
       <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
         <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
       </concept>
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
+      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
       <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
         <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
       </concept>
+      <concept id="7812454656619025412" name="jetbrains.mps.baseLanguage.structure.LocalMethodCall" flags="nn" index="1rXfSq" />
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
         <child id="1109201940907" name="parameter" index="11_B2D" />
@@ -71,6 +97,9 @@
       <concept id="1144230876926" name="jetbrains.mps.baseLanguage.structure.AbstractForStatement" flags="nn" index="1DupvO">
         <child id="1144230900587" name="variable" index="1Duv9x" />
       </concept>
+      <concept id="5497648299878491908" name="jetbrains.mps.baseLanguage.structure.BaseVariableReference" flags="nn" index="1M0zk4">
+        <reference id="5497648299878491909" name="baseVariableDeclaration" index="1M0zk5" />
+      </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
       <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
     </language>
@@ -81,6 +110,9 @@
       </concept>
     </language>
     <language id="c7d5b9dd-a05f-4be2-bc73-f2e16994cc67" name="jetbrains.mps.baseLanguage.lightweightdsl">
+      <concept id="8880393040217246788" name="jetbrains.mps.baseLanguage.lightweightdsl.structure.MethodParameterInstance" flags="ig" index="ffn8J">
+        <reference id="8880393040217294897" name="decl" index="ffrpq" />
+      </concept>
       <concept id="3751132065236767083" name="jetbrains.mps.baseLanguage.lightweightdsl.structure.DependentTypeInstance" flags="ig" index="q3mfm">
         <reference id="3751132065236767084" name="decl" index="q3mfh" />
         <reference id="9097849371505568270" name="point" index="1QQUv3" />
@@ -95,6 +127,9 @@
         <property id="6478870542308703667" name="caption" index="3tTeZt" />
         <reference id="6478870542308703669" name="decl" index="3tTeZr" />
       </concept>
+      <concept id="6478870542308871875" name="jetbrains.mps.baseLanguage.lightweightdsl.structure.BooleanPropertyInstance" flags="ig" index="3tYpMH">
+        <property id="6478870542308871876" name="value" index="3tYpME" />
+      </concept>
       <concept id="6478870542308871428" name="jetbrains.mps.baseLanguage.lightweightdsl.structure.StringPropertyInstance" flags="ig" index="3tYpXE">
         <property id="6478870542308871429" name="value" index="3tYpXF" />
       </concept>
@@ -104,12 +139,22 @@
         <reference id="5455284157994012188" name="link" index="2pIpSl" />
         <child id="1595412875168045827" name="initValue" index="28nt2d" />
       </concept>
+      <concept id="5455284157993911077" name="jetbrains.mps.lang.quotation.structure.NodeBuilderInitProperty" flags="ng" index="2pJxcG">
+        <reference id="5455284157993911078" name="property" index="2pJxcJ" />
+        <child id="1595412875168045201" name="initValue" index="28ntcv" />
+      </concept>
       <concept id="5455284157993863837" name="jetbrains.mps.lang.quotation.structure.NodeBuilder" flags="nn" index="2pJPEk">
         <child id="5455284157993863838" name="quotedNode" index="2pJPEn" />
       </concept>
       <concept id="5455284157993863840" name="jetbrains.mps.lang.quotation.structure.NodeBuilderNode" flags="nn" index="2pJPED">
         <reference id="5455284157993910961" name="concept" index="2pJxaS" />
         <child id="5455284157993911099" name="values" index="2pJxcM" />
+      </concept>
+      <concept id="6985522012210254362" name="jetbrains.mps.lang.quotation.structure.NodeBuilderPropertyExpression" flags="nn" index="WxPPo">
+        <child id="6985522012210254363" name="expression" index="WxPPp" />
+      </concept>
+      <concept id="8182547171709738802" name="jetbrains.mps.lang.quotation.structure.NodeBuilderList" flags="nn" index="36be1Y">
+        <child id="8182547171709738803" name="nodes" index="36be1Z" />
       </concept>
       <concept id="8182547171709752110" name="jetbrains.mps.lang.quotation.structure.NodeBuilderExpression" flags="nn" index="36biLy">
         <child id="8182547171709752112" name="expression" index="36biLW" />
@@ -119,16 +164,56 @@
       <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
         <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
       </concept>
+      <concept id="1140725362528" name="jetbrains.mps.lang.smodel.structure.Link_SetTargetOperation" flags="nn" index="2oxUTD">
+        <child id="1140725362529" name="linkTarget" index="2oxUTC" />
+      </concept>
+      <concept id="4497478346159780083" name="jetbrains.mps.lang.smodel.structure.LanguageRefExpression" flags="ng" index="pHN19">
+        <child id="3542851458883491298" name="languageId" index="2V$M_3" />
+      </concept>
+      <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
       <concept id="1143226024141" name="jetbrains.mps.lang.smodel.structure.SModelType" flags="in" index="H_c77" />
+      <concept id="1143234257716" name="jetbrains.mps.lang.smodel.structure.Node_GetModelOperation" flags="nn" index="I4A8Y" />
+      <concept id="1883223317721008708" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfStatement" flags="nn" index="Jncv_">
+        <reference id="1883223317721008712" name="nodeConcept" index="JncvD" />
+        <child id="1883223317721008709" name="body" index="Jncv$" />
+        <child id="1883223317721008711" name="variable" index="JncvA" />
+        <child id="1883223317721008710" name="nodeExpression" index="JncvB" />
+      </concept>
+      <concept id="1883223317721008713" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfVariable" flags="ng" index="JncvC" />
+      <concept id="1883223317721107059" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfVarReference" flags="nn" index="Jnkvi" />
       <concept id="1171323947159" name="jetbrains.mps.lang.smodel.structure.Model_NodesOperation" flags="nn" index="2SmgA7">
         <child id="1758937410080001570" name="conceptArgument" index="1dBWTz" />
+      </concept>
+      <concept id="3542851458883438784" name="jetbrains.mps.lang.smodel.structure.LanguageId" flags="nn" index="2V$Bhx">
+        <property id="3542851458883439831" name="namespace" index="2V$B1Q" />
+        <property id="3542851458883439832" name="languageId" index="2V$B1T" />
+      </concept>
+      <concept id="1139613262185" name="jetbrains.mps.lang.smodel.structure.Node_GetParentOperation" flags="nn" index="1mfA1w" />
+      <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
+        <child id="1177027386292" name="conceptArgument" index="cj9EA" />
+      </concept>
+      <concept id="6407023681583036853" name="jetbrains.mps.lang.smodel.structure.NodeAttributeQualifier" flags="ng" index="3CFYIy">
+        <reference id="6407023681583036854" name="attributeConcept" index="3CFYIx" />
+      </concept>
+      <concept id="6407023681583031218" name="jetbrains.mps.lang.smodel.structure.AttributeAccess" flags="nn" index="3CFZ6_">
+        <child id="6407023681583036852" name="qualifier" index="3CFYIz" />
       </concept>
       <concept id="1140131837776" name="jetbrains.mps.lang.smodel.structure.Node_ReplaceWithAnotherOperation" flags="nn" index="1P9Npp">
         <child id="1140131861877" name="replacementNode" index="1P9ThW" />
       </concept>
+      <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
+        <reference id="1138405853777" name="concept" index="ehGHo" />
+      </concept>
+      <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
+        <reference id="1138056395725" name="property" index="3TsBF5" />
+      </concept>
       <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="nn" index="3TrEf2">
         <reference id="1138056516764" name="link" index="3Tt5mk" />
       </concept>
+      <concept id="1138056282393" name="jetbrains.mps.lang.smodel.structure.SLinkListAccess" flags="nn" index="3Tsc0h">
+        <reference id="1138056546658" name="link" index="3TtcxE" />
+      </concept>
+      <concept id="1228341669568" name="jetbrains.mps.lang.smodel.structure.Node_DetachOperation" flags="nn" index="3YRAZt" />
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
@@ -145,7 +230,13 @@
         <child id="1204796294226" name="closure" index="23t8la" />
       </concept>
       <concept id="1204980550705" name="jetbrains.mps.baseLanguage.collections.structure.VisitAllOperation" flags="nn" index="2es0OD" />
+      <concept id="1151689724996" name="jetbrains.mps.baseLanguage.collections.structure.SequenceType" flags="in" index="A3Dl8">
+        <child id="1151689745422" name="elementType" index="A3Ik2" />
+      </concept>
+      <concept id="1235566831861" name="jetbrains.mps.baseLanguage.collections.structure.AllOperation" flags="nn" index="2HxqBE" />
       <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
+      <concept id="1202120902084" name="jetbrains.mps.baseLanguage.collections.structure.WhereOperation" flags="nn" index="3zZkjj" />
+      <concept id="1202128969694" name="jetbrains.mps.baseLanguage.collections.structure.SelectOperation" flags="nn" index="3$u5V9" />
     </language>
   </registry>
   <node concept="3SyAh_" id="1b4F2fn_UKj">
@@ -275,6 +366,919 @@
         <ref role="q3mfh" to="slm6:4F5w8gPXEEe" />
         <ref role="1QQUv3" node="1b4F2fn_UNV" resolve="execute" />
       </node>
+    </node>
+  </node>
+  <node concept="3SyAh_" id="4mjBAwsq6F6">
+    <property role="qMTe8" value="1" />
+    <property role="TrG5h" value="methodLineDocToJavaDoc" />
+    <node concept="3Tm1VV" id="4mjBAwsq6F7" role="1B3o_S" />
+    <node concept="3tTeZs" id="4mjBAwsq6F8" role="jymVt">
+      <property role="3tTeZt" value="&lt;no execute after&gt;" />
+      <ref role="3tTeZr" to="slm6:7ay_HjIMt1a" resolve="execute after" />
+    </node>
+    <node concept="3tTeZs" id="4mjBAwsq6F9" role="jymVt">
+      <property role="3tTeZt" value="&lt;no required data&gt;" />
+      <ref role="3tTeZr" to="slm6:5TUCQr2FPTh" resolve="requires annotation data" />
+    </node>
+    <node concept="3tTeZs" id="4mjBAwsq6Fa" role="jymVt">
+      <property role="3tTeZt" value="&lt;no produced data&gt;" />
+      <ref role="3tTeZr" to="slm6:5TUCQr2C271" resolve="produces annotation data" />
+    </node>
+    <node concept="2tJIrI" id="4mjBAwsq6Fb" role="jymVt" />
+    <node concept="3tYpMH" id="4mjBAwsq6Fc" role="jymVt">
+      <property role="TrG5h" value="isRerunnable" />
+      <property role="3tYpME" value="true" />
+      <ref role="25KYV2" to="slm6:1JWcQ2VeWIs" resolve="isRerunnable" />
+      <node concept="3Tm1VV" id="4mjBAwsq6Fd" role="1B3o_S" />
+      <node concept="10P_77" id="4mjBAwsq6Fe" role="1tU5fm" />
+    </node>
+    <node concept="3tTeZs" id="4mjBAwsq6Ff" role="jymVt">
+      <property role="3tTeZt" value="&lt;description&gt;" />
+      <ref role="3tTeZr" to="slm6:1_lSsE3RFpE" resolve="description" />
+    </node>
+    <node concept="q3mfD" id="4mjBAwsq6Fg" role="jymVt">
+      <property role="TrG5h" value="execute" />
+      <ref role="2VtyIY" to="slm6:4ubqdNOF9cA" resolve="execute" />
+      <node concept="3Tm1VV" id="4mjBAwsq6Fi" role="1B3o_S" />
+      <node concept="3clFbS" id="4mjBAwsq6Fk" role="3clF47">
+        <node concept="3cpWs8" id="4mjBAwsqfNW" role="3cqZAp">
+          <node concept="3cpWsn" id="4mjBAwsqfNX" role="3cpWs9">
+            <property role="TrG5h" value="models" />
+            <node concept="3uibUv" id="4mjBAwsqfNY" role="1tU5fm">
+              <ref role="3uigEE" to="wyt6:~Iterable" resolve="Iterable" />
+              <node concept="3uibUv" id="4mjBAwsqfNZ" role="11_B2D">
+                <ref role="3uigEE" to="mhbf:~SModel" resolve="SModel" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="4mjBAwsqfO0" role="33vP2m">
+              <node concept="37vLTw" id="4mjBAwsqfO1" role="2Oq$k0">
+                <ref role="3cqZAo" node="4mjBAwsq6Fm" resolve="m" />
+              </node>
+              <node concept="liA8E" id="4mjBAwsqfO2" role="2OqNvi">
+                <ref role="37wK5l" to="lui2:~SModule.getModels()" resolve="getModels" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1DcWWT" id="4mjBAwsqfO3" role="3cqZAp">
+          <node concept="3clFbS" id="4mjBAwsqfO4" role="2LFqv$">
+            <node concept="3clFbF" id="4mjBAwsqfO5" role="3cqZAp">
+              <node concept="2OqwBi" id="4mjBAwsqfO6" role="3clFbG">
+                <node concept="2OqwBi" id="4mjBAwsqfO7" role="2Oq$k0">
+                  <node concept="37vLTw" id="4mjBAwsqfO8" role="2Oq$k0">
+                    <ref role="3cqZAo" node="4mjBAwsqfOt" resolve="model" />
+                  </node>
+                  <node concept="2SmgA7" id="4mjBAwsqfO9" role="2OqNvi">
+                    <node concept="chp4Y" id="4mjBAwsqfOa" role="1dBWTz">
+                      <ref role="cht4Q" to="hba4:5A94f9Eu4RV" resolve="MethodLineDoc" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2es0OD" id="4mjBAwsqfOb" role="2OqNvi">
+                  <node concept="1bVj0M" id="4mjBAwsqfOc" role="23t8la">
+                    <node concept="3clFbS" id="4mjBAwsqfOd" role="1bW5cS">
+                      <node concept="3clFbF" id="4mjBAwsqfOe" role="3cqZAp">
+                        <node concept="1rXfSq" id="4mjBAwsqGz5" role="3clFbG">
+                          <ref role="37wK5l" node="4mjBAwsqjFC" resolve="replaceNode" />
+                          <node concept="37vLTw" id="4mjBAwsqH05" role="37wK5m">
+                            <ref role="3cqZAo" node="4mjBAwsqfOr" resolve="it" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="Rh6nW" id="4mjBAwsqfOr" role="1bW2Oz">
+                      <property role="TrG5h" value="it" />
+                      <node concept="2jxLKc" id="4mjBAwsqfOs" role="1tU5fm" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWsn" id="4mjBAwsqfOt" role="1Duv9x">
+            <property role="TrG5h" value="model" />
+            <node concept="H_c77" id="4mjBAwsqfOu" role="1tU5fm" />
+          </node>
+          <node concept="37vLTw" id="4mjBAwsqfOv" role="1DdaDG">
+            <ref role="3cqZAo" node="4mjBAwsqfNX" resolve="models" />
+          </node>
+        </node>
+      </node>
+      <node concept="ffn8J" id="4mjBAwsq6Fm" role="3clF46">
+        <property role="TrG5h" value="m" />
+        <ref role="ffrpq" to="slm6:7fCCGqboj9J" resolve="m" />
+        <node concept="3uibUv" id="4mjBAwsq6Fl" role="1tU5fm">
+          <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
+        </node>
+      </node>
+      <node concept="q3mfm" id="4mjBAwsq6Fn" role="3clF45">
+        <ref role="q3mfh" to="slm6:4F5w8gPXEEe" />
+        <ref role="1QQUv3" node="4mjBAwsq6Fg" resolve="execute" />
+      </node>
+    </node>
+    <node concept="3tTeZs" id="4mjBAwsq6Fo" role="jymVt">
+      <property role="3tTeZt" value="&lt;no result checking&gt;" />
+      <ref role="3tTeZr" to="slm6:1JWcQ2VeXpD" resolve="check" />
+    </node>
+    <node concept="3uibUv" id="4mjBAwsq6Fp" role="1zkMxy">
+      <ref role="3uigEE" to="slm6:5TUCQr2ybBO" resolve="HasMigrationScriptReference" />
+    </node>
+    <node concept="2tJIrI" id="4mjBAwsqihH" role="jymVt" />
+    <node concept="3clFb_" id="4mjBAwsqjFC" role="jymVt">
+      <property role="TrG5h" value="replaceNode" />
+      <node concept="3clFbS" id="4mjBAwsqjFF" role="3clF47">
+        <node concept="3clFbF" id="70cGcTIJ04G" role="3cqZAp">
+          <node concept="2OqwBi" id="70cGcTIJ2ng" role="3clFbG">
+            <node concept="2ShNRf" id="70cGcTIJ04$" role="2Oq$k0">
+              <node concept="1pGfFk" id="70cGcTIJ0$I" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="w1kc:~ModelImports.&lt;init&gt;(org.jetbrains.mps.openapi.model.SModel)" resolve="ModelImports" />
+                <node concept="2OqwBi" id="70cGcTIJ1Ej" role="37wK5m">
+                  <node concept="37vLTw" id="70cGcTIJ0Lf" role="2Oq$k0">
+                    <ref role="3cqZAo" node="4mjBAwsqk$7" resolve="node" />
+                  </node>
+                  <node concept="I4A8Y" id="70cGcTIJ25Q" role="2OqNvi" />
+                </node>
+              </node>
+            </node>
+            <node concept="liA8E" id="70cGcTIJ2C_" role="2OqNvi">
+              <ref role="37wK5l" to="w1kc:~ModelImports.addUsedLanguage(org.jetbrains.mps.openapi.language.SLanguage)" resolve="addUsedLanguage" />
+              <node concept="pHN19" id="70cGcTIJ2SG" role="37wK5m">
+                <node concept="2V$Bhx" id="70cGcTIJ33Z" role="2V$M_3">
+                  <property role="2V$B1T" value="f2801650-65d5-424e-bb1b-463a8781b786" />
+                  <property role="2V$B1Q" value="jetbrains.mps.baseLanguage.javadoc" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="70cGcTIJ19W" role="3cqZAp" />
+        <node concept="3cpWs8" id="4mjBAwsqPj9" role="3cqZAp">
+          <node concept="3cpWsn" id="4mjBAwsqPjc" role="3cpWs9">
+            <property role="TrG5h" value="nodeWithAnnotation" />
+            <node concept="3Tqbb2" id="4mjBAwsqPj7" role="1tU5fm" />
+            <node concept="2OqwBi" id="4mjBAwsqS3L" role="33vP2m">
+              <node concept="37vLTw" id="4mjBAwsqROK" role="2Oq$k0">
+                <ref role="3cqZAo" node="4mjBAwsqk$7" resolve="node" />
+              </node>
+              <node concept="1mfA1w" id="4mjBAwsqSK2" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4mjBAwsqUYY" role="3cqZAp">
+          <node concept="2OqwBi" id="4mjBAwsqVcQ" role="3clFbG">
+            <node concept="37vLTw" id="4mjBAwsqUYW" role="2Oq$k0">
+              <ref role="3cqZAo" node="4mjBAwsqk$7" resolve="node" />
+            </node>
+            <node concept="3YRAZt" id="4mjBAwsqVUU" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="3cpWs8" id="1LCsd5kox7z" role="3cqZAp">
+          <node concept="3cpWsn" id="1LCsd5kox7A" role="3cpWs9">
+            <property role="TrG5h" value="text" />
+            <node concept="17QB3L" id="1LCsd5kox7x" role="1tU5fm" />
+            <node concept="2OqwBi" id="1LCsd5koybV" role="33vP2m">
+              <node concept="37vLTw" id="1LCsd5koxUC" role="2Oq$k0">
+                <ref role="3cqZAo" node="4mjBAwsqk$7" resolve="node" />
+              </node>
+              <node concept="3TrcHB" id="1LCsd5koyTS" role="2OqNvi">
+                <ref role="3TsBF5" to="hba4:5A94f9Eu4Sh" resolve="text" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="1LCsd5kowC2" role="3cqZAp" />
+        <node concept="Jncv_" id="4mjBAwsqq1W" role="3cqZAp">
+          <ref role="JncvD" to="tpee:fzclF7W" resolve="BaseMethodDeclaration" />
+          <node concept="37vLTw" id="4mjBAwsqqvo" role="JncvB">
+            <ref role="3cqZAo" node="4mjBAwsqPjc" resolve="nodeWithAnnotation" />
+          </node>
+          <node concept="3clFbS" id="4mjBAwsqq1Y" role="Jncv$">
+            <node concept="3clFbF" id="4mjBAwsqWtm" role="3cqZAp">
+              <node concept="2OqwBi" id="4mjBAwsr0Ai" role="3clFbG">
+                <node concept="2OqwBi" id="4mjBAwsqX1e" role="2Oq$k0">
+                  <node concept="Jnkvi" id="4mjBAwsqZrF" role="2Oq$k0">
+                    <ref role="1M0zk5" node="4mjBAwsqq1Z" resolve="method" />
+                  </node>
+                  <node concept="3CFZ6_" id="4mjBAwsqXAe" role="2OqNvi">
+                    <node concept="3CFYIy" id="4mjBAwsr000" role="3CFYIz">
+                      <ref role="3CFYIx" to="m373:4CW56HZFIGO" resolve="MethodDocComment" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2oxUTD" id="4mjBAwsrds_" role="2OqNvi">
+                  <node concept="2pJPEk" id="4mjBAwsrfN3" role="2oxUTC">
+                    <node concept="2pJPED" id="4mjBAwsrfN5" role="2pJPEn">
+                      <ref role="2pJxaS" to="m373:4CW56HZFIGO" resolve="MethodDocComment" />
+                      <node concept="2pIpSj" id="4mjBAwsrgNU" role="2pJxcM">
+                        <ref role="2pIpSl" to="m373:7lVCwDcxZ_I" resolve="body" />
+                        <node concept="36be1Y" id="1LCsd5koFep" role="28nt2d">
+                          <node concept="36biLy" id="1LCsd5koG_t" role="36be1Z">
+                            <node concept="1rXfSq" id="1LCsd5kou5y" role="36biLW">
+                              <ref role="37wK5l" node="1LCsd5kooko" resolve="createComment" />
+                              <node concept="37vLTw" id="1LCsd5kozHL" role="37wK5m">
+                                <ref role="3cqZAo" node="1LCsd5kox7A" resolve="text" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs6" id="1LCsd5koJGQ" role="3cqZAp" />
+          </node>
+          <node concept="JncvC" id="4mjBAwsqq1Z" role="JncvA">
+            <property role="TrG5h" value="method" />
+            <node concept="2jxLKc" id="4mjBAwsqq20" role="1tU5fm" />
+          </node>
+        </node>
+        <node concept="Jncv_" id="1LCsd5ko4fI" role="3cqZAp">
+          <ref role="JncvD" to="tpee:f$Wx3kv" resolve="StaticFieldDeclaration" />
+          <node concept="37vLTw" id="1LCsd5ko4Gz" role="JncvB">
+            <ref role="3cqZAo" node="4mjBAwsqPjc" resolve="nodeWithAnnotation" />
+          </node>
+          <node concept="3clFbS" id="1LCsd5ko4fM" role="Jncv$">
+            <node concept="3clFbF" id="1LCsd5kofnz" role="3cqZAp">
+              <node concept="2OqwBi" id="1LCsd5koiuE" role="3clFbG">
+                <node concept="2OqwBi" id="1LCsd5kog1V" role="2Oq$k0">
+                  <node concept="Jnkvi" id="1LCsd5kofny" role="2Oq$k0">
+                    <ref role="1M0zk5" node="1LCsd5ko4fO" resolve="declaration" />
+                  </node>
+                  <node concept="3CFZ6_" id="1LCsd5kohkw" role="2OqNvi">
+                    <node concept="3CFYIy" id="1LCsd5kohTx" role="3CFYIz">
+                      <ref role="3CFYIx" to="m373:5VgPTPXL4JM" resolve="FieldDocComment" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2oxUTD" id="1LCsd5kojS0" role="2OqNvi">
+                  <node concept="2pJPEk" id="1LCsd5kokl2" role="2oxUTC">
+                    <node concept="2pJPED" id="1LCsd5kokl4" role="2pJPEn">
+                      <ref role="2pJxaS" to="m373:5VgPTPXL4JM" resolve="FieldDocComment" />
+                      <node concept="2pIpSj" id="1LCsd5kolrs" role="2pJxcM">
+                        <ref role="2pIpSl" to="m373:7lVCwDcxZ_I" resolve="body" />
+                        <node concept="36be1Y" id="1LCsd5koHv4" role="28nt2d">
+                          <node concept="36biLy" id="1LCsd5koHv5" role="36be1Z">
+                            <node concept="1rXfSq" id="1LCsd5koHv6" role="36biLW">
+                              <ref role="37wK5l" node="1LCsd5kooko" resolve="createComment" />
+                              <node concept="37vLTw" id="1LCsd5koHv7" role="37wK5m">
+                                <ref role="3cqZAo" node="1LCsd5kox7A" resolve="text" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs6" id="1LCsd5koKAF" role="3cqZAp" />
+          </node>
+          <node concept="JncvC" id="1LCsd5ko4fO" role="JncvA">
+            <property role="TrG5h" value="declaration" />
+            <node concept="2jxLKc" id="1LCsd5ko4fP" role="1tU5fm" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="1LCsd5ko6Xp" role="3cqZAp" />
+        <node concept="Jncv_" id="1LCsd5ko7Ow" role="3cqZAp">
+          <ref role="JncvD" to="tpee:fz12cDC" resolve="FieldDeclaration" />
+          <node concept="37vLTw" id="1LCsd5ko8hS" role="JncvB">
+            <ref role="3cqZAo" node="4mjBAwsqPjc" resolve="nodeWithAnnotation" />
+          </node>
+          <node concept="3clFbS" id="1LCsd5ko7O$" role="Jncv$">
+            <node concept="3clFbF" id="1LCsd5koAgp" role="3cqZAp">
+              <node concept="2OqwBi" id="1LCsd5koAgq" role="3clFbG">
+                <node concept="2OqwBi" id="1LCsd5koAgr" role="2Oq$k0">
+                  <node concept="Jnkvi" id="1LCsd5koAgs" role="2Oq$k0">
+                    <ref role="1M0zk5" node="1LCsd5ko7OA" resolve="declaration" />
+                  </node>
+                  <node concept="3CFZ6_" id="1LCsd5koAgt" role="2OqNvi">
+                    <node concept="3CFYIy" id="1LCsd5koAgu" role="3CFYIz">
+                      <ref role="3CFYIx" to="m373:5VgPTPXL4JM" resolve="FieldDocComment" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2oxUTD" id="1LCsd5koAgv" role="2OqNvi">
+                  <node concept="2pJPEk" id="1LCsd5koAgw" role="2oxUTC">
+                    <node concept="2pJPED" id="1LCsd5koAgx" role="2pJPEn">
+                      <ref role="2pJxaS" to="m373:5VgPTPXL4JM" resolve="FieldDocComment" />
+                      <node concept="2pIpSj" id="1LCsd5koAgy" role="2pJxcM">
+                        <ref role="2pIpSl" to="m373:7lVCwDcxZ_I" resolve="body" />
+                        <node concept="36be1Y" id="1LCsd5koI89" role="28nt2d">
+                          <node concept="36biLy" id="1LCsd5koI8a" role="36be1Z">
+                            <node concept="1rXfSq" id="1LCsd5koI8b" role="36biLW">
+                              <ref role="37wK5l" node="1LCsd5kooko" resolve="createComment" />
+                              <node concept="37vLTw" id="1LCsd5koI8c" role="37wK5m">
+                                <ref role="3cqZAo" node="1LCsd5kox7A" resolve="text" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs6" id="1LCsd5koLww" role="3cqZAp" />
+          </node>
+          <node concept="JncvC" id="1LCsd5ko7OA" role="JncvA">
+            <property role="TrG5h" value="declaration" />
+            <node concept="2jxLKc" id="1LCsd5ko7OB" role="1tU5fm" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="1LCsd5koB39" role="3cqZAp" />
+        <node concept="Jncv_" id="1LCsd5koCf5" role="3cqZAp">
+          <ref role="JncvD" to="tpee:g7pOWCK" resolve="Classifier" />
+          <node concept="37vLTw" id="1LCsd5koCJ7" role="JncvB">
+            <ref role="3cqZAo" node="4mjBAwsqPjc" resolve="nodeWithAnnotation" />
+          </node>
+          <node concept="3clFbS" id="1LCsd5koCf9" role="Jncv$">
+            <node concept="3clFbF" id="1LCsd5koIEy" role="3cqZAp">
+              <node concept="2OqwBi" id="1LCsd5koIEz" role="3clFbG">
+                <node concept="2OqwBi" id="1LCsd5koIE$" role="2Oq$k0">
+                  <node concept="Jnkvi" id="1LCsd5koIE_" role="2Oq$k0">
+                    <ref role="1M0zk5" node="1LCsd5koCfb" resolve="classifier" />
+                  </node>
+                  <node concept="3CFZ6_" id="1LCsd5koIEA" role="2OqNvi">
+                    <node concept="3CFYIy" id="1LCsd5koIEB" role="3CFYIz">
+                      <ref role="3CFYIx" to="m373:1MQnpZAqBpc" resolve="ClassifierDocComment" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2oxUTD" id="1LCsd5koIEC" role="2OqNvi">
+                  <node concept="2pJPEk" id="1LCsd5koIED" role="2oxUTC">
+                    <node concept="2pJPED" id="1LCsd5koIEE" role="2pJPEn">
+                      <ref role="2pJxaS" to="m373:1MQnpZAqBpc" resolve="ClassifierDocComment" />
+                      <node concept="2pIpSj" id="1LCsd5koIEF" role="2pJxcM">
+                        <ref role="2pIpSl" to="m373:7lVCwDcxZ_I" resolve="body" />
+                        <node concept="36be1Y" id="1LCsd5koIEG" role="28nt2d">
+                          <node concept="36biLy" id="1LCsd5koIEH" role="36be1Z">
+                            <node concept="1rXfSq" id="1LCsd5koIEI" role="36biLW">
+                              <ref role="37wK5l" node="1LCsd5kooko" resolve="createComment" />
+                              <node concept="37vLTw" id="1LCsd5koIEJ" role="37wK5m">
+                                <ref role="3cqZAo" node="1LCsd5kox7A" resolve="text" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs6" id="1LCsd5koMyD" role="3cqZAp" />
+          </node>
+          <node concept="JncvC" id="1LCsd5koCfb" role="JncvA">
+            <property role="TrG5h" value="classifier" />
+            <node concept="2jxLKc" id="1LCsd5koCfc" role="1tU5fm" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="1LCsd5kr$n4" role="3cqZAp" />
+        <node concept="3clFbF" id="1LCsd5kr_kH" role="3cqZAp">
+          <node concept="2OqwBi" id="1LCsd5krBfI" role="3clFbG">
+            <node concept="2OqwBi" id="1LCsd5kr_T7" role="2Oq$k0">
+              <node concept="37vLTw" id="1LCsd5kr_kF" role="2Oq$k0">
+                <ref role="3cqZAo" node="4mjBAwsqPjc" resolve="nodeWithAnnotation" />
+              </node>
+              <node concept="3CFZ6_" id="1LCsd5krAu2" role="2OqNvi">
+                <node concept="3CFYIy" id="1LCsd5krB18" role="3CFYIz">
+                  <ref role="3CFYIx" to="hba4:3d2YJYTUdju" resolve="BLDoc" />
+                </node>
+              </node>
+            </node>
+            <node concept="2oxUTD" id="1LCsd5krC2a" role="2OqNvi">
+              <node concept="2pJPEk" id="1LCsd5krD$Q" role="2oxUTC">
+                <node concept="2pJPED" id="1LCsd5krD$S" role="2pJPEn">
+                  <ref role="2pJxaS" to="hba4:3d2YJYTUdju" resolve="BLDoc" />
+                  <node concept="2pIpSj" id="1LCsd5krE$o" role="2pJxcM">
+                    <ref role="2pIpSl" to="hba4:3d2YJYTUdjv" resolve="text" />
+                    <node concept="2pJPED" id="1LCsd5krG3_" role="28nt2d">
+                      <ref role="2pJxaS" to="87nw:2dWzqxEB$Tx" resolve="Text" />
+                      <node concept="2pIpSj" id="1LCsd5krGyR" role="2pJxcM">
+                        <ref role="2pIpSl" to="87nw:2dWzqxEBBFI" resolve="words" />
+                        <node concept="2pJPED" id="1LCsd5krH2T" role="28nt2d">
+                          <ref role="2pJxaS" to="87nw:2dWzqxEBMSc" resolve="Word" />
+                          <node concept="2pJxcG" id="1LCsd5krHyc" role="2pJxcM">
+                            <ref role="2pJxcJ" to="87nw:2dWzqxEBMSe" resolve="escapedValue" />
+                            <node concept="WxPPo" id="1LCsd5krI20" role="28ntcv">
+                              <node concept="37vLTw" id="1LCsd5krI1Y" role="WxPPp">
+                                <ref role="3cqZAo" node="1LCsd5kox7A" resolve="text" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="4mjBAwsqk$7" role="3clF46">
+        <property role="TrG5h" value="node" />
+        <node concept="3Tqbb2" id="4mjBAwsqk$6" role="1tU5fm">
+          <ref role="ehGHo" to="hba4:5A94f9Eu4RV" resolve="MethodLineDoc" />
+        </node>
+      </node>
+      <node concept="3cqZAl" id="4mjBAwsqOfQ" role="3clF45" />
+    </node>
+    <node concept="2tJIrI" id="1LCsd5knV9j" role="jymVt" />
+    <node concept="3clFb_" id="1LCsd5kooko" role="jymVt">
+      <property role="TrG5h" value="createComment" />
+      <node concept="3clFbS" id="1LCsd5kookr" role="3clF47">
+        <node concept="3clFbF" id="1LCsd5koq1A" role="3cqZAp">
+          <node concept="2pJPEk" id="1LCsd5koq1$" role="3clFbG">
+            <node concept="2pJPED" id="1LCsd5koq1_" role="2pJPEn">
+              <ref role="2pJxaS" to="m373:7lVCwDcxZ_G" resolve="CommentLine" />
+              <node concept="2pIpSj" id="1LCsd5kor4N" role="2pJxcM">
+                <ref role="2pIpSl" to="m373:7LZmMWLAgad" resolve="part" />
+                <node concept="2pJPED" id="1LCsd5korz1" role="28nt2d">
+                  <ref role="2pJxaS" to="m373:7LZmMWLAga7" resolve="TextCommentLinePart" />
+                  <node concept="2pJxcG" id="1LCsd5kos2S" role="2pJxcM">
+                    <ref role="2pJxcJ" to="m373:7LZmMWLAga8" resolve="text" />
+                    <node concept="WxPPo" id="1LCsd5kosxZ" role="28ntcv">
+                      <node concept="37vLTw" id="1LCsd5kosxX" role="WxPPp">
+                        <ref role="3cqZAo" node="1LCsd5kooQb" resolve="text" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tqbb2" id="1LCsd5konqL" role="3clF45">
+        <ref role="ehGHo" to="m373:7lVCwDcxZ_G" resolve="CommentLine" />
+      </node>
+      <node concept="37vLTG" id="1LCsd5kooQb" role="3clF46">
+        <property role="TrG5h" value="text" />
+        <node concept="17QB3L" id="1LCsd5kooQa" role="1tU5fm" />
+      </node>
+    </node>
+  </node>
+  <node concept="3SyAh_" id="1LCsd5kp3dn">
+    <property role="qMTe8" value="2" />
+    <property role="TrG5h" value="BLDocToJavaDoc" />
+    <node concept="3Tm1VV" id="1LCsd5kp3do" role="1B3o_S" />
+    <node concept="3tTeZs" id="1LCsd5kp3dp" role="jymVt">
+      <property role="3tTeZt" value="&lt;no execute after&gt;" />
+      <ref role="3tTeZr" to="slm6:7ay_HjIMt1a" resolve="execute after" />
+    </node>
+    <node concept="3tTeZs" id="1LCsd5kp3dq" role="jymVt">
+      <property role="3tTeZt" value="&lt;no required data&gt;" />
+      <ref role="3tTeZr" to="slm6:5TUCQr2FPTh" resolve="requires annotation data" />
+    </node>
+    <node concept="3tTeZs" id="1LCsd5kp3dr" role="jymVt">
+      <property role="3tTeZt" value="&lt;no produced data&gt;" />
+      <ref role="3tTeZr" to="slm6:5TUCQr2C271" resolve="produces annotation data" />
+    </node>
+    <node concept="2tJIrI" id="1LCsd5kp3ds" role="jymVt" />
+    <node concept="3tYpMH" id="1LCsd5kp3dt" role="jymVt">
+      <property role="TrG5h" value="isRerunnable" />
+      <property role="3tYpME" value="true" />
+      <ref role="25KYV2" to="slm6:1JWcQ2VeWIs" resolve="isRerunnable" />
+      <node concept="3Tm1VV" id="1LCsd5kp3du" role="1B3o_S" />
+      <node concept="10P_77" id="1LCsd5kp3dv" role="1tU5fm" />
+    </node>
+    <node concept="3tTeZs" id="1LCsd5kp3dw" role="jymVt">
+      <property role="3tTeZt" value="&lt;description&gt;" />
+      <ref role="3tTeZr" to="slm6:1_lSsE3RFpE" resolve="description" />
+    </node>
+    <node concept="q3mfD" id="1LCsd5kp3dx" role="jymVt">
+      <property role="TrG5h" value="execute" />
+      <ref role="2VtyIY" to="slm6:4ubqdNOF9cA" resolve="execute" />
+      <node concept="3Tm1VV" id="1LCsd5kp3dz" role="1B3o_S" />
+      <node concept="3clFbS" id="1LCsd5kp3d_" role="3clF47">
+        <node concept="3cpWs8" id="1LCsd5kp9as" role="3cqZAp">
+          <node concept="3cpWsn" id="1LCsd5kp9at" role="3cpWs9">
+            <property role="TrG5h" value="models" />
+            <node concept="3uibUv" id="1LCsd5kp9au" role="1tU5fm">
+              <ref role="3uigEE" to="wyt6:~Iterable" resolve="Iterable" />
+              <node concept="3uibUv" id="1LCsd5kp9av" role="11_B2D">
+                <ref role="3uigEE" to="mhbf:~SModel" resolve="SModel" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="1LCsd5kp9aw" role="33vP2m">
+              <node concept="37vLTw" id="1LCsd5kp9ax" role="2Oq$k0">
+                <ref role="3cqZAo" node="1LCsd5kp3dB" resolve="m" />
+              </node>
+              <node concept="liA8E" id="1LCsd5kp9ay" role="2OqNvi">
+                <ref role="37wK5l" to="lui2:~SModule.getModels()" resolve="getModels" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1DcWWT" id="1LCsd5kp9az" role="3cqZAp">
+          <node concept="3clFbS" id="1LCsd5kp9a$" role="2LFqv$">
+            <node concept="3clFbF" id="1LCsd5kq$$1" role="3cqZAp">
+              <node concept="2OqwBi" id="1LCsd5kqErz" role="3clFbG">
+                <node concept="2OqwBi" id="1LCsd5kqS0i" role="2Oq$k0">
+                  <node concept="2OqwBi" id="1LCsd5kq_h_" role="2Oq$k0">
+                    <node concept="37vLTw" id="1LCsd5kq$zZ" role="2Oq$k0">
+                      <ref role="3cqZAo" node="1LCsd5kp9aN" resolve="model" />
+                    </node>
+                    <node concept="2SmgA7" id="1LCsd5kqA8y" role="2OqNvi">
+                      <node concept="chp4Y" id="1LCsd5kqBMp" role="1dBWTz">
+                        <ref role="cht4Q" to="hba4:3d2YJYTUdju" resolve="BLDoc" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3zZkjj" id="1LCsd5kqV27" role="2OqNvi">
+                    <node concept="1bVj0M" id="1LCsd5kqV29" role="23t8la">
+                      <node concept="3clFbS" id="1LCsd5kqV2a" role="1bW5cS">
+                        <node concept="3clFbF" id="1LCsd5kqVMq" role="3cqZAp">
+                          <node concept="2OqwBi" id="1LCsd5kqVMs" role="3clFbG">
+                            <node concept="2OqwBi" id="1LCsd5kqVMt" role="2Oq$k0">
+                              <node concept="2OqwBi" id="1LCsd5kqVMu" role="2Oq$k0">
+                                <node concept="37vLTw" id="1LCsd5kqVMv" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="1LCsd5kqV2b" resolve="it" />
+                                </node>
+                                <node concept="3TrEf2" id="1LCsd5kqVMw" role="2OqNvi">
+                                  <ref role="3Tt5mk" to="hba4:3d2YJYTUdjv" resolve="text" />
+                                </node>
+                              </node>
+                              <node concept="3Tsc0h" id="1LCsd5kqVMx" role="2OqNvi">
+                                <ref role="3TtcxE" to="87nw:2dWzqxEBBFI" resolve="words" />
+                              </node>
+                            </node>
+                            <node concept="2HxqBE" id="1LCsd5kqVMy" role="2OqNvi">
+                              <node concept="1bVj0M" id="1LCsd5kqVMz" role="23t8la">
+                                <node concept="3clFbS" id="1LCsd5kqVM$" role="1bW5cS">
+                                  <node concept="3clFbF" id="1LCsd5kqVM_" role="3cqZAp">
+                                    <node concept="2OqwBi" id="1LCsd5kqVMH" role="3clFbG">
+                                      <node concept="37vLTw" id="1LCsd5kqVMI" role="2Oq$k0">
+                                        <ref role="3cqZAo" node="1LCsd5kqVML" resolve="it" />
+                                      </node>
+                                      <node concept="1mIQ4w" id="1LCsd5kqVMJ" role="2OqNvi">
+                                        <node concept="chp4Y" id="1LCsd5kqVMK" role="cj9EA">
+                                          <ref role="cht4Q" to="87nw:2dWzqxEBMSc" resolve="Word" />
+                                        </node>
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                                <node concept="Rh6nW" id="1LCsd5kqVML" role="1bW2Oz">
+                                  <property role="TrG5h" value="it" />
+                                  <node concept="2jxLKc" id="1LCsd5kqVMM" role="1tU5fm" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="Rh6nW" id="1LCsd5kqV2b" role="1bW2Oz">
+                        <property role="TrG5h" value="it" />
+                        <node concept="2jxLKc" id="1LCsd5kqV2c" role="1tU5fm" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="2es0OD" id="1LCsd5kqHth" role="2OqNvi">
+                  <node concept="1bVj0M" id="1LCsd5kqHtj" role="23t8la">
+                    <node concept="3clFbS" id="1LCsd5kqHtk" role="1bW5cS">
+                      <node concept="3clFbF" id="1LCsd5kqI58" role="3cqZAp">
+                        <node concept="1rXfSq" id="1LCsd5kriju" role="3clFbG">
+                          <ref role="37wK5l" node="1LCsd5kqvor" resolve="replaceNode" />
+                          <node concept="37vLTw" id="1LCsd5kriYV" role="37wK5m">
+                            <ref role="3cqZAo" node="1LCsd5kqHtl" resolve="it" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="Rh6nW" id="1LCsd5kqHtl" role="1bW2Oz">
+                      <property role="TrG5h" value="it" />
+                      <node concept="2jxLKc" id="1LCsd5kqHtm" role="1tU5fm" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWsn" id="1LCsd5kp9aN" role="1Duv9x">
+            <property role="TrG5h" value="model" />
+            <node concept="H_c77" id="1LCsd5kp9aO" role="1tU5fm" />
+          </node>
+          <node concept="37vLTw" id="1LCsd5kp9aP" role="1DdaDG">
+            <ref role="3cqZAo" node="1LCsd5kp9at" resolve="models" />
+          </node>
+        </node>
+      </node>
+      <node concept="ffn8J" id="1LCsd5kp3dB" role="3clF46">
+        <property role="TrG5h" value="m" />
+        <ref role="ffrpq" to="slm6:7fCCGqboj9J" resolve="m" />
+        <node concept="3uibUv" id="1LCsd5kp3dA" role="1tU5fm">
+          <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
+        </node>
+      </node>
+      <node concept="q3mfm" id="1LCsd5kp3dC" role="3clF45">
+        <ref role="q3mfh" to="slm6:4F5w8gPXEEe" />
+        <ref role="1QQUv3" node="1LCsd5kp3dx" resolve="execute" />
+      </node>
+    </node>
+    <node concept="3tTeZs" id="1LCsd5kqg8s" role="jymVt">
+      <property role="3tTeZt" value="&lt;no result checking&gt;" />
+      <ref role="3tTeZr" to="slm6:1JWcQ2VeXpD" resolve="check" />
+    </node>
+    <node concept="3clFb_" id="1LCsd5kqvor" role="jymVt">
+      <property role="TrG5h" value="replaceNode" />
+      <node concept="3clFbS" id="1LCsd5kqvou" role="3clF47">
+        <node concept="3clFbF" id="70cGcTIJ45L" role="3cqZAp">
+          <node concept="2OqwBi" id="70cGcTIJ45M" role="3clFbG">
+            <node concept="2ShNRf" id="70cGcTIJ45N" role="2Oq$k0">
+              <node concept="1pGfFk" id="70cGcTIJ45O" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="w1kc:~ModelImports.&lt;init&gt;(org.jetbrains.mps.openapi.model.SModel)" resolve="ModelImports" />
+                <node concept="2OqwBi" id="70cGcTIJ45P" role="37wK5m">
+                  <node concept="37vLTw" id="70cGcTIJ45Q" role="2Oq$k0">
+                    <ref role="3cqZAo" node="1LCsd5kqwmg" resolve="node" />
+                  </node>
+                  <node concept="I4A8Y" id="70cGcTIJ45R" role="2OqNvi" />
+                </node>
+              </node>
+            </node>
+            <node concept="liA8E" id="70cGcTIJ45S" role="2OqNvi">
+              <ref role="37wK5l" to="w1kc:~ModelImports.addUsedLanguage(org.jetbrains.mps.openapi.language.SLanguage)" resolve="addUsedLanguage" />
+              <node concept="pHN19" id="70cGcTIJ45T" role="37wK5m">
+                <node concept="2V$Bhx" id="70cGcTIJ45U" role="2V$M_3">
+                  <property role="2V$B1T" value="f2801650-65d5-424e-bb1b-463a8781b786" />
+                  <property role="2V$B1Q" value="jetbrains.mps.baseLanguage.javadoc" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="70cGcTIJ3MW" role="3cqZAp" />
+        <node concept="3cpWs8" id="1LCsd5kqOw_" role="3cqZAp">
+          <node concept="3cpWsn" id="1LCsd5kqOwA" role="3cpWs9">
+            <property role="TrG5h" value="nodeWithAnnotation" />
+            <node concept="3Tqbb2" id="1LCsd5kqOwB" role="1tU5fm" />
+            <node concept="2OqwBi" id="1LCsd5kqOwC" role="33vP2m">
+              <node concept="37vLTw" id="1LCsd5kqOwD" role="2Oq$k0">
+                <ref role="3cqZAo" node="1LCsd5kqwmg" resolve="node" />
+              </node>
+              <node concept="1mfA1w" id="1LCsd5kqOwE" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="1LCsd5kr7pC" role="3cqZAp">
+          <node concept="3cpWsn" id="1LCsd5kr7pF" role="3cpWs9">
+            <property role="TrG5h" value="lines" />
+            <node concept="A3Dl8" id="1LCsd5ksjZa" role="1tU5fm">
+              <node concept="17QB3L" id="1LCsd5ksjZb" role="A3Ik2" />
+            </node>
+            <node concept="2OqwBi" id="1LCsd5krfxz" role="33vP2m">
+              <node concept="2OqwBi" id="1LCsd5kreyY" role="2Oq$k0">
+                <node concept="37vLTw" id="1LCsd5kre6X" role="2Oq$k0">
+                  <ref role="3cqZAo" node="1LCsd5kqwmg" resolve="node" />
+                </node>
+                <node concept="3TrEf2" id="1LCsd5krfd2" role="2OqNvi">
+                  <ref role="3Tt5mk" to="hba4:3d2YJYTUdjv" resolve="text" />
+                </node>
+              </node>
+              <node concept="2qgKlT" id="1LCsd5krgbo" role="2OqNvi">
+                <ref role="37wK5l" to="tbr6:7T88Na6$wwy" resolve="getTextLines" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="1LCsd5kqO9V" role="3cqZAp" />
+        <node concept="Jncv_" id="1LCsd5kroeW" role="3cqZAp">
+          <ref role="JncvD" to="tpee:f$Wx3kv" resolve="StaticFieldDeclaration" />
+          <node concept="37vLTw" id="1LCsd5kroeX" role="JncvB">
+            <ref role="3cqZAo" node="1LCsd5kqOwA" resolve="nodeWithAnnotation" />
+          </node>
+          <node concept="3clFbS" id="1LCsd5kroeY" role="Jncv$">
+            <node concept="3clFbF" id="1LCsd5krtnU" role="3cqZAp">
+              <node concept="2OqwBi" id="1LCsd5krtO2" role="3clFbG">
+                <node concept="37vLTw" id="1LCsd5krtnS" role="2Oq$k0">
+                  <ref role="3cqZAo" node="1LCsd5kqwmg" resolve="node" />
+                </node>
+                <node concept="3YRAZt" id="1LCsd5krIOF" role="2OqNvi" />
+              </node>
+            </node>
+            <node concept="3clFbF" id="1LCsd5kroeZ" role="3cqZAp">
+              <node concept="2OqwBi" id="1LCsd5krof0" role="3clFbG">
+                <node concept="2OqwBi" id="1LCsd5krof1" role="2Oq$k0">
+                  <node concept="Jnkvi" id="1LCsd5krof2" role="2Oq$k0">
+                    <ref role="1M0zk5" node="1LCsd5krofe" resolve="declaration" />
+                  </node>
+                  <node concept="3CFZ6_" id="1LCsd5krof3" role="2OqNvi">
+                    <node concept="3CFYIy" id="1LCsd5krof4" role="3CFYIz">
+                      <ref role="3CFYIx" to="m373:5VgPTPXL4JM" resolve="FieldDocComment" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2oxUTD" id="1LCsd5krof5" role="2OqNvi">
+                  <node concept="2pJPEk" id="1LCsd5krof6" role="2oxUTC">
+                    <node concept="2pJPED" id="1LCsd5krof7" role="2pJPEn">
+                      <ref role="2pJxaS" to="m373:5VgPTPXL4JM" resolve="FieldDocComment" />
+                      <node concept="2pIpSj" id="1LCsd5krof8" role="2pJxcM">
+                        <ref role="2pIpSl" to="m373:7lVCwDcxZ_I" resolve="body" />
+                        <node concept="36biLy" id="1LCsd5kssyU" role="28nt2d">
+                          <node concept="1rXfSq" id="1LCsd5kssyV" role="36biLW">
+                            <ref role="37wK5l" node="1LCsd5krs8n" resolve="createComments" />
+                            <node concept="37vLTw" id="1LCsd5kssyW" role="37wK5m">
+                              <ref role="3cqZAo" node="1LCsd5kr7pF" resolve="lines" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs6" id="1LCsd5krofd" role="3cqZAp" />
+          </node>
+          <node concept="JncvC" id="1LCsd5krofe" role="JncvA">
+            <property role="TrG5h" value="declaration" />
+            <node concept="2jxLKc" id="1LCsd5kroff" role="1tU5fm" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="1LCsd5krofg" role="3cqZAp" />
+        <node concept="Jncv_" id="1LCsd5krofh" role="3cqZAp">
+          <ref role="JncvD" to="tpee:fz12cDC" resolve="FieldDeclaration" />
+          <node concept="37vLTw" id="1LCsd5krofi" role="JncvB">
+            <ref role="3cqZAo" node="1LCsd5kqOwA" resolve="nodeWithAnnotation" />
+          </node>
+          <node concept="3clFbS" id="1LCsd5krofj" role="Jncv$">
+            <node concept="3clFbF" id="1LCsd5krK82" role="3cqZAp">
+              <node concept="2OqwBi" id="1LCsd5krKzE" role="3clFbG">
+                <node concept="37vLTw" id="1LCsd5krK80" role="2Oq$k0">
+                  <ref role="3cqZAo" node="1LCsd5kqwmg" resolve="node" />
+                </node>
+                <node concept="3YRAZt" id="1LCsd5krLuf" role="2OqNvi" />
+              </node>
+            </node>
+            <node concept="3clFbF" id="1LCsd5krofk" role="3cqZAp">
+              <node concept="2OqwBi" id="1LCsd5krofl" role="3clFbG">
+                <node concept="2OqwBi" id="1LCsd5krofm" role="2Oq$k0">
+                  <node concept="Jnkvi" id="1LCsd5krofn" role="2Oq$k0">
+                    <ref role="1M0zk5" node="1LCsd5krofz" resolve="declaration" />
+                  </node>
+                  <node concept="3CFZ6_" id="1LCsd5krofo" role="2OqNvi">
+                    <node concept="3CFYIy" id="1LCsd5krofp" role="3CFYIz">
+                      <ref role="3CFYIx" to="m373:5VgPTPXL4JM" resolve="FieldDocComment" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2oxUTD" id="1LCsd5krofq" role="2OqNvi">
+                  <node concept="2pJPEk" id="1LCsd5krofr" role="2oxUTC">
+                    <node concept="2pJPED" id="1LCsd5krofs" role="2pJPEn">
+                      <ref role="2pJxaS" to="m373:5VgPTPXL4JM" resolve="FieldDocComment" />
+                      <node concept="2pIpSj" id="1LCsd5kroft" role="2pJxcM">
+                        <ref role="2pIpSl" to="m373:7lVCwDcxZ_I" resolve="body" />
+                        <node concept="36biLy" id="1LCsd5kssjx" role="28nt2d">
+                          <node concept="1rXfSq" id="1LCsd5kssjy" role="36biLW">
+                            <ref role="37wK5l" node="1LCsd5krs8n" resolve="createComments" />
+                            <node concept="37vLTw" id="1LCsd5kssjz" role="37wK5m">
+                              <ref role="3cqZAo" node="1LCsd5kr7pF" resolve="lines" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs6" id="1LCsd5krofy" role="3cqZAp" />
+          </node>
+          <node concept="JncvC" id="1LCsd5krofz" role="JncvA">
+            <property role="TrG5h" value="declaration" />
+            <node concept="2jxLKc" id="1LCsd5krof$" role="1tU5fm" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="1LCsd5krnAZ" role="3cqZAp" />
+        <node concept="3clFbH" id="1LCsd5krnBE" role="3cqZAp" />
+        <node concept="Jncv_" id="1LCsd5kqL9G" role="3cqZAp">
+          <ref role="JncvD" to="tpee:g7pOWCK" resolve="Classifier" />
+          <node concept="37vLTw" id="1LCsd5kqZk8" role="JncvB">
+            <ref role="3cqZAo" node="1LCsd5kqOwA" resolve="nodeWithAnnotation" />
+          </node>
+          <node concept="3clFbS" id="1LCsd5kqL9I" role="Jncv$">
+            <node concept="3clFbF" id="1LCsd5kpyXR" role="3cqZAp">
+              <node concept="2OqwBi" id="1LCsd5kpzbc" role="3clFbG">
+                <node concept="37vLTw" id="1LCsd5kpyXQ" role="2Oq$k0">
+                  <ref role="3cqZAo" node="1LCsd5kqwmg" resolve="node" />
+                </node>
+                <node concept="3YRAZt" id="1LCsd5kpzUX" role="2OqNvi" />
+              </node>
+            </node>
+            <node concept="3clFbF" id="1LCsd5kpSHI" role="3cqZAp">
+              <node concept="2OqwBi" id="1LCsd5kq3tl" role="3clFbG">
+                <node concept="2OqwBi" id="1LCsd5kpTlV" role="2Oq$k0">
+                  <node concept="Jnkvi" id="1LCsd5kr4DE" role="2Oq$k0">
+                    <ref role="1M0zk5" node="1LCsd5kqL9J" resolve="classifier" />
+                  </node>
+                  <node concept="3CFZ6_" id="1LCsd5kpTXT" role="2OqNvi">
+                    <node concept="3CFYIy" id="1LCsd5kq2MZ" role="3CFYIz">
+                      <ref role="3CFYIx" to="m373:1MQnpZAqBpc" resolve="ClassifierDocComment" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2oxUTD" id="1LCsd5kq4AL" role="2OqNvi">
+                  <node concept="2pJPEk" id="1LCsd5kq58q" role="2oxUTC">
+                    <node concept="2pJPED" id="1LCsd5kq58s" role="2pJPEn">
+                      <ref role="2pJxaS" to="m373:1MQnpZAqBpc" resolve="ClassifierDocComment" />
+                      <node concept="2pIpSj" id="1LCsd5kq6lr" role="2pJxcM">
+                        <ref role="2pIpSl" to="m373:7lVCwDcxZ_I" resolve="body" />
+                        <node concept="36biLy" id="1LCsd5ksr4p" role="28nt2d">
+                          <node concept="1rXfSq" id="1LCsd5ksrlP" role="36biLW">
+                            <ref role="37wK5l" node="1LCsd5krs8n" resolve="createComments" />
+                            <node concept="37vLTw" id="1LCsd5ksrZf" role="37wK5m">
+                              <ref role="3cqZAo" node="1LCsd5kr7pF" resolve="lines" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs6" id="1LCsd5krmeK" role="3cqZAp" />
+          </node>
+          <node concept="JncvC" id="1LCsd5kqL9J" role="JncvA">
+            <property role="TrG5h" value="classifier" />
+            <node concept="2jxLKc" id="1LCsd5kqL9K" role="1tU5fm" />
+          </node>
+        </node>
+      </node>
+      <node concept="3cqZAl" id="1LCsd5krkq9" role="3clF45" />
+      <node concept="37vLTG" id="1LCsd5kqwmg" role="3clF46">
+        <property role="TrG5h" value="node" />
+        <node concept="3Tqbb2" id="1LCsd5kqwmf" role="1tU5fm">
+          <ref role="ehGHo" to="hba4:3d2YJYTUdju" resolve="BLDoc" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="1LCsd5krrkS" role="jymVt" />
+    <node concept="3clFb_" id="1LCsd5krs8n" role="jymVt">
+      <property role="TrG5h" value="createComments" />
+      <node concept="3clFbS" id="1LCsd5krs8o" role="3clF47">
+        <node concept="3clFbF" id="1LCsd5ksm2K" role="3cqZAp">
+          <node concept="2OqwBi" id="1LCsd5ksmnR" role="3clFbG">
+            <node concept="37vLTw" id="1LCsd5ksm2I" role="2Oq$k0">
+              <ref role="3cqZAo" node="1LCsd5kskIP" resolve="lines" />
+            </node>
+            <node concept="3$u5V9" id="1LCsd5ksmRt" role="2OqNvi">
+              <node concept="1bVj0M" id="1LCsd5ksmRv" role="23t8la">
+                <node concept="3clFbS" id="1LCsd5ksmRw" role="1bW5cS">
+                  <node concept="3clFbF" id="1LCsd5ksnfR" role="3cqZAp">
+                    <node concept="2pJPEk" id="1LCsd5ksnfP" role="3clFbG">
+                      <node concept="2pJPED" id="1LCsd5ksnfQ" role="2pJPEn">
+                        <ref role="2pJxaS" to="m373:7lVCwDcxZ_G" resolve="CommentLine" />
+                        <node concept="2pIpSj" id="1LCsd5ksnU_" role="2pJxcM">
+                          <ref role="2pIpSl" to="m373:7LZmMWLAgad" resolve="part" />
+                          <node concept="2pJPED" id="1LCsd5ksoaH" role="28nt2d">
+                            <ref role="2pJxaS" to="m373:7LZmMWLAga7" resolve="TextCommentLinePart" />
+                            <node concept="2pJxcG" id="1LCsd5ksoqO" role="2pJxcM">
+                              <ref role="2pJxcJ" to="m373:7LZmMWLAga8" resolve="text" />
+                              <node concept="WxPPo" id="1LCsd5ksoFG" role="28ntcv">
+                                <node concept="37vLTw" id="1LCsd5ksoFE" role="WxPPp">
+                                  <ref role="3cqZAo" node="1LCsd5ksmRx" resolve="it" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="Rh6nW" id="1LCsd5ksmRx" role="1bW2Oz">
+                  <property role="TrG5h" value="it" />
+                  <node concept="2jxLKc" id="1LCsd5ksmRy" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="1LCsd5kskIP" role="3clF46">
+        <property role="TrG5h" value="lines" />
+        <node concept="A3Dl8" id="1LCsd5kskIN" role="1tU5fm">
+          <node concept="17QB3L" id="1LCsd5ksl2T" role="A3Ik2" />
+        </node>
+      </node>
+      <node concept="A3Dl8" id="1LCsd5ksply" role="3clF45">
+        <node concept="3Tqbb2" id="1LCsd5kspRW" role="A3Ik2">
+          <ref role="ehGHo" to="m373:7lVCwDcxZ_G" resolve="CommentLine" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="1LCsd5krrIB" role="jymVt" />
+    <node concept="3uibUv" id="1LCsd5kp3dE" role="1zkMxy">
+      <ref role="3uigEE" to="slm6:5TUCQr2ybBO" resolve="HasMigrationScriptReference" />
     </node>
   </node>
 </model>

--- a/code/blutil/languages/com.mbeddr.mpsutil.blutil/languageModels/structure.mps
+++ b/code/blutil/languages/com.mbeddr.mpsutil.blutil/languageModels/structure.mps
@@ -885,6 +885,7 @@
         <ref role="trN6q" to="tpee:h9ngReX" resolve="ClassifierMember" />
       </node>
     </node>
+    <node concept="asaX9" id="4mjBAwsq6kt" role="lGtFl" />
   </node>
   <node concept="PlHQZ" id="243ufko$AbV">
     <property role="TrG5h" value="IDeprecatedLangConcept" />

--- a/code/blutil/tests/test.com.mbeddr.mpsutil.blutil.doc/models/test.com.mbeddr.mpsutil.blutil.doc@tests.mps
+++ b/code/blutil/tests/test.com.mbeddr.mpsutil.blutil.doc/models/test.com.mbeddr.mpsutil.blutil.doc@tests.mps
@@ -1,0 +1,400 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:a0ad4fb2-84d1-4370-9588-bb53940875f7(test.com.mbeddr.mpsutil.blutil.doc@tests)">
+  <persistence version="9" />
+  <languages>
+    <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="5" />
+    <use id="63e0e566-5131-447e-90e3-12ea330e1a00" name="com.mbeddr.mpsutil.blutil" version="2" />
+    <use id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc" version="2" />
+  </languages>
+  <imports>
+    <import index="sx89" ref="r:4d59030b-e7d4-4dce-b4c0-c93e903e4fc2(com.mbeddr.mpsutil.blutil.migration)" />
+  </imports>
+  <registry>
+    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="5476670926298696679" name="jetbrains.mps.lang.test.structure.MigrationTestCase" flags="lg" index="2lJO3n">
+        <child id="5476670926298696680" name="inputNodes" index="2lJO3o" />
+        <child id="5476670926298698900" name="outputNodes" index="2lJPY$" />
+        <child id="6626913010124294914" name="migration" index="3ea0P7" />
+      </concept>
+      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
+        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
+      </concept>
+      <concept id="6626913010124185481" name="jetbrains.mps.lang.test.structure.MigrationReference" flags="ng" index="3ea_Bc">
+        <reference id="6626913010124185482" name="migration" index="3ea_Bf" />
+      </concept>
+      <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
+        <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
+      </concept>
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1083245299891" name="jetbrains.mps.baseLanguage.structure.EnumConstantDeclaration" flags="ig" index="QsSxf" />
+      <concept id="1070462154015" name="jetbrains.mps.baseLanguage.structure.StaticFieldDeclaration" flags="ig" index="Wx3nA" />
+      <concept id="1068390468200" name="jetbrains.mps.baseLanguage.structure.FieldDeclaration" flags="ig" index="312cEg" />
+      <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu" />
+      <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123135" name="body" index="3clF47" />
+      </concept>
+      <concept id="1068580123165" name="jetbrains.mps.baseLanguage.structure.InstanceMethodDeclaration" flags="ig" index="3clFb_" />
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS" />
+      <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
+      <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
+        <property id="521412098689998745" name="nonStatic" index="2bfB8j" />
+      </concept>
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
+        <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+      <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
+    </language>
+    <language id="63e0e566-5131-447e-90e3-12ea330e1a00" name="com.mbeddr.mpsutil.blutil">
+      <concept id="3693790620639876318" name="com.mbeddr.mpsutil.blutil.structure.BLDoc" flags="ng" index="2aEySx">
+        <child id="3693790620639876319" name="text" index="2aEySw" />
+      </concept>
+      <concept id="6451706574539345403" name="com.mbeddr.mpsutil.blutil.structure.MethodLineDoc" flags="ng" index="NWlO9">
+        <property id="6451706574539345425" name="text" index="NWlVz" />
+      </concept>
+    </language>
+    <language id="92d2ea16-5a42-4fdf-a676-c7604efe3504" name="de.slisson.mps.richtext">
+      <concept id="2557074442922380897" name="de.slisson.mps.richtext.structure.Text" flags="ng" index="19SGf9">
+        <child id="2557074442922392302" name="words" index="19SJt6" />
+      </concept>
+      <concept id="2557074442922438156" name="de.slisson.mps.richtext.structure.Word" flags="ng" index="19SUe$">
+        <property id="2557074442922438158" name="escapedValue" index="19SUeA" />
+      </concept>
+    </language>
+    <language id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc">
+      <concept id="6832197706140896242" name="jetbrains.mps.baseLanguage.javadoc.structure.FieldDocComment" flags="ng" index="z59LJ" />
+      <concept id="5349172909345501395" name="jetbrains.mps.baseLanguage.javadoc.structure.BaseDocComment" flags="ng" index="P$AiS">
+        <child id="8465538089690331502" name="body" index="TZ5H$" />
+      </concept>
+      <concept id="5349172909345532724" name="jetbrains.mps.baseLanguage.javadoc.structure.MethodDocComment" flags="ng" index="P$JXv" />
+      <concept id="8465538089690331500" name="jetbrains.mps.baseLanguage.javadoc.structure.CommentLine" flags="ng" index="TZ5HA">
+        <child id="8970989240999019149" name="part" index="1dT_Ay" />
+      </concept>
+      <concept id="8970989240999019143" name="jetbrains.mps.baseLanguage.javadoc.structure.TextCommentLinePart" flags="ng" index="1dT_AC">
+        <property id="8970989240999019144" name="text" index="1dT_AB" />
+      </concept>
+      <concept id="2068944020170241612" name="jetbrains.mps.baseLanguage.javadoc.structure.ClassifierDocComment" flags="ng" index="3UR2Jj" />
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+      <concept id="4222318806802425298" name="jetbrains.mps.lang.core.structure.SuppressErrorsAnnotation" flags="ng" index="15s5l7">
+        <property id="8575328350543493365" name="message" index="huDt6" />
+        <property id="2423417345669755629" name="filter" index="1eyWvh" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="2lJO3n" id="1LCsd5klG1S">
+    <property role="TrG5h" value="MethodLineDoc_MethodToJavaDoc" />
+    <node concept="3ea_Bc" id="1LCsd5klG1T" role="3ea0P7">
+      <ref role="3ea_Bf" to="sx89:4mjBAwsq6F6" resolve="methodLineDocToJavaDoc" />
+    </node>
+    <node concept="1qefOq" id="1LCsd5klIBB" role="2lJO3o">
+      <node concept="3clFb_" id="1LCsd5knOpO" role="1qenE9">
+        <property role="TrG5h" value="test" />
+        <node concept="3clFbS" id="1LCsd5knOpS" role="3clF47" />
+        <node concept="3cqZAl" id="1LCsd5knOpQ" role="3clF45" />
+        <node concept="3Tm1VV" id="1LCsd5knOpR" role="1B3o_S" />
+        <node concept="NWlO9" id="1LCsd5knOpV" role="lGtFl">
+          <property role="NWlVz" value="test text" />
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="1LCsd5klKhH" role="2lJPY$">
+      <node concept="3clFb_" id="1LCsd5klLlv" role="1qenE9">
+        <property role="TrG5h" value="test" />
+        <node concept="3clFbS" id="1LCsd5klLly" role="3clF47" />
+        <node concept="3cqZAl" id="1LCsd5klLG9" role="3clF45" />
+        <node concept="3Tm1VV" id="1LCsd5klLl$" role="1B3o_S" />
+        <node concept="P$JXv" id="1LCsd5klYEp" role="lGtFl">
+          <node concept="TZ5HA" id="1LCsd5klYEq" role="TZ5H$">
+            <node concept="1dT_AC" id="1LCsd5klYEr" role="1dT_Ay">
+              <property role="1dT_AB" value="test text" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="2XOHcx" id="5yvl18N8PtL">
+    <property role="2XOHcw" value="${extensions.home}/code" />
+  </node>
+  <node concept="2lJO3n" id="1LCsd5koRMM">
+    <property role="TrG5h" value="MethodLineDoc_FieldToJavaDoc" />
+    <node concept="3ea_Bc" id="1LCsd5koRMN" role="3ea0P7">
+      <ref role="3ea_Bf" to="sx89:4mjBAwsq6F6" resolve="methodLineDocToJavaDoc" />
+    </node>
+    <node concept="1qefOq" id="1LCsd5koRMO" role="2lJO3o">
+      <node concept="312cEg" id="1LCsd5kqhVT" role="1qenE9">
+        <property role="TrG5h" value="field" />
+        <node concept="3Tm6S6" id="1LCsd5kqhVU" role="1B3o_S" />
+        <node concept="17QB3L" id="1LCsd5kqiiu" role="1tU5fm" />
+        <node concept="NWlO9" id="1LCsd5kqkkT" role="lGtFl">
+          <property role="NWlVz" value="test text" />
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="1LCsd5koRMU" role="2lJPY$">
+      <node concept="312cEg" id="1LCsd5koWYn" role="1qenE9">
+        <property role="TrG5h" value="field" />
+        <node concept="3Tm6S6" id="1LCsd5koWYo" role="1B3o_S" />
+        <node concept="17QB3L" id="1LCsd5koXkW" role="1tU5fm" />
+        <node concept="z59LJ" id="1LCsd5koYJ7" role="lGtFl">
+          <node concept="TZ5HA" id="1LCsd5koYJ8" role="TZ5H$">
+            <node concept="1dT_AC" id="1LCsd5koYJ9" role="1dT_Ay">
+              <property role="1dT_AB" value="test text" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="2lJO3n" id="1LCsd5koZ5V">
+    <property role="TrG5h" value="MethodLineDoc_StaticFieldToJavaDoc" />
+    <node concept="3ea_Bc" id="1LCsd5koZ5W" role="3ea0P7">
+      <ref role="3ea_Bf" to="sx89:4mjBAwsq6F6" resolve="methodLineDocToJavaDoc" />
+    </node>
+    <node concept="1qefOq" id="1LCsd5koZ64" role="2lJPY$">
+      <node concept="Wx3nA" id="1LCsd5kp0R9" role="1qenE9">
+        <property role="TrG5h" value="field" />
+        <node concept="17QB3L" id="1LCsd5kp0Rc" role="1tU5fm" />
+        <node concept="3Tm6S6" id="1LCsd5kp0Rb" role="1B3o_S" />
+        <node concept="z59LJ" id="1LCsd5kp0Rh" role="lGtFl">
+          <node concept="TZ5HA" id="1LCsd5kp0Ri" role="TZ5H$">
+            <node concept="1dT_AC" id="1LCsd5kp0Rj" role="1dT_Ay">
+              <property role="1dT_AB" value="test text" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="1LCsd5kql2v" role="2lJO3o">
+      <node concept="Wx3nA" id="1LCsd5kql2s" role="1qenE9">
+        <property role="TrG5h" value="field" />
+        <node concept="3Tm6S6" id="1LCsd5kql2t" role="1B3o_S" />
+        <node concept="17QB3L" id="1LCsd5kqlp2" role="1tU5fm" />
+        <node concept="NWlO9" id="1LCsd5kqnwe" role="lGtFl">
+          <property role="NWlVz" value="test text" />
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="2lJO3n" id="1LCsd5kqnR4">
+    <property role="TrG5h" value="BLDoc_FieldToJavaDoc_Test" />
+    <node concept="3ea_Bc" id="1LCsd5kqnR5" role="3ea0P7">
+      <ref role="3ea_Bf" to="sx89:1LCsd5kp3dn" resolve="BLDocToJavaDoc" />
+    </node>
+    <node concept="1qefOq" id="1LCsd5kqnR6" role="2lJO3o">
+      <node concept="312cEg" id="1LCsd5kqo$y" role="1qenE9">
+        <property role="TrG5h" value="field" />
+        <node concept="3Tm6S6" id="1LCsd5kqo$z" role="1B3o_S" />
+        <node concept="17QB3L" id="1LCsd5kqoV7" role="1tU5fm" />
+        <node concept="2aEySx" id="1LCsd5kqpCb" role="lGtFl">
+          <node concept="19SGf9" id="1LCsd5kqpCc" role="2aEySw">
+            <node concept="19SUe$" id="1LCsd5kqpCd" role="19SJt6">
+              <property role="19SUeA" value="test&#10;text" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="1LCsd5kqnRb" role="2lJPY$">
+      <node concept="312cEg" id="1LCsd5kqnRc" role="1qenE9">
+        <property role="TrG5h" value="field" />
+        <node concept="3Tm6S6" id="1LCsd5kqnRd" role="1B3o_S" />
+        <node concept="17QB3L" id="1LCsd5kqnRe" role="1tU5fm" />
+        <node concept="z59LJ" id="1LCsd5kqnRf" role="lGtFl">
+          <node concept="TZ5HA" id="1LCsd5kqnRg" role="TZ5H$">
+            <node concept="1dT_AC" id="1LCsd5kqnRh" role="1dT_Ay">
+              <property role="1dT_AB" value="test" />
+            </node>
+          </node>
+          <node concept="TZ5HA" id="1LCsd5ksgm4" role="TZ5H$">
+            <node concept="1dT_AC" id="1LCsd5ksgm5" role="1dT_Ay">
+              <property role="1dT_AB" value="text" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="2lJO3n" id="1LCsd5kqs7J">
+    <property role="TrG5h" value="BLDoc_StaticFieldToJavaDoc_Test" />
+    <node concept="3ea_Bc" id="1LCsd5kqs7K" role="3ea0P7">
+      <ref role="3ea_Bf" to="sx89:1LCsd5kp3dn" resolve="BLDocToJavaDoc" />
+    </node>
+    <node concept="1qefOq" id="1LCsd5kqs7L" role="2lJO3o">
+      <node concept="Wx3nA" id="1LCsd5kqtbJ" role="1qenE9">
+        <property role="TrG5h" value="field" />
+        <node concept="17QB3L" id="1LCsd5kqtbM" role="1tU5fm" />
+        <node concept="3Tm6S6" id="1LCsd5kqtbL" role="1B3o_S" />
+        <node concept="2aEySx" id="1LCsd5kqtbR" role="lGtFl">
+          <node concept="19SGf9" id="1LCsd5kqtbS" role="2aEySw">
+            <node concept="19SUe$" id="1LCsd5kqtbT" role="19SJt6">
+              <property role="19SUeA" value="test&#10;text" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="1LCsd5kqs7S" role="2lJPY$">
+      <node concept="Wx3nA" id="1LCsd5kqtSX" role="1qenE9">
+        <property role="TrG5h" value="field" />
+        <node concept="17QB3L" id="1LCsd5kqtT0" role="1tU5fm" />
+        <node concept="3Tm6S6" id="1LCsd5kqtSZ" role="1B3o_S" />
+        <node concept="z59LJ" id="1LCsd5kqtT5" role="lGtFl">
+          <node concept="TZ5HA" id="1LCsd5kqtT6" role="TZ5H$">
+            <node concept="1dT_AC" id="1LCsd5kqtT7" role="1dT_Ay">
+              <property role="1dT_AB" value="test" />
+            </node>
+          </node>
+          <node concept="TZ5HA" id="1LCsd5ksgmn" role="TZ5H$">
+            <node concept="1dT_AC" id="1LCsd5ksgmo" role="1dT_Ay">
+              <property role="1dT_AB" value="text" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="2lJO3n" id="1LCsd5krX_y">
+    <property role="TrG5h" value="MethodLine_EnumConstantDeclarationToBLDoc" />
+    <node concept="3ea_Bc" id="1LCsd5krX_z" role="3ea0P7">
+      <ref role="3ea_Bf" to="sx89:4mjBAwsq6F6" resolve="methodLineDocToJavaDoc" />
+    </node>
+    <node concept="1qefOq" id="1LCsd5krX_$" role="2lJO3o">
+      <node concept="QsSxf" id="1LCsd5ks2ax" role="1qenE9">
+        <property role="TrG5h" value="test" />
+        <node concept="15s5l7" id="1LCsd5ks4YY" role="lGtFl">
+          <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;constraints (cannot be child)&quot;;FLAVOUR_MESSAGE=&quot;Node 'test' cannot be child of node '(instance of TestNode)'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c895902c1(jetbrains.mps.baseLanguage.constraints)/1227128029536558389]&quot;;" />
+          <property role="huDt6" value="Node 'test' cannot be child of node '(instance of TestNode)'" />
+        </node>
+        <node concept="NWlO9" id="1LCsd5ks2Ry" role="lGtFl">
+          <property role="NWlVz" value="test text" />
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="1LCsd5ks3$$" role="2lJPY$">
+      <node concept="QsSxf" id="1LCsd5ks3$z" role="1qenE9">
+        <property role="TrG5h" value="test" />
+        <node concept="15s5l7" id="1LCsd5ks5lv" role="lGtFl">
+          <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;constraints (cannot be child)&quot;;FLAVOUR_MESSAGE=&quot;Node 'test' cannot be child of node '(instance of TestNode)'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c895902c1(jetbrains.mps.baseLanguage.constraints)/1227128029536558389]&quot;;" />
+          <property role="huDt6" value="Node 'test' cannot be child of node '(instance of TestNode)'" />
+        </node>
+        <node concept="2aEySx" id="1LCsd5ks4C5" role="lGtFl">
+          <node concept="19SGf9" id="1LCsd5ks4C6" role="2aEySw">
+            <node concept="19SUe$" id="1LCsd5ks4C7" role="19SJt6">
+              <property role="19SUeA" value="test text" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="2lJO3n" id="1LCsd5ksgkS">
+    <property role="TrG5h" value="BLDocSame_Test" />
+    <node concept="3ea_Bc" id="1LCsd5ksgkT" role="3ea0P7">
+      <ref role="3ea_Bf" to="sx89:1LCsd5kp3dn" resolve="BLDocToJavaDoc" />
+    </node>
+    <node concept="1qefOq" id="1LCsd5ksglO" role="2lJPY$">
+      <node concept="2XOHcx" id="1LCsd5ksglP" role="1qenE9">
+        <node concept="2aEySx" id="1LCsd5ksglQ" role="lGtFl">
+          <node concept="19SGf9" id="1LCsd5ksglR" role="2aEySw">
+            <node concept="19SUe$" id="1LCsd5ksglS" role="19SJt6">
+              <property role="19SUeA" value="test text" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="1LCsd5ksglq" role="2lJO3o">
+      <node concept="2XOHcx" id="1LCsd5ksglp" role="1qenE9">
+        <node concept="2aEySx" id="1LCsd5ksglr" role="lGtFl">
+          <node concept="19SGf9" id="1LCsd5ksgls" role="2aEySw">
+            <node concept="19SUe$" id="1LCsd5ksglt" role="19SJt6">
+              <property role="19SUeA" value="test text" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="2lJO3n" id="1LCsd5ksC6J">
+    <property role="TrG5h" value="BLDoc_ClassifierToJavaDoc_Test" />
+    <node concept="3ea_Bc" id="1LCsd5ksC6K" role="3ea0P7">
+      <ref role="3ea_Bf" to="sx89:1LCsd5kp3dn" resolve="BLDocToJavaDoc" />
+    </node>
+    <node concept="1qefOq" id="1LCsd5ksC6S" role="2lJPY$">
+      <node concept="312cEu" id="1LCsd5ksC8c" role="1qenE9">
+        <property role="TrG5h" value="Test" />
+        <property role="2bfB8j" value="true" />
+        <node concept="3Tm1VV" id="1LCsd5ksC8d" role="1B3o_S" />
+        <node concept="3UR2Jj" id="1LCsd5ksC8O" role="lGtFl">
+          <node concept="TZ5HA" id="1LCsd5ksC8P" role="TZ5H$">
+            <node concept="1dT_AC" id="1LCsd5ksC8Q" role="1dT_Ay">
+              <property role="1dT_AB" value="test" />
+            </node>
+          </node>
+          <node concept="TZ5HA" id="1LCsd5ksC91" role="TZ5H$">
+            <node concept="1dT_AC" id="1LCsd5ksC92" role="1dT_Ay">
+              <property role="1dT_AB" value="text" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="1LCsd5ksC7i" role="2lJO3o">
+      <node concept="312cEu" id="1LCsd5ksC7k" role="1qenE9">
+        <property role="2bfB8j" value="true" />
+        <property role="TrG5h" value="Test" />
+        <node concept="3Tm1VV" id="1LCsd5ksC7l" role="1B3o_S" />
+        <node concept="2aEySx" id="1LCsd5ksC7Y" role="lGtFl">
+          <node concept="19SGf9" id="1LCsd5ksC7Z" role="2aEySw">
+            <node concept="19SUe$" id="1LCsd5ksC80" role="19SJt6">
+              <property role="19SUeA" value="test&#10;text" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="2lJO3n" id="1LCsd5ksC9d">
+    <property role="TrG5h" value="methodLineDocToJavaDoc_Test" />
+    <node concept="3ea_Bc" id="1LCsd5ksC9e" role="3ea0P7">
+      <ref role="3ea_Bf" to="sx89:4mjBAwsq6F6" resolve="methodLineDocToJavaDoc" />
+    </node>
+    <node concept="1qefOq" id="1LCsd5ksC9f" role="2lJPY$">
+      <node concept="312cEu" id="1LCsd5ksC9g" role="1qenE9">
+        <property role="TrG5h" value="Test" />
+        <node concept="3Tm1VV" id="1LCsd5ksC9h" role="1B3o_S" />
+        <node concept="3UR2Jj" id="1LCsd5ksC9i" role="lGtFl">
+          <node concept="TZ5HA" id="1LCsd5ksC9j" role="TZ5H$">
+            <node concept="1dT_AC" id="1LCsd5ksC9k" role="1dT_Ay">
+              <property role="1dT_AB" value="test text" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="1LCsd5ksC9n" role="2lJO3o">
+      <node concept="312cEu" id="1LCsd5ksC9X" role="1qenE9">
+        <property role="TrG5h" value="Test" />
+        <node concept="3Tm1VV" id="1LCsd5ksC9Y" role="1B3o_S" />
+        <node concept="NWlO9" id="1LCsd5ksCaB" role="lGtFl">
+          <property role="NWlVz" value="test text" />
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/code/blutil/tests/test.com.mbeddr.mpsutil.blutil.doc/test.com.mbeddr.mpsutil.blutil.doc.msd
+++ b/code/blutil/tests/test.com.mbeddr.mpsutil.blutil.doc/test.com.mbeddr.mpsutil.blutil.doc.msd
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<solution name="test.com.mbeddr.mpsutil.blutil.doc" uuid="06664c6a-4e32-40cd-9fa1-502509f0505f" moduleVersion="0" compileInMPS="true">
+  <models>
+    <modelRoot contentPath="${module}" type="default">
+      <sourceRoot location="models" />
+    </modelRoot>
+  </models>
+  <facets>
+    <facet type="java">
+      <classes generated="true" path="${module}/classes_gen" />
+    </facet>
+  </facets>
+  <sourcePath />
+  <dependencies>
+    <dependency reexport="false">63e0e566-5131-447e-90e3-12ea330e1a00(com.mbeddr.mpsutil.blutil)</dependency>
+    <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
+  </dependencies>
+  <languageVersions>
+    <language slang="l:63e0e566-5131-447e-90e3-12ea330e1a00:com.mbeddr.mpsutil.blutil" version="2" />
+    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
+    <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />
+    <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
+    <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
+    <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
+    <language slang="l:f61473f9-130f-42f6-b98d-6c438812c2f6:jetbrains.mps.baseLanguage.unitTest" version="1" />
+    <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
+    <language slang="l:8585453e-6bfb-4d80-98de-b16074f1d86c:jetbrains.mps.lang.test" version="5" />
+    <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
+  </languageVersions>
+  <dependencyVersions>
+    <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
+    <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
+    <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
+    <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+    <module reference="63e0e566-5131-447e-90e3-12ea330e1a00(com.mbeddr.mpsutil.blutil)" version="0" />
+    <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
+    <module reference="fd392034-7849-419d-9071-12563d152375(jetbrains.mps.baseLanguage.closures)" version="0" />
+    <module reference="83888646-71ce-4f1c-9c53-c54016f6ad4f(jetbrains.mps.baseLanguage.collections)" version="0" />
+    <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
+    <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
+    <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
+    <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
+    <module reference="06664c6a-4e32-40cd-9fa1-502509f0505f(test.com.mbeddr.mpsutil.blutil.doc)" version="0" />
+  </dependencyVersions>
+</solution>
+

--- a/code/blutil/tests/test.ts.match/models/main@tests.mps
+++ b/code/blutil/tests/test.ts.match/models/main@tests.mps
@@ -5,6 +5,7 @@
     <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="5" />
     <use id="63e0e566-5131-447e-90e3-12ea330e1a00" name="com.mbeddr.mpsutil.blutil" version="1" />
+    <use id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc" version="2" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>

--- a/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
+++ b/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
@@ -930,6 +930,16 @@
             <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
           </node>
         </node>
+        <node concept="1SiIV0" id="34iPpyhNGWr" role="3bR37C">
+          <node concept="1BurEX" id="34iPpyhNGWs" role="1SiIV1">
+            <node concept="398BVA" id="34iPpyhNGWd" role="1BurEY">
+              <ref role="398BVh" node="5Ngh5kRcxhz" resolve="platform_lib" />
+              <node concept="2Ry0Ak" id="34iPpyhNGWe" role="iGT6I">
+                <property role="2Ry0Am" value="3rd-party.jar" />
+              </node>
+            </node>
+          </node>
+        </node>
         <node concept="3rtmxn" id="7LJ_vJOlQ5R" role="3bR31x">
           <node concept="3LXTmp" id="7LJ_vJOlQ5S" role="3rtmxm">
             <node concept="3qWCbU" id="7LJ_vJOlQ5T" role="3LXTna">
@@ -945,16 +955,6 @@
                     <property role="2Ry0Am" value="MPS.ThirdParty" />
                   </node>
                 </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="34iPpyhNGWr" role="3bR37C">
-          <node concept="1BurEX" id="34iPpyhNGWs" role="1SiIV1">
-            <node concept="398BVA" id="34iPpyhNGWd" role="1BurEY">
-              <ref role="398BVh" node="5Ngh5kRcxhz" resolve="platform_lib" />
-              <node concept="2Ry0Ak" id="34iPpyhNGWe" role="iGT6I">
-                <property role="2Ry0Am" value="3rd-party.jar" />
               </node>
             </node>
           </node>
@@ -6373,13 +6373,18 @@
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="2oNsb9219wv" role="3bR37C">
-          <node concept="Rbm2T" id="2oNsb9219ww" role="1SiIV1">
+        <node concept="1SiIV0" id="1LCsd5khcL$" role="3bR37C">
+          <node concept="3bR9La" id="1LCsd5khcL_" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:7Kfy9QB6L1S" resolve="jetbrains.mps.baseLanguage.javadoc" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="70cGcTHM3Ii" role="3bR37C">
+          <node concept="Rbm2T" id="70cGcTHM3Ij" role="1SiIV1">
             <ref role="1E1Vl2" to="ffeo:14x5$qAUbkb" resolve="jetbrains.mps.lang.access" />
           </node>
         </node>
-        <node concept="1SiIV0" id="2oNsb9219wx" role="3bR37C">
-          <node concept="Rbm2T" id="2oNsb9219wy" role="1SiIV1">
+        <node concept="1SiIV0" id="70cGcTHM3Ik" role="3bR37C">
+          <node concept="Rbm2T" id="70cGcTHM3Il" role="1SiIV1">
             <ref role="1E1Vl2" to="ffeo:7Kfy9QB6L9O" resolve="jetbrains.mps.lang.smodel" />
           </node>
         </node>
@@ -7284,6 +7289,22 @@
             <ref role="3bR37D" to="ffeo:7Kfy9QB6KZG" resolve="jetbrains.mps.baseLanguage.closures" />
           </node>
         </node>
+        <node concept="3rtmxn" id="7LJ_vJOlQ6S" role="3bR31x">
+          <node concept="3LXTmp" id="7LJ_vJOlQ6T" role="3rtmxm">
+            <node concept="3qWCbU" id="7LJ_vJOlQ6U" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="7LJ_vJOlQ6V" role="3LXTmr">
+              <ref role="398BVh" node="2fo8bJE$D4t" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="7LJ_vJOlQ6W" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="7LJ_vJOlQ6X" role="2Ry0An">
+                  <property role="2Ry0Am" value="de.itemis.model.merge" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
         <node concept="1SiIV0" id="1kvClgKIDLF" role="3bR37C">
           <node concept="Rbm2T" id="1kvClgKIDLG" role="1SiIV1">
             <ref role="1E1Vl2" to="ffeo:7Kfy9QB6L9O" resolve="jetbrains.mps.lang.smodel" />
@@ -7312,22 +7333,6 @@
         <node concept="1SiIV0" id="7_$v4qbJL31" role="3bR37C">
           <node concept="3bR9La" id="7_$v4qbJLaE" role="1SiIV1">
             <ref role="3bR37D" to="ffeo:rD7wKO6k$" resolve="MPS.Generator" />
-          </node>
-        </node>
-        <node concept="3rtmxn" id="7LJ_vJOlQ6S" role="3bR31x">
-          <node concept="3LXTmp" id="7LJ_vJOlQ6T" role="3rtmxm">
-            <node concept="3qWCbU" id="7LJ_vJOlQ6U" role="3LXTna">
-              <property role="3qWCbO" value="icons/**, resources/**" />
-            </node>
-            <node concept="398BVA" id="7LJ_vJOlQ6V" role="3LXTmr">
-              <ref role="398BVh" node="2fo8bJE$D4t" resolve="extensions.code" />
-              <node concept="2Ry0Ak" id="7LJ_vJOlQ6W" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="7LJ_vJOlQ6X" role="2Ry0An">
-                  <property role="2Ry0Am" value="de.itemis.model.merge" />
-                </node>
-              </node>
-            </node>
           </node>
         </node>
       </node>
@@ -12132,6 +12137,9 @@
       <node concept="m$_yC" id="3ofF9dt4eDr" role="m$_yJ">
         <ref role="m$_y1" node="2OJNL7ElZsF" resolve="de.q60.mps.collections.libs" />
       </node>
+      <node concept="m$_yC" id="5lBBNpx5PcJ" role="m$_yJ">
+        <ref role="m$_y1" node="4p3FRivDLPy" resolve="org.apache.commons" />
+      </node>
       <node concept="2iUeEo" id="3vhhDKcvNeO" role="2iVFfd">
         <property role="2iUeEt" value="Modelix" />
         <property role="2iUeEu" value="http://modelix.org" />
@@ -12140,9 +12148,6 @@
         <node concept="3Mxwew" id="3vhhDKcvN8v" role="3MwsjC">
           <property role="3MwjfP" value="Alternative model API with better support for persistent data structures." />
         </node>
-      </node>
-      <node concept="m$_yC" id="5lBBNpx5PcJ" role="m$_yJ">
-        <ref role="m$_y1" node="4p3FRivDLPy" resolve="org.apache.commons" />
       </node>
     </node>
     <node concept="2G$12M" id="5U8hsWC6WQb" role="3989C9">
@@ -13162,6 +13167,11 @@
         <node concept="1E0d5M" id="52ZF9D3h0uS" role="1E1XAP">
           <ref role="1E0d5P" node="52ZF9D3gLhJ" resolve="com.mbeddr.mpsutil.modellisteners.runtime" />
         </node>
+        <node concept="1SiIV0" id="52ZF9D3h0uT" role="3bR37C">
+          <node concept="1Busua" id="52ZF9D3h0uU" role="1SiIV1">
+            <ref role="1Busuk" to="ffeo:7Kfy9QB6LaO" resolve="jetbrains.mps.lang.structure" />
+          </node>
+        </node>
         <node concept="1yeLz9" id="52ZF9D3h0uV" role="1TViLv">
           <property role="TrG5h" value="com.mbeddr.mpsutil.modellisteners#5818559022136673503" />
           <property role="3LESm3" value="37132e31-f64c-4798-8f65-d49942f5121d" />
@@ -13200,11 +13210,6 @@
                 <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
               </node>
             </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="52ZF9D3h0uT" role="3bR37C">
-          <node concept="1Busua" id="52ZF9D3h0uU" role="1SiIV1">
-            <ref role="1Busuk" to="ffeo:7Kfy9QB6LaO" resolve="jetbrains.mps.lang.structure" />
           </node>
         </node>
         <node concept="1SiIV0" id="3AI_UIpOEou" role="3bR37C">
@@ -15696,6 +15701,81 @@
             <node concept="3qWCbU" id="7q24334ZKBZ" role="3LXTna">
               <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
             </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1E1JtA" id="1LCsd5knOSZ" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="test.com.mbeddr.mpsutil.blutil.doc" />
+        <property role="3LESm3" value="06664c6a-4e32-40cd-9fa1-502509f0505f" />
+        <property role="aoJFB" value="eYcmk9QOlj/sources_and_tests" />
+        <node concept="3rtmxn" id="1LCsd5knOT0" role="3bR31x">
+          <node concept="3LXTmp" id="1LCsd5knOT1" role="3rtmxm">
+            <node concept="3qWCbU" id="1LCsd5knOT2" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="1LCsd5knOT3" role="3LXTmr">
+              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="1LCsd5knOT4" role="iGT6I">
+                <property role="2Ry0Am" value="blutil" />
+                <node concept="2Ry0Ak" id="1LCsd5knOT5" role="2Ry0An">
+                  <property role="2Ry0Am" value="tests" />
+                  <node concept="2Ry0Ak" id="1LCsd5knOT6" role="2Ry0An">
+                    <property role="2Ry0Am" value="test.com.mbeddr.mpsutil.blutil.genutil" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="398BVA" id="1LCsd5knOT7" role="3LF7KH">
+          <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+          <node concept="2Ry0Ak" id="1LCsd5knOT8" role="iGT6I">
+            <property role="2Ry0Am" value="blutil" />
+            <node concept="2Ry0Ak" id="1LCsd5knOT9" role="2Ry0An">
+              <property role="2Ry0Am" value="tests" />
+              <node concept="2Ry0Ak" id="1LCsd5knRoD" role="2Ry0An">
+                <property role="2Ry0Am" value="test.com.mbeddr.mpsutil.blutil.doc" />
+                <node concept="2Ry0Ak" id="1LCsd5knS5I" role="2Ry0An">
+                  <property role="2Ry0Am" value="test.com.mbeddr.mpsutil.blutil.doc.msd" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1BupzO" id="1LCsd5knOTc" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="1LCsd5knSvQ" role="1HemKq">
+            <node concept="398BVA" id="1LCsd5knSv_" role="3LXTmr">
+              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="1LCsd5knSvA" role="iGT6I">
+                <property role="2Ry0Am" value="blutil" />
+                <node concept="2Ry0Ak" id="1LCsd5knSvB" role="2Ry0An">
+                  <property role="2Ry0Am" value="tests" />
+                  <node concept="2Ry0Ak" id="1LCsd5knSvC" role="2Ry0An">
+                    <property role="2Ry0Am" value="test.com.mbeddr.mpsutil.blutil.doc" />
+                    <node concept="2Ry0Ak" id="1LCsd5knSvD" role="2Ry0An">
+                      <property role="2Ry0Am" value="models" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="1LCsd5knSvR" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="1LCsd5knQoO" role="3bR37C">
+          <node concept="3bR9La" id="1LCsd5knQoP" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="1LCsd5knQoQ" role="3bR37C">
+          <node concept="3bR9La" id="1LCsd5knQoR" role="1SiIV1">
+            <ref role="3bR37D" node="2NyZxKpUE9j" resolve="com.mbeddr.mpsutil.blutil" />
           </node>
         </node>
       </node>


### PR DESCRIPTION
`MethodLineDoc` is not needed anymore, that's why I have marked it as deprecated. It is heavily used in mbeddr.core. There are replacement concepts in `jetbrains.mps.baseLanguage.javadoc`. `BLDoc` can only partly be migrated because there is no equivalent concept to attach documentation to any node, that's why I hav not marked it as deprecated. I've written migrations for all the cases that are possible to migrate. Especially with `BLDoc` only migrations with text content are possible because there is no 1:1 mapping between the rich text and text language.