### PR TITLE
mpsutil.intentions: Add an annotation "Toggle Show Intention In Read-Only Cell"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The project does _not_ follow Semantic Versioning and the changes are documented
 
 ### Added
 
-- mpsutil.intentions: a new style attribute `intentions-in-read-only-cell` is now available to allow intentions in read-only cells.
+- mpsutil.intentions: a new style attribute `intentions-in-read-only-cell` is now available to allow intentions in read-only cells. Single intentions can also be enabled or disabled in those cells through the intention "Toggle Show Intention In Read-Only Cell Annotation".
 - com.mbeddr.mpsutil.editor.querylist: Default editor cells now support style attributes.
 - de.slisson.mps.tables: tables now support a new property `row UI actions (experimental)`: This property adds actions to the MPS toolbar to add a new row above/below the current row or to delete the current row. These actions only work for simple tables that are based on rows (default: *false*).
 

--- a/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
+++ b/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
@@ -13002,6 +13002,11 @@
             <ref role="3bR37D" node="54z9_KDR0Ol" resolve="com.mbeddr.mpsutil.intentions" />
           </node>
         </node>
+        <node concept="1SiIV0" id="frLjuw1roZ" role="3bR37C">
+          <node concept="3bR9La" id="frLjuw1rp0" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:7Kfy9QB6L7y" resolve="jetbrains.mps.lang.intentions" />
+          </node>
+        </node>
       </node>
     </node>
     <node concept="m$_wf" id="hCVXosGNJH" role="3989C9">

--- a/code/intentionsmenu/com.mbeddr.mpsutil.intentions.runtime/com.mbeddr.mpsutil.intentions.runtime.msd
+++ b/code/intentionsmenu/com.mbeddr.mpsutil.intentions.runtime/com.mbeddr.mpsutil.intentions.runtime.msd
@@ -17,10 +17,12 @@
     <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
     <dependency reexport="true">498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)</dependency>
     <dependency reexport="false">b92f861d-0184-446d-b88b-6dcf0e070241(com.mbeddr.mpsutil.intentions)</dependency>
+    <dependency reexport="false">d7a92d38-f7db-40d0-8431-763b0c3c9f20(jetbrains.mps.lang.intentions)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:654422bf-e75f-44dc-936d-188890a746ce:de.slisson.mps.reflection" version="0" />
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
+    <language slang="l:774bf8a0-62e5-41e1-af63-f4812e60e48b:jetbrains.mps.baseLanguage.checkedDots" version="0" />
     <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />
     <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
     <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
@@ -49,7 +51,13 @@
     <module reference="b92f861d-0184-446d-b88b-6dcf0e070241(com.mbeddr.mpsutil.intentions)" version="0" />
     <module reference="4bff7bbe-ce5f-432e-84bf-60809cb9987c(com.mbeddr.mpsutil.intentions.runtime)" version="0" />
     <module reference="f0fff802-6d26-4d2e-b89d-391357265626(de.slisson.mps.hacks.editor)" version="0" />
+    <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
+    <module reference="c7d5b9dd-a05f-4be2-bc73-f2e16994cc67(jetbrains.mps.baseLanguage.lightweightdsl)" version="0" />
+    <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
+    <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
     <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
+    <module reference="d7a92d38-f7db-40d0-8431-763b0c3c9f20(jetbrains.mps.lang.intentions)" version="0" />
+    <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
   </dependencyVersions>
 </solution>
 

--- a/code/intentionsmenu/com.mbeddr.mpsutil.intentions.runtime/models/com/mbeddr/mpsutil/intentions/runtime.mps
+++ b/code/intentionsmenu/com.mbeddr.mpsutil.intentions.runtime/models/com/mbeddr/mpsutil/intentions/runtime.mps
@@ -6,6 +6,7 @@
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
     <use id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core" version="2" />
     <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="14" />
