### PR TITLE
Add an editor field to customize layout storing of diagrams

### DIFF
--- a/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
+++ b/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
@@ -18384,6 +18384,11 @@
             </node>
           </node>
         </node>
+        <node concept="1SiIV0" id="5m1M1V$YXTw" role="3bR37C">
+          <node concept="3bR9La" id="5m1M1V$YXTx" role="1SiIV1">
+            <ref role="3bR37D" node="56Tfdun3uan" resolve="de.itemis.mps.editor.diagram.layout" />
+          </node>
+        </node>
       </node>
       <node concept="1E1JtD" id="7qi8mU1Oz$h" role="2G$12L">
         <property role="BnDLt" value="true" />

--- a/code/diagram/languages/de.itemis.mps.editor.diagram/generator/template/main@generator.mps
+++ b/code/diagram/languages/de.itemis.mps.editor.diagram/generator/template/main@generator.mps
@@ -5064,9 +5064,70 @@
                                                         <node concept="3clFbF" id="2YJ6SvpdRkz" role="3cqZAp">
                                                           <node concept="2OqwBi" id="2YJ6SvpdRku" role="3clFbG">
                                                             <node concept="3TrcHB" id="2YJ6SvpdRkx" role="2OqNvi">
-                                                              <ref role="3TsBF5" to="2qld:2YJ6Svp2O0G" resolve="saveSubdiagramLayoutInDiagram" />
+                                                              <ref role="3TsBF5" to="2qld:2YJ6Svp2O0G" resolve="saveSubDiagramLayoutInDiagram" />
                                                             </node>
                                                             <node concept="30H73N" id="2YJ6SvpdRky" role="2Oq$k0" />
+                                                          </node>
+                                                        </node>
+                                                      </node>
+                                                    </node>
+                                                  </node>
+                                                </node>
+                                                <node concept="2tJIrI" id="6gw4xIYIOV1" role="jymVt" />
+                                                <node concept="3clFb_" id="6gw4xIYIZkD" role="jymVt">
+                                                  <property role="TrG5h" value="saveDiagramLayout" />
+                                                  <node concept="3clFbS" id="6gw4xIYIZkG" role="3clF47">
+                                                    <node concept="3cpWs6" id="6gw4xIYKo9P" role="3cqZAp">
+                                                      <node concept="1rXfSq" id="8dI1zL4th8" role="3cqZAk">
+                                                        <ref role="37wK5l" node="8dI1zL4thX" resolve="_query_method" />
+                                                        <node concept="1ZhdrF" id="8dI1zL4th9" role="lGtFl">
+                                                          <property role="2qtEX8" value="baseMethodDeclaration" />
+                                                          <property role="P3scX" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1204053956946/1068499141037" />
+                                                          <node concept="3$xsQk" id="8dI1zL4tha" role="3$ytzL">
+                                                            <node concept="3clFbS" id="8dI1zL4thb" role="2VODD2">
+                                                              <node concept="3clFbF" id="8dI1zL4thc" role="3cqZAp">
+                                                                <node concept="2OqwBi" id="8dI1zL4thd" role="3clFbG">
+                                                                  <node concept="1iwH70" id="8dI1zL4the" role="2OqNvi">
+                                                                    <ref role="1iwH77" to="tpc3:hG092go" resolve="query_method" />
+                                                                    <node concept="2OqwBi" id="8dI1zL4thf" role="1iwH7V">
+                                                                      <node concept="30H73N" id="8dI1zL4thg" role="2Oq$k0" />
+                                                                      <node concept="3TrEf2" id="6W4SFvZYE8m" role="2OqNvi">
+                                                                        <ref role="3Tt5mk" to="2qld:7dE4XXD8Z89" resolve="saveLayout" />
+                                                                      </node>
+                                                                    </node>
+                                                                  </node>
+                                                                  <node concept="1iwH7S" id="8dI1zL4thh" role="2Oq$k0" />
+                                                                </node>
+                                                              </node>
+                                                            </node>
+                                                          </node>
+                                                        </node>
+                                                        <node concept="37vLTw" id="8dI1zL4thi" role="37wK5m">
+                                                          <ref role="3cqZAo" node="fXNkb_c" resolve="node" />
+                                                        </node>
+                                                        <node concept="37vLTw" id="8dI1zL4thj" role="37wK5m">
+                                                          <ref role="3cqZAo" node="fXNkb_a" resolve="editorContext" />
+                                                        </node>
+                                                      </node>
+                                                    </node>
+                                                  </node>
+                                                  <node concept="3Tm1VV" id="6gw4xIYISgE" role="1B3o_S" />
+                                                  <node concept="10P_77" id="6gw4xIYIUqL" role="3clF45" />
+                                                  <node concept="2AHcQZ" id="6gw4xIYKm1J" role="2AJF6D">
+                                                    <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                                                  </node>
+                                                  <node concept="1W57fq" id="6W4SFvZZYVX" role="lGtFl">
+                                                    <node concept="3IZrLx" id="6W4SFvZZYVY" role="3IZSJc">
+                                                      <node concept="3clFbS" id="6W4SFvZZYVZ" role="2VODD2">
+                                                        <node concept="3clFbF" id="6W4SFw000Xo" role="3cqZAp">
+                                                          <node concept="3y3z36" id="6W4SFw0026F" role="3clFbG">
+                                                            <node concept="10Nm6u" id="6W4SFw002sW" role="3uHU7w" />
+                                                            <node concept="2OqwBi" id="6W4SFw001h2" role="3uHU7B">
+                                                              <node concept="30H73N" id="6W4SFw000Xn" role="2Oq$k0" />
+                                                              <node concept="3TrEf2" id="6W4SFw001D7" role="2OqNvi">
+                                                                <ref role="3Tt5mk" to="2qld:7dE4XXD8Z89" resolve="saveLayout" />
+                                                              </node>
+                                                            </node>
                                                           </node>
                                                         </node>
                                                       </node>
