### PR TITLE
Line numbers: Improve performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,16 @@ All notable changes to this project are documented in this file.
 Format of the log is _loosely_ based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). 
 The project does _not_ follow Semantic Versioning and the changes are documented in reverse chronological order, grouped by calendar month.
 
-## Dezember 2023
+## December 2023
 
 ### Added
 
 - A new language `de.itemis.mps.statistics` was added that adds a new menu `MPS Statistics` to the `Tools`  menu. The containing action writes a file `dependencies.txt` to the root folder. It contains all the used dependencies of the current project. 
 - de.slisson.mps.tables: tables now support a new property `column UI actions (experimental)`: This property adds actions to the MPS toolbar to add a new column above/below the current column or to delete the current column. These actions only work for simple tables that are based on rows (default: *false*).
+
+### Fixed
+
+- The performance of the language `de.itemis.mps.linenumbers` was improved.
 
 ## November 2023
 

--- a/code/linenumbers/de.itemis.mps.linenumbers/models/de.itemis.mps.linenumbers.plugin.mps
+++ b/code/linenumbers/de.itemis.mps.linenumbers/models/de.itemis.mps.linenumbers.plugin.mps
@@ -224,6 +224,7 @@
       <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
         <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
       </concept>
+      <concept id="1068581242867" name="jetbrains.mps.baseLanguage.structure.LongType" flags="in" index="3cpWsb" />
       <concept id="1068581242869" name="jetbrains.mps.baseLanguage.structure.MinusExpression" flags="nn" index="3cpWsd" />
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
       <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
@@ -234,6 +235,7 @@
       <concept id="1079359253375" name="jetbrains.mps.baseLanguage.structure.ParenthesizedExpression" flags="nn" index="1eOMI4">
         <child id="1079359253376" name="expression" index="1eOMHV" />
       </concept>
+      <concept id="1081506773034" name="jetbrains.mps.baseLanguage.structure.LessThanExpression" flags="nn" index="3eOVzh" />
       <concept id="1081516740877" name="jetbrains.mps.baseLanguage.structure.NotExpression" flags="nn" index="3fqX7Q">
         <child id="1081516765348" name="expression" index="3fr31v" />
       </concept>
@@ -318,13 +320,6 @@
       <concept id="1205769003971" name="jetbrains.mps.baseLanguage.classifiers.structure.DefaultClassifierMethodDeclaration" flags="ng" index="2XrIbr" />
       <concept id="1205769149993" name="jetbrains.mps.baseLanguage.classifiers.structure.DefaultClassifierMethodCallOperation" flags="nn" index="2XshWL">
         <child id="1205770614681" name="actualArgument" index="2XxRq1" />
-      </concept>
-    </language>
-    <language id="760a0a8c-eabb-4521-8bfd-65db761a9ba3" name="jetbrains.mps.baseLanguage.logging">
-      <concept id="2034914114981261497" name="jetbrains.mps.baseLanguage.logging.structure.LogLowLevelStatement" flags="ng" index="RRSsy">
-        <property id="2034914114981261751" name="severity" index="RRSoG" />
-        <child id="2034914114981261755" name="throwable" index="RRSow" />
-        <child id="2034914114981261753" name="message" index="RRSoy" />
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
@@ -2257,6 +2252,14 @@
         <property role="3cmrfH" value="30" />
       </node>
     </node>
+    <node concept="312cEg" id="1SxRp_hHhxH" role="jymVt">
+      <property role="TrG5h" value="lastUpdated" />
+      <node concept="3Tm6S6" id="1SxRp_hHeMY" role="1B3o_S" />
+      <node concept="3cpWsb" id="1SxRp_hHhrD" role="1tU5fm" />
+      <node concept="3cmrfG" id="1SxRp_hHj99" role="33vP2m">
+        <property role="3cmrfH" value="-1" />
+      </node>
+    </node>
     <node concept="2tJIrI" id="3PNI8k1Jo11" role="jymVt" />
     <node concept="3clFbW" id="3PNI8k1Jovj" role="jymVt">
       <node concept="3cqZAl" id="3PNI8k1Jovk" role="3clF45" />
@@ -2651,88 +2654,65 @@
         <node concept="10P_77" id="1ndcVOCsqWZ" role="1tU5fm" />
       </node>
       <node concept="3clFbS" id="XqsiCnMAc4" role="3clF47">
