### PR TITLE
Add a new flag to pull attribute editors into edge labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The project does _not_ follow Semantic Versioning and the changes are documented
 ### Changed
 
 - `@NotNull` annotations in the code are now checked at run time (the `javac2` compiler is used).
+- de.itemis.editor.diagram: Edge labels can now be annotated with the attribute editors of the edges. Previously they were floating in the diagram as external boxes. A new flag "use annotations from parent in label" is used to customize the behavior.
 
 ## October 2023
 

--- a/code/diagram/languages/de.itemis.mps.editor.diagram/generator/template/main@generator.mps
+++ b/code/diagram/languages/de.itemis.mps.editor.diagram/generator/template/main@generator.mps
@@ -9,6 +9,7 @@
     <use id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem" version="5" />
     <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="14" />
     <use id="13744753-c81f-424a-9c1b-cf8943bf4e86" name="jetbrains.mps.lang.sharedConcepts" version="-1" />
+    <use id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc" version="2" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -42,6 +43,9 @@
     <import index="88j9" ref="r:20c4aa5c-ab36-4815-af32-01895ee9c2f5(de.itemis.mps.editor.diagram.editor)" />
     <import index="u8j" ref="1144260c-e9a5-49a2-9add-39a1a1a7077e/java:org.eclipse.elk.alg.layered.options(de.itemis.mps.editor.diagram.runtime/)" />
     <import index="8byu" ref="r:34a4cfb6-903f-41e9-95dc-ea24a6097ced(jetbrains.mps.lang.editor.tooltips.structure)" />
+    <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" />
+    <import index="vndm" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel.language(MPS.Core/)" />
+    <import index="iwf0" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.descriptor(MPS.Editor/)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
     <import index="tpce" ref="r:00000000-0000-4000-0000-011c89590292(jetbrains.mps.lang.structure.structure)" implicit="true" />
     <import index="1njx" ref="1144260c-e9a5-49a2-9add-39a1a1a7077e/java:com.mxgraph.view(de.itemis.mps.editor.diagram.runtime/)" implicit="true" />
@@ -6846,7 +6850,7 @@
                 <node concept="3cpWsn" id="5RIhRmzydXb" role="3cpWs9">
                   <property role="TrG5h" value="accessor" />
                   <node concept="3uibUv" id="5RIhRmzydXc" role="1tU5fm">
-                    <ref role="3uigEE" to="nkm5:4teJTSBwOHa" resolve="IEdgeAccessor" />
+                    <ref role="3uigEE" to="nkm5:7jhYr4hIToa" resolve="SNodeEdgeAccessor" />
                   </node>
                   <node concept="2ShNRf" id="5RIhRmzydXd" role="33vP2m">
                     <node concept="YeOm9" id="5RIhRmzydXe" role="2ShVmc">
@@ -6854,56 +6858,6 @@
                         <property role="2bfB8j" value="true" />
                         <ref role="37wK5l" to="nkm5:7jhYr4hIVhs" resolve="SNodeEdgeAccessor" />
                         <ref role="1Y3XeK" to="nkm5:7jhYr4hIToa" resolve="SNodeEdgeAccessor" />
-                        <node concept="312cEg" id="5RIhRmzydXg" role="jymVt">
-                          <property role="TrG5h" value="labelCell" />
-                          <property role="3TUv4t" value="false" />
-                          <node concept="3Tm6S6" id="5RIhRmzydXh" role="1B3o_S" />
-                          <node concept="3uibUv" id="5RIhRmzydXi" role="1tU5fm">
-                            <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
-                          </node>
-                          <node concept="2YIFZM" id="7FkgTXZSuYx" role="33vP2m">
-                            <ref role="37wK5l" to="2o4v:7FkgTXZRBW6" resolve="getCellIfNotEmpty" />
-                            <ref role="1Pybhc" to="2o4v:7L$rKAVcmAh" resolve="DiagramUtil" />
-                            <node concept="10Nm6u" id="3koULUJ03Hw" role="37wK5m">
-                              <node concept="1W57fq" id="3koULUJ05VL" role="lGtFl">
-                                <node concept="3IZrLx" id="3koULUJ05VN" role="3IZSJc">
-                                  <node concept="3clFbS" id="3koULUJ05VP" role="2VODD2">
-                                    <node concept="3clFbF" id="3koULUJ08mQ" role="3cqZAp">
-                                      <node concept="2OqwBi" id="3koULUJ08mR" role="3clFbG">
-                                        <node concept="2OqwBi" id="3koULUJ08mS" role="2Oq$k0">
-                                          <node concept="30H73N" id="3koULUJ08mT" role="2Oq$k0" />
-                                          <node concept="3TrEf2" id="3koULUJ08mU" role="2OqNvi">
-                                            <ref role="3Tt5mk" to="2qld:1Lwguv828$4" resolve="labelCell" />
-                                          </node>
-                                        </node>
-                                        <node concept="3x8VRR" id="3koULUJ08mV" role="2OqNvi" />
-                                      </node>
-                                    </node>
-                                  </node>
-                                </node>
-                                <node concept="gft3U" id="3koULUJ072B" role="UU_$l">
-                                  <node concept="10Nm6u" id="3koULUJ088Y" role="gfFT$" />
-                                </node>
-                              </node>
-                              <node concept="5jKBG" id="3koULUJ0aEe" role="lGtFl">
-                                <ref role="v9R2y" node="5RIhRmzl00J" resolve="reduce_InlineEditorComponent_Call" />
-                                <node concept="3NFfHV" id="3koULUJ0d50" role="5jGum">
-                                  <node concept="3clFbS" id="3koULUJ0d51" role="2VODD2">
-                                    <node concept="3clFbF" id="3koULUJ0ddH" role="3cqZAp">
-                                      <node concept="2OqwBi" id="3koULUJ0ddJ" role="3clFbG">
-                                        <node concept="30H73N" id="3koULUJ0ddK" role="2Oq$k0" />
-                                        <node concept="3TrEf2" id="3koULUJ0ddL" role="2OqNvi">
-                                          <ref role="3Tt5mk" to="2qld:1Lwguv828$4" resolve="labelCell" />
-                                        </node>
-                                      </node>
-                                    </node>
-                                  </node>
-                                </node>
-                                <node concept="10Nm6u" id="3koULUJ0fLF" role="v9R3O" />
-                              </node>
-                            </node>
-                          </node>
-                        </node>
                         <node concept="312cEg" id="5RIhRmzydXH" role="jymVt">
                           <property role="TrG5h" value="startRoleCell" />
                           <property role="3TUv4t" value="false" />
@@ -7397,24 +7351,6 @@
                                 <ref role="3cqZAo" node="5RIhRmzydYJ" resolve="endShape" />
                               </node>
                             </node>
-                          </node>
-                        </node>
-                        <node concept="3clFb_" id="5RIhRmzye2l" role="jymVt">
-                          <property role="TrG5h" value="getLabelCell" />
-                          <property role="1EzhhJ" value="false" />
-                          <node concept="3uibUv" id="5RIhRmzye2m" role="3clF45">
-                            <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
-                          </node>
-                          <node concept="3Tm1VV" id="5RIhRmzye2n" role="1B3o_S" />
-                          <node concept="3clFbS" id="5RIhRmzye2o" role="3clF47">
-                            <node concept="3clFbF" id="5RIhRmzye2p" role="3cqZAp">
-                              <node concept="37vLTw" id="5RIhRmzye2q" role="3clFbG">
-                                <ref role="3cqZAo" node="5RIhRmzydXg" resolve="labelCell" />
-                              </node>
-                            </node>
-                          </node>
-                          <node concept="2AHcQZ" id="5RIhRmzye2r" role="2AJF6D">
-                            <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
                           </node>
                         </node>
                         <node concept="3clFb_" id="5RIhRmzye2s" role="jymVt">
@@ -8157,6 +8093,71 @@
                 </node>
               </node>
               <node concept="3clFbH" id="5RIhRmzye3j" role="3cqZAp" />
+              <node concept="3cpWs8" id="oe4mW5rshx" role="3cqZAp">
+                <node concept="3cpWsn" id="oe4mW5rshy" role="3cpWs9">
+                  <property role="TrG5h" value="label" />
+                  <node concept="3uibUv" id="oe4mW5rp$r" role="1tU5fm">
+                    <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+                  </node>
+                  <node concept="2YIFZM" id="oe4mW5rshz" role="33vP2m">
+                    <ref role="1Pybhc" to="2o4v:7L$rKAVcmAh" resolve="DiagramUtil" />
+                    <ref role="37wK5l" to="2o4v:7FkgTXZRBW6" resolve="getCellIfNotEmpty" />
+                    <node concept="10Nm6u" id="oe4mW5rsh$" role="37wK5m">
+                      <node concept="1W57fq" id="oe4mW5rsh_" role="lGtFl">
+                        <node concept="3IZrLx" id="oe4mW5rshA" role="3IZSJc">
+                          <node concept="3clFbS" id="oe4mW5rshB" role="2VODD2">
+                            <node concept="3clFbF" id="oe4mW5rshC" role="3cqZAp">
+                              <node concept="2OqwBi" id="oe4mW5rshD" role="3clFbG">
+                                <node concept="2OqwBi" id="oe4mW5rshE" role="2Oq$k0">
+                                  <node concept="30H73N" id="oe4mW5rshF" role="2Oq$k0" />
+                                  <node concept="3TrEf2" id="oe4mW5rshG" role="2OqNvi">
+                                    <ref role="3Tt5mk" to="2qld:1Lwguv828$4" resolve="labelCell" />
+                                  </node>
+                                </node>
+                                <node concept="3x8VRR" id="oe4mW5rshH" role="2OqNvi" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="gft3U" id="oe4mW5rshI" role="UU_$l">
+                          <node concept="10Nm6u" id="oe4mW5rshJ" role="gfFT$" />
+                        </node>
+                      </node>
+                      <node concept="5jKBG" id="oe4mW5rshK" role="lGtFl">
+                        <ref role="v9R2y" node="5RIhRmzl00J" resolve="reduce_InlineEditorComponent_Call" />
+                        <node concept="3NFfHV" id="oe4mW5rshL" role="5jGum">
+                          <node concept="3clFbS" id="oe4mW5rshM" role="2VODD2">
+                            <node concept="3clFbF" id="oe4mW5rshN" role="3cqZAp">
+                              <node concept="2OqwBi" id="oe4mW5rshO" role="3clFbG">
+                                <node concept="30H73N" id="oe4mW5rshP" role="2Oq$k0" />
+                                <node concept="3TrEf2" id="oe4mW5rshQ" role="2OqNvi">
+                                  <ref role="3Tt5mk" to="2qld:1Lwguv828$4" resolve="labelCell" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="10Nm6u" id="oe4mW5rshR" role="v9R3O" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbH" id="oe4mW5rijf" role="3cqZAp" />
+              <node concept="3clFbF" id="oe4mW5s2HM" role="3cqZAp">
+                <node concept="2OqwBi" id="oe4mW5wZdB" role="3clFbG">
+                  <node concept="37vLTw" id="oe4mW5s2HK" role="2Oq$k0">
+                    <ref role="3cqZAo" node="5RIhRmzydXb" resolve="accessor" />
+                  </node>
+                  <node concept="liA8E" id="oe4mW5x3ED" role="2OqNvi">
+                    <ref role="37wK5l" to="nkm5:oe4mW5pLhL" resolve="setLabelCell" />
+                    <node concept="37vLTw" id="oe4mW5x6JS" role="37wK5m">
+                      <ref role="3cqZAo" node="oe4mW5rshy" resolve="label" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbH" id="oe4mW5qXrz" role="3cqZAp" />
               <node concept="3clFbF" id="5RIhRmzye3k" role="3cqZAp">
                 <node concept="37vLTI" id="5RIhRmzye3l" role="3clFbG">
                   <node concept="2ShNRf" id="5RIhRmzye3m" role="37vLTx">
