### PR TITLE
fix(celllayout): cells where overlapping in some cases

### DIFF
--- a/code/celllayout/solutions/de.slisson.mps.editor.celllayout.runtime/models/de/itemis/mps/editor/celllayout/runtime.mps
+++ b/code/celllayout/solutions/de.slisson.mps.editor.celllayout.runtime/models/de/itemis/mps/editor/celllayout/runtime.mps
@@ -12212,10 +12212,19 @@
       <node concept="3clFbS" id="4U82Y3z24x5" role="3clF47">
         <node concept="3clFbJ" id="4U82Y3z24x6" role="3cqZAp">
           <node concept="3clFbS" id="4U82Y3z24x7" role="3clFbx">
-            <node concept="3cpWs6" id="4U82Y3z24x8" role="3cqZAp" />
+            <node concept="3cpWs6" id="4U82Y3z24x8" role="3cqZAp">
+              <node concept="3clFbT" id="3zGX4q3czej" role="3cqZAk" />
+            </node>
           </node>
           <node concept="37vLTw" id="4U82Y3z24x9" role="3clFbw">
             <ref role="3cqZAo" node="6SVXTgIcYgs" resolve="DISABLED" />
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3zGX4q3c$t2" role="3cqZAp">
+          <node concept="3cpWsn" id="3zGX4q3c$t3" role="3cpWs9">
+            <property role="TrG5h" value="installedAnywhere" />
+            <node concept="10P_77" id="3zGX4q3c$t4" role="1tU5fm" />
+            <node concept="3clFbT" id="3zGX4q3c$t5" role="33vP2m" />
           </node>
         </node>
         <node concept="3cpWs8" id="3ATi8gI$2CJ" role="3cqZAp">
@@ -12236,11 +12245,16 @@
         </node>
         <node concept="3clFbJ" id="3ATi8gI$2CP" role="3cqZAp">
           <node concept="3clFbS" id="3ATi8gI$2CQ" role="3clFbx">
-            <node concept="3clFbF" id="3ATi8gI$2CR" role="3cqZAp">
-              <node concept="1rXfSq" id="3ATi8gI$2CS" role="3clFbG">
-                <ref role="37wK5l" node="3ATi8gItcNs" resolve="install" />
-                <node concept="37vLTw" id="3ATi8gI$2CT" role="37wK5m">
-                  <ref role="3cqZAo" node="3ATi8gI$2CK" resolve="collectionCell" />
+            <node concept="3clFbF" id="3zGX4q3cBZs" role="3cqZAp">
+              <node concept="3vZ8r8" id="3zGX4q3cDiL" role="3clFbG">
+                <node concept="37vLTw" id="3zGX4q3cBZq" role="37vLTJ">
+                  <ref role="3cqZAo" node="3zGX4q3c$t3" resolve="installedAnywhere" />
+                </node>
+                <node concept="1rXfSq" id="3ATi8gI$2CS" role="37vLTx">
+                  <ref role="37wK5l" node="3ATi8gItcNs" resolve="install" />
+                  <node concept="37vLTw" id="3ATi8gI$2CT" role="37wK5m">
+                    <ref role="3cqZAo" node="3ATi8gI$2CK" resolve="collectionCell" />
+                  </node>
                 </node>
               </node>
             </node>
@@ -12253,10 +12267,15 @@
               </node>
               <node concept="3clFbS" id="3ATi8gI$2CX" role="2LFqv$">
                 <node concept="3clFbF" id="3ATi8gI$2CY" role="3cqZAp">
