### PR TITLE
[Breaking] Extend grammar.wrap to check constraints properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project are documented in this file.
 Format of the log is _loosely_ based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). 
 The project does _not_ follow Semantic Versioning and the changes are documented in reverse chronological order, grouped by calendar month.
 
+## September 2023
+
+### Changed
+
+- The grammar cells grammar.wrap cell now checks constraints from the containing node when combined with grammar.rule.
+
 ## July 2023
 
 ### Changed

--- a/code/.mps/modules.xml
+++ b/code/.mps/modules.xml
@@ -61,6 +61,7 @@
       <modulePath path="$PROJECT_DIR$/htmlcell/solutions/de.itemis.mps.editor.htmlcell.runtime/de.itemis.mps.editor.htmlcell.runtime.msd" folder="widgets" />
       <modulePath path="$PROJECT_DIR$/intentionsmenu/com.mbeddr.mpsutil.intentions.runtime/com.mbeddr.mpsutil.intentions.runtime.msd" folder="intentionsmenu" />
       <modulePath path="$PROJECT_DIR$/intentionsmenu/com.mbeddr.mpsutil.intentions/com.mbeddr.mpsutil.intentions.mpl" folder="intentionsmenu" />
+      <modulePath path="$PROJECT_DIR$/languages/com.mbeddr.mpsutil.intentions.sandboxlang/com.mbeddr.mpsutil.intentions.sandboxlang.mpl" folder="intentionsmenu" />
       <modulePath path="$PROJECT_DIR$/languages/de.itemis.model.merge.baselang/de.itemis.model.merge.baselang.mpl" folder="modelmerger2" />
       <modulePath path="$PROJECT_DIR$/languages/de.itemis.model.merge.baselang/sandbox/de.itemis.model.merge.baselang.sandbox.msd" folder="modelmerger2" />
       <modulePath path="$PROJECT_DIR$/languages/de.itemis.model.merge.diamond/de.itemis.model.merge.diamond.mpl" folder="modelmerger2.test.language" />
@@ -167,7 +168,6 @@
       <modulePath path="$PROJECT_DIR$/shadowmodels/solutions/test.de.q60.mps.shadowmodels.examples/test.de.q60.mps.shadowmodels.examples.msd" folder="shadowmodels.tests" />
       <modulePath path="$PROJECT_DIR$/shadowmodels/solutions/test.de.q60.mps.shadowmodels.runtime/test.de.q60.mps.shadowmodels.runtime.msd" folder="shadowmodels.tests" />
       <modulePath path="$PROJECT_DIR$/solutions/com.mbeddr.mpsutil.intentions.sandbox/com.mbeddr.mpsutil.intentions.sandbox.msd" folder="intentionsmenu" />
-      <modulePath path="$PROJECT_DIR$/languages/com.mbeddr.mpsutil.intentions.sandboxlang/com.mbeddr.mpsutil.intentions.sandboxlang.mpl" folder="intentionsmenu" />
       <modulePath path="$PROJECT_DIR$/solutions/de.itemis.model.merge.runtime/de.itemis.model.merge.runtime.msd" folder="modelmerger2" />
       <modulePath path="$PROJECT_DIR$/solutions/de.itemis.model.merge.simple.demo/de.itemis.model.merge.simple.demo.msd" folder="modelmerger2" />
       <modulePath path="$PROJECT_DIR$/solutions/de.itemis.model.merge.test.integration/de.itemis.model.merge.test.integration.msd" folder="modelmerger2" />

--- a/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
+++ b/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
@@ -14494,6 +14494,11 @@
             </node>
           </node>
         </node>
+        <node concept="1SiIV0" id="7xUDG$UKsSg" role="3bR37C">
+          <node concept="3bR9La" id="7xUDG$UKsSh" role="1SiIV1">
+            <ref role="3bR37D" node="F1NWDqweoc" resolve="com.mbeddr.mpsutil.grammarcells.sandboxlang" />
+          </node>
+        </node>
       </node>
       <node concept="1E1JtA" id="6$6tsX_CURF" role="2G$12L">
         <property role="BnDLt" value="true" />

--- a/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
+++ b/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
@@ -7923,10 +7923,16 @@
             <ref role="3bR37D" to="ffeo:3qkjbZn808a" resolve="jetbrains.mps.lang.constraints.rules.runtime" />
           </node>
         </node>
+        <node concept="1SiIV0" id="5qwwnuN8UrS" role="3bR37C">
+          <node concept="3bR9La" id="5qwwnuN8UrT" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:7Kfy9QB6Lg8" resolve="jetbrains.mps.runtime" />
+          </node>
+        </node>
       </node>
       <node concept="1E1JtD" id="F1NWDr9_MX" role="2G$12L">
         <property role="TrG5h" value="com.mbeddr.mpsutil.grammarcells" />
         <property role="3LESm3" value="9d69e719-78c8-4286-90db-fb19c107d049" />
+        <property role="BnDLt" value="true" />
         <node concept="398BVA" id="F1NWDr9AaR" role="3LF7KH">
           <ref role="398BVh" node="2fo8bJE$D4t" resolve="extensions.code" />
           <node concept="2Ry0Ak" id="F1NWDr9B5z" role="iGT6I">
@@ -8175,6 +8181,16 @@
         <node concept="1SiIV0" id="2izAb4rOrLk" role="3bR37C">
           <node concept="3bR9La" id="2izAb4rOrLl" role="1SiIV1">
             <ref role="3bR37D" to="ffeo:7Kfy9QB6LfQ" resolve="jetbrains.mps.kernel" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="5qwwnuN8Us5" role="3bR37C">
+          <node concept="3bR9La" id="5qwwnuN8Us6" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:7Kfy9QB6L4x" resolve="jetbrains.mps.lang.constraints" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="5qwwnuN8Us7" role="3bR37C">
+          <node concept="3bR9La" id="5qwwnuN8Us8" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:7Kfy9QB6Lg8" resolve="jetbrains.mps.runtime" />
           </node>
         </node>
       </node>

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells.sandboxlang/models/com/mbeddr/mpsutil/grammarcells/sandboxlang/constraints.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells.sandboxlang/models/com/mbeddr/mpsutil/grammarcells/sandboxlang/constraints.mps
@@ -58,15 +58,20 @@
       </concept>
     </language>
     <language id="3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1" name="jetbrains.mps.lang.constraints">
+      <concept id="6702802731807420587" name="jetbrains.mps.lang.constraints.structure.ConstraintFunction_CanBeAParent" flags="ig" index="9SLcT" />
+      <concept id="6702802731807424858" name="jetbrains.mps.lang.constraints.structure.ConstraintFunction_CanBeAnAncestor" flags="in" index="9SQb8" />
       <concept id="8966504967485224688" name="jetbrains.mps.lang.constraints.structure.ConstraintFunctionParameter_contextNode" flags="nn" index="2rP1CM" />
       <concept id="1147467115080" name="jetbrains.mps.lang.constraints.structure.NodePropertyConstraint" flags="ng" index="EnEH3">
         <reference id="1147467295099" name="applicableProperty" index="EomxK" />
         <child id="1212097481299" name="propertyValidator" index="QCWH9" />
       </concept>
+      <concept id="6738154313879680265" name="jetbrains.mps.lang.constraints.structure.ConstraintFunctionParameter_childNode" flags="nn" index="2H4GUG" />
       <concept id="1212096972063" name="jetbrains.mps.lang.constraints.structure.ConstraintFunction_PropertyValidator" flags="in" index="QB0g5" />
       <concept id="5564765827938091039" name="jetbrains.mps.lang.constraints.structure.ConstraintFunction_ReferentSearchScope_Scope" flags="ig" index="3dgokm" />
       <concept id="1213093968558" name="jetbrains.mps.lang.constraints.structure.ConceptConstraints" flags="ng" index="1M2fIO">
         <reference id="1213093996982" name="concept" index="1M2myG" />
+        <child id="6702802731807532730" name="canBeAncestor" index="9SGkC" />
+        <child id="6702802731807532712" name="canBeParent" index="9SGkU" />
         <child id="1213098023997" name="property" index="1MhHOB" />
         <child id="1213100494875" name="referent" index="1Mr941" />
       </concept>
@@ -87,12 +92,20 @@
         <child id="4693937538533538124" name="requestedConcept" index="v3oSu" />
       </concept>
       <concept id="1171407110247" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorOperation" flags="nn" index="2Xjw5R" />
+      <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
+        <child id="1177027386292" name="conceptArgument" index="cj9EA" />
+      </concept>
       <concept id="1144100932627" name="jetbrains.mps.lang.smodel.structure.OperationParm_Inclusion" flags="ng" index="1xIGOp" />
       <concept id="1144101972840" name="jetbrains.mps.lang.smodel.structure.OperationParm_Concept" flags="ng" index="1xMEDy">
         <child id="1207343664468" name="conceptArgument" index="ri$Ld" />
       </concept>
       <concept id="1138056282393" name="jetbrains.mps.lang.smodel.structure.SLinkListAccess" flags="nn" index="3Tsc0h">
         <reference id="1138056546658" name="link" index="3TtcxE" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
       </concept>
     </language>
   </registry>
@@ -187,6 +200,46 @@
                   <node concept="chp4Y" id="5ycts4Sltkj" role="v3oSu">
                     <ref role="cht4Q" to="ibwz:1x69AmkdY_S" resolve="Function" />
                   </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1M2fIO" id="3Lzx5PfpvuQ">
+    <property role="3GE5qa" value="grammarWrapTest" />
+    <ref role="1M2myG" to="ibwz:3Lzx5Pf0jk5" resolve="WrapStmtParent" />
+    <node concept="9SLcT" id="3Lzx5PfpvwZ" role="9SGkU">
+      <node concept="3clFbS" id="3Lzx5Pfpvx0" role="2VODD2">
+        <node concept="3clFbF" id="3Lzx5PfpvA4" role="3cqZAp">
+          <node concept="3fqX7Q" id="3Lzx5PfpvA2" role="3clFbG">
+            <node concept="2OqwBi" id="3Lzx5PfpvUD" role="3fr31v">
+              <node concept="2H4GUG" id="3Lzx5PfpvG0" role="2Oq$k0" />
+              <node concept="1mIQ4w" id="3Lzx5Pfpwdb" role="2OqNvi">
+                <node concept="chp4Y" id="3Lzx5Pfpwkr" role="cj9EA">
+                  <ref role="cht4Q" to="ibwz:3Lzx5Pf0k2q" resolve="AType" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1M2fIO" id="1$ysu_nN3EJ">
+    <property role="3GE5qa" value="grammarWrapTest" />
+    <ref role="1M2myG" to="ibwz:1$ysu_nN3Ei" resolve="WrapStmtAncestor" />
+    <node concept="9SQb8" id="1$ysu_nN4MD" role="9SGkC">
+      <node concept="3clFbS" id="1$ysu_nN4ME" role="2VODD2">
+        <node concept="3clFbF" id="1$ysu_nN4N0" role="3cqZAp">
+          <node concept="3fqX7Q" id="1$ysu_nN4N1" role="3clFbG">
+            <node concept="2OqwBi" id="1$ysu_nN4N2" role="3fr31v">
+              <node concept="2H4GUG" id="1$ysu_nN4N3" role="2Oq$k0" />
+              <node concept="1mIQ4w" id="1$ysu_nN4N4" role="2OqNvi">
+                <node concept="chp4Y" id="1$ysu_nN4N5" role="cj9EA">
+                  <ref role="cht4Q" to="ibwz:3Lzx5Pf0k2q" resolve="AType" />
                 </node>
               </node>
             </node>

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells.sandboxlang/models/com/mbeddr/mpsutil/grammarcells/sandboxlang/editor.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells.sandboxlang/models/com/mbeddr/mpsutil/grammarcells/sandboxlang/editor.mps
@@ -2744,5 +2744,76 @@
       <node concept="2iRkQZ" id="67iSu2w55ny" role="2iSdaV" />
     </node>
   </node>
+  <node concept="24kQdi" id="3Lzx5Pf0jxR">
+    <property role="3GE5qa" value="grammarWrapTest" />
+    <ref role="1XX52x" to="ibwz:3Lzx5Pf0jr2" resolve="WrapType" />
+    <node concept="PMmxH" id="3Lzx5Pf0jyX" role="2wV5jI">
+      <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
+    </node>
+  </node>
+  <node concept="24kQdi" id="3Lzx5Pf0ku6">
+    <property role="3GE5qa" value="grammarWrapTest" />
+    <ref role="1XX52x" to="ibwz:3Lzx5Pf0jk5" resolve="WrapStmtParent" />
+    <node concept="1WcQYu" id="3Lzx5Pf0kwM" role="2wV5jI">
+      <node concept="2ElW$n" id="3Lzx5Pf0kwO" role="2El2Yn" />
+      <node concept="3EZMnI" id="3Lzx5Pf0kwY" role="1LiK7o">
+        <node concept="2iRfu4" id="3Lzx5Pf0kwZ" role="2iSdaV" />
+        <node concept="1kIj98" id="3Lzx5Pf0kzI" role="3EZMnx">
+          <node concept="3F1sOY" id="3Lzx5Pf0k$m" role="1kIj9b">
+            <ref role="1NtTu8" to="ibwz:3Lzx5Pf0kj2" resolve="type" />
+          </node>
+        </node>
+        <node concept="3F0A7n" id="3Lzx5Pf0kB7" role="3EZMnx">
+          <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="24kQdi" id="3Lzx5Pf3sLe">
+    <property role="3GE5qa" value="grammarWrapTest" />
+    <ref role="1XX52x" to="ibwz:3Lzx5Pf0jeK" resolve="StmtContainerParent" />
+    <node concept="3EZMnI" id="3Lzx5Pf3sMk" role="2wV5jI">
+      <node concept="3F0ifn" id="3Lzx5Pf3sQb" role="3EZMnx">
+        <property role="3F0ifm" value="Stmt Test" />
+      </node>
+      <node concept="2iRkQZ" id="3Lzx5Pf3sQK" role="2iSdaV" />
+      <node concept="3F2HdR" id="3Lzx5Pf3sU5" role="3EZMnx">
+        <ref role="1NtTu8" to="ibwz:3Lzx5Pf0jnO" resolve="stmts" />
+        <node concept="2iRkQZ" id="3Lzx5Pf3sU7" role="2czzBx" />
+      </node>
+    </node>
+  </node>
+  <node concept="24kQdi" id="1$ysu_nN3Fa">
+    <property role="3GE5qa" value="grammarWrapTest" />
+    <ref role="1XX52x" to="ibwz:1$ysu_nN3Eg" resolve="StmtContainerAncestor" />
+    <node concept="3EZMnI" id="1$ysu_nN3Fc" role="2wV5jI">
+      <node concept="3F0ifn" id="1$ysu_nN3Fd" role="3EZMnx">
+        <property role="3F0ifm" value="Stmt Test" />
+      </node>
+      <node concept="2iRkQZ" id="1$ysu_nN3Fe" role="2iSdaV" />
+      <node concept="3F2HdR" id="1$ysu_nN3Ff" role="3EZMnx">
+        <ref role="1NtTu8" to="ibwz:1$ysu_nN3Eh" resolve="stmts" />
+        <node concept="2iRkQZ" id="1$ysu_nN3Fg" role="2czzBx" />
+      </node>
+    </node>
+  </node>
+  <node concept="24kQdi" id="1$ysu_nN4VR">
+    <property role="3GE5qa" value="grammarWrapTest" />
+    <ref role="1XX52x" to="ibwz:1$ysu_nN3Ei" resolve="WrapStmtAncestor" />
+    <node concept="1WcQYu" id="1$ysu_nN4VT" role="2wV5jI">
+      <node concept="2ElW$n" id="1$ysu_nN4VU" role="2El2Yn" />
+      <node concept="3EZMnI" id="1$ysu_nN4VV" role="1LiK7o">
+        <node concept="2iRfu4" id="1$ysu_nN4VW" role="2iSdaV" />
+        <node concept="1kIj98" id="1$ysu_nN4VX" role="3EZMnx">
+          <node concept="3F1sOY" id="1$ysu_nN4VY" role="1kIj9b">
+            <ref role="1NtTu8" to="ibwz:1$ysu_nN3Ej" resolve="type" />
+          </node>
+        </node>
+        <node concept="3F0A7n" id="1$ysu_nN4VZ" role="3EZMnx">
+          <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
+        </node>
+      </node>
+    </node>
+  </node>
 </model>
 

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells.sandboxlang/models/com/mbeddr/mpsutil/grammarcells/sandboxlang/structure.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells.sandboxlang/models/com/mbeddr/mpsutil/grammarcells/sandboxlang/structure.mps
@@ -900,5 +900,88 @@
       <ref role="PrY4T" to="tpck:h0TrEE$" resolve="INamedConcept" />
     </node>
   </node>
+  <node concept="1TIwiD" id="3Lzx5Pf0jeK">
+    <property role="EcuMT" value="4351467201262334896" />
+    <property role="TrG5h" value="StmtContainerParent" />
+    <property role="19KtqR" value="true" />
+    <property role="3GE5qa" value="grammarWrapTest" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" />
+    <node concept="1TJgyj" id="3Lzx5Pf0jnO" role="1TKVEi">
+      <property role="IQ2ns" value="4351467201262335476" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="stmts" />
+      <property role="20lbJX" value="fLJekj5/_0__n" />
+      <ref role="20lvS9" node="3Lzx5Pf0jk5" resolve="WrapStmtParent" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="3Lzx5Pf0jk5">
+    <property role="EcuMT" value="4351467201262335237" />
+    <property role="3GE5qa" value="grammarWrapTest" />
+    <property role="TrG5h" value="WrapStmtParent" />
+    <property role="34LRSv" value="wrapStmt" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" />
+    <node concept="1TJgyj" id="3Lzx5Pf0kj2" role="1TKVEi">
+      <property role="IQ2ns" value="4351467201262339266" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="type" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <ref role="20lvS9" node="3Lzx5Pf0jr2" resolve="WrapType" />
+    </node>
+    <node concept="PrWs8" id="3Lzx5PffZ$L" role="PzmwI">
+      <ref role="PrY4T" to="tpck:h0TrEE$" resolve="INamedConcept" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="3Lzx5Pf0jr2">
+    <property role="EcuMT" value="4351467201262335682" />
+    <property role="3GE5qa" value="grammarWrapTest" />
+    <property role="TrG5h" value="WrapType" />
+    <property role="R5$K7" value="true" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" />
+  </node>
+  <node concept="1TIwiD" id="3Lzx5Pf0k2q">
+    <property role="EcuMT" value="4351467201262338202" />
+    <property role="3GE5qa" value="grammarWrapTest" />
+    <property role="TrG5h" value="AType" />
+    <property role="34LRSv" value="A" />
+    <ref role="1TJDcQ" node="3Lzx5Pf0jr2" resolve="WrapType" />
+  </node>
+  <node concept="1TIwiD" id="3Lzx5Pf0k5B">
+    <property role="EcuMT" value="4351467201262338407" />
+    <property role="3GE5qa" value="grammarWrapTest" />
+    <property role="TrG5h" value="BType" />
+    <property role="34LRSv" value="B" />
+    <ref role="1TJDcQ" node="3Lzx5Pf0jr2" resolve="WrapType" />
+  </node>
+  <node concept="1TIwiD" id="1$ysu_nN3Eg">
+    <property role="EcuMT" value="1811135247170681488" />
+    <property role="TrG5h" value="StmtContainerAncestor" />
+    <property role="19KtqR" value="true" />
+    <property role="3GE5qa" value="grammarWrapTest" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+    <node concept="1TJgyj" id="1$ysu_nN3Eh" role="1TKVEi">
+      <property role="IQ2ns" value="1811135247170681489" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="stmts" />
+      <property role="20lbJX" value="fLJekj5/_0__n" />
+      <ref role="20lvS9" node="1$ysu_nN3Ei" resolve="WrapStmtAncestor" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="1$ysu_nN3Ei">
+    <property role="EcuMT" value="1811135247170681490" />
+    <property role="3GE5qa" value="grammarWrapTest" />
+    <property role="TrG5h" value="WrapStmtAncestor" />
+    <property role="34LRSv" value="wrapStmt" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+    <node concept="1TJgyj" id="1$ysu_nN3Ej" role="1TKVEi">
+      <property role="IQ2ns" value="1811135247170681491" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="type" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <ref role="20lvS9" node="3Lzx5Pf0jr2" resolve="WrapType" />
+    </node>
+    <node concept="PrWs8" id="1$ysu_nN3Ek" role="PzmwI">
+      <ref role="PrY4T" to="tpck:h0TrEE$" resolve="INamedConcept" />
+    </node>
+  </node>
 </model>
 

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/com.mbeddr.mpsutil.grammarcells.mpl
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/com.mbeddr.mpsutil.grammarcells.mpl
@@ -63,6 +63,7 @@
         <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
         <language slang="l:13744753-c81f-424a-9c1b-cf8943bf4e86:jetbrains.mps.lang.sharedConcepts" version="0" />
         <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
