### PR TITLE
com.mbeddr.mpsutil.editor.querylist: Add support for dynamic content in querylists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project are documented in this file.
 Format of the log is _loosely_ based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). 
 The project does _not_ follow Semantic Versioning and the changes are documented in reverse chronological order, grouped by calendar month.
 
+## Feburary 2024
+
+### Changed
+
+- com.mbeddr.mpsutil.editor.querylist: Dynamic generated nodes (without a model) can now be used in query lists if `read-only` is set to true.
+
 ## January 2024
 
 ### Fixed

--- a/code/diagram/languages/de.itemis.mps.editor.diagram/generator/template/main@generator.mps
+++ b/code/diagram/languages/de.itemis.mps.editor.diagram/generator/template/main@generator.mps
@@ -15292,7 +15292,7 @@
           </node>
         </node>
         <node concept="2AHcQZ" id="7EPprGLkpaN" role="2AJF6D">
-          <ref role="2AI5Lk" to="wyt6:~Override" />
+          <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
         </node>
         <node concept="raruj" id="7EPprGLktkj" role="lGtFl" />
         <node concept="1W57fq" id="7EPprGLktkl" role="lGtFl">

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells.sandboxlang/models/com/mbeddr/mpsutil/grammarcells/sandboxlang/structure.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells.sandboxlang/models/com/mbeddr/mpsutil/grammarcells/sandboxlang/structure.mps
@@ -841,7 +841,7 @@
     <property role="34LRSv" value="DemoOptionalCellsCapability" />
     <property role="R4oN_" value="A demo concept to show off the capabilities of the optional cell" />
     <property role="3GE5qa" value="CapabilitiesDemo" />
-    <ref role="1TJDcQ" to="tpck:gw2VY9q" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
     <node concept="1TJgyi" id="67iSu2wewjc" role="1TKVEl">
       <property role="IQ2nx" value="7048944721665328332" />
       <property role="TrG5h" value="property1" />
@@ -879,7 +879,7 @@
     <property role="TrG5h" value="StmtContainerParent" />
     <property role="19KtqR" value="true" />
     <property role="3GE5qa" value="grammarWrapTest" />
-    <ref role="1TJDcQ" to="tpck:gw2VY9q" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
     <node concept="1TJgyj" id="3Lzx5Pf0jnO" role="1TKVEi">
       <property role="IQ2ns" value="4351467201262335476" />
       <property role="20lmBu" value="fLJjDmT/aggregation" />
@@ -894,7 +894,7 @@
     <property role="TrG5h" value="DemoRoot" />
     <property role="34LRSv" value="DemoRoot" />
     <property role="19KtqR" value="true" />
-    <ref role="1TJDcQ" to="tpck:gw2VY9q" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
     <node concept="1TJgyj" id="67iSu2w1UsD" role="1TKVEi">
       <property role="IQ2ns" value="7048944721662027561" />
       <property role="20lmBu" value="fLJjDmT/aggregation" />
@@ -942,7 +942,7 @@
     <property role="3GE5qa" value="grammarWrapTest" />
     <property role="TrG5h" value="StmtContainerParentWhitelisting" />
     <property role="19KtqR" value="true" />
-    <ref role="1TJDcQ" to="tpck:gw2VY9q" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
     <node concept="1TJgyj" id="1045PmWki1E" role="1TKVEi">
       <property role="IQ2ns" value="1154073061512781930" />
       <property role="20lmBu" value="fLJjDmT/aggregation" />
@@ -971,7 +971,7 @@
     <property role="3GE5qa" value="grammarWrapTest" />
     <property role="TrG5h" value="WrapStmtParent" />
     <property role="34LRSv" value="wrapStmt" />
-    <ref role="1TJDcQ" to="tpck:gw2VY9q" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
     <node concept="1TJgyj" id="3Lzx5Pf0kj2" role="1TKVEi">
       <property role="IQ2ns" value="4351467201262339266" />
       <property role="20lmBu" value="fLJjDmT/aggregation" />
@@ -995,7 +995,7 @@
     <property role="3GE5qa" value="grammarWrapTest" />
     <property role="TrG5h" value="WrapStmtParentWhitelisting" />
     <property role="34LRSv" value="wrapStmt" />
-    <ref role="1TJDcQ" to="tpck:gw2VY9q" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
     <node concept="1TJgyj" id="1045PmWkiyF" role="1TKVEi">
       <property role="IQ2ns" value="1154073061512784043" />
       <property role="20lmBu" value="fLJjDmT/aggregation" />
@@ -1012,7 +1012,7 @@
     <property role="3GE5qa" value="grammarWrapTest" />
     <property role="TrG5h" value="StmtContainerAncestorWhitelisting" />
     <property role="19KtqR" value="true" />
-    <ref role="1TJDcQ" to="tpck:gw2VY9q" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
     <node concept="1TJgyj" id="6sxj0_UzcGb" role="1TKVEi">
       <property role="IQ2ns" value="7431304463732493067" />
       <property role="20lmBu" value="fLJjDmT/aggregation" />
@@ -1026,7 +1026,7 @@
     <property role="3GE5qa" value="grammarWrapTest" />
     <property role="TrG5h" value="WrapStmtAncestorWhitelisting" />
     <property role="34LRSv" value="wrapStmt" />
-    <ref role="1TJDcQ" to="tpck:gw2VY9q" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
     <node concept="PrWs8" id="6sxj0_Uzble" role="PzmwI">
       <ref role="PrY4T" to="tpck:h0TrEE$" resolve="INamedConcept" />
     </node>
@@ -1043,7 +1043,7 @@
     <property role="3GE5qa" value="grammarWrapTest" />
     <property role="TrG5h" value="WrapType" />
     <property role="R5$K7" value="true" />
-    <ref role="1TJDcQ" to="tpck:gw2VY9q" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
   </node>
   <node concept="1TIwiD" id="3aFJVZlqur9">
     <property role="EcuMT" value="3651222753554065097" />

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/generator/template/main@generator.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/generator/template/main@generator.mps
@@ -544,14 +544,14 @@
       </concept>
     </language>
     <language id="9d69e719-78c8-4286-90db-fb19c107d049" name="com.mbeddr.mpsutil.grammarcells">
-      <concept id="7272510943426055326" name="com.mbeddr.mpsutil.grammarcells.structure.SideTransformationCell_Factory" flags="ng" index="2kS2EP" />
+      <concept id="7272510943426055326" name="com.mbeddr.mpsutil.grammarcells.structure.SideTransformationCell_Factory" flags="ig" index="2kS2EP" />
       <concept id="7272510943426093121" name="com.mbeddr.mpsutil.grammarcells.structure.Parameter_SideTransformActionsBuilderContext" flags="ng" index="2kS8pE" />
       <concept id="7272510943425988699" name="com.mbeddr.mpsutil.grammarcells.structure.SideTransformationCell" flags="ng" index="2kSiTK">
         <property id="7272510943425988883" name="side" index="2kSiWS" />
         <child id="7272510943426097631" name="factory" index="2kS9vO" />
         <child id="7272510943425989076" name="wrapped" index="2kSiZZ" />
       </concept>
-      <concept id="7272510943426635554" name="com.mbeddr.mpsutil.grammarcells.structure.NodeSubstituteCell_Factory" flags="ng" index="2kYc49" />
+      <concept id="7272510943426635554" name="com.mbeddr.mpsutil.grammarcells.structure.NodeSubstituteCell_Factory" flags="ig" index="2kYc49" />
       <concept id="7272510943426635523" name="com.mbeddr.mpsutil.grammarcells.structure.NodeSubstituteCell" flags="ng" index="2kYc4C">
         <child id="7272510943426635586" name="factory" index="2kYc5D" />
         <child id="7272510943426635585" name="wrapped" index="2kYc5E" />
@@ -567,11 +567,11 @@
         <property id="745148820908747612" name="description" index="2thAuV" />
         <child id="745148820874363426" name="section" index="2vkWV5" />
       </concept>
-      <concept id="9041925471455857605" name="com.mbeddr.mpsutil.grammarcells.structure.Cell_DescriptionText" flags="ng" index="uPpia" />
+      <concept id="9041925471455857605" name="com.mbeddr.mpsutil.grammarcells.structure.Cell_DescriptionText" flags="ig" index="uPpia" />
       <concept id="745148820879066261" name="com.mbeddr.mpsutil.grammarcells.structure.TransformationLocation_SideTransformationCell" flags="ng" index="2v6KxM" />
       <concept id="1997572252229165641" name="com.mbeddr.mpsutil.grammarcells.structure.TransformationLocation_Before" flags="ng" index="wWMWC" />
       <concept id="1997572252229165700" name="com.mbeddr.mpsutil.grammarcells.structure.TransformationLocation_After" flags="ng" index="wWMZ_" />
-      <concept id="7416540197334827155" name="com.mbeddr.mpsutil.grammarcells.structure.LowLevelMenuPart_Function" flags="ng" index="2Mo9yg" />
+      <concept id="7416540197334827155" name="com.mbeddr.mpsutil.grammarcells.structure.LowLevelMenuPart_Function" flags="ig" index="2Mo9yg" />
       <concept id="7416540197334827182" name="com.mbeddr.mpsutil.grammarcells.structure.LowLevelMenuPart_parameter" flags="ng" index="2Mo9yH" />
       <concept id="7416540197333137586" name="com.mbeddr.mpsutil.grammarcells.structure.GenericMenuPart" flags="ng" index="2MBE2L">
         <child id="7416540197335105457" name="implementation" index="2MvauM" />
@@ -583,8 +583,8 @@
         <child id="6856661361479798753" name="execute" index="130oVf" />
         <child id="6856661361479798749" name="canExecute" index="130oVN" />
       </concept>
-      <concept id="6856661361479784541" name="com.mbeddr.mpsutil.grammarcells.structure.InlineActionMapItem_CanExecuteFunction" flags="ng" index="130t_N" />
-      <concept id="6856661361479784534" name="com.mbeddr.mpsutil.grammarcells.structure.InlineActionMapItem_ExecuteFunction" flags="ng" index="130t_S" />
+      <concept id="6856661361479784541" name="com.mbeddr.mpsutil.grammarcells.structure.InlineActionMapItem_CanExecuteFunction" flags="ig" index="130t_N" />
+      <concept id="6856661361479784534" name="com.mbeddr.mpsutil.grammarcells.structure.InlineActionMapItem_ExecuteFunction" flags="ig" index="130t_S" />
       <concept id="6856661361479732075" name="com.mbeddr.mpsutil.grammarcells.structure.InlineActionMapCell" flags="ng" index="130CD5">
         <child id="6856661361479798957" name="actions" index="130p63" />
         <child id="6856661361479732085" name="cell" index="130CDr" />
@@ -592,18 +592,18 @@
       <concept id="848437706375087728" name="com.mbeddr.mpsutil.grammarcells.structure.ICanHaveDescriptionText" flags="ng" index="1djCvD">
         <child id="848437706375087729" name="descriptionText" index="1djCvC" />
       </concept>
-      <concept id="4874944647490522665" name="com.mbeddr.mpsutil.grammarcells.structure.SideTransformationCell2_IsApplicable" flags="ng" index="1eYwpX" />
-      <concept id="4874944647490524676" name="com.mbeddr.mpsutil.grammarcells.structure.SideTransformationCell2_Execute" flags="ng" index="1eYxTg" />
+      <concept id="4874944647490522665" name="com.mbeddr.mpsutil.grammarcells.structure.SideTransformationCell2_IsApplicable" flags="ig" index="1eYwpX" />
+      <concept id="4874944647490524676" name="com.mbeddr.mpsutil.grammarcells.structure.SideTransformationCell2_Execute" flags="ig" index="1eYxTg" />
       <concept id="4874944647490471126" name="com.mbeddr.mpsutil.grammarcells.structure.SideTransformationCell2" flags="ng" index="1eYWM2">
         <child id="4874944647490523335" name="matchingText" index="1eYxyj" />
         <child id="4874944647490523330" name="isApplicable" index="1eYxym" />
         <child id="4874944647490524677" name="execute" index="1eYxTh" />
       </concept>
-      <concept id="4874944647490471525" name="com.mbeddr.mpsutil.grammarcells.structure.SideTransformationCell2_MatchingText" flags="ng" index="1eYWSL" />
+      <concept id="4874944647490471525" name="com.mbeddr.mpsutil.grammarcells.structure.SideTransformationCell2_MatchingText" flags="ig" index="1eYWSL" />
     </language>
     <language id="52733268-be24-4f5f-ab84-a73b7c0c03b0" name="de.slisson.mps.richtext.customcell">
-      <concept id="1161622981231" name="de.slisson.mps.richtext.customcell.structure.ConceptFunctionParameter_cell" flags="ng" index="1Q80Hy" />
-      <concept id="1176749715029" name="de.slisson.mps.richtext.customcell.structure.QueryFunction_Cell" flags="ng" index="3VJUX4" />
+      <concept id="1161622981231" name="de.slisson.mps.richtext.customcell.structure.ConceptFunctionParameter_cell" flags="nn" index="1Q80Hy" />
+      <concept id="1176749715029" name="de.slisson.mps.richtext.customcell.structure.QueryFunction_Cell" flags="in" index="3VJUX4" />
       <concept id="2490242408670732052" name="de.slisson.mps.richtext.customcell.structure.CellModel_CustomFactory" flags="ng" index="3ZSo5i">
         <child id="1073389446424" name="childCellModel" index="3EZMny" />
         <child id="2490242408670937967" name="factoryMethod" index="3ZZHOD" />

--- a/code/grammarcells/solutions/com.mbeddr.mpsutil.grammarcells.runtime/models/com/mbeddr/mpsutil/grammarcells/runtime.mps
+++ b/code/grammarcells/solutions/com.mbeddr.mpsutil.grammarcells.runtime/models/com/mbeddr/mpsutil/grammarcells/runtime.mps
@@ -3044,7 +3044,7 @@
                 <ref role="37wK5l" to="i8bi:Det6sRbgD5" resolve="asInstanceConcept" />
                 <ref role="1Pybhc" to="i8bi:5IkW5anFcyt" resolve="SNodeOperations" />
                 <node concept="37vLTw" id="4_3mV3JSKOq" role="37wK5m">
-                  <ref role="3cqZAo" node="4_3mV3JAVzT" resolve="childConcept" />
+                  <ref role="3cqZAo" node="4_3mV3JAVzT" resolve="parentConcept" />
                 </node>
               </node>
             </node>
@@ -3099,7 +3099,7 @@
                     <node concept="2OqwBi" id="6ogDZtA2c7K" role="2Oq$k0">
                       <node concept="2ShNRf" id="6ogDZtA2c7L" role="2Oq$k0">
                         <node concept="1pGfFk" id="6ogDZtA2c7M" role="2ShVmc">
-                          <ref role="37wK5l" to="pdwk:~ContainmentContext$Builder.&lt;init&gt;()" resolve="Builder" />
+                          <ref role="37wK5l" to="pdwk:~ContainmentContext$Builder.&lt;init&gt;()" resolve="ContainmentContext.Builder" />
                         </node>
                       </node>
                       <node concept="liA8E" id="6ogDZtA2c7N" role="2OqNvi">
@@ -3126,7 +3126,7 @@
                 <node concept="liA8E" id="6ogDZtA2c7V" role="2OqNvi">
                   <ref role="37wK5l" to="pdwk:~ContainmentContext$Builder.link(org.jetbrains.mps.openapi.language.SContainmentLink)" resolve="link" />
                   <node concept="37vLTw" id="6ogDZtA2c7W" role="37wK5m">
-                    <ref role="3cqZAo" node="6ogDZt_iRYF" resolve="dummyLink" />
+                    <ref role="3cqZAo" node="6ogDZt_iRYF" resolve="conceptLink" />
                   </node>
                 </node>
               </node>
@@ -3185,7 +3185,7 @@
                 <ref role="3cqZAo" node="4_3mV3K5MCz" resolve="dummyChild" />
               </node>
               <node concept="37vLTw" id="6ogDZt_UyxB" role="37wK5m">
-                <ref role="3cqZAo" node="6ogDZt_iRYF" resolve="dummyLink" />
+                <ref role="3cqZAo" node="6ogDZt_iRYF" resolve="conceptLink" />
               </node>
             </node>
           </node>
@@ -3274,7 +3274,7 @@
                             <node concept="2OqwBi" id="1iGw5Cbiv4k" role="2Oq$k0">
                               <node concept="2ShNRf" id="1iGw5Cbiv4l" role="2Oq$k0">
                                 <node concept="1pGfFk" id="1iGw5Cbiv4m" role="2ShVmc">
-                                  <ref role="37wK5l" to="pdwk:~CanBeAncestorContext$Builder.&lt;init&gt;()" resolve="Builder" />
+                                  <ref role="37wK5l" to="pdwk:~CanBeAncestorContext$Builder.&lt;init&gt;()" resolve="CanBeAncestorContext.Builder" />
                                 </node>
                               </node>
                               <node concept="liA8E" id="1iGw5Cbiv4n" role="2OqNvi">
@@ -3411,7 +3411,7 @@
                               <node concept="2OqwBi" id="3Lzx5PeGbia" role="2Oq$k0">
                                 <node concept="2ShNRf" id="3Lzx5PeGbib" role="2Oq$k0">
                                   <node concept="1pGfFk" id="3Lzx5PeGbic" role="2ShVmc">