-        <node concept="3J1_TO" id="3C4j4UfMFdq" role="3cqZAp">
-          <node concept="3uVAMA" id="3C4j4UfMGUq" role="1zxBo5">
-            <node concept="XOnhg" id="3C4j4UfMGUr" role="1zc67B">
-              <property role="TrG5h" value="ex" />
-              <node concept="nSUau" id="3C4j4UfMGUs" role="1tU5fm">
-                <node concept="3uibUv" id="3C4j4UfMI1m" role="nSUat">
-                  <ref role="3uigEE" to="wyt6:~Exception" resolve="Exception" />
-                </node>
+        <node concept="3cpWs8" id="XqsiCnNeuD" role="3cqZAp">
+          <node concept="3cpWsn" id="XqsiCnNeuE" role="3cpWs9">
+            <property role="TrG5h" value="rootCell" />
+            <node concept="3uibUv" id="XqsiCnNdEq" role="1tU5fm">
+              <ref role="3uigEE" to="g51k:~EditorCell" resolve="EditorCell" />
+            </node>
+            <node concept="2OqwBi" id="XqsiCnNeuF" role="33vP2m">
+              <node concept="1rXfSq" id="XqsiCnNeuG" role="2Oq$k0">
+                <ref role="37wK5l" node="3PNI8k1JtHm" resolve="getEditorComponent" />
+              </node>
+              <node concept="liA8E" id="XqsiCnNeuH" role="2OqNvi">
+                <ref role="37wK5l" to="exr9:~EditorComponent.getRootCell()" resolve="getRootCell" />
               </node>
             </node>
-            <node concept="3clFbS" id="3C4j4UfMGUt" role="1zc67A">
-              <node concept="RRSsy" id="3C4j4UfMNnX" role="3cqZAp">
-                <property role="RRSoG" value="gZ5fh_4/error" />
-                <node concept="Xl_RD" id="3C4j4UfMNnZ" role="RRSoy" />
-                <node concept="37vLTw" id="3C4j4UfMP5q" role="RRSow">
-                  <ref role="3cqZAo" node="3C4j4UfMGUr" resolve="ex" />
+          </node>
+        </node>
+        <node concept="3clFbF" id="509q6HGG2Qu" role="3cqZAp">
+          <node concept="37vLTI" id="509q6HGG4oH" role="3clFbG">
+            <node concept="37vLTw" id="509q6HGG2Qo" role="37vLTJ">
+              <ref role="3cqZAo" node="3PNI8k1JW2s" resolve="lines" />
+            </node>
+            <node concept="2YIFZM" id="509q6HGFLLC" role="37vLTx">
+              <ref role="1Pybhc" node="QZV4qCMo_w" resolve="LineNumberUtils" />
+              <ref role="37wK5l" node="3C4j4UfPftN" resolve="findLines" />
+              <node concept="37vLTw" id="509q6HGFLLD" role="37wK5m">
+                <ref role="3cqZAo" node="XqsiCnNeuE" resolve="rootCell" />
+              </node>
+              <node concept="37vLTw" id="1ndcVOCsyiM" role="37wK5m">
+                <ref role="3cqZAo" node="1ndcVOCsq3x" resolve="foldingChanged" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="3C4j4UfOqeH" role="3cqZAp">
+          <node concept="3clFbS" id="3C4j4UfOqeJ" role="3clFbx">
+            <node concept="3clFbF" id="509q6HGFJPs" role="3cqZAp">
+              <node concept="2OqwBi" id="509q6HGFPd2" role="3clFbG">
+                <node concept="37vLTw" id="509q6HGFLLE" role="2Oq$k0">
+                  <ref role="3cqZAo" node="3PNI8k1JW2s" resolve="lines" />
+                </node>
+                <node concept="liA8E" id="509q6HGFRz7" role="2OqNvi">
+                  <ref role="37wK5l" node="509q6HGEazj" resolve="assignLineNumber" />
+                  <node concept="3cmrfG" id="509q6HGFSQu" role="37wK5m">
+                    <property role="3cmrfH" value="1" />
+                  </node>
                 </node>
               </node>
             </node>
           </node>
