### PR TITLE
Bugfix/wrapper and optional cell description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+Format of the log is _loosely_ based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). 
+The project does _not_ follow Semantic Versioning and the changes are documented in reverse chronological order, grouped by calendar month.
+
+## July 2023
+
+### Changed
+
+- The auto-completion for a WrapperCell, where the wrapping node is not created yet, shows entries for possible wrapped nodes with the description of the wrapped nodes concept and not the description of the wrapping nodes concept.  
+- The auto-completion for an OptionalCell without a dedicated description shows no description anymore, instead of using the description of the concept which is using the OptionalCell.  

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells.sandboxlang/models/com/mbeddr/mpsutil/grammarcells/sandboxlang/editor.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells.sandboxlang/models/com/mbeddr/mpsutil/grammarcells/sandboxlang/editor.mps
@@ -60,6 +60,9 @@
         <property id="1186403713874" name="color" index="Vb096" />
         <child id="1186403803051" name="query" index="VblUZ" />
       </concept>
+      <concept id="1186403751766" name="jetbrains.mps.lang.editor.structure.FontStyleStyleClassItem" flags="ln" index="Vb9p2">
+        <property id="1186403771423" name="style" index="Vbekb" />
+      </concept>
       <concept id="1186404549998" name="jetbrains.mps.lang.editor.structure.ForegroundColorStyleClassItem" flags="ln" index="VechU" />
       <concept id="1186404574412" name="jetbrains.mps.lang.editor.structure.BackgroundColorStyleClassItem" flags="ln" index="Veino" />
       <concept id="1186414536763" name="jetbrains.mps.lang.editor.structure.BooleanStyleSheetItem" flags="ln" index="VOi$J">
@@ -76,6 +79,7 @@
       </concept>
       <concept id="1233758997495" name="jetbrains.mps.lang.editor.structure.PunctuationLeftStyleClassItem" flags="ln" index="11L4FC" />
       <concept id="1233759184865" name="jetbrains.mps.lang.editor.structure.PunctuationRightStyleClassItem" flags="ln" index="11LMrY" />
+      <concept id="5266818545798688928" name="jetbrains.mps.lang.editor.structure.ShowBoundariesInStyleClassItem" flags="lg" index="1fO$WK" />
       <concept id="5692353713941573329" name="jetbrains.mps.lang.editor.structure.QueryFunction_TransformationMenu_ActionLabelText" flags="ig" index="1hCUdq" />
       <concept id="1088013125922" name="jetbrains.mps.lang.editor.structure.CellModel_RefCell" flags="sg" stub="730538219795941030" index="1iCGBv">
         <child id="1088186146602" name="editorComponent" index="1sWHZn" />
@@ -297,6 +301,9 @@
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+      </concept>
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
@@ -1960,6 +1967,724 @@
         <ref role="PMmxG" node="7uEwlsA7BRo" resolve="TEST_optionalInComponent_component" />
       </node>
       <node concept="2iRfu4" id="7uEwlsA7BS9" role="2iSdaV" />