-                                    <ref role="37wK5l" to="pdwk:~CanBeAncestorContext$Builder.&lt;init&gt;()" resolve="Builder" />
+                                    <ref role="37wK5l" to="pdwk:~CanBeAncestorContext$Builder.&lt;init&gt;()" resolve="CanBeAncestorContext.Builder" />
                                   </node>
                                 </node>
                                 <node concept="liA8E" id="3Lzx5PeGbid" role="2OqNvi">

--- a/code/grammarcells/solutions/com.mbeddr.mpsutil.grammarcells.tests/models/com/mbeddr/mpsutil/grammarcells/tests@tests.mps
+++ b/code/grammarcells/solutions/com.mbeddr.mpsutil.grammarcells.tests/models/com/mbeddr/mpsutil/grammarcells/tests@tests.mps
@@ -3417,7 +3417,7 @@
                       <ref role="37wK5l" to="wyt6:~String.equals(java.lang.Object)" resolve="equals" />
                       <node concept="2OqwBi" id="3Lzx5Pfuvu1" role="37wK5m">
                         <node concept="35c_gC" id="3Lzx5Pfu9Gc" role="2Oq$k0">
-                          <ref role="35c_gD" to="ibwz:3Lzx5Pf0jk5" resolve="WrapStmt" />
+                          <ref role="35c_gD" to="ibwz:3Lzx5Pf0jk5" resolve="WrapStmtParent" />
                         </node>
                         <node concept="liA8E" id="3Lzx5Pfwuva" role="2OqNvi">
                           <ref role="37wK5l" to="c17a:~SAbstractConcept.getConceptAlias()" resolve="getConceptAlias" />

--- a/code/intentionsmenu/com.mbeddr.mpsutil.intentions.runtime/models/com/mbeddr/mpsutil/intentions/runtime.mps
+++ b/code/intentionsmenu/com.mbeddr.mpsutil.intentions.runtime/models/com/mbeddr/mpsutil/intentions/runtime.mps
@@ -4472,7 +4472,7 @@
         </node>
       </node>
       <node concept="1Z6Ecs" id="2iZPrFZnMN8" role="33vP2m">
-        <ref role="1Z6EpT" to="zddv:5qf1oe_$9mw" resolve="intentionsInReadOnlyCell" />
+        <ref role="1Z6EpT" to="zddv:5qf1oe_$9mw" resolve="intentions-in-read-only-cell" />
       </node>
     </node>
     <node concept="2tJIrI" id="5qf1oe_$8xF" role="jymVt" />
@@ -4516,7 +4516,7 @@
               <node concept="10Nm6u" id="5qf1oe_zNwG" role="3uHU7w" />
             </node>
             <node concept="1rXfSq" id="5qf1oe_zZ7k" role="3uHU7w">
-              <ref role="37wK5l" node="5qf1oe_zXNE" resolve="isCellsReadOnlyInEditor" />
+              <ref role="37wK5l" node="5qf1oe_zXNE" resolve="allowIntentionsInReadOnlyCells" />
               <node concept="37vLTw" id="5qf1oe_$h66" role="37wK5m">
                 <ref role="3cqZAo" node="5qf1oe_zNwt" resolve="editorComponent" />
               </node>
@@ -4574,7 +4574,7 @@
                   <node concept="10Nm6u" id="5qf1oe_zXO1" role="3uHU7w" />
                 </node>
                 <node concept="1rXfSq" id="5qf1oe_zXO2" role="3uHU7w">
-                  <ref role="37wK5l" node="5qf1oe_zyw2" resolve="isCellReadOnly" />
+                  <ref role="37wK5l" node="5qf1oe_zyw2" resolve="isAllowIntentionsInReadOnlyCell" />
                   <node concept="37vLTw" id="5qf1oe_zXO3" role="37wK5m">
                     <ref role="3cqZAo" node="5qf1oe_zXNU" resolve="cell" />
                   </node>
@@ -4607,7 +4607,7 @@
           <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
         </node>
         <node concept="3uibUv" id="5qf1oe_zyw5" role="1tU5fm">
-          <ref role="3uigEE" to="f4zo:~EditorCell" resolve="jetbrains.mps.openapi.editor.cells.EditorCell" />
+          <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
         </node>
       </node>
       <node concept="3clFbS" id="5qf1oe_zyw6" role="3clF47">

--- a/code/languages/com.mbeddr.mpsutil.intentions.sandboxlang/models/com.mbeddr.mpsutil.intentions.sandboxlang.structure.mps
+++ b/code/languages/com.mbeddr.mpsutil.intentions.sandboxlang/models/com.mbeddr.mpsutil.intentions.sandboxlang.structure.mps
@@ -49,7 +49,7 @@
     <property role="EcuMT" value="6237210071910106918" />
     <property role="TrG5h" value="Root" />
     <property role="19KtqR" value="true" />
-    <ref role="1TJDcQ" to="tpck:gw2VY9q" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
     <node concept="1TJgyj" id="5qf1oe_GcsC" role="1TKVEi">
       <property role="IQ2ns" value="6237210071910106920" />
       <property role="20lmBu" value="fLJjDmT/aggregation" />
@@ -64,7 +64,7 @@
   <node concept="1TIwiD" id="5qf1oe_GcsB">
     <property role="EcuMT" value="6237210071910106919" />
     <property role="TrG5h" value="ReadOnlyChild" />
-    <ref role="1TJDcQ" to="tpck:gw2VY9q" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
     <node concept="PrWs8" id="5qf1oe_GcsG" role="PzmwI">
       <ref role="PrY4T" node="5qf1oe_GcsF" resolve="IChild" />
     </node>
@@ -84,7 +84,7 @@
   <node concept="1TIwiD" id="5qf1oe_GdOj">
     <property role="EcuMT" value="6237210071910112531" />
     <property role="TrG5h" value="ReadOnlyChildAllowed" />
-    <ref role="1TJDcQ" to="tpck:gw2VY9q" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
     <node concept="PrWs8" id="5qf1oe_GdOk" role="PzmwI">
       <ref role="PrY4T" node="5qf1oe_GcsF" resolve="IChild" />
     </node>

--- a/code/model-api/test.org.modelix.model.mpsadapters/models/test.org.modelix.model.mpsadapters.wrappingmodelapi@tests.mps
+++ b/code/model-api/test.org.modelix.model.mpsadapters/models/test.org.modelix.model.mpsadapters.wrappingmodelapi@tests.mps
@@ -1855,7 +1855,7 @@
               </node>
               <node concept="2Hmddi" id="5pW4zr_0GS$" role="3cqZAp">
                 <node concept="37vLTw" id="5pW4zr_0GS_" role="2Hmdds">
-                  <ref role="3cqZAo" node="5pW4zr_0GSk" resolve="kernel" />
+                  <ref role="3cqZAo" node="5pW4zr_0GSk" resolve="annotations" />
                 </node>
               </node>
               <node concept="3vlDli" id="5pW4zr_0GSA" role="3cqZAp">
@@ -1864,7 +1864,7 @@
                 </node>
                 <node concept="2OqwBi" id="5pW4zr_0GSC" role="3tpDZA">
                   <node concept="37vLTw" id="5pW4zr_0GSD" role="2Oq$k0">
-                    <ref role="3cqZAo" node="5pW4zr_0GSk" resolve="kernel" />
+                    <ref role="3cqZAo" node="5pW4zr_0GSk" resolve="annotations" />
                   </node>
                   <node concept="liA8E" id="5pW4zr_0GSE" role="2OqNvi">
                     <ref role="37wK5l" to="jks5:~INode.getPropertyValue(java.lang.String)" resolve="getPropertyValue" />
@@ -1880,7 +1880,7 @@
                 </node>
                 <node concept="2OqwBi" id="5pW4zr_0GSI" role="3tpDZA">
                   <node concept="37vLTw" id="5pW4zr_0GSJ" role="2Oq$k0">
-                    <ref role="3cqZAo" node="5pW4zr_0GSk" resolve="kernel" />
+                    <ref role="3cqZAo" node="5pW4zr_0GSk" resolve="annotations" />
                   </node>
                   <node concept="liA8E" id="5pW4zr_0GSK" role="2OqNvi">
                     <ref role="37wK5l" to="jks5:~INode.getPropertyValue(java.lang.String)" resolve="getPropertyValue" />
@@ -1896,7 +1896,7 @@
                 </node>
                 <node concept="2OqwBi" id="5pW4zr_0GSO" role="3tpDZA">
                   <node concept="37vLTw" id="5pW4zr_0GSP" role="2Oq$k0">
-                    <ref role="3cqZAo" node="5pW4zr_0GSk" resolve="kernel" />
+                    <ref role="3cqZAo" node="5pW4zr_0GSk" resolve="annotations" />
                   </node>
                   <node concept="liA8E" id="5pW4zr_0GSQ" role="2OqNvi">
                     <ref role="37wK5l" to="jks5:~INode.getPropertyValue(java.lang.String)" resolve="getPropertyValue" />
@@ -1912,7 +1912,7 @@
                 </node>
                 <node concept="2OqwBi" id="5pW4zr_0GSU" role="3tpDZA">
                   <node concept="37vLTw" id="5pW4zr_0GSV" role="2Oq$k0">
-                    <ref role="3cqZAo" node="5pW4zr_0GSk" resolve="kernel" />
+                    <ref role="3cqZAo" node="5pW4zr_0GSk" resolve="annotations" />
                   </node>
                   <node concept="liA8E" id="5pW4zr_0GSW" role="2OqNvi">
                     <ref role="37wK5l" to="jks5:~INode.getPropertyValue(java.lang.String)" resolve="getPropertyValue" />

--- a/code/pagination/languages/de.itemis.mps.editor.pagination.demolang/models/de.itemis.mps.editor.pagination.demolang.structure.mps
+++ b/code/pagination/languages/de.itemis.mps.editor.pagination.demolang/models/de.itemis.mps.editor.pagination.demolang.structure.mps
@@ -63,7 +63,7 @@
     <property role="EcuMT" value="2646108724982184770" />
     <property role="TrG5h" value="Test" />
     <property role="19KtqR" value="true" />
-    <ref role="1TJDcQ" to="tpck:gw2VY9q" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
     <node concept="PrWs8" id="2iSRtQtBZH3" role="PzmwI">
       <ref role="PrY4T" to="tpck:h0TrEE$" resolve="INamedConcept" />
     </node>
@@ -102,7 +102,7 @@
   <node concept="1TIwiD" id="2iSRtQtDrgE">
     <property role="EcuMT" value="2646108724982559786" />
     <property role="TrG5h" value="ChildTest" />
-    <ref role="1TJDcQ" to="tpck:gw2VY9q" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
     <node concept="1TJgyi" id="2iSRtQtDrgF" role="1TKVEl">
       <property role="IQ2nx" value="2646108724982559787" />
       <property role="TrG5h" value="n" />

--- a/code/pagination/languages/de.itemis.mps.editor.pagination/models/de.itemis.mps.editor.pagination.plugin.mps
+++ b/code/pagination/languages/de.itemis.mps.editor.pagination/models/de.itemis.mps.editor.pagination.plugin.mps
@@ -343,7 +343,7 @@
             <property role="2bfB8j" value="true" />
             <property role="373rjd" value="true" />
             <ref role="1Y3XeK" to="wvnl:~EditorExtension" resolve="EditorExtension" />
-            <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" />
+            <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
             <node concept="3Tm1VV" id="2YsXopnqyW$" role="1B3o_S" />
             <node concept="3clFb_" id="2YsXopnqyWM" role="jymVt">
               <property role="TrG5h" value="isApplicable" />
@@ -366,7 +366,7 @@
                 </node>
               </node>
               <node concept="2AHcQZ" id="2YsXopnqyWV" role="2AJF6D">
-                <ref role="2AI5Lk" to="wyt6:~Override" />
+                <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
               </node>
             </node>
             <node concept="2tJIrI" id="2YsXopnqyWW" role="jymVt" />
@@ -407,7 +407,7 @@
                 </node>
               </node>
               <node concept="2AHcQZ" id="2YsXopnqyX6" role="2AJF6D">
-                <ref role="2AI5Lk" to="wyt6:~Override" />
+                <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
               </node>
             </node>
             <node concept="2tJIrI" id="2YsXopnqyX7" role="jymVt" />
@@ -448,7 +448,7 @@
                 </node>
               </node>
               <node concept="2AHcQZ" id="2YsXopnqyXh" role="2AJF6D">
-                <ref role="2AI5Lk" to="wyt6:~Override" />
+                <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
               </node>
             </node>
           </node>
@@ -756,14 +756,14 @@
                   </node>
                 </node>
                 <node concept="37vLTw" id="2YsXopnqO7G" role="37vLTJ">
-                  <ref role="3cqZAo" node="2YsXopnqMQr" resolve="instance" />
+                  <ref role="3cqZAo" node="2YsXopnqMQr" resolve="listener" />
                 </node>
               </node>
             </node>
             <node concept="3clFbF" id="2YsXopnqQ7C" role="3cqZAp">
               <node concept="37vLTI" id="2YsXopnqQR6" role="3clFbG">
                 <node concept="37vLTw" id="2YsXopnqQTZ" role="37vLTx">
-                  <ref role="3cqZAo" node="2YsXopnqMQr" resolve="instance" />
+                  <ref role="3cqZAo" node="2YsXopnqMQr" resolve="listener" />
                 </node>
                 <node concept="3EllGN" id="2YsXopnqQtK" role="37vLTJ">
                   <node concept="37vLTw" id="2YsXopnqQwH" role="3ElVtu">
@@ -779,7 +779,7 @@
           <node concept="3clFbC" id="2YsXopnqNFl" role="3clFbw">
             <node concept="10Nm6u" id="2YsXopnqNVU" role="3uHU7w" />
             <node concept="37vLTw" id="2YsXopnqNhi" role="3uHU7B">
-              <ref role="3cqZAo" node="2YsXopnqMQr" resolve="instance" />
+              <ref role="3cqZAo" node="2YsXopnqMQr" resolve="listener" />
             </node>
           </node>
         </node>
@@ -912,8 +912,8 @@
                   <node concept="1Y3b0j" id="2YsXopnrk3s" role="YeSDq">
                     <property role="2bfB8j" value="true" />
                     <property role="373rjd" value="true" />
-                    <ref role="1Y3XeK" to="exr9:~EditorComponent$EditorDisposeListener" resolve="EditorDisposeListener" />
-                    <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" />
+                    <ref role="1Y3XeK" to="exr9:~EditorComponent$EditorDisposeListener" resolve="EditorComponent.EditorDisposeListener" />
+                    <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
                     <node concept="3Tm1VV" id="2YsXopnrk3t" role="1B3o_S" />
                     <node concept="3clFb_" id="2YsXopnrk3H" role="jymVt">
                       <property role="TrG5h" value="editorWillBeDisposed" />
@@ -942,7 +942,7 @@
                         </node>
                       </node>
                       <node concept="2AHcQZ" id="2YsXopnrk3Q" role="2AJF6D">
-                        <ref role="2AI5Lk" to="wyt6:~Override" />
+                        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
                       </node>
                     </node>
                   </node>
@@ -1467,7 +1467,7 @@
                                 <node concept="2ShNRf" id="47Pq93ID1Y_" role="3clFbG">
                                   <node concept="1pGfFk" id="47Pq93ID1YA" role="2ShVmc">
                                     <property role="373rjd" value="true" />
-                                    <ref role="37wK5l" node="47Pq93Ih_Lp" resolve="PageChange" />
+                                    <ref role="37wK5l" node="47Pq93Ih_Lp" resolve="PaginationListener.PageChange" />
                                     <node concept="37vLTw" id="47Pq93ID1YB" role="37wK5m">
                                       <ref role="3cqZAo" node="47Pq93Icnps" resolve="paginatedCell" />
                                     </node>
@@ -1490,7 +1490,7 @@
                           </node>
                         </node>
                         <node concept="1rXfSq" id="47Pq93IDrae" role="2Oq$k0">
-                          <ref role="37wK5l" node="2IHyoywA8uO" resolve="getNewPages" />
+                          <ref role="37wK5l" node="2IHyoywA8uO" resolve="getNewPagesForTarget" />
                           <node concept="37vLTw" id="47Pq93IDraf" role="37wK5m">
                             <ref role="3cqZAo" node="47Pq93Icnpu" resolve="targetNode" />
                           </node>
@@ -1535,7 +1535,7 @@
         <node concept="3Tqbb2" id="47Pq93Icnpv" role="1tU5fm" />
       </node>
       <node concept="3uibUv" id="47Pq93IifVD" role="3clF45">
-        <ref role="3uigEE" node="47Pq93IhuNV" resolve="PageChange" />
+        <ref role="3uigEE" node="47Pq93IhuNV" resolve="PaginationListener.PageChange" />
       </node>
     </node>
     <node concept="2tJIrI" id="47Pq93Ikr0V" role="jymVt" />
@@ -1590,7 +1590,7 @@
       </node>
       <node concept="A3Dl8" id="47Pq93IehxA" role="3clF45">
         <node concept="3uibUv" id="47Pq93Iip2Y" role="A3Ik2">