-                  <node concept="1rXfSq" id="3ATi8gI$2CZ" role="3clFbG">
-                    <ref role="37wK5l" node="4U82Y3z24x2" resolve="installRecursive" />
-                    <node concept="2GrUjf" id="3ATi8gI$2D0" role="37wK5m">
-                      <ref role="2Gs0qQ" node="3ATi8gI$2CV" resolve="child" />
+                  <node concept="3vZ8r8" id="3zGX4q3cIY8" role="3clFbG">
+                    <node concept="37vLTw" id="3zGX4q3cHUE" role="37vLTJ">
+                      <ref role="3cqZAo" node="3zGX4q3c$t3" resolve="installedAnywhere" />
+                    </node>
+                    <node concept="1rXfSq" id="3ATi8gI$2CZ" role="37vLTx">
+                      <ref role="37wK5l" node="4U82Y3z24x2" resolve="installRecursive" />
+                      <node concept="2GrUjf" id="3ATi8gI$2D0" role="37wK5m">
+                        <ref role="2Gs0qQ" node="3ATi8gI$2CV" resolve="child" />
+                      </node>
                     </node>
                   </node>
                 </node>
@@ -12270,8 +12289,13 @@
             <node concept="10Nm6u" id="3ATi8gI$2D3" role="3uHU7w" />
           </node>
         </node>
+        <node concept="3cpWs6" id="3zGX4q3c_ph" role="3cqZAp">
+          <node concept="37vLTw" id="3zGX4q3cAvb" role="3cqZAk">
+            <ref role="3cqZAo" node="3zGX4q3c$t3" resolve="installedAnywhere" />
+          </node>
+        </node>
       </node>
-      <node concept="3cqZAl" id="4U82Y3z24y1" role="3clF45" />
+      <node concept="10P_77" id="3zGX4q3cydj" role="3clF45" />
       <node concept="3Tm1VV" id="4U82Y3z24y2" role="1B3o_S" />
     </node>
     <node concept="2tJIrI" id="3ATi8gIzh5Q" role="jymVt" />
@@ -12377,6 +12401,11 @@
             <property role="TrG5h" value="c" />
           </node>
           <node concept="2OqwBi" id="3ATi8gIzqht" role="2GsD0m">
+            <node concept="UnYns" id="3ATi8gIzqhw" role="2OqNvi">
+              <node concept="3uibUv" id="3ATi8gIzqhx" role="UnYnz">
+                <ref role="3uigEE" to="g51k:~EditorCell_Collection" resolve="EditorCell_Collection" />
+              </node>
+            </node>
             <node concept="2YIFZM" id="3ATi8gIzqhu" role="2Oq$k0">
               <ref role="1Pybhc" node="3ATi8gIuBJY" resolve="LayoutInterceptor.StylesRequiringInstall" />
               <ref role="37wK5l" node="3ATi8gIxRpN" resolve="collectRequiredCells" />
@@ -12384,23 +12413,224 @@
                 <ref role="3cqZAo" node="3ATi8gIzqh7" resolve="cell" />
               </node>
             </node>
-            <node concept="UnYns" id="3ATi8gIzqhw" role="2OqNvi">
-              <node concept="3uibUv" id="3ATi8gIzqhx" role="UnYnz">
-                <ref role="3uigEE" to="g51k:~EditorCell_Collection" resolve="EditorCell_Collection" />
-              </node>
-            </node>
           </node>
           <node concept="3clFbS" id="3ATi8gIzqhy" role="2LFqv$">
-            <node concept="3clFbF" id="3ATi8gI_47T" role="3cqZAp">
-              <node concept="3vZ8r8" id="3ATi8gI_4E3" role="3clFbG">
-                <node concept="37vLTw" id="3ATi8gI_4E6" role="37vLTJ">
-                  <ref role="3cqZAo" node="3ATi8gI$wiR" resolve="installedAnywhere" />
+            <node concept="1X3_iC" id="3zGX4q3cqBQ" role="lGtFl">
+              <property role="3V$3am" value="statement" />
+              <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+              <node concept="3clFbF" id="3ATi8gI_47T" role="8Wnug">
+                <node concept="3vZ8r8" id="3ATi8gI_4E3" role="3clFbG">
+                  <node concept="37vLTw" id="3ATi8gI_4E6" role="37vLTJ">
+                    <ref role="3cqZAo" node="3ATi8gI$wiR" resolve="installedAnywhere" />
+                  </node>
+                  <node concept="1rXfSq" id="3ATi8gIzqh$" role="37vLTx">
+                    <ref role="37wK5l" node="3ATi8gItcNs" resolve="install" />
+                    <node concept="2GrUjf" id="3ATi8gIzqh_" role="37wK5m">
+                      <ref role="2Gs0qQ" node="3ATi8gIzqhs" resolve="c" />
+                    </node>
+                  </node>
                 </node>
