### PR TITLE
tables: initial support for row actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The project does _not_ follow Semantic Versioning and the changes are documented
 
 - mpsutil.intentions: a new style attribute `intentions-in-read-only-cell` is now available to allow intentions in read-only cells.
 - com.mbeddr.mpsutil.editor.querylist: Default editor cells now support style attributes.
+- de.slisson.mps.tables: tables now support a new property `row UI actions (experimental)`: This property adds actions to the MPS toolbar to add a new row above/below the current row or to delete the current row. These actions only work for simple tables that are based on rows (default: *false*).
 
 ## October 2023
 

--- a/code/tables/languages/de.slisson.mps.tables.demolang/languageModels/editor.mps
+++ b/code/tables/languages/de.slisson.mps.tables.demolang/languageModels/editor.mps
@@ -312,6 +312,7 @@
         <property id="1397920687864864274" name="text" index="2rfbtB" />
       </concept>
       <concept id="1397920687864683158" name="de.slisson.mps.tables.structure.Table" flags="ng" index="2rfBfz">
+        <property id="8824145157122921765" name="rowUIActions" index="3qJzLx" />
         <child id="1397920687864865354" name="cells" index="2rf8GZ" />
         <child id="6097863121587726798" name="gridPostprocessor" index="3nFLZX" />
       </concept>
@@ -976,6 +977,7 @@
     <property role="3GE5qa" value="StaticRow" />
     <ref role="1XX52x" to="nnej:1dAqnm8oBxc" resolve="RequirementsCollection" />
     <node concept="2rfBfz" id="1dAqnm8o6CS" role="2wV5jI">
+      <property role="3qJzLx" value="true" />
       <node concept="2reSaE" id="3vizsF8spxX" role="2rf8GZ">
         <property role="1YXhso" value="Press enter to add the first requirement" />
         <ref role="2reCK$" to="nnej:1dAqnm8oYDx" resolve="requirements" />
@@ -1034,6 +1036,7 @@
         </node>
       </node>
       <node concept="2rfBfz" id="1dAqnm8qrOS" role="3EZMnx">
+        <property role="3qJzLx" value="true" />
         <node concept="2reSaE" id="1dAqnm8I7ag" role="2rf8GZ">
           <ref role="2reCK$" to="nnej:1dAqnm8qrMU" resolve="tests" />
           <node concept="1g0IQG" id="1ERZrWiwuGX" role="1geGt4" />
@@ -2580,6 +2583,7 @@
     <property role="3GE5qa" value="StateMachine2" />
     <ref role="1XX52x" to="nnej:2M7NXgi3amF" resolve="StateMachine2" />
     <node concept="2rfBfz" id="2M7NXgi3aZy" role="2wV5jI">
+      <property role="3qJzLx" value="true" />
       <node concept="2reCLu" id="ovdreqayNp" role="2rf8GZ">
         <node concept="2reCLk" id="ovdreqaBpu" role="2reCL6">
           <node concept="2r731s" id="2M7NXgi3aZB" role="2reCL6">

--- a/code/tables/languages/de.slisson.mps.tables/generator/template/main@generator.mps
+++ b/code/tables/languages/de.slisson.mps.tables/generator/template/main@generator.mps
@@ -2277,6 +2277,33 @@
                                   </node>
                                 </node>
                               </node>
+                              <node concept="3clFbF" id="7DPEkiwN2f5" role="3cqZAp">
+                                <node concept="2OqwBi" id="7DPEkiwN2f6" role="3clFbG">
+                                  <node concept="37vLTw" id="7DPEkiwN2f7" role="2Oq$k0">
+                                    <ref role="3cqZAo" node="1dAqnm8$DVo" resolve="editorCell" />
+                                  </node>
+                                  <node concept="liA8E" id="7DPEkiwN2f8" role="2OqNvi">
+                                    <ref role="37wK5l" to="hm5v:7DPEkiwMAV0" resolve="toggleRowUIActions" />
+                                    <node concept="3clFbT" id="7DPEkiwN2f9" role="37wK5m">
+                                      <property role="3clFbU" value="true" />
+                                    </node>
+                                  </node>
+                                </node>
+                                <node concept="1W57fq" id="7DPEkiwN2fa" role="lGtFl">
+                                  <node concept="3IZrLx" id="7DPEkiwN2fb" role="3IZSJc">
+                                    <node concept="3clFbS" id="7DPEkiwN2fc" role="2VODD2">
+                                      <node concept="3clFbF" id="7DPEkiwN2fd" role="3cqZAp">
+                                        <node concept="2OqwBi" id="7DPEkiwN2fe" role="3clFbG">
+                                          <node concept="30H73N" id="7DPEkiwN2ff" role="2Oq$k0" />
+                                          <node concept="3TrcHB" id="7DPEkiwN2fg" role="2OqNvi">
+                                            <ref role="3TsBF5" to="bnk3:7DPEkiwMTk_" resolve="rowUIActions" />
+                                          </node>
+                                        </node>
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
                               <node concept="3clFbH" id="m_yL2MJokU" role="3cqZAp" />
                               <node concept="3clFbF" id="63X$F8P1Lj6" role="3cqZAp">
                                 <node concept="2OqwBi" id="63X$F8P1LMw" role="3clFbG">

--- a/code/tables/languages/de.slisson.mps.tables/languageModels/editor.mps
+++ b/code/tables/languages/de.slisson.mps.tables/languageModels/editor.mps
@@ -619,6 +619,22 @@
           </node>
           <node concept="2iRfu4" id="m_yL2MI1Ty" role="2iSdaV" />
         </node>
+        <node concept="3EZMnI" id="7DPEkiwMUol" role="3EZMnx">
+          <node concept="VPM3Z" id="7DPEkiwMUom" role="3F10Kt">
+            <property role="VOm3f" value="false" />
+          </node>
+          <node concept="VPXOz" id="7DPEkiwMUon" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+          <node concept="3F0ifn" id="7DPEkiwMUoo" role="3EZMnx">
+            <property role="3F0ifm" value="row UI actions (experimental)" />
+            <ref role="1k5W1q" to="tpc5:hF4H1c8" resolve="property" />
+          </node>
+          <node concept="3F0A7n" id="7DPEkiwMUop" role="3EZMnx">
+            <ref role="1NtTu8" to="bnk3:7DPEkiwMTk_" resolve="rowUIActions" />
+          </node>
+          <node concept="2iRfu4" id="7DPEkiwMUoq" role="2iSdaV" />
+        </node>
         <node concept="VPM3Z" id="hEU$PEH" role="3F10Kt">
           <property role="VOm3f" value="false" />
         </node>

--- a/code/tables/languages/de.slisson.mps.tables/languageModels/structure.mps
+++ b/code/tables/languages/de.slisson.mps.tables/languageModels/structure.mps
@@ -105,6 +105,11 @@
       <property role="TrG5h" value="disableRightRowEndCells" />
       <ref role="AX2Wp" to="tpck:fKAQMTB" resolve="boolean" />
     </node>
+    <node concept="1TJgyi" id="7DPEkiwMTk_" role="1TKVEl">
+      <property role="IQ2nx" value="8824145157122921765" />
+      <property role="TrG5h" value="rowUIActions" />
+      <ref role="AX2Wp" to="tpck:fKAQMTB" resolve="boolean" />
+    </node>
     <node concept="PrWs8" id="5X6T0_NE_dS" role="PzmwI">
       <ref role="PrY4T" node="4UkcdCu_Hbr" resolve="IStylable" />
     </node>

--- a/code/tables/languages/de.slisson.mps.tables/runtime/de.slisson.mps.tables.runtime.msd
+++ b/code/tables/languages/de.slisson.mps.tables/runtime/de.slisson.mps.tables.runtime.msd
@@ -36,6 +36,7 @@
     <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
     <language slang="l:5dc5fc0d-37ef-4782-8192-8b5ce1f69f80:jetbrains.mps.baseLanguage.extensionMethods" version="0" />
     <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
+    <language slang="l:c7d5b9dd-a05f-4be2-bc73-f2e16994cc67:jetbrains.mps.baseLanguage.lightweightdsl" version="1" />
     <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
     <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
     <language slang="l:f61473f9-130f-42f6-b98d-6c438812c2f6:jetbrains.mps.baseLanguage.unitTest" version="1" />

--- a/code/tables/languages/de.slisson.mps.tables/runtime/models/de/slisson/mps/tables/runtime/cells.mps
+++ b/code/tables/languages/de.slisson.mps.tables/runtime/models/de/slisson/mps/tables/runtime/cells.mps
@@ -12,6 +12,7 @@
     <use id="5dc5fc0d-37ef-4782-8192-8b5ce1f69f80" name="jetbrains.mps.baseLanguage.extensionMethods" version="0" />
     <use id="63650c59-16c8-498a-99c8-005c7ee9515d" name="jetbrains.mps.lang.access" version="0" />
     <use id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc" version="2" />
+    <use id="760a0a8c-eabb-4521-8bfd-65db761a9ba3" name="jetbrains.mps.baseLanguage.logging" version="0" />
   </languages>
   <imports>
     <import index="exr9" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor(MPS.Editor/)" />
@@ -127,9 +128,6 @@
       <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
         <child id="1154032183016" name="body" index="2LFqv$" />
       </concept>
-      <concept id="1177666668936" name="jetbrains.mps.baseLanguage.structure.DoWhileStatement" flags="nn" index="MpOyq">
-        <child id="1177666688034" name="condition" index="MpTkK" />
-      </concept>
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
@@ -145,9 +143,7 @@
         <child id="1145553007750" name="creator" index="2ShVmc" />
       </concept>
       <concept id="1070462154015" name="jetbrains.mps.baseLanguage.structure.StaticFieldDeclaration" flags="ig" index="Wx3nA" />
-      <concept id="1070475354124" name="jetbrains.mps.baseLanguage.structure.ThisExpression" flags="nn" index="Xjq3P">
-        <reference id="1182955020723" name="classConcept" index="1HBi2w" />
-      </concept>
+      <concept id="1070475354124" name="jetbrains.mps.baseLanguage.structure.ThisExpression" flags="nn" index="Xjq3P" />
       <concept id="1070475587102" name="jetbrains.mps.baseLanguage.structure.SuperConstructorInvocation" flags="nn" index="XkiVB" />
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
@@ -430,6 +426,7 @@
       <concept id="1143224127713" name="jetbrains.mps.lang.smodel.structure.Node_InsertPrevSiblingOperation" flags="nn" index="HtX7F">
         <child id="1143224127716" name="insertedNode" index="HtX7I" />
       </concept>
+      <concept id="1181949435690" name="jetbrains.mps.lang.smodel.structure.Concept_NewInstance" flags="nn" index="LFhST" />
       <concept id="7504436213544206332" name="jetbrains.mps.lang.smodel.structure.Node_ContainingLinkOperation" flags="nn" index="2NL2c5" />
       <concept id="1966870290088668512" name="jetbrains.mps.lang.smodel.structure.Enum_MemberLiteral" flags="ng" index="2ViDtV">
         <reference id="1966870290088668516" name="memberDeclaration" index="2ViDtZ" />
@@ -1708,6 +1705,12 @@
       <node concept="10P_77" id="m_yL2MIozB" role="1tU5fm" />
       <node concept="3clFbT" id="m_yL2MIozC" role="33vP2m" />
     </node>
+    <node concept="312cEg" id="7DPEkiwMnAo" role="jymVt">
+      <property role="TrG5h" value="myRowUIActions" />
+      <node concept="3Tm6S6" id="7DPEkiwMih7" role="1B3o_S" />
+      <node concept="10P_77" id="7DPEkiwMlHl" role="1tU5fm" />
+      <node concept="3clFbT" id="7DPEkiwMtrI" role="33vP2m" />
+    </node>
     <node concept="2tJIrI" id="1cFYsK3ojJM" role="jymVt" />
     <node concept="3clFbW" id="1dAqnm8$zKt" role="jymVt">
       <node concept="3cqZAl" id="1dAqnm8$zKu" role="3clF45" />
@@ -1857,6 +1860,41 @@
           </node>
         </node>
       </node>
+    </node>
+    <node concept="2tJIrI" id="7DPEkiwMu6Z" role="jymVt" />
+    <node concept="3clFb_" id="7DPEkiwMAV0" role="jymVt">
+      <property role="TrG5h" value="toggleRowUIActions" />
+      <node concept="3clFbS" id="7DPEkiwMAV3" role="3clF47">
+        <node concept="3clFbF" id="7DPEkiwMKfT" role="3cqZAp">
+          <node concept="37vLTI" id="7DPEkiwMNr8" role="3clFbG">
+            <node concept="37vLTw" id="7DPEkiwMQzi" role="37vLTx">
+              <ref role="3cqZAo" node="7DPEkiwMEG5" resolve="flag" />
+            </node>
+            <node concept="37vLTw" id="7DPEkiwMKfS" role="37vLTJ">
+              <ref role="3cqZAo" node="7DPEkiwMnAo" resolve="myRowUIActions" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="7DPEkiwMxWX" role="1B3o_S" />
+      <node concept="3cqZAl" id="7DPEkiwMyEN" role="3clF45" />
+      <node concept="37vLTG" id="7DPEkiwMEG5" role="3clF46">
+        <property role="TrG5h" value="flag" />
+        <node concept="10P_77" id="7DPEkiwMEG4" role="1tU5fm" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="7DPEkiwNcp9" role="jymVt" />
+    <node concept="3clFb_" id="7DPEkiwNldl" role="jymVt">
+      <property role="TrG5h" value="rowUIActionsAllowed" />
+      <node concept="3clFbS" id="7DPEkiwNldo" role="3clF47">
+        <node concept="3clFbF" id="7DPEkiwNplT" role="3cqZAp">
+          <node concept="37vLTw" id="7DPEkiwNplS" role="3clFbG">
+            <ref role="3cqZAo" node="7DPEkiwMnAo" resolve="myRowUIActions" />
+          </node>
+        </node>
+      </node>
+      <node concept="10P_77" id="7DPEkiwNhlT" role="3clF45" />
+      <node concept="3Tm1VV" id="7DPEkiwNs1U" role="1B3o_S" />
     </node>
     <node concept="2tJIrI" id="1MCPN0ijS0A" role="jymVt" />
     <node concept="3clFb_" id="1MCPN0ikrXv" role="jymVt">
@@ -3901,6 +3939,7 @@
       <node concept="3cqZAl" id="by82KpOZtR" role="3clF45" />
       <node concept="3Tm1VV" id="by82KpOZtS" role="1B3o_S" />
     </node>
+    <node concept="2tJIrI" id="7DPEkiwLZNn" role="jymVt" />
     <node concept="3Tm1VV" id="1dAqnm8$zBo" role="1B3o_S" />
   </node>
   <node concept="312cEu" id="6OOkb_bf0Q2">
@@ -14599,6 +14638,263 @@
       <node concept="3Tqbb2" id="36rxxZPL_i" role="3clF45" />
       <node concept="3Tm1VV" id="36rxxZZsP2" role="1B3o_S" />
     </node>
+    <node concept="2tJIrI" id="7IUya7c5qMx" role="jymVt" />
+    <node concept="2YIFZL" id="7IUya7c4DQS" role="jymVt">
+      <property role="TrG5h" value="getNodeOfRowNode" />
+      <node concept="3clFbS" id="7IUya7c4DQU" role="3clF47">
+        <node concept="3clFbJ" id="7IUya7c4DR3" role="3cqZAp">
+          <node concept="3clFbS" id="7IUya7c4DR4" role="3clFbx">
+            <node concept="3cpWs6" id="7IUya7c4DR5" role="3cqZAp">
+              <node concept="10Nm6u" id="7IUya7c4DR6" role="3cqZAk" />
+            </node>
+          </node>
+          <node concept="3clFbC" id="7IUya7c4DR7" role="3clFbw">
+            <node concept="10Nm6u" id="7IUya7c4DR8" role="3uHU7w" />
+            <node concept="37vLTw" id="7IUya7c4DR9" role="3uHU7B">
+              <ref role="3cqZAo" node="7IUya7c4G4y" resolve="gridCell" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="7IUya7c4DRa" role="3cqZAp">
+          <node concept="3cpWsn" id="7IUya7c4DRb" role="3cpWs9">
+            <property role="TrG5h" value="grid" />
+            <node concept="3uibUv" id="7IUya7c4DRc" role="1tU5fm">
+              <ref role="3uigEE" to="6dpw:7C0FR5Aonzr" resolve="Grid" />
+            </node>
+            <node concept="2EnYce" id="7IUya7c4DRd" role="33vP2m">
+              <node concept="2OqwBi" id="7IUya7c4DRe" role="2Oq$k0">
+                <node concept="37vLTw" id="7IUya7c4DRf" role="2Oq$k0">
+                  <ref role="3cqZAo" node="7IUya7c4G4y" resolve="gridCell" />
+                </node>
+                <node concept="liA8E" id="7IUya7c4DRg" role="2OqNvi">
+                  <ref role="37wK5l" node="4gCFRNzc0za" resolve="getTable" />
+                </node>
+              </node>
+              <node concept="liA8E" id="7IUya7c4DRh" role="2OqNvi">
+                <ref role="37wK5l" node="7Nzu1McBs8f" resolve="getGrid" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="7IUya7c4DRi" role="3cqZAp">
+          <node concept="3clFbS" id="7IUya7c4DRj" role="3clFbx">
+            <node concept="3cpWs6" id="7IUya7c4DRk" role="3cqZAp">
+              <node concept="10Nm6u" id="7IUya7c4DRl" role="3cqZAk" />
+            </node>
+          </node>
+          <node concept="3clFbC" id="7IUya7c4DRm" role="3clFbw">
+            <node concept="10Nm6u" id="7IUya7c4DRn" role="3uHU7w" />
+            <node concept="37vLTw" id="7IUya7c4DRo" role="3uHU7B">
+              <ref role="3cqZAo" node="7IUya7c4DRb" resolve="grid" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="7IUya7c4DRp" role="3cqZAp">
+          <node concept="3cpWsn" id="7IUya7c4DRq" role="3cpWs9">
+            <property role="TrG5h" value="myPosition" />
+            <node concept="3uibUv" id="7IUya7c4DRr" role="1tU5fm">
+              <ref role="3uigEE" to="sse1:20OswHE0h3P" resolve="GridPosition" />
+            </node>
+            <node concept="2OqwBi" id="7IUya7c4DRs" role="33vP2m">
+              <node concept="37vLTw" id="7IUya7c4DRt" role="2Oq$k0">
+                <ref role="3cqZAo" node="7IUya7c4G4y" resolve="gridCell" />
+              </node>
+              <node concept="liA8E" id="7IUya7c4DRu" role="2OqNvi">
+                <ref role="37wK5l" node="4gCFRNz3a7W" resolve="getGridPosition" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7IUya7c4DRz" role="3cqZAp" />
+        <node concept="3cpWs8" id="7IUya7c4DR$" role="3cqZAp">
+          <node concept="3cpWsn" id="7IUya7c4DR_" role="3cpWs9">
+            <property role="TrG5h" value="nodesInRow" />
+            <node concept="2hMVRd" id="7IUya7c4DRA" role="1tU5fm">
+              <node concept="3Tqbb2" id="7IUya7c4DRB" role="2hN53Y" />
+            </node>
+            <node concept="2ShNRf" id="7IUya7c4DRC" role="33vP2m">
+              <node concept="2i4dXS" id="7IUya7c4DRD" role="2ShVmc">
+                <node concept="3Tqbb2" id="7IUya7c4DRE" role="HW$YZ" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7IUya7c4DRF" role="3cqZAp" />
+        <node concept="1Dw8fO" id="7IUya7c4DRG" role="3cqZAp">
+          <node concept="3clFbS" id="7IUya7c4DRH" role="2LFqv$">
+            <node concept="3cpWs8" id="7IUya7c4DRI" role="3cqZAp">
+              <node concept="3cpWsn" id="7IUya7c4DRJ" role="3cpWs9">
+                <property role="TrG5h" value="currentCell" />
+                <node concept="3uibUv" id="7IUya7c4DRK" role="1tU5fm">
+                  <ref role="3uigEE" node="20OswHE0eA6" resolve="EditorCell_GridCell" />
+                </node>
+                <node concept="10QFUN" id="7IUya7c4DRL" role="33vP2m">
+                  <node concept="3uibUv" id="7IUya7c4DRM" role="10QFUM">
+                    <ref role="3uigEE" node="20OswHE0eA6" resolve="EditorCell_GridCell" />
+                  </node>
+                  <node concept="2EnYce" id="7IUya7c4DRN" role="10QFUP">
+                    <node concept="0kSF2" id="7IUya7c4DRO" role="2Oq$k0">
+                      <node concept="3uibUv" id="7IUya7c4DRP" role="0kSFW">
+                        <ref role="3uigEE" to="6dpw:RywcYwuxY_" resolve="EditorCellGridLeaf" />
+                      </node>
+                      <node concept="2OqwBi" id="7IUya7c4DRQ" role="0kSFX">
+                        <node concept="37vLTw" id="7IUya7c4DRR" role="2Oq$k0">
+                          <ref role="3cqZAo" node="7IUya7c4DRb" resolve="grid" />
+                        </node>
+                        <node concept="liA8E" id="7IUya7c4DRS" role="2OqNvi">
+                          <ref role="37wK5l" to="6dpw:4UkcdCtMnDB" resolve="getElement" />
+                          <node concept="37vLTw" id="7IUya7c4DRT" role="37wK5m">
+                            <ref role="3cqZAo" node="7IUya7c4DSd" resolve="x" />
+                          </node>
+                          <node concept="2OqwBi" id="7IUya7c4DRU" role="37wK5m">
+                            <node concept="37vLTw" id="7IUya7c4DRV" role="2Oq$k0">
+                              <ref role="3cqZAo" node="7IUya7c4DRq" resolve="myPosition" />
+                            </node>
+                            <node concept="liA8E" id="7IUya7c4DRW" role="2OqNvi">
+                              <ref role="37wK5l" to="sse1:GrM9mu4M1z" resolve="getY" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="7IUya7c4DRX" role="2OqNvi">
+                      <ref role="37wK5l" to="6dpw:RywcYwuxZ4" resolve="getEditorCell" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbJ" id="7IUya7c4DRY" role="3cqZAp">
+              <node concept="3clFbS" id="7IUya7c4DRZ" role="3clFbx">
+                <node concept="3N13vt" id="7IUya7c4DS0" role="3cqZAp" />
+              </node>
+              <node concept="3clFbC" id="7IUya7c4DS1" role="3clFbw">
+                <node concept="10Nm6u" id="7IUya7c4DS2" role="3uHU7w" />
+                <node concept="37vLTw" id="7IUya7c4DS3" role="3uHU7B">
+                  <ref role="3cqZAo" node="7IUya7c4DRJ" resolve="currentCell" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="7IUya7c4DS4" role="3cqZAp">
+              <node concept="2OqwBi" id="7IUya7c4DS5" role="3clFbG">
+                <node concept="37vLTw" id="7IUya7c4DS6" role="2Oq$k0">
+                  <ref role="3cqZAo" node="7IUya7c4DR_" resolve="nodesInRow" />
+                </node>
+                <node concept="TSZUe" id="7IUya7c4DS7" role="2OqNvi">
+                  <node concept="2OqwBi" id="7IUya7c4DS8" role="25WWJ7">
+                    <node concept="2OqwBi" id="7IUya7c4DS9" role="2Oq$k0">
+                      <node concept="37vLTw" id="7IUya7c4DSa" role="2Oq$k0">
+                        <ref role="3cqZAo" node="7IUya7c4DRJ" resolve="currentCell" />
+                      </node>
+                      <node concept="liA8E" id="7IUya7c4DSb" role="2OqNvi">
+                        <ref role="37wK5l" node="20OswHE1rOJ" resolve="getWrappedCell" />
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="7IUya7c4DSc" role="2OqNvi">
+                      <ref role="37wK5l" to="f4zo:~EditorCell.getSNode()" resolve="getSNode" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWsn" id="7IUya7c4DSd" role="1Duv9x">
+            <property role="TrG5h" value="x" />
+            <node concept="10Oyi0" id="7IUya7c4DSe" role="1tU5fm" />
+            <node concept="3cmrfG" id="7IUya7c4DSf" role="33vP2m">
+              <property role="3cmrfH" value="0" />
+            </node>
+          </node>
+          <node concept="3eOVzh" id="7IUya7c4DSg" role="1Dwp0S">
+            <node concept="2OqwBi" id="7IUya7c4DSh" role="3uHU7w">
+              <node concept="37vLTw" id="7IUya7c4DSi" role="2Oq$k0">
+                <ref role="3cqZAo" node="7IUya7c4DRb" resolve="grid" />
+              </node>
+              <node concept="liA8E" id="7IUya7c4DSj" role="2OqNvi">
+                <ref role="37wK5l" to="6dpw:6tOcB$JGRTs" resolve="getSizeX" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="7IUya7c4DSk" role="3uHU7B">
+              <ref role="3cqZAo" node="7IUya7c4DSd" resolve="x" />
+            </node>
+          </node>
+          <node concept="3uNrnE" id="7IUya7c4DSl" role="1Dwrff">
+            <node concept="37vLTw" id="7IUya7c4DSm" role="2$L3a6">
+              <ref role="3cqZAo" node="7IUya7c4DSd" resolve="x" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="7IUya7c4DSn" role="3cqZAp">
+          <node concept="3cpWsn" id="7IUya7c4DSo" role="3cpWs9">
+            <property role="TrG5h" value="nodeOfTable" />
+            <node concept="3Tqbb2" id="7IUya7c4DSp" role="1tU5fm" />
+            <node concept="2EnYce" id="7IUya7c4DSq" role="33vP2m">
+              <node concept="2OqwBi" id="7IUya7c4DSr" role="2Oq$k0">
+                <node concept="37vLTw" id="7IUya7c4DSs" role="2Oq$k0">
+                  <ref role="3cqZAo" node="7IUya7c4G4y" resolve="gridCell" />
+                </node>
+                <node concept="liA8E" id="7IUya7c4DSt" role="2OqNvi">
+                  <ref role="37wK5l" node="4gCFRNzc0za" resolve="getTable" />
+                </node>
+              </node>
+              <node concept="liA8E" id="7IUya7c4DSu" role="2OqNvi">
+                <ref role="37wK5l" to="g51k:~EditorCell_Basic.getSNode()" resolve="getSNode" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7IUya7c4DSv" role="3cqZAp">
+          <node concept="2OqwBi" id="7IUya7c4DSw" role="3clFbG">
+            <node concept="37vLTw" id="7IUya7c4DSx" role="2Oq$k0">
+              <ref role="3cqZAo" node="7IUya7c4DR_" resolve="nodesInRow" />
+            </node>
+            <node concept="3dhRuq" id="7IUya7c4DSy" role="2OqNvi">
+              <node concept="37vLTw" id="7IUya7c4DSz" role="25WWJ7">
+                <ref role="3cqZAo" node="7IUya7c4DSo" resolve="nodeOfTable" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="7IUya7c4DS$" role="3cqZAp">
+          <node concept="3cpWsn" id="7IUya7c4DS_" role="3cpWs9">
+            <property role="TrG5h" value="lca" />
+            <node concept="3Tqbb2" id="7IUya7c4DSA" role="1tU5fm" />
+            <node concept="2YIFZM" id="7IUya7c5jiL" role="33vP2m">
+              <ref role="1Pybhc" node="4gCFRNz2KOM" resolve="TableTraversalUtil" />
+              <ref role="37wK5l" node="7IUya7c4Udx" resolve="getLowestCommonAncestor" />
+              <node concept="37vLTw" id="7IUya7c5kTc" role="37wK5m">
+                <ref role="3cqZAo" node="7IUya7c4DR_" resolve="nodesInRow" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="7IUya7c4DSD" role="3cqZAp">
+          <node concept="3K4zz7" id="7IUya7c4DSE" role="3cqZAk">
+            <node concept="37vLTw" id="7IUya7c4DSG" role="3K4GZi">
+              <ref role="3cqZAo" node="7IUya7c4DS_" resolve="lca" />
+            </node>
+            <node concept="3clFbC" id="7IUya7c4DSH" role="3K4Cdx">
+              <node concept="37vLTw" id="7IUya7c4DSI" role="3uHU7w">
+                <ref role="3cqZAo" node="7IUya7c4DSo" resolve="nodeOfTable" />
+              </node>
+              <node concept="37vLTw" id="7IUya7c4DSJ" role="3uHU7B">
+                <ref role="3cqZAo" node="7IUya7c4DS_" resolve="lca" />
+              </node>
+            </node>
+            <node concept="10Nm6u" id="7IUya7c4DSF" role="3K4E3e" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tqbb2" id="7IUya7c4DSL" role="3clF45" />
+      <node concept="3Tm1VV" id="7IUya7c4DSK" role="1B3o_S" />
+      <node concept="37vLTG" id="7IUya7c4G4y" role="3clF46">
+        <property role="TrG5h" value="gridCell" />
+        <node concept="3uibUv" id="7IUya7c4G4x" role="1tU5fm">
+          <ref role="3uigEE" node="20OswHE0eA6" resolve="EditorCell_GridCell" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="7IUya7c5r4y" role="jymVt" />
     <node concept="2tJIrI" id="36rxxZZeEB" role="jymVt" />
     <node concept="2YIFZL" id="1zEStSS9KTS" role="jymVt">
       <property role="DiZV1" value="false" />
