### PR TITLE
Support for dark theme (backport for 2021.1)

### DIFF
--- a/code/blutil/languages/com.mbeddr.mpsutil.blutil/languageModels/editor.mps
+++ b/code/blutil/languages/com.mbeddr.mpsutil.blutil/languageModels/editor.mps
@@ -20,6 +20,7 @@
     <import index="f4zo" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.cells(MPS.Editor/)" />
     <import index="cj4x" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor(MPS.Editor/)" />
     <import index="g51k" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor.cells(MPS.Editor/)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="tpce" ref="r:00000000-0000-4000-0000-011c89590292(jetbrains.mps.lang.structure.structure)" implicit="true" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
     <import index="tp25" ref="r:00000000-0000-4000-0000-011c89590301(jetbrains.mps.lang.smodel.structure)" implicit="true" />
@@ -1901,8 +1902,8 @@
                   <node concept="3clFbS" id="4kSfyefw5ru" role="3clFbx">
                     <node concept="3cpWs6" id="2$_w8oMzGER" role="3cqZAp">
                       <node concept="10M0yZ" id="2$_w8oM$egS" role="3cqZAk">
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                        <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
+                        <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                        <ref role="3cqZAo" to="lzb2:~JBColor.lightGray" resolve="lightGray" />
                       </node>
                     </node>
                   </node>
@@ -1921,8 +1922,8 @@
                     <node concept="3clFbS" id="2$_w8oM$eUs" role="9aQI4">
                       <node concept="3cpWs6" id="2$_w8oM$f$e" role="3cqZAp">
                         <node concept="10M0yZ" id="2$_w8oM$ge6" role="3cqZAk">
-                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                          <ref role="3cqZAo" to="z60i:~Color.red" resolve="red" />
+                          <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                          <ref role="3cqZAo" to="lzb2:~JBColor.red" resolve="red" />
                         </node>
                       </node>
                     </node>
@@ -1940,8 +1941,8 @@
             </node>
             <node concept="3cpWs6" id="2$_w8oM$CAj" role="3cqZAp">
               <node concept="10M0yZ" id="2$_w8oM$Dhu" role="3cqZAk">
-                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                <ref role="3cqZAo" to="z60i:~Color.red" resolve="red" />
+                <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                <ref role="3cqZAo" to="lzb2:~JBColor.red" resolve="red" />
               </node>
             </node>
           </node>
@@ -2162,8 +2163,8 @@
                     <ref role="37wK5l" node="3d2YJYTUz8q" resolve="OpeningBracketCell" />
                     <node concept="pncrf" id="3d2YJYTUdjI" role="37wK5m" />
                     <node concept="10M0yZ" id="3d2YJYTUdjJ" role="37wK5m">
-                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                      <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
+                      <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                      <ref role="3cqZAo" to="lzb2:~JBColor.gray" resolve="gray" />
                     </node>
                   </node>
                 </node>
@@ -2190,8 +2191,8 @@
                     <ref role="37wK5l" node="3d2YJYTUz5N" resolve="ClosingBracketCell" />
                     <node concept="pncrf" id="3d2YJYTUdjU" role="37wK5m" />
                     <node concept="10M0yZ" id="3d2YJYTUdjV" role="37wK5m">
-                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                      <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
+                      <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                      <ref role="3cqZAo" to="lzb2:~JBColor.gray" resolve="gray" />
                     </node>
                   </node>
                 </node>
@@ -2353,8 +2354,8 @@
                                 <node concept="liA8E" id="3d2YJYTUz6J" role="2OqNvi">
                                   <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
                                   <node concept="10M0yZ" id="3d2YJYTUz6K" role="37wK5m">
-                                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                                    <ref role="3cqZAo" to="z60i:~Color.GRAY" resolve="GRAY" />
+                                    <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                                    <ref role="3cqZAo" to="lzb2:~JBColor.GRAY" resolve="GRAY" />
                                   </node>
                                 </node>
                               </node>
@@ -2721,8 +2722,8 @@
                                 <node concept="liA8E" id="3d2YJYTUz9m" role="2OqNvi">
                                   <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
                                   <node concept="10M0yZ" id="3d2YJYTUz9n" role="37wK5m">
-                                    <ref role="3cqZAo" to="z60i:~Color.GRAY" resolve="GRAY" />
-                                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                                    <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                                    <ref role="3cqZAo" to="lzb2:~JBColor.GRAY" resolve="GRAY" />
                                   </node>
                                 </node>
                               </node>

--- a/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
+++ b/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
@@ -998,6 +998,9 @@
       <node concept="m$_yC" id="7mDAtWA2dyF" role="m$_yJ">
         <ref role="m$_y1" node="6SVXTgIe8wD" resolve="de.itemis.mps.celllayout" />
       </node>
+      <node concept="m$_yC" id="6VNWhOx081V" role="m$_yJ">
+        <ref role="m$_y1" to="ffeo:RJsmGEieyQ" resolve="jetbrains.mps.vcs" />
+      </node>
       <node concept="3_J27D" id="31bAEZ0srEi" role="m_cZH">
         <node concept="3Mxwew" id="31bAEZ0srEj" role="3MwsjC">
           <property role="3MwjfP" value="mps-multiline" />
@@ -1287,6 +1290,16 @@
             <node concept="3qWCbU" id="2eucapX07Ha" role="3LXTna">
               <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
             </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="6VNWhOx06Xh" role="3bR37C">
+          <node concept="3bR9La" id="6VNWhOx06Xi" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:39HJr_hyEzS" resolve="jetbrains.mps.ide.vcs.platform" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="6VNWhOx06Xj" role="3bR37C">
+          <node concept="3bR9La" id="6VNWhOx06Xk" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:39HJr_hyAl1" resolve="jetbrains.mps.ide.vcs.core" />
           </node>
         </node>
       </node>
@@ -5090,6 +5103,11 @@
             <node concept="3qWCbU" id="2eucapX07UU" role="3LXTna">
               <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
             </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="6VNWhOx076D" role="3bR37C">
+          <node concept="3bR9La" id="6VNWhOx076E" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1ia2VB5guYy" resolve="MPS.IDEA" />
           </node>
         </node>
       </node>
@@ -13686,6 +13704,11 @@
             </node>
           </node>
         </node>
+        <node concept="1SiIV0" id="6VNWhOx07pZ" role="3bR37C">
+          <node concept="3bR9La" id="6VNWhOx07q0" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1ia2VB5guYy" resolve="MPS.IDEA" />
+          </node>
+        </node>
       </node>
       <node concept="1E1JtD" id="2jlBy7bQx3n" role="2G$12L">
         <property role="BnDLt" value="true" />
@@ -17008,6 +17031,11 @@
             </node>
           </node>
         </node>
+        <node concept="1SiIV0" id="6VNWhOx17Hd" role="3bR37C">
+          <node concept="3bR9La" id="6VNWhOx17He" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1ia2VB5guYy" resolve="MPS.IDEA" />
+          </node>
+        </node>
       </node>
       <node concept="1E1JtD" id="7CKpyI71cs0" role="2G$12L">
         <property role="BnDLt" value="true" />
@@ -17924,6 +17952,11 @@
             <node concept="3qWCbU" id="7q24334ZKPH" role="3LXTna">
               <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
             </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="6VNWhOx17LT" role="3bR37C">
+          <node concept="3bR9La" id="6VNWhOx17LU" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1ia2VB5guYy" resolve="MPS.IDEA" />
           </node>
         </node>
       </node>

--- a/code/celllayout/languages/de.itemis.mps.celllayout/models/styles/editor.mps
+++ b/code/celllayout/languages/de.itemis.mps.celllayout/models/styles/editor.mps
@@ -11,6 +11,7 @@
     <import index="hox0" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.style(MPS.Editor/)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" />
     <import index="5ueo" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.editor.runtime.style(MPS.Editor/)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
   </imports>
   <registry>
@@ -162,8 +163,8 @@
         <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
       </node>
       <node concept="10M0yZ" id="6SVXTgIaQA2" role="3t49C2">
-        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-        <ref role="3cqZAo" to="z60i:~Color.LIGHT_GRAY" resolve="LIGHT_GRAY" />
+        <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+        <ref role="3cqZAo" to="lzb2:~JBColor.LIGHT_GRAY" resolve="LIGHT_GRAY" />
       </node>
     </node>
     <node concept="3t5Usi" id="2FAXvauFoRY" role="V601i">
@@ -173,8 +174,8 @@
         <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
       </node>
       <node concept="10M0yZ" id="2FAXvauFoS0" role="3t49C2">
-        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-        <ref role="3cqZAo" to="z60i:~Color.LIGHT_GRAY" resolve="LIGHT_GRAY" />
+        <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+        <ref role="3cqZAo" to="lzb2:~JBColor.LIGHT_GRAY" resolve="LIGHT_GRAY" />
       </node>
     </node>
     <node concept="3t5Usi" id="2FAXvauFoUY" role="V601i">
@@ -184,8 +185,8 @@
         <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
       </node>
       <node concept="10M0yZ" id="2FAXvauFoV0" role="3t49C2">
-        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-        <ref role="3cqZAo" to="z60i:~Color.LIGHT_GRAY" resolve="LIGHT_GRAY" />
+        <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+        <ref role="3cqZAo" to="lzb2:~JBColor.LIGHT_GRAY" resolve="LIGHT_GRAY" />
       </node>
     </node>
     <node concept="3t5Usi" id="2FAXvauFoXW" role="V601i">
@@ -195,8 +196,8 @@
         <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
       </node>
       <node concept="10M0yZ" id="2FAXvauFoXY" role="3t49C2">
-        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-        <ref role="3cqZAo" to="z60i:~Color.LIGHT_GRAY" resolve="LIGHT_GRAY" />
+        <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+        <ref role="3cqZAo" to="lzb2:~JBColor.LIGHT_GRAY" resolve="LIGHT_GRAY" />
       </node>
     </node>
     <node concept="3t5Usi" id="2FAXvauFp1a" role="V601i">
@@ -206,8 +207,8 @@
         <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
       </node>
       <node concept="10M0yZ" id="2FAXvauFp1c" role="3t49C2">
-        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-        <ref role="3cqZAo" to="z60i:~Color.LIGHT_GRAY" resolve="LIGHT_GRAY" />
+        <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+        <ref role="3cqZAo" to="lzb2:~JBColor.LIGHT_GRAY" resolve="LIGHT_GRAY" />
       </node>
     </node>
     <node concept="3t5Usi" id="6SVXTgI9G1E" role="V601i">
@@ -372,8 +373,8 @@
         <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
       </node>
       <node concept="10M0yZ" id="43ViAfTrUmL" role="3t49C2">
-        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-        <ref role="3cqZAo" to="z60i:~Color.BLACK" resolve="BLACK" />
+        <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+        <ref role="3cqZAo" to="lzb2:~JBColor.BLACK" resolve="BLACK" />
       </node>
     </node>
     <node concept="3t5Usi" id="43ViAfTrUko" role="V601i">
@@ -389,8 +390,8 @@
         <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
       </node>
       <node concept="10M0yZ" id="7d0q5VH9BqO" role="3t49C2">
-        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-        <ref role="3cqZAo" to="z60i:~Color.BLACK" resolve="BLACK" />
+        <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+        <ref role="3cqZAo" to="lzb2:~JBColor.BLACK" resolve="BLACK" />
       </node>
     </node>
     <node concept="3t5Usi" id="7d0q5VH9Btz" role="V601i">

--- a/code/celllayout/solutions/de.slisson.mps.editor.celllayout.runtime/models/de/itemis/mps/editor/celllayout/runtime.mps
+++ b/code/celllayout/solutions/de.slisson.mps.editor.celllayout.runtime/models/de/itemis/mps/editor/celllayout/runtime.mps
@@ -29,6 +29,7 @@
     <import index="q7tw" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:org.apache.log4j(MPS.Core/)" />
     <import index="t6h5" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang.reflect(JDK/)" />
     <import index="hhnx" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.editor.runtime(MPS.Editor/)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="guwi" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.io(JDK/)" implicit="true" />
     <import index="z8iw" ref="r:dfdf3542-dbcf-43df-870a-3c3504b3c840(jetbrains.mps.baseLanguage.collections.custom)" implicit="true" />
   </imports>
@@ -16777,13 +16778,26 @@
                   <ref role="37wK5l" node="6p1TdwlPQkC" resolve="getBrightness" />
                 </node>
               </node>
-              <node concept="17R0WA" id="6p1TdwlTKlv" role="3K4Cdx">
-                <node concept="10M0yZ" id="6p1TdwlTKpK" role="3uHU7w">
-                  <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                  <ref role="3cqZAo" to="z60i:~Color.LIGHT_GRAY" resolve="LIGHT_GRAY" />
-                </node>
-                <node concept="37vLTw" id="6p1TdwlTKg7" role="3uHU7B">
-                  <ref role="3cqZAo" node="6p1TdwlRAw1" resolve="myColor" />
+              <node concept="1eOMI4" id="2WI5qcPWII" role="3K4Cdx">
+                <node concept="22lmx$" id="2WI5qcPY4Y" role="1eOMHV">
+                  <node concept="17R0WA" id="2WI5qcQ1KM" role="3uHU7w">
+                    <node concept="10M0yZ" id="2WI5qcQ6ET" role="3uHU7w">
+                      <ref role="3cqZAo" to="lzb2:~JBColor.LIGHT_GRAY" resolve="LIGHT_GRAY" />
+                      <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                    </node>
+                    <node concept="37vLTw" id="2WI5qcPZx2" role="3uHU7B">
+                      <ref role="3cqZAo" node="6p1TdwlRAw1" resolve="myColor" />
+                    </node>
+                  </node>
+                  <node concept="17R0WA" id="6p1TdwlTKlv" role="3uHU7B">
+                    <node concept="37vLTw" id="6p1TdwlTKg7" role="3uHU7B">
+                      <ref role="3cqZAo" node="6p1TdwlRAw1" resolve="myColor" />
+                    </node>
+                    <node concept="10M0yZ" id="6p1TdwlTKpK" role="3uHU7w">
+                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                      <ref role="3cqZAo" to="z60i:~Color.LIGHT_GRAY" resolve="LIGHT_GRAY" />
+                    </node>
+                  </node>
                 </node>
               </node>
             </node>

--- a/code/conditional-editor/languages/de.slisson.mps.conditionalEditor.demolang/languageModels/editor.mps
+++ b/code/conditional-editor/languages/de.slisson.mps.conditionalEditor.demolang/languageModels/editor.mps
@@ -11,6 +11,7 @@
   </languages>
   <imports>
     <import index="z60i" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt(JDK/)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" implicit="true" />
     <import index="ye5w" ref="r:6c3a5ff5-b652-48a4-80a3-0e283d57df4d(de.slisson.mps.conditionalEditor.demolang.structure)" implicit="true" />
     <import index="tpco" ref="r:00000000-0000-4000-0000-011c89590284(jetbrains.mps.lang.core.editor)" implicit="true" />
@@ -89,15 +90,15 @@
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
       </concept>
-      <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
-        <child id="1145553007750" name="creator" index="2ShVmc" />
-      </concept>
       <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
         <child id="1137022507850" name="body" index="2VODD2" />
       </concept>
       <concept id="1070462154015" name="jetbrains.mps.baseLanguage.structure.StaticFieldDeclaration" flags="ig" index="Wx3nA" />
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
       </concept>
       <concept id="1070533707846" name="jetbrains.mps.baseLanguage.structure.StaticFieldReference" flags="nn" index="10M0yZ">
         <reference id="1144433057691" name="classifier" index="1PxDUh" />
@@ -115,6 +116,9 @@
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
+      <concept id="1111509017652" name="jetbrains.mps.baseLanguage.structure.FloatingPointConstant" flags="nn" index="3b6qkQ">
+        <property id="1113006610751" name="value" index="$nhwW" />
+      </concept>
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
@@ -124,15 +128,11 @@
       <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
         <property id="1068580123138" name="value" index="3clFbU" />
       </concept>
-      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
-        <property id="1068580320021" name="value" index="3cmrfH" />
-      </concept>
       <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
-      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
       <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
         <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
       </concept>
@@ -219,22 +219,16 @@
       <node concept="Veino" id="7klUZA6Y2R$" role="3F10Kt">
         <node concept="3ZlJ5R" id="7klUZA6Y2RB" role="VblUZ">
           <node concept="3clFbS" id="7klUZA6Y2RC" role="2VODD2">
-            <node concept="3clFbF" id="7klUZA6Y4DP" role="3cqZAp">
-              <node concept="2ShNRf" id="7klUZA6Y4DN" role="3clFbG">
-                <node concept="1pGfFk" id="7klUZA6Y5Rt" role="2ShVmc">
-                  <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int,int)" resolve="Color" />
-                  <node concept="3cmrfG" id="7klUZA6Y_XU" role="37wK5m">
-                    <property role="3cmrfH" value="0" />
-                  </node>
-                  <node concept="3cmrfG" id="7klUZA6Y6Qz" role="37wK5m">
-                    <property role="3cmrfH" value="0" />
-                  </node>
-                  <node concept="3cmrfG" id="7klUZA6Y7DS" role="37wK5m">
-                    <property role="3cmrfH" value="0" />
-                  </node>
-                  <node concept="3cmrfG" id="7klUZA6Y97e" role="37wK5m">
-                    <property role="3cmrfH" value="10" />
-                  </node>
+            <node concept="3clFbF" id="2WI5qdwHWK" role="3cqZAp">
+              <node concept="2YIFZM" id="2WI5qdwI2H" role="3clFbG">
+                <ref role="37wK5l" to="lzb2:~ColorUtil.withAlpha(java.awt.Color,double)" resolve="withAlpha" />
+                <ref role="1Pybhc" to="lzb2:~ColorUtil" resolve="ColorUtil" />
+                <node concept="10M0yZ" id="2WI5qdwIf_" role="37wK5m">
+                  <ref role="3cqZAo" to="lzb2:~JBColor.BLACK" resolve="BLACK" />
+                  <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                </node>
+                <node concept="3b6qkQ" id="2WI5qdwIjZ" role="37wK5m">
+                  <property role="$nhwW" value="0.039" />
                 </node>
               </node>
             </node>

