### PR TITLE
Better word cell code completion entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project are documented in this file.
 Format of the log is _loosely_ based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). 
 The project does _not_ follow Semantic Versioning and the changes are documented in reverse chronological order, grouped by calendar month.
 
-## Dezember 2023
+## December 2023
 
 ### Fixed
 
@@ -18,6 +18,10 @@ The project does _not_ follow Semantic Versioning and the changes are documented
 
 - A new language `de.itemis.mps.statistics` was added that adds a new menu `MPS Statistics` to the `Tools`  menu. The containing action writes a file `dependencies.txt` to the root folder. It contains all the used dependencies of the current project. 
 - de.slisson.mps.tables: tables now support a new property `column UI actions (experimental)`: This property adds actions to the MPS toolbar to add a new column above/below the current column or to delete the current column. These actions only work for simple tables that are based on rows (default: *false*).
+
+### Changed
+
+de.slisson.mps.richtext: The code completion entries of word cells are now clearer and unnecessary entries were removed.
 
 ## November 2023
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,11 @@ The project does _not_ follow Semantic Versioning and the changes are documented
 
 - A new language `de.itemis.mps.statistics` was added that adds a new menu `MPS Statistics` to the `Tools`  menu. The containing action writes a file `dependencies.txt` to the root folder. It contains all the used dependencies of the current project. 
 - de.slisson.mps.tables: tables now support a new property `column UI actions (experimental)`: This property adds actions to the MPS toolbar to add a new column above/below the current column or to delete the current column. These actions only work for simple tables that are based on rows (default: *false*).
+- de.slisson.mps.richtext: The shortcuts are now documented.
 
 ### Changed
 
-de.slisson.mps.richtext: The code completion entries of word cells are now clearer and unnecessary entries were removed.
+- de.slisson.mps.richtext: The code completion entries of word cells are now clearer and unnecessary entries were removed.
 
 ## November 2023
 

--- a/code/multiline/solutions/de.slisson.mps.editor.multiline.runtime/models/de/slisson/mps/editor/multiline/cells.mps
+++ b/code/multiline/solutions/de.slisson.mps.editor.multiline.runtime/models/de/slisson/mps/editor/multiline/cells.mps
@@ -316,6 +316,7 @@
       <concept id="1116615150612" name="jetbrains.mps.baseLanguage.structure.ClassifierClassExpression" flags="nn" index="3VsKOn">
         <reference id="1116615189566" name="classifier" index="3VsUkX" />
       </concept>
+      <concept id="1178893518978" name="jetbrains.mps.baseLanguage.structure.ThisConstructorInvocation" flags="nn" index="1VxSAg" />
       <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
       <concept id="1200397529627" name="jetbrains.mps.baseLanguage.structure.CharConstant" flags="nn" index="1Xhbcc">
         <property id="1200397540847" name="charConstant" index="1XhdNS" />
@@ -6593,7 +6594,10 @@
             </node>
             <node concept="2ShNRf" id="6tLsdkfIMj6" role="37wK5m">
               <node concept="1pGfFk" id="6tLsdkfIQur" role="2ShVmc">
-                <ref role="37wK5l" node="51$nbrvPsvu" resolve="NewLineAction" />
+                <ref role="37wK5l" node="38Vsfq8MWKz" resolve="NewLineAction" />
+                <node concept="3clFbT" id="38Vsfq8Qtjt" role="37wK5m">
+                  <property role="3clFbU" value="true" />
+                </node>
                 <node concept="Xjq3P" id="6tLsdkfIQus" role="37wK5m" />
               </node>
             </node>
@@ -9207,20 +9211,20 @@
                 <property role="TrG5h" value="newCaretPos" />
                 <node concept="10Oyi0" id="6tLsdkfI41Y" role="1tU5fm" />
                 <node concept="3cpWs3" id="6tLsdkfI45w" role="33vP2m">
-                  <node concept="2OqwBi" id="6tLsdkfI45S" role="3uHU7w">
-                    <node concept="37vLTw" id="1rfeXz7xtai" role="2Oq$k0">
-                      <ref role="3cqZAo" node="6tLsdkfI41B" resolve="text" />
-                    </node>
-                    <node concept="liA8E" id="6tLsdkfI45X" role="2OqNvi">
-                      <ref role="37wK5l" to="wyt6:~String.length()" resolve="length" />
-                    </node>
-                  </node>
                   <node concept="2OqwBi" id="6tLsdkfI43s" role="3uHU7B">
                     <node concept="37vLTw" id="1rfeXz7xsEq" role="2Oq$k0">
                       <ref role="3cqZAo" node="6tLsdkfIQN4" resolve="mlCell" />
                     </node>
                     <node concept="liA8E" id="6tLsdkfI43y" role="2OqNvi">
                       <ref role="37wK5l" node="6tLsdkfI3xV" resolve="getCaretPosition" />
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="6tLsdkfI45S" role="3uHU7w">
+                    <node concept="37vLTw" id="1rfeXz7xtai" role="2Oq$k0">
+                      <ref role="3cqZAo" node="6tLsdkfI41B" resolve="text" />
+                    </node>
+                    <node concept="liA8E" id="6tLsdkfI45X" role="2OqNvi">
+                      <ref role="37wK5l" to="wyt6:~String.length()" resolve="length" />
                     </node>
                   </node>
                 </node>
@@ -9257,6 +9261,90 @@
         </node>
       </node>
     </node>
+    <node concept="2tJIrI" id="38Vsfq8LD4E" role="jymVt" />
+    <node concept="3clFb_" id="38Vsfq8M518" role="jymVt">
+      <property role="TrG5h" value="insertTextBefore" />
+      <node concept="3clFbS" id="38Vsfq8M51b" role="3clF47">
+        <node concept="3cpWs8" id="38Vsfq8Mn7k" role="3cqZAp">
+          <node concept="3cpWsn" id="38Vsfq8Mn7l" role="3cpWs9">
+            <property role="TrG5h" value="mlCell" />
+            <node concept="1rXfSq" id="38Vsfq8Mn7m" role="33vP2m">
+              <ref role="37wK5l" node="6tLsdkfI427" resolve="getParent" />
+            </node>
+            <node concept="3uibUv" id="38Vsfq8Mn7n" role="1tU5fm">
+              <ref role="3uigEE" node="7cgOZHrhAS_" resolve="EditorCell_Multiline" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="38Vsfq8Mn7o" role="3cqZAp">
+          <node concept="3clFbS" id="38Vsfq8Mn7p" role="3clFbx">
+            <node concept="3cpWs8" id="38Vsfq8Mn7q" role="3cqZAp">
+              <node concept="3cpWsn" id="38Vsfq8Mn7r" role="3cpWs9">
+                <property role="TrG5h" value="newCaretPos" />
+                <node concept="10Oyi0" id="38Vsfq8Mn7s" role="1tU5fm" />
+                <node concept="3cpWs3" id="38Vsfq8ObDR" role="33vP2m">
+                  <node concept="3cmrfG" id="38Vsfq8ObS0" role="3uHU7w">
+                    <property role="3cmrfH" value="1" />
+                  </node>
+                  <node concept="3cpWsd" id="38Vsfq8MsIO" role="3uHU7B">
+                    <node concept="2OqwBi" id="38Vsfq8Mn7u" role="3uHU7B">
+                      <node concept="37vLTw" id="38Vsfq8Mn7v" role="2Oq$k0">
+                        <ref role="3cqZAo" node="38Vsfq8Mn7l" resolve="mlCell" />
+                      </node>
+                      <node concept="liA8E" id="38Vsfq8Mn7w" role="2OqNvi">
+                        <ref role="37wK5l" node="6tLsdkfI3xV" resolve="getCaretPosition" />
+                      </node>
+                    </node>
+                    <node concept="2OqwBi" id="38Vsfq8Mn7x" role="3uHU7w">
+                      <node concept="37vLTw" id="38Vsfq8Mn7y" role="2Oq$k0">
+                        <ref role="3cqZAo" node="38Vsfq8Mgp6" resolve="text" />
+                      </node>
+                      <node concept="liA8E" id="38Vsfq8Mn7z" role="2OqNvi">
+                        <ref role="37wK5l" to="wyt6:~String.length()" resolve="length" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="38Vsfq8Mn7$" role="3cqZAp">
+              <node concept="3nyPlj" id="38Vsfq8Mn7_" role="3clFbG">
+                <ref role="37wK5l" to="g51k:~EditorCell_Label.insertText(java.lang.String)" resolve="insertText" />
+                <node concept="37vLTw" id="38Vsfq8Mn7A" role="37wK5m">
+                  <ref role="3cqZAo" node="38Vsfq8Mgp6" resolve="text" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="38Vsfq8Mn7B" role="3cqZAp">
+              <node concept="2OqwBi" id="38Vsfq8Mn7C" role="3clFbG">
+                <node concept="37vLTw" id="38Vsfq8Mn7D" role="2Oq$k0">
+                  <ref role="3cqZAo" node="38Vsfq8Mn7l" resolve="mlCell" />
+                </node>
+                <node concept="liA8E" id="38Vsfq8Mn7E" role="2OqNvi">
+                  <ref role="37wK5l" node="16btBGPcV7x" resolve="setCaretPosition" />
+                  <node concept="37vLTw" id="38Vsfq8Mn7F" role="37wK5m">
+                    <ref role="3cqZAo" node="38Vsfq8Mn7r" resolve="newCaretPos" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3y3z36" id="38Vsfq8Mn7G" role="3clFbw">
+            <node concept="37vLTw" id="38Vsfq8Mn7H" role="3uHU7B">
+              <ref role="3cqZAo" node="38Vsfq8Mn7l" resolve="mlCell" />
+            </node>
+            <node concept="10Nm6u" id="38Vsfq8Mn7I" role="3uHU7w" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="38Vsfq8LQzB" role="1B3o_S" />
+      <node concept="3cqZAl" id="38Vsfq8LXEz" role="3clF45" />
+      <node concept="37vLTG" id="38Vsfq8Mgp6" role="3clF46">
+        <property role="TrG5h" value="text" />
+        <node concept="17QB3L" id="38Vsfq8Mgp5" role="1tU5fm" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="38Vsfq8LHHN" role="jymVt" />
     <node concept="3clFb_" id="7AUW7IrF3rb" role="jymVt">
       <property role="1EzhhJ" value="false" />
       <property role="TrG5h" value="getCellId" />
@@ -11855,25 +11943,65 @@
       </node>
       <node concept="3Tm6S6" id="51$nbrvPsbl" role="1B3o_S" />
     </node>
+    <node concept="312cEg" id="38Vsfq8NlFo" role="jymVt">
+      <property role="TrG5h" value="myInsertBefore" />
+      <node concept="3Tm6S6" id="38Vsfq8NghQ" role="1B3o_S" />
+      <node concept="10P_77" id="38Vsfq8NlBQ" role="1tU5fm" />
+      <node concept="3clFbT" id="38Vsfq8Npwn" role="33vP2m" />
+    </node>
     <node concept="2tJIrI" id="51$nbrvPso3" role="jymVt" />
     <node concept="3clFbW" id="51$nbrvPsvu" role="jymVt">
       <node concept="3cqZAl" id="51$nbrvPsvw" role="3clF45" />
       <node concept="3Tm1VV" id="51$nbrvPsvx" role="1B3o_S" />
       <node concept="3clFbS" id="51$nbrvPsvy" role="3clF47">
-        <node concept="3clFbF" id="51$nbrvPszn" role="3cqZAp">
-          <node concept="37vLTI" id="51$nbrvPsP5" role="3clFbG">
-            <node concept="37vLTw" id="51$nbrvPsQx" role="37vLTx">
-              <ref role="3cqZAo" node="51$nbrvPsz9" resolve="wordCell" />
-            </node>
-            <node concept="37vLTw" id="51$nbrvPszm" role="37vLTJ">
-              <ref role="3cqZAo" node="51$nbrvPsbk" resolve="myWordCell" />
-            </node>
+        <node concept="1VxSAg" id="38Vsfq8NaUQ" role="3cqZAp">
+          <ref role="37wK5l" node="38Vsfq8MWKz" resolve="NewLineAction" />
+          <node concept="3clFbT" id="38Vsfq8PWKH" role="37wK5m" />
+          <node concept="37vLTw" id="38Vsfq8Nbqx" role="37wK5m">
+            <ref role="3cqZAo" node="51$nbrvPsz9" resolve="wordCell" />
           </node>
         </node>
       </node>
       <node concept="37vLTG" id="51$nbrvPsz9" role="3clF46">
         <property role="TrG5h" value="wordCell" />
         <node concept="3uibUv" id="51$nbrvPsz8" role="1tU5fm">