@@ -22579,6 +22875,108 @@
         </node>
       </node>
     </node>
+    <node concept="2tJIrI" id="7IUya7cebhs" role="jymVt" />
+    <node concept="Wx3nA" id="12WeXpXuQQi" role="jymVt">
+      <property role="TrG5h" value="GRID_CELL" />
+      <property role="3TUv4t" value="false" />
+      <node concept="3Tm1VV" id="7IUya7cewAQ" role="1B3o_S" />
+      <node concept="3uibUv" id="12WeXpXuQqs" role="1tU5fm">
+        <ref role="3uigEE" to="y49u:~Condition" resolve="Condition" />
+        <node concept="3uibUv" id="12WeXpXuQHs" role="11_B2D">
+          <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+        </node>
+      </node>
+      <node concept="2ShNRf" id="12WeXpXuRll" role="33vP2m">
+        <node concept="YeOm9" id="12WeXpXuSmP" role="2ShVmc">
+          <node concept="1Y3b0j" id="12WeXpXuSmS" role="YeSDq">
+            <property role="2bfB8j" value="true" />
+            <ref role="1Y3XeK" to="y49u:~Condition" resolve="Condition" />
+            <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
+            <node concept="3Tm1VV" id="12WeXpXuSmT" role="1B3o_S" />
+            <node concept="3clFb_" id="12WeXpXuSmU" role="jymVt">
+              <property role="1EzhhJ" value="false" />
+              <property role="TrG5h" value="met" />
+              <property role="DiZV1" value="false" />
+              <node concept="3Tm1VV" id="12WeXpXuSmV" role="1B3o_S" />
+              <node concept="10P_77" id="12WeXpXuSmX" role="3clF45" />
+              <node concept="37vLTG" id="12WeXpXuSmY" role="3clF46">
+                <property role="TrG5h" value="cell" />
+                <node concept="3uibUv" id="12WeXpXuTGV" role="1tU5fm">
+                  <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+                </node>
+              </node>
+              <node concept="3clFbS" id="12WeXpXuSn0" role="3clF47">
+                <node concept="3clFbF" id="12WeXpXuTYe" role="3cqZAp">
+                  <node concept="2ZW3vV" id="12WeXpXuU4l" role="3clFbG">
+                    <node concept="3uibUv" id="12WeXpXuU6K" role="2ZW6by">
+                      <ref role="3uigEE" node="20OswHE0eA6" resolve="EditorCell_GridCell" />
+                    </node>
+                    <node concept="37vLTw" id="12WeXpXuTYd" role="2ZW6bz">
+                      <ref role="3cqZAo" node="12WeXpXuSmY" resolve="cell" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3uibUv" id="12WeXpXuTmV" role="2Ghqu4">
+              <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="7IUya7cebDm" role="jymVt" />
+    <node concept="Wx3nA" id="7DPEkiwJO$g" role="jymVt">
+      <property role="TrG5h" value="TABLE_EDITOR" />
+      <property role="3TUv4t" value="false" />
+      <node concept="3Tm1VV" id="7DPEkiwJO$h" role="1B3o_S" />
+      <node concept="3uibUv" id="7DPEkiwJO$i" role="1tU5fm">
+        <ref role="3uigEE" to="y49u:~Condition" resolve="Condition" />
+        <node concept="3uibUv" id="7DPEkiwJO$j" role="11_B2D">
+          <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+        </node>
+      </node>
+      <node concept="2ShNRf" id="7DPEkiwJO$k" role="33vP2m">
+        <node concept="YeOm9" id="7DPEkiwJO$l" role="2ShVmc">
+          <node concept="1Y3b0j" id="7DPEkiwJO$m" role="YeSDq">
+            <property role="2bfB8j" value="true" />
+            <ref role="1Y3XeK" to="y49u:~Condition" resolve="Condition" />
+            <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
+            <node concept="3Tm1VV" id="7DPEkiwJO$n" role="1B3o_S" />
+            <node concept="3clFb_" id="7DPEkiwJO$o" role="jymVt">
+              <property role="1EzhhJ" value="false" />
+              <property role="TrG5h" value="met" />
+              <property role="DiZV1" value="false" />
+              <node concept="3Tm1VV" id="7DPEkiwJO$p" role="1B3o_S" />
+              <node concept="10P_77" id="7DPEkiwJO$q" role="3clF45" />
+              <node concept="37vLTG" id="7DPEkiwJO$r" role="3clF46">
+                <property role="TrG5h" value="cell" />
+                <node concept="3uibUv" id="7DPEkiwJO$s" role="1tU5fm">
+                  <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+                </node>
+              </node>
+              <node concept="3clFbS" id="7DPEkiwJO$t" role="3clF47">
+                <node concept="3clFbF" id="7DPEkiwJO$u" role="3cqZAp">
+                  <node concept="2ZW3vV" id="7DPEkiwJO$v" role="3clFbG">
+                    <node concept="3uibUv" id="7DPEkiwJO$w" role="2ZW6by">
+                      <ref role="3uigEE" node="1dAqnm8$zBn" resolve="TableEditor" />
+                    </node>
+                    <node concept="37vLTw" id="7DPEkiwJO$x" role="2ZW6bz">
+                      <ref role="3cqZAo" node="7DPEkiwJO$r" resolve="cell" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3uibUv" id="7DPEkiwJO$y" role="2Ghqu4">
+              <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="7DPEkiwJLMg" role="jymVt" />
+    <node concept="2tJIrI" id="7IUya7cec1h" role="jymVt" />
     <node concept="3clFbW" id="4gCFRNz2KS4" role="jymVt">
       <node concept="3cqZAl" id="4gCFRNz2KS6" role="3clF45" />
       <node concept="3Tm6S6" id="4zzNcfNAtCU" role="1B3o_S" />
@@ -26212,6 +26610,131 @@
       </node>
     </node>
     <node concept="2tJIrI" id="7cmJr8BA4tA" role="jymVt" />
+    <node concept="2YIFZL" id="7IUya7c4Udx" role="jymVt">
+      <property role="TrG5h" value="getLowestCommonAncestor" />
+      <node concept="3clFbS" id="7IUya7c4UdC" role="3clF47">
+        <node concept="3cpWs8" id="7IUya7c4UdD" role="3cqZAp">
+          <node concept="3cpWsn" id="7IUya7c4UdE" role="3cpWs9">
+            <property role="TrG5h" value="candidate" />
+            <node concept="3Tqbb2" id="7IUya7c4UdF" role="1tU5fm" />
+            <node concept="2OqwBi" id="7IUya7c4UdG" role="33vP2m">
+              <node concept="37vLTw" id="7IUya7c4UdH" role="2Oq$k0">
+                <ref role="3cqZAo" node="7IUya7c4Udz" resolve="descendants" />
+              </node>
+              <node concept="1uHKPH" id="7IUya7c4UdI" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+        <node concept="2$JKZl" id="7IUya7c4UdJ" role="3cqZAp">
+          <node concept="3clFbS" id="7IUya7c4UdK" role="2LFqv$">
+            <node concept="3cpWs8" id="7IUya7c4UdL" role="3cqZAp">
+              <node concept="3cpWsn" id="7IUya7c4UdM" role="3cpWs9">
+                <property role="TrG5h" value="ancestorOfAll" />
+                <node concept="10P_77" id="7IUya7c4UdN" role="1tU5fm" />
+                <node concept="3clFbT" id="7IUya7c4UdO" role="33vP2m">
+                  <property role="3clFbU" value="true" />
+                </node>
+              </node>
+            </node>
+            <node concept="2Gpval" id="7IUya7c4UdP" role="3cqZAp">
+              <node concept="2GrKxI" id="7IUya7c4UdQ" role="2Gsz3X">
+                <property role="TrG5h" value="descendant" />
+              </node>
+              <node concept="37vLTw" id="7IUya7c4UdR" role="2GsD0m">
+                <ref role="3cqZAo" node="7IUya7c4Udz" resolve="descendants" />
+              </node>
+              <node concept="3clFbS" id="7IUya7c4UdS" role="2LFqv$">
+                <node concept="3clFbJ" id="7IUya7c4UdT" role="3cqZAp">
+                  <node concept="3clFbS" id="7IUya7c4UdU" role="3clFbx">
+                    <node concept="3clFbF" id="7IUya7c4UdV" role="3cqZAp">
+                      <node concept="37vLTI" id="7IUya7c4UdW" role="3clFbG">
+                        <node concept="3clFbT" id="7IUya7c4UdX" role="37vLTx">
+                          <property role="3clFbU" value="false" />
+                        </node>
+                        <node concept="37vLTw" id="7IUya7c4UdY" role="37vLTJ">
+                          <ref role="3cqZAo" node="7IUya7c4UdM" resolve="ancestorOfAll" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3zACq4" id="7IUya7c4UdZ" role="3cqZAp" />
+                  </node>
+                  <node concept="1Wc70l" id="7IUya7c4Ue0" role="3clFbw">
+                    <node concept="3y3z36" id="7IUya7c4Ue1" role="3uHU7B">
+                      <node concept="2GrUjf" id="7IUya7c4Ue2" role="3uHU7w">
+                        <ref role="2Gs0qQ" node="7IUya7c4UdQ" resolve="descendant" />
+                      </node>
+                      <node concept="37vLTw" id="7IUya7c4Ue3" role="3uHU7B">
+                        <ref role="3cqZAo" node="7IUya7c4UdE" resolve="candidate" />
+                      </node>
+                    </node>
+                    <node concept="3fqX7Q" id="7IUya7c4Ue4" role="3uHU7w">
+                      <node concept="2OqwBi" id="7IUya7c4Ue5" role="3fr31v">
+                        <node concept="2OqwBi" id="7IUya7c4Ue6" role="2Oq$k0">
+                          <node concept="2GrUjf" id="7IUya7c4Ue7" role="2Oq$k0">
+                            <ref role="2Gs0qQ" node="7IUya7c4UdQ" resolve="descendant" />
+                          </node>
+                          <node concept="z$bX8" id="7IUya7c4Ue8" role="2OqNvi" />
+                        </node>
+                        <node concept="3JPx81" id="7IUya7c4Ue9" role="2OqNvi">
+                          <node concept="37vLTw" id="7IUya7c4Uea" role="25WWJ7">
+                            <ref role="3cqZAo" node="7IUya7c4UdE" resolve="candidate" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbJ" id="7IUya7c4Ueb" role="3cqZAp">
+              <node concept="3clFbS" id="7IUya7c4Uec" role="3clFbx">
+                <node concept="3cpWs6" id="7IUya7c4Ued" role="3cqZAp">
+                  <node concept="37vLTw" id="7IUya7c4Uee" role="3cqZAk">
+                    <ref role="3cqZAo" node="7IUya7c4UdE" resolve="candidate" />
+                  </node>
+                </node>
+              </node>
+              <node concept="37vLTw" id="7IUya7c4Uef" role="3clFbw">
+                <ref role="3cqZAo" node="7IUya7c4UdM" resolve="ancestorOfAll" />
+              </node>
+            </node>
+            <node concept="3clFbF" id="7IUya7c4Ueg" role="3cqZAp">
+              <node concept="37vLTI" id="7IUya7c4Ueh" role="3clFbG">
+                <node concept="2OqwBi" id="7IUya7c4Uei" role="37vLTx">
+                  <node concept="37vLTw" id="7IUya7c4Uej" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7IUya7c4UdE" resolve="candidate" />
+                  </node>
+                  <node concept="1mfA1w" id="7IUya7c4Uek" role="2OqNvi" />
+                </node>
+                <node concept="37vLTw" id="7IUya7c4Uel" role="37vLTJ">
+                  <ref role="3cqZAo" node="7IUya7c4UdE" resolve="candidate" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3y3z36" id="7IUya7c4Uem" role="2$JKZa">
+            <node concept="10Nm6u" id="7IUya7c4Uen" role="3uHU7w" />
+            <node concept="37vLTw" id="7IUya7c4Ueo" role="3uHU7B">
+              <ref role="3cqZAo" node="7IUya7c4UdE" resolve="candidate" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7IUya7c4Uep" role="3cqZAp" />
+        <node concept="3cpWs6" id="7IUya7c4Ueq" role="3cqZAp">
+          <node concept="10Nm6u" id="7IUya7c4Uer" role="3cqZAk" />
+        </node>
+      </node>
+      <node concept="3Tqbb2" id="7IUya7c4UdA" role="3clF45" />
+      <node concept="37vLTG" id="7IUya7c4Udz" role="3clF46">
+        <property role="TrG5h" value="descendants" />
+        <node concept="3vKaQO" id="7IUya7c4Ud$" role="1tU5fm">
+          <node concept="3Tqbb2" id="7IUya7c4Ud_" role="3O5elw" />
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="7IUya7c4UBH" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="7IUya7c59kL" role="jymVt" />
+    <node concept="2tJIrI" id="7IUya7c59FJ" role="jymVt" />
     <node concept="312cEu" id="7cmJr8BA8Pk" role="jymVt">
       <property role="2bfB8j" value="false" />
       <property role="TrG5h" value="SameGridCellCondition" />
@@ -27522,55 +28045,6 @@
   </node>
   <node concept="312cEu" id="4db20qfqb8U">
     <property role="TrG5h" value="RowEndCell" />
-    <node concept="Wx3nA" id="12WeXpXuQQi" role="jymVt">
-      <property role="TrG5h" value="GRID_CELL" />
-      <property role="3TUv4t" value="false" />
-      <node concept="3Tm6S6" id="12WeXpXuPNw" role="1B3o_S" />
-      <node concept="3uibUv" id="12WeXpXuQqs" role="1tU5fm">
-        <ref role="3uigEE" to="y49u:~Condition" resolve="Condition" />
-        <node concept="3uibUv" id="12WeXpXuQHs" role="11_B2D">
-          <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
-        </node>
-      </node>
-      <node concept="2ShNRf" id="12WeXpXuRll" role="33vP2m">
-        <node concept="YeOm9" id="12WeXpXuSmP" role="2ShVmc">
-          <node concept="1Y3b0j" id="12WeXpXuSmS" role="YeSDq">
-            <property role="2bfB8j" value="true" />
-            <ref role="1Y3XeK" to="y49u:~Condition" resolve="Condition" />
-            <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
-            <node concept="3Tm1VV" id="12WeXpXuSmT" role="1B3o_S" />
-            <node concept="3clFb_" id="12WeXpXuSmU" role="jymVt">
-              <property role="1EzhhJ" value="false" />
-              <property role="TrG5h" value="met" />
-              <property role="DiZV1" value="false" />
-              <node concept="3Tm1VV" id="12WeXpXuSmV" role="1B3o_S" />
-              <node concept="10P_77" id="12WeXpXuSmX" role="3clF45" />
-              <node concept="37vLTG" id="12WeXpXuSmY" role="3clF46">
-                <property role="TrG5h" value="cell" />
-                <node concept="3uibUv" id="12WeXpXuTGV" role="1tU5fm">
-                  <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
-                </node>
-              </node>
-              <node concept="3clFbS" id="12WeXpXuSn0" role="3clF47">
-                <node concept="3clFbF" id="12WeXpXuTYe" role="3cqZAp">
-                  <node concept="2ZW3vV" id="12WeXpXuU4l" role="3clFbG">
-                    <node concept="3uibUv" id="12WeXpXuU6K" role="2ZW6by">
-                      <ref role="3uigEE" node="20OswHE0eA6" resolve="EditorCell_GridCell" />
-                    </node>
-                    <node concept="37vLTw" id="12WeXpXuTYd" role="2ZW6bz">
-                      <ref role="3cqZAo" node="12WeXpXuSmY" resolve="cell" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3uibUv" id="12WeXpXuTmV" role="2Ghqu4">
-              <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
-            </node>
-          </node>
-        </node>
-      </node>
-    </node>
     <node concept="2tJIrI" id="12WeXpXuPv9" role="jymVt" />
     <node concept="312cEg" id="12WeXpXn$48" role="jymVt">
       <property role="TrG5h" value="myLeftEnd" />
@@ -27611,8 +28085,12 @@
               <ref role="Rm8GQ" to="f4zo:~CellActionType.INSERT" resolve="INSERT" />
             </node>
             <node concept="2ShNRf" id="4eOnSiwSCwR" role="37wK5m">
-              <node concept="HV5vD" id="4eOnSiwSCwS" role="2ShVmc">
-                <ref role="HV5vE" node="4db20qfqg3Y" resolve="RowEndCell.InsertAction" />
+              <node concept="1pGfFk" id="7IUya7cg2uv" role="2ShVmc">
+                <ref role="37wK5l" node="7IUya7cfM4j" resolve="InsertAction" />
+                <node concept="Xjq3P" id="7IUya7cg2uu" role="37wK5m" />
+                <node concept="37vLTw" id="7IUya7cgci6" role="37wK5m">
+                  <ref role="3cqZAo" node="12WeXpXn$48" resolve="myLeftEnd" />
+                </node>
               </node>
             </node>
           </node>
@@ -27641,8 +28119,9 @@
               <ref role="Rm8GQ" to="f4zo:~CellActionType.DELETE" resolve="DELETE" />
             </node>
             <node concept="2ShNRf" id="40oIQyHKQhe" role="37wK5m">
-              <node concept="HV5vD" id="40oIQyHLg2H" role="2ShVmc">
-                <ref role="HV5vE" node="40oIQyHH57G" resolve="RowEndCell.DeleteAction" />
+              <node concept="1pGfFk" id="7IUya7ciW44" role="2ShVmc">
+                <ref role="37wK5l" node="7IUya7ciSfI" resolve="DeleteAction" />
+                <node concept="Xjq3P" id="7IUya7ciW43" role="37wK5m" />
               </node>
             </node>
           </node>