+    </node>
+  </node>
+  <node concept="24kQdi" id="67iSu2vYIfl">
+    <property role="3GE5qa" value="CapabilitiesDemo" />
+    <ref role="1XX52x" to="ibwz:67iSu2vYIfb" resolve="DemoOptionalCellsCapability" />
+    <node concept="3EZMnI" id="67iSu2vYJI2" role="2wV5jI">
+      <node concept="3F0ifn" id="67iSu2vYJKN" role="3EZMnx">
+        <property role="3F0ifm" value="Demo Node: " />
+        <node concept="Vb9p2" id="67iSu2wi3Hd" role="3F10Kt">
+          <property role="Vbekb" value="g1_k_vY/BOLD" />
+        </node>
+      </node>
+      <node concept="3F0A7n" id="67iSu2vYJIm" role="3EZMnx">
+        <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
+      </node>
+      <node concept="3F0ifn" id="67iSu2w1TO9" role="3EZMnx">
+        <node concept="pVoyu" id="67iSu2wBFDV" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="3F0ifn" id="67iSu2w1Ua_" role="3EZMnx">
+        <property role="3F0ifm" value="Optionally show a child via contstant as transformation-text" />
+        <node concept="pVoyu" id="67iSu2wBFDX" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="3F0ifn" id="67iSu2wbm$0" role="3EZMnx">
+        <property role="3F0ifm" value="With description:" />
+        <node concept="lj46D" id="67iSu2wBFby" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+        <node concept="pVoyu" id="67iSu2wBFDZ" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="_tjkj" id="67iSu2vYJKU" role="3EZMnx">
+        <node concept="3EZMnI" id="67iSu2vYJKV" role="_tjki">
+          <node concept="VPM3Z" id="67iSu2vYJKW" role="3F10Kt">
+            <property role="VOm3f" value="false" />
+          </node>
+          <node concept="3F0ifn" id="67iSu2vYJKX" role="3EZMnx">
+            <property role="3F0ifm" value="=child" />
+          </node>
+          <node concept="3F1sOY" id="67iSu2vYJKY" role="3EZMnx">
+            <ref role="1NtTu8" to="ibwz:67iSu2vYKhb" resolve="content" />
+          </node>
+          <node concept="l2Vlx" id="67iSu2vYJKZ" role="2iSdaV" />
+        </node>
+        <node concept="uPpia" id="67iSu2vYJL0" role="1djCvC">
+          <node concept="3clFbS" id="67iSu2vYJL1" role="2VODD2">
+            <node concept="3clFbF" id="67iSu2vYJL2" role="3cqZAp">
+              <node concept="Xl_RD" id="67iSu2vYJL3" role="3clFbG">
+                <property role="Xl_RC" value="Optional description for a child" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3F0ifn" id="67iSu2vYJL8" role="3EZMnx">
+        <property role="3F0ifm" value="Without a description:" />
+        <node concept="lj46D" id="67iSu2wBFg$" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+        <node concept="pVoyu" id="67iSu2wBFgA" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="_tjkj" id="67iSu2vYJL9" role="3EZMnx">
+        <node concept="3EZMnI" id="67iSu2vYJLa" role="_tjki">
+          <node concept="VPM3Z" id="67iSu2vYJLb" role="3F10Kt">
+            <property role="VOm3f" value="false" />
+          </node>
+          <node concept="3F0ifn" id="67iSu2vYJLc" role="3EZMnx">
+            <property role="3F0ifm" value="=child" />
+          </node>
+          <node concept="3F1sOY" id="67iSu2vYJLd" role="3EZMnx">
+            <ref role="1NtTu8" to="ibwz:67iSu2vYKhb" resolve="content" />
+          </node>
+          <node concept="l2Vlx" id="67iSu2vYJLe" role="2iSdaV" />
+        </node>
+      </node>
+      <node concept="3F0ifn" id="67iSu2w1U66" role="3EZMnx">
+        <node concept="pVoyu" id="67iSu2wBFE2" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+        <node concept="lj46D" id="67iSu2wYwS_" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="3EZMnI" id="67iSu2wYwao" role="3EZMnx">
+        <node concept="VPM3Z" id="67iSu2wYwar" role="3F10Kt" />
+        <node concept="3F0ifn" id="67iSu2w1Uo5" role="3EZMnx">
+          <property role="3F0ifm" value="Optionally show a child via transformation-text" />
+          <node concept="pVoyu" id="67iSu2wBFE4" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+        </node>
+        <node concept="3F0ifn" id="67iSu2vYJLj" role="3EZMnx">
+          <property role="3F0ifm" value="With description:" />
+          <node concept="pVoyu" id="67iSu2wBFPa" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+          <node concept="lj46D" id="67iSu2wBFU8" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+        </node>
+        <node concept="_tjkj" id="67iSu2vYJLk" role="3EZMnx">
+          <node concept="3EZMnI" id="67iSu2vYJLl" role="_tjki">
+            <node concept="VPM3Z" id="67iSu2vYJLm" role="3F10Kt">
+              <property role="VOm3f" value="false" />
+            </node>
+            <node concept="3F1sOY" id="67iSu2vYJLn" role="3EZMnx">
+              <ref role="1NtTu8" to="ibwz:67iSu2vYKhb" resolve="content" />
+            </node>
+            <node concept="l2Vlx" id="67iSu2vYJLo" role="2iSdaV" />
+          </node>
+          <node concept="ZYGn8" id="67iSu2vYJLp" role="ZWbT9">
+            <node concept="3clFbS" id="67iSu2vYJLq" role="2VODD2">
+              <node concept="3clFbF" id="67iSu2vYJLr" role="3cqZAp">
+                <node concept="Xl_RD" id="67iSu2vYJLs" role="3clFbG">
+                  <property role="Xl_RC" value="=child-alt" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="uPpia" id="67iSu2vYJLt" role="1djCvC">
+            <node concept="3clFbS" id="67iSu2vYJLu" role="2VODD2">
+              <node concept="3clFbF" id="67iSu2vYJLv" role="3cqZAp">
+                <node concept="Xl_RD" id="67iSu2vYJLw" role="3clFbG">
+                  <property role="Xl_RC" value="Optional description for a child (alternative)" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3F0ifn" id="67iSu2vYJL_" role="3EZMnx">
+          <property role="3F0ifm" value="Without a description:" />
+          <node concept="pVoyu" id="67iSu2wBG0o" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+          <node concept="lj46D" id="67iSu2wBG5i" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+        </node>
+        <node concept="_tjkj" id="67iSu2vYJLA" role="3EZMnx">
+          <node concept="3EZMnI" id="67iSu2vYJLB" role="_tjki">
+            <node concept="VPM3Z" id="67iSu2vYJLC" role="3F10Kt">
+              <property role="VOm3f" value="false" />
+            </node>
+            <node concept="3F1sOY" id="67iSu2vYJLD" role="3EZMnx">
+              <ref role="1NtTu8" to="ibwz:67iSu2vYKhb" resolve="content" />
+            </node>
+            <node concept="l2Vlx" id="67iSu2vYJLE" role="2iSdaV" />
+          </node>
+          <node concept="ZYGn8" id="67iSu2vYJLF" role="ZWbT9">
+            <node concept="3clFbS" id="67iSu2vYJLG" role="2VODD2">
+              <node concept="3clFbF" id="67iSu2vYJLH" role="3cqZAp">
+                <node concept="Xl_RD" id="67iSu2vYJLI" role="3clFbG">
+                  <property role="Xl_RC" value="=child-alt" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3F0ifn" id="67iSu2wevbq" role="3EZMnx">
+          <node concept="pVoyu" id="67iSu2wBG5p" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+        </node>
+        <node concept="3F0ifn" id="67iSu2wevfZ" role="3EZMnx">
+          <property role="3F0ifm" value="Optionally show a child with no transformation-text" />
+          <node concept="pVoyu" id="67iSu2wBG5r" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+        </node>
+        <node concept="3F0ifn" id="67iSu2vYJLN" role="3EZMnx">
+          <property role="3F0ifm" value="With description:" />
+          <node concept="pVoyu" id="67iSu2wBGjP" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+          <node concept="lj46D" id="67iSu2wBGjR" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+        </node>
+        <node concept="_tjkj" id="67iSu2vYJLO" role="3EZMnx">
+          <node concept="3EZMnI" id="67iSu2vYJLP" role="_tjki">
+            <node concept="VPM3Z" id="67iSu2vYJLQ" role="3F10Kt">
+              <property role="VOm3f" value="false" />
+            </node>
+            <node concept="3F1sOY" id="67iSu2vYJLR" role="3EZMnx">
+              <ref role="1NtTu8" to="ibwz:67iSu2vYKhb" resolve="content" />
+            </node>
+            <node concept="l2Vlx" id="67iSu2vYJLS" role="2iSdaV" />
+          </node>
+          <node concept="uPpia" id="67iSu2vYJLT" role="1djCvC">
+            <node concept="3clFbS" id="67iSu2vYJLU" role="2VODD2">
+              <node concept="3clFbF" id="67iSu2vYJLV" role="3cqZAp">
+                <node concept="Xl_RD" id="67iSu2vYJLW" role="3clFbG">
+                  <property role="Xl_RC" value="Optional description for a child without transformation-text" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3F0ifn" id="67iSu2vYJM1" role="3EZMnx">
+          <property role="3F0ifm" value="Without a description:" />
+          <node concept="pVoyu" id="67iSu2wBGoI" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+          <node concept="lj46D" id="67iSu2wBGoK" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+        </node>
+        <node concept="_tjkj" id="67iSu2vYJM2" role="3EZMnx">
+          <node concept="3EZMnI" id="67iSu2vYJM3" role="_tjki">
+            <node concept="VPM3Z" id="67iSu2vYJM4" role="3F10Kt">
+              <property role="VOm3f" value="false" />
+            </node>
+            <node concept="3F1sOY" id="67iSu2vYJM5" role="3EZMnx">
+              <ref role="1NtTu8" to="ibwz:67iSu2vYKhb" resolve="content" />
+            </node>
+            <node concept="l2Vlx" id="67iSu2vYJM6" role="2iSdaV" />
+          </node>
+        </node>
+        <node concept="3F0ifn" id="67iSu2wevQa" role="3EZMnx">
+          <node concept="pVoyu" id="67iSu2wBGoN" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+        </node>
+        <node concept="l2Vlx" id="67iSu2wYwav" role="2iSdaV" />
+        <node concept="pVoyu" id="67iSu2wYwSy" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+        <node concept="lj46D" id="67iSu2wYwSC" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="3F0ifn" id="67iSu2wevUL" role="3EZMnx">
+        <property role="3F0ifm" value="Optionally show a property via contstant as transformation-text" />
+        <node concept="pVoyu" id="67iSu2wBGoP" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="3F0ifn" id="67iSu2vYJMb" role="3EZMnx">
+        <property role="3F0ifm" value="With description:" />
+        <node concept="pVoyu" id="67iSu2wBGFC" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+        <node concept="lj46D" id="67iSu2wBGFE" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="_tjkj" id="67iSu2vYJMc" role="3EZMnx">
+        <node concept="3EZMnI" id="67iSu2vYJMd" role="_tjki">
+          <node concept="VPM3Z" id="67iSu2vYJMe" role="3F10Kt">
+            <property role="VOm3f" value="false" />
+          </node>
+          <node concept="l2Vlx" id="67iSu2vYJMf" role="2iSdaV" />
+          <node concept="3F0ifn" id="67iSu2vYJMg" role="3EZMnx">
+            <property role="3F0ifm" value="=property" />
+          </node>
+          <node concept="3F0A7n" id="67iSu2vYJMh" role="3EZMnx">
+            <ref role="1NtTu8" to="ibwz:67iSu2wewjc" resolve="property1" />
+          </node>
+        </node>
+        <node concept="uPpia" id="67iSu2vYJMj" role="1djCvC">
+          <node concept="3clFbS" id="67iSu2vYJMk" role="2VODD2">
+            <node concept="3clFbF" id="67iSu2vYJMl" role="3cqZAp">
+              <node concept="Xl_RD" id="67iSu2vYJMm" role="3clFbG">
+                <property role="Xl_RC" value="Optional description for a property" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3F0ifn" id="67iSu2vYJMr" role="3EZMnx">
+        <property role="3F0ifm" value="Without a description:" />
+        <node concept="pVoyu" id="67iSu2wBGKn" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+        <node concept="lj46D" id="67iSu2wBGKp" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="_tjkj" id="67iSu2vYJMs" role="3EZMnx">
+        <node concept="3EZMnI" id="67iSu2vYJMt" role="_tjki">
+          <node concept="VPM3Z" id="67iSu2vYJMu" role="3F10Kt">
+            <property role="VOm3f" value="false" />
+          </node>
+          <node concept="l2Vlx" id="67iSu2vYJMv" role="2iSdaV" />
+          <node concept="3F0ifn" id="67iSu2vYJMw" role="3EZMnx">
+            <property role="3F0ifm" value="=property" />
+          </node>
+          <node concept="3F0A7n" id="67iSu2vYJMx" role="3EZMnx">
+            <ref role="1NtTu8" to="ibwz:67iSu2wewjc" resolve="property1" />
+          </node>
+        </node>
+      </node>
+      <node concept="3F0ifn" id="67iSu2wzDq_" role="3EZMnx">
+        <node concept="pVoyu" id="67iSu2wBGKs" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+        <node concept="lj46D" id="67iSu2wYxcN" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="3EZMnI" id="67iSu2wYwWR" role="3EZMnx">
+        <node concept="VPM3Z" id="67iSu2wYwWU" role="3F10Kt" />
+        <node concept="3F0ifn" id="67iSu2wzDvd" role="3EZMnx">
+          <property role="3F0ifm" value="Optionally show a property via transformation-text" />
+          <node concept="pVoyu" id="67iSu2wBGKu" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+        </node>
+        <node concept="3F0ifn" id="67iSu2wzDOr" role="3EZMnx">
+          <property role="3F0ifm" value="With description:" />
+          <node concept="pVoyu" id="67iSu2wBH5$" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+          <node concept="lj46D" id="67iSu2wBH5A" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+        </node>
+        <node concept="_tjkj" id="67iSu2wzDOs" role="3EZMnx">
+          <node concept="3EZMnI" id="67iSu2wzDOt" role="_tjki">
+            <node concept="VPM3Z" id="67iSu2wzDOu" role="3F10Kt">
+              <property role="VOm3f" value="false" />
+            </node>
+            <node concept="l2Vlx" id="67iSu2wzDOv" role="2iSdaV" />
+            <node concept="3F0A7n" id="67iSu2wzDOx" role="3EZMnx">
+              <ref role="1NtTu8" to="ibwz:67iSu2wewjc" resolve="property1" />
+            </node>
+          </node>
+          <node concept="uPpia" id="67iSu2wzDOy" role="1djCvC">
+            <node concept="3clFbS" id="67iSu2wzDOz" role="2VODD2">
+              <node concept="3clFbF" id="67iSu2wzDO$" role="3cqZAp">
+                <node concept="Xl_RD" id="67iSu2wzDO_" role="3clFbG">
+                  <property role="Xl_RC" value="Optional description for a property (alternative)" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="ZYGn8" id="67iSu2wzEej" role="ZWbT9">
+            <node concept="3clFbS" id="67iSu2wzEek" role="2VODD2">
+              <node concept="3clFbF" id="67iSu2wzEeY" role="3cqZAp">
+                <node concept="Xl_RD" id="67iSu2wzEeX" role="3clFbG">
+                  <property role="Xl_RC" value="=property-alt" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3F0ifn" id="67iSu2wzDOF" role="3EZMnx">
+          <property role="3F0ifm" value="Without a description:" />
+          <node concept="pVoyu" id="67iSu2wBHaf" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+          <node concept="lj46D" id="67iSu2wBHah" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+        </node>
+        <node concept="_tjkj" id="67iSu2wzDOG" role="3EZMnx">
+          <node concept="3EZMnI" id="67iSu2wzDOH" role="_tjki">
+            <node concept="VPM3Z" id="67iSu2wzDOI" role="3F10Kt">
+              <property role="VOm3f" value="false" />
+            </node>
+            <node concept="l2Vlx" id="67iSu2wzDOJ" role="2iSdaV" />
+            <node concept="3F0A7n" id="67iSu2wzDOL" role="3EZMnx">
+              <ref role="1NtTu8" to="ibwz:67iSu2wewjc" resolve="property1" />
+            </node>
+          </node>
+          <node concept="ZYGn8" id="67iSu2wzEoz" role="ZWbT9">
+            <node concept="3clFbS" id="67iSu2wzEo$" role="2VODD2">
+              <node concept="3clFbF" id="67iSu2wzEpc" role="3cqZAp">
+                <node concept="Xl_RD" id="67iSu2wzEpe" role="3clFbG">
+                  <property role="Xl_RC" value="=property-alt" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3F0ifn" id="67iSu2wzDJK" role="3EZMnx">
+          <node concept="pVoyu" id="67iSu2wBHao" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+        </node>
+        <node concept="l2Vlx" id="67iSu2wYwWY" role="2iSdaV" />
+        <node concept="pVoyu" id="67iSu2wYxcG" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+        <node concept="lj46D" id="67iSu2wYxcJ" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="3F0ifn" id="67iSu2wBCb6" role="3EZMnx">
+        <property role="3F0ifm" value="Optionally show a children-list via contstant as transformation-text" />
+        <node concept="pVoyu" id="67iSu2wBHaq" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="3F0ifn" id="67iSu2wBCba" role="3EZMnx">
+        <property role="3F0ifm" value="With description:" />
+        <node concept="pVoyu" id="67iSu2wBHst" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+        <node concept="lj46D" id="67iSu2wBHsv" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="_tjkj" id="67iSu2wBCbb" role="3EZMnx">
+        <node concept="3EZMnI" id="67iSu2wBCbc" role="_tjki">
+          <node concept="VPM3Z" id="67iSu2wBCbd" role="3F10Kt">
+            <property role="VOm3f" value="false" />
+          </node>
+          <node concept="3F0ifn" id="67iSu2wBCbe" role="3EZMnx">
+            <property role="3F0ifm" value="=children" />
+          </node>
+          <node concept="3F1sOY" id="67iSu2wBCbf" role="3EZMnx">
+            <ref role="1NtTu8" to="ibwz:67iSu2vYKhb" resolve="content" />
+          </node>
+          <node concept="l2Vlx" id="67iSu2wBCbg" role="2iSdaV" />
+        </node>
+        <node concept="uPpia" id="67iSu2wBCbh" role="1djCvC">
+          <node concept="3clFbS" id="67iSu2wBCbi" role="2VODD2">
+            <node concept="3clFbF" id="67iSu2wBCbj" role="3cqZAp">
+              <node concept="Xl_RD" id="67iSu2wBCbk" role="3clFbG">
+                <property role="Xl_RC" value="Optional description for a child" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3F0ifn" id="67iSu2wBCbq" role="3EZMnx">
+        <property role="3F0ifm" value="Without a description:" />
+        <node concept="pVoyu" id="67iSu2wBHwW" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+        <node concept="lj46D" id="67iSu2wBHwY" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="_tjkj" id="67iSu2wBCbr" role="3EZMnx">
+        <node concept="3EZMnI" id="67iSu2wBCbs" role="_tjki">
+          <node concept="VPM3Z" id="67iSu2wBCbt" role="3F10Kt">
+            <property role="VOm3f" value="false" />
+          </node>
+          <node concept="3F0ifn" id="67iSu2wBCbu" role="3EZMnx">
+            <property role="3F0ifm" value="=children" />
+          </node>
+          <node concept="3F1sOY" id="67iSu2wBCbv" role="3EZMnx">
+            <ref role="1NtTu8" to="ibwz:67iSu2vYKhb" resolve="content" />
+          </node>
+          <node concept="l2Vlx" id="67iSu2wBCbw" role="2iSdaV" />
+        </node>
+      </node>
+      <node concept="3F0ifn" id="67iSu2wBCbz" role="3EZMnx">
+        <node concept="pVoyu" id="67iSu2wBHx1" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+        <node concept="lj46D" id="67iSu2wYxJn" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="3EZMnI" id="67iSu2wYxuO" role="3EZMnx">
+        <node concept="3F0ifn" id="67iSu2wBCb$" role="3EZMnx">
+          <property role="3F0ifm" value="Optionally show a children-list via transformation-text" />
+          <node concept="pVoyu" id="67iSu2wBHx3" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+        </node>
+        <node concept="3F0ifn" id="67iSu2wBCbC" role="3EZMnx">
+          <property role="3F0ifm" value="With description:" />
+          <node concept="pVoyu" id="67iSu2wBHPp" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+          <node concept="lj46D" id="67iSu2wBHPr" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+        </node>
+        <node concept="_tjkj" id="67iSu2wBCbD" role="3EZMnx">
+          <node concept="3EZMnI" id="67iSu2wBCbE" role="_tjki">
+            <node concept="VPM3Z" id="67iSu2wBCbF" role="3F10Kt">
+              <property role="VOm3f" value="false" />
+            </node>
+            <node concept="3F1sOY" id="67iSu2wBCbG" role="3EZMnx">
+              <ref role="1NtTu8" to="ibwz:67iSu2vYKhb" resolve="content" />
+            </node>
+            <node concept="l2Vlx" id="67iSu2wBCbH" role="2iSdaV" />
+          </node>
+          <node concept="ZYGn8" id="67iSu2wBCbI" role="ZWbT9">
+            <node concept="3clFbS" id="67iSu2wBCbJ" role="2VODD2">
+              <node concept="3clFbF" id="67iSu2wBCbK" role="3cqZAp">
+                <node concept="Xl_RD" id="67iSu2wBCbL" role="3clFbG">
+                  <property role="Xl_RC" value="=children-alt" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="uPpia" id="67iSu2wBCbM" role="1djCvC">
+            <node concept="3clFbS" id="67iSu2wBCbN" role="2VODD2">
+              <node concept="3clFbF" id="67iSu2wBCbO" role="3cqZAp">
+                <node concept="Xl_RD" id="67iSu2wBCbP" role="3clFbG">
+                  <property role="Xl_RC" value="Optional description for a children-list (alternative)" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3F0ifn" id="67iSu2wBCbV" role="3EZMnx">
+          <property role="3F0ifm" value="Without a description:" />
+          <node concept="pVoyu" id="67iSu2wBHTO" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+          <node concept="lj46D" id="67iSu2wBHTQ" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+        </node>
+        <node concept="_tjkj" id="67iSu2wBCbW" role="3EZMnx">
+          <node concept="3EZMnI" id="67iSu2wBCbX" role="_tjki">
+            <node concept="VPM3Z" id="67iSu2wBCbY" role="3F10Kt">
+              <property role="VOm3f" value="false" />
+            </node>
+            <node concept="3F1sOY" id="67iSu2wBCbZ" role="3EZMnx">
+              <ref role="1NtTu8" to="ibwz:67iSu2vYKhb" resolve="content" />
+            </node>
+            <node concept="l2Vlx" id="67iSu2wBCc0" role="2iSdaV" />
+          </node>
+          <node concept="ZYGn8" id="67iSu2wBCc1" role="ZWbT9">
+            <node concept="3clFbS" id="67iSu2wBCc2" role="2VODD2">
+              <node concept="3clFbF" id="67iSu2wBCc3" role="3cqZAp">
+                <node concept="Xl_RD" id="67iSu2wBCc4" role="3clFbG">
+                  <property role="Xl_RC" value="=children-alt" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3F0ifn" id="67iSu2wBC6r" role="3EZMnx">
+          <node concept="pVoyu" id="67iSu2wBHTT" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+        </node>
+        <node concept="3F0ifn" id="67iSu2wBDjp" role="3EZMnx">
+          <property role="3F0ifm" value="Optionally show a children-list with no transformation-text" />
+          <node concept="pVoyu" id="67iSu2wBHTV" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+        </node>
+        <node concept="3F0ifn" id="67iSu2wBDjt" role="3EZMnx">
+          <property role="3F0ifm" value="With description:" />
+          <node concept="pVoyu" id="67iSu2wBIbf" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+          <node concept="lj46D" id="67iSu2wBIbh" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+        </node>
+        <node concept="_tjkj" id="67iSu2wBDju" role="3EZMnx">
+          <node concept="3EZMnI" id="67iSu2wBDjv" role="_tjki">
+            <node concept="VPM3Z" id="67iSu2wBDjw" role="3F10Kt">
+              <property role="VOm3f" value="false" />
+            </node>
+            <node concept="3F1sOY" id="67iSu2wBDjx" role="3EZMnx">
+              <ref role="1NtTu8" to="ibwz:67iSu2vYKhb" resolve="content" />
+            </node>
+            <node concept="l2Vlx" id="67iSu2wBDjy" role="2iSdaV" />
+          </node>
+          <node concept="uPpia" id="67iSu2wBDjz" role="1djCvC">
+            <node concept="3clFbS" id="67iSu2wBDj$" role="2VODD2">
+              <node concept="3clFbF" id="67iSu2wBDj_" role="3cqZAp">
+                <node concept="Xl_RD" id="67iSu2wBDjA" role="3clFbG">
+                  <property role="Xl_RC" value="Optional description for a children-list without transformation-text" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3F0ifn" id="67iSu2wBDjG" role="3EZMnx">
+          <property role="3F0ifm" value="Without a description:" />
+          <node concept="pVoyu" id="67iSu2wBIfu" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+          <node concept="lj46D" id="67iSu2wBIfw" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+        </node>
+        <node concept="_tjkj" id="67iSu2wBDjH" role="3EZMnx">
+          <node concept="3EZMnI" id="67iSu2wBDjI" role="_tjki">
+            <node concept="VPM3Z" id="67iSu2wBDjJ" role="3F10Kt">
+              <property role="VOm3f" value="false" />
+            </node>
+            <node concept="3F1sOY" id="67iSu2wBDjK" role="3EZMnx">
+              <ref role="1NtTu8" to="ibwz:67iSu2vYKhb" resolve="content" />
+            </node>
+            <node concept="l2Vlx" id="67iSu2wBDjL" role="2iSdaV" />
+          </node>
+        </node>
+        <node concept="3F0ifn" id="67iSu2wBDXV" role="3EZMnx">
+          <node concept="pVoyu" id="67iSu2wBIfz" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+        </node>
+        <node concept="VPM3Z" id="67iSu2wYxuQ" role="3F10Kt" />
+        <node concept="l2Vlx" id="67iSu2wYxuT" role="2iSdaV" />
+        <node concept="pVoyu" id="67iSu2wYxzc" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+        <node concept="lj46D" id="67iSu2wYxJj" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="3F0ifn" id="67iSu2wBDXU" role="3EZMnx">
+        <property role="3F0ifm" value="Optionally show a reference with no transformation-text" />
+        <node concept="pVoyu" id="67iSu2wBIf_" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="3F0ifn" id="67iSu2wBDXI" role="3EZMnx">
+        <property role="3F0ifm" value="With description:" />
+        <node concept="pVoyu" id="67iSu2wBIww" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+        <node concept="lj46D" id="67iSu2wBIwy" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="_tjkj" id="67iSu2wBDXJ" role="3EZMnx">
+        <node concept="3EZMnI" id="67iSu2wBDXK" role="_tjki">
+          <node concept="VPM3Z" id="67iSu2wBDXL" role="3F10Kt">
+            <property role="VOm3f" value="false" />
+          </node>
+          <node concept="l2Vlx" id="67iSu2wBDXN" role="2iSdaV" />
+          <node concept="1iCGBv" id="67iSu2wBE3v" role="3EZMnx">
+            <ref role="1NtTu8" to="ibwz:67iSu2wBDHz" resolve="reference" />
+            <node concept="1sVBvm" id="67iSu2wBE3w" role="1sWHZn">
+              <node concept="3F0A7n" id="67iSu2wBE3_" role="2wV5jI">
+                <property role="1Intyy" value="true" />
+                <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="uPpia" id="67iSu2wBDXO" role="1djCvC">
+          <node concept="3clFbS" id="67iSu2wBDXP" role="2VODD2">
+            <node concept="3clFbF" id="67iSu2wBDXQ" role="3cqZAp">
+              <node concept="Xl_RD" id="67iSu2wBDXR" role="3clFbG">
+                <property role="Xl_RC" value="Optional description for a reference without transformation-text" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3F0ifn" id="67iSu2wBDXz" role="3EZMnx">
+        <property role="3F0ifm" value="Without a description:" />
+        <node concept="pVoyu" id="67iSu2wBI$A" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+        <node concept="lj46D" id="67iSu2wBI$C" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="_tjkj" id="67iSu2wBDX$" role="3EZMnx">
+        <node concept="3EZMnI" id="67iSu2wBDX_" role="_tjki">
+          <node concept="VPM3Z" id="67iSu2wBDXA" role="3F10Kt">
+            <property role="VOm3f" value="false" />
+          </node>
+          <node concept="l2Vlx" id="67iSu2wBDXC" role="2iSdaV" />
+          <node concept="1iCGBv" id="67iSu2wBE3C" role="3EZMnx">
+            <ref role="1NtTu8" to="ibwz:67iSu2wBDHz" resolve="reference" />
+            <node concept="1sVBvm" id="67iSu2wBE3D" role="1sWHZn">
+              <node concept="3F0A7n" id="67iSu2wBE3I" role="2wV5jI">
+                <property role="1Intyy" value="true" />
+                <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3F0ifn" id="67iSu2wBCVF" role="3EZMnx">
+        <node concept="pVoyu" id="67iSu2wBI$F" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="3F0ifn" id="67iSu2vYJIp" role="3EZMnx">
+        <node concept="pVoyu" id="67iSu2wBI$H" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="l2Vlx" id="67iSu2wBEot" role="2iSdaV" />
+      <node concept="1fO$WK" id="67iSu2wG2Tw" role="3F10Kt" />
+    </node>
+  </node>
+  <node concept="24kQdi" id="67iSu2w55nt">
+    <property role="3GE5qa" value="CapabilitiesDemo" />
+    <ref role="1XX52x" to="ibwz:67iSu2w1UsA" resolve="DemoRoot" />
+    <node concept="3EZMnI" id="67iSu2w55nv" role="2wV5jI">
+      <node concept="3EZMnI" id="67iSu2w55nK" role="3EZMnx">
+        <node concept="Vb9p2" id="67iSu2w55nZ" role="3F10Kt">
+          <property role="Vbekb" value="g1_k_vY/BOLD" />
+        </node>
+        <node concept="2iRfu4" id="67iSu2w55nL" role="2iSdaV" />
+        <node concept="3F0ifn" id="67iSu2w55nD" role="3EZMnx">
+          <property role="3F0ifm" value="Demo: " />
+          <node concept="Vb9p2" id="67iSu2wi3GZ" role="3F10Kt">
+            <property role="Vbekb" value="g1_k_vY/BOLD" />
+          </node>
+        </node>
+        <node concept="3F0A7n" id="67iSu2w55nT" role="3EZMnx">
+          <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
+        </node>
+      </node>
+      <node concept="3F0ifn" id="67iSu2w55o2" role="3EZMnx" />
+      <node concept="3F0ifn" id="67iSu2wi3H2" role="3EZMnx" />
+      <node concept="3F2HdR" id="67iSu2w55oh" role="3EZMnx">
+        <ref role="1NtTu8" to="ibwz:67iSu2w1UsD" resolve="content" />
+        <node concept="2iRkQZ" id="67iSu2w55oj" role="2czzBx" />
+      </node>
+      <node concept="2iRkQZ" id="67iSu2w55ny" role="2iSdaV" />
     </node>
   </node>
 </model>

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells.sandboxlang/models/com/mbeddr/mpsutil/grammarcells/sandboxlang/structure.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells.sandboxlang/models/com/mbeddr/mpsutil/grammarcells/sandboxlang/structure.mps
@@ -42,13 +42,16 @@
       </concept>
       <concept id="1169125787135" name="jetbrains.mps.lang.structure.structure.AbstractConceptDeclaration" flags="ig" index="PkWjJ">
         <property id="6714410169261853888" name="conceptId" index="EcuMT" />