@@ -5636,6 +5697,27 @@
           </node>
         </node>
       </node>
+      <node concept="2YIFZL" id="8dI1zL4thX" role="jymVt">
+        <property role="TrG5h" value="_query_method" />
+        <node concept="3clFbS" id="8dI1zL4thY" role="3clF47">
+          <node concept="3cpWs6" id="8dI1zL4thZ" role="3cqZAp">
+            <node concept="3clFbT" id="8dI1zL4ti0" role="3cqZAk" />
+          </node>
+        </node>
+        <node concept="10P_77" id="8dI1zL4ti1" role="3clF45" />
+        <node concept="37vLTG" id="8dI1zL4ti2" role="3clF46">
+          <property role="TrG5h" value="node" />
+          <node concept="3Tqbb2" id="8dI1zL4ti3" role="1tU5fm" />
+        </node>
+        <node concept="37vLTG" id="8dI1zL4ti4" role="3clF46">
+          <property role="TrG5h" value="editorContext" />
+          <node concept="3uibUv" id="8dI1zL4ti5" role="1tU5fm">
+            <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+          </node>
+        </node>
+        <node concept="3Tm1VV" id="8dI1zL4ti6" role="1B3o_S" />
+      </node>
+      <node concept="2tJIrI" id="6W4SFvZYGT2" role="jymVt" />
       <node concept="3clFb_" id="5KDKp$lLLig" role="jymVt">
         <property role="TrG5h" value="newFactoryMethod" />
         <node concept="3uibUv" id="5KDKp$lLLih" role="3clF45">

--- a/code/diagram/languages/de.itemis.mps.editor.diagram/generator/template/main@generator.mps
+++ b/code/diagram/languages/de.itemis.mps.editor.diagram/generator/template/main@generator.mps
@@ -5074,17 +5074,44 @@
                                                   </node>
                                                 </node>
                                                 <node concept="2tJIrI" id="6gw4xIYIOV1" role="jymVt" />
+                                                <node concept="3clFb_" id="28uWW3KU_to" role="jymVt">
+                                                  <property role="TrG5h" value="_query_method" />
+                                                  <node concept="3clFbS" id="28uWW3KU_tr" role="3clF47">
+                                                    <node concept="3cpWs6" id="28uWW3KUBGx" role="3cqZAp">
+                                                      <node concept="3clFbT" id="28uWW3KUEL7" role="3cqZAk">
+                                                        <property role="3clFbU" value="true" />
+                                                      </node>
+                                                    </node>
+                                                  </node>
+                                                  <node concept="3Tm6S6" id="28uWW3KUyeY" role="1B3o_S" />
+                                                  <node concept="10P_77" id="28uWW3KUzqg" role="3clF45" />
+                                                  <node concept="29HgVG" id="28uWW3KUIIk" role="lGtFl">
+                                                    <node concept="3NFfHV" id="28uWW3KUIIl" role="3NFExx">
+                                                      <node concept="3clFbS" id="28uWW3KUIIm" role="2VODD2">
+                                                        <node concept="3clFbF" id="28uWW3KUIIs" role="3cqZAp">
+                                                          <node concept="2OqwBi" id="28uWW3KUIIn" role="3clFbG">
+                                                            <node concept="3TrEf2" id="28uWW3KUIIq" role="2OqNvi">
+                                                              <ref role="3Tt5mk" to="2qld:7dE4XXD8Z89" resolve="saveLayout" />
+                                                            </node>
+                                                            <node concept="30H73N" id="28uWW3KUIIr" role="2Oq$k0" />
+                                                          </node>
+                                                        </node>
+                                                      </node>
+                                                    </node>
+                                                  </node>
+                                                </node>
+                                                <node concept="2tJIrI" id="28uWW3KUwh7" role="jymVt" />
                                                 <node concept="3clFb_" id="6gw4xIYIZkD" role="jymVt">
                                                   <property role="TrG5h" value="saveDiagramLayout" />
                                                   <node concept="3clFbS" id="6gw4xIYIZkG" role="3clF47">
                                                     <node concept="3cpWs6" id="6gw4xIYKo9P" role="3cqZAp">
-                                                      <node concept="1rXfSq" id="8dI1zL4th8" role="3cqZAk">
-                                                        <ref role="37wK5l" node="8dI1zL4thX" resolve="_query_method" />
-                                                        <node concept="1ZhdrF" id="8dI1zL4th9" role="lGtFl">
+                                                      <node concept="1rXfSq" id="28uWW3KVJDo" role="3cqZAk">
+                                                        <ref role="37wK5l" node="28uWW3KU_to" resolve="_query_method" />
+                                                        <node concept="1ZhdrF" id="28uWW3KVK_O" role="lGtFl">
                                                           <property role="2qtEX8" value="baseMethodDeclaration" />
                                                           <property role="P3scX" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1204053956946/1068499141037" />
-                                                          <node concept="3$xsQk" id="8dI1zL4tha" role="3$ytzL">
-                                                            <node concept="3clFbS" id="8dI1zL4thb" role="2VODD2">
+                                                          <node concept="3$xsQk" id="28uWW3KVK_P" role="3$ytzL">
+                                                            <node concept="3clFbS" id="28uWW3KVK_Q" role="2VODD2">
                                                               <node concept="3clFbF" id="8dI1zL4thc" role="3cqZAp">
                                                                 <node concept="2OqwBi" id="8dI1zL4thd" role="3clFbG">
                                                                   <node concept="1iwH70" id="8dI1zL4the" role="2OqNvi">
