### PR TITLE
Editor Cell and Editor Component references for the MPS console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The project does _not_ follow Semantic Versioning and the changes are documented
 - A new language `de.itemis.mps.statistics` was added that adds a new menu `MPS Statistics` to the `Tools`  menu. The containing action writes a file `dependencies.txt` to the root folder. It contains all the used dependencies of the current project. 
 - de.slisson.mps.tables: tables now support a new property `column UI actions (experimental)`: This property adds actions to the MPS toolbar to add a new column above/below the current column or to delete the current column. These actions only work for simple tables that are based on rows (default: *false*).
 - de.slisson.mps.richtext: The shortcuts are now documented.
+- A new action `Copy Cell Reference` is available in the edditor menu in `Language Debug` that creates a reference to the current select editor cell. It can be pasted into the MPS console to debug editor cells.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,8 @@ The project does _not_ follow Semantic Versioning and the changes are documented
 - A new language `de.itemis.mps.statistics` was added that adds a new menu `MPS Statistics` to the `Tools`  menu. The containing action writes a file `dependencies.txt` to the root folder. It contains all the used dependencies of the current project. 
 - de.slisson.mps.tables: tables now support a new property `column UI actions (experimental)`: This property adds actions to the MPS toolbar to add a new column above/below the current column or to delete the current column. These actions only work for simple tables that are based on rows (default: *false*).
 - de.slisson.mps.richtext: The shortcuts are now documented.
-- A new action `Copy Cell Reference` is available in the edditor menu in `Language Debug` that creates a reference to the current select editor cell. It can be pasted into the MPS console to debug editor cells. It can be activated through ctrl/cmd+alt+c.
-- - A new action `Copy Editor Component Reference` is available in the edditor menu in `Language Debug` that creates a reference to the current editor component. It can be pasted into the MPS console to debug editor cells. To refer to the current opened editor component, use the expression `#editorComponent` in the MPS console.
+- A new action `Copy Cell Reference` is available in the editor menu in `Language Debug` that creates a reference to the current select editor cell. It can be pasted into the MPS console to debug editor cells. It can be activated through ctrl/cmd+alt+c.
+- A new action `Copy Editor Component Reference` is available in the editor menu in `Language Debug` that creates a reference to the current editor component. It can be pasted into the MPS console to debug editor cells. To refer to the current opened editor component, use the expression `#currentEditorComponent` in the MPS console.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The project does _not_ follow Semantic Versioning and the changes are documented
 - de.slisson.mps.tables: tables now support a new property `column UI actions (experimental)`: This property adds actions to the MPS toolbar to add a new column above/below the current column or to delete the current column. These actions only work for simple tables that are based on rows (default: *false*).
 - de.slisson.mps.richtext: The shortcuts are now documented.
 - A new action `Copy Cell Reference` is available in the edditor menu in `Language Debug` that creates a reference to the current select editor cell. It can be pasted into the MPS console to debug editor cells.
+- - A new action `Copy Editor Component Reference` is available in the edditor menu in `Language Debug` that creates a reference to the current editor component. It can be pasted into the MPS console to debug editor cells. To refer to the current opened editor component, use the expression `#editorComponent` in the MPS console.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ The project does _not_ follow Semantic Versioning and the changes are documented
 - A new language `de.itemis.mps.statistics` was added that adds a new menu `MPS Statistics` to the `Tools`  menu. The containing action writes a file `dependencies.txt` to the root folder. It contains all the used dependencies of the current project. 
 - de.slisson.mps.tables: tables now support a new property `column UI actions (experimental)`: This property adds actions to the MPS toolbar to add a new column above/below the current column or to delete the current column. These actions only work for simple tables that are based on rows (default: *false*).
 - de.slisson.mps.richtext: The shortcuts are now documented.
-- A new action `Copy Cell Reference` is available in the edditor menu in `Language Debug` that creates a reference to the current select editor cell. It can be pasted into the MPS console to debug editor cells.
+- A new action `Copy Cell Reference` is available in the edditor menu in `Language Debug` that creates a reference to the current select editor cell. It can be pasted into the MPS console to debug editor cells. It can be activated through ctrl/cmd+alt+c.
 - - A new action `Copy Editor Component Reference` is available in the edditor menu in `Language Debug` that creates a reference to the current editor component. It can be pasted into the MPS console to debug editor cells. To refer to the current opened editor component, use the expression `#editorComponent` in the MPS console.
 
 ### Changed

--- a/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
+++ b/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
@@ -5764,6 +5764,9 @@
       <node concept="m$_yC" id="6SVXTgIenog" role="m$_yJ">
         <ref role="m$_y1" node="2Xjt3l57iTJ" resolve="de.slisson.mps.hacks" />
       </node>
+      <node concept="m$_yC" id="7_uCKm_qn6i" role="m$_yJ">
+        <ref role="m$_y1" to="ffeo:1jjxZP6JyD_" resolve="jetbrains.mps.console" />
+      </node>
       <node concept="2iUeEo" id="2QgPOUCDdVC" role="2iVFfd">
         <property role="2iUeEt" value="itemis AG" />
         <property role="2iUeEu" value="https://www.itemis.com/en/it-services/methods-and-tools/mps" />

--- a/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
+++ b/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
@@ -939,19 +939,6 @@
             <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
           </node>
         </node>
-        <node concept="1SiIV0" id="28qbqxxOALs" role="3bR37C">
-          <node concept="1BurEX" id="28qbqxxOALt" role="1SiIV1">
-            <node concept="398BVA" id="28qbqxxOALn" role="1BurEY">
-              <ref role="398BVh" node="5Ngh5kRcxhz" resolve="platform_lib" />
-              <node concept="2Ry0Ak" id="28qbqxxOALo" role="iGT6I">
-                <property role="2Ry0Am" value="app.jar" />
-              </node>
-            </node>
-            <node concept="3yrxFa" id="56z5W63g4Cc" role="2gdwQb">
-              <ref role="3yrxFb" to="ffeo:4LdE6kxkp0J" />
-            </node>
-          </node>
-        </node>
         <node concept="3rtmxn" id="7LJ_vJOlQ5R" role="3bR31x">
           <node concept="3LXTmp" id="7LJ_vJOlQ5S" role="3rtmxm">
             <node concept="3qWCbU" id="7LJ_vJOlQ5T" role="3LXTna">
@@ -968,6 +955,19 @@
                   </node>
                 </node>
               </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="28qbqxxOALs" role="3bR37C">
+          <node concept="1BurEX" id="28qbqxxOALt" role="1SiIV1">
+            <node concept="398BVA" id="28qbqxxOALn" role="1BurEY">
+              <ref role="398BVh" node="5Ngh5kRcxhz" resolve="platform_lib" />
+              <node concept="2Ry0Ak" id="28qbqxxOALo" role="iGT6I">
+                <property role="2Ry0Am" value="app.jar" />
+              </node>
+            </node>
+            <node concept="3yrxFa" id="56z5W63g4Cc" role="2gdwQb">
+              <ref role="3yrxFb" to="ffeo:4LdE6kxkp0J" />
             </node>
           </node>
         </node>
@@ -5860,6 +5860,31 @@
             <node concept="3qWCbU" id="2eucapX07Xi" role="3LXTna">
               <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
             </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="7_uCKm_mCX5" role="3bR37C">
+          <node concept="3bR9La" id="7_uCKm_mCX6" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1TaHNgiIbJ$" resolve="jetbrains.mps.ide.editor" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="7_uCKm_mCX7" role="3bR37C">
+          <node concept="3bR9La" id="7_uCKm_mCX8" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:7gQEwkA7nSV" resolve="jetbrains.mps.console" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="7_uCKm_mCX9" role="3bR37C">
+          <node concept="3bR9La" id="7_uCKm_mCXa" role="1SiIV1">
+            <ref role="3bR37D" node="2nutuZsJi6m" resolve="de.itemis.mps.editor.celllayout" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="7_uCKm_mCXb" role="3bR37C">
+          <node concept="3bR9La" id="7_uCKm_mCXc" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:7gQEwkA7rZZ" resolve="jetbrains.mps.console.base" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="7_uCKm_mCXd" role="3bR37C">
+          <node concept="3bR9La" id="7_uCKm_mCXe" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1TaHNgiIbJt" resolve="jetbrains.mps.ide.platform" />
           </node>
         </node>
       </node>

--- a/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
+++ b/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
@@ -106,9 +106,6 @@
       <concept id="4701820937132344003" name="jetbrains.mps.build.structure.BuildLayout_Container" flags="ng" index="1y1bJS">
         <child id="7389400916848037006" name="children" index="39821P" />
       </concept>
-      <concept id="5610619299014309452" name="jetbrains.mps.build.structure.BuildSource_JavaExternalJarRef" flags="ng" index="3yrxFa">
-        <reference id="5610619299014309453" name="jar" index="3yrxFb" />
-      </concept>
       <concept id="841011766566059607" name="jetbrains.mps.build.structure.BuildStringNotEmpty" flags="ng" index="3_J27D" />
       <concept id="5248329904287794596" name="jetbrains.mps.build.structure.BuildInputFiles" flags="ng" index="3LXTmp">
         <child id="5248329904287794598" name="dir" index="3LXTmr" />
@@ -203,7 +200,6 @@
         <child id="8137134783396676835" name="location" index="1HemKq" />
       </concept>
       <concept id="4278635856200826393" name="jetbrains.mps.build.mps.structure.BuildMps_ModuleDependencyJar" flags="ng" index="1BurEX">
-        <child id="2798275735916344703" name="customLocation" index="2gdwQb" />
         <child id="4278635856200826394" name="path" index="1BurEY" />
       </concept>
       <concept id="4278635856200794926" name="jetbrains.mps.build.mps.structure.BuildMps_ModuleDependencyExtendLanguage" flags="ng" index="1Busua">
@@ -955,19 +951,6 @@
                   </node>
                 </node>
               </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="28qbqxxOALs" role="3bR37C">
-          <node concept="1BurEX" id="28qbqxxOALt" role="1SiIV1">
-            <node concept="398BVA" id="28qbqxxOALn" role="1BurEY">
-              <ref role="398BVh" node="5Ngh5kRcxhz" resolve="platform_lib" />
-              <node concept="2Ry0Ak" id="28qbqxxOALo" role="iGT6I">
-                <property role="2Ry0Am" value="app.jar" />
-              </node>
-            </node>
-            <node concept="3yrxFa" id="56z5W63g4Cc" role="2gdwQb">
-              <ref role="3yrxFb" to="ffeo:4LdE6kxkp0J" />
             </node>
           </node>
         </node>
@@ -6139,9 +6122,9 @@
             <ref role="1E1Vl2" to="ffeo:7Kfy9QB6L4X" resolve="jetbrains.mps.lang.editor" />
           </node>
         </node>
-        <node concept="1SiIV0" id="1kvClgKIDJ7" role="3bR37C">
-          <node concept="Rbm2T" id="1kvClgKIDJ8" role="1SiIV1">
-            <ref role="1E1Vl2" to="ffeo:7Kfy9QB6L9O" resolve="jetbrains.mps.lang.smodel" />
+        <node concept="1SiIV0" id="7_uCKm_r97I" role="3bR37C">
+          <node concept="3bR9La" id="7_uCKm_r97J" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:7gQEwkA7rZZ" resolve="jetbrains.mps.console.base" />
           </node>
         </node>
       </node>

--- a/code/celllayout/languages/de.itemis.mps.editor.celllayout/de.itemis.mps.editor.celllayout.mpl
+++ b/code/celllayout/languages/de.itemis.mps.editor.celllayout/de.itemis.mps.editor.celllayout.mpl
@@ -41,6 +41,7 @@
         <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
         <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
         <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
+        <language slang="l:de1ad86d-6e50-4a02-b306-d4d17f64c375:jetbrains.mps.console.base" version="0" />
         <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
         <language slang="l:18bc6592-03a6-4e29-a83a-7ff23bde13ba:jetbrains.mps.lang.editor" version="14" />
         <language slang="l:b401a680-8325-4110-8fd3-84331ff25bef:jetbrains.mps.lang.generator" version="4" />
@@ -48,6 +49,7 @@
         <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
         <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
         <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
+        <language slang="l:1a8554c4-eb84-43ba-8c34-6f0d90c6e75a:jetbrains.mps.lang.smodel.query" version="3" />
         <language slang="l:c72da2b9-7cce-4447-8389-f407dc1158b7:jetbrains.mps.lang.structure" version="9" />
         <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
         <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />

--- a/code/celllayout/languages/de.itemis.mps.editor.celllayout/de.itemis.mps.editor.celllayout.mpl
+++ b/code/celllayout/languages/de.itemis.mps.editor.celllayout/de.itemis.mps.editor.celllayout.mpl
@@ -117,6 +117,7 @@
     <dependency reexport="true">848ef45d-e560-4e35-853c-f35a64cc135c(de.itemis.mps.editor.celllayout.runtime)</dependency>
     <dependency reexport="false" scope="generate-into">18bc6592-03a6-4e29-a83a-7ff23bde13ba(jetbrains.mps.lang.editor)</dependency>
     <dependency reexport="false">f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)</dependency>
+    <dependency reexport="false">de1ad86d-6e50-4a02-b306-d4d17f64c375(jetbrains.mps.console.base)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
@@ -169,6 +170,8 @@
     <module reference="fd392034-7849-419d-9071-12563d152375(jetbrains.mps.baseLanguage.closures)" version="0" />
     <module reference="83888646-71ce-4f1c-9c53-c54016f6ad4f(jetbrains.mps.baseLanguage.collections)" version="0" />
     <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
+    <module reference="a8de7923-dc6f-4aa1-b8a9-2d19ffee3edd(jetbrains.mps.console)" version="0" />
+    <module reference="de1ad86d-6e50-4a02-b306-d4d17f64c375(jetbrains.mps.console.base)" version="0" />
     <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
     <module reference="d936855b-48da-4812-a8a0-2bfddd633ac5(jetbrains.mps.lang.behavior.api)" version="0" />
     <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
@@ -177,6 +180,7 @@
     <module reference="446c26eb-2b7b-4bf0-9b35-f83fa582753e(jetbrains.mps.lang.modelapi)" version="0" />
     <module reference="d7eb0a2a-bd50-4576-beae-e4a89db35f20(jetbrains.mps.lang.scopes.runtime)" version="0" />
     <module reference="7866978e-a0f0-4cc7-81bc-4d213d9375e1(jetbrains.mps.lang.smodel)" version="1" />
+    <module reference="1a8554c4-eb84-43ba-8c34-6f0d90c6e75a(jetbrains.mps.lang.smodel.query)" version="0" />
     <module reference="c72da2b9-7cce-4447-8389-f407dc1158b7(jetbrains.mps.lang.structure)" version="0" />
     <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
   </dependencyVersions>

--- a/code/celllayout/languages/de.itemis.mps.editor.celllayout/de.itemis.mps.editor.celllayout.mpl
+++ b/code/celllayout/languages/de.itemis.mps.editor.celllayout/de.itemis.mps.editor.celllayout.mpl
@@ -116,7 +116,6 @@
     <dependency reexport="false" scope="generate-into">f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)</dependency>
     <dependency reexport="true">848ef45d-e560-4e35-853c-f35a64cc135c(de.itemis.mps.editor.celllayout.runtime)</dependency>
     <dependency reexport="false" scope="generate-into">18bc6592-03a6-4e29-a83a-7ff23bde13ba(jetbrains.mps.lang.editor)</dependency>
-    <dependency reexport="false" scope="generate-into">7866978e-a0f0-4cc7-81bc-4d213d9375e1(jetbrains.mps.lang.smodel)</dependency>
     <dependency reexport="false">f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)</dependency>
   </dependencies>
   <languageVersions>
@@ -125,6 +124,7 @@
     <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
     <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
     <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
+    <language slang="l:c7d5b9dd-a05f-4be2-bc73-f2e16994cc67:jetbrains.mps.baseLanguage.lightweightdsl" version="1" />
     <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
     <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
     <language slang="l:aee9cad2-acd4-4608-aef2-0004f6a1cdbd:jetbrains.mps.lang.actions" version="4" />
@@ -139,6 +139,7 @@
     <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
     <language slang="l:f4ad079d-bc71-4ffb-9600-9328705cf998:jetbrains.mps.lang.descriptor" version="0" />
     <language slang="l:18bc6592-03a6-4e29-a83a-7ff23bde13ba:jetbrains.mps.lang.editor" version="14" />
+    <language slang="l:d7a92d38-f7db-40d0-8431-763b0c3c9f20:jetbrains.mps.lang.intentions" version="1" />
     <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
     <language slang="l:d4615e3b-d671-4ba9-af01-2b78369b0ba7:jetbrains.mps.lang.pattern" version="2" />
     <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />

--- a/code/celllayout/languages/de.itemis.mps.editor.celllayout/generator/template/main@generator.mps
+++ b/code/celllayout/languages/de.itemis.mps.editor.celllayout/generator/template/main@generator.mps
@@ -5,6 +5,7 @@
     <use id="b401a680-8325-4110-8fd3-84331ff25bef" name="jetbrains.mps.lang.generator" version="4" />
     <use id="d7706f63-9be2-479c-a3da-ae92af1e64d5" name="jetbrains.mps.lang.generator.generationContext" version="-1" />
     <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="-1" />
+    <use id="de1ad86d-6e50-4a02-b306-d4d17f64c375" name="jetbrains.mps.console.base" version="0" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -19,9 +20,13 @@
     <import index="xggr" ref="r:12584d60-2d80-4ca9-9c6e-b79d499da0cf(de.itemis.mps.editor.celllayout.layout)" />
     <import index="qxi4" ref="r:45c19b6d-dd9a-4f15-973f-0267c5e76303(de.itemis.mps.editor.celllayout.runtime)" />
     <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" />
+    <import index="rdi9" ref="r:c30772cf-6faa-4379-900e-6719e180568e(de.itemis.mps.editor.celllayout.runtime.plugin)" />
+    <import index="w1kc" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel(MPS.Core/)" />
     <import index="pvux" ref="r:bb8c05bc-4758-44fe-b1ab-f9faa5a73d31(de.itemis.mps.editor.celllayout.structure)" implicit="true" />
     <import index="hy9h" ref="r:131747d1-61c1-40bf-8a0d-f19908d3d142(de.itemis.mps.editor.celllayout.behavior)" implicit="true" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
+    <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" implicit="true" />
+    <import index="z1c3" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.project(MPS.Core/)" implicit="true" />
   </imports>
   <registry>
     <language id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor">
@@ -208,6 +213,9 @@
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
       <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
       <concept id="7453996997717780434" name="jetbrains.mps.lang.smodel.structure.Node_GetSConceptOperation" flags="nn" index="2yIwOk" />
+      <concept id="1145404486709" name="jetbrains.mps.lang.smodel.structure.SemanticDowncastExpression" flags="nn" index="2JrnkZ">
+        <child id="1145404616321" name="leftExpression" index="2JrQYb" />
+      </concept>
       <concept id="1171999116870" name="jetbrains.mps.lang.smodel.structure.Node_IsNullOperation" flags="nn" index="3w_OXm" />
       <concept id="1172008320231" name="jetbrains.mps.lang.smodel.structure.Node_IsNotNullOperation" flags="nn" index="3x8VRR" />
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2" />
@@ -238,6 +246,15 @@
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
     </language>
+    <language id="1a8554c4-eb84-43ba-8c34-6f0d90c6e75a" name="jetbrains.mps.lang.smodel.query">
+      <concept id="4234138103881610891" name="jetbrains.mps.lang.smodel.query.structure.WithStatement" flags="ng" index="L3pyB">
+        <child id="4234138103881610935" name="scope" index="L3pyr" />
+        <child id="4234138103881610892" name="stmts" index="L3pyw" />
+      </concept>
+    </language>
+    <language id="de1ad86d-6e50-4a02-b306-d4d17f64c375" name="jetbrains.mps.console.base">
+      <concept id="752693057587755272" name="jetbrains.mps.console.base.structure.ProjectExpression" flags="ng" index="o6qdh" />
+    </language>
   </registry>
   <node concept="bUwia" id="2nutuZsJfaQ">
     <property role="TrG5h" value="mc_main" />
@@ -257,6 +274,12 @@
       <ref role="30HIoZ" to="pvux:3ATi8gIrB$_" resolve="TopDownLayoutCell" />
       <node concept="j$656" id="3ATi8gIrR2f" role="1lVwrX">
         <ref role="v9R2y" node="fXNKMVr" resolve="reduce_TopDownLayoutCell" />
+      </node>
+    </node>
+    <node concept="3aamgX" id="7_uCKm_kmjx" role="3acgRq">
+      <ref role="30HIoZ" to="pvux:7_uCKm_gkEm" resolve="CellReference" />
+      <node concept="j$656" id="7_uCKm_kmkS" role="1lVwrX">
+        <ref role="v9R2y" node="7_uCKm_kmkQ" resolve="reduce_CellReference" />
       </node>
     </node>
   </node>
@@ -1161,6 +1184,108 @@
         </node>
       </node>
       <node concept="3Tm1VV" id="h9B3Loo" role="1B3o_S" />
+    </node>
+  </node>
+  <node concept="13MO4I" id="7_uCKm_kmkQ">
+    <property role="TrG5h" value="reduce_CellReference" />
+    <ref role="3gUMe" to="pvux:7_uCKm_gkEm" resolve="CellReference" />
+    <node concept="3clFbS" id="7_uCKm_ku9r" role="13RCb5">
+      <node concept="L3pyB" id="7_uCKm_kubX" role="3cqZAp">
+        <node concept="3clFbS" id="7_uCKm_kubY" role="L3pyw">
+          <node concept="3clFbF" id="7_uCKm_kuhc" role="3cqZAp">
+            <node concept="2YIFZM" id="7_uCKm_kope" role="3clFbG">
+              <ref role="37wK5l" to="rdi9:7_uCKm_kbYu" resolve="getEditorCell" />
+              <ref role="1Pybhc" to="rdi9:7_uCKm_jZa0" resolve="DebugHelper" />
+              <node concept="o6qdh" id="7_uCKm_kukL" role="37wK5m" />
+              <node concept="2OqwBi" id="7_uCKm_lBNn" role="37wK5m">
+                <node concept="2YIFZM" id="7_uCKm_lBz1" role="2Oq$k0">
+                  <ref role="37wK5l" to="w1kc:~SNodePointer.deserialize(java.lang.String)" resolve="deserialize" />
+                  <ref role="1Pybhc" to="w1kc:~SNodePointer" resolve="SNodePointer" />
+                  <node concept="Xl_RD" id="7_uCKm_lBz2" role="37wK5m">
+                    <property role="Xl_RC" value="" />
+                    <node concept="17Uvod" id="7_uCKm_lDb1" role="lGtFl">
+                      <property role="2qtEX9" value="value" />
+                      <property role="P4ACc" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1070475926800/1070475926801" />
+                      <node concept="3zFVjK" id="7_uCKm_lDb2" role="3zH0cK">
+                        <node concept="3clFbS" id="7_uCKm_lDb3" role="2VODD2">
+                          <node concept="3clFbF" id="7_uCKm_lJK_" role="3cqZAp">
+                            <node concept="2YIFZM" id="7_uCKm_lJM7" role="3clFbG">
+                              <ref role="37wK5l" to="w1kc:~SNodePointer.serialize(org.jetbrains.mps.openapi.model.SNodeReference)" resolve="serialize" />
+                              <ref role="1Pybhc" to="w1kc:~SNodePointer" resolve="SNodePointer" />
+                              <node concept="2OqwBi" id="7_uCKm_lKpA" role="37wK5m">
+                                <node concept="2JrnkZ" id="7_uCKm_lKgp" role="2Oq$k0">
+                                  <node concept="2OqwBi" id="7_uCKm_lK57" role="2JrQYb">
+                                    <node concept="30H73N" id="7_uCKm_lJMY" role="2Oq$k0" />
+                                    <node concept="3TrEf2" id="7_uCKm_lK7v" role="2OqNvi">
+                                      <ref role="3Tt5mk" to="pvux:7_uCKm_hOEn" resolve="target" />
+                                    </node>
+                                  </node>
+                                </node>
+                                <node concept="liA8E" id="7_uCKm_lKtF" role="2OqNvi">
+                                  <ref role="37wK5l" to="mhbf:~SNode.getReference()" resolve="getReference" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="liA8E" id="7_uCKm_lC15" role="2OqNvi">
+                  <ref role="37wK5l" to="mhbf:~SNodeReference.resolve(org.jetbrains.mps.openapi.module.SRepository)" resolve="resolve" />
+                  <node concept="2OqwBi" id="7_uCKm_lCGm" role="37wK5m">
+                    <node concept="o6qdh" id="7_uCKm_lC8l" role="2Oq$k0" />
+                    <node concept="liA8E" id="7_uCKm_lD3B" role="2OqNvi">
+                      <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="Xl_RD" id="7_uCKm_kuV6" role="37wK5m">
+                <property role="Xl_RC" value="" />
+                <node concept="17Uvod" id="7_uCKm_kvIW" role="lGtFl">
+                  <property role="2qtEX9" value="value" />
+                  <property role="P4ACc" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1070475926800/1070475926801" />
+                  <node concept="3zFVjK" id="7_uCKm_kvIX" role="3zH0cK">
+                    <node concept="3clFbS" id="7_uCKm_kvIY" role="2VODD2">
+                      <node concept="3clFbF" id="7_uCKm_kvVm" role="3cqZAp">
+                        <node concept="2OqwBi" id="7_uCKm_kwc7" role="3clFbG">
+                          <node concept="30H73N" id="7_uCKm_kvVl" role="2Oq$k0" />
+                          <node concept="3TrcHB" id="7_uCKm_kwqn" role="2OqNvi">
+                            <ref role="3TsBF5" to="pvux:7_uCKm_h5oU" resolve="cellID" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3cmrfG" id="7_uCKm_kwxv" role="37wK5m">
+                <property role="3cmrfH" value="0" />
+                <node concept="17Uvod" id="7_uCKm_kw_m" role="lGtFl">
+                  <property role="2qtEX9" value="value" />
+                  <property role="P4ACc" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580320020/1068580320021" />
+                  <node concept="3zFVjK" id="7_uCKm_kw_n" role="3zH0cK">
+                    <node concept="3clFbS" id="7_uCKm_kw_o" role="2VODD2">
+                      <node concept="3clFbF" id="7_uCKm_kwOH" role="3cqZAp">
+                        <node concept="2OqwBi" id="7_uCKm_kx1D" role="3clFbG">
+                          <node concept="30H73N" id="7_uCKm_kwOG" role="2Oq$k0" />
+                          <node concept="3TrcHB" id="7_uCKm_kx4f" role="2OqNvi">
+                            <ref role="3TsBF5" to="pvux:7_uCKm_h4Ra" resolve="componentHashCode" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="raruj" id="7_uCKm_kupO" role="lGtFl" />
+            </node>
+          </node>
+        </node>
+        <node concept="10Nm6u" id="7_uCKm_kzFe" role="L3pyr" />
+      </node>
     </node>
   </node>
 </model>

