### PR TITLE
mpsutil.intentions: add a new style attribute to allow intentions in read-only-cells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ The project does _not_ follow Semantic Versioning and the changes are documented
 
 - `@NotNull` annotations in the code are now checked at run time (the `javac2` compiler is used).
 
+### Added
+
+- mpsutil.intentions: a new style attribute `intentions-in-read-only-cell` is now available to allow intentions in read-only cells.
+
 ## October 2023
 
 ### Added

--- a/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
+++ b/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
@@ -12997,6 +12997,11 @@
             </node>
           </node>
         </node>
+        <node concept="1SiIV0" id="5qf1oe_IoCJ" role="3bR37C">
+          <node concept="3bR9La" id="5qf1oe_IoCK" role="1SiIV1">
+            <ref role="3bR37D" node="54z9_KDR0Ol" resolve="com.mbeddr.mpsutil.intentions" />
+          </node>
+        </node>
       </node>
     </node>
     <node concept="m$_wf" id="hCVXosGNJH" role="3989C9">

--- a/code/intentionsmenu/com.mbeddr.mpsutil.intentions.runtime/com.mbeddr.mpsutil.intentions.runtime.msd
+++ b/code/intentionsmenu/com.mbeddr.mpsutil.intentions.runtime/com.mbeddr.mpsutil.intentions.runtime.msd
@@ -16,6 +16,7 @@
     <dependency reexport="false">1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)</dependency>
     <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
     <dependency reexport="true">498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)</dependency>
+    <dependency reexport="false">b92f861d-0184-446d-b88b-6dcf0e070241(com.mbeddr.mpsutil.intentions)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:654422bf-e75f-44dc-936d-188890a746ce:de.slisson.mps.reflection" version="0" />
@@ -27,11 +28,13 @@
     <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
     <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
     <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
+    <language slang="l:18bc6592-03a6-4e29-a83a-7ff23bde13ba:jetbrains.mps.lang.editor" version="14" />
     <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
     <language slang="l:28f9e497-3b42-4291-aeba-0a1039153ab1:jetbrains.mps.lang.plugin" version="5" />
     <language slang="l:ef7bf5ac-d06c-4342-b11d-e42104eb9343:jetbrains.mps.lang.plugin.standalone" version="0" />
     <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
     <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
+    <language slang="l:c72da2b9-7cce-4447-8389-f407dc1158b7:jetbrains.mps.lang.structure" version="9" />
     <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
   </languageVersions>
@@ -43,8 +46,10 @@
     <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
+    <module reference="b92f861d-0184-446d-b88b-6dcf0e070241(com.mbeddr.mpsutil.intentions)" version="0" />
     <module reference="4bff7bbe-ce5f-432e-84bf-60809cb9987c(com.mbeddr.mpsutil.intentions.runtime)" version="0" />
     <module reference="f0fff802-6d26-4d2e-b89d-391357265626(de.slisson.mps.hacks.editor)" version="0" />
+    <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
   </dependencyVersions>
 </solution>
 

--- a/code/intentionsmenu/com.mbeddr.mpsutil.intentions.runtime/models/com/mbeddr/mpsutil/intentions/runtime.mps
+++ b/code/intentionsmenu/com.mbeddr.mpsutil.intentions.runtime/models/com/mbeddr/mpsutil/intentions/runtime.mps
@@ -4437,23 +4437,6 @@
         </node>
       </node>
       <node concept="3clFbS" id="5qf1oe_zXNK" role="3clF47">
-        <node concept="3clFbJ" id="5qf1oe_zXNL" role="3cqZAp">
-          <node concept="2OqwBi" id="5qf1oe_zXNM" role="3clFbw">
-            <node concept="37vLTw" id="5qf1oe_zXNN" role="2Oq$k0">
-              <ref role="3cqZAo" node="5qf1oe_zXNF" resolve="editorComponent" />
-            </node>
-            <node concept="liA8E" id="5qf1oe_zXNO" role="2OqNvi">
-              <ref role="37wK5l" to="cj4x:~EditorComponent.isReadOnly()" resolve="isReadOnly" />
-            </node>
-          </node>
-          <node concept="3clFbS" id="5qf1oe_zXNP" role="3clFbx">
-            <node concept="3cpWs6" id="5qf1oe_zXNQ" role="3cqZAp">
-              <node concept="3clFbT" id="5qf1oe_zXNR" role="3cqZAk">
-                <property role="3clFbU" value="true" />
-              </node>
-            </node>
-          </node>
-        </node>
         <node concept="1DcWWT" id="5qf1oe_zXNS" role="3cqZAp">
           <node concept="37vLTw" id="5qf1oe_zXNT" role="1DdaDG">
             <ref role="3cqZAo" node="5qf1oe_zXNH" resolve="cells" />

--- a/code/intentionsmenu/com.mbeddr.mpsutil.intentions.runtime/models/com/mbeddr/mpsutil/intentions/runtime.mps
+++ b/code/intentionsmenu/com.mbeddr.mpsutil.intentions.runtime/models/com/mbeddr/mpsutil/intentions/runtime.mps
@@ -4,6 +4,8 @@
   <languages>
     <use id="654422bf-e75f-44dc-936d-188890a746ce" name="de.slisson.mps.reflection" version="-1" />
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
+    <use id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core" version="2" />
+    <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="14" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -38,12 +40,22 @@
     <import index="d2fk" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui.popup.list(MPS.IDEA/)" />
     <import index="nddn" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.intentions(MPS.Editor/)" />
     <import index="1ka" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.typechecking(MPS.Core/)" />
-    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" implicit="true" />
+    <import index="cj4x" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor(MPS.Editor/)" />
+    <import index="lwvz" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.selection(MPS.Editor/)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
+    <import index="5ueo" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.editor.runtime.style(MPS.Editor/)" />
+    <import index="zddv" ref="r:1b71c6d7-41ff-44a2-a61c-39c2a9779c34(com.mbeddr.mpsutil.intentions.editor)" />
+    <import index="hox0" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.style(MPS.Editor/)" />
   </imports>
   <registry>
     <language id="654422bf-e75f-44dc-936d-188890a746ce" name="de.slisson.mps.reflection">
       <concept id="8473566765275063380" name="de.slisson.mps.reflection.structure.ReflectionFieldAccess" flags="ng" index="1PnCL0">
         <reference id="1197029500499" name="fieldDeclaration" index="2Oxat5" />
