### PR TITLE
Cascading merge from 2021.1 into 2021.2 with migration maintenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+Format of the log is _loosely_ based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). 
+The project does _not_ follow Semantic Versioning and the changes are documented in reverse chronological order, grouped by calendar month.

--- a/build.gradle
+++ b/build.gradle
@@ -1,17 +1,6 @@
-//will pull the groovy classes/types from nexus to the classpath
-buildscript {
-    repositories {
-        mavenLocal()
-        maven { url 'https://artifacts.itemis.cloud/repository/maven-mps/' }
-        maven { url 'https://projects.itemis.de/nexus/content/repositories/mbeddr' }
-    }
-    dependencies {
-        classpath('de.itemis.mps:mps-gradle-plugin:1.7+')
-    }
-}
-
 plugins {
-   id "com.github.breadmoirai.github-release" version "2.4.1"
+    id 'de.itemis.mps.gradle.common' version '1.13.+'
+    id "com.github.breadmoirai.github-release" version "2.4.1"
 }
 
 apply plugin: 'maven-publish'
@@ -74,9 +63,7 @@ if (!project.hasProperty('nexusUsername')) {
 logger.info 'Repository username: {}', project.nexusUsername
 
 ext.dependencyRepositories = [
-        'https://artifacts.itemis.cloud/repository/maven-mps/',
-        'https://projects.itemis.de/nexus/content/repositories/mbeddr',
-        'https://projects.itemis.de/nexus/content/repositories/mbeddr_snapshots',
+        'https://artifacts.itemis.cloud/repository/maven-mps/'
 ]
 // Dependency versions
 
@@ -105,7 +92,7 @@ if (ciBuild) {
     println "##teamcity[buildNumber '${version}']"
 } else {
     println "Local build detected, version will be SNAPSHOT"
-    version = "2020.3-SNAPSHOT"
+    version = ext.mpsMajor + "." + ext.mpsMinor + "-SNAPSHOT"
 }
 
 def userHome = System.properties['user.home']
@@ -249,7 +236,7 @@ tasks.register("checkModulePaths") {
     def project = new XmlParser().parse(file)
 
     def invalidModules = project.component.projectModules.modulePath.'@path'.findAll {
-        def path = it.replaceAll("\\\$PROJECT_DIR\\\$","$rootDir/code")
+        def path = it.replace("\$PROJECT_DIR\$","$rootDir/code")
         return !(new File(path).exists())
     }
 

--- a/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
+++ b/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
@@ -964,6 +964,25 @@
             </node>
           </node>
         </node>
+        <node concept="3rtmxn" id="7ap$5GXXiui" role="3bR31x">
+          <node concept="3LXTmp" id="7ap$5GXXiuj" role="3rtmxm">
+            <node concept="3qWCbU" id="7ap$5GXXiuk" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="7ap$5GXXiul" role="3LXTmr">
+              <ref role="398BVh" node="2fo8bJE$D4t" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="7ap$5GXXium" role="iGT6I">
+                <property role="2Ry0Am" value="jackson" />
+                <node concept="2Ry0Ak" id="7ap$5GXXiun" role="2Ry0An">
+                  <property role="2Ry0Am" value="solutions" />
+                  <node concept="2Ry0Ak" id="7ap$5GXXiuo" role="2Ry0An">
+                    <property role="2Ry0Am" value="com.fasterxml.jackson" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
       </node>
     </node>
     <node concept="m$_wf" id="31bAEZ0srEa" role="3989C9">
@@ -5685,6 +5704,22 @@
             <ref role="3bR37D" to="ffeo:1TaHNgiIbJ$" resolve="jetbrains.mps.ide.editor" />
           </node>
         </node>
+        <node concept="3rtmxn" id="7ap$5GXXiuq" role="3bR31x">
+          <node concept="3LXTmp" id="7ap$5GXXiur" role="3rtmxm">
+            <node concept="3qWCbU" id="7ap$5GXXius" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="7ap$5GXXiut" role="3LXTmr">
+              <ref role="398BVh" node="2fo8bJE$D4t" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="7ap$5GXXiuu" role="iGT6I">
+                <property role="2Ry0Am" value="linenumbers" />
+                <node concept="2Ry0Ak" id="7ap$5GXXiuv" role="2Ry0An">
+                  <property role="2Ry0Am" value="de.itemis.mps.linenumbers" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
       </node>
     </node>
     <node concept="m$_wf" id="6SVXTgIe8wD" role="3989C9">
@@ -7027,6 +7062,22 @@
             <ref role="3bR37D" to="ffeo:1TaHNgiIbIQ" resolve="MPS.Core" />
           </node>
         </node>
+        <node concept="3rtmxn" id="7ap$5GXXiux" role="3bR31x">
+          <node concept="3LXTmp" id="7ap$5GXXiuy" role="3rtmxm">
+            <node concept="3qWCbU" id="7ap$5GXXiuz" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="7ap$5GXXiu$" role="3LXTmr">
+              <ref role="398BVh" node="2fo8bJE$D4t" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="7ap$5GXXiu_" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="7ap$5GXXiuA" role="2Ry0An">
+                  <property role="2Ry0Am" value="de.itemis.model.merge.runtime" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
       </node>
       <node concept="1E1JtD" id="5zr7Q_1BAoJ" role="2G$12L">
         <property role="BnDLt" value="true" />
@@ -7207,6 +7258,22 @@
         <node concept="1SiIV0" id="6sRPuS7Gc7t" role="3bR37C">
           <node concept="3bR9La" id="6sRPuS7Gc7u" role="1SiIV1">
             <ref role="3bR37D" to="ffeo:7Kfy9QB6KZG" resolve="jetbrains.mps.baseLanguage.closures" />
+          </node>
+        </node>
+        <node concept="3rtmxn" id="7ap$5GXXivj" role="3bR31x">
+          <node concept="3LXTmp" id="7ap$5GXXivk" role="3rtmxm">
+            <node concept="3qWCbU" id="7ap$5GXXivl" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="7ap$5GXXivm" role="3LXTmr">
+              <ref role="398BVh" node="2fo8bJE$D4t" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="7ap$5GXXivn" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="7ap$5GXXivo" role="2Ry0An">
+                  <property role="2Ry0Am" value="de.itemis.model.merge" />
+                </node>
+              </node>
+            </node>
           </node>
         </node>
       </node>
@@ -11680,6 +11747,9 @@
       <node concept="m$_yC" id="3ofF9dt4eDr" role="m$_yJ">
         <ref role="m$_y1" node="2OJNL7ElZsF" resolve="de.q60.mps.collections.libs" />
       </node>
+      <node concept="m$_yC" id="5lBBNpx5PcJ" role="m$_yJ">
+        <ref role="m$_y1" node="4p3FRivDLPy" resolve="org.apache.commons" />
+      </node>
       <node concept="2iUeEo" id="3vhhDKcvNeO" role="2iVFfd">
         <property role="2iUeEt" value="Modelix" />
         <property role="2iUeEu" value="http://modelix.org" />
@@ -11688,9 +11758,6 @@
         <node concept="3Mxwew" id="3vhhDKcvN8v" role="3MwsjC">
           <property role="3MwjfP" value="Alternative model API with better support for persistent data structures." />
         </node>
-      </node>
-      <node concept="m$_yC" id="5lBBNpx5PcJ" role="m$_yJ">
-        <ref role="m$_y1" node="4p3FRivDLPy" resolve="org.apache.commons" />
       </node>
     </node>
     <node concept="2G$12M" id="5U8hsWC6WQb" role="3989C9">
@@ -11895,6 +11962,22 @@
             </node>
           </node>
         </node>
+        <node concept="3rtmxn" id="7ap$5GXXiuC" role="3bR31x">
+          <node concept="3LXTmp" id="7ap$5GXXiuD" role="3rtmxm">
+            <node concept="3qWCbU" id="7ap$5GXXiuE" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="7ap$5GXXiuF" role="3LXTmr">
+              <ref role="398BVh" node="2fo8bJE$D4t" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="7ap$5GXXiuG" role="iGT6I">
+                <property role="2Ry0Am" value="model-api" />
+                <node concept="2Ry0Ak" id="7ap$5GXXiuH" role="2Ry0An">
+                  <property role="2Ry0Am" value="org.modelix.model.api" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
       </node>
       <node concept="1E1JtA" id="5U8hsWC71Xh" role="2G$12L">
         <property role="BnDLt" value="true" />
@@ -11983,6 +12066,22 @@
         <node concept="1SiIV0" id="3DfUugBWDMF" role="3bR37C">
           <node concept="3bR9La" id="3DfUugBWDMG" role="1SiIV1">
             <ref role="3bR37D" to="ffeo:1TaHNgiIbJb" resolve="MPS.Platform" />
+          </node>
+        </node>
+        <node concept="3rtmxn" id="7ap$5GXXiuJ" role="3bR31x">
+          <node concept="3LXTmp" id="7ap$5GXXiuK" role="3rtmxm">
+            <node concept="3qWCbU" id="7ap$5GXXiuL" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="7ap$5GXXiuM" role="3LXTmr">
+              <ref role="398BVh" node="2fo8bJE$D4t" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="7ap$5GXXiuN" role="iGT6I">
+                <property role="2Ry0Am" value="model-api" />
+                <node concept="2Ry0Ak" id="7ap$5GXXiuO" role="2Ry0An">
+                  <property role="2Ry0Am" value="org.modelix.model.mpsadapters" />
+                </node>
+              </node>
+            </node>
           </node>
         </node>
       </node>
@@ -15104,6 +15203,22 @@
             </node>
           </node>
         </node>
+        <node concept="3rtmxn" id="7ap$5GXXivq" role="3bR31x">
+          <node concept="3LXTmp" id="7ap$5GXXivr" role="3rtmxm">
+            <node concept="3qWCbU" id="7ap$5GXXivs" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="7ap$5GXXivt" role="3LXTmr">
+              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="7ap$5GXXivu" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="7ap$5GXXivv" role="2Ry0An">
+                  <property role="2Ry0Am" value="de.itemis.model.merge.simple.demo.annotated" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
       </node>
       <node concept="1E1JtD" id="3aF8hCvy3sT" role="2G$12L">
         <property role="BnDLt" value="true" />
@@ -15258,6 +15373,22 @@
             </node>
           </node>
         </node>
+        <node concept="3rtmxn" id="7ap$5GXXivx" role="3bR31x">
+          <node concept="3LXTmp" id="7ap$5GXXivy" role="3rtmxm">
+            <node concept="3qWCbU" id="7ap$5GXXivz" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="7ap$5GXXiv$" role="3LXTmr">
+              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="7ap$5GXXiv_" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="7ap$5GXXivA" role="2Ry0An">
+                  <property role="2Ry0Am" value="de.itemis.model.simple.demo.children" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
       </node>
       <node concept="1E1JtD" id="2UnEDPClLHk" role="2G$12L">
         <property role="BnDLt" value="true" />
@@ -15300,6 +15431,22 @@
         <node concept="1SiIV0" id="2UnEDPClLYf" role="3bR37C">
           <node concept="1Busua" id="2UnEDPClLYg" role="1SiIV1">
             <ref role="1Busuk" node="2UnEDPCh8Ac" resolve="de.itemis.model.simple.demo.property" />
+          </node>
+        </node>
+        <node concept="3rtmxn" id="7ap$5GXXivC" role="3bR31x">
+          <node concept="3LXTmp" id="7ap$5GXXivD" role="3rtmxm">
+            <node concept="3qWCbU" id="7ap$5GXXivE" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="7ap$5GXXivF" role="3LXTmr">
+              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="7ap$5GXXivG" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="7ap$5GXXivH" role="2Ry0An">
+                  <property role="2Ry0Am" value="de.itemis.model.simple.demo.collection" />
+                </node>
+              </node>
+            </node>
           </node>
         </node>
       </node>
@@ -15351,6 +15498,22 @@
             <ref role="1Busuk" node="2UnEDPClLHk" resolve="de.itemis.model.simple.demo.collection" />
           </node>
         </node>
+        <node concept="3rtmxn" id="7ap$5GXXivJ" role="3bR31x">
+          <node concept="3LXTmp" id="7ap$5GXXivK" role="3rtmxm">
+            <node concept="3qWCbU" id="7ap$5GXXivL" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="7ap$5GXXivM" role="3LXTmr">
+              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="7ap$5GXXivN" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="7ap$5GXXivO" role="2Ry0An">
+                  <property role="2Ry0Am" value="de.itemis.model.simple.demo.collection.keeper" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
       </node>
       <node concept="1E1JtD" id="2UnEDPClLQ$" role="2G$12L">
         <property role="BnDLt" value="true" />
@@ -15398,6 +15561,22 @@
         <node concept="1SiIV0" id="2UnEDPClMjW" role="3bR37C">
           <node concept="1Busua" id="2UnEDPClMjX" role="1SiIV1">
             <ref role="1Busuk" node="2UnEDPClLHk" resolve="de.itemis.model.simple.demo.collection" />
+          </node>
+        </node>
+        <node concept="3rtmxn" id="7ap$5GXXivQ" role="3bR31x">
+          <node concept="3LXTmp" id="7ap$5GXXivR" role="3rtmxm">
+            <node concept="3qWCbU" id="7ap$5GXXivS" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="7ap$5GXXivT" role="3LXTmr">
+              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="7ap$5GXXivU" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="7ap$5GXXivV" role="2Ry0An">
+                  <property role="2Ry0Am" value="de.itemis.model.simple.demo.reference" />
+                </node>
+              </node>
+            </node>
           </node>
         </node>
       </node>
@@ -15601,6 +15780,22 @@
             <ref role="3bR37D" to="ffeo:7Kfy9QB6L9O" resolve="jetbrains.mps.lang.smodel" />
           </node>
         </node>
+        <node concept="3rtmxn" id="7ap$5GXXiuQ" role="3bR31x">
+          <node concept="3LXTmp" id="7ap$5GXXiuR" role="3rtmxm">
+            <node concept="3qWCbU" id="7ap$5GXXiuS" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="7ap$5GXXiuT" role="3LXTmr">
+              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="7ap$5GXXiuU" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="7ap$5GXXiuV" role="2Ry0An">
+                  <property role="2Ry0Am" value="de.itemis.model.merge.simple.demo" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
       </node>
       <node concept="1E1JtA" id="5Jy3PcPRnpY" role="2G$12L">
         <property role="BnDLt" value="true" />
@@ -15664,6 +15859,25 @@
             </node>
             <node concept="3qWCbU" id="5Jy3PcPRn$H" role="3LXTna">
               <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+        <node concept="3rtmxn" id="7ap$5GXXiuX" role="3bR31x">
+          <node concept="3LXTmp" id="7ap$5GXXiuY" role="3rtmxm">
+            <node concept="3qWCbU" id="7ap$5GXXiuZ" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="7ap$5GXXiv0" role="3LXTmr">
+              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="7ap$5GXXiv1" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="7ap$5GXXiv2" role="2Ry0An">
+                  <property role="2Ry0Am" value="de.itemis.model.merge.baselang" />
+                  <node concept="2Ry0Ak" id="7ap$5GXXiv3" role="2Ry0An">
+                    <property role="2Ry0Am" value="sandbox" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -15893,6 +16107,22 @@
         <node concept="1SiIV0" id="4LLXBGc6jcA" role="3bR37C">
           <node concept="3bR9La" id="4LLXBGc6jcB" role="1SiIV1">
             <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
+          </node>
+        </node>
+        <node concept="3rtmxn" id="7ap$5GXXiv5" role="3bR31x">
+          <node concept="3LXTmp" id="7ap$5GXXiv6" role="3rtmxm">
+            <node concept="3qWCbU" id="7ap$5GXXiv7" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="7ap$5GXXiv8" role="3LXTmr">
+              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="7ap$5GXXiv9" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="7ap$5GXXiva" role="2Ry0An">
+                  <property role="2Ry0Am" value="de.itemis.model.merge.test.integration" />
+                </node>
+              </node>
+            </node>
           </node>
         </node>
       </node>
@@ -16431,6 +16661,22 @@
         <node concept="1SiIV0" id="7g5FWGK3ZTa" role="3bR37C">
           <node concept="3bR9La" id="7g5FWGK3ZTb" role="1SiIV1">
             <ref role="3bR37D" node="5U8hsWC71Xh" resolve="org.modelix.model.mpsadapters" />
+          </node>
+        </node>
+        <node concept="3rtmxn" id="7ap$5GXXivc" role="3bR31x">
+          <node concept="3LXTmp" id="7ap$5GXXivd" role="3rtmxm">
+            <node concept="3qWCbU" id="7ap$5GXXive" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="7ap$5GXXivf" role="3LXTmr">
+              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="7ap$5GXXivg" role="iGT6I">
+                <property role="2Ry0Am" value="model-api" />
+                <node concept="2Ry0Ak" id="7ap$5GXXivh" role="2Ry0An">
+                  <property role="2Ry0Am" value="test.org.modelix.model.mpsadapters" />
+                </node>
+              </node>
+            </node>
           </node>
         </node>
       </node>

--- a/code/diagram/languages/de.itemis.mps.editor.diagram.demoentities/languageModels/editor.mps
+++ b/code/diagram/languages/de.itemis.mps.editor.diagram.demoentities/languageModels/editor.mps
@@ -976,7 +976,10 @@
                             <node concept="Xl_RD" id="6rPpQ1NH_uJ" role="3uHU7B">
                               <property role="Xl_RC" value="returning Reference.to: " />
                             </node>
-                            <node concept="1Pxb5l" id="6rPpQ1NH_uU" role="3uHU7w" />
+                            <node concept="2OqwBi" id="XlTOHgcVWE" role="3uHU7w">
+                              <node concept="1Pxb5l" id="6rPpQ1NH_uU" role="2Oq$k0" />
+                              <node concept="2Iv5rx" id="XlTOHgcVWF" role="2OqNvi" />
+                            </node>
                           </node>
                         </node>
                       </node>
@@ -1108,7 +1111,10 @@
                             <node concept="Xl_RD" id="6rPpQ1NH_xR" role="3uHU7B">
                               <property role="Xl_RC" value="returning Reference.from on " />
                             </node>
-                            <node concept="1Pxb5l" id="6rPpQ1NH_y2" role="3uHU7w" />
+                            <node concept="2OqwBi" id="XlTOHgcVXE" role="3uHU7w">
+                              <node concept="1Pxb5l" id="6rPpQ1NH_y2" role="2Oq$k0" />
+                              <node concept="2Iv5rx" id="XlTOHgcVXF" role="2OqNvi" />
+                            </node>
                           </node>
                         </node>
                       </node>
@@ -1247,7 +1253,10 @@
                             <node concept="Xl_RD" id="6rPpQ1NH_tb" role="3uHU7B">
                               <property role="Xl_RC" value="returning Extends.from: " />
                             </node>
-                            <node concept="1Pxb5l" id="6rPpQ1NH_tm" role="3uHU7w" />
+                            <node concept="2OqwBi" id="XlTOHgcVYE" role="3uHU7w">
+                              <node concept="1Pxb5l" id="6rPpQ1NH_tm" role="2Oq$k0" />
+                              <node concept="2Iv5rx" id="XlTOHgcVYF" role="2OqNvi" />
+                            </node>
                           </node>
                         </node>
                       </node>
@@ -1379,7 +1388,10 @@
                             <node concept="Xl_RD" id="6rPpQ1NH_wj" role="3uHU7B">
                               <property role="Xl_RC" value="returning Extends.to: " />
                             </node>
-                            <node concept="1Pxb5l" id="6rPpQ1NH_wu" role="3uHU7w" />
+                            <node concept="2OqwBi" id="XlTOHgcVZE" role="3uHU7w">
+                              <node concept="1Pxb5l" id="6rPpQ1NH_wu" role="2Oq$k0" />
+                              <node concept="2Iv5rx" id="XlTOHgcVZF" role="2OqNvi" />
+                            </node>
                           </node>
                         </node>
                       </node>

--- a/code/diagram/languages/de.itemis.mps.editor.diagram/generator/template/main@generator.mps
+++ b/code/diagram/languages/de.itemis.mps.editor.diagram/generator/template/main@generator.mps
@@ -2,7 +2,7 @@
 <model ref="r:9270b118-f381-43ed-ba74-93e780e8de68(de.itemis.mps.editor.diagram.generator.template.main@generator)">
   <persistence version="9" />
   <languages>
-    <use id="b401a680-8325-4110-8fd3-84331ff25bef" name="jetbrains.mps.lang.generator" version="3" />
+    <use id="b401a680-8325-4110-8fd3-84331ff25bef" name="jetbrains.mps.lang.generator" version="4" />
     <use id="fa13cc63-c476-4d46-9c96-d53670abe7bc" name="de.itemis.mps.editor.diagram" version="-1" />
     <use id="d7706f63-9be2-479c-a3da-ae92af1e64d5" name="jetbrains.mps.lang.generator.generationContext" version="2" />
     <use id="df345b11-b8c7-4213-ac66-48d2a9b75d88" name="jetbrains.mps.baseLanguageInternal" version="-1" />

--- a/code/diagram/solutions/de.itemis.mps.editor.diagram.sandbox/models/de/itemis/mps/editor/diagram/sandbox.mps
+++ b/code/diagram/solutions/de.itemis.mps.editor.diagram.sandbox/models/de/itemis/mps/editor/diagram/sandbox.mps
@@ -1016,7 +1016,7 @@
       </node>
       <node concept="2ZRQYt" id="4uAxemPynBZ" role="2ZNJvH">
         <property role="TrG5h" value="asdfgfgf" />
-        <ref role="3QI6rI" node="2YJ6Svp6$rR" />
+        <ref role="3QI6rI" node="2YJ6Svp6$rR" resolve="Mysubcomponent" />
         <node concept="37mRI7" id="2YJ6Svp6_FY" role="lGtFl">
           <node concept="37mRIm" id="2YJ6Svp6_FZ" role="37mRID">
             <property role="37mO49" value="3435995310983890679" />

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells.sandboxlang/models/com/mbeddr/mpsutil/grammarcells/sandboxlang/editor.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells.sandboxlang/models/com/mbeddr/mpsutil/grammarcells/sandboxlang/editor.mps
@@ -547,7 +547,10 @@
               </node>
               <node concept="2xdQw9" id="6gjbwab9Q8x" role="3cqZAp">
                 <node concept="3cpWs3" id="6gjbwab9Q8y" role="9lYJi">
-                  <node concept="3gMLhr" id="6gjbwab9Qdc" role="3uHU7w" />
+                  <node concept="2OqwBi" id="XlTOHgcWvM" role="3uHU7w">
+                    <node concept="3gMLhr" id="6gjbwab9Qdc" role="2Oq$k0" />
+                    <node concept="2Iv5rx" id="XlTOHgcWvN" role="2OqNvi" />
+                  </node>
                   <node concept="Xl_RD" id="6gjbwab9Q8$" role="3uHU7B">
                     <property role="Xl_RC" value="SubstitutedNode:" />
                   </node>
@@ -558,7 +561,10 @@
                   <node concept="Xl_RD" id="6gjbwab9Qep" role="3uHU7B">
                     <property role="Xl_RC" value="ParentNode:" />
                   </node>
-                  <node concept="2gy9SH" id="6gjbwab9Qvc" role="3uHU7w" />
+                  <node concept="2OqwBi" id="XlTOHgcWvW" role="3uHU7w">
+                    <node concept="2gy9SH" id="6gjbwab9Qvc" role="2Oq$k0" />
+                    <node concept="2Iv5rx" id="XlTOHgcWvX" role="2OqNvi" />
+                  </node>
                 </node>
               </node>
               <node concept="2xdQw9" id="6gjbwab9QwE" role="3cqZAp">
@@ -588,7 +594,10 @@
               </node>
               <node concept="2xdQw9" id="6gjbwab9QSt" role="3cqZAp">
                 <node concept="3cpWs3" id="6gjbwab9QSu" role="9lYJi">
-                  <node concept="313q4" id="6gjbwab9QW2" role="3uHU7w" />
+                  <node concept="2OqwBi" id="XlTOHgcWwm" role="3uHU7w">
+                    <node concept="313q4" id="6gjbwab9QW2" role="2Oq$k0" />
+                    <node concept="2Iv5rx" id="XlTOHgcWwn" role="2OqNvi" />
+                  </node>
                   <node concept="Xl_RD" id="6gjbwab9QSw" role="3uHU7B">
                     <property role="Xl_RC" value="Node:" />
                   </node>
@@ -689,7 +698,10 @@
             <node concept="3clFbS" id="6gjbwab3Srt" role="2VODD2">
               <node concept="2xdQw9" id="6gjbwab3S$R" role="3cqZAp">
                 <node concept="3cpWs3" id="6gjbwab3S$S" role="9lYJi">
-                  <node concept="313q4" id="6gjbwab3S$T" role="3uHU7w" />
+                  <node concept="2OqwBi" id="XlTOHgcWwS" role="3uHU7w">
+                    <node concept="313q4" id="6gjbwab3S$T" role="2Oq$k0" />
+                    <node concept="2Iv5rx" id="XlTOHgcWwT" role="2OqNvi" />
+                  </node>
                   <node concept="Xl_RD" id="6gjbwab3S$U" role="3uHU7B">
                     <property role="Xl_RC" value="Node:" />
                   </node>
@@ -709,7 +721,10 @@
             <node concept="3clFbS" id="6gjbwab3S_S" role="2VODD2">
               <node concept="2xdQw9" id="6gjbwab3SAv" role="3cqZAp">
                 <node concept="3cpWs3" id="6gjbwab3SAw" role="9lYJi">
-                  <node concept="313q4" id="6gjbwab3SAx" role="3uHU7w" />
+                  <node concept="2OqwBi" id="XlTOHgcWxa" role="3uHU7w">
+                    <node concept="313q4" id="6gjbwab3SAx" role="2Oq$k0" />
+                    <node concept="2Iv5rx" id="XlTOHgcWxb" role="2OqNvi" />
+                  </node>
                   <node concept="Xl_RD" id="6gjbwab3SAy" role="3uHU7B">
                     <property role="Xl_RC" value="Node:" />
                   </node>
@@ -729,7 +744,10 @@
             <node concept="3clFbS" id="6gjbwab5uMP" role="2VODD2">
               <node concept="2xdQw9" id="6gjbwab5uW0" role="3cqZAp">
                 <node concept="3cpWs3" id="6gjbwab5uW1" role="9lYJi">
-                  <node concept="2e73FJ" id="6gjbwab5v0B" role="3uHU7w" />
+                  <node concept="2OqwBi" id="XlTOHgcWxs" role="3uHU7w">
+                    <node concept="2e73FJ" id="6gjbwab5v0B" role="2Oq$k0" />
+                    <node concept="2Iv5rx" id="XlTOHgcWxt" role="2OqNvi" />
+                  </node>
                   <node concept="Xl_RD" id="6gjbwab5uW3" role="3uHU7B">
                     <property role="Xl_RC" value="WrappedNode:" />
                   </node>
@@ -1204,7 +1222,10 @@
           <node concept="3clFbS" id="6gjbwaaGgIm" role="2VODD2">
             <node concept="2xdQw9" id="6gjbwaaGgIn" role="3cqZAp">
               <node concept="3cpWs3" id="6gjbwaaGgIo" role="9lYJi">
-                <node concept="313q4" id="6gjbwaaGgIp" role="3uHU7w" />
+                <node concept="2OqwBi" id="XlTOHgcWy0" role="3uHU7w">
+                  <node concept="313q4" id="6gjbwaaGgIp" role="2Oq$k0" />
+                  <node concept="2Iv5rx" id="XlTOHgcWy1" role="2OqNvi" />
+                </node>
                 <node concept="Xl_RD" id="6gjbwaaGgIq" role="3uHU7B">
                   <property role="Xl_RC" value="Node:" />
                 </node>
@@ -1224,7 +1245,10 @@
           <node concept="3clFbS" id="6gjbwab2h_L" role="2VODD2">
             <node concept="2xdQw9" id="6gjbwab2hEU" role="3cqZAp">
               <node concept="3cpWs3" id="6gjbwab2hEV" role="9lYJi">
-                <node concept="313q4" id="6gjbwab2hEW" role="3uHU7w" />
+                <node concept="2OqwBi" id="XlTOHgcWyi" role="3uHU7w">
+                  <node concept="313q4" id="6gjbwab2hEW" role="2Oq$k0" />
+                  <node concept="2Iv5rx" id="XlTOHgcWyj" role="2OqNvi" />
+                </node>
                 <node concept="Xl_RD" id="6gjbwab2hEX" role="3uHU7B">
                   <property role="Xl_RC" value="Node:" />
                 </node>
@@ -1375,7 +1399,10 @@
           <node concept="3clFbS" id="6gjbwaaLza5" role="2VODD2">
             <node concept="2xdQw9" id="6gjbwaaLzag" role="3cqZAp">
               <node concept="3cpWs3" id="6gjbwaaLzah" role="9lYJi">
-                <node concept="313q4" id="6gjbwaaLzai" role="3uHU7w" />
+                <node concept="2OqwBi" id="XlTOHgcWyG" role="3uHU7w">
+                  <node concept="313q4" id="6gjbwaaLzai" role="2Oq$k0" />
+                  <node concept="2Iv5rx" id="XlTOHgcWyH" role="2OqNvi" />
+                </node>
                 <node concept="Xl_RD" id="6gjbwaaLzaj" role="3uHU7B">
                   <property role="Xl_RC" value="Node:" />
                 </node>
@@ -1395,7 +1422,10 @@
           <node concept="3clFbS" id="6gjbwab2irP" role="2VODD2">
             <node concept="2xdQw9" id="6gjbwab2isB" role="3cqZAp">
               <node concept="3cpWs3" id="6gjbwab2isC" role="9lYJi">
-                <node concept="313q4" id="6gjbwab2isD" role="3uHU7w" />
+                <node concept="2OqwBi" id="XlTOHgcWyY" role="3uHU7w">
+                  <node concept="313q4" id="6gjbwab2isD" role="2Oq$k0" />
+                  <node concept="2Iv5rx" id="XlTOHgcWyZ" role="2OqNvi" />
+                </node>
                 <node concept="Xl_RD" id="6gjbwab2isE" role="3uHU7B">
                   <property role="Xl_RC" value="Node:" />
                 </node>
@@ -1651,7 +1681,10 @@
           <node concept="3clFbS" id="6gjbwaaGgMQ" role="2VODD2">
             <node concept="2xdQw9" id="6gjbwaaGgMR" role="3cqZAp">
               <node concept="3cpWs3" id="6gjbwaaGgMS" role="9lYJi">
-                <node concept="313q4" id="6gjbwaaGgMT" role="3uHU7w" />
+                <node concept="2OqwBi" id="XlTOHgcWzo" role="3uHU7w">
+                  <node concept="313q4" id="6gjbwaaGgMT" role="2Oq$k0" />
+                  <node concept="2Iv5rx" id="XlTOHgcWzp" role="2OqNvi" />
+                </node>
                 <node concept="Xl_RD" id="6gjbwaaGgMU" role="3uHU7B">
                   <property role="Xl_RC" value="Node:" />
                 </node>
@@ -1671,7 +1704,10 @@
           <node concept="3clFbS" id="6gjbwab2icM" role="2VODD2">
             <node concept="2xdQw9" id="6gjbwab2ihL" role="3cqZAp">
               <node concept="3cpWs3" id="6gjbwab2ihM" role="9lYJi">
-                <node concept="313q4" id="6gjbwab2ihN" role="3uHU7w" />
+                <node concept="2OqwBi" id="XlTOHgcWzE" role="3uHU7w">
+                  <node concept="313q4" id="6gjbwab2ihN" role="2Oq$k0" />
+                  <node concept="2Iv5rx" id="XlTOHgcWzF" role="2OqNvi" />
+                </node>
                 <node concept="Xl_RD" id="6gjbwab2ihO" role="3uHU7B">
                   <property role="Xl_RC" value="Node:" />
                 </node>
@@ -1725,7 +1761,10 @@
           <node concept="3clFbS" id="6gjbwaaGgJQ" role="2VODD2">
             <node concept="2xdQw9" id="6gjbwaaGgJR" role="3cqZAp">
               <node concept="3cpWs3" id="6gjbwaaGgJS" role="9lYJi">
-                <node concept="313q4" id="6gjbwaaGgJT" role="3uHU7w" />
+                <node concept="2OqwBi" id="XlTOHgcW$4" role="3uHU7w">
+                  <node concept="313q4" id="6gjbwaaGgJT" role="2Oq$k0" />
+                  <node concept="2Iv5rx" id="XlTOHgcW$5" role="2OqNvi" />
+                </node>
                 <node concept="Xl_RD" id="6gjbwaaGgJU" role="3uHU7B">
                   <property role="Xl_RC" value="Node:" />
                 </node>
@@ -1745,7 +1784,10 @@
           <node concept="3clFbS" id="6gjbwab2hPJ" role="2VODD2">
             <node concept="2xdQw9" id="6gjbwab2hUS" role="3cqZAp">
               <node concept="3cpWs3" id="6gjbwab2hUT" role="9lYJi">
-                <node concept="313q4" id="6gjbwab2hUU" role="3uHU7w" />
+                <node concept="2OqwBi" id="XlTOHgcW$m" role="3uHU7w">
+                  <node concept="313q4" id="6gjbwab2hUU" role="2Oq$k0" />
+                  <node concept="2Iv5rx" id="XlTOHgcW$n" role="2OqNvi" />
+                </node>
                 <node concept="Xl_RD" id="6gjbwab2hUV" role="3uHU7B">
                   <property role="Xl_RC" value="Node:" />
                 </node>
@@ -1804,7 +1846,10 @@
           <node concept="3clFbS" id="6gjbwaaGgLm" role="2VODD2">
             <node concept="2xdQw9" id="6gjbwaaGgLn" role="3cqZAp">
               <node concept="3cpWs3" id="6gjbwaaGgLo" role="9lYJi">
-                <node concept="313q4" id="6gjbwaaGgLp" role="3uHU7w" />
+                <node concept="2OqwBi" id="XlTOHgcW$K" role="3uHU7w">
+                  <node concept="313q4" id="6gjbwaaGgLp" role="2Oq$k0" />
+                  <node concept="2Iv5rx" id="XlTOHgcW$L" role="2OqNvi" />
+                </node>
                 <node concept="Xl_RD" id="6gjbwaaGgLq" role="3uHU7B">
                   <property role="Xl_RC" value="Node:" />
                 </node>
@@ -1824,7 +1869,10 @@
           <node concept="3clFbS" id="6gjbwab2i2$" role="2VODD2">
             <node concept="2xdQw9" id="6gjbwab2i3m" role="3cqZAp">
               <node concept="3cpWs3" id="6gjbwab2i3n" role="9lYJi">
-                <node concept="313q4" id="6gjbwab2i3o" role="3uHU7w" />
+                <node concept="2OqwBi" id="XlTOHgcW_2" role="3uHU7w">
+                  <node concept="313q4" id="6gjbwab2i3o" role="2Oq$k0" />
+                  <node concept="2Iv5rx" id="XlTOHgcW_3" role="2OqNvi" />
+                </node>
                 <node concept="Xl_RD" id="6gjbwab2i3p" role="3uHU7B">
                   <property role="Xl_RC" value="Node:" />
                 </node>
@@ -1866,7 +1914,10 @@
           <node concept="3clFbS" id="7uEwlsA7G6V" role="2VODD2">
             <node concept="2xdQw9" id="6gjbwaaQn9E" role="3cqZAp">
               <node concept="3cpWs3" id="6gjbwaaQn9F" role="9lYJi">
-                <node concept="pncrf" id="6gjbwaaQni4" role="3uHU7w" />
+                <node concept="2OqwBi" id="XlTOHgcW_s" role="3uHU7w">
+                  <node concept="pncrf" id="6gjbwaaQni4" role="2Oq$k0" />
+                  <node concept="2Iv5rx" id="XlTOHgcW_t" role="2OqNvi" />
+                </node>
                 <node concept="Xl_RD" id="6gjbwaaQn9H" role="3uHU7B">
                   <property role="Xl_RC" value="Node:" />
                 </node>
@@ -1894,7 +1945,10 @@
           <node concept="3clFbS" id="6gjbwaaGfTZ" role="2VODD2">
             <node concept="2xdQw9" id="6gjbwaaGfUa" role="3cqZAp">
               <node concept="3cpWs3" id="6gjbwaaGgcS" role="9lYJi">
-                <node concept="313q4" id="6gjbwaaGgdm" role="3uHU7w" />
+                <node concept="2OqwBi" id="XlTOHgcW_I" role="3uHU7w">
+                  <node concept="313q4" id="6gjbwaaGgdm" role="2Oq$k0" />
+                  <node concept="2Iv5rx" id="XlTOHgcW_J" role="2OqNvi" />
+                </node>
                 <node concept="Xl_RD" id="6gjbwaaGfUc" role="3uHU7B">
                   <property role="Xl_RC" value="Node:" />
                 </node>
@@ -1914,7 +1968,10 @@
           <node concept="3clFbS" id="6gjbwab0EZF" role="2VODD2">
             <node concept="2xdQw9" id="6gjbwab0FbE" role="3cqZAp">
               <node concept="3cpWs3" id="6gjbwab0FbF" role="9lYJi">
-                <node concept="313q4" id="6gjbwab0FbG" role="3uHU7w" />
+                <node concept="2OqwBi" id="XlTOHgcWA0" role="3uHU7w">
+                  <node concept="313q4" id="6gjbwab0FbG" role="2Oq$k0" />
+                  <node concept="2Iv5rx" id="XlTOHgcWA1" role="2OqNvi" />
+                </node>
                 <node concept="Xl_RD" id="6gjbwab0FbH" role="3uHU7B">
                   <property role="Xl_RC" value="Node:" />
                 </node>

--- a/code/htmlcell/languages/de.itemis.mps.editor.htmlcell.demolang/models/de.itemis.mps.editor.htmlcell.demolang.editor.mps
+++ b/code/htmlcell/languages/de.itemis.mps.editor.htmlcell.demolang/models/de.itemis.mps.editor.htmlcell.demolang.editor.mps
@@ -164,7 +164,7 @@
       <concept id="9175692738071681118" name="de.itemis.mps.editor.htmlcell.structure.CellModel_HTML" flags="ng" index="1jG$eK">
         <child id="9175692738071697533" name="contentProvider" index="1jGSej" />
       </concept>
-      <concept id="9175692738071695071" name="de.itemis.mps.editor.htmlcell.structure.QueryFunction_Content" flags="ng" index="1jGTkL" />
+      <concept id="9175692738071695071" name="de.itemis.mps.editor.htmlcell.structure.QueryFunction_Content" flags="ig" index="1jGTkL" />
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
       <concept id="4040588429969021681" name="jetbrains.mps.lang.smodel.structure.ModuleReferenceExpression" flags="nn" index="3rM5sP">

--- a/code/htmlcell/languages/de.itemis.mps.editor.htmlcell/de.itemis.mps.editor.htmlcell.mpl
+++ b/code/htmlcell/languages/de.itemis.mps.editor.htmlcell/de.itemis.mps.editor.htmlcell.mpl
@@ -72,7 +72,6 @@
         <module reference="83888646-71ce-4f1c-9c53-c54016f6ad4f(jetbrains.mps.baseLanguage.collections)" version="0" />
         <module reference="52b81ac7-93fd-4e9e-b972-4995882da6d4(jetbrains.mps.baseLanguage.references.runtime)" version="0" />
         <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
-        <module reference="d44dab97-aaac-44cb-9745-8a14db674c03(jetbrains.mps.baseLanguage.tuples.runtime)" version="0" />
         <module reference="2e24a298-44d1-4697-baec-5c424fed3a3b(jetbrains.mps.editorlang.runtime)" version="0" />
         <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
         <module reference="d936855b-48da-4812-a8a0-2bfddd633ac5(jetbrains.mps.lang.behavior.api)" version="0" />

--- a/code/languages/de.itemis.model.merge.baselang/models/de.itemis.model.merge.baselang.behavior.mps
+++ b/code/languages/de.itemis.model.merge.baselang/models/de.itemis.model.merge.baselang.behavior.mps
@@ -2,7 +2,7 @@
 <model ref="r:7c631b8b-8853-407f-86c9-ed76c86e019b(de.itemis.model.merge.baselang.behavior)">
   <persistence version="9" />
   <languages>
-    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="17" />
+    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
     <use id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior" version="2" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>

--- a/code/languages/de.itemis.model.merge.baselang/sandbox/models/de.itemis.model.merge.baselang.mergers.mps
+++ b/code/languages/de.itemis.model.merge.baselang/sandbox/models/de.itemis.model.merge.baselang.mergers.mps
@@ -4,7 +4,7 @@
   <languages>
     <use id="539e8939-08ef-497c-a5fd-25dd10137a55" name="de.itemis.model.merge" version="0" />
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="11" />
-    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="17" />
+    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
     <use id="e50b0500-6fd7-4c7f-a730-9d841358ca2b" name="de.itemis.model.simple.demo.property" version="0" />
   </languages>
   <imports>

--- a/code/languages/de.itemis.model.merge.baselang/sandbox/models/de.itemis.model.merge.baselang.sandbox.plugin.mps
+++ b/code/languages/de.itemis.model.merge.baselang/sandbox/models/de.itemis.model.merge.baselang.sandbox.plugin.mps
@@ -2,7 +2,7 @@
 <model ref="r:fe6cc855-59c6-4cf0-8bd9-320ea928101c(de.itemis.model.merge.baselang.sandbox.plugin)">
   <persistence version="9" />
   <languages>
-    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="18" />
+    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
     <use id="539e8939-08ef-497c-a5fd-25dd10137a55" name="de.itemis.model.merge" version="0" />
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="11" />
   </languages>

--- a/code/languages/de.itemis.model.merge.diamond/models/de.itemis.model.merge.diamond.behavior.mps
+++ b/code/languages/de.itemis.model.merge.diamond/models/de.itemis.model.merge.diamond.behavior.mps
@@ -2,7 +2,7 @@
 <model ref="r:bc57572a-f34d-4e52-9660-d6fa42c3a8f8(de.itemis.model.merge.diamond.behavior)">
   <persistence version="9" />
   <languages>
-    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="17" />
+    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
     <use id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior" version="2" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>

--- a/code/languages/de.itemis.model.merge.diamond/models/de.itemis.model.merge.diamond.structure.mps
+++ b/code/languages/de.itemis.model.merge.diamond/models/de.itemis.model.merge.diamond.structure.mps
@@ -3,6 +3,7 @@
   <persistence version="9" />
   <languages>
     <use id="c72da2b9-7cce-4447-8389-f407dc1158b7" name="jetbrains.mps.lang.structure" version="9" />
+    <use id="982eb8df-2c96-4bd7-9963-11712ea622e5" name="jetbrains.mps.lang.resources" version="2" />
     <devkit ref="78434eb8-b0e5-444b-850d-e7c4ad2da9ab(jetbrains.mps.devkit.aspect.structure)" />
   </languages>
   <imports>

--- a/code/languages/de.itemis.model.merge/de.itemis.model.merge.mpl
+++ b/code/languages/de.itemis.model.merge/de.itemis.model.merge.mpl
@@ -126,6 +126,7 @@
     <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
     <language slang="l:d4615e3b-d671-4ba9-af01-2b78369b0ba7:jetbrains.mps.lang.pattern" version="2" />
     <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
+    <language slang="l:982eb8df-2c96-4bd7-9963-11712ea622e5:jetbrains.mps.lang.resources" version="2" />
     <language slang="l:b3551702-269c-4f05-ba61-58060cef4292:jetbrains.mps.lang.rulesAndMessages" version="0" />
     <language slang="l:d8f591ec-4d86-4af2-9f92-a9e93c803ffa:jetbrains.mps.lang.scopes" version="0" />
     <language slang="l:13744753-c81f-424a-9c1b-cf8943bf4e86:jetbrains.mps.lang.sharedConcepts" version="0" />

--- a/code/languages/de.itemis.model.merge/models/de.itemis.model.merge.behavior.mps
+++ b/code/languages/de.itemis.model.merge/models/de.itemis.model.merge.behavior.mps
@@ -2,7 +2,7 @@
 <model ref="r:424d540e-f1fc-49a5-b16d-3f9264b84dee(de.itemis.model.merge.behavior)">
   <persistence version="9" />
   <languages>
-    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="17" />
+    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
     <use id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior" version="2" />
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="11" />
     <use id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc" version="2" />

--- a/code/languages/de.itemis.model.merge/models/de.itemis.model.merge.structure.mps
+++ b/code/languages/de.itemis.model.merge/models/de.itemis.model.merge.structure.mps
@@ -2,7 +2,7 @@
 <model ref="r:58892eeb-9059-4684-af0a-e0f5f7f9800d(de.itemis.model.merge.structure)">
   <persistence version="9" />
   <languages>
-    <use id="c72da2b9-7cce-4447-8389-f407dc1158b7" name="jetbrains.mps.lang.structure" version="9" />
+    <devkit ref="78434eb8-b0e5-444b-850d-e7c4ad2da9ab(jetbrains.mps.devkit.aspect.structure)" />
   </languages>
   <imports>
     <import index="tp25" ref="r:00000000-0000-4000-0000-011c89590301(jetbrains.mps.lang.smodel.structure)" />

--- a/code/languages/de.itemis.model.simple.demo.children/models/de.itemis.model.simple.demo.children.behavior.mps
+++ b/code/languages/de.itemis.model.simple.demo.children/models/de.itemis.model.simple.demo.children.behavior.mps
@@ -2,7 +2,7 @@
 <model ref="r:34303613-e885-4d56-bc11-7f8f0537663d(de.itemis.model.simple.demo.children.behavior)">
   <persistence version="9" />
   <languages>
-    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="17" />
+    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
     <use id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior" version="2" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>

--- a/code/languages/de.itemis.model.simple.demo.collection.keeper/de.itemis.model.simple.demo.collection.keeper.mpl
+++ b/code/languages/de.itemis.model.simple.demo.collection.keeper/de.itemis.model.simple.demo.collection.keeper.mpl
@@ -27,6 +27,7 @@
     <language slang="l:18bc6592-03a6-4e29-a83a-7ff23bde13ba:jetbrains.mps.lang.editor" version="14" />
     <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
     <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
+    <language slang="l:982eb8df-2c96-4bd7-9963-11712ea622e5:jetbrains.mps.lang.resources" version="2" />
     <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
     <language slang="l:c72da2b9-7cce-4447-8389-f407dc1158b7:jetbrains.mps.lang.structure" version="9" />
     <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />

--- a/code/languages/de.itemis.model.simple.demo.collection.keeper/models/de.itemis.model.simple.demo.collection.keeper.structure.mps
+++ b/code/languages/de.itemis.model.simple.demo.collection.keeper/models/de.itemis.model.simple.demo.collection.keeper.structure.mps
@@ -3,7 +3,7 @@
   <persistence version="9" />
   <attribute name="doNotGenerate" value="false" />
   <languages>
-    <use id="c72da2b9-7cce-4447-8389-f407dc1158b7" name="jetbrains.mps.lang.structure" version="9" />
+    <devkit ref="78434eb8-b0e5-444b-850d-e7c4ad2da9ab(jetbrains.mps.devkit.aspect.structure)" />
   </languages>
   <imports>
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />

--- a/code/languages/de.itemis.model.simple.demo.collection/de.itemis.model.simple.demo.collection.mpl
+++ b/code/languages/de.itemis.model.simple.demo.collection/de.itemis.model.simple.demo.collection.mpl
@@ -27,6 +27,7 @@
     <language slang="l:18bc6592-03a6-4e29-a83a-7ff23bde13ba:jetbrains.mps.lang.editor" version="14" />
     <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
     <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
+    <language slang="l:982eb8df-2c96-4bd7-9963-11712ea622e5:jetbrains.mps.lang.resources" version="2" />
     <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
     <language slang="l:c72da2b9-7cce-4447-8389-f407dc1158b7:jetbrains.mps.lang.structure" version="9" />
     <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />

--- a/code/languages/de.itemis.model.simple.demo.collection/models/de.itemis.model.simple.demo.collection.structure.mps
+++ b/code/languages/de.itemis.model.simple.demo.collection/models/de.itemis.model.simple.demo.collection.structure.mps
@@ -2,7 +2,7 @@
 <model ref="r:a3686f62-e70f-468d-94f6-43bd46b56f08(de.itemis.model.simple.demo.collection.structure)">
   <persistence version="9" />
   <languages>
-    <use id="c72da2b9-7cce-4447-8389-f407dc1158b7" name="jetbrains.mps.lang.structure" version="9" />
+    <devkit ref="78434eb8-b0e5-444b-850d-e7c4ad2da9ab(jetbrains.mps.devkit.aspect.structure)" />
   </languages>
   <imports>
     <import index="yeyq" ref="r:98a265f1-4186-4e32-a289-328d37e5000c(de.itemis.model.simple.demo.property.structure)" />

--- a/code/languages/de.itemis.model.simple.demo.property/models/de.itemis.model.simple.demo.property.behavior.mps
+++ b/code/languages/de.itemis.model.simple.demo.property/models/de.itemis.model.simple.demo.property.behavior.mps
@@ -2,7 +2,7 @@
 <model ref="r:5fe5768c-45df-40ad-99db-cae489c7dc59(de.itemis.model.simple.demo.property.behavior)">
   <persistence version="9" />
   <languages>
-    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="17" />
+    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
     <use id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior" version="2" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>

--- a/code/languages/de.itemis.model.simple.demo.reference/de.itemis.model.simple.demo.reference.mpl
+++ b/code/languages/de.itemis.model.simple.demo.reference/de.itemis.model.simple.demo.reference.mpl
@@ -37,6 +37,7 @@
     <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
     <language slang="l:d4615e3b-d671-4ba9-af01-2b78369b0ba7:jetbrains.mps.lang.pattern" version="2" />
     <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
+    <language slang="l:982eb8df-2c96-4bd7-9963-11712ea622e5:jetbrains.mps.lang.resources" version="2" />
     <language slang="l:b3551702-269c-4f05-ba61-58060cef4292:jetbrains.mps.lang.rulesAndMessages" version="0" />
     <language slang="l:d8f591ec-4d86-4af2-9f92-a9e93c803ffa:jetbrains.mps.lang.scopes" version="0" />
     <language slang="l:13744753-c81f-424a-9c1b-cf8943bf4e86:jetbrains.mps.lang.sharedConcepts" version="0" />

--- a/code/languages/de.itemis.model.simple.demo.reference/models/de.itemis.model.simple.demo.reference.behavior.mps
+++ b/code/languages/de.itemis.model.simple.demo.reference/models/de.itemis.model.simple.demo.reference.behavior.mps
@@ -3,7 +3,7 @@
   <persistence version="9" />
   <attribute name="doNotGenerate" value="false" />
   <languages>
-    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="17" />
+    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
     <use id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior" version="2" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>

--- a/code/languages/de.itemis.model.simple.demo.reference/models/de.itemis.model.simple.demo.reference.structure.mps
+++ b/code/languages/de.itemis.model.simple.demo.reference/models/de.itemis.model.simple.demo.reference.structure.mps
@@ -3,7 +3,7 @@
   <persistence version="9" />
   <attribute name="doNotGenerate" value="false" />
   <languages>
-    <use id="c72da2b9-7cce-4447-8389-f407dc1158b7" name="jetbrains.mps.lang.structure" version="9" />
+    <devkit ref="78434eb8-b0e5-444b-850d-e7c4ad2da9ab(jetbrains.mps.devkit.aspect.structure)" />
   </languages>
   <imports>
     <import index="yeyq" ref="r:98a265f1-4186-4e32-a289-328d37e5000c(de.itemis.model.simple.demo.property.structure)" />

--- a/code/linenumbers/de.itemis.mps.linenumbers/de.itemis.mps.linenumbers.msd
+++ b/code/linenumbers/de.itemis.mps.linenumbers/de.itemis.mps.linenumbers.msd
@@ -27,7 +27,6 @@
     <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
     <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
     <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
-    <language slang="l:fe9d76d7-5809-45c9-ae28-a40915b4d6ff:jetbrains.mps.lang.checkedName" version="1" />
     <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
     <language slang="l:28f9e497-3b42-4291-aeba-0a1039153ab1:jetbrains.mps.lang.plugin" version="5" />
     <language slang="l:ef7bf5ac-d06c-4342-b11d-e42104eb9343:jetbrains.mps.lang.plugin.standalone" version="0" />

--- a/code/math/solutions/de.itemis.mps.editor.math.runtime/models/de/itemis/mps/editor/math/runtime.mps
+++ b/code/math/solutions/de.itemis.mps.editor.math.runtime/models/de/itemis/mps/editor/math/runtime.mps
@@ -5,7 +5,7 @@
   <languages>
     <use id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures" version="-1" />
     <use id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections" version="1" />
-    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="18" />
+    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
     <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="14" />
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="11" />
     <use id="654422bf-e75f-44dc-936d-188890a746ce" name="de.slisson.mps.reflection" version="-1" />

--- a/code/mouseselection/solutions/de.itemis.mps.selection.runtime/models/de/itemis/mps/selection/runtime/plugin.mps
+++ b/code/mouseselection/solutions/de.itemis.mps.selection.runtime/models/de/itemis/mps/selection/runtime/plugin.mps
@@ -4,7 +4,7 @@
   <attribute name="doNotGenerate" value="false" />
   <languages>
     <use id="ef7bf5ac-d06c-4342-b11d-e42104eb9343" name="jetbrains.mps.lang.plugin.standalone" version="0" />
-    <use id="28f9e497-3b42-4291-aeba-0a1039153ab1" name="jetbrains.mps.lang.plugin" version="4" />
+    <use id="28f9e497-3b42-4291-aeba-0a1039153ab1" name="jetbrains.mps.lang.plugin" version="5" />
     <use id="443f4c36-fcf5-4eb6-9500-8d06ed259e3e" name="jetbrains.mps.baseLanguage.classifiers" version="0" />
     <use id="c0080a47-7e37-4558-bee9-9ae18e690549" name="jetbrains.mps.lang.extension" version="2" />
     <use id="774bf8a0-62e5-41e1-af63-f4812e60e48b" name="jetbrains.mps.baseLanguage.checkedDots" version="0" />

--- a/code/projectview/com.mbeddr.mpsutil.projectview.runtime/models/com/mbeddr/mpsutil/projectview/runtime/tree.mps
+++ b/code/projectview/com.mbeddr.mpsutil.projectview.runtime/models/com/mbeddr/mpsutil/projectview/runtime/tree.mps
@@ -6,7 +6,7 @@
     <use id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections" version="-1" />
     <use id="63650c59-16c8-498a-99c8-005c7ee9515d" name="jetbrains.mps.lang.access" version="-1" />
     <use id="774bf8a0-62e5-41e1-af63-f4812e60e48b" name="jetbrains.mps.baseLanguage.checkedDots" version="-1" />
-    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="18" />
+    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
     <use id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc" version="-1" />
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="11" />
   </languages>

--- a/code/shadowmodels/solutions/de.q60.mps.shadowmodels.runtime/de.q60.mps.shadowmodels.runtime.msd
+++ b/code/shadowmodels/solutions/de.q60.mps.shadowmodels.runtime/de.q60.mps.shadowmodels.runtime.msd
@@ -41,7 +41,6 @@
     <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
     <language slang="l:5dc5fc0d-37ef-4782-8192-8b5ce1f69f80:jetbrains.mps.baseLanguage.extensionMethods" version="0" />
     <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
-    <language slang="l:fdcdc48f-bfd8-4831-aa76-5abac2ffa010:jetbrains.mps.baseLanguage.jdk8" version="2" />
     <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
     <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
     <language slang="l:63650c59-16c8-498a-99c8-005c7ee9515d:jetbrains.mps.lang.access" version="0" />

--- a/code/shadowmodels/solutions/de.q60.mps.shadowmodels.runtime/models/engine.mps
+++ b/code/shadowmodels/solutions/de.q60.mps.shadowmodels.runtime/models/engine.mps
@@ -10,7 +10,6 @@
     <use id="774bf8a0-62e5-41e1-af63-f4812e60e48b" name="jetbrains.mps.baseLanguage.checkedDots" version="-1" />
     <use id="da8e6b62-7ca3-4489-86bc-b70a501ca28f" name="de.q60.mps.incremental" version="-1" />
     <use id="63e0e566-5131-447e-90e3-12ea330e1a00" name="com.mbeddr.mpsutil.blutil" version="1" />
-    <use id="fdcdc48f-bfd8-4831-aa76-5abac2ffa010" name="jetbrains.mps.baseLanguage.jdk8" version="2" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>

--- a/code/solutions/de.itemis.model.merge.runtime/models/de.itemis.model.merge.runtime.runtime.mps
+++ b/code/solutions/de.itemis.model.merge.runtime/models/de.itemis.model.merge.runtime.runtime.mps
@@ -3,7 +3,7 @@
   <persistence version="9" />
   <languages>
     <use id="c0080a47-7e37-4558-bee9-9ae18e690549" name="jetbrains.mps.lang.extension" version="2" />
-    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="18" />
+    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="11" />
     <use id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections" version="1" />
     <use id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures" version="0" />

--- a/code/solutions/de.itemis.model.merge.simple.demo/models/de.itemis.model.merge.simple.demo.plugin.mps
+++ b/code/solutions/de.itemis.model.merge.simple.demo/models/de.itemis.model.merge.simple.demo.plugin.mps
@@ -5,7 +5,7 @@
   <languages>
     <use id="539e8939-08ef-497c-a5fd-25dd10137a55" name="de.itemis.model.merge" version="0" />
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="11" />
-    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="17" />
+    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
     <use id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation" version="5" />
     <use id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures" version="0" />
   </languages>

--- a/code/solutions/de.itemis.model.merge.simple.demo/models/de.itemis.model.merge.simple.demo.plugin.mps
+++ b/code/solutions/de.itemis.model.merge.simple.demo/models/de.itemis.model.merge.simple.demo.plugin.mps
@@ -777,22 +777,24 @@
                     <ref role="2pJxaS" to="yeyq:32ggi2DCpGw" resolve="PropertyDummy" />
                     <node concept="2pJxcG" id="77Ot_5al$Nz" role="2pJxcM">
                       <ref role="2pJxcJ" to="yeyq:32ggi2DCpGx" resolve="data" />
-                      <node concept="3cpWs3" id="77Ot_5al$cy" role="28ntcv">
-                        <node concept="2OqwBi" id="77Ot_5al$qQ" role="3uHU7w">
-                          <node concept="2Iixis" id="77Ot_5al$hE" role="2Oq$k0" />
-                          <node concept="3TrcHB" id="77Ot_5al$AI" role="2OqNvi">
-                            <ref role="3TsBF5" to="yeyq:32ggi2DCpGx" resolve="data" />
-                          </node>
-                        </node>
-                        <node concept="3cpWs3" id="77Ot_5al$2B" role="3uHU7B">
-                          <node concept="2OqwBi" id="77Ot_5alzfB" role="3uHU7B">
-                            <node concept="2IszzT" id="77Ot_5alz8C" role="2Oq$k0" />
-                            <node concept="3TrcHB" id="77Ot_5alznf" role="2OqNvi">
+                      <node concept="WxPPo" id="7ap$5GXZA9_" role="28ntcv">
+                        <node concept="3cpWs3" id="77Ot_5al$cy" role="WxPPp">
+                          <node concept="2OqwBi" id="77Ot_5al$qQ" role="3uHU7w">
+                            <node concept="2Iixis" id="77Ot_5al$hE" role="2Oq$k0" />
+                            <node concept="3TrcHB" id="77Ot_5al$AI" role="2OqNvi">
                               <ref role="3TsBF5" to="yeyq:32ggi2DCpGx" resolve="data" />
                             </node>
                           </node>
-                          <node concept="Xl_RD" id="77Ot_5al$2F" role="3uHU7w">
-                            <property role="Xl_RC" value="/" />
+                          <node concept="3cpWs3" id="77Ot_5al$2B" role="3uHU7B">
+                            <node concept="2OqwBi" id="77Ot_5alzfB" role="3uHU7B">
+                              <node concept="2IszzT" id="77Ot_5alz8C" role="2Oq$k0" />
+                              <node concept="3TrcHB" id="77Ot_5alznf" role="2OqNvi">
+                                <ref role="3TsBF5" to="yeyq:32ggi2DCpGx" resolve="data" />
+                              </node>
+                            </node>
+                            <node concept="Xl_RD" id="77Ot_5al$2F" role="3uHU7w">
+                              <property role="Xl_RC" value="/" />
+                            </node>
                           </node>
                         </node>
                       </node>

--- a/code/solutions/de.itemis.model.merge.simple.demo/models/de.itemis.model.merge.simple.demo.test@tests.mps
+++ b/code/solutions/de.itemis.model.merge.simple.demo/models/de.itemis.model.merge.simple.demo.test@tests.mps
@@ -4,7 +4,7 @@
   <languages>
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="5" />
     <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
-    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="17" />
+    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
     <use id="539e8939-08ef-497c-a5fd-25dd10137a55" name="de.itemis.model.merge" version="0" />
     <use id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi" version="0" />
     <use id="8688ed72-e0ba-44cb-9688-5c8397cb5bbb" name="de.itemis.model.simple.demo.children" version="0" />

--- a/code/solutions/de.itemis.model.merge.test/models/de.itemis.model.merge.test.gen@tests.mps
+++ b/code/solutions/de.itemis.model.merge.test/models/de.itemis.model.merge.test.gen@tests.mps
@@ -6,7 +6,7 @@
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="5" />
     <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
     <use id="0ef84c01-bf36-41ed-9882-d7b70a4a4eba" name="de.itemis.model.merge.diamond" version="0" />
-    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="17" />
+    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="11" />
   </languages>
   <imports>

--- a/code/solutions/de.itemis.model.merge.test/models/de.itemis.model.merge.test.plugin.mps
+++ b/code/solutions/de.itemis.model.merge.test/models/de.itemis.model.merge.test.plugin.mps
@@ -4,7 +4,7 @@
   <languages>
     <use id="539e8939-08ef-497c-a5fd-25dd10137a55" name="de.itemis.model.merge" version="0" />
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="11" />
-    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="17" />
+    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
     <use id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation" version="5" />
   </languages>
   <imports>

--- a/code/solutions/de.itemis.model.merge.test/models/de.itemis.model.merge.test.plugin2.mps
+++ b/code/solutions/de.itemis.model.merge.test/models/de.itemis.model.merge.test.plugin2.mps
@@ -5,7 +5,7 @@
   <languages>
     <use id="539e8939-08ef-497c-a5fd-25dd10137a55" name="de.itemis.model.merge" version="0" />
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="11" />
-    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="17" />
+    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
   </languages>
   <imports>
     <import index="14sb" ref="r:798bef3e-3867-4aab-a0a7-1e9776b7e479(de.itemis.model.merge.diamond.structure)" />

--- a/code/solutions/de.itemis.model.merge.test/models/de.itemis.model.merge.test.test1@tests.mps
+++ b/code/solutions/de.itemis.model.merge.test/models/de.itemis.model.merge.test.test1@tests.mps
@@ -4,7 +4,7 @@
   <languages>
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="5" />
     <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
-    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="17" />
+    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
     <use id="539e8939-08ef-497c-a5fd-25dd10137a55" name="de.itemis.model.merge" version="0" />
     <use id="e50b0500-6fd7-4c7f-a730-9d841358ca2b" name="de.itemis.model.simple.demo.property" version="0" />
   </languages>

--- a/code/solutions/de.itemis.model.merge.test/models/de.itemis.model.merge.test.util.mps
+++ b/code/solutions/de.itemis.model.merge.test/models/de.itemis.model.merge.test.util.mps
@@ -7,7 +7,7 @@
     <use id="c0080a47-7e37-4558-bee9-9ae18e690549" name="jetbrains.mps.lang.extension" version="2" />
     <use id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures" version="0" />
     <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
-    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="17" />
+    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
     <use id="539e8939-08ef-497c-a5fd-25dd10137a55" name="de.itemis.model.merge" version="0" />
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="5" />
   </languages>

--- a/code/treenotation/com.mbeddr.mpsutil.treenotation.runtime/models/com/mbeddr/mpsutil/treenotation/runtime.mps
+++ b/code/treenotation/com.mbeddr.mpsutil.treenotation.runtime/models/com/mbeddr/mpsutil/treenotation/runtime.mps
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <model ref="r:55549eb8-b827-44b3-bd84-ef3114bd2fe2(com.mbeddr.mpsutil.treenotation.runtime)">
   <persistence version="9" />
+  <attribute name="doNotGenerate" value="false" />
   <languages>
     <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="14" />
     <use id="63650c59-16c8-498a-99c8-005c7ee9515d" name="jetbrains.mps.lang.access" version="0" />
     <use id="5dc5fc0d-37ef-4782-8192-8b5ce1f69f80" name="jetbrains.mps.baseLanguage.extensionMethods" version="0" />
     <use id="774bf8a0-62e5-41e1-af63-f4812e60e48b" name="jetbrains.mps.baseLanguage.checkedDots" version="0" />
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="11" />
-    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
+    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="17" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -12875,9 +12876,6 @@
         </node>
         <node concept="3clFbF" id="3iAZL$aoPse" role="3cqZAp">
           <node concept="2OqwBi" id="3iAZL$aoPvx" role="3clFbG">
-            <node concept="37vLTw" id="3iAZL$aoQFn" role="2Oq$k0">
-              <ref role="3cqZAo" node="2rPTijxxYI0" resolve="g2" />
-            </node>
             <node concept="liA8E" id="3iAZL$aoPvy" role="2OqNvi">
               <ref role="37wK5l" to="z60i:~Graphics2D.setRenderingHint(java.awt.RenderingHints$Key,java.lang.Object)" resolve="setRenderingHint" />
               <node concept="10M0yZ" id="3iAZL$aoPBD" role="37wK5m">
@@ -12888,6 +12886,9 @@
                 <ref role="1PxDUh" to="z60i:~RenderingHints" resolve="RenderingHints" />
                 <ref role="3cqZAo" to="z60i:~RenderingHints.VALUE_RENDER_QUALITY" resolve="VALUE_RENDER_QUALITY" />
               </node>
+            </node>
+            <node concept="37vLTw" id="3iAZL$aoQFn" role="2Oq$k0">
+              <ref role="3cqZAo" node="2rPTijxxYI0" resolve="g2" />
             </node>
           </node>
         </node>

--- a/code/treenotation/com.mbeddr.mpsutil.treenotation.runtime/models/com/mbeddr/mpsutil/treenotation/runtime.mps
+++ b/code/treenotation/com.mbeddr.mpsutil.treenotation.runtime/models/com/mbeddr/mpsutil/treenotation/runtime.mps
@@ -8,7 +8,7 @@
     <use id="5dc5fc0d-37ef-4782-8192-8b5ce1f69f80" name="jetbrains.mps.baseLanguage.extensionMethods" version="0" />
     <use id="774bf8a0-62e5-41e1-af63-f4812e60e48b" name="jetbrains.mps.baseLanguage.checkedDots" version="0" />
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="11" />
-    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="17" />
+    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>

--- a/code/treenotation/com.mbeddr.mpsutil.treenotation/generator/template/main@generator.mps
+++ b/code/treenotation/com.mbeddr.mpsutil.treenotation/generator/template/main@generator.mps
@@ -3,7 +3,7 @@
   <persistence version="9" />
   <attribute name="doNotGenerate" value="false" />
   <languages>
-    <use id="b401a680-8325-4110-8fd3-84331ff25bef" name="jetbrains.mps.lang.generator" version="3" />
+    <use id="b401a680-8325-4110-8fd3-84331ff25bef" name="jetbrains.mps.lang.generator" version="4" />
     <use id="d7706f63-9be2-479c-a3da-ae92af1e64d5" name="jetbrains.mps.lang.generator.generationContext" version="2" />
     <use id="c73b17af-16a1-4490-8072-8a84937c5206" name="com.mbeddr.mpsutil.treenotation" version="0" />
     <use id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core" version="2" />

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,9 @@
+pluginManagement {
+    repositories {
+        maven { url 'https://artifacts.itemis.cloud/repository/maven-mps' }
+
+        // Need to manually include the default Gradle plugin portal repository when overriding the defaults.
+        gradlePluginPortal()
+    }
+}
 rootProject.name = 'MPS-extensions'


### PR DESCRIPTION
- Cascading merge from MPS 2021.1 into 2021.2 (resovling conflicts)
- Execute migrations via migration assistant (after `git clean -xdf` , `./gradlew run_tests` and `make project`)
- Executed rerunnable migrations