@@ -8200,7 +8201,7 @@
                             <ref role="3cqZAo" node="5RIhRmzydXb" resolve="accessor" />
                           </node>
                           <node concept="liA8E" id="5RIhRmzye3B" role="2OqNvi">
-                            <ref role="37wK5l" to="nkm5:48DYfEsOtG6" resolve="getLabelCell" />
+                            <ref role="37wK5l" to="nkm5:oe4mW5p$_A" resolve="getLabelCell" />
                           </node>
                         </node>
                       </node>
@@ -8214,7 +8215,7 @@
                       <ref role="3cqZAo" node="5RIhRmzydXb" resolve="accessor" />
                     </node>
                     <node concept="liA8E" id="5RIhRmzye3G" role="2OqNvi">
-                      <ref role="37wK5l" to="nkm5:48DYfEsOtG6" resolve="getLabelCell" />
+                      <ref role="37wK5l" to="nkm5:oe4mW5p$_A" resolve="getLabelCell" />
                     </node>
                   </node>
                 </node>
@@ -8235,7 +8236,7 @@
                             <ref role="3cqZAo" node="5RIhRmzydXb" resolve="accessor" />
                           </node>
                           <node concept="liA8E" id="5RIhRmzye3P" role="2OqNvi">
-                            <ref role="37wK5l" to="nkm5:48DYfEsOtGd" resolve="getStartRoleCell" />
+                            <ref role="37wK5l" to="nkm5:6Q0ZYbvGjI8" resolve="getStartRoleCell" />
                           </node>
                         </node>
                       </node>
@@ -8249,7 +8250,7 @@
                       <ref role="3cqZAo" node="5RIhRmzydXb" resolve="accessor" />
                     </node>
                     <node concept="liA8E" id="5RIhRmzye3U" role="2OqNvi">
-                      <ref role="37wK5l" to="nkm5:48DYfEsOtGd" resolve="getStartRoleCell" />
+                      <ref role="37wK5l" to="nkm5:6Q0ZYbvGjI8" resolve="getStartRoleCell" />
                     </node>
                   </node>
                 </node>
@@ -8270,7 +8271,7 @@
                             <ref role="3cqZAo" node="5RIhRmzydXb" resolve="accessor" />
                           </node>
                           <node concept="liA8E" id="5RIhRmzye43" role="2OqNvi">
-                            <ref role="37wK5l" to="nkm5:48DYfEsOtGk" resolve="getEndRoleCell" />
+                            <ref role="37wK5l" to="nkm5:6Q0ZYbvGjIg" resolve="getEndRoleCell" />
                           </node>
                         </node>
                       </node>
@@ -8284,7 +8285,7 @@
                       <ref role="3cqZAo" node="5RIhRmzydXb" resolve="accessor" />
                     </node>
                     <node concept="liA8E" id="5RIhRmzye48" role="2OqNvi">
-                      <ref role="37wK5l" to="nkm5:48DYfEsOtGk" resolve="getEndRoleCell" />
+                      <ref role="37wK5l" to="nkm5:6Q0ZYbvGjIg" resolve="getEndRoleCell" />
                     </node>
                   </node>
                 </node>
@@ -15231,6 +15232,36 @@
       <node concept="3Tm1VV" id="4sEzlP8p3JF" role="1B3o_S" />
       <node concept="3uibUv" id="4sEzlP8pauF" role="1zkMxy">
         <ref role="3uigEE" to="nkm5:4ChVjVud$yH" resolve="AbstractEdgeAccessor" />
+      </node>
+      <node concept="3clFb_" id="7EPprGLkpaG" role="jymVt">
+        <property role="TrG5h" value="pullAnnotations" />
+        <node concept="3Tm1VV" id="7EPprGLkpaK" role="1B3o_S" />
+        <node concept="10P_77" id="7EPprGLkpaL" role="3clF45" />
+        <node concept="3clFbS" id="7EPprGLkpaM" role="3clF47">
+          <node concept="3cpWs6" id="7EPprGLkv1u" role="3cqZAp">
+            <node concept="3clFbT" id="7EPprGLkw69" role="3cqZAk">
+              <property role="3clFbU" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2AHcQZ" id="7EPprGLkpaN" role="2AJF6D">
+          <ref role="2AI5Lk" to="wyt6:~Override" />
+        </node>
+        <node concept="raruj" id="7EPprGLktkj" role="lGtFl" />
+        <node concept="1W57fq" id="7EPprGLktkl" role="lGtFl">
+          <node concept="3IZrLx" id="7EPprGLktko" role="3IZSJc">
+            <node concept="3clFbS" id="7EPprGLktkp" role="2VODD2">
+              <node concept="3clFbF" id="7EPprGLktkv" role="3cqZAp">
+                <node concept="2OqwBi" id="7EPprGLktkq" role="3clFbG">
+                  <node concept="3TrcHB" id="7EPprGLktkt" role="2OqNvi">
+                    <ref role="3TsBF5" to="2qld:7EPprGLi9aT" resolve="pullAnnotations" />
+                  </node>
+                  <node concept="30H73N" id="7EPprGLktku" role="2Oq$k0" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
       </node>
     </node>
   </node>

--- a/code/diagram/languages/de.itemis.mps.editor.diagram/generator/template/main@generator.mps
+++ b/code/diagram/languages/de.itemis.mps.editor.diagram/generator/template/main@generator.mps
@@ -15233,14 +15233,61 @@
       <node concept="3uibUv" id="4sEzlP8pauF" role="1zkMxy">
         <ref role="3uigEE" to="nkm5:4ChVjVud$yH" resolve="AbstractEdgeAccessor" />
       </node>
+      <node concept="3clFb_" id="4bo8pCz69G7" role="jymVt">
+        <property role="TrG5h" value="_query_method" />
+        <node concept="3clFbS" id="4bo8pCz69Ga" role="3clF47">
+          <node concept="3cpWs6" id="4bo8pCz6b77" role="3cqZAp">
+            <node concept="3clFbT" id="4bo8pCz6cMN" role="3cqZAk" />
+          </node>
+        </node>
+        <node concept="3Tm6S6" id="4bo8pCz68mX" role="1B3o_S" />
+        <node concept="10P_77" id="4bo8pCz69vH" role="3clF45" />
+        <node concept="raruj" id="4bo8pCz6ecX" role="lGtFl" />
+        <node concept="29HgVG" id="4bo8pCz6ecZ" role="lGtFl">
+          <node concept="3NFfHV" id="4bo8pCz6ed0" role="3NFExx">
+            <node concept="3clFbS" id="4bo8pCz6ed1" role="2VODD2">
+              <node concept="3clFbF" id="4bo8pCz6ed7" role="3cqZAp">
+                <node concept="2OqwBi" id="4bo8pCz6ed2" role="3clFbG">
+                  <node concept="3TrEf2" id="4bo8pCz6ed5" role="2OqNvi">
+                    <ref role="3Tt5mk" to="2qld:4bo8pCz4_QL" resolve="pullAnnotations" />
+                  </node>
+                  <node concept="30H73N" id="4bo8pCz6ed6" role="2Oq$k0" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
       <node concept="3clFb_" id="7EPprGLkpaG" role="jymVt">
         <property role="TrG5h" value="pullAnnotations" />
         <node concept="3Tm1VV" id="7EPprGLkpaK" role="1B3o_S" />
         <node concept="10P_77" id="7EPprGLkpaL" role="3clF45" />
         <node concept="3clFbS" id="7EPprGLkpaM" role="3clF47">
           <node concept="3cpWs6" id="7EPprGLkv1u" role="3cqZAp">
-            <node concept="3clFbT" id="7EPprGLkw69" role="3cqZAk">
-              <property role="3clFbU" value="true" />
+            <node concept="1rXfSq" id="4bo8pCz6hMA" role="3cqZAk">
+              <ref role="37wK5l" node="4bo8pCz69G7" resolve="_query_method" />
+              <node concept="1ZhdrF" id="4bo8pCz6iMi" role="lGtFl">
+                <property role="2qtEX8" value="baseMethodDeclaration" />
+                <property role="P3scX" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1204053956946/1068499141037" />
+                <node concept="3$xsQk" id="4bo8pCz6iMj" role="3$ytzL">
+                  <node concept="3clFbS" id="4bo8pCz6iMk" role="2VODD2">
+                    <node concept="3clFbF" id="4bo8pCz6juj" role="3cqZAp">
+                      <node concept="2OqwBi" id="4bo8pCz6jV$" role="3clFbG">
+                        <node concept="1iwH7S" id="4bo8pCz6jui" role="2Oq$k0" />
+                        <node concept="1iwH70" id="4bo8pCz6lfc" role="2OqNvi">
+                          <ref role="1iwH77" to="tpc3:hG092go" resolve="query_method" />
+                          <node concept="2OqwBi" id="4bo8pCz6lH7" role="1iwH7V">
+                            <node concept="30H73N" id="4bo8pCz6lvj" role="2Oq$k0" />
+                            <node concept="3TrEf2" id="4bo8pCz6lX9" role="2OqNvi">
+                              <ref role="3Tt5mk" to="2qld:4bo8pCz4_QL" resolve="pullAnnotations" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -15252,11 +15299,14 @@
           <node concept="3IZrLx" id="7EPprGLktko" role="3IZSJc">
             <node concept="3clFbS" id="7EPprGLktkp" role="2VODD2">
               <node concept="3clFbF" id="7EPprGLktkv" role="3cqZAp">