@@ -5101,12 +5128,6 @@
                                                               </node>
                                                             </node>
                                                           </node>
-                                                        </node>
-                                                        <node concept="37vLTw" id="8dI1zL4thi" role="37wK5m">
-                                                          <ref role="3cqZAo" node="fXNkb_c" resolve="node" />
-                                                        </node>
-                                                        <node concept="37vLTw" id="8dI1zL4thj" role="37wK5m">
-                                                          <ref role="3cqZAo" node="fXNkb_a" resolve="editorContext" />
                                                         </node>
                                                       </node>
                                                     </node>
@@ -5657,6 +5678,8 @@
             </node>
           </node>
           <node concept="3clFbH" id="5S8_I2G61xA" role="3cqZAp" />
+          <node concept="3clFbH" id="28uWW3KOVmS" role="3cqZAp" />
+          <node concept="3clFbH" id="28uWW3KOTbV" role="3cqZAp" />
           <node concept="3cpWs6" id="fXNkb_L" role="3cqZAp">
             <node concept="37vLTw" id="3GM_nagTrBQ" role="3cqZAk">
               <ref role="3cqZAo" node="hdJTozF" resolve="editorCell" />
@@ -5696,26 +5719,6 @@
             </node>
           </node>
         </node>
-      </node>
-      <node concept="2YIFZL" id="8dI1zL4thX" role="jymVt">
-        <property role="TrG5h" value="_query_method" />
-        <node concept="3clFbS" id="8dI1zL4thY" role="3clF47">
-          <node concept="3cpWs6" id="8dI1zL4thZ" role="3cqZAp">
-            <node concept="3clFbT" id="8dI1zL4ti0" role="3cqZAk" />
-          </node>
-        </node>
-        <node concept="10P_77" id="8dI1zL4ti1" role="3clF45" />
-        <node concept="37vLTG" id="8dI1zL4ti2" role="3clF46">
-          <property role="TrG5h" value="node" />
-          <node concept="3Tqbb2" id="8dI1zL4ti3" role="1tU5fm" />
-        </node>
-        <node concept="37vLTG" id="8dI1zL4ti4" role="3clF46">
-          <property role="TrG5h" value="editorContext" />
-          <node concept="3uibUv" id="8dI1zL4ti5" role="1tU5fm">
-            <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
-          </node>
-        </node>
-        <node concept="3Tm1VV" id="8dI1zL4ti6" role="1B3o_S" />
       </node>
       <node concept="2tJIrI" id="6W4SFvZYGT2" role="jymVt" />
       <node concept="3clFb_" id="5KDKp$lLLig" role="jymVt">

--- a/code/diagram/languages/de.itemis.mps.editor.diagram/languageModels/editor.mps
+++ b/code/diagram/languages/de.itemis.mps.editor.diagram/languageModels/editor.mps
@@ -731,6 +731,20 @@
             </node>
             <node concept="2iRfu4" id="2YJ6Svp2OoC" role="2iSdaV" />
           </node>
+          <node concept="3EZMnI" id="7dE4XXD8Zm_" role="3EZMnx">
+            <node concept="2iRfu4" id="7dE4XXD8ZmA" role="2iSdaV" />
+            <node concept="3F0ifn" id="7dE4XXD8ZgC" role="3EZMnx">
+              <property role="3F0ifm" value="save layout data" />
+            </node>
+            <node concept="3F1sOY" id="7dE4XXD90iS" role="3EZMnx">
+              <property role="1$x2rV" value="true (default)" />
+              <ref role="1NtTu8" to="2qld:7dE4XXD8Z89" resolve="saveLayout" />
+            </node>
+            <node concept="VPM3Z" id="7dE4XXD90al" role="3F10Kt" />
+            <node concept="VPXOz" id="7dE4XXD90ar" role="3F10Kt">
+              <property role="VOm3f" value="true" />
+            </node>
+          </node>
         </node>
         <node concept="2iRfu4" id="5qgNcfDnGw9" role="2iSdaV" />
         <node concept="3F0ifn" id="5qgNcfDnGxf" role="3EZMnx" />

--- a/code/diagram/languages/de.itemis.mps.editor.diagram/languageModels/structure.mps
+++ b/code/diagram/languages/de.itemis.mps.editor.diagram/languageModels/structure.mps
@@ -154,6 +154,12 @@
       <property role="20kJfa" value="ownerChangeHandler" />
       <ref role="20lvS9" node="5wo2$NmYEwT" resolve="OwnerChangeHandler" />
     </node>
+    <node concept="1TJgyj" id="7dE4XXD8Z89" role="1TKVEi">
+      <property role="IQ2ns" value="8316481512155640329" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="saveLayout" />
+      <ref role="20lvS9" to="tpc2:gCpkWun" resolve="QueryFunction_NodeCondition" />
+    </node>
     <node concept="1TJgyj" id="5qgNcfDnbtd" role="1TKVEi">
       <property role="20lmBu" value="fLJjDmT/aggregation" />
       <property role="20kJfa" value="contentQuery" />

--- a/code/diagram/languages/test.de.itemis.mps.editor.diagram.lang/languageModels/editor.mps
+++ b/code/diagram/languages/test.de.itemis.mps.editor.diagram.lang/languageModels/editor.mps
@@ -29,6 +29,7 @@
       <concept id="1237307900041" name="jetbrains.mps.lang.editor.structure.IndentLayoutIndentStyleClassItem" flags="ln" index="lj46D" />
       <concept id="1237308012275" name="jetbrains.mps.lang.editor.structure.IndentLayoutNewLineStyleClassItem" flags="ln" index="ljvvj" />
       <concept id="1237375020029" name="jetbrains.mps.lang.editor.structure.IndentLayoutNewLineChildrenStyleClassItem" flags="ln" index="pj6Ft" />