+          <ref role="3uigEE" node="5lTqPuSd937" resolve="EditorCell_Word" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="38Vsfq8MQxb" role="jymVt" />
+    <node concept="3clFbW" id="38Vsfq8MWKz" role="jymVt">
+      <node concept="3cqZAl" id="38Vsfq8MWK$" role="3clF45" />
+      <node concept="3clFbS" id="38Vsfq8MWKA" role="3clF47">
+        <node concept="3clFbF" id="38Vsfq8PXbM" role="3cqZAp">
+          <node concept="37vLTI" id="38Vsfq8PXPl" role="3clFbG">
+            <node concept="37vLTw" id="38Vsfq8PY1T" role="37vLTx">
+              <ref role="3cqZAo" node="38Vsfq8N3Ll" resolve="insertBefore" />
+            </node>
+            <node concept="37vLTw" id="38Vsfq8PXbL" role="37vLTJ">
+              <ref role="3cqZAo" node="38Vsfq8NlFo" resolve="myInsertBefore" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="38Vsfq8PYla" role="3cqZAp">
+          <node concept="37vLTI" id="38Vsfq8PZcl" role="3clFbG">
+            <node concept="37vLTw" id="38Vsfq8PZoo" role="37vLTx">
+              <ref role="3cqZAo" node="38Vsfq8N2rb" resolve="wordCell" />
+            </node>
+            <node concept="37vLTw" id="38Vsfq8PYl8" role="37vLTJ">
+              <ref role="3cqZAo" node="51$nbrvPsbk" resolve="myWordCell" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="38Vsfq8MRnY" role="1B3o_S" />
+      <node concept="37vLTG" id="38Vsfq8N3Ll" role="3clF46">
+        <property role="TrG5h" value="insertBefore" />
+        <node concept="10P_77" id="38Vsfq8N57G" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="38Vsfq8N2rb" role="3clF46">
+        <property role="TrG5h" value="wordCell" />
+        <node concept="3uibUv" id="38Vsfq8N2ra" role="1tU5fm">
           <ref role="3uigEE" node="5lTqPuSd937" resolve="EditorCell_Word" />
         </node>
       </node>
@@ -11916,16 +12044,40 @@
         </node>
       </node>
       <node concept="3clFbS" id="51$nbrvPnZK" role="3clF47">
-        <node concept="3clFbF" id="51$nbrvPopd" role="3cqZAp">
-          <node concept="2OqwBi" id="51$nbrvPoO$" role="3clFbG">
-            <node concept="liA8E" id="51$nbrvPqn8" role="2OqNvi">
-              <ref role="37wK5l" node="6tLsdkfI41$" resolve="insertText" />
-              <node concept="Xl_RD" id="51$nbrvPqyL" role="37wK5m">
-                <property role="Xl_RC" value="\n" />
+        <node concept="3clFbJ" id="38Vsfq8NDxI" role="3cqZAp">
+          <node concept="3clFbS" id="38Vsfq8NDxK" role="3clFbx">
+            <node concept="3clFbF" id="38Vsfq8NDYN" role="3cqZAp">
+              <node concept="2OqwBi" id="38Vsfq8NDYO" role="3clFbG">
+                <node concept="liA8E" id="38Vsfq8NDYP" role="2OqNvi">
+                  <ref role="37wK5l" node="38Vsfq8M518" resolve="insertTextBefore" />
+                  <node concept="Xl_RD" id="38Vsfq8NDYQ" role="37wK5m">
+                    <property role="Xl_RC" value="\n" />
+                  </node>
+                </node>
+                <node concept="37vLTw" id="38Vsfq8NDYR" role="2Oq$k0">
+                  <ref role="3cqZAo" node="51$nbrvPsbk" resolve="myWordCell" />
+                </node>
               </node>
             </node>
-            <node concept="37vLTw" id="51$nbrvPopc" role="2Oq$k0">
-              <ref role="3cqZAo" node="51$nbrvPsbk" resolve="myWordCell" />
+          </node>
+          <node concept="37vLTw" id="38Vsfq8NDKY" role="3clFbw">
+            <ref role="3cqZAo" node="38Vsfq8NlFo" resolve="myInsertBefore" />
+          </node>
+          <node concept="9aQIb" id="38Vsfq8NGgd" role="9aQIa">
+            <node concept="3clFbS" id="38Vsfq8NGge" role="9aQI4">
+              <node concept="3clFbF" id="51$nbrvPopd" role="3cqZAp">
+                <node concept="2OqwBi" id="51$nbrvPoO$" role="3clFbG">
+                  <node concept="liA8E" id="51$nbrvPqn8" role="2OqNvi">
+                    <ref role="37wK5l" node="6tLsdkfI41$" resolve="insertText" />
+                    <node concept="Xl_RD" id="51$nbrvPqyL" role="37wK5m">
+                      <property role="Xl_RC" value="\n" />
+                    </node>
+                  </node>
+                  <node concept="37vLTw" id="51$nbrvPopc" role="2Oq$k0">
+                    <ref role="3cqZAo" node="51$nbrvPsbk" resolve="myWordCell" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>

--- a/code/richtext/languages/javadoc/languageModels/structure.mps
+++ b/code/richtext/languages/javadoc/languageModels/structure.mps
@@ -77,6 +77,7 @@
     <property role="TrG5h" value="SeeClassTag" />
     <property role="EcuMT" value="842294157794129797" />
     <property role="34LRSv" value="@see" />
+    <property role="R4oN_" value="Javadoc tag" />
     <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
     <node concept="1TJgyj" id="IKrxbBHbue" role="1TKVEi">
       <property role="20kJfa" value="classifier" />
@@ -91,6 +92,8 @@
   <node concept="1TIwiD" id="IKrxbBHfGb">
     <property role="TrG5h" value="LinkTag" />
     <property role="EcuMT" value="842294157794147083" />
+    <property role="34LRSv" value="@link" />
+    <property role="R4oN_" value="Javadoc tag" />
     <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
     <node concept="1TJgyj" id="IKrxbBHfGy" role="1TKVEi">
       <property role="20kJfa" value="target" />
@@ -124,7 +127,7 @@
   </node>
   <node concept="1TIwiD" id="ehGfXvI$vs">
     <property role="TrG5h" value="BoldText" />
-    <property role="R4oN_" value="Bold Text" />
+    <property role="R4oN_" value="bold text" />
     <property role="34LRSv" value="&lt;b&gt;" />
     <property role="EcuMT" value="257181264606021596" />
     <ref role="1TJDcQ" node="4F4peXsrXtK" resolve="HtmlTag" />
@@ -132,6 +135,8 @@
   <node concept="1TIwiD" id="4F4peXsrXtG">
     <property role="TrG5h" value="ItalicText" />
     <property role="EcuMT" value="5387542033452750700" />
+    <property role="R4oN_" value="italicized text" />
+    <property role="34LRSv" value="&lt;i&gt;" />
     <ref role="1TJDcQ" node="4F4peXsrXtK" resolve="HtmlTag" />
     <node concept="PrWs8" id="4F4peXsrXtH" role="PzmwI">
       <ref role="PrY4T" to="87nw:2dWzqxEBBFG" resolve="IWord" />
@@ -140,6 +145,8 @@
   <node concept="1TIwiD" id="4$G0AukZXjj">
     <property role="TrG5h" value="TypeParamTag" />
     <property role="EcuMT" value="5272591907648689363" />
+    <property role="34LRSv" value="@param" />
+    <property role="R4oN_" value="Javadoc tag" />
     <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
     <node concept="1TJgyi" id="4$G0AukZXjm" role="1TKVEl">
       <property role="TrG5h" value="documentation" />

--- a/code/richtext/languages/richtext/languageModels/editor.mps
+++ b/code/richtext/languages/richtext/languageModels/editor.mps
@@ -47,12 +47,18 @@
   </imports>
   <registry>
     <language id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor">
+      <concept id="5991739802479784073" name="jetbrains.mps.lang.editor.structure.MenuTypeDefault" flags="ng" index="22hDWj" />
+      <concept id="2000375450116423800" name="jetbrains.mps.lang.editor.structure.SubstituteMenu" flags="ng" index="22mcaB" />
       <concept id="1071666914219" name="jetbrains.mps.lang.editor.structure.ConceptEditorDeclaration" flags="ig" index="24kQdi" />
       <concept id="1080736578640" name="jetbrains.mps.lang.editor.structure.BaseEditorComponent" flags="ig" index="2wURMF">
         <child id="1080736633877" name="cellModel" index="2wV5jI" />
       </concept>
       <concept id="1186402211651" name="jetbrains.mps.lang.editor.structure.StyleSheet" flags="ng" index="V5hpn">
         <child id="1186402402630" name="styles" index="V601i" />
+      </concept>
+      <concept id="1630016958697344083" name="jetbrains.mps.lang.editor.structure.IMenu_Concept" flags="ng" index="2ZABuq">
+        <reference id="6591946374543067572" name="conceptDeclaration" index="aqKnT" />
+        <child id="5991739802479788259" name="type" index="22hAXT" />
       </concept>
       <concept id="3982520150113085419" name="jetbrains.mps.lang.editor.structure.StyleAttributeDeclaration" flags="ig" index="3t5Usi">
         <child id="3982520150113092206" name="valueType" index="3t5Oan" />
@@ -8000,6 +8006,10 @@
     </node>
     <node concept="2tJIrI" id="5lBiF1A_c3v" role="jymVt" />
     <node concept="3Tm1VV" id="5lBiF1AzqCM" role="1B3o_S" />
+  </node>
+  <node concept="22mcaB" id="38Vsfq7rkAx">
+    <ref role="aqKnT" to="87nw:2dWzqxEBMSc" resolve="Word" />
+    <node concept="22hDWj" id="38Vsfq7rkDM" role="22hAXT" />
   </node>
 </model>
 

--- a/code/richtext/languages/richtext/models/de/slisson/mps/richtext/runtime.mps
+++ b/code/richtext/languages/richtext/models/de/slisson/mps/richtext/runtime.mps
@@ -119,6 +119,7 @@
       <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
         <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
       </concept>
+      <concept id="1068581242869" name="jetbrains.mps.baseLanguage.structure.MinusExpression" flags="nn" index="3cpWsd" />
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
       <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
       <concept id="1079359253375" name="jetbrains.mps.baseLanguage.structure.ParenthesizedExpression" flags="nn" index="1eOMI4">
@@ -229,6 +230,7 @@
       <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
       <concept id="1160666733551" name="jetbrains.mps.baseLanguage.collections.structure.AddAllElementsOperation" flags="nn" index="X8dFx" />
       <concept id="1240325842691" name="jetbrains.mps.baseLanguage.collections.structure.AsSequenceOperation" flags="nn" index="39bAoz" />
+      <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
       <concept id="1165595910856" name="jetbrains.mps.baseLanguage.collections.structure.GetLastOperation" flags="nn" index="1yVyf7" />
       <concept id="1225730411176" name="jetbrains.mps.baseLanguage.collections.structure.FindLastOperation" flags="nn" index="1zesIP" />
       <concept id="1202128969694" name="jetbrains.mps.baseLanguage.collections.structure.SelectOperation" flags="nn" index="3$u5V9" />
@@ -995,15 +997,310 @@
           <node concept="17QB3L" id="o1roXBZVej" role="1tU5fm" />
         </node>
         <node concept="3clFbS" id="o1roXBZOLc" role="3clF47">
-          <node concept="3clFbF" id="o1roXBZVwJ" role="3cqZAp">
-            <node concept="2OqwBi" id="o1roXBZVyj" role="3clFbG">
-              <node concept="37vLTw" id="o1roXBZVwI" role="2Oq$k0">
-                <ref role="3cqZAo" node="o1roXBZOj5" resolve="myAction" />
+          <node concept="3cpWs8" id="38Vsfq88T3G" role="3cqZAp">
+            <node concept="3cpWsn" id="38Vsfq88T3H" role="3cpWs9">
+              <property role="TrG5h" value="descriptionText" />
+              <node concept="17QB3L" id="38Vsfq893mm" role="1tU5fm" />
+              <node concept="2OqwBi" id="38Vsfq88T3I" role="33vP2m">
+                <node concept="37vLTw" id="38Vsfq88T3J" role="2Oq$k0">
+                  <ref role="3cqZAo" node="o1roXBZOj5" resolve="myAction" />
+                </node>
+                <node concept="liA8E" id="38Vsfq88T3K" role="2OqNvi">
+                  <ref role="37wK5l" to="f4zo:~SubstituteAction.getDescriptionText(java.lang.String)" resolve="getDescriptionText" />
+                  <node concept="37vLTw" id="38Vsfq88T3L" role="37wK5m">
+                    <ref role="3cqZAo" node="o1roXBZOLa" resolve="pattern" />
+                  </node>
+                </node>
               </node>