-                <node concept="2OqwBi" id="7EPprGLktkq" role="3clFbG">
-                  <node concept="3TrcHB" id="7EPprGLktkt" role="2OqNvi">
-                    <ref role="3TsBF5" to="2qld:7EPprGLi9aT" resolve="pullAnnotations" />
+                <node concept="2OqwBi" id="4bo8pCz5YvV" role="3clFbG">
+                  <node concept="2OqwBi" id="7EPprGLktkq" role="2Oq$k0">
+                    <node concept="3TrEf2" id="4bo8pCz5XL9" role="2OqNvi">
+                      <ref role="3Tt5mk" to="2qld:4bo8pCz4_QL" resolve="pullAnnotations" />
+                    </node>
+                    <node concept="30H73N" id="7EPprGLktku" role="2Oq$k0" />
                   </node>
-                  <node concept="30H73N" id="7EPprGLktku" role="2Oq$k0" />
+                  <node concept="3x8VRR" id="4bo8pCz60e$" role="2OqNvi" />
                 </node>
               </node>
             </node>

--- a/code/diagram/languages/de.itemis.mps.editor.diagram/languageModels/editor.mps
+++ b/code/diagram/languages/de.itemis.mps.editor.diagram/languageModels/editor.mps
@@ -4180,12 +4180,25 @@
         <node concept="2iRfu4" id="6clvLV1rFRS" role="2iSdaV" />
       </node>
       <node concept="3EZMnI" id="7EPprGLi9jX" role="3EZMnx">
-        <node concept="VPM3Z" id="7EPprGLi9jZ" role="3F10Kt" />
-        <node concept="3F0ifn" id="7EPprGLi9rb" role="3EZMnx">
-          <property role="3F0ifm" value="pull annotations from parent" />
+        <node concept="VPM3Z" id="4bo8pCz1Q5h" role="3F10Kt" />
+        <node concept="VPXOz" id="4bo8pCz1Q5i" role="3F10Kt">
+          <property role="VOm3f" value="true" />
         </node>
-        <node concept="3F0A7n" id="7EPprGLi9rh" role="3EZMnx">
-          <ref role="1NtTu8" to="2qld:7EPprGLi9aT" resolve="pullAnnotations" />
+        <node concept="3F0ifn" id="7EPprGLi9rb" role="3EZMnx">
+          <property role="3F0ifm" value="use annotations from parent in label" />
+        </node>
+        <node concept="3F1sOY" id="4bo8pCz4JsC" role="3EZMnx">
+          <property role="2ru_X1" value="true" />
+          <ref role="1NtTu8" to="2qld:4bo8pCz4_QL" resolve="pullAnnotations" />
+          <node concept="3F0ifn" id="4bo8pCz4KLE" role="2ruayu">
+            <property role="3F0ifm" value="false (default)" />
+            <node concept="VechU" id="4bo8pCz5kkV" role="3F10Kt">
+              <property role="Vb096" value="fLJRk5_/gray" />
+            </node>
+          </node>
+          <node concept="VPXOz" id="4bo8pCz4KLH" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
         </node>
         <node concept="2iRfu4" id="7EPprGLi9k2" role="2iSdaV" />
       </node>

--- a/code/diagram/languages/de.itemis.mps.editor.diagram/languageModels/editor.mps
+++ b/code/diagram/languages/de.itemis.mps.editor.diagram/languageModels/editor.mps
@@ -4179,6 +4179,16 @@
         </node>
         <node concept="2iRfu4" id="6clvLV1rFRS" role="2iSdaV" />
       </node>
+      <node concept="3EZMnI" id="7EPprGLi9jX" role="3EZMnx">
+        <node concept="VPM3Z" id="7EPprGLi9jZ" role="3F10Kt" />
+        <node concept="3F0ifn" id="7EPprGLi9rb" role="3EZMnx">
+          <property role="3F0ifm" value="pull annotations from parent" />
+        </node>
+        <node concept="3F0A7n" id="7EPprGLi9rh" role="3EZMnx">
+          <ref role="1NtTu8" to="2qld:7EPprGLi9aT" resolve="pullAnnotations" />
+        </node>
+        <node concept="2iRfu4" id="7EPprGLi9k2" role="2iSdaV" />
+      </node>
       <node concept="3EZMnI" id="6clvLV1rFS1" role="3EZMnx">
         <node concept="VPM3Z" id="6clvLV1rFS2" role="3F10Kt">
           <property role="VOm3f" value="false" />

--- a/code/diagram/languages/de.itemis.mps.editor.diagram/languageModels/structure.mps
+++ b/code/diagram/languages/de.itemis.mps.editor.diagram/languageModels/structure.mps
@@ -1584,13 +1584,14 @@
       <property role="IQ2ns" value="8606559630272704940" />
       <ref role="20lvS9" node="7tKD69sB2Fv" resolve="DropHandler" />
     </node>
+    <node concept="1TJgyj" id="4bo8pCz4_QL" role="1TKVEi">
+      <property role="IQ2ns" value="4816636747369831857" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="pullAnnotations" />
+      <ref role="20lvS9" to="tpc2:gCpkWun" resolve="QueryFunction_NodeCondition" />
+    </node>
     <node concept="PrWs8" id="6clvLV1rj2a" role="PrDN$">
       <ref role="PrY4T" node="6clvLV1q6UE" resolve="IInlineEditorComponentContainer" />
-    </node>
-    <node concept="1TJgyi" id="7EPprGLi9aT" role="1TKVEl">
-      <property role="IQ2nx" value="8842085298071966393" />
-      <property role="TrG5h" value="pullAnnotations" />
-      <ref role="AX2Wp" to="tpck:fKAQMTB" resolve="boolean" />
     </node>
   </node>
   <node concept="PlHQZ" id="6clvLV1q6UE">

--- a/code/diagram/languages/de.itemis.mps.editor.diagram/languageModels/structure.mps
+++ b/code/diagram/languages/de.itemis.mps.editor.diagram/languageModels/structure.mps
@@ -1587,6 +1587,11 @@
     <node concept="PrWs8" id="6clvLV1rj2a" role="PrDN$">
       <ref role="PrY4T" node="6clvLV1q6UE" resolve="IInlineEditorComponentContainer" />
     </node>
+    <node concept="1TJgyi" id="7EPprGLi9aT" role="1TKVEl">
+      <property role="IQ2nx" value="8842085298071966393" />
+      <property role="TrG5h" value="pullAnnotations" />
+      <ref role="AX2Wp" to="tpck:fKAQMTB" resolve="boolean" />
+    </node>
   </node>
   <node concept="PlHQZ" id="6clvLV1q6UE">
     <property role="3GE5qa" value="content" />

--- a/code/diagram/solutions/de.itemis.mps.editor.diagram.runtime/models/de/itemis/mps/editor/diagram/runtime/model.mps
+++ b/code/diagram/solutions/de.itemis.mps.editor.diagram.runtime/models/de/itemis/mps/editor/diagram/runtime/model.mps
@@ -54,6 +54,7 @@
     <import index="lui2" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.module(MPS.OpenAPI/)" implicit="true" />
     <import index="lwvz" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.selection(MPS.Editor/)" implicit="true" />
     <import index="22ra" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.update(MPS.Editor/)" implicit="true" />
+    <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" implicit="true" />
     <import index="z8iw" ref="r:dfdf3542-dbcf-43df-870a-3c3504b3c840(jetbrains.mps.baseLanguage.collections.custom)" implicit="true" />
     <import index="tpce" ref="r:00000000-0000-4000-0000-011c89590292(jetbrains.mps.lang.structure.structure)" implicit="true" />
   </imports>
@@ -204,6 +205,9 @@
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <property id="1176718929932" name="isFinal" index="3TUv4t" />
         <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ng" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
       </concept>
       <concept id="1109279763828" name="jetbrains.mps.baseLanguage.structure.TypeVariableDeclaration" flags="ng" index="16euLQ">
         <child id="1214996921760" name="bound" index="3ztrMU" />
@@ -424,12 +428,23 @@
       </concept>
     </language>
     <language id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc">
+      <concept id="5858074156537516430" name="jetbrains.mps.baseLanguage.javadoc.structure.ReturnBlockDocTag" flags="ng" index="x79VA">
+        <property id="5858074156537516431" name="text" index="x79VB" />
+      </concept>
       <concept id="6832197706140896242" name="jetbrains.mps.baseLanguage.javadoc.structure.FieldDocComment" flags="ng" index="z59LJ" />
+      <concept id="6832197706140518104" name="jetbrains.mps.baseLanguage.javadoc.structure.DocMethodParameterReference" flags="ng" index="zr_55" />
+      <concept id="6832197706140518103" name="jetbrains.mps.baseLanguage.javadoc.structure.BaseParameterReference" flags="ng" index="zr_5a">
+        <reference id="6832197706140518108" name="param" index="zr_51" />
+      </concept>
       <concept id="5349172909345501395" name="jetbrains.mps.baseLanguage.javadoc.structure.BaseDocComment" flags="ng" index="P$AiS">
         <child id="8465538089690331502" name="body" index="TZ5H$" />
         <child id="5383422241790532083" name="tags" index="3nqlJM" />
       </concept>
       <concept id="5349172909345532724" name="jetbrains.mps.baseLanguage.javadoc.structure.MethodDocComment" flags="ng" index="P$JXv" />
+      <concept id="8465538089690881930" name="jetbrains.mps.baseLanguage.javadoc.structure.ParameterBlockDocTag" flags="ng" index="TUZQ0">
+        <property id="8465538089690881934" name="text" index="TUZQ4" />
+        <child id="6832197706140518123" name="parameter" index="zr_5Q" />
+      </concept>
       <concept id="8465538089690331500" name="jetbrains.mps.baseLanguage.javadoc.structure.CommentLine" flags="ng" index="TZ5HA">
         <child id="8970989240999019149" name="part" index="1dT_Ay" />
       </concept>
@@ -438,6 +453,13 @@
       </concept>
       <concept id="8970989240999019143" name="jetbrains.mps.baseLanguage.javadoc.structure.TextCommentLinePart" flags="ng" index="1dT_AC">
         <property id="8970989240999019144" name="text" index="1dT_AB" />
+      </concept>
+      <concept id="2068944020170241612" name="jetbrains.mps.baseLanguage.javadoc.structure.ClassifierDocComment" flags="ng" index="3UR2Jj" />
+    </language>
+    <language id="760a0a8c-eabb-4521-8bfd-65db761a9ba3" name="jetbrains.mps.baseLanguage.logging">
+      <concept id="6332851714983831325" name="jetbrains.mps.baseLanguage.logging.structure.MsgStatement" flags="ng" index="2xdQw9">
+        <property id="6332851714983843871" name="severity" index="2xdLsb" />
+        <child id="5721587534047265374" name="message" index="9lYJi" />
       </concept>
     </language>
     <language id="df345b11-b8c7-4213-ac66-48d2a9b75d88" name="jetbrains.mps.baseLanguageInternal">
