### PR TITLE
Fixing build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,3 @@
-//will pull the groovy classes/types from nexus to the classpath
-buildscript {
-    repositories {
-        mavenLocal()
-        maven { url 'https://artifacts.itemis.cloud/repository/maven-mps/' }
-    }
-}
 plugins {
     id 'de.itemis.mps.gradle.common' version '1.13.+'
     id "com.github.breadmoirai.github-release" version "2.4.1"

--- a/build.gradle
+++ b/build.gradle
@@ -248,7 +248,7 @@ tasks.register("checkModulePaths") {
     def project = new XmlParser().parse(file)
 
     def invalidModules = project.component.projectModules.modulePath.'@path'.findAll {
-        def path = it.replaceAll("\\\$PROJECT_DIR\\\$","$rootDir/code")
+        def path = it.replace("\$PROJECT_DIR\$","$rootDir/code")
         return !(new File(path).exists())
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,13 +4,10 @@ buildscript {
         mavenLocal()
         maven { url 'https://artifacts.itemis.cloud/repository/maven-mps/' }
     }
-    dependencies {
-        classpath('de.itemis.mps:mps-gradle-plugin:1.7+')
-    }
 }
-
 plugins {
-   id "com.github.breadmoirai.github-release" version "2.4.1"
+    id 'de.itemis.mps.gradle.common' version '1.13.+'
+    id "com.github.breadmoirai.github-release" version "2.4.1"
 }
 
 apply plugin: 'maven-publish'
@@ -73,9 +70,7 @@ if (!project.hasProperty('nexusUsername')) {
 logger.info 'Repository username: {}', project.nexusUsername
 
 ext.dependencyRepositories = [
-        'https://artifacts.itemis.cloud/repository/maven-mps/',
-        'https://projects.itemis.de/nexus/content/repositories/mbeddr',
-        'https://projects.itemis.de/nexus/content/repositories/mbeddr_snapshots',
+        'https://artifacts.itemis.cloud/repository/maven-mps/'
 ]
 // Dependency versions
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,6 @@ buildscript {
     repositories {
         mavenLocal()
         maven { url 'https://artifacts.itemis.cloud/repository/maven-mps/' }
-        maven { url 'https://projects.itemis.de/nexus/content/repositories/mbeddr' }
     }
     dependencies {
         classpath('de.itemis.mps:mps-gradle-plugin:1.7+')

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,5 @@
 pluginManagement {
     repositories {
-        mavenLocal()
         maven { url 'https://artifacts.itemis.cloud/repository/maven-mps' }
 
         // Need to manually include the default Gradle plugin portal repository when overriding the defaults.

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,6 @@
 pluginManagement {
     repositories {
+        mavenLocal()
         maven { url 'https://artifacts.itemis.cloud/repository/maven-mps' }
 
         // Need to manually include the default Gradle plugin portal repository when overriding the defaults.

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,9 @@
+pluginManagement {
+    repositories {
+        maven { url 'https://artifacts.itemis.cloud/repository/maven-mps' }
+
+        // Need to manually include the default Gradle plugin portal repository when overriding the defaults.
+        gradlePluginPortal()
+    }
+}
 rootProject.name = 'MPS-extensions'


### PR DESCRIPTION
- Backported from 21.3:  see https://github.com/JetBrains/MPS-extensions/pull/646
- Fixed the `checkModulePaths`-gradle task, so correct paths are used on windows machines
(Since the `rootDirectory` variable contains the path with windows file-separators and `replaceAll()` uses a regex, all the windows-file-separators are dismissed, leading to wrong paths for all modules in the modules.xml. The regular `replace()` does the same replacement, but without the regex, keeping the windows-file-separators in place. Because the separators are still used based on the OS, this will not influence other OS.)
- Backported  from 21.3:  see https://github.com/JetBrains/MPS-extensions/pull/651