### PR TITLE
Update GrammarCells constraint checks to fix empty completion menus

### DIFF
--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells.sandboxlang/models/com/mbeddr/mpsutil/grammarcells/sandboxlang/constraints.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells.sandboxlang/models/com/mbeddr/mpsutil/grammarcells/sandboxlang/constraints.mps
@@ -61,6 +61,7 @@
       <concept id="6702802731807420587" name="jetbrains.mps.lang.constraints.structure.ConstraintFunction_CanBeAParent" flags="ig" index="9SLcT" />
       <concept id="6702802731807424858" name="jetbrains.mps.lang.constraints.structure.ConstraintFunction_CanBeAnAncestor" flags="in" index="9SQb8" />
       <concept id="8966504967485224688" name="jetbrains.mps.lang.constraints.structure.ConstraintFunctionParameter_contextNode" flags="nn" index="2rP1CM" />
+      <concept id="4303308395523096213" name="jetbrains.mps.lang.constraints.structure.ConstraintFunctionParameter_childConcept" flags="ng" index="2DD5aU" />
       <concept id="1147467115080" name="jetbrains.mps.lang.constraints.structure.NodePropertyConstraint" flags="ng" index="EnEH3">
         <reference id="1147467295099" name="applicableProperty" index="EomxK" />
         <child id="1212097481299" name="propertyValidator" index="QCWH9" />
@@ -92,6 +93,9 @@
         <child id="4693937538533538124" name="requestedConcept" index="v3oSu" />
       </concept>
       <concept id="1171407110247" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorOperation" flags="nn" index="2Xjw5R" />
+      <concept id="1180031783296" name="jetbrains.mps.lang.smodel.structure.Concept_IsSubConceptOfOperation" flags="nn" index="2Zo12i">
+        <child id="1180031783297" name="conceptArgument" index="2Zo12j" />
+      </concept>
       <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
         <child id="1177027386292" name="conceptArgument" index="cj9EA" />
       </concept>
@@ -241,6 +245,42 @@
                 <node concept="chp4Y" id="1$ysu_nN4N5" role="cj9EA">
                   <ref role="cht4Q" to="ibwz:3Lzx5Pf0k2q" resolve="AType" />
                 </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1M2fIO" id="1045PmWki_J">
+    <property role="3GE5qa" value="grammarWrapTest" />
+    <ref role="1M2myG" to="ibwz:1045PmWki5C" resolve="WrapStmtParentWhitelisting" />
+    <node concept="9SLcT" id="1045PmWkiB4" role="9SGkU">
+      <node concept="3clFbS" id="1045PmWkiB5" role="2VODD2">
+        <node concept="3clFbF" id="1045PmWkiGo" role="3cqZAp">
+          <node concept="2OqwBi" id="1045PmWkiZz" role="3clFbG">
+            <node concept="2DD5aU" id="1045PmWkiGn" role="2Oq$k0" />
+            <node concept="2Zo12i" id="x37qLVOc3J" role="2OqNvi">
+              <node concept="chp4Y" id="x37qLVOcgz" role="2Zo12j">
+                <ref role="cht4Q" to="ibwz:3Lzx5Pf0k5B" resolve="BType" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1M2fIO" id="6sxj0_Uzbmu">
+    <property role="3GE5qa" value="grammarWrapTest" />
+    <ref role="1M2myG" to="ibwz:6sxj0_Uzbld" resolve="WrapStmtAncestorWhitelisting" />
+    <node concept="9SQb8" id="6sxj0_Uzbmv" role="9SGkC">
+      <node concept="3clFbS" id="6sxj0_Uzbmw" role="2VODD2">
+        <node concept="3clFbF" id="6sxj0_Uzbqv" role="3cqZAp">
+          <node concept="2OqwBi" id="6sxj0_UzbH0" role="3clFbG">
+            <node concept="2DD5aU" id="6sxj0_Uzbqu" role="2Oq$k0" />
+            <node concept="2Zo12i" id="6sxj0_UzcnX" role="2OqNvi">
+              <node concept="chp4Y" id="6sxj0_UzcBF" role="2Zo12j">
+                <ref role="cht4Q" to="ibwz:3Lzx5Pf0k5B" resolve="BType" />
               </node>
             </node>
           </node>

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells.sandboxlang/models/com/mbeddr/mpsutil/grammarcells/sandboxlang/editor.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells.sandboxlang/models/com/mbeddr/mpsutil/grammarcells/sandboxlang/editor.mps
@@ -2772,14 +2772,14 @@
   <node concept="24kQdi" id="3Lzx5Pf3sLe">
     <property role="3GE5qa" value="grammarWrapTest" />
     <ref role="1XX52x" to="ibwz:3Lzx5Pf0jeK" resolve="StmtContainerParent" />
-    <node concept="3EZMnI" id="3Lzx5Pf3sMk" role="2wV5jI">
-      <node concept="3F0ifn" id="3Lzx5Pf3sQb" role="3EZMnx">
+    <node concept="3EZMnI" id="1045PmWkhNI" role="2wV5jI">
+      <node concept="3F0ifn" id="1045PmWkhNJ" role="3EZMnx">
         <property role="3F0ifm" value="Stmt Test" />
       </node>
-      <node concept="2iRkQZ" id="3Lzx5Pf3sQK" role="2iSdaV" />
-      <node concept="3F2HdR" id="3Lzx5Pf3sU5" role="3EZMnx">
+      <node concept="2iRkQZ" id="1045PmWkhNK" role="2iSdaV" />
+      <node concept="3F2HdR" id="1045PmWkhNL" role="3EZMnx">
         <ref role="1NtTu8" to="ibwz:3Lzx5Pf0jnO" resolve="stmts" />
-        <node concept="2iRkQZ" id="3Lzx5Pf3sU7" role="2czzBx" />
+        <node concept="2iRkQZ" id="1045PmWkhNM" role="2czzBx" />
       </node>
     </node>
   </node>
@@ -2812,6 +2812,70 @@
         <node concept="3F0A7n" id="1$ysu_nN4VZ" role="3EZMnx">
           <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
         </node>