-                <node concept="1rXfSq" id="3ATi8gIzqh$" role="37vLTx">
-                  <ref role="37wK5l" node="3ATi8gItcNs" resolve="install" />
-                  <node concept="2GrUjf" id="3ATi8gIzqh_" role="37wK5m">
+              </node>
+            </node>
+            <node concept="3clFbH" id="3zGX4q3cP34" role="3cqZAp" />
+            <node concept="3SKdUt" id="3zGX4q3cSgG" role="3cqZAp">
+              <node concept="1PaTwC" id="3zGX4q3cSgH" role="1aUNEU">
+                <node concept="3oM_SD" id="3zGX4q3cT3r" role="1PaTwD">
+                  <property role="3oM_SC" value="Using" />
+                </node>
+                <node concept="3oM_SD" id="3zGX4q3cT3t" role="1PaTwD">
+                  <property role="3oM_SC" value="the" />
+                </node>
+                <node concept="3oM_SD" id="3zGX4q3cT3w" role="1PaTwD">
+                  <property role="3oM_SC" value="MPS" />
+                </node>
+                <node concept="3oM_SD" id="3zGX4q3cT3$" role="1PaTwD">
+                  <property role="3oM_SC" value="layouter" />
+                </node>
+                <node concept="3oM_SD" id="3zGX4q3cT3D" role="1PaTwD">
+                  <property role="3oM_SC" value="instead" />
+                </node>
+                <node concept="3oM_SD" id="3zGX4q3cT3J" role="1PaTwD">
+                  <property role="3oM_SC" value="of" />
+                </node>
+                <node concept="3oM_SD" id="3zGX4q3cT3Q" role="1PaTwD">
+                  <property role="3oM_SC" value="our" />
+                </node>
+                <node concept="3oM_SD" id="3zGX4q3cT3Y" role="1PaTwD">
+                  <property role="3oM_SC" value="more" />
+                </node>
+                <node concept="3oM_SD" id="3zGX4q3cT47" role="1PaTwD">
+                  <property role="3oM_SC" value="feature" />
+                </node>
+                <node concept="3oM_SD" id="3zGX4q3cT4h" role="1PaTwD">
+                  <property role="3oM_SC" value="rich" />
+                </node>
+                <node concept="3oM_SD" id="3zGX4q3cT4P" role="1PaTwD">
+                  <property role="3oM_SC" value="algorithms" />
+                </node>
+                <node concept="3oM_SD" id="3zGX4q3cT51" role="1PaTwD">
+                  <property role="3oM_SC" value="is" />
+                </node>
+                <node concept="3oM_SD" id="3zGX4q3cT5e" role="1PaTwD">
+                  <property role="3oM_SC" value="done" />
+                </node>
+                <node concept="3oM_SD" id="3zGX4q3cT5s" role="1PaTwD">
+                  <property role="3oM_SC" value="for" />
+                </node>
+                <node concept="3oM_SD" id="3zGX4q3cT6c" role="1PaTwD">
+                  <property role="3oM_SC" value="performance" />
+                </node>
+                <node concept="3oM_SD" id="3zGX4q3cT6s" role="1PaTwD">
+                  <property role="3oM_SC" value="reasons." />
+                </node>
+              </node>
+            </node>
+            <node concept="3SKdUt" id="3zGX4q3cWuK" role="3cqZAp">
+              <node concept="1PaTwC" id="3zGX4q3cWuL" role="1aUNEU">
+                <node concept="3oM_SD" id="3zGX4q3cXbq" role="1PaTwD">
+                  <property role="3oM_SC" value="Mixing" />
+                </node>
+                <node concept="3oM_SD" id="3zGX4q3cXbs" role="1PaTwD">
+                  <property role="3oM_SC" value="both" />
+                </node>
+                <node concept="3oM_SD" id="3zGX4q3cXbv" role="1PaTwD">
+                  <property role="3oM_SC" value="layout" />
+                </node>
+                <node concept="3oM_SD" id="3zGX4q3cXbI" role="1PaTwD">
+                  <property role="3oM_SC" value="algorithms" />
+                </node>
+                <node concept="3oM_SD" id="3zGX4q3cXbN" role="1PaTwD">
+                  <property role="3oM_SC" value="often" />
+                </node>
+                <node concept="3oM_SD" id="3zGX4q3cXbT" role="1PaTwD">
+                  <property role="3oM_SC" value="causes" />
+                </node>
+                <node concept="3oM_SD" id="3zGX4q3cXch" role="1PaTwD">
+                  <property role="3oM_SC" value="overlapping" />
+                </node>
+                <node concept="3oM_SD" id="3zGX4q3cXcp" role="1PaTwD">
+                  <property role="3oM_SC" value="cells" />
+                </node>
+                <node concept="3oM_SD" id="3zGX4q3cY07" role="1PaTwD">
+                  <property role="3oM_SC" value="and" />
+                </node>
+                <node concept="3oM_SD" id="3zGX4q3cY0p" role="1PaTwD">
+                  <property role="3oM_SC" value="installing" />
+                </node>
+                <node concept="3oM_SD" id="3zGX4q3cY0O" role="1PaTwD">
+                  <property role="3oM_SC" value="the" />
+                </node>
+                <node concept="3oM_SD" id="3zGX4q3cY18" role="1PaTwD">
+                  <property role="3oM_SC" value="interceptor" />
+                </node>
+                <node concept="3oM_SD" id="3zGX4q3cY1t" role="1PaTwD">
+                  <property role="3oM_SC" value="into" />
+                </node>
+                <node concept="3oM_SD" id="3zGX4q3cY1N" role="1PaTwD">
+                  <property role="3oM_SC" value="the" />
+                </node>
+                <node concept="3oM_SD" id="3zGX4q3cY22" role="1PaTwD">
+                  <property role="3oM_SC" value="whole" />
+                </node>
+                <node concept="3oM_SD" id="3zGX4q3cY2q" role="1PaTwD">
+                  <property role="3oM_SC" value="subtree" />
+                </node>
+                <node concept="3oM_SD" id="3zGX4q3cY2N" role="1PaTwD">
+                  <property role="3oM_SC" value="is" />
+                </node>
+                <node concept="3oM_SD" id="3zGX4q3cY35" role="1PaTwD">
+                  <property role="3oM_SC" value="a" />
+                </node>
+                <node concept="3oM_SD" id="3zGX4q3cY3w" role="1PaTwD">
+                  <property role="3oM_SC" value="working" />
+                </node>
+                <node concept="3oM_SD" id="3zGX4q3cY3W" role="1PaTwD">
+                  <property role="3oM_SC" value="workaround." />
+                </node>
+              </node>
+            </node>
+            <node concept="3SKdUt" id="3zGX4q3cY9k" role="3cqZAp">
+              <node concept="1PaTwC" id="3zGX4q3cY9l" role="1aUNEU">
+                <node concept="3oM_SD" id="3zGX4q3cYWF" role="1PaTwD">
+                  <property role="3oM_SC" value="That's" />
+                </node>
+                <node concept="3oM_SD" id="3zGX4q3cYWH" role="1PaTwD">
+                  <property role="3oM_SC" value="what" />
+                </node>
+                <node concept="3oM_SD" id="3zGX4q3cYWK" role="1PaTwD">
+                  <property role="3oM_SC" value="we" />
+                </node>
+                <node concept="3oM_SD" id="3zGX4q3cYWO" role="1PaTwD">
+                  <property role="3oM_SC" value="do" />
+                </node>
+                <node concept="3oM_SD" id="3zGX4q3cYWT" role="1PaTwD">
+                  <property role="3oM_SC" value="here," />
+                </node>
+                <node concept="3oM_SD" id="3zGX4q3cYWZ" role="1PaTwD">
+                  <property role="3oM_SC" value="if" />
+                </node>
+                <node concept="3oM_SD" id="3zGX4q3cYX6" role="1PaTwD">
+                  <property role="3oM_SC" value="the" />
+                </node>
+                <node concept="3oM_SD" id="3zGX4q3cYXe" role="1PaTwD">
+                  <property role="3oM_SC" value="layout" />
+                </node>
+                <node concept="3oM_SD" id="3zGX4q3cYXn" role="1PaTwD">
+                  <property role="3oM_SC" value="algorithm" />
+                </node>
+                <node concept="3oM_SD" id="3zGX4q3cYXx" role="1PaTwD">
+                  <property role="3oM_SC" value="is" />
+                </node>
+                <node concept="3oM_SD" id="3zGX4q3cYXG" role="1PaTwD">
+                  <property role="3oM_SC" value="replaced" />
+                </node>
+                <node concept="3oM_SD" id="3zGX4q3cYXS" role="1PaTwD">
+                  <property role="3oM_SC" value="anywhere," />
+                </node>
+                <node concept="3oM_SD" id="3zGX4q3cYY5" role="1PaTwD">
+                  <property role="3oM_SC" value="we" />
+                </node>
+                <node concept="3oM_SD" id="3zGX4q3cYYj" role="1PaTwD">
+                  <property role="3oM_SC" value="replace" />
+                </node>
+                <node concept="3oM_SD" id="3zGX4q3cYYy" role="1PaTwD">
+                  <property role="3oM_SC" value="it" />
+                </node>
+                <node concept="3oM_SD" id="3zGX4q3cYYM" role="1PaTwD">
+                  <property role="3oM_SC" value="in" />
+                </node>
+                <node concept="3oM_SD" id="3zGX4q3cYZ3" role="1PaTwD">
+                  <property role="3oM_SC" value="the" />
+                </node>
+                <node concept="3oM_SD" id="3zGX4q3cYZl" role="1PaTwD">
+                  <property role="3oM_SC" value="whole" />
+                </node>
+                <node concept="3oM_SD" id="3zGX4q3d0FQ" role="1PaTwD">
+                  <property role="3oM_SC" value="subtree." />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbJ" id="3zGX4q3cLCZ" role="3cqZAp">
+              <node concept="3clFbS" id="3zGX4q3cLD1" role="3clFbx">
+                <node concept="3N13vt" id="3zGX4q3cOgV" role="3cqZAp" />
+              </node>
+              <node concept="1rXfSq" id="3zGX4q3cM$k" role="3clFbw">
+                <ref role="37wK5l" node="3zGX4q3c9Ai" resolve="isInstalled" />
+                <node concept="2GrUjf" id="3zGX4q3cNrU" role="37wK5m">
+                  <ref role="2Gs0qQ" node="3ATi8gIzqhs" resolve="c" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="3zGX4q3cu3H" role="3cqZAp">
+              <node concept="3vZ8r8" id="3zGX4q3cv57" role="3clFbG">
+                <node concept="1rXfSq" id="3zGX4q3cvSM" role="37vLTx">
+                  <ref role="37wK5l" node="4U82Y3z24x2" resolve="installRecursive" />
+                  <node concept="2GrUjf" id="3zGX4q3cxiE" role="37wK5m">
                     <ref role="2Gs0qQ" node="3ATi8gIzqhs" resolve="c" />
                   </node>