+        <language slang="l:1a8554c4-eb84-43ba-8c34-6f0d90c6e75a:jetbrains.mps.lang.smodel.query" version="3" />
         <language slang="l:c72da2b9-7cce-4447-8389-f407dc1158b7:jetbrains.mps.lang.structure" version="9" />
         <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
         <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
@@ -310,6 +311,8 @@
     <dependency reexport="false">aee9cad2-acd4-4608-aef2-0004f6a1cdbd(jetbrains.mps.lang.actions)</dependency>
     <dependency reexport="false">b1ab8c10-c118-4755-bf2a-cebab35cf533(jetbrains.mps.lang.editor.tooltips)</dependency>
     <dependency reexport="false">2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)</dependency>
+    <dependency reexport="false">9a4afe51-f114-4595-b5df-048ce3c596be(jetbrains.mps.runtime)</dependency>
+    <dependency reexport="false">3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1(jetbrains.mps.lang.constraints)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
@@ -370,6 +373,7 @@
     <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
     <module reference="aee9cad2-acd4-4608-aef2-0004f6a1cdbd(jetbrains.mps.lang.actions)" version="0" />
     <module reference="d936855b-48da-4812-a8a0-2bfddd633ac5(jetbrains.mps.lang.behavior.api)" version="0" />
+    <module reference="3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1(jetbrains.mps.lang.constraints)" version="0" />
     <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
     <module reference="a9e4c532-c5f5-4bb7-99ef-42abb73bbb70(jetbrains.mps.lang.descriptor.aspects)" version="0" />
     <module reference="18bc6592-03a6-4e29-a83a-7ff23bde13ba(jetbrains.mps.lang.editor)" version="0" />
@@ -381,6 +385,7 @@
     <module reference="7866978e-a0f0-4cc7-81bc-4d213d9375e1(jetbrains.mps.lang.smodel)" version="1" />
     <module reference="c72da2b9-7cce-4447-8389-f407dc1158b7(jetbrains.mps.lang.structure)" version="0" />
     <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
+    <module reference="9a4afe51-f114-4595-b5df-048ce3c596be(jetbrains.mps.runtime)" version="0" />
   </dependencyVersions>
   <runtime>
     <dependency reexport="false">7037b32c-9607-4f8e-81bd-1f028a4c117b(de.slisson.mps.reflection.runtime)</dependency>

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/generator/template/main@generator.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/generator/template/main@generator.mps
@@ -61,6 +61,7 @@
     <import index="qvne" ref="r:8ff33705-85bf-4855-805c-06d68fbe233c(jetbrains.mps.editor.runtime.descriptor)" />
     <import index="pdwk" ref="8e98f4e2-decf-4e97-bf80-9109e8b759ee/java:jetbrains.mps.core.aspects.constraints.rules.kinds(jetbrains.mps.lang.constraints.rules.runtime/)" />
     <import index="guwi" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.io(JDK/)" />
+    <import index="pjrh" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel.adapter(MPS.Core/)" />
     <import index="x4mf" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.menus(MPS.Editor/)" implicit="true" />
     <import index="tpcn" ref="r:00000000-0000-4000-0000-011c8959028b(jetbrains.mps.lang.structure.behavior)" implicit="true" />
     <import index="hox0" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.style(MPS.Editor/)" implicit="true" />

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/generator/template/main@generator.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/generator/template/main@generator.mps
@@ -13,6 +13,7 @@
     <use id="13744753-c81f-424a-9c1b-cf8943bf4e86" name="jetbrains.mps.lang.sharedConcepts" version="-1" />
     <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="14" />
     <use id="654422bf-e75f-44dc-936d-188890a746ce" name="de.slisson.mps.reflection" version="0" />
+    <use id="1a8554c4-eb84-43ba-8c34-6f0d90c6e75a" name="jetbrains.mps.lang.smodel.query" version="3" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -59,6 +60,7 @@
     <import index="tp27" ref="r:00000000-0000-4000-0000-011c89590303(jetbrains.mps.lang.smodel.generator.baseLanguage.template.main@generator)" />
     <import index="qvne" ref="r:8ff33705-85bf-4855-805c-06d68fbe233c(jetbrains.mps.editor.runtime.descriptor)" />
     <import index="pdwk" ref="8e98f4e2-decf-4e97-bf80-9109e8b759ee/java:jetbrains.mps.core.aspects.constraints.rules.kinds(jetbrains.mps.lang.constraints.rules.runtime/)" />
+    <import index="guwi" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.io(JDK/)" />
     <import index="x4mf" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.menus(MPS.Editor/)" implicit="true" />
     <import index="tpcn" ref="r:00000000-0000-4000-0000-011c8959028b(jetbrains.mps.lang.structure.behavior)" implicit="true" />
     <import index="hox0" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.style(MPS.Editor/)" implicit="true" />
@@ -753,6 +755,7 @@
       <concept id="6407023681583031218" name="jetbrains.mps.lang.smodel.structure.AttributeAccess" flags="nn" index="3CFZ6_">
         <child id="6407023681583036852" name="qualifier" index="3CFYIz" />
       </concept>
+      <concept id="2285351689971718149" name="jetbrains.mps.lang.smodel.structure.AggregationLinkType" flags="ig" index="3GbmH5" />
       <concept id="1172326502327" name="jetbrains.mps.lang.smodel.structure.Concept_IsExactlyOperation" flags="nn" index="3O6GUB">
         <child id="1206733650006" name="conceptArgument" index="3QVz_e" />
       </concept>
@@ -8921,23 +8924,82 @@
                         </node>
                         <node concept="3clFbJ" id="6oKG1kMzdpC" role="3cqZAp">
                           <node concept="3clFbS" id="6oKG1kMzdpE" role="3clFbx">
-                            <node concept="3clFbH" id="6oKG1kMzhqM" role="3cqZAp" />
-                            <node concept="3cpWs8" id="6rhOS_xTtum" role="3cqZAp">
-                              <node concept="3cpWsn" id="6rhOS_xTtup" role="3cpWs9">
-                                <property role="TrG5h" value="isApplicable" />
-                                <node concept="10P_77" id="6rhOS_xTtuk" role="1tU5fm" />
-                                <node concept="2YIFZM" id="Q01lBr5l0e" role="33vP2m">
-                                  <ref role="1Pybhc" to="czm:RbLMy696h3" resolve="GrammarCellsUtil" />
-                                  <ref role="37wK5l" to="czm:2mvFNoUAetF" resolve="canBeChild" />
-                                  <node concept="2GrUjf" id="2SC0PcAxYya" role="37wK5m">
-                                    <ref role="2Gs0qQ" node="7NlRaxB4F5O" resolve="subconcept" />
+                            <node concept="3clFbH" id="6ogDZt_yZ1X" role="3cqZAp" />
+                            <node concept="3cpWs8" id="6ogDZt_zXve" role="3cqZAp">
+                              <node concept="3cpWsn" id="6ogDZt_zXvf" role="3cpWs9">
+                                <property role="TrG5h" value="aggregation" />
+                                <node concept="3GbmH5" id="6ogDZt_zIPb" role="1tU5fm" />
+                                <node concept="359W_D" id="6ogDZt_zXvg" role="33vP2m">
+                                  <ref role="359W_E" to="tpck:gw2VY9q" resolve="BaseConcept" />
+                                  <ref role="359W_F" to="tpck:4uZwTti3__2" resolve="smodelAttribute" />
+                                  <node concept="1ZhdrF" id="6ogDZt_zXvh" role="lGtFl">
+                                    <property role="2qtEX8" value="conceptDeclaration" />
+                                    <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/2644386474301421077/2644386474301421078" />
+                                    <node concept="3$xsQk" id="6ogDZt_zXvi" role="3$ytzL">
+                                      <node concept="3clFbS" id="6ogDZt_zXvj" role="2VODD2">
+                                        <node concept="3clFbF" id="6ogDZt_zXvk" role="3cqZAp">
+                                          <node concept="2OqwBi" id="6ogDZt_zXvl" role="3clFbG">
+                                            <node concept="2OqwBi" id="6ogDZt_zXvm" role="2Oq$k0">
+                                              <node concept="30H73N" id="6ogDZt_zXvn" role="2Oq$k0" />
+                                              <node concept="2Xjw5R" id="6ogDZt_zXvo" role="2OqNvi">
+                                                <node concept="1xMEDy" id="6ogDZt_zXvp" role="1xVPHs">
+                                                  <node concept="chp4Y" id="6ogDZt_zXvq" role="ri$Ld">
+                                                    <ref role="cht4Q" to="tpc2:gXXWOiD" resolve="AbstractComponent" />
+                                                  </node>
+                                                </node>
+                                              </node>
+                                            </node>
+                                            <node concept="2qgKlT" id="6ogDZt_zXvr" role="2OqNvi">
+                                              <ref role="37wK5l" to="tpcb:67EYkym$wx3" resolve="getConceptDeclaration" />
+                                            </node>
+                                          </node>
+                                        </node>
+                                      </node>
+                                    </node>
                                   </node>
-                                  <node concept="37vLTw" id="Q01lBr5lK5" role="37wK5m">
-                                    <ref role="3cqZAo" node="2mvFNoUxG2A" resolve="_context" />
+                                  <node concept="1ZhdrF" id="6ogDZt_zXvs" role="lGtFl">
+                                    <property role="2qtEX8" value="linkDeclaration" />
+                                    <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/2644386474301421077/2644386474301421079" />
+                                    <node concept="3$xsQk" id="6ogDZt_zXvt" role="3$ytzL">
+                                      <node concept="3clFbS" id="6ogDZt_zXvu" role="2VODD2">
+                                        <node concept="3clFbF" id="6ogDZt_zXvv" role="3cqZAp">
+                                          <node concept="2OqwBi" id="6ogDZt_zXvw" role="3clFbG">
+                                            <node concept="30H73N" id="6ogDZt_zXvx" role="2Oq$k0" />
+                                            <node concept="2qgKlT" id="6ogDZt_zXvy" role="2OqNvi">
+                                              <ref role="37wK5l" to="karh:3O7ZvCZLQaM" resolve="getWrappedLink" />
+                                            </node>
+                                          </node>
+                                        </node>
+                                      </node>
+                                    </node>
                                   </node>
                                 </node>
                               </node>
                             </node>
+                            <node concept="3clFbH" id="6ogDZt__BmZ" role="3cqZAp" />
+                            <node concept="3cpWs8" id="6rhOS_xTtum" role="3cqZAp">
+                              <node concept="3cpWsn" id="6rhOS_xTtup" role="3cpWs9">
+                                <property role="TrG5h" value="isApplicable" />
+                                <node concept="10P_77" id="6rhOS_xTtuk" role="1tU5fm" />
+                                <node concept="2YIFZM" id="4_3mV3JNMln" role="33vP2m">
+                                  <ref role="37wK5l" to="czm:4_3mV3JAVzS" resolve="canBeChildForSubstitute" />
+                                  <ref role="1Pybhc" to="czm:RbLMy696h3" resolve="GrammarCellsUtil" />
+                                  <node concept="2GrUjf" id="4_3mV3JNMlo" role="37wK5m">
+                                    <ref role="2Gs0qQ" node="7NlRaxB4F5O" resolve="subconcept" />
+                                  </node>
+                                  <node concept="37vLTw" id="4_3mV3JNMlp" role="37wK5m">
+                                    <ref role="3cqZAo" node="2mvFNoUxG2A" resolve="_context" />
+                                  </node>
+                                  <node concept="37vLTw" id="4_3mV3JNVYg" role="37wK5m">
+                                    <ref role="3cqZAo" node="6oKG1kMzdFR" resolve="wrappedConcept" />
+                                  </node>
+                                  <node concept="37vLTw" id="6ogDZt_Bs9c" role="37wK5m">
+                                    <ref role="3cqZAo" node="6ogDZt_zXvf" resolve="aggregation" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="3clFbH" id="6ogDZt_M6zl" role="3cqZAp" />
                             <node concept="3clFbF" id="Tf4IGa0c5H" role="3cqZAp">
                               <node concept="3vZ8ra" id="Tf4IGa0c5J" role="3clFbG">
                                 <node concept="37vLTw" id="Tf4IGa0c5K" role="37vLTJ">
@@ -9065,8 +9127,25 @@
                                 </node>
                               </node>
                             </node>
+                            <node concept="3clFbH" id="6ogDZt_M8XS" role="3cqZAp" />
                             <node concept="3clFbJ" id="6rhOS_xTxEt" role="3cqZAp">
                               <node concept="3clFbS" id="6rhOS_xTxEv" role="3clFbx">
+                                <node concept="3SKdUt" id="6ogDZt_N6UC" role="3cqZAp">
+                                  <node concept="1PaTwC" id="6ogDZt_N6UD" role="1aUNEU">
+                                    <node concept="3oM_SD" id="6ogDZt_Na1T" role="1PaTwD">
+                                      <property role="3oM_SC" value="get" />
+                                    </node>
+                                    <node concept="3oM_SD" id="6ogDZt_Na1V" role="1PaTwD">
+                                      <property role="3oM_SC" value="all" />
+                                    </node>
+                                    <node concept="3oM_SD" id="6ogDZt_Na1Y" role="1PaTwD">
+                                      <property role="3oM_SC" value="available" />
+                                    </node>
+                                    <node concept="3oM_SD" id="6ogDZt_Na22" role="1PaTwD">
+                                      <property role="3oM_SC" value="actions" />
+                                    </node>
+                                  </node>
+                                </node>
                                 <node concept="3cpWs8" id="7NlRaxAY3V3" role="3cqZAp">
                                   <node concept="3cpWsn" id="7NlRaxAY3V4" role="3cpWs9">
                                     <property role="TrG5h" value="actions" />
@@ -9160,6 +9239,25 @@
                                     </node>
                                   </node>
                                 </node>
+                                <node concept="3SKdUt" id="6ogDZt_MYcX" role="3cqZAp">
+                                  <node concept="1PaTwC" id="6ogDZt_MYcY" role="1aUNEU">
+                                    <node concept="3oM_SD" id="6ogDZt_N2Gv" role="1PaTwD">
+                                      <property role="3oM_SC" value="Filter" />
+                                    </node>
+                                    <node concept="3oM_SD" id="6ogDZt_N2Gx" role="1PaTwD">
+                                      <property role="3oM_SC" value="based" />
+                                    </node>
+                                    <node concept="3oM_SD" id="6ogDZt_N2G$" role="1PaTwD">
+                                      <property role="3oM_SC" value="on" />
+                                    </node>
+                                    <node concept="3oM_SD" id="6ogDZt_N2GC" role="1PaTwD">
+                                      <property role="3oM_SC" value="grammar.rule" />
+                                    </node>
+                                    <node concept="3oM_SD" id="6ogDZt_N2GH" role="1PaTwD">
+                                      <property role="3oM_SC" value="conditions" />
+                                    </node>
+                                  </node>
+                                </node>
                                 <node concept="3cpWs8" id="76hx8dK6VwE" role="3cqZAp">
                                   <node concept="3cpWsn" id="76hx8dK6VwF" role="3cpWs9">
                                     <property role="TrG5h" value="wrappedActions" />
@@ -9169,157 +9267,201 @@
                                       </node>
                                     </node>
                                     <node concept="2OqwBi" id="7NlRaxAYHhg" role="33vP2m">
-                                      <node concept="2OqwBi" id="7NlRaxAYhPs" role="2Oq$k0">
-                                        <node concept="2OqwBi" id="7NlRaxAZ5SH" role="2Oq$k0">
-                                          <node concept="37vLTw" id="7NlRaxAY9a6" role="2Oq$k0">
-                                            <ref role="3cqZAo" node="7NlRaxAY3V4" resolve="actions" />
-                                          </node>
-                                          <node concept="3zZkjj" id="7NlRaxAZ8W7" role="2OqNvi">
-                                            <node concept="1bVj0M" id="7NlRaxAZ8W9" role="23t8la">
-                                              <node concept="3clFbS" id="7NlRaxAZ8Wa" role="1bW5cS">
-                                                <node concept="3cpWs8" id="7NlRaxAZdna" role="3cqZAp">
-                                                  <node concept="3cpWsn" id="7NlRaxAZdnb" role="3cpWs9">
-                                                    <property role="TrG5h" value="isApplicable" />
-                                                    <node concept="10P_77" id="7NlRaxAZdnc" role="1tU5fm" />
-                                                    <node concept="3clFbT" id="7NlRaxAZdnd" role="33vP2m">
-                                                      <property role="3clFbU" value="true" />
-                                                    </node>
+                                      <node concept="2OqwBi" id="6ogDZt_MdxZ" role="2Oq$k0">
+                                        <node concept="37vLTw" id="7NlRaxAY9a6" role="2Oq$k0">
+                                          <ref role="3cqZAo" node="7NlRaxAY3V4" resolve="actions" />
+                                        </node>
+                                        <node concept="3zZkjj" id="6ogDZt_Mdxv" role="2OqNvi">
+                                          <node concept="1bVj0M" id="6ogDZt_Mdx_" role="23t8la">
+                                            <node concept="3clFbS" id="6ogDZt_MdxJ" role="1bW5cS">
+                                              <node concept="3SKdUt" id="6ogDZt_T2ns" role="3cqZAp">
+                                                <node concept="1PaTwC" id="6ogDZt_T2nt" role="1aUNEU">
+                                                  <node concept="3oM_SD" id="6ogDZt_T5R2" role="1PaTwD">
+                                                    <property role="3oM_SC" value="Need" />
+                                                  </node>
+                                                  <node concept="3oM_SD" id="6ogDZt_T9zt" role="1PaTwD">
+                                                    <property role="3oM_SC" value="to" />
+                                                  </node>
+                                                  <node concept="3oM_SD" id="6ogDZt_T9zw" role="1PaTwD">
+                                                    <property role="3oM_SC" value="check" />
+                                                  </node>
+                                                  <node concept="3oM_SD" id="6ogDZt_Tchl" role="1PaTwD">
+                                                    <property role="3oM_SC" value="constraints" />
+                                                  </node>
+                                                  <node concept="3oM_SD" id="6ogDZt_Tchq" role="1PaTwD">
+                                                    <property role="3oM_SC" value="again" />
+                                                  </node>
+                                                  <node concept="3oM_SD" id="6ogDZt_Tchw" role="1PaTwD">
+                                                    <property role="3oM_SC" value="for" />
+                                                  </node>
+                                                  <node concept="3oM_SD" id="6ogDZt_TchB" role="1PaTwD">
+                                                    <property role="3oM_SC" value="concrete" />
+                                                  </node>
+                                                  <node concept="3oM_SD" id="6ogDZt_Tp0e" role="1PaTwD">
+                                                    <property role="3oM_SC" value="type" />
                                                   </node>
                                                 </node>