@@ -27655,8 +28134,9 @@
               <ref role="Rm8GQ" to="f4zo:~CellActionType.SELECT_NEXT" resolve="SELECT_NEXT" />
             </node>
             <node concept="2ShNRf" id="5AW5JoZbd$V" role="37wK5m">
-              <node concept="HV5vD" id="5AW5JoZbJZi" role="2ShVmc">
-                <ref role="HV5vE" node="5AW5JoZb6HC" resolve="RowEndCell.SelectRowNodeAction" />
+              <node concept="1pGfFk" id="7IUya7ciZ9l" role="2ShVmc">
+                <ref role="37wK5l" node="7IUya7ciXQl" resolve="SelectRowNodeAction" />
+                <node concept="Xjq3P" id="7IUya7ciZ9k" role="37wK5m" />
               </node>
             </node>
           </node>
@@ -27669,8 +28149,9 @@
               <ref role="Rm8GQ" to="f4zo:~CellActionType.SELECT_PREVIOUS" resolve="SELECT_PREVIOUS" />
             </node>
             <node concept="2ShNRf" id="5AW5JoZbKKJ" role="37wK5m">
-              <node concept="HV5vD" id="5AW5JoZbLxK" role="2ShVmc">
-                <ref role="HV5vE" node="5AW5JoZb6HC" resolve="RowEndCell.SelectRowNodeAction" />
+              <node concept="1pGfFk" id="7IUya7cj15Z" role="2ShVmc">
+                <ref role="37wK5l" node="7IUya7ciXQl" resolve="SelectRowNodeAction" />
+                <node concept="Xjq3P" id="7IUya7cj15Y" role="37wK5m" />
               </node>
             </node>
           </node>
@@ -27683,8 +28164,12 @@
               <ref role="Rm8GQ" to="f4zo:~CellActionType.PASTE" resolve="PASTE" />
             </node>
             <node concept="2ShNRf" id="5AW5JoZAbPx" role="37wK5m">
-              <node concept="HV5vD" id="5AW5JoZCEcd" role="2ShVmc">
-                <ref role="HV5vE" node="5AW5JoZCzaO" resolve="RowEndCell.PasteAction" />
+              <node concept="1pGfFk" id="7IUya7cj32B" role="2ShVmc">
+                <ref role="37wK5l" node="7IUya7cix5V" resolve="PasteAction" />
+                <node concept="Xjq3P" id="7IUya7cj32A" role="37wK5m" />
+                <node concept="37vLTw" id="7IUya7cj6aN" role="37wK5m">
+                  <ref role="3cqZAo" node="12WeXpXn$48" resolve="myLeftEnd" />
+                </node>
               </node>
             </node>
           </node>