@@ -453,6 +475,7 @@
       <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
         <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
       </concept>
+      <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
       <concept id="7453996997717780434" name="jetbrains.mps.lang.smodel.structure.Node_GetSConceptOperation" flags="nn" index="2yIwOk" />
       <concept id="1138757581985" name="jetbrains.mps.lang.smodel.structure.Link_SetNewChildOperation" flags="nn" index="zfrQC" />
       <concept id="2396822768958367367" name="jetbrains.mps.lang.smodel.structure.AbstractTypeCastExpression" flags="nn" index="$5XWr">
@@ -23640,8 +23663,56 @@
         </node>
       </node>
     </node>
+    <node concept="2tJIrI" id="oe4mW5msHO" role="jymVt" />
     <node concept="3uibUv" id="4ChVjVun_qO" role="1zkMxy">
       <ref role="3uigEE" node="4ChVjVud$yH" resolve="AbstractEdgeAccessor" />
+    </node>
+    <node concept="3clFb_" id="oe4mW5p$_A" role="jymVt">
+      <property role="TrG5h" value="getLabelCell" />
+      <node concept="3uibUv" id="oe4mW5p$_B" role="3clF45">
+        <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+      </node>
+      <node concept="3Tm1VV" id="oe4mW5p$_C" role="1B3o_S" />
+      <node concept="2AHcQZ" id="oe4mW5p$_G" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+      <node concept="3clFbS" id="oe4mW5p$_H" role="3clF47">
+        <node concept="3cpWs6" id="oe4mW5pCBQ" role="3cqZAp">
+          <node concept="2OqwBi" id="oe4mW5pDZv" role="3cqZAk">
+            <node concept="Xjq3P" id="oe4mW5pDtN" role="2Oq$k0" />
+            <node concept="2OwXpG" id="oe4mW5pIfN" role="2OqNvi">
+              <ref role="2Oxat5" node="oe4mW5lVOd" resolve="label" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="oe4mW5pINv" role="jymVt" />
+    <node concept="3clFb_" id="oe4mW5pLhL" role="jymVt">
+      <property role="TrG5h" value="setLabelCell" />
+      <node concept="3clFbS" id="oe4mW5pLhO" role="3clF47">
+        <node concept="3clFbF" id="oe4mW5pMNU" role="3cqZAp">
+          <node concept="37vLTI" id="oe4mW5pQdc" role="3clFbG">
+            <node concept="2OqwBi" id="oe4mW5pNK1" role="37vLTJ">
+              <node concept="Xjq3P" id="oe4mW5pMNT" role="2Oq$k0" />
+              <node concept="2OwXpG" id="oe4mW5pPmc" role="2OqNvi">
+                <ref role="2Oxat5" node="oe4mW5lVOd" resolve="label" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="oe4mW5xm4W" role="37vLTx">
+              <ref role="3cqZAo" node="oe4mW5xaBr" resolve="label" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="oe4mW5pK8P" role="1B3o_S" />
+      <node concept="3cqZAl" id="oe4mW5pL0w" role="3clF45" />
+      <node concept="37vLTG" id="oe4mW5xaBr" role="3clF46">
+        <property role="TrG5h" value="label" />
+        <node concept="3uibUv" id="oe4mW5xaBs" role="1tU5fm">
+          <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+        </node>
+      </node>
     </node>
   </node>
   <node concept="312cEu" id="7jhYr4hPK2r">
@@ -23732,7 +23803,24 @@
           </node>
         </node>
       </node>
+      <node concept="P$JXv" id="1Drj3Tevkdc" role="lGtFl">
+        <node concept="TZ5HA" id="1Drj3Tevkdd" role="TZ5H$">
+          <node concept="1dT_AC" id="1Drj3Tevkde" role="1dT_Ay">
+            <property role="1dT_AB" value="Turn a MPS node into a diagram accessor --&gt; forwards to fromSNode function, assuming that the call need not be duplicates safe" />
+          </node>
+        </node>
+        <node concept="TUZQ0" id="1Drj3Tevkdf" role="3nqlJM">
+          <property role="TUZQ4" value="to be visualized in a diagram" />
+          <node concept="zr_55" id="1Drj3Tevkdh" role="zr_5Q">
+            <ref role="zr_51" node="7EpvT6MAvwy" resolve="node" />
+          </node>
+        </node>
+        <node concept="x79VA" id="1Drj3Tevkdi" role="3nqlJM">
+          <property role="x79VB" value="an element accessor that visualizes the node" />
+        </node>
+      </node>
     </node>
+    <node concept="2tJIrI" id="1Drj3Tevo8j" role="jymVt" />
     <node concept="3clFb_" id="7jhYr4hPK33" role="jymVt">
       <property role="TrG5h" value="fromSNode" />
       <node concept="37vLTG" id="641jOpdAVPz" role="3clF46">
@@ -23798,6 +23886,34 @@
             </node>
           </node>
         </node>
+        <node concept="3SKdUt" id="1Drj3TevvqA" role="3cqZAp">
+          <node concept="1PaTwC" id="1Drj3TevvqB" role="1aUNEU">
+            <node concept="3oM_SD" id="1Drj3TevxsV" role="1PaTwD">
+              <property role="3oM_SC" value="require" />
+            </node>
+            <node concept="3oM_SD" id="1Drj3TevxsX" role="1PaTwD">
+              <property role="3oM_SC" value="that" />
+            </node>
+            <node concept="3oM_SD" id="1Drj3Tevxt0" role="1PaTwD">
+              <property role="3oM_SC" value="we" />
+            </node>
+            <node concept="3oM_SD" id="1Drj3Tevxt4" role="1PaTwD">
+              <property role="3oM_SC" value="are" />
+            </node>
+            <node concept="3oM_SD" id="1Drj3Tevxt9" role="1PaTwD">
+              <property role="3oM_SC" value="currently" />
+            </node>
+            <node concept="3oM_SD" id="1Drj3Tevxtf" role="1PaTwD">
+              <property role="3oM_SC" value="updating" />
+            </node>
+            <node concept="3oM_SD" id="1Drj3Tevxtm" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="1Drj3Tevxtu" role="1PaTwD">
+              <property role="3oM_SC" value="diagram" />
+            </node>
+          </node>
+        </node>
         <node concept="3clFbF" id="5P1DsEpUpMY" role="3cqZAp">
           <node concept="2YIFZM" id="5P1DsEpUqvk" role="3clFbG">
             <ref role="37wK5l" to="2o4v:5P1DsEpUnuH" resolve="checkInUpdateSession" />
@@ -23808,6 +23924,46 @@
           </node>
         </node>
         <node concept="3clFbH" id="5fq$Y9Wl3Ip" role="3cqZAp" />
+        <node concept="3SKdUt" id="1Drj3TevzSG" role="3cqZAp">
+          <node concept="1PaTwC" id="1Drj3TevzSH" role="1aUNEU">
+            <node concept="3oM_SD" id="1Drj3Tev_Vu" role="1PaTwD">
+              <property role="3oM_SC" value="disable" />
+            </node>
+            <node concept="3oM_SD" id="1Drj3Tev_Vw" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="1Drj3Tev_Vz" role="1PaTwD">
+              <property role="3oM_SC" value="cache" />
+            </node>
+            <node concept="3oM_SD" id="1Drj3Tev_VB" role="1PaTwD">
+              <property role="3oM_SC" value="for" />
+            </node>
+            <node concept="3oM_SD" id="1Drj3Tev_VG" role="1PaTwD">
+              <property role="3oM_SC" value="reading" />
+            </node>
+            <node concept="3oM_SD" id="1Drj3Tev_VM" role="1PaTwD">
+              <property role="3oM_SC" value="out" />
+            </node>
+            <node concept="3oM_SD" id="1Drj3Tev_VT" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="1Drj3Tev_W1" role="1PaTwD">
+              <property role="3oM_SC" value="editor" />
+            </node>
+            <node concept="3oM_SD" id="1Drj3Tev_Wa" role="1PaTwD">
+              <property role="3oM_SC" value="cell" />
+            </node>
+            <node concept="3oM_SD" id="1Drj3Tev_Wk" role="1PaTwD">
+              <property role="3oM_SC" value="for" />
+            </node>
+            <node concept="3oM_SD" id="1Drj3Tev_Wv" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="1Drj3Tev_WF" role="1PaTwD">
+              <property role="3oM_SC" value="node" />
+            </node>
+          </node>
+        </node>
         <node concept="3clFbF" id="7oq1PhPcYc9" role="3cqZAp">
           <node concept="2YIFZM" id="7oq1PhPcYip" role="3clFbG">
             <ref role="37wK5l" to="kvq8:7oq1PhPcG78" resolve="noCaching" />
@@ -23979,6 +24135,54 @@
                       </node>
                     </node>
                   </node>
+                  <node concept="3clFbH" id="nZF8rGAmtN" role="3cqZAp" />
+                  <node concept="3SKdUt" id="nZF8rGAmQU" role="3cqZAp">
+                    <node concept="1PaTwC" id="nZF8rGAmQV" role="1aUNEU">
+                      <node concept="3oM_SD" id="nZF8rGAoHg" role="1PaTwD">
+                        <property role="3oM_SC" value="annotationExternal" />
+                      </node>
+                      <node concept="3oM_SD" id="nZF8rGAoHi" role="1PaTwD">
+                        <property role="3oM_SC" value="can" />
+                      </node>
+                      <node concept="3oM_SD" id="nZF8rGAoHl" role="1PaTwD">
+                        <property role="3oM_SC" value="be" />
+                      </node>
+                      <node concept="3oM_SD" id="nZF8rGAoHp" role="1PaTwD">
+                        <property role="3oM_SC" value="used" />
+                      </node>
+                      <node concept="3oM_SD" id="nZF8rGAoHu" role="1PaTwD">
+                        <property role="3oM_SC" value="to" />
+                      </node>
+                      <node concept="3oM_SD" id="nZF8rGAoH$" role="1PaTwD">
+                        <property role="3oM_SC" value="pull" />
+                      </node>
+                      <node concept="3oM_SD" id="nZF8rGAoHF" role="1PaTwD">
+                        <property role="3oM_SC" value="annotations" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3SKdUt" id="4WNSWTX6p7W" role="3cqZAp">
+                    <node concept="1PaTwC" id="4WNSWTX6p7X" role="1aUNEU">
+                      <node concept="3oM_SD" id="4WNSWTX6p9u" role="1PaTwD">
+                        <property role="3oM_SC" value="external" />
+                      </node>
+                      <node concept="3oM_SD" id="4WNSWTX6p9w" role="1PaTwD">
+                        <property role="3oM_SC" value="--&gt;" />
+                      </node>
+                      <node concept="3oM_SD" id="4WNSWTX6p9z" role="1PaTwD">
+                        <property role="3oM_SC" value="separate" />
+                      </node>
+                      <node concept="3oM_SD" id="4WNSWTX6r31" role="1PaTwD">
+                        <property role="3oM_SC" value="box" />
+                      </node>
+                      <node concept="3oM_SD" id="4WNSWTX6r36" role="1PaTwD">
+                        <property role="3oM_SC" value="for" />
+                      </node>
+                      <node concept="3oM_SD" id="4WNSWTX6r3c" role="1PaTwD">
+                        <property role="3oM_SC" value="annotation" />
+                      </node>
+                    </node>
+                  </node>
                   <node concept="3cpWs8" id="6OhZPz3Iwch" role="3cqZAp">
                     <node concept="3cpWsn" id="6OhZPz3Iwck" role="3cpWs9">
                       <property role="TrG5h" value="external" />