--- a/code/diagram/languages/de.itemis.mps.editor.diagram.demo.activity/languageModels/editor.mps
+++ b/code/diagram/languages/de.itemis.mps.editor.diagram.demo.activity/languageModels/editor.mps
@@ -20,6 +20,7 @@
     <import index="mhfm" ref="3f233e7f-b8a6-46d2-a57f-795d56775243/java:org.jetbrains.annotations(Annotations/)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" />
     <import index="zn9m" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.util(MPS.IDEA/)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
     <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" implicit="true" />
   </imports>
@@ -1336,6 +1337,15 @@
               </node>
             </node>
           </node>
+          <node concept="3sA_1f" id="2pXhcZQqwcX" role="3sAl1G">
+            <property role="3sAy83" value="true" />
+            <property role="3sAy88" value="true" />
+            <property role="3sAy8m" value="true" />
+            <property role="3sAwEb" value="true" />
+            <property role="3sAwEn" value="true" />
+            <property role="3sAwEi" value="true" />
+            <property role="3g8l5v" value="false" />
+          </node>
           <node concept="2M4Efz" id="1MAkSr4CfiV" role="aCds2">
             <node concept="37q72E" id="1MAkSr4CfiZ" role="2M4AHN">
               <node concept="3clFbS" id="1MAkSr4Cfj1" role="2VODD2">
@@ -1624,15 +1634,6 @@
               </node>
             </node>
           </node>
-          <node concept="3sA_1f" id="2pXhcZQqwcX" role="3sAl1G">
-            <property role="3sAy83" value="true" />
-            <property role="3sAy88" value="true" />
-            <property role="3sAy8m" value="true" />
-            <property role="3sAwEb" value="true" />
-            <property role="3sAwEn" value="true" />
-            <property role="3sAwEi" value="true" />
-            <property role="3g8l5v" value="false" />
-          </node>
           <node concept="3fe8g" id="1MAkSr4BiCN" role="35U2g">
             <node concept="3pGojX" id="awq4$rgWNg" role="3pGojU" />
           </node>
@@ -1655,8 +1656,8 @@
             <node concept="liA8E" id="4XPshStkWNL" role="2OqNvi">
               <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
               <node concept="10M0yZ" id="4XPshStkWNM" role="37wK5m">
-                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                <ref role="3cqZAo" to="z60i:~Color.BLACK" resolve="BLACK" />
+                <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                <ref role="3cqZAo" to="lzb2:~JBColor.BLACK" resolve="BLACK" />
               </node>
             </node>
           </node>
@@ -1900,8 +1901,8 @@
             <node concept="liA8E" id="4XPshStkTtV" role="2OqNvi">
               <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
               <node concept="10M0yZ" id="4XPshStkTtW" role="37wK5m">
-                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                <ref role="3cqZAo" to="z60i:~Color.BLACK" resolve="BLACK" />
+                <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                <ref role="3cqZAo" to="lzb2:~JBColor.BLACK" resolve="BLACK" />
               </node>
             </node>
           </node>
@@ -3096,8 +3097,8 @@
             <node concept="liA8E" id="4EOrrTBL_L5" role="2OqNvi">
               <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
               <node concept="10M0yZ" id="4EOrrTBL_Wq" role="37wK5m">
-                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                <ref role="3cqZAo" to="z60i:~Color.BLACK" resolve="BLACK" />
+                <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                <ref role="3cqZAo" to="lzb2:~JBColor.BLACK" resolve="BLACK" />
               </node>
             </node>
           </node>

--- a/code/diagram/languages/de.itemis.mps.editor.diagram.demolang/languageModels/editor.mps
+++ b/code/diagram/languages/de.itemis.mps.editor.diagram.demolang/languageModels/editor.mps
@@ -20,6 +20,7 @@
     <import index="wo6c" ref="r:de91083f-90a8-4dd4-83b1-8a92d65ab81d(de.itemis.mps.editor.diagram.shapes)" />
     <import index="mhfm" ref="3f233e7f-b8a6-46d2-a57f-795d56775243/java:org.jetbrains.annotations(Annotations/)" />
     <import index="swi3" ref="r:5eabed4f-92f5-4459-b9b3-e2faa24f3467(de.itemis.mps.editor.diagram.styles.editor)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
     <import index="guwi" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.io(JDK/)" implicit="true" />
     <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" implicit="true" />
@@ -777,8 +778,8 @@
                   <node concept="3clFbS" id="7WiZGib9KZR" role="2VODD2">
                     <node concept="3clFbF" id="7WiZGib9Lfy" role="3cqZAp">
                       <node concept="10M0yZ" id="7WiZGib9Lfx" role="3clFbG">
-                        <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                        <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                        <ref role="3cqZAo" to="lzb2:~JBColor.lightGray" resolve="lightGray" />
                       </node>
                     </node>
                   </node>

--- a/code/diagram/languages/de.itemis.mps.editor.diagram.demolang/languageModels/editor.mps
+++ b/code/diagram/languages/de.itemis.mps.editor.diagram.demolang/languageModels/editor.mps
@@ -152,6 +152,9 @@
         <property id="1176718929932" name="isFinal" index="3TUv4t" />
         <child id="1068431790190" name="initializer" index="33vP2m" />
       </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ng" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
+      </concept>
       <concept id="1092119917967" name="jetbrains.mps.baseLanguage.structure.MulExpression" flags="nn" index="17qRlL" />
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
@@ -1606,18 +1609,28 @@
           <ref role="3tD7wE" to="swi3:5FmzNQoGJXe" resolve="diagram-background-color" />
           <node concept="3sjG9q" id="5FmzNQoJ3fy" role="3tD6jU">
             <node concept="3clFbS" id="5FmzNQoJ3f$" role="2VODD2">
-              <node concept="3clFbF" id="5FmzNQoJ3z6" role="3cqZAp">
-                <node concept="2ShNRf" id="5FmzNQoJ3S2" role="3clFbG">
-                  <node concept="1pGfFk" id="5FmzNQoJ5by" role="2ShVmc">
-                    <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
-                    <node concept="3cmrfG" id="5FmzNQoJ5c_" role="37wK5m">
-                      <property role="3cmrfH" value="240" />
+              <node concept="3clFbF" id="4w64dgpLe$m" role="3cqZAp">
+                <node concept="2ShNRf" id="4w64dgpL3mM" role="3clFbG">
+                  <node concept="1pGfFk" id="4w64dgpLaZ7" role="2ShVmc">
+                    <property role="373rjd" value="true" />
+                    <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                    <node concept="2ShNRf" id="21DGiA4IQGq" role="37wK5m">
+                      <node concept="1pGfFk" id="21DGiA4IQGr" role="2ShVmc">
+                        <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
+                        <node concept="3cmrfG" id="21DGiA4IQGs" role="37wK5m">
+                          <property role="3cmrfH" value="240" />
+                        </node>
+                        <node concept="3cmrfG" id="21DGiA4IQGt" role="37wK5m">
+                          <property role="3cmrfH" value="240" />
+                        </node>
+                        <node concept="3cmrfG" id="21DGiA4IQGu" role="37wK5m">
+                          <property role="3cmrfH" value="240" />
+                        </node>
+                      </node>
                     </node>
-                    <node concept="3cmrfG" id="5FmzNQoJ5fw" role="37wK5m">
-                      <property role="3cmrfH" value="240" />
-                    </node>
-                    <node concept="3cmrfG" id="5FmzNQoJ5kz" role="37wK5m">
-                      <property role="3cmrfH" value="255" />
+                    <node concept="10M0yZ" id="4w64dgpLe$o" role="37wK5m">
+                      <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                      <ref role="3cqZAo" to="lzb2:~JBColor.WHITE" resolve="WHITE" />
                     </node>
                   </node>
                 </node>

--- a/code/diagram/languages/de.itemis.mps.editor.diagram.styles/languageModels/editor.mps
+++ b/code/diagram/languages/de.itemis.mps.editor.diagram.styles/languageModels/editor.mps
@@ -9,6 +9,8 @@
     <import index="z60i" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt(JDK/)" />
     <import index="hox0" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.style(MPS.Editor/)" />
     <import index="mhfm" ref="3f233e7f-b8a6-46d2-a57f-795d56775243/java:org.jetbrains.annotations(Annotations/)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
+    <import index="exr9" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor(MPS.Editor/)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
     <import index="1y6f" ref="r:a425f003-07f2-4ded-ad56-54c06b501569(de.itemis.mps.editor.diagram.styles.structure)" implicit="true" />
   </imports>
@@ -42,9 +44,6 @@
         <child id="1068498886295" name="lValue" index="37vLTJ" />
       </concept>
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
-      <concept id="1179360813171" name="jetbrains.mps.baseLanguage.structure.HexIntegerLiteral" flags="nn" index="2nou5x">
-        <property id="1179360856892" name="value" index="2noCCI" />
-      </concept>
       <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
       <concept id="5279705229678483897" name="jetbrains.mps.baseLanguage.structure.FloatingPointFloatConstant" flags="nn" index="2$xPTn">
         <property id="5279705229678483899" name="value" index="2$xPTl" />
@@ -94,6 +93,9 @@
       <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu" />
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ng" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
       </concept>
       <concept id="1092119917967" name="jetbrains.mps.baseLanguage.structure.MulExpression" flags="nn" index="17qRlL" />
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
@@ -225,18 +227,13 @@
       <node concept="3uibUv" id="4mmPun56RuI" role="3t5Oan">
         <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
       </node>
-      <node concept="2ShNRf" id="4mmPun56RuJ" role="3t49C2">
-        <node concept="1pGfFk" id="4mmPun56RuK" role="2ShVmc">
-          <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
-          <node concept="2nou5x" id="4mmPun56RuL" role="37wK5m">
-            <property role="2noCCI" value="64" />
-          </node>
-          <node concept="2nou5x" id="4mmPun56RuM" role="37wK5m">
-            <property role="2noCCI" value="82" />
-          </node>
-          <node concept="2nou5x" id="4mmPun56RuN" role="37wK5m">
-            <property role="2noCCI" value="B9" />
-          </node>
+      <node concept="2OqwBi" id="4w64dgpT40q" role="3t49C2">
+        <node concept="10M0yZ" id="2WI5qekdZ2" role="2Oq$k0">
+          <ref role="1PxDUh" to="exr9:~MPSColors" resolve="MPSColors" />
+          <ref role="3cqZAo" to="exr9:~MPSColors.LIGHT_BLUE" resolve="LIGHT_BLUE" />
+        </node>
+        <node concept="liA8E" id="4w64dgpT4iy" role="2OqNvi">
+          <ref role="37wK5l" to="z60i:~Color.darker()" resolve="darker" />
         </node>
       </node>
     </node>
@@ -251,17 +248,32 @@
       <node concept="3uibUv" id="5FmzNQoGJYL" role="3t5Oan">
         <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
       </node>
-      <node concept="2ShNRf" id="21DGiA4IQGq" role="3t49C2">
-        <node concept="1pGfFk" id="21DGiA4IQGr" role="2ShVmc">
-          <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
-          <node concept="3cmrfG" id="21DGiA4IQGs" role="37wK5m">
-            <property role="3cmrfH" value="240" />
-          </node>
-          <node concept="3cmrfG" id="21DGiA4IQGt" role="37wK5m">
-            <property role="3cmrfH" value="240" />
-          </node>
-          <node concept="3cmrfG" id="21DGiA4IQGu" role="37wK5m">
-            <property role="3cmrfH" value="240" />
+      <node concept="10QFUN" id="4w64dgpLbxS" role="3t49C2">
+        <node concept="3uibUv" id="4w64dgpLbC_" role="10QFUM">
+          <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
+        </node>
+        <node concept="2ShNRf" id="4w64dgpL3mM" role="10QFUP">
+          <node concept="1pGfFk" id="4w64dgpLaZ7" role="2ShVmc">
+            <property role="373rjd" value="true" />
+            <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+            <node concept="2ShNRf" id="21DGiA4IQGq" role="37wK5m">
+              <node concept="1pGfFk" id="21DGiA4IQGr" role="2ShVmc">
+                <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
+                <node concept="3cmrfG" id="21DGiA4IQGs" role="37wK5m">
+                  <property role="3cmrfH" value="240" />
+                </node>
+                <node concept="3cmrfG" id="21DGiA4IQGt" role="37wK5m">
+                  <property role="3cmrfH" value="240" />
+                </node>
+                <node concept="3cmrfG" id="21DGiA4IQGu" role="37wK5m">
+                  <property role="3cmrfH" value="240" />
+                </node>
+              </node>
+            </node>
+            <node concept="10M0yZ" id="4w64dgpKIn8" role="37wK5m">
+              <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+              <ref role="3cqZAo" to="lzb2:~JBColor.WHITE" resolve="WHITE" />
+            </node>
           </node>
         </node>
       </node>

--- a/code/diagram/languages/de.itemis.mps.editor.diagram/generator/template/main@generator.mps
+++ b/code/diagram/languages/de.itemis.mps.editor.diagram/generator/template/main@generator.mps
@@ -5064,7 +5064,7 @@
                                                         <node concept="3clFbF" id="2YJ6SvpdRkz" role="3cqZAp">
                                                           <node concept="2OqwBi" id="2YJ6SvpdRku" role="3clFbG">
                                                             <node concept="3TrcHB" id="2YJ6SvpdRkx" role="2OqNvi">
-                                                              <ref role="3TsBF5" to="2qld:2YJ6Svp2O0G" resolve="saveSubdiagramLayoutInDiagram" />
+                                                              <ref role="3TsBF5" to="2qld:2YJ6Svp2O0G" resolve="saveSubDiagramLayoutInDiagram" />
                                                             </node>
                                                             <node concept="30H73N" id="2YJ6SvpdRky" role="2Oq$k0" />
                                                           </node>

--- a/code/diagram/solutions/de.itemis.mps.editor.diagram.runtime/models/de/itemis/mps/editor/diagram/runtime/shape.mps
+++ b/code/diagram/solutions/de.itemis.mps.editor.diagram.runtime/models/de/itemis/mps/editor/diagram/runtime/shape.mps
@@ -17,6 +17,9 @@
     <import index="r3rm" ref="r:7fc96130-6279-4a55-aeeb-422a6879539d(de.itemis.mps.editor.diagram.runtime.jgraph)" />
     <import index="swi3" ref="r:5eabed4f-92f5-4459-b9b3-e2faa24f3467(de.itemis.mps.editor.diagram.styles.editor)" />
     <import index="hox0" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.style(MPS.Editor/)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
+    <import index="exr9" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor(MPS.Editor/)" />
+    <import index="g1qu" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.util.ui(MPS.IDEA/)" />
   </imports>
   <registry>
     <language id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor">
@@ -95,6 +98,9 @@
       </concept>
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ng" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
       </concept>
       <concept id="1092119917967" name="jetbrains.mps.baseLanguage.structure.MulExpression" flags="nn" index="17qRlL" />
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
@@ -1855,24 +1861,47 @@
       <node concept="3cqZAl" id="6uo2fN6yu8q" role="3clF45" />
       <node concept="3Tm1VV" id="6uo2fN6yu8r" role="1B3o_S" />
       <node concept="3clFbS" id="6uo2fN6yu8s" role="3clF47">
-        <node concept="3clFbF" id="6uo2fN6yu8t" role="3cqZAp">
-          <node concept="2OqwBi" id="6uo2fN6yu8u" role="3clFbG">
-            <node concept="37vLTw" id="6uo2fN6yu8v" role="2Oq$k0">
-              <ref role="3cqZAo" node="6uo2fN6yu8A" resolve="g" />
+        <node concept="3clFbJ" id="4w64dgq$SbD" role="3cqZAp">
+          <node concept="3clFbS" id="4w64dgq$SbF" role="3clFbx">
+            <node concept="3clFbF" id="4w64dgq$UrB" role="3cqZAp">
+              <node concept="2OqwBi" id="4w64dgq$UrC" role="3clFbG">
+                <node concept="37vLTw" id="4w64dgq$UrD" role="2Oq$k0">
+                  <ref role="3cqZAo" node="6uo2fN6yu8A" resolve="g" />
+                </node>
+                <node concept="liA8E" id="4w64dgq$UrE" role="2OqNvi">
+                  <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
+                  <node concept="2YIFZM" id="oUEeqEZPtu" role="37wK5m">
+                    <ref role="37wK5l" to="lzb2:~ColorUtil.darker(java.awt.Color,int)" resolve="darker" />
+                    <ref role="1Pybhc" to="lzb2:~ColorUtil" resolve="ColorUtil" />
+                    <node concept="10M0yZ" id="4w64dgq$UrF" role="37wK5m">
+                      <ref role="3cqZAo" to="exr9:~MPSColors.LIGHT_BLUE" resolve="LIGHT_BLUE" />
+                      <ref role="1PxDUh" to="exr9:~MPSColors" resolve="MPSColors" />
+                    </node>
+                    <node concept="3cmrfG" id="oUEeqEZQeT" role="37wK5m">
+                      <property role="3cmrfH" value="3" />
+                    </node>
+                  </node>
+                </node>
+              </node>
             </node>
-            <node concept="liA8E" id="6uo2fN6yu8w" role="2OqNvi">
-              <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
-              <node concept="2ShNRf" id="61ORDkd5BwF" role="37wK5m">
-                <node concept="1pGfFk" id="61ORDkd5BwG" role="2ShVmc">
-                  <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
-                  <node concept="2nou5x" id="61ORDkd5BwH" role="37wK5m">
-                    <property role="2noCCI" value="C3" />
+          </node>
+          <node concept="2YIFZM" id="4w64dgq$TL_" role="3clFbw">
+            <ref role="37wK5l" to="g1qu:~UIUtil.isUnderDarcula()" resolve="isUnderDarcula" />
+            <ref role="1Pybhc" to="g1qu:~UIUtil" resolve="UIUtil" />
+          </node>
+          <node concept="9aQIb" id="4w64dgq$TYx" role="9aQIa">
+            <node concept="3clFbS" id="4w64dgq$TYy" role="9aQI4">
+              <node concept="3clFbF" id="6uo2fN6yu8t" role="3cqZAp">
+                <node concept="2OqwBi" id="6uo2fN6yu8u" role="3clFbG">
+                  <node concept="37vLTw" id="6uo2fN6yu8v" role="2Oq$k0">
+                    <ref role="3cqZAo" node="6uo2fN6yu8A" resolve="g" />
                   </node>