-              <node concept="liA8E" id="o1roXBZV_G" role="2OqNvi">
-                <ref role="37wK5l" to="f4zo:~SubstituteAction.getDescriptionText(java.lang.String)" resolve="getDescriptionText" />
-                <node concept="37vLTw" id="o1roXBZVHn" role="37wK5m">
-                  <ref role="3cqZAo" node="o1roXBZOLa" resolve="pattern" />
+            </node>
+          </node>
+          <node concept="3clFbH" id="38Vsfq8914t" role="3cqZAp" />
+          <node concept="3cpWs8" id="38Vsfq88QzQ" role="3cqZAp">
+            <node concept="3cpWsn" id="38Vsfq88QzR" role="3cpWs9">
+              <property role="TrG5h" value="wordNode" />
+              <node concept="3Tqbb2" id="38Vsfq88QzS" role="1tU5fm">
+                <ref role="ehGHo" to="87nw:2dWzqxEBMSc" resolve="Word" />
+              </node>
+              <node concept="1PxgMI" id="38Vsfq88QzT" role="33vP2m">
+                <node concept="2OqwBi" id="38Vsfq88QzU" role="1m5AlR">
+                  <node concept="37vLTw" id="38Vsfq88QzV" role="2Oq$k0">
+                    <ref role="3cqZAo" node="o1roXC0g1t" resolve="myWordCell" />
+                  </node>
+                  <node concept="liA8E" id="38Vsfq88QzW" role="2OqNvi">
+                    <ref role="37wK5l" to="g51k:~EditorCell_Basic.getSNode()" resolve="getSNode" />
+                  </node>
+                </node>
+                <node concept="chp4Y" id="38Vsfq88QzX" role="3oSUPX">
+                  <ref role="cht4Q" to="87nw:2dWzqxEBMSc" resolve="Word" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="38Vsfq88QzY" role="3cqZAp">
+            <node concept="3cpWsn" id="38Vsfq88QzZ" role="3cpWs9">
+              <property role="TrG5h" value="visibleMatchingText" />
+              <node concept="17QB3L" id="38Vsfq88Q$0" role="1tU5fm" />
+              <node concept="2OqwBi" id="38Vsfq88Q$1" role="33vP2m">
+                <node concept="37vLTw" id="38Vsfq88Q$2" role="2Oq$k0">
+                  <ref role="3cqZAo" node="o1roXBZOj5" resolve="myAction" />
+                </node>
+                <node concept="liA8E" id="38Vsfq88Q$3" role="2OqNvi">
+                  <ref role="37wK5l" to="f4zo:~SubstituteAction.getVisibleMatchingText(java.lang.String)" resolve="getVisibleMatchingText" />
+                  <node concept="37vLTw" id="38Vsfq88Q$4" role="37wK5m">
+                    <ref role="3cqZAo" node="o1roXBZOLa" resolve="pattern" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbH" id="38Vsfq88Q$5" role="3cqZAp" />
+          <node concept="3cpWs8" id="38Vsfq88Q$6" role="3cqZAp">
+            <node concept="3cpWsn" id="38Vsfq88Q$7" role="3cpWs9">
+              <property role="TrG5h" value="maxLength" />
+              <node concept="10Oyi0" id="38Vsfq88Q$8" role="1tU5fm" />
+              <node concept="3cmrfG" id="38Vsfq88Q$9" role="33vP2m">
+                <property role="3cmrfH" value="5" />
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="38Vsfq88Q$a" role="3cqZAp">
+            <node concept="3cpWsn" id="38Vsfq88Q$b" role="3cpWs9">
+              <property role="TrG5h" value="beforeText" />
+              <node concept="17QB3L" id="38Vsfq88Q$c" role="1tU5fm" />
+              <node concept="2OqwBi" id="38Vsfq88Q$d" role="33vP2m">
+                <node concept="2OqwBi" id="38Vsfq8a6wM" role="2Oq$k0">
+                  <node concept="2OqwBi" id="38Vsfq8a3dx" role="2Oq$k0">
+                    <node concept="2OqwBi" id="38Vsfq89SW3" role="2Oq$k0">
+                      <node concept="1rXfSq" id="38Vsfq88Q$h" role="2Oq$k0">
+                        <ref role="37wK5l" node="38Vsfq7d0jb" resolve="getSurroundingText" />
+                        <node concept="37vLTw" id="38Vsfq88Q$i" role="37wK5m">
+                          <ref role="3cqZAo" node="38Vsfq88QzR" resolve="wordNode" />
+                        </node>
+                        <node concept="3clFbT" id="38Vsfq88Q$j" role="37wK5m">
+                          <property role="3clFbU" value="true" />
+                        </node>
+                      </node>
+                      <node concept="liA8E" id="38Vsfq89X5F" role="2OqNvi">
+                        <ref role="37wK5l" to="wyt6:~String.split(java.lang.String)" resolve="split" />
+                        <node concept="Xl_RD" id="38Vsfq89Z9T" role="37wK5m">
+                          <property role="Xl_RC" value=" " />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="39bAoz" id="38Vsfq8a5dc" role="2OqNvi" />
+                  </node>
+                  <node concept="1yVyf7" id="38Vsfq8a8mA" role="2OqNvi" />
+                </node>
+                <node concept="17S1cR" id="38Vsfq88Q$o" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbH" id="38Vsfq88Q$p" role="3cqZAp" />
+          <node concept="3clFbJ" id="38Vsfq88Q$q" role="3cqZAp">
+            <node concept="3clFbS" id="38Vsfq88Q$r" role="3clFbx">
+              <node concept="3clFbF" id="38Vsfq88Q$s" role="3cqZAp">
+                <node concept="37vLTI" id="38Vsfq88Q$t" role="3clFbG">
+                  <node concept="3cpWs3" id="38Vsfq88Q$u" role="37vLTx">
+                    <node concept="2OqwBi" id="38Vsfq88Q$v" role="3uHU7w">
+                      <node concept="37vLTw" id="38Vsfq88Q$w" role="2Oq$k0">
+                        <ref role="3cqZAo" node="38Vsfq88Q$b" resolve="beforeText" />
+                      </node>
+                      <node concept="liA8E" id="38Vsfq88Q$x" role="2OqNvi">
+                        <ref role="37wK5l" to="wyt6:~String.substring(int)" resolve="substring" />
+                        <node concept="3cpWsd" id="38Vsfq88Q$y" role="37wK5m">
+                          <node concept="3cmrfG" id="38Vsfq88Q$z" role="3uHU7w">
+                            <property role="3cmrfH" value="1" />
+                          </node>
+                          <node concept="3cpWsd" id="38Vsfq88Q$$" role="3uHU7B">
+                            <node concept="2OqwBi" id="38Vsfq88Q$_" role="3uHU7B">
+                              <node concept="37vLTw" id="38Vsfq88Q$A" role="2Oq$k0">
+                                <ref role="3cqZAo" node="38Vsfq88Q$b" resolve="beforeText" />
+                              </node>
+                              <node concept="liA8E" id="38Vsfq88Q$B" role="2OqNvi">
+                                <ref role="37wK5l" to="wyt6:~String.length()" resolve="length" />
+                              </node>
+                            </node>
+                            <node concept="37vLTw" id="38Vsfq88Q$C" role="3uHU7w">
+                              <ref role="3cqZAo" node="38Vsfq88Q$7" resolve="maxLength" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="Xl_RD" id="38Vsfq88Q$D" role="3uHU7B">
+                      <property role="Xl_RC" value="..." />
+                    </node>
+                  </node>
+                  <node concept="37vLTw" id="38Vsfq88Q$E" role="37vLTJ">
+                    <ref role="3cqZAo" node="38Vsfq88Q$b" resolve="beforeText" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3eOSWO" id="38Vsfq88Q$F" role="3clFbw">
+              <node concept="37vLTw" id="38Vsfq88Q$G" role="3uHU7w">
+                <ref role="3cqZAo" node="38Vsfq88Q$7" resolve="maxLength" />
+              </node>
+              <node concept="2OqwBi" id="38Vsfq88Q$H" role="3uHU7B">
+                <node concept="37vLTw" id="38Vsfq88Q$I" role="2Oq$k0">
+                  <ref role="3cqZAo" node="38Vsfq88Q$b" resolve="beforeText" />
+                </node>
+                <node concept="liA8E" id="38Vsfq88Q$J" role="2OqNvi">
+                  <ref role="37wK5l" to="wyt6:~String.length()" resolve="length" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="38Vsfq88Q$K" role="3cqZAp">
+            <node concept="3cpWsn" id="38Vsfq88Q$L" role="3cpWs9">
+              <property role="TrG5h" value="afterText" />
+              <node concept="17QB3L" id="38Vsfq88Q$M" role="1tU5fm" />
+              <node concept="2OqwBi" id="38Vsfq8am$v" role="33vP2m">
+                <node concept="2OqwBi" id="38Vsfq8ai7J" role="2Oq$k0">
+                  <node concept="2OqwBi" id="38Vsfq8aamd" role="2Oq$k0">
+                    <node concept="1rXfSq" id="38Vsfq88Q$N" role="2Oq$k0">
+                      <ref role="37wK5l" node="38Vsfq7d0jb" resolve="getSurroundingText" />
+                      <node concept="37vLTw" id="38Vsfq88Q$O" role="37wK5m">
+                        <ref role="3cqZAo" node="38Vsfq88QzR" resolve="wordNode" />
+                      </node>
+                      <node concept="3clFbT" id="38Vsfq88Q$P" role="37wK5m" />
+                    </node>
+                    <node concept="liA8E" id="38Vsfq8acfg" role="2OqNvi">
+                      <ref role="37wK5l" to="wyt6:~String.split(java.lang.String)" resolve="split" />
+                      <node concept="Xl_RD" id="38Vsfq8aegj" role="37wK5m">
+                        <property role="Xl_RC" value=" " />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="39bAoz" id="38Vsfq8ak8O" role="2OqNvi" />
+                </node>
+                <node concept="1uHKPH" id="38Vsfq8aoxs" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbJ" id="38Vsfq88Q$Q" role="3cqZAp">
+            <node concept="3clFbS" id="38Vsfq88Q$R" role="3clFbx">
+              <node concept="3clFbF" id="38Vsfq88Q$S" role="3cqZAp">
+                <node concept="37vLTI" id="38Vsfq88Q$T" role="3clFbG">
+                  <node concept="3cpWs3" id="38Vsfq88Q$U" role="37vLTx">
+                    <node concept="2OqwBi" id="38Vsfq88Q$V" role="3uHU7B">
+                      <node concept="37vLTw" id="38Vsfq88Q$W" role="2Oq$k0">
+                        <ref role="3cqZAo" node="38Vsfq88Q$L" resolve="afterText" />
+                      </node>
+                      <node concept="liA8E" id="38Vsfq88Q$X" role="2OqNvi">
+                        <ref role="37wK5l" to="wyt6:~String.substring(int,int)" resolve="substring" />
+                        <node concept="3cmrfG" id="38Vsfq88Q$Y" role="37wK5m">
+                          <property role="3cmrfH" value="0" />
+                        </node>
+                        <node concept="37vLTw" id="38Vsfq88Q$Z" role="37wK5m">
+                          <ref role="3cqZAo" node="38Vsfq88Q$7" resolve="maxLength" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="Xl_RD" id="38Vsfq88Q_0" role="3uHU7w">
+                      <property role="Xl_RC" value="..." />
+                    </node>
+                  </node>
+                  <node concept="37vLTw" id="38Vsfq88Q_1" role="37vLTJ">
+                    <ref role="3cqZAo" node="38Vsfq88Q$L" resolve="afterText" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3eOSWO" id="38Vsfq88Q_2" role="3clFbw">
+              <node concept="37vLTw" id="38Vsfq88Q_3" role="3uHU7w">
+                <ref role="3cqZAo" node="38Vsfq88Q$7" resolve="maxLength" />
+              </node>
+              <node concept="2OqwBi" id="38Vsfq88Q_4" role="3uHU7B">
+                <node concept="37vLTw" id="38Vsfq88Q_5" role="2Oq$k0">
+                  <ref role="3cqZAo" node="38Vsfq88Q$L" resolve="afterText" />
+                </node>
+                <node concept="liA8E" id="38Vsfq88Q_6" role="2OqNvi">
+                  <ref role="37wK5l" to="wyt6:~String.length()" resolve="length" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbH" id="38Vsfq88Q_7" role="3cqZAp" />
+          <node concept="3clFbH" id="38Vsfq88Q_8" role="3cqZAp" />
+          <node concept="3clFbJ" id="38Vsfq88Q_9" role="3cqZAp">
+            <node concept="3clFbS" id="38Vsfq88Q_a" role="3clFbx">
+              <node concept="3cpWs6" id="38Vsfq88Q_b" role="3cqZAp">
+                <node concept="3cpWs3" id="38Vsfq89s3t" role="3cqZAk">
+                  <node concept="Xl_RD" id="38Vsfq89s4I" role="3uHU7w">
+                    <property role="Xl_RC" value=")" />
+                  </node>
+                  <node concept="3cpWs3" id="38Vsfq88Q_c" role="3uHU7B">
+                    <node concept="3cpWs3" id="38Vsfq88Q_d" role="3uHU7B">
+                      <node concept="Xl_RD" id="38Vsfq88Q_e" role="3uHU7w">
+                        <property role="Xl_RC" value=" " />
+                      </node>
+                      <node concept="3cpWs3" id="38Vsfq88Q_f" role="3uHU7B">
+                        <node concept="3cpWs3" id="38Vsfq88Q_g" role="3uHU7B">
+                          <node concept="Xl_RD" id="38Vsfq88Q_h" role="3uHU7w">
+                            <property role="Xl_RC" value=" " />
+                          </node>
+                          <node concept="3cpWs3" id="38Vsfq895o5" role="3uHU7B">
+                            <node concept="3cpWs3" id="38Vsfq899Q9" role="3uHU7B">
+                              <node concept="Xl_RD" id="38Vsfq899RA" role="3uHU7w">
+                                <property role="Xl_RC" value=" (" />
+                              </node>
+                              <node concept="37vLTw" id="38Vsfq897fV" role="3uHU7B">
+                                <ref role="3cqZAo" node="38Vsfq88T3H" resolve="descriptionText" />
+                              </node>
+                            </node>
+                            <node concept="37vLTw" id="38Vsfq88Q_i" role="3uHU7w">
+                              <ref role="3cqZAo" node="38Vsfq88Q$b" resolve="beforeText" />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="37vLTw" id="38Vsfq88Q_j" role="3uHU7w">
+                          <ref role="3cqZAo" node="38Vsfq88QzZ" resolve="visibleMatchingText" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="37vLTw" id="38Vsfq88Q_k" role="3uHU7w">
+                      <ref role="3cqZAo" node="38Vsfq88Q$L" resolve="afterText" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="37vLTw" id="38Vsfq88Q_l" role="3clFbw">
+              <ref role="3cqZAo" node="2u3OARMiso4" resolve="myInsertOnly" />
+            </node>
+            <node concept="9aQIb" id="38Vsfq88Q_m" role="9aQIa">
+              <node concept="3clFbS" id="38Vsfq88Q_n" role="9aQI4">
+                <node concept="3clFbH" id="38Vsfq88Q_o" role="3cqZAp" />
+                <node concept="3cpWs6" id="38Vsfq88Q_p" role="3cqZAp">
+                  <node concept="3cpWs3" id="38Vsfq89Fei" role="3cqZAk">
+                    <node concept="Xl_RD" id="38Vsfq89Ffz" role="3uHU7w">
+                      <property role="Xl_RC" value=")" />
+                    </node>
+                    <node concept="3cpWs3" id="38Vsfq88Q_q" role="3uHU7B">
+                      <node concept="3cpWs3" id="38Vsfq88Q_r" role="3uHU7B">
+                        <node concept="Xl_RD" id="38Vsfq88Q_s" role="3uHU7w">
+                          <property role="Xl_RC" value=" " />
+                        </node>
+                        <node concept="3cpWs3" id="38Vsfq89di$" role="3uHU7B">
+                          <node concept="3cpWs3" id="38Vsfq89hjh" role="3uHU7B">
+                            <node concept="Xl_RD" id="38Vsfq89hky" role="3uHU7w">
+                              <property role="Xl_RC" value=" (" />
+                            </node>
+                            <node concept="37vLTw" id="38Vsfq89fqF" role="3uHU7B">
+                              <ref role="3cqZAo" node="38Vsfq88T3H" resolve="descriptionText" />
+                            </node>
+                          </node>
+                          <node concept="37vLTw" id="38Vsfq88Q_t" role="3uHU7w">
+                            <ref role="3cqZAo" node="38Vsfq88QzZ" resolve="visibleMatchingText" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="37vLTw" id="38Vsfq88Q_u" role="3uHU7w">
+                        <ref role="3cqZAo" node="38Vsfq88Q$L" resolve="afterText" />
+                      </node>
+                    </node>
+                  </node>
                 </node>
               </node>
             </node>