+      </node>
+    </node>
+  </node>
+  <node concept="24kQdi" id="1045PmWkimx">
+    <property role="3GE5qa" value="grammarWrapTest" />
+    <ref role="1XX52x" to="ibwz:1045PmWki5C" resolve="WrapStmtParentWhitelisting" />
+    <node concept="1WcQYu" id="1045PmWkind" role="2wV5jI">
+      <node concept="2ElW$n" id="1045PmWkine" role="2El2Yn" />
+      <node concept="3EZMnI" id="1045PmWkinf" role="1LiK7o">
+        <node concept="2iRfu4" id="1045PmWking" role="2iSdaV" />
+        <node concept="1kIj98" id="1045PmWkinh" role="3EZMnx">
+          <node concept="3F1sOY" id="1045PmWkini" role="1kIj9b">
+            <ref role="1NtTu8" to="ibwz:1045PmWkiyF" resolve="type" />
+          </node>
+        </node>
+        <node concept="3F0A7n" id="1045PmWkinj" role="3EZMnx">
+          <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="24kQdi" id="x37qLVSB_Y">
+    <property role="3GE5qa" value="grammarWrapTest" />
+    <ref role="1XX52x" to="ibwz:1045PmWkhcs" resolve="StmtContainerParentWhitelisting" />
+    <node concept="3EZMnI" id="x37qLVSBDi" role="2wV5jI">
+      <node concept="3F0ifn" id="x37qLVSBDj" role="3EZMnx">
+        <property role="3F0ifm" value="Stmt Test" />
+      </node>
+      <node concept="2iRkQZ" id="x37qLVSBDk" role="2iSdaV" />
+      <node concept="3F2HdR" id="x37qLVSBDl" role="3EZMnx">
+        <ref role="1NtTu8" to="ibwz:1045PmWki1E" resolve="stmts" />
+        <node concept="2iRkQZ" id="x37qLVSBDm" role="2czzBx" />
+      </node>
+    </node>
+  </node>
+  <node concept="24kQdi" id="6sxj0_UzblG">
+    <property role="3GE5qa" value="grammarWrapTest" />
+    <ref role="1XX52x" to="ibwz:6sxj0_Uzbld" resolve="WrapStmtAncestorWhitelisting" />
+    <node concept="1WcQYu" id="6sxj0_UzblM" role="2wV5jI">
+      <node concept="2ElW$n" id="6sxj0_UzblN" role="2El2Yn" />
+      <node concept="3EZMnI" id="6sxj0_UzblO" role="1LiK7o">
+        <node concept="2iRfu4" id="6sxj0_UzblP" role="2iSdaV" />
+        <node concept="1kIj98" id="6sxj0_UzblQ" role="3EZMnx">
+          <node concept="3F1sOY" id="6sxj0_UzblR" role="1kIj9b">
+            <ref role="1NtTu8" to="ibwz:6sxj0_Uzblg" resolve="type" />
+          </node>
+        </node>
+        <node concept="3F0A7n" id="6sxj0_UzblS" role="3EZMnx">
+          <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="24kQdi" id="6sxj0_UzcGB">
+    <property role="3GE5qa" value="grammarWrapTest" />
+    <ref role="1XX52x" to="ibwz:6sxj0_Uzblc" resolve="StmtContainerAncestorWhitelisting" />
+    <node concept="3EZMnI" id="6sxj0_UzcGD" role="2wV5jI">
+      <node concept="3F0ifn" id="6sxj0_UzcGE" role="3EZMnx">
+        <property role="3F0ifm" value="Stmt Test" />
+      </node>
+      <node concept="2iRkQZ" id="6sxj0_UzcGF" role="2iSdaV" />
+      <node concept="3F2HdR" id="6sxj0_UzcGG" role="3EZMnx">
+        <ref role="1NtTu8" to="ibwz:6sxj0_UzcGb" resolve="stmts" />
+        <node concept="2iRkQZ" id="6sxj0_UzcGH" role="2czzBx" />
       </node>
     </node>
   </node>

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells.sandboxlang/models/com/mbeddr/mpsutil/grammarcells/sandboxlang/structure.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells.sandboxlang/models/com/mbeddr/mpsutil/grammarcells/sandboxlang/structure.mps
@@ -983,5 +983,67 @@
       <ref role="PrY4T" to="tpck:h0TrEE$" resolve="INamedConcept" />
     </node>
   </node>
+  <node concept="1TIwiD" id="1045PmWkhcs">
+    <property role="EcuMT" value="1154073061512778524" />
+    <property role="3GE5qa" value="grammarWrapTest" />
+    <property role="TrG5h" value="StmtContainerParentWhitelisting" />
+    <property role="19KtqR" value="true" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" />
+    <node concept="1TJgyj" id="1045PmWki1E" role="1TKVEi">
+      <property role="IQ2ns" value="1154073061512781930" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="stmts" />
+      <property role="20lbJX" value="fLJekj5/_0__n" />
+      <ref role="20lvS9" node="1045PmWki5C" resolve="WrapStmtParentWhitelisting" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="1045PmWki5C">
+    <property role="EcuMT" value="1154073061512782184" />
+    <property role="3GE5qa" value="grammarWrapTest" />
+    <property role="TrG5h" value="WrapStmtParentWhitelisting" />
+    <property role="34LRSv" value="wrapStmt" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" />
+    <node concept="1TJgyj" id="1045PmWkiyF" role="1TKVEi">
+      <property role="IQ2ns" value="1154073061512784043" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="type" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <ref role="20lvS9" node="3Lzx5Pf0jr2" resolve="WrapType" />
+    </node>
+    <node concept="PrWs8" id="1045PmWkiwF" role="PzmwI">
+      <ref role="PrY4T" to="tpck:h0TrEE$" resolve="INamedConcept" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="6sxj0_Uzblc">
+    <property role="EcuMT" value="7431304463732487500" />
+    <property role="3GE5qa" value="grammarWrapTest" />
+    <property role="TrG5h" value="StmtContainerAncestorWhitelisting" />
+    <property role="19KtqR" value="true" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" />
+    <node concept="1TJgyj" id="6sxj0_UzcGb" role="1TKVEi">
+      <property role="IQ2ns" value="7431304463732493067" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="stmts" />
+      <property role="20lbJX" value="fLJekj5/_0__n" />
+      <ref role="20lvS9" node="6sxj0_Uzbld" resolve="WrapStmtAncestorWhitelisting" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="6sxj0_Uzbld">
+    <property role="EcuMT" value="7431304463732487501" />
+    <property role="3GE5qa" value="grammarWrapTest" />
+    <property role="TrG5h" value="WrapStmtAncestorWhitelisting" />
+    <property role="34LRSv" value="wrapStmt" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" />
+    <node concept="PrWs8" id="6sxj0_Uzble" role="PzmwI">
+      <ref role="PrY4T" to="tpck:h0TrEE$" resolve="INamedConcept" />
+    </node>
+    <node concept="1TJgyj" id="6sxj0_Uzblg" role="1TKVEi">
+      <property role="IQ2ns" value="7431304463732487504" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="type" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <ref role="20lvS9" node="3Lzx5Pf0jr2" resolve="WrapType" />
+    </node>
+  </node>
 </model>
 

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/generator/template/main@generator.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/generator/template/main@generator.mps
@@ -544,14 +544,14 @@
       </concept>
     </language>
     <language id="9d69e719-78c8-4286-90db-fb19c107d049" name="com.mbeddr.mpsutil.grammarcells">