-                  <node concept="2nou5x" id="61ORDkd5BwI" role="37wK5m">
-                    <property role="2noCCI" value="D9" />
-                  </node>
-                  <node concept="2nou5x" id="61ORDkd5BwJ" role="37wK5m">
-                    <property role="2noCCI" value="FF" />
+                  <node concept="liA8E" id="6uo2fN6yu8w" role="2OqNvi">
+                    <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
+                    <node concept="10M0yZ" id="2WI5qekdZ2" role="37wK5m">
+                      <ref role="1PxDUh" to="exr9:~MPSColors" resolve="MPSColors" />
+                      <ref role="3cqZAo" to="exr9:~MPSColors.LIGHT_BLUE" resolve="LIGHT_BLUE" />
+                    </node>
                   </node>
                 </node>
               </node>
@@ -1921,17 +1950,42 @@
             </node>
             <node concept="liA8E" id="6uo2fN6yu8N" role="2OqNvi">
               <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
-              <node concept="2ShNRf" id="61ORDkd5BFP" role="37wK5m">
-                <node concept="1pGfFk" id="61ORDkd5BFQ" role="2ShVmc">
-                  <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
-                  <node concept="2nou5x" id="61ORDkd5BFR" role="37wK5m">
-                    <property role="2noCCI" value="64" />
+              <node concept="2ShNRf" id="2WI5qekCVc" role="37wK5m">
+                <node concept="1pGfFk" id="2WI5qekDzX" role="2ShVmc">
+                  <property role="373rjd" value="true" />
+                  <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                  <node concept="2ShNRf" id="61ORDkd5BFP" role="37wK5m">
+                    <node concept="1pGfFk" id="61ORDkd5BFQ" role="2ShVmc">
+                      <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
+                      <node concept="2nou5x" id="61ORDkd5BFR" role="37wK5m">
+                        <property role="2noCCI" value="64" />
+                      </node>
+                      <node concept="2nou5x" id="61ORDkd5BFS" role="37wK5m">
+                        <property role="2noCCI" value="82" />
+                      </node>
+                      <node concept="2nou5x" id="61ORDkd5BFT" role="37wK5m">
+                        <property role="2noCCI" value="B9" />
+                      </node>
+                    </node>
                   </node>
-                  <node concept="2nou5x" id="61ORDkd5BFS" role="37wK5m">
-                    <property role="2noCCI" value="82" />
-                  </node>
-                  <node concept="2nou5x" id="61ORDkd5BFT" role="37wK5m">
-                    <property role="2noCCI" value="B9" />
+                  <node concept="2OqwBi" id="4w64dgpS8is" role="37wK5m">
+                    <node concept="2ShNRf" id="2WI5qekE7T" role="2Oq$k0">
+                      <node concept="1pGfFk" id="2WI5qekE7U" role="2ShVmc">
+                        <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
+                        <node concept="2nou5x" id="2WI5qekE7V" role="37wK5m">
+                          <property role="2noCCI" value="64" />
+                        </node>
+                        <node concept="2nou5x" id="2WI5qekE7W" role="37wK5m">
+                          <property role="2noCCI" value="82" />
+                        </node>
+                        <node concept="2nou5x" id="2WI5qekE7X" role="37wK5m">
+                          <property role="2noCCI" value="B9" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="4w64dgpS8MK" role="2OqNvi">
+                      <ref role="37wK5l" to="z60i:~Color.darker()" resolve="darker" />
+                    </node>
                   </node>
                 </node>
               </node>
@@ -1977,7 +2031,7 @@
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="6uo2fN6yu93" role="3cqZAp">
+        <node concept="3clFbF" id="2WI5qekEBX" role="3cqZAp">
           <node concept="2OqwBi" id="6uo2fN6yu94" role="3clFbG">
             <node concept="37vLTw" id="6uo2fN6yu95" role="2Oq$k0">
               <ref role="3cqZAo" node="6uo2fN6yu8Y" resolve="g" />

--- a/code/diagram/solutions/de.itemis.mps.editor.diagram.shapes/de.itemis.mps.editor.diagram.shapes.msd
+++ b/code/diagram/solutions/de.itemis.mps.editor.diagram.shapes/de.itemis.mps.editor.diagram.shapes.msd
@@ -13,6 +13,7 @@
   <sourcePath />
   <dependencies>
     <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
+    <dependency reexport="false">498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:fa13cc63-c476-4d46-9c96-d53670abe7bc:de.itemis.mps.editor.diagram" version="0" />
@@ -29,7 +30,9 @@
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
   </languageVersions>
   <dependencyVersions>
+    <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
     <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
+    <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
     <module reference="f7ad14aa-a3e2-4301-8822-d919845c8bcf(de.itemis.mps.editor.diagram.shapes)" version="0" />
   </dependencyVersions>
 </solution>

--- a/code/diagram/solutions/de.itemis.mps.editor.diagram.shapes/models/de/itemis/mps/editor/diagram/shapes.mps
+++ b/code/diagram/solutions/de.itemis.mps.editor.diagram.shapes/models/de/itemis/mps/editor/diagram/shapes.mps
@@ -8,6 +8,7 @@
   <imports>
     <import index="fbzs" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt.geom(JDK/)" />
     <import index="z60i" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt(JDK/)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
@@ -28,6 +29,9 @@
       </concept>
       <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
         <child id="1137022507850" name="body" index="2VODD2" />
+      </concept>
+      <concept id="1070533707846" name="jetbrains.mps.baseLanguage.structure.StaticFieldReference" flags="nn" index="10M0yZ">
+        <reference id="1144433057691" name="classifier" index="1PxDUh" />
       </concept>
       <concept id="1070534513062" name="jetbrains.mps.baseLanguage.structure.DoubleType" flags="in" index="10P55v" />
       <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
@@ -409,19 +413,9 @@
             <node concept="2xDIQ0" id="5WYUu8HgObu" role="2Oq$k0" />
             <node concept="liA8E" id="5WYUu8HgOtt" role="2OqNvi">
               <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
-              <node concept="2ShNRf" id="5WYUu8HgOui" role="37wK5m">
-                <node concept="1pGfFk" id="5WYUu8HgRG0" role="2ShVmc">
-                  <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
-                  <node concept="3cmrfG" id="5WYUu8HgRH8" role="37wK5m">
-                    <property role="3cmrfH" value="200" />
-                  </node>
-                  <node concept="3cmrfG" id="5WYUu8HgRKt" role="37wK5m">
-                    <property role="3cmrfH" value="200" />
-                  </node>
-                  <node concept="3cmrfG" id="5WYUu8HgSoC" role="37wK5m">
-                    <property role="3cmrfH" value="200" />
-                  </node>
-                </node>
+              <node concept="10M0yZ" id="2WI5qcR4Zz" role="37wK5m">
+                <ref role="3cqZAo" to="lzb2:~JBColor.LIGHT_GRAY" resolve="LIGHT_GRAY" />
+                <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
               </node>
             </node>
           </node>

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells.sandboxlang/models/com/mbeddr/mpsutil/grammarcells/sandboxlang/editor.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells.sandboxlang/models/com/mbeddr/mpsutil/grammarcells/sandboxlang/editor.mps
@@ -10,6 +10,7 @@
   </languages>
   <imports>
     <import index="z60i" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt(JDK/)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="ibwz" ref="r:ad27d4b4-fc2c-4b6d-9e22-455eb0ccf354(com.mbeddr.mpsutil.grammarcells.sandboxlang.structure)" implicit="true" />
     <import index="tpco" ref="r:00000000-0000-4000-0000-011c89590284(jetbrains.mps.lang.core.editor)" implicit="true" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
@@ -147,6 +148,9 @@
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
       </concept>
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
+      </concept>
       <concept id="1070533707846" name="jetbrains.mps.baseLanguage.structure.StaticFieldReference" flags="nn" index="10M0yZ">
         <reference id="1144433057691" name="classifier" index="1PxDUh" />
       </concept>
@@ -154,6 +158,9 @@
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
       <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
+      <concept id="1111509017652" name="jetbrains.mps.baseLanguage.structure.FloatingPointConstant" flags="nn" index="3b6qkQ">
+        <property id="1113006610751" name="value" index="$nhwW" />
+      </concept>
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
@@ -171,7 +178,6 @@
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
-      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
       <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
@@ -787,22 +793,16 @@
               <node concept="Veino" id="1PeMnANeHGL" role="3F10Kt">
                 <node concept="3ZlJ5R" id="1PeMnANeXlY" role="VblUZ">
                   <node concept="3clFbS" id="1PeMnANeXlZ" role="2VODD2">
-                    <node concept="3clFbF" id="1PeMnANeXn0" role="3cqZAp">
-                      <node concept="2ShNRf" id="1PeMnANeXmY" role="3clFbG">
-                        <node concept="1pGfFk" id="1PeMnANeX_f" role="2ShVmc">
-                          <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int,int)" resolve="Color" />
-                          <node concept="3cmrfG" id="1PeMnANeXAr" role="37wK5m">
-                            <property role="3cmrfH" value="0" />
-                          </node>
-                          <node concept="3cmrfG" id="1PeMnANeXIN" role="37wK5m">
-                            <property role="3cmrfH" value="0" />
-                          </node>
-                          <node concept="3cmrfG" id="1PeMnANeXMY" role="37wK5m">
-                            <property role="3cmrfH" value="0" />
-                          </node>
-                          <node concept="3cmrfG" id="1PeMnANeXTM" role="37wK5m">
-                            <property role="3cmrfH" value="0" />
-                          </node>
+                    <node concept="3clFbF" id="2WI5qdaB_S" role="3cqZAp">
+                      <node concept="2YIFZM" id="2WI5qdaB_U" role="3clFbG">
+                        <ref role="1Pybhc" to="lzb2:~ColorUtil" resolve="ColorUtil" />
+                        <ref role="37wK5l" to="lzb2:~ColorUtil.withAlpha(java.awt.Color,double)" resolve="withAlpha" />
+                        <node concept="10M0yZ" id="2WI5qdaB_V" role="37wK5m">
+                          <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                          <ref role="3cqZAo" to="lzb2:~JBColor.BLACK" resolve="BLACK" />
+                        </node>
+                        <node concept="3cmrfG" id="2WI5qdaBGx" role="37wK5m">
+                          <property role="3cmrfH" value="0" />
                         </node>
                       </node>
                     </node>
@@ -850,22 +850,16 @@
               <node concept="Veino" id="1PeMnANeXYx" role="3F10Kt">
                 <node concept="3ZlJ5R" id="1PeMnANeXYy" role="VblUZ">
                   <node concept="3clFbS" id="1PeMnANeXYz" role="2VODD2">
-                    <node concept="3clFbF" id="1PeMnANeXY$" role="3cqZAp">
-                      <node concept="2ShNRf" id="1PeMnANeXY_" role="3clFbG">
-                        <node concept="1pGfFk" id="1PeMnANeXYA" role="2ShVmc">
-                          <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int,int)" resolve="Color" />
-                          <node concept="3cmrfG" id="1PeMnANeXYB" role="37wK5m">
-                            <property role="3cmrfH" value="0" />
-                          </node>
-                          <node concept="3cmrfG" id="1PeMnANeXYC" role="37wK5m">
-                            <property role="3cmrfH" value="0" />
-                          </node>
-                          <node concept="3cmrfG" id="1PeMnANeXYD" role="37wK5m">
-                            <property role="3cmrfH" value="0" />
-                          </node>
-                          <node concept="3cmrfG" id="1PeMnANeXYE" role="37wK5m">
-                            <property role="3cmrfH" value="0" />
-                          </node>
+                    <node concept="3clFbF" id="2WI5qdaBUu" role="3cqZAp">
+                      <node concept="2YIFZM" id="2WI5qdaBUw" role="3clFbG">
+                        <ref role="1Pybhc" to="lzb2:~ColorUtil" resolve="ColorUtil" />
+                        <ref role="37wK5l" to="lzb2:~ColorUtil.withAlpha(java.awt.Color,double)" resolve="withAlpha" />
+                        <node concept="10M0yZ" id="2WI5qdaBUx" role="37wK5m">
+                          <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                          <ref role="3cqZAo" to="lzb2:~JBColor.BLACK" resolve="BLACK" />
+                        </node>
+                        <node concept="3cmrfG" id="2WI5qdaC0o" role="37wK5m">
+                          <property role="3cmrfH" value="0" />
                         </node>
                       </node>
                     </node>
@@ -880,22 +874,16 @@
               <node concept="Veino" id="1PeMnANeY2I" role="3F10Kt">
                 <node concept="3ZlJ5R" id="1PeMnANeY2J" role="VblUZ">
                   <node concept="3clFbS" id="1PeMnANeY2K" role="2VODD2">
-                    <node concept="3clFbF" id="1PeMnANeY2L" role="3cqZAp">
-                      <node concept="2ShNRf" id="1PeMnANeY2M" role="3clFbG">
-                        <node concept="1pGfFk" id="1PeMnANeY2N" role="2ShVmc">
-                          <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int,int)" resolve="Color" />
-                          <node concept="3cmrfG" id="1PeMnANeY2O" role="37wK5m">
-                            <property role="3cmrfH" value="0" />
-                          </node>
-                          <node concept="3cmrfG" id="1PeMnANeY2P" role="37wK5m">
-                            <property role="3cmrfH" value="0" />
-                          </node>
-                          <node concept="3cmrfG" id="1PeMnANeY2Q" role="37wK5m">
-                            <property role="3cmrfH" value="0" />
-                          </node>
-                          <node concept="3cmrfG" id="1PeMnANeY2R" role="37wK5m">
-                            <property role="3cmrfH" value="0" />
-                          </node>
+                    <node concept="3clFbF" id="2WI5qdaC4P" role="3cqZAp">
+                      <node concept="2YIFZM" id="2WI5qdaC4R" role="3clFbG">
+                        <ref role="1Pybhc" to="lzb2:~ColorUtil" resolve="ColorUtil" />
+                        <ref role="37wK5l" to="lzb2:~ColorUtil.withAlpha(java.awt.Color,double)" resolve="withAlpha" />
+                        <node concept="10M0yZ" id="2WI5qdaC4S" role="37wK5m">
+                          <ref role="3cqZAo" to="lzb2:~JBColor.BLACK" resolve="BLACK" />
+                          <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                        </node>
+                        <node concept="3cmrfG" id="2WI5qdaCem" role="37wK5m">
+                          <property role="3cmrfH" value="0" />
                         </node>
                       </node>
                     </node>
@@ -908,22 +896,16 @@
           <node concept="Veino" id="1PeMnANe9$0" role="3F10Kt">
             <node concept="3ZlJ5R" id="1PeMnANe9_y" role="VblUZ">
               <node concept="3clFbS" id="1PeMnANe9_z" role="2VODD2">
-                <node concept="3clFbF" id="1PeMnANecua" role="3cqZAp">
-                  <node concept="2ShNRf" id="1PeMnANecu8" role="3clFbG">
-                    <node concept="1pGfFk" id="1PeMnANedtB" role="2ShVmc">
-                      <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int,int)" resolve="Color" />
-                      <node concept="3cmrfG" id="1PeMnANeduN" role="37wK5m">
-                        <property role="3cmrfH" value="0" />
-                      </node>
-                      <node concept="3cmrfG" id="1PeMnANedCF" role="37wK5m">
-                        <property role="3cmrfH" value="0" />
-                      </node>
-                      <node concept="3cmrfG" id="1PeMnANedK2" role="37wK5m">
-                        <property role="3cmrfH" value="0" />
-                      </node>
-                      <node concept="3cmrfG" id="1PeMnANedQQ" role="37wK5m">
-                        <property role="3cmrfH" value="20" />
-                      </node>
+                <node concept="3clFbF" id="2WI5qdaB1q" role="3cqZAp">
+                  <node concept="2YIFZM" id="2WI5qd69dq" role="3clFbG">
+                    <ref role="1Pybhc" to="lzb2:~ColorUtil" resolve="ColorUtil" />
+                    <ref role="37wK5l" to="lzb2:~ColorUtil.withAlpha(java.awt.Color,double)" resolve="withAlpha" />
+                    <node concept="10M0yZ" id="2WI5qd69h0" role="37wK5m">
+                      <ref role="3cqZAo" to="lzb2:~JBColor.BLACK" resolve="BLACK" />
+                      <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                    </node>
+                    <node concept="3b6qkQ" id="2WI5qd69lt" role="37wK5m">
+                      <property role="$nhwW" value="0.1275" />
                     </node>
                   </node>
                 </node>

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/models/com/mbeddr/mpsutil/grammarcells/editor.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/models/com/mbeddr/mpsutil/grammarcells/editor.mps
@@ -7,6 +7,7 @@
   </languages>
   <imports>
     <import index="z60i" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt(JDK/)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="teg0" ref="r:96165ed2-ef22-48c7-bfe5-8fce083cbabb(com.mbeddr.mpsutil.grammarcells.structure)" implicit="true" />
     <import index="tpco" ref="r:00000000-0000-4000-0000-011c89590284(jetbrains.mps.lang.core.editor)" implicit="true" />
     <import index="tpc5" ref="r:00000000-0000-4000-0000-011c89590299(jetbrains.mps.lang.editor.editor)" implicit="true" />

--- a/code/languages/de.itemis.model.merge/models/de.itemis.model.merge.editor.mps
+++ b/code/languages/de.itemis.model.merge/models/de.itemis.model.merge.editor.mps
@@ -16,6 +16,7 @@
     <import index="av1m" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.menus.style(MPS.Editor/)" />
     <import index="rnx3" ref="r:424d540e-f1fc-49a5-b16d-3f9264b84dee(de.itemis.model.merge.behavior)" />
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
     <import index="tpco" ref="r:00000000-0000-4000-0000-011c89590284(jetbrains.mps.lang.core.editor)" implicit="true" />
     <import index="guwi" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.io(JDK/)" implicit="true" />
@@ -1370,8 +1371,8 @@
             <node concept="liA8E" id="1VmHfRxJ0pk" role="2OqNvi">
               <ref role="37wK5l" to="av1m:~EditorMenuItemStyle.setTextColor(java.awt.Color)" resolve="setTextColor" />
               <node concept="10M0yZ" id="1VmHfRxJ0pl" role="37wK5m">
-                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                <ref role="3cqZAo" to="z60i:~Color.LIGHT_GRAY" resolve="LIGHT_GRAY" />
+                <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                <ref role="3cqZAo" to="lzb2:~JBColor.LIGHT_GRAY" resolve="LIGHT_GRAY" />
               </node>
             </node>
           </node>