@@ -1150,137 +1447,29 @@
           <node concept="17QB3L" id="o1roXBZZp6" role="1tU5fm" />
         </node>
         <node concept="3clFbS" id="o1roXBZOLW" role="3clF47">
-          <node concept="3cpWs8" id="38Vsfq7eloM" role="3cqZAp">
-            <node concept="3cpWsn" id="38Vsfq7eloP" role="3cpWs9">
-              <property role="TrG5h" value="wordNode" />
-              <node concept="3Tqbb2" id="38Vsfq7eloQ" role="1tU5fm">
-                <ref role="ehGHo" to="87nw:2dWzqxEBMSc" resolve="Word" />
-              </node>
-              <node concept="1PxgMI" id="38Vsfq7eloR" role="33vP2m">
-                <node concept="2OqwBi" id="38Vsfq7eloS" role="1m5AlR">
-                  <node concept="37vLTw" id="38Vsfq7eloT" role="2Oq$k0">
-                    <ref role="3cqZAo" node="o1roXC0g1t" resolve="myWordCell" />
-                  </node>
-                  <node concept="liA8E" id="38Vsfq7eloU" role="2OqNvi">
-                    <ref role="37wK5l" to="g51k:~EditorCell_Basic.getSNode()" resolve="getSNode" />
-                  </node>
-                </node>
-                <node concept="chp4Y" id="38Vsfq7eloV" role="3oSUPX">
-                  <ref role="cht4Q" to="87nw:2dWzqxEBMSc" resolve="Word" />
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3cpWs8" id="38Vsfq7eyZg" role="3cqZAp">
-            <node concept="3cpWsn" id="38Vsfq7eyZj" role="3cpWs9">
-              <property role="TrG5h" value="visibleMatchingText" />
-              <node concept="17QB3L" id="38Vsfq7eyZe" role="1tU5fm" />
-              <node concept="2OqwBi" id="38Vsfq7eDrD" role="33vP2m">
-                <node concept="37vLTw" id="38Vsfq7eDrE" role="2Oq$k0">
+          <node concept="3clFbF" id="38Vsfq89o7U" role="3cqZAp">
+            <node concept="3cpWs3" id="38Vsfq8aSPT" role="3clFbG">
+              <node concept="2OqwBi" id="o1roXBZZ3L" role="3uHU7B">
+                <node concept="37vLTw" id="o1roXBZZ24" role="2Oq$k0">
                   <ref role="3cqZAo" node="o1roXBZOj5" resolve="myAction" />
                 </node>
-                <node concept="liA8E" id="38Vsfq7eDrF" role="2OqNvi">
+                <node concept="liA8E" id="o1roXBZZc0" role="2OqNvi">
                   <ref role="37wK5l" to="f4zo:~SubstituteAction.getVisibleMatchingText(java.lang.String)" resolve="getVisibleMatchingText" />
-                  <node concept="37vLTw" id="38Vsfq7eDrG" role="37wK5m">
+                  <node concept="37vLTw" id="o1roXBZZj_" role="37wK5m">
                     <ref role="3cqZAo" node="o1roXBZOLU" resolve="pattern" />
                   </node>
                 </node>
               </node>
-            </node>
-          </node>
-          <node concept="3clFbH" id="38Vsfq7oKtX" role="3cqZAp" />
-          <node concept="3cpWs8" id="38Vsfq7h$Eh" role="3cqZAp">
-            <node concept="3cpWsn" id="38Vsfq7h$Ei" role="3cpWs9">
-              <property role="TrG5h" value="beforeText" />
-              <node concept="17QB3L" id="38Vsfq7hzRS" role="1tU5fm" />
-              <node concept="2OqwBi" id="38Vsfq7jKo6" role="33vP2m">
-                <node concept="2OqwBi" id="38Vsfq7j7za" role="2Oq$k0">
-                  <node concept="2OqwBi" id="38Vsfq7j2Xb" role="2Oq$k0">
-                    <node concept="2OqwBi" id="38Vsfq7iU1Z" role="2Oq$k0">
-                      <node concept="1rXfSq" id="38Vsfq7h$Ej" role="2Oq$k0">
-                        <ref role="37wK5l" node="38Vsfq7d0jb" resolve="getSurroundingText" />
-                        <node concept="37vLTw" id="38Vsfq7h$Ek" role="37wK5m">
-                          <ref role="3cqZAo" node="38Vsfq7eloP" resolve="wordNode" />
-                        </node>
-                        <node concept="3clFbT" id="38Vsfq7h$El" role="37wK5m">
-                          <property role="3clFbU" value="true" />
-                        </node>
-                      </node>
-                      <node concept="liA8E" id="38Vsfq7iX2n" role="2OqNvi">
-                        <ref role="37wK5l" to="wyt6:~String.split(java.lang.String)" resolve="split" />
-                        <node concept="Xl_RD" id="38Vsfq7iYFW" role="37wK5m">
-                          <property role="Xl_RC" value="\\\\n" />
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="39bAoz" id="38Vsfq7j4Hg" role="2OqNvi" />
+              <node concept="1eOMI4" id="38Vsfq8biou" role="3uHU7w">
+                <node concept="3K4zz7" id="38Vsfq8aUvG" role="1eOMHV">
+                  <node concept="Xl_RD" id="38Vsfq8aYUb" role="3K4E3e">
+                    <property role="Xl_RC" value="*" />
                   </node>
-                  <node concept="1yVyf7" id="38Vsfq7j9YC" role="2OqNvi" />
-                </node>
-                <node concept="17S1cR" id="38Vsfq7jMNl" role="2OqNvi" />
-              </node>
-            </node>
-          </node>
-          <node concept="3cpWs8" id="38Vsfq7hE02" role="3cqZAp">
-            <node concept="3cpWsn" id="38Vsfq7hE03" role="3cpWs9">
-              <property role="TrG5h" value="afterText" />
-              <node concept="17QB3L" id="38Vsfq7hE04" role="1tU5fm" />
-              <node concept="1rXfSq" id="38Vsfq7hE05" role="33vP2m">
-                <ref role="37wK5l" node="38Vsfq7d0jb" resolve="getSurroundingText" />
-                <node concept="37vLTw" id="38Vsfq7hE06" role="37wK5m">
-                  <ref role="3cqZAo" node="38Vsfq7eloP" resolve="wordNode" />
-                </node>
-                <node concept="3clFbT" id="38Vsfq7hE07" role="37wK5m" />
-              </node>
-            </node>
-          </node>
-          <node concept="3clFbH" id="38Vsfq7mSGm" role="3cqZAp" />
-          <node concept="3clFbJ" id="38Vsfq7dWpS" role="3cqZAp">
-            <node concept="3clFbS" id="38Vsfq7dWpU" role="3clFbx">
-              <node concept="3cpWs6" id="38Vsfq7eha9" role="3cqZAp">
-                <node concept="3cpWs3" id="38Vsfq7eN04" role="3cqZAk">
-                  <node concept="3cpWs3" id="38Vsfq7p9xq" role="3uHU7B">
-                    <node concept="Xl_RD" id="38Vsfq7p9z5" role="3uHU7w">
-                      <property role="Xl_RC" value=" " />
-                    </node>
-                    <node concept="3cpWs3" id="38Vsfq7esya" role="3uHU7B">
-                      <node concept="3cpWs3" id="38Vsfq7p74j" role="3uHU7B">
-                        <node concept="Xl_RD" id="38Vsfq7p7M3" role="3uHU7w">
-                          <property role="Xl_RC" value=" " />
-                        </node>
-                        <node concept="37vLTw" id="38Vsfq7hMb_" role="3uHU7B">
-                          <ref role="3cqZAo" node="38Vsfq7h$Ei" resolve="beforeText" />
-                        </node>
-                      </node>
-                      <node concept="37vLTw" id="38Vsfq7eL3o" role="3uHU7w">
-                        <ref role="3cqZAo" node="38Vsfq7eyZj" resolve="visibleMatchingText" />
-                      </node>
-                    </node>
+                  <node concept="Xl_RD" id="38Vsfq8b67Y" role="3K4GZi">
+                    <property role="Xl_RC" value="" />
                   </node>
-                  <node concept="37vLTw" id="38Vsfq7h$En" role="3uHU7w">
-                    <ref role="3cqZAo" node="38Vsfq7hE03" resolve="afterText" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="37vLTw" id="38Vsfq7dXJE" role="3clFbw">
-              <ref role="3cqZAo" node="2u3OARMiso4" resolve="myInsertOnly" />
-            </node>
-            <node concept="9aQIb" id="38Vsfq7dZjX" role="9aQIa">
-              <node concept="3clFbS" id="38Vsfq7dZjY" role="9aQI4">
-                <node concept="3cpWs6" id="38Vsfq7e1IW" role="3cqZAp">
-                  <node concept="3cpWs3" id="38Vsfq7e5n5" role="3cqZAk">
-                    <node concept="3cpWs3" id="38Vsfq7pe45" role="3uHU7B">
-                      <node concept="Xl_RD" id="38Vsfq7pe5u" role="3uHU7w">
-                        <property role="Xl_RC" value=" " />
-                      </node>
-                      <node concept="37vLTw" id="38Vsfq7eJxo" role="3uHU7B">
-                        <ref role="3cqZAo" node="38Vsfq7eyZj" resolve="visibleMatchingText" />
-                      </node>
-                    </node>
-                    <node concept="37vLTw" id="38Vsfq7h$Em" role="3uHU7w">
-                      <ref role="3cqZAo" node="38Vsfq7hE03" resolve="afterText" />
-                    </node>
+                  <node concept="37vLTw" id="38Vsfq8aWTE" role="3K4Cdx">
+                    <ref role="3cqZAo" node="2u3OARMiso4" resolve="myInsertOnly" />
                   </node>
                 </node>
               </node>

--- a/code/richtext/languages/richtext/models/de/slisson/mps/richtext/runtime.mps
+++ b/code/richtext/languages/richtext/models/de/slisson/mps/richtext/runtime.mps
@@ -1271,33 +1271,43 @@
             </node>
             <node concept="9aQIb" id="38Vsfq88Q_m" role="9aQIa">
               <node concept="3clFbS" id="38Vsfq88Q_n" role="9aQI4">