--- a/code/celllayout/languages/de.itemis.mps.editor.celllayout/generator/template/main@generator.mps
+++ b/code/celllayout/languages/de.itemis.mps.editor.celllayout/generator/template/main@generator.mps
@@ -82,6 +82,7 @@
         <child id="1068580123135" name="body" index="3clF47" />
       </concept>
       <concept id="1068580123165" name="jetbrains.mps.baseLanguage.structure.InstanceMethodDeclaration" flags="ig" index="3clFb_" />
+      <concept id="1068580123152" name="jetbrains.mps.baseLanguage.structure.EqualsExpression" flags="nn" index="3clFbC" />
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
@@ -194,6 +195,7 @@
       </concept>
       <concept id="1168024337012" name="jetbrains.mps.lang.generator.structure.SourceSubstituteMacro_SourceNodeQuery" flags="in" index="3NFfHV" />
       <concept id="1118773211870" name="jetbrains.mps.lang.generator.structure.IfMacro" flags="ln" index="1W57fq">
+        <child id="1194989344771" name="alternativeConsequence" index="UU_$l" />
         <child id="1167945861827" name="conditionFunction" index="3IZSJc" />
       </concept>
       <concept id="1118786554307" name="jetbrains.mps.lang.generator.structure.LoopMacro" flags="ln" index="1WS0z7">
@@ -280,6 +282,12 @@
       <ref role="30HIoZ" to="pvux:7_uCKm_gkEm" resolve="CellReference" />
       <node concept="j$656" id="7_uCKm_kmkS" role="1lVwrX">
         <ref role="v9R2y" node="7_uCKm_kmkQ" resolve="reduce_CellReference" />
+      </node>
+    </node>
+    <node concept="3aamgX" id="7_uCKm_ng8x" role="3acgRq">
+      <ref role="30HIoZ" to="pvux:7_uCKm_ncp6" resolve="EditorComponentReference" />
+      <node concept="j$656" id="7_uCKm_nghM" role="1lVwrX">
+        <ref role="v9R2y" node="7_uCKm_nghK" resolve="reduce_CurrentEditorComponentReference" />
       </node>
     </node>
   </node>
@@ -1188,6 +1196,7 @@
   </node>
   <node concept="13MO4I" id="7_uCKm_kmkQ">
     <property role="TrG5h" value="reduce_CellReference" />
+    <property role="3GE5qa" value="debug" />
     <ref role="3gUMe" to="pvux:7_uCKm_gkEm" resolve="CellReference" />
     <node concept="3clFbS" id="7_uCKm_ku9r" role="13RCb5">
       <node concept="L3pyB" id="7_uCKm_kubX" role="3cqZAp">
@@ -1286,6 +1295,68 @@
         </node>
         <node concept="10Nm6u" id="7_uCKm_kzFe" role="L3pyr" />
       </node>
+    </node>
+  </node>
+  <node concept="13MO4I" id="7_uCKm_nghK">
+    <property role="TrG5h" value="reduce_CurrentEditorComponentReference" />
+    <ref role="3gUMe" to="pvux:7_uCKm_ncp6" resolve="EditorComponentReference" />
+    <node concept="L3pyB" id="7_uCKm_ngVr" role="13RCb5">
+      <node concept="3clFbS" id="7_uCKm_ngVs" role="L3pyw">
+        <node concept="3clFbF" id="7_uCKm_ngVt" role="3cqZAp">
+          <node concept="2YIFZM" id="7_uCKm_nI32" role="3clFbG">
+            <ref role="37wK5l" to="rdi9:7_uCKm_nknH" resolve="getCurrentEditorComponent" />
+            <ref role="1Pybhc" to="rdi9:7_uCKm_jZa0" resolve="DebugHelper" />
+            <node concept="o6qdh" id="7_uCKm_nI33" role="37wK5m" />
+            <node concept="raruj" id="7_uCKm_nI34" role="lGtFl" />
+            <node concept="1W57fq" id="7_uCKm_ocmq" role="lGtFl">
+              <node concept="3IZrLx" id="7_uCKm_ocmr" role="3IZSJc">
+                <node concept="3clFbS" id="7_uCKm_ocms" role="2VODD2">
+                  <node concept="3clFbF" id="7_uCKm_octP" role="3cqZAp">
+                    <node concept="3clFbC" id="7_uCKm_ocZo" role="3clFbG">
+                      <node concept="3cmrfG" id="7_uCKm_od0S" role="3uHU7w">
+                        <property role="3cmrfH" value="-1" />
+                      </node>
+                      <node concept="2OqwBi" id="7_uCKm_ocAA" role="3uHU7B">
+                        <node concept="30H73N" id="7_uCKm_octO" role="2Oq$k0" />
+                        <node concept="3TrcHB" id="7_uCKm_ocCM" role="2OqNvi">
+                          <ref role="3TsBF5" to="pvux:7_uCKm_nXFw" resolve="componentHashCode" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="gft3U" id="7_uCKm_od8G" role="UU_$l">
+                <node concept="2YIFZM" id="7_uCKm_odw7" role="gfFT$">
+                  <ref role="37wK5l" to="rdi9:7_uCKm_kbKO" resolve="getEditorComponent" />
+                  <ref role="1Pybhc" to="rdi9:7_uCKm_jZa0" resolve="DebugHelper" />
+                  <node concept="o6qdh" id="7_uCKm_odzE" role="37wK5m" />
+                  <node concept="3cmrfG" id="7_uCKm_odPa" role="37wK5m">
+                    <property role="3cmrfH" value="0" />
+                    <node concept="17Uvod" id="7_uCKm_odXz" role="lGtFl">
+                      <property role="2qtEX9" value="value" />
+                      <property role="P4ACc" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580320020/1068580320021" />
+                      <node concept="3zFVjK" id="7_uCKm_odX$" role="3zH0cK">
+                        <node concept="3clFbS" id="7_uCKm_odX_" role="2VODD2">
+                          <node concept="3clFbF" id="7_uCKm_oebl" role="3cqZAp">
+                            <node concept="2OqwBi" id="7_uCKm_oeyn" role="3clFbG">
+                              <node concept="30H73N" id="7_uCKm_oebk" role="2Oq$k0" />
+                              <node concept="3TrcHB" id="7_uCKm_oeKB" role="2OqNvi">
+                                <ref role="3TsBF5" to="pvux:7_uCKm_nXFw" resolve="componentHashCode" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="10Nm6u" id="7_uCKm_ngW3" role="L3pyr" />
     </node>
   </node>
 </model>

--- a/code/celllayout/languages/de.itemis.mps.editor.celllayout/models/behavior.mps
+++ b/code/celllayout/languages/de.itemis.mps.editor.celllayout/models/behavior.mps
@@ -12,10 +12,21 @@
     <import index="tpcb" ref="r:00000000-0000-4000-0000-011c89590297(jetbrains.mps.lang.editor.behavior)" />
     <import index="hox0" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.style(MPS.Editor/)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" />
+    <import index="cj4x" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor(MPS.Editor/)" />
+    <import index="4nm9" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.project(MPS.IDEA/)" />
+    <import index="iwsx" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.fileEditor(MPS.IDEA/)" />
+    <import index="k3nr" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.ide.editor(MPS.Editor/)" />
+    <import index="f4zo" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.cells(MPS.Editor/)" />
+    <import index="z1c3" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.project(MPS.Core/)" />
+    <import index="alof" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.ide.project(MPS.Platform/)" />
+    <import index="w1kc" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel(MPS.Core/)" />
+    <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
+    <import index="rdi9" ref="r:c30772cf-6faa-4379-900e-6719e180568e(de.itemis.mps.editor.celllayout.runtime.plugin)" />
     <import index="pvux" ref="r:bb8c05bc-4758-44fe-b1ab-f9faa5a73d31(de.itemis.mps.editor.celllayout.structure)" implicit="true" />
   </imports>
   <registry>
     <language id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior">
+      <concept id="6496299201655527393" name="jetbrains.mps.lang.behavior.structure.LocalBehaviorMethodCall" flags="nn" index="BsUDl" />
       <concept id="1225194240794" name="jetbrains.mps.lang.behavior.structure.ConceptBehavior" flags="ng" index="13h7C7">
         <reference id="1225194240799" name="concept" index="13h7C2" />
         <child id="1225194240805" name="method" index="13h7CS" />
@@ -28,6 +39,7 @@
         <property id="1225194472834" name="isAbstract" index="13i0iv" />
         <reference id="1225194472831" name="overriddenMethod" index="13i0hy" />
       </concept>
+      <concept id="1225194691553" name="jetbrains.mps.lang.behavior.structure.ThisNodeExpression" flags="nn" index="13iPFW" />
     </language>
     <language id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor">
       <concept id="6029276237631252951" name="jetbrains.mps.lang.editor.structure.StyleAttributeReferenceExpression" flags="ng" index="1Z6Ecs">
@@ -35,6 +47,7 @@
       </concept>
     </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1080223426719" name="jetbrains.mps.baseLanguage.structure.OrExpression" flags="nn" index="22lmx$" />
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
@@ -42,25 +55,77 @@
       <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
         <child id="1137022507850" name="body" index="2VODD2" />
       </concept>
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
+      </concept>
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
+      <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
+      <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
+      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
+      <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
       <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
         <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123134" name="parameter" index="3clF46" />
         <child id="1068580123135" name="body" index="3clF47" />
       </concept>
+      <concept id="1068580123152" name="jetbrains.mps.baseLanguage.structure.EqualsExpression" flags="nn" index="3clFbC" />
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
+      <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
+        <child id="1068580123160" name="condition" index="3clFbw" />
+        <child id="1068580123161" name="ifTrue" index="3clFbx" />
+      </concept>
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
+        <property id="1068580123138" name="value" index="3clFbU" />
+      </concept>
+      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
+        <property id="1068580320021" name="value" index="3cmrfH" />
+      </concept>
+      <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
+      <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
+        <child id="1068581517676" name="expression" index="3cqZAk" />
+      </concept>
+      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
+        <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
+      </concept>
+      <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1079359253375" name="jetbrains.mps.baseLanguage.structure.ParenthesizedExpression" flags="nn" index="1eOMI4">
+        <child id="1079359253376" name="expression" index="1eOMHV" />
+      </concept>
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
         <child id="1109201940907" name="parameter" index="11_B2D" />
       </concept>
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
+        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
+        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
+      </concept>
       <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
+      <concept id="1225892208569" name="jetbrains.mps.baseLanguage.structure.ShiftLeftExpression" flags="nn" index="1GRDU$" />
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+      <concept id="320030840061144153" name="jetbrains.mps.baseLanguage.structure.ShiftRightUnsignedExpression" flags="nn" index="1ZsPo3" />
     </language>
     <language id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation">
       <concept id="1196350785113" name="jetbrains.mps.lang.quotation.structure.Quotation" flags="nn" index="2c44tf">
@@ -70,6 +135,9 @@
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
         <reference id="1138405853777" name="concept" index="ehGHo" />
+      </concept>
+      <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
+        <reference id="1138056395725" name="property" index="3TsBF5" />
       </concept>
       <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="nn" index="3TrEf2">
         <reference id="1138056516764" name="link" index="3Tt5mk" />
@@ -916,6 +984,169 @@
     </node>
     <node concept="13hLZK" id="7d0q5VHb7R7" role="13h7CW">
       <node concept="3clFbS" id="7d0q5VHb7R8" role="2VODD2" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="7_uCKm_h8el">
+    <ref role="13h7C2" to="pvux:7_uCKm_gkEm" resolve="CellReference" />
+    <node concept="13i0hz" id="7_uCKm_hUKY" role="13h7CS">
+      <property role="TrG5h" value="getText" />
+      <node concept="3Tm1VV" id="7_uCKm_hUKZ" role="1B3o_S" />
+      <node concept="17QB3L" id="7_uCKm_hUVv" role="3clF45" />
+      <node concept="3clFbS" id="7_uCKm_hUL1" role="3clF47">
+        <node concept="3cpWs8" id="25MaZwhj0Rn" role="3cqZAp">
+          <node concept="3cpWsn" id="25MaZwhj0Ro" role="3cpWs9">
+            <property role="TrG5h" value="id" />
+            <node concept="10Oyi0" id="25MaZwhj0Rs" role="1tU5fm" />
+            <node concept="2YIFZM" id="7_uCKm_hXtG" role="33vP2m">
+              <ref role="37wK5l" to="33ny:~Objects.hash(java.lang.Object...)" resolve="hash" />
+              <ref role="1Pybhc" to="33ny:~Objects" resolve="Objects" />
+              <node concept="2OqwBi" id="7_uCKm_hY5c" role="37wK5m">
+                <node concept="13iPFW" id="7_uCKm_hXyR" role="2Oq$k0" />
+                <node concept="3TrcHB" id="7_uCKm_hYki" role="2OqNvi">
+                  <ref role="3TsBF5" to="pvux:7_uCKm_h4Ra" resolve="componentHashCode" />
+                </node>
+              </node>
+              <node concept="2OqwBi" id="7_uCKm_hYXY" role="37wK5m">
+                <node concept="13iPFW" id="7_uCKm_hYOQ" role="2Oq$k0" />
+                <node concept="3TrcHB" id="7_uCKm_hZ3Q" role="2OqNvi">
+                  <ref role="3TsBF5" to="pvux:7_uCKm_h5oU" resolve="cellID" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="25MaZwhj0Rt" role="3cqZAp">
+          <node concept="3cpWs3" id="25MaZwhj0Ru" role="3clFbG">
+            <node concept="Xl_RD" id="25MaZwhj0Rv" role="3uHU7B">
+              <property role="Xl_RC" value="cellRef@" />
+            </node>
+            <node concept="1eOMI4" id="25MaZwhj0Rw" role="3uHU7w">
+              <node concept="3cpWs3" id="25MaZwhj0Rx" role="1eOMHV">
+                <node concept="1eOMI4" id="25MaZwhj0Ry" role="3uHU7B">
+                  <node concept="1ZsPo3" id="25MaZwhj0Rz" role="1eOMHV">
+                    <node concept="37vLTw" id="25MaZwhj0R$" role="3uHU7B">
+                      <ref role="3cqZAo" node="25MaZwhj0Ro" resolve="id" />
+                    </node>
+                    <node concept="3cmrfG" id="25MaZwhj0R_" role="3uHU7w">
+                      <property role="3cmrfH" value="16" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="1eOMI4" id="25MaZwhj0RA" role="3uHU7w">
+                  <node concept="1ZsPo3" id="25MaZwhj0RB" role="1eOMHV">
+                    <node concept="3cmrfG" id="25MaZwhj0RC" role="3uHU7w">
+                      <property role="3cmrfH" value="16" />
+                    </node>
+                    <node concept="1GRDU$" id="25MaZwhj0RD" role="3uHU7B">
+                      <node concept="37vLTw" id="25MaZwhj0RE" role="3uHU7B">
+                        <ref role="3cqZAo" node="25MaZwhj0Ro" resolve="id" />
+                      </node>
+                      <node concept="3cmrfG" id="25MaZwhj0RF" role="3uHU7w">
+                        <property role="3cmrfH" value="16" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="13i0hz" id="7_uCKm_i1sQ" role="13h7CS">
+      <property role="TrG5h" value="getTextWhenBroken" />
+      <node concept="3Tm1VV" id="7_uCKm_i1sR" role="1B3o_S" />
+      <node concept="17QB3L" id="7_uCKm_i1DR" role="3clF45" />
+      <node concept="3clFbS" id="7_uCKm_i1sT" role="3clF47">
+        <node concept="3clFbF" id="7_uCKm_i1Kx" role="3cqZAp">
+          <node concept="3cpWs3" id="7_uCKm_i3Zf" role="3clFbG">
+            <node concept="BsUDl" id="7_uCKm_i1Kw" role="3uHU7B">
+              <ref role="37wK5l" node="7_uCKm_hUKY" resolve="getText" />
+            </node>
+            <node concept="Xl_RD" id="7_uCKm_i4eg" role="3uHU7w">
+              <property role="Xl_RC" value=" (editor cell not found or editor was reopened)" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="13i0hz" id="7_uCKm_i2tI" role="13h7CS">
+      <property role="TrG5h" value="isBroken" />
+      <node concept="3Tm1VV" id="7_uCKm_i2tJ" role="1B3o_S" />
+      <node concept="10P_77" id="7_uCKm_i2Iv" role="3clF45" />
+      <node concept="3clFbS" id="7_uCKm_i2tL" role="3clF47">
+        <node concept="3clFbJ" id="7m$hACyWkdO" role="3cqZAp">
+          <node concept="3clFbS" id="7m$hACyWkdP" role="3clFbx">
+            <node concept="3cpWs6" id="7m$hACyWkdQ" role="3cqZAp">
+              <node concept="3clFbT" id="7m$hACyWko1" role="3cqZAk">
+                <property role="3clFbU" value="true" />
+              </node>
+            </node>
+          </node>
+          <node concept="22lmx$" id="7_uCKm_i7Nv" role="3clFbw">
+            <node concept="3clFbC" id="7_uCKm_i8GP" role="3uHU7w">
+              <node concept="10Nm6u" id="7_uCKm_i8Ig" role="3uHU7w" />
+              <node concept="2YIFZM" id="7_uCKm_kPFc" role="3uHU7B">
+                <ref role="37wK5l" to="rdi9:7_uCKm_kbYu" resolve="getEditorCell" />
+                <ref role="1Pybhc" to="rdi9:7_uCKm_jZa0" resolve="DebugHelper" />
+                <node concept="37vLTw" id="7_uCKm_kPNF" role="37wK5m">
+                  <ref role="3cqZAo" node="7_uCKm_i8pH" resolve="project" />
+                </node>
+                <node concept="2OqwBi" id="7_uCKm_kQbI" role="37wK5m">
+                  <node concept="13iPFW" id="7_uCKm_kQ0K" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="7_uCKm_kQsA" role="2OqNvi">
+                    <ref role="3Tt5mk" to="pvux:7_uCKm_hOEn" resolve="target" />
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="7_uCKm_kQAk" role="37wK5m">
+                  <node concept="13iPFW" id="7_uCKm_kQ$j" role="2Oq$k0" />
+                  <node concept="3TrcHB" id="7_uCKm_kQFH" role="2OqNvi">
+                    <ref role="3TsBF5" to="pvux:7_uCKm_h5oU" resolve="cellID" />
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="7_uCKm_kQPO" role="37wK5m">
+                  <node concept="13iPFW" id="7_uCKm_kQLO" role="2Oq$k0" />
+                  <node concept="3TrcHB" id="7_uCKm_kQWe" role="2OqNvi">
+                    <ref role="3TsBF5" to="pvux:7_uCKm_h4Ra" resolve="componentHashCode" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="22lmx$" id="7m$hACyWkdS" role="3uHU7B">
+              <node concept="3clFbC" id="7m$hACyWke2" role="3uHU7B">
+                <node concept="10Nm6u" id="7m$hACyWke3" role="3uHU7w" />
+                <node concept="2OqwBi" id="7m$hACyWke4" role="3uHU7B">
+                  <node concept="13iPFW" id="7m$hACyWke5" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="7m$hACyWke6" role="2OqNvi">
+                    <ref role="3Tt5mk" to="pvux:7_uCKm_hOEn" resolve="target" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbC" id="7_uCKm_i5eZ" role="3uHU7w">
+                <node concept="2OqwBi" id="7_uCKm_i4S$" role="3uHU7B">
+                  <node concept="13iPFW" id="7_uCKm_i4HS" role="2Oq$k0" />
+                  <node concept="3TrcHB" id="7_uCKm_i56B" role="2OqNvi">
+                    <ref role="3TsBF5" to="pvux:7_uCKm_h5oU" resolve="cellID" />
+                  </node>
+                </node>
+                <node concept="10Nm6u" id="7_uCKm_i5yX" role="3uHU7w" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="7_uCKm_i8ME" role="3cqZAp">
+          <node concept="3clFbT" id="7_uCKm_i8Pi" role="3cqZAk" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="7_uCKm_i8pH" role="3clF46">
+        <property role="TrG5h" value="project" />
+        <node concept="3uibUv" id="7_uCKm_i8pG" role="1tU5fm">
+          <ref role="3uigEE" to="z1c3:~Project" resolve="Project" />
+        </node>
+      </node>
+    </node>
+    <node concept="13hLZK" id="7_uCKm_h8em" role="13h7CW">
+      <node concept="3clFbS" id="7_uCKm_h8en" role="2VODD2" />
     </node>
   </node>
 </model>

--- a/code/celllayout/languages/de.itemis.mps.editor.celllayout/models/behavior.mps
+++ b/code/celllayout/languages/de.itemis.mps.editor.celllayout/models/behavior.mps
@@ -13,13 +13,7 @@
     <import index="hox0" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.style(MPS.Editor/)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" />
     <import index="cj4x" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor(MPS.Editor/)" />
-    <import index="4nm9" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.project(MPS.IDEA/)" />
-    <import index="iwsx" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.fileEditor(MPS.IDEA/)" />
-    <import index="k3nr" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.ide.editor(MPS.Editor/)" />
-    <import index="f4zo" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.cells(MPS.Editor/)" />
     <import index="z1c3" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.project(MPS.Core/)" />
-    <import index="alof" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.ide.project(MPS.Platform/)" />
-    <import index="w1kc" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel(MPS.Core/)" />
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
     <import index="rdi9" ref="r:c30772cf-6faa-4379-900e-6719e180568e(de.itemis.mps.editor.celllayout.runtime.plugin)" />
     <import index="pvux" ref="r:bb8c05bc-4758-44fe-b1ab-f9faa5a73d31(de.itemis.mps.editor.celllayout.structure)" implicit="true" />
@@ -48,6 +42,11 @@
     </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
       <concept id="1080223426719" name="jetbrains.mps.baseLanguage.structure.OrExpression" flags="nn" index="22lmx$" />
+      <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
+        <child id="1068498886297" name="rValue" index="37vLTx" />
+        <child id="1068498886295" name="lValue" index="37vLTJ" />
+      </concept>
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
@@ -71,6 +70,7 @@
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
       <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
+      <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
       <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
@@ -84,6 +84,7 @@
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
       <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
         <child id="1068580123160" name="condition" index="3clFbw" />
         <child id="1068580123161" name="ifTrue" index="3clFbx" />
@@ -133,6 +134,10 @@
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
+      <concept id="2644386474300074836" name="jetbrains.mps.lang.smodel.structure.ConceptIdRefExpression" flags="nn" index="35c_gC">
+        <reference id="2644386474300074837" name="conceptDeclaration" index="35c_gD" />
+      </concept>
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
         <reference id="1138405853777" name="concept" index="ehGHo" />
       </concept>
@@ -987,6 +992,7 @@
     </node>
   </node>
   <node concept="13h7C7" id="7_uCKm_h8el">
+    <property role="3GE5qa" value="debug" />
     <ref role="13h7C2" to="pvux:7_uCKm_gkEm" resolve="CellReference" />
     <node concept="13i0hz" id="7_uCKm_hUKY" role="13h7CS">
       <property role="TrG5h" value="getText" />
@@ -1147,6 +1153,256 @@
     </node>
     <node concept="13hLZK" id="7_uCKm_h8em" role="13h7CW">
       <node concept="3clFbS" id="7_uCKm_h8en" role="2VODD2" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="7_uCKm_nXIo">