@@ -1394,8 +1395,8 @@
             <node concept="liA8E" id="1VmHfRxJ0pt" role="2OqNvi">
               <ref role="37wK5l" to="av1m:~EditorMenuItemStyle.setTextColor(java.awt.Color)" resolve="setTextColor" />
               <node concept="10M0yZ" id="1VmHfRxJ0pu" role="37wK5m">
-                <ref role="3cqZAo" to="z60i:~Color.RED" resolve="RED" />
-                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                <ref role="3cqZAo" to="lzb2:~JBColor.RED" resolve="RED" />
               </node>
             </node>
           </node>

--- a/code/math/languages/de.itemis.mps.editor.math.java/de.itemis.mps.editor.math.java.mpl
+++ b/code/math/languages/de.itemis.mps.editor.math.java/de.itemis.mps.editor.math.java.mpl
@@ -70,6 +70,7 @@
     <dependency reexport="false">0fcee1cf-8f59-441b-b9c7-7ff7bdd6bc97(de.itemis.mps.editor.math.symbols)</dependency>
     <dependency reexport="false">d7eb0a2a-bd50-4576-beae-e4a89db35f20(jetbrains.mps.lang.scopes.runtime)</dependency>
     <dependency reexport="false" scope="generate-into">fd392034-7849-419d-9071-12563d152375(jetbrains.mps.baseLanguage.closures)</dependency>
+    <dependency reexport="false">498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:766348f7-6a67-4b85-9323-384840132299:de.itemis.mps.editor.math" version="0" />
@@ -111,6 +112,7 @@
     <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
     <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
     <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
+    <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="766348f7-6a67-4b85-9323-384840132299(de.itemis.mps.editor.math)" version="0" />
     <module reference="6ce9daa6-c7bc-4847-a19c-5cd82a4a13fc(de.itemis.mps.editor.math.java)" version="0" />

--- a/code/math/languages/de.itemis.mps.editor.math.java/languageModels/editor.mps
+++ b/code/math/languages/de.itemis.mps.editor.math.java/languageModels/editor.mps
@@ -14,6 +14,7 @@
     <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" />
     <import index="z60i" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt(JDK/)" />
     <import index="19h7" ref="r:c367b380-739b-4331-a16f-a542455fc0c8(de.itemis.mps.editor.math.editor)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
   </imports>
   <registry>
@@ -389,8 +390,8 @@
           <node concept="3clFbS" id="7$IFRLylKCL" role="2VODD2">
             <node concept="3clFbF" id="7$IFRLylLoV" role="3cqZAp">
               <node concept="10M0yZ" id="7$IFRLylLCt" role="3clFbG">
-                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                <ref role="3cqZAo" to="z60i:~Color.YELLOW" resolve="YELLOW" />
+                <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                <ref role="3cqZAo" to="lzb2:~JBColor.YELLOW" resolve="YELLOW" />
               </node>
             </node>
           </node>

--- a/code/math/solutions/de.itemis.mps.editor.math.runtime/models/de/itemis/mps/editor/math/runtime.mps
+++ b/code/math/solutions/de.itemis.mps.editor.math.runtime/models/de/itemis/mps/editor/math/runtime.mps
@@ -35,6 +35,7 @@
     <import index="kvq8" ref="r:2e938759-cfd0-47cd-9046-896d85204f59(de.slisson.mps.hacks.editor)" />
     <import index="9hsz" ref="r:16d53f5e-7835-4b72-9581-fafeae0db9b1(jetbrains.mps.lang.editor.enumMigration)" />
     <import index="nlpl" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.editor.runtime.commands(MPS.Editor/)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="lui2" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.module(MPS.OpenAPI/)" implicit="true" />
     <import index="tpc2" ref="r:00000000-0000-4000-0000-011c8959029e(jetbrains.mps.lang.editor.structure)" implicit="true" />
   </imports>
@@ -1446,8 +1447,8 @@
                   <ref role="3cqZAo" node="5PByBculMLL" resolve="foregroundColor" />
                 </node>
                 <node concept="10M0yZ" id="5PByBculO9b" role="3K4GZi">
-                  <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                  <ref role="3cqZAo" to="z60i:~Color.BLACK" resolve="BLACK" />
+                  <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                  <ref role="3cqZAo" to="lzb2:~JBColor.BLACK" resolve="BLACK" />
                 </node>
                 <node concept="3y3z36" id="5PByBculNzg" role="3K4Cdx">
                   <node concept="10Nm6u" id="5PByBculNNL" role="3uHU7w" />

--- a/code/math/solutions/de.itemis.mps.editor.math.runtime/models/de/itemis/mps/editor/math/runtime.mps
+++ b/code/math/solutions/de.itemis.mps.editor.math.runtime/models/de/itemis/mps/editor/math/runtime.mps
@@ -6867,21 +6867,15 @@
                     </node>
                     <node concept="liA8E" id="CZjRlGePvT" role="2OqNvi">
                       <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
-                      <node concept="2ShNRf" id="CZjRlGePvU" role="37wK5m">
-                        <node concept="1pGfFk" id="CZjRlGePvV" role="2ShVmc">
-                          <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int,int)" resolve="Color" />
-                          <node concept="3cmrfG" id="CZjRlGePvW" role="37wK5m">
-                            <property role="3cmrfH" value="0" />
-                          </node>
-                          <node concept="3cmrfG" id="CZjRlGePvX" role="37wK5m">
-                            <property role="3cmrfH" value="0" />
-                          </node>
-                          <node concept="3cmrfG" id="CZjRlGePvY" role="37wK5m">
-                            <property role="3cmrfH" value="255" />
-                          </node>
-                          <node concept="3cmrfG" id="CZjRlGePvZ" role="37wK5m">
-                            <property role="3cmrfH" value="50" />
-                          </node>
+                      <node concept="2YIFZM" id="2WI5qdvsTJ" role="37wK5m">
+                        <ref role="1Pybhc" to="lzb2:~ColorUtil" resolve="ColorUtil" />
+                        <ref role="37wK5l" to="lzb2:~ColorUtil.withAlpha(java.awt.Color,double)" resolve="withAlpha" />
+                        <node concept="10M0yZ" id="2WI5qdvtAX" role="37wK5m">
+                          <ref role="3cqZAo" to="lzb2:~JBColor.BLUE" resolve="BLUE" />
+                          <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                        </node>
+                        <node concept="3b6qkQ" id="2WI5qdvsTL" role="37wK5m">
+                          <property role="$nhwW" value="0.196" />
                         </node>
                       </node>
                     </node>
@@ -6977,21 +6971,15 @@
                     </node>
                     <node concept="liA8E" id="CZjRlG4EvV" role="2OqNvi">
                       <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
-                      <node concept="2ShNRf" id="CZjRlG4EvW" role="37wK5m">
-                        <node concept="1pGfFk" id="CZjRlG4EvX" role="2ShVmc">
-                          <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int,int)" resolve="Color" />
-                          <node concept="3cmrfG" id="CZjRlG4EvY" role="37wK5m">
-                            <property role="3cmrfH" value="0" />
-                          </node>
-                          <node concept="3cmrfG" id="CZjRlG4EvZ" role="37wK5m">
-                            <property role="3cmrfH" value="0" />
-                          </node>
-                          <node concept="3cmrfG" id="CZjRlG4Ew0" role="37wK5m">
-                            <property role="3cmrfH" value="0" />
-                          </node>
-                          <node concept="3cmrfG" id="CZjRlG4Ew1" role="37wK5m">
-                            <property role="3cmrfH" value="30" />
-                          </node>
+                      <node concept="2YIFZM" id="2WI5qdvkkd" role="37wK5m">
+                        <ref role="1Pybhc" to="lzb2:~ColorUtil" resolve="ColorUtil" />
+                        <ref role="37wK5l" to="lzb2:~ColorUtil.withAlpha(java.awt.Color,double)" resolve="withAlpha" />
+                        <node concept="10M0yZ" id="2WI5qdvlEJ" role="37wK5m">
+                          <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                          <ref role="3cqZAo" to="lzb2:~JBColor.BLACK" resolve="BLACK" />
+                        </node>
+                        <node concept="3b6qkQ" id="2WI5qdvooX" role="37wK5m">
+                          <property role="$nhwW" value="0.117" />
                         </node>
                       </node>
                     </node>

--- a/code/mouseselection/solutions/de.itemis.mps.selection.runtime/models/de/itemis/mps/selection/runtime/linear.mps
+++ b/code/mouseselection/solutions/de.itemis.mps.selection.runtime/models/de/itemis/mps/selection/runtime/linear.mps
@@ -24,6 +24,7 @@
     <import index="b8lf" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor.selection(MPS.Editor/)" />
     <import index="4jas" ref="r:b1829bc1-5615-478b-87a3-55032e34acfd(de.itemis.mps.selection.runtime)" />
     <import index="6tp1" ref="r:5c0390a8-12e2-407a-ba93-793107153436(de.itemis.mps.selection.runtime.mouse)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" implicit="true" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
   </imports>
@@ -3176,8 +3177,8 @@
                 <node concept="liA8E" id="4ZiZg53HGXf" role="2OqNvi">
                   <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
                   <node concept="10M0yZ" id="4ZiZg53HHaG" role="37wK5m">
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                    <ref role="3cqZAo" to="z60i:~Color.BLACK" resolve="BLACK" />
+                    <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                    <ref role="3cqZAo" to="lzb2:~JBColor.BLACK" resolve="BLACK" />
                   </node>
                 </node>
               </node>

--- a/code/multiline/solutions/de.slisson.mps.editor.multiline.runtime/models/de/slisson/mps/editor/multiline/cells.mps
+++ b/code/multiline/solutions/de.slisson.mps.editor.multiline.runtime/models/de/slisson/mps/editor/multiline/cells.mps
@@ -42,6 +42,8 @@
     <import index="xggr" ref="r:12584d60-2d80-4ca9-9c6e-b79d499da0cf(de.itemis.mps.editor.celllayout.layout)" />
     <import index="kcid" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor.cellLayout(MPS.Editor/)" />
     <import index="y49u" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.util(MPS.OpenAPI/)" />
+    <import index="hdhb" ref="r:07568eb8-30c0-4bb3-9dcb-50ee4b8de59a(jetbrains.mps.vcs.diff.ui.common)" />
+    <import index="btf5" ref="r:9b4a89e1-ec38-42c4-b1bd-96ab47ffcb3f(jetbrains.mps.vcs.diff.changes)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
     <import index="22ra" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.update(MPS.Editor/)" implicit="true" />
   </imports>
@@ -4427,17 +4429,16 @@
             <node concept="3uibUv" id="3gBYXhg3xPC" role="1tU5fm">
               <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
             </node>
-            <node concept="2ShNRf" id="3gBYXhg3xPE" role="33vP2m">
-              <node concept="1pGfFk" id="3gBYXhg3xPF" role="2ShVmc">
-                <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
-                <node concept="3cmrfG" id="3gBYXhg3xPG" role="37wK5m">
-                  <property role="3cmrfH" value="214" />
-                </node>
-                <node concept="3cmrfG" id="3gBYXhg3xPH" role="37wK5m">
-                  <property role="3cmrfH" value="245" />
-                </node>
-                <node concept="3cmrfG" id="3gBYXhg3xPI" role="37wK5m">
-                  <property role="3cmrfH" value="214" />
+            <node concept="2OqwBi" id="2WI5qdzlvl" role="33vP2m">
+              <node concept="2YIFZM" id="2WI5qdyCLV" role="2Oq$k0">
+                <ref role="37wK5l" to="hdhb:3$C2wb7p0AM" resolve="getInstance" />
+                <ref role="1Pybhc" to="hdhb:42hl10VH9R2" resolve="ChangeColors" />
+              </node>
+              <node concept="liA8E" id="2WI5qdzwxO" role="2OqNvi">
+                <ref role="37wK5l" to="hdhb:3$C2wb7oVfi" resolve="getDiffColor" />
+                <node concept="Rm8GO" id="2WI5qd$hnA" role="37wK5m">
+                  <ref role="Rm8GQ" to="btf5:7inhnIFBpHO" resolve="ADD" />
+                  <ref role="1Px2BO" to="btf5:7inhnIFBpHM" resolve="ChangeType" />
                 </node>
               </node>
             </node>
@@ -4449,17 +4450,16 @@
             <node concept="3uibUv" id="3gBYXhg3xPR" role="1tU5fm">
               <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
             </node>
-            <node concept="2ShNRf" id="3gBYXhg3xPT" role="33vP2m">
-              <node concept="1pGfFk" id="3gBYXhg3xPU" role="2ShVmc">
-                <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
-                <node concept="3cmrfG" id="3gBYXhg3xPV" role="37wK5m">
-                  <property role="3cmrfH" value="203" />
-                </node>
-                <node concept="3cmrfG" id="3gBYXhg3xPW" role="37wK5m">
-                  <property role="3cmrfH" value="203" />
-                </node>
-                <node concept="3cmrfG" id="3gBYXhg3xPX" role="37wK5m">
-                  <property role="3cmrfH" value="203" />
+            <node concept="2OqwBi" id="2WI5qd$AkL" role="33vP2m">
+              <node concept="2YIFZM" id="2WI5qd$AkM" role="2Oq$k0">
+                <ref role="1Pybhc" to="hdhb:42hl10VH9R2" resolve="ChangeColors" />
+                <ref role="37wK5l" to="hdhb:3$C2wb7p0AM" resolve="getInstance" />
+              </node>
+              <node concept="liA8E" id="2WI5qd$AkN" role="2OqNvi">
+                <ref role="37wK5l" to="hdhb:3$C2wb7oVfi" resolve="getDiffColor" />
+                <node concept="Rm8GO" id="2WI5qd$Hk9" role="37wK5m">
+                  <ref role="Rm8GQ" to="btf5:7inhnIFBpHU" resolve="DELETE" />
+                  <ref role="1Px2BO" to="btf5:7inhnIFBpHM" resolve="ChangeType" />
                 </node>
               </node>
             </node>
@@ -4471,17 +4471,16 @@
             <node concept="3uibUv" id="6nUV0qFJ6Hj" role="1tU5fm">
               <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
             </node>
-            <node concept="2ShNRf" id="6nUV0qFJ6Hl" role="33vP2m">
-              <node concept="1pGfFk" id="6nUV0qFJeGJ" role="2ShVmc">
-                <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
-                <node concept="3cmrfG" id="6nUV0qFJeGK" role="37wK5m">
-                  <property role="3cmrfH" value="188" />
-                </node>
-                <node concept="3cmrfG" id="6nUV0qFJeGM" role="37wK5m">
-                  <property role="3cmrfH" value="207" />
-                </node>
-                <node concept="3cmrfG" id="6nUV0qFJeH4" role="37wK5m">
-                  <property role="3cmrfH" value="249" />
+            <node concept="2OqwBi" id="2WI5qd$Q_V" role="33vP2m">
+              <node concept="2YIFZM" id="2WI5qd$Q_W" role="2Oq$k0">
+                <ref role="1Pybhc" to="hdhb:42hl10VH9R2" resolve="ChangeColors" />
+                <ref role="37wK5l" to="hdhb:3$C2wb7p0AM" resolve="getInstance" />
+              </node>
+              <node concept="liA8E" id="2WI5qd$Q_X" role="2OqNvi">
+                <ref role="37wK5l" to="hdhb:3$C2wb7oVfi" resolve="getDiffColor" />
+                <node concept="Rm8GO" id="2WI5qd$Y2z" role="37wK5m">
+                  <ref role="Rm8GQ" to="btf5:7inhnIFBpI0" resolve="CHANGE" />
+                  <ref role="1Px2BO" to="btf5:7inhnIFBpHM" resolve="ChangeType" />
                 </node>
               </node>
             </node>

--- a/code/multiline/solutions/de.slisson.mps.editor.multiline.runtime/runtime.msd
+++ b/code/multiline/solutions/de.slisson.mps.editor.multiline.runtime/runtime.msd
@@ -25,6 +25,8 @@
     <dependency reexport="false">cce85e64-7b37-4ad5-b0e6-9d18324cdfb3(de.itemis.mps.selection.runtime)</dependency>
     <dependency reexport="false">6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)</dependency>
     <dependency reexport="true">848ef45d-e560-4e35-853c-f35a64cc135c(de.itemis.mps.editor.celllayout.runtime)</dependency>
+    <dependency reexport="false">6fd1293f-7f65-4ffd-99dc-4719eca7c171(jetbrains.mps.ide.vcs.platform)</dependency>
+    <dependency reexport="false">85836058-a162-41d7-bb1d-52e99d873f28(jetbrains.mps.ide.vcs.core)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
@@ -56,6 +58,8 @@
     <module reference="cce85e64-7b37-4ad5-b0e6-9d18324cdfb3(de.itemis.mps.selection.runtime)" version="0" />
     <module reference="dc038ceb-b7ea-4fea-ac12-55f7400e97ba(de.slisson.mps.editor.multiline.runtime)" version="0" />
     <module reference="f0fff802-6d26-4d2e-b89d-391357265626(de.slisson.mps.hacks.editor)" version="0" />
+    <module reference="85836058-a162-41d7-bb1d-52e99d873f28(jetbrains.mps.ide.vcs.core)" version="0" />
+    <module reference="6fd1293f-7f65-4ffd-99dc-4719eca7c171(jetbrains.mps.ide.vcs.platform)" version="0" />
     <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
   </dependencyVersions>
 </solution>

--- a/code/projectview/com.mbeddr.mpsutil.projectview.runtime/models/com/mbeddr/mpsutil/projectview/runtime/tree.mps
+++ b/code/projectview/com.mbeddr.mpsutil.projectview.runtime/models/com/mbeddr/mpsutil/projectview/runtime/tree.mps
@@ -77,9 +77,10 @@
     <import index="jkm4" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.ui(MPS.IDEA/)" />
     <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="4hrd" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.ide.vfs(MPS.Platform/)" />
-    <import index="ewej" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt.font(JDK/)" />
     <import index="32g5" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.library(MPS.Core/)" />
     <import index="w0gx" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.project.structure.modules(MPS.Core/)" />
+    <import index="ewej" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt.font(JDK/)" />
+    <import index="exr9" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor(MPS.Editor/)" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
@@ -200,6 +201,9 @@
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <property id="1176718929932" name="isFinal" index="3TUv4t" />
         <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ng" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
       </concept>
       <concept id="1109279763828" name="jetbrains.mps.baseLanguage.structure.TypeVariableDeclaration" flags="ng" index="16euLQ">
         <child id="1214996921760" name="bound" index="3ztrMU" />