+      <concept id="1142886221719" name="jetbrains.mps.lang.editor.structure.QueryFunction_NodeCondition" flags="in" index="pkWqt" />
       <concept id="1142886811589" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameter_node" flags="nn" index="pncrf" />
       <concept id="1080736578640" name="jetbrains.mps.lang.editor.structure.BaseEditorComponent" flags="ig" index="2wURMF">
         <child id="1080736633877" name="cellModel" index="2wV5jI" />
@@ -108,6 +109,7 @@
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
+      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT" />
       <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
         <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
       </concept>
@@ -139,6 +141,7 @@
         <child id="6554619383001456819" name="targetId" index="23hSWE" />
       </concept>
       <concept id="1110129820007229393" name="de.itemis.mps.editor.diagram.structure.CellModel_Diagram" flags="ng" index="27vDVx">
+        <child id="8316481512155640329" name="saveLayout" index="qiu7m" />
         <child id="1981294357059564524" name="paletteSources" index="1RuSHk" />
       </concept>
       <concept id="3155126767689025629" name="de.itemis.mps.editor.diagram.structure.Content_Childs" flags="ng" index="aDKH9">
@@ -874,6 +877,82 @@
               </node>
             </node>
           </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="24kQdi" id="28uWW3KZptk">
+    <ref role="1XX52x" to="7nxb:28uWW3KZps3" resolve="DiagramWithoutLayoutStore" />
+    <node concept="2aJ2om" id="28uWW3KZpv2" role="CpUAK">
+      <ref role="2$4xQ3" node="24zrZPPz$8v" resolve="asDiagram" />
+    </node>
+    <node concept="27vDVx" id="28uWW3KZpv4" role="2wV5jI">
+      <node concept="aDKH9" id="28uWW3KZpv5" role="aCds2">
+        <ref role="aDKIf" to="7nxb:24zrZPPzcAP" resolve="elements" />
+      </node>
+      <node concept="1RuTs0" id="28uWW3KZpv6" role="1RuSHk">
+        <ref role="1RuSHD" to="7nxb:24zrZPPzcAP" resolve="elements" />
+      </node>
+      <node concept="pkWqt" id="28uWW3KZpva" role="qiu7m">
+        <node concept="3clFbS" id="28uWW3KZpvb" role="2VODD2">
+          <node concept="3clFbF" id="28uWW3KZpz5" role="3cqZAp">
+            <node concept="3clFbT" id="28uWW3KZpz4" role="3clFbG" />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="24kQdi" id="28uWW3KZpEB">
+    <ref role="1XX52x" to="7nxb:28uWW3KZps3" resolve="DiagramWithoutLayoutStore" />
+    <node concept="3EZMnI" id="28uWW3KZpFv" role="2wV5jI">
+      <node concept="l2Vlx" id="28uWW3KZpFw" role="2iSdaV" />
+      <node concept="3F0ifn" id="28uWW3KZpFx" role="3EZMnx">
+        <property role="3F0ifm" value="diagramWithoutLayout" />
+      </node>
+      <node concept="3F0ifn" id="28uWW3KZpFy" role="3EZMnx">
+        <property role="3F0ifm" value="{" />
+        <node concept="3mYdg7" id="28uWW3KZpFz" role="3F10Kt">
+          <property role="1413C4" value="body-brace" />
+        </node>
+        <node concept="ljvvj" id="28uWW3KZpF$" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="3EZMnI" id="28uWW3KZpF_" role="3EZMnx">
+        <node concept="l2Vlx" id="28uWW3KZpFA" role="2iSdaV" />
+        <node concept="lj46D" id="28uWW3KZpFB" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+        <node concept="3F0ifn" id="28uWW3KZpFC" role="3EZMnx">
+          <property role="3F0ifm" value="elements" />
+        </node>
+        <node concept="3F0ifn" id="28uWW3KZpFD" role="3EZMnx">
+          <property role="3F0ifm" value=":" />
+          <node concept="11L4FC" id="28uWW3KZpFE" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+          <node concept="ljvvj" id="28uWW3KZpFF" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+        </node>
+        <node concept="3F2HdR" id="28uWW3KZpFG" role="3EZMnx">
+          <ref role="1NtTu8" to="7nxb:24zrZPPzcAP" resolve="elements" />
+          <node concept="l2Vlx" id="28uWW3KZpFH" role="2czzBx" />
+          <node concept="pj6Ft" id="28uWW3KZpFI" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+          <node concept="lj46D" id="28uWW3KZpFJ" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+          <node concept="ljvvj" id="28uWW3KZpFK" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+        </node>
+      </node>
+      <node concept="3F0ifn" id="28uWW3KZpFL" role="3EZMnx">
+        <property role="3F0ifm" value="}" />
+        <node concept="3mYdg7" id="28uWW3KZpFM" role="3F10Kt">
+          <property role="1413C4" value="body-brace" />
         </node>
       </node>
     </node>

--- a/code/diagram/languages/test.de.itemis.mps.editor.diagram.lang/languageModels/structure.mps
+++ b/code/diagram/languages/test.de.itemis.mps.editor.diagram.lang/languageModels/structure.mps
@@ -225,5 +225,10 @@
       <ref role="20lvS9" to="tpck:gw2VY9q" resolve="BaseConcept" />
     </node>
   </node>