@@ -28076,1004 +28561,6 @@
       </node>
       <node concept="2AHcQZ" id="4eOnSiwVNsk" role="2AJF6D">
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-      </node>
-    </node>
-    <node concept="312cEu" id="4db20qfqg3Y" role="jymVt">
-      <property role="2bfB8j" value="true" />
-      <property role="TrG5h" value="InsertAction" />
-      <node concept="3clFb_" id="4db20qfqkmQ" role="jymVt">
-        <property role="1EzhhJ" value="false" />
-        <property role="TrG5h" value="execute" />
-        <property role="DiZV1" value="false" />
-        <node concept="3Tm1VV" id="4db20qfqkmR" role="1B3o_S" />
-        <node concept="3cqZAl" id="4db20qfqkmT" role="3clF45" />
-        <node concept="37vLTG" id="4db20qfqkmU" role="3clF46">
-          <property role="TrG5h" value="context" />
-          <node concept="3uibUv" id="4db20qfqkmV" role="1tU5fm">
-            <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
-          </node>
-        </node>
-        <node concept="3clFbS" id="4db20qfqkmY" role="3clF47">
-          <node concept="3cpWs8" id="12WeXpXvhU7" role="3cqZAp">
-            <node concept="3cpWsn" id="12WeXpXvhU8" role="3cpWs9">
-              <property role="TrG5h" value="gridCell" />
-              <node concept="3uibUv" id="12WeXpXvhU9" role="1tU5fm">
-                <ref role="3uigEE" node="20OswHE0eA6" resolve="EditorCell_GridCell" />
-              </node>
-              <node concept="10QFUN" id="12WeXpXvjh7" role="33vP2m">
-                <node concept="3uibUv" id="12WeXpXvjwd" role="10QFUM">
-                  <ref role="3uigEE" node="20OswHE0eA6" resolve="EditorCell_GridCell" />
-                </node>
-                <node concept="2YIFZM" id="6eBFmDECd0i" role="10QFUP">
-                  <ref role="1Pybhc" node="4gCFRNz2KOM" resolve="TableTraversalUtil" />
-                  <ref role="37wK5l" node="12WeXpXvbfw" resolve="getParent" />
-                  <node concept="Xjq3P" id="6eBFmDECd0j" role="37wK5m">
-                    <ref role="1HBi2w" node="4db20qfqb8U" resolve="RowEndCell" />
-                  </node>
-                  <node concept="10M0yZ" id="6eBFmDECd0k" role="37wK5m">
-                    <ref role="1PxDUh" node="4db20qfqb8U" resolve="RowEndCell" />
-                    <ref role="3cqZAo" node="12WeXpXuQQi" resolve="GRID_CELL" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3cpWs8" id="12WeXpXvENY" role="3cqZAp">
-            <node concept="3cpWsn" id="12WeXpXvENZ" role="3cpWs9">
-              <property role="TrG5h" value="grid" />
-              <node concept="3uibUv" id="6eBFmDECe79" role="1tU5fm">
-                <ref role="3uigEE" to="6dpw:7C0FR5Aonzr" resolve="Grid" />
-              </node>
-              <node concept="2OqwBi" id="12WeXpXvTSE" role="33vP2m">
-                <node concept="2OqwBi" id="12WeXpXvFSf" role="2Oq$k0">
-                  <node concept="37vLTw" id="12WeXpXvEYq" role="2Oq$k0">
-                    <ref role="3cqZAo" node="12WeXpXvhU8" resolve="gridCell" />
-                  </node>
-                  <node concept="liA8E" id="12WeXpXvSII" role="2OqNvi">
-                    <ref role="37wK5l" node="4gCFRNzc0za" resolve="getTable" />
-                  </node>
-                </node>
-                <node concept="liA8E" id="12WeXpXvWwY" role="2OqNvi">
-                  <ref role="37wK5l" node="7Nzu1McBs8f" resolve="getGrid" />
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3cpWs8" id="12WeXpXvr7s" role="3cqZAp">
-            <node concept="3cpWsn" id="12WeXpXvr7t" role="3cpWs9">
-              <property role="TrG5h" value="myPosition" />
-              <node concept="3uibUv" id="12WeXpXvr7u" role="1tU5fm">
-                <ref role="3uigEE" to="sse1:20OswHE0h3P" resolve="GridPosition" />
-              </node>
-              <node concept="2OqwBi" id="12WeXpXvki9" role="33vP2m">
-                <node concept="37vLTw" id="12WeXpXvjGd" role="2Oq$k0">
-                  <ref role="3cqZAo" node="12WeXpXvhU8" resolve="gridCell" />
-                </node>
-                <node concept="liA8E" id="12WeXpXvpfF" role="2OqNvi">
-                  <ref role="37wK5l" node="4gCFRNz3a7W" resolve="getGridPosition" />
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3cpWs8" id="12WeXpXvs70" role="3cqZAp">
-            <node concept="3cpWsn" id="12WeXpXvs71" role="3cpWs9">
-              <property role="TrG5h" value="nextPos" />
-              <node concept="3uibUv" id="12WeXpXvBdH" role="1tU5fm">
-                <ref role="3uigEE" to="sse1:20OswHE0h3P" resolve="GridPosition" />
-              </node>
-              <node concept="37vLTw" id="7AHcygnWeYJ" role="33vP2m">
-                <ref role="3cqZAo" node="12WeXpXvr7t" resolve="myPosition" />
-              </node>
-            </node>
-          </node>
-          <node concept="2$JKZl" id="7VyBODhivQf" role="3cqZAp">
-            <node concept="3clFbS" id="7VyBODhivQh" role="2LFqv$">
-              <node concept="MpOyq" id="7AHcygnYLbn" role="3cqZAp">
-                <node concept="3clFbS" id="7AHcygnYLbp" role="2LFqv$">
-                  <node concept="3clFbF" id="7AHcygnWg8s" role="3cqZAp">
-                    <node concept="37vLTI" id="7AHcygnWgcJ" role="3clFbG">
-                      <node concept="37vLTw" id="7AHcygnWg8r" role="37vLTJ">
-                        <ref role="3cqZAo" node="12WeXpXvs71" resolve="nextPos" />
-                      </node>
-                      <node concept="3K4zz7" id="12WeXpXvvSt" role="37vLTx">
-                        <node concept="2OqwBi" id="6eBFmDEEtLU" role="3K4E3e">
-                          <node concept="37vLTw" id="6eBFmDEEtj6" role="2Oq$k0">
-                            <ref role="3cqZAo" node="12WeXpXvENZ" resolve="grid" />
-                          </node>
-                          <node concept="liA8E" id="6eBFmDEEuC9" role="2OqNvi">
-                            <ref role="37wK5l" to="6dpw:20OswHE0P4u" resolve="next" />
-                            <node concept="37vLTw" id="6eBFmDEEuDP" role="37wK5m">
-                              <ref role="3cqZAo" node="12WeXpXvs71" resolve="nextPos" />
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="2OqwBi" id="6eBFmDEEv5w" role="3K4GZi">
-                          <node concept="37vLTw" id="6eBFmDEEuJd" role="2Oq$k0">
-                            <ref role="3cqZAo" node="12WeXpXvENZ" resolve="grid" />
-                          </node>
-                          <node concept="liA8E" id="6eBFmDEEvEe" role="2OqNvi">
-                            <ref role="37wK5l" to="6dpw:2UGBFGot4RB" resolve="previous" />
-                            <node concept="37vLTw" id="6eBFmDEEvFw" role="37wK5m">
-                              <ref role="3cqZAo" node="12WeXpXvs71" resolve="nextPos" />
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="37vLTw" id="2Z_4Bnadehy" role="3K4Cdx">
-                          <ref role="3cqZAo" node="12WeXpXn$48" resolve="myLeftEnd" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3clFbJ" id="7VyBODhiAm5" role="3cqZAp">
-                    <node concept="3clFbS" id="7VyBODhiAm8" role="3clFbx">
-                      <node concept="3cpWs6" id="7VyBODhiAwy" role="3cqZAp" />
-                    </node>
-                    <node concept="3clFbC" id="7VyBODhiAv0" role="3clFbw">
-                      <node concept="10Nm6u" id="7VyBODhiAvA" role="3uHU7w" />
-                      <node concept="37vLTw" id="7VyBODhiAq7" role="3uHU7B">
-                        <ref role="3cqZAo" node="12WeXpXvs71" resolve="nextPos" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="2EnYce" id="7AHcygnWrSW" role="MpTkK">
-                  <node concept="0kSF2" id="7AHcygnWkf1" role="2Oq$k0">
-                    <node concept="3uibUv" id="7AHcygnWlg$" role="0kSFW">
-                      <ref role="3uigEE" node="20OswHE0eA6" resolve="EditorCell_GridCell" />
-                    </node>
-                    <node concept="2OqwBi" id="7AHcygnWgTr" role="0kSFX">
-                      <node concept="37vLTw" id="7AHcygnWgGc" role="2Oq$k0">
-                        <ref role="3cqZAo" node="12WeXpXvENZ" resolve="grid" />
-                      </node>
-                      <node concept="liA8E" id="7AHcygnWjEM" role="2OqNvi">
-                        <ref role="37wK5l" to="6dpw:20OswHEb5oT" resolve="getElement" />
-                        <node concept="37vLTw" id="7AHcygnWjFS" role="37wK5m">
-                          <ref role="3cqZAo" node="12WeXpXvs71" resolve="nextPos" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="liA8E" id="7AHcygnWrPP" role="2OqNvi">
-                    <ref role="37wK5l" node="7AHcygnW0SW" resolve="isEmptyCell" />
-                  </node>
-                </node>
-              </node>
-              <node concept="3clFbH" id="7AHcygnWsUq" role="3cqZAp" />
-            </node>
-            <node concept="3y3z36" id="7VyBODhiy7J" role="2$JKZa">
-              <node concept="10Nm6u" id="7VyBODhiyvx" role="3uHU7w" />
-              <node concept="37vLTw" id="7VyBODhixDs" role="3uHU7B">
-                <ref role="3cqZAo" node="12WeXpXvs71" resolve="nextPos" />
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm6S6" id="4db20qfqgh1" role="1B3o_S" />
-      <node concept="3uibUv" id="4db20qfqjYb" role="1zkMxy">
-        <ref role="3uigEE" to="3ahc:~AbstractCellAction" resolve="AbstractCellAction" />
-      </node>
-    </node>
-    <node concept="312cEu" id="40oIQyHH57G" role="jymVt">
-      <property role="2bfB8j" value="true" />
-      <property role="TrG5h" value="DeleteAction" />
-      <node concept="3clFb_" id="40oIQyHH57H" role="jymVt">
-        <property role="1EzhhJ" value="false" />
-        <property role="TrG5h" value="execute" />
-        <property role="DiZV1" value="false" />
-        <node concept="3Tm1VV" id="40oIQyHH57I" role="1B3o_S" />
-        <node concept="3cqZAl" id="40oIQyHH57J" role="3clF45" />
-        <node concept="37vLTG" id="40oIQyHH57K" role="3clF46">
-          <property role="TrG5h" value="context" />
-          <node concept="3uibUv" id="40oIQyHH57L" role="1tU5fm">
-            <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
-          </node>
-        </node>
-        <node concept="3clFbS" id="40oIQyHH57M" role="3clF47">
-          <node concept="3clFbF" id="5AW5JoZaRHC" role="3cqZAp">
-            <node concept="2OqwBi" id="5AW5JoZaT6h" role="3clFbG">
-              <node concept="1rXfSq" id="5AW5JoZaRHB" role="2Oq$k0">
-                <ref role="37wK5l" node="5AW5JoZaa8O" resolve="getNodeOfRow" />
-              </node>
-              <node concept="3YRAZt" id="5AW5JoZaUvp" role="2OqNvi" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm6S6" id="40oIQyHH5ac" role="1B3o_S" />
-      <node concept="3uibUv" id="40oIQyHH5ad" role="1zkMxy">
-        <ref role="3uigEE" to="3ahc:~AbstractCellAction" resolve="AbstractCellAction" />
-      </node>
-    </node>
-    <node concept="2tJIrI" id="5AW5JoZwLHK" role="jymVt" />
-    <node concept="312cEu" id="5AW5JoZb6HC" role="jymVt">
-      <property role="2bfB8j" value="true" />
-      <property role="TrG5h" value="SelectRowNodeAction" />
-      <node concept="3clFb_" id="5AW5JoZbc1A" role="jymVt">
-        <property role="1EzhhJ" value="false" />
-        <property role="TrG5h" value="canExecute" />
-        <property role="DiZV1" value="false" />
-        <node concept="3Tm1VV" id="5AW5JoZbc1B" role="1B3o_S" />
-        <node concept="10P_77" id="5AW5JoZbc1D" role="3clF45" />
-        <node concept="37vLTG" id="5AW5JoZbc1E" role="3clF46">
-          <property role="TrG5h" value="context" />
-          <node concept="3uibUv" id="5AW5JoZbc1F" role="1tU5fm">
-            <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
-          </node>
-        </node>
-        <node concept="3clFbS" id="5AW5JoZbc1G" role="3clF47">
-          <node concept="3clFbF" id="5AW5JoZbclS" role="3cqZAp">
-            <node concept="3y3z36" id="5AW5JoZbctG" role="3clFbG">
-              <node concept="10Nm6u" id="5AW5JoZbc$F" role="3uHU7w" />
-              <node concept="1rXfSq" id="5AW5JoZbclR" role="3uHU7B">
-                <ref role="37wK5l" node="5AW5JoZaa8O" resolve="getNodeOfRow" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="2AHcQZ" id="5AW5JoZbc1H" role="2AJF6D">
-          <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-        </node>
-      </node>
-      <node concept="3clFb_" id="5AW5JoZba6F" role="jymVt">
-        <property role="1EzhhJ" value="false" />
-        <property role="TrG5h" value="execute" />
-        <property role="DiZV1" value="false" />
-        <node concept="3Tm1VV" id="5AW5JoZba6G" role="1B3o_S" />
-        <node concept="3cqZAl" id="5AW5JoZba6H" role="3clF45" />
-        <node concept="37vLTG" id="5AW5JoZba6I" role="3clF46">
-          <property role="TrG5h" value="context" />
-          <node concept="3uibUv" id="5AW5JoZba6J" role="1tU5fm">
-            <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
-          </node>
-        </node>
-        <node concept="3clFbS" id="5AW5JoZba6K" role="3clF47">
-          <node concept="3clFbF" id="5AW5JoZbaoE" role="3cqZAp">
-            <node concept="2OqwBi" id="5AW5JoZbaTa" role="3clFbG">
-              <node concept="2OqwBi" id="5AW5JoZbaqB" role="2Oq$k0">
-                <node concept="37vLTw" id="5AW5JoZbaoD" role="2Oq$k0">
-                  <ref role="3cqZAo" node="5AW5JoZba6I" resolve="context" />
-                </node>
-                <node concept="liA8E" id="5AW5JoZbaRN" role="2OqNvi">
-                  <ref role="37wK5l" to="cj4x:~EditorContext.getSelectionManager()" resolve="getSelectionManager" />
-                </node>
-              </node>
-              <node concept="liA8E" id="5AW5JoZbbp4" role="2OqNvi">
-                <ref role="37wK5l" to="lwvz:~SelectionManager.setSelection(org.jetbrains.mps.openapi.model.SNode)" resolve="setSelection" />
-                <node concept="1rXfSq" id="5AW5JoZbbqX" role="37wK5m">
-                  <ref role="37wK5l" node="5AW5JoZaa8O" resolve="getNodeOfRow" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5AW5JoZb6HD" role="1B3o_S" />
-      <node concept="3uibUv" id="5AW5JoZb9Sz" role="1zkMxy">
-        <ref role="3uigEE" to="3ahc:~AbstractCellAction" resolve="AbstractCellAction" />
-      </node>
-    </node>
-    <node concept="2tJIrI" id="5AW5JoZwO8W" role="jymVt" />
-    <node concept="312cEu" id="5AW5JoZCzaO" role="jymVt">
-      <property role="2bfB8j" value="true" />
-      <property role="TrG5h" value="PasteAction" />
-      <node concept="2tJIrI" id="5AW5JoZC_J5" role="jymVt" />
-      <node concept="3clFb_" id="5AW5JoZDd8b" role="jymVt">
-        <property role="1EzhhJ" value="false" />
-        <property role="TrG5h" value="canExecute" />
-        <property role="DiZV1" value="false" />
-        <node concept="3Tm1VV" id="5AW5JoZDd8c" role="1B3o_S" />
-        <node concept="10P_77" id="5AW5JoZDd8e" role="3clF45" />
-        <node concept="37vLTG" id="5AW5JoZDd8f" role="3clF46">
-          <property role="TrG5h" value="context" />
-          <node concept="3uibUv" id="5AW5JoZDd8g" role="1tU5fm">
-            <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
-          </node>
-        </node>
-        <node concept="3clFbS" id="5AW5JoZDd8h" role="3clF47">
-          <node concept="3cpWs8" id="5AW5JoZDdtB" role="3cqZAp">
-            <node concept="3cpWsn" id="5AW5JoZDdtC" role="3cpWs9">
-              <property role="TrG5h" value="nodeOfRow" />
-              <node concept="3Tqbb2" id="5AW5JoZDdtD" role="1tU5fm" />
-              <node concept="1rXfSq" id="5AW5JoZDdtE" role="33vP2m">
-                <ref role="37wK5l" node="5AW5JoZaa8O" resolve="getNodeOfRow" />
-              </node>
-            </node>
-          </node>
-          <node concept="3clFbJ" id="5AW5JoZDdtF" role="3cqZAp">
-            <node concept="3clFbS" id="5AW5JoZDdtG" role="3clFbx">
-              <node concept="3cpWs6" id="5AW5JoZDdtH" role="3cqZAp">
-                <node concept="3clFbT" id="5AW5JoZDdWk" role="3cqZAk">
-                  <property role="3clFbU" value="false" />
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbC" id="5AW5JoZDdtI" role="3clFbw">
-              <node concept="10Nm6u" id="5AW5JoZDdtJ" role="3uHU7w" />
-              <node concept="37vLTw" id="5AW5JoZDdtK" role="3uHU7B">
-                <ref role="3cqZAo" node="5AW5JoZDdtC" resolve="nodeOfRow" />
-              </node>
-            </node>
-          </node>
-          <node concept="3clFbJ" id="5AW5JoZGCuI" role="3cqZAp">
-            <node concept="3clFbS" id="5AW5JoZGCuL" role="3clFbx">
-              <node concept="3cpWs6" id="5AW5JoZGDty" role="3cqZAp">
-                <node concept="3clFbT" id="5AW5JoZGDA0" role="3cqZAk">
-                  <property role="3clFbU" value="false" />
-                </node>
-              </node>
-            </node>
-            <node concept="3fqX7Q" id="6$f9FDeDenA" role="3clFbw">
-              <node concept="2OqwBi" id="6$f9FDeDenC" role="3fr31v">
-                <node concept="2OqwBi" id="6$f9FDeDenD" role="2Oq$k0">
-                  <node concept="37vLTw" id="6$f9FDeDenE" role="2Oq$k0">
-                    <ref role="3cqZAo" node="5AW5JoZDdtC" resolve="nodeOfRow" />
-                  </node>
-                  <node concept="2NL2c5" id="6$f9FDeDenF" role="2OqNvi" />
-                </node>
-                <node concept="liA8E" id="6$f9FDeDenG" role="2OqNvi">
-                  <ref role="37wK5l" to="c17a:~SAbstractLink.isMultiple()" resolve="isMultiple" />
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3clFbH" id="5AW5JoZGEFJ" role="3cqZAp" />
-          <node concept="3cpWs8" id="5AW5JoZGEjw" role="3cqZAp">
-            <node concept="3cpWsn" id="5AW5JoZGEjx" role="3cpWs9">
-              <property role="TrG5h" value="pasteNodeData" />
-              <node concept="3uibUv" id="5AW5JoZGEjy" role="1tU5fm">
-                <ref role="3uigEE" to="qzxn:~PasteNodeData" resolve="PasteNodeData" />
-              </node>
-              <node concept="2YIFZM" id="5AW5JoZGEjz" role="33vP2m">
-                <ref role="1Pybhc" to="dp1x:5tGs5KqKfGH" resolve="CopyPasteUtil" />
-                <ref role="37wK5l" to="dp1x:5tGs5KqKiKf" resolve="getPasteNodeDataFromClipboard" />
-                <node concept="2OqwBi" id="5AW5JoZGEj$" role="37wK5m">
-                  <node concept="1rXfSq" id="5AW5JoZGEj_" role="2Oq$k0">
-                    <ref role="37wK5l" to="g51k:~EditorCell_Basic.getSNode()" resolve="getSNode" />
-                  </node>
-                  <node concept="liA8E" id="5AW5JoZGEjA" role="2OqNvi">
-                    <ref role="37wK5l" to="mhbf:~SNode.getModel()" resolve="getModel" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3cpWs8" id="5AW5JoZGRhF" role="3cqZAp">
-            <node concept="3cpWsn" id="5AW5JoZGRhG" role="3cpWs9">
-              <property role="TrG5h" value="nodesToPaste" />
-              <node concept="_YKpA" id="5AW5JoZGRhH" role="1tU5fm">
-                <node concept="3Tqbb2" id="5AW5JoZGRhI" role="_ZDj9" />
-              </node>
-              <node concept="2OqwBi" id="5AW5JoZGRhJ" role="33vP2m">
-                <node concept="37vLTw" id="5AW5JoZGRhK" role="2Oq$k0">
-                  <ref role="3cqZAo" node="5AW5JoZGEjx" resolve="pasteNodeData" />
-                </node>
-                <node concept="liA8E" id="5AW5JoZGRhL" role="2OqNvi">
-                  <ref role="37wK5l" to="qzxn:~PasteNodeData.getNodes()" resolve="getNodes" />
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3cpWs8" id="5AW5JoZGMEz" role="3cqZAp">
-            <node concept="3cpWsn" id="5AW5JoZGMEA" role="3cpWs9">
-              <property role="TrG5h" value="targetConcept" />
-              <node concept="3bZ5Sz" id="1a1JAUSCaXd" role="1tU5fm" />
-              <node concept="2OqwBi" id="5AW5JoZGNX4" role="33vP2m">
-                <node concept="2OqwBi" id="5AW5JoZGNdq" role="2Oq$k0">
-                  <node concept="37vLTw" id="5AW5JoZGNaG" role="2Oq$k0">
-                    <ref role="3cqZAo" node="5AW5JoZDdtC" resolve="nodeOfRow" />
-                  </node>
-                  <node concept="2NL2c5" id="6$f9FDeDfma" role="2OqNvi" />
-                </node>
-                <node concept="liA8E" id="6$f9FDeDfPV" role="2OqNvi">
-                  <ref role="37wK5l" to="c17a:~SAbstractLink.getTargetConcept()" resolve="getTargetConcept" />
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="2Gpval" id="5AW5JoZGFQC" role="3cqZAp">
-            <node concept="2GrKxI" id="5AW5JoZGFQE" role="2Gsz3X">
-              <property role="TrG5h" value="nodeToPaste" />
-            </node>
-            <node concept="3clFbS" id="5AW5JoZGFQI" role="2LFqv$">
-              <node concept="3clFbJ" id="5AW5JoZGHqr" role="3cqZAp">
-                <property role="TyiWK" value="true" />
-                <property role="TyiWL" value="false" />
-                <node concept="3clFbS" id="5AW5JoZGHqs" role="3clFbx">
-                  <node concept="3cpWs6" id="5AW5JoZGUql" role="3cqZAp">
-                    <node concept="3clFbT" id="5AW5JoZGUR0" role="3cqZAk">
-                      <property role="3clFbU" value="false" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="3fqX7Q" id="5AW5JoZGUhV" role="3clFbw">
-                  <node concept="2OqwBi" id="5AW5JoZGUhX" role="3fr31v">
-                    <node concept="2OqwBi" id="5AW5JoZGUhY" role="2Oq$k0">
-                      <node concept="2GrUjf" id="5AW5JoZGUhZ" role="2Oq$k0">
-                        <ref role="2Gs0qQ" node="5AW5JoZGFQE" resolve="nodeToPaste" />
-                      </node>
-                      <node concept="2yIwOk" id="1a1JAUSC7yl" role="2OqNvi" />
-                    </node>
-                    <node concept="2Zo12i" id="5AW5JoZGUi1" role="2OqNvi">
-                      <node concept="25Kdxt" id="5AW5JoZGUi2" role="2Zo12j">
-                        <node concept="37vLTw" id="5AW5JoZGUi3" role="25KhWn">
-                          <ref role="3cqZAo" node="5AW5JoZGMEA" resolve="targetConcept" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="37vLTw" id="5AW5JoZGSkb" role="2GsD0m">
-              <ref role="3cqZAo" node="5AW5JoZGRhG" resolve="nodesToPaste" />
-            </node>
-          </node>
-          <node concept="3cpWs6" id="5AW5JoZGWkb" role="3cqZAp">
-            <node concept="3clFbT" id="5AW5JoZGWSR" role="3cqZAk">
-              <property role="3clFbU" value="true" />
-            </node>
-          </node>
-        </node>
-        <node concept="2AHcQZ" id="5AW5JoZDd8i" role="2AJF6D">
-          <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-        </node>
-      </node>
-      <node concept="3clFb_" id="5AW5JoZCT0u" role="jymVt">
-        <property role="1EzhhJ" value="false" />
-        <property role="TrG5h" value="execute" />
-        <property role="DiZV1" value="false" />
-        <node concept="3Tm1VV" id="5AW5JoZCT0v" role="1B3o_S" />
-        <node concept="3cqZAl" id="5AW5JoZCT0x" role="3clF45" />
-        <node concept="37vLTG" id="5AW5JoZCT0y" role="3clF46">
-          <property role="TrG5h" value="context" />
-          <node concept="3uibUv" id="5AW5JoZCT0z" role="1tU5fm">
-            <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
-          </node>
-        </node>
-        <node concept="3clFbS" id="5AW5JoZCT0A" role="3clF47">
-          <node concept="3cpWs8" id="5AW5JoZCTeG" role="3cqZAp">
-            <node concept="3cpWsn" id="5AW5JoZCTeJ" role="3cpWs9">
-              <property role="TrG5h" value="nodeOfRow" />
-              <node concept="3Tqbb2" id="5AW5JoZCTeF" role="1tU5fm" />
-              <node concept="1rXfSq" id="5AW5JoZCTik" role="33vP2m">
-                <ref role="37wK5l" node="5AW5JoZaa8O" resolve="getNodeOfRow" />
-              </node>
-            </node>
-          </node>
-          <node concept="3clFbJ" id="5AW5JoZCTpL" role="3cqZAp">
-            <node concept="3clFbS" id="5AW5JoZCTpO" role="3clFbx">
-              <node concept="3cpWs6" id="5AW5JoZCTwc" role="3cqZAp" />
-            </node>
-            <node concept="3clFbC" id="5AW5JoZCTuc" role="3clFbw">
-              <node concept="10Nm6u" id="5AW5JoZCTvm" role="3uHU7w" />
-              <node concept="37vLTw" id="5AW5JoZCTrH" role="3uHU7B">
-                <ref role="3cqZAo" node="5AW5JoZCTeJ" resolve="nodeOfRow" />
-              </node>
-            </node>
-          </node>
-          <node concept="3clFbH" id="5AW5JoZDjcZ" role="3cqZAp" />
-          <node concept="3cpWs8" id="5AW5JoZDmP3" role="3cqZAp">
-            <node concept="3cpWsn" id="5AW5JoZDmP4" role="3cpWs9">
-              <property role="TrG5h" value="pasteNodeData" />
-              <node concept="3uibUv" id="5AW5JoZDmP5" role="1tU5fm">
-                <ref role="3uigEE" to="qzxn:~PasteNodeData" resolve="PasteNodeData" />
-              </node>
-              <node concept="2YIFZM" id="5AW5JoZDAXv" role="33vP2m">
-                <ref role="1Pybhc" to="dp1x:5tGs5KqKfGH" resolve="CopyPasteUtil" />
-                <ref role="37wK5l" to="dp1x:5tGs5KqKiKf" resolve="getPasteNodeDataFromClipboard" />
-                <node concept="2OqwBi" id="5AW5JoZDEyY" role="37wK5m">
-                  <node concept="1rXfSq" id="5AW5JoZDEpX" role="2Oq$k0">
-                    <ref role="37wK5l" to="g51k:~EditorCell_Basic.getSNode()" resolve="getSNode" />
-                  </node>
-                  <node concept="liA8E" id="5AW5JoZDETk" role="2OqNvi">
-                    <ref role="37wK5l" to="mhbf:~SNode.getModel()" resolve="getModel" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3cpWs8" id="5AW5JoZDSEp" role="3cqZAp">
-            <node concept="3cpWsn" id="5AW5JoZDSEs" role="3cpWs9">
-              <property role="TrG5h" value="nodesToPaste" />
-              <node concept="_YKpA" id="5AW5JoZDSEl" role="1tU5fm">
-                <node concept="3Tqbb2" id="5AW5JoZDSWH" role="_ZDj9" />
-              </node>
-              <node concept="2OqwBi" id="5AW5JoZDT5F" role="33vP2m">
-                <node concept="37vLTw" id="5AW5JoZDT3C" role="2Oq$k0">
-                  <ref role="3cqZAo" node="5AW5JoZDmP4" resolve="pasteNodeData" />
-                </node>
-                <node concept="liA8E" id="5AW5JoZDTzh" role="2OqNvi">
-                  <ref role="37wK5l" to="qzxn:~PasteNodeData.getNodes()" resolve="getNodes" />
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3clFbJ" id="5AW5JoZE96C" role="3cqZAp">
-            <property role="TyiWK" value="false" />
-            <property role="TyiWL" value="true" />
-            <node concept="3clFbS" id="5AW5JoZE96F" role="3clFbx">
-              <node concept="3clFbF" id="5AW5JoZE9Ha" role="3cqZAp">
-                <node concept="37vLTI" id="5AW5JoZEakB" role="3clFbG">
-                  <node concept="2OqwBi" id="5AW5JoZEaY5" role="37vLTx">
-                    <node concept="37vLTw" id="5AW5JoZEamS" role="2Oq$k0">
-                      <ref role="3cqZAo" node="5AW5JoZDSEs" resolve="nodesToPaste" />
-                    </node>
-                    <node concept="35Qw8J" id="5AW5JoZEfTS" role="2OqNvi" />
-                  </node>
-                  <node concept="37vLTw" id="5AW5JoZE9H9" role="37vLTJ">
-                    <ref role="3cqZAo" node="5AW5JoZDSEs" resolve="nodesToPaste" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3fqX7Q" id="5AW5JoZE9xq" role="3clFbw">
-              <node concept="37vLTw" id="5AW5JoZE9xs" role="3fr31v">
-                <ref role="3cqZAo" node="12WeXpXn$48" resolve="myLeftEnd" />
-              </node>
-            </node>
-          </node>
-          <node concept="2Gpval" id="5AW5JoZDIqy" role="3cqZAp">
-            <node concept="2GrKxI" id="5AW5JoZDIq$" role="2Gsz3X">
-              <property role="TrG5h" value="nodeToPaste" />
-            </node>
-            <node concept="37vLTw" id="1a1JAUSDHqA" role="2GsD0m">
-              <ref role="3cqZAo" node="5AW5JoZDSEs" resolve="nodesToPaste" />
-            </node>
-            <node concept="3clFbS" id="5AW5JoZDIqC" role="2LFqv$">
-              <node concept="3clFbJ" id="5AW5JoZDUdg" role="3cqZAp">
-                <node concept="3clFbS" id="5AW5JoZDUdh" role="3clFbx">
-                  <node concept="3clFbF" id="5AW5JoZDUkV" role="3cqZAp">
-                    <node concept="2OqwBi" id="5AW5JoZDUne" role="3clFbG">
-                      <node concept="37vLTw" id="5AW5JoZDUkU" role="2Oq$k0">
-                        <ref role="3cqZAo" node="5AW5JoZCTeJ" resolve="nodeOfRow" />
-                      </node>
-                      <node concept="HtX7F" id="5AW5JoZDUN$" role="2OqNvi">
-                        <node concept="2GrUjf" id="5AW5JoZDUSH" role="HtX7I">
-                          <ref role="2Gs0qQ" node="5AW5JoZDIq$" resolve="nodeToPaste" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="37vLTw" id="5AW5JoZDUe7" role="3clFbw">
-                  <ref role="3cqZAo" node="12WeXpXn$48" resolve="myLeftEnd" />
-                </node>
-                <node concept="9aQIb" id="5AW5JoZDUTr" role="9aQIa">
-                  <node concept="3clFbS" id="5AW5JoZDUTs" role="9aQI4">
-                    <node concept="3clFbF" id="5AW5JoZE4Rb" role="3cqZAp">
-                      <node concept="2OqwBi" id="5AW5JoZE4Tg" role="3clFbG">
-                        <node concept="37vLTw" id="5AW5JoZE4Ra" role="2Oq$k0">
-                          <ref role="3cqZAo" node="5AW5JoZCTeJ" resolve="nodeOfRow" />
-                        </node>
-                        <node concept="HtI8k" id="5AW5JoZE5lq" role="2OqNvi">
-                          <node concept="2GrUjf" id="5AW5JoZE95i" role="HtI8F">
-                            <ref role="2Gs0qQ" node="5AW5JoZDIq$" resolve="nodeToPaste" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5AW5JoZCzaP" role="1B3o_S" />
-      <node concept="3uibUv" id="5AW5JoZC_yV" role="1zkMxy">
-        <ref role="3uigEE" to="3ahc:~AbstractCellAction" resolve="AbstractCellAction" />
-      </node>
-    </node>
-    <node concept="2tJIrI" id="5AW5JoZCxcK" role="jymVt" />
-    <node concept="3clFb_" id="5AW5JoZaa8O" role="jymVt">
-      <property role="1EzhhJ" value="false" />
-      <property role="TrG5h" value="getNodeOfRow" />
-      <property role="od$2w" value="false" />
-      <property role="DiZV1" value="false" />
-      <node concept="3clFbS" id="5AW5JoZaa8R" role="3clF47">
-        <node concept="3cpWs8" id="5AW5JoZac2n" role="3cqZAp">
-          <node concept="3cpWsn" id="5AW5JoZac2o" role="3cpWs9">
-            <property role="TrG5h" value="gridCell" />
-            <node concept="3uibUv" id="5AW5JoZac2p" role="1tU5fm">
-              <ref role="3uigEE" node="20OswHE0eA6" resolve="EditorCell_GridCell" />
-            </node>
-            <node concept="10QFUN" id="5AW5JoZac2q" role="33vP2m">
-              <node concept="3uibUv" id="5AW5JoZac2r" role="10QFUM">
-                <ref role="3uigEE" node="20OswHE0eA6" resolve="EditorCell_GridCell" />
-              </node>
-              <node concept="2YIFZM" id="5AW5JoZac2s" role="10QFUP">
-                <ref role="1Pybhc" node="4gCFRNz2KOM" resolve="TableTraversalUtil" />
-                <ref role="37wK5l" node="12WeXpXvbfw" resolve="getParent" />
-                <node concept="Xjq3P" id="5AW5JoZac2t" role="37wK5m">
-                  <ref role="1HBi2w" node="4db20qfqb8U" resolve="RowEndCell" />
-                </node>
-                <node concept="10M0yZ" id="7Nzu1McDW7a" role="37wK5m">
-                  <ref role="1PxDUh" node="4db20qfqb8U" resolve="RowEndCell" />
-                  <ref role="3cqZAo" node="12WeXpXuQQi" resolve="GRID_CELL" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbJ" id="5AW5JoZzAX2" role="3cqZAp">
-          <node concept="3clFbS" id="5AW5JoZzAX5" role="3clFbx">
-            <node concept="3cpWs6" id="5AW5JoZzE1R" role="3cqZAp">
-              <node concept="10Nm6u" id="5AW5JoZzFdy" role="3cqZAk" />
-            </node>
-          </node>
-          <node concept="3clFbC" id="5AW5JoZzDtA" role="3clFbw">
-            <node concept="10Nm6u" id="5AW5JoZzE04" role="3uHU7w" />
-            <node concept="37vLTw" id="5AW5JoZzCwM" role="3uHU7B">
-              <ref role="3cqZAo" node="5AW5JoZac2o" resolve="gridCell" />
-            </node>
-          </node>
-        </node>
-        <node concept="3cpWs8" id="5AW5JoZac2H" role="3cqZAp">
-          <node concept="3cpWsn" id="5AW5JoZac2I" role="3cpWs9">
-            <property role="TrG5h" value="grid" />
-            <node concept="3uibUv" id="6eBFmDEE_UA" role="1tU5fm">
-              <ref role="3uigEE" to="6dpw:7C0FR5Aonzr" resolve="Grid" />
-            </node>
-            <node concept="2EnYce" id="5AW5JoZzG_J" role="33vP2m">
-              <node concept="2OqwBi" id="5AW5JoZac2L" role="2Oq$k0">
-                <node concept="37vLTw" id="5AW5JoZac2M" role="2Oq$k0">
-                  <ref role="3cqZAo" node="5AW5JoZac2o" resolve="gridCell" />
-                </node>
-                <node concept="liA8E" id="5AW5JoZac2N" role="2OqNvi">
-                  <ref role="37wK5l" node="4gCFRNzc0za" resolve="getTable" />
-                </node>
-              </node>
-              <node concept="liA8E" id="5AW5JoZac2O" role="2OqNvi">
-                <ref role="37wK5l" node="7Nzu1McBs8f" resolve="getGrid" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbJ" id="5AW5JoZzIwU" role="3cqZAp">
-          <node concept="3clFbS" id="5AW5JoZzIwX" role="3clFbx">
-            <node concept="3cpWs6" id="5AW5JoZzL5M" role="3cqZAp">
-              <node concept="10Nm6u" id="5AW5JoZzMi9" role="3cqZAk" />
-            </node>
-          </node>
-          <node concept="3clFbC" id="5AW5JoZzKwZ" role="3clFbw">
-            <node concept="10Nm6u" id="5AW5JoZzL3V" role="3uHU7w" />
-            <node concept="37vLTw" id="5AW5JoZzJWR" role="3uHU7B">
-              <ref role="3cqZAo" node="5AW5JoZac2I" resolve="grid" />
-            </node>
-          </node>
-        </node>
-        <node concept="3cpWs8" id="5AW5JoZac2P" role="3cqZAp">
-          <node concept="3cpWsn" id="5AW5JoZac2Q" role="3cpWs9">
-            <property role="TrG5h" value="myPosition" />
-            <node concept="3uibUv" id="5AW5JoZac2R" role="1tU5fm">
-              <ref role="3uigEE" to="sse1:20OswHE0h3P" resolve="GridPosition" />
-            </node>
-            <node concept="2OqwBi" id="5AW5JoZac2S" role="33vP2m">
-              <node concept="37vLTw" id="5AW5JoZac2T" role="2Oq$k0">
-                <ref role="3cqZAo" node="5AW5JoZac2o" resolve="gridCell" />
-              </node>
-              <node concept="liA8E" id="5AW5JoZac2U" role="2OqNvi">
-                <ref role="37wK5l" node="4gCFRNz3a7W" resolve="getGridPosition" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3cpWs8" id="5AW5JoZac2V" role="3cqZAp">
-          <node concept="3cpWsn" id="5AW5JoZac2W" role="3cpWs9">
-            <property role="TrG5h" value="nextPos" />
-            <node concept="3uibUv" id="5AW5JoZac2X" role="1tU5fm">
-              <ref role="3uigEE" to="sse1:20OswHE0h3P" resolve="GridPosition" />
-            </node>
-            <node concept="37vLTw" id="5AW5JoZac2Y" role="33vP2m">
-              <ref role="3cqZAo" node="5AW5JoZac2Q" resolve="myPosition" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbH" id="5AW5JoZac2Z" role="3cqZAp" />
-        <node concept="3cpWs8" id="5AW5JoZac30" role="3cqZAp">
-          <node concept="3cpWsn" id="5AW5JoZac31" role="3cpWs9">
-            <property role="TrG5h" value="nodesInRow" />
-            <node concept="2hMVRd" id="5AW5JoZac32" role="1tU5fm">
-              <node concept="3Tqbb2" id="5AW5JoZac33" role="2hN53Y" />
-            </node>
-            <node concept="2ShNRf" id="5AW5JoZac34" role="33vP2m">
-              <node concept="2i4dXS" id="5AW5JoZac35" role="2ShVmc">
-                <node concept="3Tqbb2" id="5AW5JoZac36" role="HW$YZ" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbH" id="5AW5JoZac37" role="3cqZAp" />
-        <node concept="1Dw8fO" id="5AW5JoZac38" role="3cqZAp">
-          <node concept="3clFbS" id="5AW5JoZac39" role="2LFqv$">
-            <node concept="3cpWs8" id="5AW5JoZac3a" role="3cqZAp">
-              <node concept="3cpWsn" id="5AW5JoZac3b" role="3cpWs9">
-                <property role="TrG5h" value="currentCell" />
-                <node concept="3uibUv" id="5AW5JoZac3c" role="1tU5fm">
-                  <ref role="3uigEE" node="20OswHE0eA6" resolve="EditorCell_GridCell" />
-                </node>
-                <node concept="10QFUN" id="5AW5JoZac3d" role="33vP2m">
-                  <node concept="3uibUv" id="5AW5JoZac3e" role="10QFUM">
-                    <ref role="3uigEE" node="20OswHE0eA6" resolve="EditorCell_GridCell" />
-                  </node>
-                  <node concept="2EnYce" id="6_jcnh_ruwW" role="10QFUP">
-                    <node concept="0kSF2" id="2vJRo8ghULc" role="2Oq$k0">
-                      <node concept="3uibUv" id="2vJRo8gigmd" role="0kSFW">
-                        <ref role="3uigEE" to="6dpw:RywcYwuxY_" resolve="EditorCellGridLeaf" />
-                      </node>
-                      <node concept="2OqwBi" id="5AW5JoZac3f" role="0kSFX">
-                        <node concept="37vLTw" id="5AW5JoZac3g" role="2Oq$k0">
-                          <ref role="3cqZAo" node="5AW5JoZac2I" resolve="grid" />
-                        </node>
-                        <node concept="liA8E" id="5AW5JoZac3h" role="2OqNvi">
-                          <ref role="37wK5l" to="6dpw:4UkcdCtMnDB" resolve="getElement" />
-                          <node concept="37vLTw" id="5AW5JoZac3i" role="37wK5m">
-                            <ref role="3cqZAo" node="5AW5JoZac3t" resolve="x" />
-                          </node>
-                          <node concept="2OqwBi" id="5AW5JoZac3j" role="37wK5m">
-                            <node concept="37vLTw" id="5AW5JoZac3k" role="2Oq$k0">
-                              <ref role="3cqZAo" node="5AW5JoZac2Q" resolve="myPosition" />
-                            </node>
-                            <node concept="liA8E" id="5AW5JoZac3l" role="2OqNvi">
-                              <ref role="37wK5l" to="sse1:GrM9mu4M1z" resolve="getY" />
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="liA8E" id="2vJRo8gihEf" role="2OqNvi">
-                      <ref role="37wK5l" to="6dpw:RywcYwuxZ4" resolve="getEditorCell" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbJ" id="5wgIeCrcuMs" role="3cqZAp">
-              <node concept="3clFbS" id="5wgIeCrcuMv" role="3clFbx">
-                <node concept="3N13vt" id="5wgIeCrcvEr" role="3cqZAp" />
-              </node>
-              <node concept="3clFbC" id="5wgIeCrcvCp" role="3clFbw">
-                <node concept="10Nm6u" id="5wgIeCrcvDi" role="3uHU7w" />
-                <node concept="37vLTw" id="5wgIeCrcvdX" role="3uHU7B">
-                  <ref role="3cqZAo" node="5AW5JoZac3b" resolve="currentCell" />
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbF" id="5AW5JoZac3m" role="3cqZAp">
-              <node concept="2OqwBi" id="5AW5JoZac3n" role="3clFbG">
-                <node concept="37vLTw" id="5AW5JoZac3o" role="2Oq$k0">
-                  <ref role="3cqZAo" node="5AW5JoZac31" resolve="nodesInRow" />
-                </node>
-                <node concept="TSZUe" id="5AW5JoZac3p" role="2OqNvi">
-                  <node concept="2OqwBi" id="5AW5JoZac3q" role="25WWJ7">
-                    <node concept="2OqwBi" id="6sRTg7sjczh" role="2Oq$k0">
-                      <node concept="37vLTw" id="5AW5JoZac3r" role="2Oq$k0">
-                        <ref role="3cqZAo" node="5AW5JoZac3b" resolve="currentCell" />
-                      </node>
-                      <node concept="liA8E" id="6sRTg7sjeF1" role="2OqNvi">
-                        <ref role="37wK5l" node="20OswHE1rOJ" resolve="getWrappedCell" />
-                      </node>
-                    </node>
-                    <node concept="liA8E" id="5AW5JoZac3s" role="2OqNvi">
-                      <ref role="37wK5l" to="f4zo:~EditorCell.getSNode()" resolve="getSNode" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3cpWsn" id="5AW5JoZac3t" role="1Duv9x">
-            <property role="TrG5h" value="x" />
-            <node concept="10Oyi0" id="5AW5JoZac3u" role="1tU5fm" />
-            <node concept="3cmrfG" id="5AW5JoZac3v" role="33vP2m">
-              <property role="3cmrfH" value="0" />
-            </node>
-          </node>
-          <node concept="3eOVzh" id="5AW5JoZac3w" role="1Dwp0S">
-            <node concept="2OqwBi" id="5AW5JoZac3x" role="3uHU7w">
-              <node concept="37vLTw" id="5AW5JoZac3y" role="2Oq$k0">
-                <ref role="3cqZAo" node="5AW5JoZac2I" resolve="grid" />
-              </node>
-              <node concept="liA8E" id="5AW5JoZac3z" role="2OqNvi">
-                <ref role="37wK5l" to="6dpw:6tOcB$JGRTs" resolve="getSizeX" />
-              </node>
-            </node>
-            <node concept="37vLTw" id="5AW5JoZac3$" role="3uHU7B">
-              <ref role="3cqZAo" node="5AW5JoZac3t" resolve="x" />
-            </node>
-          </node>
-          <node concept="3uNrnE" id="5AW5JoZac3_" role="1Dwrff">
-            <node concept="37vLTw" id="5AW5JoZac3A" role="2$L3a6">
-              <ref role="3cqZAo" node="5AW5JoZac3t" resolve="x" />
-            </node>
-          </node>
-        </node>
-        <node concept="3cpWs8" id="5AW5JoZac3B" role="3cqZAp">
-          <node concept="3cpWsn" id="5AW5JoZac3C" role="3cpWs9">
-            <property role="TrG5h" value="nodeOfTable" />
-            <node concept="3Tqbb2" id="5AW5JoZac3D" role="1tU5fm" />
-            <node concept="2EnYce" id="5wgIeCrcCz9" role="33vP2m">
-              <node concept="2OqwBi" id="5AW5JoZac3F" role="2Oq$k0">
-                <node concept="37vLTw" id="5AW5JoZac3G" role="2Oq$k0">
-                  <ref role="3cqZAo" node="5AW5JoZac2o" resolve="gridCell" />
-                </node>
-                <node concept="liA8E" id="5AW5JoZac3H" role="2OqNvi">
-                  <ref role="37wK5l" node="4gCFRNzc0za" resolve="getTable" />
-                </node>
-              </node>
-              <node concept="liA8E" id="5AW5JoZac3I" role="2OqNvi">
-                <ref role="37wK5l" to="g51k:~EditorCell_Basic.getSNode()" resolve="getSNode" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="5AW5JoZac3J" role="3cqZAp">
-          <node concept="2OqwBi" id="5AW5JoZac3K" role="3clFbG">
-            <node concept="37vLTw" id="5AW5JoZac3L" role="2Oq$k0">
-              <ref role="3cqZAo" node="5AW5JoZac31" resolve="nodesInRow" />
-            </node>
-            <node concept="3dhRuq" id="5AW5JoZac3M" role="2OqNvi">
-              <node concept="37vLTw" id="5AW5JoZac3N" role="25WWJ7">
-                <ref role="3cqZAo" node="5AW5JoZac3C" resolve="nodeOfTable" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3cpWs8" id="5AW5JoZac3O" role="3cqZAp">
-          <node concept="3cpWsn" id="5AW5JoZac3P" role="3cpWs9">
-            <property role="TrG5h" value="lca" />
-            <node concept="3Tqbb2" id="5AW5JoZac3Q" role="1tU5fm" />
-            <node concept="1rXfSq" id="5AW5JoZac3R" role="33vP2m">
-              <ref role="37wK5l" node="40oIQyHJ4hI" resolve="getLowestCommonAncestor" />
-              <node concept="37vLTw" id="5AW5JoZac3S" role="37wK5m">
-                <ref role="3cqZAo" node="5AW5JoZac31" resolve="nodesInRow" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3cpWs6" id="5AW5JoZawtz" role="3cqZAp">
-          <node concept="3K4zz7" id="5AW5JoZaEkZ" role="3cqZAk">
-            <node concept="10Nm6u" id="5AW5JoZaGoA" role="3K4E3e" />
-            <node concept="37vLTw" id="5AW5JoZaIgR" role="3K4GZi">
-              <ref role="3cqZAo" node="5AW5JoZac3P" resolve="lca" />
-            </node>
-            <node concept="3clFbC" id="5AW5JoZaA3b" role="3K4Cdx">
-              <node concept="37vLTw" id="5AW5JoZaCbG" role="3uHU7w">
-                <ref role="3cqZAo" node="5AW5JoZac3C" resolve="nodeOfTable" />
-              </node>
-              <node concept="37vLTw" id="5AW5JoZazPT" role="3uHU7B">
-                <ref role="3cqZAo" node="5AW5JoZac3P" resolve="lca" />
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm6S6" id="5AW5JoZa8u3" role="1B3o_S" />
-      <node concept="3Tqbb2" id="5AW5JoZaa3U" role="3clF45" />
-    </node>
-    <node concept="2tJIrI" id="5AW5JoZwC6k" role="jymVt" />
-    <node concept="3clFb_" id="40oIQyHJ4hI" role="jymVt">
-      <property role="TrG5h" value="getLowestCommonAncestor" />
-      <node concept="37vLTG" id="40oIQyHJi_P" role="3clF46">
-        <property role="TrG5h" value="descendants" />
-        <node concept="3vKaQO" id="40oIQyHJk5h" role="1tU5fm">
-          <node concept="3Tqbb2" id="40oIQyHJkbK" role="3O5elw" />
-        </node>
-      </node>
-      <node concept="3Tqbb2" id="40oIQyHJ7Ml" role="3clF45" />
-      <node concept="3Tm6S6" id="40oIQyHJ5RQ" role="1B3o_S" />
-      <node concept="3clFbS" id="40oIQyHJ4hM" role="3clF47">
-        <node concept="3cpWs8" id="40oIQyHK9Ur" role="3cqZAp">
-          <node concept="3cpWsn" id="40oIQyHK9Uu" role="3cpWs9">
-            <property role="TrG5h" value="candidate" />
-            <node concept="3Tqbb2" id="40oIQyHK9Up" role="1tU5fm" />
-            <node concept="2OqwBi" id="40oIQyHKcae" role="33vP2m">
-              <node concept="37vLTw" id="40oIQyHKbmV" role="2Oq$k0">
-                <ref role="3cqZAo" node="40oIQyHJi_P" resolve="descendants" />
-              </node>
-              <node concept="1uHKPH" id="40oIQyHKdGZ" role="2OqNvi" />
-            </node>
-          </node>
-        </node>
-        <node concept="2$JKZl" id="40oIQyHKfsH" role="3cqZAp">
-          <node concept="3clFbS" id="40oIQyHKfsJ" role="2LFqv$">
-            <node concept="3cpWs8" id="40oIQyHKgOt" role="3cqZAp">
-              <node concept="3cpWsn" id="40oIQyHKgOw" role="3cpWs9">
-                <property role="TrG5h" value="ancestorOfAll" />
-                <node concept="10P_77" id="40oIQyHKgOs" role="1tU5fm" />
-                <node concept="3clFbT" id="40oIQyHKgXo" role="33vP2m">
-                  <property role="3clFbU" value="true" />
-                </node>
-              </node>
-            </node>
-            <node concept="2Gpval" id="40oIQyHKgZC" role="3cqZAp">
-              <node concept="2GrKxI" id="40oIQyHKgZE" role="2Gsz3X">
-                <property role="TrG5h" value="descendant" />
-              </node>
-              <node concept="37vLTw" id="40oIQyHKh5U" role="2GsD0m">
-                <ref role="3cqZAo" node="40oIQyHJi_P" resolve="descendants" />
-              </node>
-              <node concept="3clFbS" id="40oIQyHKgZI" role="2LFqv$">
-                <node concept="3clFbJ" id="40oIQyHKvjo" role="3cqZAp">
-                  <node concept="3clFbS" id="40oIQyHKvjp" role="3clFbx">
-                    <node concept="3clFbF" id="40oIQyHKvMj" role="3cqZAp">
-                      <node concept="37vLTI" id="40oIQyHKw61" role="3clFbG">
-                        <node concept="3clFbT" id="40oIQyHKw6D" role="37vLTx">
-                          <property role="3clFbU" value="false" />
-                        </node>
-                        <node concept="37vLTw" id="40oIQyHKvMi" role="37vLTJ">
-                          <ref role="3cqZAo" node="40oIQyHKgOw" resolve="ancestorOfAll" />
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="3zACq4" id="40oIQyHKwb0" role="3cqZAp" />
-                  </node>
-                  <node concept="1Wc70l" id="40oIQyHTpsj" role="3clFbw">
-                    <node concept="3y3z36" id="40oIQyHTpGW" role="3uHU7B">
-                      <node concept="2GrUjf" id="40oIQyHTpM1" role="3uHU7w">
-                        <ref role="2Gs0qQ" node="40oIQyHKgZE" resolve="descendant" />
-                      </node>
-                      <node concept="37vLTw" id="40oIQyHTpzO" role="3uHU7B">
-                        <ref role="3cqZAo" node="40oIQyHK9Uu" resolve="candidate" />
-                      </node>
-                    </node>
-                    <node concept="3fqX7Q" id="40oIQyHKvFH" role="3uHU7w">
-                      <node concept="2OqwBi" id="40oIQyHKvFJ" role="3fr31v">
-                        <node concept="2OqwBi" id="40oIQyHKvFK" role="2Oq$k0">
-                          <node concept="2GrUjf" id="40oIQyHKvFL" role="2Oq$k0">
-                            <ref role="2Gs0qQ" node="40oIQyHKgZE" resolve="descendant" />
-                          </node>
-                          <node concept="z$bX8" id="40oIQyHKvFM" role="2OqNvi" />
-                        </node>
-                        <node concept="3JPx81" id="40oIQyHKvFN" role="2OqNvi">
-                          <node concept="37vLTw" id="40oIQyHKvFO" role="25WWJ7">
-                            <ref role="3cqZAo" node="40oIQyHK9Uu" resolve="candidate" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbJ" id="40oIQyHKwcO" role="3cqZAp">
-              <node concept="3clFbS" id="40oIQyHKwcR" role="3clFbx">
-                <node concept="3cpWs6" id="40oIQyHKwfA" role="3cqZAp">
-                  <node concept="37vLTw" id="40oIQyHKxMJ" role="3cqZAk">
-                    <ref role="3cqZAo" node="40oIQyHK9Uu" resolve="candidate" />
-                  </node>
-                </node>
-              </node>
-              <node concept="37vLTw" id="40oIQyHKweE" role="3clFbw">
-                <ref role="3cqZAo" node="40oIQyHKgOw" resolve="ancestorOfAll" />
-              </node>
-            </node>
-            <node concept="3clFbF" id="40oIQyHK_xL" role="3cqZAp">
-              <node concept="37vLTI" id="40oIQyHKB9b" role="3clFbG">
-                <node concept="2OqwBi" id="40oIQyHKBg0" role="37vLTx">
-                  <node concept="37vLTw" id="40oIQyHKBaM" role="2Oq$k0">
-                    <ref role="3cqZAo" node="40oIQyHK9Uu" resolve="candidate" />
-                  </node>
-                  <node concept="1mfA1w" id="40oIQyHKBDv" role="2OqNvi" />
-                </node>
-                <node concept="37vLTw" id="40oIQyHK_xK" role="37vLTJ">
-                  <ref role="3cqZAo" node="40oIQyHK9Uu" resolve="candidate" />
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3y3z36" id="40oIQyHKgM6" role="2$JKZa">
-            <node concept="10Nm6u" id="40oIQyHKgNz" role="3uHU7w" />
-            <node concept="37vLTw" id="40oIQyHKgGw" role="3uHU7B">
-              <ref role="3cqZAo" node="40oIQyHK9Uu" resolve="candidate" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbH" id="40oIQyHKdIN" role="3cqZAp" />
-        <node concept="3cpWs6" id="40oIQyHJltH" role="3cqZAp">
-          <node concept="10Nm6u" id="40oIQyHJnhD" role="3cqZAk" />
-        </node>
       </node>
     </node>
     <node concept="3Tm1VV" id="4db20qfqb8V" role="1B3o_S" />