+      </concept>
+    </language>
+    <language id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor">
+      <concept id="6029276237631252951" name="jetbrains.mps.lang.editor.structure.StyleAttributeReferenceExpression" flags="ng" index="1Z6Ecs">
+        <reference id="6029276237631253682" name="attributeDeclaration" index="1Z6EpT" />
       </concept>
     </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
@@ -88,6 +100,7 @@
       <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
         <child id="1145553007750" name="creator" index="2ShVmc" />
       </concept>
+      <concept id="1070462154015" name="jetbrains.mps.baseLanguage.structure.StaticFieldDeclaration" flags="ig" index="Wx3nA" />
       <concept id="1070475354124" name="jetbrains.mps.baseLanguage.structure.ThisExpression" flags="nn" index="Xjq3P" />
       <concept id="1070475587102" name="jetbrains.mps.baseLanguage.structure.SuperConstructorInvocation" flags="nn" index="XkiVB" />
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
@@ -96,6 +109,7 @@
       <concept id="1182160077978" name="jetbrains.mps.baseLanguage.structure.AnonymousClassCreator" flags="nn" index="YeOm9">
         <child id="1182160096073" name="cls" index="YeSDq" />
       </concept>
+      <concept id="1081236700938" name="jetbrains.mps.baseLanguage.structure.StaticMethodDeclaration" flags="ig" index="2YIFZL" />
       <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
       </concept>
@@ -547,28 +561,41 @@
           </node>
         </node>
         <node concept="3clFbJ" id="3pwG8PSkQDw" role="3cqZAp">
-          <node concept="22lmx$" id="3pwG8PSkQDx" role="3clFbw">
-            <node concept="2YIFZM" id="3pwG8PSkTS1" role="3uHU7B">
-              <ref role="1Pybhc" to="3ahc:~ReadOnlyUtil" resolve="ReadOnlyUtil" />
-              <ref role="37wK5l" to="3ahc:~ReadOnlyUtil.isSelectionReadOnlyInEditor(jetbrains.mps.openapi.editor.EditorComponent)" resolve="isSelectionReadOnlyInEditor" />
-              <node concept="37vLTw" id="3pwG8PSkQDz" role="37wK5m">
-                <ref role="3cqZAo" node="3pwG8PSkQAX" resolve="myEditor" />
+          <node concept="1Wc70l" id="5qf1oe_$EA7" role="3clFbw">
+            <node concept="3fqX7Q" id="5qf1oe__0gk" role="3uHU7w">
+              <node concept="2YIFZM" id="5qf1oe__0gm" role="3fr31v">
+                <ref role="37wK5l" node="5qf1oe_zNws" resolve="allowIntentionsInReadOnlySelection" />
+                <ref role="1Pybhc" node="5qf1oe_zyw0" resolve="StyleUtil" />
+                <node concept="37vLTw" id="5qf1oe__0gn" role="37wK5m">
+                  <ref role="3cqZAo" node="3pwG8PSkQAX" resolve="myEditor" />
+                </node>
               </node>
             </node>
-            <node concept="2YIFZM" id="3pwG8PSkTS4" role="3uHU7w">
-              <ref role="1Pybhc" to="w1kc:~SModelOperations" resolve="SModelOperations" />
-              <ref role="37wK5l" to="w1kc:~SModelOperations.isReadOnly(org.jetbrains.mps.openapi.model.SModel)" resolve="isReadOnly" />
-              <node concept="2OqwBi" id="3pwG8PSkQD_" role="37wK5m">
-                <node concept="2OqwBi" id="3pwG8PSkTS8" role="2Oq$k0">
-                  <node concept="37vLTw" id="3pwG8PSkTS7" role="2Oq$k0">
+            <node concept="1eOMI4" id="5qf1oe_$A82" role="3uHU7B">
+              <node concept="22lmx$" id="3pwG8PSkQDx" role="1eOMHV">
+                <node concept="2YIFZM" id="3pwG8PSkTS1" role="3uHU7B">
+                  <ref role="1Pybhc" to="3ahc:~ReadOnlyUtil" resolve="ReadOnlyUtil" />
+                  <ref role="37wK5l" to="3ahc:~ReadOnlyUtil.isSelectionReadOnlyInEditor(jetbrains.mps.openapi.editor.EditorComponent)" resolve="isSelectionReadOnlyInEditor" />
+                  <node concept="37vLTw" id="3pwG8PSkQDz" role="37wK5m">
                     <ref role="3cqZAo" node="3pwG8PSkQAX" resolve="myEditor" />
                   </node>
-                  <node concept="liA8E" id="3pwG8PSkTS9" role="2OqNvi">
-                    <ref role="37wK5l" to="exr9:~EditorComponent.getSelectedNode()" resolve="getSelectedNode" />
-                  </node>
                 </node>
-                <node concept="liA8E" id="3pwG8PSkQDB" role="2OqNvi">
-                  <ref role="37wK5l" to="mhbf:~SNode.getModel()" resolve="getModel" />
+                <node concept="2YIFZM" id="3pwG8PSkTS4" role="3uHU7w">
+                  <ref role="1Pybhc" to="w1kc:~SModelOperations" resolve="SModelOperations" />
+                  <ref role="37wK5l" to="w1kc:~SModelOperations.isReadOnly(org.jetbrains.mps.openapi.model.SModel)" resolve="isReadOnly" />
+                  <node concept="2OqwBi" id="3pwG8PSkQD_" role="37wK5m">
+                    <node concept="2OqwBi" id="3pwG8PSkTS8" role="2Oq$k0">
+                      <node concept="37vLTw" id="3pwG8PSkTS7" role="2Oq$k0">
+                        <ref role="3cqZAo" node="3pwG8PSkQAX" resolve="myEditor" />
+                      </node>
+                      <node concept="liA8E" id="3pwG8PSkTS9" role="2OqNvi">
+                        <ref role="37wK5l" to="exr9:~EditorComponent.getSelectedNode()" resolve="getSelectedNode" />
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="3pwG8PSkQDB" role="2OqNvi">
+                      <ref role="37wK5l" to="mhbf:~SNode.getModel()" resolve="getModel" />
+                    </node>
+                  </node>
                 </node>
               </node>
             </node>