-                                                <node concept="3cpWs8" id="7NlRaxAZdnk" role="3cqZAp">
-                                                  <node concept="3cpWsn" id="7NlRaxAZdnl" role="3cpWs9">
-                                                    <property role="TrG5h" value="wrappedConcept" />
-                                                    <property role="3TUv4t" value="true" />
-                                                    <node concept="3bZ5Sz" id="7NlRaxAZdnm" role="1tU5fm" />
-                                                    <node concept="2OqwBi" id="7NlRaxAZpfp" role="33vP2m">
-                                                      <node concept="37vLTw" id="7NlRaxAZpfq" role="2Oq$k0">
-                                                        <ref role="3cqZAo" node="7NlRaxAZ8Wb" resolve="it" />
+                                              </node>
+                                              <node concept="3cpWs8" id="6ogDZt_Mdv_" role="3cqZAp">
+                                                <node concept="3cpWsn" id="6ogDZt_Mdvz" role="3cpWs9">
+                                                  <property role="TrG5h" value="isApplicable" />
+                                                  <node concept="10P_77" id="6ogDZt_MdvD" role="1tU5fm" />
+                                                  <node concept="2YIFZM" id="6ogDZt_S2VS" role="33vP2m">
+                                                    <ref role="1Pybhc" to="czm:RbLMy696h3" resolve="GrammarCellsUtil" />
+                                                    <ref role="37wK5l" to="czm:4_3mV3JAVzS" resolve="canBeChildForSubstitute" />
+                                                    <node concept="2GrUjf" id="6ogDZt_S7gd" role="37wK5m">
+                                                      <ref role="2Gs0qQ" node="7NlRaxB4F5O" resolve="subconcept" />
+                                                    </node>
+                                                    <node concept="37vLTw" id="6ogDZt_Sf84" role="37wK5m">
+                                                      <ref role="3cqZAo" node="2mvFNoUxG2A" resolve="_context" />
+                                                    </node>
+                                                    <node concept="2OqwBi" id="6ogDZt_SmAM" role="37wK5m">
+                                                      <node concept="37vLTw" id="6ogDZt_SjUA" role="2Oq$k0">
+                                                        <ref role="3cqZAo" node="6ogDZt_MdxH" resolve="it" />
                                                       </node>
-                                                      <node concept="liA8E" id="7NlRaxAZpfr" role="2OqNvi">
+                                                      <node concept="liA8E" id="6ogDZt_SrJM" role="2OqNvi">
                                                         <ref role="37wK5l" to="78sh:~SubstituteMenuItem.getOutputConcept()" resolve="getOutputConcept" />
                                                       </node>
                                                     </node>
+                                                    <node concept="37vLTw" id="6ogDZt_SzkD" role="37wK5m">
+                                                      <ref role="3cqZAo" node="6ogDZt_zXvf" resolve="aggregation" />
+                                                    </node>
                                                   </node>
                                                 </node>
-                                                <node concept="3clFbJ" id="4dRlb$vR0$j" role="3cqZAp">
-                                                  <node concept="3clFbS" id="4dRlb$vR0$l" role="3clFbx">
-                                                    <node concept="3cpWs6" id="4dRlb$vR2vg" role="3cqZAp">
-                                                      <node concept="3clFbT" id="4dRlb$vR2E9" role="3cqZAk">
-                                                        <property role="3clFbU" value="false" />
+                                              </node>
+                                              <node concept="3cpWs8" id="6ogDZt_MdvH" role="3cqZAp">
+                                                <node concept="3cpWsn" id="6ogDZt_MdvF" role="3cpWs9">
+                                                  <property role="TrG5h" value="wrappedConcept" />
+                                                  <property role="3TUv4t" value="true" />
+                                                  <node concept="3bZ5Sz" id="6ogDZt_MdvL" role="1tU5fm" />
+                                                  <node concept="2OqwBi" id="6ogDZt_MdvN" role="33vP2m">
+                                                    <node concept="37vLTw" id="6ogDZt_MdvP" role="2Oq$k0">
+                                                      <ref role="3cqZAo" node="6ogDZt_MdxH" resolve="it" />
+                                                    </node>
+                                                    <node concept="liA8E" id="6ogDZt_MdvT" role="2OqNvi">
+                                                      <ref role="37wK5l" to="78sh:~SubstituteMenuItem.getOutputConcept()" resolve="getOutputConcept" />
+                                                    </node>
+                                                  </node>
+                                                </node>
+                                              </node>
+                                              <node concept="3clFbJ" id="6ogDZt_Mdv3" role="3cqZAp">
+                                                <node concept="3clFbS" id="6ogDZt_Mdv5" role="3clFbx">
+                                                  <node concept="3cpWs6" id="6ogDZt_Mdy1" role="3cqZAp">
+                                                    <node concept="3clFbT" id="6ogDZt_MdxR" role="3cqZAk">
+                                                      <property role="3clFbU" value="false" />
+                                                    </node>
+                                                  </node>
+                                                </node>
+                                                <node concept="2OqwBi" id="6ogDZt_MdvJ" role="3clFbw">
+                                                  <node concept="37vLTw" id="6ogDZt_Mdvx" role="2Oq$k0">
+                                                    <ref role="3cqZAo" node="6ogDZt_MdvF" resolve="wrappedConcept" />
+                                                  </node>
+                                                  <node concept="2Zo12i" id="6ogDZt_Mdvn" role="2OqNvi">
+                                                    <node concept="25Kdxt" id="6ogDZt_Mdvb" role="2Zo12j">
+                                                      <node concept="37vLTw" id="6ogDZt_Mdv9" role="25KhWn">
+                                                        <ref role="3cqZAo" node="My09KfuUbg" resolve="expectedOutputConcept" />
                                                       </node>
                                                     </node>
                                                   </node>
-                                                  <node concept="2OqwBi" id="4dRlb$vR1d4" role="3clFbw">
-                                                    <node concept="37vLTw" id="4dRlb$vR0Ti" role="2Oq$k0">
-                                                      <ref role="3cqZAo" node="7NlRaxAZdnl" resolve="wrappedConcept" />
+                                                </node>
+                                              </node>
+                                              <node concept="3cpWs8" id="6ogDZt_Mdvv" role="3cqZAp">
+                                                <node concept="3cpWsn" id="6ogDZt_Mdvd" role="3cpWs9">
+                                                  <property role="TrG5h" value="editorContext" />
+                                                  <property role="3TUv4t" value="true" />
+                                                  <node concept="3uibUv" id="6ogDZt_Mdvf" role="1tU5fm">
+                                                    <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+                                                  </node>
+                                                  <node concept="2OqwBi" id="6ogDZt_Mdvh" role="33vP2m">
+                                                    <node concept="37vLTw" id="6ogDZt_Mdvj" role="2Oq$k0">
+                                                      <ref role="3cqZAo" node="2mvFNoUxG2A" resolve="_context" />
                                                     </node>
-                                                    <node concept="2Zo12i" id="4dRlb$vR1$R" role="2OqNvi">
-                                                      <node concept="25Kdxt" id="4dRlb$vR1S6" role="2Zo12j">
-                                                        <node concept="37vLTw" id="4dRlb$vR2c0" role="25KhWn">
-                                                          <ref role="3cqZAo" node="My09KfuUbg" resolve="expectedOutputConcept" />
+                                                    <node concept="liA8E" id="6ogDZt_Mdvl" role="2OqNvi">
+                                                      <ref role="37wK5l" to="78sh:~SubstituteMenuContext.getEditorContext()" resolve="getEditorContext" />
+                                                    </node>
+                                                  </node>
+                                                </node>
+                                              </node>
+                                              <node concept="3cpWs8" id="6ogDZt_MdxV" role="3cqZAp">
+                                                <node concept="3cpWsn" id="6ogDZt_MdxX" role="3cpWs9">
+                                                  <property role="TrG5h" value="smartReferent" />
+                                                  <property role="3TUv4t" value="true" />
+                                                  <node concept="3Tqbb2" id="6ogDZt_MdxT" role="1tU5fm" />
+                                                  <node concept="3K4zz7" id="6ogDZt_MdwP" role="33vP2m">
+                                                    <node concept="10Nm6u" id="6ogDZt_Mdy3" role="3K4GZi" />
+                                                    <node concept="1eOMI4" id="6ogDZt_Mdy5" role="3K4Cdx">
+                                                      <node concept="2ZW3vV" id="6ogDZt_Mdy7" role="1eOMHV">
+                                                        <node concept="3uibUv" id="6ogDZt_Mdyl" role="2ZW6by">
+                                                          <ref role="3uigEE" to="qtqj:~ReferenceScopeSubstituteMenuItem" resolve="ReferenceScopeSubstituteMenuItem" />
+                                                        </node>
+                                                        <node concept="37vLTw" id="6ogDZt_Mdyp" role="2ZW6bz">
+                                                          <ref role="3cqZAo" node="6ogDZt_MdxH" resolve="it" />
                                                         </node>
                                                       </node>
                                                     </node>
-                                                  </node>
-                                                </node>
-                                                <node concept="3cpWs8" id="2q0cFwF27cf" role="3cqZAp">
-                                                  <node concept="3cpWsn" id="2q0cFwF27cg" role="3cpWs9">
-                                                    <property role="TrG5h" value="editorContext" />
-                                                    <property role="3TUv4t" value="true" />
-                                                    <node concept="3uibUv" id="2q0cFwF27ch" role="1tU5fm">
-                                                      <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
-                                                    </node>
-                                                    <node concept="2OqwBi" id="2q0cFwF27ci" role="33vP2m">
-                                                      <node concept="37vLTw" id="2q0cFwF27cj" role="2Oq$k0">
-                                                        <ref role="3cqZAo" node="2mvFNoUxG2A" resolve="_context" />
-                                                      </node>
-                                                      <node concept="liA8E" id="2q0cFwF27ck" role="2OqNvi">
-                                                        <ref role="37wK5l" to="78sh:~SubstituteMenuContext.getEditorContext()" resolve="getEditorContext" />
-                                                      </node>
-                                                    </node>
-                                                  </node>
-                                                </node>
-                                                <node concept="3cpWs8" id="2q0cFwF2tAG" role="3cqZAp">
-                                                  <node concept="3cpWsn" id="2q0cFwF2tAJ" role="3cpWs9">
-                                                    <property role="TrG5h" value="smartReferent" />
-                                                    <property role="3TUv4t" value="true" />
-                                                    <node concept="3Tqbb2" id="2q0cFwF2tAE" role="1tU5fm" />
-                                                    <node concept="3K4zz7" id="2q0cFwF3bX1" role="33vP2m">
-                                                      <node concept="10Nm6u" id="2q0cFwF3ofj" role="3K4GZi" />
-                                                      <node concept="1eOMI4" id="2q0cFwF3e36" role="3K4Cdx">
-                                                        <node concept="2ZW3vV" id="2q0cFwF3e37" role="1eOMHV">
-                                                          <node concept="3uibUv" id="2q0cFwF3e38" role="2ZW6by">
+                                                    <node concept="2OqwBi" id="6ogDZt_MdwR" role="3K4E3e">
+                                                      <node concept="1eOMI4" id="6ogDZt_Mdx9" role="2Oq$k0">
+                                                        <node concept="10QFUN" id="6ogDZt_MdwV" role="1eOMHV">
+                                                          <node concept="3uibUv" id="6ogDZt_Mdx3" role="10QFUM">
                                                             <ref role="3uigEE" to="qtqj:~ReferenceScopeSubstituteMenuItem" resolve="ReferenceScopeSubstituteMenuItem" />
                                                           </node>
-                                                          <node concept="37vLTw" id="2q0cFwF3e39" role="2ZW6bz">
-                                                            <ref role="3cqZAo" node="7NlRaxAZ8Wb" resolve="it" />
+                                                          <node concept="37vLTw" id="6ogDZt_MdwZ" role="10QFUP">
+                                                            <ref role="3cqZAo" node="6ogDZt_MdxH" resolve="it" />
                                                           </node>
                                                         </node>
                                                       </node>
-                                                      <node concept="2OqwBi" id="2q0cFwF2PH6" role="3K4E3e">
-                                                        <node concept="1eOMI4" id="2q0cFwF2Sl8" role="2Oq$k0">
-                                                          <node concept="10QFUN" id="2q0cFwF2Sl5" role="1eOMHV">
-                                                            <node concept="3uibUv" id="2q0cFwF2Sla" role="10QFUM">
-                                                              <ref role="3uigEE" to="qtqj:~ReferenceScopeSubstituteMenuItem" resolve="ReferenceScopeSubstituteMenuItem" />
-                                                            </node>
-                                                            <node concept="37vLTw" id="2q0cFwF2Slb" role="10QFUP">
-                                                              <ref role="3cqZAo" node="7NlRaxAZ8Wb" resolve="it" />
-                                                            </node>
-                                                          </node>
-                                                        </node>
-                                                        <node concept="1PnCL0" id="2q0cFwF2Zkf" role="2OqNvi">
-                                                          <ref role="2Oxat5" to="qtqj:~ReferenceScopeSubstituteMenuItem.myReferent" resolve="myReferent" />
-                                                        </node>
+                                                      <node concept="1PnCL0" id="6ogDZt_Mdvt" role="2OqNvi">
+                                                        <ref role="2Oxat5" to="qtqj:~ReferenceScopeSubstituteMenuItem.myReferent" resolve="myReferent" />
                                                       </node>
                                                     </node>
                                                   </node>
                                                 </node>
-                                                <node concept="3clFbH" id="2q0cFwF2zuA" role="3cqZAp" />
-                                                <node concept="3clFbF" id="7NlRaxAZdnr" role="3cqZAp">
-                                                  <node concept="3vZ8ra" id="7NlRaxAZdns" role="3clFbG">
-                                                    <node concept="37vLTw" id="7NlRaxAZdnt" role="37vLTJ">
-                                                      <ref role="3cqZAo" node="7NlRaxAZdnb" resolve="isApplicable" />
-                                                    </node>
-                                                    <node concept="2OqwBi" id="7NlRaxAZdnu" role="37vLTx">
-                                                      <node concept="2ShNRf" id="7NlRaxAZdnv" role="2Oq$k0">
-                                                        <node concept="YeOm9" id="7NlRaxAZdnw" role="2ShVmc">
-                                                          <node concept="1Y3b0j" id="7NlRaxAZdnx" role="YeSDq">
-                                                            <property role="2bfB8j" value="true" />
-                                                            <ref role="1Y3XeK" to="wyt6:~Object" resolve="Object" />
-                                                            <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
-                                                            <node concept="3Tm1VV" id="7NlRaxAZdny" role="1B3o_S" />
-                                                            <node concept="3clFb_" id="7NlRaxAZdnz" role="jymVt">
-                                                              <property role="TrG5h" value="query" />
-                                                              <node concept="37vLTG" id="7NlRaxAZdn$" role="3clF46">
-                                                                <property role="TrG5h" value="expectedConcept" />
-                                                                <node concept="3bZ5Sz" id="7NlRaxAZdn_" role="1tU5fm" />
-                                                              </node>
-                                                              <node concept="10P_77" id="7NlRaxAZdnA" role="3clF45" />
-                                                              <node concept="3Tm1VV" id="7NlRaxAZdnB" role="1B3o_S" />
-                                                              <node concept="3clFbS" id="7NlRaxAZdnC" role="3clF47">
-                                                                <node concept="3clFbF" id="7NlRaxAZdnD" role="3cqZAp">
-                                                                  <node concept="3clFbT" id="7NlRaxAZdnE" role="3clFbG">
-                                                                    <property role="3clFbU" value="true" />
-                                                                  </node>
-                                                                  <node concept="2b32R4" id="7NlRaxAZdnF" role="lGtFl">
-                                                                    <node concept="3JmXsc" id="7NlRaxAZdnG" role="2P8S$">
-                                                                      <node concept="3clFbS" id="7NlRaxAZdnH" role="2VODD2">
-                                                                        <node concept="3clFbF" id="7NlRaxAZdnI" role="3cqZAp">
-                                                                          <node concept="2OqwBi" id="7NlRaxAZdnJ" role="3clFbG">
-                                                                            <node concept="2OqwBi" id="7NlRaxAZdnK" role="2Oq$k0">
-                                                                              <node concept="2OqwBi" id="7NlRaxAZdnL" role="2Oq$k0">
-                                                                                <node concept="30H73N" id="7NlRaxAZdnM" role="2Oq$k0" />
-                                                                                <node concept="3TrEf2" id="7NlRaxAZdnN" role="2OqNvi">
-                                                                                  <ref role="3Tt5mk" to="teg0:6rhOS_xTjUw" resolve="substituteCondition" />
-                                                                                </node>
-                                                                              </node>
-                                                                              <node concept="2qgKlT" id="7NlRaxAZdnO" role="2OqNvi">
-                                                                                <ref role="37wK5l" to="tpek:i2fhZ_m" resolve="getBody" />
+                                              </node>
+                                              <node concept="3clFbH" id="6ogDZt_MdxP" role="3cqZAp" />
+                                              <node concept="3clFbF" id="6ogDZt_MdvR" role="3cqZAp">
+                                                <node concept="3vZ8ra" id="6ogDZt_MdvZ" role="3clFbG">
+                                                  <node concept="37vLTw" id="6ogDZt_MdvX" role="37vLTJ">
+                                                    <ref role="3cqZAo" node="6ogDZt_Mdvz" resolve="isApplicable" />
+                                                  </node>
+                                                  <node concept="2OqwBi" id="6ogDZt_Mdw5" role="37vLTx">
+                                                    <node concept="2ShNRf" id="6ogDZt_Mdw3" role="2Oq$k0">
+                                                      <node concept="YeOm9" id="6ogDZt_Mdw9" role="2ShVmc">
+                                                        <node concept="1Y3b0j" id="6ogDZt_Mdw7" role="YeSDq">
+                                                          <property role="2bfB8j" value="true" />
+                                                          <ref role="1Y3XeK" to="wyt6:~Object" resolve="Object" />
+                                                          <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
+                                                          <node concept="3Tm1VV" id="6ogDZt_Mdwd" role="1B3o_S" />
+                                                          <node concept="3clFb_" id="6ogDZt_Mdwb" role="jymVt">
+                                                            <property role="TrG5h" value="query" />
+                                                            <node concept="37vLTG" id="6ogDZt_Mdwl" role="3clF46">
+                                                              <property role="TrG5h" value="expectedConcept" />
+                                                              <node concept="3bZ5Sz" id="6ogDZt_Mdwj" role="1tU5fm" />
+                                                            </node>
+                                                            <node concept="10P_77" id="6ogDZt_Mdwp" role="3clF45" />
+                                                            <node concept="3Tm1VV" id="6ogDZt_Mdwn" role="1B3o_S" />
+                                                            <node concept="3clFbS" id="6ogDZt_Mdwt" role="3clF47">
+                                                              <node concept="3clFbF" id="6ogDZt_Mdwr" role="3cqZAp">
+                                                                <node concept="3clFbT" id="6ogDZt_Mdwx" role="3clFbG">
+                                                                  <property role="3clFbU" value="true" />
+                                                                </node>
+                                                                <node concept="2b32R4" id="6ogDZt_Mdwv" role="lGtFl">
+                                                                  <node concept="3JmXsc" id="6ogDZt_Mdw_" role="2P8S$">
+                                                                    <node concept="3clFbS" id="6ogDZt_Mdwz" role="2VODD2">
+                                                                      <node concept="3clFbF" id="6ogDZt_MdwD" role="3cqZAp">
+                                                                        <node concept="2OqwBi" id="6ogDZt_MdwB" role="3clFbG">
+                                                                          <node concept="2OqwBi" id="6ogDZt_MdwH" role="2Oq$k0">
+                                                                            <node concept="2OqwBi" id="6ogDZt_MdwF" role="2Oq$k0">
+                                                                              <node concept="30H73N" id="6ogDZt_MdwL" role="2Oq$k0" />
+                                                                              <node concept="3TrEf2" id="6ogDZt_MdwJ" role="2OqNvi">
+                                                                                <ref role="3Tt5mk" to="teg0:6rhOS_xTjUw" resolve="substituteCondition" />
                                                                               </node>
                                                                             </node>