@@ -24009,61 +24213,423 @@
                       </node>
                     </node>
                   </node>
-                  <node concept="3clFbJ" id="6OhZPz3IpIQ" role="3cqZAp">
-                    <node concept="3clFbS" id="6OhZPz3IpIS" role="3clFbx">
-                      <node concept="3cpWs8" id="5mBxd1UORUt" role="3cqZAp">
-                        <node concept="3cpWsn" id="5mBxd1UORUu" role="3cpWs9">
-                          <property role="TrG5h" value="annotation" />
-                          <node concept="3uibUv" id="5mBxd1UORUp" role="1tU5fm">
-                            <ref role="3uigEE" node="5mBxd1UMCBM" resolve="AnnotationAccessor" />
-                          </node>
-                          <node concept="2ShNRf" id="5mBxd1UORUv" role="33vP2m">
-                            <node concept="1pGfFk" id="5mBxd1UORUw" role="2ShVmc">
-                              <ref role="37wK5l" node="5mBxd1UMCR6" resolve="AnnotationAccessor" />
-                              <node concept="2OqwBi" id="6vSjNpcQVOl" role="37wK5m">
-                                <node concept="37vLTw" id="6vSjNpcQVJr" role="2Oq$k0">
-                                  <ref role="3cqZAo" node="641jOpdC12B" resolve="cell" />
-                                </node>
-                                <node concept="liA8E" id="6vSjNpcQW5I" role="2OqNvi">
-                                  <ref role="37wK5l" to="f4zo:~EditorCell.getSNode()" resolve="getSNode" />
-                                </node>
-                              </node>
-                              <node concept="2OqwBi" id="7oq1PhOPh4_" role="37wK5m">
-                                <node concept="2OqwBi" id="7oq1PhOPe46" role="2Oq$k0">
-                                  <node concept="37vLTw" id="7oq1PhOPdI6" role="2Oq$k0">
-                                    <ref role="3cqZAo" node="641jOpdC1hU" resolve="accessors" />
-                                  </node>
-                                  <node concept="1uHKPH" id="7oq1PhOPf$9" role="2OqNvi" />
-                                </node>
-                                <node concept="liA8E" id="7oq1PhOPhoF" role="2OqNvi">
-                                  <ref role="37wK5l" node="gKFhvETcIU" resolve="getId" />
-                                </node>
-                              </node>
-                            </node>
-                          </node>
+                  <node concept="3cpWs8" id="oe4mW5euFH" role="3cqZAp">
+                    <node concept="3cpWsn" id="oe4mW5euFK" role="3cpWs9">
+                      <property role="TrG5h" value="isEdgeAccessor" />
+                      <node concept="10P_77" id="oe4mW5euFF" role="1tU5fm" />
+                      <node concept="2ZW3vV" id="oe4mW5f0qO" role="33vP2m">
+                        <node concept="3uibUv" id="oe4mW5f2pb" role="2ZW6by">
+                          <ref role="3uigEE" node="7jhYr4hIToa" resolve="SNodeEdgeAccessor" />
                         </node>
-                      </node>
-                      <node concept="3clFbF" id="5mBxd1UOSsm" role="3cqZAp">
-                        <node concept="2OqwBi" id="5mBxd1UOS_w" role="3clFbG">
-                          <node concept="37vLTw" id="5mBxd1UOSsk" role="2Oq$k0">
-                            <ref role="3cqZAo" node="5mBxd1UORUu" resolve="annotation" />
-                          </node>
-                          <node concept="liA8E" id="5mBxd1UOVuc" role="2OqNvi">
-                            <ref role="37wK5l" node="63AkbuPirIn" resolve="setRootCell" />
-                            <node concept="37vLTw" id="5mBxd1UOV_A" role="37wK5m">
-                              <ref role="3cqZAo" node="641jOpdC12B" resolve="cell" />
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="3clFbF" id="7oq1PhOQGht" role="3cqZAp">
-                        <node concept="2OqwBi" id="7oq1PhOQGB3" role="3clFbG">
-                          <node concept="37vLTw" id="7oq1PhOQGhr" role="2Oq$k0">
+                        <node concept="2OqwBi" id="oe4mW5eHhf" role="2ZW6bz">
+                          <node concept="37vLTw" id="oe4mW5eENx" role="2Oq$k0">
                             <ref role="3cqZAo" node="641jOpdC1hU" resolve="accessors" />
                           </node>