@@ -34794,6 +34281,851 @@
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
+  </node>
+  <node concept="312cEu" id="7IUya7cfCUM">
+    <property role="TrG5h" value="TableActions" />
+    <node concept="2tJIrI" id="7IUya7cfFbM" role="jymVt" />
+    <node concept="312cEu" id="7IUya7ch5ON" role="jymVt">
+      <property role="TrG5h" value="AbstractTableCellAction" />
+      <property role="1sVAO0" value="true" />
+      <node concept="2tJIrI" id="7IUya7chjKU" role="jymVt" />
+      <node concept="312cEg" id="7IUya7chwf5" role="jymVt">
+        <property role="TrG5h" value="cell" />
+        <node concept="3Tm6S6" id="7IUya7ci1k8" role="1B3o_S" />
+        <node concept="3uibUv" id="7IUya7chwf7" role="1tU5fm">
+          <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+        </node>
+      </node>
+      <node concept="2tJIrI" id="7IUya7chv3U" role="jymVt" />
+      <node concept="3clFbW" id="7IUya7chrcn" role="jymVt">
+        <node concept="3cqZAl" id="7IUya7chrco" role="3clF45" />
+        <node concept="3clFbS" id="7IUya7chrcq" role="3clF47">
+          <node concept="3clFbF" id="7IUya7chT8i" role="3cqZAp">
+            <node concept="37vLTI" id="7IUya7chUyd" role="3clFbG">
+              <node concept="37vLTw" id="7IUya7chV3A" role="37vLTx">
+                <ref role="3cqZAo" node="7IUya7chsvz" resolve="cell" />
+              </node>
+              <node concept="2OqwBi" id="7IUya7chTh0" role="37vLTJ">
+                <node concept="Xjq3P" id="7IUya7chT8h" role="2Oq$k0" />
+                <node concept="2OwXpG" id="7IUya7chTZS" role="2OqNvi">
+                  <ref role="2Oxat5" node="7IUya7chwf5" resolve="cell" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3Tm1VV" id="7IUya7chrcr" role="1B3o_S" />
+        <node concept="37vLTG" id="7IUya7chsvz" role="3clF46">
+          <property role="TrG5h" value="cell" />
+          <node concept="3uibUv" id="7IUya7chsvy" role="1tU5fm">
+            <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+          </node>
+        </node>
+      </node>
+      <node concept="2tJIrI" id="7IUya7chGH_" role="jymVt" />
+      <node concept="3clFb_" id="7IUya7cczGL" role="jymVt">
+        <property role="TrG5h" value="getGridCell" />
+        <node concept="3clFbS" id="7IUya7cczGO" role="3clF47">
+          <node concept="3clFbF" id="7IUya7ccA1t" role="3cqZAp">
+            <node concept="10QFUN" id="5AW5JoZac2q" role="3clFbG">
+              <node concept="3uibUv" id="5AW5JoZac2r" role="10QFUM">
+                <ref role="3uigEE" node="20OswHE0eA6" resolve="EditorCell_GridCell" />
+              </node>
+              <node concept="2YIFZM" id="5AW5JoZac2s" role="10QFUP">
+                <ref role="1Pybhc" node="4gCFRNz2KOM" resolve="TableTraversalUtil" />
+                <ref role="37wK5l" node="12WeXpXvbfw" resolve="getParent" />
+                <node concept="37vLTw" id="7IUya7chJup" role="37wK5m">
+                  <ref role="3cqZAo" node="7IUya7chwf5" resolve="cell" />
+                </node>
+                <node concept="10M0yZ" id="7IUya7ceoKj" role="37wK5m">
+                  <ref role="1PxDUh" node="4gCFRNz2KOM" resolve="TableTraversalUtil" />
+                  <ref role="3cqZAo" node="12WeXpXuQQi" resolve="GRID_CELL" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3Tm1VV" id="7IUya7ccuac" role="1B3o_S" />
+        <node concept="3uibUv" id="7IUya7ccwGD" role="3clF45">
+          <ref role="3uigEE" node="20OswHE0eA6" resolve="EditorCell_GridCell" />
+        </node>
+      </node>
+      <node concept="2tJIrI" id="7DPEkiwPvBo" role="jymVt" />
+      <node concept="3clFb_" id="7DPEkiwPwCE" role="jymVt">
+        <property role="TrG5h" value="getTableEditor" />
+        <node concept="3clFbS" id="7DPEkiwPwCF" role="3clF47">
+          <node concept="3clFbF" id="7DPEkiwPwCG" role="3cqZAp">
+            <node concept="10QFUN" id="7DPEkiwPwCH" role="3clFbG">
+              <node concept="3uibUv" id="7DPEkiwPwCI" role="10QFUM">
+                <ref role="3uigEE" node="1dAqnm8$zBn" resolve="TableEditor" />
+              </node>
+              <node concept="2YIFZM" id="7DPEkiwPwCJ" role="10QFUP">
+                <ref role="1Pybhc" node="4gCFRNz2KOM" resolve="TableTraversalUtil" />
+                <ref role="37wK5l" node="12WeXpXvbfw" resolve="getParent" />
+                <node concept="37vLTw" id="7DPEkiwPwCK" role="37wK5m">
+                  <ref role="3cqZAo" node="7IUya7chwf5" resolve="cell" />
+                </node>
+                <node concept="10M0yZ" id="7DPEkiwP_RS" role="37wK5m">
+                  <ref role="3cqZAo" node="7DPEkiwJO$g" resolve="TABLE_EDITOR" />
+                  <ref role="1PxDUh" node="4gCFRNz2KOM" resolve="TableTraversalUtil" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3Tm1VV" id="7DPEkiwPwCM" role="1B3o_S" />
+        <node concept="3uibUv" id="7DPEkiwPwCN" role="3clF45">
+          <ref role="3uigEE" node="1dAqnm8$zBn" resolve="TableEditor" />
+        </node>
+      </node>
+      <node concept="2tJIrI" id="7DPEkiwPvCr" role="jymVt" />
+      <node concept="2tJIrI" id="7IUya7chQat" role="jymVt" />
+      <node concept="3clFb_" id="7IUya7ccS5V" role="jymVt">
+        <property role="TrG5h" value="getNodeOfRow" />
+        <node concept="3clFbS" id="7IUya7ccS5Y" role="3clF47">
+          <node concept="3clFbF" id="7IUya7ccUy1" role="3cqZAp">
+            <node concept="2YIFZM" id="7IUya7ccUy3" role="3clFbG">
+              <ref role="37wK5l" node="7IUya7c4DQS" resolve="getNodeOfRowNode" />
+              <ref role="1Pybhc" node="6tOcB$JKlIC" resolve="TableUtils" />
+              <node concept="1rXfSq" id="7IUya7ccUy4" role="37wK5m">
+                <ref role="37wK5l" node="7IUya7cczGL" resolve="getGridCell" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3Tm1VV" id="7IUya7ccLO8" role="1B3o_S" />
+        <node concept="3Tqbb2" id="7IUya7ccORn" role="3clF45" />
+      </node>
+      <node concept="2tJIrI" id="7IUya7ci1kb" role="jymVt" />
+      <node concept="3clFb_" id="7IUya7ci41k" role="jymVt">
+        <property role="TrG5h" value="getEditorCell" />
+        <node concept="3clFbS" id="7IUya7ci41n" role="3clF47">
+          <node concept="3clFbF" id="7IUya7ci5O2" role="3cqZAp">
+            <node concept="37vLTw" id="7IUya7ci5O1" role="3clFbG">
+              <ref role="3cqZAo" node="7IUya7chwf5" resolve="cell" />
+            </node>
+          </node>
+        </node>
+        <node concept="3Tm1VV" id="7IUya7ci2sw" role="1B3o_S" />
+        <node concept="3uibUv" id="7IUya7ci3wG" role="3clF45">
+          <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+        </node>
+      </node>
+      <node concept="2tJIrI" id="7IUya7cjdxg" role="jymVt" />
+      <node concept="2tJIrI" id="7IUya7cjdxX" role="jymVt" />
+      <node concept="3Tm1VV" id="7IUya7ch29M" role="1B3o_S" />
+      <node concept="3uibUv" id="7IUya7chcjg" role="1zkMxy">
+        <ref role="3uigEE" to="3ahc:~AbstractCellAction" resolve="AbstractCellAction" />
+      </node>
+      <node concept="3clFb_" id="7IUya7cjexf" role="jymVt">
+        <property role="TrG5h" value="canExecute" />
+        <node concept="3Tm1VV" id="7IUya7cjexg" role="1B3o_S" />
+        <node concept="10P_77" id="7IUya7cjexi" role="3clF45" />
+        <node concept="37vLTG" id="7IUya7cjexj" role="3clF46">
+          <property role="TrG5h" value="context" />
+          <node concept="3uibUv" id="7IUya7cjexk" role="1tU5fm">
+            <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+          </node>
+        </node>
+        <node concept="3clFbS" id="7IUya7cjexl" role="3clF47">
+          <node concept="3cpWs8" id="1Q$LIXOlMEZ" role="3cqZAp">
+            <node concept="3cpWsn" id="1Q$LIXOlMF0" role="3cpWs9">
+              <property role="TrG5h" value="gridCell" />
+              <node concept="3uibUv" id="1Q$LIXOlM4I" role="1tU5fm">
+                <ref role="3uigEE" node="20OswHE0eA6" resolve="EditorCell_GridCell" />
+              </node>
+              <node concept="1rXfSq" id="1Q$LIXOlMF1" role="33vP2m">
+                <ref role="37wK5l" node="7IUya7cczGL" resolve="getGridCell" />
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="7DPEkiwPE2h" role="3cqZAp">
+            <node concept="3cpWsn" id="7DPEkiwPE2i" role="3cpWs9">
+              <property role="TrG5h" value="tableEditor" />
+              <node concept="3uibUv" id="7DPEkiwPDqk" role="1tU5fm">
+                <ref role="3uigEE" node="1dAqnm8$zBn" resolve="TableEditor" />
+              </node>
+              <node concept="1rXfSq" id="7DPEkiwPE2j" role="33vP2m">
+                <ref role="37wK5l" node="7DPEkiwPwCE" resolve="getTableEditor" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="7IUya7cjhEe" role="3cqZAp">
+            <node concept="1Wc70l" id="7DPEkiwPLQ0" role="3clFbG">
+              <node concept="2OqwBi" id="7DPEkiwPONM" role="3uHU7w">
+                <node concept="37vLTw" id="7DPEkiwPNBt" role="2Oq$k0">
+                  <ref role="3cqZAo" node="7DPEkiwPE2i" resolve="tableEditor" />
+                </node>
+                <node concept="liA8E" id="7DPEkiwPQFl" role="2OqNvi">
+                  <ref role="37wK5l" node="7DPEkiwNldl" resolve="rowUIActionsAllowed" />
+                </node>
+              </node>
+              <node concept="1Wc70l" id="7DPEkiwPFYO" role="3uHU7B">
+                <node concept="1Wc70l" id="1Q$LIXOlKJL" role="3uHU7B">
+                  <node concept="3y3z36" id="7IUya7cjjjU" role="3uHU7B">
+                    <node concept="37vLTw" id="1Q$LIXOlMF2" role="3uHU7B">
+                      <ref role="3cqZAo" node="1Q$LIXOlMF0" resolve="gridCell" />
+                    </node>
+                    <node concept="10Nm6u" id="7IUya7cjla6" role="3uHU7w" />
+                  </node>
+                  <node concept="3y3z36" id="1Q$LIXOlHZ7" role="3uHU7w">
+                    <node concept="2YIFZM" id="1Q$LIXOlHmp" role="3uHU7B">
+                      <ref role="1Pybhc" node="6tOcB$JKlIC" resolve="TableUtils" />
+                      <ref role="37wK5l" node="7IUya7c4DQS" resolve="getNodeOfRowNode" />
+                      <node concept="37vLTw" id="1Q$LIXOlMF3" role="37wK5m">
+                        <ref role="3cqZAo" node="1Q$LIXOlMF0" resolve="gridCell" />
+                      </node>
+                    </node>
+                    <node concept="10Nm6u" id="1Q$LIXOlIvs" role="3uHU7w" />
+                  </node>
+                </node>
+                <node concept="3y3z36" id="7DPEkiwPIT8" role="3uHU7w">
+                  <node concept="37vLTw" id="7DPEkiwPH7o" role="3uHU7B">
+                    <ref role="3cqZAo" node="7DPEkiwPE2i" resolve="tableEditor" />
+                  </node>
+                  <node concept="10Nm6u" id="7DPEkiwPKHs" role="3uHU7w" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2AHcQZ" id="7IUya7cjexm" role="2AJF6D">
+          <ref role="2AI5Lk" to="wyt6:~Override" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="7IUya7cgZJl" role="jymVt" />
+    <node concept="312cEu" id="4db20qfqg3Y" role="jymVt">
+      <property role="TrG5h" value="InsertAction" />
+      <node concept="2tJIrI" id="7IUya7cfHyk" role="jymVt" />
+      <node concept="312cEg" id="7IUya7cfP4l" role="jymVt">
+        <property role="TrG5h" value="leftSide" />
+        <node concept="3Tm6S6" id="7IUya7cfOd7" role="1B3o_S" />
+        <node concept="10P_77" id="7IUya7cfONW" role="1tU5fm" />
+      </node>
+      <node concept="2tJIrI" id="7IUya7cfNjK" role="jymVt" />
+      <node concept="3clFbW" id="7IUya7cfM4j" role="jymVt">
+        <node concept="3cqZAl" id="7IUya7cfM4k" role="3clF45" />
+        <node concept="3clFbS" id="7IUya7cfM4m" role="3clF47">
+          <node concept="XkiVB" id="7IUya7chYfC" role="3cqZAp">
+            <ref role="37wK5l" node="7IUya7chrcn" resolve="AbstractTableCellAction" />
+            <node concept="37vLTw" id="7IUya7chZ4v" role="37wK5m">
+              <ref role="3cqZAo" node="7IUya7cfRzt" resolve="cell" />
+            </node>
+          </node>
+          <node concept="3clFbF" id="7IUya7cfQ6s" role="3cqZAp">
+            <node concept="37vLTI" id="7IUya7cfQWB" role="3clFbG">
+              <node concept="37vLTw" id="7IUya7cfRoh" role="37vLTx">
+                <ref role="3cqZAo" node="7IUya7cfN09" resolve="leftSide" />
+              </node>
+              <node concept="2OqwBi" id="7IUya7cfQf4" role="37vLTJ">
+                <node concept="Xjq3P" id="7IUya7cfQ6r" role="2Oq$k0" />
+                <node concept="2OwXpG" id="7IUya7cfQB1" role="2OqNvi">
+                  <ref role="2Oxat5" node="7IUya7cfP4l" resolve="leftSide" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3Tm1VV" id="7IUya7cfM4n" role="1B3o_S" />
+        <node concept="37vLTG" id="7IUya7cfRzt" role="3clF46">
+          <property role="TrG5h" value="cell" />
+          <node concept="3uibUv" id="7IUya7cfRR5" role="1tU5fm">
+            <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+          </node>
+        </node>
+        <node concept="37vLTG" id="7IUya7cfN09" role="3clF46">
+          <property role="TrG5h" value="leftSide" />
+          <node concept="10P_77" id="7IUya7cfN08" role="1tU5fm" />
+        </node>
+      </node>
+      <node concept="2tJIrI" id="7IUya7cfHOe" role="jymVt" />
+      <node concept="3clFb_" id="4db20qfqkmQ" role="jymVt">
+        <property role="1EzhhJ" value="false" />
+        <property role="TrG5h" value="execute" />
+        <property role="DiZV1" value="false" />
+        <node concept="3Tm1VV" id="4db20qfqkmR" role="1B3o_S" />
+        <node concept="3cqZAl" id="4db20qfqkmT" role="3clF45" />
+        <node concept="37vLTG" id="4db20qfqkmU" role="3clF46">
+          <property role="TrG5h" value="context" />
+          <node concept="3uibUv" id="4db20qfqkmV" role="1tU5fm">
+            <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+          </node>
+        </node>
+        <node concept="3clFbS" id="4db20qfqkmY" role="3clF47">
+          <node concept="3cpWs8" id="7IUya7ckKxo" role="3cqZAp">
+            <node concept="3cpWsn" id="7IUya7ckKxp" role="3cpWs9">
+              <property role="TrG5h" value="nodeOfRow" />
+              <node concept="3Tqbb2" id="7IUya7ckKxq" role="1tU5fm" />
+              <node concept="2YIFZM" id="7IUya7ckKxr" role="33vP2m">
+                <ref role="1Pybhc" node="6tOcB$JKlIC" resolve="TableUtils" />
+                <ref role="37wK5l" node="7IUya7c4DQS" resolve="getNodeOfRowNode" />
+                <node concept="1rXfSq" id="7IUya7ckKxs" role="37wK5m">
+                  <ref role="37wK5l" node="7IUya7cczGL" resolve="getGridCell" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbJ" id="7IUya7ckLrE" role="3cqZAp">
+            <node concept="3clFbS" id="7IUya7ckLrG" role="3clFbx">
+              <node concept="3clFbF" id="7IUya7ckMkv" role="3cqZAp">
+                <node concept="2OqwBi" id="7IUya7ckMBF" role="3clFbG">
+                  <node concept="37vLTw" id="7IUya7ckMkt" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7IUya7ckKxp" resolve="nodeOfRow" />
+                  </node>
+                  <node concept="HtX7F" id="7IUya7ckN0p" role="2OqNvi">
+                    <node concept="2OqwBi" id="F5PM1gashf" role="HtX7I">
+                      <node concept="2OqwBi" id="F5PM1garF7" role="2Oq$k0">
+                        <node concept="37vLTw" id="F5PM1garry" role="2Oq$k0">
+                          <ref role="3cqZAo" node="7IUya7ckKxp" resolve="nodeOfRow" />
+                        </node>
+                        <node concept="2yIwOk" id="F5PM1gas4U" role="2OqNvi" />
+                      </node>
+                      <node concept="LFhST" id="F5PM1gasQH" role="2OqNvi" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="37vLTw" id="7IUya7ckLE3" role="3clFbw">
+              <ref role="3cqZAo" node="7IUya7cfP4l" resolve="leftSide" />
+            </node>
+            <node concept="9aQIb" id="F5PM1gat1y" role="9aQIa">
+              <node concept="3clFbS" id="F5PM1gat1z" role="9aQI4">
+                <node concept="3clFbF" id="F5PM1gatb3" role="3cqZAp">
+                  <node concept="2OqwBi" id="F5PM1gatb4" role="3clFbG">
+                    <node concept="37vLTw" id="F5PM1gatb5" role="2Oq$k0">
+                      <ref role="3cqZAo" node="7IUya7ckKxp" resolve="nodeOfRow" />
+                    </node>
+                    <node concept="HtI8k" id="F5PM1gatpa" role="2OqNvi">
+                      <node concept="2OqwBi" id="F5PM1gat$o" role="HtI8F">
+                        <node concept="2OqwBi" id="F5PM1gat$p" role="2Oq$k0">
+                          <node concept="37vLTw" id="F5PM1gat$q" role="2Oq$k0">
+                            <ref role="3cqZAo" node="7IUya7ckKxp" resolve="nodeOfRow" />
+                          </node>
+                          <node concept="2yIwOk" id="F5PM1gat$r" role="2OqNvi" />
+                        </node>
+                        <node concept="LFhST" id="F5PM1gat$s" role="2OqNvi" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="7IUya7cfFCG" role="1B3o_S" />
+      <node concept="3uibUv" id="7IUya7chVZy" role="1zkMxy">
+        <ref role="3uigEE" node="7IUya7ch5ON" resolve="AbstractTableCellAction" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="7IUya7cfFbO" role="jymVt" />
+    <node concept="312cEu" id="5AW5JoZb6HC" role="jymVt">
+      <property role="TrG5h" value="SelectRowNodeAction" />
+      <node concept="3clFbW" id="7IUya7ciXQl" role="jymVt">
+        <node concept="3cqZAl" id="7IUya7ciXQm" role="3clF45" />
+        <node concept="3Tm1VV" id="7IUya7ciXQu" role="1B3o_S" />
+        <node concept="37vLTG" id="7IUya7ciXQv" role="3clF46">
+          <property role="TrG5h" value="cell" />
+          <node concept="3uibUv" id="7IUya7ciXQw" role="1tU5fm">
+            <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+          </node>
+        </node>
+        <node concept="3clFbS" id="7IUya7ciXQx" role="3clF47">
+          <node concept="XkiVB" id="7IUya7ciXQy" role="3cqZAp">
+            <ref role="37wK5l" node="7IUya7chrcn" resolve="AbstractTableCellAction" />
+            <node concept="37vLTw" id="7IUya7ciXQz" role="37wK5m">
+              <ref role="3cqZAo" node="7IUya7ciXQv" resolve="cell" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2tJIrI" id="7IUya7ciYkP" role="jymVt" />
+      <node concept="3clFb_" id="5AW5JoZbc1A" role="jymVt">
+        <property role="1EzhhJ" value="false" />
+        <property role="TrG5h" value="canExecute" />
+        <property role="DiZV1" value="false" />
+        <node concept="3Tm1VV" id="5AW5JoZbc1B" role="1B3o_S" />
+        <node concept="10P_77" id="5AW5JoZbc1D" role="3clF45" />
+        <node concept="37vLTG" id="5AW5JoZbc1E" role="3clF46">
+          <property role="TrG5h" value="context" />
+          <node concept="3uibUv" id="5AW5JoZbc1F" role="1tU5fm">
+            <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+          </node>
+        </node>
+        <node concept="3clFbS" id="5AW5JoZbc1G" role="3clF47">
+          <node concept="3clFbF" id="5AW5JoZbclS" role="3cqZAp">
+            <node concept="3y3z36" id="5AW5JoZbctG" role="3clFbG">
+              <node concept="10Nm6u" id="5AW5JoZbc$F" role="3uHU7w" />
+              <node concept="1rXfSq" id="5AW5JoZbclR" role="3uHU7B">
+                <ref role="37wK5l" node="7IUya7ccS5V" resolve="getNodeOfRow" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2AHcQZ" id="5AW5JoZbc1H" role="2AJF6D">
+          <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+        </node>
+      </node>
+      <node concept="3clFb_" id="5AW5JoZba6F" role="jymVt">
+        <property role="1EzhhJ" value="false" />
+        <property role="TrG5h" value="execute" />
+        <property role="DiZV1" value="false" />
+        <node concept="3Tm1VV" id="5AW5JoZba6G" role="1B3o_S" />
+        <node concept="3cqZAl" id="5AW5JoZba6H" role="3clF45" />
+        <node concept="37vLTG" id="5AW5JoZba6I" role="3clF46">
+          <property role="TrG5h" value="context" />
+          <node concept="3uibUv" id="5AW5JoZba6J" role="1tU5fm">
+            <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+          </node>
+        </node>
+        <node concept="3clFbS" id="5AW5JoZba6K" role="3clF47">
+          <node concept="3clFbF" id="5AW5JoZbaoE" role="3cqZAp">
+            <node concept="2OqwBi" id="5AW5JoZbaTa" role="3clFbG">
+              <node concept="2OqwBi" id="5AW5JoZbaqB" role="2Oq$k0">
+                <node concept="37vLTw" id="5AW5JoZbaoD" role="2Oq$k0">
+                  <ref role="3cqZAo" node="5AW5JoZba6I" resolve="context" />
+                </node>
+                <node concept="liA8E" id="5AW5JoZbaRN" role="2OqNvi">
+                  <ref role="37wK5l" to="cj4x:~EditorContext.getSelectionManager()" resolve="getSelectionManager" />
+                </node>
+              </node>
+              <node concept="liA8E" id="5AW5JoZbbp4" role="2OqNvi">
+                <ref role="37wK5l" to="lwvz:~SelectionManager.setSelection(org.jetbrains.mps.openapi.model.SNode)" resolve="setSelection" />
+                <node concept="1rXfSq" id="5AW5JoZbbqX" role="37wK5m">
+                  <ref role="37wK5l" node="7IUya7ccS5V" resolve="getNodeOfRow" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="5AW5JoZb6HD" role="1B3o_S" />
+      <node concept="3uibUv" id="7IUya7cik3F" role="1zkMxy">
+        <ref role="3uigEE" node="7IUya7ch5ON" resolve="AbstractTableCellAction" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="7IUya7cgA7G" role="jymVt" />
+    <node concept="312cEu" id="5AW5JoZCzaO" role="jymVt">
+      <property role="TrG5h" value="PasteAction" />
+      <node concept="2tJIrI" id="5AW5JoZC_J5" role="jymVt" />
+      <node concept="312cEg" id="7IUya7ci_FD" role="jymVt">
+        <property role="TrG5h" value="leftSide" />
+        <node concept="3Tm6S6" id="7IUya7ci$fS" role="1B3o_S" />
+        <node concept="10P_77" id="7IUya7ci_0y" role="1tU5fm" />
+      </node>
+      <node concept="2tJIrI" id="7IUya7cizM5" role="jymVt" />
+      <node concept="3clFbW" id="7IUya7cix5V" role="jymVt">
+        <node concept="3cqZAl" id="7IUya7cix5W" role="3clF45" />
+        <node concept="3clFbS" id="7IUya7cix5Y" role="3clF47">
+          <node concept="XkiVB" id="7IUya7ciN1Y" role="3cqZAp">
+            <ref role="37wK5l" node="7IUya7chrcn" resolve="AbstractTableCellAction" />
+            <node concept="37vLTw" id="7IUya7ciNyi" role="37wK5m">
+              <ref role="3cqZAo" node="7IUya7ciKjU" resolve="cell" />
+            </node>
+          </node>
+          <node concept="3clFbF" id="7IUya7ciBr3" role="3cqZAp">
+            <node concept="37vLTI" id="7IUya7ciCUk" role="3clFbG">
+              <node concept="37vLTw" id="7IUya7ciDDV" role="37vLTx">
+                <ref role="3cqZAo" node="7IUya7ciyC_" resolve="leftSide" />
+              </node>
+              <node concept="2OqwBi" id="7IUya7ciB_Q" role="37vLTJ">
+                <node concept="Xjq3P" id="7IUya7ciBr2" role="2Oq$k0" />
+                <node concept="2OwXpG" id="7IUya7ciCtN" role="2OqNvi">
+                  <ref role="2Oxat5" node="7IUya7ci_FD" resolve="leftSide" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3Tm1VV" id="7IUya7cix5Z" role="1B3o_S" />
+        <node concept="37vLTG" id="7IUya7ciKjU" role="3clF46">
+          <property role="TrG5h" value="cell" />
+          <node concept="3uibUv" id="7IUya7ciKT3" role="1tU5fm">
+            <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+          </node>
+        </node>
+        <node concept="37vLTG" id="7IUya7ciyC_" role="3clF46">
+          <property role="TrG5h" value="leftSide" />
+          <node concept="10P_77" id="7IUya7ciyC$" role="1tU5fm" />
+        </node>
+      </node>
+      <node concept="2tJIrI" id="7IUya7cimRi" role="jymVt" />
+      <node concept="3clFb_" id="5AW5JoZDd8b" role="jymVt">
+        <property role="1EzhhJ" value="false" />
+        <property role="TrG5h" value="canExecute" />
+        <property role="DiZV1" value="false" />
+        <node concept="3Tm1VV" id="5AW5JoZDd8c" role="1B3o_S" />
+        <node concept="10P_77" id="5AW5JoZDd8e" role="3clF45" />
+        <node concept="37vLTG" id="5AW5JoZDd8f" role="3clF46">
+          <property role="TrG5h" value="context" />
+          <node concept="3uibUv" id="5AW5JoZDd8g" role="1tU5fm">
+            <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+          </node>
+        </node>
+        <node concept="3clFbS" id="5AW5JoZDd8h" role="3clF47">
+          <node concept="3cpWs8" id="5AW5JoZDdtB" role="3cqZAp">
+            <node concept="3cpWsn" id="5AW5JoZDdtC" role="3cpWs9">
+              <property role="TrG5h" value="nodeOfRow" />
+              <node concept="3Tqbb2" id="5AW5JoZDdtD" role="1tU5fm" />
+              <node concept="1rXfSq" id="5AW5JoZDdtE" role="33vP2m">
+                <ref role="37wK5l" node="7IUya7ccS5V" resolve="getNodeOfRow" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbJ" id="5AW5JoZDdtF" role="3cqZAp">
+            <node concept="3clFbS" id="5AW5JoZDdtG" role="3clFbx">
+              <node concept="3cpWs6" id="5AW5JoZDdtH" role="3cqZAp">
+                <node concept="3clFbT" id="5AW5JoZDdWk" role="3cqZAk">
+                  <property role="3clFbU" value="false" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbC" id="5AW5JoZDdtI" role="3clFbw">
+              <node concept="10Nm6u" id="5AW5JoZDdtJ" role="3uHU7w" />
+              <node concept="37vLTw" id="5AW5JoZDdtK" role="3uHU7B">
+                <ref role="3cqZAo" node="5AW5JoZDdtC" resolve="nodeOfRow" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbJ" id="5AW5JoZGCuI" role="3cqZAp">
+            <node concept="3clFbS" id="5AW5JoZGCuL" role="3clFbx">
+              <node concept="3cpWs6" id="5AW5JoZGDty" role="3cqZAp">
+                <node concept="3clFbT" id="5AW5JoZGDA0" role="3cqZAk">
+                  <property role="3clFbU" value="false" />
+                </node>
+              </node>
+            </node>
+            <node concept="3fqX7Q" id="6$f9FDeDenA" role="3clFbw">
+              <node concept="2OqwBi" id="6$f9FDeDenC" role="3fr31v">
+                <node concept="2OqwBi" id="6$f9FDeDenD" role="2Oq$k0">
+                  <node concept="37vLTw" id="6$f9FDeDenE" role="2Oq$k0">
+                    <ref role="3cqZAo" node="5AW5JoZDdtC" resolve="nodeOfRow" />
+                  </node>
+                  <node concept="2NL2c5" id="6$f9FDeDenF" role="2OqNvi" />
+                </node>
+                <node concept="liA8E" id="6$f9FDeDenG" role="2OqNvi">
+                  <ref role="37wK5l" to="c17a:~SAbstractLink.isMultiple()" resolve="isMultiple" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbH" id="5AW5JoZGEFJ" role="3cqZAp" />
+          <node concept="3cpWs8" id="5AW5JoZGEjw" role="3cqZAp">
+            <node concept="3cpWsn" id="5AW5JoZGEjx" role="3cpWs9">
+              <property role="TrG5h" value="pasteNodeData" />
+              <node concept="3uibUv" id="5AW5JoZGEjy" role="1tU5fm">
+                <ref role="3uigEE" to="qzxn:~PasteNodeData" resolve="PasteNodeData" />
+              </node>
+              <node concept="2YIFZM" id="5AW5JoZGEjz" role="33vP2m">
+                <ref role="37wK5l" to="dp1x:5tGs5KqKiKf" resolve="getPasteNodeDataFromClipboard" />
+                <ref role="1Pybhc" to="dp1x:5tGs5KqKfGH" resolve="CopyPasteUtil" />
+                <node concept="2OqwBi" id="7IUya7citgP" role="37wK5m">
+                  <node concept="2OqwBi" id="7IUya7ciqIy" role="2Oq$k0">
+                    <node concept="1rXfSq" id="7IUya7cipik" role="2Oq$k0">
+                      <ref role="37wK5l" node="7IUya7ci41k" resolve="getEditorCell" />
+                    </node>
+                    <node concept="liA8E" id="7IUya7cis_d" role="2OqNvi">
+                      <ref role="37wK5l" to="f4zo:~EditorCell.getSNode()" resolve="getSNode" />
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="7IUya7ciuLH" role="2OqNvi">
+                    <ref role="37wK5l" to="mhbf:~SNode.getModel()" resolve="getModel" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="5AW5JoZGRhF" role="3cqZAp">
+            <node concept="3cpWsn" id="5AW5JoZGRhG" role="3cpWs9">
+              <property role="TrG5h" value="nodesToPaste" />
+              <node concept="_YKpA" id="5AW5JoZGRhH" role="1tU5fm">
+                <node concept="3Tqbb2" id="5AW5JoZGRhI" role="_ZDj9" />
+              </node>
+              <node concept="2OqwBi" id="5AW5JoZGRhJ" role="33vP2m">
+                <node concept="37vLTw" id="5AW5JoZGRhK" role="2Oq$k0">
+                  <ref role="3cqZAo" node="5AW5JoZGEjx" resolve="pasteNodeData" />
+                </node>
+                <node concept="liA8E" id="5AW5JoZGRhL" role="2OqNvi">
+                  <ref role="37wK5l" to="qzxn:~PasteNodeData.getNodes()" resolve="getNodes" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="5AW5JoZGMEz" role="3cqZAp">
+            <node concept="3cpWsn" id="5AW5JoZGMEA" role="3cpWs9">
+              <property role="TrG5h" value="targetConcept" />
+              <node concept="3bZ5Sz" id="1a1JAUSCaXd" role="1tU5fm" />
+              <node concept="2OqwBi" id="5AW5JoZGNX4" role="33vP2m">
+                <node concept="2OqwBi" id="5AW5JoZGNdq" role="2Oq$k0">
+                  <node concept="37vLTw" id="5AW5JoZGNaG" role="2Oq$k0">
+                    <ref role="3cqZAo" node="5AW5JoZDdtC" resolve="nodeOfRow" />
+                  </node>
+                  <node concept="2NL2c5" id="6$f9FDeDfma" role="2OqNvi" />
+                </node>
+                <node concept="liA8E" id="6$f9FDeDfPV" role="2OqNvi">
+                  <ref role="37wK5l" to="c17a:~SAbstractLink.getTargetConcept()" resolve="getTargetConcept" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2Gpval" id="5AW5JoZGFQC" role="3cqZAp">
+            <node concept="2GrKxI" id="5AW5JoZGFQE" role="2Gsz3X">
+              <property role="TrG5h" value="nodeToPaste" />
+            </node>
+            <node concept="3clFbS" id="5AW5JoZGFQI" role="2LFqv$">
+              <node concept="3clFbJ" id="5AW5JoZGHqr" role="3cqZAp">
+                <property role="TyiWK" value="true" />
+                <property role="TyiWL" value="false" />
+                <node concept="3clFbS" id="5AW5JoZGHqs" role="3clFbx">
+                  <node concept="3cpWs6" id="5AW5JoZGUql" role="3cqZAp">
+                    <node concept="3clFbT" id="5AW5JoZGUR0" role="3cqZAk">
+                      <property role="3clFbU" value="false" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3fqX7Q" id="5AW5JoZGUhV" role="3clFbw">
+                  <node concept="2OqwBi" id="5AW5JoZGUhX" role="3fr31v">
+                    <node concept="2OqwBi" id="5AW5JoZGUhY" role="2Oq$k0">
+                      <node concept="2GrUjf" id="5AW5JoZGUhZ" role="2Oq$k0">
+                        <ref role="2Gs0qQ" node="5AW5JoZGFQE" resolve="nodeToPaste" />
+                      </node>
+                      <node concept="2yIwOk" id="1a1JAUSC7yl" role="2OqNvi" />
+                    </node>
+                    <node concept="2Zo12i" id="5AW5JoZGUi1" role="2OqNvi">
+                      <node concept="25Kdxt" id="5AW5JoZGUi2" role="2Zo12j">
+                        <node concept="37vLTw" id="5AW5JoZGUi3" role="25KhWn">
+                          <ref role="3cqZAo" node="5AW5JoZGMEA" resolve="targetConcept" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="37vLTw" id="5AW5JoZGSkb" role="2GsD0m">
+              <ref role="3cqZAo" node="5AW5JoZGRhG" resolve="nodesToPaste" />
+            </node>
+          </node>
+          <node concept="3cpWs6" id="5AW5JoZGWkb" role="3cqZAp">
+            <node concept="3clFbT" id="5AW5JoZGWSR" role="3cqZAk">
+              <property role="3clFbU" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2AHcQZ" id="5AW5JoZDd8i" role="2AJF6D">
+          <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+        </node>
+      </node>
+      <node concept="3clFb_" id="5AW5JoZCT0u" role="jymVt">
+        <property role="1EzhhJ" value="false" />
+        <property role="TrG5h" value="execute" />
+        <property role="DiZV1" value="false" />
+        <node concept="3Tm1VV" id="5AW5JoZCT0v" role="1B3o_S" />
+        <node concept="3cqZAl" id="5AW5JoZCT0x" role="3clF45" />
+        <node concept="37vLTG" id="5AW5JoZCT0y" role="3clF46">
+          <property role="TrG5h" value="context" />
+          <node concept="3uibUv" id="5AW5JoZCT0z" role="1tU5fm">
+            <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+          </node>
+        </node>
+        <node concept="3clFbS" id="5AW5JoZCT0A" role="3clF47">
+          <node concept="3cpWs8" id="5AW5JoZCTeG" role="3cqZAp">
+            <node concept="3cpWsn" id="5AW5JoZCTeJ" role="3cpWs9">
+              <property role="TrG5h" value="nodeOfRow" />
+              <node concept="3Tqbb2" id="5AW5JoZCTeF" role="1tU5fm" />
+              <node concept="2YIFZM" id="7IUya7ccaom" role="33vP2m">
+                <ref role="1Pybhc" node="6tOcB$JKlIC" resolve="TableUtils" />
+                <ref role="37wK5l" node="7IUya7c4DQS" resolve="getNodeOfRowNode" />
+                <node concept="1rXfSq" id="7IUya7ccEPv" role="37wK5m">
+                  <ref role="37wK5l" node="7IUya7cczGL" resolve="getGridCell" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbJ" id="5AW5JoZCTpL" role="3cqZAp">
+            <node concept="3clFbS" id="5AW5JoZCTpO" role="3clFbx">
+              <node concept="3cpWs6" id="5AW5JoZCTwc" role="3cqZAp" />
+            </node>
+            <node concept="3clFbC" id="5AW5JoZCTuc" role="3clFbw">
+              <node concept="10Nm6u" id="5AW5JoZCTvm" role="3uHU7w" />
+              <node concept="37vLTw" id="5AW5JoZCTrH" role="3uHU7B">
+                <ref role="3cqZAo" node="5AW5JoZCTeJ" resolve="nodeOfRow" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbH" id="5AW5JoZDjcZ" role="3cqZAp" />
+          <node concept="3cpWs8" id="5AW5JoZDmP3" role="3cqZAp">
+            <node concept="3cpWsn" id="5AW5JoZDmP4" role="3cpWs9">
+              <property role="TrG5h" value="pasteNodeData" />
+              <node concept="3uibUv" id="5AW5JoZDmP5" role="1tU5fm">
+                <ref role="3uigEE" to="qzxn:~PasteNodeData" resolve="PasteNodeData" />
+              </node>
+              <node concept="2YIFZM" id="5AW5JoZDAXv" role="33vP2m">
+                <ref role="1Pybhc" to="dp1x:5tGs5KqKfGH" resolve="CopyPasteUtil" />
+                <ref role="37wK5l" to="dp1x:5tGs5KqKiKf" resolve="getPasteNodeDataFromClipboard" />
+                <node concept="2OqwBi" id="7IUya7ciJ6A" role="37wK5m">
+                  <node concept="2OqwBi" id="7IUya7ciJ6B" role="2Oq$k0">
+                    <node concept="1rXfSq" id="7IUya7ciJ6C" role="2Oq$k0">
+                      <ref role="37wK5l" node="7IUya7ci41k" resolve="getEditorCell" />
+                    </node>
+                    <node concept="liA8E" id="7IUya7ciJ6D" role="2OqNvi">
+                      <ref role="37wK5l" to="f4zo:~EditorCell.getSNode()" resolve="getSNode" />
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="7IUya7ciJ6E" role="2OqNvi">
+                    <ref role="37wK5l" to="mhbf:~SNode.getModel()" resolve="getModel" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="5AW5JoZDSEp" role="3cqZAp">
+            <node concept="3cpWsn" id="5AW5JoZDSEs" role="3cpWs9">
+              <property role="TrG5h" value="nodesToPaste" />
+              <node concept="_YKpA" id="5AW5JoZDSEl" role="1tU5fm">
+                <node concept="3Tqbb2" id="5AW5JoZDSWH" role="_ZDj9" />
+              </node>
+              <node concept="2OqwBi" id="5AW5JoZDT5F" role="33vP2m">
+                <node concept="37vLTw" id="5AW5JoZDT3C" role="2Oq$k0">
+                  <ref role="3cqZAo" node="5AW5JoZDmP4" resolve="pasteNodeData" />
+                </node>
+                <node concept="liA8E" id="5AW5JoZDTzh" role="2OqNvi">
+                  <ref role="37wK5l" to="qzxn:~PasteNodeData.getNodes()" resolve="getNodes" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbJ" id="5AW5JoZE96C" role="3cqZAp">
+            <property role="TyiWK" value="false" />
+            <property role="TyiWL" value="true" />
+            <node concept="3clFbS" id="5AW5JoZE96F" role="3clFbx">
+              <node concept="3clFbF" id="5AW5JoZE9Ha" role="3cqZAp">
+                <node concept="37vLTI" id="5AW5JoZEakB" role="3clFbG">
+                  <node concept="2OqwBi" id="5AW5JoZEaY5" role="37vLTx">
+                    <node concept="37vLTw" id="5AW5JoZEamS" role="2Oq$k0">
+                      <ref role="3cqZAo" node="5AW5JoZDSEs" resolve="nodesToPaste" />
+                    </node>
+                    <node concept="35Qw8J" id="5AW5JoZEfTS" role="2OqNvi" />
+                  </node>
+                  <node concept="37vLTw" id="5AW5JoZE9H9" role="37vLTJ">
+                    <ref role="3cqZAo" node="5AW5JoZDSEs" resolve="nodesToPaste" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3fqX7Q" id="5AW5JoZE9xq" role="3clFbw">
+              <node concept="37vLTw" id="7IUya7ciPmb" role="3fr31v">
+                <ref role="3cqZAo" node="7IUya7ci_FD" resolve="leftSide" />
+              </node>
+            </node>
+          </node>
+          <node concept="2Gpval" id="5AW5JoZDIqy" role="3cqZAp">
+            <node concept="2GrKxI" id="5AW5JoZDIq$" role="2Gsz3X">
+              <property role="TrG5h" value="nodeToPaste" />
+            </node>
+            <node concept="37vLTw" id="1a1JAUSDHqA" role="2GsD0m">
+              <ref role="3cqZAo" node="5AW5JoZDSEs" resolve="nodesToPaste" />
+            </node>
+            <node concept="3clFbS" id="5AW5JoZDIqC" role="2LFqv$">
+              <node concept="3clFbJ" id="5AW5JoZDUdg" role="3cqZAp">
+                <node concept="3clFbS" id="5AW5JoZDUdh" role="3clFbx">
+                  <node concept="3clFbF" id="5AW5JoZDUkV" role="3cqZAp">
+                    <node concept="2OqwBi" id="5AW5JoZDUne" role="3clFbG">
+                      <node concept="37vLTw" id="5AW5JoZDUkU" role="2Oq$k0">
+                        <ref role="3cqZAo" node="5AW5JoZCTeJ" resolve="nodeOfRow" />
+                      </node>
+                      <node concept="HtX7F" id="5AW5JoZDUN$" role="2OqNvi">
+                        <node concept="2GrUjf" id="5AW5JoZDUSH" role="HtX7I">
+                          <ref role="2Gs0qQ" node="5AW5JoZDIq$" resolve="nodeToPaste" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="9aQIb" id="5AW5JoZDUTr" role="9aQIa">
+                  <node concept="3clFbS" id="5AW5JoZDUTs" role="9aQI4">
+                    <node concept="3clFbF" id="5AW5JoZE4Rb" role="3cqZAp">
+                      <node concept="2OqwBi" id="5AW5JoZE4Tg" role="3clFbG">
+                        <node concept="37vLTw" id="5AW5JoZE4Ra" role="2Oq$k0">
+                          <ref role="3cqZAo" node="5AW5JoZCTeJ" resolve="nodeOfRow" />
+                        </node>
+                        <node concept="HtI8k" id="5AW5JoZE5lq" role="2OqNvi">
+                          <node concept="2GrUjf" id="5AW5JoZE95i" role="HtI8F">
+                            <ref role="2Gs0qQ" node="5AW5JoZDIq$" resolve="nodeToPaste" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="37vLTw" id="7IUya7ciQSo" role="3clFbw">
+                  <ref role="3cqZAo" node="7IUya7ci_FD" resolve="leftSide" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="5AW5JoZCzaP" role="1B3o_S" />
+      <node concept="3uibUv" id="7IUya7cilrl" role="1zkMxy">
+        <ref role="3uigEE" node="7IUya7ch5ON" resolve="AbstractTableCellAction" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="7IUya7cgFfk" role="jymVt" />
+    <node concept="312cEu" id="40oIQyHH57G" role="jymVt">
+      <property role="TrG5h" value="DeleteAction" />
+      <node concept="2tJIrI" id="7IUya7ciRZk" role="jymVt" />
+      <node concept="3clFbW" id="7IUya7ciSfI" role="jymVt">
+        <node concept="3cqZAl" id="7IUya7ciSfJ" role="3clF45" />
+        <node concept="3clFbS" id="7IUya7ciSfL" role="3clF47">
+          <node concept="XkiVB" id="7IUya7ciSEJ" role="3cqZAp">
+            <ref role="37wK5l" node="7IUya7chrcn" resolve="AbstractTableCellAction" />
+            <node concept="37vLTw" id="7IUya7ciTaX" role="37wK5m">
+              <ref role="3cqZAo" node="7IUya7ciSo5" resolve="cell" />
+            </node>
+          </node>
+        </node>
+        <node concept="3Tm1VV" id="7IUya7ciSfM" role="1B3o_S" />
+        <node concept="37vLTG" id="7IUya7ciSo5" role="3clF46">
+          <property role="TrG5h" value="cell" />
+          <node concept="3uibUv" id="7IUya7ciSo4" role="1tU5fm">
+            <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+          </node>
+        </node>
+      </node>
+      <node concept="2tJIrI" id="7IUya7ciS7B" role="jymVt" />
+      <node concept="3clFb_" id="40oIQyHH57H" role="jymVt">
+        <property role="1EzhhJ" value="false" />
+        <property role="TrG5h" value="execute" />
+        <property role="DiZV1" value="false" />
+        <node concept="3Tm1VV" id="40oIQyHH57I" role="1B3o_S" />
+        <node concept="3cqZAl" id="40oIQyHH57J" role="3clF45" />
+        <node concept="37vLTG" id="40oIQyHH57K" role="3clF46">
+          <property role="TrG5h" value="context" />
+          <node concept="3uibUv" id="40oIQyHH57L" role="1tU5fm">
+            <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+          </node>
+        </node>
+        <node concept="3clFbS" id="40oIQyHH57M" role="3clF47">
+          <node concept="3clFbF" id="5AW5JoZaRHC" role="3cqZAp">
+            <node concept="2OqwBi" id="5AW5JoZaT6h" role="3clFbG">
+              <node concept="1rXfSq" id="5AW5JoZaRHB" role="2Oq$k0">
+                <ref role="37wK5l" node="7IUya7ccS5V" resolve="getNodeOfRow" />
+              </node>
+              <node concept="3YRAZt" id="5AW5JoZaUvp" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="7IUya7cgVB1" role="1B3o_S" />
+      <node concept="3uibUv" id="7IUya7ciRuz" role="1zkMxy">
+        <ref role="3uigEE" node="7IUya7ch5ON" resolve="AbstractTableCellAction" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="7IUya7cgTJe" role="jymVt" />
+    <node concept="3Tm1VV" id="7IUya7cfCUN" role="1B3o_S" />
   </node>
 </model>
 