+  <node concept="1TIwiD" id="28uWW3KZps3">
+    <property role="EcuMT" value="2458670456593291011" />
+    <property role="TrG5h" value="DiagramWithoutLayoutStore" />
+    <ref role="1TJDcQ" node="24zrZPPzcal" resolve="Diagram" />
+  </node>
 </model>
 

--- a/code/diagram/solutions/de.itemis.mps.editor.diagram.runtime/models/de/itemis/mps/editor/diagram/runtime/model.mps
+++ b/code/diagram/solutions/de.itemis.mps.editor.diagram.runtime/models/de/itemis/mps/editor/diagram/runtime/model.mps
@@ -27878,24 +27878,34 @@
       <node concept="3cqZAl" id="7L$rKAVfIJa" role="3clF45" />
       <node concept="3Tm1VV" id="7L$rKAVfIJb" role="1B3o_S" />
       <node concept="3clFbS" id="7L$rKAVfIJd" role="3clF47">
-        <node concept="3clFbF" id="7L$rKAVgUjL" role="3cqZAp">
-          <node concept="2OqwBi" id="7L$rKAVgUpB" role="3clFbG">
-            <node concept="37vLTw" id="7L$rKAVgUjK" role="2Oq$k0">
-              <ref role="3cqZAo" node="7L$rKAVgRB2" resolve="myLayoutMap" />
+        <node concept="3clFbJ" id="6W4SFvZZdor" role="3cqZAp">
+          <node concept="3clFbS" id="6W4SFvZZdot" role="3clFbx">
+            <node concept="3clFbF" id="7L$rKAVgUjL" role="3cqZAp">
+              <node concept="2OqwBi" id="7L$rKAVgUpB" role="3clFbG">
+                <node concept="37vLTw" id="7L$rKAVgUjK" role="2Oq$k0">
+                  <ref role="3cqZAo" node="7L$rKAVgRB2" resolve="myLayoutMap" />
+                </node>
+                <node concept="liA8E" id="7L$rKAVgUDV" role="2OqNvi">
+                  <ref role="37wK5l" node="7L$rKAVfYPL" resolve="setValue" />
+                  <node concept="2OqwBi" id="7L$rKAVgUMd" role="37wK5m">
+                    <node concept="37vLTw" id="7L$rKAVgUFN" role="2Oq$k0">
+                      <ref role="3cqZAo" node="7L$rKAVfIJ4" resolve="key" />
+                    </node>
+                    <node concept="liA8E" id="7L$rKAVgV4X" role="2OqNvi">
+                      <ref role="37wK5l" node="7L$rKAVbO88" resolve="serialize" />
+                    </node>
+                  </node>
+                  <node concept="37vLTw" id="7L$rKAVgV9q" role="37wK5m">
+                    <ref role="3cqZAo" node="7L$rKAVfIJ7" resolve="data" />
+                  </node>
+                </node>
+              </node>
             </node>
-            <node concept="liA8E" id="7L$rKAVgUDV" role="2OqNvi">
-              <ref role="37wK5l" node="7L$rKAVfYPL" resolve="setValue" />
-              <node concept="2OqwBi" id="7L$rKAVgUMd" role="37wK5m">
-                <node concept="37vLTw" id="7L$rKAVgUFN" role="2Oq$k0">
-                  <ref role="3cqZAo" node="7L$rKAVfIJ4" resolve="key" />
-                </node>
-                <node concept="liA8E" id="7L$rKAVgV4X" role="2OqNvi">
-                  <ref role="37wK5l" node="7L$rKAVbO88" resolve="serialize" />
-                </node>
-              </node>
-              <node concept="37vLTw" id="7L$rKAVgV9q" role="37wK5m">
-                <ref role="3cqZAo" node="7L$rKAVfIJ7" resolve="data" />
-              </node>
+          </node>
+          <node concept="2OqwBi" id="6W4SFvZZenu" role="3clFbw">
+            <node concept="Xjq3P" id="6W4SFvZZdSo" role="2Oq$k0" />
+            <node concept="liA8E" id="6W4SFvZZfnR" role="2OqNvi">
+              <ref role="37wK5l" node="6gw4xIYJmMS" resolve="saveDiagramLayout" />
             </node>
           </node>
         </node>
@@ -28095,6 +28105,19 @@
       <node concept="2AHcQZ" id="5wo2$NmYmpc" role="2AJF6D">
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
+    </node>
+    <node concept="2tJIrI" id="6gw4xIYJ1ZA" role="jymVt" />
+    <node concept="3clFb_" id="6gw4xIYJmMS" role="jymVt">
+      <property role="TrG5h" value="saveDiagramLayout" />
+      <node concept="3clFbS" id="6gw4xIYJmMV" role="3clF47">
+        <node concept="3cpWs6" id="6gw4xIYJnnd" role="3cqZAp">
+          <node concept="3clFbT" id="6gw4xIYJo94" role="3cqZAk">
+            <property role="3clFbU" value="true" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="6gw4xIYJmea" role="1B3o_S" />
+      <node concept="10P_77" id="6gw4xIYJmCk" role="3clF45" />
     </node>
   </node>
   <node concept="312cEu" id="63AkbuPiu1I">

--- a/code/diagram/solutions/test.de.itemis.mps.editor.diagram.solution/models/test/de/itemis/mps/editor/diagram/solution@tests.mps
+++ b/code/diagram/solutions/test.de.itemis.mps.editor.diagram.solution/models/test/de/itemis/mps/editor/diagram/solution@tests.mps
@@ -34,6 +34,7 @@
     <import index="lwbc" ref="r:e350f223-18f3-4a2f-a233-47968595d142(test.de.itemis.mps.editor.diagram.lang.editor)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" />
     <import index="18t6" ref="1144260c-e9a5-49a2-9add-39a1a1a7077e/java:com.mxgraph.util(de.itemis.mps.editor.diagram.runtime/)" />
