### PR TITLE
[Breaking] Celllayout: fit the grid when layouting the root layoutable container

### DIFF
--- a/code/celllayout/languages/test.de.itemis.mps.editor.celllayout.lang/models/editor.mps
+++ b/code/celllayout/languages/test.de.itemis.mps.editor.celllayout.lang/models/editor.mps
@@ -52,6 +52,8 @@
     <language id="1919c723-b60b-4592-9318-9ce96d91da44" name="de.itemis.mps.editor.celllayout">
       <concept id="4682418030828725523" name="de.itemis.mps.editor.celllayout.structure.HorizontalLineCell" flags="ng" index="2T_mXK" />
       <concept id="9000758320091481718" name="de.itemis.mps.editor.celllayout.structure.GridLayoutFlattenStyle" flags="lg" index="1QQdxR" />
+      <concept id="2728748097294410385" name="de.itemis.mps.editor.celllayout.structure.GrowXStyle" flags="lg" index="3T7XtY" />
+      <concept id="2728748097294412051" name="de.itemis.mps.editor.celllayout.structure.PushXStyle" flags="lg" index="3T7XNW" />
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
@@ -545,6 +547,8 @@
         <ref role="1NtTu8" to="ayyv:1pn4Qu08Obs" resolve="property1" />
       </node>
       <node concept="2iRkQZ" id="1pn4Qu08Ob6" role="2iSdaV" />
+      <node concept="3T7XNW" id="IT3nkH7wT0" role="3F10Kt" />
+      <node concept="3T7XtY" id="IT3nkH7wT5" role="3F10Kt" />
     </node>
   </node>
 </model>

--- a/code/celllayout/solutions/de.slisson.mps.editor.celllayout.runtime/models/de/itemis/mps/editor/celllayout/layout.mps
+++ b/code/celllayout/solutions/de.slisson.mps.editor.celllayout.runtime/models/de/itemis/mps/editor/celllayout/layout.mps
@@ -3065,8 +3065,16 @@
             <node concept="37vLTw" id="1XCA2wmsrXj" role="37wK5m">
               <ref role="3cqZAo" node="40e1npHrxWg" resolve="sizeConstraint" />
             </node>
-            <node concept="3clFbT" id="36CzSVYOsyl" role="37wK5m">
-              <property role="3clFbU" value="false" />
+            <node concept="3clFbC" id="IT3nkH6o_m" role="37wK5m">
+              <node concept="10Nm6u" id="IT3nkH6qVF" role="3uHU7w" />
+              <node concept="2OqwBi" id="IT3nkH6j$c" role="3uHU7B">
+                <node concept="37vLTw" id="IT3nkH6h8q" role="2Oq$k0">
+                  <ref role="3cqZAo" node="40e1npHrxWe" resolve="container" />
+                </node>
+                <node concept="liA8E" id="IT3nkH6mw6" role="2OqNvi">
+                  <ref role="37wK5l" node="3Osd_yx2aIO" resolve="getParent" />
+                </node>
+              </node>
             </node>
           </node>
         </node>


### PR DESCRIPTION
With this change, the width of cells with pushX/growX is the maximum of the text width (`preferences->Editor->MPS Editor->text width`) and the widest cell in the editor. The text width was not considered on purpose in the past. That means that, for example, horizontal lines had the width of the widest cell in the editor which doesn't make any sense to me. What's the point of having a maximum width for the editor if it is not always considered in the maximum width calculation? Was there any reason to disable the fitting for the preferred inner size? I couldn't find any examples where this causes layout issues, so I changed it.

Before:
![Screenshot 2023-04-15 at 20 05 54](https://user-images.githubusercontent.com/88385944/232246114-2561d340-287b-4f02-96a9-49302414a61d.png)
After:
![Screenshot 2023-04-15 at 20 13 24](https://user-images.githubusercontent.com/88385944/232246516-ec7d7492-6f15-4385-a531-06119713e8ca.png)

The lines might appear a bit long in this example because I have set the text width to 180. With a more standard text width like 100 it looks normal.

![Screenshot 2023-04-15 at 20 06 38](https://user-images.githubusercontent.com/88385944/232246559-affd1034-cc3e-4f4b-aab3-8471ae215c08.png)

You can even restore the old behavior by placing pushX/growX: false commands at specific levels in the editor. In the following example, the content collection of the test suite has the flags set, which makes the red lines the width of the content. The black line after the header has the full editor text width:

![Screenshot 2023-04-15 at 22 11 41](https://user-images.githubusercontent.com/88385944/232251408-0c224cbc-1259-4660-b10b-86aa71d97cc0.png)