-                                                                            <node concept="3Tsc0h" id="7NlRaxAZdnP" role="2OqNvi">
-                                                                              <ref role="3TtcxE" to="tpee:fzcqZ_x" resolve="statement" />
+                                                                            <node concept="2qgKlT" id="6ogDZt_MdwT" role="2OqNvi">
+                                                                              <ref role="37wK5l" to="tpek:i2fhZ_m" resolve="getBody" />
                                                                             </node>
+                                                                          </node>
+                                                                          <node concept="3Tsc0h" id="6ogDZt_MdwN" role="2OqNvi">
+                                                                            <ref role="3TtcxE" to="tpee:fzcqZ_x" resolve="statement" />
                                                                           </node>
                                                                         </node>
                                                                       </node>
@@ -9331,91 +9473,123 @@
                                                           </node>
                                                         </node>
                                                       </node>
-                                                      <node concept="liA8E" id="7NlRaxAZdnQ" role="2OqNvi">
-                                                        <ref role="37wK5l" node="7NlRaxAZdnz" resolve="query" />
-                                                        <node concept="37vLTw" id="My09KfLNyq" role="37wK5m">
-                                                          <ref role="3cqZAo" node="My09KfuUbg" resolve="expectedOutputConcept" />
-                                                        </node>
+                                                    </node>
+                                                    <node concept="liA8E" id="6ogDZt_MdwX" role="2OqNvi">
+                                                      <ref role="37wK5l" node="6ogDZt_Mdwb" resolve="query" />
+                                                      <node concept="37vLTw" id="6ogDZt_Mdwf" role="37wK5m">
+                                                        <ref role="3cqZAo" node="My09KfuUbg" resolve="expectedOutputConcept" />
                                                       </node>
                                                     </node>
                                                   </node>
-                                                  <node concept="1W57fq" id="7NlRaxAZdnS" role="lGtFl">
-                                                    <node concept="3IZrLx" id="7NlRaxAZdnT" role="3IZSJc">
-                                                      <node concept="3clFbS" id="7NlRaxAZdnU" role="2VODD2">
-                                                        <node concept="3clFbJ" id="2q0cFwFybrF" role="3cqZAp">
-                                                          <node concept="3clFbS" id="2q0cFwFybrH" role="3clFbx">
-                                                            <node concept="3cpWs6" id="2q0cFwFykQ0" role="3cqZAp">
-                                                              <node concept="3clFbT" id="2q0cFwFymUW" role="3cqZAk" />
-                                                            </node>
-                                                          </node>
-                                                          <node concept="2OqwBi" id="7NlRaxAZdo6" role="3clFbw">
-                                                            <node concept="2OqwBi" id="7NlRaxAZdo7" role="2Oq$k0">
-                                                              <node concept="30H73N" id="7NlRaxAZdo8" role="2Oq$k0" />
-                                                              <node concept="3TrEf2" id="7NlRaxAZdo9" role="2OqNvi">
-                                                                <ref role="3Tt5mk" to="teg0:6rhOS_xTjUw" resolve="substituteCondition" />
-                                                              </node>
-                                                            </node>
-                                                            <node concept="3w_OXm" id="2q0cFwFyiH4" role="2OqNvi" />
+                                                </node>
+                                                <node concept="1W57fq" id="6ogDZt_Mdx5" role="lGtFl">
+                                                  <node concept="3IZrLx" id="6ogDZt_Mdx1" role="3IZSJc">
+                                                    <node concept="3clFbS" id="6ogDZt_Mdxb" role="2VODD2">
+                                                      <node concept="3clFbJ" id="6ogDZt_MdvV" role="3cqZAp">
+                                                        <node concept="3clFbS" id="6ogDZt_Mdw1" role="3clFbx">
+                                                          <node concept="3cpWs6" id="6ogDZt_Mdvp" role="3cqZAp">
+                                                            <node concept="3clFbT" id="6ogDZt_Mdv7" role="3cqZAk" />
                                                           </node>
                                                         </node>
-                                                        <node concept="3clFbF" id="7NlRaxAZdnV" role="3cqZAp">
-                                                          <node concept="22lmx$" id="2q0cFwFxWmc" role="3clFbG">
-                                                            <node concept="2OqwBi" id="7NlRaxAZdnX" role="3uHU7B">
-                                                              <node concept="2OqwBi" id="7NlRaxAZdnY" role="2Oq$k0">
-                                                                <node concept="2OqwBi" id="7NlRaxAZdnZ" role="2Oq$k0">
-                                                                  <node concept="30H73N" id="7NlRaxAZdo0" role="2Oq$k0" />
-                                                                  <node concept="3TrEf2" id="7NlRaxAZdo1" role="2OqNvi">
-                                                                    <ref role="3Tt5mk" to="teg0:6rhOS_xTjUw" resolve="substituteCondition" />
-                                                                  </node>
+                                                        <node concept="2OqwBi" id="6ogDZt_Mdxz" role="3clFbw">
+                                                          <node concept="2OqwBi" id="6ogDZt_Mdxx" role="2Oq$k0">
+                                                            <node concept="30H73N" id="6ogDZt_MdxD" role="2Oq$k0" />
+                                                            <node concept="3TrEf2" id="6ogDZt_MdxB" role="2OqNvi">
+                                                              <ref role="3Tt5mk" to="teg0:6rhOS_xTjUw" resolve="substituteCondition" />
+                                                            </node>
+                                                          </node>
+                                                          <node concept="3w_OXm" id="6ogDZt_Mdy9" role="2OqNvi" />
+                                                        </node>
+                                                      </node>
+                                                      <node concept="3clFbF" id="6ogDZt_Mdx7" role="3cqZAp">
+                                                        <node concept="22lmx$" id="6ogDZt_Mdvr" role="3clFbG">
+                                                          <node concept="2OqwBi" id="6ogDZt_Mdxd" role="3uHU7B">
+                                                            <node concept="2OqwBi" id="6ogDZt_Mdxh" role="2Oq$k0">
+                                                              <node concept="2OqwBi" id="6ogDZt_Mdxf" role="2Oq$k0">
+                                                                <node concept="30H73N" id="6ogDZt_Mdxl" role="2Oq$k0" />
+                                                                <node concept="3TrEf2" id="6ogDZt_Mdxj" role="2OqNvi">
+                                                                  <ref role="3Tt5mk" to="teg0:6rhOS_xTjUw" resolve="substituteCondition" />
                                                                 </node>
-                                                                <node concept="2Rf3mk" id="7NlRaxAZdo2" role="2OqNvi">
-                                                                  <node concept="1xMEDy" id="7NlRaxAZdo3" role="1xVPHs">
-                                                                    <node concept="chp4Y" id="7NlRaxAZdo4" role="ri$Ld">
-                                                                      <ref role="cht4Q" to="teg0:5wt0D$BOnvU" resolve="Parameter_wrappedConcept" />
-                                                                    </node>
+                                                              </node>
+                                                              <node concept="2Rf3mk" id="6ogDZt_Mdxp" role="2OqNvi">
+                                                                <node concept="1xMEDy" id="6ogDZt_Mdxn" role="1xVPHs">
+                                                                  <node concept="chp4Y" id="6ogDZt_Mdxt" role="ri$Ld">
+                                                                    <ref role="cht4Q" to="teg0:5wt0D$BOnvU" resolve="Parameter_wrappedConcept" />
                                                                   </node>
                                                                 </node>
                                                               </node>
-                                                              <node concept="3GX2aA" id="7NlRaxAZdo5" role="2OqNvi" />
                                                             </node>
-                                                            <node concept="2OqwBi" id="2q0cFwFy157" role="3uHU7w">
-                                                              <node concept="2OqwBi" id="2q0cFwFy158" role="2Oq$k0">
-                                                                <node concept="2OqwBi" id="2q0cFwFy159" role="2Oq$k0">
-                                                                  <node concept="30H73N" id="2q0cFwFy15a" role="2Oq$k0" />
-                                                                  <node concept="3TrEf2" id="2q0cFwFy15b" role="2OqNvi">
-                                                                    <ref role="3Tt5mk" to="teg0:6rhOS_xTjUw" resolve="substituteCondition" />
-                                                                  </node>
+                                                            <node concept="3GX2aA" id="6ogDZt_Mdxr" role="2OqNvi" />
+                                                          </node>
+                                                          <node concept="2OqwBi" id="6ogDZt_Mdyb" role="3uHU7w">
+                                                            <node concept="2OqwBi" id="6ogDZt_Mdyd" role="2Oq$k0">
+                                                              <node concept="2OqwBi" id="6ogDZt_Mdyf" role="2Oq$k0">
+                                                                <node concept="30H73N" id="6ogDZt_Mdyh" role="2Oq$k0" />
+                                                                <node concept="3TrEf2" id="6ogDZt_Mdyj" role="2OqNvi">
+                                                                  <ref role="3Tt5mk" to="teg0:6rhOS_xTjUw" resolve="substituteCondition" />
                                                                 </node>
-                                                                <node concept="2Rf3mk" id="2q0cFwFy15c" role="2OqNvi">
-                                                                  <node concept="1xMEDy" id="2q0cFwFy15d" role="1xVPHs">
-                                                                    <node concept="chp4Y" id="2q0cFwFy6vj" role="ri$Ld">
-                                                                      <ref role="cht4Q" to="teg0:2q0cFwEBOkL" resolve="Parameter_smartReferent" />
-                                                                    </node>
+                                                              </node>
+                                                              <node concept="2Rf3mk" id="6ogDZt_Mdyn" role="2OqNvi">
+                                                                <node concept="1xMEDy" id="6ogDZt_Mdyr" role="1xVPHs">
+                                                                  <node concept="chp4Y" id="6ogDZt_Mdwh" role="ri$Ld">
+                                                                    <ref role="cht4Q" to="teg0:2q0cFwEBOkL" resolve="Parameter_smartReferent" />
                                                                   </node>
                                                                 </node>
                                                               </node>
-                                                              <node concept="3GX2aA" id="2q0cFwFy15f" role="2OqNvi" />
                                                             </node>
+                                                            <node concept="3GX2aA" id="6ogDZt_Mdyt" role="2OqNvi" />
                                                           </node>
                                                         </node>
                                                       </node>
                                                     </node>
                                                   </node>
                                                 </node>
-                                                <node concept="3clFbF" id="7NlRaxAZdob" role="3cqZAp">
-                                                  <node concept="37vLTw" id="7NlRaxAZdoc" role="3clFbG">
-                                                    <ref role="3cqZAo" node="7NlRaxAZdnb" resolve="isApplicable" />
-                                                  </node>
+                                              </node>
+                                              <node concept="3clFbF" id="6ogDZt_MdxF" role="3cqZAp">
+                                                <node concept="37vLTw" id="6ogDZt_MdxL" role="3clFbG">
+                                                  <ref role="3cqZAo" node="6ogDZt_Mdvz" resolve="isApplicable" />
                                                 </node>
                                               </node>
-                                              <node concept="Rh6nW" id="7NlRaxAZ8Wb" role="1bW2Oz">
-                                                <property role="TrG5h" value="it" />
-                                                <node concept="2jxLKc" id="7NlRaxAZ8Wc" role="1tU5fm" />
-                                              </node>
+                                            </node>
+                                            <node concept="Rh6nW" id="6ogDZt_MdxH" role="1bW2Oz">
+                                              <property role="TrG5h" value="it" />
+                                              <node concept="2jxLKc" id="6ogDZt_MdxN" role="1tU5fm" />
                                             </node>
                                           </node>
                                         </node>
-                                        <node concept="3$u5V9" id="7NlRaxAYjOb" role="2OqNvi">
+                                      </node>
+                                      <node concept="ANE8D" id="7NlRaxAYIJI" role="2OqNvi" />
+                                    </node>
+                                  </node>
+                                </node>
+                                <node concept="3clFbH" id="6ogDZt_O9wU" role="3cqZAp" />
+                                <node concept="3SKdUt" id="6ogDZt_O5n$" role="3cqZAp">
+                                  <node concept="1PaTwC" id="6ogDZt_O5n_" role="1aUNEU">
+                                    <node concept="3oM_SD" id="6ogDZt_O9oS" role="1PaTwD">
+                                      <property role="3oM_SC" value="Create" />
+                                    </node>
+                                    <node concept="3oM_SD" id="6ogDZt_O9oU" role="1PaTwD">
+                                      <property role="3oM_SC" value="wrapper" />
+                                    </node>
+                                    <node concept="3oM_SD" id="6ogDZt_O9oX" role="1PaTwD">
+                                      <property role="3oM_SC" value="objects" />
+                                    </node>
+                                    <node concept="3oM_SD" id="6ogDZt_O9p1" role="1PaTwD">
+                                      <property role="3oM_SC" value="for" />
+                                    </node>
+                                    <node concept="3oM_SD" id="6ogDZt_O9p6" role="1PaTwD">
+                                      <property role="3oM_SC" value="items" />
+                                    </node>
+                                  </node>
+                                </node>
+                                <node concept="3clFbF" id="6ogDZt_Nj4v" role="3cqZAp">
+                                  <node concept="37vLTI" id="6ogDZt_Nly8" role="3clFbG">
+                                    <node concept="2OqwBi" id="6ogDZt_NPNo" role="37vLTx">
+                                      <node concept="2OqwBi" id="6ogDZt_NpED" role="2Oq$k0">
+                                        <node concept="37vLTw" id="6ogDZt_Nnpc" role="2Oq$k0">
+                                          <ref role="3cqZAo" node="76hx8dK6VwF" resolve="wrappedActions" />
+                                        </node>
+                                        <node concept="3$u5V9" id="6ogDZt_NtJ7" role="2OqNvi">
                                           <node concept="1bVj0M" id="7NlRaxAYjOd" role="23t8la">
                                             <node concept="3clFbS" id="7NlRaxAYjOe" role="1bW5cS">
                                               <node concept="3cpWs8" id="2q0cFwFhxmF" role="3cqZAp">
@@ -10144,7 +10318,10 @@
                                           </node>
                                         </node>
                                       </node>
-                                      <node concept="ANE8D" id="7NlRaxAYIJI" role="2OqNvi" />
+                                      <node concept="ANE8D" id="6ogDZt_NXau" role="2OqNvi" />
+                                    </node>
+                                    <node concept="37vLTw" id="6ogDZt_Nj4t" role="37vLTJ">
+                                      <ref role="3cqZAo" node="76hx8dK6VwF" resolve="wrappedActions" />
                                     </node>
                                   </node>
                                 </node>

--- a/code/grammarcells/solutions/com.mbeddr.mpsutil.grammarcells.runtime/com.mbeddr.mpsutil.grammarcells.runtime.msd
+++ b/code/grammarcells/solutions/com.mbeddr.mpsutil.grammarcells.runtime/com.mbeddr.mpsutil.grammarcells.runtime.msd
@@ -27,6 +27,7 @@
     <dependency reexport="false">2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)</dependency>
     <dependency reexport="false">8d29d73f-ed99-4652-ae0a-083cdfe53c34(jetbrains.mps.ide.platform)</dependency>
     <dependency reexport="false">8e98f4e2-decf-4e97-bf80-9109e8b759ee(jetbrains.mps.lang.constraints.rules.runtime)</dependency>
+    <dependency reexport="false">9a4afe51-f114-4595-b5df-048ce3c596be(jetbrains.mps.runtime)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:654422bf-e75f-44dc-936d-188890a746ce:de.slisson.mps.reflection" version="0" />
@@ -49,6 +50,7 @@
     <language slang="l:ef7bf5ac-d06c-4342-b11d-e42104eb9343:jetbrains.mps.lang.plugin.standalone" version="0" />
     <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
     <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
+    <language slang="l:1a8554c4-eb84-43ba-8c34-6f0d90c6e75a:jetbrains.mps.lang.smodel.query" version="3" />
     <language slang="l:c72da2b9-7cce-4447-8389-f407dc1158b7:jetbrains.mps.lang.structure" version="9" />
     <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
@@ -74,6 +76,7 @@
     <module reference="d7eb0a2a-bd50-4576-beae-e4a89db35f20(jetbrains.mps.lang.scopes.runtime)" version="0" />
     <module reference="c72da2b9-7cce-4447-8389-f407dc1158b7(jetbrains.mps.lang.structure)" version="0" />
     <module reference="8fe4c62a-2020-4ff4-8eda-f322a55bdc9f(jetbrains.mps.refactoring.runtime)" version="0" />
+    <module reference="9a4afe51-f114-4595-b5df-048ce3c596be(jetbrains.mps.runtime)" version="0" />
   </dependencyVersions>
 </solution>
 

--- a/code/grammarcells/solutions/com.mbeddr.mpsutil.grammarcells.runtime/models/com/mbeddr/mpsutil/grammarcells/runtime.mps
+++ b/code/grammarcells/solutions/com.mbeddr.mpsutil.grammarcells.runtime/models/com/mbeddr/mpsutil/grammarcells/runtime.mps
@@ -3069,6 +3069,22 @@
             </node>
           </node>
         </node>
