### PR TITLE
bugfix/avoid unnecessary layouting of subdiagrams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The project does _not_ follow Semantic Versioning and the changes are documented
 
 ## Feburary 2024
 
+- de.itemis.mps.editor.diagram: Avoid unnecessary layouting of sub-diagrams
 - de.itemis.mps.editor.diagram: A layouting bug related to ports was fixed.
 
 ## January 2024


### PR DESCRIPTION
During model2graph, imbricated diagrams are layouted again and again - this leads to big performance problems of diagrams with several sub-diagrams (e.g. component architectures where the internal structure of top-components are displayed). 

This fix performs only one layouting of the subdiagrams as part of the layout of the top-diagram.