-          <node concept="3clFbS" id="3C4j4UfMFds" role="1zxBo7">
-            <node concept="3cpWs8" id="XqsiCnNeuD" role="3cqZAp">
-              <node concept="3cpWsn" id="XqsiCnNeuE" role="3cpWs9">
-                <property role="TrG5h" value="rootCell" />
-                <node concept="3uibUv" id="XqsiCnNdEq" role="1tU5fm">
-                  <ref role="3uigEE" to="g51k:~EditorCell" resolve="EditorCell" />
-                </node>
-                <node concept="2OqwBi" id="XqsiCnNeuF" role="33vP2m">
-                  <node concept="1rXfSq" id="XqsiCnNeuG" role="2Oq$k0">
-                    <ref role="37wK5l" node="3PNI8k1JtHm" resolve="getEditorComponent" />
-                  </node>
-                  <node concept="liA8E" id="XqsiCnNeuH" role="2OqNvi">
-                    <ref role="37wK5l" to="exr9:~EditorComponent.getRootCell()" resolve="getRootCell" />
-                  </node>
-                </node>
-              </node>
+          <node concept="3y3z36" id="3C4j4UfOtCQ" role="3clFbw">
+            <node concept="10Nm6u" id="3C4j4UfOtD1" role="3uHU7w" />
+            <node concept="37vLTw" id="3C4j4UfOrTq" role="3uHU7B">
+              <ref role="3cqZAo" node="3PNI8k1JW2s" resolve="lines" />
             </node>
-            <node concept="3clFbF" id="509q6HGG2Qu" role="3cqZAp">
-              <node concept="37vLTI" id="509q6HGG4oH" role="3clFbG">
-                <node concept="37vLTw" id="509q6HGG2Qo" role="37vLTJ">
-                  <ref role="3cqZAo" node="3PNI8k1JW2s" resolve="lines" />
-                </node>
-                <node concept="2YIFZM" id="509q6HGFLLC" role="37vLTx">
-                  <ref role="1Pybhc" node="QZV4qCMo_w" resolve="LineNumberUtils" />
-                  <ref role="37wK5l" node="3C4j4UfPftN" resolve="findLines" />
-                  <node concept="37vLTw" id="509q6HGFLLD" role="37wK5m">
-                    <ref role="3cqZAo" node="XqsiCnNeuE" resolve="rootCell" />
-                  </node>
-                  <node concept="37vLTw" id="1ndcVOCsyiM" role="37wK5m">
-                    <ref role="3cqZAo" node="1ndcVOCsq3x" resolve="foldingChanged" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbJ" id="3C4j4UfOqeH" role="3cqZAp">
-              <node concept="3clFbS" id="3C4j4UfOqeJ" role="3clFbx">
-                <node concept="3clFbF" id="509q6HGFJPs" role="3cqZAp">
-                  <node concept="2OqwBi" id="509q6HGFPd2" role="3clFbG">
-                    <node concept="37vLTw" id="509q6HGFLLE" role="2Oq$k0">
-                      <ref role="3cqZAo" node="3PNI8k1JW2s" resolve="lines" />
-                    </node>
-                    <node concept="liA8E" id="509q6HGFRz7" role="2OqNvi">
-                      <ref role="37wK5l" node="509q6HGEazj" resolve="assignLineNumber" />
-                      <node concept="3cmrfG" id="509q6HGFSQu" role="37wK5m">
-                        <property role="3cmrfH" value="1" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3y3z36" id="3C4j4UfOtCQ" role="3clFbw">
-                <node concept="10Nm6u" id="3C4j4UfOtD1" role="3uHU7w" />
-                <node concept="37vLTw" id="3C4j4UfOrTq" role="3uHU7B">
-                  <ref role="3cqZAo" node="3PNI8k1JW2s" resolve="lines" />
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbF" id="3GQAmbHeasU" role="3cqZAp">
-              <node concept="1rXfSq" id="3GQAmbHeasS" role="3clFbG">
-                <ref role="37wK5l" node="3GQAmbHcMFo" resolve="calculateWidth" />
-              </node>
-            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="3GQAmbHeasU" role="3cqZAp">
+          <node concept="1rXfSq" id="3GQAmbHeasS" role="3clFbG">
+            <ref role="37wK5l" node="3GQAmbHcMFo" resolve="calculateWidth" />
           </node>
         </node>
       </node>
@@ -3228,6 +3208,75 @@
         <node concept="10P_77" id="EMOkVNgjeI" role="1tU5fm" />
       </node>
       <node concept="3clFbS" id="EMOkVNgjeJ" role="3clF47">