+        <property id="4628067390765907488" name="conceptShortDescription" index="R4oN_" />
         <property id="4628067390765956807" name="final" index="R5$K2" />
         <property id="4628067390765956802" name="abstract" index="R5$K7" />
         <property id="5092175715804935370" name="conceptAlias" index="34LRSv" />
         <child id="1071489727083" name="linkDeclaration" index="1TKVEi" />
         <child id="1071489727084" name="propertyDeclaration" index="1TKVEl" />
       </concept>
-      <concept id="1169125989551" name="jetbrains.mps.lang.structure.structure.InterfaceConceptDeclaration" flags="ig" index="PlHQZ" />
+      <concept id="1169125989551" name="jetbrains.mps.lang.structure.structure.InterfaceConceptDeclaration" flags="ig" index="PlHQZ">
+        <child id="1169127546356" name="extends" index="PrDN$" />
+      </concept>
       <concept id="1169127622168" name="jetbrains.mps.lang.structure.structure.InterfaceConceptReference" flags="ig" index="PrWs8">
         <reference id="1169127628841" name="intfc" index="PrY4T" />
       </concept>
@@ -72,6 +75,7 @@
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
         <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
       </concept>
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
@@ -176,6 +180,7 @@
     <property role="TrG5h" value="IntType" />
     <property role="34LRSv" value="int" />
     <property role="EcuMT" value="1749127723000290684" />