@@ -4311,6 +4338,200 @@
           </node>
         </node>
       </node>
+    </node>
+  </node>
+  <node concept="312cEu" id="5qf1oe_zyw0">
+    <property role="TrG5h" value="StyleUtil" />
+    <property role="2bfB8j" value="true" />
+    <node concept="3Tm1VV" id="5qf1oe_zyw1" role="1B3o_S" />
+    <node concept="Wx3nA" id="2iZPrFZnMN9" role="jymVt">
+      <property role="3TUv4t" value="true" />
+      <property role="TrG5h" value="INTENTIONS_IN_READONLY_CELL" />
+      <node concept="3Tm1VV" id="5qf1oe_$8ZN" role="1B3o_S" />
+      <node concept="3uibUv" id="2iZPrFZnMN6" role="1tU5fm">
+        <ref role="3uigEE" to="hox0:~StyleAttribute" resolve="StyleAttribute" />
+        <node concept="3uibUv" id="2iZPrFZnMN7" role="11_B2D">
+          <ref role="3uigEE" to="wyt6:~Boolean" resolve="Boolean" />
+        </node>
+      </node>
+      <node concept="1Z6Ecs" id="2iZPrFZnMN8" role="33vP2m">
+        <ref role="1Z6EpT" to="zddv:5qf1oe_$9mw" resolve="intentionsInReadOnlyCell" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="5qf1oe_$8xF" role="jymVt" />
+    <node concept="2tJIrI" id="5qf1oe_$8Ay" role="jymVt" />
+    <node concept="2YIFZL" id="5qf1oe_zNws" role="jymVt">
+      <property role="TrG5h" value="allowIntentionsInReadOnlySelection" />
+      <node concept="37vLTG" id="5qf1oe_zNwt" role="3clF46">
+        <property role="TrG5h" value="editorComponent" />
+        <node concept="3uibUv" id="5qf1oe_zNwu" role="1tU5fm">
+          <ref role="3uigEE" to="cj4x:~EditorComponent" resolve="EditorComponent" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="5qf1oe_zNwv" role="3clF47">
+        <node concept="3cpWs8" id="5qf1oe_zNww" role="3cqZAp">
+          <node concept="3cpWsn" id="5qf1oe_zNwx" role="3cpWs9">
+            <property role="TrG5h" value="selection" />
+            <node concept="3uibUv" id="5qf1oe_zNwy" role="1tU5fm">
+              <ref role="3uigEE" to="lwvz:~Selection" resolve="Selection" />
+            </node>
+            <node concept="2OqwBi" id="5qf1oe_zNwz" role="33vP2m">
+              <node concept="2OqwBi" id="5qf1oe_zNw$" role="2Oq$k0">
+                <node concept="37vLTw" id="5qf1oe_zNw_" role="2Oq$k0">
+                  <ref role="3cqZAo" node="5qf1oe_zNwt" resolve="editorComponent" />
+                </node>
+                <node concept="liA8E" id="5qf1oe_zNwA" role="2OqNvi">
+                  <ref role="37wK5l" to="cj4x:~EditorComponent.getSelectionManager()" resolve="getSelectionManager" />
+                </node>
+              </node>
+              <node concept="liA8E" id="5qf1oe_zNwB" role="2OqNvi">
+                <ref role="37wK5l" to="lwvz:~SelectionManager.getSelection()" resolve="getSelection" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="5qf1oe_zNwC" role="3cqZAp">
+          <node concept="22lmx$" id="5qf1oe_zNwD" role="3cqZAk">
+            <node concept="3clFbC" id="5qf1oe_zNwE" role="3uHU7B">
+              <node concept="37vLTw" id="5qf1oe_zNwF" role="3uHU7B">
+                <ref role="3cqZAo" node="5qf1oe_zNwx" resolve="selection" />
+              </node>
+              <node concept="10Nm6u" id="5qf1oe_zNwG" role="3uHU7w" />
+            </node>
+            <node concept="1rXfSq" id="5qf1oe_zZ7k" role="3uHU7w">
+              <ref role="37wK5l" node="5qf1oe_zXNE" resolve="isCellsReadOnlyInEditor" />
+              <node concept="37vLTw" id="5qf1oe_$h66" role="37wK5m">
+                <ref role="3cqZAo" node="5qf1oe_zNwt" resolve="editorComponent" />
+              </node>
+              <node concept="2OqwBi" id="5qf1oe_$mWQ" role="37wK5m">
+                <node concept="37vLTw" id="5qf1oe_$mJW" role="2Oq$k0">
+                  <ref role="3cqZAo" node="5qf1oe_zNwx" resolve="selection" />
+                </node>
+                <node concept="liA8E" id="5qf1oe_$n5i" role="2OqNvi">
+                  <ref role="37wK5l" to="lwvz:~Selection.getSelectedCells()" resolve="getSelectedCells" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="5qf1oe_zNwM" role="1B3o_S" />
+      <node concept="10P_77" id="5qf1oe_zNwN" role="3clF45" />
+    </node>
+    <node concept="2tJIrI" id="5qf1oe_zXGa" role="jymVt" />
+    <node concept="2YIFZL" id="5qf1oe_zXNE" role="jymVt">
+      <property role="TrG5h" value="allowIntentionsInReadOnlyCells" />
+      <node concept="37vLTG" id="5qf1oe_zXNF" role="3clF46">
+        <property role="TrG5h" value="editorComponent" />
+        <node concept="3uibUv" id="5qf1oe_zXNG" role="1tU5fm">
+          <ref role="3uigEE" to="cj4x:~EditorComponent" resolve="EditorComponent" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="5qf1oe_zXNH" role="3clF46">
+        <property role="TrG5h" value="cells" />
+        <node concept="3uibUv" id="5qf1oe_zXNI" role="1tU5fm">
+          <ref role="3uigEE" to="wyt6:~Iterable" resolve="Iterable" />
+          <node concept="3uibUv" id="5qf1oe_zXNJ" role="11_B2D">
+            <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbS" id="5qf1oe_zXNK" role="3clF47">
+        <node concept="3clFbJ" id="5qf1oe_zXNL" role="3cqZAp">
+          <node concept="2OqwBi" id="5qf1oe_zXNM" role="3clFbw">
+            <node concept="37vLTw" id="5qf1oe_zXNN" role="2Oq$k0">
+              <ref role="3cqZAo" node="5qf1oe_zXNF" resolve="editorComponent" />
+            </node>
+            <node concept="liA8E" id="5qf1oe_zXNO" role="2OqNvi">
+              <ref role="37wK5l" to="cj4x:~EditorComponent.isReadOnly()" resolve="isReadOnly" />
+            </node>
+          </node>
+          <node concept="3clFbS" id="5qf1oe_zXNP" role="3clFbx">
+            <node concept="3cpWs6" id="5qf1oe_zXNQ" role="3cqZAp">
+              <node concept="3clFbT" id="5qf1oe_zXNR" role="3cqZAk">
+                <property role="3clFbU" value="true" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1DcWWT" id="5qf1oe_zXNS" role="3cqZAp">
+          <node concept="37vLTw" id="5qf1oe_zXNT" role="1DdaDG">
+            <ref role="3cqZAo" node="5qf1oe_zXNH" resolve="cells" />
+          </node>
+          <node concept="3cpWsn" id="5qf1oe_zXNU" role="1Duv9x">
+            <property role="TrG5h" value="cell" />
+            <node concept="3uibUv" id="5qf1oe_zXNV" role="1tU5fm">
+              <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+            </node>
+          </node>
+          <node concept="3clFbS" id="5qf1oe_zXNW" role="2LFqv$">
+            <node concept="3clFbJ" id="5qf1oe_zXNX" role="3cqZAp">
+              <node concept="22lmx$" id="5qf1oe_zXNY" role="3clFbw">
+                <node concept="3clFbC" id="5qf1oe_zXNZ" role="3uHU7B">
+                  <node concept="37vLTw" id="5qf1oe_zXO0" role="3uHU7B">
+                    <ref role="3cqZAo" node="5qf1oe_zXNU" resolve="cell" />
+                  </node>
+                  <node concept="10Nm6u" id="5qf1oe_zXO1" role="3uHU7w" />
+                </node>
+                <node concept="1rXfSq" id="5qf1oe_zXO2" role="3uHU7w">
+                  <ref role="37wK5l" node="5qf1oe_zyw2" resolve="isCellReadOnly" />
+                  <node concept="37vLTw" id="5qf1oe_zXO3" role="37wK5m">
+                    <ref role="3cqZAo" node="5qf1oe_zXNU" resolve="cell" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbS" id="5qf1oe_zXO4" role="3clFbx">
+                <node concept="3cpWs6" id="5qf1oe_zXO5" role="3cqZAp">
+                  <node concept="3clFbT" id="5qf1oe_zXO6" role="3cqZAk">
+                    <property role="3clFbU" value="true" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="5qf1oe_zXO7" role="3cqZAp">
+          <node concept="3clFbT" id="5qf1oe_zXO8" role="3cqZAk" />
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="5qf1oe_zXO9" role="1B3o_S" />
+      <node concept="10P_77" id="5qf1oe_zXOa" role="3clF45" />
+    </node>
+    <node concept="2tJIrI" id="5qf1oe_zXJT" role="jymVt" />
+    <node concept="2tJIrI" id="5qf1oe_zMRh" role="jymVt" />
+    <node concept="2YIFZL" id="5qf1oe_zyw2" role="jymVt">
+      <property role="TrG5h" value="isAllowIntentionsInReadOnlyCell" />
+      <node concept="37vLTG" id="5qf1oe_zyw3" role="3clF46">
+        <property role="TrG5h" value="cell" />
+        <node concept="2AHcQZ" id="5qf1oe_zyw4" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+        <node concept="3uibUv" id="5qf1oe_zyw5" role="1tU5fm">
+          <ref role="3uigEE" to="f4zo:~EditorCell" resolve="jetbrains.mps.openapi.editor.cells.EditorCell" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="5qf1oe_zyw6" role="3clF47">
+        <node concept="3clFbF" id="5qf1oe_$3Wk" role="3cqZAp">
+          <node concept="2OqwBi" id="5qf1oe_$56t" role="3clFbG">
+            <node concept="2OqwBi" id="5qf1oe_$4nJ" role="2Oq$k0">
+              <node concept="37vLTw" id="5qf1oe_$3Wj" role="2Oq$k0">
+                <ref role="3cqZAo" node="5qf1oe_zyw3" resolve="cell" />
+              </node>
+              <node concept="liA8E" id="5qf1oe_$4Il" role="2OqNvi">
+                <ref role="37wK5l" to="f4zo:~EditorCell.getStyle()" resolve="getStyle" />
+              </node>
+            </node>
+            <node concept="liA8E" id="5qf1oe_$5uC" role="2OqNvi">
+              <ref role="37wK5l" to="hox0:~Style.get(jetbrains.mps.openapi.editor.style.StyleAttribute)" resolve="get" />
+              <node concept="37vLTw" id="5qf1oe_$nPc" role="37wK5m">
+                <ref role="3cqZAo" node="2iZPrFZnMN9" resolve="INTENTIONS_IN_READONLY_CELL" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="5qf1oe_zywb" role="1B3o_S" />
+      <node concept="10P_77" id="5qf1oe_zywc" role="3clF45" />
     </node>
   </node>
 </model>