+    <use id="774bf8a0-62e5-41e1-af63-f4812e60e48b" name="jetbrains.mps.baseLanguage.checkedDots" version="0" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -46,6 +47,8 @@
     <import index="5ueo" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.editor.runtime.style(MPS.Editor/)" />
     <import index="zddv" ref="r:1b71c6d7-41ff-44a2-a61c-39c2a9779c34(com.mbeddr.mpsutil.intentions.editor)" />
     <import index="hox0" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.style(MPS.Editor/)" />
+    <import index="tegv" ref="r:b91d2412-f094-4e55-8db6-3c782d7edc40(com.mbeddr.mpsutil.intentions.structure)" />
+    <import index="tp3j" ref="r:00000000-0000-4000-0000-011c89590353(jetbrains.mps.lang.intentions.structure)" />
   </imports>
   <registry>
     <language id="654422bf-e75f-44dc-936d-188890a746ce" name="de.slisson.mps.reflection">
@@ -242,6 +245,9 @@
       </concept>
       <concept id="8064396509828172209" name="jetbrains.mps.baseLanguage.structure.UnaryMinus" flags="nn" index="1ZRNhn" />
     </language>
+    <language id="774bf8a0-62e5-41e1-af63-f4812e60e48b" name="jetbrains.mps.baseLanguage.checkedDots">
+      <concept id="4079382982702596667" name="jetbrains.mps.baseLanguage.checkedDots.structure.CheckedDotExpression" flags="nn" index="2EnYce" />
+    </language>
     <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
       <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
         <property id="890797661671409019" name="forceMultiLine" index="3yWfEV" />
@@ -249,7 +255,29 @@
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
-      <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2" />
+      <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
+        <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
+      </concept>
+      <concept id="2396822768958367367" name="jetbrains.mps.lang.smodel.structure.AbstractTypeCastExpression" flags="nn" index="$5XWr">
+        <child id="6733348108486823193" name="leftExpression" index="1m5AlR" />
+        <child id="3906496115198199033" name="conceptArgument" index="3oSUPX" />
+      </concept>
+      <concept id="1171999116870" name="jetbrains.mps.lang.smodel.structure.Node_IsNullOperation" flags="nn" index="3w_OXm" />
+      <concept id="6407023681583036853" name="jetbrains.mps.lang.smodel.structure.NodeAttributeQualifier" flags="ng" index="3CFYIy">
+        <reference id="6407023681583036854" name="attributeConcept" index="3CFYIx" />
+      </concept>
+      <concept id="6407023681583031218" name="jetbrains.mps.lang.smodel.structure.AttributeAccess" flags="nn" index="3CFZ6_">
+        <child id="6407023681583036852" name="qualifier" index="3CFYIz" />
+      </concept>
+      <concept id="1140137987495" name="jetbrains.mps.lang.smodel.structure.SNodeTypeCastExpression" flags="nn" index="1PxgMI">
+        <property id="1238684351431" name="asCast" index="1BlNFB" />
+      </concept>
+      <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
+        <reference id="1138405853777" name="concept" index="ehGHo" />
+      </concept>
+      <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
+        <reference id="1138056395725" name="property" index="3TsBF5" />
+      </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
@@ -275,6 +303,12 @@
       </concept>
     </language>
     <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="nn" index="25WWJ4">
+        <child id="540871147943773366" name="argument" index="25WWJ7" />
+      </concept>
+      <concept id="1226511727824" name="jetbrains.mps.baseLanguage.collections.structure.SetType" flags="in" index="2hMVRd">
+        <child id="1226511765987" name="elementType" index="2hN53Y" />
+      </concept>
       <concept id="1153943597977" name="jetbrains.mps.baseLanguage.collections.structure.ForEachStatement" flags="nn" index="2Gpval">
         <child id="1153944400369" name="variable" index="2Gsz3X" />
         <child id="1153944424730" name="inputSequence" index="2GsD0m" />
@@ -283,6 +317,7 @@
       <concept id="1153944233411" name="jetbrains.mps.baseLanguage.collections.structure.ForEachVariableReference" flags="nn" index="2GrUjf">
         <reference id="1153944258490" name="variable" index="2Gs0qQ" />
       </concept>