-          <ref role="3uigEE" node="47Pq93IhuNV" resolve="PageChange" />
+          <ref role="3uigEE" node="47Pq93IhuNV" resolve="PaginationListener.PageChange" />
         </node>
       </node>
     </node>
@@ -1900,7 +1900,7 @@
                                                         <property role="TrG5h" value="changesToApply" />
                                                         <node concept="A3Dl8" id="47Pq93Iiro5" role="1tU5fm">
                                                           <node concept="3uibUv" id="47Pq93Ii$1X" role="A3Ik2">
-                                                            <ref role="3uigEE" node="47Pq93IhuNV" resolve="PageChange" />
+                                                            <ref role="3uigEE" node="47Pq93IhuNV" resolve="PaginationListener.PageChange" />
                                                           </node>
                                                         </node>
                                                         <node concept="1rXfSq" id="47Pq93Iiroa" role="33vP2m">
@@ -2041,7 +2041,7 @@
         </node>
       </node>
       <node concept="2AHcQZ" id="2YsXopnrIgK" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" />
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
     <node concept="2tJIrI" id="47Pq93IhlNs" role="jymVt" />

--- a/code/pagination/solutions/de.itemis.mps.editor.pagination.runtime/models/de.itemis.mps.editor.pagination.runtime.pages.mps
+++ b/code/pagination/solutions/de.itemis.mps.editor.pagination.runtime/models/de.itemis.mps.editor.pagination.runtime.pages.mps
@@ -214,7 +214,7 @@
       <property role="3TUv4t" value="true" />
       <node concept="3Tm6S6" id="4J8HQTrm7Nq" role="1B3o_S" />
       <node concept="3uibUv" id="4J8HQTrm8fz" role="1tU5fm">
-        <ref role="3uigEE" node="4J8HQTrlAnB" />
+        <ref role="3uigEE" node="4J8HQTrlAnB" resolve="PageNumber" />
       </node>
     </node>
     <node concept="312cEg" id="4J8HQTrmd0s" role="jymVt">
@@ -241,7 +241,7 @@
       <node concept="37vLTG" id="4J8HQTrm5h7" role="3clF46">
         <property role="TrG5h" value="pageNumber" />
         <node concept="3uibUv" id="4J8HQTrm5h8" role="1tU5fm">
-          <ref role="3uigEE" node="4J8HQTrlAnB" />
+          <ref role="3uigEE" node="4J8HQTrlAnB" resolve="PageNumber" />
         </node>
       </node>
       <node concept="37vLTG" id="4J8HQTrm5h9" role="3clF46">
@@ -322,7 +322,7 @@
                       <ref role="3cqZAo" node="4J8HQTrm5h7" resolve="pageNumber" />
                     </node>
                     <node concept="liA8E" id="4J8HQTrm6K6" role="2OqNvi">
-                      <ref role="37wK5l" node="4J8HQTrlAqj" />
+                      <ref role="37wK5l" node="4J8HQTrlAqj" resolve="getValue" />
                     </node>
                   </node>
                 </node>
@@ -368,7 +368,7 @@
           <node concept="2ShNRf" id="4J8HQTrnlDr" role="37wK5m">
             <node concept="1pGfFk" id="4J8HQTrnlQH" role="2ShVmc">
               <property role="373rjd" value="true" />
-              <ref role="37wK5l" node="4J8HQTrlLuu" />
+              <ref role="37wK5l" node="4J8HQTrlLuu" resolve="PageNumber" />
             </node>
           </node>
           <node concept="37vLTw" id="4J8HQTrnm5I" role="37wK5m">
@@ -496,7 +496,7 @@
                 <ref role="37wK5l" node="4J8HQTrm5h5" resolve="Page" />
                 <node concept="2OqwBi" id="4J8HQTrmtI8" role="37wK5m">
                   <node concept="liA8E" id="4J8HQTrmtIc" role="2OqNvi">
-                    <ref role="37wK5l" node="4J8HQTrlAqp" />
+                    <ref role="37wK5l" node="4J8HQTrlAqp" resolve="next" />
                   </node>
                   <node concept="1rXfSq" id="4J8HQTrmQ5L" role="2Oq$k0">
                     <ref role="37wK5l" node="4J8HQTrmNTf" resolve="getPageNumber" />
@@ -522,7 +522,7 @@
         <node concept="3clFbF" id="4J8HQTrmqH1" role="3cqZAp">
           <node concept="2OqwBi" id="4J8HQTrmsee" role="3clFbG">
             <node concept="liA8E" id="4J8HQTrmsmX" role="2OqNvi">
-              <ref role="37wK5l" node="4J8HQTrmkTv" />
+              <ref role="37wK5l" node="4J8HQTrmkTv" resolve="hasPrevious" />
             </node>
             <node concept="1rXfSq" id="4J8HQTrmPQ0" role="2Oq$k0">
               <ref role="37wK5l" node="4J8HQTrmNTf" resolve="getPageNumber" />
@@ -549,7 +549,7 @@
                 <ref role="37wK5l" node="4J8HQTrm5h5" resolve="Page" />
                 <node concept="2OqwBi" id="4J8HQTrmeKW" role="37wK5m">
                   <node concept="liA8E" id="4J8HQTrmeL0" role="2OqNvi">
-                    <ref role="37wK5l" node="4J8HQTrlAq$" />
+                    <ref role="37wK5l" node="4J8HQTrlAq$" resolve="previous" />
                   </node>
                   <node concept="1rXfSq" id="4J8HQTrmQEo" role="2Oq$k0">
                     <ref role="37wK5l" node="4J8HQTrmNTf" resolve="getPageNumber" />
@@ -583,7 +583,7 @@
       </node>
       <node concept="3Tm1VV" id="4J8HQTrmNHe" role="1B3o_S" />
       <node concept="3uibUv" id="4J8HQTrmOqg" role="3clF45">
-        <ref role="3uigEE" node="4J8HQTrlAnB" />
+        <ref role="3uigEE" node="4J8HQTrlAnB" resolve="PageNumber" />
       </node>
     </node>
     <node concept="2tJIrI" id="4J8HQTrmR7m" role="jymVt" />
@@ -667,7 +667,7 @@
                     </node>
                   </node>
                   <node concept="liA8E" id="4J8HQTrn06w" role="2OqNvi">
-                    <ref role="37wK5l" node="4J8HQTrlAqR" />
+                    <ref role="37wK5l" node="4J8HQTrlAqR" resolve="equals" />
                     <node concept="1rXfSq" id="4J8HQTrn0jL" role="37wK5m">
                       <ref role="37wK5l" node="4J8HQTrmNTf" resolve="getPageNumber" />
                     </node>
@@ -707,7 +707,7 @@
                   <ref role="37wK5l" node="4J8HQTrmNTf" resolve="getPageNumber" />
                 </node>
                 <node concept="liA8E" id="4J8HQTrn545" role="2OqNvi">
-                  <ref role="37wK5l" node="4J8HQTrlArf" />
+                  <ref role="37wK5l" node="4J8HQTrlArf" resolve="hashCode" />
                 </node>
               </node>
               <node concept="3cmrfG" id="4J8HQTrnxXO" role="3uHU7w">
@@ -741,7 +741,7 @@
                 <ref role="37wK5l" node="4J8HQTrmNTf" resolve="getPageNumber" />
               </node>
               <node concept="liA8E" id="4J8HQTrn6Vn" role="2OqNvi">
-                <ref role="37wK5l" node="4J8HQTrlO81" />
+                <ref role="37wK5l" node="4J8HQTrlO81" resolve="toString" />
               </node>
             </node>
             <node concept="1rXfSq" id="4J8HQTrnKlS" role="37wK5m">
@@ -1558,7 +1558,7 @@
       <node concept="3clFbS" id="47Pq93IsiHq" role="3clF47">
         <node concept="3clFbF" id="47Pq93IsodK" role="3cqZAp">
           <node concept="1rXfSq" id="47Pq93IwFQ6" role="3clFbG">
-            <ref role="37wK5l" node="47Pq93ItnRc" resolve="setPagesTo" />
+            <ref role="37wK5l" node="47Pq93ItnRc" resolve="getPagesWith" />
             <node concept="2ShNRf" id="47Pq93IwIXl" role="37wK5m">
               <node concept="1pGfFk" id="47Pq93IwKBr" role="2ShVmc">
                 <property role="373rjd" value="true" />
@@ -1586,7 +1586,7 @@
       <node concept="3clFbS" id="47Pq93ItnRd" role="3clF47">
         <node concept="3clFbF" id="47Pq93I$KPI" role="3cqZAp">
           <node concept="1rXfSq" id="47Pq93I$KPG" role="3clFbG">
-            <ref role="37wK5l" node="47Pq93I$0rY" resolve="setPagesTo" />
+            <ref role="37wK5l" node="47Pq93I$0rY" resolve="getPagesWith" />
             <node concept="2ShNRf" id="47Pq93I$Pwi" role="37wK5m">
               <node concept="1pGfFk" id="47Pq93I$Pwj" role="2ShVmc">
                 <property role="373rjd" value="true" />

--- a/code/pagination/solutions/de.itemis.mps.editor.pagination.runtime/models/de.itemis.mps.editor.pagination.runtime.plugin.utils.mps
+++ b/code/pagination/solutions/de.itemis.mps.editor.pagination.runtime/models/de.itemis.mps.editor.pagination.runtime.plugin.utils.mps
@@ -195,7 +195,7 @@
           <node concept="3clFbC" id="1AFv0dCu7vI" role="3clFbw">
             <node concept="10Nm6u" id="1AFv0dCu8P2" role="3uHU7w" />
             <node concept="37vLTw" id="1AFv0dCu6al" role="3uHU7B">
-              <ref role="3cqZAo" node="1AFv0dCriQ6" resolve="editorCell" />
+              <ref role="3cqZAo" node="1AFv0dCriQ6" resolve="cell" />
             </node>
           </node>
         </node>
@@ -210,7 +210,7 @@
             </node>
             <node concept="3K4zz7" id="1AFv0dCtpPt" role="33vP2m">
               <node concept="37vLTw" id="1AFv0dCtpPu" role="3K4Cdx">
-                <ref role="3cqZAo" node="1AFv0dCtfw_" resolve="includeStartingEditorCell" />
+                <ref role="3cqZAo" node="1AFv0dCtfw_" resolve="includeStart" />
               </node>
               <node concept="2ShNRf" id="1AFv0dCtpPv" role="3K4E3e">
                 <node concept="2HTt$P" id="1AFv0dCtpPw" role="2ShVmc">
@@ -218,7 +218,7 @@
                     <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
                   </node>
                   <node concept="37vLTw" id="1AFv0dCtpPy" role="2HTEbv">
-                    <ref role="3cqZAo" node="1AFv0dCriQ6" resolve="editorCell" />
+                    <ref role="3cqZAo" node="1AFv0dCriQ6" resolve="cell" />
                   </node>
                 </node>
               </node>
@@ -236,7 +236,7 @@
         <node concept="3clFbF" id="1AFv0dCtyMR" role="3cqZAp">
           <node concept="2OqwBi" id="1AFv0dCtHO8" role="3clFbG">
             <node concept="37vLTw" id="1AFv0dCtyMP" role="2Oq$k0">
-              <ref role="3cqZAo" node="1AFv0dCtpPs" resolve="initialEditorCells" />
+              <ref role="3cqZAo" node="1AFv0dCtpPs" resolve="initialCells" />
             </node>
             <node concept="3QWeyG" id="1AFv0dCtJp6" role="2OqNvi">
               <node concept="2ShNRf" id="1AFv0dCtKlo" role="576Qk">
@@ -248,10 +248,10 @@
                     <node concept="3clFbS" id="1AFv0dCtO4Q" role="1bW5cS">
                       <node concept="3clFbF" id="1AFv0dCtPjY" role="3cqZAp">
                         <node concept="1rXfSq" id="1AFv0dCtPjX" role="3clFbG">
-                          <ref role="37wK5l" node="1AFv0dCHujU" resolve="getEditorCellAncestors" />
+                          <ref role="37wK5l" node="1AFv0dCHujU" resolve="getAncestors" />
                           <node concept="2OqwBi" id="1AFv0dCusHw" role="37wK5m">
                             <node concept="37vLTw" id="1AFv0dCusHx" role="2Oq$k0">
-                              <ref role="3cqZAo" node="1AFv0dCriQ6" resolve="editorCell" />
+                              <ref role="3cqZAo" node="1AFv0dCriQ6" resolve="cell" />
                             </node>
                             <node concept="liA8E" id="1AFv0dCusHy" role="2OqNvi">
                               <ref role="37wK5l" to="f4zo:~EditorCell.getParent()" resolve="getParent" />
@@ -306,7 +306,7 @@
           <node concept="3clFbC" id="1AFv0dCuxmj" role="3clFbw">
             <node concept="10Nm6u" id="1AFv0dCuxmk" role="3uHU7w" />
             <node concept="37vLTw" id="1AFv0dCuxml" role="3uHU7B">
-              <ref role="3cqZAo" node="1AFv0dCrm1V" resolve="editorCell" />
+              <ref role="3cqZAo" node="1AFv0dCrm1V" resolve="cell" />
             </node>
           </node>
         </node>
@@ -321,7 +321,7 @@
             </node>
             <node concept="3K4zz7" id="1AFv0dCuxmr" role="33vP2m">
               <node concept="37vLTw" id="1AFv0dCuxms" role="3K4Cdx">
-                <ref role="3cqZAo" node="1AFv0dCuyF3" resolve="includeStartingEditorCell" />
+                <ref role="3cqZAo" node="1AFv0dCuyF3" resolve="includeStart" />
               </node>
               <node concept="2ShNRf" id="1AFv0dCuxmt" role="3K4E3e">
                 <node concept="2HTt$P" id="1AFv0dCuxmu" role="2ShVmc">
@@ -329,7 +329,7 @@
                     <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
                   </node>
                   <node concept="37vLTw" id="1AFv0dCuxmw" role="2HTEbv">
-                    <ref role="3cqZAo" node="1AFv0dCrm1V" resolve="editorCell" />
+                    <ref role="3cqZAo" node="1AFv0dCrm1V" resolve="cell" />
                   </node>
                 </node>
               </node>
@@ -348,7 +348,7 @@
           <node concept="3clFbS" id="1AFv0dCuFGm" role="3clFbx">
             <node concept="3cpWs6" id="1AFv0dCuLyF" role="3cqZAp">
               <node concept="37vLTw" id="1AFv0dCuMNz" role="3cqZAk">
-                <ref role="3cqZAo" node="1AFv0dCuxmo" resolve="initialEditorCells" />
+                <ref role="3cqZAo" node="1AFv0dCuxmo" resolve="initialCells" />
               </node>
             </node>
           </node>
@@ -358,7 +358,7 @@
                 <ref role="3uigEE" to="f4zo:~EditorCell_Collection" resolve="EditorCell_Collection" />
               </node>
               <node concept="37vLTw" id="1AFv0dCv50J" role="2ZW6bz">
-                <ref role="3cqZAo" node="1AFv0dCrm1V" resolve="editorCell" />
+                <ref role="3cqZAo" node="1AFv0dCrm1V" resolve="cell" />
               </node>
             </node>
           </node>
@@ -374,7 +374,7 @@
                 <ref role="3uigEE" to="f4zo:~EditorCell_Collection" resolve="EditorCell_Collection" />
               </node>
               <node concept="37vLTw" id="1AFv0dCvdw6" role="0kSFX">
-                <ref role="3cqZAo" node="1AFv0dCrm1V" resolve="editorCell" />
+                <ref role="3cqZAo" node="1AFv0dCrm1V" resolve="cell" />
               </node>
             </node>
           </node>
@@ -383,7 +383,7 @@
         <node concept="3clFbF" id="1AFv0dCuxm_" role="3cqZAp">
           <node concept="2OqwBi" id="1AFv0dCuxmA" role="3clFbG">
             <node concept="37vLTw" id="1AFv0dCuxmB" role="2Oq$k0">
-              <ref role="3cqZAo" node="1AFv0dCuxmo" resolve="initialEditorCells" />
+              <ref role="3cqZAo" node="1AFv0dCuxmo" resolve="initialCells" />
             </node>
             <node concept="3QWeyG" id="1AFv0dCuxmC" role="2OqNvi">
               <node concept="2OqwBi" id="1AFv0dCxfFm" role="576Qk">
@@ -409,7 +409,7 @@
                             </node>
                           </node>
                           <node concept="37vLTw" id="1AFv0dCx6eu" role="1DdaDG">
-                            <ref role="3cqZAo" node="1AFv0dCvdw3" resolve="editorCellAsCollection" />
+                            <ref role="3cqZAo" node="1AFv0dCvdw3" resolve="cellAsCollection" />
                           </node>
                         </node>
                       </node>
@@ -421,7 +421,7 @@
                     <node concept="3clFbS" id="1AFv0dCxhnA" role="1bW5cS">
                       <node concept="3clFbF" id="1AFv0dCxmn_" role="3cqZAp">
                         <node concept="1rXfSq" id="1AFv0dCxmn$" role="3clFbG">