--- a/code/intentionsmenu/com.mbeddr.mpsutil.intentions/languageModels/editor.mps
+++ b/code/intentionsmenu/com.mbeddr.mpsutil.intentions/languageModels/editor.mps
@@ -25,8 +25,15 @@
         <child id="1164833692344" name="valuesFunction" index="PvTIR" />
       </concept>
       <concept id="1149850725784" name="jetbrains.mps.lang.editor.structure.CellModel_AttributedNodeCell" flags="ng" index="2SsqMj" />
+      <concept id="1186402211651" name="jetbrains.mps.lang.editor.structure.StyleSheet" flags="ng" index="V5hpn">
+        <child id="1186402402630" name="styles" index="V601i" />
+      </concept>
       <concept id="1186414536763" name="jetbrains.mps.lang.editor.structure.BooleanStyleSheetItem" flags="ln" index="VOi$J">
         <property id="1186414551515" name="flag" index="VOm3f" />
+      </concept>
+      <concept id="3982520150113085419" name="jetbrains.mps.lang.editor.structure.StyleAttributeDeclaration" flags="ig" index="3t5Usi">
+        <child id="3982520150113147643" name="defaultValue" index="3t49C2" />
+        <child id="3982520150113092206" name="valueType" index="3t5Oan" />
       </concept>
       <concept id="1219226236603" name="jetbrains.mps.lang.editor.structure.DrawBracketsStyleClassItem" flags="ln" index="3vyZuw" />
       <concept id="1139848536355" name="jetbrains.mps.lang.editor.structure.CellModel_WithRole" flags="ng" index="1$h60E">