--- a/code/tables/languages/de.slisson.mps.tables/runtime/models/de/slisson/mps/tables/runtime/plugin.mps
+++ b/code/tables/languages/de.slisson.mps.tables/runtime/models/de/slisson/mps/tables/runtime/plugin.mps
@@ -5,6 +5,9 @@
     <use id="ef7bf5ac-d06c-4342-b11d-e42104eb9343" name="jetbrains.mps.lang.plugin.standalone" version="0" />
     <use id="c0080a47-7e37-4558-bee9-9ae18e690549" name="jetbrains.mps.lang.extension" version="2" />
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
+    <use id="28f9e497-3b42-4291-aeba-0a1039153ab1" name="jetbrains.mps.lang.plugin" version="5" />
+    <use id="774bf8a0-62e5-41e1-af63-f4812e60e48b" name="jetbrains.mps.baseLanguage.checkedDots" version="0" />
+    <use id="c7d5b9dd-a05f-4be2-bc73-f2e16994cc67" name="jetbrains.mps.baseLanguage.lightweightdsl" version="1" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -17,10 +20,66 @@
     <import index="hm5v" ref="r:3d8b4628-659e-4af1-a607-3cc893005b62(de.slisson.mps.tables.runtime.cells)" />
     <import index="9p8b" ref="r:2a738fcb-23b4-4d1d-9f52-870528559e28(de.slisson.mps.tables.runtime.selection)" />
     <import index="6tp1" ref="r:5c0390a8-12e2-407a-ba93-793107153436(de.itemis.mps.selection.runtime.mouse)" />