-                          <ref role="37wK5l" node="1AFv0dCH$Ru" resolve="getEditorCellDescendants" />
+                          <ref role="37wK5l" node="1AFv0dCH$Ru" resolve="getDescendants" />
                           <node concept="37vLTw" id="1AFv0dCxnF0" role="37wK5m">
                             <ref role="3cqZAo" node="1AFv0dCxhnB" resolve="childEditorCell" />
                           </node>

--- a/code/pagination/solutions/de.itemis.mps.editor.pagination.runtime/models/de.itemis.mps.editor.pagination.runtime.ui.mps
+++ b/code/pagination/solutions/de.itemis.mps.editor.pagination.runtime/models/de.itemis.mps.editor.pagination.runtime.ui.mps
@@ -149,7 +149,7 @@
       <node concept="3cqZAl" id="5K4KrT2tECQ" role="3clF45" />
       <node concept="3clFbS" id="5K4KrT2tECS" role="3clF47">
         <node concept="XkiVB" id="5K4KrT2vn4b" role="3cqZAp">
-          <ref role="37wK5l" node="5K4KrT2v2$W" />
+          <ref role="37wK5l" node="5K4KrT2v2$W" resolve="ChangePageJButton" />
           <node concept="Xl_RD" id="5K4KrT2tJeQ" role="37wK5m">
             <property role="Xl_RC" value="previous" />
           </node>
@@ -192,7 +192,7 @@
     <node concept="2tJIrI" id="5K4KrT2vlle" role="jymVt" />
     <node concept="3Tm1VV" id="5K4KrT2tArE" role="1B3o_S" />
     <node concept="3uibUv" id="5K4KrT2vkuj" role="1zkMxy">
-      <ref role="3uigEE" node="5K4KrT2v0$1" />
+      <ref role="3uigEE" node="5K4KrT2v0$1" resolve="ChangePageJButton" />
     </node>
     <node concept="3clFb_" id="5K4KrT2vkSb" role="jymVt">
       <property role="TrG5h" value="getActionListener" />
@@ -225,7 +225,7 @@
           <node concept="2ShNRf" id="5K4KrT2tKy1" role="3clFbG">
             <node concept="1pGfFk" id="5K4KrT2tLnC" role="2ShVmc">
               <property role="373rjd" value="true" />
-              <ref role="37wK5l" node="5K4KrT2oBj1" />
+              <ref role="37wK5l" node="5K4KrT2oBj1" resolve="PreviousPageActionListener" />
               <node concept="37vLTw" id="5K4KrT2tLVH" role="37wK5m">
                 <ref role="3cqZAo" node="5K4KrT2vkSc" resolve="node" />
               </node>
@@ -255,7 +255,7 @@
       <node concept="3cqZAl" id="5K4KrT2oBj2" role="3clF45" />
       <node concept="3clFbS" id="5K4KrT2oBj4" role="3clF47">
         <node concept="XkiVB" id="5K4KrT2qx8j" role="3cqZAp">
-          <ref role="37wK5l" node="5K4KrT2qfDj" />
+          <ref role="37wK5l" node="5K4KrT2qfDj" resolve="PageActionListener" />
           <node concept="37vLTw" id="5K4KrT2qxd$" role="37wK5m">
             <ref role="3cqZAo" node="5K4KrT2oI4b" resolve="node" />
           </node>
@@ -294,7 +294,7 @@
     </node>
     <node concept="2tJIrI" id="5K4KrT2oHFY" role="jymVt" />
     <node concept="3uibUv" id="5K4KrT2qwt3" role="1zkMxy">
-      <ref role="3uigEE" node="5K4KrT2qePX" />
+      <ref role="3uigEE" node="5K4KrT2qePX" resolve="PageActionListener" />
     </node>
     <node concept="3clFb_" id="5K4KrT2qxKP" role="jymVt">
       <property role="TrG5h" value="canMove" />
@@ -589,7 +589,7 @@
       <node concept="3cqZAl" id="5K4KrT2uIGJ" role="3clF45" />
       <node concept="3clFbS" id="5K4KrT2uIGK" role="3clF47">
         <node concept="XkiVB" id="5K4KrT2vbRO" role="3cqZAp">
-          <ref role="37wK5l" node="5K4KrT2v2$W" />
+          <ref role="37wK5l" node="5K4KrT2v2$W" resolve="ChangePageJButton" />
           <node concept="Xl_RD" id="5K4KrT2vjKW" role="37wK5m">
             <property role="Xl_RC" value="next" />
           </node>
@@ -632,7 +632,7 @@
     <node concept="2tJIrI" id="5K4KrT2vjid" role="jymVt" />
     <node concept="3Tm1VV" id="5K4KrT2uIH4" role="1B3o_S" />
     <node concept="3uibUv" id="5K4KrT2vaXe" role="1zkMxy">
-      <ref role="3uigEE" node="5K4KrT2v0$1" />
+      <ref role="3uigEE" node="5K4KrT2v0$1" resolve="ChangePageJButton" />
     </node>
     <node concept="3clFb_" id="5K4KrT2vdLF" role="jymVt">
       <property role="TrG5h" value="getActionListener" />
@@ -665,7 +665,7 @@
           <node concept="2ShNRf" id="5K4KrT2velW" role="3clFbG">
             <node concept="1pGfFk" id="5K4KrT2vf36" role="2ShVmc">
               <property role="373rjd" value="true" />
-              <ref role="37wK5l" node="5K4KrT2pDgH" />
+              <ref role="37wK5l" node="5K4KrT2pDgH" resolve="NextPageActionListener" />
               <node concept="37vLTw" id="5K4KrT2vfvK" role="37wK5m">
                 <ref role="3cqZAo" node="5K4KrT2vdLG" resolve="node" />
               </node>

--- a/code/querylist/com.mbeddr.mpsutil.editor.querylist.demolang/languageModels/editor.mps
+++ b/code/querylist/com.mbeddr.mpsutil.editor.querylist.demolang/languageModels/editor.mps
@@ -83,6 +83,12 @@
       </concept>
       <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="1239714755177" name="jetbrains.mps.baseLanguage.structure.AbstractUnaryNumberOperation" flags="nn" index="2$Kvd9">
+        <child id="1239714902950" name="expression" index="2$L3a6" />
+      </concept>
+      <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
+        <child id="1154032183016" name="body" index="2LFqv$" />
+      </concept>
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
@@ -100,6 +106,7 @@
         <child id="1182160096073" name="cls" index="YeSDq" />
       </concept>
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
+      <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <child id="1068431790190" name="initializer" index="33vP2m" />
       </concept>
@@ -132,6 +139,9 @@
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
+      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
+        <property id="1068580320021" name="value" index="3cmrfH" />
+      </concept>
       <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
       <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
         <child id="1068581517676" name="expression" index="3cqZAk" />
@@ -140,6 +150,7 @@
         <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
       </concept>
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1081506773034" name="jetbrains.mps.baseLanguage.structure.LessThanExpression" flags="nn" index="3eOVzh" />
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
@@ -155,8 +166,16 @@
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
+      <concept id="1214918800624" name="jetbrains.mps.baseLanguage.structure.PostfixIncrementExpression" flags="nn" index="3uNrnE" />
       <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="1144230876926" name="jetbrains.mps.baseLanguage.structure.AbstractForStatement" flags="nn" index="1DupvO">
+        <child id="1144230900587" name="variable" index="1Duv9x" />
+      </concept>
+      <concept id="1144231330558" name="jetbrains.mps.baseLanguage.structure.ForStatement" flags="nn" index="1Dw8fO">
+        <child id="1144231399730" name="condition" index="1Dwp0S" />
+        <child id="1144231408325" name="iteration" index="1Dwrff" />
       </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
       <concept id="1170345865475" name="jetbrains.mps.baseLanguage.structure.AnonymousClass" flags="ig" index="1Y3b0j">
@@ -172,6 +191,20 @@
     <language id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation">
       <concept id="1196350785113" name="jetbrains.mps.lang.quotation.structure.Quotation" flags="nn" index="2c44tf">
         <child id="1196350785114" name="quotedNode" index="2c44tc" />
+      </concept>
+      <concept id="5455284157993911077" name="jetbrains.mps.lang.quotation.structure.NodeBuilderInitProperty" flags="ng" index="2pJxcG">
+        <reference id="5455284157993911078" name="property" index="2pJxcJ" />
+        <child id="1595412875168045201" name="initValue" index="28ntcv" />
+      </concept>
+      <concept id="5455284157993863837" name="jetbrains.mps.lang.quotation.structure.NodeBuilder" flags="nn" index="2pJPEk">
+        <child id="5455284157993863838" name="quotedNode" index="2pJPEn" />
+      </concept>
+      <concept id="5455284157993863840" name="jetbrains.mps.lang.quotation.structure.NodeBuilderNode" flags="nn" index="2pJPED">
+        <reference id="5455284157993910961" name="concept" index="2pJxaS" />
+        <child id="5455284157993911099" name="values" index="2pJxcM" />
+      </concept>
+      <concept id="6985522012210254362" name="jetbrains.mps.lang.quotation.structure.NodeBuilderPropertyExpression" flags="nn" index="WxPPo">
+        <child id="6985522012210254363" name="expression" index="WxPPp" />
       </concept>
     </language>
     <language id="120e1c9d-4e27-4478-b2af-b2c3bd3850b0" name="com.mbeddr.mpsutil.editor.querylist">
@@ -285,8 +318,16 @@
       <concept id="1224414427926" name="jetbrains.mps.baseLanguage.collections.structure.SequenceCreator" flags="nn" index="kMnCb">
         <child id="1224414456414" name="elementType" index="kMuH3" />
       </concept>
+      <concept id="1151688443754" name="jetbrains.mps.baseLanguage.collections.structure.ListType" flags="in" index="_YKpA">
+        <child id="1151688676805" name="elementType" index="_ZDj9" />
+      </concept>
+      <concept id="1237721394592" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerCreator" flags="nn" index="HWqM0">
+        <child id="1237721435807" name="elementType" index="HW$YZ" />
+        <child id="1562299158920737514" name="initSize" index="3lWHg$" />
+      </concept>
       <concept id="1227022159410" name="jetbrains.mps.baseLanguage.collections.structure.AddFirstElementOperation" flags="nn" index="2Ke4WJ" />
       <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
+      <concept id="1160600644654" name="jetbrains.mps.baseLanguage.collections.structure.ListCreatorWithInit" flags="nn" index="Tc6Ow" />
       <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
       <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
       <concept id="1225727723840" name="jetbrains.mps.baseLanguage.collections.structure.FindFirstOperation" flags="nn" index="1z4cxt" />
@@ -1480,6 +1521,199 @@
         </node>
       </node>
       <node concept="2iRkQZ" id="1GpxVmAerDZ" role="2iSdaV" />
+    </node>
+  </node>
+  <node concept="24kQdi" id="5vc9XxaCZJz">
+    <ref role="1XX52x" to="gei:5vc9XxaCl$K" resolve="RootDynamicContent" />
+    <node concept="3EZMnI" id="5vc9XxaKnwG" role="2wV5jI">
+      <node concept="3F0ifn" id="5vc9XxaKnAZ" role="3EZMnx">
+        <property role="3F0ifm" value="Numbers" />
+      </node>
+      <node concept="2iRkQZ" id="5vc9XxaKnwH" role="2iSdaV" />
+      <node concept="s8t4o" id="5vc9XxaD0k9" role="3EZMnx">
+        <property role="28Zw97" value="true" />
+        <ref role="28F8cf" to="tpee:fzcmrck" resolve="IntegerConstant" />
+        <node concept="xShMh" id="5vc9XxaD0kb" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+        <node concept="s8sZD" id="5vc9XxaD0kc" role="sbcd9">
+          <node concept="3clFbS" id="5vc9XxaD0kd" role="2VODD2">
+            <node concept="3cpWs8" id="5vc9XxaD257" role="3cqZAp">
+              <node concept="3cpWsn" id="5vc9XxaD25a" role="3cpWs9">
+                <property role="TrG5h" value="size" />
+                <node concept="10Oyi0" id="5vc9XxaD255" role="1tU5fm" />
+                <node concept="3cmrfG" id="5vc9XxaD26H" role="33vP2m">
+                  <property role="3cmrfH" value="10" />
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs8" id="5vc9XxaD0mT" role="3cqZAp">
+              <node concept="3cpWsn" id="5vc9XxaD0mW" role="3cpWs9">
+                <property role="TrG5h" value="numbers" />
+                <node concept="_YKpA" id="5vc9XxaD0mR" role="1tU5fm">
+                  <node concept="3Tqbb2" id="5vc9XxaD0nG" role="_ZDj9">
+                    <ref role="ehGHo" to="tpee:fzcmrck" resolve="IntegerConstant" />
+                  </node>
+                </node>
+                <node concept="2ShNRf" id="5vc9XxaD0qO" role="33vP2m">
+                  <node concept="Tc6Ow" id="5vc9XxaD1$J" role="2ShVmc">
+                    <node concept="3Tqbb2" id="5vc9XxaD1LN" role="HW$YZ">
+                      <ref role="ehGHo" to="tpee:fzcmrck" resolve="IntegerConstant" />
+                    </node>
+                    <node concept="37vLTw" id="5vc9XxaD27v" role="3lWHg$">
+                      <ref role="3cqZAo" node="5vc9XxaD25a" resolve="size" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="1Dw8fO" id="5vc9XxaD2k5" role="3cqZAp">
+              <node concept="3clFbS" id="5vc9XxaD2k7" role="2LFqv$">
+                <node concept="3clFbF" id="5vc9XxaD3jZ" role="3cqZAp">
+                  <node concept="2OqwBi" id="5vc9XxaD4TC" role="3clFbG">
+                    <node concept="37vLTw" id="5vc9XxaD3jX" role="2Oq$k0">
+                      <ref role="3cqZAo" node="5vc9XxaD0mW" resolve="numbers" />
+                    </node>
+                    <node concept="TSZUe" id="5vc9XxaD6Cu" role="2OqNvi">
+                      <node concept="2pJPEk" id="5vc9XxaD6Hp" role="25WWJ7">
+                        <node concept="2pJPED" id="5vc9XxaD6Hr" role="2pJPEn">
+                          <ref role="2pJxaS" to="tpee:fzcmrck" resolve="IntegerConstant" />
+                          <node concept="2pJxcG" id="5vc9XxaD7w6" role="2pJxcM">
+                            <ref role="2pJxcJ" to="tpee:fzcmrcl" resolve="value" />
+                            <node concept="WxPPo" id="5vc9XxaD8Oa" role="28ntcv">
+                              <node concept="37vLTw" id="5vc9XxaD8O6" role="WxPPp">
+                                <ref role="3cqZAo" node="5vc9XxaD2k8" resolve="i" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3cpWsn" id="5vc9XxaD2k8" role="1Duv9x">
+                <property role="TrG5h" value="i" />
+                <node concept="10Oyi0" id="5vc9XxaD2kt" role="1tU5fm" />
+                <node concept="3cmrfG" id="5vc9XxaD2lU" role="33vP2m">
+                  <property role="3cmrfH" value="0" />
+                </node>
+              </node>
+              <node concept="3eOVzh" id="5vc9XxaD3cC" role="1Dwp0S">
+                <node concept="37vLTw" id="5vc9XxaD3du" role="3uHU7w">
+                  <ref role="3cqZAo" node="5vc9XxaD25a" resolve="size" />
+                </node>
+                <node concept="37vLTw" id="5vc9XxaD2m0" role="3uHU7B">
+                  <ref role="3cqZAo" node="5vc9XxaD2k8" resolve="i" />
+                </node>
+              </node>
+              <node concept="3uNrnE" id="5vc9XxaD3iS" role="1Dwrff">
+                <node concept="37vLTw" id="5vc9XxaD3iU" role="2$L3a6">
+                  <ref role="3cqZAo" node="5vc9XxaD2k8" resolve="i" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="5vc9XxaD8PO" role="3cqZAp">
+              <node concept="37vLTw" id="5vc9XxaD8PM" role="3clFbG">
+                <ref role="3cqZAo" node="5vc9XxaD0mW" resolve="numbers" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3F0ifn" id="5vc9XxaKnCh" role="3EZMnx" />
+      <node concept="3F0ifn" id="5vc9XxaKnDp" role="3EZMnx">
+        <property role="3F0ifm" value="Empty because not read-only" />
+      </node>
+      <node concept="s8t4o" id="5vc9XxaKnFR" role="3EZMnx">
+        <property role="28Zw97" value="true" />
+        <ref role="28F8cf" to="tpee:fzcmrck" resolve="IntegerConstant" />
+        <node concept="s8sZD" id="5vc9XxaKnFT" role="sbcd9">
+          <node concept="3clFbS" id="5vc9XxaKnFU" role="2VODD2">
+            <node concept="3cpWs8" id="5vc9XxaKnFV" role="3cqZAp">
+              <node concept="3cpWsn" id="5vc9XxaKnFW" role="3cpWs9">
+                <property role="TrG5h" value="size" />
+                <node concept="10Oyi0" id="5vc9XxaKnFX" role="1tU5fm" />
+                <node concept="3cmrfG" id="5vc9XxaKnFY" role="33vP2m">
+                  <property role="3cmrfH" value="10" />
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs8" id="5vc9XxaKnFZ" role="3cqZAp">
+              <node concept="3cpWsn" id="5vc9XxaKnG0" role="3cpWs9">
+                <property role="TrG5h" value="numbers" />
+                <node concept="_YKpA" id="5vc9XxaKnG1" role="1tU5fm">
+                  <node concept="3Tqbb2" id="5vc9XxaKnG2" role="_ZDj9">
+                    <ref role="ehGHo" to="tpee:fzcmrck" resolve="IntegerConstant" />
+                  </node>
+                </node>
+                <node concept="2ShNRf" id="5vc9XxaKnG3" role="33vP2m">
+                  <node concept="Tc6Ow" id="5vc9XxaKnG4" role="2ShVmc">
+                    <node concept="3Tqbb2" id="5vc9XxaKnG5" role="HW$YZ">
+                      <ref role="ehGHo" to="tpee:fzcmrck" resolve="IntegerConstant" />
+                    </node>
+                    <node concept="37vLTw" id="5vc9XxaKnG6" role="3lWHg$">
+                      <ref role="3cqZAo" node="5vc9XxaKnFW" resolve="size" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="1Dw8fO" id="5vc9XxaKnG7" role="3cqZAp">
+              <node concept="3clFbS" id="5vc9XxaKnG8" role="2LFqv$">
+                <node concept="3clFbF" id="5vc9XxaKnG9" role="3cqZAp">
+                  <node concept="2OqwBi" id="5vc9XxaKnGa" role="3clFbG">
+                    <node concept="37vLTw" id="5vc9XxaKnGb" role="2Oq$k0">
+                      <ref role="3cqZAo" node="5vc9XxaKnG0" resolve="numbers" />
+                    </node>
+                    <node concept="TSZUe" id="5vc9XxaKnGc" role="2OqNvi">
+                      <node concept="2pJPEk" id="5vc9XxaKnGd" role="25WWJ7">
+                        <node concept="2pJPED" id="5vc9XxaKnGe" role="2pJPEn">
+                          <ref role="2pJxaS" to="tpee:fzcmrck" resolve="IntegerConstant" />
+                          <node concept="2pJxcG" id="5vc9XxaKnGf" role="2pJxcM">
+                            <ref role="2pJxcJ" to="tpee:fzcmrcl" resolve="value" />
+                            <node concept="WxPPo" id="5vc9XxaKnGg" role="28ntcv">
+                              <node concept="37vLTw" id="5vc9XxaKnGh" role="WxPPp">
+                                <ref role="3cqZAo" node="5vc9XxaKnGi" resolve="i" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3cpWsn" id="5vc9XxaKnGi" role="1Duv9x">
+                <property role="TrG5h" value="i" />
+                <node concept="10Oyi0" id="5vc9XxaKnGj" role="1tU5fm" />
+                <node concept="3cmrfG" id="5vc9XxaKnGk" role="33vP2m">
+                  <property role="3cmrfH" value="0" />
+                </node>
+              </node>
+              <node concept="3eOVzh" id="5vc9XxaKnGl" role="1Dwp0S">
+                <node concept="37vLTw" id="5vc9XxaKnGm" role="3uHU7w">
+                  <ref role="3cqZAo" node="5vc9XxaKnFW" resolve="size" />
+                </node>
+                <node concept="37vLTw" id="5vc9XxaKnGn" role="3uHU7B">
+                  <ref role="3cqZAo" node="5vc9XxaKnGi" resolve="i" />
+                </node>
+              </node>
+              <node concept="3uNrnE" id="5vc9XxaKnGo" role="1Dwrff">
+                <node concept="37vLTw" id="5vc9XxaKnGp" role="2$L3a6">
+                  <ref role="3cqZAo" node="5vc9XxaKnGi" resolve="i" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="5vc9XxaKnGq" role="3cqZAp">
+              <node concept="37vLTw" id="5vc9XxaKnGr" role="3clFbG">
+                <ref role="3cqZAo" node="5vc9XxaKnG0" resolve="numbers" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3F0ifn" id="5vc9XxaKnED" role="3EZMnx" />
     </node>
   </node>
 </model>