@@ -60,6 +67,7 @@
       <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
         <child id="1137022507850" name="body" index="2VODD2" />
       </concept>
+      <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
@@ -72,6 +80,7 @@
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
+      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT" />
     </language>
     <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
       <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
@@ -214,6 +223,14 @@
         </node>
       </node>
       <node concept="2SsqMj" id="54z9_KDO5Tc" role="3EZMnx" />
+    </node>
+  </node>
+  <node concept="V5hpn" id="5qf1oe_$9jz">
+    <property role="TrG5h" value="IntentionStyles" />
+    <node concept="3t5Usi" id="5qf1oe_$9mw" role="V601i">
+      <property role="TrG5h" value="intentions-in-read-only-cell" />
+      <node concept="10P_77" id="5qf1oe_$9mA" role="3t5Oan" />
+      <node concept="3clFbT" id="5qf1oe_$9mE" role="3t49C2" />
     </node>
   </node>
 </model>

--- a/code/languages/com.mbeddr.mpsutil.intentions.sandboxlang/com.mbeddr.mpsutil.intentions.sandboxlang.mpl
+++ b/code/languages/com.mbeddr.mpsutil.intentions.sandboxlang/com.mbeddr.mpsutil.intentions.sandboxlang.mpl
@@ -55,6 +55,9 @@
     </generator>
   </generators>
   <sourcePath />
+  <dependencies>
+    <dependency reexport="false">b92f861d-0184-446d-b88b-6dcf0e070241(com.mbeddr.mpsutil.intentions)</dependency>
+  </dependencies>
   <languageVersions>
     <language slang="l:b92f861d-0184-446d-b88b-6dcf0e070241:com.mbeddr.mpsutil.intentions" version="0" />
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
@@ -97,6 +100,7 @@
     <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
     <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+    <module reference="b92f861d-0184-446d-b88b-6dcf0e070241(com.mbeddr.mpsutil.intentions)" version="0" />
     <module reference="4972ae94-72e7-499b-8766-0d6acffdb4f2(com.mbeddr.mpsutil.intentions.sandboxlang)" version="0" />
     <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
     <module reference="a9e4c532-c5f5-4bb7-99ef-42abb73bbb70(jetbrains.mps.lang.descriptor.aspects)" version="0" />

--- a/code/languages/com.mbeddr.mpsutil.intentions.sandboxlang/models/com.mbeddr.mpsutil.intentions.sandboxlang.editor.mps
+++ b/code/languages/com.mbeddr.mpsutil.intentions.sandboxlang/models/com.mbeddr.mpsutil.intentions.sandboxlang.editor.mps
@@ -7,20 +7,65 @@
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
+    <import index="zddv" ref="r:1b71c6d7-41ff-44a2-a61c-39c2a9779c34(com.mbeddr.mpsutil.intentions.editor)" />
     <import index="iikq" ref="r:7a511fd5-d829-4752-8daa-0ca5c0705ea8(com.mbeddr.mpsutil.intentions.sandboxlang.structure)" implicit="true" />
     <import index="tpco" ref="r:00000000-0000-4000-0000-011c89590284(jetbrains.mps.lang.core.editor)" implicit="true" />
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
   </imports>
   <registry>
     <language id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor">
       <concept id="1071666914219" name="jetbrains.mps.lang.editor.structure.ConceptEditorDeclaration" flags="ig" index="24kQdi" />
+      <concept id="1140524381322" name="jetbrains.mps.lang.editor.structure.CellModel_ListWithRole" flags="ng" index="2czfm3">
+        <child id="1140524464360" name="cellLayout" index="2czzBx" />
+      </concept>
+      <concept id="1106270549637" name="jetbrains.mps.lang.editor.structure.CellLayout_Horizontal" flags="nn" index="2iRfu4" />
+      <concept id="1106270571710" name="jetbrains.mps.lang.editor.structure.CellLayout_Vertical" flags="nn" index="2iRkQZ" />
       <concept id="1080736578640" name="jetbrains.mps.lang.editor.structure.BaseEditorComponent" flags="ig" index="2wURMF">
         <child id="1080736633877" name="cellModel" index="2wV5jI" />
       </concept>
+      <concept id="795210086017940429" name="jetbrains.mps.lang.editor.structure.ReadOnlyStyleClassItem" flags="lg" index="xShMh" />
       <concept id="1078939183254" name="jetbrains.mps.lang.editor.structure.CellModel_Component" flags="sg" stub="3162947552742194261" index="PMmxH">
         <reference id="1078939183255" name="editorComponent" index="PMmxG" />
       </concept>