+    <property role="3GE5qa" value="debug" />
+    <ref role="13h7C2" to="pvux:7_uCKm_ncp6" resolve="EditorComponentReference" />
+    <node concept="13i0hz" id="7_uCKm_oD5J" role="13h7CS">
+      <property role="TrG5h" value="getInvalidComponentHashCode" />
+      <property role="2Ki8OM" value="true" />
+      <node concept="3Tm1VV" id="7_uCKm_oENg" role="1B3o_S" />
+      <node concept="10Oyi0" id="7_uCKm_oEIO" role="3clF45" />
+      <node concept="3clFbS" id="7_uCKm_oD5M" role="3clF47">
+        <node concept="3clFbF" id="7_uCKm_oDvY" role="3cqZAp">
+          <node concept="3cmrfG" id="7_uCKm_oDxE" role="3clFbG">
+            <property role="3cmrfH" value="-1" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="13i0hz" id="7_uCKm_o3kH" role="13h7CS">
+      <property role="TrG5h" value="getText" />
+      <node concept="3Tm1VV" id="7_uCKm_o3kI" role="1B3o_S" />
+      <node concept="17QB3L" id="7_uCKm_o3kJ" role="3clF45" />
+      <node concept="3clFbS" id="7_uCKm_o3kK" role="3clF47">
+        <node concept="3cpWs8" id="7_uCKm_o3kL" role="3cqZAp">
+          <node concept="3cpWsn" id="7_uCKm_o3kM" role="3cpWs9">
+            <property role="TrG5h" value="id" />
+            <node concept="10Oyi0" id="7_uCKm_o3kN" role="1tU5fm" />
+            <node concept="2OqwBi" id="7_uCKm_o3kP" role="33vP2m">
+              <node concept="13iPFW" id="7_uCKm_o3kQ" role="2Oq$k0" />
+              <node concept="3TrcHB" id="7_uCKm_o3kR" role="2OqNvi">
+                <ref role="3TsBF5" to="pvux:7_uCKm_nXFw" resolve="componentHashCode" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7_uCKm_o3kV" role="3cqZAp">
+          <node concept="3cpWs3" id="7_uCKm_o3kW" role="3clFbG">
+            <node concept="Xl_RD" id="7_uCKm_o3kX" role="3uHU7B">
+              <property role="Xl_RC" value="editorComponentRef@" />
+            </node>
+            <node concept="1eOMI4" id="7_uCKm_o3kY" role="3uHU7w">
+              <node concept="3cpWs3" id="7_uCKm_o3kZ" role="1eOMHV">
+                <node concept="1eOMI4" id="7_uCKm_o3l0" role="3uHU7B">
+                  <node concept="1ZsPo3" id="7_uCKm_o3l1" role="1eOMHV">
+                    <node concept="37vLTw" id="7_uCKm_o3l2" role="3uHU7B">
+                      <ref role="3cqZAo" node="7_uCKm_o3kM" resolve="id" />
+                    </node>
+                    <node concept="3cmrfG" id="7_uCKm_o3l3" role="3uHU7w">
+                      <property role="3cmrfH" value="16" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="1eOMI4" id="7_uCKm_o3l4" role="3uHU7w">
+                  <node concept="1ZsPo3" id="7_uCKm_o3l5" role="1eOMHV">
+                    <node concept="3cmrfG" id="7_uCKm_o3l6" role="3uHU7w">
+                      <property role="3cmrfH" value="16" />
+                    </node>
+                    <node concept="1GRDU$" id="7_uCKm_o3l7" role="3uHU7B">
+                      <node concept="37vLTw" id="7_uCKm_o3l8" role="3uHU7B">
+                        <ref role="3cqZAo" node="7_uCKm_o3kM" resolve="id" />
+                      </node>
+                      <node concept="3cmrfG" id="7_uCKm_o3l9" role="3uHU7w">
+                        <property role="3cmrfH" value="16" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="13i0hz" id="7_uCKm_o3la" role="13h7CS">
+      <property role="TrG5h" value="getTextWhenBroken" />
+      <node concept="3Tm1VV" id="7_uCKm_o3lb" role="1B3o_S" />
+      <node concept="17QB3L" id="7_uCKm_o3lc" role="3clF45" />
+      <node concept="3clFbS" id="7_uCKm_o3ld" role="3clF47">
+        <node concept="3clFbF" id="7_uCKm_o3le" role="3cqZAp">
+          <node concept="3cpWs3" id="7_uCKm_o3lf" role="3clFbG">
+            <node concept="BsUDl" id="7_uCKm_o3lg" role="3uHU7B">
+              <ref role="37wK5l" node="7_uCKm_o3kH" resolve="getText" />
+            </node>
+            <node concept="Xl_RD" id="7_uCKm_o3lh" role="3uHU7w">
+              <property role="Xl_RC" value=" (editor component not found or it was reopened)" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="13i0hz" id="7_uCKm_plXx" role="13h7CS">
+      <property role="TrG5h" value="getEditorComponent" />
+      <node concept="3Tm1VV" id="7_uCKm_plXy" role="1B3o_S" />
+      <node concept="3uibUv" id="7_uCKm_pm90" role="3clF45">
+        <ref role="3uigEE" to="cj4x:~EditorComponent" resolve="EditorComponent" />
+      </node>
+      <node concept="3clFbS" id="7_uCKm_plX$" role="3clF47">
+        <node concept="3clFbJ" id="7_uCKm_pmwM" role="3cqZAp">
+          <node concept="3clFbS" id="7_uCKm_pmwN" role="3clFbx">
+            <node concept="3cpWs6" id="7_uCKm_pmwO" role="3cqZAp">
+              <node concept="2YIFZM" id="7_uCKm_pmwR" role="3cqZAk">
+                <ref role="37wK5l" to="rdi9:7_uCKm_nknH" resolve="getCurrentEditorComponent" />
+                <ref role="1Pybhc" to="rdi9:7_uCKm_jZa0" resolve="DebugHelper" />
+                <node concept="37vLTw" id="7_uCKm_pmwS" role="37wK5m">
+                  <ref role="3cqZAo" node="7_uCKm_pmk3" resolve="project" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbC" id="7_uCKm_pmwT" role="3clFbw">
+            <node concept="2OqwBi" id="7_uCKm_pmwU" role="3uHU7B">
+              <node concept="13iPFW" id="7_uCKm_pmwV" role="2Oq$k0" />
+              <node concept="3TrcHB" id="7_uCKm_pmwW" role="2OqNvi">
+                <ref role="3TsBF5" to="pvux:7_uCKm_nXFw" resolve="componentHashCode" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="7_uCKm_pmwX" role="3uHU7w">
+              <node concept="35c_gC" id="7_uCKm_pmwY" role="2Oq$k0">
+                <ref role="35c_gD" to="pvux:7_uCKm_ncp6" resolve="EditorComponentReference" />
+              </node>
+              <node concept="2qgKlT" id="7_uCKm_pmwZ" role="2OqNvi">
+                <ref role="37wK5l" node="7_uCKm_oD5J" resolve="getInvalidComponentHashCode" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7_uCKm_pmx0" role="3cqZAp" />
+        <node concept="3cpWs6" id="7_uCKm_pmx1" role="3cqZAp">
+          <node concept="2YIFZM" id="7_uCKm_pmx4" role="3cqZAk">
+            <ref role="37wK5l" to="rdi9:7_uCKm_kbKO" resolve="getEditorComponent" />
+            <ref role="1Pybhc" to="rdi9:7_uCKm_jZa0" resolve="DebugHelper" />
+            <node concept="37vLTw" id="7_uCKm_pmx5" role="37wK5m">
+              <ref role="3cqZAo" node="7_uCKm_pmk3" resolve="project" />
+            </node>
+            <node concept="2OqwBi" id="7_uCKm_pmx6" role="37wK5m">
+              <node concept="13iPFW" id="7_uCKm_pmx7" role="2Oq$k0" />
+              <node concept="3TrcHB" id="7_uCKm_pmx8" role="2OqNvi">
+                <ref role="3TsBF5" to="pvux:7_uCKm_nXFw" resolve="componentHashCode" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="7_uCKm_pmk3" role="3clF46">
+        <property role="TrG5h" value="project" />
+        <node concept="3uibUv" id="7_uCKm_pmk2" role="1tU5fm">
+          <ref role="3uigEE" to="z1c3:~Project" resolve="Project" />
+        </node>
+      </node>
+    </node>
+    <node concept="13i0hz" id="7_uCKm_pPxc" role="13h7CS">
+      <property role="TrG5h" value="getEditedNode" />
+      <node concept="3Tm1VV" id="7_uCKm_pPxd" role="1B3o_S" />
+      <node concept="3Tqbb2" id="7_uCKm_pPF1" role="3clF45" />
+      <node concept="3clFbS" id="7_uCKm_pPxf" role="3clF47">
+        <node concept="3cpWs8" id="7_uCKm_ppFr" role="3cqZAp">
+          <node concept="3cpWsn" id="7_uCKm_ppFs" role="3cpWs9">
+            <property role="TrG5h" value="editorComponent" />
+            <node concept="3uibUv" id="7_uCKm_ppCQ" role="1tU5fm">
+              <ref role="3uigEE" to="cj4x:~EditorComponent" resolve="EditorComponent" />
+            </node>
+            <node concept="2OqwBi" id="7_uCKm_ppFt" role="33vP2m">
+              <node concept="13iPFW" id="7_uCKm_pPYs" role="2Oq$k0" />
+              <node concept="2qgKlT" id="7_uCKm_ppFv" role="2OqNvi">
+                <ref role="37wK5l" node="7_uCKm_plXx" resolve="getEditorComponent" />
+                <node concept="37vLTw" id="7_uCKm_pQjZ" role="37wK5m">
+                  <ref role="3cqZAo" node="7_uCKm_pQ5m" resolve="project" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7_uCKm_pQn0" role="3cqZAp" />
+        <node concept="3clFbJ" id="7_uCKm_ppLP" role="3cqZAp">
+          <node concept="3clFbS" id="7_uCKm_ppLR" role="3clFbx">
+            <node concept="3cpWs6" id="7_uCKm_ppXN" role="3cqZAp">
+              <node concept="10Nm6u" id="7_uCKm_pq0l" role="3cqZAk" />
+            </node>
+          </node>
+          <node concept="3clFbC" id="7_uCKm_ppSo" role="3clFbw">
+            <node concept="10Nm6u" id="7_uCKm_ppUk" role="3uHU7w" />
+            <node concept="37vLTw" id="7_uCKm_ppOM" role="3uHU7B">
+              <ref role="3cqZAo" node="7_uCKm_ppFs" resolve="editorComponent" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7_uCKm_pQq4" role="3cqZAp" />
+        <node concept="3cpWs6" id="7_uCKm_pqf7" role="3cqZAp">
+          <node concept="2OqwBi" id="7_uCKm_pqkY" role="3cqZAk">
+            <node concept="37vLTw" id="7_uCKm_pqj1" role="2Oq$k0">
+              <ref role="3cqZAo" node="7_uCKm_ppFs" resolve="editorComponent" />
+            </node>
+            <node concept="liA8E" id="7_uCKm_pqvH" role="2OqNvi">
+              <ref role="37wK5l" to="cj4x:~EditorComponent.getEditedNode()" resolve="getEditedNode" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="7_uCKm_pQ5m" role="3clF46">
+        <property role="TrG5h" value="project" />
+        <node concept="3uibUv" id="7_uCKm_pQ5l" role="1tU5fm">
+          <ref role="3uigEE" to="z1c3:~Project" resolve="Project" />
+        </node>
+      </node>
+    </node>
+    <node concept="13i0hz" id="7_uCKm_o3li" role="13h7CS">
+      <property role="TrG5h" value="isBroken" />
+      <node concept="3Tm1VV" id="7_uCKm_o3lj" role="1B3o_S" />
+      <node concept="10P_77" id="7_uCKm_o3lk" role="3clF45" />
+      <node concept="3clFbS" id="7_uCKm_o3ll" role="3clF47">
+        <node concept="3clFbF" id="7_uCKm_pnMh" role="3cqZAp">
+          <node concept="3clFbC" id="7_uCKm_po1T" role="3clFbG">
+            <node concept="10Nm6u" id="7_uCKm_po5I" role="3uHU7w" />
+            <node concept="BsUDl" id="7_uCKm_pnMf" role="3uHU7B">
+              <ref role="37wK5l" node="7_uCKm_plXx" resolve="getEditorComponent" />
+              <node concept="37vLTw" id="7_uCKm_pnR6" role="37wK5m">
+                <ref role="3cqZAo" node="7_uCKm_o3lP" resolve="project" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="7_uCKm_o3lP" role="3clF46">
+        <property role="TrG5h" value="project" />
+        <node concept="3uibUv" id="7_uCKm_o3lQ" role="1tU5fm">
+          <ref role="3uigEE" to="z1c3:~Project" resolve="Project" />
+        </node>
+      </node>
+    </node>
+    <node concept="13hLZK" id="7_uCKm_nXIp" role="13h7CW">
+      <node concept="3clFbS" id="7_uCKm_nXIq" role="2VODD2">
+        <node concept="3clFbF" id="7_uCKm_nXKe" role="3cqZAp">
+          <node concept="37vLTI" id="7_uCKm_nZq_" role="3clFbG">
+            <node concept="2OqwBi" id="7_uCKm_nXV2" role="37vLTJ">
+              <node concept="13iPFW" id="7_uCKm_nXKd" role="2Oq$k0" />
+              <node concept="3TrcHB" id="7_uCKm_nYaf" role="2OqNvi">
+                <ref role="3TsBF5" to="pvux:7_uCKm_nXFw" resolve="componentHashCode" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="7_uCKm_oG64" role="37vLTx">
+              <node concept="35c_gC" id="7_uCKm_oFDI" role="2Oq$k0">
+                <ref role="35c_gD" to="pvux:7_uCKm_ncp6" resolve="EditorComponentReference" />
+              </node>
+              <node concept="2qgKlT" id="7_uCKm_oGu8" role="2OqNvi">
+                <ref role="37wK5l" node="7_uCKm_oD5J" resolve="getInvalidComponentHashCode" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
     </node>
   </node>
 </model>

--- a/code/celllayout/languages/de.itemis.mps.editor.celllayout/models/constraints.mps
+++ b/code/celllayout/languages/de.itemis.mps.editor.celllayout/models/constraints.mps
@@ -2,9 +2,104 @@
 <model ref="r:17a5067a-3a81-4f86-b470-f5688a8af81d(de.itemis.mps.editor.celllayout.constraints)">
   <persistence version="9" />
   <languages>
+    <use id="3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1" name="jetbrains.mps.lang.constraints" version="6" />
     <devkit ref="00000000-0000-4000-0000-5604ebd4f22c(jetbrains.mps.devkit.aspect.constraints)" />
   </languages>
-  <imports />
-  <registry />
+  <imports>
+    <import index="eynw" ref="r:359b1d2b-77c4-46df-9bf2-b25cbea32254(jetbrains.mps.console.base.structure)" />
+    <import index="pvux" ref="r:bb8c05bc-4758-44fe-b1ab-f9faa5a73d31(de.itemis.mps.editor.celllayout.structure)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
+        <child id="1137022507850" name="body" index="2VODD2" />
+      </concept>
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+    </language>
+    <language id="3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1" name="jetbrains.mps.lang.constraints">
+      <concept id="6702802731807424858" name="jetbrains.mps.lang.constraints.structure.ConstraintFunction_CanBeAnAncestor" flags="in" index="9SQb8" />
+      <concept id="1202989658459" name="jetbrains.mps.lang.constraints.structure.ConstraintFunctionParameter_parentNode" flags="nn" index="nLn13" />
+      <concept id="1213093968558" name="jetbrains.mps.lang.constraints.structure.ConceptConstraints" flags="ng" index="1M2fIO">
+        <reference id="1213093996982" name="concept" index="1M2myG" />
+        <child id="6702802731807532730" name="canBeAncestor" index="9SGkC" />
+      </concept>
+    </language>
+    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
+        <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
+      </concept>
+      <concept id="1138411891628" name="jetbrains.mps.lang.smodel.structure.SNodeOperation" flags="nn" index="eCIE_">
+        <child id="1144104376918" name="parameter" index="1xVPHs" />
+      </concept>
+      <concept id="1171407110247" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorOperation" flags="nn" index="2Xjw5R" />
+      <concept id="1172008320231" name="jetbrains.mps.lang.smodel.structure.Node_IsNotNullOperation" flags="nn" index="3x8VRR" />
+      <concept id="1144100932627" name="jetbrains.mps.lang.smodel.structure.OperationParm_Inclusion" flags="ng" index="1xIGOp" />
+      <concept id="1144101972840" name="jetbrains.mps.lang.smodel.structure.OperationParm_Concept" flags="ng" index="1xMEDy">
+        <child id="1207343664468" name="conceptArgument" index="ri$Ld" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="1M2fIO" id="7_uCKm_r6CX">
+    <property role="3GE5qa" value="debug" />
+    <ref role="1M2myG" to="pvux:7_uCKm_ncp6" resolve="EditorComponentReference" />
+    <node concept="9SQb8" id="7_uCKm_r6EA" role="9SGkC">
+      <node concept="3clFbS" id="7_uCKm_r6EB" role="2VODD2">
+        <node concept="3clFbF" id="7_uCKm_r78a" role="3cqZAp">
+          <node concept="2OqwBi" id="7_uCKm_r83K" role="3clFbG">
+            <node concept="2OqwBi" id="7_uCKm_r7eG" role="2Oq$k0">
+              <node concept="nLn13" id="7_uCKm_r789" role="2Oq$k0" />
+              <node concept="2Xjw5R" id="7_uCKm_r7p5" role="2OqNvi">
+                <node concept="1xMEDy" id="7_uCKm_r7p7" role="1xVPHs">
+                  <node concept="chp4Y" id="7_uCKm_r7wH" role="ri$Ld">
+                    <ref role="cht4Q" to="eynw:5WvH$QO98uv" resolve="Command" />
+                  </node>
+                </node>
+                <node concept="1xIGOp" id="7_uCKm_r8uo" role="1xVPHs" />
+              </node>
+            </node>
+            <node concept="3x8VRR" id="7_uCKm_r8nn" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1M2fIO" id="7_uCKm_r8P7">
+    <property role="3GE5qa" value="debug" />
+    <ref role="1M2myG" to="pvux:7_uCKm_gkEm" resolve="CellReference" />
+    <node concept="9SQb8" id="7_uCKm_r8QK" role="9SGkC">
+      <node concept="3clFbS" id="7_uCKm_r8QL" role="2VODD2">
+        <node concept="3clFbF" id="7_uCKm_r8S3" role="3cqZAp">
+          <node concept="2OqwBi" id="7_uCKm_r8S5" role="3clFbG">
+            <node concept="2OqwBi" id="7_uCKm_r8S6" role="2Oq$k0">
+              <node concept="nLn13" id="7_uCKm_r8S7" role="2Oq$k0" />
+              <node concept="2Xjw5R" id="7_uCKm_r8S8" role="2OqNvi">
+                <node concept="1xMEDy" id="7_uCKm_r8S9" role="1xVPHs">
+                  <node concept="chp4Y" id="7_uCKm_r8Sa" role="ri$Ld">
+                    <ref role="cht4Q" to="eynw:5WvH$QO98uv" resolve="Command" />
+                  </node>
+                </node>
+                <node concept="1xIGOp" id="7_uCKm_r8Sb" role="1xVPHs" />
+              </node>
+            </node>
+            <node concept="3x8VRR" id="7_uCKm_r8Sc" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
 </model>
 

--- a/code/celllayout/languages/de.itemis.mps.editor.celllayout/models/de.itemis.mps.editor.celllayout.intentions.mps
+++ b/code/celllayout/languages/de.itemis.mps.editor.celllayout/models/de.itemis.mps.editor.celllayout.intentions.mps
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:edbfe0d0-5752-4d49-8836-09676a6f6070(de.itemis.mps.editor.celllayout.intentions)">
+  <persistence version="9" />
+  <languages>
+    <use id="d7a92d38-f7db-40d0-8431-763b0c3c9f20" name="jetbrains.mps.lang.intentions" version="1" />
+    <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
+  </languages>
+  <imports>
+    <import index="pvux" ref="r:bb8c05bc-4758-44fe-b1ab-f9faa5a73d31(de.itemis.mps.editor.celllayout.structure)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
+        <child id="1068498886297" name="rValue" index="37vLTx" />
+        <child id="1068498886295" name="lValue" index="37vLTJ" />
+      </concept>
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
+        <child id="1137022507850" name="body" index="2VODD2" />
+      </concept>
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
+        <property id="1068580320021" name="value" index="3cmrfH" />
+      </concept>
+    </language>
+    <language id="d7a92d38-f7db-40d0-8431-763b0c3c9f20" name="jetbrains.mps.lang.intentions">
+      <concept id="1192794744107" name="jetbrains.mps.lang.intentions.structure.IntentionDeclaration" flags="ig" index="2S6QgY" />
+      <concept id="1192794782375" name="jetbrains.mps.lang.intentions.structure.DescriptionBlock" flags="in" index="2S6ZIM" />
+      <concept id="1192795911897" name="jetbrains.mps.lang.intentions.structure.ExecuteBlock" flags="in" index="2Sbjvc" />
+      <concept id="1192796902958" name="jetbrains.mps.lang.intentions.structure.ConceptFunctionParameter_node" flags="nn" index="2Sf5sV" />
+      <concept id="2522969319638091381" name="jetbrains.mps.lang.intentions.structure.BaseIntentionDeclaration" flags="ig" index="2ZfUlf">
+        <reference id="2522969319638198290" name="forConcept" index="2ZfgGC" />
+        <child id="2522969319638198291" name="executeFunction" index="2ZfgGD" />
+        <child id="2522969319638093993" name="descriptionFunction" index="2ZfVej" />
+      </concept>
+    </language>
+    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
+        <reference id="1138056395725" name="property" index="3TsBF5" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="2S6QgY" id="7_uCKm_o__5">
+    <property role="3GE5qa" value="debug" />
+    <property role="TrG5h" value="ReferenceCurrentEditorComponent" />
+    <ref role="2ZfgGC" to="pvux:7_uCKm_ncp6" resolve="EditorComponentReference" />
+    <node concept="2S6ZIM" id="7_uCKm_o__6" role="2ZfVej">
+      <node concept="3clFbS" id="7_uCKm_o__7" role="2VODD2">
+        <node concept="3clFbF" id="7_uCKm_oAfx" role="3cqZAp">
+          <node concept="Xl_RD" id="7_uCKm_oAfw" role="3clFbG">
+            <property role="Xl_RC" value="Reference Current Editor Component" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2Sbjvc" id="7_uCKm_o__8" role="2ZfgGD">
+      <node concept="3clFbS" id="7_uCKm_o__9" role="2VODD2">
+        <node concept="3clFbF" id="7_uCKm_oAvR" role="3cqZAp">
+          <node concept="37vLTI" id="7_uCKm_oBVx" role="3clFbG">
+            <node concept="3cmrfG" id="7_uCKm_oBWn" role="37vLTx">
+              <property role="3cmrfH" value="-1" />
+            </node>
+            <node concept="2OqwBi" id="7_uCKm_oAEh" role="37vLTJ">
+              <node concept="2Sf5sV" id="7_uCKm_oAvQ" role="2Oq$k0" />
+              <node concept="3TrcHB" id="7_uCKm_oARk" role="2OqNvi">
+                <ref role="3TsBF5" to="pvux:7_uCKm_nXFw" resolve="componentHashCode" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/code/celllayout/languages/de.itemis.mps.editor.celllayout/models/editor.mps
+++ b/code/celllayout/languages/de.itemis.mps.editor.celllayout/models/editor.mps
@@ -12,9 +12,9 @@
     <import index="tpco" ref="r:00000000-0000-4000-0000-011c89590284(jetbrains.mps.lang.core.editor)" />
     <import index="tpen" ref="r:00000000-0000-4000-0000-011c895902c3(jetbrains.mps.baseLanguage.editor)" />
     <import index="alof" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.ide.project(MPS.Platform/)" />
+    <import index="cj4x" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor(MPS.Editor/)" />
     <import index="pvux" ref="r:bb8c05bc-4758-44fe-b1ab-f9faa5a73d31(de.itemis.mps.editor.celllayout.structure)" implicit="true" />
     <import index="hy9h" ref="r:131747d1-61c1-40bf-8a0d-f19908d3d142(de.itemis.mps.editor.celllayout.behavior)" implicit="true" />
-    <import index="cj4x" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor(MPS.Editor/)" implicit="true" />
   </imports>
   <registry>
     <language id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor">
@@ -151,6 +151,9 @@
       </concept>
       <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
         <property id="1068580123138" name="value" index="3clFbU" />
+      </concept>
+      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
+        <property id="1068580320021" name="value" index="3cmrfH" />
       </concept>
       <concept id="1081516740877" name="jetbrains.mps.baseLanguage.structure.NotExpression" flags="nn" index="3fqX7Q">
         <child id="1081516765348" name="expression" index="3fr31v" />
@@ -727,6 +730,7 @@
     </node>
   </node>
   <node concept="24kQdi" id="7_uCKm_hMf5">
+    <property role="3GE5qa" value="debug" />
     <ref role="1XX52x" to="pvux:7_uCKm_gkEm" resolve="CellReference" />
     <node concept="1QoScp" id="55XVrlFSRUw" role="2wV5jI">
       <property role="1QpmdY" value="true" />