--- a/code/querylist/com.mbeddr.mpsutil.editor.querylist.demolang/languageModels/structure.mps
+++ b/code/querylist/com.mbeddr.mpsutil.editor.querylist.demolang/languageModels/structure.mps
@@ -127,7 +127,7 @@
     <property role="EcuMT" value="6326475386467211568" />
     <property role="TrG5h" value="RootDynamicContent" />
     <property role="19KtqR" value="true" />
-    <ref role="1TJDcQ" to="tpck:gw2VY9q" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
   </node>
 </model>
 

--- a/code/querylist/com.mbeddr.mpsutil.editor.querylist.demolang/languageModels/structure.mps
+++ b/code/querylist/com.mbeddr.mpsutil.editor.querylist.demolang/languageModels/structure.mps
@@ -123,5 +123,11 @@
       <ref role="20lvS9" to="tpee:f$Xl_Og" resolve="StringLiteral" />
     </node>
   </node>
+  <node concept="1TIwiD" id="5vc9XxaCl$K">
+    <property role="EcuMT" value="6326475386467211568" />
+    <property role="TrG5h" value="RootDynamicContent" />
+    <property role="19KtqR" value="true" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" />
+  </node>
 </model>
 

--- a/code/querylist/com.mbeddr.mpsutil.editor.querylist.runtime/models/com/mbeddr/mpsutil/editor/querylist/runtime.mps
+++ b/code/querylist/com.mbeddr.mpsutil.editor.querylist.runtime/models/com/mbeddr/mpsutil/editor/querylist/runtime.mps
@@ -239,6 +239,7 @@
       <concept id="1116615150612" name="jetbrains.mps.baseLanguage.structure.ClassifierClassExpression" flags="nn" index="3VsKOn">
         <reference id="1116615189566" name="classifier" index="3VsUkX" />
       </concept>
+      <concept id="1178893518978" name="jetbrains.mps.baseLanguage.structure.ThisConstructorInvocation" flags="nn" index="1VxSAg" />
       <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
       <concept id="1170345865475" name="jetbrains.mps.baseLanguage.structure.AnonymousClass" flags="ig" index="1Y3b0j">
         <reference id="1170346070688" name="classifier" index="1Y3XeK" />
@@ -705,26 +706,26 @@
       <node concept="3Tm6S6" id="1SwultAiTII" role="1B3o_S" />
       <node concept="3Tqbb2" id="1SwultAiTIK" role="1tU5fm" />
     </node>
+    <node concept="312cEg" id="5vc9Xxa$Y6e" role="jymVt">
+      <property role="TrG5h" value="myReadOnly" />
+      <node concept="3Tm6S6" id="5vc9Xxa$V3k" role="1B3o_S" />
+      <node concept="10P_77" id="5vc9Xxa$Vjf" role="1tU5fm" />
+      <node concept="3clFbT" id="5vc9Xxa_2tf" role="33vP2m" />
+    </node>
     <node concept="2tJIrI" id="1BXECvJT4Dp" role="jymVt" />
     <node concept="3clFbW" id="1BXECvJT4Ug" role="jymVt">
       <node concept="3cqZAl" id="1BXECvJT4Ui" role="3clF45" />
       <node concept="3Tm1VV" id="1BXECvJT4Uj" role="1B3o_S" />
       <node concept="3clFbS" id="1BXECvJT4Uk" role="3clF47">
-        <node concept="XkiVB" id="1BXECvJT51l" role="3cqZAp">
-          <ref role="37wK5l" to="emqf:~AbstractCellListHandler.&lt;init&gt;(jetbrains.mps.openapi.editor.EditorContext)" resolve="AbstractCellListHandler" />
-          <node concept="37vLTw" id="1BXECvJT5bk" role="37wK5m">
+        <node concept="1VxSAg" id="5vc9Xxa_7ot" role="3cqZAp">
+          <ref role="37wK5l" node="5vc9Xxa$Ii1" resolve="QueryListHandler" />
+          <node concept="37vLTw" id="5vc9Xxa_7QB" role="37wK5m">
             <ref role="3cqZAo" node="1BXECvJT53g" resolve="context" />
           </node>
-        </node>
-        <node concept="3clFbF" id="1SwultAiTIL" role="3cqZAp">
-          <node concept="37vLTI" id="1SwultAiTIN" role="3clFbG">
-            <node concept="37vLTw" id="1SwultAiTIQ" role="37vLTJ">
-              <ref role="3cqZAo" node="1SwultAiTIH" resolve="myOwner" />
-            </node>
-            <node concept="37vLTw" id="1SwultAiTIR" role="37vLTx">
-              <ref role="3cqZAo" node="1BXECvJT55G" resolve="owner" />
-            </node>
+          <node concept="37vLTw" id="5vc9Xxa_8cT" role="37wK5m">
+            <ref role="3cqZAo" node="1BXECvJT55G" resolve="owner" />
           </node>
+          <node concept="3clFbT" id="5vc9Xxa_8kA" role="37wK5m" />
         </node>
       </node>
       <node concept="37vLTG" id="1BXECvJT53g" role="3clF46">
@@ -736,6 +737,61 @@
       <node concept="37vLTG" id="1BXECvJT55G" role="3clF46">
         <property role="TrG5h" value="owner" />
         <node concept="3Tqbb2" id="1BXECvJT586" role="1tU5fm" />
+      </node>
+      <node concept="P$JXv" id="5vc9XxaAWIu" role="lGtFl">
+        <node concept="TZ5HI" id="5vc9XxaAWIv" role="3nqlJM">
+          <node concept="TZ5HA" id="5vc9XxaAWIw" role="3HnX3l" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="5vc9XxaAWIx" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="5vc9Xxa$Mn4" role="jymVt" />
+    <node concept="3clFbW" id="5vc9Xxa$Ii1" role="jymVt">
+      <node concept="3cqZAl" id="5vc9Xxa$Ii2" role="3clF45" />
+      <node concept="3Tm1VV" id="5vc9Xxa$Ii3" role="1B3o_S" />
+      <node concept="3clFbS" id="5vc9Xxa$Ii4" role="3clF47">
+        <node concept="XkiVB" id="5vc9Xxa$Ii5" role="3cqZAp">
+          <ref role="37wK5l" to="emqf:~AbstractCellListHandler.&lt;init&gt;(jetbrains.mps.openapi.editor.EditorContext)" resolve="AbstractCellListHandler" />
+          <node concept="37vLTw" id="5vc9Xxa$Ii6" role="37wK5m">
+            <ref role="3cqZAo" node="5vc9Xxa$Iib" resolve="context" />
+          </node>
+        </node>
+        <node concept="3clFbF" id="5vc9Xxa$Ii7" role="3cqZAp">
+          <node concept="37vLTI" id="5vc9Xxa$Ii8" role="3clFbG">
+            <node concept="37vLTw" id="5vc9Xxa$Ii9" role="37vLTJ">
+              <ref role="3cqZAo" node="1SwultAiTIH" resolve="myOwner" />
+            </node>
+            <node concept="37vLTw" id="5vc9Xxa$Iia" role="37vLTx">
+              <ref role="3cqZAo" node="5vc9Xxa$Iid" resolve="owner" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="5vc9Xxa_4do" role="3cqZAp">
+          <node concept="37vLTI" id="5vc9Xxa_4NN" role="3clFbG">
+            <node concept="37vLTw" id="5vc9Xxa_6nn" role="37vLTx">
+              <ref role="3cqZAo" node="5vc9Xxa_2KE" resolve="readonly" />
+            </node>
+            <node concept="37vLTw" id="5vc9Xxa_4dm" role="37vLTJ">
+              <ref role="3cqZAo" node="5vc9Xxa$Y6e" resolve="myReadOnly" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="5vc9Xxa$Iib" role="3clF46">
+        <property role="TrG5h" value="context" />
+        <node concept="3uibUv" id="5vc9Xxa$Iic" role="1tU5fm">
+          <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="5vc9Xxa$Iid" role="3clF46">
+        <property role="TrG5h" value="owner" />
+        <node concept="3Tqbb2" id="5vc9Xxa$Iie" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="5vc9Xxa_2KE" role="3clF46">
+        <property role="TrG5h" value="readOnly" />
+        <node concept="10P_77" id="5vc9Xxa_3cx" role="1tU5fm" />
       </node>
     </node>
     <node concept="2tJIrI" id="1BXECvJT4NA" role="jymVt" />
@@ -1665,13 +1721,18 @@
                 <node concept="1bVj0M" id="5bKNAZ5i3K$" role="23t8la">
                   <node concept="3clFbS" id="5bKNAZ5i3K_" role="1bW5cS">
                     <node concept="3clFbF" id="5bKNAZ5i3R_" role="3cqZAp">
-                      <node concept="3y3z36" id="5bKNAZ5i4oI" role="3clFbG">
-                        <node concept="10Nm6u" id="5bKNAZ5i4uL" role="3uHU7w" />
-                        <node concept="2OqwBi" id="5bKNAZ5i3Ya" role="3uHU7B">
-                          <node concept="37vLTw" id="5bKNAZ5i3R$" role="2Oq$k0">
-                            <ref role="3cqZAo" node="5bKNAZ5i3KA" resolve="it" />
+                      <node concept="22lmx$" id="5vc9Xxa_D9z" role="3clFbG">
+                        <node concept="37vLTw" id="5vc9Xxa_QNU" role="3uHU7w">
+                          <ref role="3cqZAo" node="5vc9Xxa$Y6e" resolve="myReadOnly" />
+                        </node>
+                        <node concept="3y3z36" id="5bKNAZ5i4oI" role="3uHU7B">
+                          <node concept="2OqwBi" id="5bKNAZ5i3Ya" role="3uHU7B">
+                            <node concept="37vLTw" id="5bKNAZ5i3R$" role="2Oq$k0">
+                              <ref role="3cqZAo" node="5bKNAZ5i3KA" resolve="it" />
+                            </node>
+                            <node concept="I4A8Y" id="5bKNAZ5i44q" role="2OqNvi" />
                           </node>
-                          <node concept="I4A8Y" id="5bKNAZ5i44q" role="2OqNvi" />
+                          <node concept="10Nm6u" id="5bKNAZ5i4uL" role="3uHU7w" />
                         </node>
                       </node>
                     </node>

--- a/code/querylist/com.mbeddr.mpsutil.editor.querylist.runtime/models/com/mbeddr/mpsutil/editor/querylist/runtime.mps
+++ b/code/querylist/com.mbeddr.mpsutil.editor.querylist.runtime/models/com/mbeddr/mpsutil/editor/querylist/runtime.mps
@@ -744,7 +744,7 @@
         </node>
       </node>
       <node concept="2AHcQZ" id="5vc9XxaAWIx" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" />
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="2tJIrI" id="5vc9Xxa$Mn4" role="jymVt" />
@@ -771,7 +771,7 @@
         <node concept="3clFbF" id="5vc9Xxa_4do" role="3cqZAp">
           <node concept="37vLTI" id="5vc9Xxa_4NN" role="3clFbG">
             <node concept="37vLTw" id="5vc9Xxa_6nn" role="37vLTx">
-              <ref role="3cqZAo" node="5vc9Xxa_2KE" resolve="readonly" />
+              <ref role="3cqZAo" node="5vc9Xxa_2KE" resolve="readOnly" />
             </node>
             <node concept="37vLTw" id="5vc9Xxa_4dm" role="37vLTJ">
               <ref role="3cqZAo" node="5vc9Xxa$Y6e" resolve="myReadOnly" />

--- a/code/querylist/com.mbeddr.mpsutil.editor.querylist.sandbox/models/com/mbeddr/mpsutil/editor/querylist/sandbox.mps
+++ b/code/querylist/com.mbeddr.mpsutil.editor.querylist.sandbox/models/com/mbeddr/mpsutil/editor/querylist/sandbox.mps
@@ -95,6 +95,7 @@
         <child id="393429538060968390" name="statementWrappers" index="2hc9Zi" />
         <child id="6202678563380435709" name="statementList" index="sbcQR" />
       </concept>
+      <concept id="6326475386467211568" name="com.mbeddr.mpsutil.editor.querylist.demolang.structure.RootDynamicContent" flags="ng" index="trnVC" />
       <concept id="1952741127689452125" name="com.mbeddr.mpsutil.editor.querylist.demolang.structure.RootWithChildren" flags="ng" index="2X83RC">
         <child id="1952741127689452126" name="names1" index="2X83RF" />
         <child id="1952741127690160050" name="names3" index="2Xng07" />
@@ -363,5 +364,6 @@
       <property role="Xl_RC" value="Domino" />
     </node>
   </node>
+  <node concept="trnVC" id="5vc9XxaKm$o" />
 </model>
 

--- a/code/querylist/com.mbeddr.mpsutil.editor.querylist/generator/template/main@generator.mps
+++ b/code/querylist/com.mbeddr.mpsutil.editor.querylist/generator/template/main@generator.mps
@@ -819,7 +819,7 @@
                       </node>
                       <node concept="2ShNRf" id="1WjrBsNI_nm" role="33vP2m">
                         <node concept="1pGfFk" id="1WjrBsNI_nn" role="2ShVmc">