+    <property role="R4oN_" value="int type description" />
     <ref role="1TJDcQ" node="1x69Amke5PV" resolve="Type" />
   </node>
   <node concept="1TIwiD" id="6oKG1kMxhfx">
@@ -218,7 +223,15 @@
   <node concept="1TIwiD" id="6oKG1kMxn82">
     <property role="TrG5h" value="LocalVariableDeclaration" />
     <property role="EcuMT" value="7363578995839169026" />
+    <property role="R4oN_" value="localVarDecl description" />
     <ref role="1TJDcQ" node="6oKG1kMxn7T" resolve="VariableDeclaration" />
+    <node concept="1TJgyj" id="67iSu2vw5Hp" role="1TKVEi">
+      <property role="IQ2ns" value="7048944721653160793" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="list" />
+      <property role="20lbJX" value="fLJekj5/_0__n" />
+      <ref role="20lvS9" node="4qdNcH$3auc" resolve="PlusExpression" />
+    </node>
     <node concept="1TJgyi" id="qT5MFml3Gb" role="1TKVEl">
       <property role="TrG5h" value="static" />
       <property role="IQ2nx" value="484443907670948619" />
@@ -226,6 +239,11 @@
     </node>
     <node concept="PrWs8" id="6oKG1kMxn83" role="PzmwI">
       <ref role="PrY4T" node="1x69AmkdYA2" resolve="IStatement" />