-                <node concept="3clFbH" id="38Vsfq88Q_o" role="3cqZAp" />
-                <node concept="3cpWs6" id="38Vsfq88Q_p" role="3cqZAp">
-                  <node concept="3cpWs3" id="38Vsfq89Fei" role="3cqZAk">
-                    <node concept="Xl_RD" id="38Vsfq89Ffz" role="3uHU7w">
-                      <property role="Xl_RC" value=")" />
-                    </node>
-                    <node concept="3cpWs3" id="38Vsfq88Q_q" role="3uHU7B">
-                      <node concept="3cpWs3" id="38Vsfq88Q_r" role="3uHU7B">
-                        <node concept="Xl_RD" id="38Vsfq88Q_s" role="3uHU7w">
-                          <property role="Xl_RC" value=" " />
-                        </node>
-                        <node concept="3cpWs3" id="38Vsfq89di$" role="3uHU7B">
-                          <node concept="3cpWs3" id="38Vsfq89hjh" role="3uHU7B">
-                            <node concept="Xl_RD" id="38Vsfq89hky" role="3uHU7w">
-                              <property role="Xl_RC" value=" (" />
-                            </node>
-                            <node concept="37vLTw" id="38Vsfq89fqF" role="3uHU7B">
-                              <ref role="3cqZAo" node="38Vsfq88T3H" resolve="descriptionText" />
-                            </node>
-                          </node>
-                          <node concept="37vLTw" id="38Vsfq88Q_t" role="3uHU7w">
-                            <ref role="3cqZAo" node="38Vsfq88QzZ" resolve="visibleMatchingText" />
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="37vLTw" id="38Vsfq88Q_u" role="3uHU7w">
+                <node concept="3cpWs6" id="38Vsfq8p6LW" role="3cqZAp">
+                  <node concept="3K4zz7" id="38Vsfq8pcm9" role="3cqZAk">
+                    <node concept="2OqwBi" id="38Vsfq8pg1K" role="3K4Cdx">
+                      <node concept="37vLTw" id="38Vsfq8pe7d" role="2Oq$k0">
                         <ref role="3cqZAo" node="38Vsfq88Q$L" resolve="afterText" />
+                      </node>
+                      <node concept="17RvpY" id="38Vsfq8pjxA" role="2OqNvi" />
+                    </node>
+                    <node concept="37vLTw" id="38Vsfq8pqBs" role="3K4GZi">
+                      <ref role="3cqZAo" node="38Vsfq88T3H" resolve="descriptionText" />
+                    </node>
+                    <node concept="3cpWs3" id="38Vsfq89Fei" role="3K4E3e">
+                      <node concept="Xl_RD" id="38Vsfq89Ffz" role="3uHU7w">
+                        <property role="Xl_RC" value=")" />
+                      </node>
+                      <node concept="3cpWs3" id="38Vsfq88Q_q" role="3uHU7B">
+                        <node concept="3cpWs3" id="38Vsfq88Q_r" role="3uHU7B">
+                          <node concept="Xl_RD" id="38Vsfq88Q_s" role="3uHU7w">
+                            <property role="Xl_RC" value=" " />
+                          </node>
+                          <node concept="3cpWs3" id="38Vsfq89di$" role="3uHU7B">
+                            <node concept="3cpWs3" id="38Vsfq89hjh" role="3uHU7B">
+                              <node concept="Xl_RD" id="38Vsfq89hky" role="3uHU7w">
+                                <property role="Xl_RC" value=" (" />
+                              </node>
+                              <node concept="37vLTw" id="38Vsfq89fqF" role="3uHU7B">
+                                <ref role="3cqZAo" node="38Vsfq88T3H" resolve="descriptionText" />
+                              </node>
+                            </node>
+                            <node concept="37vLTw" id="38Vsfq88Q_t" role="3uHU7w">
+                              <ref role="3cqZAo" node="38Vsfq88QzZ" resolve="visibleMatchingText" />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="37vLTw" id="38Vsfq88Q_u" role="3uHU7w">
+                          <ref role="3cqZAo" node="38Vsfq88Q$L" resolve="afterText" />
+                        </node>
                       </node>
                     </node>
                   </node>

--- a/code/richtext/languages/richtext/models/de/slisson/mps/richtext/runtime.mps
+++ b/code/richtext/languages/richtext/models/de/slisson/mps/richtext/runtime.mps
@@ -6,6 +6,8 @@
     <use id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures" version="-1" />
     <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
+    <use id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc" version="2" />
+    <use id="760a0a8c-eabb-4521-8bfd-65db761a9ba3" name="jetbrains.mps.baseLanguage.logging" version="0" />
   </languages>
   <imports>
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
@@ -76,6 +78,7 @@
       <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
       <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
       <concept id="1225271408483" name="jetbrains.mps.baseLanguage.structure.IsNotEmptyOperation" flags="nn" index="17RvpY" />
+      <concept id="1225271546410" name="jetbrains.mps.baseLanguage.structure.TrimOperation" flags="nn" index="17S1cR" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
@@ -154,6 +157,7 @@
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
       <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
       <concept id="1146644641414" name="jetbrains.mps.baseLanguage.structure.ProtectedVisibility" flags="nn" index="3Tmbuc" />
+      <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
     </language>
     <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
       <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
@@ -224,6 +228,8 @@
       <concept id="1151702311717" name="jetbrains.mps.baseLanguage.collections.structure.ToListOperation" flags="nn" index="ANE8D" />
       <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
       <concept id="1160666733551" name="jetbrains.mps.baseLanguage.collections.structure.AddAllElementsOperation" flags="nn" index="X8dFx" />
+      <concept id="1240325842691" name="jetbrains.mps.baseLanguage.collections.structure.AsSequenceOperation" flags="nn" index="39bAoz" />
+      <concept id="1165595910856" name="jetbrains.mps.baseLanguage.collections.structure.GetLastOperation" flags="nn" index="1yVyf7" />
       <concept id="1225730411176" name="jetbrains.mps.baseLanguage.collections.structure.FindLastOperation" flags="nn" index="1zesIP" />
       <concept id="1202128969694" name="jetbrains.mps.baseLanguage.collections.structure.SelectOperation" flags="nn" index="3$u5V9" />
     </language>
@@ -787,15 +793,94 @@
           <node concept="17QB3L" id="o1roXBZPxm" role="1tU5fm" />
         </node>
         <node concept="3clFbS" id="o1roXBZOKA" role="3clF47">
-          <node concept="3clFbF" id="o1roXBZPIP" role="3cqZAp">
-            <node concept="2OqwBi" id="o1roXBZPOW" role="3clFbG">
-              <node concept="37vLTw" id="o1roXBZPIO" role="2Oq$k0">
-                <ref role="3cqZAo" node="o1roXBZOj5" resolve="myAction" />
+          <node concept="3cpWs8" id="38Vsfq7ngLO" role="3cqZAp">
+            <node concept="3cpWsn" id="38Vsfq7ngLR" role="3cpWs9">
+              <property role="TrG5h" value="additionalCond" />
+              <node concept="10P_77" id="38Vsfq7ngLM" role="1tU5fm" />
+              <node concept="3clFbT" id="38Vsfq7nu4b" role="33vP2m">
+                <property role="3clFbU" value="true" />
               </node>
-              <node concept="liA8E" id="o1roXBZPWG" role="2OqNvi">
-                <ref role="37wK5l" to="f4zo:~SubstituteAction.canSubstitute(java.lang.String)" resolve="canSubstitute" />
-                <node concept="37vLTw" id="o1roXBZQ87" role="37wK5m">
-                  <ref role="3cqZAo" node="o1roXBZOK$" resolve="pattern" />
+            </node>
+          </node>
+          <node concept="3cpWs8" id="38Vsfq7nbsu" role="3cqZAp">
+            <node concept="3cpWsn" id="38Vsfq7nbsv" role="3cpWs9">
+              <property role="TrG5h" value="wordNode" />
+              <node concept="3Tqbb2" id="38Vsfq7nbsw" role="1tU5fm">
+                <ref role="ehGHo" to="87nw:2dWzqxEBMSc" resolve="Word" />
+              </node>
+              <node concept="1PxgMI" id="38Vsfq7nbsx" role="33vP2m">
+                <node concept="2OqwBi" id="38Vsfq7nbsy" role="1m5AlR">
+                  <node concept="37vLTw" id="38Vsfq7nbsz" role="2Oq$k0">
+                    <ref role="3cqZAo" node="o1roXC0g1t" resolve="myWordCell" />
+                  </node>
+                  <node concept="liA8E" id="38Vsfq7nbs$" role="2OqNvi">
+                    <ref role="37wK5l" to="g51k:~EditorCell_Basic.getSNode()" resolve="getSNode" />
+                  </node>
+                </node>
+                <node concept="chp4Y" id="38Vsfq7nbs_" role="3oSUPX">
+                  <ref role="cht4Q" to="87nw:2dWzqxEBMSc" resolve="Word" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="38Vsfq7nbsW" role="3cqZAp">
+            <node concept="3cpWsn" id="38Vsfq7nbsX" role="3cpWs9">
+              <property role="TrG5h" value="afterText" />
+              <node concept="17QB3L" id="38Vsfq7nbsY" role="1tU5fm" />
+              <node concept="1rXfSq" id="38Vsfq7nbsZ" role="33vP2m">
+                <ref role="37wK5l" node="38Vsfq7d0jb" resolve="getSurroundingText" />
+                <node concept="37vLTw" id="38Vsfq7nbt0" role="37wK5m">
+                  <ref role="3cqZAo" node="38Vsfq7nbsv" resolve="wordNode" />
+                </node>
+                <node concept="3clFbT" id="38Vsfq7nbt1" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbJ" id="38Vsfq7n_1P" role="3cqZAp">
+            <node concept="3clFbS" id="38Vsfq7n_1R" role="3clFbx">
+              <node concept="3clFbF" id="38Vsfq7nU0V" role="3cqZAp">
+                <node concept="37vLTI" id="38Vsfq7nWn0" role="3clFbG">
+                  <node concept="3clFbT" id="38Vsfq7nXqX" role="37vLTx" />
+                  <node concept="37vLTw" id="38Vsfq7nU0T" role="37vLTJ">
+                    <ref role="3cqZAo" node="38Vsfq7ngLR" resolve="additionalCond" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="1Wc70l" id="38Vsfq7nGRq" role="3clFbw">
+              <node concept="3clFbC" id="38Vsfq7nQrr" role="3uHU7w">
+                <node concept="3cmrfG" id="38Vsfq7nSpe" role="3uHU7w">
+                  <property role="3cmrfH" value="0" />
+                </node>
+                <node concept="2OqwBi" id="38Vsfq7nKZW" role="3uHU7B">
+                  <node concept="37vLTw" id="38Vsfq7nIVK" role="2Oq$k0">
+                    <ref role="3cqZAo" node="38Vsfq7nbsX" resolve="afterText" />
+                  </node>
+                  <node concept="liA8E" id="38Vsfq7nN1W" role="2OqNvi">
+                    <ref role="37wK5l" to="wyt6:~String.length()" resolve="length" />
+                  </node>
+                </node>
+              </node>
+              <node concept="37vLTw" id="38Vsfq7nF0d" role="3uHU7B">
+                <ref role="3cqZAo" node="2u3OARMiso4" resolve="myInsertOnly" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbH" id="38Vsfq7naan" role="3cqZAp" />
+          <node concept="3clFbF" id="o1roXBZPIP" role="3cqZAp">
+            <node concept="1Wc70l" id="38Vsfq7nBp2" role="3clFbG">
+              <node concept="37vLTw" id="38Vsfq7nDpb" role="3uHU7w">
+                <ref role="3cqZAo" node="38Vsfq7ngLR" resolve="additionalCond" />
+              </node>
+              <node concept="2OqwBi" id="o1roXBZPOW" role="3uHU7B">
+                <node concept="37vLTw" id="o1roXBZPIO" role="2Oq$k0">
+                  <ref role="3cqZAo" node="o1roXBZOj5" resolve="myAction" />
+                </node>
+                <node concept="liA8E" id="o1roXBZPWG" role="2OqNvi">
+                  <ref role="37wK5l" to="f4zo:~SubstituteAction.canSubstitute(java.lang.String)" resolve="canSubstitute" />
+                  <node concept="37vLTw" id="o1roXBZQ87" role="37wK5m">
+                    <ref role="3cqZAo" node="o1roXBZOK$" resolve="pattern" />
+                  </node>
                 </node>
               </node>
             </node>
@@ -858,6 +943,7 @@
           </node>
         </node>
       </node>
+      <node concept="2tJIrI" id="38Vsfq7cH5K" role="jymVt" />
       <node concept="3clFb_" id="o1roXBZOKV" role="jymVt">
         <property role="1EzhhJ" value="false" />
         <property role="TrG5h" value="getActionType" />
@@ -896,6 +982,7 @@
           </node>
         </node>
       </node>
+      <node concept="2tJIrI" id="38Vsfq7cET_" role="jymVt" />
       <node concept="3clFb_" id="o1roXBZOL6" role="jymVt">
         <property role="1EzhhJ" value="false" />
         <property role="TrG5h" value="getDescriptionText" />