+      <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
     </language>
   </registry>
   <node concept="312cEu" id="3pwG8PSkQAz">
@@ -2222,18 +2257,6 @@
           <node concept="3cpWsn" id="3pwG8PSkQPv" role="3cpWs9">
             <property role="3TUv4t" value="true" />
             <property role="TrG5h" value="result" />
-            <node concept="3uibUv" id="3pwG8PSkQPx" role="1tU5fm">
-              <ref role="3uigEE" to="33ny:~Set" resolve="Set" />
-              <node concept="3uibUv" id="3pwG8PSkQPy" role="11_B2D">
-                <ref role="3uigEE" to="18ew:~Pair" resolve="Pair" />
-                <node concept="3uibUv" id="7me2y0SL9o9" role="11_B2D">
-                  <ref role="3uigEE" to="nddn:~IntentionExecutable" resolve="IntentionExecutable" />
-                </node>
-                <node concept="3uibUv" id="3pwG8PSkQP$" role="11_B2D">
-                  <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
-                </node>
-              </node>
-            </node>
             <node concept="2ShNRf" id="3pwG8PSl47G" role="33vP2m">
               <node concept="1pGfFk" id="3pwG8PSl47H" role="2ShVmc">
                 <ref role="37wK5l" to="33ny:~LinkedHashSet.&lt;init&gt;()" resolve="LinkedHashSet" />
@@ -2245,6 +2268,17 @@
                   <node concept="3uibUv" id="3pwG8PSkQPC" role="11_B2D">
                     <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
                   </node>
+                </node>
+              </node>
+            </node>
+            <node concept="2hMVRd" id="frLjuvQHTD" role="1tU5fm">
+              <node concept="3uibUv" id="frLjuvQLMc" role="2hN53Y">
+                <ref role="3uigEE" to="18ew:~Pair" resolve="Pair" />
+                <node concept="3uibUv" id="frLjuvQLMd" role="11_B2D">
+                  <ref role="3uigEE" to="nddn:~IntentionExecutable" resolve="IntentionExecutable" />
+                </node>
+                <node concept="3uibUv" id="frLjuvQLMe" role="11_B2D">
+                  <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
                 </node>
               </node>
             </node>
@@ -2379,23 +2413,124 @@
                 </node>
               </node>
             </node>