+    </node>
+    <node concept="1TJgyj" id="67iSu2vs_Uh" role="1TKVEi">
+      <property role="IQ2ns" value="7048944721652244113" />
+      <property role="20kJfa" value="anyType" />
+      <ref role="20lvS9" node="6oKG1kMxn82" resolve="LocalVariableDeclaration" />
     </node>
   </node>
   <node concept="PlHQZ" id="6oKG1kMxn8A">
@@ -249,6 +267,7 @@
   <node concept="1TIwiD" id="RbLMy6d5VT">
     <property role="TrG5h" value="ArrayType" />
     <property role="EcuMT" value="994107119629524729" />
+    <property role="R4oN_" value="arraytype description" />
     <ref role="1TJDcQ" node="1x69Amke5PV" resolve="Type" />
     <node concept="1TJgyj" id="RbLMy6d5VU" role="1TKVEi">
       <property role="20lmBu" value="fLJjDmT/aggregation" />
@@ -814,6 +833,71 @@
     </node>
     <node concept="PrWs8" id="7uEwlsA9zQg" role="PzmwI">
       <ref role="PrY4T" node="1x69AmkdYA2" resolve="IStatement" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="67iSu2vYIfb">
+    <property role="EcuMT" value="7048944721661191115" />
+    <property role="TrG5h" value="DemoOptionalCellsCapability" />
+    <property role="34LRSv" value="DemoOptionalCellsCapability" />
+    <property role="R4oN_" value="A demo concept to show off the capabilities of the optional cell" />
+    <property role="3GE5qa" value="CapabilitiesDemo" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" />
+    <node concept="1TJgyi" id="67iSu2wewjc" role="1TKVEl">
+      <property role="IQ2nx" value="7048944721665328332" />
+      <property role="TrG5h" value="property1" />
+      <ref role="AX2Wp" to="tpck:fKAQMTB" resolve="boolean" />
+    </node>
+    <node concept="1TJgyi" id="67iSu2wp5CY" role="1TKVEl">
+      <property role="IQ2nx" value="7048944721668102718" />
+      <property role="TrG5h" value="property2" />
+      <ref role="AX2Wp" to="tpck:fKAQMTB" resolve="boolean" />
+    </node>
+    <node concept="1TJgyj" id="67iSu2vYKhb" role="1TKVEi">
+      <property role="IQ2ns" value="7048944721661199435" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="content" />
+      <ref role="20lvS9" node="6oKG1kMxn8A" resolve="IExpression" />
+    </node>
+    <node concept="1TJgyj" id="67iSu2wBBSa" role="1TKVEi">
+      <property role="IQ2ns" value="7048944721671912970" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="contentList" />
+      <property role="20lbJX" value="fLJekj5/_0__n" />
+      <ref role="20lvS9" node="6oKG1kMxn8A" resolve="IExpression" />
+    </node>
+    <node concept="PrWs8" id="67iSu2w1UsI" role="PzmwI">
+      <ref role="PrY4T" node="67iSu2w1UsF" resolve="IDemoContent" />
+    </node>
+    <node concept="1TJgyj" id="67iSu2wBDHz" role="1TKVEi">
+      <property role="IQ2ns" value="7048944721671920483" />
+      <property role="20kJfa" value="reference" />
+      <ref role="20lvS9" node="67iSu2w1UsF" resolve="IDemoContent" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="67iSu2w1UsA">
+    <property role="EcuMT" value="7048944721662027558" />
+    <property role="3GE5qa" value="CapabilitiesDemo" />
+    <property role="TrG5h" value="DemoRoot" />
+    <property role="34LRSv" value="DemoRoot" />
+    <property role="19KtqR" value="true" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" />
+    <node concept="1TJgyj" id="67iSu2w1UsD" role="1TKVEi">
+      <property role="IQ2ns" value="7048944721662027561" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="content" />
+      <property role="20lbJX" value="fLJekj5/_0__n" />
+      <ref role="20lvS9" node="67iSu2w1UsF" resolve="IDemoContent" />
+    </node>
+    <node concept="PrWs8" id="67iSu2w1UsB" role="PzmwI">
+      <ref role="PrY4T" to="tpck:h0TrEE$" resolve="INamedConcept" />
+    </node>
+  </node>
+  <node concept="PlHQZ" id="67iSu2w1UsF">
+    <property role="EcuMT" value="7048944721662027563" />
+    <property role="3GE5qa" value="CapabilitiesDemo" />
+    <property role="TrG5h" value="IDemoContent" />
+    <node concept="PrWs8" id="67iSu2w1UsG" role="PrDN$">
+      <ref role="PrY4T" to="tpck:h0TrEE$" resolve="INamedConcept" />
     </node>
   </node>
 </model>

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/generator/template/main@generator.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/generator/template/main@generator.mps
@@ -564,6 +564,7 @@
         <property id="745148820908747612" name="description" index="2thAuV" />
         <child id="745148820874363426" name="section" index="2vkWV5" />
       </concept>
+      <concept id="9041925471455857605" name="com.mbeddr.mpsutil.grammarcells.structure.Cell_DescriptionText" flags="ig" index="uPpia" />
       <concept id="745148820879066261" name="com.mbeddr.mpsutil.grammarcells.structure.TransformationLocation_SideTransformationCell" flags="ng" index="2v6KxM" />
       <concept id="1997572252229165641" name="com.mbeddr.mpsutil.grammarcells.structure.TransformationLocation_Before" flags="ng" index="wWMWC" />
       <concept id="1997572252229165700" name="com.mbeddr.mpsutil.grammarcells.structure.TransformationLocation_After" flags="ng" index="wWMZ_" />
@@ -584,6 +585,9 @@
       <concept id="6856661361479732075" name="com.mbeddr.mpsutil.grammarcells.structure.InlineActionMapCell" flags="ng" index="130CD5">
         <child id="6856661361479798957" name="actions" index="130p63" />
         <child id="6856661361479732085" name="cell" index="130CDr" />
+      </concept>
+      <concept id="848437706375087728" name="com.mbeddr.mpsutil.grammarcells.structure.ICanHaveDescriptionText" flags="ng" index="1djCvD">
+        <child id="848437706375087729" name="descriptionText" index="1djCvC" />
       </concept>
       <concept id="4874944647490522665" name="com.mbeddr.mpsutil.grammarcells.structure.SideTransformationCell2_IsApplicable" flags="ig" index="1eYwpX" />
       <concept id="4874944647490524676" name="com.mbeddr.mpsutil.grammarcells.structure.SideTransformationCell2_Execute" flags="ig" index="1eYxTg" />
@@ -5173,6 +5177,106 @@
               </node>
             </node>
             <node concept="raruj" id="3KoBPk18Piy" role="lGtFl" />