+    <import index="suqv" ref="r:9a28b49a-e98c-4186-a7e1-7e782b3f4fc3(de.itemis.mps.editor.diagram.layout.structure)" />
     <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" implicit="true" />
     <import index="vux5" ref="r:d4785159-376e-4d99-a1d3-5a6f377de3e6(de.itemis.mps.editor.diagram.demo.activity.structure)" implicit="true" />
     <import index="22ra" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.update(MPS.Editor/)" implicit="true" />
@@ -57,6 +58,10 @@
       <concept id="5773579205429866751" name="jetbrains.mps.lang.test.structure.EditorComponentExpression" flags="nn" index="369mXd" />
       <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
         <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
+      </concept>
+      <concept id="1210673684636" name="jetbrains.mps.lang.test.structure.TestNodeAnnotation" flags="ng" index="3xLA65" />
+      <concept id="1210674524691" name="jetbrains.mps.lang.test.structure.TestNodeReference" flags="nn" index="3xONca">
+        <reference id="1210674534086" name="declaration" index="3xOPvv" />
       </concept>
     </language>
     <language id="5dc5fc0d-37ef-4782-8192-8b5ce1f69f80" name="jetbrains.mps.baseLanguage.extensionMethods">
@@ -192,6 +197,10 @@
       <concept id="1081516740877" name="jetbrains.mps.baseLanguage.structure.NotExpression" flags="nn" index="3fqX7Q">
         <child id="1081516765348" name="expression" index="3fr31v" />
       </concept>
+      <concept id="1160998861373" name="jetbrains.mps.baseLanguage.structure.AssertStatement" flags="nn" index="1gVbGN">
+        <child id="1160998896846" name="condition" index="1gVkn0" />
+        <child id="1160998916832" name="message" index="1gVpfI" />
+      </concept>
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
@@ -265,6 +274,16 @@
       </concept>
     </language>
     <language id="aff569ad-098d-414a-aa23-96963959392c" name="test.de.itemis.mps.editor.diagram.lang">
+      <concept id="2458670456593291011" name="test.de.itemis.mps.editor.diagram.lang.structure.DiagramWithoutLayoutStore" flags="ng" index="3iSQj3" />
+      <concept id="2387875361826161165" name="test.de.itemis.mps.editor.diagram.lang.structure.TextBoxContent" flags="ng" index="1kFiRK">
+        <property id="2387875361826161173" name="value" index="1kFiRC" />
+      </concept>
+      <concept id="2387875361826064795" name="test.de.itemis.mps.editor.diagram.lang.structure.Box" flags="ng" index="1kFUpA">
+        <child id="2387875361826161150" name="content" index="1kFiS3" />
+      </concept>
+      <concept id="2387875361826062997" name="test.de.itemis.mps.editor.diagram.lang.structure.Diagram" flags="ng" index="1kFUPC">
+        <child id="2387875361826064821" name="elements" index="1kFUp8" />
+      </concept>
       <concept id="2387875361827277749" name="test.de.itemis.mps.editor.diagram.lang.structure.ForceHint" flags="ng" index="1kJ2h8">
         <reference id="2387875361827280390" name="hint" index="1kJ3BV" />
         <child id="2387875361827277750" name="wrapped" index="1kJ2hb" />
@@ -330,6 +349,12 @@
       </concept>
       <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
         <child id="1177027386292" name="conceptArgument" index="cj9EA" />
+      </concept>
+      <concept id="6407023681583036853" name="jetbrains.mps.lang.smodel.structure.NodeAttributeQualifier" flags="ng" index="3CFYIy">
+        <reference id="6407023681583036854" name="attributeConcept" index="3CFYIx" />
+      </concept>
+      <concept id="6407023681583031218" name="jetbrains.mps.lang.smodel.structure.AttributeAccess" flags="nn" index="3CFZ6_">
+        <child id="6407023681583036852" name="qualifier" index="3CFYIz" />
       </concept>
       <concept id="1140137987495" name="jetbrains.mps.lang.smodel.structure.SNodeTypeCastExpression" flags="nn" index="1PxgMI" />
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
@@ -8929,6 +8954,49 @@
       </node>
       <node concept="3Tm1VV" id="6L_GEhdyyN9" role="1B3o_S" />
       <node concept="3cqZAl" id="6L_GEhdyyNa" role="3clF45" />