-            <node concept="3clFbF" id="3pwG8PSkQQy" role="3cqZAp">
-              <node concept="2OqwBi" id="3pwG8PSl48q" role="3clFbG">
-                <node concept="37vLTw" id="3pwG8PSl48p" role="2Oq$k0">
-                  <ref role="3cqZAo" node="3pwG8PSkQPv" resolve="result" />
-                </node>
-                <node concept="liA8E" id="3pwG8PSl48r" role="2OqNvi">
-                  <ref role="37wK5l" to="33ny:~Set.addAll(java.util.Collection)" resolve="addAll" />
-                  <node concept="37vLTw" id="3pwG8PSkQQ$" role="37wK5m">
-                    <ref role="3cqZAo" node="3pwG8PSkQPY" resolve="availableIntentions" />
+            <node concept="2Gpval" id="frLjuvY9Rz" role="3cqZAp">
+              <node concept="3clFbS" id="frLjuvY9RC" role="2LFqv$">
+                <node concept="3cpWs8" id="frLjuvY9RD" role="3cqZAp">
+                  <node concept="3cpWsn" id="frLjuvY9RE" role="3cpWs9">
+                    <property role="TrG5h" value="intentionDeclaration" />
+                    <node concept="3Tqbb2" id="frLjuvY9RF" role="1tU5fm">
+                      <ref role="ehGHo" to="tp3j:2c3oNEsfcpP" resolve="BaseIntentionDeclaration" />
+                    </node>
+                    <node concept="1PxgMI" id="frLjuvY9RG" role="33vP2m">
+                      <property role="1BlNFB" value="true" />
+                      <node concept="chp4Y" id="frLjuvY9RH" role="3oSUPX">
+                        <ref role="cht4Q" to="tp3j:2c3oNEsfcpP" resolve="BaseIntentionDeclaration" />
+                      </node>
+                      <node concept="2EnYce" id="frLjuvYBZ2" role="1m5AlR">
+                        <node concept="2EnYce" id="frLjuvYuOE" role="2Oq$k0">
+                          <node concept="2EnYce" id="frLjuvYpL0" role="2Oq$k0">
+                            <node concept="2EnYce" id="frLjuvYl7X" role="2Oq$k0">
+                              <node concept="2GrUjf" id="frLjuvY9Sf" role="2Oq$k0">
+                                <ref role="2Gs0qQ" node="frLjuvY9Se" resolve="availableIntention" />
+                              </node>
+                              <node concept="2OwXpG" id="frLjuvY9RN" role="2OqNvi">
+                                <ref role="2Oxat6" to="18ew:~Pair.o1" resolve="o1" />
+                              </node>
+                            </node>
+                            <node concept="liA8E" id="frLjuvY9RO" role="2OqNvi">
+                              <ref role="37wK5l" to="nddn:~IntentionExecutable.getDescriptor()" resolve="getDescriptor" />
+                            </node>
+                          </node>
+                          <node concept="liA8E" id="frLjuvY9RP" role="2OqNvi">
+                            <ref role="37wK5l" to="nddn:~IntentionDescriptor.getIntentionNodeReference()" resolve="getIntentionNodeReference" />
+                          </node>
+                        </node>
+                        <node concept="liA8E" id="frLjuvY9RQ" role="2OqNvi">
+                          <ref role="37wK5l" to="mhbf:~SNodeReference.resolve(org.jetbrains.mps.openapi.module.SRepository)" resolve="resolve" />
+                          <node concept="2OqwBi" id="frLjuvYGGo" role="37wK5m">
+                            <node concept="37vLTw" id="frLjuvY9RS" role="2Oq$k0">
+                              <ref role="3cqZAo" node="3pwG8PSkQPH" resolve="editorContext" />
+                            </node>
+                            <node concept="liA8E" id="frLjuvY9RT" role="2OqNvi">
+                              <ref role="37wK5l" to="exr9:~EditorContext.getRepository()" resolve="getRepository" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
                   </node>
                 </node>