+            <node concept="uPpia" id="67iSu2ukYGh" role="1djCvC">
+              <node concept="3clFbS" id="67iSu2ukYGi" role="2VODD2">
+                <node concept="3cpWs6" id="67iSu2uTr_I" role="3cqZAp">
+                  <node concept="Xl_RD" id="67iSu2uTsih" role="3cqZAk">
+                    <property role="Xl_RC" value="OptionalCells description" />
+                  </node>
+                  <node concept="1W57fq" id="67iSu2uTt5g" role="lGtFl">
+                    <node concept="3IZrLx" id="67iSu2uTt5h" role="3IZSJc">
+                      <node concept="3clFbS" id="67iSu2uTt5i" role="2VODD2">
+                        <node concept="3clFbF" id="67iSu2uTtvo" role="3cqZAp">
+                          <node concept="2OqwBi" id="67iSu2uTtvp" role="3clFbG">
+                            <node concept="2OqwBi" id="67iSu2uTtvq" role="2Oq$k0">
+                              <node concept="30H73N" id="67iSu2uTtvr" role="2Oq$k0" />
+                              <node concept="3TrEf2" id="67iSu2uTtvs" role="2OqNvi">
+                                <ref role="3Tt5mk" to="teg0:J6gp_6ycpL" resolve="descriptionText" />
+                              </node>
+                            </node>
+                            <node concept="3x8VRR" id="67iSu2uTtvt" role="2OqNvi" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="gft3U" id="67iSu2uTtOO" role="UU_$l">
+                      <node concept="3clFbS" id="67iSu2uTubl" role="gfFT$">
+                        <node concept="3SKdUt" id="67iSu2uWZUH" role="3cqZAp">
+                          <node concept="1PaTwC" id="67iSu2uWZUI" role="1aUNEU">
+                            <node concept="3oM_SD" id="67iSu2uWZUJ" role="1PaTwD">
+                              <property role="3oM_SC" value="if" />
+                            </node>
+                            <node concept="3oM_SD" id="67iSu2uWZUK" role="1PaTwD">
+                              <property role="3oM_SC" value="no" />
+                            </node>
+                            <node concept="3oM_SD" id="67iSu2uWZUL" role="1PaTwD">
+                              <property role="3oM_SC" value="description" />
+                            </node>
+                            <node concept="3oM_SD" id="67iSu2uWZUM" role="1PaTwD">
+                              <property role="3oM_SC" value="was" />
+                            </node>
+                            <node concept="3oM_SD" id="67iSu2uWZUN" role="1PaTwD">
+                              <property role="3oM_SC" value="set" />
+                            </node>
+                            <node concept="3oM_SD" id="67iSu2uWZUO" role="1PaTwD">
+                              <property role="3oM_SC" value="on" />
+                            </node>
+                            <node concept="3oM_SD" id="67iSu2uWZUP" role="1PaTwD">
+                              <property role="3oM_SC" value="the" />
+                            </node>
+                            <node concept="3oM_SD" id="67iSu2uWZUQ" role="1PaTwD">
+                              <property role="3oM_SC" value="optionalCell," />
+                            </node>
+                            <node concept="3oM_SD" id="67iSu2uWZUR" role="1PaTwD">
+                              <property role="3oM_SC" value="the" />
+                            </node>
+                            <node concept="3oM_SD" id="67iSu2uWZUS" role="1PaTwD">
+                              <property role="3oM_SC" value="description" />
+                            </node>
+                            <node concept="3oM_SD" id="67iSu2uWZUT" role="1PaTwD">
+                              <property role="3oM_SC" value="shall" />
+                            </node>
+                            <node concept="3oM_SD" id="67iSu2uWZUU" role="1PaTwD">
+                              <property role="3oM_SC" value="be" />
+                            </node>
+                            <node concept="3oM_SD" id="67iSu2uWZUV" role="1PaTwD">
+                              <property role="3oM_SC" value="blank" />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3cpWs6" id="67iSu2uTubD" role="3cqZAp">
+                          <node concept="Xl_RD" id="67iSu2uTuyj" role="3cqZAk" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2b32R4" id="67iSu2vam9n" role="lGtFl">
+                    <node concept="3JmXsc" id="67iSu2vam9o" role="2P8S$">
+                      <node concept="3clFbS" id="67iSu2vam9p" role="2VODD2">
+                        <node concept="3clFbF" id="67iSu2uX2Rx" role="3cqZAp">
+                          <node concept="2OqwBi" id="67iSu2va5Ch" role="3clFbG">
+                            <node concept="2OqwBi" id="67iSu2va4HZ" role="2Oq$k0">
+                              <node concept="2OqwBi" id="67iSu2uX2Ry" role="2Oq$k0">
+                                <node concept="30H73N" id="67iSu2uX2Rz" role="2Oq$k0" />
+                                <node concept="3TrEf2" id="67iSu2uX2R$" role="2OqNvi">
+                                  <ref role="3Tt5mk" to="teg0:J6gp_6ycpL" resolve="descriptionText" />
+                                </node>
+                              </node>
+                              <node concept="3TrEf2" id="67iSu2va5fO" role="2OqNvi">
+                                <ref role="3Tt5mk" to="tpee:gyVODHa" resolve="body" />
+                              </node>
+                            </node>
+                            <node concept="3Tsc0h" id="67iSu2va65Q" role="2OqNvi">
+                              <ref role="3TtcxE" to="tpee:fzcqZ_x" resolve="statement" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
           </node>
           <node concept="130CD5" id="3KoBPk18Piz" role="3EZMnx">
             <node concept="130t_x" id="3KoBPk18Pi$" role="130p63">
@@ -9821,14 +9925,14 @@
                                                                         <ref role="3uigEE" to="wyt6:~String" resolve="String" />
                                                                       </node>
                                                                       <node concept="2OqwBi" id="dN43cbh1cb" role="33vP2m">
+                                                                        <node concept="37vLTw" id="p_Zcg76xPl" role="2Oq$k0">
+                                                                          <ref role="3cqZAo" node="7NlRaxAYjOf" resolve="it" />
+                                                                        </node>
                                                                         <node concept="liA8E" id="p_Zcg76xPj" role="2OqNvi">
                                                                           <ref role="37wK5l" to="78sh:~SubstituteMenuItem.getDescriptionText(java.lang.String)" resolve="getDescriptionText" />
                                                                           <node concept="37vLTw" id="p_Zcg76xPk" role="37wK5m">
                                                                             <ref role="3cqZAo" node="dN43caW990" resolve="pattern" />
                                                                           </node>
-                                                                        </node>
-                                                                        <node concept="37vLTw" id="p_Zcg76xPl" role="2Oq$k0">
-                                                                          <ref role="3cqZAo" node="7NlRaxAYjOf" resolve="it" />
                                                                         </node>
                                                                       </node>
                                                                     </node>
@@ -9837,12 +9941,6 @@
                                                                     <node concept="3K4zz7" id="dN43cbhgzp" role="3clFbG">
                                                                       <node concept="37vLTw" id="dN43cbhgzq" role="3K4E3e">
                                                                         <ref role="3cqZAo" node="dN43cbhgzm" resolve="description" />
-                                                                      </node>
-                                                                      <node concept="2OqwBi" id="dN43cbh4eU" role="3K4Cdx">
-                                                                        <node concept="37vLTw" id="dN43cbhgzu" role="2Oq$k0">
-                                                                          <ref role="3cqZAo" node="dN43cbhgzm" resolve="description" />
-                                                                        </node>
-                                                                        <node concept="17RvpY" id="dN43cbh5g4" role="2OqNvi" />
                                                                       </node>
                                                                       <node concept="2OqwBi" id="dN43cbhgzr" role="3K4GZi">
                                                                         <node concept="liA8E" id="dN43cbhgzt" role="2OqNvi">
@@ -9856,6 +9954,12 @@
                                                                             <ref role="37wK5l" to="78sh:~SubstituteMenuItem.getOutputConcept()" resolve="getOutputConcept" />
                                                                           </node>
                                                                         </node>
+                                                                      </node>
+                                                                      <node concept="2OqwBi" id="dN43cbh4eU" role="3K4Cdx">
+                                                                        <node concept="37vLTw" id="dN43cbhgzu" role="2Oq$k0">
+                                                                          <ref role="3cqZAo" node="dN43cbhgzm" resolve="description" />
+                                                                        </node>
+                                                                        <node concept="17RvpY" id="dN43cbh5g4" role="2OqNvi" />
                                                                       </node>
                                                                     </node>
                                                                   </node>

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/generator/template/main@generator.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/generator/template/main@generator.mps
@@ -6325,6 +6325,70 @@
                                             </node>
                                           </node>
                                         </node>
+                                        <node concept="gft3U" id="67iSu2vAo1j" role="UU_$l">
+                                          <node concept="3clFb_" id="67iSu2vAo1k" role="gfFT$">
+                                            <property role="TrG5h" value="getShortDescriptionText" />
+                                            <node concept="37vLTG" id="67iSu2vAo1l" role="3clF46">
+                                              <property role="TrG5h" value="pattern" />
+                                              <node concept="17QB3L" id="67iSu2vAo1m" role="1tU5fm" />
+                                              <node concept="2AHcQZ" id="67iSu2vAo1n" role="2AJF6D">
+                                                <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+                                              </node>
+                                            </node>
+                                            <node concept="3clFbS" id="67iSu2vAo1o" role="3clF47">
+                                              <node concept="3SKdUt" id="67iSu2vAo1p" role="3cqZAp">
+                                                <node concept="1PaTwC" id="67iSu2vAo1q" role="1aUNEU">
+                                                  <node concept="3oM_SD" id="67iSu2vAo1r" role="1PaTwD">
+                                                    <property role="3oM_SC" value="if" />
+                                                  </node>
+                                                  <node concept="3oM_SD" id="67iSu2vAo1s" role="1PaTwD">
+                                                    <property role="3oM_SC" value="no" />
+                                                  </node>
+                                                  <node concept="3oM_SD" id="67iSu2vAo1t" role="1PaTwD">
+                                                    <property role="3oM_SC" value="description" />
+                                                  </node>
+                                                  <node concept="3oM_SD" id="67iSu2vAo1u" role="1PaTwD">
+                                                    <property role="3oM_SC" value="was" />
+                                                  </node>
+                                                  <node concept="3oM_SD" id="67iSu2vAo1v" role="1PaTwD">
+                                                    <property role="3oM_SC" value="set" />
+                                                  </node>
+                                                  <node concept="3oM_SD" id="67iSu2vAo1w" role="1PaTwD">
+                                                    <property role="3oM_SC" value="on" />
+                                                  </node>
+                                                  <node concept="3oM_SD" id="67iSu2vAo1x" role="1PaTwD">
+                                                    <property role="3oM_SC" value="the" />
+                                                  </node>
+                                                  <node concept="3oM_SD" id="67iSu2vAo1y" role="1PaTwD">
+                                                    <property role="3oM_SC" value="optionalCell," />
+                                                  </node>
+                                                  <node concept="3oM_SD" id="67iSu2vAo1z" role="1PaTwD">
+                                                    <property role="3oM_SC" value="the" />
+                                                  </node>
+                                                  <node concept="3oM_SD" id="67iSu2vAo1$" role="1PaTwD">
+                                                    <property role="3oM_SC" value="description" />
+                                                  </node>
+                                                  <node concept="3oM_SD" id="67iSu2vAo1_" role="1PaTwD">
+                                                    <property role="3oM_SC" value="shall" />
+                                                  </node>
+                                                  <node concept="3oM_SD" id="67iSu2vAo1A" role="1PaTwD">
+                                                    <property role="3oM_SC" value="be" />
+                                                  </node>
+                                                  <node concept="3oM_SD" id="67iSu2vAo1B" role="1PaTwD">
+                                                    <property role="3oM_SC" value="blank" />
+                                                  </node>
+                                                </node>
+                                              </node>
+                                              <node concept="3cpWs6" id="67iSu2vAo1C" role="3cqZAp">
+                                                <node concept="Xl_RD" id="67iSu2vAo1D" role="3cqZAk">
+                                                  <property role="Xl_RC" value="" />
+                                                </node>
+                                              </node>
+                                            </node>
+                                            <node concept="17QB3L" id="67iSu2vAo1E" role="3clF45" />
+                                            <node concept="3Tm1VV" id="67iSu2vAo1F" role="1B3o_S" />
+                                          </node>
+                                        </node>
                                       </node>
                                     </node>
                                     <node concept="2tJIrI" id="J6gp_6z2Oo" role="jymVt" />

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/generator/template/main@generator.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/generator/template/main@generator.mps
@@ -3470,9 +3470,72 @@
                                               </node>
                                             </node>
                                           </node>