+      <concept id="1186414536763" name="jetbrains.mps.lang.editor.structure.BooleanStyleSheetItem" flags="ln" index="VOi$J">
+        <property id="1186414551515" name="flag" index="VOm3f" />
+      </concept>
+      <concept id="3982520150125052579" name="jetbrains.mps.lang.editor.structure.QueryFunction_AttributeStyleParameter" flags="ig" index="3sjG9q" />
+      <concept id="3982520150122341378" name="jetbrains.mps.lang.editor.structure.AttributeStyleClassItem" flags="lg" index="3tD6jV">
+        <reference id="3982520150122346707" name="attribute" index="3tD7wE" />
+        <child id="3982520150122341379" name="query" index="3tD6jU" />
+      </concept>
+      <concept id="1139848536355" name="jetbrains.mps.lang.editor.structure.CellModel_WithRole" flags="ng" index="1$h60E">
+        <reference id="1140103550593" name="relationDeclaration" index="1NtTu8" />
+      </concept>
+      <concept id="1073389446423" name="jetbrains.mps.lang.editor.structure.CellModel_Collection" flags="sn" stub="3013115976261988961" index="3EZMnI">
+        <child id="1106270802874" name="cellLayout" index="2iSdaV" />
+        <child id="1073389446424" name="childCellModel" index="3EZMnx" />
+      </concept>
+      <concept id="1073389577006" name="jetbrains.mps.lang.editor.structure.CellModel_Constant" flags="sn" stub="3610246225209162225" index="3F0ifn">
+        <property id="1073389577007" name="text" index="3F0ifm" />
+      </concept>
+      <concept id="1073389658414" name="jetbrains.mps.lang.editor.structure.CellModel_Property" flags="sg" stub="730538219796134133" index="3F0A7n" />
+      <concept id="1219418625346" name="jetbrains.mps.lang.editor.structure.IStyleContainer" flags="ng" index="3F0Thp">
+        <child id="1219418656006" name="styleItem" index="3F10Kt" />
+      </concept>
+      <concept id="1073390211982" name="jetbrains.mps.lang.editor.structure.CellModel_RefNodeList" flags="sg" stub="2794558372793454595" index="3F2HdR" />
       <concept id="1166049232041" name="jetbrains.mps.lang.editor.structure.AbstractComponent" flags="ng" index="1XWOmA">
         <reference id="1166049300910" name="conceptDeclaration" index="1XX52x" />
+      </concept>
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
+        <child id="1137022507850" name="body" index="2VODD2" />
+      </concept>
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
+        <property id="1068580123138" name="value" index="3clFbU" />
       </concept>
     </language>
   </registry>
@@ -28,6 +73,62 @@
     <ref role="1XX52x" to="iikq:197NvysM_3t" resolve="DemoNodeWithIntentions" />
     <node concept="PMmxH" id="3pZvzolnXtY" role="2wV5jI">
       <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
+    </node>
+  </node>
+  <node concept="24kQdi" id="5qf1oe_GcsR">
+    <ref role="1XX52x" to="iikq:5qf1oe_GcsA" resolve="Root" />
+    <node concept="3EZMnI" id="5qf1oe_GcsW" role="2wV5jI">
+      <node concept="2iRkQZ" id="5qf1oe_GcsX" role="2iSdaV" />
+      <node concept="3EZMnI" id="5qf1oe_H6Ib" role="3EZMnx">
+        <node concept="2iRfu4" id="5qf1oe_H6Ic" role="2iSdaV" />
+        <node concept="3F0ifn" id="5qf1oe_GcsT" role="3EZMnx">
+          <property role="3F0ifm" value="root" />
+        </node>
+        <node concept="3F0A7n" id="5qf1oe_H6In" role="3EZMnx">
+          <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
+        </node>
+      </node>
+      <node concept="3F0ifn" id="5qf1oe_Gct2" role="3EZMnx" />
+      <node concept="3F2HdR" id="5qf1oe_Gct9" role="3EZMnx">
+        <ref role="1NtTu8" to="iikq:5qf1oe_GcsC" resolve="children" />
+        <node concept="2iRkQZ" id="5qf1oe_Gctb" role="2czzBx" />
+      </node>
+    </node>
+  </node>
+  <node concept="24kQdi" id="5qf1oe_GdNJ">
+    <ref role="1XX52x" to="iikq:5qf1oe_GcsE" resolve="Child" />
+    <node concept="3F0ifn" id="5qf1oe_GdNL" role="2wV5jI">
+      <property role="3F0ifm" value="child" />
+    </node>
+  </node>
+  <node concept="24kQdi" id="5qf1oe_GdOe">
+    <ref role="1XX52x" to="iikq:5qf1oe_GcsB" resolve="ReadOnlyChild" />
+    <node concept="3F0ifn" id="5qf1oe_GdOg" role="2wV5jI">
+      <property role="3F0ifm" value="read-only-child" />
+      <node concept="xShMh" id="5qf1oe_GdOm" role="3F10Kt">
+        <property role="VOm3f" value="true" />
+      </node>
+    </node>
+  </node>
+  <node concept="24kQdi" id="5qf1oe_GdOA">
+    <ref role="1XX52x" to="iikq:5qf1oe_GdOj" resolve="ReadOnlyChildAllowed" />
+    <node concept="3F0ifn" id="5qf1oe_GdOC" role="2wV5jI">
+      <property role="3F0ifm" value="read-only-child-allowed" />
+      <node concept="xShMh" id="5qf1oe_GdOF" role="3F10Kt">
+        <property role="VOm3f" value="true" />
+      </node>
+      <node concept="3tD6jV" id="5qf1oe_GeBz" role="3F10Kt">
+        <ref role="3tD7wE" to="zddv:5qf1oe_$9mw" resolve="intentions-in-read-only-cell" />
+        <node concept="3sjG9q" id="5qf1oe_GeB_" role="3tD6jU">
+          <node concept="3clFbS" id="5qf1oe_GeBB" role="2VODD2">
+            <node concept="3clFbF" id="5qf1oe_GeFz" role="3cqZAp">
+              <node concept="3clFbT" id="5qf1oe_GeFy" role="3clFbG">
+                <property role="3clFbU" value="true" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
     </node>
   </node>
 </model>