+                <node concept="3clFbJ" id="frLjuvZcBR" role="3cqZAp">
+                  <node concept="3clFbS" id="frLjuvZcBT" role="3clFbx">
+                    <node concept="3clFbF" id="frLjuvY9RW" role="3cqZAp">
+                      <node concept="2OqwBi" id="frLjuvY9RX" role="3clFbG">
+                        <node concept="37vLTw" id="frLjuvY9RY" role="2Oq$k0">
+                          <ref role="3cqZAo" node="3pwG8PSkQPv" resolve="result" />
+                        </node>
+                        <node concept="TSZUe" id="frLjuvY9RZ" role="2OqNvi">
+                          <node concept="2GrUjf" id="frLjuvY9Sg" role="25WWJ7">
+                            <ref role="2Gs0qQ" node="frLjuvY9Se" resolve="availableIntention" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="22lmx$" id="frLjuvZFR9" role="3clFbw">
+                    <node concept="3fqX7Q" id="frLjuvZBA8" role="3uHU7B">
+                      <node concept="2YIFZM" id="frLjuvZBAa" role="3fr31v">
+                        <ref role="37wK5l" to="3ahc:~ReadOnlyUtil.isSelectionReadOnlyInEditor(jetbrains.mps.openapi.editor.EditorComponent)" resolve="isSelectionReadOnlyInEditor" />
+                        <ref role="1Pybhc" to="3ahc:~ReadOnlyUtil" resolve="ReadOnlyUtil" />
+                        <node concept="37vLTw" id="frLjuvZBAb" role="37wK5m">
+                          <ref role="3cqZAo" node="3pwG8PSkQAX" resolve="myEditor" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="1eOMI4" id="frLjuvZr4F" role="3uHU7w">
+                      <node concept="22lmx$" id="frLjuvY9S1" role="1eOMHV">
+                        <node concept="2OqwBi" id="frLjuvY9S2" role="3uHU7B">
+                          <node concept="2OqwBi" id="frLjuvY9S3" role="2Oq$k0">
+                            <node concept="37vLTw" id="frLjuvY9S4" role="2Oq$k0">
+                              <ref role="3cqZAo" node="frLjuvY9RE" resolve="intentionDeclaration" />
+                            </node>
+                            <node concept="3CFZ6_" id="frLjuvY9S5" role="2OqNvi">
+                              <node concept="3CFYIy" id="frLjuvY9S6" role="3CFYIz">
+                                <ref role="3CFYIx" to="tegv:frLjuvP$7P" resolve="ShowIntentionInReadyOnlyCell" />
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="3w_OXm" id="frLjuvY9S7" role="2OqNvi" />
+                        </node>
+                        <node concept="2OqwBi" id="frLjuvY9S8" role="3uHU7w">
+                          <node concept="2OqwBi" id="frLjuvY9S9" role="2Oq$k0">
+                            <node concept="37vLTw" id="frLjuvY9Sa" role="2Oq$k0">
+                              <ref role="3cqZAo" node="frLjuvY9RE" resolve="intentionDeclaration" />
+                            </node>
+                            <node concept="3CFZ6_" id="frLjuvY9Sb" role="2OqNvi">
+                              <node concept="3CFYIy" id="frLjuvY9Sc" role="3CFYIz">
+                                <ref role="3CFYIx" to="tegv:frLjuvP$7P" resolve="ShowIntentionInReadyOnlyCell" />
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="3TrcHB" id="frLjuvY9Sd" role="2OqNvi">
+                            <ref role="3TsBF5" to="tegv:frLjuvPGIB" resolve="flag" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="37vLTw" id="frLjuvY9RB" role="2GsD0m">
+                <ref role="3cqZAo" node="3pwG8PSkQPY" resolve="availableIntentions" />
+              </node>
+              <node concept="2GrKxI" id="frLjuvY9Se" role="2Gsz3X">
+                <property role="TrG5h" value="availableIntention" />
               </node>
             </node>
           </node>
         </node>
         <node concept="3cpWs6" id="3pwG8PSkQQ_" role="3cqZAp">
-          <node concept="37vLTw" id="3pwG8PSkQQA" role="3cqZAk">
+          <node concept="37vLTw" id="frLjuvY24D" role="3cqZAk">
             <ref role="3cqZAo" node="3pwG8PSkQPv" resolve="result" />
           </node>
         </node>

--- a/code/intentionsmenu/com.mbeddr.mpsutil.intentions/languageModels/editor.mps
+++ b/code/intentionsmenu/com.mbeddr.mpsutil.intentions/languageModels/editor.mps
@@ -233,5 +233,24 @@
       <node concept="3clFbT" id="5qf1oe_$9mE" role="3t49C2" />
     </node>
   </node>
+  <node concept="24kQdi" id="frLjuvPGID">
+    <ref role="1XX52x" to="tegv:frLjuvP$7P" resolve="ShowIntentionInReadyOnlyCell" />
+    <node concept="3EZMnI" id="frLjuvPGIE" role="2wV5jI">
+      <node concept="2iRkQZ" id="frLjuvPGIF" role="2iSdaV" />
+      <node concept="3EZMnI" id="frLjuvPGIG" role="3EZMnx">
+        <node concept="3F0ifn" id="frLjuvPHyu" role="3EZMnx">
+          <property role="3F0ifm" value="show intention in ready-only cell:" />
+        </node>
+        <node concept="3F0A7n" id="frLjuvPGII" role="3EZMnx">
+          <ref role="1NtTu8" to="tegv:frLjuvPGIB" resolve="flag" />
+        </node>
+        <node concept="2iRfu4" id="frLjuvPGJo" role="2iSdaV" />
+        <node concept="3vyZuw" id="frLjuvPGJp" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="2SsqMj" id="frLjuvPGJq" role="3EZMnx" />
+    </node>
+  </node>
 </model>
 