+                                          <node concept="gft3U" id="5V6IKbkLSSq" role="UU_$l">
+                                            <node concept="3clFb_" id="5V6IKbkLVbZ" role="gfFT$">
+                                              <property role="TrG5h" value="getShortDescriptionText" />
+                                              <node concept="37vLTG" id="5V6IKbkLVOD" role="3clF46">
+                                                <property role="TrG5h" value="pattern" />
+                                                <node concept="17QB3L" id="5V6IKbkLVYm" role="1tU5fm" />
+                                                <node concept="2AHcQZ" id="5V6IKbkLWfR" role="2AJF6D">
+                                                  <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+                                                </node>
+                                              </node>
+                                              <node concept="3clFbS" id="5V6IKbkLVc2" role="3clF47">
+                                                <node concept="3SKdUt" id="5V6IKbl0ale" role="3cqZAp">
+                                                  <node concept="1PaTwC" id="5V6IKbl0alf" role="1aUNEU">
+                                                    <node concept="3oM_SD" id="5V6IKbl0bY_" role="1PaTwD">
+                                                      <property role="3oM_SC" value="if" />
+                                                    </node>
+                                                    <node concept="3oM_SD" id="5V6IKbl0bZn" role="1PaTwD">
+                                                      <property role="3oM_SC" value="no" />
+                                                    </node>
+                                                    <node concept="3oM_SD" id="5V6IKbl0c7s" role="1PaTwD">
+                                                      <property role="3oM_SC" value="description" />
+                                                    </node>
+                                                    <node concept="3oM_SD" id="5V6IKbl0cgU" role="1PaTwD">
+                                                      <property role="3oM_SC" value="was" />
+                                                    </node>
+                                                    <node concept="3oM_SD" id="5V6IKbl0civ" role="1PaTwD">
+                                                      <property role="3oM_SC" value="set" />
+                                                    </node>
+                                                    <node concept="3oM_SD" id="5V6IKbl0cm_" role="1PaTwD">
+                                                      <property role="3oM_SC" value="on" />
+                                                    </node>
+                                                    <node concept="3oM_SD" id="5V6IKbl0co8" role="1PaTwD">
+                                                      <property role="3oM_SC" value="the" />
+                                                    </node>
+                                                    <node concept="3oM_SD" id="5V6IKbl0cqM" role="1PaTwD">
+                                                      <property role="3oM_SC" value="optionalCell," />
+                                                    </node>
+                                                    <node concept="3oM_SD" id="5V6IKbl0cFn" role="1PaTwD">
+                                                      <property role="3oM_SC" value="the" />
+                                                    </node>
+                                                    <node concept="3oM_SD" id="5V6IKbl0cMI" role="1PaTwD">
+                                                      <property role="3oM_SC" value="description" />
+                                                    </node>
+                                                    <node concept="3oM_SD" id="5V6IKbl0cUx" role="1PaTwD">
+                                                      <property role="3oM_SC" value="shall" />
+                                                    </node>
+                                                    <node concept="3oM_SD" id="5V6IKbl0cZ6" role="1PaTwD">
+                                                      <property role="3oM_SC" value="be" />
+                                                    </node>
+                                                    <node concept="3oM_SD" id="5V6IKbl0d1n" role="1PaTwD">
+                                                      <property role="3oM_SC" value="blank" />
+                                                    </node>
+                                                  </node>
+                                                </node>
+                                                <node concept="3cpWs6" id="5V6IKbkMe1N" role="3cqZAp">
+                                                  <node concept="Xl_RD" id="5V6IKbl0749" role="3cqZAk">
+                                                    <property role="Xl_RC" value="" />
+                                                  </node>
+                                                </node>
+                                              </node>
+                                              <node concept="17QB3L" id="5V6IKbkLVhj" role="3clF45" />
+                                              <node concept="3Tm1VV" id="5V6IKbkLVc4" role="1B3o_S" />
+                                            </node>
+                                          </node>
                                         </node>
                                       </node>
-                                      <node concept="2tJIrI" id="4xgCL2SOi7W" role="jymVt" />
                                     </node>
                                   </node>
                                 </node>
@@ -9610,11 +9673,11 @@
                                                                             <ref role="3uigEE" to="wyt6:~String" resolve="String" />
                                                                           </node>
                                                                           <node concept="2OqwBi" id="dN43ccHKe6" role="33vP2m">
-                                                                            <node concept="1rXfSq" id="dN43ccHKe7" role="2Oq$k0">
-                                                                              <ref role="37wK5l" node="7NlRaxBn2jp" resolve="getOutputConcept" />
-                                                                            </node>
                                                                             <node concept="liA8E" id="dN43ccHKe8" role="2OqNvi">
                                                                               <ref role="37wK5l" to="c17a:~SAbstractConcept.getShortDescription()" resolve="getShortDescription" />
+                                                                            </node>
+                                                                            <node concept="1rXfSq" id="dN43ccHKe7" role="2Oq$k0">
+                                                                              <ref role="37wK5l" node="7NlRaxBn2jp" resolve="getOutputConcept" />
                                                                             </node>
                                                                           </node>
                                                                         </node>
@@ -9625,11 +9688,11 @@
                                                                             <ref role="3cqZAo" node="dN43ccHKe4" resolve="description" />
                                                                           </node>
                                                                           <node concept="2OqwBi" id="dN43ccHKec" role="3K4GZi">
-                                                                            <node concept="1rXfSq" id="dN43ccHKed" role="2Oq$k0">
-                                                                              <ref role="37wK5l" node="7NlRaxBn2jp" resolve="getOutputConcept" />
-                                                                            </node>
                                                                             <node concept="liA8E" id="dN43ccHKee" role="2OqNvi">
                                                                               <ref role="37wK5l" to="c17a:~SAbstractConcept.getName()" resolve="getName" />
+                                                                            </node>
+                                                                            <node concept="1rXfSq" id="dN43ccHKed" role="2Oq$k0">
+                                                                              <ref role="37wK5l" node="7NlRaxBn2jp" resolve="getOutputConcept" />
                                                                             </node>
                                                                           </node>
                                                                           <node concept="2OqwBi" id="dN43ccHKef" role="3K4Cdx">

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/generator/template/main@generator.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/generator/template/main@generator.mps
@@ -9674,10 +9674,13 @@
                                                                           </node>
                                                                           <node concept="2OqwBi" id="dN43ccHKe6" role="33vP2m">
                                                                             <node concept="liA8E" id="dN43ccHKe8" role="2OqNvi">
-                                                                              <ref role="37wK5l" to="c17a:~SAbstractConcept.getShortDescription()" resolve="getShortDescription" />
+                                                                              <ref role="37wK5l" to="78sh:~SubstituteMenuItem.getDescriptionText(java.lang.String)" resolve="getDescriptionText" />
+                                                                              <node concept="37vLTw" id="4WFxjNhoMY6" role="37wK5m">
+                                                                                <ref role="3cqZAo" node="6uixmKZ3tkg" resolve="pattern" />
+                                                                              </node>
                                                                             </node>
-                                                                            <node concept="1rXfSq" id="dN43ccHKe7" role="2Oq$k0">
-                                                                              <ref role="37wK5l" node="7NlRaxBn2jp" resolve="getOutputConcept" />
+                                                                            <node concept="37vLTw" id="4WFxjNhoadm" role="2Oq$k0">
+                                                                              <ref role="3cqZAo" node="7NlRaxAYjOf" resolve="it" />
                                                                             </node>
                                                                           </node>
                                                                         </node>
@@ -9687,12 +9690,17 @@
                                                                           <node concept="37vLTw" id="dN43ccHKeb" role="3K4E3e">
                                                                             <ref role="3cqZAo" node="dN43ccHKe4" resolve="description" />
                                                                           </node>
-                                                                          <node concept="2OqwBi" id="dN43ccHKec" role="3K4GZi">
-                                                                            <node concept="liA8E" id="dN43ccHKee" role="2OqNvi">
+                                                                          <node concept="2OqwBi" id="4WFxjNhponD" role="3K4GZi">
+                                                                            <node concept="liA8E" id="4WFxjNhpuNf" role="2OqNvi">
                                                                               <ref role="37wK5l" to="c17a:~SAbstractConcept.getName()" resolve="getName" />
                                                                             </node>