-      <concept id="7272510943426055326" name="com.mbeddr.mpsutil.grammarcells.structure.SideTransformationCell_Factory" flags="ig" index="2kS2EP" />
+      <concept id="7272510943426055326" name="com.mbeddr.mpsutil.grammarcells.structure.SideTransformationCell_Factory" flags="ng" index="2kS2EP" />
       <concept id="7272510943426093121" name="com.mbeddr.mpsutil.grammarcells.structure.Parameter_SideTransformActionsBuilderContext" flags="ng" index="2kS8pE" />
       <concept id="7272510943425988699" name="com.mbeddr.mpsutil.grammarcells.structure.SideTransformationCell" flags="ng" index="2kSiTK">
         <property id="7272510943425988883" name="side" index="2kSiWS" />
         <child id="7272510943426097631" name="factory" index="2kS9vO" />
         <child id="7272510943425989076" name="wrapped" index="2kSiZZ" />
       </concept>
-      <concept id="7272510943426635554" name="com.mbeddr.mpsutil.grammarcells.structure.NodeSubstituteCell_Factory" flags="ig" index="2kYc49" />
+      <concept id="7272510943426635554" name="com.mbeddr.mpsutil.grammarcells.structure.NodeSubstituteCell_Factory" flags="ng" index="2kYc49" />
       <concept id="7272510943426635523" name="com.mbeddr.mpsutil.grammarcells.structure.NodeSubstituteCell" flags="ng" index="2kYc4C">
         <child id="7272510943426635586" name="factory" index="2kYc5D" />
         <child id="7272510943426635585" name="wrapped" index="2kYc5E" />
@@ -567,11 +567,11 @@
         <property id="745148820908747612" name="description" index="2thAuV" />
         <child id="745148820874363426" name="section" index="2vkWV5" />
       </concept>
-      <concept id="9041925471455857605" name="com.mbeddr.mpsutil.grammarcells.structure.Cell_DescriptionText" flags="ig" index="uPpia" />
+      <concept id="9041925471455857605" name="com.mbeddr.mpsutil.grammarcells.structure.Cell_DescriptionText" flags="ng" index="uPpia" />
       <concept id="745148820879066261" name="com.mbeddr.mpsutil.grammarcells.structure.TransformationLocation_SideTransformationCell" flags="ng" index="2v6KxM" />
       <concept id="1997572252229165641" name="com.mbeddr.mpsutil.grammarcells.structure.TransformationLocation_Before" flags="ng" index="wWMWC" />
       <concept id="1997572252229165700" name="com.mbeddr.mpsutil.grammarcells.structure.TransformationLocation_After" flags="ng" index="wWMZ_" />
-      <concept id="7416540197334827155" name="com.mbeddr.mpsutil.grammarcells.structure.LowLevelMenuPart_Function" flags="ig" index="2Mo9yg" />
+      <concept id="7416540197334827155" name="com.mbeddr.mpsutil.grammarcells.structure.LowLevelMenuPart_Function" flags="ng" index="2Mo9yg" />
       <concept id="7416540197334827182" name="com.mbeddr.mpsutil.grammarcells.structure.LowLevelMenuPart_parameter" flags="ng" index="2Mo9yH" />
       <concept id="7416540197333137586" name="com.mbeddr.mpsutil.grammarcells.structure.GenericMenuPart" flags="ng" index="2MBE2L">
         <child id="7416540197335105457" name="implementation" index="2MvauM" />
@@ -583,8 +583,8 @@
         <child id="6856661361479798753" name="execute" index="130oVf" />
         <child id="6856661361479798749" name="canExecute" index="130oVN" />
       </concept>
-      <concept id="6856661361479784541" name="com.mbeddr.mpsutil.grammarcells.structure.InlineActionMapItem_CanExecuteFunction" flags="ig" index="130t_N" />
-      <concept id="6856661361479784534" name="com.mbeddr.mpsutil.grammarcells.structure.InlineActionMapItem_ExecuteFunction" flags="ig" index="130t_S" />
+      <concept id="6856661361479784541" name="com.mbeddr.mpsutil.grammarcells.structure.InlineActionMapItem_CanExecuteFunction" flags="ng" index="130t_N" />
+      <concept id="6856661361479784534" name="com.mbeddr.mpsutil.grammarcells.structure.InlineActionMapItem_ExecuteFunction" flags="ng" index="130t_S" />
       <concept id="6856661361479732075" name="com.mbeddr.mpsutil.grammarcells.structure.InlineActionMapCell" flags="ng" index="130CD5">
         <child id="6856661361479798957" name="actions" index="130p63" />
         <child id="6856661361479732085" name="cell" index="130CDr" />
@@ -592,18 +592,18 @@
       <concept id="848437706375087728" name="com.mbeddr.mpsutil.grammarcells.structure.ICanHaveDescriptionText" flags="ng" index="1djCvD">
         <child id="848437706375087729" name="descriptionText" index="1djCvC" />
       </concept>