@@ -810,6 +814,125 @@
         </node>
         <node concept="VechU" id="55XVrlFSRUP" role="3F10Kt">
           <property role="Vb096" value="fLJRk5_/gray" />
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="24kQdi" id="7_uCKm_ndpY">
+    <property role="3GE5qa" value="debug" />
+    <ref role="1XX52x" to="pvux:7_uCKm_ncp6" resolve="EditorComponentReference" />
+    <node concept="1QoScp" id="7_uCKm_o01c" role="2wV5jI">
+      <property role="1QpmdY" value="true" />
+      <node concept="3F0ifn" id="7_uCKm_o01e" role="1QoS34">
+        <property role="3F0ifm" value="#currentEditorComponent" />
+      </node>
+      <node concept="pkWqt" id="7_uCKm_o01f" role="3e4ffs">
+        <node concept="3clFbS" id="7_uCKm_o01h" role="2VODD2">
+          <node concept="3clFbF" id="7_uCKm_o0b8" role="3cqZAp">
+            <node concept="3clFbC" id="7_uCKm_o0En" role="3clFbG">
+              <node concept="3cmrfG" id="7_uCKm_o1bk" role="3uHU7w">
+                <property role="3cmrfH" value="-1" />
+              </node>
+              <node concept="2OqwBi" id="7_uCKm_o0rE" role="3uHU7B">
+                <node concept="pncrf" id="7_uCKm_o0b7" role="2Oq$k0" />
+                <node concept="3TrcHB" id="7_uCKm_o0tQ" role="2OqNvi">
+                  <ref role="3TsBF5" to="pvux:7_uCKm_nXFw" resolve="componentHashCode" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1QoScp" id="7_uCKm_o21U" role="1QoVPY">
+        <property role="1QpmdY" value="true" />
+        <node concept="1HlG4h" id="7_uCKm_o21V" role="1QoS34">
+          <node concept="VechU" id="7_uCKm_o21W" role="3F10Kt">
+            <property role="Vb096" value="g1_eI4o/DARK_BLUE" />
+          </node>
+          <node concept="VQ3r3" id="7_uCKm_o21X" role="3F10Kt">
+            <property role="2USNnj" value="gtbM8PH/2" />
+          </node>
+          <node concept="3k4GqR" id="7_uCKm_pkF4" role="3F10Kt">
+            <node concept="3k4GqP" id="7_uCKm_pkF6" role="3k4GqO">
+              <node concept="3clFbS" id="7_uCKm_pkF8" role="2VODD2">
+                <node concept="3clFbF" id="7_uCKm_pQFA" role="3cqZAp">
+                  <node concept="2OqwBi" id="7_uCKm_pQRY" role="3clFbG">
+                    <node concept="pncrf" id="7_uCKm_pQF_" role="2Oq$k0" />
+                    <node concept="2qgKlT" id="7_uCKm_pR6u" role="2OqNvi">
+                      <ref role="37wK5l" to="hy9h:7_uCKm_pPxc" resolve="getEditedNode" />
+                      <node concept="2YIFZM" id="7_uCKm_pRgl" role="37wK5m">
+                        <ref role="37wK5l" to="alof:~ProjectHelper.getProject(org.jetbrains.mps.openapi.module.SRepository)" resolve="getProject" />
+                        <ref role="1Pybhc" to="alof:~ProjectHelper" resolve="ProjectHelper" />
+                        <node concept="2OqwBi" id="7_uCKm_pRpW" role="37wK5m">
+                          <node concept="1Q80Hx" id="7_uCKm_pRjd" role="2Oq$k0" />
+                          <node concept="liA8E" id="7_uCKm_pRzT" role="2OqNvi">
+                            <ref role="37wK5l" to="cj4x:~EditorContext.getRepository()" resolve="getRepository" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1HfYo3" id="7_uCKm_o226" role="1HlULh">
+            <node concept="3TQlhw" id="7_uCKm_o227" role="1Hhtcw">
+              <node concept="3clFbS" id="7_uCKm_o228" role="2VODD2">
+                <node concept="3clFbF" id="7_uCKm_o229" role="3cqZAp">
+                  <node concept="2OqwBi" id="7_uCKm_o22a" role="3clFbG">
+                    <node concept="pncrf" id="7_uCKm_o22b" role="2Oq$k0" />
+                    <node concept="2qgKlT" id="7_uCKm_o22c" role="2OqNvi">
+                      <ref role="37wK5l" to="hy9h:7_uCKm_o3kH" resolve="getText" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="pkWqt" id="7_uCKm_o22d" role="3e4ffs">
+          <node concept="3clFbS" id="7_uCKm_o22e" role="2VODD2">
+            <node concept="3clFbF" id="7_uCKm_o22f" role="3cqZAp">
+              <node concept="3fqX7Q" id="7_uCKm_o22g" role="3clFbG">
+                <node concept="2OqwBi" id="7_uCKm_o22h" role="3fr31v">
+                  <node concept="pncrf" id="7_uCKm_o22i" role="2Oq$k0" />
+                  <node concept="2qgKlT" id="7_uCKm_o22j" role="2OqNvi">
+                    <ref role="37wK5l" to="hy9h:7_uCKm_o3li" resolve="isBroken" />
+                    <node concept="2YIFZM" id="7_uCKm_o22k" role="37wK5m">
+                      <ref role="37wK5l" to="alof:~ProjectHelper.getProject(org.jetbrains.mps.openapi.module.SRepository)" resolve="getProject" />
+                      <ref role="1Pybhc" to="alof:~ProjectHelper" resolve="ProjectHelper" />
+                      <node concept="2OqwBi" id="7_uCKm_o22l" role="37wK5m">
+                        <node concept="1Q80Hx" id="7_uCKm_o22m" role="2Oq$k0" />
+                        <node concept="liA8E" id="7_uCKm_o22n" role="2OqNvi">
+                          <ref role="37wK5l" to="cj4x:~EditorContext.getRepository()" resolve="getRepository" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1HlG4h" id="7_uCKm_o22o" role="1QoVPY">
+          <node concept="1HfYo3" id="7_uCKm_o22p" role="1HlULh">
+            <node concept="3TQlhw" id="7_uCKm_o22q" role="1Hhtcw">
+              <node concept="3clFbS" id="7_uCKm_o22r" role="2VODD2">
+                <node concept="3clFbF" id="7_uCKm_o22s" role="3cqZAp">
+                  <node concept="2OqwBi" id="7_uCKm_o22t" role="3clFbG">
+                    <node concept="pncrf" id="7_uCKm_o22u" role="2Oq$k0" />
+                    <node concept="2qgKlT" id="7_uCKm_o22v" role="2OqNvi">
+                      <ref role="37wK5l" to="hy9h:7_uCKm_o3la" resolve="getTextWhenBroken" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="VechU" id="7_uCKm_o22w" role="3F10Kt">
+            <property role="Vb096" value="fLJRk5_/gray" />
+          </node>
         </node>
       </node>
     </node>

--- a/code/celllayout/languages/de.itemis.mps.editor.celllayout/models/editor.mps
+++ b/code/celllayout/languages/de.itemis.mps.editor.celllayout/models/editor.mps
@@ -11,7 +11,10 @@
     <import index="tpc5" ref="r:00000000-0000-4000-0000-011c89590299(jetbrains.mps.lang.editor.editor)" />
     <import index="tpco" ref="r:00000000-0000-4000-0000-011c89590284(jetbrains.mps.lang.core.editor)" />
     <import index="tpen" ref="r:00000000-0000-4000-0000-011c895902c3(jetbrains.mps.baseLanguage.editor)" />
+    <import index="alof" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.ide.project(MPS.Platform/)" />
     <import index="pvux" ref="r:bb8c05bc-4758-44fe-b1ab-f9faa5a73d31(de.itemis.mps.editor.celllayout.structure)" implicit="true" />
+    <import index="hy9h" ref="r:131747d1-61c1-40bf-8a0d-f19908d3d142(de.itemis.mps.editor.celllayout.behavior)" implicit="true" />
+    <import index="cj4x" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor(MPS.Editor/)" implicit="true" />
   </imports>
   <registry>
     <language id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor">
@@ -47,12 +50,20 @@
       <concept id="1186403751766" name="jetbrains.mps.lang.editor.structure.FontStyleStyleClassItem" flags="ln" index="Vb9p2">
         <property id="1186403771423" name="style" index="Vbekb" />
       </concept>
+      <concept id="1186404549998" name="jetbrains.mps.lang.editor.structure.ForegroundColorStyleClassItem" flags="ln" index="VechU" />
       <concept id="1186404574412" name="jetbrains.mps.lang.editor.structure.BackgroundColorStyleClassItem" flags="ln" index="Veino" />
       <concept id="1186414536763" name="jetbrains.mps.lang.editor.structure.BooleanStyleSheetItem" flags="ln" index="VOi$J">
         <property id="1186414551515" name="flag" index="VOm3f" />
       </concept>
       <concept id="1186414928363" name="jetbrains.mps.lang.editor.structure.SelectableStyleSheetItem" flags="ln" index="VPM3Z" />
       <concept id="1186414976055" name="jetbrains.mps.lang.editor.structure.DrawBorderStyleClassItem" flags="ln" index="VPXOz" />
+      <concept id="1186414999511" name="jetbrains.mps.lang.editor.structure.UnderlinedStyleClassItem" flags="ln" index="VQ3r3">
+        <property id="1214316229833" name="underlined" index="2USNnj" />
+      </concept>
+      <concept id="7597241200646296619" name="jetbrains.mps.lang.editor.structure.QueryFunction_SNode" flags="in" index="3k4GqP" />
+      <concept id="7597241200646296617" name="jetbrains.mps.lang.editor.structure.NavigatableNodeStyleClassItem" flags="ln" index="3k4GqR">
+        <child id="7597241200646296618" name="functionNode" index="3k4GqO" />
+      </concept>
       <concept id="1381004262292414836" name="jetbrains.mps.lang.editor.structure.ICellStyle" flags="ng" index="1k5N5V">
         <reference id="1381004262292426837" name="parentStyleClass" index="1k5W1q" />
       </concept>
@@ -61,6 +72,9 @@
         <child id="1165424453112" name="handlerFunction" index="1oHujR" />
       </concept>
       <concept id="1165424657443" name="jetbrains.mps.lang.editor.structure.CellMenuPart_Generic_Item_Handler" flags="in" index="1oIgkG" />
+      <concept id="1227861515039" name="jetbrains.mps.lang.editor.structure.NavigatableReferenceStyleClassItem" flags="ln" index="3yfXC2">
+        <reference id="1227861587090" name="link" index="3ygfmf" />
+      </concept>
       <concept id="1139848536355" name="jetbrains.mps.lang.editor.structure.CellModel_WithRole" flags="ng" index="1$h60E">
         <reference id="1140103550593" name="relationDeclaration" index="1NtTu8" />
       </concept>
@@ -85,6 +99,20 @@
         <child id="16410578721629643" name="emptyCellModel" index="2ruayu" />
       </concept>
       <concept id="1163613822479" name="jetbrains.mps.lang.editor.structure.CellMenuPart_Abstract_editedNode" flags="nn" index="3GMtW1" />
+      <concept id="1225898583838" name="jetbrains.mps.lang.editor.structure.ReadOnlyModelAccessor" flags="ng" index="1HfYo3">
+        <child id="1225898971709" name="getter" index="1Hhtcw" />
+      </concept>
+      <concept id="1225900081164" name="jetbrains.mps.lang.editor.structure.CellModel_ReadOnlyModelAccessor" flags="sg" stub="3708815482283559694" index="1HlG4h">
+        <child id="1225900141900" name="modelAccessor" index="1HlULh" />
+      </concept>
+      <concept id="1161622981231" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameter_editorContext" flags="nn" index="1Q80Hx" />
+      <concept id="1088612959204" name="jetbrains.mps.lang.editor.structure.CellModel_Alternation" flags="sg" stub="8104358048506729361" index="1QoScp">
+        <property id="1088613081987" name="vertical" index="1QpmdY" />
+        <child id="1145918517974" name="alternationCondition" index="3e4ffs" />
+        <child id="1088612958265" name="ifTrueCellModel" index="1QoS34" />
+        <child id="1088612973955" name="ifFalseCellModel" index="1QoVPY" />
+      </concept>
+      <concept id="1176717841777" name="jetbrains.mps.lang.editor.structure.QueryFunction_ModelAccess_Getter" flags="in" index="3TQlhw" />
       <concept id="1166049232041" name="jetbrains.mps.lang.editor.structure.AbstractComponent" flags="ng" index="1XWOmA">
         <reference id="1166049300910" name="conceptDeclaration" index="1XX52x" />
       </concept>
@@ -94,6 +122,7 @@
         <child id="1068498886297" name="rValue" index="37vLTx" />
         <child id="1068498886295" name="lValue" index="37vLTJ" />
       </concept>
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
@@ -106,6 +135,9 @@
       </concept>
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
       </concept>
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
       <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
@@ -123,6 +155,10 @@
       <concept id="1081516740877" name="jetbrains.mps.baseLanguage.structure.NotExpression" flags="nn" index="3fqX7Q">
         <child id="1081516765348" name="expression" index="3fr31v" />
       </concept>
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
       <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
@@ -133,6 +169,7 @@
       <concept id="767145758118872830" name="jetbrains.mps.lang.actions.structure.NF_Link_SetNewChildOperation" flags="nn" index="2DeJnY" />
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
       <concept id="1171999116870" name="jetbrains.mps.lang.smodel.structure.Node_IsNullOperation" flags="nn" index="3w_OXm" />
       <concept id="1172008320231" name="jetbrains.mps.lang.smodel.structure.Node_IsNotNullOperation" flags="nn" index="3x8VRR" />
       <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
@@ -687,6 +724,94 @@
         <ref role="1NtTu8" to="pvux:3ATi8gIrB$A" resolve="childCell" />
       </node>
       <node concept="2iRkQZ" id="3ATi8gIrB_7" role="2iSdaV" />
+    </node>
+  </node>
+  <node concept="24kQdi" id="7_uCKm_hMf5">
+    <ref role="1XX52x" to="pvux:7_uCKm_gkEm" resolve="CellReference" />
+    <node concept="1QoScp" id="55XVrlFSRUw" role="2wV5jI">
+      <property role="1QpmdY" value="true" />
+      <node concept="1HlG4h" id="3nEXLh2n4F_" role="1QoS34">
+        <node concept="VechU" id="3nEXLh2n4FA" role="3F10Kt">
+          <property role="Vb096" value="g1_eI4o/DARK_BLUE" />
+        </node>
+        <node concept="VQ3r3" id="3nEXLh2n4FB" role="3F10Kt">
+          <property role="2USNnj" value="gtbM8PH/2" />
+        </node>
+        <node concept="3k4GqR" id="3nEXLh2n5ah" role="3F10Kt">
+          <node concept="3k4GqP" id="3nEXLh2n5aj" role="3k4GqO">
+            <node concept="3clFbS" id="3nEXLh2n5al" role="2VODD2">
+              <node concept="3clFbF" id="3nEXLh2n5rt" role="3cqZAp">
+                <node concept="2OqwBi" id="3nEXLh2n5A6" role="3clFbG">
+                  <node concept="pncrf" id="3nEXLh2n5rs" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="3nEXLh2n64q" role="2OqNvi">
+                    <ref role="3Tt5mk" to="pvux:7_uCKm_hOEn" resolve="target" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3yfXC2" id="3nEXLh2n6_8" role="3F10Kt">
+          <ref role="3ygfmf" to="pvux:7_uCKm_hOEn" resolve="target" />
+        </node>
+        <node concept="1HfYo3" id="3nEXLh2n4FD" role="1HlULh">
+          <node concept="3TQlhw" id="3nEXLh2n4FE" role="1Hhtcw">
+            <node concept="3clFbS" id="3nEXLh2n4FF" role="2VODD2">
+              <node concept="3clFbF" id="7m$hACyVUF8" role="3cqZAp">
+                <node concept="2OqwBi" id="7m$hACyVUR_" role="3clFbG">
+                  <node concept="pncrf" id="7m$hACyVUF6" role="2Oq$k0" />
+                  <node concept="2qgKlT" id="5E451Quvmpy" role="2OqNvi">
+                    <ref role="37wK5l" to="hy9h:7_uCKm_hUKY" resolve="getText" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="pkWqt" id="55XVrlFSRUx" role="3e4ffs">
+        <node concept="3clFbS" id="55XVrlFSRUy" role="2VODD2">
+          <node concept="3clFbF" id="7m$hACyVOsQ" role="3cqZAp">
+            <node concept="3fqX7Q" id="7m$hACyVPsf" role="3clFbG">
+              <node concept="2OqwBi" id="7m$hACyVPsh" role="3fr31v">
+                <node concept="pncrf" id="7m$hACyVPsi" role="2Oq$k0" />
+                <node concept="2qgKlT" id="7m$hACyVPsj" role="2OqNvi">
+                  <ref role="37wK5l" to="hy9h:7_uCKm_i2tI" resolve="isBroken" />
+                  <node concept="2YIFZM" id="7_uCKm_i9WR" role="37wK5m">
+                    <ref role="37wK5l" to="alof:~ProjectHelper.getProject(org.jetbrains.mps.openapi.module.SRepository)" resolve="getProject" />
+                    <ref role="1Pybhc" to="alof:~ProjectHelper" resolve="ProjectHelper" />
+                    <node concept="2OqwBi" id="7_uCKm_iaaL" role="37wK5m">
+                      <node concept="1Q80Hx" id="7_uCKm_i9ZY" role="2Oq$k0" />
+                      <node concept="liA8E" id="7_uCKm_iakP" role="2OqNvi">
+                        <ref role="37wK5l" to="cj4x:~EditorContext.getRepository()" resolve="getRepository" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1HlG4h" id="55XVrlFSRUH" role="1QoVPY">
+        <node concept="1HfYo3" id="55XVrlFSRUI" role="1HlULh">
+          <node concept="3TQlhw" id="55XVrlFSRUJ" role="1Hhtcw">
+            <node concept="3clFbS" id="55XVrlFSRUK" role="2VODD2">
+              <node concept="3clFbF" id="55XVrlFSRUL" role="3cqZAp">
+                <node concept="2OqwBi" id="55XVrlFSRUM" role="3clFbG">
+                  <node concept="pncrf" id="55XVrlFSRUN" role="2Oq$k0" />
+                  <node concept="2qgKlT" id="55XVrlFSRUO" role="2OqNvi">
+                    <ref role="37wK5l" to="hy9h:7_uCKm_i1sQ" resolve="getTextWhenBroken" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="VechU" id="55XVrlFSRUP" role="3F10Kt">
+          <property role="Vb096" value="fLJRk5_/gray" />
+        </node>
+      </node>
     </node>
   </node>
 </model>

--- a/code/celllayout/languages/de.itemis.mps.editor.celllayout/models/editor.mps
+++ b/code/celllayout/languages/de.itemis.mps.editor.celllayout/models/editor.mps
@@ -823,8 +823,8 @@
     <ref role="1XX52x" to="pvux:7_uCKm_ncp6" resolve="EditorComponentReference" />
     <node concept="1QoScp" id="7_uCKm_o01c" role="2wV5jI">
       <property role="1QpmdY" value="true" />
-      <node concept="3F0ifn" id="7_uCKm_o01e" role="1QoS34">
-        <property role="3F0ifm" value="#currentEditorComponent" />
+      <node concept="PMmxH" id="7_uCKm_rqa7" role="1QoS34">
+        <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
       </node>
       <node concept="pkWqt" id="7_uCKm_o01f" role="3e4ffs">
         <node concept="3clFbS" id="7_uCKm_o01h" role="2VODD2">

--- a/code/celllayout/languages/de.itemis.mps.editor.celllayout/models/structure.mps
+++ b/code/celllayout/languages/de.itemis.mps.editor.celllayout/models/structure.mps
@@ -316,7 +316,7 @@
     <property role="EcuMT" value="8745606771044566598" />
     <property role="3GE5qa" value="debug" />
     <property role="TrG5h" value="EditorComponentReference" />
-    <property role="34LRSv" value="#editorComponent" />
+    <property role="34LRSv" value="#currentEditorComponent" />
     <ref role="1TJDcQ" to="tpee:fz3vP1J" resolve="Expression" />
     <node concept="1TJgyi" id="7_uCKm_nXFw" role="1TKVEl">
       <property role="IQ2nx" value="8745606771044768480" />

--- a/code/celllayout/languages/de.itemis.mps.editor.celllayout/models/structure.mps
+++ b/code/celllayout/languages/de.itemis.mps.editor.celllayout/models/structure.mps
@@ -7,6 +7,7 @@
   </languages>
   <imports>
     <import index="tpc2" ref="r:00000000-0000-4000-0000-011c8959029e(jetbrains.mps.lang.editor.structure)" />
+    <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
   </imports>
   <registry>
@@ -287,6 +288,28 @@
       <property role="20kJfa" value="childCell" />
       <property role="20lbJX" value="fLJekj4/_1" />
       <ref role="20lvS9" to="tpc2:fBEYTCT" resolve="EditorCellModel" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="7_uCKm_gkEm">
+    <property role="EcuMT" value="8745606771042765462" />
+    <property role="TrG5h" value="CellReference" />
+    <property role="34LRSv" value="cellReference" />
+    <ref role="1TJDcQ" to="tpee:fz3vP1J" resolve="Expression" />
+    <node concept="1TJgyj" id="7_uCKm_hOEn" role="1TKVEi">
+      <property role="IQ2ns" value="8745606771043158679" />
+      <property role="20kJfa" value="target" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <ref role="20lvS9" to="tpck:gw2VY9q" resolve="BaseConcept" />
+    </node>
+    <node concept="1TJgyi" id="7_uCKm_h4Ra" role="1TKVEl">
+      <property role="IQ2nx" value="8745606771042962890" />
+      <property role="TrG5h" value="componentHashCode" />
+      <ref role="AX2Wp" to="tpck:fKAQMTA" resolve="integer" />
+    </node>
+    <node concept="1TJgyi" id="7_uCKm_h5oU" role="1TKVEl">
+      <property role="IQ2nx" value="8745606771042965050" />
+      <property role="TrG5h" value="cellID" />
+      <ref role="AX2Wp" to="tpck:fKAOsGN" resolve="string" />
     </node>
   </node>
 </model>

--- a/code/celllayout/languages/de.itemis.mps.editor.celllayout/models/structure.mps
+++ b/code/celllayout/languages/de.itemis.mps.editor.celllayout/models/structure.mps
@@ -2,7 +2,6 @@
 <model ref="r:bb8c05bc-4758-44fe-b1ab-f9faa5a73d31(de.itemis.mps.editor.celllayout.structure)">
   <persistence version="9" />
   <languages>
-    <use id="982eb8df-2c96-4bd7-9963-11712ea622e5" name="jetbrains.mps.lang.resources" version="2" />
     <devkit ref="78434eb8-b0e5-444b-850d-e7c4ad2da9ab(jetbrains.mps.devkit.aspect.structure)" />
   </languages>
   <imports>
@@ -294,6 +293,7 @@
     <property role="EcuMT" value="8745606771042765462" />
     <property role="TrG5h" value="CellReference" />
     <property role="34LRSv" value="cellReference" />
+    <property role="3GE5qa" value="debug" />
     <ref role="1TJDcQ" to="tpee:fz3vP1J" resolve="Expression" />
     <node concept="1TJgyj" id="7_uCKm_hOEn" role="1TKVEi">
       <property role="IQ2ns" value="8745606771043158679" />
@@ -310,6 +310,18 @@
       <property role="IQ2nx" value="8745606771042965050" />
       <property role="TrG5h" value="cellID" />
       <ref role="AX2Wp" to="tpck:fKAOsGN" resolve="string" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="7_uCKm_ncp6">
+    <property role="EcuMT" value="8745606771044566598" />
+    <property role="3GE5qa" value="debug" />
+    <property role="TrG5h" value="EditorComponentReference" />
+    <property role="34LRSv" value="#editorComponent" />
+    <ref role="1TJDcQ" to="tpee:fz3vP1J" resolve="Expression" />
+    <node concept="1TJgyi" id="7_uCKm_nXFw" role="1TKVEl">
+      <property role="IQ2nx" value="8745606771044768480" />
+      <property role="TrG5h" value="componentHashCode" />
+      <ref role="AX2Wp" to="tpck:fKAQMTA" resolve="integer" />
     </node>
   </node>
 </model>

--- a/code/celllayout/languages/de.itemis.mps.editor.celllayout/models/typesystem.mps
+++ b/code/celllayout/languages/de.itemis.mps.editor.celllayout/models/typesystem.mps
@@ -4,7 +4,80 @@
   <languages>
     <devkit ref="00000000-0000-4000-0000-1de82b3a4936(jetbrains.mps.devkit.aspect.typesystem)" />
   </languages>
-  <imports />
-  <registry />
+  <imports>
+    <import index="f4zo" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.cells(MPS.Editor/)" />
+    <import index="pvux" ref="r:bb8c05bc-4758-44fe-b1ab-f9faa5a73d31(de.itemis.mps.editor.celllayout.structure)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+        <reference id="1107535924139" name="classifier" index="3uigEE" />
+      </concept>
+    </language>
+    <language id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation">
+      <concept id="1196350785113" name="jetbrains.mps.lang.quotation.structure.Quotation" flags="nn" index="2c44tf">
+        <child id="1196350785114" name="quotedNode" index="2c44tc" />
+      </concept>
+    </language>
+    <language id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem">
+      <concept id="1185788614172" name="jetbrains.mps.lang.typesystem.structure.NormalTypeClause" flags="ng" index="mw_s8">
+        <child id="1185788644032" name="normalType" index="mwGJk" />
+      </concept>
+      <concept id="1195213580585" name="jetbrains.mps.lang.typesystem.structure.AbstractCheckingRule" flags="ig" index="18hYwZ">
+        <child id="1195213635060" name="body" index="18ibNy" />
+      </concept>
+      <concept id="1174642788531" name="jetbrains.mps.lang.typesystem.structure.ConceptReference" flags="ig" index="1YaCAy">
+        <reference id="1174642800329" name="concept" index="1YaFvo" />
+      </concept>
+      <concept id="1174643105530" name="jetbrains.mps.lang.typesystem.structure.InferenceRule" flags="ig" index="1YbPZF" />
+      <concept id="1174648085619" name="jetbrains.mps.lang.typesystem.structure.AbstractRule" flags="ng" index="1YuPPy">
+        <child id="1174648101952" name="applicableNode" index="1YuTPh" />
+      </concept>
+      <concept id="1174650418652" name="jetbrains.mps.lang.typesystem.structure.ApplicableNodeReference" flags="nn" index="1YBJjd">
+        <reference id="1174650432090" name="applicableNode" index="1YBMHb" />
+      </concept>
+      <concept id="1174657487114" name="jetbrains.mps.lang.typesystem.structure.TypeOfExpression" flags="nn" index="1Z2H0r">
+        <child id="1174657509053" name="term" index="1Z2MuG" />
+      </concept>
+      <concept id="1174658326157" name="jetbrains.mps.lang.typesystem.structure.CreateEquationStatement" flags="nn" index="1Z5TYs" />
+      <concept id="1174660718586" name="jetbrains.mps.lang.typesystem.structure.AbstractEquationStatement" flags="nn" index="1Zf1VF">
+        <child id="1174660783413" name="leftExpression" index="1ZfhK$" />
+        <child id="1174660783414" name="rightExpression" index="1ZfhKB" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="1YbPZF" id="7_uCKm_l7z4">
+    <property role="TrG5h" value="typeof_CellReference" />
+    <node concept="3clFbS" id="7_uCKm_l7z5" role="18ibNy">
+      <node concept="1Z5TYs" id="7_uCKm_l7YR" role="3cqZAp">
+        <node concept="mw_s8" id="7_uCKm_l821" role="1ZfhKB">
+          <node concept="2c44tf" id="7_uCKm_l81X" role="mwGJk">
+            <node concept="3uibUv" id="7_uCKm_l8vu" role="2c44tc">
+              <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+            </node>
+          </node>
+        </node>
+        <node concept="mw_s8" id="7_uCKm_l7YU" role="1ZfhK$">
+          <node concept="1Z2H0r" id="7_uCKm_l7I5" role="mwGJk">
+            <node concept="1YBJjd" id="7_uCKm_l7NA" role="1Z2MuG">
+              <ref role="1YBMHb" node="7_uCKm_l7z7" resolve="cellReference" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1YaCAy" id="7_uCKm_l7z7" role="1YuTPh">
+      <property role="TrG5h" value="cellReference" />
+      <ref role="1YaFvo" to="pvux:7_uCKm_gkEm" resolve="CellReference" />
+    </node>
+  </node>
 </model>
 

--- a/code/celllayout/languages/de.itemis.mps.editor.celllayout/models/typesystem.mps
+++ b/code/celllayout/languages/de.itemis.mps.editor.celllayout/models/typesystem.mps
@@ -6,6 +6,7 @@
   </languages>
   <imports>
     <import index="f4zo" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.cells(MPS.Editor/)" />
+    <import index="cj4x" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor(MPS.Editor/)" />
     <import index="pvux" ref="r:bb8c05bc-4758-44fe-b1ab-f9faa5a73d31(de.itemis.mps.editor.celllayout.structure)" implicit="true" />
   </imports>
   <registry>
@@ -49,6 +50,9 @@
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+      </concept>
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
@@ -56,6 +60,7 @@
   </registry>
   <node concept="1YbPZF" id="7_uCKm_l7z4">
     <property role="TrG5h" value="typeof_CellReference" />