+        <node concept="3clFbF" id="3Lzx5PeGJ2T" role="3cqZAp">
+          <node concept="2OqwBi" id="3Lzx5PeGKn5" role="3clFbG">
+            <node concept="37vLTw" id="3Lzx5PeGJ2R" role="2Oq$k0">
+              <ref role="3cqZAo" node="4_3mV3JBBhA" resolve="dummyParent" />
+            </node>
+            <node concept="liA8E" id="3Lzx5PeGMmS" role="2OqNvi">
+              <ref role="37wK5l" to="mhbf:~SNode.addChild(org.jetbrains.mps.openapi.language.SContainmentLink,org.jetbrains.mps.openapi.model.SNode)" resolve="addChild" />
+              <node concept="37vLTw" id="3Lzx5PeGPsB" role="37wK5m">
+                <ref role="3cqZAo" node="6ogDZt_iRYF" resolve="conceptLink" />
+              </node>
+              <node concept="37vLTw" id="3Lzx5PeGT43" role="37wK5m">
+                <ref role="3cqZAo" node="4_3mV3K5MCz" resolve="dummyChild" />
+              </node>
+            </node>
+          </node>
+        </node>
         <node concept="3clFbH" id="6ogDZtA2UCh" role="3cqZAp" />
         <node concept="3cpWs8" id="6ogDZtA2c7D" role="3cqZAp">
           <node concept="3cpWsn" id="6ogDZtA2c7E" role="3cpWs9">
@@ -3161,12 +3177,12 @@
             <property role="TrG5h" value="canBeAncestor" />
             <node concept="10P_77" id="4_3mV3JAV$T" role="1tU5fm" />
             <node concept="1rXfSq" id="4_3mV3JAV$U" role="33vP2m">
-              <ref role="37wK5l" node="1iGw5Cbi$yl" resolve="canBeAncestor" />
+              <ref role="37wK5l" node="3Lzx5PeFXWv" resolve="canBeAncestorForSubstitute" />
               <node concept="37vLTw" id="4_3mV3JE6q1" role="37wK5m">
                 <ref role="3cqZAo" node="4_3mV3JBBhA" resolve="dummyParent" />
               </node>
-              <node concept="37vLTw" id="4_3mV3JEbwt" role="37wK5m">
-                <ref role="3cqZAo" node="4_3mV3JBquO" resolve="substituteConcept" />
+              <node concept="37vLTw" id="3Lzx5PeGETG" role="37wK5m">
+                <ref role="3cqZAo" node="4_3mV3K5MCz" resolve="dummyChild" />
               </node>
               <node concept="37vLTw" id="6ogDZt_UyxB" role="37wK5m">
                 <ref role="3cqZAo" node="6ogDZt_iRYF" resolve="dummyLink" />
@@ -3260,22 +3276,6 @@
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="6ogDZt_YUwB" role="3cqZAp">
-          <node concept="2OqwBi" id="6ogDZt_YXk0" role="3clFbG">
-            <node concept="37vLTw" id="6ogDZt_YUw_" role="2Oq$k0">
-              <ref role="3cqZAo" node="1iGw5CbiaEV" resolve="parentNode" />
-            </node>
-            <node concept="liA8E" id="6ogDZt_YZHL" role="2OqNvi">
-              <ref role="37wK5l" to="mhbf:~SNode.addChild(org.jetbrains.mps.openapi.language.SContainmentLink,org.jetbrains.mps.openapi.model.SNode)" resolve="addChild" />
-              <node concept="37vLTw" id="6ogDZt_Z2hE" role="37wK5m">
-                <ref role="3cqZAo" node="1iGw5CbinvN" resolve="slink" />
-              </node>
-              <node concept="37vLTw" id="6ogDZt_Z8NU" role="37wK5m">
-                <ref role="3cqZAo" node="6ogDZt_U0r2" resolve="dummyChild" />
-              </node>
-            </node>
-          </node>
-        </node>
         <node concept="2$JKZl" id="1iGw5CbihFE" role="3cqZAp">
           <node concept="3clFbS" id="1iGw5CbihFG" role="2LFqv$">
             <node concept="3cpWs8" id="1iGw5Cbiv4d" role="3cqZAp">
@@ -3289,32 +3289,24 @@
                     <node concept="2OqwBi" id="1iGw5Cbiv4h" role="37wK5m">
                       <node concept="2OqwBi" id="1iGw5Cbiv4i" role="2Oq$k0">
                         <node concept="2OqwBi" id="1iGw5Cbiv4j" role="2Oq$k0">
-                          <node concept="2OqwBi" id="6ogDZt_ZbjZ" role="2Oq$k0">
-                            <node concept="2OqwBi" id="wZ3fvyujrO" role="2Oq$k0">
-                              <node concept="2OqwBi" id="1iGw5Cbiv4k" role="2Oq$k0">
-                                <node concept="2ShNRf" id="1iGw5Cbiv4l" role="2Oq$k0">
-                                  <node concept="1pGfFk" id="1iGw5Cbiv4m" role="2ShVmc">
-                                    <ref role="37wK5l" to="pdwk:~CanBeAncestorContext$Builder.&lt;init&gt;()" resolve="Builder" />
-                                  </node>
-                                </node>
-                                <node concept="liA8E" id="1iGw5Cbiv4n" role="2OqNvi">
-                                  <ref role="37wK5l" to="pdwk:~CanBeAncestorContext$Builder.ancestorNode(org.jetbrains.mps.openapi.model.SNode)" resolve="ancestorNode" />
-                                  <node concept="37vLTw" id="1iGw5Cbiv4o" role="37wK5m">
-                                    <ref role="3cqZAo" node="1iGw5Cbidgv" resolve="ancestorNode" />
-                                  </node>
+                          <node concept="2OqwBi" id="wZ3fvyujrO" role="2Oq$k0">
+                            <node concept="2OqwBi" id="1iGw5Cbiv4k" role="2Oq$k0">
+                              <node concept="2ShNRf" id="1iGw5Cbiv4l" role="2Oq$k0">
+                                <node concept="1pGfFk" id="1iGw5Cbiv4m" role="2ShVmc">
+                                  <ref role="37wK5l" to="pdwk:~CanBeAncestorContext$Builder.&lt;init&gt;()" resolve="Builder" />
                                 </node>
                               </node>
-                              <node concept="liA8E" id="wZ3fvyujF$" role="2OqNvi">
-                                <ref role="37wK5l" to="pdwk:~CanBeAncestorContext$Builder.parentNode(org.jetbrains.mps.openapi.model.SNode)" resolve="parentNode" />
-                                <node concept="37vLTw" id="wZ3fvyumn3" role="37wK5m">
-                                  <ref role="3cqZAo" node="1iGw5CbiaEV" resolve="parentNode" />
+                              <node concept="liA8E" id="1iGw5Cbiv4n" role="2OqNvi">
+                                <ref role="37wK5l" to="pdwk:~CanBeAncestorContext$Builder.ancestorNode(org.jetbrains.mps.openapi.model.SNode)" resolve="ancestorNode" />
+                                <node concept="37vLTw" id="1iGw5Cbiv4o" role="37wK5m">
+                                  <ref role="3cqZAo" node="1iGw5Cbidgv" resolve="ancestorNode" />
                                 </node>
                               </node>
                             </node>
-                            <node concept="liA8E" id="6ogDZt_Zelz" role="2OqNvi">
-                              <ref role="37wK5l" to="pdwk:~CanBeAncestorContext$Builder.descendantNode(org.jetbrains.mps.openapi.model.SNode)" resolve="descendantNode" />
-                              <node concept="37vLTw" id="6ogDZt_ZhBK" role="37wK5m">
-                                <ref role="3cqZAo" node="6ogDZt_U0r2" resolve="dummyChild" />
+                            <node concept="liA8E" id="wZ3fvyujF$" role="2OqNvi">
+                              <ref role="37wK5l" to="pdwk:~CanBeAncestorContext$Builder.parentNode(org.jetbrains.mps.openapi.model.SNode)" resolve="parentNode" />
+                              <node concept="37vLTw" id="wZ3fvyumn3" role="37wK5m">
+                                <ref role="3cqZAo" node="1iGw5CbiaEV" resolve="parentNode" />
                               </node>
                             </node>
                           </node>
@@ -3406,6 +3398,155 @@
       <node concept="3Tm1VV" id="1iGw5Cbi6WG" role="1B3o_S" />
     </node>
     <node concept="2tJIrI" id="My09KgFqSy" role="jymVt" />
+    <node concept="2YIFZL" id="3Lzx5PeFXWv" role="jymVt">
+      <property role="TrG5h" value="canBeAncestorForSubstitute" />
+      <node concept="3clFbS" id="3Lzx5PeFXWy" role="3clF47">
+        <node concept="3cpWs8" id="3Lzx5PeGbhI" role="3cqZAp">
+          <node concept="3cpWsn" id="3Lzx5PeGbhJ" role="3cpWs9">
+            <property role="TrG5h" value="ancestorNode" />
+            <node concept="3uibUv" id="3Lzx5PeGbhK" role="1tU5fm">
+              <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
+            </node>
+            <node concept="37vLTw" id="3Lzx5PeGbhL" role="33vP2m">
+              <ref role="3cqZAo" node="3Lzx5PeG1dW" resolve="parentNode" />
+            </node>
+          </node>
+        </node>
+        <node concept="2$JKZl" id="3Lzx5PeGbhY" role="3cqZAp">
+          <node concept="3clFbS" id="3Lzx5PeGbhZ" role="2LFqv$">
+            <node concept="3cpWs8" id="3Lzx5PeGbi0" role="3cqZAp">
+              <node concept="3cpWsn" id="3Lzx5PeGbi1" role="3cpWs9">
+                <property role="TrG5h" value="canBe" />
+                <node concept="10P_77" id="3Lzx5PeGbi2" role="1tU5fm" />
+                <node concept="2OqwBi" id="3Lzx5PeGbi3" role="33vP2m">
+                  <node concept="2YIFZM" id="3Lzx5PeGbi4" role="2Oq$k0">
+                    <ref role="37wK5l" to="ykok:~ConstraintsCanBeFacade.checkCanBeAncestor(jetbrains.mps.core.aspects.constraints.rules.kinds.CanBeAncestorContext)" resolve="checkCanBeAncestor" />
+                    <ref role="1Pybhc" to="ykok:~ConstraintsCanBeFacade" resolve="ConstraintsCanBeFacade" />
+                    <node concept="2OqwBi" id="3Lzx5PeGbi5" role="37wK5m">
+                      <node concept="2OqwBi" id="3Lzx5PeGbi6" role="2Oq$k0">
+                        <node concept="2OqwBi" id="3Lzx5PeGbi7" role="2Oq$k0">
+                          <node concept="2OqwBi" id="3Lzx5PeGbi8" role="2Oq$k0">
+                            <node concept="2OqwBi" id="3Lzx5PeGbi9" role="2Oq$k0">
+                              <node concept="2OqwBi" id="3Lzx5PeGbia" role="2Oq$k0">
+                                <node concept="2ShNRf" id="3Lzx5PeGbib" role="2Oq$k0">
+                                  <node concept="1pGfFk" id="3Lzx5PeGbic" role="2ShVmc">
+                                    <ref role="37wK5l" to="pdwk:~CanBeAncestorContext$Builder.&lt;init&gt;()" resolve="Builder" />
+                                  </node>
+                                </node>
+                                <node concept="liA8E" id="3Lzx5PeGbid" role="2OqNvi">
+                                  <ref role="37wK5l" to="pdwk:~CanBeAncestorContext$Builder.ancestorNode(org.jetbrains.mps.openapi.model.SNode)" resolve="ancestorNode" />
+                                  <node concept="37vLTw" id="3Lzx5PeGbie" role="37wK5m">
+                                    <ref role="3cqZAo" node="3Lzx5PeGbhJ" resolve="ancestorNode" />
+                                  </node>
+                                </node>
+                              </node>
+                              <node concept="liA8E" id="3Lzx5PeGbif" role="2OqNvi">
+                                <ref role="37wK5l" to="pdwk:~CanBeAncestorContext$Builder.parentNode(org.jetbrains.mps.openapi.model.SNode)" resolve="parentNode" />
+                                <node concept="37vLTw" id="3Lzx5PeGbig" role="37wK5m">
+                                  <ref role="3cqZAo" node="3Lzx5PeG1dW" resolve="parentNode" />
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="liA8E" id="3Lzx5PeGbih" role="2OqNvi">
+                              <ref role="37wK5l" to="pdwk:~CanBeAncestorContext$Builder.descendantNode(org.jetbrains.mps.openapi.model.SNode)" resolve="descendantNode" />
+                              <node concept="37vLTw" id="3Lzx5PeGbii" role="37wK5m">
+                                <ref role="3cqZAo" node="3Lzx5PeG5q$" resolve="childNode" />
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="liA8E" id="3Lzx5PeGbij" role="2OqNvi">
+                            <ref role="37wK5l" to="pdwk:~CanBeAncestorContext$Builder.childConcept(org.jetbrains.mps.openapi.language.SAbstractConcept)" resolve="childConcept" />
+                            <node concept="2OqwBi" id="3Lzx5PeGoWi" role="37wK5m">
+                              <node concept="37vLTw" id="3Lzx5PeGbik" role="2Oq$k0">
+                                <ref role="3cqZAo" node="3Lzx5PeG5q$" resolve="childNode" />
+                              </node>
+                              <node concept="liA8E" id="3Lzx5PeGqI5" role="2OqNvi">
+                                <ref role="37wK5l" to="mhbf:~SNode.getConcept()" resolve="getConcept" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="liA8E" id="3Lzx5PeGbil" role="2OqNvi">
+                          <ref role="37wK5l" to="pdwk:~CanBeAncestorContext$Builder.link(org.jetbrains.mps.openapi.language.SContainmentLink)" resolve="link" />
+                          <node concept="37vLTw" id="3Lzx5PeGbim" role="37wK5m">
+                            <ref role="3cqZAo" node="3Lzx5PeG7FK" resolve="link" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="liA8E" id="3Lzx5PeGbin" role="2OqNvi">
+                        <ref role="37wK5l" to="pdwk:~CanBeAncestorContext$Builder.build()" resolve="build" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="3Lzx5PeGbio" role="2OqNvi">
+                    <ref role="37wK5l" to="33ny:~List.isEmpty()" resolve="isEmpty" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbJ" id="3Lzx5PeGbip" role="3cqZAp">
+              <node concept="3clFbS" id="3Lzx5PeGbiq" role="3clFbx">
+                <node concept="3cpWs6" id="3Lzx5PeGbir" role="3cqZAp">
+                  <node concept="3clFbT" id="3Lzx5PeGbis" role="3cqZAk" />
+                </node>
+              </node>
+              <node concept="3fqX7Q" id="3Lzx5PeGbit" role="3clFbw">
+                <node concept="37vLTw" id="3Lzx5PeGbiu" role="3fr31v">
+                  <ref role="3cqZAo" node="3Lzx5PeGbi1" resolve="canBe" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="3Lzx5PeGbiv" role="3cqZAp">
+              <node concept="37vLTI" id="3Lzx5PeGbiw" role="3clFbG">
+                <node concept="2OqwBi" id="3Lzx5PeGbix" role="37vLTx">
+                  <node concept="37vLTw" id="3Lzx5PeGbiy" role="2Oq$k0">
+                    <ref role="3cqZAo" node="3Lzx5PeGbhJ" resolve="ancestorNode" />
+                  </node>
+                  <node concept="liA8E" id="3Lzx5PeGbiz" role="2OqNvi">
+                    <ref role="37wK5l" to="mhbf:~SNode.getParent()" resolve="getParent" />
+                  </node>
+                </node>
+                <node concept="37vLTw" id="3Lzx5PeGbi$" role="37vLTJ">
+                  <ref role="3cqZAo" node="3Lzx5PeGbhJ" resolve="ancestorNode" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3y3z36" id="3Lzx5PeGbi_" role="2$JKZa">
+            <node concept="10Nm6u" id="3Lzx5PeGbiA" role="3uHU7w" />
+            <node concept="37vLTw" id="3Lzx5PeGbiB" role="3uHU7B">
+              <ref role="3cqZAo" node="3Lzx5PeGbhJ" resolve="ancestorNode" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="3Lzx5PeGbiC" role="3cqZAp">
+          <node concept="3clFbT" id="3Lzx5PeGbiD" role="3cqZAk">
+            <property role="3clFbU" value="true" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="3Lzx5PeFSrO" role="1B3o_S" />
+      <node concept="10P_77" id="3Lzx5PeFWLE" role="3clF45" />
+      <node concept="37vLTG" id="3Lzx5PeG1dW" role="3clF46">
+        <property role="TrG5h" value="parentNode" />
+        <node concept="3uibUv" id="3Lzx5PeG1dV" role="1tU5fm">
+          <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="3Lzx5PeG5q$" role="3clF46">
+        <property role="TrG5h" value="childNode" />
+        <node concept="3uibUv" id="3Lzx5PeG6vP" role="1tU5fm">
+          <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="3Lzx5PeG7FK" role="3clF46">
+        <property role="TrG5h" value="link" />
+        <node concept="3uibUv" id="3Lzx5PeG8UV" role="1tU5fm">
+          <ref role="3uigEE" to="c17a:~SContainmentLink" resolve="SContainmentLink" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="3Lzx5PeFLC9" role="jymVt" />
     <node concept="2YIFZL" id="My09KhaUTQ" role="jymVt">
       <property role="DiZV1" value="false" />
       <property role="od$2w" value="false" />

--- a/code/grammarcells/solutions/com.mbeddr.mpsutil.grammarcells.runtime/models/com/mbeddr/mpsutil/grammarcells/runtime.mps
+++ b/code/grammarcells/solutions/com.mbeddr.mpsutil.grammarcells.runtime/models/com/mbeddr/mpsutil/grammarcells/runtime.mps
@@ -3257,25 +3257,6 @@
             </node>
           </node>
         </node>
-        <node concept="3cpWs8" id="6ogDZt_U0qZ" role="3cqZAp">
-          <node concept="3cpWsn" id="6ogDZt_U0r2" role="3cpWs9">
-            <property role="TrG5h" value="dummyChild" />
-            <node concept="3uibUv" id="6ogDZt_U0r3" role="1tU5fm">
-              <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
-            </node>
-            <node concept="2YIFZM" id="6ogDZt_U0r4" role="33vP2m">
-              <ref role="1Pybhc" to="i51s:~SConceptOperations" resolve="SConceptOperations" />
-              <ref role="37wK5l" to="i51s:~SConceptOperations.createNewNode(org.jetbrains.mps.openapi.language.SConcept)" resolve="createNewNode" />
-              <node concept="2YIFZM" id="6ogDZt_U0r5" role="37wK5m">
-                <ref role="37wK5l" to="i8bi:Det6sRbgD5" resolve="asInstanceConcept" />
-                <ref role="1Pybhc" to="i8bi:5IkW5anFcyt" resolve="SNodeOperations" />
-                <node concept="37vLTw" id="6ogDZt_U0r6" role="37wK5m">
-                  <ref role="3cqZAo" node="1iGw5Cbilgi" resolve="childConcept" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
         <node concept="2$JKZl" id="1iGw5CbihFE" role="3cqZAp">
           <node concept="3clFbS" id="1iGw5CbihFG" role="2LFqv$">
             <node concept="3cpWs8" id="1iGw5Cbiv4d" role="3cqZAp">

--- a/code/grammarcells/solutions/com.mbeddr.mpsutil.grammarcells.runtime/models/com/mbeddr/mpsutil/grammarcells/runtime.mps
+++ b/code/grammarcells/solutions/com.mbeddr.mpsutil.grammarcells.runtime/models/com/mbeddr/mpsutil/grammarcells/runtime.mps
@@ -11,6 +11,7 @@
     <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="14" />
     <use id="aee9cad2-acd4-4608-aef2-0004f6a1cdbd" name="jetbrains.mps.lang.actions" version="4" />
     <use id="c0080a47-7e37-4558-bee9-9ae18e690549" name="jetbrains.mps.lang.extension" version="2" />