-                          <ref role="37wK5l" node="1BXECvJWl_s" resolve="GeneratedQueryListHandler" />
+                          <ref role="37wK5l" node="1BXECvJWl_s" resolve="_context_class_.GeneratedQueryListHandler" />
                           <node concept="37vLTw" id="1WjrBsNI_no" role="37wK5m">
                             <ref role="3cqZAo" node="fYh_FQ2" resolve="editorContext" />
                           </node>
@@ -1608,7 +1608,7 @@
           <node concept="3Tm1VV" id="1BXECvJWl_v" role="1B3o_S" />
           <node concept="3clFbS" id="1BXECvJWl_w" role="3clF47">
             <node concept="1VxSAg" id="5vc9XxaAf85" role="3cqZAp">
-              <ref role="37wK5l" node="5vc9XxaAaFz" resolve="GeneratedQueryListHandler" />
+              <ref role="37wK5l" node="5vc9XxaAaFz" resolve="_context_class_.GeneratedQueryListHandler" />
               <node concept="37vLTw" id="5vc9XxaAgTr" role="37wK5m">
                 <ref role="3cqZAo" node="1BXECvJWlHy" resolve="context" />
               </node>
@@ -1634,7 +1634,7 @@
             </node>
           </node>
           <node concept="2AHcQZ" id="5vc9XxaATPi" role="2AJF6D">
-            <ref role="2AI5Lk" to="wyt6:~Deprecated" />
+            <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
           </node>
         </node>
         <node concept="2tJIrI" id="5vc9XxaAfFg" role="jymVt" />

--- a/code/querylist/com.mbeddr.mpsutil.editor.querylist/generator/template/main@generator.mps
+++ b/code/querylist/com.mbeddr.mpsutil.editor.querylist/generator/template/main@generator.mps
@@ -8,6 +8,7 @@
     <use id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core" version="2" />
     <use id="df345b11-b8c7-4213-ac66-48d2a9b75d88" name="jetbrains.mps.baseLanguageInternal" version="0" />
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
+    <use id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc" version="2" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -221,6 +222,7 @@
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
       <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
       <concept id="1146644641414" name="jetbrains.mps.baseLanguage.structure.ProtectedVisibility" flags="nn" index="3Tmbuc" />
+      <concept id="1178893518978" name="jetbrains.mps.baseLanguage.structure.ThisConstructorInvocation" flags="nn" index="1VxSAg" />
       <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
       <concept id="1170345865475" name="jetbrains.mps.baseLanguage.structure.AnonymousClass" flags="ig" index="1Y3b0j">
         <reference id="1170346070688" name="classifier" index="1Y3XeK" />
@@ -297,6 +299,16 @@
         <child id="1199569916463" name="body" index="1bW5cS" />
       </concept>
     </language>
+    <language id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc">
+      <concept id="5349172909345501395" name="jetbrains.mps.baseLanguage.javadoc.structure.BaseDocComment" flags="ng" index="P$AiS">
+        <child id="5383422241790532083" name="tags" index="3nqlJM" />
+      </concept>
+      <concept id="5349172909345532724" name="jetbrains.mps.baseLanguage.javadoc.structure.MethodDocComment" flags="ng" index="P$JXv" />
+      <concept id="8465538089690331500" name="jetbrains.mps.baseLanguage.javadoc.structure.CommentLine" flags="ng" index="TZ5HA" />
+      <concept id="8465538089690331492" name="jetbrains.mps.baseLanguage.javadoc.structure.DeprecatedBlockDocTag" flags="ng" index="TZ5HI">
+        <child id="2667874559098216723" name="text" index="3HnX3l" />
+      </concept>
+    </language>
     <language id="d7706f63-9be2-479c-a3da-ae92af1e64d5" name="jetbrains.mps.lang.generator.generationContext">
       <concept id="1218047638031" name="jetbrains.mps.lang.generator.generationContext.structure.GenerationContextOp_CreateUniqueName" flags="nn" index="2piZGk">
         <child id="1218047638032" name="baseName" index="2piZGb" />
@@ -336,6 +348,9 @@
         <child id="1145404616321" name="leftExpression" index="2JrQYb" />
       </concept>
       <concept id="1171310072040" name="jetbrains.mps.lang.smodel.structure.Node_GetContainingRootOperation" flags="nn" index="2Rxl7S" />
+      <concept id="2644386474300074836" name="jetbrains.mps.lang.smodel.structure.ConceptIdRefExpression" flags="nn" index="35c_gC">
+        <reference id="2644386474300074837" name="conceptDeclaration" index="35c_gD" />
+      </concept>
       <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
         <child id="1177027386292" name="conceptArgument" index="cj9EA" />
       </concept>
@@ -804,7 +819,7 @@
                       </node>
                       <node concept="2ShNRf" id="1WjrBsNI_nm" role="33vP2m">
                         <node concept="1pGfFk" id="1WjrBsNI_nn" role="2ShVmc">
-                          <ref role="37wK5l" node="1BXECvJWl_s" resolve="_context_class_.GeneratedQueryListHandler" />
+                          <ref role="37wK5l" node="1BXECvJWl_s" resolve="GeneratedQueryListHandler" />
                           <node concept="37vLTw" id="1WjrBsNI_no" role="37wK5m">
                             <ref role="3cqZAo" node="fYh_FQ2" resolve="editorContext" />
                           </node>
@@ -1592,14 +1607,15 @@
           <node concept="3cqZAl" id="1BXECvJWl_u" role="3clF45" />
           <node concept="3Tm1VV" id="1BXECvJWl_v" role="1B3o_S" />
           <node concept="3clFbS" id="1BXECvJWl_w" role="3clF47">
-            <node concept="XkiVB" id="1BXECvJWlES" role="3cqZAp">
-              <ref role="37wK5l" to="d2zl:1BXECvJT4Ug" resolve="QueryListHandler" />
-              <node concept="37vLTw" id="1BXECvJWlPa" role="37wK5m">
+            <node concept="1VxSAg" id="5vc9XxaAf85" role="3cqZAp">
+              <ref role="37wK5l" node="5vc9XxaAaFz" resolve="GeneratedQueryListHandler" />
+              <node concept="37vLTw" id="5vc9XxaAgTr" role="37wK5m">
                 <ref role="3cqZAo" node="1BXECvJWlHy" resolve="context" />
               </node>
-              <node concept="37vLTw" id="1BXECvJWlQl" role="37wK5m">
+              <node concept="37vLTw" id="5vc9XxaAkll" role="37wK5m">
                 <ref role="3cqZAo" node="1BXECvJWlKM" resolve="node" />
               </node>
+              <node concept="3clFbT" id="5vc9XxaAmmg" role="37wK5m" />
             </node>
           </node>
           <node concept="37vLTG" id="1BXECvJWlHy" role="3clF46">
@@ -1612,7 +1628,49 @@
             <property role="TrG5h" value="node" />
             <node concept="3Tqbb2" id="1BXECvJWlNW" role="1tU5fm" />
           </node>
+          <node concept="P$JXv" id="5vc9XxaATPf" role="lGtFl">
+            <node concept="TZ5HI" id="5vc9XxaATPg" role="3nqlJM">
+              <node concept="TZ5HA" id="5vc9XxaATPh" role="3HnX3l" />
+            </node>
+          </node>
+          <node concept="2AHcQZ" id="5vc9XxaATPi" role="2AJF6D">
+            <ref role="2AI5Lk" to="wyt6:~Deprecated" />
+          </node>
         </node>
+        <node concept="2tJIrI" id="5vc9XxaAfFg" role="jymVt" />
+        <node concept="3clFbW" id="5vc9XxaAaFz" role="jymVt">
+          <node concept="3cqZAl" id="5vc9XxaAaF$" role="3clF45" />
+          <node concept="3Tm1VV" id="5vc9XxaAaF_" role="1B3o_S" />
+          <node concept="3clFbS" id="5vc9XxaAaFA" role="3clF47">
+            <node concept="XkiVB" id="5vc9XxaAaFB" role="3cqZAp">
+              <ref role="37wK5l" to="d2zl:5vc9Xxa$Ii1" resolve="QueryListHandler" />
+              <node concept="37vLTw" id="5vc9XxaAaFC" role="37wK5m">
+                <ref role="3cqZAo" node="5vc9XxaAaFE" resolve="context" />
+              </node>
+              <node concept="37vLTw" id="5vc9XxaAaFD" role="37wK5m">
+                <ref role="3cqZAo" node="5vc9XxaAaFG" resolve="node" />
+              </node>
+              <node concept="37vLTw" id="5vc9XxaAqip" role="37wK5m">
+                <ref role="3cqZAo" node="5vc9XxaAbj4" resolve="readOnly" />
+              </node>
+            </node>
+          </node>
+          <node concept="37vLTG" id="5vc9XxaAaFE" role="3clF46">
+            <property role="TrG5h" value="context" />
+            <node concept="3uibUv" id="5vc9XxaAaFF" role="1tU5fm">
+              <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+            </node>
+          </node>
+          <node concept="37vLTG" id="5vc9XxaAaFG" role="3clF46">
+            <property role="TrG5h" value="node" />
+            <node concept="3Tqbb2" id="5vc9XxaAaFH" role="1tU5fm" />
+          </node>
+          <node concept="37vLTG" id="5vc9XxaAbj4" role="3clF46">
+            <property role="TrG5h" value="readOnly" />
+            <node concept="10P_77" id="5vc9XxaAbtE" role="1tU5fm" />
+          </node>
+        </node>
+        <node concept="2tJIrI" id="5vc9XxaAnNO" role="jymVt" />
         <node concept="3clFb_" id="lPJxikaSvi" role="jymVt">
           <property role="1EzhhJ" value="false" />
           <property role="TrG5h" value="getSubstituteInfo" />
@@ -1792,12 +1850,34 @@
           </node>
           <node concept="3clFbS" id="heOoiM4" role="3clF47">
             <node concept="XkiVB" id="heOoiM5" role="3cqZAp">
-              <ref role="37wK5l" to="d2zl:1BXECvJT4Ug" resolve="QueryListHandler" />
+              <ref role="37wK5l" to="d2zl:5vc9Xxa$Ii1" resolve="QueryListHandler" />
               <node concept="37vLTw" id="1BXECvJTDed" role="37wK5m">
                 <ref role="3cqZAo" node="heOoiMl" resolve="context" />
               </node>
               <node concept="37vLTw" id="2BHiRxgmFoX" role="37wK5m">
                 <ref role="3cqZAo" node="heOoiMh" resolve="ownerNode" />
+              </node>
+              <node concept="3clFbT" id="5vc9XxaBkeU" role="37wK5m">
+                <node concept="17Uvod" id="5vc9XxaBkTN" role="lGtFl">
+                  <property role="2qtEX9" value="value" />
+                  <property role="P4ACc" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123137/1068580123138" />
+                  <node concept="3zFVjK" id="5vc9XxaBkTO" role="3zH0cK">
+                    <node concept="3clFbS" id="5vc9XxaBkTP" role="2VODD2">
+                      <node concept="3clFbF" id="5vc9XxaBlwe" role="3cqZAp">
+                        <node concept="2OqwBi" id="5vc9XxaBlwf" role="3clFbG">
+                          <node concept="30H73N" id="5vc9XxaBlwg" role="2Oq$k0" />
+                          <node concept="2qgKlT" id="5vc9XxaBlwh" role="2OqNvi">
+                            <ref role="37wK5l" to="tpcb:i0pNf1r" resolve="getBooleanStyleValue" />
+                            <node concept="35c_gC" id="5vc9XxaBlwi" role="37wK5m">
+                              <ref role="35c_gD" to="tpc2:G99PKEU3Jd" resolve="ReadOnlyStyleClassItem" />
+                            </node>
+                            <node concept="3clFbT" id="5vc9XxaBlwj" role="37wK5m" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
               </node>
             </node>
             <node concept="3clFbF" id="1AuRJ4GJnll" role="3cqZAp">
@@ -5302,7 +5382,7 @@
                   <ref role="3cqZAo" node="8dI1zL4mCv" resolve="emptyCell" />
                 </node>
                 <node concept="3nyPlj" id="8dI1zL4mCR" role="37vLTx">
-                  <ref role="37wK5l" to="emqf:~AbstractCellListHandler.createEmptyCell()" resolve="createEmptyCell" />
+                  <ref role="37wK5l" to="p9jd:~RefNodeListHandler.createEmptyCell()" resolve="createEmptyCell" />
                 </node>
               </node>
               <node concept="1W57fq" id="8dI1zL4mCT" role="lGtFl">

--- a/code/querylist/com.mbeddr.mpsutil.editor.querylist/languageModels/structure.mps
+++ b/code/querylist/com.mbeddr.mpsutil.editor.querylist/languageModels/structure.mps
@@ -16,7 +16,9 @@
       <concept id="6491077959632463275" name="jetbrains.mps.lang.structure.structure.EnumPropertyMigrationInfo" flags="ng" index="3l_iC">
         <child id="6491077959632463286" name="oldProperty" index="3l_iP" />
       </concept>
-      <concept id="1224240836180" name="jetbrains.mps.lang.structure.structure.DeprecatedNodeAnnotation" flags="ig" index="asaX9" />
+      <concept id="1224240836180" name="jetbrains.mps.lang.structure.structure.DeprecatedNodeAnnotation" flags="ig" index="asaX9">
+        <property id="1225118933224" name="comment" index="YLQ7P" />
+      </concept>
       <concept id="1169125787135" name="jetbrains.mps.lang.structure.structure.AbstractConceptDeclaration" flags="ig" index="PkWjJ">
         <property id="6714410169261853888" name="conceptId" index="EcuMT" />
         <property id="5092175715804935370" name="conceptAlias" index="34LRSv" />
@@ -99,6 +101,9 @@
       <property role="TrG5h" value="readOnly" />
       <property role="IQ2nx" value="1140017977771" />
       <ref role="AX2Wp" to="tpck:fKAQMTB" resolve="boolean" />
+      <node concept="asaX9" id="5vc9XxaAxBX" role="lGtFl">
+        <property role="YLQ7P" value="this property is not used" />
+      </node>
     </node>
     <node concept="1TJgyi" id="g_O74Lt" role="1TKVEl">
       <property role="TrG5h" value="allowEmptyText" />

--- a/code/statistics/models/de.itemis.mps.statistics.plugin.mps
+++ b/code/statistics/models/de.itemis.mps.statistics.plugin.mps
@@ -278,11 +278,11 @@
                     <node concept="3clFbF" id="5WCc3M3CKu4" role="3cqZAp">
                       <node concept="2OqwBi" id="5WCc3M3CLkV" role="3clFbG">
                         <node concept="37vLTw" id="5WCc3M3CKu2" role="2Oq$k0">
-                          <ref role="3cqZAo" node="5WCc3M3CyI4" resolve="languages" />
+                          <ref role="3cqZAo" node="5WCc3M3CyI4" resolve="dependencies" />
                         </node>
                         <node concept="TSZUe" id="5WCc3M3CMAn" role="2OqNvi">
                           <node concept="37vLTw" id="5WCc3M3CMHl" role="25WWJ7">
-                            <ref role="3cqZAo" node="5WCc3M3CJiU" resolve="toString" />
+                            <ref role="3cqZAo" node="5WCc3M3CJiU" resolve="dependencyStr" />
                           </node>
                         </node>
                       </node>
@@ -293,7 +293,7 @@
                     <node concept="2XshWL" id="5WCc3M3DfGy" role="2OqNvi">
                       <ref role="2WH_rO" node="5WCc3M3DcW0" resolve="isAllowed" />
                       <node concept="37vLTw" id="5WCc3M3DfIn" role="2XxRq1">
-                        <ref role="3cqZAo" node="5WCc3M3CJiU" resolve="toString" />
+                        <ref role="3cqZAo" node="5WCc3M3CJiU" resolve="dependencyStr" />
                       </node>
                     </node>
                   </node>
@@ -455,7 +455,7 @@
               <node concept="2OqwBi" id="5WCc3M3DEMB" role="2GsD0m">
                 <node concept="2OqwBi" id="5WCc3M3DCrh" role="2Oq$k0">
                   <node concept="37vLTw" id="5WCc3M3DB9T" role="2Oq$k0">
-                    <ref role="3cqZAo" node="5WCc3M3CyI4" resolve="languages" />
+                    <ref role="3cqZAo" node="5WCc3M3CyI4" resolve="dependencies" />
                   </node>
                   <node concept="ANE8D" id="5WCc3M3DE1T" role="2OqNvi" />
                 </node>

--- a/code/tables/languages/de.slisson.mps.tables/generator/template/main@generator.mps
+++ b/code/tables/languages/de.slisson.mps.tables/generator/template/main@generator.mps
@@ -2283,7 +2283,7 @@
                                     <ref role="3cqZAo" node="1dAqnm8$DVo" resolve="editorCell" />
                                   </node>
                                   <node concept="liA8E" id="7DPEkiwN2f8" role="2OqNvi">
-                                    <ref role="37wK5l" to="hm5v:7DPEkiwMAV0" resolve="toggleRowAndColumnUIActions" />
+                                    <ref role="37wK5l" to="hm5v:7DPEkiwMAV0" resolve="toggleRowUIActions" />
                                     <node concept="3clFbT" id="7DPEkiwN2f9" role="37wK5m">
                                       <property role="3clFbU" value="true" />
                                     </node>