+    <property role="3GE5qa" value="debug" />
     <node concept="3clFbS" id="7_uCKm_l7z5" role="18ibNy">
       <node concept="1Z5TYs" id="7_uCKm_l7YR" role="3cqZAp">
         <node concept="mw_s8" id="7_uCKm_l821" role="1ZfhKB">
@@ -77,6 +82,32 @@
     <node concept="1YaCAy" id="7_uCKm_l7z7" role="1YuTPh">
       <property role="TrG5h" value="cellReference" />
       <ref role="1YaFvo" to="pvux:7_uCKm_gkEm" resolve="CellReference" />
+    </node>
+  </node>
+  <node concept="1YbPZF" id="7_uCKm_nenw">
+    <property role="TrG5h" value="typeof_EditorComponentReference" />
+    <property role="3GE5qa" value="debug" />
+    <node concept="3clFbS" id="7_uCKm_nenx" role="18ibNy">
+      <node concept="1Z5TYs" id="7_uCKm_nePF" role="3cqZAp">
+        <node concept="mw_s8" id="7_uCKm_nePI" role="1ZfhK$">
+          <node concept="1Z2H0r" id="7_uCKm_nesv" role="mwGJk">
+            <node concept="1YBJjd" id="7_uCKm_ney3" role="1Z2MuG">
+              <ref role="1YBMHb" node="7_uCKm_nenz" resolve="editorComponentReference" />
+            </node>
+          </node>
+        </node>
+        <node concept="mw_s8" id="7_uCKm_nfRR" role="1ZfhKB">
+          <node concept="2c44tf" id="7_uCKm_nfRS" role="mwGJk">
+            <node concept="3uibUv" id="7_uCKm_nfRT" role="2c44tc">
+              <ref role="3uigEE" to="cj4x:~EditorComponent" resolve="EditorComponent" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1YaCAy" id="7_uCKm_nenz" role="1YuTPh">
+      <property role="TrG5h" value="editorComponentReference" />
+      <ref role="1YaFvo" to="pvux:7_uCKm_ncp6" resolve="EditorComponentReference" />
     </node>
   </node>
 </model>

--- a/code/celllayout/solutions/de.slisson.mps.editor.celllayout.runtime/de.itemis.mps.editor.celllayout.runtime.msd
+++ b/code/celllayout/solutions/de.slisson.mps.editor.celllayout.runtime/de.itemis.mps.editor.celllayout.runtime.msd
@@ -16,8 +16,14 @@
     <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
     <dependency reexport="true">f0fff802-6d26-4d2e-b89d-391357265626(de.slisson.mps.hacks.editor)</dependency>
     <dependency reexport="true">24c96a96-b7a1-4f30-82da-0f8e279a2661(de.itemis.mps.editor.celllayout.styles)</dependency>
+    <dependency reexport="false">a8de7923-dc6f-4aa1-b8a9-2d19ffee3edd(jetbrains.mps.console)</dependency>
+    <dependency reexport="false">de1ad86d-6e50-4a02-b306-d4d17f64c375(jetbrains.mps.console.base)</dependency>
+    <dependency reexport="false">1919c723-b60b-4592-9318-9ce96d91da44(de.itemis.mps.editor.celllayout)</dependency>
+    <dependency reexport="false">5b1f863d-65a0-41a6-a801-33896be24202(jetbrains.mps.ide.editor)</dependency>
+    <dependency reexport="false">8d29d73f-ed99-4652-ae0a-083cdfe53c34(jetbrains.mps.ide.platform)</dependency>
   </dependencies>
   <languageVersions>
+    <language slang="l:1919c723-b60b-4592-9318-9ce96d91da44:de.itemis.mps.editor.celllayout" version="0" />
     <language slang="l:654422bf-e75f-44dc-936d-188890a746ce:de.slisson.mps.reflection" version="0" />
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
     <language slang="l:774bf8a0-62e5-41e1-af63-f4812e60e48b:jetbrains.mps.baseLanguage.checkedDots" version="0" />
@@ -28,6 +34,7 @@
     <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
     <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
     <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
+    <language slang="l:de1ad86d-6e50-4a02-b306-d4d17f64c375:jetbrains.mps.console.base" version="0" />
     <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
     <language slang="l:18bc6592-03a6-4e29-a83a-7ff23bde13ba:jetbrains.mps.lang.editor" version="14" />
     <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
@@ -35,6 +42,7 @@
     <language slang="l:ef7bf5ac-d06c-4342-b11d-e42104eb9343:jetbrains.mps.lang.plugin.standalone" version="0" />
     <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
     <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
+    <language slang="l:1a8554c4-eb84-43ba-8c34-6f0d90c6e75a:jetbrains.mps.lang.smodel.query" version="3" />
     <language slang="l:c72da2b9-7cce-4447-8389-f407dc1158b7:jetbrains.mps.lang.structure" version="9" />
     <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
@@ -47,10 +55,31 @@
     <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
+    <module reference="1919c723-b60b-4592-9318-9ce96d91da44(de.itemis.mps.editor.celllayout)" version="0" />
     <module reference="848ef45d-e560-4e35-853c-f35a64cc135c(de.itemis.mps.editor.celllayout.runtime)" version="0" />
     <module reference="24c96a96-b7a1-4f30-82da-0f8e279a2661(de.itemis.mps.editor.celllayout.styles)" version="0" />
     <module reference="f0fff802-6d26-4d2e-b89d-391357265626(de.slisson.mps.hacks.editor)" version="0" />
+    <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
+    <module reference="443f4c36-fcf5-4eb6-9500-8d06ed259e3e(jetbrains.mps.baseLanguage.classifiers)" version="0" />
+    <module reference="fd392034-7849-419d-9071-12563d152375(jetbrains.mps.baseLanguage.closures)" version="0" />
+    <module reference="83888646-71ce-4f1c-9c53-c54016f6ad4f(jetbrains.mps.baseLanguage.collections)" version="0" />
+    <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
+    <module reference="a8de7923-dc6f-4aa1-b8a9-2d19ffee3edd(jetbrains.mps.console)" version="0" />
+    <module reference="de1ad86d-6e50-4a02-b306-d4d17f64c375(jetbrains.mps.console.base)" version="0" />
+    <module reference="fdaaf35f-8ee3-4c37-b09d-9efaeaaa7a41(jetbrains.mps.core.tool.environment)" version="0" />
+    <module reference="5b1f863d-65a0-41a6-a801-33896be24202(jetbrains.mps.ide.editor)" version="0" />
+    <module reference="8d29d73f-ed99-4652-ae0a-083cdfe53c34(jetbrains.mps.ide.platform)" version="0" />
+    <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
+    <module reference="d936855b-48da-4812-a8a0-2bfddd633ac5(jetbrains.mps.lang.behavior.api)" version="0" />
     <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
+    <module reference="18bc6592-03a6-4e29-a83a-7ff23bde13ba(jetbrains.mps.lang.editor)" version="0" />
+    <module reference="446c26eb-2b7b-4bf0-9b35-f83fa582753e(jetbrains.mps.lang.modelapi)" version="0" />
+    <module reference="d7eb0a2a-bd50-4576-beae-e4a89db35f20(jetbrains.mps.lang.scopes.runtime)" version="0" />
+    <module reference="7866978e-a0f0-4cc7-81bc-4d213d9375e1(jetbrains.mps.lang.smodel)" version="1" />
+    <module reference="1a8554c4-eb84-43ba-8c34-6f0d90c6e75a(jetbrains.mps.lang.smodel.query)" version="0" />
+    <module reference="c72da2b9-7cce-4447-8389-f407dc1158b7(jetbrains.mps.lang.structure)" version="0" />
+    <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
+    <module reference="8fe4c62a-2020-4ff4-8eda-f322a55bdc9f(jetbrains.mps.refactoring.runtime)" version="0" />
   </dependencyVersions>
 </solution>
 

--- a/code/celllayout/solutions/de.slisson.mps.editor.celllayout.runtime/de.itemis.mps.editor.celllayout.runtime.msd
+++ b/code/celllayout/solutions/de.slisson.mps.editor.celllayout.runtime/de.itemis.mps.editor.celllayout.runtime.msd
@@ -17,13 +17,10 @@
     <dependency reexport="true">f0fff802-6d26-4d2e-b89d-391357265626(de.slisson.mps.hacks.editor)</dependency>
     <dependency reexport="true">24c96a96-b7a1-4f30-82da-0f8e279a2661(de.itemis.mps.editor.celllayout.styles)</dependency>
     <dependency reexport="false">a8de7923-dc6f-4aa1-b8a9-2d19ffee3edd(jetbrains.mps.console)</dependency>
-    <dependency reexport="false">de1ad86d-6e50-4a02-b306-d4d17f64c375(jetbrains.mps.console.base)</dependency>
     <dependency reexport="false">1919c723-b60b-4592-9318-9ce96d91da44(de.itemis.mps.editor.celllayout)</dependency>
-    <dependency reexport="false">5b1f863d-65a0-41a6-a801-33896be24202(jetbrains.mps.ide.editor)</dependency>
     <dependency reexport="false">8d29d73f-ed99-4652-ae0a-083cdfe53c34(jetbrains.mps.ide.platform)</dependency>
   </dependencies>
   <languageVersions>
-    <language slang="l:1919c723-b60b-4592-9318-9ce96d91da44:de.itemis.mps.editor.celllayout" version="0" />
     <language slang="l:654422bf-e75f-44dc-936d-188890a746ce:de.slisson.mps.reflection" version="0" />
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
     <language slang="l:774bf8a0-62e5-41e1-af63-f4812e60e48b:jetbrains.mps.baseLanguage.checkedDots" version="0" />
@@ -34,7 +31,6 @@
     <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
     <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
     <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
-    <language slang="l:de1ad86d-6e50-4a02-b306-d4d17f64c375:jetbrains.mps.console.base" version="0" />
     <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
     <language slang="l:18bc6592-03a6-4e29-a83a-7ff23bde13ba:jetbrains.mps.lang.editor" version="14" />
     <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
@@ -42,7 +38,6 @@
     <language slang="l:ef7bf5ac-d06c-4342-b11d-e42104eb9343:jetbrains.mps.lang.plugin.standalone" version="0" />
     <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
     <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
-    <language slang="l:1a8554c4-eb84-43ba-8c34-6f0d90c6e75a:jetbrains.mps.lang.smodel.query" version="3" />
     <language slang="l:c72da2b9-7cce-4447-8389-f407dc1158b7:jetbrains.mps.lang.structure" version="9" />
     <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
@@ -65,9 +60,7 @@
     <module reference="83888646-71ce-4f1c-9c53-c54016f6ad4f(jetbrains.mps.baseLanguage.collections)" version="0" />
     <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
     <module reference="a8de7923-dc6f-4aa1-b8a9-2d19ffee3edd(jetbrains.mps.console)" version="0" />
-    <module reference="de1ad86d-6e50-4a02-b306-d4d17f64c375(jetbrains.mps.console.base)" version="0" />
     <module reference="fdaaf35f-8ee3-4c37-b09d-9efaeaaa7a41(jetbrains.mps.core.tool.environment)" version="0" />
-    <module reference="5b1f863d-65a0-41a6-a801-33896be24202(jetbrains.mps.ide.editor)" version="0" />
     <module reference="8d29d73f-ed99-4652-ae0a-083cdfe53c34(jetbrains.mps.ide.platform)" version="0" />
     <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
     <module reference="d936855b-48da-4812-a8a0-2bfddd633ac5(jetbrains.mps.lang.behavior.api)" version="0" />
@@ -76,7 +69,6 @@
     <module reference="446c26eb-2b7b-4bf0-9b35-f83fa582753e(jetbrains.mps.lang.modelapi)" version="0" />
     <module reference="d7eb0a2a-bd50-4576-beae-e4a89db35f20(jetbrains.mps.lang.scopes.runtime)" version="0" />
     <module reference="7866978e-a0f0-4cc7-81bc-4d213d9375e1(jetbrains.mps.lang.smodel)" version="1" />
-    <module reference="1a8554c4-eb84-43ba-8c34-6f0d90c6e75a(jetbrains.mps.lang.smodel.query)" version="0" />
     <module reference="c72da2b9-7cce-4447-8389-f407dc1158b7(jetbrains.mps.lang.structure)" version="0" />
     <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
     <module reference="8fe4c62a-2020-4ff4-8eda-f322a55bdc9f(jetbrains.mps.refactoring.runtime)" version="0" />

--- a/code/celllayout/solutions/de.slisson.mps.editor.celllayout.runtime/models/de/itemis/mps/editor/celllayout/runtime.mps
+++ b/code/celllayout/solutions/de.slisson.mps.editor.celllayout.runtime/models/de/itemis/mps/editor/celllayout/runtime.mps
@@ -27,7 +27,6 @@
     <import index="z0fb" ref="r:0b928dd6-dd7e-45a8-b309-a2e315b7877a(de.itemis.mps.editor.celllayout.styles.editor)" />
     <import index="fbzs" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt.geom(JDK/)" />
     <import index="q7tw" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:org.apache.log4j(MPS.Core/)" />
-    <import index="t6h5" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang.reflect(JDK/)" />
     <import index="hhnx" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.editor.runtime(MPS.Editor/)" />
     <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="guwi" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.io(JDK/)" implicit="true" />

--- a/code/celllayout/solutions/de.slisson.mps.editor.celllayout.runtime/models/de/itemis/mps/editor/celllayout/runtime/plugin.mps
+++ b/code/celllayout/solutions/de.slisson.mps.editor.celllayout.runtime/models/de/itemis/mps/editor/celllayout/runtime/plugin.mps
@@ -1208,6 +1208,74 @@
                     </node>
                   </node>
                 </node>
+                <node concept="3clFbJ" id="58ijd26rFm" role="3cqZAp">
+                  <node concept="3clFbS" id="58ijd26rFo" role="3clFbx">
+                    <node concept="3cpWs8" id="58ijd26svH" role="3cqZAp">
+                      <node concept="3cpWsn" id="58ijd26svI" role="3cpWs9">
+                        <property role="TrG5h" value="currentNodeEditorComponent" />
+                        <node concept="3uibUv" id="58ijd26svJ" role="1tU5fm">
+                          <ref role="3uigEE" to="exr9:~NodeEditorComponent" resolve="NodeEditorComponent" />
+                        </node>
+                        <node concept="1eOMI4" id="58ijd26tdu" role="33vP2m">
+                          <node concept="10QFUN" id="58ijd26tdr" role="1eOMHV">
+                            <node concept="3uibUv" id="58ijd26tdw" role="10QFUM">
+                              <ref role="3uigEE" to="exr9:~NodeEditorComponent" resolve="NodeEditorComponent" />
+                            </node>
+                            <node concept="37vLTw" id="58ijd26tdx" role="10QFUP">
+                              <ref role="3cqZAo" node="7_uCKm_n_HI" resolve="currentEditorComponent" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3cpWs8" id="58ijd27jzG" role="3cqZAp">
+                      <node concept="3cpWsn" id="58ijd27jzH" role="3cpWs9">
+                        <property role="TrG5h" value="inspectorComponent" />
+                        <node concept="3uibUv" id="58ijd27iBr" role="1tU5fm">
+                          <ref role="3uigEE" to="exr9:~EditorComponent" resolve="EditorComponent" />
+                        </node>
+                        <node concept="2OqwBi" id="58ijd27jzI" role="33vP2m">
+                          <node concept="37vLTw" id="58ijd27jzJ" role="2Oq$k0">
+                            <ref role="3cqZAo" node="58ijd26svI" resolve="currentNodeEditorComponent" />
+                          </node>
+                          <node concept="liA8E" id="58ijd27jzK" role="2OqNvi">
+                            <ref role="37wK5l" to="exr9:~NodeEditorComponent.getInspector()" resolve="getInspector" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbJ" id="58ijd26wXt" role="3cqZAp">
+                      <node concept="3clFbS" id="58ijd26wXv" role="3clFbx">
+                        <node concept="3cpWs6" id="58ijd26$Zg" role="3cqZAp">
+                          <node concept="37vLTw" id="58ijd27jZM" role="3cqZAk">
+                            <ref role="3cqZAo" node="58ijd27jzH" resolve="inspector" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbC" id="58ijd26$dm" role="3clFbw">
+                        <node concept="37vLTw" id="58ijd26$oL" role="3uHU7w">
+                          <ref role="3cqZAo" node="7_uCKm_kbLN" resolve="hashCode" />
+                        </node>
+                        <node concept="2OqwBi" id="58ijd26xTA" role="3uHU7B">
+                          <node concept="37vLTw" id="58ijd27jzL" role="2Oq$k0">
+                            <ref role="3cqZAo" node="58ijd27jzH" resolve="inspector" />
+                          </node>
+                          <node concept="liA8E" id="58ijd26yLK" role="2OqNvi">
+                            <ref role="37wK5l" to="wyt6:~Object.hashCode()" resolve="hashCode" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2ZW3vV" id="58ijd26s2u" role="3clFbw">
+                    <node concept="3uibUv" id="58ijd26seP" role="2ZW6by">
+                      <ref role="3uigEE" to="exr9:~NodeEditorComponent" resolve="NodeEditorComponent" />
+                    </node>
+                    <node concept="37vLTw" id="58ijd26rNF" role="2ZW6bz">
+                      <ref role="3cqZAo" node="7_uCKm_n_HI" resolve="currentEditorComponent" />
+                    </node>
+                  </node>
+                </node>
               </node>
               <node concept="2ZW3vV" id="7_uCKm_nCz8" role="3clFbw">
                 <node concept="3uibUv" id="7_uCKm_nCTk" role="2ZW6by">

--- a/code/celllayout/solutions/de.slisson.mps.editor.celllayout.runtime/models/de/itemis/mps/editor/celllayout/runtime/plugin.mps
+++ b/code/celllayout/solutions/de.slisson.mps.editor.celllayout.runtime/models/de/itemis/mps/editor/celllayout/runtime/plugin.mps
@@ -4,8 +4,6 @@
   <languages>
     <use id="28f9e497-3b42-4291-aeba-0a1039153ab1" name="jetbrains.mps.lang.plugin" version="5" />
     <use id="ef7bf5ac-d06c-4342-b11d-e42104eb9343" name="jetbrains.mps.lang.plugin.standalone" version="0" />
-    <use id="de1ad86d-6e50-4a02-b306-d4d17f64c375" name="jetbrains.mps.console.base" version="0" />
-    <use id="1919c723-b60b-4592-9318-9ce96d91da44" name="de.itemis.mps.editor.celllayout" version="0" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -19,15 +17,13 @@
     <import index="z60i" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt(JDK/)" />
     <import index="qq03" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.ide.actions(MPS.Platform/)" />
     <import index="qgo0" ref="r:de40a5a4-f08c-4c67-ac43-e1f5c384f7d6(jetbrains.mps.console.tool)" />
-    <import index="eynw" ref="r:359b1d2b-77c4-46df-9bf2-b25cbea32254(jetbrains.mps.console.base.structure)" />
     <import index="pvux" ref="r:bb8c05bc-4758-44fe-b1ab-f9faa5a73d31(de.itemis.mps.editor.celllayout.structure)" />
-    <import index="ekwn" ref="r:9832fb5f-2578-4b58-8014-a5de79da988e(jetbrains.mps.ide.editor.actions)" />
     <import index="z1c3" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.project(MPS.Core/)" />
     <import index="alof" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.ide.project(MPS.Platform/)" />
     <import index="iwsx" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.fileEditor(MPS.IDEA/)" />
     <import index="4nm9" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.project(MPS.IDEA/)" />
-    <import index="1i7y" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor.datatransfer(MPS.Editor/)" />
     <import index="dp1x" ref="r:84719e1a-99f6-4297-90ba-8ad2a947fa4a(jetbrains.mps.ide.datatransfer)" />
+    <import index="w1kc" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel(MPS.Core/)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
     <import index="z1c4" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.project(MPS.Platform/)" implicit="true" />
     <import index="tprs" ref="r:00000000-0000-4000-0000-011c895904a4(jetbrains.mps.ide.actions)" implicit="true" />
@@ -138,6 +134,9 @@
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <child id="1068431790190" name="initializer" index="33vP2m" />
       </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ng" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
+      </concept>
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
@@ -161,6 +160,7 @@
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
       <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
         <child id="1068580123160" name="condition" index="3clFbw" />
         <child id="1068580123161" name="ifTrue" index="3clFbx" />
@@ -186,6 +186,7 @@
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
+      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
       <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
         <property id="521412098689998745" name="nonStatic" index="2bfB8j" />
         <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
@@ -244,9 +245,28 @@
         <child id="8182547171709752112" name="expression" index="36biLW" />
       </concept>
     </language>
+    <language id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi">
+      <concept id="361130699826193248" name="jetbrains.mps.lang.modelapi.structure.ModelPointer" flags="ng" index="1dCxOl">
+        <property id="1863527487546097494" name="modelId" index="1XweGQ" />
+        <child id="679099339649067980" name="name" index="1j$8Uc" />
+      </concept>
+      <concept id="679099339649053840" name="jetbrains.mps.lang.modelapi.structure.ModelName" flags="ng" index="1j_P7g">
+        <property id="679099339649053841" name="value" index="1j_P7h" />
+      </concept>
+    </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="4497478346159780083" name="jetbrains.mps.lang.smodel.structure.LanguageRefExpression" flags="ng" index="pHN19">
+        <child id="3542851458883491298" name="languageId" index="2V$M_3" />
+      </concept>
+      <concept id="3542851458883438784" name="jetbrains.mps.lang.smodel.structure.LanguageId" flags="nn" index="2V$Bhx">
+        <property id="3542851458883439831" name="namespace" index="2V$B1Q" />
+        <property id="3542851458883439832" name="languageId" index="2V$B1T" />
+      </concept>
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
         <reference id="1138405853777" name="concept" index="ehGHo" />
+      </concept>
+      <concept id="1863527487546129879" name="jetbrains.mps.lang.smodel.structure.ModelPointerExpression" flags="ng" index="1Xw6AR">
+        <child id="1863527487546132519" name="modelRef" index="1XwpL7" />
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
@@ -888,6 +908,63 @@
         </node>
         <node concept="3clFbJ" id="7_uCKm_owDG" role="3cqZAp">
           <node concept="3clFbS" id="7_uCKm_owDI" role="3clFbx">
+            <node concept="3cpWs8" id="7_uCKm_stLj" role="3cqZAp">
+              <node concept="3cpWsn" id="7_uCKm_stLk" role="3cpWs9">
+                <property role="TrG5h" value="imports" />
+                <node concept="3uibUv" id="7_uCKm_stLl" role="1tU5fm">
+                  <ref role="3uigEE" to="w1kc:~ModelImports" resolve="ModelImports" />
+                </node>
+                <node concept="2ShNRf" id="7_uCKm_stLm" role="33vP2m">
+                  <node concept="1pGfFk" id="7_uCKm_stLn" role="2ShVmc">
+                    <property role="373rjd" value="true" />
+                    <ref role="37wK5l" to="w1kc:~ModelImports.&lt;init&gt;(org.jetbrains.mps.openapi.model.SModel)" resolve="ModelImports" />
+                    <node concept="2OqwBi" id="7_uCKm_stLo" role="37wK5m">
+                      <node concept="37vLTw" id="7_uCKm_stLp" role="2Oq$k0">
+                        <ref role="3cqZAo" node="7_uCKm_izgq" resolve="currentTab" />
+                      </node>
+                      <node concept="liA8E" id="7_uCKm_stLq" role="2OqNvi">
+                        <ref role="37wK5l" to="qgo0:7M1Gaz36FXw" resolve="getConsoleModel" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="7_uCKm_stLr" role="3cqZAp">
+              <node concept="2OqwBi" id="7_uCKm_stLs" role="3clFbG">
+                <node concept="37vLTw" id="7_uCKm_stLt" role="2Oq$k0">
+                  <ref role="3cqZAo" node="7_uCKm_stLk" resolve="imports" />
+                </node>
+                <node concept="liA8E" id="7_uCKm_stLu" role="2OqNvi">
+                  <ref role="37wK5l" to="w1kc:~ModelImports.addUsedLanguage(org.jetbrains.mps.openapi.language.SLanguage)" resolve="addUsedLanguage" />
+                  <node concept="pHN19" id="7_uCKm_stLv" role="37wK5m">
+                    <node concept="2V$Bhx" id="7_uCKm_stLw" role="2V$M_3">
+                      <property role="2V$B1T" value="1919c723-b60b-4592-9318-9ce96d91da44" />
+                      <property role="2V$B1Q" value="de.itemis.mps.editor.celllayout" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="7_uCKm_suXk" role="3cqZAp">
+              <node concept="2OqwBi" id="7_uCKm_sv6e" role="3clFbG">
+                <node concept="37vLTw" id="7_uCKm_suXi" role="2Oq$k0">
+                  <ref role="3cqZAo" node="7_uCKm_stLk" resolve="imports" />
+                </node>
+                <node concept="liA8E" id="7_uCKm_svyE" role="2OqNvi">
+                  <ref role="37wK5l" to="w1kc:~ModelImports.addModelImport(org.jetbrains.mps.openapi.model.SModelReference)" resolve="addModelImport" />
+                  <node concept="1Xw6AR" id="7_uCKm_svzO" role="37wK5m">
+                    <node concept="1dCxOl" id="7_uCKm_sv$Q" role="1XwpL7">
+                      <property role="1XweGQ" value="r:c30772cf-6faa-4379-900e-6719e180568e" />
+                      <node concept="1j_P7g" id="7_uCKm_sv$R" role="1j$8Uc">
+                        <property role="1j_P7h" value="de.itemis.mps.editor.celllayout.runtime.plugin" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbH" id="7_uCKm_stCs" role="3cqZAp" />
             <node concept="3clFbF" id="7_uCKm_liGn" role="3cqZAp">
               <node concept="2OqwBi" id="7_uCKm_lk5L" role="3clFbG">
                 <node concept="37vLTw" id="7_uCKm_liGl" role="2Oq$k0">
@@ -1383,6 +1460,45 @@
         </node>
         <node concept="3clFbJ" id="7_uCKm_orLT" role="3cqZAp">
           <node concept="3clFbS" id="7_uCKm_orLV" role="3clFbx">