+    <use id="1a8554c4-eb84-43ba-8c34-6f0d90c6e75a" name="jetbrains.mps.lang.smodel.query" version="3" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -69,6 +70,7 @@
     <import index="sn11" ref="r:836426ab-a6f4-4fa3-9a9c-34c02ed6ab5d(jetbrains.mps.ide.icons)" />
     <import index="pdwk" ref="8e98f4e2-decf-4e97-bf80-9109e8b759ee/java:jetbrains.mps.core.aspects.constraints.rules.kinds(jetbrains.mps.lang.constraints.rules.runtime/)" />
     <import index="6r6f" ref="r:d5239ba2-cf7c-43a5-8408-24daf38044ca(com.mbeddr.mpsutil.grammarcells.runtime.plugin)" />
+    <import index="i8bi" ref="r:c3548bac-30eb-4a2a-937c-0111d5697309(jetbrains.mps.lang.smodel.generator.smodelAdapter)" />
     <import index="lwvz" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.selection(MPS.Editor/)" implicit="true" />
     <import index="hox0" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.style(MPS.Editor/)" implicit="true" />
     <import index="z8iw" ref="r:dfdf3542-dbcf-43df-870a-3c3504b3c840(jetbrains.mps.baseLanguage.collections.custom)" implicit="true" />
@@ -2970,6 +2972,261 @@
       <node concept="3Tm1VV" id="2mvFNoUAeu7" role="1B3o_S" />
     </node>
     <node concept="2tJIrI" id="1iGw5Cbi3du" role="jymVt" />
+    <node concept="2YIFZL" id="4_3mV3JAVzS" role="jymVt">
+      <property role="TrG5h" value="canBeChildForSubstitute" />
+      <property role="DiZV1" value="false" />
+      <property role="od$2w" value="false" />
+      <node concept="37vLTG" id="4_3mV3JAVzT" role="3clF46">
+        <property role="TrG5h" value="parentConcept" />
+        <node concept="3uibUv" id="4_3mV3JDB1C" role="1tU5fm">
+          <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="4_3mV3JAVzV" role="3clF46">
+        <property role="TrG5h" value="context" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3uibUv" id="4_3mV3JAVzW" role="1tU5fm">
+          <ref role="3uigEE" to="78sh:~SubstituteMenuContext" resolve="SubstituteMenuContext" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="4_3mV3JBquO" role="3clF46">
+        <property role="TrG5h" value="substituteConcept" />
+        <node concept="3bZ5Sz" id="4_3mV3JBsu0" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="6ogDZt_iRYF" role="3clF46">
+        <property role="TrG5h" value="conceptLink" />
+        <node concept="3uibUv" id="6ogDZt_FAxh" role="1tU5fm">
+          <ref role="3uigEE" to="c17a:~SContainmentLink" resolve="SContainmentLink" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="4_3mV3JAVzX" role="3clF47">
+        <node concept="3cpWs8" id="4_3mV3JAVzY" role="3cqZAp">
+          <node concept="3cpWsn" id="4_3mV3JAVzZ" role="3cpWs9">
+            <property role="TrG5h" value="slink" />
+            <node concept="3uibUv" id="4_3mV3JAV$0" role="1tU5fm">
+              <ref role="3uigEE" to="c17a:~SContainmentLink" resolve="SContainmentLink" />
+            </node>
+            <node concept="2OqwBi" id="4_3mV3JAV$1" role="33vP2m">
+              <node concept="37vLTw" id="4_3mV3JAV$2" role="2Oq$k0">
+                <ref role="3cqZAo" node="4_3mV3JAVzV" resolve="context" />
+              </node>
+              <node concept="liA8E" id="4_3mV3JAV$3" role="2OqNvi">
+                <ref role="37wK5l" to="78sh:~SubstituteMenuContext.getLink()" resolve="getLink" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="4_3mV3JAV$4" role="3cqZAp">
+          <node concept="3clFbS" id="4_3mV3JAV$5" role="3clFbx">
+            <node concept="3cpWs6" id="4_3mV3JAV$6" role="3cqZAp">
+              <node concept="3clFbT" id="4_3mV3JAV$7" role="3cqZAk">
+                <property role="3clFbU" value="true" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbC" id="4_3mV3JAV$8" role="3clFbw">
+            <node concept="10Nm6u" id="4_3mV3JAV$9" role="3uHU7w" />
+            <node concept="37vLTw" id="4_3mV3JAV$a" role="3uHU7B">
+              <ref role="3cqZAo" node="4_3mV3JAVzZ" resolve="slink" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="4_3mV3JBBh_" role="3cqZAp">
+          <node concept="3cpWsn" id="4_3mV3JBBhA" role="3cpWs9">
+            <property role="TrG5h" value="dummyParent" />
+            <node concept="3uibUv" id="4_3mV3JBBhB" role="1tU5fm">
+              <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
+            </node>
+            <node concept="2YIFZM" id="4_3mV3JPbIv" role="33vP2m">
+              <ref role="37wK5l" to="i51s:~SConceptOperations.createNewNode(org.jetbrains.mps.openapi.language.SConcept)" resolve="createNewNode" />
+              <ref role="1Pybhc" to="i51s:~SConceptOperations" resolve="SConceptOperations" />
+              <node concept="2YIFZM" id="Det6sRbBsb" role="37wK5m">
+                <ref role="37wK5l" to="i8bi:Det6sRbgD5" resolve="asInstanceConcept" />
+                <ref role="1Pybhc" to="i8bi:5IkW5anFcyt" resolve="SNodeOperations" />
+                <node concept="37vLTw" id="4_3mV3JSKOq" role="37wK5m">
+                  <ref role="3cqZAo" node="4_3mV3JAVzT" resolve="childConcept" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="4_3mV3K5MCy" role="3cqZAp">
+          <node concept="3cpWsn" id="4_3mV3K5MCz" role="3cpWs9">
+            <property role="TrG5h" value="dummyChild" />
+            <node concept="3uibUv" id="4_3mV3K5MC$" role="1tU5fm">
+              <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
+            </node>
+            <node concept="2YIFZM" id="4_3mV3K5V8f" role="33vP2m">
+              <ref role="1Pybhc" to="i51s:~SConceptOperations" resolve="SConceptOperations" />
+              <ref role="37wK5l" to="i51s:~SConceptOperations.createNewNode(org.jetbrains.mps.openapi.language.SConcept)" resolve="createNewNode" />
+              <node concept="2YIFZM" id="4_3mV3K5V8g" role="37wK5m">
+                <ref role="1Pybhc" to="i8bi:5IkW5anFcyt" resolve="SNodeOperations" />
+                <ref role="37wK5l" to="i8bi:Det6sRbgD5" resolve="asInstanceConcept" />
+                <node concept="37vLTw" id="4_3mV3K60xr" role="37wK5m">
+                  <ref role="3cqZAo" node="4_3mV3JBquO" resolve="substituteConcept" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6ogDZtA2UCh" role="3cqZAp" />
+        <node concept="3cpWs8" id="6ogDZtA2c7D" role="3cqZAp">
+          <node concept="3cpWsn" id="6ogDZtA2c7E" role="3cpWs9">
+            <property role="TrG5h" value="build" />
+            <node concept="3uibUv" id="6ogDZtA2aaK" role="1tU5fm">
+              <ref role="3uigEE" to="pdwk:~ContainmentContext" resolve="ContainmentContext" />
+            </node>
+            <node concept="2OqwBi" id="6ogDZtA2c7F" role="33vP2m">
+              <node concept="2OqwBi" id="6ogDZtA2c7G" role="2Oq$k0">
+                <node concept="2OqwBi" id="6ogDZtA2c7I" role="2Oq$k0">
+                  <node concept="2OqwBi" id="6ogDZtA2c7J" role="2Oq$k0">
+                    <node concept="2OqwBi" id="6ogDZtA2c7K" role="2Oq$k0">
+                      <node concept="2ShNRf" id="6ogDZtA2c7L" role="2Oq$k0">
+                        <node concept="1pGfFk" id="6ogDZtA2c7M" role="2ShVmc">
+                          <ref role="37wK5l" to="pdwk:~ContainmentContext$Builder.&lt;init&gt;()" resolve="Builder" />
+                        </node>
+                      </node>
+                      <node concept="liA8E" id="6ogDZtA2c7N" role="2OqNvi">
+                        <ref role="37wK5l" to="pdwk:~ContainmentContext$Builder.parentNode(org.jetbrains.mps.openapi.model.SNode)" resolve="parentNode" />
+                        <node concept="37vLTw" id="6ogDZtA2c7O" role="37wK5m">
+                          <ref role="3cqZAo" node="4_3mV3JBBhA" resolve="dummyParent" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="6ogDZtA2c7P" role="2OqNvi">
+                      <ref role="37wK5l" to="pdwk:~ContainmentContext$Builder.childNode(org.jetbrains.mps.openapi.model.SNode)" resolve="childNode" />
+                      <node concept="37vLTw" id="6ogDZtA2c7Q" role="37wK5m">
+                        <ref role="3cqZAo" node="4_3mV3K5MCz" resolve="dummyChild" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="6ogDZtA2c7R" role="2OqNvi">
+                    <ref role="37wK5l" to="pdwk:~ContainmentContext$Builder.childConcept(org.jetbrains.mps.openapi.language.SAbstractConcept)" resolve="childConcept" />
+                    <node concept="37vLTw" id="6ogDZtA2c7S" role="37wK5m">
+                      <ref role="3cqZAo" node="4_3mV3JBquO" resolve="substituteConcept" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="liA8E" id="6ogDZtA2c7V" role="2OqNvi">
+                  <ref role="37wK5l" to="pdwk:~ContainmentContext$Builder.link(org.jetbrains.mps.openapi.language.SContainmentLink)" resolve="link" />
+                  <node concept="37vLTw" id="6ogDZtA2c7W" role="37wK5m">
+                    <ref role="3cqZAo" node="6ogDZt_iRYF" resolve="dummyLink" />
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="6ogDZtA2c7X" role="2OqNvi">
+                <ref role="37wK5l" to="pdwk:~ContainmentContext$Builder.build()" resolve="build" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="4_3mV3JAV$h" role="3cqZAp">
+          <node concept="3cpWsn" id="4_3mV3JAV$i" role="3cpWs9">
+            <property role="TrG5h" value="canBeChild" />
+            <node concept="10P_77" id="4_3mV3JAV$j" role="1tU5fm" />
+            <node concept="2OqwBi" id="4_3mV3JAV$k" role="33vP2m">
+              <node concept="2YIFZM" id="4_3mV3JAV$l" role="2Oq$k0">
+                <ref role="1Pybhc" to="ykok:~ConstraintsCanBeFacade" resolve="ConstraintsCanBeFacade" />
+                <ref role="37wK5l" to="ykok:~ConstraintsCanBeFacade.checkCanBeChild(jetbrains.mps.core.aspects.constraints.rules.kinds.ContainmentContext)" resolve="checkCanBeChild" />
+                <node concept="37vLTw" id="6ogDZtA2c7Y" role="37wK5m">
+                  <ref role="3cqZAo" node="6ogDZtA2c7E" resolve="build" />
+                </node>
+              </node>
+              <node concept="liA8E" id="4_3mV3JAV$z" role="2OqNvi">
+                <ref role="37wK5l" to="33ny:~List.isEmpty()" resolve="isEmpty" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="4_3mV3JAV$$" role="3cqZAp">
+          <node concept="3cpWsn" id="4_3mV3JAV$_" role="3cpWs9">
+            <property role="TrG5h" value="canBeParent" />
+            <node concept="10P_77" id="4_3mV3JAV$A" role="1tU5fm" />
+            <node concept="2OqwBi" id="4_3mV3JAV$B" role="33vP2m">
+              <node concept="2YIFZM" id="4_3mV3JAV$C" role="2Oq$k0">
+                <ref role="1Pybhc" to="ykok:~ConstraintsCanBeFacade" resolve="ConstraintsCanBeFacade" />
+                <ref role="37wK5l" to="ykok:~ConstraintsCanBeFacade.checkCanBeParent(jetbrains.mps.core.aspects.constraints.rules.kinds.ContainmentContext)" resolve="checkCanBeParent" />
+                <node concept="37vLTw" id="4_3mV3KfcnX" role="37wK5m">
+                  <ref role="3cqZAo" node="6ogDZtA2c7E" resolve="build" />
+                </node>
+              </node>
+              <node concept="liA8E" id="4_3mV3JAV$Q" role="2OqNvi">
+                <ref role="37wK5l" to="33ny:~List.isEmpty()" resolve="isEmpty" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="4_3mV3JAV$R" role="3cqZAp">
+          <node concept="3cpWsn" id="4_3mV3JAV$S" role="3cpWs9">
+            <property role="TrG5h" value="canBeAncestor" />
+            <node concept="10P_77" id="4_3mV3JAV$T" role="1tU5fm" />
+            <node concept="1rXfSq" id="4_3mV3JAV$U" role="33vP2m">
+              <ref role="37wK5l" node="1iGw5Cbi$yl" resolve="canBeAncestor" />
+              <node concept="37vLTw" id="4_3mV3JE6q1" role="37wK5m">
+                <ref role="3cqZAo" node="4_3mV3JBBhA" resolve="dummyParent" />
+              </node>
+              <node concept="37vLTw" id="4_3mV3JEbwt" role="37wK5m">
+                <ref role="3cqZAo" node="4_3mV3JBquO" resolve="substituteConcept" />
+              </node>
+              <node concept="37vLTw" id="6ogDZt_UyxB" role="37wK5m">
+                <ref role="3cqZAo" node="6ogDZt_iRYF" resolve="dummyLink" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="4_3mV3JAV_j" role="3cqZAp">
+          <node concept="3clFbS" id="4_3mV3JAV_k" role="3clFbx">
+            <node concept="3cpWs6" id="4_3mV3JAV_l" role="3cqZAp">
+              <node concept="3clFbT" id="4_3mV3JAV_m" role="3cqZAk">
+                <property role="3clFbU" value="false" />
+              </node>
+            </node>
+          </node>
+          <node concept="3fqX7Q" id="4_3mV3JAV_n" role="3clFbw">
+            <node concept="37vLTw" id="4_3mV3JAV_o" role="3fr31v">
+              <ref role="3cqZAo" node="4_3mV3JAV$i" resolve="canBeChild" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="4_3mV3JAV_p" role="3cqZAp">
+          <node concept="3clFbS" id="4_3mV3JAV_q" role="3clFbx">
+            <node concept="3cpWs6" id="4_3mV3JAV_r" role="3cqZAp">
+              <node concept="3clFbT" id="4_3mV3JAV_s" role="3cqZAk">
+                <property role="3clFbU" value="false" />
+              </node>
+            </node>
+          </node>
+          <node concept="3fqX7Q" id="4_3mV3JAV_t" role="3clFbw">
+            <node concept="37vLTw" id="4_3mV3JAV_u" role="3fr31v">
+              <ref role="3cqZAo" node="4_3mV3JAV$_" resolve="canBeParent" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="4_3mV3JAV_v" role="3cqZAp">
+          <node concept="3clFbS" id="4_3mV3JAV_w" role="3clFbx">
+            <node concept="3cpWs6" id="4_3mV3JAV_x" role="3cqZAp">
+              <node concept="3clFbT" id="4_3mV3JAV_y" role="3cqZAk">
+                <property role="3clFbU" value="false" />
+              </node>
+            </node>
+          </node>
+          <node concept="3fqX7Q" id="4_3mV3JAV_z" role="3clFbw">
+            <node concept="37vLTw" id="4_3mV3JAV_$" role="3fr31v">
+              <ref role="3cqZAo" node="4_3mV3JAV$S" resolve="canBeAncestor" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="4_3mV3JAV__" role="3cqZAp">
+          <node concept="3clFbT" id="4_3mV3JAV_A" role="3cqZAk">
+            <property role="3clFbU" value="true" />
+          </node>
+        </node>
+      </node>
+      <node concept="10P_77" id="4_3mV3JAV_B" role="3clF45" />
+      <node concept="3Tm1VV" id="4_3mV3JAV_C" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="4_3mV3JASmz" role="jymVt" />
+    <node concept="2tJIrI" id="4_3mV3JASGB" role="jymVt" />
     <node concept="2YIFZL" id="1iGw5Cbi$yl" role="jymVt">
       <property role="TrG5h" value="canBeAncestor" />
       <node concept="3clFbS" id="1iGw5Cbi6WH" role="3clF47">
@@ -2981,6 +3238,41 @@
             </node>
             <node concept="37vLTw" id="1iGw5Cbiu9Q" role="33vP2m">
               <ref role="3cqZAo" node="1iGw5CbiaEV" resolve="parentNode" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="6ogDZt_U0qZ" role="3cqZAp">
+          <node concept="3cpWsn" id="6ogDZt_U0r2" role="3cpWs9">
+            <property role="TrG5h" value="dummyChild" />
+            <node concept="3uibUv" id="6ogDZt_U0r3" role="1tU5fm">
+              <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
+            </node>
+            <node concept="2YIFZM" id="6ogDZt_U0r4" role="33vP2m">
+              <ref role="1Pybhc" to="i51s:~SConceptOperations" resolve="SConceptOperations" />
+              <ref role="37wK5l" to="i51s:~SConceptOperations.createNewNode(org.jetbrains.mps.openapi.language.SConcept)" resolve="createNewNode" />
+              <node concept="2YIFZM" id="6ogDZt_U0r5" role="37wK5m">
+                <ref role="37wK5l" to="i8bi:Det6sRbgD5" resolve="asInstanceConcept" />
+                <ref role="1Pybhc" to="i8bi:5IkW5anFcyt" resolve="SNodeOperations" />
+                <node concept="37vLTw" id="6ogDZt_U0r6" role="37wK5m">
+                  <ref role="3cqZAo" node="1iGw5Cbilgi" resolve="childConcept" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6ogDZt_YUwB" role="3cqZAp">
+          <node concept="2OqwBi" id="6ogDZt_YXk0" role="3clFbG">
+            <node concept="37vLTw" id="6ogDZt_YUw_" role="2Oq$k0">
+              <ref role="3cqZAo" node="1iGw5CbiaEV" resolve="parentNode" />
+            </node>
+            <node concept="liA8E" id="6ogDZt_YZHL" role="2OqNvi">
+              <ref role="37wK5l" to="mhbf:~SNode.addChild(org.jetbrains.mps.openapi.language.SContainmentLink,org.jetbrains.mps.openapi.model.SNode)" resolve="addChild" />
+              <node concept="37vLTw" id="6ogDZt_Z2hE" role="37wK5m">
+                <ref role="3cqZAo" node="1iGw5CbinvN" resolve="slink" />
+              </node>
+              <node concept="37vLTw" id="6ogDZt_Z8NU" role="37wK5m">
+                <ref role="3cqZAo" node="6ogDZt_U0r2" resolve="dummyChild" />
+              </node>
             </node>
           </node>
         </node>