--- a/code/languages/com.mbeddr.mpsutil.intentions.sandboxlang/models/com.mbeddr.mpsutil.intentions.sandboxlang.intentions.mps
+++ b/code/languages/com.mbeddr.mpsutil.intentions.sandboxlang/models/com.mbeddr.mpsutil.intentions.sandboxlang.intentions.mps
@@ -8,15 +8,25 @@
   </languages>
   <imports>
     <import index="iikq" ref="r:7a511fd5-d829-4752-8daa-0ca5c0705ea8(com.mbeddr.mpsutil.intentions.sandboxlang.structure)" implicit="true" />
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
+        <child id="1068498886297" name="rValue" index="37vLTx" />
+        <child id="1068498886295" name="lValue" index="37vLTJ" />
+      </concept>
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
       <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
         <child id="1137022507850" name="body" index="2VODD2" />
       </concept>
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
       </concept>
+      <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
@@ -41,10 +51,26 @@
       <concept id="1192794744107" name="jetbrains.mps.lang.intentions.structure.IntentionDeclaration" flags="ig" index="2S6QgY" />
       <concept id="1192794782375" name="jetbrains.mps.lang.intentions.structure.DescriptionBlock" flags="in" index="2S6ZIM" />
       <concept id="1192795911897" name="jetbrains.mps.lang.intentions.structure.ExecuteBlock" flags="in" index="2Sbjvc" />
+      <concept id="1192796902958" name="jetbrains.mps.lang.intentions.structure.ConceptFunctionParameter_node" flags="nn" index="2Sf5sV" />
       <concept id="2522969319638091381" name="jetbrains.mps.lang.intentions.structure.BaseIntentionDeclaration" flags="ig" index="2ZfUlf">
         <reference id="2522969319638198290" name="forConcept" index="2ZfgGC" />
         <child id="2522969319638198291" name="executeFunction" index="2ZfgGD" />
         <child id="2522969319638093993" name="descriptionFunction" index="2ZfVej" />
+      </concept>
+    </language>
+    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
+        <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
+      </concept>
+      <concept id="1138411891628" name="jetbrains.mps.lang.smodel.structure.SNodeOperation" flags="nn" index="eCIE_">
+        <child id="1144104376918" name="parameter" index="1xVPHs" />
+      </concept>
+      <concept id="1171407110247" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorOperation" flags="nn" index="2Xjw5R" />
+      <concept id="1144101972840" name="jetbrains.mps.lang.smodel.structure.OperationParm_Concept" flags="ng" index="1xMEDy">
+        <child id="1207343664468" name="conceptArgument" index="ri$Ld" />
+      </concept>
+      <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
+        <reference id="1138056395725" name="property" index="3TsBF5" />
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
@@ -181,6 +207,45 @@
     </node>
     <node concept="2Sbjvc" id="5KWvuz1t2tb" role="2ZfgGD">
       <node concept="3clFbS" id="5KWvuz1t2tc" role="2VODD2" />
+    </node>
+  </node>
+  <node concept="2S6QgY" id="5qf1oe_Gctg">
+    <property role="TrG5h" value="ChildIntention" />
+    <ref role="2ZfgGC" to="iikq:5qf1oe_GcsF" resolve="IChild" />
+    <node concept="2S6ZIM" id="5qf1oe_Gcth" role="2ZfVej">
+      <node concept="3clFbS" id="5qf1oe_Gcti" role="2VODD2">
+        <node concept="3clFbF" id="5qf1oe_Gcyk" role="3cqZAp">
+          <node concept="Xl_RD" id="5qf1oe_Gcyj" role="3clFbG">
+            <property role="Xl_RC" value="Add a Change" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2Sbjvc" id="5qf1oe_Gctj" role="2ZfgGD">
+      <node concept="3clFbS" id="5qf1oe_Gctk" role="2VODD2">
+        <node concept="3clFbF" id="5qf1oe_H9Ng" role="3cqZAp">
+          <node concept="37vLTI" id="5qf1oe_HaHF" role="3clFbG">
+            <node concept="Xl_RD" id="5qf1oe_HaIj" role="37vLTx">
+              <property role="Xl_RC" value="Changed" />
+            </node>
+            <node concept="2OqwBi" id="5qf1oe_Hafc" role="37vLTJ">
+              <node concept="2OqwBi" id="5qf1oe_H9V4" role="2Oq$k0">
+                <node concept="2Sf5sV" id="5qf1oe_H9Nf" role="2Oq$k0" />
+                <node concept="2Xjw5R" id="5qf1oe_Ha3J" role="2OqNvi">
+                  <node concept="1xMEDy" id="5qf1oe_Ha3L" role="1xVPHs">
+                    <node concept="chp4Y" id="5qf1oe_Ha66" role="ri$Ld">
+                      <ref role="cht4Q" to="iikq:5qf1oe_GcsA" resolve="Root" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3TrcHB" id="5qf1oe_HaqF" role="2OqNvi">
+                <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
     </node>
   </node>
 </model>

--- a/code/languages/com.mbeddr.mpsutil.intentions.sandboxlang/models/com.mbeddr.mpsutil.intentions.sandboxlang.structure.mps
+++ b/code/languages/com.mbeddr.mpsutil.intentions.sandboxlang/models/com.mbeddr.mpsutil.intentions.sandboxlang.structure.mps
@@ -13,10 +13,23 @@
       <concept id="1169125787135" name="jetbrains.mps.lang.structure.structure.AbstractConceptDeclaration" flags="ig" index="PkWjJ">
         <property id="6714410169261853888" name="conceptId" index="EcuMT" />
         <property id="5092175715804935370" name="conceptAlias" index="34LRSv" />
+        <child id="1071489727083" name="linkDeclaration" index="1TKVEi" />
+      </concept>
+      <concept id="1169125989551" name="jetbrains.mps.lang.structure.structure.InterfaceConceptDeclaration" flags="ig" index="PlHQZ" />
+      <concept id="1169127622168" name="jetbrains.mps.lang.structure.structure.InterfaceConceptReference" flags="ig" index="PrWs8">
+        <reference id="1169127628841" name="intfc" index="PrY4T" />
       </concept>
       <concept id="1071489090640" name="jetbrains.mps.lang.structure.structure.ConceptDeclaration" flags="ig" index="1TIwiD">
         <property id="1096454100552" name="rootable" index="19KtqR" />
         <reference id="1071489389519" name="extends" index="1TJDcQ" />