+    </node>
+  </node>
+  <node concept="LiM7Y" id="28uWW3KZ$3$">
+    <property role="TrG5h" value="DiagramWithoutLayout" />
+    <node concept="1qefOq" id="28uWW3KZ$4W" role="25YQCW">
+      <node concept="1kJ2h8" id="28uWW3KZMVS" role="1qenE9">
+        <ref role="1kJ3BV" to="lwbc:24zrZPPz$8v" resolve="asDiagram" />
+        <node concept="3iSQj3" id="28uWW3KZMWi" role="1kJ2hb">
+          <node concept="1kFUpA" id="28uWW3KZN07" role="1kFUp8">
+            <node concept="1kFiRK" id="28uWW3KZN7Z" role="1kFiS3">
+              <property role="1kFiRC" value="Test" />
+            </node>
+          </node>
+          <node concept="1kFUpA" id="28uWW3KZN7P" role="1kFUp8">
+            <node concept="1kFiRK" id="28uWW3KZN7W" role="1kFiS3">
+              <property role="1kFiRC" value="ABC" />
+            </node>
+          </node>
+          <node concept="3xLA65" id="28uWW3KZNbT" role="lGtFl">
+            <property role="TrG5h" value="diagram" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3clFbS" id="28uWW3KZNbY" role="LjaKd">
+      <node concept="1gVbGN" id="28uWW3L0xwk" role="3cqZAp">
+        <node concept="3clFbC" id="28uWW3L0xKM" role="1gVkn0">
+          <node concept="10Nm6u" id="28uWW3L0xTQ" role="3uHU7w" />
+          <node concept="2OqwBi" id="28uWW3KZNjw" role="3uHU7B">
+            <node concept="3xONca" id="28uWW3KZNbV" role="2Oq$k0">
+              <ref role="3xOPvv" node="28uWW3KZNbT" resolve="diagram" />
+            </node>
+            <node concept="3CFZ6_" id="28uWW3L0iuG" role="2OqNvi">
+              <node concept="3CFYIy" id="28uWW3L0vd6" role="3CFYIz">
+                <ref role="3CFYIx" to="suqv:7L$rKAVfLie" resolve="LayoutMap" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="Xl_RD" id="28uWW3L0xUO" role="1gVpfI">
+          <property role="Xl_RC" value="Diagrams do not properly implement layout saving handler" />
+        </node>
+      </node>
     </node>
   </node>
 </model>

--- a/code/diagram/solutions/test.de.itemis.mps.editor.diagram.solution/models/test/de/itemis/mps/editor/diagram/solution@tests.mps
+++ b/code/diagram/solutions/test.de.itemis.mps.editor.diagram.solution/models/test/de/itemis/mps/editor/diagram/solution@tests.mps
@@ -56,6 +56,10 @@
         <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
       </concept>
       <concept id="5773579205429866751" name="jetbrains.mps.lang.test.structure.EditorComponentExpression" flags="nn" index="369mXd" />
+      <concept id="1216913645126" name="jetbrains.mps.lang.test.structure.NodesTestCase" flags="lg" index="1lH9Xt">
+        <child id="1217501822150" name="nodesToCheck" index="1SKRRt" />
+        <child id="1217501895093" name="testMethods" index="1SL9yI" />
+      </concept>
       <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
         <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
       </concept>
@@ -63,6 +67,7 @@
       <concept id="1210674524691" name="jetbrains.mps.lang.test.structure.TestNodeReference" flags="nn" index="3xONca">
         <reference id="1210674534086" name="declaration" index="3xOPvv" />
       </concept>
+      <concept id="1225978065297" name="jetbrains.mps.lang.test.structure.SimpleNodeTest" flags="ng" index="1LZb2c" />
     </language>
     <language id="5dc5fc0d-37ef-4782-8192-8b5ce1f69f80" name="jetbrains.mps.baseLanguage.extensionMethods">
       <concept id="8022092943110829337" name="jetbrains.mps.baseLanguage.extensionMethods.structure.BaseExtensionMethodContainer" flags="ng" index="a7sou">
@@ -196,10 +201,6 @@
       <concept id="1081506773034" name="jetbrains.mps.baseLanguage.structure.LessThanExpression" flags="nn" index="3eOVzh" />
       <concept id="1081516740877" name="jetbrains.mps.baseLanguage.structure.NotExpression" flags="nn" index="3fqX7Q">
         <child id="1081516765348" name="expression" index="3fr31v" />
-      </concept>
-      <concept id="1160998861373" name="jetbrains.mps.baseLanguage.structure.AssertStatement" flags="nn" index="1gVbGN">
-        <child id="1160998896846" name="condition" index="1gVkn0" />
-        <child id="1160998916832" name="message" index="1gVpfI" />
       </concept>
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
@@ -337,6 +338,9 @@
       <concept id="1171978097730" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertEquals" flags="nn" index="3vlDli" />
       <concept id="1171981022339" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertTrue" flags="nn" index="3vwNmj">
         <child id="1171981057159" name="condition" index="3vwVQn" />
+      </concept>
+      <concept id="1172028177041" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertIsNull" flags="nn" index="3ykFI1">
+        <child id="1172028236559" name="expression" index="3ykU8v" />
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
@@ -8956,45 +8960,43 @@
       <node concept="3cqZAl" id="6L_GEhdyyNa" role="3clF45" />
     </node>
   </node>
-  <node concept="LiM7Y" id="28uWW3KZ$3$">
-    <property role="TrG5h" value="DiagramWithoutLayout" />
-    <node concept="1qefOq" id="28uWW3KZ$4W" role="25YQCW">
-      <node concept="1kJ2h8" id="28uWW3KZMVS" role="1qenE9">
-        <ref role="1kJ3BV" to="lwbc:24zrZPPz$8v" resolve="asDiagram" />
-        <node concept="3iSQj3" id="28uWW3KZMWi" role="1kJ2hb">
-          <node concept="1kFUpA" id="28uWW3KZN07" role="1kFUp8">
-            <node concept="1kFiRK" id="28uWW3KZN7Z" role="1kFiS3">
-              <property role="1kFiRC" value="Test" />
+  <node concept="1lH9Xt" id="6MGkAko5nZ8">
+    <property role="TrG5h" value="DiagramWithoutLayoutInfo" />
+    <node concept="1LZb2c" id="6MGkAko5nZD" role="1SL9yI">
+      <property role="TrG5h" value="layout_info_empty" />
+      <node concept="3cqZAl" id="6MGkAko5nZE" role="3clF45" />
+      <node concept="3clFbS" id="6MGkAko5nZI" role="3clF47">
+        <node concept="3ykFI1" id="6MGkAko5o0w" role="3cqZAp">
+          <node concept="2OqwBi" id="6MGkAko5o85" role="3ykU8v">
+            <node concept="3xONca" id="6MGkAko5o0G" role="2Oq$k0">
+              <ref role="3xOPvv" node="6MGkAko5nZj" resolve="diagram" />
             </node>