+                </node>
+                <node concept="37vLTw" id="3zGX4q3cu3F" role="37vLTJ">
+                  <ref role="3cqZAo" node="3ATi8gI$wiR" resolve="installedAnywhere" />
                 </node>
               </node>
             </node>
@@ -12620,6 +12850,75 @@
       </node>
       <node concept="10P_77" id="3ATi8gI$x1v" role="3clF45" />
       <node concept="3Tm1VV" id="3ATi8gItjkU" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="3zGX4q3bLj1" role="jymVt" />
+    <node concept="2YIFZL" id="3zGX4q3c9Ai" role="jymVt">
+      <property role="TrG5h" value="isInstalled" />
+      <node concept="3clFbS" id="3zGX4q3bOkQ" role="3clF47">
+        <node concept="3cpWs8" id="3zGX4q3ccGf" role="3cqZAp">
+          <node concept="3cpWsn" id="3zGX4q3ccGg" role="3cpWs9">
+            <property role="TrG5h" value="collectionCell" />
+            <node concept="3uibUv" id="3zGX4q3ccGh" role="1tU5fm">
+              <ref role="3uigEE" to="g51k:~EditorCell_Collection" resolve="EditorCell_Collection" />
+            </node>
+            <node concept="0kSF2" id="3zGX4q3ccGi" role="33vP2m">
+              <node concept="3uibUv" id="3zGX4q3ccGj" role="0kSFW">
+                <ref role="3uigEE" to="g51k:~EditorCell_Collection" resolve="EditorCell_Collection" />
+              </node>
+              <node concept="37vLTw" id="3zGX4q3ccGk" role="0kSFX">
+                <ref role="3cqZAo" node="3zGX4q3bVq1" resolve="cell" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="3zGX4q3ccGl" role="3cqZAp">
+          <node concept="3clFbS" id="3zGX4q3ccGm" role="3clFbx">
+            <node concept="3cpWs6" id="3zGX4q3ccGn" role="3cqZAp">
+              <node concept="3clFbT" id="3zGX4q3cewK" role="3cqZAk" />
+            </node>
+          </node>
+          <node concept="3clFbC" id="3zGX4q3ccGo" role="3clFbw">
+            <node concept="10Nm6u" id="3zGX4q3ccGp" role="3uHU7w" />
+            <node concept="37vLTw" id="3zGX4q3ccGq" role="3uHU7B">
+              <ref role="3cqZAo" node="3zGX4q3ccGg" resolve="collectionCell" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3zGX4q3cgTW" role="3cqZAp">
+          <node concept="3cpWsn" id="3zGX4q3cgTX" role="3cpWs9">
+            <property role="TrG5h" value="layout" />
+            <node concept="3uibUv" id="3zGX4q3cgTY" role="1tU5fm">
+              <ref role="3uigEE" to="kcid:~CellLayout" resolve="CellLayout" />
+            </node>
+            <node concept="2OqwBi" id="3zGX4q3cgTZ" role="33vP2m">
+              <node concept="37vLTw" id="3zGX4q3cgU0" role="2Oq$k0">
+                <ref role="3cqZAo" node="3zGX4q3ccGg" resolve="collectionCell" />
+              </node>
+              <node concept="liA8E" id="3zGX4q3cgU1" role="2OqNvi">
+                <ref role="37wK5l" to="g51k:~EditorCell_Collection.getCellLayout()" resolve="getCellLayout" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="3zGX4q3ciKk" role="3cqZAp">
+          <node concept="2ZW3vV" id="3zGX4q3clLo" role="3cqZAk">
+            <node concept="3uibUv" id="3zGX4q3cmxr" role="2ZW6by">
+              <ref role="3uigEE" node="3Osd_yxgaDz" resolve="LayoutInterceptor" />
+            </node>
+            <node concept="37vLTw" id="3zGX4q3ckRs" role="2ZW6bz">
+              <ref role="3cqZAo" node="3zGX4q3cgTX" resolve="layout" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="3zGX4q3bVq1" role="3clF46">
+        <property role="TrG5h" value="cell" />
+        <node concept="3uibUv" id="3zGX4q3bXdb" role="1tU5fm">
+          <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+        </node>
+      </node>
+      <node concept="10P_77" id="3zGX4q3bRnv" role="3clF45" />
+      <node concept="3Tm1VV" id="3zGX4q3bOkP" role="1B3o_S" />
     </node>
     <node concept="2tJIrI" id="3oUU9KDF1lh" role="jymVt" />
     <node concept="2YIFZL" id="3oUU9KDF3kp" role="jymVt">


### PR DESCRIPTION
When cells with our own layout algorithm were mixed with the default MPS layouter then cells were overlapping especially if the content was bigger than the configured "Text width".
Now, if we replace the layouter somewhere, it is replaced in the whole subtree.