@@ -2997,24 +3289,32 @@
                     <node concept="2OqwBi" id="1iGw5Cbiv4h" role="37wK5m">
                       <node concept="2OqwBi" id="1iGw5Cbiv4i" role="2Oq$k0">
                         <node concept="2OqwBi" id="1iGw5Cbiv4j" role="2Oq$k0">
-                          <node concept="2OqwBi" id="wZ3fvyujrO" role="2Oq$k0">
-                            <node concept="2OqwBi" id="1iGw5Cbiv4k" role="2Oq$k0">
-                              <node concept="2ShNRf" id="1iGw5Cbiv4l" role="2Oq$k0">
-                                <node concept="1pGfFk" id="1iGw5Cbiv4m" role="2ShVmc">
-                                  <ref role="37wK5l" to="pdwk:~CanBeAncestorContext$Builder.&lt;init&gt;()" resolve="CanBeAncestorContext.Builder" />
+                          <node concept="2OqwBi" id="6ogDZt_ZbjZ" role="2Oq$k0">
+                            <node concept="2OqwBi" id="wZ3fvyujrO" role="2Oq$k0">
+                              <node concept="2OqwBi" id="1iGw5Cbiv4k" role="2Oq$k0">
+                                <node concept="2ShNRf" id="1iGw5Cbiv4l" role="2Oq$k0">
+                                  <node concept="1pGfFk" id="1iGw5Cbiv4m" role="2ShVmc">
+                                    <ref role="37wK5l" to="pdwk:~CanBeAncestorContext$Builder.&lt;init&gt;()" resolve="Builder" />
+                                  </node>
+                                </node>
+                                <node concept="liA8E" id="1iGw5Cbiv4n" role="2OqNvi">
+                                  <ref role="37wK5l" to="pdwk:~CanBeAncestorContext$Builder.ancestorNode(org.jetbrains.mps.openapi.model.SNode)" resolve="ancestorNode" />
+                                  <node concept="37vLTw" id="1iGw5Cbiv4o" role="37wK5m">
+                                    <ref role="3cqZAo" node="1iGw5Cbidgv" resolve="ancestorNode" />
+                                  </node>
                                 </node>
                               </node>
-                              <node concept="liA8E" id="1iGw5Cbiv4n" role="2OqNvi">
-                                <ref role="37wK5l" to="pdwk:~CanBeAncestorContext$Builder.ancestorNode(org.jetbrains.mps.openapi.model.SNode)" resolve="ancestorNode" />
-                                <node concept="37vLTw" id="1iGw5Cbiv4o" role="37wK5m">
-                                  <ref role="3cqZAo" node="1iGw5Cbidgv" resolve="ancestorNode" />
+                              <node concept="liA8E" id="wZ3fvyujF$" role="2OqNvi">
+                                <ref role="37wK5l" to="pdwk:~CanBeAncestorContext$Builder.parentNode(org.jetbrains.mps.openapi.model.SNode)" resolve="parentNode" />
+                                <node concept="37vLTw" id="wZ3fvyumn3" role="37wK5m">
+                                  <ref role="3cqZAo" node="1iGw5CbiaEV" resolve="parentNode" />
                                 </node>
                               </node>
                             </node>
-                            <node concept="liA8E" id="wZ3fvyujF$" role="2OqNvi">
-                              <ref role="37wK5l" to="pdwk:~CanBeAncestorContext$Builder.parentNode(org.jetbrains.mps.openapi.model.SNode)" resolve="parentNode" />
-                              <node concept="37vLTw" id="wZ3fvyumn3" role="37wK5m">
-                                <ref role="3cqZAo" node="1iGw5CbiaEV" resolve="parentNode" />
+                            <node concept="liA8E" id="6ogDZt_Zelz" role="2OqNvi">
+                              <ref role="37wK5l" to="pdwk:~CanBeAncestorContext$Builder.descendantNode(org.jetbrains.mps.openapi.model.SNode)" resolve="descendantNode" />
+                              <node concept="37vLTw" id="6ogDZt_ZhBK" role="37wK5m">
+                                <ref role="3cqZAo" node="6ogDZt_U0r2" resolve="dummyChild" />
                               </node>
                             </node>
                           </node>

--- a/code/grammarcells/solutions/com.mbeddr.mpsutil.grammarcells.sandbox/models/com/mbeddr/mpsutil/editor/cells/sandbox.mps
+++ b/code/grammarcells/solutions/com.mbeddr.mpsutil.grammarcells.sandbox/models/com/mbeddr/mpsutil/editor/cells/sandbox.mps
@@ -109,8 +109,8 @@
             </node>
           </node>
         </node>
-        <node concept="2cssZR" id="2uT2PLmVCR0" role="2cssZA" />
-        <node concept="2cssZR" id="6oKG1kMzd0B" role="2cssZA" />
+        <node concept="2cssZR" id="3Lzx5PeOXBn" role="2cssZA" />
+        <node concept="2cssZR" id="3Lzx5PeOXEl" role="2cssZA" />
         <node concept="2cssZR" id="4qdNcH$3aon" role="2cssZA" />
         <node concept="1kHs8n" id="RbLMy69LtH" role="2cssZA">
           <property role="1kHkrk" value="true" />

--- a/code/grammarcells/solutions/com.mbeddr.mpsutil.grammarcells.tests/com.mbeddr.mpsutil.grammarcells.tests.msd
+++ b/code/grammarcells/solutions/com.mbeddr.mpsutil.grammarcells.tests/com.mbeddr.mpsutil.grammarcells.tests.msd
@@ -16,6 +16,7 @@
     <dependency reexport="false">5b1f863d-65a0-41a6-a801-33896be24202(jetbrains.mps.ide.editor)</dependency>
     <dependency reexport="false">1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)</dependency>
     <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
+    <dependency reexport="false">a257f68c-93a3-47b0-838b-6905dd9c20f6(com.mbeddr.mpsutil.grammarcells.sandboxlang)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:b4f35ed8-45af-4efa-abe4-00ac26956e69:com.mbeddr.mpsutil.grammarcells.runtimelang" version="0" />
@@ -23,9 +24,12 @@
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
     <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />
     <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
+    <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
     <language slang="l:5dc5fc0d-37ef-4782-8192-8b5ce1f69f80:jetbrains.mps.baseLanguage.extensionMethods" version="0" />
     <language slang="l:f61473f9-130f-42f6-b98d-6c438812c2f6:jetbrains.mps.baseLanguage.unitTest" version="1" />
     <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
+    <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
+    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
     <language slang="l:8585453e-6bfb-4d80-98de-b16074f1d86c:jetbrains.mps.lang.test" version="5" />
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
   </languageVersions>
@@ -37,8 +41,10 @@
     <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
+    <module reference="a257f68c-93a3-47b0-838b-6905dd9c20f6(com.mbeddr.mpsutil.grammarcells.sandboxlang)" version="0" />
     <module reference="c24d4a42-505e-4ffb-a24c-28919615a5bc(com.mbeddr.mpsutil.grammarcells.tests)" version="0" />
     <module reference="5b1f863d-65a0-41a6-a801-33896be24202(jetbrains.mps.ide.editor)" version="0" />
+    <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
   </dependencyVersions>
 </solution>
 

--- a/code/grammarcells/solutions/com.mbeddr.mpsutil.grammarcells.tests/models/com/mbeddr/mpsutil/grammarcells/tests@tests.mps
+++ b/code/grammarcells/solutions/com.mbeddr.mpsutil.grammarcells.tests/models/com/mbeddr/mpsutil/grammarcells/tests@tests.mps
@@ -9,6 +9,8 @@
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
     <use id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures" version="0" />
     <use id="b4f35ed8-45af-4efa-abe4-00ac26956e69" name="com.mbeddr.mpsutil.grammarcells.runtimelang" version="0" />
+    <use id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections" version="1" />
+    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
   </languages>
   <imports>
     <import index="ekwn" ref="r:9832fb5f-2578-4b58-8014-a5de79da988e(jetbrains.mps.ide.editor.actions)" />
@@ -19,6 +21,9 @@
     <import index="lwvz" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.selection(MPS.Editor/)" />
     <import index="22ra" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.update(MPS.Editor/)" />
     <import index="bd8o" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.application(MPS.IDEA/)" />
+    <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
+    <import index="ibwz" ref="r:ad27d4b4-fc2c-4b6d-9e22-455eb0ccf354(com.mbeddr.mpsutil.grammarcells.sandboxlang.structure)" />
+    <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" implicit="true" />
   </imports>
   <registry>
     <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
@@ -26,6 +31,7 @@
         <child id="1101347953350127927" name="actionReference" index="3iKnsn" />
       </concept>
       <concept id="1229187653856" name="jetbrains.mps.lang.test.structure.EditorTestCase" flags="lg" index="LiM7Y">
+        <property id="1883175908513350760" name="description" index="3YCmrE" />
         <child id="3143335925185262946" name="testNodeBefore" index="25YQCW" />
         <child id="3143335925185262981" name="testNodeResult" index="25YQFr" />
         <child id="1229187755283" name="code" index="LjaKd" />
@@ -64,6 +70,7 @@
       <concept id="3316739663067157299" name="jetbrains.mps.baseLanguage.extensionMethods.structure.ThisExtensionExpression" flags="nn" index="2V_BSl" />
     </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
@@ -97,6 +104,7 @@
         <child id="1068580123134" name="parameter" index="3clF46" />
         <child id="1068580123135" name="body" index="3clF47" />
       </concept>
+      <concept id="1068580123152" name="jetbrains.mps.baseLanguage.structure.EqualsExpression" flags="nn" index="3clFbC" />
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
@@ -108,6 +116,7 @@
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
+      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT" />
       <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
         <property id="1068580320021" name="value" index="3cmrfH" />
       </concept>
@@ -118,6 +127,13 @@
       <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
       <concept id="1079359253375" name="jetbrains.mps.baseLanguage.structure.ParenthesizedExpression" flags="nn" index="1eOMI4">
         <child id="1079359253376" name="expression" index="1eOMHV" />
+      </concept>
+      <concept id="1081516740877" name="jetbrains.mps.baseLanguage.structure.NotExpression" flags="nn" index="3fqX7Q">
+        <child id="1081516765348" name="expression" index="3fr31v" />
+      </concept>
+      <concept id="1160998861373" name="jetbrains.mps.baseLanguage.structure.AssertStatement" flags="nn" index="1gVbGN">
+        <child id="1160998896846" name="condition" index="1gVkn0" />
+        <child id="1160998916832" name="message" index="1gVpfI" />
       </concept>
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
@@ -141,6 +157,7 @@
     </language>
     <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
       <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
+        <child id="1199569906740" name="parameter" index="1bW2Oz" />
         <child id="1199569916463" name="body" index="1bW5cS" />
       </concept>
     </language>
@@ -153,6 +170,11 @@
         <child id="8427750732757990724" name="expected" index="3tpDZB" />
       </concept>
       <concept id="1171978097730" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertEquals" flags="nn" index="3vlDli" />
+    </language>
+    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="2644386474300074836" name="jetbrains.mps.lang.smodel.structure.ConceptIdRefExpression" flags="nn" index="35c_gC">
+        <reference id="2644386474300074837" name="conceptDeclaration" index="35c_gD" />
+      </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
@@ -226,6 +248,7 @@
         <property id="5465812603479727090" name="flagA" index="34AmLC" />
         <child id="5465812603479727085" name="childA" index="34AmLR" />
       </concept>
+      <concept id="1811135247170681488" name="com.mbeddr.mpsutil.grammarcells.sandboxlang.structure.StmtContainerAncestor" flags="ng" index="1eV$HT" />
       <concept id="8622846647855906237" name="com.mbeddr.mpsutil.grammarcells.sandboxlang.structure.TEST_optionalInComponent" flags="ng" index="1hHfNE">
         <child id="8622846647855952043" name="optionalChildren" index="1hHr7W" />
       </concept>
@@ -262,6 +285,7 @@
         <child id="5083944728300233289" name="right" index="ywYU2" />
         <child id="5083944728300233286" name="left" index="ywYUd" />
       </concept>
+      <concept id="4351467201262334896" name="com.mbeddr.mpsutil.grammarcells.sandboxlang.structure.StmtContainerParent" flags="ng" index="1NoFvH" />
       <concept id="5020734785399285455" name="com.mbeddr.mpsutil.grammarcells.sandboxlang.structure.FractionExpression" flags="ng" index="3QxHPw" />
       <concept id="5020734785399285456" name="com.mbeddr.mpsutil.grammarcells.sandboxlang.structure.DivExpression" flags="ng" index="3QxHPZ" />
       <concept id="3715388205391558016" name="com.mbeddr.mpsutil.grammarcells.sandboxlang.structure.TEST_OptionalNextToRenderingConditon" flags="ng" index="1Uxo1z">
@@ -269,6 +293,17 @@
         <child id="3715388205391558067" name="expr" index="1Uxo1g" />
         <child id="3715388205391955609" name="expr2" index="1UBZdU" />
       </concept>
+    </language>
+    <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
+        <child id="1204796294226" name="closure" index="23t8la" />
+      </concept>
+      <concept id="1151688443754" name="jetbrains.mps.baseLanguage.collections.structure.ListType" flags="in" index="_YKpA">
+        <child id="1151688676805" name="elementType" index="_ZDj9" />
+      </concept>
+      <concept id="1235566554328" name="jetbrains.mps.baseLanguage.collections.structure.AnyOperation" flags="nn" index="2HwmR7" />
+      <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
+      <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
     </language>
     <language id="b4f35ed8-45af-4efa-abe4-00ac26956e69" name="com.mbeddr.mpsutil.grammarcells.runtimelang">
       <concept id="5083944728301309881" name="com.mbeddr.mpsutil.grammarcells.runtimelang.structure.ArbitraryTextAnnotation" flags="ng" index="y$OdM">
@@ -2973,6 +3008,430 @@
           <node concept="yzEQC" id="7uEwlsA9wLX" role="yzEPe" />
         </node>
         <node concept="2cssZD" id="7uEwlsA9wLY" role="2cssWm" />