@@ -6839,17 +6843,6 @@
           </node>
         </node>
         <node concept="3clFbJ" id="4gq8yQBZ72u" role="3cqZAp">
-          <node concept="3fqX7Q" id="4gq8yQBZ72v" role="3clFbw">
-            <node concept="2OqwBi" id="4gq8yQBZ72w" role="3fr31v">
-              <node concept="2YIFZM" id="4gq8yQBZ72x" role="2Oq$k0">
-                <ref role="37wK5l" to="bd8o:~ApplicationManager.getApplication():com.intellij.openapi.application.Application" resolve="getApplication" />
-                <ref role="1Pybhc" to="bd8o:~ApplicationManager" resolve="ApplicationManager" />
-              </node>
-              <node concept="liA8E" id="4gq8yQBZ72y" role="2OqNvi">
-                <ref role="37wK5l" to="bd8o:~Application.isUnitTestMode():boolean" resolve="isUnitTestMode" />
-              </node>
-            </node>
-          </node>
           <node concept="3clFbS" id="4gq8yQBZ72z" role="3clFbx">
             <node concept="3clFbF" id="4gq8yQBZ72$" role="3cqZAp">
               <node concept="2OqwBi" id="4gq8yQBZ72_" role="3clFbG">
@@ -7020,6 +7013,17 @@
                     <ref role="3cqZAo" node="4gq8yQBZ72d" resolve="autoFocusContents" />
                   </node>
                 </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3fqX7Q" id="4gq8yQBZ72v" role="3clFbw">
+            <node concept="2OqwBi" id="4gq8yQBZ72w" role="3fr31v">
+              <node concept="2YIFZM" id="4gq8yQBZ72x" role="2Oq$k0">
+                <ref role="37wK5l" to="bd8o:~ApplicationManager.getApplication():com.intellij.openapi.application.Application" resolve="getApplication" />
+                <ref role="1Pybhc" to="bd8o:~ApplicationManager" resolve="ApplicationManager" />
+              </node>
+              <node concept="liA8E" id="4gq8yQBZ72y" role="2OqNvi">
+                <ref role="37wK5l" to="bd8o:~Application.isUnitTestMode():boolean" resolve="isUnitTestMode" />
               </node>
             </node>
           </node>
@@ -8762,9 +8766,6 @@
         <node concept="3cqZAl" id="4QICnJ5IYaF" role="3clF45" />
       </node>
     </node>
-    <node concept="2tJIrI" id="4QICnJ5IU3D" role="jymVt" />
-    <node concept="2tJIrI" id="4QICnJ5HHNe" role="jymVt" />
-    <node concept="2tJIrI" id="4gq8yQBZ2xQ" role="jymVt" />
     <node concept="3Tm1VV" id="2ZGhpRfcKKG" role="1B3o_S" />
     <node concept="3uibUv" id="4gq8yQBUjzp" role="1zkMxy">
       <ref role="3uigEE" to="rvbb:~BaseLogicalViewProjectPane" resolve="BaseLogicalViewProjectPane" />
@@ -8772,6 +8773,9 @@
     <node concept="3uibUv" id="4gq8yQBZoXR" role="EKbjA">
       <ref role="3uigEE" to="vuys:~ProjectViewPaneOverride" resolve="ProjectViewPaneOverride" />
     </node>
+    <node concept="2tJIrI" id="4QICnJ5IU3D" role="jymVt" />
+    <node concept="2tJIrI" id="4QICnJ5HHNe" role="jymVt" />
+    <node concept="2tJIrI" id="4gq8yQBZ2xQ" role="jymVt" />
   </node>
   <node concept="312cEu" id="7diJr$Rkh9d">
     <property role="TrG5h" value="CustomTreeNode" />
@@ -9290,6 +9294,10 @@
               <node concept="3clFbS" id="Ggg0Z74y$Q" role="3clFbx">
                 <node concept="3clFbF" id="7PvgUNuOLtd" role="3cqZAp">
                   <node concept="2OqwBi" id="7PvgUNuOLte" role="3clFbG">
+                    <node concept="liA8E" id="7PvgUNuOLtl" role="2OqNvi">
+                      <ref role="37wK5l" to="rgfa:~DefaultTreeModel.nodeStructureChanged(javax.swing.tree.TreeNode)" resolve="nodeStructureChanged" />
+                      <node concept="Xjq3P" id="7PvgUNuOLtm" role="37wK5m" />
+                    </node>
                     <node concept="1eOMI4" id="7PvgUNuOLtf" role="2Oq$k0">
                       <node concept="10QFUN" id="7PvgUNuOLtg" role="1eOMHV">
                         <node concept="2OqwBi" id="7PvgUNuOLth" role="10QFUP">
@@ -9304,10 +9312,6 @@
                           <ref role="3uigEE" to="rgfa:~DefaultTreeModel" resolve="DefaultTreeModel" />
                         </node>
                       </node>
-                    </node>
-                    <node concept="liA8E" id="7PvgUNuOLtl" role="2OqNvi">
-                      <ref role="37wK5l" to="rgfa:~DefaultTreeModel.nodeStructureChanged(javax.swing.tree.TreeNode)" resolve="nodeStructureChanged" />
-                      <node concept="Xjq3P" id="7PvgUNuOLtm" role="37wK5m" />
                     </node>
                   </node>
                 </node>
@@ -9739,6 +9743,10 @@
                 <node concept="3clFbS" id="Ggg0Z73ZXt" role="3clFbx">
                   <node concept="3clFbF" id="Ggg0Z6Y9ui" role="3cqZAp">
                     <node concept="2OqwBi" id="Ggg0Z6Y9uj" role="3clFbG">
+                      <node concept="liA8E" id="Ggg0Z6Y9uq" role="2OqNvi">
+                        <ref role="37wK5l" to="rgfa:~DefaultTreeModel.nodeStructureChanged(javax.swing.tree.TreeNode)" resolve="nodeStructureChanged" />
+                        <node concept="Xjq3P" id="Ggg0Z6Y9ur" role="37wK5m" />
+                      </node>
                       <node concept="1eOMI4" id="Ggg0Z6Y9uk" role="2Oq$k0">
                         <node concept="10QFUN" id="Ggg0Z6Y9ul" role="1eOMHV">
                           <node concept="2OqwBi" id="Ggg0Z6Y9um" role="10QFUP">
@@ -9753,10 +9761,6 @@
                             <ref role="3uigEE" to="rgfa:~DefaultTreeModel" resolve="DefaultTreeModel" />
                           </node>
                         </node>
-                      </node>
-                      <node concept="liA8E" id="Ggg0Z6Y9uq" role="2OqNvi">
-                        <ref role="37wK5l" to="rgfa:~DefaultTreeModel.nodeStructureChanged(javax.swing.tree.TreeNode)" resolve="nodeStructureChanged" />
-                        <node concept="Xjq3P" id="Ggg0Z6Y9ur" role="37wK5m" />
                       </node>
                     </node>
                   </node>
@@ -17889,12 +17893,17 @@
                           </node>
                           <node concept="liA8E" id="4dJXybkiiQY" role="2OqNvi">
                             <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
-                            <node concept="2ShNRf" id="4dJXybkiiQZ" role="37wK5m">
-                              <node concept="1pGfFk" id="4dJXybkiiR0" role="2ShVmc">
-                                <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int)" resolve="Color" />
-                                <node concept="10M0yZ" id="4dJXybkil5E" role="37wK5m">
-                                  <ref role="1PxDUh" to="cj4x:~ColorConstants" resolve="ColorConstants" />
+                            <node concept="2ShNRf" id="2WI5qdjux1" role="37wK5m">
+                              <node concept="1pGfFk" id="2WI5qdj$RP" role="2ShVmc">
+                                <property role="373rjd" value="true" />
+                                <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(int,int)" resolve="JBColor" />
+                                <node concept="10M0yZ" id="2WI5qdjDDg" role="37wK5m">
                                   <ref role="3cqZAo" to="cj4x:~ColorConstants.WARNING" resolve="WARNING" />
+                                  <ref role="1PxDUh" to="cj4x:~ColorConstants" resolve="ColorConstants" />
+                                </node>
+                                <node concept="10M0yZ" id="2WI5qdjKuW" role="37wK5m">
+                                  <ref role="3cqZAo" to="cj4x:~ColorConstants.WARNING_DARK" resolve="WARNING_DARK" />
+                                  <ref role="1PxDUh" to="cj4x:~ColorConstants" resolve="ColorConstants" />
                                 </node>
                               </node>
                             </node>
@@ -17911,14 +17920,9 @@
                         </node>
                         <node concept="liA8E" id="4dJXybkiiUO" role="2OqNvi">
                           <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
-                          <node concept="2ShNRf" id="4dJXybkiiUP" role="37wK5m">
-                            <node concept="1pGfFk" id="4dJXybkiiUQ" role="2ShVmc">
-                              <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int)" resolve="Color" />
-                              <node concept="10M0yZ" id="4dJXybkil5F" role="37wK5m">
-                                <ref role="1PxDUh" to="cj4x:~ColorConstants" resolve="ColorConstants" />
-                                <ref role="3cqZAo" to="cj4x:~ColorConstants.ERROR" resolve="ERROR" />
-                              </node>
-                            </node>
+                          <node concept="10M0yZ" id="2WI5qdjoLC" role="37wK5m">
+                            <ref role="3cqZAo" to="exr9:~MPSColors.RED" resolve="RED" />
+                            <ref role="1PxDUh" to="exr9:~MPSColors" resolve="MPSColors" />
                           </node>
                         </node>
                       </node>
@@ -19075,7 +19079,6 @@
       <property role="34CwA1" value="false" />
       <property role="eg7rD" value="false" />
       <property role="TrG5h" value="myExpandedPathsRaw" />
-      <property role="3TUv4t" value="false" />
       <node concept="3uibUv" id="1zw8Mi3XbvL" role="1tU5fm">
         <ref role="3uigEE" to="33ny:~List" resolve="List" />
         <node concept="3uibUv" id="1zw8Mi3XbvM" role="11_B2D">
@@ -19095,7 +19098,6 @@
       <property role="34CwA1" value="false" />
       <property role="eg7rD" value="false" />
       <property role="TrG5h" value="mySelectedPathsRaw" />
-      <property role="3TUv4t" value="false" />
       <node concept="3uibUv" id="1zw8Mi3XbvR" role="1tU5fm">
         <ref role="3uigEE" to="33ny:~List" resolve="List" />
         <node concept="3uibUv" id="1zw8Mi3XbvS" role="11_B2D">

--- a/code/richtext/languages/richtext/models/de/slisson/mps/richtext/runtime/vcs.mps
+++ b/code/richtext/languages/richtext/models/de/slisson/mps/richtext/runtime/vcs.mps
@@ -20,6 +20,7 @@
     <import index="lui2" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.module(MPS.OpenAPI/)" />
     <import index="q7tw" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:org.apache.log4j(MPS.Core/)" />
     <import index="wtuq" ref="r:ebe120ba-74f3-4913-8ba8-dc7299e610f9(de.slisson.mps.richtext.util)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
     <import index="cj4x" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor(MPS.Editor/)" implicit="true" />
     <import index="tbr6" ref="r:6a005c26-87c0-43c4-8cf3-49ffba1099df(de.slisson.mps.richtext.behavior)" implicit="true" />
@@ -1220,8 +1221,8 @@
                                     </node>
                                   </node>
                                   <node concept="10M0yZ" id="6nUV0qFIOOe" role="37wK5m">
-                                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
                                     <ref role="3cqZAo" to="z60i:~Color.WHITE" resolve="WHITE" />
+                                    <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                                   </node>
                                   <node concept="3clFbT" id="6nUV0qFIOOf" role="37wK5m" />
                                 </node>
@@ -1792,8 +1793,8 @@
                                     </node>
                                   </node>
                                   <node concept="10M0yZ" id="6nUV0qFIONU" role="37wK5m">
-                                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
                                     <ref role="3cqZAo" to="z60i:~Color.WHITE" resolve="WHITE" />
+                                    <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                                   </node>
                                   <node concept="3clFbT" id="6nUV0qFIONZ" role="37wK5m" />
                                 </node>

--- a/code/shadowmodels/languages/de.q60.mps.incremental/models/editor.mps
+++ b/code/shadowmodels/languages/de.q60.mps.incremental/models/editor.mps
@@ -11,6 +11,7 @@
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" />
     <import index="g51k" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor.cells(MPS.Editor/)" />
     <import index="z60i" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt(JDK/)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="tpco" ref="r:00000000-0000-4000-0000-011c89590284(jetbrains.mps.lang.core.editor)" implicit="true" />
   </imports>
   <registry>
@@ -101,6 +102,12 @@
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
       </concept>
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
+      </concept>
+      <concept id="1070533707846" name="jetbrains.mps.baseLanguage.structure.StaticFieldReference" flags="nn" index="10M0yZ">
+        <reference id="1144433057691" name="classifier" index="1PxDUh" />
+      </concept>
       <concept id="1070534934090" name="jetbrains.mps.baseLanguage.structure.CastExpression" flags="nn" index="10QFUN">
         <child id="1070534934091" name="type" index="10QFUM" />
         <child id="1070534934092" name="expression" index="10QFUP" />
@@ -115,14 +122,14 @@
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
+      <concept id="1111509017652" name="jetbrains.mps.baseLanguage.structure.FloatingPointConstant" flags="nn" index="3b6qkQ">
+        <property id="1113006610751" name="value" index="$nhwW" />
+      </concept>
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
-      </concept>
-      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
-        <property id="1068580320021" name="value" index="3cmrfH" />
       </concept>
       <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
         <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
@@ -135,7 +142,6 @@
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
-      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
       </concept>
@@ -317,22 +323,16 @@
             <node concept="Veino" id="VwH9CcWICo" role="3F10Kt">
               <node concept="3ZlJ5R" id="VwH9CcWICp" role="VblUZ">
                 <node concept="3clFbS" id="VwH9CcWICq" role="2VODD2">
-                  <node concept="3clFbF" id="VwH9CcWICr" role="3cqZAp">
-                    <node concept="2ShNRf" id="VwH9CcWICs" role="3clFbG">
-                      <node concept="1pGfFk" id="VwH9CcWICt" role="2ShVmc">
-                        <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int,int)" resolve="Color" />
-                        <node concept="3cmrfG" id="VwH9CcWICu" role="37wK5m">
-                          <property role="3cmrfH" value="0" />
-                        </node>
-                        <node concept="3cmrfG" id="VwH9CcWICv" role="37wK5m">
-                          <property role="3cmrfH" value="0" />
-                        </node>
-                        <node concept="3cmrfG" id="VwH9CcWICw" role="37wK5m">
-                          <property role="3cmrfH" value="0" />
-                        </node>
-                        <node concept="3cmrfG" id="VwH9CcWICx" role="37wK5m">
-                          <property role="3cmrfH" value="20" />
-                        </node>
+                  <node concept="3clFbF" id="2WI5qdKV6l" role="3cqZAp">
+                    <node concept="2YIFZM" id="2WI5qdKV6m" role="3clFbG">
+                      <ref role="1Pybhc" to="lzb2:~ColorUtil" resolve="ColorUtil" />
+                      <ref role="37wK5l" to="lzb2:~ColorUtil.withAlpha(java.awt.Color,double)" resolve="withAlpha" />
+                      <node concept="10M0yZ" id="2WI5qdKV6n" role="37wK5m">
+                        <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                        <ref role="3cqZAo" to="lzb2:~JBColor.DARK_GRAY" resolve="DARK_GRAY" />
+                      </node>
+                      <node concept="3b6qkQ" id="2WI5qdKV6o" role="37wK5m">
+                        <property role="$nhwW" value="0.078" />
                       </node>
                     </node>
                   </node>
@@ -597,22 +597,16 @@
             <node concept="Veino" id="7qGGLAkSijr" role="3F10Kt">
               <node concept="3ZlJ5R" id="7qGGLAkSijs" role="VblUZ">
                 <node concept="3clFbS" id="7qGGLAkSijt" role="2VODD2">
-                  <node concept="3clFbF" id="7qGGLAkSiju" role="3cqZAp">
-                    <node concept="2ShNRf" id="7qGGLAkSijv" role="3clFbG">
-                      <node concept="1pGfFk" id="7qGGLAkSijw" role="2ShVmc">
-                        <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int,int)" resolve="Color" />
-                        <node concept="3cmrfG" id="7qGGLAkSijx" role="37wK5m">
-                          <property role="3cmrfH" value="0" />
-                        </node>
-                        <node concept="3cmrfG" id="7qGGLAkSijy" role="37wK5m">
-                          <property role="3cmrfH" value="0" />
-                        </node>
-                        <node concept="3cmrfG" id="7qGGLAkSijz" role="37wK5m">
-                          <property role="3cmrfH" value="0" />
-                        </node>
-                        <node concept="3cmrfG" id="7qGGLAkSij$" role="37wK5m">
-                          <property role="3cmrfH" value="20" />
-                        </node>
+                  <node concept="3clFbF" id="2WI5qdKdBQ" role="3cqZAp">
+                    <node concept="2YIFZM" id="2WI5qdKdJS" role="3clFbG">
+                      <ref role="37wK5l" to="lzb2:~ColorUtil.withAlpha(java.awt.Color,double)" resolve="withAlpha" />
+                      <ref role="1Pybhc" to="lzb2:~ColorUtil" resolve="ColorUtil" />
+                      <node concept="10M0yZ" id="2WI5qdKD_K" role="37wK5m">
+                        <ref role="3cqZAo" to="lzb2:~JBColor.DARK_GRAY" resolve="DARK_GRAY" />
+                        <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                      </node>
+                      <node concept="3b6qkQ" id="2WI5qdKiAa" role="37wK5m">
+                        <property role="$nhwW" value="0.078" />
                       </node>
                     </node>
                   </node>

--- a/code/shadowmodels/solutions/de.q60.mps.shadowmodels.debugview/models/pf.mps
+++ b/code/shadowmodels/solutions/de.q60.mps.shadowmodels.debugview/models/pf.mps
@@ -44,6 +44,7 @@
     <import index="e55s" ref="r:340cdae2-711c-4186-bc13-94d9832e5a1d(de.q60.mps.explorer)" />
     <import index="jks5" ref="cc99dce1-49f3-4392-8dbf-e22ca47bd0af/java:org.modelix.model.api(org.modelix.model.api/)" />
     <import index="xxte" ref="r:a79f28f8-6055-40c6-bc5e-47a42a3b97e8(org.modelix.model.mpsadapters.mps)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="1ctc" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util.stream(JDK/)" implicit="true" />
     <import index="oyp0" ref="r:ff4bc8f2-4e53-41b7-a27c-792a5dcc86cb(de.q60.mps.shadowmodels.transformation.structure)" implicit="true" />
     <import index="hm90" ref="r:61d96d59-75af-4854-9d37-c81762926dfe(de.q60.mps.shadowmodels.transformation.behavior)" implicit="true" />