@@ -2296,7 +2296,7 @@
                                         <node concept="2OqwBi" id="7DPEkiwN2fe" role="3clFbG">
                                           <node concept="30H73N" id="7DPEkiwN2ff" role="2Oq$k0" />
                                           <node concept="3TrcHB" id="7DPEkiwN2fg" role="2OqNvi">
-                                            <ref role="3TsBF5" to="bnk3:7DPEkiwMTk_" resolve="rowAndColumnUIActions" />
+                                            <ref role="3TsBF5" to="bnk3:7DPEkiwMTk_" resolve="rowUIActions" />
                                           </node>
                                         </node>
                                       </node>

--- a/code/tables/languages/de.slisson.mps.tables/runtime/models/de/slisson/mps/tables/runtime/cells.mps
+++ b/code/tables/languages/de.slisson.mps.tables/runtime/models/de/slisson/mps/tables/runtime/cells.mps
@@ -1881,7 +1881,7 @@
               <ref role="3cqZAo" node="7DPEkiwMEG5" resolve="flag" />
             </node>
             <node concept="37vLTw" id="7DPEkiwMKfS" role="37vLTJ">
-              <ref role="3cqZAo" node="7DPEkiwMnAo" resolve="myRowAndColumnUIActions" />
+              <ref role="3cqZAo" node="7DPEkiwMnAo" resolve="myRowUIActions" />
             </node>
           </node>
         </node>
@@ -1921,7 +1921,7 @@
       <node concept="3clFbS" id="7DPEkiwNldo" role="3clF47">
         <node concept="3clFbF" id="7DPEkiwNplT" role="3cqZAp">
           <node concept="37vLTw" id="7DPEkiwNplS" role="3clFbG">
-            <ref role="3cqZAo" node="7DPEkiwMnAo" resolve="myRowAndColumnUIActions" />
+            <ref role="3cqZAo" node="7DPEkiwMnAo" resolve="myRowUIActions" />
           </node>
         </node>
       </node>
@@ -28131,7 +28131,7 @@
             </node>
             <node concept="2ShNRf" id="4eOnSiwSCwR" role="37wK5m">
               <node concept="1pGfFk" id="7IUya7cg2uv" role="2ShVmc">
-                <ref role="37wK5l" node="7IUya7cfM4j" resolve="InsertAction" />
+                <ref role="37wK5l" node="7IUya7cfM4j" resolve="TableActions.InsertRowAction" />
                 <node concept="Xjq3P" id="7IUya7cg2uu" role="37wK5m" />
                 <node concept="37vLTw" id="7IUya7cgci6" role="37wK5m">
                   <ref role="3cqZAo" node="12WeXpXn$48" resolve="myLeftEnd" />
@@ -28165,7 +28165,7 @@
             </node>
             <node concept="2ShNRf" id="40oIQyHKQhe" role="37wK5m">
               <node concept="1pGfFk" id="7IUya7ciW44" role="2ShVmc">
-                <ref role="37wK5l" node="7IUya7ciSfI" resolve="DeleteAction" />
+                <ref role="37wK5l" node="7IUya7ciSfI" resolve="TableActions.DeleteRowAction" />
                 <node concept="Xjq3P" id="7IUya7ciW43" role="37wK5m" />
               </node>
             </node>
@@ -28180,7 +28180,7 @@
             </node>
             <node concept="2ShNRf" id="5AW5JoZbd$V" role="37wK5m">
               <node concept="1pGfFk" id="7IUya7ciZ9l" role="2ShVmc">
-                <ref role="37wK5l" node="7IUya7ciXQl" resolve="SelectRowNodeAction" />
+                <ref role="37wK5l" node="7IUya7ciXQl" resolve="TableActions.SelectRowNodeAction" />
                 <node concept="Xjq3P" id="7IUya7ciZ9k" role="37wK5m" />
               </node>
             </node>
@@ -28195,7 +28195,7 @@
             </node>
             <node concept="2ShNRf" id="5AW5JoZbKKJ" role="37wK5m">
               <node concept="1pGfFk" id="7IUya7cj15Z" role="2ShVmc">
-                <ref role="37wK5l" node="7IUya7ciXQl" resolve="SelectRowNodeAction" />
+                <ref role="37wK5l" node="7IUya7ciXQl" resolve="TableActions.SelectRowNodeAction" />
                 <node concept="Xjq3P" id="7IUya7cj15Y" role="37wK5m" />
               </node>
             </node>
@@ -28210,7 +28210,7 @@
             </node>
             <node concept="2ShNRf" id="5AW5JoZAbPx" role="37wK5m">
               <node concept="1pGfFk" id="7IUya7cj32B" role="2ShVmc">
-                <ref role="37wK5l" node="7IUya7cix5V" resolve="PasteAction" />
+                <ref role="37wK5l" node="7IUya7cix5V" resolve="TableActions.PasteAction" />
                 <node concept="Xjq3P" id="7IUya7cj32A" role="37wK5m" />
                 <node concept="37vLTw" id="7IUya7cj6aN" role="37wK5m">
                   <ref role="3cqZAo" node="12WeXpXn$48" resolve="myLeftEnd" />
@@ -34336,11 +34336,11 @@
       <node concept="3Tm1VV" id="56WqtlUi2Y0" role="1B3o_S" />
       <node concept="QsSxf" id="56WqtlUikN_" role="Qtgdg">
         <property role="TrG5h" value="ROW" />
-        <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" />
+        <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
       </node>
       <node concept="QsSxf" id="56WqtlUilBp" role="Qtgdg">
         <property role="TrG5h" value="COLUMN" />
-        <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" />
+        <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
       </node>
     </node>
     <node concept="2tJIrI" id="56WqtlUi0Gs" role="jymVt" />
@@ -34388,7 +34388,7 @@
         <node concept="3clFbS" id="56WqtlUiwfU" role="3clF47" />
         <node concept="3Tm1VV" id="56WqtlUiqVJ" role="1B3o_S" />
         <node concept="3uibUv" id="56WqtlUitmr" role="3clF45">
-          <ref role="3uigEE" node="56WqtlUi2XZ" resolve="TableActionType" />
+          <ref role="3uigEE" node="56WqtlUi2XZ" resolve="TableActions.TableActionType" />
         </node>
       </node>
       <node concept="2tJIrI" id="7IUya7chGH_" role="jymVt" />
@@ -34568,7 +34568,7 @@
                   </node>
                   <node concept="Rm8GO" id="56WqtlUjcxL" role="3uHU7w">
                     <ref role="Rm8GQ" node="56WqtlUilBp" resolve="COLUMN" />
-                    <ref role="1Px2BO" node="56WqtlUi2XZ" resolve="TableActionType" />
+                    <ref role="1Px2BO" node="56WqtlUi2XZ" resolve="TableActions.TableActionType" />
                   </node>
                 </node>
               </node>
@@ -34584,7 +34584,7 @@
           </node>
         </node>
         <node concept="2AHcQZ" id="7IUya7cjexm" role="2AJF6D">
-          <ref role="2AI5Lk" to="wyt6:~Override" />
+          <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
         </node>
       </node>
     </node>
@@ -34600,7 +34600,7 @@
       <node concept="2tJIrI" id="6R0q0mZqdfT" role="jymVt" />
       <node concept="3Tm1VV" id="6R0q0mZpWsr" role="1B3o_S" />
       <node concept="3uibUv" id="6R0q0mZpZDz" role="1zkMxy">
-        <ref role="3uigEE" node="7IUya7ch5ON" resolve="AbstractTableCellAction" />
+        <ref role="3uigEE" node="7IUya7ch5ON" resolve="TableActions.AbstractTableCellAction" />
       </node>
       <node concept="3clFbW" id="6R0q0mZq1YX" role="jymVt">
         <node concept="3cqZAl" id="6R0q0mZq1YY" role="3clF45" />
@@ -34617,7 +34617,7 @@
         </node>
         <node concept="3clFbS" id="6R0q0mZq1Z9" role="3clF47">
           <node concept="XkiVB" id="6R0q0mZq1Za" role="3cqZAp">
-            <ref role="37wK5l" node="7IUya7chrcn" resolve="AbstractTableCellAction" />
+            <ref role="37wK5l" node="7IUya7chrcn" resolve="TableActions.AbstractTableCellAction" />
             <node concept="37vLTw" id="6R0q0mZq1Zb" role="37wK5m">
               <ref role="3cqZAo" node="6R0q0mZq1Z7" resolve="cell" />
             </node>
@@ -34642,13 +34642,13 @@
         <property role="TrG5h" value="getActionType" />
         <node concept="3Tm1VV" id="56WqtlUizPt" role="1B3o_S" />
         <node concept="3uibUv" id="56WqtlUizPu" role="3clF45">
-          <ref role="3uigEE" node="56WqtlUi2XZ" resolve="TableActionType" />
+          <ref role="3uigEE" node="56WqtlUi2XZ" resolve="TableActions.TableActionType" />
         </node>
         <node concept="3clFbS" id="56WqtlUizPv" role="3clF47">
           <node concept="3clFbF" id="56WqtlUiBoA" role="3cqZAp">
             <node concept="Rm8GO" id="56WqtlUiCdQ" role="3clFbG">
               <ref role="Rm8GQ" node="56WqtlUilBp" resolve="COLUMN" />
-              <ref role="1Px2BO" node="56WqtlUi2XZ" resolve="TableActionType" />
+              <ref role="1Px2BO" node="56WqtlUi2XZ" resolve="TableActions.TableActionType" />
             </node>
           </node>
         </node>
@@ -34949,7 +34949,7 @@
           </node>
         </node>
         <node concept="2AHcQZ" id="6R0q0mZq0c$" role="2AJF6D">
-          <ref role="2AI5Lk" to="wyt6:~Override" />
+          <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
         </node>
       </node>
       <node concept="2tJIrI" id="56WqtlUiAvB" role="jymVt" />
@@ -34968,7 +34968,7 @@
         <node concept="3cqZAl" id="7IUya7cfM4k" role="3clF45" />
         <node concept="3clFbS" id="7IUya7cfM4m" role="3clF47">
           <node concept="XkiVB" id="7IUya7chYfC" role="3cqZAp">
-            <ref role="37wK5l" node="7IUya7chrcn" resolve="AbstractTableCellAction" />
+            <ref role="37wK5l" node="7IUya7chrcn" resolve="TableActions.AbstractTableCellAction" />
             <node concept="37vLTw" id="7IUya7chZ4v" role="37wK5m">
               <ref role="3cqZAo" node="7IUya7cfRzt" resolve="cell" />
             </node>
@@ -34976,12 +34976,12 @@
           <node concept="3clFbF" id="7IUya7cfQ6s" role="3cqZAp">
             <node concept="37vLTI" id="7IUya7cfQWB" role="3clFbG">
               <node concept="37vLTw" id="7IUya7cfRoh" role="37vLTx">
-                <ref role="3cqZAo" node="7IUya7cfN09" resolve="leftSide" />
+                <ref role="3cqZAo" node="7IUya7cfN09" resolve="before" />
               </node>
               <node concept="2OqwBi" id="7IUya7cfQf4" role="37vLTJ">
                 <node concept="Xjq3P" id="7IUya7cfQ6r" role="2Oq$k0" />
                 <node concept="2OwXpG" id="7IUya7cfQB1" role="2OqNvi">
-                  <ref role="2Oxat5" node="7IUya7cfP4l" resolve="leftSide" />
+                  <ref role="2Oxat5" node="7IUya7cfP4l" resolve="before" />
                 </node>
               </node>
             </node>
@@ -35004,13 +35004,13 @@
         <property role="TrG5h" value="getActionType" />
         <node concept="3Tm1VV" id="56WqtlUiFhi" role="1B3o_S" />
         <node concept="3uibUv" id="56WqtlUiFhj" role="3clF45">
-          <ref role="3uigEE" node="56WqtlUi2XZ" resolve="TableActionType" />
+          <ref role="3uigEE" node="56WqtlUi2XZ" resolve="TableActions.TableActionType" />
         </node>
         <node concept="3clFbS" id="56WqtlUiFhk" role="3clF47">
           <node concept="3clFbF" id="56WqtlUiFhl" role="3cqZAp">
             <node concept="Rm8GO" id="56WqtlUiGo4" role="3clFbG">
               <ref role="Rm8GQ" node="56WqtlUikN_" resolve="ROW" />
-              <ref role="1Px2BO" node="56WqtlUi2XZ" resolve="TableActionType" />
+              <ref role="1Px2BO" node="56WqtlUi2XZ" resolve="TableActions.TableActionType" />
             </node>
           </node>
         </node>
@@ -35067,7 +35067,7 @@
               </node>
             </node>
             <node concept="37vLTw" id="7IUya7ckLE3" role="3clFbw">
-              <ref role="3cqZAo" node="7IUya7cfP4l" resolve="leftSide" />
+              <ref role="3cqZAo" node="7IUya7cfP4l" resolve="before" />
             </node>
             <node concept="9aQIb" id="F5PM1gat1y" role="9aQIa">
               <node concept="3clFbS" id="F5PM1gat1z" role="9aQI4">
@@ -35096,7 +35096,7 @@
       </node>
       <node concept="3Tm1VV" id="7IUya7cfFCG" role="1B3o_S" />
       <node concept="3uibUv" id="7IUya7chVZy" role="1zkMxy">
-        <ref role="3uigEE" node="7IUya7ch5ON" resolve="AbstractTableCellAction" />
+        <ref role="3uigEE" node="7IUya7ch5ON" resolve="TableActions.AbstractTableCellAction" />
       </node>
     </node>
     <node concept="2tJIrI" id="7IUya7cfFbO" role="jymVt" />
@@ -35113,7 +35113,7 @@
         </node>
         <node concept="3clFbS" id="7IUya7ciXQx" role="3clF47">
           <node concept="XkiVB" id="7IUya7ciXQy" role="3cqZAp">
-            <ref role="37wK5l" node="7IUya7chrcn" resolve="AbstractTableCellAction" />
+            <ref role="37wK5l" node="7IUya7chrcn" resolve="TableActions.AbstractTableCellAction" />
             <node concept="37vLTw" id="7IUya7ciXQz" role="37wK5m">
               <ref role="3cqZAo" node="7IUya7ciXQv" resolve="cell" />
             </node>
@@ -35125,13 +35125,13 @@
         <property role="TrG5h" value="getActionType" />
         <node concept="3Tm1VV" id="56WqtlUiHfi" role="1B3o_S" />
         <node concept="3uibUv" id="56WqtlUiHfj" role="3clF45">
-          <ref role="3uigEE" node="56WqtlUi2XZ" resolve="TableActionType" />
+          <ref role="3uigEE" node="56WqtlUi2XZ" resolve="TableActions.TableActionType" />
         </node>
         <node concept="3clFbS" id="56WqtlUiHfk" role="3clF47">
           <node concept="3clFbF" id="56WqtlUiHfl" role="3cqZAp">
             <node concept="Rm8GO" id="56WqtlUiIEP" role="3clFbG">
               <ref role="Rm8GQ" node="56WqtlUikN_" resolve="ROW" />
-              <ref role="1Px2BO" node="56WqtlUi2XZ" resolve="TableActionType" />
+              <ref role="1Px2BO" node="56WqtlUi2XZ" resolve="TableActions.TableActionType" />
             </node>
           </node>
         </node>
@@ -35201,7 +35201,7 @@
       </node>
       <node concept="3Tm1VV" id="5AW5JoZb6HD" role="1B3o_S" />
       <node concept="3uibUv" id="7IUya7cik3F" role="1zkMxy">
-        <ref role="3uigEE" node="7IUya7ch5ON" resolve="AbstractTableCellAction" />
+        <ref role="3uigEE" node="7IUya7ch5ON" resolve="TableActions.AbstractTableCellAction" />
       </node>
     </node>
     <node concept="2tJIrI" id="7IUya7cgA7G" role="jymVt" />
@@ -35218,7 +35218,7 @@
         <node concept="3cqZAl" id="7IUya7cix5W" role="3clF45" />
         <node concept="3clFbS" id="7IUya7cix5Y" role="3clF47">
           <node concept="XkiVB" id="7IUya7ciN1Y" role="3cqZAp">
-            <ref role="37wK5l" node="7IUya7chrcn" resolve="AbstractTableCellAction" />
+            <ref role="37wK5l" node="7IUya7chrcn" resolve="TableActions.AbstractTableCellAction" />
             <node concept="37vLTw" id="7IUya7ciNyi" role="37wK5m">
               <ref role="3cqZAo" node="7IUya7ciKjU" resolve="cell" />
             </node>
@@ -35254,13 +35254,13 @@
         <property role="TrG5h" value="getActionType" />
         <node concept="3Tm1VV" id="56WqtlUiK3z" role="1B3o_S" />
         <node concept="3uibUv" id="56WqtlUiK3$" role="3clF45">
-          <ref role="3uigEE" node="56WqtlUi2XZ" resolve="TableActionType" />
+          <ref role="3uigEE" node="56WqtlUi2XZ" resolve="TableActions.TableActionType" />
         </node>
         <node concept="3clFbS" id="56WqtlUiK3_" role="3clF47">
           <node concept="3clFbF" id="56WqtlUiK3A" role="3cqZAp">
             <node concept="Rm8GO" id="56WqtlUiLfX" role="3clFbG">
               <ref role="Rm8GQ" node="56WqtlUikN_" resolve="ROW" />