@@ -923,6 +1010,7 @@
           </node>
         </node>
       </node>
+      <node concept="2tJIrI" id="38Vsfq7cC_1" role="jymVt" />
       <node concept="3clFb_" id="o1roXBZOLf" role="jymVt">
         <property role="1EzhhJ" value="false" />
         <property role="TrG5h" value="getIconNode" />
@@ -952,6 +1040,7 @@
           </node>
         </node>
       </node>
+      <node concept="2tJIrI" id="38Vsfq7cA8y" role="jymVt" />
       <node concept="3clFb_" id="o1roXBZOLo" role="jymVt">
         <property role="1EzhhJ" value="false" />
         <property role="TrG5h" value="getMatchingText" />
@@ -979,6 +1068,7 @@
           </node>
         </node>
       </node>
+      <node concept="2tJIrI" id="38Vsfq7c$4S" role="jymVt" />
       <node concept="3clFb_" id="o1roXBZOLx" role="jymVt">
         <property role="1EzhhJ" value="false" />
         <property role="TrG5h" value="getOutputConcept" />
@@ -1001,6 +1091,7 @@
           </node>
         </node>
       </node>
+      <node concept="2tJIrI" id="38Vsfq7cxSP" role="jymVt" />
       <node concept="3clFb_" id="o1roXBZOLC" role="jymVt">
         <property role="1EzhhJ" value="false" />
         <property role="TrG5h" value="getParameterObject" />
@@ -1023,6 +1114,7 @@
           </node>
         </node>
       </node>
+      <node concept="2tJIrI" id="38Vsfq7cw59" role="jymVt" />
       <node concept="3clFb_" id="o1roXBZOLJ" role="jymVt">
         <property role="1EzhhJ" value="false" />
         <property role="TrG5h" value="getSourceNode" />
@@ -1045,6 +1137,7 @@
           </node>
         </node>
       </node>
+      <node concept="2tJIrI" id="38Vsfq7cu12" role="jymVt" />
       <node concept="3clFb_" id="o1roXBZOLQ" role="jymVt">
         <property role="1EzhhJ" value="false" />
         <property role="TrG5h" value="getVisibleMatchingText" />
@@ -1057,29 +1150,137 @@
           <node concept="17QB3L" id="o1roXBZZp6" role="1tU5fm" />
         </node>
         <node concept="3clFbS" id="o1roXBZOLW" role="3clF47">
-          <node concept="3clFbF" id="o1roXBZZ25" role="3cqZAp">
-            <node concept="3cpWs3" id="2u3OARMnaZM" role="3clFbG">
-              <node concept="2OqwBi" id="o1roXBZZ3L" role="3uHU7w">
-                <node concept="37vLTw" id="o1roXBZZ24" role="2Oq$k0">
+          <node concept="3cpWs8" id="38Vsfq7eloM" role="3cqZAp">
+            <node concept="3cpWsn" id="38Vsfq7eloP" role="3cpWs9">
+              <property role="TrG5h" value="wordNode" />
+              <node concept="3Tqbb2" id="38Vsfq7eloQ" role="1tU5fm">
+                <ref role="ehGHo" to="87nw:2dWzqxEBMSc" resolve="Word" />
+              </node>
+              <node concept="1PxgMI" id="38Vsfq7eloR" role="33vP2m">
+                <node concept="2OqwBi" id="38Vsfq7eloS" role="1m5AlR">
+                  <node concept="37vLTw" id="38Vsfq7eloT" role="2Oq$k0">
+                    <ref role="3cqZAo" node="o1roXC0g1t" resolve="myWordCell" />
+                  </node>
+                  <node concept="liA8E" id="38Vsfq7eloU" role="2OqNvi">
+                    <ref role="37wK5l" to="g51k:~EditorCell_Basic.getSNode()" resolve="getSNode" />
+                  </node>
+                </node>
+                <node concept="chp4Y" id="38Vsfq7eloV" role="3oSUPX">
+                  <ref role="cht4Q" to="87nw:2dWzqxEBMSc" resolve="Word" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="38Vsfq7eyZg" role="3cqZAp">
+            <node concept="3cpWsn" id="38Vsfq7eyZj" role="3cpWs9">
+              <property role="TrG5h" value="visibleMatchingText" />
+              <node concept="17QB3L" id="38Vsfq7eyZe" role="1tU5fm" />
+              <node concept="2OqwBi" id="38Vsfq7eDrD" role="33vP2m">
+                <node concept="37vLTw" id="38Vsfq7eDrE" role="2Oq$k0">
                   <ref role="3cqZAo" node="o1roXBZOj5" resolve="myAction" />
                 </node>
-                <node concept="liA8E" id="o1roXBZZc0" role="2OqNvi">
+                <node concept="liA8E" id="38Vsfq7eDrF" role="2OqNvi">
                   <ref role="37wK5l" to="f4zo:~SubstituteAction.getVisibleMatchingText(java.lang.String)" resolve="getVisibleMatchingText" />
-                  <node concept="37vLTw" id="o1roXBZZj_" role="37wK5m">
+                  <node concept="37vLTw" id="38Vsfq7eDrG" role="37wK5m">
                     <ref role="3cqZAo" node="o1roXBZOLU" resolve="pattern" />
                   </node>
                 </node>
               </node>
-              <node concept="1eOMI4" id="2u3OARMmIQ1" role="3uHU7B">
-                <node concept="3K4zz7" id="2u3OARMmIPX" role="1eOMHV">
-                  <node concept="Xl_RD" id="2u3OARMmJ84" role="3K4E3e">
-                    <property role="Xl_RC" value=".." />
+            </node>
+          </node>
+          <node concept="3clFbH" id="38Vsfq7oKtX" role="3cqZAp" />
+          <node concept="3cpWs8" id="38Vsfq7h$Eh" role="3cqZAp">
+            <node concept="3cpWsn" id="38Vsfq7h$Ei" role="3cpWs9">
+              <property role="TrG5h" value="beforeText" />
+              <node concept="17QB3L" id="38Vsfq7hzRS" role="1tU5fm" />
+              <node concept="2OqwBi" id="38Vsfq7jKo6" role="33vP2m">
+                <node concept="2OqwBi" id="38Vsfq7j7za" role="2Oq$k0">
+                  <node concept="2OqwBi" id="38Vsfq7j2Xb" role="2Oq$k0">
+                    <node concept="2OqwBi" id="38Vsfq7iU1Z" role="2Oq$k0">
+                      <node concept="1rXfSq" id="38Vsfq7h$Ej" role="2Oq$k0">
+                        <ref role="37wK5l" node="38Vsfq7d0jb" resolve="getSurroundingText" />
+                        <node concept="37vLTw" id="38Vsfq7h$Ek" role="37wK5m">
+                          <ref role="3cqZAo" node="38Vsfq7eloP" resolve="wordNode" />
+                        </node>
+                        <node concept="3clFbT" id="38Vsfq7h$El" role="37wK5m">
+                          <property role="3clFbU" value="true" />
+                        </node>
+                      </node>
+                      <node concept="liA8E" id="38Vsfq7iX2n" role="2OqNvi">
+                        <ref role="37wK5l" to="wyt6:~String.split(java.lang.String)" resolve="split" />
+                        <node concept="Xl_RD" id="38Vsfq7iYFW" role="37wK5m">
+                          <property role="Xl_RC" value="\\\\n" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="39bAoz" id="38Vsfq7j4Hg" role="2OqNvi" />
                   </node>
-                  <node concept="Xl_RD" id="2u3OARMmJcl" role="3K4GZi">
-                    <property role="Xl_RC" value="" />
+                  <node concept="1yVyf7" id="38Vsfq7j9YC" role="2OqNvi" />
+                </node>
+                <node concept="17S1cR" id="38Vsfq7jMNl" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="38Vsfq7hE02" role="3cqZAp">
+            <node concept="3cpWsn" id="38Vsfq7hE03" role="3cpWs9">
+              <property role="TrG5h" value="afterText" />
+              <node concept="17QB3L" id="38Vsfq7hE04" role="1tU5fm" />
+              <node concept="1rXfSq" id="38Vsfq7hE05" role="33vP2m">
+                <ref role="37wK5l" node="38Vsfq7d0jb" resolve="getSurroundingText" />
+                <node concept="37vLTw" id="38Vsfq7hE06" role="37wK5m">
+                  <ref role="3cqZAo" node="38Vsfq7eloP" resolve="wordNode" />
+                </node>
+                <node concept="3clFbT" id="38Vsfq7hE07" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbH" id="38Vsfq7mSGm" role="3cqZAp" />
+          <node concept="3clFbJ" id="38Vsfq7dWpS" role="3cqZAp">
+            <node concept="3clFbS" id="38Vsfq7dWpU" role="3clFbx">
+              <node concept="3cpWs6" id="38Vsfq7eha9" role="3cqZAp">
+                <node concept="3cpWs3" id="38Vsfq7eN04" role="3cqZAk">
+                  <node concept="3cpWs3" id="38Vsfq7p9xq" role="3uHU7B">
+                    <node concept="Xl_RD" id="38Vsfq7p9z5" role="3uHU7w">
+                      <property role="Xl_RC" value=" " />
+                    </node>
+                    <node concept="3cpWs3" id="38Vsfq7esya" role="3uHU7B">
+                      <node concept="3cpWs3" id="38Vsfq7p74j" role="3uHU7B">
+                        <node concept="Xl_RD" id="38Vsfq7p7M3" role="3uHU7w">
+                          <property role="Xl_RC" value=" " />
+                        </node>
+                        <node concept="37vLTw" id="38Vsfq7hMb_" role="3uHU7B">
+                          <ref role="3cqZAo" node="38Vsfq7h$Ei" resolve="beforeText" />
+                        </node>
+                      </node>
+                      <node concept="37vLTw" id="38Vsfq7eL3o" role="3uHU7w">
+                        <ref role="3cqZAo" node="38Vsfq7eyZj" resolve="visibleMatchingText" />
+                      </node>
+                    </node>
                   </node>
-                  <node concept="37vLTw" id="2u3OARMmIbK" role="3K4Cdx">
-                    <ref role="3cqZAo" node="2u3OARMiso4" resolve="myInsertOnly" />
+                  <node concept="37vLTw" id="38Vsfq7h$En" role="3uHU7w">
+                    <ref role="3cqZAo" node="38Vsfq7hE03" resolve="afterText" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="37vLTw" id="38Vsfq7dXJE" role="3clFbw">
+              <ref role="3cqZAo" node="2u3OARMiso4" resolve="myInsertOnly" />
+            </node>
+            <node concept="9aQIb" id="38Vsfq7dZjX" role="9aQIa">
+              <node concept="3clFbS" id="38Vsfq7dZjY" role="9aQI4">
+                <node concept="3cpWs6" id="38Vsfq7e1IW" role="3cqZAp">
+                  <node concept="3cpWs3" id="38Vsfq7e5n5" role="3cqZAk">
+                    <node concept="3cpWs3" id="38Vsfq7pe45" role="3uHU7B">
+                      <node concept="Xl_RD" id="38Vsfq7pe5u" role="3uHU7w">
+                        <property role="Xl_RC" value=" " />
+                      </node>
+                      <node concept="37vLTw" id="38Vsfq7eJxo" role="3uHU7B">
+                        <ref role="3cqZAo" node="38Vsfq7eyZj" resolve="visibleMatchingText" />
+                      </node>
+                    </node>
+                    <node concept="37vLTw" id="38Vsfq7h$Em" role="3uHU7w">
+                      <ref role="3cqZAo" node="38Vsfq7hE03" resolve="afterText" />
+                    </node>
                   </node>
                 </node>
               </node>
@@ -1087,6 +1288,7 @@
           </node>
         </node>
       </node>
+      <node concept="2tJIrI" id="38Vsfq7crXh" role="jymVt" />
       <node concept="3clFb_" id="o1roXBZOLZ" role="jymVt">
         <property role="1EzhhJ" value="false" />
         <property role="TrG5h" value="isReferentPresentation" />
@@ -1107,6 +1309,177 @@
           </node>
         </node>
       </node>