@@ -7755,8 +7756,8 @@
                 <node concept="liA8E" id="7pNuz6_YGT6" role="2OqNvi">
                   <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
                   <node concept="10M0yZ" id="7pNuz6_YHnx" role="37wK5m">
-                    <ref role="3cqZAo" to="z60i:~Color.BLACK" resolve="BLACK" />
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                    <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                    <ref role="3cqZAo" to="lzb2:~JBColor.BLACK" resolve="BLACK" />
                   </node>
                 </node>
               </node>

--- a/code/shadowmodels/solutions/de.q60.mps.shadowmodels.runtime/models/plugin.mps
+++ b/code/shadowmodels/solutions/de.q60.mps.shadowmodels.runtime/models/plugin.mps
@@ -49,6 +49,7 @@
     <import index="y071" ref="r:57711a24-29ad-4bd9-8062-d4259c0a2ba5(de.q60.mps.logging.runtime)" />
     <import index="zy2h" ref="r:ec0fe8c4-38e5-4216-9425-8861454eaf8a(de.q60.mps.util.invalidation)" />
     <import index="xxte" ref="r:a79f28f8-6055-40c6-bc5e-47a42a3b97e8(org.modelix.model.mpsadapters.mps)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="1m72" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.components(MPS.IDEA/)" implicit="true" />
     <import index="tprs" ref="r:00000000-0000-4000-0000-011c895904a4(jetbrains.mps.ide.actions)" implicit="true" />
   </imports>
@@ -4183,22 +4184,12 @@
             <ref role="3cqZAo" node="4NO8rntV3yC" resolve="offsetY" />
           </node>
           <node concept="10M0yZ" id="5wnrAmTLGD$" role="37wK5m">
-            <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-            <ref role="3cqZAo" to="z60i:~Color.BLACK" resolve="BLACK" />
+            <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+            <ref role="3cqZAo" to="lzb2:~JBColor.BLACK" resolve="BLACK" />
           </node>
-          <node concept="2ShNRf" id="5wnrAmTLG_g" role="37wK5m">
-            <node concept="1pGfFk" id="5wnrAmTLG_h" role="2ShVmc">
-              <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
-              <node concept="3cmrfG" id="5wnrAmTLG_i" role="37wK5m">
-                <property role="3cmrfH" value="200" />
-              </node>
-              <node concept="3cmrfG" id="5wnrAmTLG_j" role="37wK5m">
-                <property role="3cmrfH" value="200" />
-              </node>
-              <node concept="3cmrfG" id="5wnrAmTLG_k" role="37wK5m">
-                <property role="3cmrfH" value="200" />
-              </node>
-            </node>
+          <node concept="10M0yZ" id="2WI5qcS8iM" role="37wK5m">
+            <ref role="3cqZAo" to="lzb2:~JBColor.LIGHT_GRAY" resolve="LIGHT_GRAY" />
+            <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
           </node>
         </node>
       </node>

--- a/code/tables/languages/de.slisson.mps.tables/languageModels/editor.mps
+++ b/code/tables/languages/de.slisson.mps.tables/languageModels/editor.mps
@@ -20,6 +20,7 @@
     <import index="z60i" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt(JDK/)" />
     <import index="oghc" ref="r:356c0504-b4a3-4458-9604-13fbb48838d7(de.slisson.mps.tables.runtime.style)" />
     <import index="cj4x" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor(MPS.Editor/)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="tpce" ref="r:00000000-0000-4000-0000-011c89590292(jetbrains.mps.lang.structure.structure)" implicit="true" />
   </imports>
   <registry>
@@ -3022,8 +3023,8 @@
         <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
       </node>
       <node concept="10M0yZ" id="5PDTdguqQlH" role="3t49C2">
-        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-        <ref role="3cqZAo" to="z60i:~Color.LIGHT_GRAY" resolve="LIGHT_GRAY" />
+        <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+        <ref role="3cqZAo" to="lzb2:~JBColor.LIGHT_GRAY" resolve="LIGHT_GRAY" />
       </node>
     </node>
     <node concept="3t5Usi" id="5PDTdguqQlI" role="V601i">
@@ -3033,8 +3034,8 @@
         <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
       </node>
       <node concept="10M0yZ" id="5PDTdguqQlK" role="3t49C2">
-        <ref role="3cqZAo" to="z60i:~Color.LIGHT_GRAY" resolve="LIGHT_GRAY" />
-        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+        <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+        <ref role="3cqZAo" to="lzb2:~JBColor.LIGHT_GRAY" resolve="LIGHT_GRAY" />
       </node>
     </node>
     <node concept="3t5Usi" id="5PDTdguqQlL" role="V601i">
@@ -3044,8 +3045,8 @@
         <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
       </node>
       <node concept="10M0yZ" id="5PDTdguqQlN" role="3t49C2">
-        <ref role="3cqZAo" to="z60i:~Color.LIGHT_GRAY" resolve="LIGHT_GRAY" />
-        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+        <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+        <ref role="3cqZAo" to="lzb2:~JBColor.LIGHT_GRAY" resolve="LIGHT_GRAY" />
       </node>
     </node>
     <node concept="3t5Usi" id="5PDTdguqQlO" role="V601i">
@@ -3055,8 +3056,8 @@
         <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
       </node>
       <node concept="10M0yZ" id="5PDTdguqQlQ" role="3t49C2">
-        <ref role="3cqZAo" to="z60i:~Color.LIGHT_GRAY" resolve="LIGHT_GRAY" />
-        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+        <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+        <ref role="3cqZAo" to="lzb2:~JBColor.LIGHT_GRAY" resolve="LIGHT_GRAY" />
       </node>
     </node>
     <node concept="3t5Usi" id="5PDTdguqQlR" role="V601i">
@@ -3098,8 +3099,8 @@
         <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
       </node>
       <node concept="10M0yZ" id="5PDTdguqQm5" role="3t49C2">
-        <ref role="3cqZAo" to="z60i:~Color.LIGHT_GRAY" resolve="LIGHT_GRAY" />
-        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+        <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+        <ref role="3cqZAo" to="lzb2:~JBColor.LIGHT_GRAY" resolve="LIGHT_GRAY" />
       </node>
     </node>
     <node concept="3t5Usi" id="5PDTdguqQm6" role="V601i">
@@ -3109,8 +3110,8 @@
         <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
       </node>
       <node concept="10M0yZ" id="5PDTdguqQm8" role="3t49C2">
-        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-        <ref role="3cqZAo" to="z60i:~Color.LIGHT_GRAY" resolve="LIGHT_GRAY" />
+        <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+        <ref role="3cqZAo" to="lzb2:~JBColor.LIGHT_GRAY" resolve="LIGHT_GRAY" />
       </node>
     </node>
     <node concept="3t5Usi" id="5PDTdguqQm9" role="V601i">
@@ -3120,8 +3121,8 @@
         <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
       </node>
       <node concept="10M0yZ" id="5PDTdguqQmb" role="3t49C2">
-        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-        <ref role="3cqZAo" to="z60i:~Color.LIGHT_GRAY" resolve="LIGHT_GRAY" />
+        <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+        <ref role="3cqZAo" to="lzb2:~JBColor.LIGHT_GRAY" resolve="LIGHT_GRAY" />
       </node>
     </node>
     <node concept="3t5Usi" id="5PDTdguqQmc" role="V601i">
@@ -3131,8 +3132,8 @@
         <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
       </node>
       <node concept="10M0yZ" id="5PDTdguqQme" role="3t49C2">
-        <ref role="3cqZAo" to="z60i:~Color.LIGHT_GRAY" resolve="LIGHT_GRAY" />
-        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+        <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+        <ref role="3cqZAo" to="lzb2:~JBColor.LIGHT_GRAY" resolve="LIGHT_GRAY" />
       </node>
     </node>
     <node concept="3t5Usi" id="5PDTdguqQmf" role="V601i">
@@ -3174,8 +3175,8 @@
         <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
       </node>
       <node concept="10M0yZ" id="5PDTdguqQmt" role="3t49C2">
-        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-        <ref role="3cqZAo" to="z60i:~Color.LIGHT_GRAY" resolve="LIGHT_GRAY" />
+        <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+        <ref role="3cqZAo" to="lzb2:~JBColor.LIGHT_GRAY" resolve="LIGHT_GRAY" />
       </node>
     </node>
     <node concept="3t5Usi" id="5PDTdguqQmu" role="V601i">
@@ -3185,8 +3186,8 @@
         <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
       </node>
       <node concept="10M0yZ" id="5PDTdguqQmw" role="3t49C2">
-        <ref role="3cqZAo" to="z60i:~Color.LIGHT_GRAY" resolve="LIGHT_GRAY" />
-        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+        <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+        <ref role="3cqZAo" to="lzb2:~JBColor.LIGHT_GRAY" resolve="LIGHT_GRAY" />
       </node>
     </node>
     <node concept="3t5Usi" id="5PDTdguqQmx" role="V601i">
@@ -3196,8 +3197,8 @@
         <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
       </node>
       <node concept="10M0yZ" id="5PDTdguqQmz" role="3t49C2">
-        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-        <ref role="3cqZAo" to="z60i:~Color.LIGHT_GRAY" resolve="LIGHT_GRAY" />
+        <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+        <ref role="3cqZAo" to="lzb2:~JBColor.LIGHT_GRAY" resolve="LIGHT_GRAY" />
       </node>
     </node>
     <node concept="3t5Usi" id="5PDTdguqQm$" role="V601i">
@@ -3207,8 +3208,8 @@
         <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
       </node>
       <node concept="10M0yZ" id="5PDTdguqQmA" role="3t49C2">
-        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-        <ref role="3cqZAo" to="z60i:~Color.LIGHT_GRAY" resolve="LIGHT_GRAY" />
+        <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+        <ref role="3cqZAo" to="lzb2:~JBColor.LIGHT_GRAY" resolve="LIGHT_GRAY" />
       </node>
     </node>
     <node concept="3t5Usi" id="5PDTdguqQmB" role="V601i">

--- a/code/tables/languages/de.slisson.mps.tables/runtime/models/de/slisson/mps/tables/runtime/cells.mps
+++ b/code/tables/languages/de.slisson.mps.tables/runtime/models/de/slisson/mps/tables/runtime/cells.mps
@@ -60,6 +60,7 @@
     <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" />
     <import index="kvq8" ref="r:2e938759-cfd0-47cd-9046-896d85204f59(de.slisson.mps.hacks.editor)" />
     <import index="9hsz" ref="r:16d53f5e-7835-4b72-9581-fafeae0db9b1(jetbrains.mps.lang.editor.enumMigration)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="z8iw" ref="r:dfdf3542-dbcf-43df-870a-3c3504b3c840(jetbrains.mps.baseLanguage.collections.custom)" implicit="true" />
     <import index="tpc2" ref="r:00000000-0000-4000-0000-011c8959029e(jetbrains.mps.lang.editor.structure)" implicit="true" />
     <import index="nivk" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.editor.runtime.descriptor(MPS.Editor/)" implicit="true" />
@@ -12268,8 +12269,8 @@
                         <node concept="liA8E" id="7VuKdVa5Us_" role="2OqNvi">
                           <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
                           <node concept="10M0yZ" id="7VuKdVa7FRR" role="37wK5m">
-                            <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
-                            <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                            <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                            <ref role="3cqZAo" to="lzb2:~JBColor.lightGray" resolve="lightGray" />
                           </node>
                         </node>
                       </node>

--- a/code/tables/languages/de.slisson.mps.tables/runtime/models/de/slisson/mps/tables/runtime/cells.mps
+++ b/code/tables/languages/de.slisson.mps.tables/runtime/models/de/slisson/mps/tables/runtime/cells.mps
@@ -212,6 +212,9 @@
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
+      <concept id="1111509017652" name="jetbrains.mps.baseLanguage.structure.FloatingPointConstant" flags="nn" index="3b6qkQ">
+        <property id="1113006610751" name="value" index="$nhwW" />
+      </concept>
       <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
         <property id="4276006055363816570" name="isSynchronized" index="od$2w" />
         <property id="1181808852946" name="isFinal" index="DiZV1" />
@@ -27877,21 +27880,15 @@
                 </node>
                 <node concept="liA8E" id="CZjRlG4EvV" role="2OqNvi">
                   <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
-                  <node concept="2ShNRf" id="CZjRlG4EvW" role="37wK5m">
-                    <node concept="1pGfFk" id="CZjRlG4EvX" role="2ShVmc">
-                      <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int,int)" resolve="Color" />
-                      <node concept="3cmrfG" id="CZjRlG4EvY" role="37wK5m">
-                        <property role="3cmrfH" value="0" />
-                      </node>
-                      <node concept="3cmrfG" id="CZjRlG4EvZ" role="37wK5m">
-                        <property role="3cmrfH" value="0" />
-                      </node>
-                      <node concept="3cmrfG" id="CZjRlG4Ew0" role="37wK5m">
-                        <property role="3cmrfH" value="0" />
-                      </node>
-                      <node concept="3cmrfG" id="CZjRlG4Ew1" role="37wK5m">
-                        <property role="3cmrfH" value="30" />
-                      </node>
+                  <node concept="2YIFZM" id="2WI5qdE8Sr" role="37wK5m">
+                    <ref role="1Pybhc" to="lzb2:~ColorUtil" resolve="ColorUtil" />
+                    <ref role="37wK5l" to="lzb2:~ColorUtil.withAlpha(java.awt.Color,double)" resolve="withAlpha" />
+                    <node concept="10M0yZ" id="2WI5qdEewK" role="37wK5m">
+                      <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                      <ref role="3cqZAo" to="lzb2:~JBColor.BLACK" resolve="BLACK" />
+                    </node>
+                    <node concept="3b6qkQ" id="2WI5qdEov9" role="37wK5m">
+                      <property role="$nhwW" value="0.117" />
                     </node>
                   </node>
                 </node>

--- a/code/tables/languages/de.slisson.mps.tables/runtime/models/de/slisson/mps/tables/runtime/gridmodel.mps
+++ b/code/tables/languages/de.slisson.mps.tables/runtime/models/de/slisson/mps/tables/runtime/gridmodel.mps
@@ -32,6 +32,7 @@
     <import index="tpce" ref="r:00000000-0000-4000-0000-011c89590292(jetbrains.mps.lang.structure.structure)" />
     <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" />
     <import index="zce0" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.smodel.action(MPS.Editor/)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="22ra" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.update(MPS.Editor/)" implicit="true" />
   </imports>
   <registry>
@@ -24667,8 +24668,8 @@
                             <ref role="37wK5l" node="2c3czgponU5" resolve="createConstant" />
                             <node concept="Xl_RD" id="RywcYwuy46" role="37wK5m" />
                             <node concept="10M0yZ" id="2c3czgpoEbP" role="37wK5m">
-                              <ref role="3cqZAo" to="z60i:~Color.LIGHT_GRAY" resolve="LIGHT_GRAY" />
-                              <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                              <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                              <ref role="3cqZAo" to="lzb2:~JBColor.LIGHT_GRAY" resolve="LIGHT_GRAY" />
                             </node>
                             <node concept="3clFbT" id="2c3czgpoEBA" role="37wK5m">
                               <property role="3clFbU" value="false" />
@@ -25543,8 +25544,8 @@
                         <ref role="3cqZAo" to="5ueo:~StyleAttributes.TEXT_COLOR" resolve="TEXT_COLOR" />
                       </node>
                       <node concept="10M0yZ" id="2c3czgpmthd" role="37wK5m">
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                        <ref role="3cqZAo" to="z60i:~Color.LIGHT_GRAY" resolve="LIGHT_GRAY" />
+                        <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                        <ref role="3cqZAo" to="lzb2:~JBColor.LIGHT_GRAY" resolve="LIGHT_GRAY" />
                       </node>
                     </node>
                   </node>

--- a/code/tooltips/solutions/de.itemis.mps.tooltips.runtime/models/de/itemis/mps/tooltips/runtime.mps
+++ b/code/tooltips/solutions/de.itemis.mps.tooltips.runtime/models/de/itemis/mps/tooltips/runtime.mps
@@ -28,6 +28,7 @@
     <import index="kcid" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor.cellLayout(MPS.Editor/)" />
     <import index="88dm" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.ide.tooltips(MPS.Platform/)" />
     <import index="3qmy" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.classloading(MPS.Core/)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="22ra" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.update(MPS.Editor/)" implicit="true" />
   </imports>
   <registry>
@@ -1392,8 +1393,8 @@
             <node concept="liA8E" id="2a194$K08vi" role="2OqNvi">
               <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
               <node concept="10M0yZ" id="7CEHNszDLZH" role="37wK5m">
-                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                <ref role="3cqZAo" to="z60i:~Color.BLUE" resolve="BLUE" />
+                <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                <ref role="3cqZAo" to="lzb2:~JBColor.BLUE" resolve="BLUE" />
               </node>
             </node>
           </node>

--- a/code/treenotation/com.mbeddr.mpsutil.treenotation.runtime/models/com/mbeddr/mpsutil/treenotation/runtime.mps
+++ b/code/treenotation/com.mbeddr.mpsutil.treenotation.runtime/models/com/mbeddr/mpsutil/treenotation/runtime.mps
@@ -36,6 +36,7 @@
     <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" />
     <import index="zce0" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.smodel.action(MPS.Editor/)" />
     <import index="sn11" ref="r:836426ab-a6f4-4fa3-9a9c-34c02ed6ab5d(jetbrains.mps.ide.icons)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="lui2" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.module(MPS.OpenAPI/)" implicit="true" />
   </imports>
   <registry>
@@ -4897,8 +4898,8 @@
                     <node concept="liA8E" id="7GMtHW6slpR" role="2OqNvi">
                       <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
                       <node concept="10M0yZ" id="7GMtHW6slxj" role="37wK5m">
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                        <ref role="3cqZAo" to="z60i:~Color.WHITE" resolve="WHITE" />
+                        <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                        <ref role="3cqZAo" to="lzb2:~JBColor.WHITE" resolve="WHITE" />
                       </node>
                     </node>
                   </node>