-              <ref role="1Px2BO" node="56WqtlUi2XZ" resolve="TableActionType" />
+              <ref role="1Px2BO" node="56WqtlUi2XZ" resolve="TableActions.TableActionType" />
             </node>
           </node>
         </node>
@@ -35587,7 +35587,7 @@
       </node>
       <node concept="3Tm1VV" id="5AW5JoZCzaP" role="1B3o_S" />
       <node concept="3uibUv" id="7IUya7cilrl" role="1zkMxy">
-        <ref role="3uigEE" node="7IUya7ch5ON" resolve="AbstractTableCellAction" />
+        <ref role="3uigEE" node="7IUya7ch5ON" resolve="TableActions.AbstractTableCellAction" />
       </node>
     </node>
     <node concept="2tJIrI" id="7IUya7cgFfk" role="jymVt" />
@@ -35598,7 +35598,7 @@
         <node concept="3cqZAl" id="7IUya7ciSfJ" role="3clF45" />
         <node concept="3clFbS" id="7IUya7ciSfL" role="3clF47">
           <node concept="XkiVB" id="7IUya7ciSEJ" role="3cqZAp">
-            <ref role="37wK5l" node="7IUya7chrcn" resolve="AbstractTableCellAction" />
+            <ref role="37wK5l" node="7IUya7chrcn" resolve="TableActions.AbstractTableCellAction" />
             <node concept="37vLTw" id="7IUya7ciTaX" role="37wK5m">
               <ref role="3cqZAo" node="7IUya7ciSo5" resolve="cell" />
             </node>
@@ -35617,13 +35617,13 @@
         <property role="TrG5h" value="getActionType" />
         <node concept="3Tm1VV" id="56WqtlUiNG_" role="1B3o_S" />
         <node concept="3uibUv" id="56WqtlUiNGA" role="3clF45">
-          <ref role="3uigEE" node="56WqtlUi2XZ" resolve="TableActionType" />
+          <ref role="3uigEE" node="56WqtlUi2XZ" resolve="TableActions.TableActionType" />
         </node>
         <node concept="3clFbS" id="56WqtlUiNGB" role="3clF47">
           <node concept="3clFbF" id="56WqtlUiNGC" role="3cqZAp">
             <node concept="Rm8GO" id="56WqtlUiOv4" role="3clFbG">
               <ref role="Rm8GQ" node="56WqtlUikN_" resolve="ROW" />
-              <ref role="1Px2BO" node="56WqtlUi2XZ" resolve="TableActionType" />
+              <ref role="1Px2BO" node="56WqtlUi2XZ" resolve="TableActions.TableActionType" />
             </node>
           </node>
         </node>
@@ -35657,7 +35657,7 @@
       </node>
       <node concept="3Tm1VV" id="7IUya7cgVB1" role="1B3o_S" />
       <node concept="3uibUv" id="7IUya7ciRuz" role="1zkMxy">
-        <ref role="3uigEE" node="7IUya7ch5ON" resolve="AbstractTableCellAction" />
+        <ref role="3uigEE" node="7IUya7ch5ON" resolve="TableActions.AbstractTableCellAction" />
       </node>
     </node>
     <node concept="2tJIrI" id="6R0q0mZRJbf" role="jymVt" />
@@ -35668,7 +35668,7 @@
         <node concept="3cqZAl" id="6R0q0mZRHmp" role="3clF45" />
         <node concept="3clFbS" id="6R0q0mZRHmq" role="3clF47">
           <node concept="XkiVB" id="6R0q0mZRHmr" role="3cqZAp">
-            <ref role="37wK5l" node="7IUya7chrcn" resolve="AbstractTableCellAction" />
+            <ref role="37wK5l" node="7IUya7chrcn" resolve="TableActions.AbstractTableCellAction" />
             <node concept="37vLTw" id="6R0q0mZRHms" role="37wK5m">
               <ref role="3cqZAo" node="6R0q0mZRHmu" resolve="cell" />
             </node>
@@ -35687,12 +35687,12 @@
         <property role="TrG5h" value="getActionType" />
         <node concept="3Tm1VV" id="56WqtlUiRAk" role="1B3o_S" />
         <node concept="3uibUv" id="56WqtlUiRAl" role="3clF45">
-          <ref role="3uigEE" node="56WqtlUi2XZ" resolve="TableActionType" />
+          <ref role="3uigEE" node="56WqtlUi2XZ" resolve="TableActions.TableActionType" />
         </node>
         <node concept="3clFbS" id="56WqtlUiRAm" role="3clF47">
           <node concept="3clFbF" id="56WqtlUiRAn" role="3cqZAp">
             <node concept="Rm8GO" id="56WqtlUiRAo" role="3clFbG">
-              <ref role="1Px2BO" node="56WqtlUi2XZ" resolve="TableActionType" />
+              <ref role="1Px2BO" node="56WqtlUi2XZ" resolve="TableActions.TableActionType" />
               <ref role="Rm8GQ" node="56WqtlUilBp" resolve="COLUMN" />
             </node>
           </node>
@@ -35894,7 +35894,7 @@
       </node>
       <node concept="3Tm1VV" id="6R0q0mZRHmF" role="1B3o_S" />
       <node concept="3uibUv" id="6R0q0mZRHmG" role="1zkMxy">
-        <ref role="3uigEE" node="7IUya7ch5ON" resolve="AbstractTableCellAction" />
+        <ref role="3uigEE" node="7IUya7ch5ON" resolve="TableActions.AbstractTableCellAction" />
       </node>
     </node>
     <node concept="2tJIrI" id="7IUya7cgTJe" role="jymVt" />

--- a/code/tables/languages/de.slisson.mps.tables/runtime/models/de/slisson/mps/tables/runtime/plugin.mps
+++ b/code/tables/languages/de.slisson.mps.tables/runtime/models/de/slisson/mps/tables/runtime/plugin.mps
@@ -622,7 +622,7 @@
             <node concept="2ShNRf" id="7IUya7cjmzT" role="2Oq$k0">
               <node concept="1pGfFk" id="7IUya7cjmzU" role="2ShVmc">
                 <property role="373rjd" value="true" />
-                <ref role="37wK5l" to="hm5v:7IUya7ciSfI" resolve="DeleteAction" />
+                <ref role="37wK5l" to="hm5v:7IUya7ciSfI" resolve="TableActions.DeleteRowAction" />
                 <node concept="2OqwBi" id="7IUya7cjmzV" role="37wK5m">
                   <node concept="2WthIp" id="7IUya7cjmzW" role="2Oq$k0" />
                   <node concept="1DTwFV" id="7IUya7cjmzX" role="2OqNvi">
@@ -661,7 +661,7 @@
             <node concept="2ShNRf" id="7IUya7cj8SK" role="2Oq$k0">
               <node concept="1pGfFk" id="7IUya7cj94f" role="2ShVmc">
                 <property role="373rjd" value="true" />
-                <ref role="37wK5l" to="hm5v:7IUya7ciSfI" resolve="DeleteAction" />
+                <ref role="37wK5l" to="hm5v:7IUya7ciSfI" resolve="TableActions.DeleteRowAction" />
                 <node concept="2OqwBi" id="7IUya7cj99U" role="37wK5m">
                   <node concept="2WthIp" id="7IUya7cj99X" role="2Oq$k0" />
                   <node concept="1DTwFV" id="7IUya7cj99Z" role="2OqNvi">
@@ -686,7 +686,7 @@
     <node concept="1QGGSu" id="506gpRRkycw" role="3Uehp1">
       <node concept="10M0yZ" id="506gpRRl6rv" role="3xaMm5">
         <ref role="3cqZAo" to="z2i8:~AllIcons$Vcs.Remove" resolve="Remove" />
-        <ref role="1PxDUh" to="z2i8:~AllIcons$Vcs" resolve="Vcs" />
+        <ref role="1PxDUh" to="z2i8:~AllIcons$Vcs" resolve="AllIcons.Vcs" />
       </node>
     </node>
   </node>
@@ -728,7 +728,7 @@
         </node>
         <node concept="2JFkCU" id="6R0q0mZQNaK" role="3cqZAp">
           <node concept="tCFHf" id="6R0q0mZQNaL" role="2JFLmv">
-            <ref role="tCJdB" node="6R0q0mZQKWi" resolve="DeleteColumn" />
+            <ref role="tCJdB" node="6R0q0mZQKWi" resolve="DeleteTableColumn" />
           </node>
         </node>
         <node concept="2JFkCU" id="F5PM1gbFgf" role="3cqZAp">
@@ -749,7 +749,7 @@
             <node concept="2ShNRf" id="7IUya7cjq3c" role="2Oq$k0">
               <node concept="1pGfFk" id="7IUya7cjq3d" role="2ShVmc">
                 <property role="373rjd" value="true" />
-                <ref role="37wK5l" to="hm5v:7IUya7cfM4j" resolve="InsertAction" />
+                <ref role="37wK5l" to="hm5v:7IUya7cfM4j" resolve="TableActions.InsertRowAction" />
                 <node concept="2OqwBi" id="7IUya7cjq3e" role="37wK5m">
                   <node concept="2WthIp" id="7IUya7cjq3f" role="2Oq$k0" />
                   <node concept="1DTwFV" id="7IUya7cjq3g" role="2OqNvi">
@@ -791,7 +791,7 @@
             <node concept="2ShNRf" id="7IUya7cjo98" role="2Oq$k0">
               <node concept="1pGfFk" id="7IUya7cjon5" role="2ShVmc">
                 <property role="373rjd" value="true" />
-                <ref role="37wK5l" to="hm5v:7IUya7cfM4j" resolve="InsertAction" />
+                <ref role="37wK5l" to="hm5v:7IUya7cfM4j" resolve="TableActions.InsertRowAction" />
                 <node concept="2OqwBi" id="7IUya7cjoA_" role="37wK5m">
                   <node concept="2WthIp" id="7IUya7cjoAC" role="2Oq$k0" />
                   <node concept="1DTwFV" id="7IUya7cjoAE" role="2OqNvi">
@@ -832,7 +832,7 @@
             <node concept="2ShNRf" id="7IUya7cjqna" role="2Oq$k0">
               <node concept="1pGfFk" id="7IUya7cjqnb" role="2ShVmc">
                 <property role="373rjd" value="true" />
-                <ref role="37wK5l" to="hm5v:7IUya7cfM4j" resolve="InsertAction" />
+                <ref role="37wK5l" to="hm5v:7IUya7cfM4j" resolve="TableActions.InsertRowAction" />
                 <node concept="2OqwBi" id="7IUya7cjqnc" role="37wK5m">
                   <node concept="2WthIp" id="7IUya7cjqnd" role="2Oq$k0" />
                   <node concept="1DTwFV" id="7IUya7cjqne" role="2OqNvi">
@@ -872,7 +872,7 @@
             <node concept="2ShNRf" id="7IUya7cjqns" role="2Oq$k0">
               <node concept="1pGfFk" id="7IUya7cjqnt" role="2ShVmc">
                 <property role="373rjd" value="true" />
-                <ref role="37wK5l" to="hm5v:7IUya7cfM4j" resolve="InsertAction" />
+                <ref role="37wK5l" to="hm5v:7IUya7cfM4j" resolve="TableActions.InsertRowAction" />
                 <node concept="2OqwBi" id="7IUya7cjqnu" role="37wK5m">
                   <node concept="2WthIp" id="7IUya7cjqnv" role="2Oq$k0" />
                   <node concept="1DTwFV" id="7IUya7cjqnw" role="2OqNvi">
@@ -911,7 +911,7 @@
             <node concept="2ShNRf" id="6R0q0mZqoFx" role="2Oq$k0">
               <node concept="1pGfFk" id="6R0q0mZqoFy" role="2ShVmc">
                 <property role="373rjd" value="true" />
-                <ref role="37wK5l" to="hm5v:6R0q0mZq1YX" resolve="InsertColumnAction" />
+                <ref role="37wK5l" to="hm5v:6R0q0mZq1YX" resolve="TableActions.InsertColumnAction" />
                 <node concept="2OqwBi" id="6R0q0mZqoFz" role="37wK5m">
                   <node concept="2WthIp" id="6R0q0mZqoF$" role="2Oq$k0" />
                   <node concept="1DTwFV" id="6R0q0mZqoF_" role="2OqNvi">
@@ -951,7 +951,7 @@
             <node concept="2ShNRf" id="6R0q0mZqnWg" role="2Oq$k0">
               <node concept="1pGfFk" id="6R0q0mZqnWh" role="2ShVmc">
                 <property role="373rjd" value="true" />
-                <ref role="37wK5l" to="hm5v:6R0q0mZq1YX" resolve="InsertColumnAction" />
+                <ref role="37wK5l" to="hm5v:6R0q0mZq1YX" resolve="TableActions.InsertColumnAction" />
                 <node concept="2OqwBi" id="6R0q0mZqnWi" role="37wK5m">
                   <node concept="2WthIp" id="6R0q0mZqnWj" role="2Oq$k0" />
                   <node concept="1DTwFV" id="6R0q0mZqnWk" role="2OqNvi">
@@ -990,7 +990,7 @@
             <node concept="2ShNRf" id="6R0q0mZqnw4" role="2Oq$k0">
               <node concept="1pGfFk" id="6R0q0mZqnw5" role="2ShVmc">
                 <property role="373rjd" value="true" />
-                <ref role="37wK5l" to="hm5v:6R0q0mZq1YX" resolve="InsertColumnAction" />
+                <ref role="37wK5l" to="hm5v:6R0q0mZq1YX" resolve="TableActions.InsertColumnAction" />
                 <node concept="2OqwBi" id="6R0q0mZqnw6" role="37wK5m">
                   <node concept="2WthIp" id="6R0q0mZqnw7" role="2Oq$k0" />
                   <node concept="1DTwFV" id="6R0q0mZqnw8" role="2OqNvi">
@@ -1032,7 +1032,7 @@
             <node concept="2ShNRf" id="6R0q0mZqmnL" role="2Oq$k0">
               <node concept="1pGfFk" id="6R0q0mZqmR9" role="2ShVmc">
                 <property role="373rjd" value="true" />
-                <ref role="37wK5l" to="hm5v:6R0q0mZq1YX" resolve="InsertColumnAction" />
+                <ref role="37wK5l" to="hm5v:6R0q0mZq1YX" resolve="TableActions.InsertColumnAction" />
                 <node concept="2OqwBi" id="6R0q0mZqn0H" role="37wK5m">
                   <node concept="2WthIp" id="6R0q0mZqn0K" role="2Oq$k0" />
                   <node concept="1DTwFV" id="6R0q0mZqn0M" role="2OqNvi">
@@ -1073,7 +1073,7 @@
             <node concept="2ShNRf" id="6R0q0mZS8fb" role="2Oq$k0">
               <node concept="1pGfFk" id="6R0q0mZS8fc" role="2ShVmc">
                 <property role="373rjd" value="true" />
-                <ref role="37wK5l" to="hm5v:6R0q0mZRHmo" resolve="DeleteColumnAction" />
+                <ref role="37wK5l" to="hm5v:6R0q0mZRHmo" resolve="TableActions.DeleteColumnAction" />
                 <node concept="2OqwBi" id="6R0q0mZS8fd" role="37wK5m">
                   <node concept="2WthIp" id="6R0q0mZS8fe" role="2Oq$k0" />
                   <node concept="1DTwFV" id="6R0q0mZS8ff" role="2OqNvi">
@@ -1112,7 +1112,7 @@
             <node concept="2ShNRf" id="6R0q0mZS75M" role="2Oq$k0">
               <node concept="1pGfFk" id="6R0q0mZS7gf" role="2ShVmc">
                 <property role="373rjd" value="true" />
-                <ref role="37wK5l" to="hm5v:6R0q0mZRHmo" resolve="DeleteColumnAction" />
+                <ref role="37wK5l" to="hm5v:6R0q0mZRHmo" resolve="TableActions.DeleteColumnAction" />
                 <node concept="2OqwBi" id="6R0q0mZS7no" role="37wK5m">
                   <node concept="2WthIp" id="6R0q0mZS7nr" role="2Oq$k0" />
                   <node concept="1DTwFV" id="6R0q0mZS7nt" role="2OqNvi">
@@ -1137,7 +1137,7 @@
     <node concept="1QGGSu" id="6R0q0mZQKWL" role="3Uehp1">
       <node concept="10M0yZ" id="6R0q0mZSZL2" role="3xaMm5">
         <ref role="3cqZAo" to="z2i8:~AllIcons$General.Remove" resolve="Remove" />
-        <ref role="1PxDUh" to="z2i8:~AllIcons$General" resolve="General" />
+        <ref role="1PxDUh" to="z2i8:~AllIcons$General" resolve="AllIcons.General" />
       </node>
     </node>
   </node>


### PR DESCRIPTION
Dynamic generated nodes (without a model) can now be used in query lists if `read-only` is set to true.

All other actions like inserting nodes, deleting etc. won't work when the cell is not read-only because the node is not attached to any model.