-                                                                            <node concept="1rXfSq" id="dN43ccHKed" role="2Oq$k0">
-                                                                              <ref role="37wK5l" node="7NlRaxBn2jp" resolve="getOutputConcept" />
+                                                                            <node concept="2OqwBi" id="4WFxjNhpfXs" role="2Oq$k0">
+                                                                              <node concept="37vLTw" id="4WFxjNhpdr6" role="2Oq$k0">
+                                                                                <ref role="3cqZAo" node="7NlRaxAYjOf" resolve="it" />
+                                                                              </node>
+                                                                              <node concept="liA8E" id="4WFxjNhpkpe" role="2OqNvi">
+                                                                                <ref role="37wK5l" to="78sh:~SubstituteMenuItem.getOutputConcept()" resolve="getOutputConcept" />
+                                                                              </node>
                                                                             </node>
                                                                           </node>
                                                                           <node concept="2OqwBi" id="dN43ccHKef" role="3K4Cdx">
@@ -9813,11 +9821,14 @@
                                                                         <ref role="3uigEE" to="wyt6:~String" resolve="String" />
                                                                       </node>
                                                                       <node concept="2OqwBi" id="dN43cbh1cb" role="33vP2m">
-                                                                        <node concept="1rXfSq" id="dN43cbhgzo" role="2Oq$k0">
-                                                                          <ref role="37wK5l" node="7NlRaxBn2jp" resolve="getOutputConcept" />
+                                                                        <node concept="liA8E" id="p_Zcg76xPj" role="2OqNvi">
+                                                                          <ref role="37wK5l" to="78sh:~SubstituteMenuItem.getDescriptionText(java.lang.String)" resolve="getDescriptionText" />
+                                                                          <node concept="37vLTw" id="p_Zcg76xPk" role="37wK5m">
+                                                                            <ref role="3cqZAo" node="dN43caW990" resolve="pattern" />
+                                                                          </node>
                                                                         </node>
-                                                                        <node concept="liA8E" id="dN43cbh1UR" role="2OqNvi">
-                                                                          <ref role="37wK5l" to="c17a:~SAbstractConcept.getShortDescription()" resolve="getShortDescription" />
+                                                                        <node concept="37vLTw" id="p_Zcg76xPl" role="2Oq$k0">
+                                                                          <ref role="3cqZAo" node="7NlRaxAYjOf" resolve="it" />
                                                                         </node>
                                                                       </node>
                                                                     </node>
@@ -9827,19 +9838,24 @@
                                                                       <node concept="37vLTw" id="dN43cbhgzq" role="3K4E3e">
                                                                         <ref role="3cqZAo" node="dN43cbhgzm" resolve="description" />
                                                                       </node>
-                                                                      <node concept="2OqwBi" id="dN43cbhgzr" role="3K4GZi">
-                                                                        <node concept="1rXfSq" id="dN43cbhgzs" role="2Oq$k0">
-                                                                          <ref role="37wK5l" node="7NlRaxBn2jp" resolve="getOutputConcept" />
-                                                                        </node>
-                                                                        <node concept="liA8E" id="dN43cbhgzt" role="2OqNvi">
-                                                                          <ref role="37wK5l" to="c17a:~SAbstractConcept.getName()" resolve="getName" />
-                                                                        </node>
-                                                                      </node>
                                                                       <node concept="2OqwBi" id="dN43cbh4eU" role="3K4Cdx">
                                                                         <node concept="37vLTw" id="dN43cbhgzu" role="2Oq$k0">
                                                                           <ref role="3cqZAo" node="dN43cbhgzm" resolve="description" />
                                                                         </node>
                                                                         <node concept="17RvpY" id="dN43cbh5g4" role="2OqNvi" />
+                                                                      </node>
+                                                                      <node concept="2OqwBi" id="dN43cbhgzr" role="3K4GZi">
+                                                                        <node concept="liA8E" id="dN43cbhgzt" role="2OqNvi">
+                                                                          <ref role="37wK5l" to="c17a:~SAbstractConcept.getName()" resolve="getName" />
+                                                                        </node>
+                                                                        <node concept="2OqwBi" id="p_Zcg76Abc" role="2Oq$k0">
+                                                                          <node concept="37vLTw" id="p_Zcg76Abd" role="2Oq$k0">
+                                                                            <ref role="3cqZAo" node="7NlRaxAYjOf" resolve="it" />
+                                                                          </node>
+                                                                          <node concept="liA8E" id="p_Zcg76Abe" role="2OqNvi">
+                                                                            <ref role="37wK5l" to="78sh:~SubstituteMenuItem.getOutputConcept()" resolve="getOutputConcept" />
+                                                                          </node>
+                                                                        </node>
                                                                       </node>
                                                                     </node>
                                                                   </node>
@@ -9954,6 +9970,7 @@
                                             </node>
                                             <node concept="Rh6nW" id="7NlRaxAYjOf" role="1bW2Oz">
                                               <property role="TrG5h" value="it" />
+                                              <property role="3TUv4t" value="true" />
                                               <node concept="2jxLKc" id="7NlRaxAYjOg" role="1tU5fm" />
                                             </node>
                                           </node>

--- a/code/grammarcells/solutions/com.mbeddr.mpsutil.grammarcells.sandbox/models/com/mbeddr/mpsutil/editor/cells/sandbox.mps
+++ b/code/grammarcells/solutions/com.mbeddr.mpsutil.grammarcells.sandbox/models/com/mbeddr/mpsutil/editor/cells/sandbox.mps
@@ -43,6 +43,9 @@
       <concept id="4330386229151410873" name="com.mbeddr.mpsutil.grammarcells.sandboxlang.structure.UnitExpression" flags="ng" index="WMbnG">
         <child id="4330386229151410880" name="expression" index="WMbml" />
       </concept>
+      <concept id="7048944721662027558" name="com.mbeddr.mpsutil.grammarcells.sandboxlang.structure.DemoRoot" flags="ng" index="31Pkr6">
+        <child id="7048944721662027561" name="content" index="31Pkr9" />
+      </concept>
       <concept id="7363578995839144929" name="com.mbeddr.mpsutil.grammarcells.sandboxlang.structure.StringType" flags="ng" index="1kHqfO" />
       <concept id="7363578995839169017" name="com.mbeddr.mpsutil.grammarcells.sandboxlang.structure.VariableDeclaration" flags="ng" index="1kHs7G">
         <property id="7363578995839203005" name="volatile" index="1kHkqC" />
@@ -57,6 +60,11 @@
       <concept id="2862331529395169336" name="com.mbeddr.mpsutil.grammarcells.sandboxlang.structure.BinaryExpression" flags="ng" index="1LhId$">
         <child id="5083944728300233289" name="right" index="ywYU2" />
         <child id="5083944728300233286" name="left" index="ywYUd" />
+      </concept>
+      <concept id="7048944721661191115" name="com.mbeddr.mpsutil.grammarcells.sandboxlang.structure.DemoOptionalCellsCapability" flags="ng" index="3Ya08F">
+        <property id="7048944721665328332" name="property1" index="31UekG" />
+        <reference id="7048944721671920483" name="reference" index="31j7E3" />
+        <child id="7048944721661199435" name="content" index="3YaumF" />
       </concept>
     </language>
   </registry>
@@ -440,6 +448,20 @@
     <node concept="2cssZD" id="1x69Amke1Gi" role="2cssWm" />
     <node concept="2cssZD" id="4qdNcH$0Xu5" role="2cssWm" />
     <node concept="2cssZD" id="4qdNcH$0Xv8" role="2cssWm" />
+  </node>
+  <node concept="31Pkr6" id="67iSu2w55nl">
+    <property role="TrG5h" value="Optional Cell Capabilities Demo" />
+    <node concept="3Ya08F" id="67iSu2w8daj" role="31Pkr9">
+      <property role="TrG5h" value="Optional cell with all optional content" />
+      <property role="31UekG" value="true" />
+      <ref role="31j7E3" node="67iSu2w8daj" resolve="Optional cell with all optional content" />
+      <node concept="1kHs8M" id="67iSu2wbmzr" role="3YaumF">
+        <property role="1kHs8z" value="foo" />
+      </node>
+    </node>
+    <node concept="3Ya08F" id="67iSu2w8day" role="31Pkr9">
+      <property role="TrG5h" value="Optional cell with no optional contecnt" />
+    </node>
   </node>
 </model>
 


### PR DESCRIPTION
##  WrapperCell: Changed default description in auto-completion
When using a WrapperCell and the wrapper-node is not created yet, the auto-completion would list all entries that can be wrapped by its name. Additionally it shows a description, which is by default the description of the wrapper. This is inconsistent (name and description are not from different concepts) and can lead to confusion. To mitigate this confusion the description is now used from the wrapped concept, in the default case.

We strongly recommend to specify a dedicated description in the WrapperCell, since the default description can still lead to confusion.

## OptionalCell: Removed description in auto-completion when no dedicated description is set
When using an OptionalCell without a dedicated description, by default, the OptionalCells entry in the auto-completion would use the description of the concept that is using this  OptionalCell.  This is more confusing than helpful. Therefore the entry will show a description only when a dedicated description is provided in the OptionalCell, and will be blank otherwise.

We strongly recommend to specify a dedicated description in the OptionalCell, since no description can lead to confusion.

## Further changes
- Added a demo-node to showcase the capabilities of OptionalCells and the different outcomes when (not) using dedicated descriptions.