+      </node>
+    </node>
+  </node>
+  <node concept="LiM7Y" id="3Lzx5Pf0iSH">
+    <property role="TrG5h" value="GrammarWrapFilterConstraintsParentNode" />
+    <property role="3YCmrE" value="Check whether grammar.wrap correctly applies node constraints for parent restrictions" />
+    <node concept="1qefOq" id="3Lzx5Pf3sGK" role="25YQCW">
+      <node concept="1NoFvH" id="3Lzx5Pf3sJA" role="1qenE9">
+        <node concept="LIFWc" id="3Lzx5Pfpw_B" role="lGtFl">
+          <property role="ZRATv" value="true" />
+          <property role="OXtK3" value="true" />
+          <property role="p6zMq" value="0" />
+          <property role="p6zMs" value="0" />
+          <property role="LIFWd" value="empty_stmts" />
+        </node>
+      </node>
+    </node>
+    <node concept="3clFbS" id="3Lzx5PfpxzN" role="LjaKd">
+      <node concept="3cpWs8" id="3Lzx5PfpxzI" role="3cqZAp">
+        <node concept="3cpWsn" id="3Lzx5PfpxzL" role="3cpWs9">
+          <property role="TrG5h" value="si" />
+          <node concept="3uibUv" id="3Lzx5PfpxzH" role="1tU5fm">
+            <ref role="3uigEE" to="f4zo:~SubstituteInfo" resolve="SubstituteInfo" />
+          </node>
+          <node concept="2OqwBi" id="3Lzx5Pfp$t5" role="33vP2m">
+            <node concept="2OqwBi" id="3Lzx5Pfpy7p" role="2Oq$k0">
+              <node concept="369mXd" id="3Lzx5PfpxMV" role="2Oq$k0" />
+              <node concept="liA8E" id="3Lzx5Pfp$nU" role="2OqNvi">
+                <ref role="37wK5l" to="exr9:~EditorComponent.getSelectedCell()" resolve="getSelectedCell" />
+              </node>
+            </node>
+            <node concept="liA8E" id="3Lzx5Pfp$E9" role="2OqNvi">
+              <ref role="37wK5l" to="f4zo:~EditorCell.getSubstituteInfo()" resolve="getSubstituteInfo" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3cpWs8" id="3Lzx5PfthMu" role="3cqZAp">
+        <node concept="3cpWsn" id="3Lzx5PfthMx" role="3cpWs9">
+          <property role="TrG5h" value="actions" />
+          <node concept="_YKpA" id="3Lzx5PfthMq" role="1tU5fm">
+            <node concept="3uibUv" id="3Lzx5Pftw_F" role="_ZDj9">
+              <ref role="3uigEE" to="f4zo:~SubstituteAction" resolve="SubstituteAction" />
+            </node>
+          </node>
+          <node concept="2OqwBi" id="3Lzx5PfpHUS" role="33vP2m">
+            <node concept="37vLTw" id="3Lzx5PfpHUT" role="2Oq$k0">
+              <ref role="3cqZAo" node="3Lzx5PfpxzL" resolve="si" />
+            </node>
+            <node concept="liA8E" id="3Lzx5PfpHUU" role="2OqNvi">
+              <ref role="37wK5l" to="f4zo:~SubstituteInfo.getMatchingActions(java.lang.String,boolean)" resolve="getMatchingActions" />
+              <node concept="Xl_RD" id="3Lzx5PfpHUV" role="37wK5m">
+                <property role="Xl_RC" value="" />
+              </node>
+              <node concept="3clFbT" id="3Lzx5PfpHUW" role="37wK5m" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1gVbGN" id="3Lzx5PfpIip" role="3cqZAp">
+        <node concept="3clFbC" id="3Lzx5PfpJWG" role="1gVkn0">
+          <node concept="3cmrfG" id="3Lzx5PfpK3S" role="3uHU7w">
+            <property role="3cmrfH" value="2" />
+          </node>
+          <node concept="2OqwBi" id="3Lzx5PfpIMB" role="3uHU7B">
+            <node concept="37vLTw" id="3Lzx5PfpInr" role="2Oq$k0">
+              <ref role="3cqZAo" node="3Lzx5PfthMx" resolve="actions" />
+            </node>
+            <node concept="34oBXx" id="3Lzx5PftxCc" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="Xl_RD" id="3Lzx5PftDji" role="1gVpfI">
+          <property role="Xl_RC" value="Maximum of 2 actions, Type B and WrapStmt expected" />
+        </node>
+      </node>
+      <node concept="1gVbGN" id="3Lzx5PfsXDS" role="3cqZAp">
+        <node concept="3fqX7Q" id="3Lzx5PfsZzQ" role="1gVkn0">
+          <node concept="2OqwBi" id="3Lzx5PfsZzS" role="3fr31v">
+            <node concept="37vLTw" id="3Lzx5PfsZzT" role="2Oq$k0">
+              <ref role="3cqZAo" node="3Lzx5PfthMx" resolve="actions" />
+            </node>
+            <node concept="2HwmR7" id="3Lzx5Pfty7H" role="2OqNvi">
+              <node concept="1bVj0M" id="3Lzx5Pfty7J" role="23t8la">
+                <node concept="3clFbS" id="3Lzx5Pfty7K" role="1bW5cS">
+                  <node concept="3clFbF" id="3Lzx5Pftyju" role="3cqZAp">
+                    <node concept="2OqwBi" id="3Lzx5Pft$G9" role="3clFbG">
+                      <node concept="2OqwBi" id="3Lzx5Pftywm" role="2Oq$k0">
+                        <node concept="37vLTw" id="3Lzx5Pftyjt" role="2Oq$k0">
+                          <ref role="3cqZAo" node="3Lzx5Pfty7L" resolve="it" />
+                        </node>
+                        <node concept="liA8E" id="3Lzx5Pft$8d" role="2OqNvi">
+                          <ref role="37wK5l" to="f4zo:~SubstituteAction.getMatchingText(java.lang.String)" resolve="getMatchingText" />
+                          <node concept="Xl_RD" id="3Lzx5Pft$l1" role="37wK5m">
+                            <property role="Xl_RC" value="" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="liA8E" id="3Lzx5PftAKJ" role="2OqNvi">
+                        <ref role="37wK5l" to="wyt6:~String.equals(java.lang.Object)" resolve="equals" />
+                        <node concept="2OqwBi" id="3Lzx5PfuA9t" role="37wK5m">
+                          <node concept="35c_gC" id="3Lzx5Pfu_6u" role="2Oq$k0">
+                            <ref role="35c_gD" to="ibwz:3Lzx5Pf0k2q" resolve="AType" />
+                          </node>
+                          <node concept="liA8E" id="3Lzx5PfuKWn" role="2OqNvi">
+                            <ref role="37wK5l" to="c17a:~SAbstractConcept.getConceptAlias()" resolve="getConceptAlias" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="Rh6nW" id="3Lzx5Pfty7L" role="1bW2Oz">
+                  <property role="TrG5h" value="it" />
+                  <node concept="2jxLKc" id="3Lzx5Pfty7M" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="Xl_RD" id="3Lzx5PftBGT" role="1gVpfI">
+          <property role="Xl_RC" value="Type A not excluded from autocomplete menu" />
+        </node>
+      </node>
+      <node concept="1gVbGN" id="3Lzx5PftFtx" role="3cqZAp">
+        <node concept="2OqwBi" id="3Lzx5PftGpQ" role="1gVkn0">
+          <node concept="37vLTw" id="3Lzx5PftFEJ" role="2Oq$k0">
+            <ref role="3cqZAo" node="3Lzx5PfthMx" resolve="actions" />
+          </node>
+          <node concept="2HwmR7" id="3Lzx5PftHnM" role="2OqNvi">
+            <node concept="1bVj0M" id="3Lzx5PftHnO" role="23t8la">
+              <node concept="3clFbS" id="3Lzx5PftHnP" role="1bW5cS">
+                <node concept="3clFbF" id="3Lzx5PftHBZ" role="3cqZAp">
+                  <node concept="2OqwBi" id="3Lzx5PftKOb" role="3clFbG">
+                    <node concept="2OqwBi" id="3Lzx5PftHSu" role="2Oq$k0">
+                      <node concept="37vLTw" id="3Lzx5PftHBY" role="2Oq$k0">
+                        <ref role="3cqZAo" node="3Lzx5PftHnQ" resolve="it" />
+                      </node>
+                      <node concept="liA8E" id="3Lzx5PftJE3" role="2OqNvi">
+                        <ref role="37wK5l" to="f4zo:~SubstituteAction.getMatchingText(java.lang.String)" resolve="getMatchingText" />
+                        <node concept="Xl_RD" id="3Lzx5PftJWU" role="37wK5m" />
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="3Lzx5PftMKC" role="2OqNvi">
+                      <ref role="37wK5l" to="wyt6:~String.equals(java.lang.Object)" resolve="equals" />
+                      <node concept="2OqwBi" id="3Lzx5PfuyJD" role="37wK5m">
+                        <node concept="35c_gC" id="3Lzx5PfuxhQ" role="2Oq$k0">
+                          <ref role="35c_gD" to="ibwz:3Lzx5Pf0k5B" resolve="BType" />
+                        </node>
+                        <node concept="liA8E" id="3Lzx5PfuIUA" role="2OqNvi">
+                          <ref role="37wK5l" to="c17a:~SAbstractConcept.getConceptAlias()" resolve="getConceptAlias" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="Rh6nW" id="3Lzx5PftHnQ" role="1bW2Oz">
+                <property role="TrG5h" value="it" />
+                <node concept="2jxLKc" id="3Lzx5PftHnR" role="1tU5fm" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="Xl_RD" id="3Lzx5PftNG7" role="1gVpfI">
+          <property role="Xl_RC" value="Type B not included in autocomplete menu" />
+        </node>
+      </node>
+      <node concept="1gVbGN" id="3Lzx5PftQwR" role="3cqZAp">
+        <node concept="2OqwBi" id="3Lzx5PftRF_" role="1gVkn0">
+          <node concept="37vLTw" id="3Lzx5PftQWq" role="2Oq$k0">
+            <ref role="3cqZAo" node="3Lzx5PfthMx" resolve="actions" />
+          </node>
+          <node concept="2HwmR7" id="3Lzx5PftSHR" role="2OqNvi">
+            <node concept="1bVj0M" id="3Lzx5PftSHT" role="23t8la">
+              <node concept="3clFbS" id="3Lzx5PftSHU" role="1bW5cS">
+                <node concept="3clFbF" id="3Lzx5PftT2q" role="3cqZAp">
+                  <node concept="2OqwBi" id="3Lzx5PftVZj" role="3clFbG">
+                    <node concept="2OqwBi" id="3Lzx5PftTmX" role="2Oq$k0">
+                      <node concept="37vLTw" id="3Lzx5PftT2p" role="2Oq$k0">
+                        <ref role="3cqZAo" node="3Lzx5PftSHV" resolve="it" />
+                      </node>
+                      <node concept="liA8E" id="3Lzx5PftV7p" role="2OqNvi">
+                        <ref role="37wK5l" to="f4zo:~SubstituteAction.getMatchingText(java.lang.String)" resolve="getMatchingText" />
+                        <node concept="Xl_RD" id="3Lzx5PftVuA" role="37wK5m">
+                          <property role="Xl_RC" value="" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="3Lzx5PftYbT" role="2OqNvi">
+                      <ref role="37wK5l" to="wyt6:~String.equals(java.lang.Object)" resolve="equals" />
+                      <node concept="2OqwBi" id="3Lzx5Pfuvu1" role="37wK5m">
+                        <node concept="35c_gC" id="3Lzx5Pfu9Gc" role="2Oq$k0">
+                          <ref role="35c_gD" to="ibwz:3Lzx5Pf0jk5" resolve="WrapStmt" />
+                        </node>
+                        <node concept="liA8E" id="3Lzx5Pfwuva" role="2OqNvi">
+                          <ref role="37wK5l" to="c17a:~SAbstractConcept.getConceptAlias()" resolve="getConceptAlias" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="Rh6nW" id="3Lzx5PftSHV" role="1bW2Oz">
+                <property role="TrG5h" value="it" />
+                <node concept="2jxLKc" id="3Lzx5PftSHW" role="1tU5fm" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="Xl_RD" id="3Lzx5PfuTN9" role="1gVpfI">
+          <property role="Xl_RC" value="Default wrapped Stmt not included in autocomplete menu" />
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="LiM7Y" id="1$ysu_nQFfa">
+    <property role="TrG5h" value="GrammarWrapFilterConstraintsAncestorNode" />
+    <property role="3YCmrE" value="Check whether grammar.wrap correctly applies node constraints for ancestor restrictions" />
+    <node concept="1qefOq" id="1$ysu_nQIgm" role="25YQCW">
+      <node concept="1eV$HT" id="1$ysu_nQIgy" role="1qenE9">
+        <node concept="LIFWc" id="1$ysu_nQIgG" role="lGtFl">
+          <property role="ZRATv" value="true" />
+          <property role="OXtK3" value="true" />
+          <property role="p6zMq" value="0" />
+          <property role="p6zMs" value="0" />
+          <property role="LIFWd" value="empty_stmts" />
+        </node>
+      </node>
+    </node>
+    <node concept="3clFbS" id="1$ysu_nQItn" role="LjaKd">
+      <node concept="3cpWs8" id="1$ysu_nQItx" role="3cqZAp">
+        <node concept="3cpWsn" id="1$ysu_nQIty" role="3cpWs9">
+          <property role="TrG5h" value="si" />
+          <node concept="3uibUv" id="1$ysu_nQItz" role="1tU5fm">
+            <ref role="3uigEE" to="f4zo:~SubstituteInfo" resolve="SubstituteInfo" />
+          </node>
+          <node concept="2OqwBi" id="1$ysu_nQIt$" role="33vP2m">
+            <node concept="2OqwBi" id="1$ysu_nQIt_" role="2Oq$k0">
+              <node concept="369mXd" id="1$ysu_nQItA" role="2Oq$k0" />
+              <node concept="liA8E" id="1$ysu_nQItB" role="2OqNvi">
+                <ref role="37wK5l" to="exr9:~EditorComponent.getSelectedCell()" resolve="getSelectedCell" />
+              </node>
+            </node>
+            <node concept="liA8E" id="1$ysu_nQItC" role="2OqNvi">
+              <ref role="37wK5l" to="f4zo:~EditorCell.getSubstituteInfo()" resolve="getSubstituteInfo" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3cpWs8" id="1$ysu_nQItD" role="3cqZAp">
+        <node concept="3cpWsn" id="1$ysu_nQItE" role="3cpWs9">
+          <property role="TrG5h" value="actions" />
+          <node concept="_YKpA" id="1$ysu_nQItF" role="1tU5fm">
+            <node concept="3uibUv" id="1$ysu_nQItG" role="_ZDj9">
+              <ref role="3uigEE" to="f4zo:~SubstituteAction" resolve="SubstituteAction" />
+            </node>
+          </node>
+          <node concept="2OqwBi" id="1$ysu_nQItH" role="33vP2m">
+            <node concept="37vLTw" id="1$ysu_nQItI" role="2Oq$k0">
+              <ref role="3cqZAo" node="1$ysu_nQIty" resolve="si" />
+            </node>
+            <node concept="liA8E" id="1$ysu_nQItJ" role="2OqNvi">
+              <ref role="37wK5l" to="f4zo:~SubstituteInfo.getMatchingActions(java.lang.String,boolean)" resolve="getMatchingActions" />
+              <node concept="Xl_RD" id="1$ysu_nQItK" role="37wK5m">
+                <property role="Xl_RC" value="" />
+              </node>
+              <node concept="3clFbT" id="1$ysu_nQItL" role="37wK5m" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1gVbGN" id="1$ysu_nQItM" role="3cqZAp">
+        <node concept="3clFbC" id="1$ysu_nQItN" role="1gVkn0">
+          <node concept="3cmrfG" id="1$ysu_nQItO" role="3uHU7w">
+            <property role="3cmrfH" value="2" />
+          </node>
+          <node concept="2OqwBi" id="1$ysu_nQItP" role="3uHU7B">
+            <node concept="37vLTw" id="1$ysu_nQItQ" role="2Oq$k0">
+              <ref role="3cqZAo" node="1$ysu_nQItE" resolve="actions" />
+            </node>
+            <node concept="34oBXx" id="1$ysu_nQItR" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="Xl_RD" id="1$ysu_nQItS" role="1gVpfI">
+          <property role="Xl_RC" value="Maximum of 2 actions, Type B and WrapStmt expected" />
+        </node>
+      </node>
+      <node concept="1gVbGN" id="1$ysu_nQItT" role="3cqZAp">
+        <node concept="3fqX7Q" id="1$ysu_nQItU" role="1gVkn0">
+          <node concept="2OqwBi" id="1$ysu_nQItV" role="3fr31v">
+            <node concept="37vLTw" id="1$ysu_nQItW" role="2Oq$k0">
+              <ref role="3cqZAo" node="1$ysu_nQItE" resolve="actions" />
+            </node>
+            <node concept="2HwmR7" id="1$ysu_nQItX" role="2OqNvi">
+              <node concept="1bVj0M" id="1$ysu_nQItY" role="23t8la">
+                <node concept="3clFbS" id="1$ysu_nQItZ" role="1bW5cS">
+                  <node concept="3clFbF" id="1$ysu_nQIu0" role="3cqZAp">
+                    <node concept="2OqwBi" id="1$ysu_nQIu1" role="3clFbG">
+                      <node concept="2OqwBi" id="1$ysu_nQIu2" role="2Oq$k0">
+                        <node concept="37vLTw" id="1$ysu_nQIu3" role="2Oq$k0">
+                          <ref role="3cqZAo" node="1$ysu_nQIua" resolve="it" />
+                        </node>
+                        <node concept="liA8E" id="1$ysu_nQIu4" role="2OqNvi">
+                          <ref role="37wK5l" to="f4zo:~SubstituteAction.getMatchingText(java.lang.String)" resolve="getMatchingText" />
+                          <node concept="Xl_RD" id="1$ysu_nQIu5" role="37wK5m">
+                            <property role="Xl_RC" value="" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="liA8E" id="1$ysu_nQIu6" role="2OqNvi">
+                        <ref role="37wK5l" to="wyt6:~String.equals(java.lang.Object)" resolve="equals" />
+                        <node concept="2OqwBi" id="1$ysu_nQIu7" role="37wK5m">
+                          <node concept="35c_gC" id="1$ysu_nQIu8" role="2Oq$k0">
+                            <ref role="35c_gD" to="ibwz:3Lzx5Pf0k2q" resolve="AType" />
+                          </node>
+                          <node concept="liA8E" id="1$ysu_nQIu9" role="2OqNvi">
+                            <ref role="37wK5l" to="c17a:~SAbstractConcept.getConceptAlias()" resolve="getConceptAlias" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="Rh6nW" id="1$ysu_nQIua" role="1bW2Oz">
+                  <property role="TrG5h" value="it" />
+                  <node concept="2jxLKc" id="1$ysu_nQIub" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="Xl_RD" id="1$ysu_nQIuc" role="1gVpfI">
+          <property role="Xl_RC" value="Type A not excluded from autocomplete menu" />
+        </node>
+      </node>
+      <node concept="1gVbGN" id="1$ysu_nQIud" role="3cqZAp">
+        <node concept="2OqwBi" id="1$ysu_nQIue" role="1gVkn0">
+          <node concept="37vLTw" id="1$ysu_nQIuf" role="2Oq$k0">
+            <ref role="3cqZAo" node="1$ysu_nQItE" resolve="actions" />
+          </node>
+          <node concept="2HwmR7" id="1$ysu_nQIug" role="2OqNvi">
+            <node concept="1bVj0M" id="1$ysu_nQIuh" role="23t8la">
+              <node concept="3clFbS" id="1$ysu_nQIui" role="1bW5cS">
+                <node concept="3clFbF" id="1$ysu_nQIuj" role="3cqZAp">
+                  <node concept="2OqwBi" id="1$ysu_nQIuk" role="3clFbG">
+                    <node concept="2OqwBi" id="1$ysu_nQIul" role="2Oq$k0">
+                      <node concept="37vLTw" id="1$ysu_nQIum" role="2Oq$k0">
+                        <ref role="3cqZAo" node="1$ysu_nQIut" resolve="it" />
+                      </node>
+                      <node concept="liA8E" id="1$ysu_nQIun" role="2OqNvi">
+                        <ref role="37wK5l" to="f4zo:~SubstituteAction.getMatchingText(java.lang.String)" resolve="getMatchingText" />
+                        <node concept="Xl_RD" id="1$ysu_nQIuo" role="37wK5m" />
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="1$ysu_nQIup" role="2OqNvi">
+                      <ref role="37wK5l" to="wyt6:~String.equals(java.lang.Object)" resolve="equals" />
+                      <node concept="2OqwBi" id="1$ysu_nQIuq" role="37wK5m">
+                        <node concept="35c_gC" id="1$ysu_nQIur" role="2Oq$k0">
+                          <ref role="35c_gD" to="ibwz:3Lzx5Pf0k5B" resolve="BType" />
+                        </node>
+                        <node concept="liA8E" id="1$ysu_nQIus" role="2OqNvi">
+                          <ref role="37wK5l" to="c17a:~SAbstractConcept.getConceptAlias()" resolve="getConceptAlias" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="Rh6nW" id="1$ysu_nQIut" role="1bW2Oz">
+                <property role="TrG5h" value="it" />
+                <node concept="2jxLKc" id="1$ysu_nQIuu" role="1tU5fm" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="Xl_RD" id="1$ysu_nQIuv" role="1gVpfI">
+          <property role="Xl_RC" value="Type B not included in autocomplete menu" />
+        </node>
+      </node>
+      <node concept="1gVbGN" id="1$ysu_nQIuw" role="3cqZAp">
+        <node concept="2OqwBi" id="1$ysu_nQIux" role="1gVkn0">
+          <node concept="37vLTw" id="1$ysu_nQIuy" role="2Oq$k0">
+            <ref role="3cqZAo" node="1$ysu_nQItE" resolve="actions" />
+          </node>
+          <node concept="2HwmR7" id="1$ysu_nQIuz" role="2OqNvi">
+            <node concept="1bVj0M" id="1$ysu_nQIu$" role="23t8la">
+              <node concept="3clFbS" id="1$ysu_nQIu_" role="1bW5cS">
+                <node concept="3clFbF" id="1$ysu_nQIuA" role="3cqZAp">
+                  <node concept="2OqwBi" id="1$ysu_nQIuB" role="3clFbG">
+                    <node concept="2OqwBi" id="1$ysu_nQIuC" role="2Oq$k0">
+                      <node concept="37vLTw" id="1$ysu_nQIuD" role="2Oq$k0">
+                        <ref role="3cqZAo" node="1$ysu_nQIuK" resolve="it" />
+                      </node>
+                      <node concept="liA8E" id="1$ysu_nQIuE" role="2OqNvi">
+                        <ref role="37wK5l" to="f4zo:~SubstituteAction.getMatchingText(java.lang.String)" resolve="getMatchingText" />
+                        <node concept="Xl_RD" id="1$ysu_nQIuF" role="37wK5m">
+                          <property role="Xl_RC" value="" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="1$ysu_nQIuG" role="2OqNvi">
+                      <ref role="37wK5l" to="wyt6:~String.equals(java.lang.Object)" resolve="equals" />
+                      <node concept="2OqwBi" id="1$ysu_nQIuH" role="37wK5m">
+                        <node concept="35c_gC" id="1$ysu_nQIuI" role="2Oq$k0">
+                          <ref role="35c_gD" to="ibwz:3Lzx5Pf0jk5" resolve="WrapStmtParent" />
+                        </node>
+                        <node concept="liA8E" id="1$ysu_nQIuJ" role="2OqNvi">
+                          <ref role="37wK5l" to="c17a:~SAbstractConcept.getConceptAlias()" resolve="getConceptAlias" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="Rh6nW" id="1$ysu_nQIuK" role="1bW2Oz">
+                <property role="TrG5h" value="it" />
+                <node concept="2jxLKc" id="1$ysu_nQIuL" role="1tU5fm" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="Xl_RD" id="1$ysu_nQIuM" role="1gVpfI">
+          <property role="Xl_RC" value="Default wrapped Stmt not included in autocomplete menu" />
+        </node>
       </node>
     </node>
   </node>


### PR DESCRIPTION
Previously, if concept `A` contained concept `B` with an editor defined with grammar.rule with a grammar.wrap for `B`, constraints from `A` limiting occurrences of `B` were not taken into account when building the completion menu items. 

This PR fixes this issue.

The PR is a breaking change because it alters completion menus for all concepts that fall under the above description.

Fixes #641.