+    <import index="k3nr" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.ide.editor(MPS.Editor/)" />
+    <import index="sse1" ref="r:caea7020-da0a-4ba8-aff6-69334bbc9e02(de.slisson.mps.tables.runtime.simplegrid)" />
+    <import index="6dpw" ref="r:ea653f2d-c829-4182-b311-a544ef1f4c1f(de.slisson.mps.tables.runtime.gridmodel)" />
+    <import index="qkt" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.actionSystem(MPS.IDEA/)" />
+    <import index="mhfm" ref="3f233e7f-b8a6-46d2-a57f-795d56775243/java:org.jetbrains.annotations(Annotations/)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
+    <import index="fnpx" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.notification(MPS.IDEA/)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
     <import index="90d" ref="r:421d64ed-8024-497f-aeab-8bddeb389dd2(jetbrains.mps.lang.extension.methods)" implicit="true" />
+    <import index="tprs" ref="r:00000000-0000-4000-0000-011c895904a4(jetbrains.mps.ide.actions)" implicit="true" />
   </imports>
   <registry>
+    <language id="982eb8df-2c96-4bd7-9963-11712ea622e5" name="jetbrains.mps.lang.resources">
+      <concept id="2756621024541681849" name="jetbrains.mps.lang.resources.structure.Text" flags="ng" index="1irPie">
+        <property id="2756621024541681854" name="text" index="1irPi9" />
+        <child id="1860120738943552534" name="color" index="3PKjny" />
+      </concept>
+      <concept id="2756621024541674821" name="jetbrains.mps.lang.resources.structure.TextIcon" flags="ng" index="1irR5M">
+        <property id="1358878980655415353" name="iconId" index="2$rrk2" />
+        <child id="2756621024541675110" name="layers" index="1irR9h" />
+      </concept>
+      <concept id="1860120738943552477" name="jetbrains.mps.lang.resources.structure.ColorLiteral" flags="ng" index="3PKj8D">
+        <property id="1860120738943552481" name="val" index="3PKj8l" />
+      </concept>
+    </language>
+    <language id="28f9e497-3b42-4291-aeba-0a1039153ab1" name="jetbrains.mps.lang.plugin">
+      <concept id="1204908117386" name="jetbrains.mps.lang.plugin.structure.Separator" flags="ng" index="2a7GMi" />
+      <concept id="1207145360364" name="jetbrains.mps.lang.plugin.structure.BuildGroupBlock" flags="in" index="fu6FP" />
+      <concept id="1203071646776" name="jetbrains.mps.lang.plugin.structure.ActionDeclaration" flags="ng" index="sE7Ow">
+        <property id="1205250923097" name="caption" index="2uzpH1" />
+        <property id="7458746815261976739" name="requiredAccess" index="2YLI8m" />
+        <child id="1203083196627" name="updateBlock" index="tmbBb" />
+        <child id="1203083461638" name="executeFunction" index="tncku" />
+        <child id="1217413222820" name="parameter" index="1NuT2Z" />
+        <child id="8976425910813834639" name="icon" index="3Uehp1" />
+      </concept>
+      <concept id="1203083511112" name="jetbrains.mps.lang.plugin.structure.ExecuteBlock" flags="in" index="tnohg" />
+      <concept id="1203087890642" name="jetbrains.mps.lang.plugin.structure.ActionGroupDeclaration" flags="ng" index="tC5Ba">
+        <child id="1204991552650" name="modifier" index="2f5YQi" />
+        <child id="1207145245948" name="contents" index="ftER_" />
+      </concept>
+      <concept id="1203088046679" name="jetbrains.mps.lang.plugin.structure.ActionInstance" flags="ng" index="tCFHf">
+        <reference id="1203088061055" name="action" index="tCJdB" />
+      </concept>
+      <concept id="1203092361741" name="jetbrains.mps.lang.plugin.structure.ModificationStatement" flags="lg" index="tT9cl">
+        <reference id="1203092736097" name="modifiedGroup" index="tU$_T" />
+      </concept>
+      <concept id="1227013049127" name="jetbrains.mps.lang.plugin.structure.AddStatement" flags="nn" index="2JFkCU">
+        <child id="1227013166210" name="item" index="2JFLmv" />
+      </concept>
+      <concept id="1205681243813" name="jetbrains.mps.lang.plugin.structure.IsApplicableBlock" flags="in" index="2ScWuX" />
+      <concept id="5538333046911348654" name="jetbrains.mps.lang.plugin.structure.RequiredCondition" flags="ng" index="1oajcY" />
+      <concept id="1217252042208" name="jetbrains.mps.lang.plugin.structure.ActionDataParameterDeclaration" flags="ng" index="1DS2jV">
+        <reference id="1217252646389" name="key" index="1DUlNI" />
+      </concept>
+      <concept id="1217252428768" name="jetbrains.mps.lang.plugin.structure.ActionDataParameterReferenceOperation" flags="nn" index="1DTwFV" />
+      <concept id="1217413147516" name="jetbrains.mps.lang.plugin.structure.ActionParameter" flags="ng" index="1NuADB">
+        <child id="5538333046911298738" name="condition" index="1oa70y" />
+      </concept>
+    </language>
     <language id="ef7bf5ac-d06c-4342-b11d-e42104eb9343" name="jetbrains.mps.lang.plugin.standalone">
       <concept id="7520713872864775836" name="jetbrains.mps.lang.plugin.standalone.structure.StandalonePluginDescriptor" flags="ng" index="2DaZZR" />
     </language>
@@ -44,8 +103,21 @@
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
       </concept>
+      <concept id="1083260308424" name="jetbrains.mps.baseLanguage.structure.EnumConstantReference" flags="nn" index="Rm8GO">
+        <reference id="1083260308426" name="enumConstantDeclaration" index="Rm8GQ" />
+        <reference id="1144432896254" name="enumClass" index="1Px2BO" />
+      </concept>
       <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
         <child id="1145553007750" name="creator" index="2ShVmc" />
+      </concept>
+      <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
+        <child id="1137022507850" name="body" index="2VODD2" />
+      </concept>
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="1182160077978" name="jetbrains.mps.baseLanguage.structure.AnonymousClassCreator" flags="nn" index="YeOm9">
+        <child id="1182160096073" name="cls" index="YeSDq" />
       </concept>
       <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
@@ -64,6 +136,9 @@
       </concept>
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ng" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
       </concept>
       <concept id="1109279763828" name="jetbrains.mps.baseLanguage.structure.TypeVariableDeclaration" flags="ng" index="16euLQ" />
       <concept id="1109279851642" name="jetbrains.mps.baseLanguage.structure.GenericDeclaration" flags="ng" index="16eOlS">
@@ -100,6 +175,9 @@
       </concept>
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
+        <property id="1068580123138" name="value" index="3clFbU" />
       </concept>
       <concept id="1068580123140" name="jetbrains.mps.baseLanguage.structure.ConstructorDeclaration" flags="ig" index="3clFbW" />
       <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
@@ -142,6 +220,9 @@
         <reference id="1116615189566" name="classifier" index="3VsUkX" />
       </concept>
       <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
+      <concept id="1170345865475" name="jetbrains.mps.baseLanguage.structure.AnonymousClass" flags="ig" index="1Y3b0j">
+        <reference id="1170346070688" name="classifier" index="1Y3XeK" />
+      </concept>
     </language>
     <language id="c0080a47-7e37-4558-bee9-9ae18e690549" name="jetbrains.mps.lang.extension">
       <concept id="126958800891274162" name="jetbrains.mps.lang.extension.structure.Extension" flags="ig" index="1lYeZD">
@@ -161,7 +242,16 @@
         <reference id="6478870542308703669" name="decl" index="3tTeZr" />
       </concept>
     </language>
+    <language id="443f4c36-fcf5-4eb6-9500-8d06ed259e3e" name="jetbrains.mps.baseLanguage.classifiers">
+      <concept id="1205752633985" name="jetbrains.mps.baseLanguage.classifiers.structure.ThisClassifierExpression" flags="nn" index="2WthIp" />
+      <concept id="1205756064662" name="jetbrains.mps.baseLanguage.classifiers.structure.IMemberOperation" flags="ng" index="2WEnae">
+        <reference id="1205756909548" name="member" index="2WH_rO" />
+      </concept>
+    </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+      </concept>
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
@@ -539,6 +629,400 @@
       <node concept="q3mfm" id="4imEbjrwYw1" role="3clF45">
         <ref role="q3mfh" to="90d:3zLwYDe0sv$" />
         <ref role="1QQUv3" node="4imEbjrwYvY" resolve="get" />
