### PR TITLE
Fix size of parent cell before layouting the ports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project are documented in this file.
 Format of the log is _loosely_ based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). 
 The project does _not_ follow Semantic Versioning and the changes are documented in reverse chronological order, grouped by calendar month.
 
+## December 2023
+
+- The size of diagram cells is now recalculated before layouting the ports to fix some layout issues.
+
 ## November 2023
 
 ### Changed


### PR DESCRIPTION
The problem was reproducible by dropping elements from the palette. An example of broken ports can be seen here:
<img width="210" alt="Screenshot 2023-12-04 at 09 17 35" src="https://github.com/JetBrains/MPS-extensions/assets/88385944/ee48fdff-79a7-4da3-b253-4ce32c4e2ebe">

The problem is that ports don't always have the correct size from the parent cell for positioning them:

<img width="210" alt="Screenshot 2023-12-04 at 09 18 17" src="https://github.com/JetBrains/MPS-extensions/assets/88385944/d8e4f29b-bc00-4078-bd6a-7e0c44b403b9">

I am correcting the size of the parent cell now before layouting the ports. In the past, we just run the layouter 5 times. We still have issues with ports that are on the south side and when resizing cells with ports where the ports are at the wrong location:

<img width="255" alt="Screenshot 2023-12-04 at 09 18 34" src="https://github.com/JetBrains/MPS-extensions/assets/88385944/524894a4-29c3-45a2-9bdc-72adee7f1f9e">