-                          <node concept="TSZUe" id="7oq1PhOQJzP" role="2OqNvi">
-                            <node concept="37vLTw" id="7oq1PhOQJCk" role="25WWJ7">
-                              <ref role="3cqZAo" node="5mBxd1UORUu" resolve="annotation" />
+                          <node concept="1uHKPH" id="oe4mW5eLNh" role="2OqNvi" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2xdQw9" id="oe4mW55a$H" role="3cqZAp">
+                    <property role="2xdLsb" value="h1akgim/info" />
+                    <node concept="3cpWs3" id="oe4mW5feAU" role="9lYJi">
+                      <node concept="37vLTw" id="oe4mW5fj1N" role="3uHU7w">
+                        <ref role="3cqZAo" node="oe4mW5euFK" resolve="isEdgeAccessor" />
+                      </node>
+                      <node concept="3cpWs3" id="oe4mW5f6a9" role="3uHU7B">
+                        <node concept="3cpWs3" id="oe4mW5c2YH" role="3uHU7B">
+                          <node concept="3cpWs3" id="oe4mW5bPZ0" role="3uHU7B">
+                            <node concept="3cpWs3" id="oe4mW5aK_3" role="3uHU7B">
+                              <node concept="3cpWs3" id="oe4mW5aFi9" role="3uHU7B">
+                                <node concept="3cpWs3" id="oe4mW55hf4" role="3uHU7B">
+                                  <node concept="Xl_RD" id="oe4mW55a$J" role="3uHU7B">
+                                    <property role="Xl_RC" value="External property for accessor of " />
+                                  </node>
+                                  <node concept="2OqwBi" id="oe4mW583VX" role="3uHU7w">
+                                    <node concept="37vLTw" id="oe4mW581T3" role="2Oq$k0">
+                                      <ref role="3cqZAo" node="641jOpdAVPz" resolve="node" />
+                                    </node>
+                                    <node concept="2qgKlT" id="oe4mW587cu" role="2OqNvi">
+                                      <ref role="37wK5l" to="tpcu:22G2W3WJ92t" resolve="getDetailedPresentation" />
+                                    </node>
+                                  </node>
+                                </node>
+                                <node concept="Xl_RD" id="oe4mW5aHcV" role="3uHU7w">
+                                  <property role="Xl_RC" value=": " />
+                                </node>
+                              </node>
+                              <node concept="37vLTw" id="oe4mW5aNJ7" role="3uHU7w">
+                                <ref role="3cqZAo" node="6OhZPz3Iwck" resolve="external" />
+                              </node>
+                            </node>
+                            <node concept="Xl_RD" id="oe4mW5bRUc" role="3uHU7w">
+                              <property role="Xl_RC" value=", boxAccessor:" />
+                            </node>
+                          </node>
+                          <node concept="37vLTw" id="oe4mW5c5s0" role="3uHU7w">
+                            <ref role="3cqZAo" node="6OhZPz3I$M2" resolve="boxAccessor" />
+                          </node>
+                        </node>
+                        <node concept="Xl_RD" id="oe4mW5f86E" role="3uHU7w">
+                          <property role="Xl_RC" value=" isEdgeAccessor:" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbJ" id="6OhZPz3IpIQ" role="3cqZAp">
+                    <node concept="3clFbS" id="6OhZPz3IpIS" role="3clFbx">
+                      <node concept="3clFbJ" id="3BQn3_gx3hK" role="3cqZAp">
+                        <node concept="3clFbS" id="3BQn3_gx3hM" role="3clFbx">
+                          <node concept="2xdQw9" id="oe4mW5zMQr" role="3cqZAp">
+                            <property role="2xdLsb" value="h1akgim/info" />
+                            <node concept="3cpWs3" id="7EPprGLqKgD" role="9lYJi">
+                              <node concept="2OqwBi" id="7EPprGLr4H_" role="3uHU7w">
+                                <node concept="0kSF2" id="7EPprGLr03L" role="2Oq$k0">
+                                  <node concept="3uibUv" id="7EPprGLr03N" role="0kSFW">
+                                    <ref role="3uigEE" node="7jhYr4hIToa" resolve="SNodeEdgeAccessor" />
+                                  </node>
+                                  <node concept="2OqwBi" id="7EPprGLqR0o" role="0kSFX">
+                                    <node concept="37vLTw" id="7EPprGLqOcZ" role="2Oq$k0">
+                                      <ref role="3cqZAo" node="641jOpdC1hU" resolve="accessors" />
+                                    </node>
+                                    <node concept="1uHKPH" id="7EPprGLqVKU" role="2OqNvi" />
+                                  </node>
+                                </node>
+                                <node concept="liA8E" id="7EPprGLra1X" role="2OqNvi">
+                                  <ref role="37wK5l" node="7EPprGLk7uH" resolve="pullAnnotations" />
+                                </node>
+                              </node>
+                              <node concept="Xl_RD" id="oe4mW5zMQt" role="3uHU7B">
+                                <property role="Xl_RC" value="Pulling annotation for edge" />
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="3cpWs8" id="oe4mW5gECz" role="3cqZAp">
+                            <node concept="3cpWsn" id="oe4mW5gEC$" role="3cpWs9">
+                              <property role="TrG5h" value="accessor" />
+                              <node concept="3uibUv" id="oe4mW5gEC_" role="1tU5fm">
+                                <ref role="3uigEE" node="7jhYr4hIToa" resolve="SNodeEdgeAccessor" />
+                              </node>
+                              <node concept="0kSF2" id="oe4mW5gXRh" role="33vP2m">
+                                <node concept="3uibUv" id="oe4mW5gXRk" role="0kSFW">
+                                  <ref role="3uigEE" node="7jhYr4hIToa" resolve="SNodeEdgeAccessor" />
+                                </node>
+                                <node concept="2OqwBi" id="oe4mW5gNfY" role="0kSFX">
+                                  <node concept="37vLTw" id="oe4mW5gKRU" role="2Oq$k0">
+                                    <ref role="3cqZAo" node="641jOpdC1hU" resolve="accessors" />
+                                  </node>
+                                  <node concept="1uHKPH" id="oe4mW5gTCr" role="2OqNvi" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="3SKdUt" id="7EPprGLeazd" role="3cqZAp">
+                            <node concept="1PaTwC" id="7EPprGLeaze" role="1aUNEU">
+                              <node concept="3oM_SD" id="7EPprGLea$f" role="1PaTwD">
+                                <property role="3oM_SC" value="if" />
+                              </node>
+                              <node concept="3oM_SD" id="7EPprGLecqK" role="1PaTwD">
+                                <property role="3oM_SC" value="label" />
+                              </node>
+                              <node concept="3oM_SD" id="7EPprGLecsw" role="1PaTwD">
+                                <property role="3oM_SC" value="undefined" />
+                              </node>
+                              <node concept="3oM_SD" id="7EPprGLec_E" role="1PaTwD">
+                                <property role="3oM_SC" value="use" />
+                              </node>
+                              <node concept="3oM_SD" id="7EPprGLec_J" role="1PaTwD">
+                                <property role="3oM_SC" value="parent" />
+                              </node>
+                              <node concept="3oM_SD" id="7EPprGLec_P" role="1PaTwD">
+                                <property role="3oM_SC" value="as" />
+                              </node>
+                              <node concept="3oM_SD" id="7EPprGLecBc" role="1PaTwD">
+                                <property role="3oM_SC" value="accessor.getRootCell" />
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="3cpWs8" id="oe4mW5h_Xb" role="3cqZAp">
+                            <node concept="3cpWsn" id="oe4mW5h_Xc" role="3cpWs9">
+                              <property role="TrG5h" value="collection" />
+                              <node concept="3uibUv" id="oe4mW5h_Xd" role="1tU5fm">
+                                <ref role="3uigEE" to="g51k:~EditorCell_Collection" resolve="EditorCell_Collection" />
+                              </node>
+                              <node concept="2ShNRf" id="oe4mW5hHcu" role="33vP2m">
+                                <node concept="1pGfFk" id="oe4mW5hX1t" role="2ShVmc">
+                                  <property role="373rjd" value="true" />
+                                  <ref role="37wK5l" to="g51k:~EditorCell_Collection.&lt;init&gt;(jetbrains.mps.openapi.editor.EditorContext,org.jetbrains.mps.openapi.model.SNode,jetbrains.mps.nodeEditor.cellLayout.CellLayout)" resolve="EditorCell_Collection" />
+                                  <node concept="2OqwBi" id="oe4mW5ke0O" role="37wK5m">
+                                    <node concept="37vLTw" id="oe4mW5kbSl" role="2Oq$k0">
+                                      <ref role="3cqZAo" node="641jOpdC0Ad" resolve="myEditorComponent" />
+                                    </node>
+                                    <node concept="liA8E" id="oe4mW5kg3V" role="2OqNvi">
+                                      <ref role="37wK5l" to="cj4x:~EditorComponent.getEditorContext()" resolve="getEditorContext" />
+                                    </node>
+                                  </node>
+                                  <node concept="37vLTw" id="oe4mW5jWDZ" role="37wK5m">
+                                    <ref role="3cqZAo" node="641jOpdAVPz" resolve="node" />
+                                  </node>
+                                  <node concept="2ShNRf" id="oe4mW5jqfV" role="37wK5m">
+                                    <node concept="1pGfFk" id="oe4mW5jyl6" role="2ShVmc">
+                                      <property role="373rjd" value="true" />
+                                      <ref role="37wK5l" to="kcid:~CellLayout_Vertical.&lt;init&gt;()" resolve="CellLayout_Vertical" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="3cpWs8" id="oe4mW5hnRC" role="3cqZAp">
+                            <node concept="3cpWsn" id="oe4mW5hnRD" role="3cpWs9">
+                              <property role="TrG5h" value="labelCell" />
+                              <node concept="3uibUv" id="oe4mW5hnwR" role="1tU5fm">
+                                <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+                              </node>
+                              <node concept="2OqwBi" id="oe4mW5hnRE" role="33vP2m">
+                                <node concept="37vLTw" id="oe4mW5hnRF" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="oe4mW5gEC$" resolve="accessor" />
+                                </node>
+                                <node concept="liA8E" id="oe4mW5hnRG" role="2OqNvi">
+                                  <ref role="37wK5l" node="oe4mW5p$_A" resolve="getLabelCell" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="3cpWs8" id="7EPprGLemzX" role="3cqZAp">
+                            <node concept="3cpWsn" id="7EPprGLemzY" role="3cpWs9">
+                              <property role="TrG5h" value="parent" />
+                              <node concept="3uibUv" id="7EPprGLemzZ" role="1tU5fm">
+                                <ref role="3uigEE" to="f4zo:~EditorCell_Collection" resolve="EditorCell_Collection" />
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="3clFbJ" id="7EPprGLewRY" role="3cqZAp">
+                            <node concept="3clFbS" id="7EPprGLewS0" role="3clFbx">
+                              <node concept="3clFbF" id="7EPprGLeR77" role="3cqZAp">
+                                <node concept="37vLTI" id="7EPprGLeXeR" role="3clFbG">
+                                  <node concept="0kSF2" id="7EPprGLfXsW" role="37vLTx">
+                                    <node concept="3uibUv" id="7EPprGLfXsZ" role="0kSFW">
+                                      <ref role="3uigEE" to="g51k:~EditorCell_Collection" resolve="EditorCell_Collection" />
+                                    </node>
+                                    <node concept="2OqwBi" id="7EPprGLf2CE" role="0kSFX">
+                                      <node concept="37vLTw" id="7EPprGLf0LJ" role="2Oq$k0">
+                                        <ref role="3cqZAo" node="oe4mW5gEC$" resolve="accessor" />
+                                      </node>
+                                      <node concept="liA8E" id="7EPprGLfbt2" role="2OqNvi">
+                                        <ref role="37wK5l" node="4ChVjVud$zV" resolve="getRootEditorCell" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                  <node concept="37vLTw" id="7EPprGLeR76" role="37vLTJ">
+                                    <ref role="3cqZAo" node="7EPprGLemzY" resolve="parent" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="3clFbC" id="7EPprGLeJep" role="3clFbw">
+                              <node concept="10Nm6u" id="7EPprGLeLFZ" role="3uHU7w" />
+                              <node concept="37vLTw" id="7EPprGLe$vQ" role="3uHU7B">
+                                <ref role="3cqZAo" node="oe4mW5hnRD" resolve="labelCell" />
+                              </node>
+                            </node>
+                            <node concept="9aQIb" id="7EPprGLfhG0" role="9aQIa">
+                              <node concept="3clFbS" id="7EPprGLfhG1" role="9aQI4">
+                                <node concept="3clFbF" id="7EPprGLfkIa" role="3cqZAp">
+                                  <node concept="37vLTI" id="7EPprGLfmYC" role="3clFbG">
+                                    <node concept="2OqwBi" id="7EPprGLfsok" role="37vLTx">
+                                      <node concept="37vLTw" id="7EPprGLfqzL" role="2Oq$k0">
+                                        <ref role="3cqZAo" node="oe4mW5hnRD" resolve="labelCell" />
+                                      </node>
+                                      <node concept="liA8E" id="7EPprGLfuGi" role="2OqNvi">
+                                        <ref role="37wK5l" to="f4zo:~EditorCell.getParent()" resolve="getParent" />
+                                      </node>
+                                    </node>
+                                    <node concept="37vLTw" id="7EPprGLfkI9" role="37vLTJ">
+                                      <ref role="3cqZAo" node="7EPprGLemzY" resolve="parent" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="3clFbF" id="3BQn3_gtM3j" role="3cqZAp">
+                            <node concept="2OqwBi" id="3BQn3_gtOI9" role="3clFbG">
+                              <node concept="37vLTw" id="3BQn3_gtM3h" role="2Oq$k0">
+                                <ref role="3cqZAo" node="7EPprGLemzY" resolve="parent" />
+                              </node>
+                              <node concept="liA8E" id="3BQn3_gtSEa" role="2OqNvi">
+                                <ref role="37wK5l" to="f4zo:~EditorCell_Collection.addEditorCellBefore(jetbrains.mps.openapi.editor.cells.EditorCell,jetbrains.mps.openapi.editor.cells.EditorCell)" resolve="addEditorCellBefore" />
+                                <node concept="37vLTw" id="3BQn3_gtWBV" role="37wK5m">
+                                  <ref role="3cqZAo" node="oe4mW5h_Xc" resolve="collection" />
+                                </node>
+                                <node concept="37vLTw" id="3BQn3_gu2_6" role="37wK5m">
+                                  <ref role="3cqZAo" node="oe4mW5hnRD" resolve="labelCell" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="3clFbJ" id="7EPprGLgfbA" role="3cqZAp">
+                            <node concept="3clFbS" id="7EPprGLgfbC" role="3clFbx">
+                              <node concept="3clFbF" id="3BQn3_grScQ" role="3cqZAp">
+                                <node concept="2OqwBi" id="3BQn3_grUm_" role="3clFbG">
+                                  <node concept="37vLTw" id="3BQn3_grScO" role="2Oq$k0">
+                                    <ref role="3cqZAo" node="7EPprGLemzY" resolve="parent" />
+                                  </node>
+                                  <node concept="liA8E" id="3BQn3_grXqh" role="2OqNvi">
+                                    <ref role="37wK5l" to="f4zo:~EditorCell_Collection.removeCell(jetbrains.mps.openapi.editor.cells.EditorCell)" resolve="removeCell" />
+                                    <node concept="37vLTw" id="3BQn3_gs16Q" role="37wK5m">
+                                      <ref role="3cqZAo" node="oe4mW5hnRD" resolve="labelCell" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                              <node concept="3clFbF" id="oe4mW5kmVE" role="3cqZAp">
+                                <node concept="2OqwBi" id="oe4mW5kp7D" role="3clFbG">
+                                  <node concept="37vLTw" id="oe4mW5kmVC" role="2Oq$k0">
+                                    <ref role="3cqZAo" node="oe4mW5h_Xc" resolve="collection" />
+                                  </node>
+                                  <node concept="liA8E" id="oe4mW5krSS" role="2OqNvi">
+                                    <ref role="37wK5l" to="g51k:~EditorCell_Collection.addEditorCell(jetbrains.mps.openapi.editor.cells.EditorCell)" resolve="addEditorCell" />
+                                    <node concept="37vLTw" id="oe4mW5kvoF" role="37wK5m">
+                                      <ref role="3cqZAo" node="oe4mW5hnRD" resolve="labelCell" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                              <node concept="3clFbF" id="oe4mW5k_cc" role="3cqZAp">
+                                <node concept="2OqwBi" id="oe4mW5kINH" role="3clFbG">
+                                  <node concept="37vLTw" id="oe4mW5kGcU" role="2Oq$k0">
+                                    <ref role="3cqZAo" node="oe4mW5h_Xc" resolve="collection" />
+                                  </node>
+                                  <node concept="liA8E" id="oe4mW5kNs6" role="2OqNvi">
+                                    <ref role="37wK5l" to="g51k:~EditorCell_Collection.addEditorCellBefore(jetbrains.mps.openapi.editor.cells.EditorCell,jetbrains.mps.openapi.editor.cells.EditorCell)" resolve="addEditorCellBefore" />
+                                    <node concept="37vLTw" id="oe4mW5kT4Y" role="37wK5m">
+                                      <ref role="3cqZAo" node="641jOpdC12B" resolve="cell" />
+                                    </node>
+                                    <node concept="37vLTw" id="oe4mW5kYjE" role="37wK5m">
+                                      <ref role="3cqZAo" node="oe4mW5hnRD" resolve="labelCell" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="3y3z36" id="7EPprGLglaA" role="3clFbw">
+                              <node concept="10Nm6u" id="7EPprGLgnRJ" role="3uHU7w" />
+                              <node concept="37vLTw" id="7EPprGLgiRR" role="3uHU7B">
+                                <ref role="3cqZAo" node="oe4mW5hnRD" resolve="labelCell" />
+                              </node>
+                            </node>
+                            <node concept="9aQIb" id="7EPprGLgDhJ" role="9aQIa">
+                              <node concept="3clFbS" id="7EPprGLgDhK" role="9aQI4">
+                                <node concept="3clFbF" id="7EPprGLgHfF" role="3cqZAp">
+                                  <node concept="2OqwBi" id="7EPprGLgJ$3" role="3clFbG">
+                                    <node concept="37vLTw" id="7EPprGLgHfE" role="2Oq$k0">
+                                      <ref role="3cqZAo" node="oe4mW5h_Xc" resolve="collection" />
+                                    </node>
+                                    <node concept="liA8E" id="7EPprGLgO0S" role="2OqNvi">
+                                      <ref role="37wK5l" to="g51k:~EditorCell_Collection.addEditorCell(jetbrains.mps.openapi.editor.cells.EditorCell)" resolve="addEditorCell" />
+                                      <node concept="37vLTw" id="7EPprGLgQJG" role="37wK5m">
+                                        <ref role="3cqZAo" node="641jOpdC12B" resolve="cell" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="3clFbF" id="oe4mW5xxG$" role="3cqZAp">
+                            <node concept="2OqwBi" id="oe4mW5xzpa" role="3clFbG">
+                              <node concept="37vLTw" id="oe4mW5xxGy" role="2Oq$k0">
+                                <ref role="3cqZAo" node="oe4mW5gEC$" resolve="accessor" />
+                              </node>
+                              <node concept="liA8E" id="oe4mW5xA6Y" role="2OqNvi">
+                                <ref role="37wK5l" node="oe4mW5pLhL" resolve="setLabelCell" />
+                                <node concept="37vLTw" id="oe4mW5xD_$" role="37wK5m">
+                                  <ref role="3cqZAo" node="oe4mW5h_Xc" resolve="collection" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="1Wc70l" id="7EPprGLs2vg" role="3clFbw">
+                          <node concept="2OqwBi" id="7EPprGLsodL" role="3uHU7w">
+                            <node concept="0kSF2" id="7EPprGLsiRR" role="2Oq$k0">
+                              <node concept="3uibUv" id="7EPprGLsiRT" role="0kSFW">
+                                <ref role="3uigEE" node="7jhYr4hIToa" resolve="SNodeEdgeAccessor" />
+                              </node>
+                              <node concept="2OqwBi" id="7EPprGLs9NC" role="0kSFX">
+                                <node concept="37vLTw" id="7EPprGLs6Ig" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="641jOpdC1hU" resolve="accessors" />
+                                </node>
+                                <node concept="1uHKPH" id="7EPprGLsgJE" role="2OqNvi" />
+                              </node>
+                            </node>
+                            <node concept="liA8E" id="7EPprGLsraV" role="2OqNvi">
+                              <ref role="37wK5l" node="7EPprGLk7uH" resolve="pullAnnotations" />
+                            </node>
+                          </node>
+                          <node concept="37vLTw" id="3BQn3_gx8gy" role="3uHU7B">
+                            <ref role="3cqZAo" node="oe4mW5euFK" resolve="isEdgeAccessor" />
+                          </node>
+                        </node>
+                        <node concept="9aQIb" id="3BQn3_gxjxd" role="9aQIa">
+                          <node concept="3clFbS" id="3BQn3_gxjxe" role="9aQI4">
+                            <node concept="3cpWs8" id="5mBxd1UORUt" role="3cqZAp">
+                              <node concept="3cpWsn" id="5mBxd1UORUu" role="3cpWs9">
+                                <property role="TrG5h" value="annotation" />
+                                <node concept="3uibUv" id="5mBxd1UORUp" role="1tU5fm">
+                                  <ref role="3uigEE" node="5mBxd1UMCBM" resolve="AnnotationAccessor" />
+                                </node>
+                                <node concept="2ShNRf" id="5mBxd1UORUv" role="33vP2m">
+                                  <node concept="1pGfFk" id="5mBxd1UORUw" role="2ShVmc">
+                                    <ref role="37wK5l" node="5mBxd1UMCR6" resolve="AnnotationAccessor" />
+                                    <node concept="2OqwBi" id="6vSjNpcQVOl" role="37wK5m">
+                                      <node concept="37vLTw" id="6vSjNpcQVJr" role="2Oq$k0">
+                                        <ref role="3cqZAo" node="641jOpdC12B" resolve="cell" />
+                                      </node>
+                                      <node concept="liA8E" id="6vSjNpcQW5I" role="2OqNvi">
+                                        <ref role="37wK5l" to="f4zo:~EditorCell.getSNode()" resolve="getSNode" />
+                                      </node>
+                                    </node>
+                                    <node concept="2OqwBi" id="7oq1PhOPh4_" role="37wK5m">
+                                      <node concept="2OqwBi" id="7oq1PhOPe46" role="2Oq$k0">
+                                        <node concept="37vLTw" id="7oq1PhOPdI6" role="2Oq$k0">
+                                          <ref role="3cqZAo" node="641jOpdC1hU" resolve="accessors" />
+                                        </node>
+                                        <node concept="1uHKPH" id="7oq1PhOPf$9" role="2OqNvi" />
+                                      </node>
+                                      <node concept="liA8E" id="7oq1PhOPhoF" role="2OqNvi">
+                                        <ref role="37wK5l" node="gKFhvETcIU" resolve="getId" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="3clFbF" id="5mBxd1UOSsm" role="3cqZAp">
+                              <node concept="2OqwBi" id="5mBxd1UOS_w" role="3clFbG">
+                                <node concept="37vLTw" id="5mBxd1UOSsk" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="5mBxd1UORUu" resolve="annotation" />
+                                </node>
+                                <node concept="liA8E" id="5mBxd1UOVuc" role="2OqNvi">
+                                  <ref role="37wK5l" node="63AkbuPirIn" resolve="setRootCell" />
+                                  <node concept="37vLTw" id="5mBxd1UOV_A" role="37wK5m">
+                                    <ref role="3cqZAo" node="641jOpdC12B" resolve="cell" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="3clFbF" id="7oq1PhOQGht" role="3cqZAp">
+                              <node concept="2OqwBi" id="7oq1PhOQGB3" role="3clFbG">
+                                <node concept="37vLTw" id="7oq1PhOQGhr" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="641jOpdC1hU" resolve="accessors" />
+                                </node>
+                                <node concept="TSZUe" id="7oq1PhOQJzP" role="2OqNvi">
+                                  <node concept="37vLTw" id="7oq1PhOQJCk" role="25WWJ7">
+                                    <ref role="3cqZAo" node="5mBxd1UORUu" resolve="annotation" />
+                                  </node>
+                                </node>
+                              </node>
                             </node>
                           </node>
                         </node>