@@ -4925,8 +4926,8 @@
                     <node concept="liA8E" id="7GMtHW6sm6I" role="2OqNvi">
                       <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
                       <node concept="10M0yZ" id="7GMtHW6smec" role="37wK5m">
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                        <ref role="3cqZAo" to="z60i:~Color.BLACK" resolve="BLACK" />
+                        <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                        <ref role="3cqZAo" to="lzb2:~JBColor.BLACK" resolve="BLACK" />
                       </node>
                     </node>
                   </node>
@@ -7132,8 +7133,8 @@
             <node concept="liA8E" id="JAaUnmWmWq" role="2OqNvi">
               <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
               <node concept="10M0yZ" id="JAaUnmWn3Q" role="37wK5m">
-                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                <ref role="3cqZAo" to="z60i:~Color.RED" resolve="RED" />
+                <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                <ref role="3cqZAo" to="lzb2:~JBColor.RED" resolve="RED" />
               </node>
             </node>
           </node>
@@ -7676,7 +7677,6 @@
             </node>
           </node>
         </node>
-        <node concept="3clFbH" id="JAaUnmWtuF" role="3cqZAp" />
         <node concept="3clFbF" id="JAaUnmWu2M" role="3cqZAp">
           <node concept="2OqwBi" id="JAaUnmWufl" role="3clFbG">
             <node concept="37vLTw" id="JAaUnmWu2K" role="2Oq$k0">
@@ -8299,8 +8299,8 @@
                   <node concept="liA8E" id="21DGiA5nvsR" role="2OqNvi">
                     <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
                     <node concept="10M0yZ" id="4Q9g1gQHcBT" role="37wK5m">
-                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                      <ref role="3cqZAo" to="z60i:~Color.WHITE" resolve="WHITE" />
+                      <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                      <ref role="3cqZAo" to="lzb2:~JBColor.WHITE" resolve="WHITE" />
                     </node>
                   </node>
                 </node>
@@ -8326,8 +8326,8 @@
                   <node concept="liA8E" id="21DGiA5nvt4" role="2OqNvi">
                     <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
                     <node concept="10M0yZ" id="4Q9g1gQHF08" role="37wK5m">
-                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                      <ref role="3cqZAo" to="z60i:~Color.GRAY" resolve="GRAY" />
+                      <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                      <ref role="3cqZAo" to="lzb2:~JBColor.GRAY" resolve="GRAY" />
                     </node>
                   </node>
                 </node>
@@ -8371,8 +8371,8 @@
                   <node concept="liA8E" id="21DGiA5nvto" role="2OqNvi">
                     <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
                     <node concept="10M0yZ" id="21DGiA5nvtp" role="37wK5m">
-                      <ref role="3cqZAo" to="z60i:~Color.BLACK" resolve="BLACK" />
-                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                      <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                      <ref role="3cqZAo" to="lzb2:~JBColor.BLACK" resolve="BLACK" />
                     </node>
                   </node>
                 </node>
@@ -8924,8 +8924,8 @@
             <node concept="liA8E" id="JAaUnmWT8v" role="2OqNvi">
               <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
               <node concept="10M0yZ" id="JAaUnmWT8w" role="37wK5m">
-                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                <ref role="3cqZAo" to="z60i:~Color.BLUE" resolve="BLUE" />
+                <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                <ref role="3cqZAo" to="lzb2:~JBColor.BLUE" resolve="BLUE" />
               </node>
             </node>
           </node>

--- a/code/treenotation/com.mbeddr.mpsutil.treenotation.runtime/models/com/mbeddr/mpsutil/treenotation/runtime.mps
+++ b/code/treenotation/com.mbeddr.mpsutil.treenotation.runtime/models/com/mbeddr/mpsutil/treenotation/runtime.mps
@@ -7684,19 +7684,9 @@
             </node>
             <node concept="liA8E" id="JAaUnmWuzi" role="2OqNvi">
               <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
-              <node concept="2ShNRf" id="JAaUnmWuVB" role="37wK5m">
-                <node concept="1pGfFk" id="JAaUnmWuVA" role="2ShVmc">
-                  <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
-                  <node concept="3cmrfG" id="JAaUnmWv3e" role="37wK5m">
-                    <property role="3cmrfH" value="0" />
-                  </node>
-                  <node concept="3cmrfG" id="JAaUnmWvhh" role="37wK5m">
-                    <property role="3cmrfH" value="150" />
-                  </node>
-                  <node concept="3cmrfG" id="JAaUnmWvvW" role="37wK5m">
-                    <property role="3cmrfH" value="0" />
-                  </node>
-                </node>
+              <node concept="10M0yZ" id="2WI5qdmB0W" role="37wK5m">
+                <ref role="3cqZAo" to="exr9:~MPSColors.DARK_GREEN" resolve="DARK_GREEN" />
+                <ref role="1PxDUh" to="exr9:~MPSColors" resolve="MPSColors" />
               </node>
             </node>
           </node>

--- a/code/treenotation/com.mbeddr.mpsutil.treenotation.sandboxlang/models/editor.mps
+++ b/code/treenotation/com.mbeddr.mpsutil.treenotation.sandboxlang/models/editor.mps
@@ -15,6 +15,7 @@
     <import index="4io5" ref="b0f8641f-bd77-4421-8425-30d9088a82f7/java:org.apache.commons.math3.geometry.euclidean.twod(org.apache.commons/)" />
     <import index="4hco" ref="r:55549eb8-b827-44b3-bd84-ef3114bd2fe2(com.mbeddr.mpsutil.treenotation.runtime)" />
     <import index="cj4x" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor(MPS.Editor/)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="uin2" ref="r:74912edc-30f3-44ff-8b9f-c9c8b1fb4035(com.mbeddr.mpsutil.treenotation.sandboxlang.structure)" implicit="true" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
@@ -373,8 +374,8 @@
                 <node concept="3clFbS" id="7GMtHW6qOhv" role="2VODD2">
                   <node concept="3clFbF" id="7GMtHW6qPYg" role="3cqZAp">
                     <node concept="10M0yZ" id="7GMtHW6qQ3j" role="3clFbG">
-                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                      <ref role="3cqZAo" to="z60i:~Color.BLUE" resolve="BLUE" />
+                      <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                      <ref role="3cqZAo" to="lzb2:~JBColor.BLUE" resolve="BLUE" />
                     </node>
                   </node>
                 </node>
@@ -387,8 +388,8 @@
                   <property role="3cmrfH" value="13" />
                 </node>
                 <node concept="10M0yZ" id="7fqbBL2pY_o" role="15NUvb">
-                  <ref role="3cqZAo" to="z60i:~Color.MAGENTA" resolve="MAGENTA" />
-                  <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                  <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                  <ref role="3cqZAo" to="lzb2:~JBColor.MAGENTA" resolve="MAGENTA" />
                 </node>
               </node>
             </node>
@@ -407,8 +408,8 @@
                       <property role="3cmrfH" value="10" />
                     </node>
                     <node concept="10M0yZ" id="7fqbBL2pY_P" role="15NUvb">
-                      <ref role="3cqZAo" to="z60i:~Color.CYAN" resolve="CYAN" />
-                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                      <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                      <ref role="3cqZAo" to="lzb2:~JBColor.CYAN" resolve="CYAN" />
                     </node>
                   </node>
                 </node>
@@ -466,8 +467,8 @@
                 <property role="$nhwW" value="10.0" />
               </node>
               <node concept="10M0yZ" id="7fqbBL2pYlN" role="15NUvb">
-                <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
-                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                <ref role="3cqZAo" to="lzb2:~JBColor.black" resolve="black" />
               </node>
             </node>
           </node>
@@ -550,8 +551,8 @@
                   <property role="$nhwW" value="20.0" />
                 </node>
                 <node concept="10M0yZ" id="7fqbBL2pYmt" role="15NUvb">
-                  <ref role="3cqZAo" to="z60i:~Color.green" resolve="green" />
-                  <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                  <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                  <ref role="3cqZAo" to="lzb2:~JBColor.green" resolve="green" />
                 </node>
               </node>
               <node concept="37fpnE" id="2rPTijxRT8h" role="37fetC" />
@@ -1058,8 +1059,8 @@
           <property role="$nhwW" value="6.0" />
         </node>
         <node concept="10M0yZ" id="7fqbBL2pN8s" role="15NUvb">
-          <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
-          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+          <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+          <ref role="3cqZAo" to="lzb2:~JBColor.gray" resolve="gray" />
         </node>
       </node>
       <node concept="3u$I1K" id="7CiTYi$wnL6" role="15K7wI">
@@ -1089,8 +1090,8 @@
             <property role="$nhwW" value="10.0" />
           </node>
           <node concept="10M0yZ" id="7fqbBL2pN7D" role="15NUvb">
-            <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
-            <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+            <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+            <ref role="3cqZAo" to="lzb2:~JBColor.black" resolve="black" />
           </node>
         </node>
       </node>
@@ -1635,8 +1636,8 @@
           <property role="$nhwW" value="7.0" />
         </node>
         <node concept="10M0yZ" id="7fqbBL2pNMF" role="15NUvb">
-          <ref role="3cqZAo" to="z60i:~Color.orange" resolve="orange" />
-          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+          <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+          <ref role="3cqZAo" to="lzb2:~JBColor.orange" resolve="orange" />
         </node>
       </node>
       <node concept="3u$I1K" id="7fqbBL2mR95" role="15K7wI">
@@ -1666,8 +1667,8 @@
             <property role="$nhwW" value="7.0" />
           </node>
           <node concept="10M0yZ" id="7fqbBL2pNKI" role="15NUvb">
-            <ref role="3cqZAo" to="z60i:~Color.blue" resolve="blue" />
-            <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+            <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+            <ref role="3cqZAo" to="lzb2:~JBColor.blue" resolve="blue" />
           </node>
         </node>
       </node>

--- a/code/treenotation/com.mbeddr.mpsutil.treenotation.styles/com.mbeddr.mpsutil.treenotation.styles.mpl
+++ b/code/treenotation/com.mbeddr.mpsutil.treenotation.styles/com.mbeddr.mpsutil.treenotation.styles.mpl
@@ -12,6 +12,9 @@
   </facets>
   <accessoryModels />
   <sourcePath />
+  <dependencies>
+    <dependency reexport="false">498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)</dependency>
+  </dependencies>
   <languageVersions>
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
     <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />
@@ -48,6 +51,7 @@
     <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
     <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
     <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
+    <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="bda054c4-5d71-46ca-aba0-7104e3070b5a(com.mbeddr.mpsutil.treenotation.styles)" version="0" />
     <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />

--- a/code/treenotation/com.mbeddr.mpsutil.treenotation.styles/models/editor.mps
+++ b/code/treenotation/com.mbeddr.mpsutil.treenotation.styles/models/editor.mps
@@ -8,6 +8,7 @@
   </languages>
   <imports>
     <import index="z60i" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt(JDK/)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
   </imports>
@@ -123,8 +124,8 @@
         <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
       </node>
       <node concept="10M0yZ" id="7GMtHW6qHam" role="3t49C2">
-        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-        <ref role="3cqZAo" to="z60i:~Color.BLACK" resolve="BLACK" />
+        <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+        <ref role="3cqZAo" to="lzb2:~JBColor.BLACK" resolve="BLACK" />
       </node>
     </node>
     <node concept="3t5Usi" id="7GMtHW6qHaD" role="V601i">

--- a/code/widgets/languages/de.itemis.mps.editor.collapsible.testlang/de.itemis.mps.editor.collapsible.testlang.mpl
+++ b/code/widgets/languages/de.itemis.mps.editor.collapsible.testlang/de.itemis.mps.editor.collapsible.testlang.mpl
@@ -12,6 +12,9 @@
   </facets>
   <accessoryModels />
   <sourcePath />
+  <dependencies>
+    <dependency reexport="false">498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)</dependency>
+  </dependencies>
   <languageVersions>
     <language slang="l:3bdedd09-792a-4e15-a4db-83970df3ee86:de.itemis.mps.editor.collapsible" version="0" />
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
@@ -49,6 +52,7 @@
     <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
     <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
     <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
+    <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="d92a0cd8-920d-42ea-923c-f8c68d0a9444(de.itemis.mps.editor.collapsible.testlang)" version="0" />
     <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />

--- a/code/widgets/languages/de.itemis.mps.editor.collapsible.testlang/models/editor.mps
+++ b/code/widgets/languages/de.itemis.mps.editor.collapsible.testlang/models/editor.mps
@@ -8,6 +8,7 @@
   </languages>
   <imports>
     <import index="z60i" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt(JDK/)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="n12" ref="r:7e4984f5-9a8f-4f8b-a5ad-97797cae2191(de.itemis.mps.editor.collapsible.testlang.structure)" implicit="true" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
   </imports>
@@ -151,8 +152,8 @@
               <node concept="liA8E" id="7CjItjXtbK_" role="2OqNvi">
                 <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
                 <node concept="10M0yZ" id="7CjItjXtbNn" role="37wK5m">
-                  <ref role="3cqZAo" to="z60i:~Color.RED" resolve="RED" />
-                  <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                  <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                  <ref role="3cqZAo" to="lzb2:~JBColor.RED" resolve="RED" />
                 </node>
               </node>
             </node>
@@ -219,12 +220,12 @@
                 <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
                 <node concept="3K4zz7" id="7CjItjXudl$" role="37wK5m">
                   <node concept="10M0yZ" id="7CjItjXudnd" role="3K4E3e">
-                    <ref role="3cqZAo" to="z60i:~Color.GREEN" resolve="GREEN" />
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                    <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                    <ref role="3cqZAo" to="lzb2:~JBColor.GREEN" resolve="GREEN" />
                   </node>
                   <node concept="10M0yZ" id="7CjItjXudpo" role="3K4GZi">
-                    <ref role="3cqZAo" to="z60i:~Color.RED" resolve="RED" />
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                    <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                    <ref role="3cqZAo" to="lzb2:~JBColor.RED" resolve="RED" />
                   </node>
                   <node concept="2DP$1s" id="7CjItjXucZf" role="3K4Cdx" />
                 </node>
@@ -273,8 +274,8 @@
               <node concept="liA8E" id="7CjItjXunkV" role="2OqNvi">
                 <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
                 <node concept="10M0yZ" id="7CjItjXunJE" role="37wK5m">
-                  <ref role="3cqZAo" to="z60i:~Color.BLUE" resolve="BLUE" />
-                  <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                  <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                  <ref role="3cqZAo" to="lzb2:~JBColor.BLUE" resolve="BLUE" />
                 </node>
               </node>
             </node>
@@ -321,8 +322,8 @@
               <node concept="liA8E" id="7CjItjXunK$" role="2OqNvi">
                 <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
                 <node concept="10M0yZ" id="7CjItjXunZ6" role="37wK5m">
-                  <ref role="3cqZAo" to="z60i:~Color.MAGENTA" resolve="MAGENTA" />
-                  <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                  <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                  <ref role="3cqZAo" to="lzb2:~JBColor.MAGENTA" resolve="MAGENTA" />
                 </node>
               </node>
             </node>
@@ -394,12 +395,12 @@
                     <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
                     <node concept="3K4zz7" id="62nlqxEmoiq" role="37wK5m">
                       <node concept="10M0yZ" id="62nlqxEmoir" role="3K4E3e">
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                        <ref role="3cqZAo" to="z60i:~Color.GREEN" resolve="GREEN" />
+                        <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                        <ref role="3cqZAo" to="lzb2:~JBColor.GREEN" resolve="GREEN" />
                       </node>
                       <node concept="10M0yZ" id="62nlqxEmois" role="3K4GZi">
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                        <ref role="3cqZAo" to="z60i:~Color.RED" resolve="RED" />
+                        <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                        <ref role="3cqZAo" to="lzb2:~JBColor.RED" resolve="RED" />
                       </node>
                       <node concept="2DP$1s" id="62nlqxEmoit" role="3K4Cdx" />
                     </node>
@@ -448,8 +449,8 @@
                   <node concept="liA8E" id="62nlqxEmp0W" role="2OqNvi">
                     <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
                     <node concept="10M0yZ" id="62nlqxEmp0X" role="37wK5m">
-                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                      <ref role="3cqZAo" to="z60i:~Color.BLUE" resolve="BLUE" />
+                      <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                      <ref role="3cqZAo" to="lzb2:~JBColor.BLUE" resolve="BLUE" />
                     </node>
                   </node>
                 </node>
@@ -496,8 +497,8 @@
                   <node concept="liA8E" id="62nlqxEmpYB" role="2OqNvi">
                     <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
                     <node concept="10M0yZ" id="62nlqxEmpYC" role="37wK5m">
-                      <ref role="3cqZAo" to="z60i:~Color.MAGENTA" resolve="MAGENTA" />
-                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                      <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                      <ref role="3cqZAo" to="lzb2:~JBColor.MAGENTA" resolve="MAGENTA" />
                     </node>
                   </node>
                 </node>
@@ -550,12 +551,12 @@
                 <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
                 <node concept="3K4zz7" id="62nlqxEmo0h" role="37wK5m">
                   <node concept="10M0yZ" id="62nlqxEmo0i" role="3K4E3e">
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                    <ref role="3cqZAo" to="z60i:~Color.GREEN" resolve="GREEN" />
+                    <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                    <ref role="3cqZAo" to="lzb2:~JBColor.GREEN" resolve="GREEN" />
                   </node>
                   <node concept="10M0yZ" id="62nlqxEmo0j" role="3K4GZi">
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                    <ref role="3cqZAo" to="z60i:~Color.RED" resolve="RED" />
+                    <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                    <ref role="3cqZAo" to="lzb2:~JBColor.RED" resolve="RED" />
                   </node>
                   <node concept="2DP$1s" id="62nlqxEmo0k" role="3K4Cdx" />
                 </node>
@@ -604,8 +605,8 @@
               <node concept="liA8E" id="62nlqxEmoG3" role="2OqNvi">
                 <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
                 <node concept="10M0yZ" id="62nlqxEmoG4" role="37wK5m">
-                  <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                  <ref role="3cqZAo" to="z60i:~Color.BLUE" resolve="BLUE" />
+                  <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                  <ref role="3cqZAo" to="lzb2:~JBColor.BLUE" resolve="BLUE" />
                 </node>
               </node>
             </node>