--- a/code/intentionsmenu/com.mbeddr.mpsutil.intentions/languageModels/intentions.mps
+++ b/code/intentionsmenu/com.mbeddr.mpsutil.intentions/languageModels/intentions.mps
@@ -53,6 +53,9 @@
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
+      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
+        <property id="1068580123138" name="value" index="3clFbU" />
+      </concept>
       <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
         <property id="1068580320021" name="value" index="3cmrfH" />
       </concept>
@@ -84,9 +87,28 @@
         <child id="2522969319638093993" name="descriptionFunction" index="2ZfVej" />
       </concept>
     </language>
+    <language id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation">
+      <concept id="5455284157993911077" name="jetbrains.mps.lang.quotation.structure.NodeBuilderInitProperty" flags="ng" index="2pJxcG">
+        <reference id="5455284157993911078" name="property" index="2pJxcJ" />
+        <child id="1595412875168045201" name="initValue" index="28ntcv" />
+      </concept>
+      <concept id="5455284157993863837" name="jetbrains.mps.lang.quotation.structure.NodeBuilder" flags="nn" index="2pJPEk">
+        <child id="5455284157993863838" name="quotedNode" index="2pJPEn" />
+      </concept>
+      <concept id="5455284157993863840" name="jetbrains.mps.lang.quotation.structure.NodeBuilderNode" flags="nn" index="2pJPED">
+        <reference id="5455284157993910961" name="concept" index="2pJxaS" />
+        <child id="5455284157993911099" name="values" index="2pJxcM" />
+      </concept>
+      <concept id="6985522012210254362" name="jetbrains.mps.lang.quotation.structure.NodeBuilderPropertyExpression" flags="nn" index="WxPPo">
+        <child id="6985522012210254363" name="expression" index="WxPPp" />
+      </concept>
+    </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
       <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
         <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
+      </concept>
+      <concept id="1140725362528" name="jetbrains.mps.lang.smodel.structure.Link_SetTargetOperation" flags="nn" index="2oxUTD">
+        <child id="1140725362529" name="linkTarget" index="2oxUTC" />
       </concept>
       <concept id="1138757581985" name="jetbrains.mps.lang.smodel.structure.Link_SetNewChildOperation" flags="nn" index="zfrQC" />
       <concept id="1143234257716" name="jetbrains.mps.lang.smodel.structure.Node_GetModelOperation" flags="nn" index="I4A8Y" />
@@ -324,6 +346,83 @@
         <node concept="3clFbF" id="54z9_KDPbup" role="3cqZAp">
           <node concept="Xl_RD" id="54z9_KDPbuo" role="3clFbG">
             <property role="Xl_RC" value="Toggle Group Annotation" />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="2S6QgY" id="frLjuvYWqn">