-      <concept id="4874944647490522665" name="com.mbeddr.mpsutil.grammarcells.structure.SideTransformationCell2_IsApplicable" flags="ig" index="1eYwpX" />
-      <concept id="4874944647490524676" name="com.mbeddr.mpsutil.grammarcells.structure.SideTransformationCell2_Execute" flags="ig" index="1eYxTg" />
+      <concept id="4874944647490522665" name="com.mbeddr.mpsutil.grammarcells.structure.SideTransformationCell2_IsApplicable" flags="ng" index="1eYwpX" />
+      <concept id="4874944647490524676" name="com.mbeddr.mpsutil.grammarcells.structure.SideTransformationCell2_Execute" flags="ng" index="1eYxTg" />
       <concept id="4874944647490471126" name="com.mbeddr.mpsutil.grammarcells.structure.SideTransformationCell2" flags="ng" index="1eYWM2">
         <child id="4874944647490523335" name="matchingText" index="1eYxyj" />
         <child id="4874944647490523330" name="isApplicable" index="1eYxym" />
         <child id="4874944647490524677" name="execute" index="1eYxTh" />
       </concept>
-      <concept id="4874944647490471525" name="com.mbeddr.mpsutil.grammarcells.structure.SideTransformationCell2_MatchingText" flags="ig" index="1eYWSL" />
+      <concept id="4874944647490471525" name="com.mbeddr.mpsutil.grammarcells.structure.SideTransformationCell2_MatchingText" flags="ng" index="1eYWSL" />
     </language>
     <language id="52733268-be24-4f5f-ab84-a73b7c0c03b0" name="de.slisson.mps.richtext.customcell">
-      <concept id="1161622981231" name="de.slisson.mps.richtext.customcell.structure.ConceptFunctionParameter_cell" flags="nn" index="1Q80Hy" />
-      <concept id="1176749715029" name="de.slisson.mps.richtext.customcell.structure.QueryFunction_Cell" flags="in" index="3VJUX4" />
+      <concept id="1161622981231" name="de.slisson.mps.richtext.customcell.structure.ConceptFunctionParameter_cell" flags="ng" index="1Q80Hy" />
+      <concept id="1176749715029" name="de.slisson.mps.richtext.customcell.structure.QueryFunction_Cell" flags="ng" index="3VJUX4" />
       <concept id="2490242408670732052" name="de.slisson.mps.richtext.customcell.structure.CellModel_CustomFactory" flags="ng" index="3ZSo5i">
         <child id="1073389446424" name="childCellModel" index="3EZMny" />
         <child id="2490242408670937967" name="factoryMethod" index="3ZZHOD" />
@@ -8982,20 +8982,14 @@
                               <node concept="3cpWsn" id="6rhOS_xTtup" role="3cpWs9">
                                 <property role="TrG5h" value="isApplicable" />
                                 <node concept="10P_77" id="6rhOS_xTtuk" role="1tU5fm" />
-                                <node concept="2YIFZM" id="4_3mV3JNMln" role="33vP2m">
-                                  <ref role="37wK5l" to="czm:4_3mV3JAVzS" resolve="canBeChildForSubstitute" />
+                                <node concept="2YIFZM" id="4DMP0ZwggIM" role="33vP2m">
+                                  <ref role="37wK5l" to="czm:2mvFNoUAetF" resolve="canBeChild" />
                                   <ref role="1Pybhc" to="czm:RbLMy696h3" resolve="GrammarCellsUtil" />
-                                  <node concept="2GrUjf" id="4_3mV3JNMlo" role="37wK5m">
+                                  <node concept="2GrUjf" id="4DMP0ZwggIN" role="37wK5m">
                                     <ref role="2Gs0qQ" node="7NlRaxB4F5O" resolve="subconcept" />
                                   </node>
-                                  <node concept="37vLTw" id="4_3mV3JNMlp" role="37wK5m">
+                                  <node concept="37vLTw" id="4DMP0ZwggIO" role="37wK5m">
                                     <ref role="3cqZAo" node="2mvFNoUxG2A" resolve="_context" />
-                                  </node>
-                                  <node concept="37vLTw" id="4_3mV3JNVYg" role="37wK5m">
-                                    <ref role="3cqZAo" node="6oKG1kMzdFR" resolve="wrappedConcept" />
-                                  </node>
-                                  <node concept="37vLTw" id="6ogDZt_Bs9c" role="37wK5m">
-                                    <ref role="3cqZAo" node="6ogDZt_zXvf" resolve="aggregation" />
                                   </node>
                                 </node>
                               </node>

--- a/code/grammarcells/solutions/com.mbeddr.mpsutil.grammarcells.tests/models/com/mbeddr/mpsutil/grammarcells/tests@tests.mps
+++ b/code/grammarcells/solutions/com.mbeddr.mpsutil.grammarcells.tests/models/com/mbeddr/mpsutil/grammarcells/tests@tests.mps
@@ -224,6 +224,7 @@
       <concept id="1749127723000261010" name="com.mbeddr.mpsutil.grammarcells.sandboxlang.structure.EmptyStatement" flags="ng" index="2cssZR" />
       <concept id="1749127723000290684" name="com.mbeddr.mpsutil.grammarcells.sandboxlang.structure.IntType" flags="ng" index="2cvBGp" />
       <concept id="2312097807578461524" name="com.mbeddr.mpsutil.grammarcells.sandboxlang.structure.PostIncrement" flags="ng" index="2qI$Rw" />
+      <concept id="7431304463732487500" name="com.mbeddr.mpsutil.grammarcells.sandboxlang.structure.StmtContainerAncestorWhitelisting" flags="ng" index="tFv_5" />
       <concept id="5083944728300136332" name="com.mbeddr.mpsutil.grammarcells.sandboxlang.structure.PlusExpression" flags="ng" index="ywmH7" />
       <concept id="5083944728300233282" name="com.mbeddr.mpsutil.grammarcells.sandboxlang.structure.MulExpression" flags="ng" index="ywYU9" />
       <concept id="5083944728299528547" name="com.mbeddr.mpsutil.grammarcells.sandboxlang.structure.Visibility" flags="ng" index="yzEQC" />
@@ -233,6 +234,7 @@
       <concept id="5083944728300729103" name="com.mbeddr.mpsutil.grammarcells.sandboxlang.structure.IntLiteral" flags="ng" index="yA7Z4">
         <property id="5083944728300729107" name="value" index="yA7Zo" />
       </concept>
