### PR TITLE
Reusable workflow for cascading merges

### DIFF
--- a/.github/workflows/PR-into-2022-2.yml
+++ b/.github/workflows/PR-into-2022-2.yml
@@ -12,42 +12,9 @@ jobs:
   merge-and-pr:
     # only trigger if it was actually merged
     if: github.event.pull_request.merged == true
-
-    runs-on: ubuntu-latest
-    steps:
-      # checkout the target branch
-      - name: Checkout 2022.2
-        uses: actions/checkout@v3
-        with:
-          ref: 'maintenance/mps20222'
-          fetch-depth: 0
-
-      # actually merge from the previous branch
-      - name: Perform merge from 2021.3 to 2022.2
-        run: |
-          # setup to allow to merge and commit
-          git config user.name 'github-actions[bot]'
-          git config user.email 'github-actions[bot]@users.noreply.github.com'
-          
-          # actual merge operation
-          git merge --no-ff --message "Merge 2021.3 -> 2022.2" origin/maintenance/mps20213 -- || ( echo "Merge failed. Please merge manually!" ; exit 1 )
-
-      # actually merge from the previous branch
-      - name: Prepare environment variables for PR
-        run: |
-          NEW_TITLE='${{ github.event.pull_request.title }}'
-          NEW_TITLE="${NEW_TITLE% (2021.2 -> 2021.3)} (2021.3 -> 2022.2)"
-
-          echo "NEW_TITLE=$NEW_TITLE" >> $GITHUB_ENV
-
-      # create a PR based on the merge
-      - name: Create PR for MPS 2022.2
-        uses: peter-evans/create-pull-request@v5
-        with:
-          branch: 'merge/mps20222'
-          commit-message: Merge maintenance/mps20213 into maintenance/mps20222
-          title: ${{ env.NEW_TITLE }}
-          body: |
-            This is an automatic PR which merges changes from `maintenance/mps20213` to `maintenance/mps20222`
-            
-            [Link to previous PR for `maintenance/mps20213`](${{ github.event.pull_request._links.html.href }})
+    uses: ./.github/workflows/PR-into-next-version.yml
+    with:
+      from-version: 2021.3
+      from-branch: maintenance/mps20213
+      to-version: 2022.2
+      to-branch: maintenance/mps20222

--- a/.github/workflows/PR-into-next-version.yml
+++ b/.github/workflows/PR-into-next-version.yml
@@ -1,6 +1,5 @@
 name: Merge and PR into next version
 
-run-name: Merge 2021.3 -> 2022.2
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/PR-into-next-version.yml
+++ b/.github/workflows/PR-into-next-version.yml
@@ -1,0 +1,66 @@
+name: Merge and PR into next version
+
+run-name: Merge 2021.3 -> 2022.2
+on:
+  workflow_call:
+    inputs:
+      from-branch:
+        required: true
+        type: string
+        description: source branch name, e.g. 'maintenance/mps20213'
+      from-version:
+        required: true
+        type: string
+        description: source version (human-readable), e.g. '2021.3'
+      to-branch:
+        required: true
+        type: string
+        description: destination branch name, e.g. 'maintenance/mps20222'
+      to-version:
+        required: true
+        type: string
+        description: destination version (human-readable), e.g. '2022.2'
+
+jobs:
+  merge-and-pr:
+    # only trigger if it was actually merged
+    if: github.event.pull_request.merged == true
+
+    runs-on: ubuntu-latest
+    steps:
+      # checkout the target branch
+      - name: Checkout ${{ inputs.to-version }}
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.to-branch }}
+          fetch-depth: 0
+
+      # actually merge from the previous branch
+      - name: Perform merge from ${{ inputs.from-version }} to ${{ inputs.to-version }}
+        run: |
+          # setup to allow to merge and commit
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          
+          # actual merge operation
+          git merge --no-ff --message "Merge ${{ inputs.from-branch }}" origin/${{ inputs.from-branch }} -- || ( echo "Merge failed. Please merge manually!" ; exit 1 )
+
+      # actually merge from the previous branch
+      - name: Prepare environment variables for PR
+        run: |
+          NEW_TITLE='${{ github.event.pull_request.title }}'
+          NEW_TITLE="${NEW_TITLE% (* -> ${{ inputs.from-version }})} (${{ inputs.from-version }} -> ${{ inputs.to-version }})"
+
+          echo "NEW_TITLE=$NEW_TITLE" >> $GITHUB_ENV
+
+      # create a PR based on the merge
+      - name: Create PR for ${{ inputs.to-version }}
+        uses: peter-evans/create-pull-request@v5
+        with:
+          branch: 'merge/${{ inputs.to-branch }}'
+          commit-message: Merge ${{ inputs.from-branch }}
+          title: ${{ env.NEW_TITLE }}
+          body: |
+            This is an automatic PR which merges changes from `${{ inputs.from-branch }}` to `${{ inputs.to-branch }}`
+            
+            [Link to previous PR for `${{ inputs.from-branch }}`](${{ github.event.pull_request._links.html.href }})


### PR DESCRIPTION
An attempt to make the cascading PR workflow reusable so that it doesn't have to be copied-and-pasted for each new version.