+    <property role="TrG5h" value="addShowIntentionInReadyOnlyCellAnnotation" />
+    <property role="2ZfUl0" value="true" />
+    <ref role="2ZfgGC" to="tp3j:2c3oNEsfcpP" resolve="BaseIntentionDeclaration" />
+    <node concept="2Sbjvc" id="frLjuvYWqo" role="2ZfgGD">
+      <node concept="3clFbS" id="frLjuvYWqp" role="2VODD2">
+        <node concept="3clFbJ" id="frLjuvYWqq" role="3cqZAp">
+          <node concept="3clFbS" id="frLjuvYWqr" role="3clFbx">
+            <node concept="3clFbF" id="frLjuw0cXz" role="3cqZAp">
+              <node concept="2OqwBi" id="frLjuw0dAJ" role="3clFbG">
+                <node concept="2OqwBi" id="frLjuw0d6X" role="2Oq$k0">
+                  <node concept="2Sf5sV" id="frLjuw0cXy" role="2Oq$k0" />
+                  <node concept="3CFZ6_" id="frLjuw0dpC" role="2OqNvi">
+                    <node concept="3CFYIy" id="frLjuw0dq8" role="3CFYIz">
+                      <ref role="3CFYIx" to="tegv:frLjuvP$7P" resolve="ShowIntentionInReadyOnlyCell" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2oxUTD" id="frLjuw0dP$" role="2OqNvi">
+                  <node concept="2pJPEk" id="frLjuw0dUN" role="2oxUTC">
+                    <node concept="2pJPED" id="frLjuw0dUP" role="2pJPEn">
+                      <ref role="2pJxaS" to="tegv:frLjuvP$7P" resolve="ShowIntentionInReadyOnlyCell" />
+                      <node concept="2pJxcG" id="frLjuw0e7u" role="2pJxcM">
+                        <ref role="2pJxcJ" to="tegv:frLjuvPGIB" resolve="flag" />
+                        <node concept="WxPPo" id="frLjuw0eaF" role="28ntcv">
+                          <node concept="3clFbT" id="frLjuw0eaE" role="WxPPp">
+                            <property role="3clFbU" value="true" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="frLjuvYWrz" role="3clFbw">
+            <node concept="2OqwBi" id="frLjuvYWr$" role="2Oq$k0">
+              <node concept="2Sf5sV" id="frLjuvYWr_" role="2Oq$k0" />
+              <node concept="3CFZ6_" id="frLjuvYWrA" role="2OqNvi">
+                <node concept="3CFYIy" id="frLjuvYWrB" role="3CFYIz">
+                  <ref role="3CFYIx" to="tegv:frLjuvP$7P" resolve="ShowIntentionInReadyOnlyCell" />
+                </node>
+              </node>
+            </node>
+            <node concept="3w_OXm" id="frLjuvYWrC" role="2OqNvi" />
+          </node>
+          <node concept="9aQIb" id="frLjuvYWrD" role="9aQIa">
+            <node concept="3clFbS" id="frLjuvYWrE" role="9aQI4">
+              <node concept="3clFbF" id="frLjuvYWrF" role="3cqZAp">
+                <node concept="2OqwBi" id="frLjuvYWrG" role="3clFbG">
+                  <node concept="2OqwBi" id="frLjuvYWrH" role="2Oq$k0">
+                    <node concept="2Sf5sV" id="frLjuvYWrI" role="2Oq$k0" />
+                    <node concept="3CFZ6_" id="frLjuvYWrJ" role="2OqNvi">
+                      <node concept="3CFYIy" id="frLjuvYWrK" role="3CFYIz">
+                        <ref role="3CFYIx" to="tegv:frLjuvP$7P" resolve="ShowIntentionInReadyOnlyCell" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3YRAZt" id="frLjuvYWrL" role="2OqNvi" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2S6ZIM" id="frLjuvYWrM" role="2ZfVej">
+      <node concept="3clFbS" id="frLjuvYWrN" role="2VODD2">
+        <node concept="3clFbF" id="frLjuvYWrO" role="3cqZAp">
+          <node concept="Xl_RD" id="frLjuvYWrP" role="3clFbG">
+            <property role="Xl_RC" value="Toggle Show Intention In Read-Only Cell Annotation" />
           </node>
         </node>
       </node>

--- a/code/intentionsmenu/com.mbeddr.mpsutil.intentions/languageModels/structure.mps
+++ b/code/intentionsmenu/com.mbeddr.mpsutil.intentions/languageModels/structure.mps
@@ -55,5 +55,21 @@
       <ref role="AX2Wp" to="tpck:fKAOsGN" resolve="string" />
     </node>
   </node>