+      <node concept="2tJIrI" id="38Vsfq7cofn" role="jymVt" />
+      <node concept="3clFb_" id="38Vsfq7d0jb" role="jymVt">
+        <property role="TrG5h" value="getSurroundingText" />
+        <node concept="3clFbS" id="38Vsfq7d0je" role="3clF47">
+          <node concept="3cpWs8" id="38Vsfq7d2qa" role="3cqZAp">
+            <node concept="3cpWsn" id="38Vsfq7d2qb" role="3cpWs9">
+              <property role="TrG5h" value="start" />
+              <node concept="3cpWs3" id="38Vsfq7d2qc" role="33vP2m">
+                <node concept="2OqwBi" id="38Vsfq7d2qd" role="3uHU7B">
+                  <node concept="2OqwBi" id="38Vsfq7d2qe" role="2Oq$k0">
+                    <node concept="2OqwBi" id="38Vsfq7d2qf" role="2Oq$k0">
+                      <node concept="37vLTw" id="38Vsfq7d2qg" role="2Oq$k0">
+                        <ref role="3cqZAo" node="o1roXC0g1t" resolve="myWordCell" />
+                      </node>
+                      <node concept="liA8E" id="38Vsfq7d2qh" role="2OqNvi">
+                        <ref role="37wK5l" to="93vl:6tLsdkfI427" resolve="getParent" />
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="38Vsfq7d2qi" role="2OqNvi">
+                      <ref role="37wK5l" to="93vl:6tLsdkfIE9c" resolve="getTextBefore" />
+                      <node concept="37vLTw" id="38Vsfq7d2qj" role="37wK5m">
+                        <ref role="3cqZAo" node="o1roXC0g1t" resolve="myWordCell" />
+                      </node>
+                      <node concept="3cmrfG" id="38Vsfq7d2qk" role="37wK5m">
+                        <property role="3cmrfH" value="0" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="38Vsfq7d2ql" role="2OqNvi">
+                    <ref role="37wK5l" to="wyt6:~String.length()" resolve="length" />
+                  </node>
+                </node>
+                <node concept="1eOMI4" id="38Vsfq7d2qm" role="3uHU7w">
+                  <node concept="3K4zz7" id="38Vsfq7d2qn" role="1eOMHV">
+                    <node concept="2OqwBi" id="38Vsfq7d2qo" role="3K4E3e">
+                      <node concept="37vLTw" id="38Vsfq7d2qp" role="2Oq$k0">
+                        <ref role="3cqZAo" node="o1roXC0g1t" resolve="myWordCell" />
+                      </node>
+                      <node concept="liA8E" id="38Vsfq7d2qq" role="2OqNvi">
+                        <ref role="37wK5l" to="g51k:~EditorCell_Label.getCaretPosition()" resolve="getCaretPosition" />
+                      </node>
+                    </node>
+                    <node concept="3cmrfG" id="38Vsfq7d2qr" role="3K4GZi">
+                      <property role="3cmrfH" value="0" />
+                    </node>
+                    <node concept="37vLTw" id="38Vsfq7d2qs" role="3K4Cdx">
+                      <ref role="3cqZAo" node="2u3OARMiso4" resolve="myInsertOnly" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="10Oyi0" id="38Vsfq7d2qt" role="1tU5fm" />
+            </node>
+          </node>
+          <node concept="3cpWs8" id="38Vsfq7d2qu" role="3cqZAp">
+            <node concept="3cpWsn" id="38Vsfq7d2qv" role="3cpWs9">
+              <property role="TrG5h" value="end" />
+              <node concept="10Oyi0" id="38Vsfq7d2qw" role="1tU5fm" />
+              <node concept="3cpWs3" id="38Vsfq7d2qx" role="33vP2m">
+                <node concept="37vLTw" id="38Vsfq7d2qy" role="3uHU7B">
+                  <ref role="3cqZAo" node="38Vsfq7d2qb" resolve="start" />
+                </node>
+                <node concept="1eOMI4" id="38Vsfq7d2qz" role="3uHU7w">
+                  <node concept="3K4zz7" id="38Vsfq7d2q$" role="1eOMHV">
+                    <node concept="3cmrfG" id="38Vsfq7d2q_" role="3K4E3e">
+                      <property role="3cmrfH" value="0" />
+                    </node>
+                    <node concept="2OqwBi" id="38Vsfq7d2qA" role="3K4GZi">
+                      <node concept="37vLTw" id="38Vsfq7d2qB" role="2Oq$k0">
+                        <ref role="3cqZAo" node="o1roXC0g1t" resolve="myWordCell" />
+                      </node>
+                      <node concept="liA8E" id="38Vsfq7d2qC" role="2OqNvi">
+                        <ref role="37wK5l" to="g51k:~EditorCell_Label.getCaretPosition()" resolve="getCaretPosition" />
+                      </node>
+                    </node>
+                    <node concept="37vLTw" id="38Vsfq7d2qD" role="3K4Cdx">
+                      <ref role="3cqZAo" node="2u3OARMiso4" resolve="myInsertOnly" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbH" id="38Vsfq7d2qE" role="3cqZAp" />
+          <node concept="3cpWs8" id="38Vsfq7d2qF" role="3cqZAp">
+            <node concept="3cpWsn" id="38Vsfq7d2qG" role="3cpWs9">
+              <property role="TrG5h" value="s" />
+              <node concept="17QB3L" id="38Vsfq7d2qH" role="1tU5fm" />
+              <node concept="2OqwBi" id="38Vsfq7d2qI" role="33vP2m">
+                <node concept="37vLTw" id="38Vsfq7d2qJ" role="2Oq$k0">
+                  <ref role="3cqZAo" node="38Vsfq7d5Z6" resolve="wordNode" />
+                </node>
+                <node concept="2qgKlT" id="38Vsfq7d2qK" role="2OqNvi">
+                  <ref role="37wK5l" to="tbr6:ehGfXvI_DB" resolve="getText" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbJ" id="38Vsfq7d2qL" role="3cqZAp">
+            <node concept="3clFbS" id="38Vsfq7d2qM" role="3clFbx">
+              <node concept="3clFbF" id="38Vsfq7d2qN" role="3cqZAp">
+                <node concept="37vLTI" id="38Vsfq7d2qO" role="3clFbG">
+                  <node concept="Xl_RD" id="38Vsfq7d2qP" role="37vLTx">
+                    <property role="Xl_RC" value="" />
+                  </node>
+                  <node concept="37vLTw" id="38Vsfq7d2qQ" role="37vLTJ">
+                    <ref role="3cqZAo" node="38Vsfq7d2qG" resolve="s" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbC" id="38Vsfq7d2qR" role="3clFbw">
+              <node concept="10Nm6u" id="38Vsfq7d2qS" role="3uHU7w" />
+              <node concept="37vLTw" id="38Vsfq7d2qT" role="3uHU7B">
+                <ref role="3cqZAo" node="38Vsfq7d2qG" resolve="s" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="38Vsfq7doqd" role="3cqZAp">
+            <node concept="3K4zz7" id="38Vsfq7dqFI" role="3clFbG">
+              <node concept="37vLTw" id="38Vsfq7doqb" role="3K4Cdx">
+                <ref role="3cqZAo" node="38Vsfq7dgAg" resolve="before" />
+              </node>
+              <node concept="2YIFZM" id="38Vsfq7d2qW" role="3K4E3e">
+                <ref role="1Pybhc" to="wtuq:4$G0AukZNCp" resolve="RichtextUtil" />
+                <ref role="37wK5l" to="wtuq:5LEeV$496dG" resolve="safeSubstring" />
+                <node concept="37vLTw" id="38Vsfq7d2qX" role="37wK5m">
+                  <ref role="3cqZAo" node="38Vsfq7d2qG" resolve="s" />
+                </node>
+                <node concept="3cmrfG" id="38Vsfq7d2qY" role="37wK5m">
+                  <property role="3cmrfH" value="0" />
+                </node>
+                <node concept="37vLTw" id="38Vsfq7d2qZ" role="37wK5m">
+                  <ref role="3cqZAo" node="38Vsfq7d2qb" resolve="start" />
+                </node>
+              </node>
+              <node concept="2YIFZM" id="38Vsfq7duIx" role="3K4GZi">
+                <ref role="37wK5l" to="wtuq:5LEeV$496dG" resolve="safeSubstring" />
+                <ref role="1Pybhc" to="wtuq:4$G0AukZNCp" resolve="RichtextUtil" />
+                <node concept="37vLTw" id="38Vsfq7duIy" role="37wK5m">
+                  <ref role="3cqZAo" node="38Vsfq7d2qG" resolve="s" />
+                </node>
+                <node concept="37vLTw" id="38Vsfq7duIz" role="37wK5m">
+                  <ref role="3cqZAo" node="38Vsfq7d2qv" resolve="end" />
+                </node>
+                <node concept="2OqwBi" id="38Vsfq7duI$" role="37wK5m">
+                  <node concept="37vLTw" id="38Vsfq7duI_" role="2Oq$k0">
+                    <ref role="3cqZAo" node="38Vsfq7d2qG" resolve="s" />
+                  </node>
+                  <node concept="liA8E" id="38Vsfq7duIA" role="2OqNvi">
+                    <ref role="37wK5l" to="wyt6:~String.length()" resolve="length" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3Tm6S6" id="38Vsfq7cYy$" role="1B3o_S" />
+        <node concept="17QB3L" id="38Vsfq7cZWE" role="3clF45" />
+        <node concept="37vLTG" id="38Vsfq7d5Z6" role="3clF46">
+          <property role="TrG5h" value="wordNode" />
+          <node concept="3Tqbb2" id="38Vsfq7d5Z5" role="1tU5fm">
+            <ref role="ehGHo" to="87nw:2dWzqxEBMSc" resolve="Word" />
+          </node>
+        </node>
+        <node concept="37vLTG" id="38Vsfq7dgAg" role="3clF46">
+          <property role="TrG5h" value="before" />
+          <node concept="10P_77" id="38Vsfq7dgBi" role="1tU5fm" />
+        </node>
+      </node>
+      <node concept="2tJIrI" id="38Vsfq7cpLm" role="jymVt" />
       <node concept="3clFb_" id="o1roXBZOM6" role="jymVt">
         <property role="1EzhhJ" value="false" />
         <property role="TrG5h" value="substitute" />
@@ -1259,164 +1632,36 @@
               </node>
             </node>
           </node>
-          <node concept="3clFbH" id="o1roXC0nGt" role="3cqZAp" />
-          <node concept="3cpWs8" id="o1roXC0u0d" role="3cqZAp">
-            <node concept="3cpWsn" id="o1roXC0u0e" role="3cpWs9">
-              <property role="TrG5h" value="start" />
-              <node concept="3cpWs3" id="2u3OARMk4WJ" role="33vP2m">
-                <node concept="2OqwBi" id="o1roXC0u0g" role="3uHU7B">
-                  <node concept="2OqwBi" id="o1roXC0u0h" role="2Oq$k0">
-                    <node concept="2OqwBi" id="o1roXC0u0i" role="2Oq$k0">
-                      <node concept="37vLTw" id="o1roXC0u0j" role="2Oq$k0">
-                        <ref role="3cqZAo" node="o1roXC0g1t" resolve="myWordCell" />
-                      </node>
-                      <node concept="liA8E" id="o1roXC0u0k" role="2OqNvi">
-                        <ref role="37wK5l" to="93vl:6tLsdkfI427" resolve="getParent" />
-                      </node>
-                    </node>
-                    <node concept="liA8E" id="o1roXC0u0l" role="2OqNvi">
-                      <ref role="37wK5l" to="93vl:6tLsdkfIE9c" resolve="getTextBefore" />
-                      <node concept="37vLTw" id="o1roXC0u0m" role="37wK5m">
-                        <ref role="3cqZAo" node="o1roXC0g1t" resolve="myWordCell" />
-                      </node>
-                      <node concept="3cmrfG" id="o1roXC0u0n" role="37wK5m">
-                        <property role="3cmrfH" value="0" />
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="liA8E" id="o1roXC0u0o" role="2OqNvi">
-                    <ref role="37wK5l" to="wyt6:~String.length()" resolve="length" />
-                  </node>
-                </node>
-                <node concept="1eOMI4" id="2u3OARMkf03" role="3uHU7w">
-                  <node concept="3K4zz7" id="2u3OARMk96V" role="1eOMHV">
-                    <node concept="2OqwBi" id="2u3OARMkcO_" role="3K4E3e">
-                      <node concept="37vLTw" id="2u3OARMkcOA" role="2Oq$k0">
-                        <ref role="3cqZAo" node="o1roXC0g1t" resolve="myWordCell" />
-                      </node>
-                      <node concept="liA8E" id="2u3OARMkcOB" role="2OqNvi">
-                        <ref role="37wK5l" to="g51k:~EditorCell_Label.getCaretPosition()" resolve="getCaretPosition" />
-                      </node>
-                    </node>
-                    <node concept="3cmrfG" id="2u3OARMkcek" role="3K4GZi">
-                      <property role="3cmrfH" value="0" />
-                    </node>
-                    <node concept="37vLTw" id="2u3OARMk85K" role="3K4Cdx">
-                      <ref role="3cqZAo" node="2u3OARMiso4" resolve="myInsertOnly" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="10Oyi0" id="o1roXC0u0f" role="1tU5fm" />
-            </node>
-          </node>
-          <node concept="3cpWs8" id="o1roXC0u0p" role="3cqZAp">
-            <node concept="3cpWsn" id="o1roXC0u0q" role="3cpWs9">
-              <property role="TrG5h" value="end" />
-              <node concept="10Oyi0" id="o1roXC0u0r" role="1tU5fm" />
-              <node concept="3cpWs3" id="o1roXC0u0s" role="33vP2m">
-                <node concept="37vLTw" id="o1roXC0u0w" role="3uHU7B">
-                  <ref role="3cqZAo" node="o1roXC0u0e" resolve="start" />
-                </node>
-                <node concept="1eOMI4" id="2u3OARMkmJb" role="3uHU7w">
-                  <node concept="3K4zz7" id="2u3OARMkjgy" role="1eOMHV">
-                    <node concept="3cmrfG" id="2u3OARMkjYt" role="3K4E3e">
-                      <property role="3cmrfH" value="0" />
-                    </node>
-                    <node concept="2OqwBi" id="o1roXC0u0t" role="3K4GZi">
-                      <node concept="37vLTw" id="o1roXC0u0u" role="2Oq$k0">
-                        <ref role="3cqZAo" node="o1roXC0g1t" resolve="myWordCell" />
-                      </node>
-                      <node concept="liA8E" id="o1roXC0u0v" role="2OqNvi">
-                        <ref role="37wK5l" to="g51k:~EditorCell_Label.getCaretPosition()" resolve="getCaretPosition" />
-                      </node>
-                    </node>
-                    <node concept="37vLTw" id="2u3OARMkind" role="3K4Cdx">
-                      <ref role="3cqZAo" node="2u3OARMiso4" resolve="myInsertOnly" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
           <node concept="3clFbH" id="o1roXC0uGm" role="3cqZAp" />