@@ -652,8 +653,8 @@
               <node concept="liA8E" id="62nlqxEmpAI" role="2OqNvi">
                 <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
                 <node concept="10M0yZ" id="62nlqxEmpAJ" role="37wK5m">
-                  <ref role="3cqZAo" to="z60i:~Color.MAGENTA" resolve="MAGENTA" />
-                  <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                  <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                  <ref role="3cqZAo" to="lzb2:~JBColor.MAGENTA" resolve="MAGENTA" />
                 </node>
               </node>
             </node>
@@ -725,12 +726,12 @@
                     <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
                     <node concept="3K4zz7" id="62nlqxEmuXv" role="37wK5m">
                       <node concept="10M0yZ" id="62nlqxEmuXw" role="3K4E3e">
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                        <ref role="3cqZAo" to="z60i:~Color.GREEN" resolve="GREEN" />
+                        <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                        <ref role="3cqZAo" to="lzb2:~JBColor.GREEN" resolve="GREEN" />
                       </node>
                       <node concept="10M0yZ" id="62nlqxEmuXx" role="3K4GZi">
-                        <ref role="3cqZAo" to="z60i:~Color.RED" resolve="RED" />
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                        <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                        <ref role="3cqZAo" to="lzb2:~JBColor.RED" resolve="RED" />
                       </node>
                       <node concept="2DP$1s" id="62nlqxEmuXy" role="3K4Cdx" />
                     </node>
@@ -779,8 +780,8 @@
                   <node concept="liA8E" id="62nlqxEmuXS" role="2OqNvi">
                     <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
                     <node concept="10M0yZ" id="62nlqxEmuXT" role="37wK5m">
-                      <ref role="3cqZAo" to="z60i:~Color.BLUE" resolve="BLUE" />
-                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                      <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                      <ref role="3cqZAo" to="lzb2:~JBColor.BLUE" resolve="BLUE" />
                     </node>
                   </node>
                 </node>
@@ -827,8 +828,8 @@
                   <node concept="liA8E" id="62nlqxEmuYf" role="2OqNvi">
                     <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
                     <node concept="10M0yZ" id="62nlqxEmuYg" role="37wK5m">
-                      <ref role="3cqZAo" to="z60i:~Color.MAGENTA" resolve="MAGENTA" />
-                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                      <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                      <ref role="3cqZAo" to="lzb2:~JBColor.MAGENTA" resolve="MAGENTA" />
                     </node>
                   </node>
                 </node>
@@ -881,12 +882,12 @@
                 <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
                 <node concept="3K4zz7" id="62nlqxEmuYC" role="37wK5m">
                   <node concept="10M0yZ" id="62nlqxEmuYD" role="3K4E3e">
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                    <ref role="3cqZAo" to="z60i:~Color.GREEN" resolve="GREEN" />
+                    <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                    <ref role="3cqZAo" to="lzb2:~JBColor.GREEN" resolve="GREEN" />
                   </node>
                   <node concept="10M0yZ" id="62nlqxEmuYE" role="3K4GZi">
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                    <ref role="3cqZAo" to="z60i:~Color.RED" resolve="RED" />
+                    <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                    <ref role="3cqZAo" to="lzb2:~JBColor.RED" resolve="RED" />
                   </node>
                   <node concept="2DP$1s" id="62nlqxEmuYF" role="3K4Cdx" />
                 </node>
@@ -935,8 +936,8 @@
               <node concept="liA8E" id="62nlqxEmuZ1" role="2OqNvi">
                 <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
                 <node concept="10M0yZ" id="62nlqxEmuZ2" role="37wK5m">
-                  <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                  <ref role="3cqZAo" to="z60i:~Color.BLUE" resolve="BLUE" />
+                  <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                  <ref role="3cqZAo" to="lzb2:~JBColor.BLUE" resolve="BLUE" />
                 </node>
               </node>
             </node>
@@ -983,8 +984,8 @@
               <node concept="liA8E" id="62nlqxEmuZo" role="2OqNvi">
                 <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
                 <node concept="10M0yZ" id="62nlqxEmuZp" role="37wK5m">
-                  <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                  <ref role="3cqZAo" to="z60i:~Color.MAGENTA" resolve="MAGENTA" />
+                  <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                  <ref role="3cqZAo" to="lzb2:~JBColor.MAGENTA" resolve="MAGENTA" />
                 </node>
               </node>
             </node>

--- a/code/widgets/languages/de.itemis.mps.editor.enumeration/runtime/models/de.itemis.mps.editor.enumeration.runtime.mps
+++ b/code/widgets/languages/de.itemis.mps.editor.enumeration/runtime/models/de.itemis.mps.editor.enumeration.runtime.mps
@@ -30,6 +30,7 @@
     <import index="zf81" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.net(JDK/)" />
     <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" />
     <import index="3a50" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.ide(MPS.Platform/)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="hox0" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.style(MPS.Editor/)" implicit="true" />
   </imports>
   <registry>
@@ -2579,8 +2580,8 @@
                   <node concept="liA8E" id="4KKQOHJkK6R" role="2OqNvi">
                     <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
                     <node concept="10M0yZ" id="4KKQOHJkK7L" role="37wK5m">
-                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                      <ref role="3cqZAo" to="z60i:~Color.BLACK" resolve="BLACK" />
+                      <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                      <ref role="3cqZAo" to="lzb2:~JBColor.BLACK" resolve="BLACK" />
                     </node>
                   </node>
                 </node>

--- a/code/widgets/solutions/de.itemis.mps.editor.bool.runtime/models/de/itemis/mps/editor/bool/runtime.mps
+++ b/code/widgets/solutions/de.itemis.mps.editor.bool.runtime/models/de/itemis/mps/editor/bool/runtime.mps
@@ -4221,21 +4221,15 @@
                 </node>
                 <node concept="liA8E" id="QvUN5MZxF0" role="2OqNvi">
                   <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
-                  <node concept="2ShNRf" id="QvUN5MZxFU" role="37wK5m">
-                    <node concept="1pGfFk" id="QvUN5MZDQ1" role="2ShVmc">
-                      <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int,int)" resolve="Color" />
-                      <node concept="3cmrfG" id="QvUN5MZDRg" role="37wK5m">
-                        <property role="3cmrfH" value="0" />
-                      </node>
-                      <node concept="3cmrfG" id="QvUN5MZEaq" role="37wK5m">
-                        <property role="3cmrfH" value="0" />
-                      </node>
-                      <node concept="3cmrfG" id="QvUN5MZEE3" role="37wK5m">
-                        <property role="3cmrfH" value="0" />
-                      </node>
-                      <node concept="3cmrfG" id="QvUN5MZF1q" role="37wK5m">
-                        <property role="3cmrfH" value="30" />
-                      </node>
+                  <node concept="2YIFZM" id="2WI5qdoevw" role="37wK5m">
+                    <ref role="1Pybhc" to="lzb2:~ColorUtil" resolve="ColorUtil" />
+                    <ref role="37wK5l" to="lzb2:~ColorUtil.withAlpha(java.awt.Color,double)" resolve="withAlpha" />
+                    <node concept="10M0yZ" id="2WI5qdofkt" role="37wK5m">
+                      <ref role="3cqZAo" to="lzb2:~JBColor.BLACK" resolve="BLACK" />
+                      <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                    </node>
+                    <node concept="3b6qkQ" id="2WI5qdog7M" role="37wK5m">
+                      <property role="$nhwW" value="0.117" />
                     </node>
                   </node>
                 </node>

--- a/code/widgets/solutions/de.itemis.mps.editor.bool.runtime/models/de/itemis/mps/editor/bool/runtime.mps
+++ b/code/widgets/solutions/de.itemis.mps.editor.bool.runtime/models/de/itemis/mps/editor/bool/runtime.mps
@@ -33,6 +33,7 @@
     <import index="5ueo" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.editor.runtime.style(MPS.Editor/)" />
     <import index="zf81" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.net(JDK/)" />
     <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="hox0" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.style(MPS.Editor/)" implicit="true" />
     <import index="22ra" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.update(MPS.Editor/)" implicit="true" />
   </imports>
@@ -2506,8 +2507,8 @@
                   <node concept="liA8E" id="4KKQOHJkK6R" role="2OqNvi">
                     <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
                     <node concept="10M0yZ" id="4KKQOHJkK7L" role="37wK5m">
-                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                      <ref role="3cqZAo" to="z60i:~Color.BLACK" resolve="BLACK" />
+                      <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                      <ref role="3cqZAo" to="lzb2:~JBColor.BLACK" resolve="BLACK" />
                     </node>
                   </node>
                 </node>

--- a/code/widgets/solutions/de.itemis.mps.editor.collapsible.runtime/models/de/itemis/mps/editor/collapsible/runtime.mps
+++ b/code/widgets/solutions/de.itemis.mps.editor.collapsible.runtime/models/de/itemis/mps/editor/collapsible/runtime.mps
@@ -25,6 +25,7 @@
     <import index="5usg" ref="r:3838bb8b-fecd-4f7c-841e-325717a43980(de.itemis.mps.tooltips.runtime)" />
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
     <import index="lui2" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.module(MPS.OpenAPI/)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="z8iw" ref="r:dfdf3542-dbcf-43df-870a-3c3504b3c840(jetbrains.mps.baseLanguage.collections.custom)" implicit="true" />
     <import index="dxuu" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:javax.swing(JDK/)" implicit="true" />
   </imports>
@@ -1628,8 +1629,8 @@
                           <node concept="liA8E" id="48DYfEtnxur" role="2OqNvi">
                             <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
                             <node concept="10M0yZ" id="48DYfEtnxvl" role="37wK5m">
-                              <ref role="3cqZAo" to="z60i:~Color.GRAY" resolve="GRAY" />
-                              <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                              <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                              <ref role="3cqZAo" to="lzb2:~JBColor.GRAY" resolve="GRAY" />
                             </node>
                           </node>
                         </node>
@@ -3841,23 +3842,13 @@
                 <node concept="liA8E" id="48DYfEtwvVa" role="2OqNvi">
                   <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
                   <node concept="3K4zz7" id="48DYfEtwwmO" role="37wK5m">
-                    <node concept="2ShNRf" id="48DYfEtwwsj" role="3K4E3e">
-                      <node concept="1pGfFk" id="48DYfEtwwL5" role="2ShVmc">
-                        <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
-                        <node concept="3cmrfG" id="48DYfEtwwL$" role="37wK5m">
-                          <property role="3cmrfH" value="200" />
-                        </node>
-                        <node concept="3cmrfG" id="48DYfEtwwNB" role="37wK5m">
-                          <property role="3cmrfH" value="200" />
-                        </node>
-                        <node concept="3cmrfG" id="48DYfEtwxio" role="37wK5m">
-                          <property role="3cmrfH" value="200" />
-                        </node>
-                      </node>
+                    <node concept="10M0yZ" id="2WI5qcQkpk" role="3K4E3e">
+                      <ref role="3cqZAo" to="lzb2:~JBColor.LIGHT_GRAY" resolve="LIGHT_GRAY" />
+                      <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                     </node>
                     <node concept="10M0yZ" id="48DYfEtwxBB" role="3K4GZi">
-                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                      <ref role="3cqZAo" to="z60i:~Color.WHITE" resolve="WHITE" />
+                      <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                      <ref role="3cqZAo" to="lzb2:~JBColor.WHITE" resolve="WHITE" />
                     </node>
                     <node concept="37vLTw" id="48DYfEtwvW6" role="3K4Cdx">
                       <ref role="3cqZAo" node="48DYfEtb43H" resolve="myIsHighlighted" />
@@ -3906,8 +3897,8 @@
                 <node concept="liA8E" id="48DYfEt2xwu" role="2OqNvi">
                   <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
                   <node concept="10M0yZ" id="48DYfEt2xxq" role="37wK5m">
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                    <ref role="3cqZAo" to="z60i:~Color.GRAY" resolve="GRAY" />
+                    <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                    <ref role="3cqZAo" to="lzb2:~JBColor.GRAY" resolve="GRAY" />
                   </node>
                 </node>
               </node>

--- a/code/widgets/solutions/de.itemis.mps.editor.dropdown.runtime/models/de/itemis/mps/editor/dropdown/runtime.mps
+++ b/code/widgets/solutions/de.itemis.mps.editor.dropdown.runtime/models/de/itemis/mps/editor/dropdown/runtime.mps
@@ -202,10 +202,24 @@
         <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
       </node>
       <node concept="2YIFZM" id="2WI5qdsu9_" role="33vP2m">
-        <ref role="37wK5l" to="lzb2:~JBColor.namedColor(java.lang.String)" resolve="namedColor" />
         <ref role="1Pybhc" to="lzb2:~JBColor" resolve="JBColor" />
+        <ref role="37wK5l" to="lzb2:~JBColor.namedColor(java.lang.String,java.awt.Color)" resolve="namedColor" />
         <node concept="Xl_RD" id="2WI5qdswUT" role="37wK5m">
           <property role="Xl_RC" value="Component.borderColor" />
+        </node>
+        <node concept="2ShNRf" id="7szUFELH2FG" role="37wK5m">
+          <node concept="1pGfFk" id="7szUFELH2FF" role="2ShVmc">
+            <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
+            <node concept="3cmrfG" id="7szUFELH2IR" role="37wK5m">
+              <property role="3cmrfH" value="150" />
+            </node>
+            <node concept="3cmrfG" id="7szUFELH2Pe" role="37wK5m">
+              <property role="3cmrfH" value="150" />
+            </node>
+            <node concept="3cmrfG" id="7szUFELH36o" role="37wK5m">
+              <property role="3cmrfH" value="150" />
+            </node>
+          </node>
         </node>
       </node>
     </node>

--- a/code/widgets/solutions/de.itemis.mps.editor.dropdown.runtime/models/de/itemis/mps/editor/dropdown/runtime.mps
+++ b/code/widgets/solutions/de.itemis.mps.editor.dropdown.runtime/models/de/itemis/mps/editor/dropdown/runtime.mps
@@ -16,6 +16,7 @@
     <import index="py4t" ref="r:4e973dcf-7005-4515-8904-9c030ef293d4(de.itemis.mps.mouselistener.runtime)" />
     <import index="hyam" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt.event(JDK/)" />
     <import index="exr9" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor(MPS.Editor/)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
   </imports>
   <registry>
@@ -49,6 +50,9 @@
       <concept id="1070462154015" name="jetbrains.mps.baseLanguage.structure.StaticFieldDeclaration" flags="ig" index="Wx3nA" />
       <concept id="1070475354124" name="jetbrains.mps.baseLanguage.structure.ThisExpression" flags="nn" index="Xjq3P" />
       <concept id="1070475587102" name="jetbrains.mps.baseLanguage.structure.SuperConstructorInvocation" flags="nn" index="XkiVB" />
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
       <concept id="1182160077978" name="jetbrains.mps.baseLanguage.structure.AnonymousClassCreator" flags="nn" index="YeOm9">
         <child id="1182160096073" name="cls" index="YeSDq" />
       </concept>
@@ -197,18 +201,11 @@
       <node concept="3uibUv" id="7szUFELGYVN" role="1tU5fm">
         <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
       </node>
-      <node concept="2ShNRf" id="7szUFELH2FG" role="33vP2m">
-        <node concept="1pGfFk" id="7szUFELH2FF" role="2ShVmc">
-          <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
-          <node concept="3cmrfG" id="7szUFELH2IR" role="37wK5m">
-            <property role="3cmrfH" value="150" />
-          </node>
-          <node concept="3cmrfG" id="7szUFELH2Pe" role="37wK5m">
-            <property role="3cmrfH" value="150" />
-          </node>
-          <node concept="3cmrfG" id="7szUFELH36o" role="37wK5m">
-            <property role="3cmrfH" value="150" />
-          </node>
+      <node concept="2YIFZM" id="2WI5qdsu9_" role="33vP2m">
+        <ref role="37wK5l" to="lzb2:~JBColor.namedColor(java.lang.String)" resolve="namedColor" />
+        <ref role="1Pybhc" to="lzb2:~JBColor" resolve="JBColor" />
+        <node concept="Xl_RD" id="2WI5qdswUT" role="37wK5m">
+          <property role="Xl_RC" value="Component.borderColor" />
         </node>
       </node>
     </node>

--- a/code/widgets/solutions/de.itemis.mps.editor.dropdown.runtime/models/de/itemis/mps/editor/dropdown/runtime.mps
+++ b/code/widgets/solutions/de.itemis.mps.editor.dropdown.runtime/models/de/itemis/mps/editor/dropdown/runtime.mps
@@ -953,21 +953,16 @@
                         <ref role="3cqZAo" node="3_TG3j996Nd" resolve="isHighlighted" />
                       </node>
                       <node concept="10M0yZ" id="7szUFELG2wb" role="3K4GZi">
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                        <ref role="3cqZAo" to="z60i:~Color.WHITE" resolve="WHITE" />
+                        <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                        <ref role="3cqZAo" to="lzb2:~JBColor.WHITE" resolve="WHITE" />
                       </node>
-                      <node concept="2ShNRf" id="7szUFELFPMr" role="3K4E3e">
-                        <node concept="1pGfFk" id="7szUFELFQ5Y" role="2ShVmc">
-                          <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
-                          <node concept="3cmrfG" id="7szUFELFQ7W" role="37wK5m">
-                            <property role="3cmrfH" value="200" />
-                          </node>
-                          <node concept="3cmrfG" id="7szUFELFQaG" role="37wK5m">
-                            <property role="3cmrfH" value="200" />
-                          </node>
-                          <node concept="3cmrfG" id="7szUFELFQqP" role="37wK5m">
-                            <property role="3cmrfH" value="255" />
-                          </node>
+                      <node concept="2OqwBi" id="2WI5qdtkSo" role="3K4E3e">
+                        <node concept="2YIFZM" id="2WI5qdtkqn" role="2Oq$k0">
+                          <ref role="1Pybhc" to="exr9:~EditorSettings" resolve="EditorSettings" />
+                          <ref role="37wK5l" to="exr9:~EditorSettings.getInstance()" resolve="getInstance" />
+                        </node>
+                        <node concept="liA8E" id="2WI5qdtnB1" role="2OqNvi">
+                          <ref role="37wK5l" to="exr9:~EditorSettings.getSelectionBackgroundColor()" resolve="getSelectionBackgroundColor" />
                         </node>
                       </node>
                     </node>


### PR DESCRIPTION
Changes are cherry-picked from https://github.com/JetBrains/MPS-extensions/pull/512. The original PR was made for 2021.2 and later.