@@ -24202,6 +24768,28 @@
       </node>
       <node concept="2AHcQZ" id="4ChVjVucuu2" role="2AJF6D">
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+      <node concept="P$JXv" id="1Drj3TevqtS" role="lGtFl">
+        <node concept="TZ5HA" id="1Drj3TevqtT" role="TZ5H$">
+          <node concept="1dT_AC" id="1Drj3TevqtU" role="1dT_Ay">
+            <property role="1dT_AB" value="Translate a node into a diagram accessor for visualization" />
+          </node>
+        </node>
+        <node concept="TUZQ0" id="1Drj3TevqtV" role="3nqlJM">
+          <property role="TUZQ4" value="to be visualized in a diagram" />
+          <node concept="zr_55" id="1Drj3TevqtX" role="zr_5Q">
+            <ref role="zr_51" node="641jOpdAVPz" resolve="node" />
+          </node>
+        </node>
+        <node concept="TUZQ0" id="1Drj3TevqtY" role="3nqlJM">
+          <property role="TUZQ4" value="TODO" />
+          <node concept="zr_55" id="1Drj3Tevqu0" role="zr_5Q">
+            <ref role="zr_51" node="7EpvT6MydZb" resolve="duplicatesSafe" />
+          </node>
+        </node>
+        <node concept="x79VA" id="1Drj3Tevqu1" role="3nqlJM">
+          <property role="x79VB" value="an element accessor that visualizes the node" />
+        </node>
       </node>
     </node>
     <node concept="2tJIrI" id="4rVJEOjJ7Z0" role="jymVt" />
@@ -24774,6 +25362,13 @@
     <node concept="3uibUv" id="4ChVjVucujk" role="EKbjA">
       <ref role="3uigEE" node="4ChVjVucpK0" resolve="IAccessorFactory" />
     </node>