+            <node concept="3cpWs8" id="7_uCKm_s9yi" role="3cqZAp">
+              <node concept="3cpWsn" id="7_uCKm_s9yj" role="3cpWs9">
+                <property role="TrG5h" value="imports" />
+                <node concept="3uibUv" id="7_uCKm_s9eA" role="1tU5fm">
+                  <ref role="3uigEE" to="w1kc:~ModelImports" resolve="ModelImports" />
+                </node>
+                <node concept="2ShNRf" id="7_uCKm_s9yk" role="33vP2m">
+                  <node concept="1pGfFk" id="7_uCKm_s9yl" role="2ShVmc">
+                    <property role="373rjd" value="true" />
+                    <ref role="37wK5l" to="w1kc:~ModelImports.&lt;init&gt;(org.jetbrains.mps.openapi.model.SModel)" resolve="ModelImports" />
+                    <node concept="2OqwBi" id="7_uCKm_s9ym" role="37wK5m">
+                      <node concept="37vLTw" id="7_uCKm_s9yn" role="2Oq$k0">
+                        <ref role="3cqZAo" node="7_uCKm_nUfy" resolve="currentTab" />
+                      </node>
+                      <node concept="liA8E" id="7_uCKm_s9yo" role="2OqNvi">
+                        <ref role="37wK5l" to="qgo0:7M1Gaz36FXw" resolve="getConsoleModel" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="7_uCKm_s7yA" role="3cqZAp">
+              <node concept="2OqwBi" id="7_uCKm_s9dI" role="3clFbG">
+                <node concept="37vLTw" id="7_uCKm_s9yp" role="2Oq$k0">
+                  <ref role="3cqZAo" node="7_uCKm_s9yj" resolve="imports" />
+                </node>
+                <node concept="liA8E" id="7_uCKm_s9OW" role="2OqNvi">
+                  <ref role="37wK5l" to="w1kc:~ModelImports.addUsedLanguage(org.jetbrains.mps.openapi.language.SLanguage)" resolve="addUsedLanguage" />
+                  <node concept="pHN19" id="7_uCKm_s0lV" role="37wK5m">
+                    <node concept="2V$Bhx" id="7_uCKm_s0mO" role="2V$M_3">
+                      <property role="2V$B1T" value="1919c723-b60b-4592-9318-9ce96d91da44" />
+                      <property role="2V$B1Q" value="de.itemis.mps.editor.celllayout" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbH" id="7_uCKm_srPw" role="3cqZAp" />
             <node concept="3clFbF" id="7_uCKm_nUfB" role="3cqZAp">
               <node concept="2OqwBi" id="7_uCKm_nUfC" role="3clFbG">
                 <node concept="37vLTw" id="7_uCKm_nUfD" role="2Oq$k0">

--- a/code/celllayout/solutions/de.slisson.mps.editor.celllayout.runtime/models/de/itemis/mps/editor/celllayout/runtime/plugin.mps
+++ b/code/celllayout/solutions/de.slisson.mps.editor.celllayout.runtime/models/de/itemis/mps/editor/celllayout/runtime/plugin.mps
@@ -33,6 +33,10 @@
       <concept id="1207145163717" name="jetbrains.mps.lang.plugin.structure.ElementListContents" flags="ng" index="ftmFs">
         <child id="1207145201301" name="reference" index="ftvYc" />
       </concept>
+      <concept id="1207318242772" name="jetbrains.mps.lang.plugin.structure.KeyMapKeystroke" flags="ng" index="pLAjd">
+        <property id="1207318242773" name="modifiers" index="pLAjc" />
+        <property id="1207318242774" name="keycode" index="pLAjf" />
+      </concept>
       <concept id="1203071646776" name="jetbrains.mps.lang.plugin.structure.ActionDeclaration" flags="ng" index="sE7Ow">
         <property id="1205250923097" name="caption" index="2uzpH1" />
         <property id="7458746815261976739" name="requiredAccess" index="2YLI8m" />
@@ -53,6 +57,15 @@
         <reference id="1203092736097" name="modifiedGroup" index="tU$_T" />
       </concept>
       <concept id="1205681243813" name="jetbrains.mps.lang.plugin.structure.IsApplicableBlock" flags="in" index="2ScWuX" />
+      <concept id="1562714432501166198" name="jetbrains.mps.lang.plugin.structure.SimpleShortcutChange" flags="lg" index="Zd509">
+        <child id="1562714432501166206" name="keystroke" index="Zd501" />
+      </concept>
+      <concept id="1562714432501166197" name="jetbrains.mps.lang.plugin.structure.KeymapChangesDeclaration" flags="ng" index="Zd50a">
+        <child id="1562714432501166199" name="shortcutChange" index="Zd508" />
+      </concept>
+      <concept id="6193305307616715384" name="jetbrains.mps.lang.plugin.structure.ShortcutChange" flags="ng" index="1bYyw_">
+        <reference id="6193305307616734326" name="action" index="1bYAoF" />
+      </concept>
       <concept id="5538333046911348654" name="jetbrains.mps.lang.plugin.structure.RequiredCondition" flags="ng" index="1oajcY" />
       <concept id="1217252042208" name="jetbrains.mps.lang.plugin.structure.ActionDataParameterDeclaration" flags="ng" index="1DS2jV">
         <reference id="1217252646389" name="key" index="1DUlNI" />
@@ -403,7 +416,7 @@
           <node concept="1Y3b0j" id="6IJAP0oQf0Q" role="YeSDq">
             <property role="2bfB8j" value="true" />
             <ref role="1Y3XeK" node="6IJAP0oQf_3" resolve="DoNothingAdditionalPainter" />
-            <ref role="37wK5l" to="exr9:~AbstractAdditionalPainter.&lt;init&gt;()" resolve="AbstractAdditionalPainter" />
+            <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" />
             <node concept="3Tm1VV" id="6IJAP0oQf0R" role="1B3o_S" />
             <node concept="3clFb_" id="6IJAP0oQf2H" role="jymVt">
               <property role="1EzhhJ" value="false" />
@@ -1528,6 +1541,16 @@
       <property role="TrG5h" value="mpsProject" />
       <ref role="1DUlNI" to="qq03:~MPSCommonDataKeys.MPS_PROJECT" resolve="MPS_PROJECT" />
       <node concept="1oajcY" id="7_uCKm_nUfK" role="1oa70y" />
+    </node>
+  </node>
+  <node concept="Zd50a" id="58ijd243fK">
+    <property role="TrG5h" value="EditorCellDebug" />
+    <node concept="Zd509" id="58ijd243fL" role="Zd508">
+      <ref role="1bYAoF" node="7_uCKm_ijPf" resolve="CopyEditorCellReference" />
+      <node concept="pLAjd" id="58ijd243fM" role="Zd501">
+        <property role="pLAjc" value="ctrl+alt" />
+        <property role="pLAjf" value="VK_C" />
+      </node>
     </node>
   </node>
 </model>

--- a/code/celllayout/solutions/de.slisson.mps.editor.celllayout.runtime/models/de/itemis/mps/editor/celllayout/runtime/plugin.mps
+++ b/code/celllayout/solutions/de.slisson.mps.editor.celllayout.runtime/models/de/itemis/mps/editor/celllayout/runtime/plugin.mps
@@ -24,6 +24,7 @@
     <import index="4nm9" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.project(MPS.IDEA/)" />
     <import index="dp1x" ref="r:84719e1a-99f6-4297-90ba-8ad2a947fa4a(jetbrains.mps.ide.datatransfer)" />
     <import index="w1kc" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel(MPS.Core/)" />
+    <import index="zyr2" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor.inspector(MPS.Editor/)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
     <import index="z1c4" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.project(MPS.Platform/)" implicit="true" />
     <import index="tprs" ref="r:00000000-0000-4000-0000-011c895904a4(jetbrains.mps.ide.actions)" implicit="true" />
@@ -91,6 +92,7 @@
         <child id="1224071154657" name="classifierType" index="0kSFW" />
         <child id="1224071154656" name="expression" index="0kSFX" />
       </concept>
+      <concept id="1080223426719" name="jetbrains.mps.baseLanguage.structure.OrExpression" flags="nn" index="22lmx$" />
       <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
         <child id="1068498886297" name="rValue" index="37vLTx" />
         <child id="1068498886295" name="lValue" index="37vLTJ" />
@@ -156,6 +158,7 @@
       <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
       <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
       <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
+      <concept id="1225271283259" name="jetbrains.mps.baseLanguage.structure.NPEEqualsExpression" flags="nn" index="17R0WA" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
@@ -1018,6 +1021,46 @@
       <ref role="1DUlNI" to="qq03:~MPSCommonDataKeys.NODE" resolve="NODE" />
       <node concept="1oajcY" id="7_uCKm_iIiT" role="1oa70y" />
     </node>
+    <node concept="2ScWuX" id="58ijd27OWO" role="tmbBb">
+      <node concept="3clFbS" id="58ijd27OWP" role="2VODD2">
+        <node concept="3cpWs6" id="58ijd27YNI" role="3cqZAp">
+          <node concept="22lmx$" id="58ijd27Prt" role="3cqZAk">
+            <node concept="17R0WA" id="58ijd27Pru" role="3uHU7B">
+              <node concept="3VsKOn" id="58ijd27Prv" role="3uHU7w">
+                <ref role="3VsUkX" to="exr9:~NodeEditorComponent" resolve="NodeEditorComponent" />
+              </node>
+              <node concept="2OqwBi" id="58ijd27Prw" role="3uHU7B">
+                <node concept="2OqwBi" id="58ijd27Prx" role="2Oq$k0">
+                  <node concept="2WthIp" id="58ijd27Pry" role="2Oq$k0" />
+                  <node concept="1DTwFV" id="58ijd27Prz" role="2OqNvi">
+                    <ref role="2WH_rO" node="7_uCKm_iG0$" resolve="component" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="58ijd27Pr$" role="2OqNvi">
+                  <ref role="37wK5l" to="wyt6:~Object.getClass()" resolve="getClass" />
+                </node>
+              </node>
+            </node>
+            <node concept="17R0WA" id="58ijd27Pr_" role="3uHU7w">
+              <node concept="3VsKOn" id="58ijd27PrA" role="3uHU7w">
+                <ref role="3VsUkX" to="zyr2:~InspectorEditorComponent" resolve="InspectorEditorComponent" />
+              </node>
+              <node concept="2OqwBi" id="58ijd27PrB" role="3uHU7B">
+                <node concept="2OqwBi" id="58ijd27PrC" role="2Oq$k0">
+                  <node concept="2WthIp" id="58ijd27PrD" role="2Oq$k0" />
+                  <node concept="1DTwFV" id="58ijd27PrE" role="2OqNvi">
+                    <ref role="2WH_rO" node="7_uCKm_iG0$" resolve="component" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="58ijd27PrF" role="2OqNvi">
+                  <ref role="37wK5l" to="wyt6:~Object.getClass()" resolve="getClass" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
   </node>
   <node concept="tC5Ba" id="7_uCKm_j756">
     <property role="TrG5h" value="EditorCellDebug" />
@@ -1609,6 +1652,46 @@
       <property role="TrG5h" value="mpsProject" />
       <ref role="1DUlNI" to="qq03:~MPSCommonDataKeys.MPS_PROJECT" resolve="MPS_PROJECT" />
       <node concept="1oajcY" id="7_uCKm_nUfK" role="1oa70y" />
+    </node>
+    <node concept="2ScWuX" id="58ijd27E2Z" role="tmbBb">
+      <node concept="3clFbS" id="58ijd27E30" role="2VODD2">
+        <node concept="3cpWs6" id="58ijd27WJB" role="3cqZAp">
+          <node concept="22lmx$" id="58ijd27IgT" role="3cqZAk">
+            <node concept="17R0WA" id="58ijd27MYv" role="3uHU7B">
+              <node concept="3VsKOn" id="58ijd27Nvm" role="3uHU7w">
+                <ref role="3VsUkX" to="exr9:~NodeEditorComponent" resolve="NodeEditorComponent" />
+              </node>
+              <node concept="2OqwBi" id="58ijd27LkQ" role="3uHU7B">
+                <node concept="2OqwBi" id="58ijd27LdL" role="2Oq$k0">
+                  <node concept="2WthIp" id="58ijd27LcM" role="2Oq$k0" />
+                  <node concept="1DTwFV" id="58ijd27LhK" role="2OqNvi">
+                    <ref role="2WH_rO" node="7_uCKm_nUfF" resolve="component" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="58ijd27M9t" role="2OqNvi">
+                  <ref role="37wK5l" to="wyt6:~Object.getClass()" resolve="getClass" />
+                </node>
+              </node>
+            </node>
+            <node concept="17R0WA" id="58ijd27NCR" role="3uHU7w">
+              <node concept="3VsKOn" id="58ijd27NCS" role="3uHU7w">
+                <ref role="3VsUkX" to="zyr2:~InspectorEditorComponent" resolve="InspectorEditorComponent" />
+              </node>
+              <node concept="2OqwBi" id="58ijd27NCT" role="3uHU7B">
+                <node concept="2OqwBi" id="58ijd27NCU" role="2Oq$k0">
+                  <node concept="2WthIp" id="58ijd27NCV" role="2Oq$k0" />
+                  <node concept="1DTwFV" id="58ijd27NCW" role="2OqNvi">
+                    <ref role="2WH_rO" node="7_uCKm_nUfF" resolve="component" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="58ijd27NCX" role="2OqNvi">
+                  <ref role="37wK5l" to="wyt6:~Object.getClass()" resolve="getClass" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
     </node>
   </node>
   <node concept="Zd50a" id="58ijd243fK">

--- a/code/celllayout/solutions/de.slisson.mps.editor.celllayout.runtime/models/de/itemis/mps/editor/celllayout/runtime/plugin.mps
+++ b/code/celllayout/solutions/de.slisson.mps.editor.celllayout.runtime/models/de/itemis/mps/editor/celllayout/runtime/plugin.mps
@@ -78,6 +78,10 @@
       <concept id="7520713872864775836" name="jetbrains.mps.lang.plugin.standalone.structure.StandalonePluginDescriptor" flags="ng" index="2DaZZR" />
     </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1224071154655" name="jetbrains.mps.baseLanguage.structure.AsExpression" flags="nn" index="0kSF2">
+        <child id="1224071154657" name="classifierType" index="0kSFW" />
+        <child id="1224071154656" name="expression" index="0kSFX" />
+      </concept>
       <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
         <child id="1068498886297" name="rValue" index="37vLTx" />
         <child id="1068498886295" name="lValue" index="37vLTJ" />
@@ -157,7 +161,6 @@
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
-      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
       <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
         <child id="1068580123160" name="condition" index="3clFbw" />
         <child id="1068580123161" name="ifTrue" index="3clFbx" />
@@ -883,13 +886,23 @@
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="7_uCKm_liGn" role="3cqZAp">
-          <node concept="2OqwBi" id="7_uCKm_lk5L" role="3clFbG">
-            <node concept="37vLTw" id="7_uCKm_liGl" role="2Oq$k0">
-              <ref role="3cqZAo" node="7_uCKm_izgq" resolve="currentTab" />
+        <node concept="3clFbJ" id="7_uCKm_owDG" role="3cqZAp">
+          <node concept="3clFbS" id="7_uCKm_owDI" role="3clFbx">
+            <node concept="3clFbF" id="7_uCKm_liGn" role="3cqZAp">
+              <node concept="2OqwBi" id="7_uCKm_lk5L" role="3clFbG">
+                <node concept="37vLTw" id="7_uCKm_liGl" role="2Oq$k0">
+                  <ref role="3cqZAo" node="7_uCKm_izgq" resolve="currentTab" />
+                </node>
+                <node concept="liA8E" id="7_uCKm_llWA" role="2OqNvi">
+                  <ref role="37wK5l" to="qgo0:3ZgZ1njQR0n" resolve="activate" />
+                </node>
+              </node>
             </node>
-            <node concept="liA8E" id="7_uCKm_llWA" role="2OqNvi">
-              <ref role="37wK5l" to="qgo0:3ZgZ1njQR0n" resolve="activate" />
+          </node>
+          <node concept="3y3z36" id="7_uCKm_oyjp" role="3clFbw">
+            <node concept="10Nm6u" id="7_uCKm_oyVA" role="3uHU7w" />
+            <node concept="37vLTw" id="7_uCKm_owUW" role="3uHU7B">
+              <ref role="3cqZAo" node="7_uCKm_izgq" resolve="currentTab" />
             </node>
           </node>
         </node>
@@ -926,10 +939,94 @@
       <node concept="tCFHf" id="7_uCKm_j75E" role="ftvYc">
         <ref role="tCJdB" node="7_uCKm_ijPf" resolve="CopyEditorCellReference" />
       </node>
+      <node concept="tCFHf" id="7_uCKm_ozJ3" role="ftvYc">
+        <ref role="tCJdB" node="7_uCKm_nUeU" resolve="CopyCurrentEditorComponent" />
+      </node>
     </node>
   </node>
   <node concept="312cEu" id="7_uCKm_jZa0">
     <property role="TrG5h" value="DebugHelper" />
+    <node concept="2YIFZL" id="7_uCKm_nknH" role="jymVt">
+      <property role="TrG5h" value="getCurrentEditorComponent" />
+      <node concept="37vLTG" id="7_uCKm_nktE" role="3clF46">
+        <property role="TrG5h" value="project" />
+        <node concept="3uibUv" id="7_uCKm_nktF" role="1tU5fm">
+          <ref role="3uigEE" to="z1c3:~Project" resolve="Project" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="7_uCKm_nknK" role="3clF47">
+        <node concept="3cpWs8" id="7_uCKm_nqvg" role="3cqZAp">
+          <node concept="3cpWsn" id="7_uCKm_nqvh" role="3cpWs9">
+            <property role="TrG5h" value="ideaProject" />
+            <node concept="3uibUv" id="7_uCKm_nqvi" role="1tU5fm">
+              <ref role="3uigEE" to="4nm9:~Project" resolve="Project" />
+            </node>
+            <node concept="2YIFZM" id="7_uCKm_nqvj" role="33vP2m">
+              <ref role="37wK5l" to="alof:~ProjectHelper.toIdeaProject(jetbrains.mps.project.Project)" resolve="toIdeaProject" />
+              <ref role="1Pybhc" to="alof:~ProjectHelper" resolve="ProjectHelper" />
+              <node concept="37vLTw" id="7_uCKm_nqvk" role="37wK5m">
+                <ref role="3cqZAo" node="7_uCKm_nktE" resolve="project" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="7_uCKm_nrLj" role="3cqZAp">
+          <node concept="3cpWsn" id="7_uCKm_nrLk" role="3cpWs9">
+            <property role="TrG5h" value="editor" />
+            <node concept="3uibUv" id="7_uCKm_nrJG" role="1tU5fm">
+              <ref role="3uigEE" to="iwsx:~FileEditor" resolve="FileEditor" />
+            </node>
+            <node concept="2OqwBi" id="7_uCKm_nrLl" role="33vP2m">
+              <node concept="2YIFZM" id="7_uCKm_nrLm" role="2Oq$k0">
+                <ref role="37wK5l" to="iwsx:~FileEditorManager.getInstance(com.intellij.openapi.project.Project)" resolve="getInstance" />
+                <ref role="1Pybhc" to="iwsx:~FileEditorManager" resolve="FileEditorManager" />
+                <node concept="37vLTw" id="7_uCKm_nrLn" role="37wK5m">
+                  <ref role="3cqZAo" node="7_uCKm_nqvh" resolve="ideaProject" />
+                </node>
+              </node>
+              <node concept="liA8E" id="7_uCKm_nrLo" role="2OqNvi">
+                <ref role="37wK5l" to="iwsx:~FileEditorManager.getSelectedEditor()" resolve="getSelectedEditor" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="7_uCKm_nseD" role="3cqZAp">
+          <node concept="3clFbS" id="7_uCKm_nseF" role="3clFbx">
+            <node concept="3cpWs6" id="7_uCKm_n$Tm" role="3cqZAp">
+              <node concept="1rXfSq" id="7_uCKm_nwPj" role="3cqZAk">
+                <ref role="37wK5l" node="7_uCKm_nuhj" resolve="getEditorComponentFromEditor" />
+                <node concept="1eOMI4" id="7_uCKm_nza5" role="37wK5m">
+                  <node concept="0kSF2" id="7_uCKm_nEGg" role="1eOMHV">
+                    <node concept="3uibUv" id="7_uCKm_nEGi" role="0kSFW">
+                      <ref role="3uigEE" to="k3nr:~MPSFileNodeEditor" resolve="MPSFileNodeEditor" />
+                    </node>
+                    <node concept="37vLTw" id="7_uCKm_nx4K" role="0kSFX">
+                      <ref role="3cqZAo" node="7_uCKm_nrLk" resolve="editor" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2ZW3vV" id="7_uCKm_nsGx" role="3clFbw">
+            <node concept="3uibUv" id="7_uCKm_nsVB" role="2ZW6by">
+              <ref role="3uigEE" to="k3nr:~MPSFileNodeEditor" resolve="MPSFileNodeEditor" />
+            </node>
+            <node concept="37vLTw" id="7_uCKm_nsrJ" role="2ZW6bz">
+              <ref role="3cqZAo" node="7_uCKm_nrLk" resolve="editor" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="7_uCKm_n$5k" role="3cqZAp">
+          <node concept="10Nm6u" id="7_uCKm_n$cI" role="3cqZAk" />
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="7_uCKm_njJh" role="1B3o_S" />
+      <node concept="3uibUv" id="7_uCKm_nkn2" role="3clF45">
+        <ref role="3uigEE" to="cj4x:~EditorComponent" resolve="EditorComponent" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="7_uCKm_niFw" role="jymVt" />
     <node concept="2YIFZL" id="7_uCKm_kbKO" role="jymVt">
       <property role="TrG5h" value="getEditorComponent" />
       <node concept="3clFbS" id="7_uCKm_kbKQ" role="3clF47">
@@ -978,97 +1075,56 @@
             <ref role="3cqZAo" node="7_uCKm_kbKX" resolve="editors" />
           </node>
           <node concept="3clFbS" id="7_uCKm_kbL7" role="2LFqv$">
-            <node concept="3clFbJ" id="7_uCKm_kbL8" role="3cqZAp">
-              <node concept="2ZW3vV" id="7_uCKm_kbL9" role="3clFbw">
-                <node concept="3uibUv" id="7_uCKm_kbLa" role="2ZW6by">
-                  <ref role="3uigEE" to="k3nr:~MPSFileNodeEditor" resolve="MPSFileNodeEditor" />
-                </node>
-                <node concept="2GrUjf" id="7_uCKm_kbLb" role="2ZW6bz">
-                  <ref role="2Gs0qQ" node="7_uCKm_kbL5" resolve="editor" />
-                </node>
-              </node>
-              <node concept="3clFbS" id="7_uCKm_kbLc" role="3clFbx">
-                <node concept="3cpWs8" id="7_uCKm_kbLd" role="3cqZAp">
-                  <node concept="3cpWsn" id="7_uCKm_kbLe" role="3cpWs9">
-                    <property role="TrG5h" value="mpsEditor" />
-                    <node concept="3uibUv" id="7_uCKm_kbLf" role="1tU5fm">
-                      <ref role="3uigEE" to="k3nr:~MPSFileNodeEditor" resolve="MPSFileNodeEditor" />
+            <node concept="3clFbJ" id="7_uCKm_nBRs" role="3cqZAp">
+              <node concept="3clFbS" id="7_uCKm_nBRu" role="3clFbx">
+                <node concept="3cpWs8" id="7_uCKm_n_HH" role="3cqZAp">
+                  <node concept="3cpWsn" id="7_uCKm_n_HI" role="3cpWs9">
+                    <property role="TrG5h" value="currentEditorComponent" />
+                    <node concept="3uibUv" id="7_uCKm_n_HJ" role="1tU5fm">
+                      <ref role="3uigEE" to="cj4x:~EditorComponent" resolve="EditorComponent" />
                     </node>
-                    <node concept="1eOMI4" id="7_uCKm_kbLg" role="33vP2m">
-                      <node concept="10QFUN" id="7_uCKm_kbLh" role="1eOMHV">
-                        <node concept="3uibUv" id="7_uCKm_kbLi" role="10QFUM">
+                    <node concept="1rXfSq" id="7_uCKm_nBj3" role="33vP2m">
+                      <ref role="37wK5l" node="7_uCKm_nuhj" resolve="getEditorComponentFromEditor" />
+                      <node concept="0kSF2" id="7_uCKm_nDU5" role="37wK5m">
+                        <node concept="3uibUv" id="7_uCKm_nDU8" role="0kSFW">
                           <ref role="3uigEE" to="k3nr:~MPSFileNodeEditor" resolve="MPSFileNodeEditor" />
                         </node>
-                        <node concept="2GrUjf" id="7_uCKm_kbLj" role="10QFUP">
+                        <node concept="2GrUjf" id="7_uCKm_nDIy" role="0kSFX">
                           <ref role="2Gs0qQ" node="7_uCKm_kbL5" resolve="editor" />
                         </node>
                       </node>
                     </node>
                   </node>
                 </node>
-                <node concept="3cpWs8" id="7_uCKm_kbLk" role="3cqZAp">
-                  <node concept="3cpWsn" id="7_uCKm_kbLl" role="3cpWs9">
-                    <property role="TrG5h" value="nodeEditor" />
-                    <node concept="3uibUv" id="7_uCKm_kbLm" role="1tU5fm">
-                      <ref role="3uigEE" to="cj4x:~Editor" resolve="Editor" />
-                    </node>
-                    <node concept="2OqwBi" id="7_uCKm_kbLn" role="33vP2m">
-                      <node concept="37vLTw" id="7_uCKm_kbLo" role="2Oq$k0">
-                        <ref role="3cqZAo" node="7_uCKm_kbLe" resolve="mpsEditor" />
+                <node concept="3clFbJ" id="7_uCKm_kbLy" role="3cqZAp">
+                  <node concept="3clFbS" id="7_uCKm_kbLz" role="3clFbx">
+                    <node concept="3cpWs6" id="7_uCKm_kbL$" role="3cqZAp">
+                      <node concept="37vLTw" id="7_uCKm_kbL_" role="3cqZAk">
+                        <ref role="3cqZAo" node="7_uCKm_n_HI" resolve="currentEditorComponent" />
                       </node>