+        <node concept="3cpWs8" id="1SxRp_hHuNy" role="3cqZAp">
+          <node concept="3cpWsn" id="1SxRp_hHuN_" role="3cpWs9">
+            <property role="TrG5h" value="currentUpdate" />
+            <node concept="3cpWsb" id="1SxRp_hHuNw" role="1tU5fm" />
+            <node concept="2YIFZM" id="1SxRp_hHC2I" role="33vP2m">
+              <ref role="1Pybhc" to="wyt6:~System" resolve="System" />
+              <ref role="37wK5l" to="wyt6:~System.nanoTime()" resolve="nanoTime" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="1SxRp_hJ7aW" role="3cqZAp" />
+        <node concept="3clFbJ" id="1SxRp_hHTIF" role="3cqZAp">
+          <node concept="3clFbS" id="1SxRp_hHTIH" role="3clFbx">
+            <node concept="3cpWs8" id="1SxRp_hIfaA" role="3cqZAp">
+              <node concept="3cpWsn" id="1SxRp_hIfaD" role="3cpWs9">
+                <property role="TrG5h" value="timeDiffInMS" />
+                <node concept="3cpWsb" id="1SxRp_hIfa$" role="1tU5fm" />
+                <node concept="FJ1c_" id="1SxRp_hIE4s" role="33vP2m">
+                  <node concept="3cmrfG" id="1SxRp_hIGgX" role="3uHU7w">
+                    <property role="3cmrfH" value="1000000" />
+                  </node>
+                  <node concept="1eOMI4" id="1SxRp_hIxPq" role="3uHU7B">
+                    <node concept="3cpWsd" id="1SxRp_hIqgp" role="1eOMHV">
+                      <node concept="37vLTw" id="1SxRp_hIol4" role="3uHU7B">
+                        <ref role="3cqZAo" node="1SxRp_hHuN_" resolve="currentUpdate" />
+                      </node>
+                      <node concept="37vLTw" id="1SxRp_hKumg" role="3uHU7w">
+                        <ref role="3cqZAo" node="1SxRp_hHhxH" resolve="lastUpdated" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbJ" id="1SxRp_hJk4T" role="3cqZAp">
+              <node concept="3clFbS" id="1SxRp_hJk4V" role="3clFbx">
+                <node concept="3cpWs6" id="1SxRp_hJvJB" role="3cqZAp" />
+              </node>
+              <node concept="3eOVzh" id="1SxRp_hJpvy" role="3clFbw">
+                <node concept="3cmrfG" id="1SxRp_hJr8b" role="3uHU7w">
+                  <property role="3cmrfH" value="250" />
+                </node>
+                <node concept="37vLTw" id="1SxRp_hJmuz" role="3uHU7B">
+                  <ref role="3cqZAo" node="1SxRp_hIfaD" resolve="timeDiffInMS" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3y3z36" id="1SxRp_hHZ9g" role="3clFbw">
+            <node concept="37vLTw" id="1SxRp_hHWpI" role="3uHU7B">
+              <ref role="3cqZAo" node="1SxRp_hHhxH" resolve="lastUpdated" />
+            </node>
+            <node concept="3cmrfG" id="1SxRp_hI6cv" role="3uHU7w">
+              <property role="3cmrfH" value="-1" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="1SxRp_hHFs3" role="3cqZAp" />
+        <node concept="3clFbF" id="1SxRp_hJ2gH" role="3cqZAp">
+          <node concept="37vLTI" id="1SxRp_hJdO$" role="3clFbG">
+            <node concept="37vLTw" id="1SxRp_hJg8R" role="37vLTx">
+              <ref role="3cqZAo" node="1SxRp_hHuN_" resolve="currentUpdate" />
+            </node>
+            <node concept="37vLTw" id="1SxRp_hJ2gF" role="37vLTJ">
+              <ref role="3cqZAo" node="1SxRp_hHhxH" resolve="lastUpdated" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="1SxRp_hLH1k" role="3cqZAp" />
         <node concept="3clFbJ" id="3C3Ej5lKAQ_" role="3cqZAp">
           <node concept="3clFbS" id="3C3Ej5lKAQB" role="3clFbx">
             <node concept="3cpWs8" id="5QVAbkkflYM" role="3cqZAp">


### PR DESCRIPTION
This PR fixes https://github.com/JetBrains/MPS-extensions/issues/726

The left highlighter gets way too many relayout events which we can't influence, so we have to throttle the number of events. I've selected 250ms, which means that the line numbers only update 4 times per second or less. I've tried to create many new lines in the mbeddr documentation for testing and the update interval seems to be sufficient for small and large editors.
