### PR TITLE
Backport: Remove build script block dependency to old nexus.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,6 @@ buildscript {
     repositories {
         mavenLocal()
         maven { url 'https://artifacts.itemis.cloud/repository/maven-mps/' }
-        maven { url 'https://projects.itemis.de/nexus/content/repositories/mbeddr' }
     }
     dependencies {
         classpath('de.itemis.mps:mps-gradle-plugin:1.7+')


### PR DESCRIPTION
(cherry picked from commit 19722d108a1dee7f014d8fa4da9927ad5ef773a4)