+  <node concept="1TIwiD" id="frLjuvP$7P">
+    <property role="TrG5h" value="ShowIntentionInReadyOnlyCell" />
+    <property role="EcuMT" value="278032644708909557" />
+    <ref role="1TJDcQ" to="tpck:2ULFgo8_XDk" resolve="NodeAttribute" />
+    <node concept="1TJgyi" id="frLjuvPGIB" role="1TKVEl">
+      <property role="IQ2nx" value="278032644708944807" />
+      <property role="TrG5h" value="flag" />
+      <ref role="AX2Wp" to="tpck:fKAQMTB" resolve="boolean" />
+    </node>
+    <node concept="M6xJ_" id="frLjuvP$7Q" role="lGtFl">
+      <property role="Hh88m" value="showIntentionInReadyOnlyCell" />
+      <node concept="trNpa" id="frLjuvP$7R" role="EQaZv">
+        <ref role="trN6q" to="tp3j:2c3oNEsfcpP" resolve="BaseIntentionDeclaration" />
+      </node>
+    </node>
+  </node>
 </model>
 

--- a/code/languages/com.mbeddr.mpsutil.intentions.sandboxlang/models/com.mbeddr.mpsutil.intentions.sandboxlang.intentions.mps
+++ b/code/languages/com.mbeddr.mpsutil.intentions.sandboxlang/models/com.mbeddr.mpsutil.intentions.sandboxlang.intentions.mps
@@ -43,6 +43,7 @@
       </concept>
     </language>
     <language id="b92f861d-0184-446d-b88b-6dcf0e070241" name="com.mbeddr.mpsutil.intentions">
+      <concept id="278032644708909557" name="com.mbeddr.mpsutil.intentions.structure.ShowIntentionInReadyOnlyCell" flags="ng" index="2s3oj2" />
       <concept id="5846558918537398687" name="com.mbeddr.mpsutil.intentions.structure.IntentionGroupAnnotation" flags="ng" index="1SWQZ3">
         <property id="5846558918537400330" name="label" index="1SWRpm" />
       </concept>
@@ -247,6 +248,46 @@
         </node>
       </node>
     </node>
+  </node>
+  <node concept="2S6QgY" id="frLjuvPz1B">
+    <property role="TrG5h" value="ChildIntentionNotVisible" />
+    <ref role="2ZfgGC" to="iikq:5qf1oe_GcsF" resolve="IChild" />
+    <node concept="2S6ZIM" id="frLjuvPz1C" role="2ZfVej">
+      <node concept="3clFbS" id="frLjuvPz1D" role="2VODD2">
+        <node concept="3clFbF" id="frLjuvPz1E" role="3cqZAp">
+          <node concept="Xl_RD" id="frLjuvPz1F" role="3clFbG">
+            <property role="Xl_RC" value="Not Visible In Ready-Only Cell" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2Sbjvc" id="frLjuvPz1G" role="2ZfgGD">
+      <node concept="3clFbS" id="frLjuvPz1H" role="2VODD2">
+        <node concept="3clFbF" id="frLjuvPz1I" role="3cqZAp">
+          <node concept="37vLTI" id="frLjuvPz1J" role="3clFbG">
+            <node concept="Xl_RD" id="frLjuvPz1K" role="37vLTx">
+              <property role="Xl_RC" value="Changed" />
+            </node>
+            <node concept="2OqwBi" id="frLjuvPz1L" role="37vLTJ">
+              <node concept="2OqwBi" id="frLjuvPz1M" role="2Oq$k0">
+                <node concept="2Sf5sV" id="frLjuvPz1N" role="2Oq$k0" />
+                <node concept="2Xjw5R" id="frLjuvPz1O" role="2OqNvi">
+                  <node concept="1xMEDy" id="frLjuvPz1P" role="1xVPHs">
+                    <node concept="chp4Y" id="frLjuvPz1Q" role="ri$Ld">
+                      <ref role="cht4Q" to="iikq:5qf1oe_GcsA" resolve="Root" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3TrcHB" id="frLjuvPz1R" role="2OqNvi">
+                <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2s3oj2" id="frLjuw0Btu" role="lGtFl" />
   </node>
 </model>
 


### PR DESCRIPTION
This is a follow-up of https://github.com/JetBrains/MPS-extensions/pull/691: Intentions in read-only cells can now be disabled by adding this annotation to an intention declaration and setting the flag to true.