-                      <node concept="liA8E" id="7_uCKm_kbLp" role="2OqNvi">
-                        <ref role="37wK5l" to="k3nr:~MPSFileNodeEditor.getNodeEditor()" resolve="getNodeEditor" />
+                    </node>
+                  </node>
+                  <node concept="3clFbC" id="7_uCKm_kbLA" role="3clFbw">
+                    <node concept="37vLTw" id="7_uCKm_kbLB" role="3uHU7w">
+                      <ref role="3cqZAo" node="7_uCKm_kbLN" resolve="hashCode" />
+                    </node>
+                    <node concept="2OqwBi" id="7_uCKm_kbLC" role="3uHU7B">
+                      <node concept="37vLTw" id="7_uCKm_kbLD" role="2Oq$k0">
+                        <ref role="3cqZAo" node="7_uCKm_n_HI" resolve="currentEditorComponent" />
+                      </node>
+                      <node concept="liA8E" id="7_uCKm_kbLE" role="2OqNvi">
+                        <ref role="37wK5l" to="wyt6:~Object.hashCode()" resolve="hashCode" />
                       </node>
                     </node>
                   </node>
                 </node>
-                <node concept="3clFbJ" id="7_uCKm_kbLq" role="3cqZAp">
-                  <node concept="3clFbS" id="7_uCKm_kbLr" role="3clFbx">
-                    <node concept="3cpWs8" id="7_uCKm_kbLs" role="3cqZAp">
-                      <node concept="3cpWsn" id="7_uCKm_kbLt" role="3cpWs9">
-                        <property role="TrG5h" value="currentEditorComponent" />
-                        <node concept="3uibUv" id="7_uCKm_kbLu" role="1tU5fm">
-                          <ref role="3uigEE" to="cj4x:~EditorComponent" resolve="EditorComponent" />
-                        </node>
-                        <node concept="2OqwBi" id="7_uCKm_kbLv" role="33vP2m">
-                          <node concept="37vLTw" id="7_uCKm_kbLw" role="2Oq$k0">
-                            <ref role="3cqZAo" node="7_uCKm_kbLl" resolve="nodeEditor" />
-                          </node>
-                          <node concept="liA8E" id="7_uCKm_kbLx" role="2OqNvi">
-                            <ref role="37wK5l" to="cj4x:~Editor.getCurrentEditorComponent()" resolve="getCurrentEditorComponent" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="3clFbJ" id="7_uCKm_kbLy" role="3cqZAp">
-                      <node concept="3clFbS" id="7_uCKm_kbLz" role="3clFbx">
-                        <node concept="3cpWs6" id="7_uCKm_kbL$" role="3cqZAp">
-                          <node concept="37vLTw" id="7_uCKm_kbL_" role="3cqZAk">
-                            <ref role="3cqZAo" node="7_uCKm_kbLt" resolve="currentEditorComponent" />
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="3clFbC" id="7_uCKm_kbLA" role="3clFbw">
-                        <node concept="37vLTw" id="7_uCKm_kbLB" role="3uHU7w">
-                          <ref role="3cqZAo" node="7_uCKm_kbLN" resolve="hashCode" />
-                        </node>
-                        <node concept="2OqwBi" id="7_uCKm_kbLC" role="3uHU7B">
-                          <node concept="37vLTw" id="7_uCKm_kbLD" role="2Oq$k0">
-                            <ref role="3cqZAo" node="7_uCKm_kbLt" resolve="currentEditorComponent" />
-                          </node>
-                          <node concept="liA8E" id="7_uCKm_kbLE" role="2OqNvi">
-                            <ref role="37wK5l" to="wyt6:~Object.hashCode()" resolve="hashCode" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3y3z36" id="7_uCKm_kbLF" role="3clFbw">
-                    <node concept="10Nm6u" id="7_uCKm_kbLG" role="3uHU7w" />
-                    <node concept="37vLTw" id="7_uCKm_kbLH" role="3uHU7B">
-                      <ref role="3cqZAo" node="7_uCKm_kbLl" resolve="nodeEditor" />
-                    </node>
-                  </node>
+              </node>
+              <node concept="2ZW3vV" id="7_uCKm_nCz8" role="3clFbw">
+                <node concept="3uibUv" id="7_uCKm_nCTk" role="2ZW6by">
+                  <ref role="3uigEE" to="k3nr:~MPSFileNodeEditor" resolve="MPSFileNodeEditor" />
+                </node>
+                <node concept="2GrUjf" id="7_uCKm_nCcY" role="2ZW6bz">
+                  <ref role="2Gs0qQ" node="7_uCKm_kbL5" resolve="editor" />
                 </node>
               </node>
             </node>
@@ -1092,6 +1148,79 @@
         <node concept="10Oyi0" id="7_uCKm_kbLO" role="1tU5fm" />
       </node>
       <node concept="3Tm1VV" id="7_uCKm_kbLP" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="7_uCKm_nsYj" role="jymVt" />
+    <node concept="2YIFZL" id="7_uCKm_nuhj" role="jymVt">
+      <property role="TrG5h" value="getEditorComponentFromEditor" />
+      <node concept="3clFbS" id="7_uCKm_nuhm" role="3clF47">
+        <node concept="3cpWs8" id="7_uCKm_kbLd" role="3cqZAp">
+          <node concept="3cpWsn" id="7_uCKm_kbLe" role="3cpWs9">
+            <property role="TrG5h" value="mpsEditor" />
+            <node concept="3uibUv" id="7_uCKm_kbLf" role="1tU5fm">
+              <ref role="3uigEE" to="k3nr:~MPSFileNodeEditor" resolve="MPSFileNodeEditor" />
+            </node>
+            <node concept="1eOMI4" id="7_uCKm_kbLg" role="33vP2m">
+              <node concept="10QFUN" id="7_uCKm_kbLh" role="1eOMHV">
+                <node concept="3uibUv" id="7_uCKm_kbLi" role="10QFUM">
+                  <ref role="3uigEE" to="k3nr:~MPSFileNodeEditor" resolve="MPSFileNodeEditor" />
+                </node>
+                <node concept="37vLTw" id="7_uCKm_nwkw" role="10QFUP">
+                  <ref role="3cqZAo" node="7_uCKm_nw1w" resolve="editor" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="7_uCKm_kbLk" role="3cqZAp">
+          <node concept="3cpWsn" id="7_uCKm_kbLl" role="3cpWs9">
+            <property role="TrG5h" value="nodeEditor" />
+            <node concept="3uibUv" id="7_uCKm_kbLm" role="1tU5fm">
+              <ref role="3uigEE" to="cj4x:~Editor" resolve="Editor" />
+            </node>
+            <node concept="2OqwBi" id="7_uCKm_kbLn" role="33vP2m">
+              <node concept="37vLTw" id="7_uCKm_kbLo" role="2Oq$k0">
+                <ref role="3cqZAo" node="7_uCKm_kbLe" resolve="mpsEditor" />
+              </node>
+              <node concept="liA8E" id="7_uCKm_kbLp" role="2OqNvi">
+                <ref role="37wK5l" to="k3nr:~MPSFileNodeEditor.getNodeEditor()" resolve="getNodeEditor" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="7_uCKm_kbLq" role="3cqZAp">
+          <node concept="3clFbS" id="7_uCKm_kbLr" role="3clFbx">
+            <node concept="3cpWs6" id="7_uCKm_nyZl" role="3cqZAp">
+              <node concept="2OqwBi" id="7_uCKm_kbLv" role="3cqZAk">
+                <node concept="37vLTw" id="7_uCKm_kbLw" role="2Oq$k0">
+                  <ref role="3cqZAo" node="7_uCKm_kbLl" resolve="nodeEditor" />
+                </node>
+                <node concept="liA8E" id="7_uCKm_kbLx" role="2OqNvi">
+                  <ref role="37wK5l" to="cj4x:~Editor.getCurrentEditorComponent()" resolve="getCurrentEditorComponent" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3y3z36" id="7_uCKm_kbLF" role="3clFbw">
+            <node concept="10Nm6u" id="7_uCKm_kbLG" role="3uHU7w" />
+            <node concept="37vLTw" id="7_uCKm_kbLH" role="3uHU7B">
+              <ref role="3cqZAo" node="7_uCKm_kbLl" resolve="nodeEditor" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="7_uCKm_nyan" role="3cqZAp">
+          <node concept="10Nm6u" id="7_uCKm_nyhK" role="3cqZAk" />
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="7_uCKm_ntCk" role="1B3o_S" />
+      <node concept="3uibUv" id="7_uCKm_nugw" role="3clF45">
+        <ref role="3uigEE" to="cj4x:~EditorComponent" resolve="EditorComponent" />
+      </node>
+      <node concept="37vLTG" id="7_uCKm_nw1w" role="3clF46">
+        <property role="TrG5h" value="editor" />
+        <node concept="3uibUv" id="7_uCKm_nw1v" role="1tU5fm">
+          <ref role="3uigEE" to="k3nr:~MPSFileNodeEditor" resolve="MPSFileNodeEditor" />
+        </node>
+      </node>
     </node>
     <node concept="2tJIrI" id="7_uCKm_kcmC" role="jymVt" />
     <node concept="2YIFZL" id="7_uCKm_kbYu" role="jymVt">
@@ -1127,7 +1256,6 @@
             </node>
           </node>
         </node>
-        <node concept="3clFbH" id="7_uCKm_mhLK" role="3cqZAp" />
         <node concept="3clFbF" id="7_uCKm_kbYA" role="3cqZAp">
           <node concept="2OqwBi" id="7_uCKm_kbYB" role="3clFbG">
             <node concept="37vLTw" id="7_uCKm_kbYC" role="2Oq$k0">
@@ -1170,6 +1298,121 @@
     </node>
     <node concept="2tJIrI" id="7_uCKm_k0Fi" role="jymVt" />
     <node concept="3Tm1VV" id="7_uCKm_jZa1" role="1B3o_S" />
+  </node>
+  <node concept="sE7Ow" id="7_uCKm_nUeU">
+    <property role="TrG5h" value="CopyCurrentEditorComponent" />
+    <property role="2uzpH1" value="Copy Editor Component Reference" />
+    <property role="2YLI8m" value="6u2MFnph2yk/editorCommand" />
+    <node concept="tnohg" id="7_uCKm_nUeV" role="tncku">
+      <node concept="3clFbS" id="7_uCKm_nUeW" role="2VODD2">
+        <node concept="3cpWs8" id="7_uCKm_ootF" role="3cqZAp">
+          <node concept="3cpWsn" id="7_uCKm_ootI" role="3cpWs9">
+            <property role="TrG5h" value="editorComponentRef" />
+            <node concept="3Tqbb2" id="7_uCKm_ootD" role="1tU5fm">
+              <ref role="ehGHo" to="pvux:7_uCKm_ncp6" resolve="EditorComponentReference" />
+            </node>
+            <node concept="2pJPEk" id="7_uCKm_ooGU" role="33vP2m">
+              <node concept="2pJPED" id="7_uCKm_ooGW" role="2pJPEn">
+                <ref role="2pJxaS" to="pvux:7_uCKm_ncp6" resolve="EditorComponentReference" />
+                <node concept="2pJxcG" id="7_uCKm_ooJC" role="2pJxcM">
+                  <ref role="2pJxcJ" to="pvux:7_uCKm_nXFw" resolve="componentHashCode" />
+                  <node concept="WxPPo" id="7_uCKm_ooN8" role="28ntcv">
+                    <node concept="2OqwBi" id="7_uCKm_opOj" role="WxPPp">
+                      <node concept="2OqwBi" id="7_uCKm_ooN2" role="2Oq$k0">
+                        <node concept="2WthIp" id="7_uCKm_ooN5" role="2Oq$k0" />
+                        <node concept="1DTwFV" id="7_uCKm_ooN7" role="2OqNvi">
+                          <ref role="2WH_rO" node="7_uCKm_nUfF" resolve="component" />
+                        </node>
+                      </node>
+                      <node concept="liA8E" id="7_uCKm_oqBO" role="2OqNvi">
+                        <ref role="37wK5l" to="wyt6:~Object.hashCode()" resolve="hashCode" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7_uCKm_nUfl" role="3cqZAp">
+          <node concept="2YIFZM" id="7_uCKm_nUfm" role="3clFbG">
+            <ref role="37wK5l" to="dp1x:5tGs5KqKiJI" resolve="copyNodeToClipboard" />
+            <ref role="1Pybhc" to="dp1x:5tGs5KqKfGH" resolve="CopyPasteUtil" />
+            <node concept="37vLTw" id="7_uCKm_ori$" role="37wK5m">
+              <ref role="3cqZAo" node="7_uCKm_ootI" resolve="editorComponentRef" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="7_uCKm_nUfo" role="3cqZAp">
+          <node concept="3cpWsn" id="7_uCKm_nUfp" role="3cpWs9">
+            <property role="TrG5h" value="ct" />
+            <node concept="3uibUv" id="7_uCKm_nUfq" role="1tU5fm">
+              <ref role="3uigEE" to="qgo0:1iC2RjkXjYJ" resolve="ConsoleTool" />
+            </node>
+            <node concept="2OqwBi" id="7_uCKm_nUfr" role="33vP2m">
+              <node concept="2OqwBi" id="7_uCKm_nUfs" role="2Oq$k0">
+                <node concept="2WthIp" id="7_uCKm_nUft" role="2Oq$k0" />
+                <node concept="1DTwFV" id="7_uCKm_nUfu" role="2OqNvi">
+                  <ref role="2WH_rO" node="7_uCKm_nUfJ" resolve="mpsProject" />
+                </node>
+              </node>
+              <node concept="liA8E" id="7_uCKm_nUfv" role="2OqNvi">
+                <ref role="37wK5l" to="z1c4:~MPSProject.getComponent(java.lang.Class)" resolve="getComponent" />
+                <node concept="3VsKOn" id="7_uCKm_nUfw" role="37wK5m">
+                  <ref role="3VsUkX" to="qgo0:1iC2RjkXjYJ" resolve="ConsoleTool" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="7_uCKm_nUfx" role="3cqZAp">
+          <node concept="3cpWsn" id="7_uCKm_nUfy" role="3cpWs9">
+            <property role="TrG5h" value="currentTab" />
+            <node concept="3uibUv" id="7_uCKm_nUfz" role="1tU5fm">
+              <ref role="3uigEE" to="qgo0:6ysF3v1jo8G" resolve="DialogConsoleTab" />
+            </node>
+            <node concept="2OqwBi" id="7_uCKm_nUf$" role="33vP2m">
+              <node concept="37vLTw" id="7_uCKm_nUf_" role="2Oq$k0">
+                <ref role="3cqZAo" node="7_uCKm_nUfp" resolve="ct" />
+              </node>
+              <node concept="liA8E" id="7_uCKm_nUfA" role="2OqNvi">
+                <ref role="37wK5l" to="qgo0:5VzHAnbXFEZ" resolve="getCurrentEditableTab" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="7_uCKm_orLT" role="3cqZAp">
+          <node concept="3clFbS" id="7_uCKm_orLV" role="3clFbx">
+            <node concept="3clFbF" id="7_uCKm_nUfB" role="3cqZAp">
+              <node concept="2OqwBi" id="7_uCKm_nUfC" role="3clFbG">
+                <node concept="37vLTw" id="7_uCKm_nUfD" role="2Oq$k0">
+                  <ref role="3cqZAo" node="7_uCKm_nUfy" resolve="currentTab" />
+                </node>
+                <node concept="liA8E" id="7_uCKm_nUfE" role="2OqNvi">
+                  <ref role="37wK5l" to="qgo0:3ZgZ1njQR0n" resolve="activate" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3y3z36" id="7_uCKm_otp$" role="3clFbw">
+            <node concept="10Nm6u" id="7_uCKm_otZR" role="3uHU7w" />
+            <node concept="37vLTw" id="7_uCKm_os2D" role="3uHU7B">
+              <ref role="3cqZAo" node="7_uCKm_nUfy" resolve="currentTab" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1DS2jV" id="7_uCKm_nUfF" role="1NuT2Z">
+      <property role="TrG5h" value="component" />
+      <ref role="1DUlNI" to="k3nr:~MPSEditorDataKeys.EDITOR_COMPONENT" resolve="EDITOR_COMPONENT" />
+      <node concept="1oajcY" id="7_uCKm_nUfG" role="1oa70y" />
+    </node>
+    <node concept="1DS2jV" id="7_uCKm_nUfJ" role="1NuT2Z">
+      <property role="TrG5h" value="mpsProject" />
+      <ref role="1DUlNI" to="qq03:~MPSCommonDataKeys.MPS_PROJECT" resolve="MPS_PROJECT" />
+      <node concept="1oajcY" id="7_uCKm_nUfK" role="1oa70y" />
+    </node>
   </node>
 </model>
 

--- a/code/celllayout/solutions/de.slisson.mps.editor.celllayout.runtime/models/de/itemis/mps/editor/celllayout/runtime/plugin.mps
+++ b/code/celllayout/solutions/de.slisson.mps.editor.celllayout.runtime/models/de/itemis/mps/editor/celllayout/runtime/plugin.mps
@@ -4,6 +4,8 @@
   <languages>
     <use id="28f9e497-3b42-4291-aeba-0a1039153ab1" name="jetbrains.mps.lang.plugin" version="5" />
     <use id="ef7bf5ac-d06c-4342-b11d-e42104eb9343" name="jetbrains.mps.lang.plugin.standalone" version="0" />
+    <use id="de1ad86d-6e50-4a02-b306-d4d17f64c375" name="jetbrains.mps.console.base" version="0" />
+    <use id="1919c723-b60b-4592-9318-9ce96d91da44" name="de.itemis.mps.editor.celllayout" version="0" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -15,17 +17,45 @@
     <import index="cj4x" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor(MPS.Editor/)" />
     <import index="f4zo" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.cells(MPS.Editor/)" />
     <import index="z60i" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt(JDK/)" />
+    <import index="qq03" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.ide.actions(MPS.Platform/)" />
+    <import index="qgo0" ref="r:de40a5a4-f08c-4c67-ac43-e1f5c384f7d6(jetbrains.mps.console.tool)" />
+    <import index="eynw" ref="r:359b1d2b-77c4-46df-9bf2-b25cbea32254(jetbrains.mps.console.base.structure)" />
+    <import index="pvux" ref="r:bb8c05bc-4758-44fe-b1ab-f9faa5a73d31(de.itemis.mps.editor.celllayout.structure)" />
+    <import index="ekwn" ref="r:9832fb5f-2578-4b58-8014-a5de79da988e(jetbrains.mps.ide.editor.actions)" />
+    <import index="z1c3" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.project(MPS.Core/)" />
+    <import index="alof" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.ide.project(MPS.Platform/)" />
+    <import index="iwsx" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.fileEditor(MPS.IDEA/)" />
+    <import index="4nm9" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.project(MPS.IDEA/)" />
+    <import index="1i7y" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor.datatransfer(MPS.Editor/)" />
+    <import index="dp1x" ref="r:84719e1a-99f6-4297-90ba-8ad2a947fa4a(jetbrains.mps.ide.datatransfer)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
+    <import index="z1c4" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.project(MPS.Platform/)" implicit="true" />
+    <import index="tprs" ref="r:00000000-0000-4000-0000-011c895904a4(jetbrains.mps.ide.actions)" implicit="true" />
   </imports>
   <registry>
     <language id="28f9e497-3b42-4291-aeba-0a1039153ab1" name="jetbrains.mps.lang.plugin">
+      <concept id="1207145163717" name="jetbrains.mps.lang.plugin.structure.ElementListContents" flags="ng" index="ftmFs">
+        <child id="1207145201301" name="reference" index="ftvYc" />
+      </concept>
       <concept id="1203071646776" name="jetbrains.mps.lang.plugin.structure.ActionDeclaration" flags="ng" index="sE7Ow">
         <property id="1205250923097" name="caption" index="2uzpH1" />
+        <property id="7458746815261976739" name="requiredAccess" index="2YLI8m" />
         <child id="1203083196627" name="updateBlock" index="tmbBb" />
         <child id="1203083461638" name="executeFunction" index="tncku" />
         <child id="1217413222820" name="parameter" index="1NuT2Z" />
       </concept>
       <concept id="1203083511112" name="jetbrains.mps.lang.plugin.structure.ExecuteBlock" flags="in" index="tnohg" />
+      <concept id="1203087890642" name="jetbrains.mps.lang.plugin.structure.ActionGroupDeclaration" flags="ng" index="tC5Ba">
+        <child id="1204991552650" name="modifier" index="2f5YQi" />
+        <child id="1207145245948" name="contents" index="ftER_" />
+      </concept>
+      <concept id="1203088046679" name="jetbrains.mps.lang.plugin.structure.ActionInstance" flags="ng" index="tCFHf">
+        <reference id="1203088061055" name="action" index="tCJdB" />
+      </concept>
+      <concept id="1203092361741" name="jetbrains.mps.lang.plugin.structure.ModificationStatement" flags="lg" index="tT9cl">
+        <reference id="1204992316090" name="point" index="2f8Tey" />
+        <reference id="1203092736097" name="modifiedGroup" index="tU$_T" />
+      </concept>
       <concept id="1205681243813" name="jetbrains.mps.lang.plugin.structure.IsApplicableBlock" flags="in" index="2ScWuX" />
       <concept id="5538333046911348654" name="jetbrains.mps.lang.plugin.structure.RequiredCondition" flags="ng" index="1oajcY" />
       <concept id="1217252042208" name="jetbrains.mps.lang.plugin.structure.ActionDataParameterDeclaration" flags="ng" index="1DS2jV">
@@ -53,6 +83,7 @@
         <child id="1068498886295" name="lValue" index="37vLTJ" />
       </concept>
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
       <concept id="1188207840427" name="jetbrains.mps.baseLanguage.structure.AnnotationInstance" flags="nn" index="2AHcQZ">
         <reference id="1188208074048" name="annotation" index="2AI5Lk" />
       </concept>
@@ -61,6 +92,9 @@
       </concept>
       <concept id="2820489544401957797" name="jetbrains.mps.baseLanguage.structure.DefaultClassCreator" flags="nn" index="HV5vD">
         <reference id="2820489544401957798" name="classifier" index="HV5vE" />
+      </concept>
+      <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
+        <child id="1154032183016" name="body" index="2LFqv$" />
       </concept>
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
@@ -76,10 +110,24 @@
       <concept id="1182160077978" name="jetbrains.mps.baseLanguage.structure.AnonymousClassCreator" flags="nn" index="YeOm9">
         <child id="1182160096073" name="cls" index="YeSDq" />
       </concept>
+      <concept id="1081236700938" name="jetbrains.mps.baseLanguage.structure.StaticMethodDeclaration" flags="ig" index="2YIFZL" />
       <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
       </concept>
+      <concept id="1081256982272" name="jetbrains.mps.baseLanguage.structure.InstanceOfExpression" flags="nn" index="2ZW3vV">
+        <child id="1081256993305" name="classType" index="2ZW6by" />
+        <child id="1081256993304" name="leftExpression" index="2ZW6bz" />
+      </concept>
+      <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
+      <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
       <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
+      <concept id="1070534760951" name="jetbrains.mps.baseLanguage.structure.ArrayType" flags="in" index="10Q1$e">
+        <child id="1070534760952" name="componentType" index="10Q1$1" />
+      </concept>
+      <concept id="1070534934090" name="jetbrains.mps.baseLanguage.structure.CastExpression" flags="nn" index="10QFUN">
+        <child id="1070534934091" name="type" index="10QFUM" />
+        <child id="1070534934092" name="expression" index="10QFUP" />
+      </concept>
       <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu">
         <child id="1165602531693" name="superclass" index="1zkMxy" />
       </concept>
@@ -91,6 +139,7 @@
       </concept>
       <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
       <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
+      <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
@@ -104,9 +153,11 @@
       <concept id="1068580123165" name="jetbrains.mps.baseLanguage.structure.InstanceMethodDeclaration" flags="ig" index="3clFb_">
         <property id="1178608670077" name="isAbstract" index="1EzhhJ" />
       </concept>
+      <concept id="1068580123152" name="jetbrains.mps.baseLanguage.structure.EqualsExpression" flags="nn" index="3clFbC" />
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
       <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
         <child id="1068580123160" name="condition" index="3clFbw" />
         <child id="1068580123161" name="ifTrue" index="3clFbx" />
@@ -117,11 +168,17 @@
       <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
         <property id="1068580123138" name="value" index="3clFbU" />
       </concept>
+      <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
+        <child id="1068581517676" name="expression" index="3cqZAk" />
+      </concept>
       <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
         <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
       </concept>
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
       <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
+      <concept id="1079359253375" name="jetbrains.mps.baseLanguage.structure.ParenthesizedExpression" flags="nn" index="1eOMI4">
+        <child id="1079359253376" name="expression" index="1eOMHV" />
+      </concept>
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
@@ -130,14 +187,23 @@
         <property id="521412098689998745" name="nonStatic" index="2bfB8j" />
         <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
       </concept>
+      <concept id="7812454656619025412" name="jetbrains.mps.baseLanguage.structure.LocalMethodCall" flags="nn" index="1rXfSq" />
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
       </concept>
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
+        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
+        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
+      </concept>
+      <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
       <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
       <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
+      <concept id="1116615150612" name="jetbrains.mps.baseLanguage.structure.ClassifierClassExpression" flags="nn" index="3VsKOn">
+        <reference id="1116615189566" name="classifier" index="3VsUkX" />
+      </concept>
       <concept id="1170345865475" name="jetbrains.mps.baseLanguage.structure.AnonymousClass" flags="ig" index="1Y3b0j">
         <reference id="1170346070688" name="classifier" index="1Y3XeK" />
       </concept>
@@ -152,9 +218,47 @@
         <reference id="1205756909548" name="member" index="2WH_rO" />
       </concept>
     </language>