+      </node>
+    </node>
+  </node>
+  <node concept="sE7Ow" id="7IUya7c4kr_">
+    <property role="TrG5h" value="DeleteTableRow" />
+    <property role="2uzpH1" value="Delete Table Row" />
+    <property role="2YLI8m" value="6u2MFnph2yk/editorCommand" />
+    <property role="3GE5qa" value="actions" />
+    <node concept="tnohg" id="7IUya7c4krA" role="tncku">
+      <node concept="3clFbS" id="7IUya7c4krB" role="2VODD2">
+        <node concept="3clFbF" id="7IUya7cjmzQ" role="3cqZAp">
+          <node concept="2OqwBi" id="7IUya7cjmzS" role="3clFbG">
+            <node concept="2ShNRf" id="7IUya7cjmzT" role="2Oq$k0">
+              <node concept="1pGfFk" id="7IUya7cjmzU" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="hm5v:7IUya7ciSfI" resolve="DeleteAction" />
+                <node concept="2OqwBi" id="7IUya7cjmzV" role="37wK5m">
+                  <node concept="2WthIp" id="7IUya7cjmzW" role="2Oq$k0" />
+                  <node concept="1DTwFV" id="7IUya7cjmzX" role="2OqNvi">
+                    <ref role="2WH_rO" node="7IUya7c4kto" resolve="cell" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="liA8E" id="7IUya7cjmzY" role="2OqNvi">
+              <ref role="37wK5l" to="hm5v:40oIQyHH57H" resolve="execute" />
+              <node concept="2OqwBi" id="7IUya7cjn5Q" role="37wK5m">
+                <node concept="2WthIp" id="7IUya7cjn5T" role="2Oq$k0" />
+                <node concept="1DTwFV" id="7IUya7cjn5V" role="2OqNvi">
+                  <ref role="2WH_rO" node="7IUya7cjaQn" resolve="context" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1DS2jV" id="7IUya7c4kto" role="1NuT2Z">
+      <property role="TrG5h" value="cell" />
+      <ref role="1DUlNI" to="k3nr:~MPSEditorDataKeys.EDITOR_CELL" resolve="EDITOR_CELL" />
+      <node concept="1oajcY" id="7IUya7c4ktp" role="1oa70y" />
+    </node>
+    <node concept="1DS2jV" id="7IUya7cjaQn" role="1NuT2Z">
+      <property role="TrG5h" value="context" />
+      <ref role="1DUlNI" to="k3nr:~MPSEditorDataKeys.EDITOR_CONTEXT" resolve="EDITOR_CONTEXT" />
+      <node concept="1oajcY" id="7IUya7cjaQo" role="1oa70y" />
+    </node>
+    <node concept="2ScWuX" id="7IUya7c4nF3" role="tmbBb">
+      <node concept="3clFbS" id="7IUya7c4nF4" role="2VODD2">
+        <node concept="3clFbF" id="7IUya7cj8SO" role="3cqZAp">
+          <node concept="2OqwBi" id="7IUya7cj9_a" role="3clFbG">
+            <node concept="2ShNRf" id="7IUya7cj8SK" role="2Oq$k0">
+              <node concept="1pGfFk" id="7IUya7cj94f" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="hm5v:7IUya7ciSfI" resolve="DeleteAction" />
+                <node concept="2OqwBi" id="7IUya7cj99U" role="37wK5m">
+                  <node concept="2WthIp" id="7IUya7cj99X" role="2Oq$k0" />
+                  <node concept="1DTwFV" id="7IUya7cj99Z" role="2OqNvi">
+                    <ref role="2WH_rO" node="7IUya7c4kto" resolve="cell" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="liA8E" id="7IUya7cja2q" role="2OqNvi">
+              <ref role="37wK5l" to="hm5v:7IUya7cjexf" resolve="canExecute" />
+              <node concept="2OqwBi" id="7IUya7cjb3p" role="37wK5m">
+                <node concept="2WthIp" id="7IUya7cjb3s" role="2Oq$k0" />
+                <node concept="1DTwFV" id="7IUya7cjb3u" role="2OqNvi">
+                  <ref role="2WH_rO" node="7IUya7cjaQn" resolve="context" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1irR5M" id="7IUya7cdRM1" role="3Uehp1">
+      <property role="2$rrk2" value="1" />
+      <node concept="1irPie" id="7IUya7cdRTT" role="1irR9h">
+        <property role="1irPi9" value="X" />
+        <node concept="3PKj8D" id="7IUya7cdRU5" role="3PKjny">
+          <property role="3PKj8l" value="FF0000" />
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="tC5Ba" id="7IUya7cdgXZ">
+    <property role="TrG5h" value="TableActions" />
+    <property role="3GE5qa" value="actions" />
+    <node concept="tT9cl" id="7IUya7cdgY6" role="2f5YQi">
+      <ref role="tU$_T" to="tprs:WmrxDqdZv8" resolve="MPSToolBarRun" />
+    </node>
+    <node concept="fu6FP" id="F5PM1gbEUw" role="ftER_">
+      <node concept="3clFbS" id="F5PM1gbEUy" role="2VODD2">
+        <node concept="2JFkCU" id="F5PM1gbFc6" role="3cqZAp">
+          <node concept="2a7GMi" id="F5PM1gbFct" role="2JFLmv" />
+        </node>
+        <node concept="2JFkCU" id="F5PM1gd7iH" role="3cqZAp">
+          <node concept="tCFHf" id="F5PM1gd7j9" role="2JFLmv">
+            <ref role="tCJdB" node="F5PM1gd1Pe" resolve="TableActionsLabel" />
+          </node>
+        </node>
+        <node concept="2JFkCU" id="F5PM1gbFks" role="3cqZAp">
+          <node concept="tCFHf" id="F5PM1gbFkR" role="2JFLmv">
+            <ref role="tCJdB" node="7IUya7cfBRk" resolve="InsertTableRowBefore" />
+          </node>
+        </node>
+        <node concept="2JFkCU" id="F5PM1gbFoH" role="3cqZAp">
+          <node concept="tCFHf" id="F5PM1gbFpa" role="2JFLmv">
+            <ref role="tCJdB" node="7IUya7cjqn5" resolve="InsertTableRowAfter" />
+          </node>
+        </node>
+        <node concept="2JFkCU" id="F5PM1gbFAA" role="3cqZAp">
+          <node concept="tCFHf" id="F5PM1gbFB5" role="2JFLmv">
+            <ref role="tCJdB" node="7IUya7c4kr_" resolve="DeleteTableRow" />
+          </node>
+        </node>
+        <node concept="2JFkCU" id="F5PM1gbFgf" role="3cqZAp">
+          <node concept="2a7GMi" id="F5PM1gbFgC" role="2JFLmv" />
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="sE7Ow" id="7IUya7cfBRk">
+    <property role="TrG5h" value="InsertTableRowBefore" />
+    <property role="2uzpH1" value="Insert a New Row Before This Row" />
+    <property role="2YLI8m" value="6u2MFnph2yk/editorCommand" />
+    <property role="3GE5qa" value="actions" />
+    <node concept="tnohg" id="7IUya7cfBRl" role="tncku">
+      <node concept="3clFbS" id="7IUya7cfBRm" role="2VODD2">
+        <node concept="3clFbF" id="7IUya7cjq3a" role="3cqZAp">
+          <node concept="2OqwBi" id="7IUya7cjq3b" role="3clFbG">
+            <node concept="2ShNRf" id="7IUya7cjq3c" role="2Oq$k0">
+              <node concept="1pGfFk" id="7IUya7cjq3d" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="hm5v:7IUya7cfM4j" resolve="InsertAction" />
+                <node concept="2OqwBi" id="7IUya7cjq3e" role="37wK5m">
+                  <node concept="2WthIp" id="7IUya7cjq3f" role="2Oq$k0" />
+                  <node concept="1DTwFV" id="7IUya7cjq3g" role="2OqNvi">
+                    <ref role="2WH_rO" node="7IUya7cfBRA" resolve="cell" />
+                  </node>
+                </node>
+                <node concept="3clFbT" id="7IUya7cjq3h" role="37wK5m">
+                  <property role="3clFbU" value="true" />
+                </node>
+              </node>
+            </node>
+            <node concept="liA8E" id="7IUya7cjq3i" role="2OqNvi">
+              <ref role="37wK5l" to="hm5v:4db20qfqkmQ" resolve="execute" />
+              <node concept="2OqwBi" id="7IUya7cjq3j" role="37wK5m">
+                <node concept="2WthIp" id="7IUya7cjq3k" role="2Oq$k0" />
+                <node concept="1DTwFV" id="7IUya7cjq3l" role="2OqNvi">
+                  <ref role="2WH_rO" node="7IUya7cjpF5" resolve="context" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1DS2jV" id="7IUya7cfBRA" role="1NuT2Z">
+      <property role="TrG5h" value="cell" />
+      <ref role="1DUlNI" to="k3nr:~MPSEditorDataKeys.EDITOR_CELL" resolve="EDITOR_CELL" />
+      <node concept="1oajcY" id="7IUya7cfBRB" role="1oa70y" />
+    </node>
+    <node concept="1DS2jV" id="7IUya7cjpF5" role="1NuT2Z">
+      <property role="TrG5h" value="context" />
+      <ref role="1DUlNI" to="k3nr:~MPSEditorDataKeys.EDITOR_CONTEXT" resolve="EDITOR_CONTEXT" />
+      <node concept="1oajcY" id="7IUya7cjpF6" role="1oa70y" />
+    </node>
+    <node concept="2ScWuX" id="7IUya7cfBRC" role="tmbBb">
+      <node concept="3clFbS" id="7IUya7cfBRD" role="2VODD2">
+        <node concept="3clFbF" id="7IUya7cjo9a" role="3cqZAp">
+          <node concept="2OqwBi" id="7IUya7cjpmI" role="3clFbG">
+            <node concept="2ShNRf" id="7IUya7cjo98" role="2Oq$k0">
+              <node concept="1pGfFk" id="7IUya7cjon5" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="hm5v:7IUya7cfM4j" resolve="InsertAction" />
+                <node concept="2OqwBi" id="7IUya7cjoA_" role="37wK5m">
+                  <node concept="2WthIp" id="7IUya7cjoAC" role="2Oq$k0" />
+                  <node concept="1DTwFV" id="7IUya7cjoAE" role="2OqNvi">
+                    <ref role="2WH_rO" node="7IUya7cfBRA" resolve="cell" />
+                  </node>
+                </node>
+                <node concept="3clFbT" id="7IUya7cjp8l" role="37wK5m">
+                  <property role="3clFbU" value="true" />
+                </node>
+              </node>
+            </node>
+            <node concept="liA8E" id="7IUya7cjpvh" role="2OqNvi">
+              <ref role="37wK5l" to="hm5v:7IUya7cjexf" resolve="canExecute" />
+              <node concept="2OqwBi" id="7IUya7cjpQo" role="37wK5m">
+                <node concept="2WthIp" id="7IUya7cjpQr" role="2Oq$k0" />
+                <node concept="1DTwFV" id="7IUya7cjpQt" role="2OqNvi">
+                  <ref role="2WH_rO" node="7IUya7cjpF5" resolve="context" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1irR5M" id="7IUya7cfBRO" role="3Uehp1">
+      <property role="2$rrk2" value="2" />
+      <node concept="1irPie" id="7IUya7cfBRP" role="1irR9h">
+        <property role="1irPi9" value="↑" />
+        <node concept="3PKj8D" id="7IUya7cfBRQ" role="3PKjny">
+          <property role="3PKj8l" value="0000FF" />
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="sE7Ow" id="7IUya7cjqn5">
+    <property role="TrG5h" value="InsertTableRowAfter" />
+    <property role="2uzpH1" value="Insert a New Row After This Row" />
+    <property role="2YLI8m" value="6u2MFnph2yk/editorCommand" />
+    <property role="3GE5qa" value="actions" />
+    <node concept="tnohg" id="7IUya7cjqn6" role="tncku">
+      <node concept="3clFbS" id="7IUya7cjqn7" role="2VODD2">
+        <node concept="3clFbF" id="7IUya7cjqn8" role="3cqZAp">
+          <node concept="2OqwBi" id="7IUya7cjqn9" role="3clFbG">
+            <node concept="2ShNRf" id="7IUya7cjqna" role="2Oq$k0">
+              <node concept="1pGfFk" id="7IUya7cjqnb" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="hm5v:7IUya7cfM4j" resolve="InsertAction" />
+                <node concept="2OqwBi" id="7IUya7cjqnc" role="37wK5m">
+                  <node concept="2WthIp" id="7IUya7cjqnd" role="2Oq$k0" />
+                  <node concept="1DTwFV" id="7IUya7cjqne" role="2OqNvi">
+                    <ref role="2WH_rO" node="7IUya7cjqnk" resolve="cell" />
+                  </node>
+                </node>
+                <node concept="3clFbT" id="7IUya7cjqnf" role="37wK5m" />
+              </node>
+            </node>
+            <node concept="liA8E" id="7IUya7cjqng" role="2OqNvi">
+              <ref role="37wK5l" to="hm5v:4db20qfqkmQ" resolve="execute" />
+              <node concept="2OqwBi" id="7IUya7cjqnh" role="37wK5m">
+                <node concept="2WthIp" id="7IUya7cjqni" role="2Oq$k0" />
+                <node concept="1DTwFV" id="7IUya7cjqnj" role="2OqNvi">
+                  <ref role="2WH_rO" node="7IUya7cjqnm" resolve="context" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1DS2jV" id="7IUya7cjqnk" role="1NuT2Z">
+      <property role="TrG5h" value="cell" />
+      <ref role="1DUlNI" to="k3nr:~MPSEditorDataKeys.EDITOR_CELL" resolve="EDITOR_CELL" />
+      <node concept="1oajcY" id="7IUya7cjqnl" role="1oa70y" />
+    </node>
+    <node concept="1DS2jV" id="7IUya7cjqnm" role="1NuT2Z">
+      <property role="TrG5h" value="context" />
+      <ref role="1DUlNI" to="k3nr:~MPSEditorDataKeys.EDITOR_CONTEXT" resolve="EDITOR_CONTEXT" />
+      <node concept="1oajcY" id="7IUya7cjqnn" role="1oa70y" />
+    </node>
+    <node concept="2ScWuX" id="7IUya7cjqno" role="tmbBb">
+      <node concept="3clFbS" id="7IUya7cjqnp" role="2VODD2">
+        <node concept="3clFbF" id="7IUya7cjqnq" role="3cqZAp">
+          <node concept="2OqwBi" id="7IUya7cjqnr" role="3clFbG">
+            <node concept="2ShNRf" id="7IUya7cjqns" role="2Oq$k0">
+              <node concept="1pGfFk" id="7IUya7cjqnt" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="hm5v:7IUya7cfM4j" resolve="InsertAction" />
+                <node concept="2OqwBi" id="7IUya7cjqnu" role="37wK5m">
+                  <node concept="2WthIp" id="7IUya7cjqnv" role="2Oq$k0" />
+                  <node concept="1DTwFV" id="7IUya7cjqnw" role="2OqNvi">
+                    <ref role="2WH_rO" node="7IUya7cjqnk" resolve="cell" />
+                  </node>
+                </node>
+                <node concept="3clFbT" id="7IUya7cjqnx" role="37wK5m" />
+              </node>
+            </node>
+            <node concept="liA8E" id="7IUya7cjqny" role="2OqNvi">
+              <ref role="37wK5l" to="hm5v:7IUya7cjexf" resolve="canExecute" />
+              <node concept="2OqwBi" id="7IUya7cjqnz" role="37wK5m">
+                <node concept="2WthIp" id="7IUya7cjqn$" role="2Oq$k0" />
+                <node concept="1DTwFV" id="7IUya7cjqn_" role="2OqNvi">
+                  <ref role="2WH_rO" node="7IUya7cjqnm" resolve="context" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1irR5M" id="7IUya7cjqnA" role="3Uehp1">
+      <property role="2$rrk2" value="3" />
+      <node concept="1irPie" id="7IUya7cjqnB" role="1irR9h">
+        <property role="1irPi9" value="↓" />
+        <node concept="3PKj8D" id="7IUya7cjqnC" role="3PKjny">
+          <property role="3PKj8l" value="0000FF" />
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="sE7Ow" id="F5PM1gd1Pe">
+    <property role="TrG5h" value="TableActionsLabel" />
+    <property role="2uzpH1" value="Table Actions" />
+    <property role="2YLI8m" value="6u2MFnph2yk/editorCommand" />
+    <property role="3GE5qa" value="actions" />
+    <node concept="tnohg" id="F5PM1gd1Pf" role="tncku">
+      <node concept="3clFbS" id="F5PM1gd1Pg" role="2VODD2">
+        <node concept="3clFbF" id="7DPEkix32d3" role="3cqZAp">
+          <node concept="2YIFZM" id="7DPEkix32es" role="3clFbG">
+            <ref role="37wK5l" to="fnpx:~Notifications$Bus.notify(com.intellij.notification.Notification)" resolve="notify" />
+            <ref role="1Pybhc" to="fnpx:~Notifications$Bus" resolve="Bus" />
+            <node concept="2ShNRf" id="7DPEkix32fi" role="37wK5m">
+              <node concept="1pGfFk" id="7DPEkix3pam" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="fnpx:~Notification.&lt;init&gt;(java.lang.String,java.lang.String,com.intellij.notification.NotificationType)" resolve="Notification" />
+                <node concept="Xl_RD" id="7DPEkix3pbZ" role="37wK5m">
+                  <property role="Xl_RC" value="Table Actions" />
+                </node>
+                <node concept="Xl_RD" id="7DPEkix3peh" role="37wK5m">
+                  <property role="Xl_RC" value="Table actions can be used to insert or delete rows in the currently selected table." />
+                </node>
+                <node concept="Rm8GO" id="7DPEkix3p$B" role="37wK5m">
+                  <ref role="Rm8GQ" to="fnpx:~NotificationType.INFORMATION" resolve="INFORMATION" />
+                  <ref role="1Px2BO" to="fnpx:~NotificationType" resolve="NotificationType" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1DS2jV" id="F5PM1gd1Ps" role="1NuT2Z">
+      <property role="TrG5h" value="cell" />
+      <ref role="1DUlNI" to="k3nr:~MPSEditorDataKeys.EDITOR_CELL" resolve="EDITOR_CELL" />
+      <node concept="1oajcY" id="F5PM1gd1Pt" role="1oa70y" />
+    </node>
+    <node concept="1DS2jV" id="1Q$LIXOmHg9" role="1NuT2Z">
+      <property role="TrG5h" value="context" />
+      <ref role="1DUlNI" to="k3nr:~MPSEditorDataKeys.EDITOR_CONTEXT" resolve="EDITOR_CONTEXT" />
+      <node concept="1oajcY" id="1Q$LIXOmHga" role="1oa70y" />
+    </node>
+    <node concept="2ScWuX" id="F5PM1gd1Pw" role="tmbBb">
+      <node concept="3clFbS" id="F5PM1gd1Px" role="2VODD2">
+        <node concept="3clFbF" id="1Q$LIXOmmU7" role="3cqZAp">
+          <node concept="2OqwBi" id="1Q$LIXOmCt3" role="3clFbG">
+            <node concept="2ShNRf" id="1Q$LIXOmmTL" role="2Oq$k0">
+              <node concept="YeOm9" id="1Q$LIXOmBYr" role="2ShVmc">
+                <node concept="1Y3b0j" id="1Q$LIXOmBYu" role="YeSDq">
+                  <property role="2bfB8j" value="true" />
+                  <property role="373rjd" value="true" />
+                  <ref role="37wK5l" to="hm5v:7IUya7chrcn" resolve="AbstractTableCellAction" />
+                  <ref role="1Y3XeK" to="hm5v:7IUya7ch5ON" resolve="AbstractTableCellAction" />
+                  <node concept="3Tm1VV" id="1Q$LIXOmBYv" role="1B3o_S" />
+                  <node concept="2OqwBi" id="1Q$LIXOmBG7" role="37wK5m">
+                    <node concept="2WthIp" id="1Q$LIXOmBGa" role="2Oq$k0" />
+                    <node concept="1DTwFV" id="1Q$LIXOmBGc" role="2OqNvi">
+                      <ref role="2WH_rO" node="F5PM1gd1Ps" resolve="cell" />
+                    </node>
+                  </node>
+                  <node concept="3clFb_" id="1Q$LIXOmC0w" role="jymVt">
+                    <property role="TrG5h" value="execute" />
+                    <node concept="3Tm1VV" id="1Q$LIXOmC0x" role="1B3o_S" />
+                    <node concept="3cqZAl" id="1Q$LIXOmC0z" role="3clF45" />
+                    <node concept="37vLTG" id="1Q$LIXOmC0$" role="3clF46">
+                      <property role="TrG5h" value="context" />
+                      <node concept="3uibUv" id="1Q$LIXOmC0_" role="1tU5fm">
+                        <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+                      </node>
+                    </node>
+                    <node concept="3clFbS" id="1Q$LIXOmC0E" role="3clF47" />
+                    <node concept="2AHcQZ" id="1Q$LIXOmC0F" role="2AJF6D">
+                      <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="liA8E" id="1Q$LIXOmCR$" role="2OqNvi">
+              <ref role="37wK5l" to="hm5v:7IUya7cjexf" resolve="canExecute" />
+              <node concept="2OqwBi" id="1Q$LIXOmHqM" role="37wK5m">
+                <node concept="2WthIp" id="1Q$LIXOmHqP" role="2Oq$k0" />
+                <node concept="1DTwFV" id="1Q$LIXOmHqR" role="2OqNvi">
+                  <ref role="2WH_rO" node="1Q$LIXOmHg9" resolve="context" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1irR5M" id="F5PM1gd1PH" role="3Uehp1">
+      <property role="2$rrk2" value="0" />
+      <node concept="1irPie" id="F5PM1gd1PI" role="1irR9h">
+        <property role="1irPi9" value="?" />
+        <node concept="3PKj8D" id="F5PM1gd1PJ" role="3PKjny">
+          <property role="3PKj8l" value="000000" />
+        </node>
       </node>
     </node>
   </node>

--- a/docs/extensions/editor/tables.md
+++ b/docs/extensions/editor/tables.md
@@ -17,7 +17,8 @@ be done in other editors by using the `partial table` cell.
 - **disable left row end cells**: there's a special cell to the left of table rows that's used, for example, for inserting
  new table rows. This flag can disable this cell (default: *false*).
 - **disable right row end cells**: there's a special cell to the left of table rows that's used, for example, for inserting
-    new table rows. This flag can disable this cell (default: *false).
+    new table rows. This flag can disable this cell (default: *false*).
+- **row UI actions (experimental)**: add actions to the MPS toolbar to add a new row above/below the current row or to delete the current row. These actions only work for simple tables that are based on rows (default: *false*).
 
 ## Cell
 


### PR DESCRIPTION
Tables now support a new property _row UI actions (experimental)_: This property adds actions to the MPS toolbar to add a new row above (up arrow)/below(down arrow) the current row or to delete the current row (x). These actions only work for simple tables that are based on rows. The property is set to false by default.

![](https://github.com/JetBrains/MPS-extensions/assets/88385944/c643fb67-b4c0-45ea-9e78-847e92469a25)