-          <node concept="3cpWs8" id="o1roXC0nVe" role="3cqZAp">
-            <node concept="3cpWsn" id="o1roXC0nVf" role="3cpWs9">
-              <property role="TrG5h" value="s" />
-              <node concept="17QB3L" id="o1roXC0nVg" role="1tU5fm" />
-              <node concept="2OqwBi" id="o1roXC0nVh" role="33vP2m">
-                <node concept="37vLTw" id="o1roXC0qR0" role="2Oq$k0">
-                  <ref role="3cqZAo" node="o1roXC0oWA" resolve="wordNode" />
-                </node>
-                <node concept="2qgKlT" id="o1roXC0nVj" role="2OqNvi">
-                  <ref role="37wK5l" to="tbr6:ehGfXvI_DB" resolve="getText" />
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3clFbJ" id="o1roXC0nVk" role="3cqZAp">
-            <node concept="3clFbS" id="o1roXC0nVl" role="3clFbx">
-              <node concept="3clFbF" id="o1roXC0nVm" role="3cqZAp">
-                <node concept="37vLTI" id="o1roXC0nVn" role="3clFbG">
-                  <node concept="Xl_RD" id="o1roXC0nVo" role="37vLTx">
-                    <property role="Xl_RC" value="" />
-                  </node>
-                  <node concept="37vLTw" id="o1roXC0nVp" role="37vLTJ">
-                    <ref role="3cqZAo" node="o1roXC0nVf" resolve="s" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbC" id="o1roXC0nVq" role="3clFbw">
-              <node concept="10Nm6u" id="o1roXC0nVr" role="3uHU7w" />
-              <node concept="37vLTw" id="o1roXC0nVs" role="3uHU7B">
-                <ref role="3cqZAo" node="o1roXC0nVf" resolve="s" />
-              </node>
-            </node>
-          </node>
           <node concept="3cpWs8" id="o1roXC0nVt" role="3cqZAp">
             <node concept="3cpWsn" id="o1roXC0nVu" role="3cpWs9">
               <property role="TrG5h" value="s1" />
-              <node concept="2YIFZM" id="o1roXC0nVv" role="33vP2m">
-                <ref role="1Pybhc" to="wtuq:4$G0AukZNCp" resolve="RichtextUtil" />
-                <ref role="37wK5l" to="wtuq:5LEeV$496dG" resolve="safeSubstring" />
-                <node concept="37vLTw" id="o1roXC0nVw" role="37wK5m">
-                  <ref role="3cqZAo" node="o1roXC0nVf" resolve="s" />
+              <node concept="17QB3L" id="o1roXC0nVz" role="1tU5fm" />
+              <node concept="1rXfSq" id="38Vsfq7d$WW" role="33vP2m">
+                <ref role="37wK5l" node="38Vsfq7d0jb" resolve="getSurroundingText" />
+                <node concept="37vLTw" id="38Vsfq7dAy_" role="37wK5m">
+                  <ref role="3cqZAo" node="o1roXC0oWA" resolve="wordNode" />
                 </node>
-                <node concept="3cmrfG" id="o1roXC0nVx" role="37wK5m">
-                  <property role="3cmrfH" value="0" />
-                </node>
-                <node concept="37vLTw" id="o1roXC0w7k" role="37wK5m">
-                  <ref role="3cqZAo" node="o1roXC0u0e" resolve="start" />
+                <node concept="3clFbT" id="38Vsfq7dDU7" role="37wK5m">
+                  <property role="3clFbU" value="true" />
                 </node>
               </node>
-              <node concept="17QB3L" id="o1roXC0nVz" role="1tU5fm" />
             </node>
           </node>
           <node concept="3cpWs8" id="o1roXC0nV$" role="3cqZAp">
             <node concept="3cpWsn" id="o1roXC0nV_" role="3cpWs9">
               <property role="TrG5h" value="s2" />
-              <node concept="2YIFZM" id="o1roXC0nVA" role="33vP2m">
-                <ref role="37wK5l" to="wtuq:5LEeV$496dG" resolve="safeSubstring" />
-                <ref role="1Pybhc" to="wtuq:4$G0AukZNCp" resolve="RichtextUtil" />
-                <node concept="37vLTw" id="o1roXC0nVB" role="37wK5m">
-                  <ref role="3cqZAo" node="o1roXC0nVf" resolve="s" />
-                </node>
-                <node concept="37vLTw" id="o1roXC0w3Q" role="37wK5m">
-                  <ref role="3cqZAo" node="o1roXC0u0q" resolve="end" />
-                </node>
-                <node concept="2OqwBi" id="o1roXC0nVD" role="37wK5m">
-                  <node concept="37vLTw" id="o1roXC0nVE" role="2Oq$k0">
-                    <ref role="3cqZAo" node="o1roXC0nVf" resolve="s" />
-                  </node>
-                  <node concept="liA8E" id="o1roXC0nVF" role="2OqNvi">
-                    <ref role="37wK5l" to="wyt6:~String.length()" resolve="length" />
-                  </node>
-                </node>
-              </node>
               <node concept="17QB3L" id="o1roXC0nVG" role="1tU5fm" />
+              <node concept="1rXfSq" id="38Vsfq7dFBZ" role="33vP2m">
+                <ref role="37wK5l" node="38Vsfq7d0jb" resolve="getSurroundingText" />
+                <node concept="37vLTw" id="38Vsfq7dFC0" role="37wK5m">
+                  <ref role="3cqZAo" node="o1roXC0oWA" resolve="wordNode" />
+                </node>
+                <node concept="3clFbT" id="38Vsfq7dFC1" role="37wK5m" />
+              </node>
             </node>
           </node>
+          <node concept="3clFbH" id="38Vsfq7dTfd" role="3cqZAp" />
           <node concept="3clFbF" id="o1roXC0nVH" role="3cqZAp">
             <node concept="2OqwBi" id="o1roXC0nVI" role="3clFbG">
               <node concept="37vLTw" id="o1roXC0qXw" role="2Oq$k0">

--- a/code/richtext/languages/richtext/models/de/slisson/mps/richtext/runtime.mps
+++ b/code/richtext/languages/richtext/models/de/slisson/mps/richtext/runtime.mps
@@ -1095,7 +1095,27 @@
               </node>
             </node>
           </node>
-          <node concept="3clFbH" id="38Vsfq88Q$p" role="3cqZAp" />
+          <node concept="3clFbJ" id="38Vsfq8Z4iY" role="3cqZAp">
+            <node concept="3clFbS" id="38Vsfq8Z4j0" role="3clFbx">
+              <node concept="3clFbF" id="38Vsfq8ZceF" role="3cqZAp">
+                <node concept="37vLTI" id="38Vsfq8Zes8" role="3clFbG">
+                  <node concept="Xl_RD" id="38Vsfq8Zgg4" role="37vLTx">
+                    <property role="Xl_RC" value="" />
+                  </node>
+                  <node concept="37vLTw" id="38Vsfq8ZceD" role="37vLTJ">
+                    <ref role="3cqZAo" node="38Vsfq88Q$b" resolve="beforeText" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbC" id="38Vsfq8Z8Wr" role="3clFbw">
+              <node concept="10Nm6u" id="38Vsfq8ZacN" role="3uHU7w" />
+              <node concept="37vLTw" id="38Vsfq8Z6yE" role="3uHU7B">
+                <ref role="3cqZAo" node="38Vsfq88Q$b" resolve="beforeText" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbH" id="38Vsfq8Z0KP" role="3cqZAp" />
           <node concept="3clFbJ" id="38Vsfq88Q$q" role="3cqZAp">
             <node concept="3clFbS" id="38Vsfq88Q$r" role="3clFbx">
               <node concept="3clFbF" id="38Vsfq88Q$s" role="3cqZAp">
@@ -1175,6 +1195,26 @@
                   <node concept="39bAoz" id="38Vsfq8ak8O" role="2OqNvi" />
                 </node>
                 <node concept="1uHKPH" id="38Vsfq8aoxs" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbJ" id="38Vsfq8YOcU" role="3cqZAp">
+            <node concept="3clFbS" id="38Vsfq8YOcW" role="3clFbx">
+              <node concept="3clFbF" id="38Vsfq8YVBn" role="3cqZAp">
+                <node concept="37vLTI" id="38Vsfq8YXue" role="3clFbG">
+                  <node concept="Xl_RD" id="38Vsfq8YZ1o" role="37vLTx">
+                    <property role="Xl_RC" value="" />
+                  </node>
+                  <node concept="37vLTw" id="38Vsfq8YVBl" role="37vLTJ">
+                    <ref role="3cqZAo" node="38Vsfq88Q$L" resolve="afterText" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbC" id="38Vsfq8YSjN" role="3clFbw">
+              <node concept="10Nm6u" id="38Vsfq8YTY$" role="3uHU7w" />
+              <node concept="37vLTw" id="38Vsfq8YQ36" role="3uHU7B">
+                <ref role="3cqZAo" node="38Vsfq88Q$L" resolve="afterText" />
               </node>
             </node>
           </node>

--- a/docs/extensions/editor/richtext.md
+++ b/docs/extensions/editor/richtext.md
@@ -19,7 +19,45 @@ The following screenshot shows a simple example from the [mbeddr documentation l
 
 All the different looking strings (e.g. @sect, @node, footnode) are implemented as concepts that implement [IWord](http://127.0.0.1:63320/node?ref=r%3Aca2ab6bb-f6e7-4c0f-a88c-b78b9b31fff3%28de.slisson.mps.richtext.structure%29%2F2557074442922392300).
 
-### Compatibility with the [Text language](https://www.jetbrains.com/help/mps/generic-placeholders-and-generic-comments.html#thetextlanguage)( jetbrains.mps.lang.text)
+## Keyboard Shortcuts
+
+This languages add additional keyboard shortcuts to the editor:
+
+### Windows/Linux
+
+| Shortcut              | Description                                        |
+| --------------------- | -------------------------------------------------- |
+| ++ctrl+a++            | select the full text                               |
+| ++ctrl+back++         | delete text until the start of the word            |
+| ++ctrl+del++          | delete text until the end of the word              |
+| ++ctrl+shift+back++   | delete text until the start of the line            |
+| ++ctrl+shift+del++    | delete text until end of the line                  |
+| ++ctrl+d++            | duplicate the current line                         |
+| ++shift+left++        | increase selection to the character to the left    |
+| ++shift+right++       | increase selection to the character to the right   |
+| ++alt+shift+left++    | increase selection to the start of the word        |
+| ++alt+shift+right++   | increase selection to the end of the word          |
+| ++ctrl+shift+home++   | increase selection to the start of the full text   |
+| ++ctrl+shift+end++    | increase selection to the end of the full text     |
+
+### Mac
+
+| Shortcut               | Description                                        |
+| ---------------------- | -------------------------------------------------- |
+| ++cmd+a++              | select the full text                               |
+| ++cmd+back++           | delete text until the start of the word            |
+| ++cmd+del++            | delete text until the end of the word              |
+| ++cmd+shift+back++     | delete text until the start of the line            |
+| ++cmd+shift+del++      | delete text until end of the line                  |
+| ++cmd+d++              | duplicate the current line                         |
+| ++shift+left++           | increase selection to the character to the left    |
+| ++shift+right++        | increase selection to the character to the right   |
+| ++alt+shift+left++     | increase selection to the start of the word        |
+| ++alt+shift+right++    | increase selection to the end of the word          |
+| ++cmd+shift+fn+left++  | increase selection to the start of the full text   |
+| ++cmd+shift+fn+right++ | increase selection to the end of the full text     |
+
+## Compatibility with the [Text language](https://www.jetbrains.com/help/mps/generic-placeholders-and-generic-comments.html#thetextlanguage)( jetbrains.mps.lang.text)
 
 Both languages have similar goals but are not compatible with each other.
 The text language is line based and has builtin support for some formatting options like bold, italic, underlined and some 


### PR DESCRIPTION
The code completion entries of word cells are now clearer and unnecessary entries were removed.

Edit: I am not so sure about the second code completion entry. Do we really need this functionality? It inserts the entry at the current cursor position instead of replacing everything below the cursor. I've tried to add an explanation to the description but it still looks confusing:

<img width="934" alt="Screenshot 2023-12-17 at 18 06 16" src="https://github.com/JetBrains/MPS-extensions/assets/88385944/f3d5eb61-6702-4588-a9d9-c826ef4daf74">