### PR TITLE
Update mkdocs-material to latest version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-mkdocs-material==7.3.6
+mkdocs-material==9.1.3
 mkdocs-autolinks-plugin==0.5.0
 autolink-references-mkdocs-plugin==0.2.1


### PR DESCRIPTION
This is now possible due to a few build agents having a high enough Python version installed. I've restricted the suitable agents in the build configuration.