+    <node concept="3UR2Jj" id="1Drj3TevfMu" role="lGtFl">
+      <node concept="TZ5HA" id="1Drj3TevfMv" role="TZ5H$">
+        <node concept="1dT_AC" id="1Drj3TevfMw" role="1dT_Ay">
+          <property role="1dT_AB" value="Creates the various model access objects to present them in a diagram" />
+        </node>
+      </node>
+    </node>
   </node>
   <node concept="3HP615" id="641jOpdAX3p">
     <property role="3GE5qa" value="accessor" />
@@ -24901,6 +25496,14 @@
     <property role="TrG5h" value="AbstractEdgeAccessor" />
     <property role="1sVAO0" value="true" />
     <node concept="2tJIrI" id="63AkbuPiqhM" role="jymVt" />
+    <node concept="312cEg" id="oe4mW5lVOd" role="jymVt">
+      <property role="TrG5h" value="label" />
+      <node concept="3Tmbuc" id="oe4mW5pGYA" role="1B3o_S" />
+      <node concept="3uibUv" id="oe4mW5lVgB" role="1tU5fm">
+        <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="oe4mW5m15Z" role="jymVt" />
     <node concept="3clFbW" id="4rVJEOko35H" role="jymVt">
       <node concept="3cqZAl" id="4rVJEOko35J" role="3clF45" />
       <node concept="3Tm1VV" id="4rVJEOko35K" role="1B3o_S" />
@@ -26680,6 +27283,16 @@
       <node concept="3cqZAl" id="7tKD69sBEBN" role="3clF45" />
       <node concept="3Tm1VV" id="7tKD69sBEBO" role="1B3o_S" />
       <node concept="3clFbS" id="7tKD69sBEBR" role="3clF47" />
+    </node>
+    <node concept="3clFb_" id="7EPprGLk7uH" role="jymVt">
+      <property role="TrG5h" value="pullAnnotations" />
+      <node concept="3clFbS" id="7EPprGLk7uK" role="3clF47">
+        <node concept="3cpWs6" id="7EPprGLkdeY" role="3cqZAp">
+          <node concept="3clFbT" id="7EPprGLkgx5" role="3cqZAk" />
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="7EPprGLk1dO" role="1B3o_S" />
+      <node concept="10P_77" id="7EPprGLk6V7" role="3clF45" />
     </node>
     <node concept="3uibUv" id="63AkbuPiuDm" role="1zkMxy">
       <ref role="3uigEE" node="63AkbuPiu1I" resolve="AbstractDiagramElementAccessor" />

--- a/code/diagram/solutions/de.itemis.mps.editor.diagram.runtime/models/de/itemis/mps/editor/diagram/runtime/model.mps
+++ b/code/diagram/solutions/de.itemis.mps.editor.diagram.runtime/models/de/itemis/mps/editor/diagram/runtime/model.mps
@@ -54,7 +54,6 @@
     <import index="lui2" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.module(MPS.OpenAPI/)" implicit="true" />
     <import index="lwvz" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.selection(MPS.Editor/)" implicit="true" />
     <import index="22ra" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.update(MPS.Editor/)" implicit="true" />
-    <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" implicit="true" />
     <import index="z8iw" ref="r:dfdf3542-dbcf-43df-870a-3c3504b3c840(jetbrains.mps.baseLanguage.collections.custom)" implicit="true" />
     <import index="tpce" ref="r:00000000-0000-4000-0000-011c89590292(jetbrains.mps.lang.structure.structure)" implicit="true" />
   </imports>
@@ -456,12 +455,6 @@
       </concept>
       <concept id="2068944020170241612" name="jetbrains.mps.baseLanguage.javadoc.structure.ClassifierDocComment" flags="ng" index="3UR2Jj" />
     </language>
-    <language id="760a0a8c-eabb-4521-8bfd-65db761a9ba3" name="jetbrains.mps.baseLanguage.logging">
-      <concept id="6332851714983831325" name="jetbrains.mps.baseLanguage.logging.structure.MsgStatement" flags="ng" index="2xdQw9">
-        <property id="6332851714983843871" name="severity" index="2xdLsb" />
-        <child id="5721587534047265374" name="message" index="9lYJi" />
-      </concept>
-    </language>
     <language id="df345b11-b8c7-4213-ac66-48d2a9b75d88" name="jetbrains.mps.baseLanguageInternal">
       <concept id="1176743162354" name="jetbrains.mps.baseLanguageInternal.structure.InternalVariableReference" flags="nn" index="3VmV3z">
         <property id="1176743296073" name="name" index="3VnrPo" />
@@ -475,7 +468,6 @@
       <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
         <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
       </concept>
-      <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
       <concept id="7453996997717780434" name="jetbrains.mps.lang.smodel.structure.Node_GetSConceptOperation" flags="nn" index="2yIwOk" />
       <concept id="1138757581985" name="jetbrains.mps.lang.smodel.structure.Link_SetNewChildOperation" flags="nn" index="zfrQC" />
       <concept id="2396822768958367367" name="jetbrains.mps.lang.smodel.structure.AbstractTypeCastExpression" flags="nn" index="$5XWr">
@@ -24230,80 +24222,10 @@
                       </node>
                     </node>
                   </node>
-                  <node concept="2xdQw9" id="oe4mW55a$H" role="3cqZAp">
-                    <property role="2xdLsb" value="h1akgim/info" />
-                    <node concept="3cpWs3" id="oe4mW5feAU" role="9lYJi">
-                      <node concept="37vLTw" id="oe4mW5fj1N" role="3uHU7w">
-                        <ref role="3cqZAo" node="oe4mW5euFK" resolve="isEdgeAccessor" />
-                      </node>
-                      <node concept="3cpWs3" id="oe4mW5f6a9" role="3uHU7B">
-                        <node concept="3cpWs3" id="oe4mW5c2YH" role="3uHU7B">
-                          <node concept="3cpWs3" id="oe4mW5bPZ0" role="3uHU7B">
-                            <node concept="3cpWs3" id="oe4mW5aK_3" role="3uHU7B">
-                              <node concept="3cpWs3" id="oe4mW5aFi9" role="3uHU7B">
-                                <node concept="3cpWs3" id="oe4mW55hf4" role="3uHU7B">
-                                  <node concept="Xl_RD" id="oe4mW55a$J" role="3uHU7B">
-                                    <property role="Xl_RC" value="External property for accessor of " />
-                                  </node>
-                                  <node concept="2OqwBi" id="oe4mW583VX" role="3uHU7w">
-                                    <node concept="37vLTw" id="oe4mW581T3" role="2Oq$k0">
-                                      <ref role="3cqZAo" node="641jOpdAVPz" resolve="node" />
-                                    </node>
-                                    <node concept="2qgKlT" id="oe4mW587cu" role="2OqNvi">
-                                      <ref role="37wK5l" to="tpcu:22G2W3WJ92t" resolve="getDetailedPresentation" />
-                                    </node>
-                                  </node>
-                                </node>
-                                <node concept="Xl_RD" id="oe4mW5aHcV" role="3uHU7w">
-                                  <property role="Xl_RC" value=": " />
-                                </node>
-                              </node>
-                              <node concept="37vLTw" id="oe4mW5aNJ7" role="3uHU7w">
-                                <ref role="3cqZAo" node="6OhZPz3Iwck" resolve="external" />
-                              </node>
-                            </node>
-                            <node concept="Xl_RD" id="oe4mW5bRUc" role="3uHU7w">
-                              <property role="Xl_RC" value=", boxAccessor:" />
-                            </node>
-                          </node>
-                          <node concept="37vLTw" id="oe4mW5c5s0" role="3uHU7w">
-                            <ref role="3cqZAo" node="6OhZPz3I$M2" resolve="boxAccessor" />
-                          </node>
-                        </node>
-                        <node concept="Xl_RD" id="oe4mW5f86E" role="3uHU7w">
-                          <property role="Xl_RC" value=" isEdgeAccessor:" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
                   <node concept="3clFbJ" id="6OhZPz3IpIQ" role="3cqZAp">
                     <node concept="3clFbS" id="6OhZPz3IpIS" role="3clFbx">
                       <node concept="3clFbJ" id="3BQn3_gx3hK" role="3cqZAp">
                         <node concept="3clFbS" id="3BQn3_gx3hM" role="3clFbx">
-                          <node concept="2xdQw9" id="oe4mW5zMQr" role="3cqZAp">
-                            <property role="2xdLsb" value="h1akgim/info" />
-                            <node concept="3cpWs3" id="7EPprGLqKgD" role="9lYJi">
-                              <node concept="2OqwBi" id="7EPprGLr4H_" role="3uHU7w">
-                                <node concept="0kSF2" id="7EPprGLr03L" role="2Oq$k0">
-                                  <node concept="3uibUv" id="7EPprGLr03N" role="0kSFW">
-                                    <ref role="3uigEE" node="7jhYr4hIToa" resolve="SNodeEdgeAccessor" />
-                                  </node>
-                                  <node concept="2OqwBi" id="7EPprGLqR0o" role="0kSFX">
-                                    <node concept="37vLTw" id="7EPprGLqOcZ" role="2Oq$k0">
-                                      <ref role="3cqZAo" node="641jOpdC1hU" resolve="accessors" />
-                                    </node>
-                                    <node concept="1uHKPH" id="7EPprGLqVKU" role="2OqNvi" />
-                                  </node>
-                                </node>
-                                <node concept="liA8E" id="7EPprGLra1X" role="2OqNvi">
-                                  <ref role="37wK5l" node="7EPprGLk7uH" resolve="pullAnnotations" />
-                                </node>
-                              </node>
-                              <node concept="Xl_RD" id="oe4mW5zMQt" role="3uHU7B">
-                                <property role="Xl_RC" value="Pulling annotation for edge" />
-                              </node>
-                            </node>
-                          </node>
                           <node concept="3cpWs8" id="oe4mW5gECz" role="3cqZAp">
                             <node concept="3cpWsn" id="oe4mW5gEC$" role="3cpWs9">
                               <property role="TrG5h" value="accessor" />


### PR DESCRIPTION
Previously, if a model node had an attribute annotation and is used as an edge in a diagram, the attribute editor would be added as an _external box_ in the diagram (also see example node `R1` in the repo):

![image](https://github.com/JetBrains/MPS-extensions/assets/3237993/30d6e9a2-fc9f-4721-9428-8616f6e14167)

In this picture, the annotation `Component Annotation` is floating around in the diagram. Auto-layouting also does not work.

This PR adds support for pulling these annotations into the edge labels:

![image](https://github.com/JetBrains/MPS-extensions/assets/3237993/fa63cb04-11da-44dd-ad79-603065ce6d6a)

The key difference is that in the new setting, the annotation is part of the edge label and thus also automatically layouted.


To apply this change, the PR adds a new flag `pullAnnotations` as a boolean query over the node and the editor context. The standard behavior from above is retained by leaving it at the default `false` value.

This work was done jointly with @slisson. 