+      <concept id="1154073061512778524" name="com.mbeddr.mpsutil.grammarcells.sandboxlang.structure.StmtContainerParentWhitelisting" flags="ng" index="2Glgh9" />
       <concept id="2111846799818005528" name="com.mbeddr.mpsutil.grammarcells.sandboxlang.structure.MinusExpression" flags="ng" index="2Iv5lx" />
       <concept id="4330386229150009025" name="com.mbeddr.mpsutil.grammarcells.sandboxlang.structure.OptionalType" flags="ng" index="WC_Ak">
         <child id="4330386229150009029" name="type" index="WC_Ag" />
@@ -3430,6 +3432,429 @@
           </node>
         </node>
         <node concept="Xl_RD" id="1$ysu_nQIuM" role="1gVpfI">
+          <property role="Xl_RC" value="Default wrapped Stmt not included in autocomplete menu" />
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="LiM7Y" id="x37qLVOcTj">
+    <property role="TrG5h" value="GrammarWrapFilterConstraintsParentWhitelisting" />
+    <property role="3YCmrE" value="Tests whitelisting of concepts with grammar cells" />
+    <node concept="1qefOq" id="x37qLVOdaE" role="25YQCW">
+      <node concept="2Glgh9" id="x37qLVSBy8" role="1qenE9">
+        <node concept="LIFWc" id="6sxj0_UugE5" role="lGtFl">
+          <property role="ZRATv" value="true" />
+          <property role="OXtK3" value="true" />
+          <property role="p6zMq" value="0" />
+          <property role="p6zMs" value="0" />
+          <property role="LIFWd" value="empty_stmts" />
+        </node>
+      </node>
+    </node>
+    <node concept="3clFbS" id="6sxj0_UufKW" role="LjaKd">
+      <node concept="3cpWs8" id="6sxj0_UufLK" role="3cqZAp">
+        <node concept="3cpWsn" id="6sxj0_UufLL" role="3cpWs9">
+          <property role="TrG5h" value="si" />
+          <node concept="3uibUv" id="6sxj0_UufLM" role="1tU5fm">
+            <ref role="3uigEE" to="f4zo:~SubstituteInfo" resolve="SubstituteInfo" />
+          </node>
+          <node concept="2OqwBi" id="6sxj0_UufLN" role="33vP2m">
+            <node concept="2OqwBi" id="6sxj0_UufLO" role="2Oq$k0">
+              <node concept="369mXd" id="6sxj0_UufLP" role="2Oq$k0" />
+              <node concept="liA8E" id="6sxj0_UufLQ" role="2OqNvi">
+                <ref role="37wK5l" to="exr9:~EditorComponent.getSelectedCell()" resolve="getSelectedCell" />
+              </node>
+            </node>
+            <node concept="liA8E" id="6sxj0_UufLR" role="2OqNvi">
+              <ref role="37wK5l" to="f4zo:~EditorCell.getSubstituteInfo()" resolve="getSubstituteInfo" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3cpWs8" id="6sxj0_UufLS" role="3cqZAp">
+        <node concept="3cpWsn" id="6sxj0_UufLT" role="3cpWs9">
+          <property role="TrG5h" value="actions" />
+          <node concept="_YKpA" id="6sxj0_UufLU" role="1tU5fm">
+            <node concept="3uibUv" id="6sxj0_UufLV" role="_ZDj9">
+              <ref role="3uigEE" to="f4zo:~SubstituteAction" resolve="SubstituteAction" />
+            </node>
+          </node>
+          <node concept="2OqwBi" id="6sxj0_UufLW" role="33vP2m">
+            <node concept="37vLTw" id="6sxj0_UufLX" role="2Oq$k0">
+              <ref role="3cqZAo" node="6sxj0_UufLL" resolve="si" />
+            </node>
+            <node concept="liA8E" id="6sxj0_UufLY" role="2OqNvi">
+              <ref role="37wK5l" to="f4zo:~SubstituteInfo.getMatchingActions(java.lang.String,boolean)" resolve="getMatchingActions" />
+              <node concept="Xl_RD" id="6sxj0_UufLZ" role="37wK5m">
+                <property role="Xl_RC" value="" />
+              </node>
+              <node concept="3clFbT" id="6sxj0_UufM0" role="37wK5m" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1gVbGN" id="6sxj0_UufM1" role="3cqZAp">
+        <node concept="3clFbC" id="6sxj0_UufM2" role="1gVkn0">
+          <node concept="3cmrfG" id="6sxj0_UufM3" role="3uHU7w">
+            <property role="3cmrfH" value="2" />
+          </node>
+          <node concept="2OqwBi" id="6sxj0_UufM4" role="3uHU7B">
+            <node concept="37vLTw" id="6sxj0_UufM5" role="2Oq$k0">
+              <ref role="3cqZAo" node="6sxj0_UufLT" resolve="actions" />
+            </node>
+            <node concept="34oBXx" id="6sxj0_UufM6" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="Xl_RD" id="6sxj0_UufM7" role="1gVpfI">
+          <property role="Xl_RC" value="Maximum of 2 actions, Type A and WrapStmt expected" />
+        </node>
+      </node>
+      <node concept="1gVbGN" id="6sxj0_UufM8" role="3cqZAp">
+        <node concept="3fqX7Q" id="6sxj0_UufM9" role="1gVkn0">
+          <node concept="2OqwBi" id="6sxj0_UufMa" role="3fr31v">
+            <node concept="37vLTw" id="6sxj0_UufMb" role="2Oq$k0">
+              <ref role="3cqZAo" node="6sxj0_UufLT" resolve="actions" />
+            </node>
+            <node concept="2HwmR7" id="6sxj0_UufMc" role="2OqNvi">
+              <node concept="1bVj0M" id="6sxj0_UufMd" role="23t8la">
+                <node concept="3clFbS" id="6sxj0_UufMe" role="1bW5cS">
+                  <node concept="3clFbF" id="6sxj0_UufMf" role="3cqZAp">
+                    <node concept="2OqwBi" id="6sxj0_UufMg" role="3clFbG">
+                      <node concept="2OqwBi" id="6sxj0_UufMh" role="2Oq$k0">
+                        <node concept="37vLTw" id="6sxj0_UufMi" role="2Oq$k0">
+                          <ref role="3cqZAo" node="6sxj0_UufMp" resolve="it" />
+                        </node>
+                        <node concept="liA8E" id="6sxj0_UufMj" role="2OqNvi">
+                          <ref role="37wK5l" to="f4zo:~SubstituteAction.getMatchingText(java.lang.String)" resolve="getMatchingText" />
+                          <node concept="Xl_RD" id="6sxj0_UufMk" role="37wK5m">
+                            <property role="Xl_RC" value="" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="liA8E" id="6sxj0_UufMl" role="2OqNvi">
+                        <ref role="37wK5l" to="wyt6:~String.equals(java.lang.Object)" resolve="equals" />
+                        <node concept="2OqwBi" id="6sxj0_UufMm" role="37wK5m">
+                          <node concept="35c_gC" id="6sxj0_UufMn" role="2Oq$k0">
+                            <ref role="35c_gD" to="ibwz:3Lzx5Pf0k2q" resolve="AType" />
+                          </node>
+                          <node concept="liA8E" id="6sxj0_UufMo" role="2OqNvi">
+                            <ref role="37wK5l" to="c17a:~SAbstractConcept.getConceptAlias()" resolve="getConceptAlias" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="Rh6nW" id="6sxj0_UufMp" role="1bW2Oz">
+                  <property role="TrG5h" value="it" />
+                  <node concept="2jxLKc" id="6sxj0_UufMq" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="Xl_RD" id="6sxj0_UufMr" role="1gVpfI">
+          <property role="Xl_RC" value="Type A not excluded from autocomplete menu" />
+        </node>
+      </node>
+      <node concept="1gVbGN" id="6sxj0_UufMs" role="3cqZAp">
+        <node concept="2OqwBi" id="6sxj0_UufMt" role="1gVkn0">
+          <node concept="37vLTw" id="6sxj0_UufMu" role="2Oq$k0">
+            <ref role="3cqZAo" node="6sxj0_UufLT" resolve="actions" />
+          </node>
+          <node concept="2HwmR7" id="6sxj0_UufMv" role="2OqNvi">
+            <node concept="1bVj0M" id="6sxj0_UufMw" role="23t8la">
+              <node concept="3clFbS" id="6sxj0_UufMx" role="1bW5cS">
+                <node concept="3clFbF" id="6sxj0_UufMy" role="3cqZAp">
+                  <node concept="2OqwBi" id="6sxj0_UufMz" role="3clFbG">
+                    <node concept="2OqwBi" id="6sxj0_UufM$" role="2Oq$k0">
+                      <node concept="37vLTw" id="6sxj0_UufM_" role="2Oq$k0">
+                        <ref role="3cqZAo" node="6sxj0_UufMG" resolve="it" />
+                      </node>
+                      <node concept="liA8E" id="6sxj0_UufMA" role="2OqNvi">
+                        <ref role="37wK5l" to="f4zo:~SubstituteAction.getMatchingText(java.lang.String)" resolve="getMatchingText" />
+                        <node concept="Xl_RD" id="6sxj0_UufMB" role="37wK5m" />
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="6sxj0_UufMC" role="2OqNvi">
+                      <ref role="37wK5l" to="wyt6:~String.equals(java.lang.Object)" resolve="equals" />
+                      <node concept="2OqwBi" id="6sxj0_UufMD" role="37wK5m">
+                        <node concept="35c_gC" id="6sxj0_UufME" role="2Oq$k0">
+                          <ref role="35c_gD" to="ibwz:3Lzx5Pf0k5B" resolve="BType" />
+                        </node>
+                        <node concept="liA8E" id="6sxj0_UufMF" role="2OqNvi">
+                          <ref role="37wK5l" to="c17a:~SAbstractConcept.getConceptAlias()" resolve="getConceptAlias" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="Rh6nW" id="6sxj0_UufMG" role="1bW2Oz">
+                <property role="TrG5h" value="it" />
+                <node concept="2jxLKc" id="6sxj0_UufMH" role="1tU5fm" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="Xl_RD" id="6sxj0_UufMI" role="1gVpfI">
+          <property role="Xl_RC" value="Type B not included in autocomplete menu" />
+        </node>
+      </node>
+      <node concept="1gVbGN" id="6sxj0_UufMJ" role="3cqZAp">
+        <node concept="2OqwBi" id="6sxj0_UufMK" role="1gVkn0">
+          <node concept="37vLTw" id="6sxj0_UufML" role="2Oq$k0">
+            <ref role="3cqZAo" node="6sxj0_UufLT" resolve="actions" />
+          </node>
+          <node concept="2HwmR7" id="6sxj0_UufMM" role="2OqNvi">
+            <node concept="1bVj0M" id="6sxj0_UufMN" role="23t8la">
+              <node concept="3clFbS" id="6sxj0_UufMO" role="1bW5cS">
+                <node concept="3clFbF" id="6sxj0_UufMP" role="3cqZAp">
+                  <node concept="2OqwBi" id="6sxj0_UufMQ" role="3clFbG">
+                    <node concept="2OqwBi" id="6sxj0_UufMR" role="2Oq$k0">
+                      <node concept="37vLTw" id="6sxj0_UufMS" role="2Oq$k0">
+                        <ref role="3cqZAo" node="6sxj0_UufMZ" resolve="it" />
+                      </node>
+                      <node concept="liA8E" id="6sxj0_UufMT" role="2OqNvi">
+                        <ref role="37wK5l" to="f4zo:~SubstituteAction.getMatchingText(java.lang.String)" resolve="getMatchingText" />
+                        <node concept="Xl_RD" id="6sxj0_UufMU" role="37wK5m">
+                          <property role="Xl_RC" value="" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="6sxj0_UufMV" role="2OqNvi">
+                      <ref role="37wK5l" to="wyt6:~String.equals(java.lang.Object)" resolve="equals" />
+                      <node concept="2OqwBi" id="6sxj0_UufMW" role="37wK5m">
+                        <node concept="35c_gC" id="6sxj0_UufMX" role="2Oq$k0">
+                          <ref role="35c_gD" to="ibwz:1045PmWki5C" resolve="WrapStmtParentWhitelisting" />
+                        </node>
+                        <node concept="liA8E" id="6sxj0_UufMY" role="2OqNvi">
+                          <ref role="37wK5l" to="c17a:~SAbstractConcept.getConceptAlias()" resolve="getConceptAlias" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="Rh6nW" id="6sxj0_UufMZ" role="1bW2Oz">
+                <property role="TrG5h" value="it" />
+                <node concept="2jxLKc" id="6sxj0_UufN0" role="1tU5fm" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="Xl_RD" id="6sxj0_UufN1" role="1gVpfI">
+          <property role="Xl_RC" value="Default wrapped Stmt not included in autocomplete menu" />
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="LiM7Y" id="6sxj0_UzcRB">
+    <property role="TrG5h" value="GrammarWrapFilterConstraintsAncestorWhitelisting" />
+    <node concept="1qefOq" id="6sxj0_UzcSg" role="25YQCW">
+      <node concept="tFv_5" id="6sxj0_UAAEu" role="1qenE9">
+        <node concept="LIFWc" id="6sxj0_UAAEG" role="lGtFl">
+          <property role="ZRATv" value="true" />
+          <property role="OXtK3" value="true" />
+          <property role="p6zMq" value="0" />
+          <property role="p6zMs" value="0" />
+          <property role="LIFWd" value="empty_stmts" />
+        </node>
+      </node>
+    </node>
+    <node concept="3clFbS" id="6sxj0_UABs0" role="LjaKd">
+      <node concept="3cpWs8" id="6sxj0_UABsa" role="3cqZAp">
+        <node concept="3cpWsn" id="6sxj0_UABsb" role="3cpWs9">
+          <property role="TrG5h" value="si" />
+          <node concept="3uibUv" id="6sxj0_UABsc" role="1tU5fm">
+            <ref role="3uigEE" to="f4zo:~SubstituteInfo" resolve="SubstituteInfo" />
+          </node>
+          <node concept="2OqwBi" id="6sxj0_UABsd" role="33vP2m">
+            <node concept="2OqwBi" id="6sxj0_UABse" role="2Oq$k0">
+              <node concept="369mXd" id="6sxj0_UABsf" role="2Oq$k0" />
+              <node concept="liA8E" id="6sxj0_UABsg" role="2OqNvi">
+                <ref role="37wK5l" to="exr9:~EditorComponent.getSelectedCell()" resolve="getSelectedCell" />
+              </node>
+            </node>
+            <node concept="liA8E" id="6sxj0_UABsh" role="2OqNvi">
+              <ref role="37wK5l" to="f4zo:~EditorCell.getSubstituteInfo()" resolve="getSubstituteInfo" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3cpWs8" id="6sxj0_UABsi" role="3cqZAp">
+        <node concept="3cpWsn" id="6sxj0_UABsj" role="3cpWs9">
+          <property role="TrG5h" value="actions" />
+          <node concept="_YKpA" id="6sxj0_UABsk" role="1tU5fm">
+            <node concept="3uibUv" id="6sxj0_UABsl" role="_ZDj9">
+              <ref role="3uigEE" to="f4zo:~SubstituteAction" resolve="SubstituteAction" />
+            </node>
+          </node>
+          <node concept="2OqwBi" id="6sxj0_UABsm" role="33vP2m">
+            <node concept="37vLTw" id="6sxj0_UABsn" role="2Oq$k0">
+              <ref role="3cqZAo" node="6sxj0_UABsb" resolve="si" />
+            </node>
+            <node concept="liA8E" id="6sxj0_UABso" role="2OqNvi">
+              <ref role="37wK5l" to="f4zo:~SubstituteInfo.getMatchingActions(java.lang.String,boolean)" resolve="getMatchingActions" />
+              <node concept="Xl_RD" id="6sxj0_UABsp" role="37wK5m">
+                <property role="Xl_RC" value="" />
+              </node>
+              <node concept="3clFbT" id="6sxj0_UABsq" role="37wK5m" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1gVbGN" id="6sxj0_UABsr" role="3cqZAp">
+        <node concept="3clFbC" id="6sxj0_UABss" role="1gVkn0">
+          <node concept="3cmrfG" id="6sxj0_UABst" role="3uHU7w">
+            <property role="3cmrfH" value="2" />
+          </node>
+          <node concept="2OqwBi" id="6sxj0_UABsu" role="3uHU7B">
+            <node concept="37vLTw" id="6sxj0_UABsv" role="2Oq$k0">
+              <ref role="3cqZAo" node="6sxj0_UABsj" resolve="actions" />
+            </node>
+            <node concept="34oBXx" id="6sxj0_UABsw" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="Xl_RD" id="6sxj0_UABsx" role="1gVpfI">
+          <property role="Xl_RC" value="Maximum of 2 actions, Type A and WrapStmt expected" />
+        </node>
+      </node>
+      <node concept="1gVbGN" id="6sxj0_UABsy" role="3cqZAp">
+        <node concept="3fqX7Q" id="6sxj0_UABsz" role="1gVkn0">
+          <node concept="2OqwBi" id="6sxj0_UABs$" role="3fr31v">
+            <node concept="37vLTw" id="6sxj0_UABs_" role="2Oq$k0">
+              <ref role="3cqZAo" node="6sxj0_UABsj" resolve="actions" />
+            </node>
+            <node concept="2HwmR7" id="6sxj0_UABsA" role="2OqNvi">
+              <node concept="1bVj0M" id="6sxj0_UABsB" role="23t8la">
+                <node concept="3clFbS" id="6sxj0_UABsC" role="1bW5cS">
+                  <node concept="3clFbF" id="6sxj0_UABsD" role="3cqZAp">
+                    <node concept="2OqwBi" id="6sxj0_UABsE" role="3clFbG">
+                      <node concept="2OqwBi" id="6sxj0_UABsF" role="2Oq$k0">
+                        <node concept="37vLTw" id="6sxj0_UABsG" role="2Oq$k0">
+                          <ref role="3cqZAo" node="6sxj0_UABsN" resolve="it" />
+                        </node>
+                        <node concept="liA8E" id="6sxj0_UABsH" role="2OqNvi">
+                          <ref role="37wK5l" to="f4zo:~SubstituteAction.getMatchingText(java.lang.String)" resolve="getMatchingText" />
+                          <node concept="Xl_RD" id="6sxj0_UABsI" role="37wK5m">
+                            <property role="Xl_RC" value="" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="liA8E" id="6sxj0_UABsJ" role="2OqNvi">
+                        <ref role="37wK5l" to="wyt6:~String.equals(java.lang.Object)" resolve="equals" />
+                        <node concept="2OqwBi" id="6sxj0_UABsK" role="37wK5m">
+                          <node concept="35c_gC" id="6sxj0_UABsL" role="2Oq$k0">
+                            <ref role="35c_gD" to="ibwz:3Lzx5Pf0k2q" resolve="AType" />
+                          </node>
+                          <node concept="liA8E" id="6sxj0_UABsM" role="2OqNvi">
+                            <ref role="37wK5l" to="c17a:~SAbstractConcept.getConceptAlias()" resolve="getConceptAlias" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="Rh6nW" id="6sxj0_UABsN" role="1bW2Oz">
+                  <property role="TrG5h" value="it" />
+                  <node concept="2jxLKc" id="6sxj0_UABsO" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="Xl_RD" id="6sxj0_UABsP" role="1gVpfI">
+          <property role="Xl_RC" value="Type A not excluded from autocomplete menu" />
+        </node>
+      </node>
+      <node concept="1gVbGN" id="6sxj0_UABsQ" role="3cqZAp">
+        <node concept="2OqwBi" id="6sxj0_UABsR" role="1gVkn0">
+          <node concept="37vLTw" id="6sxj0_UABsS" role="2Oq$k0">
+            <ref role="3cqZAo" node="6sxj0_UABsj" resolve="actions" />
+          </node>
+          <node concept="2HwmR7" id="6sxj0_UABsT" role="2OqNvi">
+            <node concept="1bVj0M" id="6sxj0_UABsU" role="23t8la">
+              <node concept="3clFbS" id="6sxj0_UABsV" role="1bW5cS">
+                <node concept="3clFbF" id="6sxj0_UABsW" role="3cqZAp">
+                  <node concept="2OqwBi" id="6sxj0_UABsX" role="3clFbG">
+                    <node concept="2OqwBi" id="6sxj0_UABsY" role="2Oq$k0">
+                      <node concept="37vLTw" id="6sxj0_UABsZ" role="2Oq$k0">
+                        <ref role="3cqZAo" node="6sxj0_UABt6" resolve="it" />
+                      </node>
+                      <node concept="liA8E" id="6sxj0_UABt0" role="2OqNvi">
+                        <ref role="37wK5l" to="f4zo:~SubstituteAction.getMatchingText(java.lang.String)" resolve="getMatchingText" />
+                        <node concept="Xl_RD" id="6sxj0_UABt1" role="37wK5m" />
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="6sxj0_UABt2" role="2OqNvi">
+                      <ref role="37wK5l" to="wyt6:~String.equals(java.lang.Object)" resolve="equals" />
+                      <node concept="2OqwBi" id="6sxj0_UABt3" role="37wK5m">
+                        <node concept="35c_gC" id="6sxj0_UABt4" role="2Oq$k0">
+                          <ref role="35c_gD" to="ibwz:3Lzx5Pf0k5B" resolve="BType" />
+                        </node>
+                        <node concept="liA8E" id="6sxj0_UABt5" role="2OqNvi">
+                          <ref role="37wK5l" to="c17a:~SAbstractConcept.getConceptAlias()" resolve="getConceptAlias" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="Rh6nW" id="6sxj0_UABt6" role="1bW2Oz">
+                <property role="TrG5h" value="it" />
+                <node concept="2jxLKc" id="6sxj0_UABt7" role="1tU5fm" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="Xl_RD" id="6sxj0_UABt8" role="1gVpfI">
+          <property role="Xl_RC" value="Type B not included in autocomplete menu" />
+        </node>
+      </node>
+      <node concept="1gVbGN" id="6sxj0_UABt9" role="3cqZAp">
+        <node concept="2OqwBi" id="6sxj0_UABta" role="1gVkn0">
+          <node concept="37vLTw" id="6sxj0_UABtb" role="2Oq$k0">
+            <ref role="3cqZAo" node="6sxj0_UABsj" resolve="actions" />
+          </node>
+          <node concept="2HwmR7" id="6sxj0_UABtc" role="2OqNvi">
+            <node concept="1bVj0M" id="6sxj0_UABtd" role="23t8la">
+              <node concept="3clFbS" id="6sxj0_UABte" role="1bW5cS">
+                <node concept="3clFbF" id="6sxj0_UABtf" role="3cqZAp">
+                  <node concept="2OqwBi" id="6sxj0_UABtg" role="3clFbG">
+                    <node concept="2OqwBi" id="6sxj0_UABth" role="2Oq$k0">
+                      <node concept="37vLTw" id="6sxj0_UABti" role="2Oq$k0">
+                        <ref role="3cqZAo" node="6sxj0_UABtp" resolve="it" />
+                      </node>
+                      <node concept="liA8E" id="6sxj0_UABtj" role="2OqNvi">
+                        <ref role="37wK5l" to="f4zo:~SubstituteAction.getMatchingText(java.lang.String)" resolve="getMatchingText" />
+                        <node concept="Xl_RD" id="6sxj0_UABtk" role="37wK5m">
+                          <property role="Xl_RC" value="" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="6sxj0_UABtl" role="2OqNvi">
+                      <ref role="37wK5l" to="wyt6:~String.equals(java.lang.Object)" resolve="equals" />
+                      <node concept="2OqwBi" id="6sxj0_UABtm" role="37wK5m">
+                        <node concept="35c_gC" id="6sxj0_UABtn" role="2Oq$k0">
+                          <ref role="35c_gD" to="ibwz:1045PmWki5C" resolve="WrapStmtParentWhitelisting" />
+                        </node>
+                        <node concept="liA8E" id="6sxj0_UABto" role="2OqNvi">
+                          <ref role="37wK5l" to="c17a:~SAbstractConcept.getConceptAlias()" resolve="getConceptAlias" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="Rh6nW" id="6sxj0_UABtp" role="1bW2Oz">
+                <property role="TrG5h" value="it" />
+                <node concept="2jxLKc" id="6sxj0_UABtq" role="1tU5fm" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="Xl_RD" id="6sxj0_UABtr" role="1gVpfI">
           <property role="Xl_RC" value="Default wrapped Stmt not included in autocomplete menu" />
         </node>
       </node>


### PR DESCRIPTION
The changes from #664 were causing some completion menus to become empty since the constraints were not set up to check for abstract dummy nodes. This PR addresses this issue by moving the earlier constraint test back to its original version. The filtering is then performed when building the concrete action list.