+        <child id="1169129564478" name="implements" index="PzmwI" />
+      </concept>
+      <concept id="1071489288298" name="jetbrains.mps.lang.structure.structure.LinkDeclaration" flags="ig" index="1TJgyj">
+        <property id="1071599776563" name="role" index="20kJfa" />
+        <property id="1071599893252" name="sourceCardinality" index="20lbJX" />
+        <property id="1071599937831" name="metaClass" index="20lmBu" />
+        <property id="241647608299431140" name="linkId" index="IQ2ns" />
+        <reference id="1071599976176" name="target" index="20lvS9" />
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
@@ -31,6 +44,50 @@
     <property role="19KtqR" value="true" />
     <property role="34LRSv" value="DemoNodeWithIntentions" />
     <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+  </node>
+  <node concept="1TIwiD" id="5qf1oe_GcsA">
+    <property role="EcuMT" value="6237210071910106918" />
+    <property role="TrG5h" value="Root" />
+    <property role="19KtqR" value="true" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" />
+    <node concept="1TJgyj" id="5qf1oe_GcsC" role="1TKVEi">
+      <property role="IQ2ns" value="6237210071910106920" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="children" />
+      <property role="20lbJX" value="fLJekj5/_0__n" />
+      <ref role="20lvS9" node="5qf1oe_GcsF" resolve="IChild" />
+    </node>
+    <node concept="PrWs8" id="5qf1oe_H6D8" role="PzmwI">
+      <ref role="PrY4T" to="tpck:h0TrEE$" resolve="INamedConcept" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="5qf1oe_GcsB">
+    <property role="EcuMT" value="6237210071910106919" />
+    <property role="TrG5h" value="ReadOnlyChild" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" />
+    <node concept="PrWs8" id="5qf1oe_GcsG" role="PzmwI">
+      <ref role="PrY4T" node="5qf1oe_GcsF" resolve="IChild" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="5qf1oe_GcsE">
+    <property role="EcuMT" value="6237210071910106922" />
+    <property role="TrG5h" value="Child" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+    <node concept="PrWs8" id="5qf1oe_GcsI" role="PzmwI">
+      <ref role="PrY4T" node="5qf1oe_GcsF" resolve="IChild" />
+    </node>
+  </node>
+  <node concept="PlHQZ" id="5qf1oe_GcsF">
+    <property role="EcuMT" value="6237210071910106923" />
+    <property role="TrG5h" value="IChild" />
+  </node>
+  <node concept="1TIwiD" id="5qf1oe_GdOj">
+    <property role="EcuMT" value="6237210071910112531" />
+    <property role="TrG5h" value="ReadOnlyChildAllowed" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" />
+    <node concept="PrWs8" id="5qf1oe_GdOk" role="PzmwI">
+      <ref role="PrY4T" node="5qf1oe_GcsF" resolve="IChild" />
+    </node>
   </node>
 </model>
 

--- a/code/solutions/com.mbeddr.mpsutil.intentions.sandbox/models/com.mbeddr.mpsutil.intentions.sandbox.sandbox.mps
+++ b/code/solutions/com.mbeddr.mpsutil.intentions.sandbox/models/com.mbeddr.mpsutil.intentions.sandbox.sandbox.mps
@@ -6,10 +6,27 @@
   </languages>
   <imports />
   <registry>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
     <language id="4972ae94-72e7-499b-8766-0d6acffdb4f2" name="com.mbeddr.mpsutil.intentions.sandboxlang">
       <concept id="1317247883695247581" name="com.mbeddr.mpsutil.intentions.sandboxlang.structure.DemoNodeWithIntentions" flags="ng" index="2ezpO_" />
+      <concept id="6237210071910106919" name="com.mbeddr.mpsutil.intentions.sandboxlang.structure.ReadOnlyChild" flags="ng" index="3NfWa$" />
+      <concept id="6237210071910106918" name="com.mbeddr.mpsutil.intentions.sandboxlang.structure.Root" flags="ng" index="3NfWa_">
+        <child id="6237210071910106920" name="children" index="3NfWaF" />
+      </concept>
+      <concept id="6237210071910106922" name="com.mbeddr.mpsutil.intentions.sandboxlang.structure.Child" flags="ng" index="3NfWaD" />
+      <concept id="6237210071910112531" name="com.mbeddr.mpsutil.intentions.sandboxlang.structure.ReadOnlyChildAllowed" flags="ng" index="3NfXyg" />
     </language>
   </registry>
   <node concept="2ezpO_" id="197NvysMAlM" />
+  <node concept="3NfWa_" id="5qf1oe_Gzny">
+    <property role="TrG5h" value="Root" />
+    <node concept="3NfWaD" id="5qf1oe_Gznz" role="3NfWaF" />
+    <node concept="3NfXyg" id="5qf1oe_GznI" role="3NfWaF" />
+    <node concept="3NfWa$" id="5qf1oe_G_us" role="3NfWaF" />
+  </node>
 </model>
 

--- a/docs/extensions/utils/intentions-menu.md
+++ b/docs/extensions/utils/intentions-menu.md
@@ -5,4 +5,7 @@
 A language that adds support for grouping intentions. Invoke the intention `Toggle Group Annotation` to add it to a group.
 The intentions will be grouped together if they use the same label in the annotation.
 
+Additionally, it adds support for enabling intentions in read-only cells when the style attribute `intentions-in-read-only-cell` of the stylesheet
+`IntentionStyles` is set to true.
+
 ![example: intention group](../img/intention_group_example.png)


### PR DESCRIPTION
The main idea is to still allow the intention menu even if nodes are, for example, just projected into the editor through a query list and read-only.

I've tried to add tests but couldn't find a way to test this. The `invoke intention` statement in the editor test doesn't check if the cell is read-only and trying to invoke a demo intention through actions or key presses also didn't work.