-          </node>
-          <node concept="1kFUpA" id="28uWW3KZN7P" role="1kFUp8">
-            <node concept="1kFiRK" id="28uWW3KZN7W" role="1kFiS3">
-              <property role="1kFiRC" value="ABC" />
-            </node>
-          </node>
-          <node concept="3xLA65" id="28uWW3KZNbT" role="lGtFl">
-            <property role="TrG5h" value="diagram" />
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="3clFbS" id="28uWW3KZNbY" role="LjaKd">
-      <node concept="1gVbGN" id="28uWW3L0xwk" role="3cqZAp">
-        <node concept="3clFbC" id="28uWW3L0xKM" role="1gVkn0">
-          <node concept="10Nm6u" id="28uWW3L0xTQ" role="3uHU7w" />
-          <node concept="2OqwBi" id="28uWW3KZNjw" role="3uHU7B">
-            <node concept="3xONca" id="28uWW3KZNbV" role="2Oq$k0">
-              <ref role="3xOPvv" node="28uWW3KZNbT" resolve="diagram" />
-            </node>
-            <node concept="3CFZ6_" id="28uWW3L0iuG" role="2OqNvi">
-              <node concept="3CFYIy" id="28uWW3L0vd6" role="3CFYIz">
+            <node concept="3CFZ6_" id="6MGkAko5oPM" role="2OqNvi">
+              <node concept="3CFYIy" id="6MGkAko5oSu" role="3CFYIz">
                 <ref role="3CFYIx" to="suqv:7L$rKAVfLie" resolve="LayoutMap" />
               </node>
             </node>
           </node>
         </node>
-        <node concept="Xl_RD" id="28uWW3L0xUO" role="1gVpfI">
-          <property role="Xl_RC" value="Diagrams do not properly implement layout saving handler" />
+      </node>
+    </node>
+    <node concept="1qefOq" id="6MGkAko5nZ9" role="1SKRRt">
+      <node concept="1kJ2h8" id="6MGkAko5nZd" role="1qenE9">
+        <ref role="1kJ3BV" to="lwbc:24zrZPPz$8v" resolve="asDiagram" />
+        <node concept="3iSQj3" id="6MGkAko5nZe" role="1kJ2hb">
+          <node concept="1kFUpA" id="6MGkAko5nZf" role="1kFUp8">
+            <node concept="1kFiRK" id="6MGkAko5nZg" role="1kFiS3">
+              <property role="1kFiRC" value="Test" />
+            </node>
+          </node>
+          <node concept="1kFUpA" id="6MGkAko5nZh" role="1kFUp8">
+            <node concept="1kFiRK" id="6MGkAko5nZi" role="1kFiS3">
+              <property role="1kFiRC" value="ABC" />
+            </node>
+          </node>
+          <node concept="3xLA65" id="6MGkAko5nZj" role="lGtFl">
+            <property role="TrG5h" value="diagram" />
+          </node>
         </node>
       </node>
     </node>

--- a/code/diagram/solutions/test.de.itemis.mps.editor.diagram.solution/test.de.itemis.mps.editor.diagram.solution.msd
+++ b/code/diagram/solutions/test.de.itemis.mps.editor.diagram.solution/test.de.itemis.mps.editor.diagram.solution.msd
@@ -18,6 +18,7 @@
     <dependency reexport="false">5a82b7b8-2303-45be-b960-4e3ff16e82ce(de.itemis.mps.editor.diagram.demo.activity)</dependency>
     <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
     <dependency reexport="false">aff569ad-098d-414a-aa23-96963959392c(test.de.itemis.mps.editor.diagram.lang)</dependency>
+    <dependency reexport="false">8ca79d43-eb45-4791-bdd4-0d6130ff895b(de.itemis.mps.editor.diagram.layout)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:5a82b7b8-2303-45be-b960-4e3ff16e82ce:de.itemis.mps.editor.diagram.demo.activity" version="0" />
@@ -50,6 +51,7 @@
     <module reference="24c96a96-b7a1-4f30-82da-0f8e279a2661(de.itemis.mps.editor.celllayout.styles)" version="0" />
     <module reference="7b45fa94-2707-4a1a-9e6a-ce40c4aaf35a(de.itemis.mps.editor.collapsible.runtime)" version="0" />
     <module reference="5a82b7b8-2303-45be-b960-4e3ff16e82ce(de.itemis.mps.editor.diagram.demo.activity)" version="0" />
+    <module reference="8ca79d43-eb45-4791-bdd4-0d6130ff895b(de.itemis.mps.editor.diagram.layout)" version="0" />
     <module reference="1144260c-e9a5-49a2-9add-39a1a1a7077e(de.itemis.mps.editor.diagram.runtime)" version="0" />
     <module reference="56c81845-acaf-48a7-bcd8-e29b36c98dd7(de.itemis.mps.editor.diagram.styles)" version="0" />
     <module reference="5c13c612-0f7b-4f0a-ab8b-565186b418de(de.itemis.mps.mouselistener.runtime)" version="0" />


### PR DESCRIPTION
This PR adds a new field to the diagram editor to customize the behavior when the layout of a diagram is stored in the layout map variable. 

The field is a function that takes as input an editor context and a node, and returns a boolean value. If the value is true, the layout is stored in the layout map, if it is false, no layout is stored.

A small test that ensures that no layout is stored is included in the diagram tests.