+    <language id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation">
+      <concept id="5455284157994012186" name="jetbrains.mps.lang.quotation.structure.NodeBuilderInitLink" flags="ng" index="2pIpSj">
+        <reference id="5455284157994012188" name="link" index="2pIpSl" />
+        <child id="1595412875168045827" name="initValue" index="28nt2d" />
+      </concept>
+      <concept id="5455284157993911077" name="jetbrains.mps.lang.quotation.structure.NodeBuilderInitProperty" flags="ng" index="2pJxcG">
+        <reference id="5455284157993911078" name="property" index="2pJxcJ" />
+        <child id="1595412875168045201" name="initValue" index="28ntcv" />
+      </concept>
+      <concept id="5455284157993863837" name="jetbrains.mps.lang.quotation.structure.NodeBuilder" flags="nn" index="2pJPEk">
+        <child id="5455284157993863838" name="quotedNode" index="2pJPEn" />
+      </concept>
+      <concept id="5455284157993863840" name="jetbrains.mps.lang.quotation.structure.NodeBuilderNode" flags="nn" index="2pJPED">
+        <reference id="5455284157993910961" name="concept" index="2pJxaS" />
+        <child id="5455284157993911099" name="values" index="2pJxcM" />
+      </concept>
+      <concept id="6985522012210254362" name="jetbrains.mps.lang.quotation.structure.NodeBuilderPropertyExpression" flags="nn" index="WxPPo">
+        <child id="6985522012210254363" name="expression" index="WxPPp" />
+      </concept>
+      <concept id="8182547171709752110" name="jetbrains.mps.lang.quotation.structure.NodeBuilderExpression" flags="nn" index="36biLy">
+        <child id="8182547171709752112" name="expression" index="36biLW" />
+      </concept>
+    </language>
+    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
+        <reference id="1138405853777" name="concept" index="ehGHo" />
+      </concept>
+    </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+    <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="1153943597977" name="jetbrains.mps.baseLanguage.collections.structure.ForEachStatement" flags="nn" index="2Gpval">
+        <child id="1153944400369" name="variable" index="2Gsz3X" />
+        <child id="1153944424730" name="inputSequence" index="2GsD0m" />
+      </concept>
+      <concept id="1153944193378" name="jetbrains.mps.baseLanguage.collections.structure.ForEachVariable" flags="nr" index="2GrKxI" />
+      <concept id="1153944233411" name="jetbrains.mps.baseLanguage.collections.structure.ForEachVariableReference" flags="nn" index="2GrUjf">
+        <reference id="1153944258490" name="variable" index="2Gs0qQ" />
       </concept>
     </language>
   </registry>
@@ -669,6 +773,403 @@
         </node>
       </node>
     </node>
+  </node>
+  <node concept="sE7Ow" id="7_uCKm_ijPf">
+    <property role="TrG5h" value="CopyEditorCellReference" />
+    <property role="2uzpH1" value="Copy Cell Reference" />
+    <property role="2YLI8m" value="6u2MFnph2yk/editorCommand" />
+    <node concept="tnohg" id="7_uCKm_ijPg" role="tncku">
+      <node concept="3clFbS" id="7_uCKm_ijPh" role="2VODD2">
+        <node concept="3cpWs8" id="7_uCKm_jm4c" role="3cqZAp">
+          <node concept="3cpWsn" id="7_uCKm_jm4f" role="3cpWs9">
+            <property role="TrG5h" value="cellRef" />
+            <node concept="3Tqbb2" id="7_uCKm_jm4a" role="1tU5fm">
+              <ref role="ehGHo" to="pvux:7_uCKm_gkEm" resolve="CellReference" />
+            </node>
+            <node concept="2pJPEk" id="7_uCKm_iEbn" role="33vP2m">
+              <node concept="2pJPED" id="7_uCKm_iEbp" role="2pJPEn">
+                <ref role="2pJxaS" to="pvux:7_uCKm_gkEm" resolve="CellReference" />
+                <node concept="2pJxcG" id="7_uCKm_iEU$" role="2pJxcM">
+                  <ref role="2pJxcJ" to="pvux:7_uCKm_h5oU" resolve="cellID" />
+                  <node concept="WxPPo" id="7_uCKm_iEWf" role="28ntcv">
+                    <node concept="2OqwBi" id="7_uCKm_iFoJ" role="WxPPp">
+                      <node concept="2OqwBi" id="7_uCKm_iEW9" role="2Oq$k0">
+                        <node concept="2WthIp" id="7_uCKm_iEWc" role="2Oq$k0" />
+                        <node concept="1DTwFV" id="7_uCKm_iEWe" role="2OqNvi">
+                          <ref role="2WH_rO" node="7_uCKm_ik60" resolve="cell" />
+                        </node>
+                      </node>
+                      <node concept="liA8E" id="7_uCKm_iFxA" role="2OqNvi">
+                        <ref role="37wK5l" to="f4zo:~EditorCell.getCellId()" resolve="getCellId" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="2pJxcG" id="7_uCKm_iFEA" role="2pJxcM">
+                  <ref role="2pJxcJ" to="pvux:7_uCKm_h4Ra" resolve="componentHashCode" />
+                  <node concept="WxPPo" id="7_uCKm_iGhZ" role="28ntcv">
+                    <node concept="2OqwBi" id="7_uCKm_iH0z" role="WxPPp">
+                      <node concept="2OqwBi" id="7_uCKm_iGhT" role="2Oq$k0">
+                        <node concept="2WthIp" id="7_uCKm_iGhW" role="2Oq$k0" />
+                        <node concept="1DTwFV" id="7_uCKm_iGhY" role="2OqNvi">
+                          <ref role="2WH_rO" node="7_uCKm_iG0$" resolve="component" />
+                        </node>
+                      </node>
+                      <node concept="liA8E" id="7_uCKm_iHNM" role="2OqNvi">
+                        <ref role="37wK5l" to="wyt6:~Object.hashCode()" resolve="hashCode" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="2pIpSj" id="7_uCKm_iHX6" role="2pJxcM">
+                  <ref role="2pIpSl" to="pvux:7_uCKm_hOEn" resolve="target" />
+                  <node concept="36biLy" id="7_uCKm_iLHy" role="28nt2d">
+                    <node concept="2OqwBi" id="7_uCKm_iLI_" role="36biLW">
+                      <node concept="2WthIp" id="7_uCKm_iLIC" role="2Oq$k0" />
+                      <node concept="1DTwFV" id="7_uCKm_iLIE" role="2OqNvi">
+                        <ref role="2WH_rO" node="7_uCKm_iIiS" resolve="node" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7_uCKm_lgbJ" role="3cqZAp">
+          <node concept="2YIFZM" id="7_uCKm_lhfs" role="3clFbG">
+            <ref role="37wK5l" to="dp1x:5tGs5KqKiJI" resolve="copyNodeToClipboard" />
+            <ref role="1Pybhc" to="dp1x:5tGs5KqKfGH" resolve="CopyPasteUtil" />
+            <node concept="37vLTw" id="7_uCKm_lhnD" role="37wK5m">
+              <ref role="3cqZAo" node="7_uCKm_jm4f" resolve="cellRef" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="7_uCKm_ir_J" role="3cqZAp">
+          <node concept="3cpWsn" id="7_uCKm_ir_K" role="3cpWs9">
+            <property role="TrG5h" value="ct" />
+            <node concept="3uibUv" id="7_uCKm_ir_L" role="1tU5fm">
+              <ref role="3uigEE" to="qgo0:1iC2RjkXjYJ" resolve="ConsoleTool" />
+            </node>
+            <node concept="2OqwBi" id="7_uCKm_issU" role="33vP2m">
+              <node concept="2OqwBi" id="7_uCKm_irCF" role="2Oq$k0">
+                <node concept="2WthIp" id="7_uCKm_irCI" role="2Oq$k0" />
+                <node concept="1DTwFV" id="7_uCKm_irCK" role="2OqNvi">
+                  <ref role="2WH_rO" node="7_uCKm_iqTJ" resolve="mpsProject" />
+                </node>
+              </node>
+              <node concept="liA8E" id="7_uCKm_it40" role="2OqNvi">
+                <ref role="37wK5l" to="z1c4:~MPSProject.getComponent(java.lang.Class)" resolve="getComponent" />
+                <node concept="3VsKOn" id="7_uCKm_it8D" role="37wK5m">
+                  <ref role="3VsUkX" to="qgo0:1iC2RjkXjYJ" resolve="ConsoleTool" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="7_uCKm_izgp" role="3cqZAp">
+          <node concept="3cpWsn" id="7_uCKm_izgq" role="3cpWs9">
+            <property role="TrG5h" value="currentTab" />
+            <node concept="3uibUv" id="7_uCKm_izfI" role="1tU5fm">
+              <ref role="3uigEE" to="qgo0:6ysF3v1jo8G" resolve="DialogConsoleTab" />
+            </node>
+            <node concept="2OqwBi" id="7_uCKm_izgr" role="33vP2m">
+              <node concept="37vLTw" id="7_uCKm_izgs" role="2Oq$k0">
+                <ref role="3cqZAo" node="7_uCKm_ir_K" resolve="ct" />
+              </node>
+              <node concept="liA8E" id="7_uCKm_izgt" role="2OqNvi">
+                <ref role="37wK5l" to="qgo0:5VzHAnbXFEZ" resolve="getCurrentEditableTab" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7_uCKm_liGn" role="3cqZAp">
+          <node concept="2OqwBi" id="7_uCKm_lk5L" role="3clFbG">
+            <node concept="37vLTw" id="7_uCKm_liGl" role="2Oq$k0">
+              <ref role="3cqZAo" node="7_uCKm_izgq" resolve="currentTab" />
+            </node>
+            <node concept="liA8E" id="7_uCKm_llWA" role="2OqNvi">
+              <ref role="37wK5l" to="qgo0:3ZgZ1njQR0n" resolve="activate" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1DS2jV" id="7_uCKm_iG0$" role="1NuT2Z">
+      <property role="TrG5h" value="component" />
+      <ref role="1DUlNI" to="k3nr:~MPSEditorDataKeys.EDITOR_COMPONENT" resolve="EDITOR_COMPONENT" />
+      <node concept="1oajcY" id="7_uCKm_iG0_" role="1oa70y" />
+    </node>
+    <node concept="1DS2jV" id="7_uCKm_ik60" role="1NuT2Z">
+      <property role="TrG5h" value="cell" />
+      <ref role="1DUlNI" to="k3nr:~MPSEditorDataKeys.EDITOR_CELL" resolve="EDITOR_CELL" />
+      <node concept="1oajcY" id="7_uCKm_ik61" role="1oa70y" />
+    </node>
+    <node concept="1DS2jV" id="7_uCKm_iqTJ" role="1NuT2Z">
+      <property role="TrG5h" value="mpsProject" />
+      <ref role="1DUlNI" to="qq03:~MPSCommonDataKeys.MPS_PROJECT" resolve="MPS_PROJECT" />
+      <node concept="1oajcY" id="7_uCKm_iqTK" role="1oa70y" />
+    </node>
+    <node concept="1DS2jV" id="7_uCKm_iIiS" role="1NuT2Z">
+      <property role="TrG5h" value="node" />
+      <ref role="1DUlNI" to="qq03:~MPSCommonDataKeys.NODE" resolve="NODE" />
+      <node concept="1oajcY" id="7_uCKm_iIiT" role="1oa70y" />
+    </node>
+  </node>
+  <node concept="tC5Ba" id="7_uCKm_j756">
+    <property role="TrG5h" value="EditorCellDebug" />
+    <node concept="tT9cl" id="2jM9X_IgWME" role="2f5YQi">
+      <ref role="tU$_T" to="tprs:1GlxrIveqTo" resolve="DebugActions" />
+      <ref role="2f8Tey" to="tprs:6f0maSpvUZm" resolve="editor" />
+    </node>
+    <node concept="ftmFs" id="7_uCKm_j75B" role="ftER_">
+      <node concept="tCFHf" id="7_uCKm_j75E" role="ftvYc">
+        <ref role="tCJdB" node="7_uCKm_ijPf" resolve="CopyEditorCellReference" />
+      </node>
+    </node>
+  </node>
+  <node concept="312cEu" id="7_uCKm_jZa0">
+    <property role="TrG5h" value="DebugHelper" />
+    <node concept="2YIFZL" id="7_uCKm_kbKO" role="jymVt">
+      <property role="TrG5h" value="getEditorComponent" />
+      <node concept="3clFbS" id="7_uCKm_kbKQ" role="3clF47">
+        <node concept="3cpWs8" id="7_uCKm_kbKR" role="3cqZAp">
+          <node concept="3cpWsn" id="7_uCKm_kbKS" role="3cpWs9">
+            <property role="TrG5h" value="ideaProject" />
+            <node concept="3uibUv" id="7_uCKm_kbKT" role="1tU5fm">
+              <ref role="3uigEE" to="4nm9:~Project" resolve="Project" />
+            </node>
+            <node concept="2YIFZM" id="7_uCKm_kbKU" role="33vP2m">
+              <ref role="37wK5l" to="alof:~ProjectHelper.toIdeaProject(jetbrains.mps.project.Project)" resolve="toIdeaProject" />
+              <ref role="1Pybhc" to="alof:~ProjectHelper" resolve="ProjectHelper" />
+              <node concept="37vLTw" id="7_uCKm_kbKV" role="37wK5m">
+                <ref role="3cqZAo" node="7_uCKm_kbLL" resolve="project" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="7_uCKm_kbKW" role="3cqZAp">
+          <node concept="3cpWsn" id="7_uCKm_kbKX" role="3cpWs9">
+            <property role="TrG5h" value="editors" />
+            <node concept="10Q1$e" id="7_uCKm_kbKY" role="1tU5fm">
+              <node concept="3uibUv" id="7_uCKm_kbKZ" role="10Q1$1">
+                <ref role="3uigEE" to="iwsx:~FileEditor" resolve="FileEditor" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="7_uCKm_kbL0" role="33vP2m">
+              <node concept="2YIFZM" id="7_uCKm_kbL1" role="2Oq$k0">
+                <ref role="37wK5l" to="iwsx:~FileEditorManager.getInstance(com.intellij.openapi.project.Project)" resolve="getInstance" />
+                <ref role="1Pybhc" to="iwsx:~FileEditorManager" resolve="FileEditorManager" />
+                <node concept="37vLTw" id="7_uCKm_kbL2" role="37wK5m">
+                  <ref role="3cqZAo" node="7_uCKm_kbKS" resolve="ideaProject" />
+                </node>
+              </node>
+              <node concept="liA8E" id="7_uCKm_kbL3" role="2OqNvi">
+                <ref role="37wK5l" to="iwsx:~FileEditorManager.getAllEditors()" resolve="getAllEditors" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2Gpval" id="7_uCKm_kbL4" role="3cqZAp">
+          <node concept="2GrKxI" id="7_uCKm_kbL5" role="2Gsz3X">
+            <property role="TrG5h" value="editor" />
+          </node>
+          <node concept="37vLTw" id="7_uCKm_kbL6" role="2GsD0m">
+            <ref role="3cqZAo" node="7_uCKm_kbKX" resolve="editors" />
+          </node>
+          <node concept="3clFbS" id="7_uCKm_kbL7" role="2LFqv$">
+            <node concept="3clFbJ" id="7_uCKm_kbL8" role="3cqZAp">
+              <node concept="2ZW3vV" id="7_uCKm_kbL9" role="3clFbw">
+                <node concept="3uibUv" id="7_uCKm_kbLa" role="2ZW6by">
+                  <ref role="3uigEE" to="k3nr:~MPSFileNodeEditor" resolve="MPSFileNodeEditor" />
+                </node>
+                <node concept="2GrUjf" id="7_uCKm_kbLb" role="2ZW6bz">
+                  <ref role="2Gs0qQ" node="7_uCKm_kbL5" resolve="editor" />
+                </node>
+              </node>
+              <node concept="3clFbS" id="7_uCKm_kbLc" role="3clFbx">
+                <node concept="3cpWs8" id="7_uCKm_kbLd" role="3cqZAp">
+                  <node concept="3cpWsn" id="7_uCKm_kbLe" role="3cpWs9">
+                    <property role="TrG5h" value="mpsEditor" />
+                    <node concept="3uibUv" id="7_uCKm_kbLf" role="1tU5fm">
+                      <ref role="3uigEE" to="k3nr:~MPSFileNodeEditor" resolve="MPSFileNodeEditor" />
+                    </node>
+                    <node concept="1eOMI4" id="7_uCKm_kbLg" role="33vP2m">
+                      <node concept="10QFUN" id="7_uCKm_kbLh" role="1eOMHV">
+                        <node concept="3uibUv" id="7_uCKm_kbLi" role="10QFUM">
+                          <ref role="3uigEE" to="k3nr:~MPSFileNodeEditor" resolve="MPSFileNodeEditor" />
+                        </node>
+                        <node concept="2GrUjf" id="7_uCKm_kbLj" role="10QFUP">
+                          <ref role="2Gs0qQ" node="7_uCKm_kbL5" resolve="editor" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3cpWs8" id="7_uCKm_kbLk" role="3cqZAp">
+                  <node concept="3cpWsn" id="7_uCKm_kbLl" role="3cpWs9">
+                    <property role="TrG5h" value="nodeEditor" />
+                    <node concept="3uibUv" id="7_uCKm_kbLm" role="1tU5fm">
+                      <ref role="3uigEE" to="cj4x:~Editor" resolve="Editor" />
+                    </node>
+                    <node concept="2OqwBi" id="7_uCKm_kbLn" role="33vP2m">
+                      <node concept="37vLTw" id="7_uCKm_kbLo" role="2Oq$k0">
+                        <ref role="3cqZAo" node="7_uCKm_kbLe" resolve="mpsEditor" />
+                      </node>
+                      <node concept="liA8E" id="7_uCKm_kbLp" role="2OqNvi">
+                        <ref role="37wK5l" to="k3nr:~MPSFileNodeEditor.getNodeEditor()" resolve="getNodeEditor" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbJ" id="7_uCKm_kbLq" role="3cqZAp">
+                  <node concept="3clFbS" id="7_uCKm_kbLr" role="3clFbx">
+                    <node concept="3cpWs8" id="7_uCKm_kbLs" role="3cqZAp">
+                      <node concept="3cpWsn" id="7_uCKm_kbLt" role="3cpWs9">
+                        <property role="TrG5h" value="currentEditorComponent" />
+                        <node concept="3uibUv" id="7_uCKm_kbLu" role="1tU5fm">
+                          <ref role="3uigEE" to="cj4x:~EditorComponent" resolve="EditorComponent" />
+                        </node>
+                        <node concept="2OqwBi" id="7_uCKm_kbLv" role="33vP2m">
+                          <node concept="37vLTw" id="7_uCKm_kbLw" role="2Oq$k0">
+                            <ref role="3cqZAo" node="7_uCKm_kbLl" resolve="nodeEditor" />
+                          </node>
+                          <node concept="liA8E" id="7_uCKm_kbLx" role="2OqNvi">
+                            <ref role="37wK5l" to="cj4x:~Editor.getCurrentEditorComponent()" resolve="getCurrentEditorComponent" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbJ" id="7_uCKm_kbLy" role="3cqZAp">
+                      <node concept="3clFbS" id="7_uCKm_kbLz" role="3clFbx">
+                        <node concept="3cpWs6" id="7_uCKm_kbL$" role="3cqZAp">
+                          <node concept="37vLTw" id="7_uCKm_kbL_" role="3cqZAk">
+                            <ref role="3cqZAo" node="7_uCKm_kbLt" resolve="currentEditorComponent" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbC" id="7_uCKm_kbLA" role="3clFbw">
+                        <node concept="37vLTw" id="7_uCKm_kbLB" role="3uHU7w">
+                          <ref role="3cqZAo" node="7_uCKm_kbLN" resolve="hashCode" />
+                        </node>
+                        <node concept="2OqwBi" id="7_uCKm_kbLC" role="3uHU7B">
+                          <node concept="37vLTw" id="7_uCKm_kbLD" role="2Oq$k0">
+                            <ref role="3cqZAo" node="7_uCKm_kbLt" resolve="currentEditorComponent" />
+                          </node>
+                          <node concept="liA8E" id="7_uCKm_kbLE" role="2OqNvi">
+                            <ref role="37wK5l" to="wyt6:~Object.hashCode()" resolve="hashCode" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3y3z36" id="7_uCKm_kbLF" role="3clFbw">
+                    <node concept="10Nm6u" id="7_uCKm_kbLG" role="3uHU7w" />
+                    <node concept="37vLTw" id="7_uCKm_kbLH" role="3uHU7B">
+                      <ref role="3cqZAo" node="7_uCKm_kbLl" resolve="nodeEditor" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="7_uCKm_kbLI" role="3cqZAp">
+          <node concept="10Nm6u" id="7_uCKm_kbLJ" role="3cqZAk" />
+        </node>
+      </node>
+      <node concept="3uibUv" id="7_uCKm_kbLK" role="3clF45">
+        <ref role="3uigEE" to="cj4x:~EditorComponent" resolve="EditorComponent" />
+      </node>
+      <node concept="37vLTG" id="7_uCKm_kbLL" role="3clF46">
+        <property role="TrG5h" value="project" />
+        <node concept="3uibUv" id="7_uCKm_kbLM" role="1tU5fm">
+          <ref role="3uigEE" to="z1c3:~Project" resolve="Project" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="7_uCKm_kbLN" role="3clF46">
+        <property role="TrG5h" value="hashCode" />
+        <node concept="10Oyi0" id="7_uCKm_kbLO" role="1tU5fm" />
+      </node>
+      <node concept="3Tm1VV" id="7_uCKm_kbLP" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="7_uCKm_kcmC" role="jymVt" />
+    <node concept="2YIFZL" id="7_uCKm_kbYu" role="jymVt">
+      <property role="TrG5h" value="getEditorCell" />
+      <node concept="3clFbS" id="7_uCKm_kbYw" role="3clF47">
+        <node concept="3cpWs8" id="7_uCKm_kbYx" role="3cqZAp">
+          <node concept="3cpWsn" id="7_uCKm_kbYy" role="3cpWs9">
+            <property role="TrG5h" value="editorComponent" />
+            <node concept="3uibUv" id="7_uCKm_kbYz" role="1tU5fm">
+              <ref role="3uigEE" to="cj4x:~EditorComponent" resolve="EditorComponent" />
+            </node>
+            <node concept="1rXfSq" id="7_uCKm_kbY$" role="33vP2m">
+              <ref role="37wK5l" node="7_uCKm_kbKO" resolve="getEditorComponent" />
+              <node concept="37vLTw" id="7_uCKm_kbY_" role="37wK5m">
+                <ref role="3cqZAo" node="7_uCKm_kbYL" resolve="project" />
+              </node>
+              <node concept="37vLTw" id="7_uCKm_kcU_" role="37wK5m">
+                <ref role="3cqZAo" node="7_uCKm_kcyG" resolve="hashCode" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="7_uCKm_mgEk" role="3cqZAp">
+          <node concept="3clFbS" id="7_uCKm_mgEm" role="3clFbx">
+            <node concept="3cpWs6" id="7_uCKm_mhAl" role="3cqZAp">
+              <node concept="10Nm6u" id="7_uCKm_mhJv" role="3cqZAk" />
+            </node>
+          </node>
+          <node concept="3clFbC" id="7_uCKm_mgTg" role="3clFbw">
+            <node concept="10Nm6u" id="7_uCKm_mh0f" role="3uHU7w" />
+            <node concept="37vLTw" id="7_uCKm_mgIA" role="3uHU7B">
+              <ref role="3cqZAo" node="7_uCKm_kbYy" resolve="editorComponent" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7_uCKm_mhLK" role="3cqZAp" />
+        <node concept="3clFbF" id="7_uCKm_kbYA" role="3cqZAp">
+          <node concept="2OqwBi" id="7_uCKm_kbYB" role="3clFbG">
+            <node concept="37vLTw" id="7_uCKm_kbYC" role="2Oq$k0">
+              <ref role="3cqZAo" node="7_uCKm_kbYy" resolve="editorComponent" />
+            </node>
+            <node concept="liA8E" id="7_uCKm_kbYD" role="2OqNvi">
+              <ref role="37wK5l" to="cj4x:~EditorComponent.findCellWithId(org.jetbrains.mps.openapi.model.SNode,java.lang.String)" resolve="findCellWithId" />
+              <node concept="37vLTw" id="7_uCKm_kd9W" role="37wK5m">
+                <ref role="3cqZAo" node="7_uCKm_kbYN" resolve="target" />
+              </node>
+              <node concept="37vLTw" id="7_uCKm_kdqE" role="37wK5m">
+                <ref role="3cqZAo" node="7_uCKm_kbYP" resolve="cellID" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3uibUv" id="7_uCKm_kbYK" role="3clF45">
+        <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+      </node>
+      <node concept="37vLTG" id="7_uCKm_kbYL" role="3clF46">
+        <property role="TrG5h" value="project" />
+        <node concept="3uibUv" id="7_uCKm_kbYM" role="1tU5fm">
+          <ref role="3uigEE" to="z1c3:~Project" resolve="Project" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="7_uCKm_kbYN" role="3clF46">
+        <property role="TrG5h" value="target" />
+        <node concept="3Tqbb2" id="7_uCKm_kbYO" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="7_uCKm_kbYP" role="3clF46">
+        <property role="TrG5h" value="cellID" />
+        <node concept="17QB3L" id="7_uCKm_kbYQ" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="7_uCKm_kcyG" role="3clF46">
+        <property role="TrG5h" value="componentHashCode" />
+        <node concept="10Oyi0" id="7_uCKm_kcO2" role="1tU5fm" />
+      </node>
+      <node concept="3Tm1VV" id="7_uCKm_kbYR" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="7_uCKm_k0Fi" role="jymVt" />
+    <node concept="3Tm1VV" id="7_uCKm_jZa1" role="1B3o_S" />
   </node>
 </model>
 


### PR DESCRIPTION
- A new action `Copy Cell Reference` is available in the editor menu in `Language Debug` that creates a reference to the current select editor cell. It can be pasted into the MPS console to debug editor cells. It can be activated through ctrl/cmd+alt+c.
- A new action `Copy Editor Component Reference` is available in the editor menu in `Language Debug` that creates a reference to the current editor component. It can be pasted into the MPS console to debug editor cells. To refer to the currently opened editor component, use the expression `#currentEditorComponent` in the MPS console.

Remark: The references stop working when the corresponding editor is closed or reopened because they use the hashcode of the editor component.

Examples:

```java
#currentEditorComponent.scrollToCell(cellRef@102119)

#print editorComponentRef@52770.getDeepestSelectedCell()

#currentEditorComponent.getSelectedNode().delete()

cellRef@102119 as EditorCell_Property.synchronizeViewWithModel()

cellRef@102119 as EditorCell_Property.getStyle().set(StyleAttributes.BACKGROUND_COLOR, Color.LIGHT_GRAY)
```