### PR TITLE
Implement editor components with parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project are documented in this file.
 Format of the log is _loosely_ based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). 
 The project does _not_ follow Semantic Versioning and the changes are documented in reverse chronological order, grouped by calendar month.
 
+## March 2024
+
+### Added
+
+- de.slisson.mps.conditionalEditor: Support for editor components with parameters was added.
+
 ## February 2024
 
 ### Changed

--- a/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
+++ b/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
@@ -4077,6 +4077,16 @@
               </node>
             </node>
           </node>
+          <node concept="1SiIV0" id="ng7qrr_nA0" role="3bR37C">
+            <node concept="3bR9La" id="ng7qrr_nA1" role="1SiIV1">
+              <ref role="3bR37D" to="ffeo:5cCcm$KATVz" resolve="jetbrains.mps.lang.migration.runtime" />
+            </node>
+          </node>
+          <node concept="1SiIV0" id="ng7qrr_nA2" role="3bR37C">
+            <node concept="3bR9La" id="ng7qrr_nA3" role="1SiIV1">
+              <ref role="3bR37D" to="ffeo:2Qa9MYMHrcB" resolve="jetbrains.mps.editorlang.runtime" />
+            </node>
+          </node>
         </node>
         <node concept="3rtmxn" id="3xFG3bj5MkF" role="3bR31x">
           <node concept="3LXTmp" id="3xFG3bj5MkG" role="3rtmxm">
@@ -4120,6 +4130,16 @@
             <node concept="3qWCbU" id="2eucapX07Ox" role="3LXTna">
               <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
             </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="ng7qrr_n_L" role="3bR37C">
+          <node concept="3bR9La" id="ng7qrr_n_M" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="ng7qrr_n_N" role="3bR37C">
+          <node concept="3bR9La" id="ng7qrr_n_O" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:7Kfy9QB6LfQ" resolve="jetbrains.mps.kernel" />
           </node>
         </node>
       </node>
@@ -19222,6 +19242,11 @@
             <node concept="3qWCbU" id="7q24334ZKST" role="3LXTna">
               <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
             </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="ng7qrr_oew" role="3bR37C">
+          <node concept="3bR9La" id="ng7qrr_oex" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
           </node>
         </node>
       </node>

--- a/code/celllayout/solutions/de.itemis.mps.editor.celllayout.sandbox/de.itemis.mps.editor.celllayout.sandbox.msd
+++ b/code/celllayout/solutions/de.itemis.mps.editor.celllayout.sandbox/de.itemis.mps.editor.celllayout.sandbox.msd
@@ -11,6 +11,9 @@
     </facet>
   </facets>
   <sourcePath />
+  <dependencies>
+    <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
+  </dependencies>
   <languageVersions>
     <language slang="l:a49c7665-6e20-479f-8483-903f65b74ed2:de.itemis.mps.editor.celllayout.sandboxlang" version="0" />
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
@@ -27,6 +30,7 @@
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
   </languageVersions>
   <dependencyVersions>
+    <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
     <module reference="3d5ab66d-c2b3-48c1-883a-d9c0e3febd61(de.itemis.mps.editor.celllayout.sandbox)" version="0" />
   </dependencyVersions>
 </solution>

--- a/code/conditional-editor/languages/de.slisson.mps.conditionalEditor.demolang/languageModels/editor.mps
+++ b/code/conditional-editor/languages/de.slisson.mps.conditionalEditor.demolang/languageModels/editor.mps
@@ -10,14 +10,23 @@
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
-    <import index="z60i" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt(JDK/)" />
     <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" implicit="true" />
     <import index="ye5w" ref="r:6c3a5ff5-b652-48a4-80a3-0e283d57df4d(de.slisson.mps.conditionalEditor.demolang.structure)" implicit="true" />
     <import index="tpco" ref="r:00000000-0000-4000-0000-011c89590284(jetbrains.mps.lang.core.editor)" implicit="true" />
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
   </imports>
   <registry>
     <language id="b8bb702e-43ed-4090-a902-d180d3e5f292" name="de.slisson.mps.conditionalEditor">
+      <concept id="6733065834258977599" name="de.slisson.mps.conditionalEditor.structure.EditorComponentParameterReference" flags="ng" index="2D8Zic">
+        <reference id="6733065834258977600" name="parameter" index="2D8ZjN" />
+      </concept>
+      <concept id="6733065834259135109" name="de.slisson.mps.conditionalEditor.structure.CellModel_ComponentWithParameters" flags="sg" stub="6733065834259138549" index="2D9hOQ">
+        <child id="6733065834259138558" name="arguments" index="2D9m1d" />
+      </concept>
+      <concept id="6733065834252958387" name="de.slisson.mps.conditionalEditor.structure.EditorComponentDeclarationWithParameters" flags="ig" index="2IxXO0">
+        <child id="6733065834252994198" name="parameters" index="2Iya4_" />
+      </concept>
       <concept id="2877762237607058140" name="de.slisson.mps.conditionalEditor.structure.NextEditor" flags="ng" index="Rtstu" />
       <concept id="2877762237606985499" name="de.slisson.mps.conditionalEditor.structure.EditorCondition" flags="ig" index="RtMap" />
       <concept id="2877762237606934069" name="de.slisson.mps.conditionalEditor.structure.ConditionalConceptEditorDeclaration" flags="ig" index="RtYIR">
@@ -112,6 +121,7 @@
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
+      <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
       <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
@@ -149,6 +159,20 @@
       <concept id="1196350785113" name="jetbrains.mps.lang.quotation.structure.Quotation" flags="nn" index="2c44tf">
         <child id="1196350785114" name="quotedNode" index="2c44tc" />
       </concept>
+      <concept id="5455284157993911077" name="jetbrains.mps.lang.quotation.structure.NodeBuilderInitProperty" flags="ng" index="2pJxcG">
+        <reference id="5455284157993911078" name="property" index="2pJxcJ" />
+        <child id="1595412875168045201" name="initValue" index="28ntcv" />
+      </concept>
+      <concept id="5455284157993863837" name="jetbrains.mps.lang.quotation.structure.NodeBuilder" flags="nn" index="2pJPEk">
+        <child id="5455284157993863838" name="quotedNode" index="2pJPEn" />
+      </concept>
+      <concept id="5455284157993863840" name="jetbrains.mps.lang.quotation.structure.NodeBuilderNode" flags="nn" index="2pJPED">
+        <reference id="5455284157993910961" name="concept" index="2pJxaS" />
+        <child id="5455284157993911099" name="values" index="2pJxcM" />
+      </concept>
+      <concept id="6985522012210254362" name="jetbrains.mps.lang.quotation.structure.NodeBuilderPropertyExpression" flags="nn" index="WxPPo">
+        <child id="6985522012210254363" name="expression" index="WxPPp" />
+      </concept>
     </language>
     <language id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem">
       <concept id="1176543928247" name="jetbrains.mps.lang.typesystem.structure.IsSubtypeExpression" flags="nn" index="3JuTUA">
@@ -158,7 +182,21 @@
       <concept id="1176544042499" name="jetbrains.mps.lang.typesystem.structure.Node_TypeOperation" flags="nn" index="3JvlWi" />
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
+        <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
+      </concept>
+      <concept id="2396822768958367367" name="jetbrains.mps.lang.smodel.structure.AbstractTypeCastExpression" flags="nn" index="$5XWr">
+        <child id="6733348108486823193" name="leftExpression" index="1m5AlR" />
+        <child id="3906496115198199033" name="conceptArgument" index="3oSUPX" />
+      </concept>
       <concept id="8329979535468945057" name="jetbrains.mps.lang.smodel.structure.Node_PresentationOperation" flags="ng" index="2Iv5rx" />
+      <concept id="1140137987495" name="jetbrains.mps.lang.smodel.structure.SNodeTypeCastExpression" flags="nn" index="1PxgMI">
+        <property id="1238684351431" name="asCast" index="1BlNFB" />
+      </concept>
+      <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2" />
+      <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
+        <reference id="1138056395725" name="property" index="3TsBF5" />
+      </concept>
       <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="nn" index="3TrEf2">
         <reference id="1138056516764" name="link" index="3Tt5mk" />
       </concept>
@@ -431,6 +469,108 @@
       <node concept="l2Vlx" id="6eakByRhOnf" role="2iSdaV" />
       <node concept="3F0ifn" id="6eakByRhOno" role="3EZMnx">
         <property role="3F0ifm" value="inspector cell" />
+      </node>
+    </node>
+  </node>
+  <node concept="2IxXO0" id="5PKDVfNYsHJ">
+    <property role="TrG5h" value="EditorComponentWithParameters" />
+    <ref role="1XX52x" to="ye5w:5PKDVfNYsHN" resolve="Interface" />
+    <node concept="3EZMnI" id="5PKDVfOff5w" role="2wV5jI">
+      <node concept="2iRfu4" id="5PKDVfOff5x" role="2iSdaV" />
+      <node concept="3F0ifn" id="5PKDVfNYx5T" role="3EZMnx">
+        <property role="3F0ifm" value="Node:" />
+      </node>
+      <node concept="1HlG4h" id="5PKDVfOpgs8" role="3EZMnx">
+        <node concept="1HfYo3" id="5PKDVfOpgsa" role="1HlULh">
+          <node concept="3TQlhw" id="5PKDVfOpgsc" role="1Hhtcw">
+            <node concept="3clFbS" id="5PKDVfOpgse" role="2VODD2">
+              <node concept="3clFbF" id="5PKDVfOpgx1" role="3cqZAp">
+                <node concept="2OqwBi" id="5PKDVfOphq8" role="3clFbG">
+                  <node concept="1PxgMI" id="5PKDVfOph8Y" role="2Oq$k0">
+                    <property role="1BlNFB" value="true" />
+                    <node concept="chp4Y" id="5PKDVfOphe5" role="3oSUPX">
+                      <ref role="cht4Q" to="tpck:h0TrEE$" resolve="INamedConcept" />
+                    </node>
+                    <node concept="2D8Zic" id="5PKDVfOpgx0" role="1m5AlR">
+                      <ref role="2D8ZjN" node="5PKDVfNYx5u" resolve="suppliedNode" />
+                    </node>
+                  </node>
+                  <node concept="3TrcHB" id="5PKDVfOphJc" role="2OqNvi">
+                    <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3F0ifn" id="5PKDVfOphQF" role="3EZMnx">
+        <property role="3F0ifm" value="Name:" />
+      </node>
+      <node concept="1HlG4h" id="5PKDVfOphRa" role="3EZMnx">
+        <node concept="1HfYo3" id="5PKDVfOphRc" role="1HlULh">
+          <node concept="3TQlhw" id="5PKDVfOphRe" role="1Hhtcw">
+            <node concept="3clFbS" id="5PKDVfOphRg" role="2VODD2">
+              <node concept="3clFbF" id="5PKDVfOphWc" role="3cqZAp">
+                <node concept="2D8Zic" id="5PKDVfOphWb" role="3clFbG">
+                  <ref role="2D8ZjN" node="5PKDVfNYx5$" resolve="name" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="37vLTG" id="5PKDVfNYx5u" role="2Iya4_">
+      <property role="TrG5h" value="suppliedNode" />
+      <node concept="3Tqbb2" id="5PKDVfNYx5t" role="1tU5fm" />
+    </node>
+    <node concept="19Szcq" id="5PKDVfNYx5$" role="2Iya4_">
+      <property role="TrG5h" value="name" />
+      <node concept="17QB3L" id="5PKDVfNYx5O" role="1tU5fm" />
+    </node>
+  </node>
+  <node concept="24kQdi" id="5PKDVfOfiUW">
+    <ref role="1XX52x" to="ye5w:5PKDVfNYsHL" resolve="A" />
+    <node concept="2D9hOQ" id="5PKDVfOoJQo" role="2wV5jI">
+      <ref role="PMmxG" node="5PKDVfNYsHJ" resolve="EditorComponent" />
+      <node concept="2pJPEk" id="5PKDVfOpeVi" role="2D9m1d">
+        <node concept="2pJPED" id="5PKDVfOpeVj" role="2pJPEn">
+          <ref role="2pJxaS" to="tpee:fz12cDA" resolve="ClassConcept" />
+          <node concept="2pJxcG" id="5PKDVfOpeVE" role="2pJxcM">
+            <ref role="2pJxcJ" to="tpck:h0TrG11" resolve="name" />
+            <node concept="WxPPo" id="5PKDVfOpeWc" role="28ntcv">
+              <node concept="Xl_RD" id="5PKDVfOpeWb" role="WxPPp">
+                <property role="Xl_RC" value="AClass" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="Xl_RD" id="5PKDVfOpf0P" role="2D9m1d">
+        <property role="Xl_RC" value="Hello from A" />
+      </node>
+    </node>
+  </node>
+  <node concept="24kQdi" id="5PKDVfOfiV7">
+    <ref role="1XX52x" to="ye5w:5PKDVfNYsHM" resolve="B" />
+    <node concept="2D9hOQ" id="5PKDVfOpf38" role="2wV5jI">
+      <ref role="PMmxG" node="5PKDVfNYsHJ" resolve="EditorComponent" />
+      <node concept="2pJPEk" id="5PKDVfOpf39" role="2D9m1d">
+        <node concept="2pJPED" id="5PKDVfOpf3a" role="2pJPEn">
+          <ref role="2pJxaS" to="tpee:fz12cDA" resolve="ClassConcept" />
+          <node concept="2pJxcG" id="5PKDVfOpf3b" role="2pJxcM">
+            <ref role="2pJxcJ" to="tpck:h0TrG11" resolve="name" />
+            <node concept="WxPPo" id="5PKDVfOpf3c" role="28ntcv">
+              <node concept="Xl_RD" id="5PKDVfOpf3d" role="WxPPp">
+                <property role="Xl_RC" value="BClass" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="Xl_RD" id="5PKDVfOpf3e" role="2D9m1d">
+        <property role="Xl_RC" value="Hello from B" />
       </node>
     </node>
   </node>

--- a/code/conditional-editor/languages/de.slisson.mps.conditionalEditor.demolang/languageModels/editor.mps
+++ b/code/conditional-editor/languages/de.slisson.mps.conditionalEditor.demolang/languageModels/editor.mps
@@ -19,6 +19,7 @@
     <import index="guwi" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.io(JDK/)" />
     <import index="82uw" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util.function(JDK/)" />
     <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" />
+    <import index="cj4x" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor(MPS.Editor/)" implicit="true" />
   </imports>
   <registry>
     <language id="b8bb702e-43ed-4090-a902-d180d3e5f292" name="de.slisson.mps.conditionalEditor">
@@ -37,6 +38,9 @@
         <property id="2877762237607078183" name="priority" index="Rtri_" />
         <property id="8436908933892732653" name="uniqueName" index="3NULOk" />
         <child id="2877762237607015161" name="condition" index="RtEXV" />
+      </concept>
+      <concept id="1452226863088593034" name="de.slisson.mps.conditionalEditor.structure.ComponentArgument" flags="ig" index="1nyV0D">
+        <reference id="1452226863088593886" name="variable" index="1nyVdX" />
       </concept>
     </language>
     <language id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor">
@@ -76,6 +80,9 @@
       </concept>
       <concept id="1186414928363" name="jetbrains.mps.lang.editor.structure.SelectableStyleSheetItem" flags="ln" index="VPM3Z" />
       <concept id="1186414976055" name="jetbrains.mps.lang.editor.structure.DrawBorderStyleClassItem" flags="ln" index="VPXOz" />
+      <concept id="1139848536355" name="jetbrains.mps.lang.editor.structure.CellModel_WithRole" flags="ng" index="1$h60E">
+        <reference id="1140103550593" name="relationDeclaration" index="1NtTu8" />
+      </concept>
       <concept id="1073389446423" name="jetbrains.mps.lang.editor.structure.CellModel_Collection" flags="sn" stub="3013115976261988961" index="3EZMnI">
         <child id="1106270802874" name="cellLayout" index="2iSdaV" />
         <child id="1073389446424" name="childCellModel" index="3EZMnx" />
@@ -83,6 +90,7 @@
       <concept id="1073389577006" name="jetbrains.mps.lang.editor.structure.CellModel_Constant" flags="sn" stub="3610246225209162225" index="3F0ifn">
         <property id="1073389577007" name="text" index="3F0ifm" />
       </concept>
+      <concept id="1073389658414" name="jetbrains.mps.lang.editor.structure.CellModel_Property" flags="sg" stub="730538219796134133" index="3F0A7n" />
       <concept id="1219418625346" name="jetbrains.mps.lang.editor.structure.IStyleContainer" flags="ng" index="3F0Thp">
         <child id="1219418656006" name="styleItem" index="3F10Kt" />
       </concept>
@@ -92,6 +100,7 @@
       <concept id="1225900081164" name="jetbrains.mps.lang.editor.structure.CellModel_ReadOnlyModelAccessor" flags="sg" stub="3708815482283559694" index="1HlG4h">
         <child id="1225900141900" name="modelAccessor" index="1HlULh" />
       </concept>
+      <concept id="1161622981231" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameter_editorContext" flags="nn" index="1Q80Hx" />
       <concept id="1176717841777" name="jetbrains.mps.lang.editor.structure.QueryFunction_ModelAccess_Getter" flags="in" index="3TQlhw" />
       <concept id="1166049232041" name="jetbrains.mps.lang.editor.structure.AbstractComponent" flags="ng" index="1XWOmA">
         <reference id="1166049300910" name="conceptDeclaration" index="1XX52x" />
@@ -208,20 +217,6 @@
       <concept id="1196350785113" name="jetbrains.mps.lang.quotation.structure.Quotation" flags="nn" index="2c44tf">
         <child id="1196350785114" name="quotedNode" index="2c44tc" />
       </concept>
-      <concept id="5455284157993911077" name="jetbrains.mps.lang.quotation.structure.NodeBuilderInitProperty" flags="ng" index="2pJxcG">
-        <reference id="5455284157993911078" name="property" index="2pJxcJ" />
-        <child id="1595412875168045201" name="initValue" index="28ntcv" />
-      </concept>
-      <concept id="5455284157993863837" name="jetbrains.mps.lang.quotation.structure.NodeBuilder" flags="nn" index="2pJPEk">
-        <child id="5455284157993863838" name="quotedNode" index="2pJPEn" />
-      </concept>
-      <concept id="5455284157993863840" name="jetbrains.mps.lang.quotation.structure.NodeBuilderNode" flags="nn" index="2pJPED">
-        <reference id="5455284157993910961" name="concept" index="2pJxaS" />
-        <child id="5455284157993911099" name="values" index="2pJxcM" />
-      </concept>
-      <concept id="6985522012210254362" name="jetbrains.mps.lang.quotation.structure.NodeBuilderPropertyExpression" flags="nn" index="WxPPo">
-        <child id="6985522012210254363" name="expression" index="WxPPp" />
-      </concept>
     </language>
     <language id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem">
       <concept id="1176543928247" name="jetbrains.mps.lang.typesystem.structure.IsSubtypeExpression" flags="nn" index="3JuTUA">
@@ -231,18 +226,10 @@
       <concept id="1176544042499" name="jetbrains.mps.lang.typesystem.structure.Node_TypeOperation" flags="nn" index="3JvlWi" />
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
-      <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
-        <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
-      </concept>
-      <concept id="2396822768958367367" name="jetbrains.mps.lang.smodel.structure.AbstractTypeCastExpression" flags="nn" index="$5XWr">
-        <child id="6733348108486823193" name="leftExpression" index="1m5AlR" />
-        <child id="3906496115198199033" name="conceptArgument" index="3oSUPX" />
-      </concept>
       <concept id="8329979535468945057" name="jetbrains.mps.lang.smodel.structure.Node_PresentationOperation" flags="ng" index="2Iv5rx" />
-      <concept id="1140137987495" name="jetbrains.mps.lang.smodel.structure.SNodeTypeCastExpression" flags="nn" index="1PxgMI">
-        <property id="1238684351431" name="asCast" index="1BlNFB" />
+      <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
+        <reference id="1138405853777" name="concept" index="ehGHo" />
       </concept>
-      <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2" />
       <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
         <reference id="1138056395725" name="property" index="3TsBF5" />
       </concept>
@@ -571,17 +558,11 @@
           <node concept="3TQlhw" id="5PKDVfOpgsc" role="1Hhtcw">
             <node concept="3clFbS" id="5PKDVfOpgse" role="2VODD2">
               <node concept="3clFbF" id="5PKDVfOpgx1" role="3cqZAp">
-                <node concept="2OqwBi" id="5PKDVfOphq8" role="3clFbG">
-                  <node concept="1PxgMI" id="5PKDVfOph8Y" role="2Oq$k0">
-                    <property role="1BlNFB" value="true" />
-                    <node concept="chp4Y" id="5PKDVfOphe5" role="3oSUPX">
-                      <ref role="cht4Q" to="tpck:h0TrEE$" resolve="INamedConcept" />
-                    </node>
-                    <node concept="2D8Zic" id="5PKDVfOpgx0" role="1m5AlR">
-                      <ref role="2D8ZjN" node="1gBmad3BNJm" resolve="suppliedNode" />
-                    </node>
+                <node concept="2OqwBi" id="1gBmad3QGVo" role="3clFbG">
+                  <node concept="2D8Zic" id="5PKDVfOpgx0" role="2Oq$k0">
+                    <ref role="2D8ZjN" node="1gBmad3BNJm" resolve="suppliedNode" />
                   </node>
-                  <node concept="3TrcHB" id="5PKDVfOphJc" role="2OqNvi">
+                  <node concept="3TrcHB" id="1gBmad3QO3l" role="2OqNvi">
                     <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
                   </node>
                 </node>
@@ -606,10 +587,28 @@
           </node>
         </node>
       </node>
+      <node concept="3F0ifn" id="1gBmad3QBYs" role="3EZMnx">
+        <property role="3F0ifm" value="Component ID:" />
+      </node>
+      <node concept="1HlG4h" id="1gBmad3QCWc" role="3EZMnx">
+        <node concept="1HfYo3" id="1gBmad3QCWe" role="1HlULh">
+          <node concept="3TQlhw" id="1gBmad3QCWg" role="1Hhtcw">
+            <node concept="3clFbS" id="1gBmad3QCWi" role="2VODD2">
+              <node concept="3clFbF" id="1gBmad3QCZq" role="3cqZAp">
+                <node concept="2D8Zic" id="1gBmad3QCZp" role="3clFbG">
+                  <ref role="2D8ZjN" node="1gBmad3PiPd" resolve="componentInfo" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
     </node>
     <node concept="19Szcq" id="1gBmad3BNJm" role="2Iya4_">
       <property role="TrG5h" value="suppliedNode" />
-      <node concept="3Tqbb2" id="1gBmad3BOMr" role="1tU5fm" />
+      <node concept="3Tqbb2" id="1gBmad3BOMr" role="1tU5fm">
+        <ref role="ehGHo" to="tpck:h0TrEE$" resolve="INamedConcept" />
+      </node>
     </node>
     <node concept="19Szcq" id="5PKDVfNYx5$" role="2Iya4_">
       <property role="TrG5h" value="name" />
@@ -621,106 +620,190 @@
         <ref role="3uigEE" node="6LUJA7fXc$" resolve="SerializableRunnable" />
       </node>
     </node>
+    <node concept="19Szcq" id="1gBmad3PiPd" role="2Iya4_">
+      <property role="TrG5h" value="componentInfo" />
+      <node concept="17QB3L" id="1gBmad3PiRD" role="1tU5fm" />
+    </node>
   </node>
   <node concept="24kQdi" id="5PKDVfOfiUW">
     <ref role="1XX52x" to="ye5w:5PKDVfNYsHL" resolve="A" />
-    <node concept="2D9hOQ" id="5PKDVfOoJQo" role="2wV5jI">
-      <ref role="PMmxG" node="5PKDVfNYsHJ" resolve="EditorComponent" />
-      <node concept="2pJPEk" id="5PKDVfOpeVi" role="2D9m1d">
-        <node concept="2pJPED" id="5PKDVfOpeVj" role="2pJPEn">
-          <ref role="2pJxaS" to="tpee:fz12cDA" resolve="ClassConcept" />
-          <node concept="2pJxcG" id="5PKDVfOpeVE" role="2pJxcM">
-            <ref role="2pJxcJ" to="tpck:h0TrG11" resolve="name" />
-            <node concept="WxPPo" id="5PKDVfOpeWc" role="28ntcv">
-              <node concept="Xl_RD" id="5PKDVfOpeWb" role="WxPPp">
-                <property role="Xl_RC" value="AClass" />
+    <node concept="3EZMnI" id="1gBmad3QKK0" role="2wV5jI">
+      <node concept="3EZMnI" id="1gBmad3QLm_" role="3EZMnx">
+        <node concept="2iRfu4" id="1gBmad3QLmA" role="2iSdaV" />
+        <node concept="3F0ifn" id="1gBmad3QKTH" role="3EZMnx">
+          <property role="3F0ifm" value="A:" />
+        </node>
+        <node concept="3F0A7n" id="1gBmad3QLui" role="3EZMnx">
+          <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
+        </node>
+      </node>
+      <node concept="3F0ifn" id="1gBmad3QKUh" role="3EZMnx" />
+      <node concept="2D9hOQ" id="5PKDVfOoJQo" role="3EZMnx">
+        <ref role="PMmxG" node="5PKDVfNYsHJ" resolve="EditorComponentWithParameters" />
+        <node concept="1nyV0D" id="1gBmad3GKsS" role="2D9m1d">
+          <ref role="1nyVdX" node="1gBmad3BNJm" resolve="suppliedNode" />
+          <node concept="3clFbS" id="1gBmad3GKsU" role="2VODD2">
+            <node concept="3clFbF" id="1gBmad3GKX1" role="3cqZAp">
+              <node concept="pncrf" id="1gBmad3Pe1c" role="3clFbG" />
+            </node>
+          </node>
+        </node>
+        <node concept="1nyV0D" id="1gBmad3HqMp" role="2D9m1d">
+          <ref role="1nyVdX" node="5PKDVfNYx5$" resolve="name" />
+          <node concept="3clFbS" id="1gBmad3HqMq" role="2VODD2">
+            <node concept="3clFbF" id="1gBmad3L0Ed" role="3cqZAp">
+              <node concept="Xl_RD" id="5PKDVfOpf0P" role="3clFbG">
+                <property role="Xl_RC" value="Hello from A" />
               </node>
             </node>
           </node>
         </node>
-      </node>
-      <node concept="Xl_RD" id="5PKDVfOpf0P" role="2D9m1d">
-        <property role="Xl_RC" value="Hello from A" />
-      </node>
-      <node concept="2ShNRf" id="6LUJA7h4Lr" role="2D9m1d">
-        <node concept="YeOm9" id="6LUJA7h52G" role="2ShVmc">
-          <node concept="1Y3b0j" id="6LUJA7h52J" role="YeSDq">
-            <property role="2bfB8j" value="true" />
-            <property role="373rjd" value="true" />
-            <ref role="1Y3XeK" node="6LUJA7fXc$" resolve="SerializablePredicate" />
-            <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
-            <node concept="3Tm1VV" id="6LUJA7h52K" role="1B3o_S" />
-            <node concept="3clFb_" id="6LUJA7h53b" role="jymVt">
-              <property role="TrG5h" value="test" />
-              <node concept="3Tm1VV" id="6LUJA7h53c" role="1B3o_S" />
-              <node concept="10P_77" id="6LUJA7h53e" role="3clF45" />
-              <node concept="37vLTG" id="6LUJA7h53f" role="3clF46">
-                <property role="TrG5h" value="node" />
-                <node concept="3Tqbb2" id="6LUJA7hvRR" role="1tU5fm" />
-              </node>
-              <node concept="3clFbS" id="6LUJA7h53h" role="3clF47">
-                <node concept="3clFbF" id="6LUJA7h5Jg" role="3cqZAp">
-                  <node concept="3clFbT" id="6LUJA7h5Jf" role="3clFbG">
-                    <property role="3clFbU" value="true" />
+        <node concept="1nyV0D" id="1gBmad3Hvbu" role="2D9m1d">
+          <ref role="1nyVdX" node="6LUJA7fQCK" resolve="cond" />
+          <node concept="3clFbS" id="1gBmad3Hvbv" role="2VODD2">
+            <node concept="3clFbF" id="1gBmad3Hvjb" role="3cqZAp">
+              <node concept="2ShNRf" id="6LUJA7h4Lr" role="3clFbG">
+                <node concept="YeOm9" id="6LUJA7h52G" role="2ShVmc">
+                  <node concept="1Y3b0j" id="6LUJA7h52J" role="YeSDq">
+                    <property role="2bfB8j" value="true" />
+                    <property role="373rjd" value="true" />
+                    <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
+                    <ref role="1Y3XeK" node="6LUJA7fXc$" resolve="SerializablePredicate" />
+                    <node concept="3Tm1VV" id="6LUJA7h52K" role="1B3o_S" />
+                    <node concept="3clFb_" id="6LUJA7h53b" role="jymVt">
+                      <property role="TrG5h" value="test" />
+                      <node concept="3Tm1VV" id="6LUJA7h53c" role="1B3o_S" />
+                      <node concept="10P_77" id="6LUJA7h53e" role="3clF45" />
+                      <node concept="37vLTG" id="6LUJA7h53f" role="3clF46">
+                        <property role="TrG5h" value="node" />
+                        <node concept="3Tqbb2" id="6LUJA7hvRR" role="1tU5fm" />
+                      </node>
+                      <node concept="3clFbS" id="6LUJA7h53h" role="3clF47">
+                        <node concept="3clFbF" id="6LUJA7h5Jg" role="3cqZAp">
+                          <node concept="3clFbT" id="6LUJA7h5Jf" role="3clFbG">
+                            <property role="3clFbU" value="true" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="2AHcQZ" id="6LUJA7h53j" role="2AJF6D">
+                        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                      </node>
+                    </node>
+                    <node concept="3Tqbb2" id="6LUJA7hvF3" role="2Ghqu4" />
                   </node>
                 </node>
               </node>
-              <node concept="2AHcQZ" id="6LUJA7h53j" role="2AJF6D">
-                <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+            </node>
+          </node>
+        </node>
+        <node concept="1nyV0D" id="1gBmad3QrRX" role="2D9m1d">
+          <ref role="1nyVdX" node="1gBmad3PiPd" resolve="componentInfo" />
+          <node concept="3clFbS" id="1gBmad3QrRY" role="2VODD2">
+            <node concept="3clFbF" id="1gBmad3Qvrn" role="3cqZAp">
+              <node concept="2OqwBi" id="1gBmad3QwGh" role="3clFbG">
+                <node concept="2OqwBi" id="1gBmad3QvM7" role="2Oq$k0">
+                  <node concept="1Q80Hx" id="1gBmad3Qvrm" role="2Oq$k0" />
+                  <node concept="liA8E" id="1gBmad3Qwlv" role="2OqNvi">
+                    <ref role="37wK5l" to="cj4x:~EditorContext.getEditorComponent()" resolve="getEditorComponent" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="1gBmad3QxaB" role="2OqNvi">
+                  <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
+                </node>
               </node>
             </node>
-            <node concept="3Tqbb2" id="6LUJA7hvF3" role="2Ghqu4" />
           </node>
         </node>
       </node>
+      <node concept="2iRkQZ" id="1gBmad3QKTF" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="5PKDVfOfiV7">
     <ref role="1XX52x" to="ye5w:5PKDVfNYsHM" resolve="B" />
-    <node concept="2D9hOQ" id="5PKDVfOpf38" role="2wV5jI">
-      <ref role="PMmxG" node="5PKDVfNYsHJ" resolve="EditorComponent" />
-      <node concept="2pJPEk" id="5PKDVfOpf39" role="2D9m1d">
-        <node concept="2pJPED" id="5PKDVfOpf3a" role="2pJPEn">
-          <ref role="2pJxaS" to="tpee:fz12cDA" resolve="ClassConcept" />
-          <node concept="2pJxcG" id="5PKDVfOpf3b" role="2pJxcM">
-            <ref role="2pJxcJ" to="tpck:h0TrG11" resolve="name" />
-            <node concept="WxPPo" id="5PKDVfOpf3c" role="28ntcv">
-              <node concept="Xl_RD" id="5PKDVfOpf3d" role="WxPPp">
-                <property role="Xl_RC" value="BClass" />
+    <node concept="3EZMnI" id="1gBmad3QLUU" role="2wV5jI">
+      <node concept="3EZMnI" id="1gBmad3QMwx" role="3EZMnx">
+        <node concept="2iRfu4" id="1gBmad3QMwy" role="2iSdaV" />
+        <node concept="3F0ifn" id="1gBmad3QMwz" role="3EZMnx">
+          <property role="3F0ifm" value="B:" />
+        </node>
+        <node concept="3F0A7n" id="1gBmad3QMw$" role="3EZMnx">
+          <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
+        </node>
+      </node>
+      <node concept="3F0ifn" id="1gBmad3QMoV" role="3EZMnx" />
+      <node concept="2iRkQZ" id="1gBmad3QLUV" role="2iSdaV" />
+      <node concept="2D9hOQ" id="5PKDVfOpf38" role="3EZMnx">
+        <ref role="PMmxG" node="5PKDVfNYsHJ" resolve="EditorComponentWithParameters" />
+        <node concept="1nyV0D" id="1gBmad3HvOK" role="2D9m1d">
+          <ref role="1nyVdX" node="1gBmad3BNJm" resolve="suppliedNode" />
+          <node concept="3clFbS" id="1gBmad3HvOL" role="2VODD2">
+            <node concept="3clFbF" id="1gBmad3PeID" role="3cqZAp">
+              <node concept="pncrf" id="1gBmad3PeIC" role="3clFbG" />
+            </node>
+          </node>
+        </node>
+        <node concept="1nyV0D" id="1gBmad3Hwsj" role="2D9m1d">
+          <ref role="1nyVdX" node="5PKDVfNYx5$" resolve="name" />
+          <node concept="3clFbS" id="1gBmad3Hwsk" role="2VODD2">
+            <node concept="3clFbF" id="1gBmad3L01G" role="3cqZAp">
+              <node concept="Xl_RD" id="5PKDVfOpf3e" role="3clFbG">
+                <property role="Xl_RC" value="Hello from B" />
               </node>
             </node>
           </node>
         </node>
-      </node>
-      <node concept="Xl_RD" id="5PKDVfOpf3e" role="2D9m1d">
-        <property role="Xl_RC" value="Hello from B" />
-      </node>
-      <node concept="2ShNRf" id="6LUJA7h5TL" role="2D9m1d">
-        <node concept="YeOm9" id="6LUJA7h5TM" role="2ShVmc">
-          <node concept="1Y3b0j" id="6LUJA7h5TN" role="YeSDq">
-            <property role="2bfB8j" value="true" />
-            <property role="373rjd" value="true" />
-            <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
-            <ref role="1Y3XeK" node="6LUJA7fXc$" resolve="SerializablePredicate" />
-            <node concept="3Tm1VV" id="6LUJA7h5TO" role="1B3o_S" />
-            <node concept="3clFb_" id="6LUJA7h5TP" role="jymVt">
-              <property role="TrG5h" value="test" />
-              <node concept="3Tm1VV" id="6LUJA7h5TQ" role="1B3o_S" />
-              <node concept="10P_77" id="6LUJA7h5TR" role="3clF45" />
-              <node concept="37vLTG" id="6LUJA7h5TS" role="3clF46">
-                <property role="TrG5h" value="node" />
-                <node concept="3Tqbb2" id="6LUJA7hv9K" role="1tU5fm" />
-              </node>
-              <node concept="3clFbS" id="6LUJA7h5TU" role="3clF47">
-                <node concept="3clFbF" id="6LUJA7h5TV" role="3cqZAp">
-                  <node concept="3clFbT" id="6LUJA7h5TW" role="3clFbG" />
+        <node concept="1nyV0D" id="1gBmad3Hxi8" role="2D9m1d">
+          <ref role="1nyVdX" node="6LUJA7fQCK" resolve="cond" />
+          <node concept="3clFbS" id="1gBmad3Hxi9" role="2VODD2">
+            <node concept="3clFbF" id="1gBmad3Hxny" role="3cqZAp">
+              <node concept="2ShNRf" id="6LUJA7h5TL" role="3clFbG">
+                <node concept="YeOm9" id="6LUJA7h5TM" role="2ShVmc">
+                  <node concept="1Y3b0j" id="6LUJA7h5TN" role="YeSDq">
+                    <property role="2bfB8j" value="true" />
+                    <property role="373rjd" value="true" />
+                    <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
+                    <ref role="1Y3XeK" node="6LUJA7fXc$" resolve="SerializablePredicate" />
+                    <node concept="3Tm1VV" id="6LUJA7h5TO" role="1B3o_S" />
+                    <node concept="3clFb_" id="6LUJA7h5TP" role="jymVt">
+                      <property role="TrG5h" value="test" />
+                      <node concept="3Tm1VV" id="6LUJA7h5TQ" role="1B3o_S" />
+                      <node concept="10P_77" id="6LUJA7h5TR" role="3clF45" />
+                      <node concept="37vLTG" id="6LUJA7h5TS" role="3clF46">
+                        <property role="TrG5h" value="node" />
+                        <node concept="3Tqbb2" id="6LUJA7hv9K" role="1tU5fm" />
+                      </node>
+                      <node concept="3clFbS" id="6LUJA7h5TU" role="3clF47">
+                        <node concept="3clFbF" id="6LUJA7h5TV" role="3cqZAp">
+                          <node concept="3clFbT" id="6LUJA7h5TW" role="3clFbG" />
+                        </node>
+                      </node>
+                      <node concept="2AHcQZ" id="6LUJA7h5TX" role="2AJF6D">
+                        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                      </node>
+                    </node>
+                    <node concept="3Tqbb2" id="6LUJA7hvmP" role="2Ghqu4" />
+                  </node>
                 </node>
               </node>
-              <node concept="2AHcQZ" id="6LUJA7h5TX" role="2AJF6D">
-                <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+            </node>
+          </node>
+        </node>
+        <node concept="1nyV0D" id="1gBmad3QxSb" role="2D9m1d">
+          <ref role="1nyVdX" node="1gBmad3PiPd" resolve="componentInfo" />
+          <node concept="3clFbS" id="1gBmad3QxSc" role="2VODD2">
+            <node concept="3clFbF" id="1gBmad3QxSC" role="3cqZAp">
+              <node concept="2OqwBi" id="1gBmad3QxSE" role="3clFbG">
+                <node concept="2OqwBi" id="1gBmad3QxSF" role="2Oq$k0">
+                  <node concept="1Q80Hx" id="1gBmad3QxSG" role="2Oq$k0" />
+                  <node concept="liA8E" id="1gBmad3QxSH" role="2OqNvi">
+                    <ref role="37wK5l" to="cj4x:~EditorContext.getEditorComponent()" resolve="getEditorComponent" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="1gBmad3QxSI" role="2OqNvi">
+                  <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
+                </node>
               </node>
             </node>
-            <node concept="3Tqbb2" id="6LUJA7hvmP" role="2Ghqu4" />
           </node>
         </node>
       </node>

--- a/code/conditional-editor/languages/de.slisson.mps.conditionalEditor.demolang/languageModels/editor.mps
+++ b/code/conditional-editor/languages/de.slisson.mps.conditionalEditor.demolang/languageModels/editor.mps
@@ -138,6 +138,13 @@
       <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ng" index="366HgL">
         <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
       </concept>
+      <concept id="1109279763828" name="jetbrains.mps.baseLanguage.structure.TypeVariableDeclaration" flags="ng" index="16euLQ" />
+      <concept id="1109279851642" name="jetbrains.mps.baseLanguage.structure.GenericDeclaration" flags="ng" index="16eOlS">
+        <child id="1109279881614" name="typeVariableDeclaration" index="16eVyc" />
+      </concept>
+      <concept id="1109283449304" name="jetbrains.mps.baseLanguage.structure.TypeVariableReference" flags="in" index="16syzq">
+        <reference id="1109283546497" name="typeVariableDeclaration" index="16sUi3" />
+      </concept>
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
@@ -194,6 +201,7 @@
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
       <concept id="1170345865475" name="jetbrains.mps.baseLanguage.structure.AnonymousClass" flags="ig" index="1Y3b0j">
         <reference id="1170346070688" name="classifier" index="1Y3XeK" />
+        <child id="1201186121363" name="typeParameter" index="2Ghqu4" />
       </concept>
     </language>
     <language id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation">
@@ -541,7 +549,7 @@
                   <ref role="1Pybhc" to="wyt6:~String" resolve="String" />
                   <ref role="37wK5l" to="wyt6:~String.valueOf(boolean)" resolve="valueOf" />
                   <node concept="2OqwBi" id="6LUJA7fR5x" role="37wK5m">
-                    <node concept="37vLTw" id="6LUJA7ha6K" role="2Oq$k0">
+                    <node concept="37vLTw" id="6LUJA7hF$8" role="2Oq$k0">
                       <ref role="3cqZAo" node="6LUJA7h9ez" resolve="predicate" />
                     </node>
                     <node concept="liA8E" id="6LUJA7g06N" role="2OqNvi">
@@ -570,7 +578,7 @@
                       <ref role="cht4Q" to="tpck:h0TrEE$" resolve="INamedConcept" />
                     </node>
                     <node concept="2D8Zic" id="5PKDVfOpgx0" role="1m5AlR">
-                      <ref role="2D8ZjN" node="5PKDVfNYx5u" resolve="suppliedNode" />
+                      <ref role="2D8ZjN" node="1gBmad3BNJm" resolve="suppliedNode" />
                     </node>
                   </node>
                   <node concept="3TrcHB" id="5PKDVfOphJc" role="2OqNvi">
@@ -599,9 +607,9 @@
         </node>
       </node>
     </node>
-    <node concept="37vLTG" id="5PKDVfNYx5u" role="2Iya4_">
+    <node concept="19Szcq" id="1gBmad3BNJm" role="2Iya4_">
       <property role="TrG5h" value="suppliedNode" />
-      <node concept="3Tqbb2" id="5PKDVfNYx5t" role="1tU5fm" />
+      <node concept="3Tqbb2" id="1gBmad3BOMr" role="1tU5fm" />
     </node>
     <node concept="19Szcq" id="5PKDVfNYx5$" role="2Iya4_">
       <property role="TrG5h" value="name" />
@@ -640,7 +648,7 @@
             <property role="2bfB8j" value="true" />
             <property role="373rjd" value="true" />
             <ref role="1Y3XeK" node="6LUJA7fXc$" resolve="SerializablePredicate" />
-            <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" />
+            <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
             <node concept="3Tm1VV" id="6LUJA7h52K" role="1B3o_S" />
             <node concept="3clFb_" id="6LUJA7h53b" role="jymVt">
               <property role="TrG5h" value="test" />
@@ -648,7 +656,7 @@
               <node concept="10P_77" id="6LUJA7h53e" role="3clF45" />
               <node concept="37vLTG" id="6LUJA7h53f" role="3clF46">
                 <property role="TrG5h" value="node" />
-                <node concept="3Tqbb2" id="6LUJA7h5ek" role="1tU5fm" />
+                <node concept="3Tqbb2" id="6LUJA7hvRR" role="1tU5fm" />
               </node>
               <node concept="3clFbS" id="6LUJA7h53h" role="3clF47">
                 <node concept="3clFbF" id="6LUJA7h5Jg" role="3cqZAp">
@@ -658,9 +666,10 @@
                 </node>
               </node>
               <node concept="2AHcQZ" id="6LUJA7h53j" role="2AJF6D">
-                <ref role="2AI5Lk" to="wyt6:~Override" />
+                <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
               </node>
             </node>
+            <node concept="3Tqbb2" id="6LUJA7hvF3" role="2Ghqu4" />
           </node>
         </node>
       </node>
@@ -700,7 +709,7 @@
               <node concept="10P_77" id="6LUJA7h5TR" role="3clF45" />
               <node concept="37vLTG" id="6LUJA7h5TS" role="3clF46">
                 <property role="TrG5h" value="node" />
-                <node concept="3Tqbb2" id="6LUJA7h5TT" role="1tU5fm" />
+                <node concept="3Tqbb2" id="6LUJA7hv9K" role="1tU5fm" />
               </node>
               <node concept="3clFbS" id="6LUJA7h5TU" role="3clF47">
                 <node concept="3clFbF" id="6LUJA7h5TV" role="3cqZAp">
@@ -711,6 +720,7 @@
                 <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
               </node>
             </node>
+            <node concept="3Tqbb2" id="6LUJA7hvmP" role="2Ghqu4" />
           </node>
         </node>
       </node>
@@ -721,12 +731,17 @@
     <property role="2bfB8j" value="true" />
     <node concept="3uibUv" id="6LUJA7fZu0" role="3HQHJm">
       <ref role="3uigEE" to="82uw:~Predicate" resolve="Predicate" />
-      <node concept="3Tqbb2" id="6LUJA7h3YQ" role="11_B2D" />
+      <node concept="16syzq" id="6LUJA7hmXs" role="11_B2D">
+        <ref role="16sUi3" node="6LUJA7hmRl" resolve="T" />
+      </node>
     </node>
     <node concept="3uibUv" id="6LUJA7fXfc" role="3HQHJm">
       <ref role="3uigEE" to="guwi:~Serializable" resolve="Serializable" />
     </node>
     <node concept="3Tm1VV" id="6LUJA7gOad" role="1B3o_S" />
+    <node concept="16euLQ" id="6LUJA7hmRl" role="16eVyc">
+      <property role="TrG5h" value="T" />
+    </node>
   </node>
 </model>
 

--- a/code/conditional-editor/languages/de.slisson.mps.conditionalEditor.demolang/languageModels/editor.mps
+++ b/code/conditional-editor/languages/de.slisson.mps.conditionalEditor.demolang/languageModels/editor.mps
@@ -11,10 +11,14 @@
   </languages>
   <imports>
     <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
-    <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" implicit="true" />
-    <import index="ye5w" ref="r:6c3a5ff5-b652-48a4-80a3-0e283d57df4d(de.slisson.mps.conditionalEditor.demolang.structure)" implicit="true" />
-    <import index="tpco" ref="r:00000000-0000-4000-0000-011c89590284(jetbrains.mps.lang.core.editor)" implicit="true" />
-    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
+    <import index="tpco" ref="r:00000000-0000-4000-0000-011c89590284(jetbrains.mps.lang.core.editor)" />
+    <import index="ye5w" ref="r:6c3a5ff5-b652-48a4-80a3-0e283d57df4d(de.slisson.mps.conditionalEditor.demolang.structure)" />
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" />
+    <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" />
+    <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" />
+    <import index="guwi" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.io(JDK/)" />
+    <import index="82uw" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util.function(JDK/)" />
+    <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" />
   </imports>
   <registry>
     <language id="b8bb702e-43ed-4090-a902-d180d3e5f292" name="de.slisson.mps.conditionalEditor">
@@ -95,9 +99,19 @@
       <concept id="1176809959526" name="jetbrains.mps.lang.editor.structure.QueryFunction_Color" flags="in" index="3ZlJ5R" />
     </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="1188207840427" name="jetbrains.mps.baseLanguage.structure.AnnotationInstance" flags="nn" index="2AHcQZ">
+        <reference id="1188208074048" name="annotation" index="2AI5Lk" />
+      </concept>
+      <concept id="1188208481402" name="jetbrains.mps.baseLanguage.structure.HasAnnotation" flags="ng" index="2AJDlI">
+        <child id="1188208488637" name="annotation" index="2AJF6D" />
+      </concept>
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
+        <child id="1145553007750" name="creator" index="2ShVmc" />
       </concept>
       <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
         <child id="1137022507850" name="body" index="2VODD2" />
@@ -105,6 +119,9 @@
       <concept id="1070462154015" name="jetbrains.mps.baseLanguage.structure.StaticFieldDeclaration" flags="ig" index="Wx3nA" />
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="1182160077978" name="jetbrains.mps.baseLanguage.structure.AnonymousClassCreator" flags="nn" index="YeOm9">
+        <child id="1182160096073" name="cls" index="YeSDq" />
       </concept>
       <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
@@ -118,6 +135,9 @@
         <property id="1176718929932" name="isFinal" index="3TUv4t" />
         <child id="1068431790190" name="initializer" index="33vP2m" />
       </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ng" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
+      </concept>
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
@@ -129,6 +149,12 @@
       <concept id="1111509017652" name="jetbrains.mps.baseLanguage.structure.FloatingPointConstant" flags="nn" index="3b6qkQ">
         <property id="1113006610751" name="value" index="$nhwW" />
       </concept>
+      <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123134" name="parameter" index="3clF46" />
+        <child id="1068580123135" name="body" index="3clF47" />
+      </concept>
+      <concept id="1068580123165" name="jetbrains.mps.baseLanguage.structure.InstanceMethodDeclaration" flags="ig" index="3clFb_" />
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
@@ -139,12 +165,21 @@
         <property id="1068580123138" name="value" index="3clFbU" />
       </concept>
       <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
+      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
+        <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
+      </concept>
+      <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
       <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
+        <property id="521412098689998745" name="nonStatic" index="2bfB8j" />
         <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
+      </concept>
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+        <reference id="1107535924139" name="classifier" index="3uigEE" />
+        <child id="1109201940907" name="parameter" index="11_B2D" />
       </concept>
       <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
@@ -153,7 +188,13 @@
       <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
+      <concept id="1107796713796" name="jetbrains.mps.baseLanguage.structure.Interface" flags="ig" index="3HP615">
+        <child id="1107797138135" name="extendedInterface" index="3HQHJm" />
+      </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+      <concept id="1170345865475" name="jetbrains.mps.baseLanguage.structure.AnonymousClass" flags="ig" index="1Y3b0j">
+        <reference id="1170346070688" name="classifier" index="1Y3XeK" />
+      </concept>
     </language>
     <language id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation">
       <concept id="1196350785113" name="jetbrains.mps.lang.quotation.structure.Quotation" flags="nn" index="2c44tf">
@@ -477,6 +518,43 @@
     <ref role="1XX52x" to="ye5w:5PKDVfNYsHN" resolve="Interface" />
     <node concept="3EZMnI" id="5PKDVfOff5w" role="2wV5jI">
       <node concept="2iRfu4" id="5PKDVfOff5x" role="2iSdaV" />
+      <node concept="3F0ifn" id="6LUJA7fQUH" role="3EZMnx">
+        <property role="3F0ifm" value="Condition:" />
+      </node>
+      <node concept="1HlG4h" id="6LUJA7fQVn" role="3EZMnx">
+        <node concept="1HfYo3" id="6LUJA7fQVp" role="1HlULh">
+          <node concept="3TQlhw" id="6LUJA7fQVr" role="1Hhtcw">
+            <node concept="3clFbS" id="6LUJA7fQVt" role="2VODD2">
+              <node concept="3cpWs8" id="6LUJA7h9ey" role="3cqZAp">
+                <node concept="3cpWsn" id="6LUJA7h9ez" role="3cpWs9">
+                  <property role="TrG5h" value="predicate" />
+                  <node concept="3uibUv" id="6LUJA7h9e$" role="1tU5fm">
+                    <ref role="3uigEE" node="6LUJA7fXc$" resolve="SerializablePredicate" />
+                  </node>
+                  <node concept="2D8Zic" id="6LUJA7h9Cb" role="33vP2m">
+                    <ref role="2D8ZjN" node="6LUJA7fQCK" resolve="cond" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbF" id="6LUJA7fTH7" role="3cqZAp">
+                <node concept="2YIFZM" id="6LUJA7fTHU" role="3clFbG">
+                  <ref role="1Pybhc" to="wyt6:~String" resolve="String" />
+                  <ref role="37wK5l" to="wyt6:~String.valueOf(boolean)" resolve="valueOf" />
+                  <node concept="2OqwBi" id="6LUJA7fR5x" role="37wK5m">
+                    <node concept="37vLTw" id="6LUJA7ha6K" role="2Oq$k0">
+                      <ref role="3cqZAo" node="6LUJA7h9ez" resolve="predicate" />
+                    </node>
+                    <node concept="liA8E" id="6LUJA7g06N" role="2OqNvi">
+                      <ref role="37wK5l" to="82uw:~Predicate.test(java.lang.Object)" resolve="test" />
+                      <node concept="pncrf" id="6LUJA7g1lX" role="37wK5m" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
       <node concept="3F0ifn" id="5PKDVfNYx5T" role="3EZMnx">
         <property role="3F0ifm" value="Node:" />
       </node>
@@ -529,6 +607,12 @@
       <property role="TrG5h" value="name" />
       <node concept="17QB3L" id="5PKDVfNYx5O" role="1tU5fm" />
     </node>
+    <node concept="19Szcq" id="6LUJA7fQCK" role="2Iya4_">
+      <property role="TrG5h" value="cond" />
+      <node concept="3uibUv" id="6LUJA7fY7s" role="1tU5fm">
+        <ref role="3uigEE" node="6LUJA7fXc$" resolve="SerializableRunnable" />
+      </node>
+    </node>
   </node>
   <node concept="24kQdi" id="5PKDVfOfiUW">
     <ref role="1XX52x" to="ye5w:5PKDVfNYsHL" resolve="A" />
@@ -549,6 +633,36 @@
       </node>
       <node concept="Xl_RD" id="5PKDVfOpf0P" role="2D9m1d">
         <property role="Xl_RC" value="Hello from A" />
+      </node>
+      <node concept="2ShNRf" id="6LUJA7h4Lr" role="2D9m1d">
+        <node concept="YeOm9" id="6LUJA7h52G" role="2ShVmc">
+          <node concept="1Y3b0j" id="6LUJA7h52J" role="YeSDq">
+            <property role="2bfB8j" value="true" />
+            <property role="373rjd" value="true" />
+            <ref role="1Y3XeK" node="6LUJA7fXc$" resolve="SerializablePredicate" />
+            <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" />
+            <node concept="3Tm1VV" id="6LUJA7h52K" role="1B3o_S" />
+            <node concept="3clFb_" id="6LUJA7h53b" role="jymVt">
+              <property role="TrG5h" value="test" />
+              <node concept="3Tm1VV" id="6LUJA7h53c" role="1B3o_S" />
+              <node concept="10P_77" id="6LUJA7h53e" role="3clF45" />
+              <node concept="37vLTG" id="6LUJA7h53f" role="3clF46">
+                <property role="TrG5h" value="node" />
+                <node concept="3Tqbb2" id="6LUJA7h5ek" role="1tU5fm" />
+              </node>
+              <node concept="3clFbS" id="6LUJA7h53h" role="3clF47">
+                <node concept="3clFbF" id="6LUJA7h5Jg" role="3cqZAp">
+                  <node concept="3clFbT" id="6LUJA7h5Jf" role="3clFbG">
+                    <property role="3clFbU" value="true" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2AHcQZ" id="6LUJA7h53j" role="2AJF6D">
+                <ref role="2AI5Lk" to="wyt6:~Override" />
+              </node>
+            </node>
+          </node>
+        </node>
       </node>
     </node>
   </node>
@@ -572,7 +686,47 @@
       <node concept="Xl_RD" id="5PKDVfOpf3e" role="2D9m1d">
         <property role="Xl_RC" value="Hello from B" />
       </node>
+      <node concept="2ShNRf" id="6LUJA7h5TL" role="2D9m1d">
+        <node concept="YeOm9" id="6LUJA7h5TM" role="2ShVmc">
+          <node concept="1Y3b0j" id="6LUJA7h5TN" role="YeSDq">
+            <property role="2bfB8j" value="true" />
+            <property role="373rjd" value="true" />
+            <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
+            <ref role="1Y3XeK" node="6LUJA7fXc$" resolve="SerializablePredicate" />
+            <node concept="3Tm1VV" id="6LUJA7h5TO" role="1B3o_S" />
+            <node concept="3clFb_" id="6LUJA7h5TP" role="jymVt">
+              <property role="TrG5h" value="test" />
+              <node concept="3Tm1VV" id="6LUJA7h5TQ" role="1B3o_S" />
+              <node concept="10P_77" id="6LUJA7h5TR" role="3clF45" />
+              <node concept="37vLTG" id="6LUJA7h5TS" role="3clF46">
+                <property role="TrG5h" value="node" />
+                <node concept="3Tqbb2" id="6LUJA7h5TT" role="1tU5fm" />
+              </node>
+              <node concept="3clFbS" id="6LUJA7h5TU" role="3clF47">
+                <node concept="3clFbF" id="6LUJA7h5TV" role="3cqZAp">
+                  <node concept="3clFbT" id="6LUJA7h5TW" role="3clFbG" />
+                </node>
+              </node>
+              <node concept="2AHcQZ" id="6LUJA7h5TX" role="2AJF6D">
+                <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
     </node>
+  </node>
+  <node concept="3HP615" id="6LUJA7fXc$">
+    <property role="TrG5h" value="SerializablePredicate" />
+    <property role="2bfB8j" value="true" />
+    <node concept="3uibUv" id="6LUJA7fZu0" role="3HQHJm">
+      <ref role="3uigEE" to="82uw:~Predicate" resolve="Predicate" />
+      <node concept="3Tqbb2" id="6LUJA7h3YQ" role="11_B2D" />
+    </node>
+    <node concept="3uibUv" id="6LUJA7fXfc" role="3HQHJm">
+      <ref role="3uigEE" to="guwi:~Serializable" resolve="Serializable" />
+    </node>
+    <node concept="3Tm1VV" id="6LUJA7gOad" role="1B3o_S" />
   </node>
 </model>
 

--- a/code/conditional-editor/languages/de.slisson.mps.conditionalEditor.demolang/languageModels/structure.mps
+++ b/code/conditional-editor/languages/de.slisson.mps.conditionalEditor.demolang/languageModels/structure.mps
@@ -8,6 +8,7 @@
   </languages>
   <imports>
     <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" />
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
   </imports>
   <registry>
     <language id="c72da2b9-7cce-4447-8389-f407dc1158b7" name="jetbrains.mps.lang.structure">
@@ -15,8 +16,14 @@
         <property id="6714410169261853888" name="conceptId" index="EcuMT" />
         <property id="5092175715804935370" name="conceptAlias" index="34LRSv" />
       </concept>
+      <concept id="1169125989551" name="jetbrains.mps.lang.structure.structure.InterfaceConceptDeclaration" flags="ig" index="PlHQZ" />
+      <concept id="1169127622168" name="jetbrains.mps.lang.structure.structure.InterfaceConceptReference" flags="ig" index="PrWs8">
+        <reference id="1169127628841" name="intfc" index="PrY4T" />
+      </concept>
       <concept id="1071489090640" name="jetbrains.mps.lang.structure.structure.ConceptDeclaration" flags="ig" index="1TIwiD">
+        <property id="1096454100552" name="rootable" index="19KtqR" />
         <reference id="1071489389519" name="extends" index="1TJDcQ" />
+        <child id="1169129564478" name="implements" index="PzmwI" />
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
@@ -30,6 +37,28 @@
     <property role="34LRSv" value="expressionWithInspector" />
     <property role="EcuMT" value="7172636034965390688" />
     <ref role="1TJDcQ" to="tpee:fz3vP1J" resolve="Expression" />
+  </node>
+  <node concept="1TIwiD" id="5PKDVfNYsHL">
+    <property role="EcuMT" value="6733065834253110129" />
+    <property role="TrG5h" value="A" />
+    <property role="19KtqR" value="true" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" />
+    <node concept="PrWs8" id="5PKDVfNYsHO" role="PzmwI">
+      <ref role="PrY4T" node="5PKDVfNYsHN" resolve="Interface" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="5PKDVfNYsHM">
+    <property role="EcuMT" value="6733065834253110130" />
+    <property role="TrG5h" value="B" />
+    <property role="19KtqR" value="true" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" />
+    <node concept="PrWs8" id="5PKDVfNYsHQ" role="PzmwI">
+      <ref role="PrY4T" node="5PKDVfNYsHN" resolve="Interface" />
+    </node>
+  </node>
+  <node concept="PlHQZ" id="5PKDVfNYsHN">
+    <property role="EcuMT" value="6733065834253110131" />
+    <property role="TrG5h" value="Interface" />
   </node>
 </model>
 

--- a/code/conditional-editor/languages/de.slisson.mps.conditionalEditor.demolang/languageModels/structure.mps
+++ b/code/conditional-editor/languages/de.slisson.mps.conditionalEditor.demolang/languageModels/structure.mps
@@ -16,7 +16,9 @@
         <property id="6714410169261853888" name="conceptId" index="EcuMT" />
         <property id="5092175715804935370" name="conceptAlias" index="34LRSv" />
       </concept>
-      <concept id="1169125989551" name="jetbrains.mps.lang.structure.structure.InterfaceConceptDeclaration" flags="ig" index="PlHQZ" />
+      <concept id="1169125989551" name="jetbrains.mps.lang.structure.structure.InterfaceConceptDeclaration" flags="ig" index="PlHQZ">
+        <child id="1169127546356" name="extends" index="PrDN$" />
+      </concept>
       <concept id="1169127622168" name="jetbrains.mps.lang.structure.structure.InterfaceConceptReference" flags="ig" index="PrWs8">
         <reference id="1169127628841" name="intfc" index="PrY4T" />
       </concept>
@@ -59,6 +61,9 @@
   <node concept="PlHQZ" id="5PKDVfNYsHN">
     <property role="EcuMT" value="6733065834253110131" />
     <property role="TrG5h" value="Interface" />
+    <node concept="PrWs8" id="1gBmad3QKjq" role="PrDN$">
+      <ref role="PrY4T" to="tpck:h0TrEE$" resolve="INamedConcept" />
+    </node>
   </node>
 </model>
 

--- a/code/conditional-editor/languages/de.slisson.mps.conditionalEditor/de.slisson.mps.conditionalEditor.mpl
+++ b/code/conditional-editor/languages/de.slisson.mps.conditionalEditor/de.slisson.mps.conditionalEditor.mpl
@@ -34,10 +34,13 @@
         <dependency reexport="false">18bc6592-03a6-4e29-a83a-7ff23bde13ba(jetbrains.mps.lang.editor)</dependency>
         <dependency reexport="false">ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)</dependency>
         <dependency reexport="false">5474e4cd-6621-4b33-a39a-75552543ba57(de.slisson.mps.conditionalEditor.hints)</dependency>
+        <dependency reexport="false">528ff3b9-5fc4-40dd-931f-c6ce3650640e(jetbrains.mps.lang.migration.runtime)</dependency>
+        <dependency reexport="false">2e24a298-44d1-4697-baec-5c424fed3a3b(jetbrains.mps.editorlang.runtime)</dependency>
       </dependencies>
       <languageVersions>
         <language slang="l:b8bb702e-43ed-4090-a902-d180d3e5f292:de.slisson.mps.conditionalEditor" version="0" />
         <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
+        <language slang="l:774bf8a0-62e5-41e1-af63-f4812e60e48b:jetbrains.mps.baseLanguage.checkedDots" version="0" />
         <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />
         <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
         <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
@@ -77,6 +80,7 @@
         <module reference="83888646-71ce-4f1c-9c53-c54016f6ad4f(jetbrains.mps.baseLanguage.collections)" version="0" />
         <module reference="52b81ac7-93fd-4e9e-b972-4995882da6d4(jetbrains.mps.baseLanguage.references.runtime)" version="0" />
         <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
+        <module reference="2e24a298-44d1-4697-baec-5c424fed3a3b(jetbrains.mps.editorlang.runtime)" version="0" />
         <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
         <module reference="d936855b-48da-4812-a8a0-2bfddd633ac5(jetbrains.mps.lang.behavior.api)" version="0" />
         <module reference="d936855b-48da-4812-a8a0-2bfddd633ac4(jetbrains.mps.lang.behavior.runtime)" version="0" />
@@ -84,6 +88,7 @@
         <module reference="3ac18869-0828-4401-abad-822a47bf83f1(jetbrains.mps.lang.descriptor#9020561928507175817)" version="0" />
         <module reference="18bc6592-03a6-4e29-a83a-7ff23bde13ba(jetbrains.mps.lang.editor)" version="0" />
         <module reference="0647eca7-da98-422a-8a8b-6ebc0bd014ea(jetbrains.mps.lang.editor#1129914002149)" version="0" />
+        <module reference="528ff3b9-5fc4-40dd-931f-c6ce3650640e(jetbrains.mps.lang.migration.runtime)" version="0" />
         <module reference="446c26eb-2b7b-4bf0-9b35-f83fa582753e(jetbrains.mps.lang.modelapi)" version="0" />
         <module reference="d7eb0a2a-bd50-4576-beae-e4a89db35f20(jetbrains.mps.lang.scopes.runtime)" version="0" />
         <module reference="7866978e-a0f0-4cc7-81bc-4d213d9375e1(jetbrains.mps.lang.smodel)" version="1" />
@@ -130,6 +135,8 @@
     <dependency reexport="false">13744753-c81f-424a-9c1b-cf8943bf4e86(jetbrains.mps.lang.sharedConcepts)</dependency>
     <dependency reexport="false">c72da2b9-7cce-4447-8389-f407dc1158b7(jetbrains.mps.lang.structure)</dependency>
     <dependency reexport="false">8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)</dependency>
+    <dependency reexport="false">2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)</dependency>
+    <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />

--- a/code/conditional-editor/languages/de.slisson.mps.conditionalEditor/generator/template/main@generator.mps
+++ b/code/conditional-editor/languages/de.slisson.mps.conditionalEditor/generator/template/main@generator.mps
@@ -8,6 +8,7 @@
     <use id="13744753-c81f-424a-9c1b-cf8943bf4e86" name="jetbrains.mps.lang.sharedConcepts" version="0" />
     <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="14" />
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
+    <use id="774bf8a0-62e5-41e1-af63-f4812e60e48b" name="jetbrains.mps.baseLanguage.checkedDots" version="0" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -23,9 +24,16 @@
     <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" />
     <import index="461n" ref="r:3b46a963-6deb-4d82-bdc0-36b5d9297fcf(de.slisson.mps.conditionalEditor.hints.editor)" />
     <import index="mhfm" ref="3f233e7f-b8a6-46d2-a57f-795d56775243/java:org.jetbrains.annotations(Annotations/)" />
+    <import index="iwf0" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.descriptor(MPS.Editor/)" />
+    <import index="6f4m" ref="528ff3b9-5fc4-40dd-931f-c6ce3650640e/r:f69c3fa1-0e30-4980-84e2-190ae44e4c3d(jetbrains.mps.lang.migration.runtime/jetbrains.mps.lang.migration.runtime.base)" />
+    <import index="fwk" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.textgen.trace(MPS.Core/)" />
+    <import index="ao3" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.text(MPS.Core/)" />
+    <import index="qvne" ref="r:8ff33705-85bf-4855-805c-06d68fbe233c(jetbrains.mps.editor.runtime.descriptor)" />
     <import index="91fu" ref="r:8d20232d-87e2-425b-b4d7-a9790e401b85(de.slisson.mps.conditionalEditor.structure)" implicit="true" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
+    <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" implicit="true" />
+    <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" implicit="true" />
   </imports>
   <registry>
     <language id="b8bb702e-43ed-4090-a902-d180d3e5f292" name="de.slisson.mps.conditionalEditor">
@@ -73,6 +81,7 @@
         <child id="1068498886295" name="lValue" index="37vLTJ" />
       </concept>
       <concept id="1215695189714" name="jetbrains.mps.baseLanguage.structure.PlusAssignmentExpression" flags="nn" index="d57v9" />
+      <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
       <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
       <concept id="1188207840427" name="jetbrains.mps.baseLanguage.structure.AnnotationInstance" flags="nn" index="2AHcQZ">
@@ -94,6 +103,7 @@
       <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
         <child id="1137022507850" name="body" index="2VODD2" />
       </concept>
+      <concept id="1070475587102" name="jetbrains.mps.baseLanguage.structure.SuperConstructorInvocation" flags="nn" index="XkiVB" />
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
       </concept>
@@ -104,11 +114,16 @@
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
       <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
       <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
+      <concept id="1070534934090" name="jetbrains.mps.baseLanguage.structure.CastExpression" flags="nn" index="10QFUN">
+        <child id="1070534934091" name="type" index="10QFUM" />
+        <child id="1070534934092" name="expression" index="10QFUP" />
+      </concept>
       <concept id="1068390468200" name="jetbrains.mps.baseLanguage.structure.FieldDeclaration" flags="ig" index="312cEg">
         <property id="8606350594693632173" name="isTransient" index="eg7rD" />
         <property id="1240249534625" name="isVolatile" index="34CwA1" />
       </concept>
       <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu">
+        <property id="1075300953594" name="abstractClass" index="1sVAO0" />
         <child id="1095933932569" name="implementedInterface" index="EKbjA" />
         <child id="1165602531693" name="superclass" index="1zkMxy" />
       </concept>
@@ -171,6 +186,7 @@
       <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
         <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
       </concept>
+      <concept id="7812454656619025412" name="jetbrains.mps.baseLanguage.structure.LocalMethodCall" flags="nn" index="1rXfSq" />
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
         <child id="1109201940907" name="parameter" index="11_B2D" />
@@ -203,6 +219,7 @@
         <property id="1184950341882" name="topPriorityGroup" index="3$yP7D" />
         <child id="1167328349397" name="reductionMappingRule" index="3acgRq" />
         <child id="1167514678247" name="rootMappingRule" index="3lj3bC" />
+        <child id="1195502100749" name="preMappingScript" index="1puA0r" />
         <child id="1195502346405" name="postMappingScript" index="1pvy6N" />
       </concept>
       <concept id="1177093525992" name="jetbrains.mps.lang.generator.structure.InlineTemplate_RuleConsequence" flags="lg" index="gft3U">
@@ -221,6 +238,9 @@
       </concept>
       <concept id="1722980698497626400" name="jetbrains.mps.lang.generator.structure.ITemplateCall" flags="ng" index="v9R3L">
         <reference id="1722980698497626483" name="template" index="v9R2y" />
+      </concept>
+      <concept id="2880994019885263148" name="jetbrains.mps.lang.generator.structure.LoopMacroNamespaceAccessor" flags="ng" index="$GB7w">
+        <property id="1501378878163388321" name="variable" index="26SvY3" />
       </concept>
       <concept id="1167168920554" name="jetbrains.mps.lang.generator.structure.BaseMappingRule_Condition" flags="in" index="30G5F_" />
       <concept id="1167169188348" name="jetbrains.mps.lang.generator.structure.TemplateFunctionParameter_sourceNode" flags="nn" index="30H73N" />
@@ -243,6 +263,8 @@
         <reference id="1167514355421" name="template" index="3lhOvi" />
       </concept>
       <concept id="1195499912406" name="jetbrains.mps.lang.generator.structure.MappingScript" flags="lg" index="1pmfR0">
+        <property id="1195595592106" name="scriptKind" index="1v3f2W" />
+        <property id="1195595611951" name="modifiesModel" index="1v3jST" />
         <child id="1195501105008" name="codeBlock" index="1pqMTA" />
       </concept>
       <concept id="1195500722856" name="jetbrains.mps.lang.generator.structure.MappingScript_CodeBlock" flags="in" index="1pplIY" />
@@ -269,6 +291,12 @@
         <child id="1167770376702" name="referentFunction" index="3$ytzL" />
       </concept>
     </language>
+    <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
+      <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
+        <child id="1199569906740" name="parameter" index="1bW2Oz" />
+        <child id="1199569916463" name="body" index="1bW5cS" />
+      </concept>
+    </language>
     <language id="d7706f63-9be2-479c-a3da-ae92af1e64d5" name="jetbrains.mps.lang.generator.generationContext">
       <concept id="1216860049635" name="jetbrains.mps.lang.generator.generationContext.structure.TemplateFunctionParameter_generationContext" flags="nn" index="1iwH7S" />
     </language>
@@ -289,11 +317,17 @@
         <child id="6733348108486823193" name="leftExpression" index="1m5AlR" />
         <child id="3906496115198199033" name="conceptArgument" index="3oSUPX" />
       </concept>
+      <concept id="1145404486709" name="jetbrains.mps.lang.smodel.structure.SemanticDowncastExpression" flags="nn" index="2JrnkZ">
+        <child id="1145404616321" name="leftExpression" index="2JrQYb" />
+      </concept>
       <concept id="1171305280644" name="jetbrains.mps.lang.smodel.structure.Node_GetDescendantsOperation" flags="nn" index="2Rf3mk" />
       <concept id="1171323947159" name="jetbrains.mps.lang.smodel.structure.Model_NodesOperation" flags="nn" index="2SmgA7">
         <child id="1758937410080001570" name="conceptArgument" index="1dBWTz" />
       </concept>
       <concept id="1171407110247" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorOperation" flags="nn" index="2Xjw5R" />
+      <concept id="2644386474300074836" name="jetbrains.mps.lang.smodel.structure.ConceptIdRefExpression" flags="nn" index="35c_gC">
+        <reference id="2644386474300074837" name="conceptDeclaration" index="35c_gD" />
+      </concept>
       <concept id="1139613262185" name="jetbrains.mps.lang.smodel.structure.Node_GetParentOperation" flags="nn" index="1mfA1w" />
       <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
         <child id="1177027386292" name="conceptArgument" index="cj9EA" />
@@ -301,6 +335,10 @@
       <concept id="1172008320231" name="jetbrains.mps.lang.smodel.structure.Node_IsNotNullOperation" flags="nn" index="3x8VRR" />
       <concept id="1144101972840" name="jetbrains.mps.lang.smodel.structure.OperationParm_Concept" flags="ng" index="1xMEDy">
         <child id="1207343664468" name="conceptArgument" index="ri$Ld" />
+      </concept>
+      <concept id="1144146199828" name="jetbrains.mps.lang.smodel.structure.Node_CopyOperation" flags="nn" index="1$rogu" />
+      <concept id="1140131837776" name="jetbrains.mps.lang.smodel.structure.Node_ReplaceWithAnotherOperation" flags="nn" index="1P9Npp">
+        <child id="1140131861877" name="replacementNode" index="1P9ThW" />
       </concept>
       <concept id="1140137987495" name="jetbrains.mps.lang.smodel.structure.SNodeTypeCastExpression" flags="nn" index="1PxgMI" />
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
@@ -343,9 +381,13 @@
       </concept>
     </language>
     <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
+        <child id="1204796294226" name="closure" index="23t8la" />
+      </concept>
       <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="nn" index="25WWJ4">
         <child id="540871147943773366" name="argument" index="25WWJ7" />
       </concept>
+      <concept id="1204980550705" name="jetbrains.mps.baseLanguage.collections.structure.VisitAllOperation" flags="nn" index="2es0OD" />
       <concept id="1153943597977" name="jetbrains.mps.baseLanguage.collections.structure.ForEachStatement" flags="nn" index="2Gpval">
         <child id="1153944400369" name="variable" index="2Gsz3X" />
         <child id="1153944424730" name="inputSequence" index="2GsD0m" />
@@ -354,7 +396,9 @@
       <concept id="1153944233411" name="jetbrains.mps.baseLanguage.collections.structure.ForEachVariableReference" flags="nn" index="2GrUjf">
         <reference id="1153944258490" name="variable" index="2Gs0qQ" />
       </concept>
+      <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
       <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
+      <concept id="1162934736510" name="jetbrains.mps.baseLanguage.collections.structure.GetElementOperation" flags="nn" index="34jXtK" />
       <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
       <concept id="1176501494711" name="jetbrains.mps.baseLanguage.collections.structure.IsNotEmptyOperation" flags="nn" index="3GX2aA" />
     </language>
@@ -383,6 +427,21 @@
       <node concept="j$656" id="1CDgnklDN5C" role="1lVwrX">
         <ref role="v9R2y" node="1CDgnklDLqa" resolve="reduce_DummyWrapperCell" />
       </node>
+    </node>
+    <node concept="3aamgX" id="5PKDVfOkTuY" role="3acgRq">
+      <ref role="30HIoZ" to="91fu:5PKDVfOkPcZ" resolve="EditorComponentParameterReference" />
+      <node concept="j$656" id="5PKDVfOkTvc" role="1lVwrX">
+        <ref role="v9R2y" node="5PKDVfOkTva" resolve="reduce_EditorComponentDeclarationReference" />
+      </node>
+    </node>
+    <node concept="3aamgX" id="5PKDVfOlWDd" role="3acgRq">
+      <ref role="30HIoZ" to="91fu:5PKDVfOlrE5" resolve="CellModel_ComponentWithParameters" />
+      <node concept="j$656" id="5PKDVfOlWDr" role="1lVwrX">
+        <ref role="v9R2y" node="fYhRo0G" resolve="reduce_CellModel_ComponentWithParameters" />
+      </node>
+    </node>
+    <node concept="1puMqW" id="5PKDVfOaCwS" role="1puA0r">
+      <ref role="1puQsG" node="5PKDVfOavlQ" resolve="replaceEditorComponentDeclarationsWithEditorComponent" />
     </node>
   </node>
   <node concept="312cEu" id="fXkgKyo">
@@ -1610,6 +1669,472 @@
         </node>
       </node>
       <node concept="3Tm1VV" id="3MtSE7vpEol" role="1B3o_S" />
+    </node>
+  </node>
+  <node concept="312cEu" id="fXMS0ov">
+    <property role="TrG5h" value="class_EditorComponentDeclaration" />
+    <property role="3GE5qa" value="editorComponentWithParameters" />
+    <node concept="3Tm1VV" id="h9B3Lwv" role="1B3o_S" />
+    <node concept="n94m4" id="heQtBVi" role="lGtFl">
+      <ref role="n9lRv" to="91fu:5PKDVfNXREN" resolve="EditorComponentDeclarationWithParameters" />
+    </node>
+    <node concept="29HgVG" id="5PKDVfO9PSv" role="lGtFl">
+      <node concept="3NFfHV" id="5PKDVfO9PSF" role="3NFExx">
+        <node concept="3clFbS" id="5PKDVfO9PSG" role="2VODD2">
+          <node concept="3clFbF" id="5PKDVfOaidu" role="3cqZAp">
+            <node concept="2YIFZM" id="5PKDVfOahTt" role="3clFbG">
+              <ref role="1Pybhc" to="6f4m:4dr7st0kFTM" resolve="RefactoringRuntime" />
+              <ref role="37wK5l" to="6f4m:6gEjUfBKG6M" resolve="replaceWithNewConcept" />
+              <node concept="2OqwBi" id="5PKDVfOag9W" role="37wK5m">
+                <node concept="30H73N" id="5PKDVfOafS7" role="2Oq$k0" />
+                <node concept="1$rogu" id="5PKDVfOahag" role="2OqNvi" />
+              </node>
+              <node concept="35c_gC" id="5PKDVfOahYt" role="37wK5m">
+                <ref role="35c_gD" to="tpc2:fGPKFH7" resolve="EditorComponentDeclaration" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1pmfR0" id="5PKDVfOavlQ">
+    <property role="1v3f2W" value="hpv1Zf2/pre_processing" />
+    <property role="TrG5h" value="replaceEditorComponentDeclarationsWithEditorComponent" />
+    <property role="1v3jST" value="true" />
+    <property role="3GE5qa" value="editorComponentWithParameters" />
+    <node concept="1pplIY" id="5PKDVfOavlR" role="1pqMTA">
+      <node concept="3clFbS" id="5PKDVfOavlS" role="2VODD2">
+        <node concept="3clFbF" id="5PKDVfOavmt" role="3cqZAp">
+          <node concept="2OqwBi" id="5PKDVfOaz0y" role="3clFbG">
+            <node concept="2OqwBi" id="5PKDVfOavtF" role="2Oq$k0">
+              <node concept="1Q6Npb" id="5PKDVfOavms" role="2Oq$k0" />
+              <node concept="2SmgA7" id="5PKDVfOav$a" role="2OqNvi">
+                <node concept="chp4Y" id="5PKDVfOavKK" role="1dBWTz">
+                  <ref role="cht4Q" to="91fu:5PKDVfNXREN" resolve="EditorComponentDeclarationWithParameters" />
+                </node>
+              </node>
+            </node>
+            <node concept="2es0OD" id="5PKDVfOaACF" role="2OqNvi">
+              <node concept="1bVj0M" id="5PKDVfOaACH" role="23t8la">
+                <node concept="3clFbS" id="5PKDVfOaACI" role="1bW5cS">
+                  <node concept="3cpWs8" id="5PKDVfOaClJ" role="3cqZAp">
+                    <node concept="3cpWsn" id="5PKDVfOaClK" role="3cpWs9">
+                      <property role="TrG5h" value="newNode" />
+                      <node concept="3Tqbb2" id="5PKDVfOaChg" role="1tU5fm" />
+                      <node concept="2YIFZM" id="5PKDVfOaClL" role="33vP2m">
+                        <ref role="37wK5l" to="6f4m:6gEjUfBKG6M" resolve="replaceWithNewConcept" />
+                        <ref role="1Pybhc" to="6f4m:4dr7st0kFTM" resolve="RefactoringRuntime" />
+                        <node concept="37vLTw" id="5PKDVfOaClM" role="37wK5m">
+                          <ref role="3cqZAo" node="5PKDVfOaACJ" resolve="it" />
+                        </node>
+                        <node concept="35c_gC" id="5PKDVfOaClN" role="37wK5m">
+                          <ref role="35c_gD" to="tpc2:fGPKFH7" resolve="EditorComponentDeclaration" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbF" id="5PKDVfOaAEU" role="3cqZAp">
+                    <node concept="2OqwBi" id="5PKDVfOaAV3" role="3clFbG">
+                      <node concept="37vLTw" id="5PKDVfOaAET" role="2Oq$k0">
+                        <ref role="3cqZAo" node="5PKDVfOaACJ" resolve="it" />
+                      </node>
+                      <node concept="1P9Npp" id="5PKDVfOaBrN" role="2OqNvi">
+                        <node concept="37vLTw" id="5PKDVfOaClO" role="1P9ThW">
+                          <ref role="3cqZAo" node="5PKDVfOaClK" resolve="replaceWithNewConcept" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="Rh6nW" id="5PKDVfOaACJ" role="1bW2Oz">
+                  <property role="TrG5h" value="it" />
+                  <node concept="2jxLKc" id="5PKDVfOaACK" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="13MO4I" id="5PKDVfOkTva">
+    <property role="TrG5h" value="reduce_EditorComponentParameterReference" />
+    <property role="3GE5qa" value="editorComponentWithParameters" />
+    <ref role="3gUMe" to="91fu:5PKDVfOkPcZ" resolve="EditorComponentParameterReference" />
+    <node concept="312cEu" id="5PKDVfOkTvp" role="13RCb5">
+      <property role="TrG5h" value="Test" />
+      <property role="1sVAO0" value="true" />
+      <node concept="3clFbW" id="5PKDVfOl2Rq" role="jymVt">
+        <node concept="37vLTG" id="5PKDVfOl2Rr" role="3clF46">
+          <property role="TrG5h" value="editorContext" />
+          <node concept="3uibUv" id="5PKDVfOl2Rs" role="1tU5fm">
+            <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+          </node>
+          <node concept="2AHcQZ" id="5PKDVfOl2Rt" role="2AJF6D">
+            <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+          </node>
+        </node>
+        <node concept="3cqZAl" id="5PKDVfOl2Ru" role="3clF45" />
+        <node concept="3Tm1VV" id="5PKDVfOl2Rv" role="1B3o_S" />
+        <node concept="3clFbS" id="5PKDVfOl2R_" role="3clF47">
+          <node concept="XkiVB" id="5PKDVfOl2RA" role="3cqZAp">
+            <ref role="37wK5l" to="qvne:3IQYjJJTK4k" resolve="AbstractEditorBuilder" />
+            <node concept="37vLTw" id="5PKDVfOl2RB" role="37wK5m">
+              <ref role="3cqZAo" node="5PKDVfOl2Rr" resolve="editorContext" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2tJIrI" id="5PKDVfOl35v" role="jymVt" />
+      <node concept="3clFb_" id="5PKDVfOkTws" role="jymVt">
+        <property role="TrG5h" value="method" />
+        <node concept="3clFbS" id="5PKDVfOkTwv" role="3clF47">
+          <node concept="3cpWs8" id="5PKDVfOpy3H" role="3cqZAp">
+            <node concept="3cpWsn" id="5PKDVfOpy3I" role="3cpWs9">
+              <property role="TrG5h" value="value" />
+              <node concept="3uibUv" id="5PKDVfOpy3J" role="1tU5fm">
+                <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+              </node>
+              <node concept="10QFUN" id="5PKDVfOplHe" role="33vP2m">
+                <node concept="3uibUv" id="5PKDVfOpmzK" role="10QFUM">
+                  <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+                  <node concept="29HgVG" id="5PKDVfOpvPy" role="lGtFl">
+                    <node concept="3NFfHV" id="5PKDVfOpvSt" role="3NFExx">
+                      <node concept="3clFbS" id="5PKDVfOpvSu" role="2VODD2">
+                        <node concept="3clFbF" id="5PKDVfOpvSH" role="3cqZAp">
+                          <node concept="2OqwBi" id="5PKDVfOpwKU" role="3clFbG">
+                            <node concept="2OqwBi" id="5PKDVfOpwae" role="2Oq$k0">
+                              <node concept="30H73N" id="5PKDVfOpvSG" role="2Oq$k0" />
+                              <node concept="3TrEf2" id="5PKDVfOpwzC" role="2OqNvi">
+                                <ref role="3Tt5mk" to="91fu:5PKDVfOkPd0" resolve="parameter" />
+                              </node>
+                            </node>
+                            <node concept="3TrEf2" id="5PKDVfOpx6H" role="2OqNvi">
+                              <ref role="3Tt5mk" to="tpee:4VkOLwjf83e" resolve="type" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="5PKDVfOkZV8" role="10QFUP">
+                  <node concept="liA8E" id="5PKDVfOl07$" role="2OqNvi">
+                    <ref role="37wK5l" to="mhbf:~SNode.getUserObject(java.lang.Object)" resolve="getUserObject" />
+                    <node concept="Xl_RD" id="5PKDVfOl0ba" role="37wK5m">
+                      <property role="Xl_RC" value="key" />
+                      <node concept="17Uvod" id="5PKDVfOl0hu" role="lGtFl">
+                        <property role="2qtEX9" value="value" />
+                        <property role="P4ACc" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1070475926800/1070475926801" />
+                        <node concept="3zFVjK" id="5PKDVfOl0hv" role="3zH0cK">
+                          <node concept="3clFbS" id="5PKDVfOl0hw" role="2VODD2">
+                            <node concept="3clFbF" id="37WLJ3LoW92" role="3cqZAp">
+                              <node concept="3cpWs3" id="37WLJ3LoW94" role="3clFbG">
+                                <node concept="3cpWs3" id="37WLJ3LoW9b" role="3uHU7B">
+                                  <node concept="Xl_RD" id="37WLJ3LoW9c" role="3uHU7w">
+                                    <property role="Xl_RC" value="_parameter_" />
+                                  </node>
+                                  <node concept="3cpWs3" id="37WLJ3LoW9d" role="3uHU7B">
+                                    <node concept="Xl_RD" id="37WLJ3LoW9e" role="3uHU7B">
+                                      <property role="Xl_RC" value="editor_component_" />
+                                    </node>
+                                    <node concept="2OqwBi" id="57s2K5APfeP" role="3uHU7w">
+                                      <node concept="2OqwBi" id="37WLJ3LoX_t" role="2Oq$k0">
+                                        <node concept="30H73N" id="37WLJ3LoX9s" role="2Oq$k0" />
+                                        <node concept="2Xjw5R" id="37WLJ3LoYkv" role="2OqNvi">
+                                          <node concept="1xMEDy" id="37WLJ3LoYkx" role="1xVPHs">
+                                            <node concept="chp4Y" id="37WLJ3LoZbi" role="ri$Ld">
+                                              <ref role="cht4Q" to="tpc2:fGPKFH7" resolve="EditorComponentDeclaration" />
+                                            </node>
+                                          </node>
+                                        </node>
+                                      </node>
+                                      <node concept="2qgKlT" id="57s2K5APglC" role="2OqNvi">
+                                        <ref role="37wK5l" to="tpcu:hEwIO9y" resolve="getFqName" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                                <node concept="2OqwBi" id="37WLJ3Lp3cN" role="3uHU7w">
+                                  <node concept="2OqwBi" id="37WLJ3Lp1ZE" role="2Oq$k0">
+                                    <node concept="30H73N" id="37WLJ3Lp1zd" role="2Oq$k0" />
+                                    <node concept="3TrEf2" id="37WLJ3Lp2y2" role="2OqNvi">
+                                      <ref role="3Tt5mk" to="91fu:5PKDVfOkPd0" resolve="parameter" />
+                                    </node>
+                                  </node>
+                                  <node concept="3TrcHB" id="37WLJ3Lp46e" role="2OqNvi">
+                                    <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2JrnkZ" id="1Pv0$Zu5ote" role="2Oq$k0">
+                    <node concept="1rXfSq" id="1Pv0$Zu5nGh" role="2JrQYb">
+                      <ref role="37wK5l" to="qvne:6OQfiPCHBgy" resolve="getNode" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="raruj" id="1Pv0$Zu4gNk" role="lGtFl" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3Tm1VV" id="5PKDVfOkTw3" role="1B3o_S" />
+        <node concept="3cqZAl" id="5PKDVfOkTwh" role="3clF45" />
+      </node>
+      <node concept="3Tm1VV" id="5PKDVfOkTvq" role="1B3o_S" />
+      <node concept="3uibUv" id="5PKDVfOkZac" role="1zkMxy">
+        <ref role="3uigEE" to="qvne:3IQYjJJTK3Q" resolve="AbstractEditorBuilder" />
+      </node>
+    </node>
+  </node>
+  <node concept="13MO4I" id="fYhRo0G">
+    <property role="TrG5h" value="reduce_CellModel_ComponentWithParameters" />
+    <property role="3GE5qa" value="editorComponentWithParameters" />
+    <ref role="3gUMe" to="91fu:5PKDVfOlrE5" resolve="CellModel_ComponentWithParameters" />
+    <node concept="312cEu" id="fYhRrsc" role="13RCb5">
+      <property role="TrG5h" value="_context_class_" />
+      <property role="1sVAO0" value="true" />
+      <node concept="3uibUv" id="1aFmvcpB5x2" role="1zkMxy">
+        <ref role="3uigEE" to="tpc3:7GOmDNDyRby" resolve="CellFactoryContextClass" />
+      </node>
+      <node concept="3clFb_" id="fYhRrsi" role="jymVt">
+        <property role="TrG5h" value="_cell_factory_method_" />
+        <node concept="3uibUv" id="5Hr2i_R0FhF" role="3clF45">
+          <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+        </node>
+        <node concept="3Tm6S6" id="1y7DiaVv2W3" role="1B3o_S" />
+        <node concept="raruj" id="fYhRrsI" role="lGtFl">
+          <ref role="2sdACS" to="tpc3:2dNBF9rpTiT" resolve="cellFactory.factoryMethod" />
+        </node>
+        <node concept="17Uvod" id="fYhRrsJ" role="lGtFl">
+          <property role="2qtEX9" value="name" />
+          <property role="P4ACc" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c/1169194658468/1169194664001" />
+          <node concept="3zFVjK" id="hBforze" role="3zH0cK">
+            <node concept="3clFbS" id="hBforzf" role="2VODD2">
+              <node concept="3clFbF" id="hBforzg" role="3cqZAp">
+                <node concept="2OqwBi" id="hHfEn$b" role="3clFbG">
+                  <node concept="30H73N" id="hHfEnt5" role="2Oq$k0" />
+                  <node concept="2qgKlT" id="hHfEnMS" role="2OqNvi">
+                    <ref role="37wK5l" to="tpcb:hHfE2BD" resolve="getFactoryMethodName" />
+                    <node concept="1iwH7S" id="hT7Dm8g" role="37wK5m" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbS" id="fYhRrsj" role="3clF47">
+          <node concept="3clFbF" id="5PKDVfOlX1z" role="3cqZAp">
+            <node concept="2OqwBi" id="5PKDVfOlXs2" role="3clFbG">
+              <node concept="37vLTw" id="5PKDVfOlX1x" role="2Oq$k0">
+                <ref role="3cqZAo" to="tpc3:7GOmDNDA2zg" resolve="myNode" />
+              </node>
+              <node concept="liA8E" id="5PKDVfOlXWr" role="2OqNvi">
+                <ref role="37wK5l" to="f4zo:~EditorCell.putUserObject(java.lang.Object,java.lang.Object)" resolve="putUserObject" />
+                <node concept="Xl_RD" id="5PKDVfOlY1E" role="37wK5m">
+                  <property role="Xl_RC" value="key" />
+                  <node concept="17Uvod" id="5PKDVfOm0p_" role="lGtFl">
+                    <property role="2qtEX9" value="value" />
+                    <property role="P4ACc" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1070475926800/1070475926801" />
+                    <node concept="3zFVjK" id="5PKDVfOm0pA" role="3zH0cK">
+                      <node concept="3clFbS" id="5PKDVfOm0pB" role="2VODD2">
+                        <node concept="3SKdUt" id="ng7qrrB60a" role="3cqZAp">
+                          <node concept="1PaTwC" id="ng7qrrB60b" role="1aUNEU">
+                            <node concept="3oM_SD" id="ng7qrrB6aP" role="1PaTwD">
+                              <property role="3oM_SC" value="FIXME" />
+                            </node>
+                            <node concept="3oM_SD" id="ng7qrrB6CX" role="1PaTwD">
+                              <property role="3oM_SC" value="EditorComponentDeclarationWithParameters#" />
+                            </node>
+                            <node concept="3oM_SD" id="ng7qrrB6Xn" role="1PaTwD">
+                              <property role="3oM_SC" value="" />
+                            </node>
+                            <node concept="3oM_SD" id="ng7qrrB6Xp" role="1PaTwD">
+                              <property role="3oM_SC" value="getUserObjectKeyForParameter" />
+                            </node>
+                            <node concept="3oM_SD" id="ng7qrrB6Xv" role="1PaTwD">
+                              <property role="3oM_SC" value="throws" />
+                            </node>
+                            <node concept="3oM_SD" id="ng7qrrB77p" role="1PaTwD">
+                              <property role="3oM_SC" value="with" />
+                            </node>
+                            <node concept="3oM_SD" id="ng7qrrB7hn" role="1PaTwD">
+                              <property role="3oM_SC" value="IllegalArgumentException" />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3cpWs8" id="ng7qrrB2MR" role="3cqZAp">
+                          <node concept="3cpWsn" id="ng7qrrB2MS" role="3cpWs9">
+                            <property role="TrG5h" value="editorComponent" />
+                            <node concept="3Tqbb2" id="ng7qrrB2sD" role="1tU5fm">
+                              <ref role="ehGHo" to="91fu:5PKDVfNXREN" resolve="EditorComponentDeclarationWithParameters" />
+                            </node>
+                            <node concept="2OqwBi" id="ng7qrrB2MT" role="33vP2m">
+                              <node concept="$GB7w" id="ng7qrrB2MU" role="2Oq$k0">
+                                <property role="26SvY3" value="1jlY2aid0ut/inputNode" />
+                              </node>
+                              <node concept="3TrEf2" id="ng7qrrB2MV" role="2OqNvi">
+                                <ref role="3Tt5mk" to="91fu:fGPMmyn" resolve="editorComponent" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3clFbF" id="6lJ4OOEJ9VN" role="3cqZAp">
+                          <node concept="3cpWs3" id="6lJ4OOEJ9VO" role="3clFbG">
+                            <node concept="2OqwBi" id="6lJ4OOEJ9VP" role="3uHU7w">
+                              <node concept="2OqwBi" id="6lJ4OOEJd9h" role="2Oq$k0">
+                                <node concept="2OqwBi" id="6lJ4OOEJ9VQ" role="2Oq$k0">
+                                  <node concept="3Tsc0h" id="6lJ4OOEJaHE" role="2OqNvi">
+                                    <ref role="3TtcxE" to="91fu:5PKDVfNY0qm" resolve="parameters" />
+                                  </node>
+                                  <node concept="37vLTw" id="ng7qrrB3XD" role="2Oq$k0">
+                                    <ref role="3cqZAo" node="ng7qrrB2MS" resolve="editorComponent" />
+                                  </node>
+                                </node>
+                                <node concept="34jXtK" id="6lJ4OOEJf8Y" role="2OqNvi">
+                                  <node concept="$GB7w" id="ng7qrrB4Yg" role="25WWJ7">
+                                    <property role="26SvY3" value="1jlY2aid0uu/index" />
+                                  </node>
+                                </node>
+                              </node>
+                              <node concept="3TrcHB" id="6lJ4OOEJ9VT" role="2OqNvi">
+                                <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                              </node>
+                            </node>
+                            <node concept="3cpWs3" id="6lJ4OOEJ9VU" role="3uHU7B">
+                              <node concept="Xl_RD" id="6lJ4OOEJ9VV" role="3uHU7w">
+                                <property role="Xl_RC" value="_parameter_" />
+                              </node>
+                              <node concept="3cpWs3" id="6lJ4OOEJ9VW" role="3uHU7B">
+                                <node concept="Xl_RD" id="6lJ4OOEJ9VX" role="3uHU7B">
+                                  <property role="Xl_RC" value="editor_component_" />
+                                </node>
+                                <node concept="2OqwBi" id="57s2K5APA$B" role="3uHU7w">
+                                  <node concept="37vLTw" id="6lJ4OOEJ9VY" role="2Oq$k0">
+                                    <ref role="3cqZAo" node="ng7qrrB2MS" resolve="editorComponent" />
+                                  </node>
+                                  <node concept="2qgKlT" id="57s2K5APBhQ" role="2OqNvi">
+                                    <ref role="37wK5l" to="tpcu:hEwIO9y" resolve="getFqName" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="Xl_RD" id="5PKDVfOlYBN" role="37wK5m">
+                  <property role="Xl_RC" value="value" />
+                  <node concept="29HgVG" id="5PKDVfOmm_Q" role="lGtFl">
+                    <node concept="3NFfHV" id="5PKDVfOmmJn" role="3NFExx">
+                      <node concept="3clFbS" id="5PKDVfOmmJo" role="2VODD2">
+                        <node concept="3clFbF" id="5PKDVfOmmJB" role="3cqZAp">
+                          <node concept="30H73N" id="5PKDVfOmmJA" role="3clFbG" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="1WS0z7" id="5PKDVfOlZZD" role="lGtFl">
+              <node concept="3JmXsc" id="5PKDVfOlZZG" role="3Jn$fo">
+                <node concept="3clFbS" id="5PKDVfOlZZH" role="2VODD2">
+                  <node concept="3clFbF" id="5PKDVfOlZZN" role="3cqZAp">
+                    <node concept="2OqwBi" id="5PKDVfOlZZI" role="3clFbG">
+                      <node concept="3Tsc0h" id="5PKDVfOlZZL" role="2OqNvi">
+                        <ref role="3TtcxE" to="91fu:5PKDVfOlsvY" resolve="arguments" />
+                      </node>
+                      <node concept="30H73N" id="5PKDVfOlZZM" role="2Oq$k0" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="gZgDYwu" role="3cqZAp">
+            <node concept="3cpWsn" id="gZgDYwv" role="3cpWs9">
+              <property role="TrG5h" value="editorCell" />
+              <node concept="2OqwBi" id="28ODomSEjlR" role="33vP2m">
+                <node concept="1rXfSq" id="6OQfiPCs3Kk" role="2Oq$k0">
+                  <ref role="37wK5l" to="qvne:6OQfiPCHBjx" resolve="getCellFactory" />
+                </node>
+                <node concept="liA8E" id="6e9uNXzmKH" role="2OqNvi">
+                  <ref role="37wK5l" to="f4zo:~EditorCellFactory.createEditorComponentCell(org.jetbrains.mps.openapi.model.SNode,java.lang.String)" resolve="createEditorComponentCell" />
+                  <node concept="37vLTw" id="1aFmvcpB7d8" role="37wK5m">
+                    <ref role="3cqZAo" to="tpc3:7GOmDNDA2zg" resolve="myNode" />
+                  </node>
+                  <node concept="Xl_RD" id="6e9uNXzViU" role="37wK5m">
+                    <property role="Xl_RC" value="editorComponentId" />
+                    <node concept="17Uvod" id="6e9uNXzVCP" role="lGtFl">
+                      <property role="2qtEX9" value="value" />
+                      <property role="P4ACc" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1070475926800/1070475926801" />
+                      <node concept="3zFVjK" id="6e9uNXzVCQ" role="3zH0cK">
+                        <node concept="3clFbS" id="6e9uNXzVCR" role="2VODD2">
+                          <node concept="3clFbF" id="6e9uNXzW4V" role="3cqZAp">
+                            <node concept="2OqwBi" id="6e9uNXzZLQ" role="3clFbG">
+                              <node concept="2qgKlT" id="6e9uNX$3CX" role="2OqNvi">
+                                <ref role="37wK5l" to="tpcu:hEwIO9y" resolve="getFqName" />
+                              </node>
+                              <node concept="2OqwBi" id="6e9uNXzWfv" role="2Oq$k0">
+                                <node concept="3TrEf2" id="6e9uNXzYpn" role="2OqNvi">
+                                  <ref role="3Tt5mk" to="91fu:fGPMmyn" resolve="editorComponent" />
+                                </node>
+                                <node concept="30H73N" id="6e9uNXzW4U" role="2Oq$k0" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3uibUv" id="5Hr2i_R0CYX" role="1tU5fm">
+                <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="4v1iCryNF1X" role="3cqZAp">
+            <node concept="5jKBG" id="za$VMvkNOv" role="lGtFl">
+              <ref role="v9R2y" to="tpc3:4v1iCryNDHi" resolve="template_cellSetupBlock" />
+            </node>
+            <node concept="3cpWsn" id="4v1iCryNF1Y" role="3cpWs9">
+              <property role="TrG5h" value="i" />
+              <node concept="10Oyi0" id="4v1iCryNF1Z" role="1tU5fm" />
+            </node>
+          </node>
+          <node concept="3clFbF" id="13c7lpEz__Z" role="3cqZAp">
+            <node concept="2OqwBi" id="13c7lpEz_A1" role="3clFbG">
+              <node concept="37vLTw" id="3GM_nagTsgE" role="2Oq$k0">
+                <ref role="3cqZAo" node="gZgDYwv" resolve="editorCell" />
+              </node>
+              <node concept="liA8E" id="13c7lpEz_A5" role="2OqNvi">
+                <ref role="37wK5l" to="f4zo:~EditorCell.setSubstituteInfo(jetbrains.mps.openapi.editor.cells.SubstituteInfo)" resolve="setSubstituteInfo" />
+                <node concept="10Nm6u" id="13c7lpEz_A6" role="37wK5m" />
+              </node>
+            </node>
+            <node concept="5jKBG" id="13c7lpEz_A8" role="lGtFl">
+              <ref role="v9R2y" to="tpc3:5t2DUc51aVQ" resolve="template_cellSetSubstituteInfo" />
+            </node>
+          </node>
+          <node concept="3cpWs6" id="fYhRrsC" role="3cqZAp">
+            <node concept="37vLTw" id="3GM_nagTz20" role="3cqZAk">
+              <ref role="3cqZAo" node="gZgDYwv" resolve="editorCell" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="h9B3Lo2" role="1B3o_S" />
     </node>
   </node>
 </model>

--- a/code/conditional-editor/languages/de.slisson.mps.conditionalEditor/generator/template/main@generator.mps
+++ b/code/conditional-editor/languages/de.slisson.mps.conditionalEditor/generator/template/main@generator.mps
@@ -34,6 +34,7 @@
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
     <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" implicit="true" />
     <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" implicit="true" />
+    <import index="tpek" ref="r:00000000-0000-4000-0000-011c895902c0(jetbrains.mps.baseLanguage.behavior)" implicit="true" />
   </imports>
   <registry>
     <language id="b8bb702e-43ed-4090-a902-d180d3e5f292" name="de.slisson.mps.conditionalEditor">
@@ -217,6 +218,7 @@
       </concept>
       <concept id="1095416546421" name="jetbrains.mps.lang.generator.structure.MappingConfiguration" flags="ig" index="bUwia">
         <property id="1184950341882" name="topPriorityGroup" index="3$yP7D" />
+        <child id="1200911492601" name="mappingLabel" index="2rTMjI" />
         <child id="1167328349397" name="reductionMappingRule" index="3acgRq" />
         <child id="1167514678247" name="rootMappingRule" index="3lj3bC" />
         <child id="1195502100749" name="preMappingScript" index="1puA0r" />
@@ -235,6 +237,10 @@
       </concept>
       <concept id="1095672379244" name="jetbrains.mps.lang.generator.structure.TemplateFragment" flags="ng" index="raruj">
         <reference id="1200916687663" name="labelDeclaration" index="2sdACS" />
+      </concept>
+      <concept id="1200911316486" name="jetbrains.mps.lang.generator.structure.MappingLabelDeclaration" flags="lg" index="2rT7sh">
+        <reference id="1200911342686" name="sourceConcept" index="2rTdP9" />
+        <reference id="1200913004646" name="targetConcept" index="2rZz_L" />
       </concept>
       <concept id="1722980698497626400" name="jetbrains.mps.lang.generator.structure.ITemplateCall" flags="ng" index="v9R3L">
         <reference id="1722980698497626483" name="template" index="v9R2y" />
@@ -255,6 +261,9 @@
       </concept>
       <concept id="1087833241328" name="jetbrains.mps.lang.generator.structure.PropertyMacro" flags="ln" index="17Uvod">
         <child id="1167756362303" name="propertyValueFunction" index="3zH0cK" />
+      </concept>
+      <concept id="1087833466690" name="jetbrains.mps.lang.generator.structure.NodeMacro" flags="lg" index="17VmuZ">
+        <reference id="1200912223215" name="mappingLabel" index="2rW$FS" />
       </concept>
       <concept id="1167327847730" name="jetbrains.mps.lang.generator.structure.Reduction_MappingRule" flags="lg" index="3aamgX">
         <child id="1169672767469" name="ruleConsequence" index="1lVwrX" />
@@ -298,6 +307,10 @@
       </concept>
     </language>
     <language id="d7706f63-9be2-479c-a3da-ae92af1e64d5" name="jetbrains.mps.lang.generator.generationContext">
+      <concept id="1216860049627" name="jetbrains.mps.lang.generator.generationContext.structure.GenerationContextOp_GetOutputByLabelAndInput" flags="nn" index="1iwH70">
+        <reference id="1216860049628" name="label" index="1iwH77" />
+        <child id="1216860049632" name="inputNode" index="1iwH7V" />
+      </concept>
       <concept id="1216860049635" name="jetbrains.mps.lang.generator.generationContext.structure.TemplateFunctionParameter_generationContext" flags="nn" index="1iwH7S" />
     </language>
     <language id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation">
@@ -405,6 +418,11 @@
   </registry>
   <node concept="bUwia" id="2vJRo8guWG$">
     <property role="TrG5h" value="mc02_main" />
+    <node concept="2rT7sh" id="1gBmad3HMig" role="2rTMjI">
+      <property role="TrG5h" value="componentParameter" />
+      <ref role="2rTdP9" to="91fu:1gBmad3Feya" resolve="ComponentArgument" />
+      <ref role="2rZz_L" to="tpee:fzclF8t" resolve="InstanceMethodDeclaration" />
+    </node>
     <node concept="1puMqW" id="59YMGDNQJ$O" role="1pvy6N">
       <ref role="1puQsG" node="59YMGDNQJ$S" resolve="script_uniqueName" />
     </node>
@@ -1937,7 +1955,7 @@
                 <ref role="3cqZAo" to="tpc3:7GOmDNDA2zg" resolve="myNode" />
               </node>
               <node concept="liA8E" id="5PKDVfOlXWr" role="2OqNvi">
-                <ref role="37wK5l" to="f4zo:~EditorCell.putUserObject(java.lang.Object,java.lang.Object)" resolve="putUserObject" />
+                <ref role="37wK5l" to="mhbf:~SNode.putUserObject(java.lang.Object,java.lang.Object)" resolve="putUserObject" />
                 <node concept="Xl_RD" id="5PKDVfOlY1E" role="37wK5m">
                   <property role="Xl_RC" value="key" />
                   <node concept="17Uvod" id="5PKDVfOm0p_" role="lGtFl">
@@ -2032,16 +2050,30 @@
                     </node>
                   </node>
                 </node>
-                <node concept="Xl_RD" id="5PKDVfOlYBN" role="37wK5m">
-                  <property role="Xl_RC" value="value" />
-                  <node concept="29HgVG" id="5PKDVfOmm_Q" role="lGtFl">
-                    <node concept="3NFfHV" id="5PKDVfOmmJn" role="3NFExx">
-                      <node concept="3clFbS" id="5PKDVfOmmJo" role="2VODD2">
-                        <node concept="3clFbF" id="5PKDVfOmmJB" role="3cqZAp">
-                          <node concept="30H73N" id="5PKDVfOmmJA" role="3clFbG" />
+                <node concept="1rXfSq" id="1gBmad3Ikzi" role="37wK5m">
+                  <ref role="37wK5l" node="1gBmad3HOyI" resolve="getParameter" />
+                  <node concept="1ZhdrF" id="1gBmad3IlJX" role="lGtFl">
+                    <property role="2qtEX8" value="baseMethodDeclaration" />
+                    <property role="P3scX" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1204053956946/1068499141037" />
+                    <node concept="3$xsQk" id="1gBmad3IlJY" role="3$ytzL">
+                      <node concept="3clFbS" id="1gBmad3IlJZ" role="2VODD2">
+                        <node concept="3clFbF" id="1gBmad3ImgM" role="3cqZAp">
+                          <node concept="2OqwBi" id="1gBmad3In2H" role="3clFbG">
+                            <node concept="1iwH7S" id="1gBmad3ImgL" role="2Oq$k0" />
+                            <node concept="1iwH70" id="1gBmad3IojR" role="2OqNvi">
+                              <ref role="1iwH77" node="1gBmad3HMig" resolve="componentParameter" />
+                              <node concept="30H73N" id="1gBmad3Ipll" role="1iwH7V" />
+                            </node>
+                          </node>
                         </node>
                       </node>
                     </node>
+                  </node>
+                  <node concept="1rXfSq" id="1gBmad3IxuM" role="37wK5m">
+                    <ref role="37wK5l" to="qvne:6OQfiPCHBdf" resolve="getEditorContext" />
+                  </node>
+                  <node concept="1rXfSq" id="1gBmad3IzHn" role="37wK5m">
+                    <ref role="37wK5l" to="qvne:6OQfiPCHBgy" resolve="getNode" />
                   </node>
                 </node>
               </node>
@@ -2132,6 +2164,121 @@
               <ref role="3cqZAo" node="gZgDYwv" resolve="editorCell" />
             </node>
           </node>
+        </node>
+      </node>
+      <node concept="2tJIrI" id="1gBmad3HMHA" role="jymVt" />
+      <node concept="3clFb_" id="1gBmad3HOyI" role="jymVt">
+        <property role="TrG5h" value="getParameter" />
+        <node concept="3clFbS" id="1gBmad3HOyL" role="3clF47">
+          <node concept="1W57fq" id="1gBmad3MLAf" role="lGtFl">
+            <node concept="3IZrLx" id="1gBmad3MLAg" role="3IZSJc">
+              <node concept="3clFbS" id="1gBmad3MLAh" role="2VODD2">
+                <node concept="3clFbF" id="1gBmad3MMAp" role="3cqZAp">
+                  <node concept="2OqwBi" id="1gBmad3MP0K" role="3clFbG">
+                    <node concept="2OqwBi" id="1gBmad3MNnL" role="2Oq$k0">
+                      <node concept="30H73N" id="1gBmad3MMAo" role="2Oq$k0" />
+                      <node concept="3TrEf2" id="1gBmad3MO0x" role="2OqNvi">
+                        <ref role="3Tt5mk" to="tpee:gyVODHa" resolve="body" />
+                      </node>
+                    </node>
+                    <node concept="3x8VRR" id="1gBmad3MPXl" role="2OqNvi" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="gft3U" id="1gBmad3MRWB" role="UU_$l">
+              <node concept="3cpWs6" id="1gBmad3MTxx" role="gfFT$">
+                <node concept="10Nm6u" id="1gBmad3MUEk" role="3cqZAk" />
+              </node>
+            </node>
+          </node>
+          <node concept="29HgVG" id="1gBmad3MFmm" role="lGtFl">
+            <node concept="3NFfHV" id="1gBmad3MGdU" role="3NFExx">
+              <node concept="3clFbS" id="1gBmad3MGdV" role="2VODD2">
+                <node concept="3clFbF" id="1gBmad3MG$A" role="3cqZAp">
+                  <node concept="2OqwBi" id="1gBmad3MHbu" role="3clFbG">
+                    <node concept="30H73N" id="1gBmad3MG$_" role="2Oq$k0" />
+                    <node concept="3TrEf2" id="1gBmad3MIeM" role="2OqNvi">
+                      <ref role="3Tt5mk" to="tpee:gyVODHa" resolve="body" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs6" id="1gBmad3MJra" role="3cqZAp">
+            <node concept="10Nm6u" id="1gBmad3MKh$" role="3cqZAk" />
+          </node>
+        </node>
+        <node concept="3Tm6S6" id="1gBmad3HNCn" role="1B3o_S" />
+        <node concept="3uibUv" id="1gBmad3HOxX" role="3clF45">
+          <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+          <node concept="29HgVG" id="1gBmad3HWRu" role="lGtFl">
+            <node concept="3NFfHV" id="1gBmad3HWRv" role="3NFExx">
+              <node concept="3clFbS" id="1gBmad3HWRw" role="2VODD2">
+                <node concept="3clFbF" id="1gBmad3HWRA" role="3cqZAp">
+                  <node concept="2OqwBi" id="1gBmad3HWRx" role="3clFbG">
+                    <node concept="30H73N" id="1gBmad3HWR_" role="2Oq$k0" />
+                    <node concept="2qgKlT" id="1gBmad3HXP9" role="2OqNvi">
+                      <ref role="37wK5l" to="tpek:hEwIGRD" resolve="getExpectedReturnType" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="raruj" id="1gBmad3HVBC" role="lGtFl" />
+        <node concept="1WS0z7" id="1gBmad3HVBE" role="lGtFl">
+          <ref role="2rW$FS" node="1gBmad3HMig" resolve="componentParameter" />
+          <node concept="3JmXsc" id="1gBmad3HVBH" role="3Jn$fo">
+            <node concept="3clFbS" id="1gBmad3HVBI" role="2VODD2">
+              <node concept="3clFbF" id="1gBmad3HVBO" role="3cqZAp">
+                <node concept="2OqwBi" id="1gBmad3HVBJ" role="3clFbG">
+                  <node concept="3Tsc0h" id="1gBmad3HVBM" role="2OqNvi">
+                    <ref role="3TtcxE" to="91fu:5PKDVfOlsvY" resolve="arguments" />
+                  </node>
+                  <node concept="30H73N" id="1gBmad3HVBN" role="2Oq$k0" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="17Uvod" id="1gBmad3HYaa" role="lGtFl">
+          <property role="2qtEX9" value="name" />
+          <property role="P4ACc" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c/1169194658468/1169194664001" />
+          <node concept="3zFVjK" id="1gBmad3HYab" role="3zH0cK">
+            <node concept="3clFbS" id="1gBmad3HYac" role="2VODD2">
+              <node concept="3clFbF" id="1gBmad3K0Qu" role="3cqZAp">
+                <node concept="3cpWs3" id="1gBmad3K161" role="3clFbG">
+                  <node concept="Xl_RD" id="1gBmad3K0Qt" role="3uHU7B">
+                    <property role="Xl_RC" value="getParameter_" />
+                  </node>
+                  <node concept="2OqwBi" id="1gBmad3K2ZB" role="3uHU7w">
+                    <node concept="2OqwBi" id="1gBmad3K20T" role="2Oq$k0">
+                      <node concept="30H73N" id="1gBmad3K1Of" role="2Oq$k0" />
+                      <node concept="3TrEf2" id="1gBmad3K2ua" role="2OqNvi">
+                        <ref role="3Tt5mk" to="91fu:1gBmad3FeJu" resolve="variable" />
+                      </node>
+                    </node>
+                    <node concept="3TrcHB" id="1gBmad3K3lp" role="2OqNvi">
+                      <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="37vLTG" id="1gBmad3K_Dr" role="3clF46">
+          <property role="TrG5h" value="editorContext" />
+          <node concept="3uibUv" id="1gBmad3K_Dq" role="1tU5fm">
+            <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+          </node>
+        </node>
+        <node concept="37vLTG" id="1gBmad3KC$V" role="3clF46">
+          <property role="TrG5h" value="node" />
+          <node concept="3Tqbb2" id="1gBmad3KDED" role="1tU5fm" />
         </node>
       </node>
       <node concept="3Tm1VV" id="h9B3Lo2" role="1B3o_S" />

--- a/code/conditional-editor/languages/de.slisson.mps.conditionalEditor/languageModels/behavior.mps
+++ b/code/conditional-editor/languages/de.slisson.mps.conditionalEditor/languageModels/behavior.mps
@@ -25,6 +25,7 @@
         <property id="1225194472834" name="isAbstract" index="13i0iv" />
         <reference id="1225194472831" name="overriddenMethod" index="13i0hy" />
       </concept>
+      <concept id="1225194691553" name="jetbrains.mps.lang.behavior.structure.ThisNodeExpression" flags="nn" index="13iPFW" />
     </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
@@ -83,6 +84,9 @@
         <reference id="6677504323281689839" name="conceptDeclaraton" index="3bZ5Sy" />
       </concept>
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2" />
+      <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="nn" index="3TrEf2">
+        <reference id="1138056516764" name="link" index="3Tt5mk" />
+      </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
@@ -97,6 +101,7 @@
         <child id="1151688676805" name="elementType" index="_ZDj9" />
       </concept>
       <concept id="1237721394592" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerCreator" flags="nn" index="HWqM0">
+        <child id="1237721435808" name="initValue" index="HW$Y0" />
         <child id="1237721435807" name="elementType" index="HW$YZ" />
       </concept>
       <concept id="1160600644654" name="jetbrains.mps.baseLanguage.collections.structure.ListCreatorWithInit" flags="nn" index="Tc6Ow" />
@@ -183,6 +188,60 @@
           <ref role="3bZ5Sy" to="tpee:g76ryKb" resolve="ConceptFunctionParameter" />
         </node>
       </node>
+    </node>
+  </node>
+  <node concept="13h7C7" id="1gBmad3FeCB">
+    <ref role="13h7C2" to="91fu:1gBmad3Feya" resolve="ComponentArgument" />
+    <node concept="13i0hz" id="1$t5g3Q$5u2" role="13h7CS">
+      <property role="TrG5h" value="getParameterConcepts" />
+      <ref role="13i0hy" to="tpek:2xELmDxyi2v" resolve="getParameterConcepts" />
+      <node concept="3clFbS" id="1$t5g3Q$5u5" role="3clF47">
+        <node concept="3clFbF" id="1$t5g3Q$8IS" role="3cqZAp">
+          <node concept="2ShNRf" id="1$t5g3Q$8IQ" role="3clFbG">
+            <node concept="Tc6Ow" id="1$t5g3Q$9Xa" role="2ShVmc">
+              <node concept="3bZ5Sz" id="1$t5g3Q$aex" role="HW$YZ">
+                <ref role="3bZ5Sy" to="tpee:g76ryKb" resolve="ConceptFunctionParameter" />
+              </node>
+              <node concept="35c_gC" id="1$t5g3Q$asf" role="HW$Y0">
+                <ref role="35c_gD" to="tpc2:gTQ80DJ" resolve="ConceptFunctionParameter_editorContext" />
+              </node>
+              <node concept="35c_gC" id="1$t5g3Q$aYW" role="HW$Y0">
+                <ref role="35c_gD" to="tpc2:gCpncv5" resolve="ConceptFunctionParameter_node" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="_YKpA" id="1$t5g3Q$5uy" role="3clF45">
+        <node concept="3bZ5Sz" id="1$t5g3Q$5uz" role="_ZDj9">
+          <ref role="3bZ5Sy" to="tpee:g76ryKb" resolve="ConceptFunctionParameter" />
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="1$t5g3Q$5u$" role="1B3o_S" />
+    </node>
+    <node concept="13i0hz" id="1$t5g3Q$5uQ" role="13h7CS">
+      <property role="TrG5h" value="getExpectedReturnType" />
+      <ref role="13i0hy" to="tpek:hEwIGRD" resolve="getExpectedReturnType" />
+      <node concept="3clFbS" id="1$t5g3Q$5uT" role="3clF47">
+        <node concept="3clFbF" id="1gBmad3FftD" role="3cqZAp">
+          <node concept="2OqwBi" id="1gBmad3FgEz" role="3clFbG">
+            <node concept="2OqwBi" id="1gBmad3FfGH" role="2Oq$k0">
+              <node concept="13iPFW" id="1gBmad3FftC" role="2Oq$k0" />
+              <node concept="3TrEf2" id="1gBmad3Fg3b" role="2OqNvi">
+                <ref role="3Tt5mk" to="91fu:1gBmad3FeJu" resolve="variable" />
+              </node>
+            </node>
+            <node concept="3TrEf2" id="1gBmad3FtB2" role="2OqNvi">
+              <ref role="3Tt5mk" to="tpee:4VkOLwjf83e" resolve="type" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tqbb2" id="1$t5g3Q$5vH" role="3clF45" />
+      <node concept="3Tm1VV" id="1$t5g3Q$5vI" role="1B3o_S" />
+    </node>
+    <node concept="13hLZK" id="1gBmad3FeCC" role="13h7CW">
+      <node concept="3clFbS" id="1gBmad3FeCD" role="2VODD2" />
     </node>
   </node>
 </model>

--- a/code/conditional-editor/languages/de.slisson.mps.conditionalEditor/languageModels/constraints.mps
+++ b/code/conditional-editor/languages/de.slisson.mps.conditionalEditor/languageModels/constraints.mps
@@ -12,6 +12,7 @@
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
     <import index="tpcb" ref="r:00000000-0000-4000-0000-011c89590297(jetbrains.mps.lang.editor.behavior)" implicit="true" />
     <import index="tpc2" ref="r:00000000-0000-4000-0000-011c8959029e(jetbrains.mps.lang.editor.structure)" implicit="true" />
+    <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" implicit="true" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
@@ -43,6 +44,7 @@
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
       <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
+      <concept id="1225271283259" name="jetbrains.mps.baseLanguage.structure.NPEEqualsExpression" flags="nn" index="17R0WA" />
       <concept id="1225271408483" name="jetbrains.mps.baseLanguage.structure.IsNotEmptyOperation" flags="nn" index="17RvpY" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
@@ -50,12 +52,16 @@
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
       <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
         <child id="1068580123160" name="condition" index="3clFbw" />
         <child id="1068580123161" name="ifTrue" index="3clFbx" />
       </concept>
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
+        <property id="1068580123138" name="value" index="3clFbU" />
       </concept>
       <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
       <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
@@ -79,6 +85,8 @@
       <concept id="6702802731807424858" name="jetbrains.mps.lang.constraints.structure.ConstraintFunction_CanBeAnAncestor" flags="in" index="9SQb8" />
       <concept id="1202989658459" name="jetbrains.mps.lang.constraints.structure.ConstraintFunctionParameter_parentNode" flags="nn" index="nLn13" />
       <concept id="8966504967485224688" name="jetbrains.mps.lang.constraints.structure.ConstraintFunctionParameter_contextNode" flags="nn" index="2rP1CM" />
+      <concept id="4303308395523343364" name="jetbrains.mps.lang.constraints.structure.ConstraintFunctionParameter_link" flags="ng" index="2DA6wF" />
+      <concept id="4303308395523096213" name="jetbrains.mps.lang.constraints.structure.ConstraintFunctionParameter_childConcept" flags="ng" index="2DD5aU" />
       <concept id="1147467115080" name="jetbrains.mps.lang.constraints.structure.NodePropertyConstraint" flags="ng" index="EnEH3">
         <reference id="1147467295099" name="applicableProperty" index="EomxK" />
         <child id="1147468630220" name="propertyGetter" index="EtsB7" />
@@ -107,10 +115,17 @@
       </concept>
       <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
       <concept id="1171407110247" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorOperation" flags="nn" index="2Xjw5R" />
+      <concept id="2644386474301421077" name="jetbrains.mps.lang.smodel.structure.LinkIdRefExpression" flags="nn" index="359W_D">
+        <reference id="2644386474301421078" name="conceptDeclaration" index="359W_E" />
+        <reference id="2644386474301421079" name="linkDeclaration" index="359W_F" />
+      </concept>
       <concept id="1172008320231" name="jetbrains.mps.lang.smodel.structure.Node_IsNotNullOperation" flags="nn" index="3x8VRR" />
       <concept id="1144100932627" name="jetbrains.mps.lang.smodel.structure.OperationParm_Inclusion" flags="ng" index="1xIGOp" />
       <concept id="1144101972840" name="jetbrains.mps.lang.smodel.structure.OperationParm_Concept" flags="ng" index="1xMEDy">
         <child id="1207343664468" name="conceptArgument" index="ri$Ld" />
+      </concept>
+      <concept id="1172326502327" name="jetbrains.mps.lang.smodel.structure.Concept_IsExactlyOperation" flags="nn" index="3O6GUB">
+        <child id="1206733650006" name="conceptArgument" index="3QVz_e" />
       </concept>
       <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
         <reference id="1138056395725" name="property" index="3TsBF5" />
@@ -314,6 +329,40 @@
               </node>
             </node>
             <node concept="3x8VRR" id="5PKDVfOkTkn" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1M2fIO" id="1gBmad3B_H4">
+    <ref role="1M2myG" to="91fu:5PKDVfNXREN" resolve="EditorComponentDeclarationWithParameters" />
+    <node concept="9SQb8" id="1gBmad3BKoc" role="9SGkC">
+      <node concept="3clFbS" id="1gBmad3BKod" role="2VODD2">
+        <node concept="3clFbJ" id="1gBmad3B_Rw" role="3cqZAp">
+          <node concept="17R0WA" id="1gBmad3BAyC" role="3clFbw">
+            <node concept="359W_D" id="1gBmad3BAzd" role="3uHU7w">
+              <ref role="359W_E" to="91fu:5PKDVfNXREN" resolve="EditorComponentDeclarationWithParameters" />
+              <ref role="359W_F" to="91fu:5PKDVfNY0qm" resolve="parameters" />
+            </node>
+            <node concept="2DA6wF" id="1gBmad3B_VB" role="3uHU7B" />
+          </node>
+          <node concept="3clFbS" id="1gBmad3B_Ry" role="3clFbx">
+            <node concept="3cpWs6" id="1gBmad3BAOh" role="3cqZAp">
+              <node concept="2OqwBi" id="1gBmad3BBeO" role="3cqZAk">
+                <node concept="2DD5aU" id="1gBmad3BAWh" role="2Oq$k0" />
+                <node concept="3O6GUB" id="1gBmad3BBuT" role="2OqNvi">
+                  <node concept="chp4Y" id="1gBmad3BCxa" role="3QVz_e">
+                    <ref role="cht4Q" to="tpee:4k3qd$cSlJ3" resolve="BaseVariableDeclaration" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="1gBmad3BCCv" role="3cqZAp" />
+        <node concept="3cpWs6" id="1gBmad3BCJT" role="3cqZAp">
+          <node concept="3clFbT" id="1gBmad3BCKj" role="3cqZAk">
+            <property role="3clFbU" value="true" />
           </node>
         </node>
       </node>

--- a/code/conditional-editor/languages/de.slisson.mps.conditionalEditor/languageModels/constraints.mps
+++ b/code/conditional-editor/languages/de.slisson.mps.conditionalEditor/languageModels/constraints.mps
@@ -3,9 +3,11 @@
   <persistence version="9" />
   <attribute name="concise" value="true" />
   <languages>
+    <use id="3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1" name="jetbrains.mps.lang.constraints" version="6" />
     <devkit ref="00000000-0000-4000-0000-5604ebd4f22c(jetbrains.mps.devkit.aspect.constraints)" />
   </languages>
   <imports>
+    <import index="o8zo" ref="r:314576fc-3aee-4386-a0a5-a38348ac317d(jetbrains.mps.scope)" />
     <import index="91fu" ref="r:8d20232d-87e2-425b-b4d7-a9790e401b85(de.slisson.mps.conditionalEditor.structure)" implicit="true" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
     <import index="tpcb" ref="r:00000000-0000-4000-0000-011c89590297(jetbrains.mps.lang.editor.behavior)" implicit="true" />
@@ -30,6 +32,9 @@
       </concept>
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
       </concept>
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <child id="1068431790190" name="initializer" index="33vP2m" />
@@ -62,6 +67,7 @@
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
       <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
@@ -70,17 +76,26 @@
     </language>
     <language id="3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1" name="jetbrains.mps.lang.constraints">
       <concept id="6702802731807351367" name="jetbrains.mps.lang.constraints.structure.ConstraintFunction_CanBeAChild" flags="in" index="9S07l" />
+      <concept id="6702802731807424858" name="jetbrains.mps.lang.constraints.structure.ConstraintFunction_CanBeAnAncestor" flags="in" index="9SQb8" />
       <concept id="1202989658459" name="jetbrains.mps.lang.constraints.structure.ConstraintFunctionParameter_parentNode" flags="nn" index="nLn13" />
+      <concept id="8966504967485224688" name="jetbrains.mps.lang.constraints.structure.ConstraintFunctionParameter_contextNode" flags="nn" index="2rP1CM" />
       <concept id="1147467115080" name="jetbrains.mps.lang.constraints.structure.NodePropertyConstraint" flags="ng" index="EnEH3">
         <reference id="1147467295099" name="applicableProperty" index="EomxK" />
         <child id="1147468630220" name="propertyGetter" index="EtsB7" />
       </concept>
       <concept id="1147467790433" name="jetbrains.mps.lang.constraints.structure.ConstraintFunction_PropertyGetter" flags="in" index="Eqf_E" />
       <concept id="1147468365020" name="jetbrains.mps.lang.constraints.structure.ConstraintsFunctionParameter_node" flags="nn" index="EsrRn" />
+      <concept id="5564765827938091039" name="jetbrains.mps.lang.constraints.structure.ConstraintFunction_ReferentSearchScope_Scope" flags="ig" index="3dgokm" />
       <concept id="1213093968558" name="jetbrains.mps.lang.constraints.structure.ConceptConstraints" flags="ng" index="1M2fIO">
         <reference id="1213093996982" name="concept" index="1M2myG" />
+        <child id="6702802731807532730" name="canBeAncestor" index="9SGkC" />
         <child id="6702802731807737306" name="canBeChild" index="9Vyp8" />
         <child id="1213098023997" name="property" index="1MhHOB" />
+        <child id="1213100494875" name="referent" index="1Mr941" />
+      </concept>
+      <concept id="1148687176410" name="jetbrains.mps.lang.constraints.structure.NodeReferentConstraint" flags="ng" index="1N5Pfh">
+        <reference id="1148687202698" name="applicableLink" index="1N5Vy1" />
+        <child id="1148687345559" name="searchScopeFactory" index="1N6uqs" />
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
@@ -247,6 +262,58 @@
                 <ref role="3cqZAo" node="5qKdWqHV7RO" resolve="editorName" />
               </node>
             </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1M2fIO" id="5PKDVfOkPdp">
+    <ref role="1M2myG" to="91fu:5PKDVfOkPcZ" resolve="EditorComponentParameterReference" />
+    <node concept="1N5Pfh" id="5PKDVfOkPdq" role="1Mr941">
+      <ref role="1N5Vy1" to="91fu:5PKDVfOkPd0" resolve="parameter" />
+      <node concept="3dgokm" id="5PKDVfOkPga" role="1N6uqs">
+        <node concept="3clFbS" id="5PKDVfOkPgc" role="2VODD2">
+          <node concept="3clFbF" id="5PKDVfOkPz3" role="3cqZAp">
+            <node concept="2YIFZM" id="5PKDVfOkPCc" role="3clFbG">
+              <ref role="37wK5l" to="o8zo:4IP40Bi3eAf" resolve="forNamedElements" />
+              <ref role="1Pybhc" to="o8zo:4IP40Bi3e_R" resolve="ListScope" />
+              <node concept="2OqwBi" id="5PKDVfOkR3f" role="37wK5m">
+                <node concept="2OqwBi" id="5PKDVfOkPR5" role="2Oq$k0">
+                  <node concept="2rP1CM" id="5PKDVfOkPEx" role="2Oq$k0" />
+                  <node concept="2Xjw5R" id="5PKDVfOkQ5L" role="2OqNvi">
+                    <node concept="1xMEDy" id="5PKDVfOkQ5N" role="1xVPHs">
+                      <node concept="chp4Y" id="5PKDVfOkQDC" role="ri$Ld">
+                        <ref role="cht4Q" to="91fu:5PKDVfNXREN" resolve="EditorComponentDeclarationWithParameters" />
+                      </node>
+                    </node>
+                    <node concept="1xIGOp" id="5PKDVfOkSkf" role="1xVPHs" />
+                  </node>
+                </node>
+                <node concept="3Tsc0h" id="5PKDVfOkRxA" role="2OqNvi">
+                  <ref role="3TtcxE" to="91fu:5PKDVfNY0qm" resolve="parameters" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="9SQb8" id="5PKDVfOkREm" role="9SGkC">
+      <node concept="3clFbS" id="5PKDVfOkREn" role="2VODD2">
+        <node concept="3clFbF" id="5PKDVfOkRIV" role="3cqZAp">
+          <node concept="2OqwBi" id="5PKDVfOkSQm" role="3clFbG">
+            <node concept="2OqwBi" id="5PKDVfOkRU7" role="2Oq$k0">
+              <node concept="nLn13" id="5PKDVfOkRIU" role="2Oq$k0" />
+              <node concept="2Xjw5R" id="5PKDVfOkS4K" role="2OqNvi">
+                <node concept="1xMEDy" id="5PKDVfOkS4M" role="1xVPHs">
+                  <node concept="chp4Y" id="5PKDVfOkSr9" role="ri$Ld">
+                    <ref role="cht4Q" to="91fu:5PKDVfNXREN" resolve="EditorComponentDeclarationWithParameters" />
+                  </node>
+                </node>
+                <node concept="1xIGOp" id="5PKDVfOkSB0" role="1xVPHs" />
+              </node>
+            </node>
+            <node concept="3x8VRR" id="5PKDVfOkTkn" role="2OqNvi" />
           </node>
         </node>
       </node>

--- a/code/conditional-editor/languages/de.slisson.mps.conditionalEditor/languageModels/constraints.mps
+++ b/code/conditional-editor/languages/de.slisson.mps.conditionalEditor/languageModels/constraints.mps
@@ -368,5 +368,42 @@
       </node>
     </node>
   </node>
+  <node concept="1M2fIO" id="1gBmad3FvZr">
+    <ref role="1M2myG" to="91fu:1gBmad3Feya" resolve="ComponentArgument" />
+    <node concept="1N5Pfh" id="1gBmad3Fw5S" role="1Mr941">
+      <ref role="1N5Vy1" to="91fu:1gBmad3FeJu" resolve="variable" />
+      <node concept="3dgokm" id="1gBmad3Fw6S" role="1N6uqs">
+        <node concept="3clFbS" id="1gBmad3Fw6U" role="2VODD2">
+          <node concept="3clFbF" id="1gBmad3FwoX" role="3cqZAp">
+            <node concept="2YIFZM" id="1gBmad3GxuP" role="3clFbG">
+              <ref role="37wK5l" to="o8zo:4IP40Bi3eAf" resolve="forNamedElements" />
+              <ref role="1Pybhc" to="o8zo:4IP40Bi3e_R" resolve="ListScope" />
+              <node concept="2OqwBi" id="1gBmad3Gykf" role="37wK5m">
+                <node concept="2OqwBi" id="1gBmad3GxuQ" role="2Oq$k0">
+                  <node concept="2OqwBi" id="1gBmad3GxuR" role="2Oq$k0">
+                    <node concept="2rP1CM" id="1gBmad3GxuS" role="2Oq$k0" />
+                    <node concept="2Xjw5R" id="1gBmad3GxuT" role="2OqNvi">
+                      <node concept="1xMEDy" id="1gBmad3GxuU" role="1xVPHs">
+                        <node concept="chp4Y" id="1gBmad3GxuV" role="ri$Ld">
+                          <ref role="cht4Q" to="91fu:5PKDVfOlrE5" resolve="CellModel_ComponentWithParameters" />
+                        </node>
+                      </node>
+                      <node concept="1xIGOp" id="1gBmad3GxuW" role="1xVPHs" />
+                    </node>
+                  </node>
+                  <node concept="3TrEf2" id="1gBmad3GxXl" role="2OqNvi">
+                    <ref role="3Tt5mk" to="91fu:fGPMmyn" resolve="editorComponent" />
+                  </node>
+                </node>
+                <node concept="3Tsc0h" id="1gBmad3GyUO" role="2OqNvi">
+                  <ref role="3TtcxE" to="91fu:5PKDVfNY0qm" resolve="parameters" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
 </model>
 

--- a/code/conditional-editor/languages/de.slisson.mps.conditionalEditor/languageModels/editor.mps
+++ b/code/conditional-editor/languages/de.slisson.mps.conditionalEditor/languageModels/editor.mps
@@ -5,7 +5,7 @@
   <languages>
     <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="14" />
     <use id="aee9cad2-acd4-4608-aef2-0004f6a1cdbd" name="jetbrains.mps.lang.actions" version="4" />
-    <use id="760a0a8c-eabb-4521-8bfd-65db761a9ba3" name="jetbrains.mps.baseLanguage.logging" version="0" />
+    <use id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation" version="5" />
   </languages>
   <imports>
     <import index="tpc2" ref="r:00000000-0000-4000-0000-011c8959029e(jetbrains.mps.lang.editor.structure)" />
@@ -16,6 +16,7 @@
     <import index="91fu" ref="r:8d20232d-87e2-425b-b4d7-a9790e401b85(de.slisson.mps.conditionalEditor.structure)" implicit="true" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
     <import index="tpco" ref="r:00000000-0000-4000-0000-011c89590284(jetbrains.mps.lang.core.editor)" implicit="true" />
+    <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" implicit="true" />
   </imports>
   <registry>
     <language id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor">
@@ -27,8 +28,10 @@
       <concept id="1071666914219" name="jetbrains.mps.lang.editor.structure.ConceptEditorDeclaration" flags="ig" index="24kQdi">
         <child id="1078153129734" name="inspectedCellModel" index="6VMZX" />
       </concept>
+      <concept id="1176897764478" name="jetbrains.mps.lang.editor.structure.QueryFunction_NodeFactory" flags="in" index="4$FPG" />
       <concept id="1140524381322" name="jetbrains.mps.lang.editor.structure.CellModel_ListWithRole" flags="ng" index="2czfm3">
         <property id="1140524450557" name="separatorText" index="2czwfO" />
+        <child id="1176897874615" name="nodeFactory" index="4_6I_" />
         <child id="1140524464360" name="cellLayout" index="2czzBx" />
         <child id="1140524464359" name="emptyCellModel" index="2czzBI" />
         <child id="1233141163694" name="separatorStyle" index="sWeuL" />
@@ -36,10 +39,8 @@
       <concept id="1106270549637" name="jetbrains.mps.lang.editor.structure.CellLayout_Horizontal" flags="nn" index="2iRfu4" />
       <concept id="1106270571710" name="jetbrains.mps.lang.editor.structure.CellLayout_Vertical" flags="nn" index="2iRkQZ" />
       <concept id="6089045305654894366" name="jetbrains.mps.lang.editor.structure.SubstituteMenuReference_Default" flags="ng" index="2kknPJ" />
-      <concept id="1237303669825" name="jetbrains.mps.lang.editor.structure.CellLayout_Indent" flags="nn" index="l2Vlx" />
       <concept id="1142886221719" name="jetbrains.mps.lang.editor.structure.QueryFunction_NodeCondition" flags="in" index="pkWqt" />
       <concept id="1142886811589" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameter_node" flags="nn" index="pncrf" />
-      <concept id="1237385578942" name="jetbrains.mps.lang.editor.structure.IndentLayoutOnNewLineStyleClassItem" flags="ln" index="pVoyu" />
       <concept id="1233148810477" name="jetbrains.mps.lang.editor.structure.InlineStyleDeclaration" flags="ng" index="tppnM" />
       <concept id="1177327570013" name="jetbrains.mps.lang.editor.structure.QueryFunction_SubstituteMenu_Substitute" flags="in" index="ucgPf" />
       <concept id="8478191136883534237" name="jetbrains.mps.lang.editor.structure.IExtensibleSubstituteMenuPart" flags="ng" index="upBLQ">
@@ -103,6 +104,7 @@
       </concept>
       <concept id="7580468736840446506" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameter_model" flags="nn" index="1rpKSd" />
       <concept id="1088185857835" name="jetbrains.mps.lang.editor.structure.InlineEditorComponent" flags="ig" index="1sVBvm" />
+      <concept id="8899501406397518321" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameter_index" flags="nn" index="3tUb2h" />
       <concept id="5425882385312046132" name="jetbrains.mps.lang.editor.structure.QueryFunctionParameter_SubstituteMenu_CurrentTargetNode" flags="nn" index="1yR$tW" />
       <concept id="1215007762405" name="jetbrains.mps.lang.editor.structure.FloatStyleClassItem" flags="ln" index="3$6MrZ">
         <property id="1215007802031" name="value" index="3$6WeP" />
@@ -112,6 +114,9 @@
         <property id="1140017977771" name="readOnly" index="1Intyy" />
         <property id="1140114345053" name="allowEmptyText" index="1O74Pk" />
         <reference id="1140103550593" name="relationDeclaration" index="1NtTu8" />
+      </concept>
+      <concept id="7991336459489871999" name="jetbrains.mps.lang.editor.structure.IOutputConceptSubstituteMenuPart" flags="ng" index="3EoQpk">
+        <reference id="7991336459489872009" name="outputConcept" index="3EoQqy" />
       </concept>
       <concept id="1073389214265" name="jetbrains.mps.lang.editor.structure.EditorCellModel" flags="ng" index="3EYTF0">
         <reference id="1081339532145" name="keyMap" index="34QXea" />
@@ -132,6 +137,9 @@
       <concept id="1073389882823" name="jetbrains.mps.lang.editor.structure.CellModel_RefNode" flags="sg" stub="730538219795960754" index="3F1sOY" />
       <concept id="1073390211982" name="jetbrains.mps.lang.editor.structure.CellModel_RefNodeList" flags="sg" stub="2794558372793454595" index="3F2HdR" />
       <concept id="1198256887712" name="jetbrains.mps.lang.editor.structure.CellModel_Indent" flags="ng" index="3XFhqQ" />
+      <concept id="8428109087107030357" name="jetbrains.mps.lang.editor.structure.SubstituteMenuPart_ReferenceScope" flags="ng" index="3XHNnq">
+        <reference id="8428109087107339113" name="reference" index="3XGfJA" />
+      </concept>
       <concept id="1166049232041" name="jetbrains.mps.lang.editor.structure.AbstractComponent" flags="ng" index="1XWOmA">
         <reference id="1166049300910" name="conceptDeclaration" index="1XX52x" />
       </concept>
@@ -142,6 +150,9 @@
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
+        <child id="1145553007750" name="creator" index="2ShVmc" />
       </concept>
       <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
         <child id="1137022507850" name="body" index="2VODD2" />
@@ -181,6 +192,7 @@
         <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
       </concept>
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1081506773034" name="jetbrains.mps.baseLanguage.structure.LessThanExpression" flags="nn" index="3eOVzh" />
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
@@ -198,6 +210,22 @@
       <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
         <child id="1199569906740" name="parameter" index="1bW2Oz" />
         <child id="1199569916463" name="body" index="1bW5cS" />
+      </concept>
+    </language>
+    <language id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation">
+      <concept id="5455284157994012186" name="jetbrains.mps.lang.quotation.structure.NodeBuilderInitLink" flags="ng" index="2pIpSj">
+        <reference id="5455284157994012188" name="link" index="2pIpSl" />
+        <child id="1595412875168045827" name="initValue" index="28nt2d" />
+      </concept>
+      <concept id="5455284157993863837" name="jetbrains.mps.lang.quotation.structure.NodeBuilder" flags="nn" index="2pJPEk">
+        <child id="5455284157993863838" name="quotedNode" index="2pJPEn" />
+      </concept>
+      <concept id="5455284157993863840" name="jetbrains.mps.lang.quotation.structure.NodeBuilderNode" flags="nn" index="2pJPED">
+        <reference id="5455284157993910961" name="concept" index="2pJxaS" />
+        <child id="5455284157993911099" name="values" index="2pJxcM" />
+      </concept>
+      <concept id="8182547171709752110" name="jetbrains.mps.lang.quotation.structure.NodeBuilderExpression" flags="nn" index="36biLy">
+        <child id="8182547171709752112" name="expression" index="36biLW" />
       </concept>
     </language>
     <language id="aee9cad2-acd4-4608-aef2-0004f6a1cdbd" name="jetbrains.mps.lang.actions">
@@ -220,6 +248,9 @@
       <concept id="2644386474300074836" name="jetbrains.mps.lang.smodel.structure.ConceptIdRefExpression" flags="nn" index="35c_gC">
         <reference id="2644386474300074837" name="conceptDeclaration" index="35c_gD" />
       </concept>
+      <concept id="1180636770613" name="jetbrains.mps.lang.smodel.structure.SNodeCreator" flags="nn" index="3zrR0B">
+        <child id="1180636770616" name="createdType" index="3zrR0E" />
+      </concept>
       <concept id="1140137987495" name="jetbrains.mps.lang.smodel.structure.SNodeTypeCastExpression" flags="nn" index="1PxgMI">
         <property id="1238684351431" name="asCast" index="1BlNFB" />
       </concept>
@@ -232,6 +263,9 @@
       <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="nn" index="3TrEf2">
         <reference id="1138056516764" name="link" index="3Tt5mk" />
       </concept>
+      <concept id="1138056282393" name="jetbrains.mps.lang.smodel.structure.SLinkListAccess" flags="nn" index="3Tsc0h">
+        <reference id="1138056546658" name="link" index="3TtcxE" />
+      </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
@@ -242,7 +276,12 @@
       <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
         <child id="1204796294226" name="closure" index="23t8la" />
       </concept>
+      <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="nn" index="25WWJ4">
+        <child id="540871147943773366" name="argument" index="25WWJ7" />
+      </concept>
       <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
+      <concept id="1162934736510" name="jetbrains.mps.baseLanguage.collections.structure.GetElementOperation" flags="nn" index="34jXtK" />
+      <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
       <concept id="1202120902084" name="jetbrains.mps.baseLanguage.collections.structure.WhereOperation" flags="nn" index="3zZkjj" />
       <concept id="1202128969694" name="jetbrains.mps.baseLanguage.collections.structure.SelectOperation" flags="nn" index="3$u5V9" />
     </language>
@@ -791,31 +830,80 @@
       <node concept="3F0ifn" id="1gBmad3ClGb" role="3EZMnx" />
       <node concept="3EZMnI" id="3h9t8JnexrB" role="3EZMnx">
         <node concept="3F0ifn" id="3h9t8JnexrE" role="3EZMnx">
-          <property role="3F0ifm" value="Component" />
+          <property role="3F0ifm" value="Component:" />
           <ref role="1k5W1q" to="tpc5:hF4yUZ8" resolve="header" />
         </node>
-        <node concept="3EZMnI" id="3h9t8JnexrF" role="3EZMnx">
-          <node concept="3EZMnI" id="1gBmad3Em1t" role="3EZMnx">
-            <node concept="3F0ifn" id="3K0abI4qFqo" role="3EZMnx">
-              <property role="3F0ifm" value="arguments" />
-              <ref role="1k5W1q" to="tpc5:hF4H1c8" resolve="property" />
-            </node>
-            <node concept="3F2HdR" id="1gBmad3Ca0B" role="3EZMnx">
-              <property role="2czwfO" value="," />
-              <ref role="1NtTu8" to="91fu:5PKDVfOlsvY" resolve="arguments" />
-              <node concept="l2Vlx" id="1gBmad3EGfy" role="2czzBx" />
-              <node concept="tppnM" id="1gBmad3EGf_" role="sWeuL">
-                <node concept="pVoyu" id="1gBmad3ESoA" role="3F10Kt">
-                  <property role="VOm3f" value="true" />
+        <node concept="3F2HdR" id="1gBmad3Ca0B" role="3EZMnx">
+          <ref role="1NtTu8" to="91fu:5PKDVfOlsvY" resolve="arguments" />
+          <node concept="2EHx9g" id="1gBmad3S7ci" role="2czzBx" />
+          <node concept="4$FPG" id="1gBmad3ONml" role="4_6I_">
+            <node concept="3clFbS" id="1gBmad3ONmm" role="2VODD2">
+              <node concept="3clFbJ" id="1gBmad3OO6x" role="3cqZAp">
+                <node concept="3clFbS" id="1gBmad3OO6z" role="3clFbx">
+                  <node concept="3cpWs6" id="1gBmad3OT4I" role="3cqZAp">
+                    <node concept="2pJPEk" id="1gBmad3ONU0" role="3cqZAk">
+                      <node concept="2pJPED" id="1gBmad3ONU1" role="2pJPEn">
+                        <ref role="2pJxaS" to="91fu:1gBmad3Feya" resolve="ComponentArgument" />
+                        <node concept="2pIpSj" id="1gBmad3OO2_" role="2pJxcM">
+                          <ref role="2pIpSl" to="91fu:1gBmad3FeJu" resolve="variable" />
+                          <node concept="36biLy" id="1gBmad3OO2E" role="28nt2d">
+                            <node concept="2OqwBi" id="1gBmad3OUmk" role="36biLW">
+                              <node concept="2OqwBi" id="1gBmad3OT7Q" role="2Oq$k0">
+                                <node concept="2OqwBi" id="1gBmad3OT7R" role="2Oq$k0">
+                                  <node concept="pncrf" id="1gBmad3OT7S" role="2Oq$k0" />
+                                  <node concept="3TrEf2" id="1gBmad3OT7T" role="2OqNvi">
+                                    <ref role="3Tt5mk" to="91fu:fGPMmyn" resolve="editorComponent" />
+                                  </node>
+                                </node>
+                                <node concept="3Tsc0h" id="1gBmad3OT7U" role="2OqNvi">
+                                  <ref role="3TtcxE" to="91fu:5PKDVfNY0qm" resolve="parameters" />
+                                </node>
+                              </node>
+                              <node concept="34jXtK" id="1gBmad3OUX$" role="2OqNvi">
+                                <node concept="3tUb2h" id="1gBmad3OV5h" role="25WWJ7" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="2pIpSj" id="1gBmad3OVpo" role="2pJxcM">
+                          <ref role="2pIpSl" to="tpee:gyVODHa" resolve="body" />
+                          <node concept="2pJPED" id="1gBmad3OVst" role="28nt2d">
+                            <ref role="2pJxaS" to="tpee:fzclF80" resolve="StatementList" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3eOVzh" id="1gBmad3OORk" role="3clFbw">
+                  <node concept="2OqwBi" id="1gBmad3ORws" role="3uHU7w">
+                    <node concept="2OqwBi" id="1gBmad3OPVX" role="2Oq$k0">
+                      <node concept="2OqwBi" id="1gBmad3OPvo" role="2Oq$k0">
+                        <node concept="pncrf" id="1gBmad3OP3F" role="2Oq$k0" />
+                        <node concept="3TrEf2" id="1gBmad3OPCx" role="2OqNvi">
+                          <ref role="3Tt5mk" to="91fu:fGPMmyn" resolve="editorComponent" />
+                        </node>
+                      </node>
+                      <node concept="3Tsc0h" id="1gBmad3OQ6g" role="2OqNvi">
+                        <ref role="3TtcxE" to="91fu:5PKDVfNY0qm" resolve="parameters" />
+                      </node>
+                    </node>
+                    <node concept="34oBXx" id="1gBmad3OSD2" role="2OqNvi" />
+                  </node>
+                  <node concept="3tUb2h" id="1gBmad3OO7e" role="3uHU7B" />
+                </node>
+              </node>
+              <node concept="3cpWs6" id="1gBmad3OVt3" role="3cqZAp">
+                <node concept="2ShNRf" id="1gBmad3OVNr" role="3cqZAk">
+                  <node concept="3zrR0B" id="1gBmad3OVNp" role="2ShVmc">
+                    <node concept="3Tqbb2" id="1gBmad3OVNq" role="3zrR0E">
+                      <ref role="ehGHo" to="91fu:1gBmad3Feya" resolve="ComponentArgument" />
+                    </node>
+                  </node>
                 </node>
               </node>
             </node>
-            <node concept="VPXOz" id="1gBmad3Em1u" role="3F10Kt">
-              <property role="VOm3f" value="true" />
-            </node>
-            <node concept="2iRfu4" id="3K0abI4qFqs" role="2iSdaV" />
           </node>
-          <node concept="2EHx9g" id="3h9t8Jnexsx" role="2iSdaV" />
         </node>
         <node concept="2iRkQZ" id="3h9t8JnexrD" role="2iSdaV" />
       </node>
@@ -988,6 +1076,34 @@
     </node>
     <node concept="2kknPJ" id="5PKDVfOnfIu" role="1IG6uw">
       <ref role="2ZyFGn" to="tpc2:fBEYTCT" resolve="EditorCellModel" />
+    </node>
+  </node>
+  <node concept="22mcaB" id="1gBmad3FvSS">
+    <ref role="aqKnT" to="91fu:1gBmad3Feya" resolve="ComponentArgument" />
+    <node concept="22hDWj" id="1gBmad3FvZl" role="22hAXT" />
+    <node concept="3XHNnq" id="1gBmad3FvZn" role="3ft7WO">
+      <ref role="3XGfJA" to="91fu:1gBmad3FeJu" resolve="variable" />
+      <ref role="3EoQqy" to="91fu:1gBmad3Feya" resolve="ComponentArgument" />
+    </node>
+  </node>
+  <node concept="24kQdi" id="1gBmad3GYEt">
+    <ref role="1XX52x" to="91fu:1gBmad3Feya" resolve="ComponentArgument" />
+    <node concept="3EZMnI" id="1gBmad3H19V" role="2wV5jI">
+      <node concept="2iRfu4" id="1gBmad3H19W" role="2iSdaV" />
+      <node concept="1iCGBv" id="1gBmad3GYKV" role="3EZMnx">
+        <ref role="1NtTu8" to="91fu:1gBmad3FeJu" resolve="variable" />
+        <node concept="1sVBvm" id="1gBmad3GYKX" role="1sWHZn">
+          <node concept="3F0A7n" id="1gBmad3RRHK" role="2wV5jI">
+            <property role="1Intyy" value="true" />
+            <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
+            <ref role="1k5W1q" to="tpc5:hF4H1c8" resolve="property" />
+          </node>
+        </node>
+      </node>
+      <node concept="B$lHz" id="1gBmad3SmqF" role="3EZMnx" />
+      <node concept="VPXOz" id="1gBmad3H1FR" role="3F10Kt">
+        <property role="VOm3f" value="true" />
+      </node>
     </node>
   </node>
 </model>

--- a/code/conditional-editor/languages/de.slisson.mps.conditionalEditor/languageModels/editor.mps
+++ b/code/conditional-editor/languages/de.slisson.mps.conditionalEditor/languageModels/editor.mps
@@ -4,17 +4,25 @@
   <attribute name="concise" value="true" />
   <languages>
     <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="14" />
+    <use id="aee9cad2-acd4-4608-aef2-0004f6a1cdbd" name="jetbrains.mps.lang.actions" version="4" />
+    <use id="760a0a8c-eabb-4521-8bfd-65db761a9ba3" name="jetbrains.mps.baseLanguage.logging" version="0" />
   </languages>
   <imports>
     <import index="tpc2" ref="r:00000000-0000-4000-0000-011c8959029e(jetbrains.mps.lang.editor.structure)" />
     <import index="tpd3" ref="r:00000000-0000-4000-0000-011c895902bb(jetbrains.mps.lang.sharedConcepts.editor)" />
     <import index="tpc5" ref="r:00000000-0000-4000-0000-011c89590299(jetbrains.mps.lang.editor.editor)" />
+    <import index="o8zo" ref="r:314576fc-3aee-4386-a0a5-a38348ac317d(jetbrains.mps.scope)" />
+    <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
     <import index="91fu" ref="r:8d20232d-87e2-425b-b4d7-a9790e401b85(de.slisson.mps.conditionalEditor.structure)" implicit="true" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
+    <import index="tpco" ref="r:00000000-0000-4000-0000-011c89590284(jetbrains.mps.lang.core.editor)" implicit="true" />
   </imports>
   <registry>
     <language id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor">
       <concept id="5991739802479784073" name="jetbrains.mps.lang.editor.structure.MenuTypeDefault" flags="ng" index="22hDWj" />
+      <concept id="2000375450116454183" name="jetbrains.mps.lang.editor.structure.ISubstituteMenu" flags="ng" index="22mbnS">
+        <child id="414384289274416996" name="parts" index="3ft7WO" />
+      </concept>
       <concept id="2000375450116423800" name="jetbrains.mps.lang.editor.structure.SubstituteMenu" flags="ng" index="22mcaB" />
       <concept id="1071666914219" name="jetbrains.mps.lang.editor.structure.ConceptEditorDeclaration" flags="ig" index="24kQdi" />
       <concept id="1140524381322" name="jetbrains.mps.lang.editor.structure.CellModel_ListWithRole" flags="ng" index="2czfm3">
@@ -25,9 +33,24 @@
       </concept>
       <concept id="1106270549637" name="jetbrains.mps.lang.editor.structure.CellLayout_Horizontal" flags="nn" index="2iRfu4" />
       <concept id="1106270571710" name="jetbrains.mps.lang.editor.structure.CellLayout_Vertical" flags="nn" index="2iRkQZ" />
+      <concept id="6089045305654894366" name="jetbrains.mps.lang.editor.structure.SubstituteMenuReference_Default" flags="ng" index="2kknPJ" />
       <concept id="1233148810477" name="jetbrains.mps.lang.editor.structure.InlineStyleDeclaration" flags="ng" index="tppnM" />
+      <concept id="1177327570013" name="jetbrains.mps.lang.editor.structure.QueryFunction_SubstituteMenu_Substitute" flags="in" index="ucgPf" />
+      <concept id="8478191136883534237" name="jetbrains.mps.lang.editor.structure.IExtensibleSubstituteMenuPart" flags="ng" index="upBLQ">
+        <child id="8478191136883534238" name="features" index="upBLP" />
+      </concept>
+      <concept id="1177335944525" name="jetbrains.mps.lang.editor.structure.QueryFunction_SubstituteMenu_SubstituteString" flags="in" index="uGdhv" />
       <concept id="1080736578640" name="jetbrains.mps.lang.editor.structure.BaseEditorComponent" flags="ig" index="2wURMF">
         <child id="1080736633877" name="cellModel" index="2wV5jI" />
+      </concept>
+      <concept id="8371900013785948369" name="jetbrains.mps.lang.editor.structure.QueryFunction_SubstituteMenu_Parameter" flags="ig" index="2$S_p_" />
+      <concept id="8383079901754291618" name="jetbrains.mps.lang.editor.structure.CellModel_NextEditor" flags="ng" index="B$lHz" />
+      <concept id="308059530142752797" name="jetbrains.mps.lang.editor.structure.SubstituteMenuPart_Parameterized" flags="ng" index="2F$Pav">
+        <child id="8371900013785948359" name="part" index="2$S_pN" />
+        <child id="8371900013785948365" name="parameterQuery" index="2$S_pT" />
+      </concept>
+      <concept id="1078939183254" name="jetbrains.mps.lang.editor.structure.CellModel_Component" flags="sg" stub="3162947552742194261" index="PMmxH">
+        <reference id="1078939183255" name="editorComponent" index="PMmxG" />
       </concept>
       <concept id="1186403694788" name="jetbrains.mps.lang.editor.structure.ColorStyleClassItem" flags="ln" index="VaVBg">
         <property id="1186403713874" name="color" index="Vb096" />
@@ -39,22 +62,42 @@
       </concept>
       <concept id="1186414928363" name="jetbrains.mps.lang.editor.structure.SelectableStyleSheetItem" flags="ln" index="VPM3Z" />
       <concept id="1186414976055" name="jetbrains.mps.lang.editor.structure.DrawBorderStyleClassItem" flags="ln" index="VPXOz" />
+      <concept id="1630016958697718209" name="jetbrains.mps.lang.editor.structure.IMenuReference_Default" flags="ng" index="2Z_bC8">
+        <reference id="1630016958698373342" name="concept" index="2ZyFGn" />
+      </concept>
       <concept id="1630016958697344083" name="jetbrains.mps.lang.editor.structure.IMenu_Concept" flags="ng" index="2ZABuq">
         <reference id="6591946374543067572" name="conceptDeclaration" index="aqKnT" />
         <child id="5991739802479788259" name="type" index="22hAXT" />
+      </concept>
+      <concept id="1630016958697286851" name="jetbrains.mps.lang.editor.structure.QueryFunctionParameter_parameterObject" flags="ng" index="2ZBlsa" />
+      <concept id="1630016958697057551" name="jetbrains.mps.lang.editor.structure.IMenuPartParameterized" flags="ng" index="2ZBHr6">
+        <child id="1630016958697057552" name="parameterType" index="2ZBHrp" />
       </concept>
       <concept id="1233758997495" name="jetbrains.mps.lang.editor.structure.PunctuationLeftStyleClassItem" flags="ln" index="11L4FC" />
       <concept id="1214472762472" name="jetbrains.mps.lang.editor.structure.DefaultCaretPositionStyleClassItem" flags="ln" index="34dVlM">
         <property id="1214472762473" name="position" index="34dVlN" />
       </concept>
       <concept id="1233823429331" name="jetbrains.mps.lang.editor.structure.HorizontalGapStyleClassItem" flags="ln" index="15ARfc" />
+      <concept id="8998492695583125082" name="jetbrains.mps.lang.editor.structure.SubstituteFeature_MatchingText" flags="ng" index="16NfWO">
+        <child id="8998492695583129244" name="query" index="16NeZM" />
+      </concept>
+      <concept id="1154465273778" name="jetbrains.mps.lang.editor.structure.QueryFunctionParameter_SubstituteMenu_ParentNode" flags="nn" index="3bvxqY" />
+      <concept id="7342352913006985483" name="jetbrains.mps.lang.editor.structure.SubstituteMenuPart_Action" flags="ng" index="3eGOop">
+        <child id="8612453216082699922" name="substituteHandler" index="3aKz83" />
+      </concept>
       <concept id="1088013125922" name="jetbrains.mps.lang.editor.structure.CellModel_RefCell" flags="sg" stub="730538219795941030" index="1iCGBv">
         <child id="1088186146602" name="editorComponent" index="1sWHZn" />
       </concept>
       <concept id="1381004262292414836" name="jetbrains.mps.lang.editor.structure.ICellStyle" flags="ng" index="1k5N5V">
         <reference id="1381004262292426837" name="parentStyleClass" index="1k5W1q" />
       </concept>
+      <concept id="3308396621974588243" name="jetbrains.mps.lang.editor.structure.SubstituteMenu_Contribution" flags="ng" index="3p309x">
+        <child id="7173407872095451092" name="menuReference" index="1IG6uw" />
+      </concept>
+      <concept id="7580468736840446506" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameter_model" flags="nn" index="1rpKSd" />
       <concept id="1088185857835" name="jetbrains.mps.lang.editor.structure.InlineEditorComponent" flags="ig" index="1sVBvm" />
+      <concept id="1219226236603" name="jetbrains.mps.lang.editor.structure.DrawBracketsStyleClassItem" flags="ln" index="3vyZuw" />
+      <concept id="5425882385312046132" name="jetbrains.mps.lang.editor.structure.QueryFunctionParameter_SubstituteMenu_CurrentTargetNode" flags="nn" index="1yR$tW" />
       <concept id="1215007762405" name="jetbrains.mps.lang.editor.structure.FloatStyleClassItem" flags="ln" index="3$6MrZ">
         <property id="1215007802031" name="value" index="3$6WeP" />
       </concept>
@@ -84,6 +127,116 @@
       <concept id="1166049232041" name="jetbrains.mps.lang.editor.structure.AbstractComponent" flags="ng" index="1XWOmA">
         <reference id="1166049300910" name="conceptDeclaration" index="1XX52x" />
       </concept>
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
+        <child id="1137022507850" name="body" index="2VODD2" />
+      </concept>
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
+      </concept>
+      <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
+      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123152" name="jetbrains.mps.baseLanguage.structure.EqualsExpression" flags="nn" index="3clFbC" />
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
+        <child id="1068580123160" name="condition" index="3clFbw" />
+        <child id="1068580123161" name="ifTrue" index="3clFbx" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
+      <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
+        <child id="1068581517676" name="expression" index="3cqZAk" />
+      </concept>
+      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
+        <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
+      </concept>
+      <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+        <reference id="1107535924139" name="classifier" index="3uigEE" />
+      </concept>
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
+        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
+        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
+      </concept>
+      <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
+    </language>
+    <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
+      <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
+        <child id="1199569906740" name="parameter" index="1bW2Oz" />
+        <child id="1199569916463" name="body" index="1bW5cS" />
+      </concept>
+    </language>
+    <language id="aee9cad2-acd4-4608-aef2-0004f6a1cdbd" name="jetbrains.mps.lang.actions">
+      <concept id="5480835971642155304" name="jetbrains.mps.lang.actions.structure.NF_Model_CreateNewNodeOperation" flags="nn" index="15TzpJ" />
+    </language>
+    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
+        <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
+      </concept>
+      <concept id="1140725362528" name="jetbrains.mps.lang.smodel.structure.Link_SetTargetOperation" flags="nn" index="2oxUTD">
+        <child id="1140725362529" name="linkTarget" index="2oxUTC" />
+      </concept>
+      <concept id="2396822768958367367" name="jetbrains.mps.lang.smodel.structure.AbstractTypeCastExpression" flags="nn" index="$5XWr">
+        <child id="6733348108486823193" name="leftExpression" index="1m5AlR" />
+        <child id="3906496115198199033" name="conceptArgument" index="3oSUPX" />
+      </concept>
+      <concept id="1143235216708" name="jetbrains.mps.lang.smodel.structure.Model_CreateNewNodeOperation" flags="nn" index="I8ghe">
+        <reference id="1143235391024" name="concept" index="I8UWU" />
+      </concept>
+      <concept id="2644386474300074836" name="jetbrains.mps.lang.smodel.structure.ConceptIdRefExpression" flags="nn" index="35c_gC">
+        <reference id="2644386474300074837" name="conceptDeclaration" index="35c_gD" />
+      </concept>
+      <concept id="1140137987495" name="jetbrains.mps.lang.smodel.structure.SNodeTypeCastExpression" flags="nn" index="1PxgMI">
+        <property id="1238684351431" name="asCast" index="1BlNFB" />
+      </concept>
+      <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
+        <reference id="1138405853777" name="concept" index="ehGHo" />
+      </concept>
+      <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
+        <reference id="1138056395725" name="property" index="3TsBF5" />
+      </concept>
+      <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="nn" index="3TrEf2">
+        <reference id="1138056516764" name="link" index="3Tt5mk" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+    <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
+        <child id="1204796294226" name="closure" index="23t8la" />
+      </concept>
+      <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
+      <concept id="1202120902084" name="jetbrains.mps.baseLanguage.collections.structure.WhereOperation" flags="nn" index="3zZkjj" />
+      <concept id="1202128969694" name="jetbrains.mps.baseLanguage.collections.structure.SelectOperation" flags="nn" index="3$u5V9" />
     </language>
   </registry>
   <node concept="24kQdi" id="2vJRo8gA3Du">
@@ -345,6 +498,265 @@
   <node concept="22mcaB" id="4iNiUqGz3jy">
     <ref role="aqKnT" to="91fu:59YMGDNQGbN" resolve="UniqueNameInfo" />
     <node concept="22hDWj" id="7q24335a1C2" role="22hAXT" />
+  </node>
+  <node concept="24kQdi" id="5PKDVfNY0qv">
+    <ref role="1XX52x" to="91fu:5PKDVfNXREN" resolve="EditorComponentDeclarationWithParameters" />
+    <node concept="3EZMnI" id="5PKDVfNY0q$" role="2wV5jI">
+      <node concept="3EZMnI" id="5PKDVfNY0qH" role="3EZMnx">
+        <node concept="3vyZuw" id="54z9_KDO752" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+        <node concept="2iRfu4" id="5PKDVfNY0qI" role="2iSdaV" />
+        <node concept="3F0ifn" id="5PKDVfNY0qE" role="3EZMnx">
+          <property role="3F0ifm" value="parameters:" />
+        </node>
+        <node concept="3F2HdR" id="5PKDVfNY0qR" role="3EZMnx">
+          <property role="2czwfO" value="," />
+          <ref role="1NtTu8" to="91fu:5PKDVfNY0qm" resolve="parameters" />
+          <node concept="2iRfu4" id="5PKDVfNY0qT" role="2czzBx" />
+        </node>
+      </node>
+      <node concept="2iRkQZ" id="5PKDVfNY0q_" role="2iSdaV" />
+      <node concept="B$lHz" id="5PKDVfNY0qx" role="3EZMnx" />
+    </node>
+  </node>
+  <node concept="24kQdi" id="5PKDVfOkPd9">
+    <ref role="1XX52x" to="91fu:5PKDVfOkPcZ" resolve="EditorComponentParameterReference" />
+    <node concept="1iCGBv" id="5PKDVfOkPdb" role="2wV5jI">
+      <ref role="1NtTu8" to="91fu:5PKDVfOkPd0" resolve="parameter" />
+      <node concept="1sVBvm" id="5PKDVfOkPdd" role="1sWHZn">
+        <node concept="3F0A7n" id="5PKDVfOkPdk" role="2wV5jI">
+          <property role="1Intyy" value="true" />
+          <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="24kQdi" id="5PKDVfOlsvS">
+    <ref role="1XX52x" to="91fu:5PKDVfOlsvP" resolve="StubCellModel_ComponentWithParameters" />
+    <node concept="PMmxH" id="5PKDVfOlsvT" role="2wV5jI">
+      <ref role="PMmxG" to="tpco:37EzmTDC95l" />
+    </node>
+  </node>
+  <node concept="22mcaB" id="5PKDVfOlsvU">
+    <ref role="aqKnT" to="91fu:5PKDVfOlsvP" resolve="StubCellModel_ComponentWithParameters" />
+    <node concept="22hDWj" id="5PKDVfOlsvV" role="22hAXT" />
+  </node>
+  <node concept="24kQdi" id="5PKDVfOlN0X">
+    <ref role="1XX52x" to="91fu:5PKDVfOlrE5" resolve="CellModel_ComponentWithParameters" />
+    <node concept="3EZMnI" id="fGPO59B" role="2wV5jI">
+      <ref role="1k5W1q" to="tpc5:i0pPgF8" resolve="rootCellModelStyle" />
+      <ref role="34QXea" to="tpc5:hsh$IoV" resolve="CellModel_Component_KeyMap" />
+      <node concept="PMmxH" id="h7TNd$C" role="3EZMnx">
+        <ref role="PMmxG" to="tpc5:h7TMiuR" resolve="_OpenTag" />
+      </node>
+      <node concept="3EZMnI" id="1QVEC_icNbM" role="3EZMnx">
+        <ref role="1k5W1q" to="tpc5:hX1xO3O" resolve="bordered" />
+        <node concept="2iRfu4" id="1QVEC_icNbN" role="2iSdaV" />
+        <node concept="1iCGBv" id="g_U$WEE" role="3EZMnx">
+          <property role="1$x2rV" value="&lt;no component&gt;" />
+          <ref role="1NtTu8" to="91fu:fGPMmyn" resolve="editorComponent" />
+          <node concept="1sVBvm" id="g_U$WED" role="1sWHZn">
+            <node concept="3F0A7n" id="g_U$Y3k" role="2wV5jI">
+              <property role="1Intyy" value="true" />
+              <property role="1$x2rV" value="&lt;no name&gt;" />
+              <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
+            </node>
+          </node>
+        </node>
+        <node concept="3F0ifn" id="1QVEC_ibSpd" role="3EZMnx">
+          <property role="3F0ifm" value="(" />
+          <ref role="1k5W1q" to="tpc5:hFCSAw$" resolve="LeftParen" />
+          <node concept="11L4FC" id="1QVEC_icXov" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+        </node>
+        <node concept="3F2HdR" id="5PKDVfOlN1j" role="3EZMnx">
+          <property role="2czwfO" value="," />
+          <ref role="1NtTu8" to="91fu:5PKDVfOlsvY" resolve="arguments" />
+          <node concept="2iRfu4" id="5PKDVfOlN1l" role="2czzBx" />
+        </node>
+      </node>
+      <node concept="3F0ifn" id="5PKDVfOlN1$" role="3EZMnx">
+        <property role="3F0ifm" value=")" />
+        <ref role="1k5W1q" to="tpc5:hFCSUmN" resolve="RightParen" />
+      </node>
+      <node concept="PMmxH" id="h7TNf64" role="3EZMnx">
+        <ref role="PMmxG" to="tpc5:h7TMK$j" resolve="_CloseTag" />
+        <node concept="VPXOz" id="hEUNSmG" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="2iRfu4" id="i2IxuQV" role="2iSdaV" />
+    </node>
+  </node>
+  <node concept="3p309x" id="5PKDVfOnfIs">
+    <property role="TrG5h" value="AddParameterizedCellModel_Component" />
+    <node concept="2F$Pav" id="1wEcoXjJtv2" role="3ft7WO">
+      <node concept="3Tqbb2" id="1wEcoXjJtv3" role="2ZBHrp">
+        <ref role="ehGHo" to="91fu:5PKDVfNXREN" resolve="EditorComponentDeclarationWithParameters" />
+      </node>
+      <node concept="2$S_p_" id="1wEcoXjJtv4" role="2$S_pT">
+        <node concept="3clFbS" id="1wEcoXjJtv5" role="2VODD2">
+          <node concept="3cpWs8" id="1wEcoXjJtv6" role="3cqZAp">
+            <node concept="3cpWsn" id="1wEcoXjJtv7" role="3cpWs9">
+              <property role="TrG5h" value="scope" />
+              <node concept="3uibUv" id="1wEcoXjJtv8" role="1tU5fm">
+                <ref role="3uigEE" to="o8zo:3fifI_xCtN$" resolve="Scope" />
+              </node>
+              <node concept="2YIFZM" id="1wEcoXjJtv9" role="33vP2m">
+                <ref role="37wK5l" to="o8zo:52_Geb4SiYg" resolve="getScope" />
+                <ref role="1Pybhc" to="o8zo:3fifI_xCtN$" resolve="Scope" />
+                <node concept="3bvxqY" id="1wEcoXjJtvG" role="37wK5m" />
+                <node concept="1yR$tW" id="1wEcoXjJtvH" role="37wK5m" />
+                <node concept="35c_gC" id="EB2Sz2SLTf" role="37wK5m">
+                  <ref role="35c_gD" to="tpc2:fGPKFH7" resolve="EditorComponentDeclaration" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbJ" id="1wEcoXjJtvd" role="3cqZAp">
+            <node concept="3clFbC" id="1wEcoXjJtve" role="3clFbw">
+              <node concept="10Nm6u" id="1wEcoXjJtvf" role="3uHU7w" />
+              <node concept="37vLTw" id="1wEcoXjJtvg" role="3uHU7B">
+                <ref role="3cqZAo" node="1wEcoXjJtv7" resolve="scope" />
+              </node>
+            </node>
+            <node concept="3clFbS" id="1wEcoXjJtvh" role="3clFbx">
+              <node concept="3cpWs6" id="1wEcoXjJtvi" role="3cqZAp">
+                <node concept="2YIFZM" id="1wEcoXjJtvj" role="3cqZAk">
+                  <ref role="37wK5l" to="33ny:~Collections.emptyList()" resolve="emptyList" />
+                  <ref role="1Pybhc" to="33ny:~Collections" resolve="Collections" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs6" id="1wEcoXjJtvk" role="3cqZAp">
+            <node concept="2OqwBi" id="1wEcoXjJtvl" role="3cqZAk">
+              <node concept="2OqwBi" id="1wEcoXjJtvm" role="2Oq$k0">
+                <node concept="3$u5V9" id="1wEcoXjJtvn" role="2OqNvi">
+                  <node concept="1bVj0M" id="1wEcoXjJtvo" role="23t8la">
+                    <node concept="3clFbS" id="1wEcoXjJtvp" role="1bW5cS">
+                      <node concept="3clFbF" id="1wEcoXjJtvq" role="3cqZAp">
+                        <node concept="1PxgMI" id="1wEcoXjJtvr" role="3clFbG">
+                          <property role="1BlNFB" value="true" />
+                          <node concept="chp4Y" id="714IaVdH0rj" role="3oSUPX">
+                            <ref role="cht4Q" to="91fu:5PKDVfNXREN" resolve="EditorComponentDeclarationWithParameters" />
+                          </node>
+                          <node concept="37vLTw" id="1wEcoXjJtvs" role="1m5AlR">
+                            <ref role="3cqZAo" node="1wEcoXjJtvt" resolve="it" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="Rh6nW" id="1wEcoXjJtvt" role="1bW2Oz">
+                      <property role="TrG5h" value="it" />
+                      <node concept="2jxLKc" id="1wEcoXjJtvu" role="1tU5fm" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="1wEcoXjJtvv" role="2Oq$k0">
+                  <node concept="37vLTw" id="1wEcoXjJtvw" role="2Oq$k0">
+                    <ref role="3cqZAo" node="1wEcoXjJtv7" resolve="scope" />
+                  </node>
+                  <node concept="liA8E" id="1wEcoXjJtvx" role="2OqNvi">
+                    <ref role="37wK5l" to="o8zo:3fifI_xCtP7" resolve="getAvailableElements" />
+                    <node concept="Xl_RD" id="1wEcoXjJtvy" role="37wK5m">
+                      <property role="Xl_RC" value="" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3zZkjj" id="1wEcoXjJtvz" role="2OqNvi">
+                <node concept="1bVj0M" id="1wEcoXjJtv$" role="23t8la">
+                  <node concept="3clFbS" id="1wEcoXjJtv_" role="1bW5cS">
+                    <node concept="3clFbF" id="1wEcoXjJtvA" role="3cqZAp">
+                      <node concept="3y3z36" id="1wEcoXjJtvB" role="3clFbG">
+                        <node concept="10Nm6u" id="1wEcoXjJtvC" role="3uHU7w" />
+                        <node concept="37vLTw" id="1wEcoXjJtvD" role="3uHU7B">
+                          <ref role="3cqZAo" node="1wEcoXjJtvE" resolve="it" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Rh6nW" id="1wEcoXjJtvE" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="1wEcoXjJtvF" role="1tU5fm" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3eGOop" id="1wEcoXjJtw8" role="2$S_pN">
+        <node concept="16NfWO" id="1wEcoXjJtw9" role="upBLP">
+          <node concept="uGdhv" id="1wEcoXjJtwa" role="16NeZM">
+            <node concept="3clFbS" id="1wEcoXjJtwb" role="2VODD2">
+              <node concept="3clFbF" id="1wEcoXjJtwc" role="3cqZAp">
+                <node concept="3cpWs3" id="1wEcoXjJtwd" role="3clFbG">
+                  <node concept="3cpWs3" id="1wEcoXjJtwf" role="3uHU7B">
+                    <node concept="Xl_RD" id="1wEcoXjJtwg" role="3uHU7B">
+                      <property role="Xl_RC" value="#" />
+                    </node>
+                    <node concept="2OqwBi" id="1wEcoXjJtwh" role="3uHU7w">
+                      <node concept="2ZBlsa" id="1wEcoXjJtwk" role="2Oq$k0" />
+                      <node concept="3TrcHB" id="1wEcoXjJtwj" role="2OqNvi">
+                        <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Xl_RD" id="1wEcoXjJtwe" role="3uHU7w">
+                    <property role="Xl_RC" value="#(args)" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="ucgPf" id="1wEcoXjJtwJ" role="3aKz83">
+          <node concept="3clFbS" id="1wEcoXjJtwK" role="2VODD2">
+            <node concept="3cpWs8" id="1wEcoXjJtwL" role="3cqZAp">
+              <node concept="3cpWsn" id="1wEcoXjJtwM" role="3cpWs9">
+                <property role="TrG5h" value="component" />
+                <node concept="3Tqbb2" id="1wEcoXjJtwN" role="1tU5fm">
+                  <ref role="ehGHo" to="91fu:5PKDVfOlrE5" resolve="CellModel_ComponentWithParameters" />
+                </node>
+                <node concept="2OqwBi" id="1wEcoXjJtwO" role="33vP2m">
+                  <node concept="1rpKSd" id="1wEcoXjJtx0" role="2Oq$k0" />
+                  <node concept="15TzpJ" id="1wEcoXjJtwQ" role="2OqNvi">
+                    <ref role="I8UWU" to="91fu:5PKDVfOlrE5" resolve="CellModel_ComponentWithParameters" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="1wEcoXjJtwR" role="3cqZAp">
+              <node concept="2OqwBi" id="1wEcoXjJtwS" role="3clFbG">
+                <node concept="2OqwBi" id="1wEcoXjJtwT" role="2Oq$k0">
+                  <node concept="37vLTw" id="1wEcoXjJtwU" role="2Oq$k0">
+                    <ref role="3cqZAo" node="1wEcoXjJtwM" resolve="component" />
+                  </node>
+                  <node concept="3TrEf2" id="1wEcoXjJtwV" role="2OqNvi">
+                    <ref role="3Tt5mk" to="91fu:fGPMmyn" resolve="editorComponent" />
+                  </node>
+                </node>
+                <node concept="2oxUTD" id="1wEcoXjJtwW" role="2OqNvi">
+                  <node concept="2ZBlsa" id="1wEcoXjJtx1" role="2oxUTC" />
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs6" id="1wEcoXjJtwY" role="3cqZAp">
+              <node concept="37vLTw" id="1wEcoXjJtwZ" role="3cqZAk">
+                <ref role="3cqZAo" node="1wEcoXjJtwM" resolve="component" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2kknPJ" id="5PKDVfOnfIu" role="1IG6uw">
+      <ref role="2ZyFGn" to="tpc2:fBEYTCT" resolve="EditorCellModel" />
+    </node>
   </node>
 </model>
 

--- a/code/conditional-editor/languages/de.slisson.mps.conditionalEditor/languageModels/editor.mps
+++ b/code/conditional-editor/languages/de.slisson.mps.conditionalEditor/languageModels/editor.mps
@@ -24,7 +24,9 @@
         <child id="414384289274416996" name="parts" index="3ft7WO" />
       </concept>
       <concept id="2000375450116423800" name="jetbrains.mps.lang.editor.structure.SubstituteMenu" flags="ng" index="22mcaB" />
-      <concept id="1071666914219" name="jetbrains.mps.lang.editor.structure.ConceptEditorDeclaration" flags="ig" index="24kQdi" />
+      <concept id="1071666914219" name="jetbrains.mps.lang.editor.structure.ConceptEditorDeclaration" flags="ig" index="24kQdi">
+        <child id="1078153129734" name="inspectedCellModel" index="6VMZX" />
+      </concept>
       <concept id="1140524381322" name="jetbrains.mps.lang.editor.structure.CellModel_ListWithRole" flags="ng" index="2czfm3">
         <property id="1140524450557" name="separatorText" index="2czwfO" />
         <child id="1140524464360" name="cellLayout" index="2czzBx" />
@@ -34,6 +36,10 @@
       <concept id="1106270549637" name="jetbrains.mps.lang.editor.structure.CellLayout_Horizontal" flags="nn" index="2iRfu4" />
       <concept id="1106270571710" name="jetbrains.mps.lang.editor.structure.CellLayout_Vertical" flags="nn" index="2iRkQZ" />
       <concept id="6089045305654894366" name="jetbrains.mps.lang.editor.structure.SubstituteMenuReference_Default" flags="ng" index="2kknPJ" />
+      <concept id="1237303669825" name="jetbrains.mps.lang.editor.structure.CellLayout_Indent" flags="nn" index="l2Vlx" />
+      <concept id="1142886221719" name="jetbrains.mps.lang.editor.structure.QueryFunction_NodeCondition" flags="in" index="pkWqt" />
+      <concept id="1142886811589" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameter_node" flags="nn" index="pncrf" />
+      <concept id="1237385578942" name="jetbrains.mps.lang.editor.structure.IndentLayoutOnNewLineStyleClassItem" flags="ln" index="pVoyu" />
       <concept id="1233148810477" name="jetbrains.mps.lang.editor.structure.InlineStyleDeclaration" flags="ng" index="tppnM" />
       <concept id="1177327570013" name="jetbrains.mps.lang.editor.structure.QueryFunction_SubstituteMenu_Substitute" flags="in" index="ucgPf" />
       <concept id="8478191136883534237" name="jetbrains.mps.lang.editor.structure.IExtensibleSubstituteMenuPart" flags="ng" index="upBLQ">
@@ -45,6 +51,7 @@
       </concept>
       <concept id="8371900013785948369" name="jetbrains.mps.lang.editor.structure.QueryFunction_SubstituteMenu_Parameter" flags="ig" index="2$S_p_" />
       <concept id="8383079901754291618" name="jetbrains.mps.lang.editor.structure.CellModel_NextEditor" flags="ng" index="B$lHz" />
+      <concept id="1239814640496" name="jetbrains.mps.lang.editor.structure.CellLayout_VerticalGrid" flags="nn" index="2EHx9g" />
       <concept id="308059530142752797" name="jetbrains.mps.lang.editor.structure.SubstituteMenuPart_Parameterized" flags="ng" index="2F$Pav">
         <child id="8371900013785948359" name="part" index="2$S_pN" />
         <child id="8371900013785948365" name="parameterQuery" index="2$S_pT" />
@@ -96,7 +103,6 @@
       </concept>
       <concept id="7580468736840446506" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameter_model" flags="nn" index="1rpKSd" />
       <concept id="1088185857835" name="jetbrains.mps.lang.editor.structure.InlineEditorComponent" flags="ig" index="1sVBvm" />
-      <concept id="1219226236603" name="jetbrains.mps.lang.editor.structure.DrawBracketsStyleClassItem" flags="ln" index="3vyZuw" />
       <concept id="5425882385312046132" name="jetbrains.mps.lang.editor.structure.QueryFunctionParameter_SubstituteMenu_CurrentTargetNode" flags="nn" index="1yR$tW" />
       <concept id="1215007762405" name="jetbrains.mps.lang.editor.structure.FloatStyleClassItem" flags="ln" index="3$6MrZ">
         <property id="1215007802031" name="value" index="3$6WeP" />
@@ -109,12 +115,14 @@
       </concept>
       <concept id="1073389214265" name="jetbrains.mps.lang.editor.structure.EditorCellModel" flags="ng" index="3EYTF0">
         <reference id="1081339532145" name="keyMap" index="34QXea" />
+        <child id="1142887637401" name="renderingCondition" index="pqm2j" />
       </concept>
       <concept id="1073389446423" name="jetbrains.mps.lang.editor.structure.CellModel_Collection" flags="sn" stub="3013115976261988961" index="3EZMnI">
         <child id="1106270802874" name="cellLayout" index="2iSdaV" />
         <child id="1073389446424" name="childCellModel" index="3EZMnx" />
       </concept>
       <concept id="1073389577006" name="jetbrains.mps.lang.editor.structure.CellModel_Constant" flags="sn" stub="3610246225209162225" index="3F0ifn">
+        <property id="1082639509531" name="nullText" index="ilYzB" />
         <property id="1073389577007" name="text" index="3F0ifm" />
       </concept>
       <concept id="1073389658414" name="jetbrains.mps.lang.editor.structure.CellModel_Property" flags="sg" stub="730538219796134133" index="3F0A7n" />
@@ -501,23 +509,227 @@
   </node>
   <node concept="24kQdi" id="5PKDVfNY0qv">
     <ref role="1XX52x" to="91fu:5PKDVfNXREN" resolve="EditorComponentDeclarationWithParameters" />
-    <node concept="3EZMnI" id="5PKDVfNY0q$" role="2wV5jI">
-      <node concept="3EZMnI" id="5PKDVfNY0qH" role="3EZMnx">
-        <node concept="3vyZuw" id="54z9_KDO752" role="3F10Kt">
-          <property role="VOm3f" value="true" />
+    <node concept="3EZMnI" id="fGTPXmC" role="2wV5jI">
+      <node concept="3EZMnI" id="fGTPXmD" role="3EZMnx">
+        <node concept="3F0ifn" id="fGTPXmE" role="3EZMnx">
+          <property role="3F0ifm" value="editor component" />
         </node>
-        <node concept="2iRfu4" id="5PKDVfNY0qI" role="2iSdaV" />
-        <node concept="3F0ifn" id="5PKDVfNY0qE" role="3EZMnx">
-          <property role="3F0ifm" value="parameters:" />
+        <node concept="3F0A7n" id="gyQosa8" role="3EZMnx">
+          <property role="1$x2rV" value="&lt;no name&gt;" />
+          <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
         </node>
-        <node concept="3F2HdR" id="5PKDVfNY0qR" role="3EZMnx">
-          <property role="2czwfO" value="," />
-          <ref role="1NtTu8" to="91fu:5PKDVfNY0qm" resolve="parameters" />
-          <node concept="2iRfu4" id="5PKDVfNY0qT" role="2czzBx" />
+        <node concept="VPM3Z" id="hEU$P0d" role="3F10Kt">
+          <property role="VOm3f" value="false" />
+        </node>
+        <node concept="2iRfu4" id="i2IxuQf" role="2iSdaV" />
+      </node>
+      <node concept="3EZMnI" id="2nZuqX0H6uj" role="3EZMnx">
+        <node concept="VPM3Z" id="2nZuqX0H6ul" role="3F10Kt">
+          <property role="VOm3f" value="false" />
+        </node>
+        <node concept="2iRfu4" id="2nZuqX0H6uo" role="2iSdaV" />
+        <node concept="3XFhqQ" id="2nZuqX0H6vy" role="3EZMnx" />
+        <node concept="3EZMnI" id="2nZuqX0H6vB" role="3EZMnx">
+          <node concept="3F0ifn" id="2nZuqX0H6vM" role="3EZMnx">
+            <property role="3F0ifm" value="overrides:" />
+            <node concept="VPM3Z" id="23C0l7wMCR1" role="3F10Kt" />
+          </node>
+          <node concept="3EZMnI" id="2nZuqX0H6B6" role="3EZMnx">
+            <node concept="3XFhqQ" id="xLfwuvnLUf" role="3EZMnx" />
+            <node concept="15ARfc" id="xLfwuvinf6" role="3F10Kt">
+              <property role="3$6WeP" value="0.0" />
+            </node>
+            <node concept="3F1sOY" id="2nZuqX0H6Gw" role="3EZMnx">
+              <property role="1$x2rV" value="&lt;no EditorComponent&gt;" />
+              <ref role="1NtTu8" to="tpc2:66t_lsklggO" resolve="overridenEditorComponent" />
+            </node>
+            <node concept="VPM3Z" id="2nZuqX0H6B8" role="3F10Kt">
+              <property role="VOm3f" value="false" />
+            </node>
+            <node concept="2iRfu4" id="2nZuqX0H6Bb" role="2iSdaV" />
+          </node>
+          <node concept="VPM3Z" id="2nZuqX0H6vD" role="3F10Kt">
+            <property role="VOm3f" value="false" />
+          </node>
+          <node concept="2iRkQZ" id="2nZuqX0H6vG" role="2iSdaV" />
         </node>
       </node>
-      <node concept="2iRkQZ" id="5PKDVfNY0q_" role="2iSdaV" />
-      <node concept="B$lHz" id="5PKDVfNY0qx" role="3EZMnx" />
+      <node concept="3EZMnI" id="6nWbOYo64zE" role="3EZMnx">
+        <node concept="VPM3Z" id="6nWbOYo64zF" role="3F10Kt">
+          <property role="VOm3f" value="false" />
+        </node>
+        <node concept="2iRfu4" id="6nWbOYo64zG" role="2iSdaV" />
+        <node concept="3XFhqQ" id="6nWbOYo64zH" role="3EZMnx" />
+        <node concept="3EZMnI" id="6nWbOYo64zI" role="3EZMnx">
+          <node concept="3F0ifn" id="6nWbOYo64zJ" role="3EZMnx">
+            <property role="3F0ifm" value="applicable in context:" />
+            <node concept="VPM3Z" id="23C0l7wMCU3" role="3F10Kt" />
+          </node>
+          <node concept="3EZMnI" id="6nWbOYo64zK" role="3EZMnx">
+            <node concept="3XFhqQ" id="6nWbOYo64zL" role="3EZMnx" />
+            <node concept="3F2HdR" id="6nWbOYo69MS" role="3EZMnx">
+              <property role="2czwfO" value="&amp;" />
+              <ref role="1NtTu8" to="tpc2:6nWbOYo69_Q" resolve="contextHints" />
+              <node concept="2iRfu4" id="6nWbOYo69MT" role="2czzBx" />
+              <node concept="tppnM" id="6nWbOYo6aSz" role="sWeuL">
+                <node concept="11L4FC" id="6nWbOYo6aS$" role="3F10Kt" />
+                <node concept="Vb9p2" id="6nWbOYo6aS_" role="3F10Kt" />
+              </node>
+              <node concept="3F0ifn" id="6nWbOYo6i57" role="2czzBI">
+                <property role="ilYzB" value="&lt;default&gt;" />
+                <ref role="34QXea" to="tpc5:6nWbOYo6aXk" resolve="EditorComponent_DefaultContextHintLabel" />
+                <node concept="VechU" id="6nWbOYo6j9W" role="3F10Kt">
+                  <property role="Vb096" value="fLJRk5_/gray" />
+                </node>
+                <node concept="34dVlM" id="6nWbOYo6j9X" role="3F10Kt">
+                  <property role="34dVlN" value="hrC1nx$/FIRST" />
+                </node>
+              </node>
+            </node>
+            <node concept="15ARfc" id="6nWbOYo64zM" role="3F10Kt">
+              <property role="3$6WeP" value="0.0" />
+            </node>
+            <node concept="VPM3Z" id="6nWbOYo64zO" role="3F10Kt">
+              <property role="VOm3f" value="false" />
+            </node>
+            <node concept="2iRfu4" id="6nWbOYo64zP" role="2iSdaV" />
+          </node>
+          <node concept="VPM3Z" id="6nWbOYo64zQ" role="3F10Kt">
+            <property role="VOm3f" value="false" />
+          </node>
+          <node concept="2iRkQZ" id="6nWbOYo64zR" role="2iSdaV" />
+        </node>
+        <node concept="pkWqt" id="6nWbOYoec1d" role="pqm2j">
+          <node concept="3clFbS" id="6nWbOYoec1e" role="2VODD2">
+            <node concept="3clFbF" id="6nWbOYoecek" role="3cqZAp">
+              <node concept="3y3z36" id="6nWbOYoehtI" role="3clFbG">
+                <node concept="10Nm6u" id="6nWbOYoehtV" role="3uHU7w" />
+                <node concept="2OqwBi" id="6nWbOYoeco6" role="3uHU7B">
+                  <node concept="3TrEf2" id="6nWbOYoefG2" role="2OqNvi">
+                    <ref role="3Tt5mk" to="tpc2:66t_lsklggO" resolve="overridenEditorComponent" />
+                  </node>
+                  <node concept="pncrf" id="6nWbOYoecej" role="2Oq$k0" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3EZMnI" id="fGTPXmI" role="3EZMnx">
+        <node concept="3XFhqQ" id="hOINf6v" role="3EZMnx" />
+        <node concept="3EZMnI" id="fGTPXmK" role="3EZMnx">
+          <node concept="3F0ifn" id="fGTPXmL" role="3EZMnx">
+            <property role="3F0ifm" value="applicable concept:" />
+            <node concept="VPM3Z" id="23C0l7wMCX5" role="3F10Kt" />
+          </node>
+          <node concept="3EZMnI" id="fGTPXmM" role="3EZMnx">
+            <node concept="3XFhqQ" id="xLfwuvtbnA" role="3EZMnx" />
+            <node concept="1iCGBv" id="g6iiV0p" role="3EZMnx">
+              <property role="1$x2rV" value="&lt;choose concept&gt;" />
+              <ref role="1NtTu8" to="tpc2:gXXX56I" resolve="conceptDeclaration" />
+              <node concept="1sVBvm" id="g6iiSea" role="1sWHZn">
+                <node concept="3F0A7n" id="g6iiV0q" role="2wV5jI">
+                  <property role="1Intyy" value="true" />
+                  <ref role="1k5W1q" to="tpd3:hwSE21y" resolve="ReferenceOnConcept" />
+                  <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
+                </node>
+              </node>
+            </node>
+            <node concept="15ARfc" id="hX6pU91" role="3F10Kt">
+              <property role="3$6WeP" value="0.0" />
+            </node>
+            <node concept="VPM3Z" id="hEU$PvP" role="3F10Kt">
+              <property role="VOm3f" value="false" />
+            </node>
+            <node concept="2iRfu4" id="i2IxuRy" role="2iSdaV" />
+          </node>
+          <node concept="VPM3Z" id="hEU$P2w" role="3F10Kt">
+            <property role="VOm3f" value="false" />
+          </node>
+          <node concept="2iRkQZ" id="i2IxuSs" role="2iSdaV" />
+        </node>
+        <node concept="15ARfc" id="hX6pOUd" role="3F10Kt">
+          <property role="3$6WeP" value="0.0" />
+        </node>
+        <node concept="VPM3Z" id="hEU$Pja" role="3F10Kt">
+          <property role="VOm3f" value="false" />
+        </node>
+        <node concept="2iRfu4" id="i2IxuOu" role="2iSdaV" />
+      </node>
+      <node concept="3EZMnI" id="1gBmad3BQd$" role="3EZMnx">
+        <node concept="3XFhqQ" id="1gBmad3BQd_" role="3EZMnx" />
+        <node concept="3EZMnI" id="1gBmad3BQdA" role="3EZMnx">
+          <node concept="3F0ifn" id="1gBmad3BQdB" role="3EZMnx">
+            <property role="3F0ifm" value="parameters:" />
+            <node concept="VPM3Z" id="1gBmad3BQdC" role="3F10Kt" />
+          </node>
+          <node concept="3EZMnI" id="1gBmad3BQdD" role="3EZMnx">
+            <node concept="3XFhqQ" id="1gBmad3BQdE" role="3EZMnx" />
+            <node concept="3F2HdR" id="1gBmad3BQn5" role="3EZMnx">
+              <ref role="1NtTu8" to="91fu:5PKDVfNY0qm" resolve="parameters" />
+              <node concept="2iRkQZ" id="1gBmad3BQnb" role="2czzBx" />
+            </node>
+            <node concept="15ARfc" id="1gBmad3BQdI" role="3F10Kt">
+              <property role="3$6WeP" value="0.0" />
+            </node>
+            <node concept="VPM3Z" id="1gBmad3BQdJ" role="3F10Kt">
+              <property role="VOm3f" value="false" />
+            </node>
+            <node concept="2iRfu4" id="1gBmad3BQdK" role="2iSdaV" />
+          </node>
+          <node concept="VPM3Z" id="1gBmad3BQdL" role="3F10Kt">
+            <property role="VOm3f" value="false" />
+          </node>
+          <node concept="2iRkQZ" id="1gBmad3BQdM" role="2iSdaV" />
+        </node>
+        <node concept="15ARfc" id="1gBmad3BQdN" role="3F10Kt">
+          <property role="3$6WeP" value="0.0" />
+        </node>
+        <node concept="VPM3Z" id="1gBmad3BQdO" role="3F10Kt">
+          <property role="VOm3f" value="false" />
+        </node>
+        <node concept="2iRfu4" id="1gBmad3BQdP" role="2iSdaV" />
+      </node>
+      <node concept="3EZMnI" id="fGTPXmP" role="3EZMnx">
+        <node concept="3XFhqQ" id="hOINfJx" role="3EZMnx" />
+        <node concept="3EZMnI" id="fGTPXmR" role="3EZMnx">
+          <node concept="3F0ifn" id="fGTPXmS" role="3EZMnx">
+            <node concept="VPM3Z" id="hEU$PJd" role="3F10Kt">
+              <property role="VOm3f" value="false" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="fGTPXmT" role="3EZMnx">
+            <property role="3F0ifm" value="component cell layout:" />
+            <node concept="VPM3Z" id="23C0l7wMCY7" role="3F10Kt" />
+          </node>
+          <node concept="3EZMnI" id="fGTPXmU" role="3EZMnx">
+            <node concept="3XFhqQ" id="xLfwuvtbnP" role="3EZMnx" />
+            <node concept="3F1sOY" id="g_TZx2p" role="3EZMnx">
+              <ref role="1NtTu8" to="tpc2:fIwV5gl" resolve="cellModel" />
+              <ref role="34QXea" to="tpc5:gtczF7b" resolve="EditorCellModel_KeyMap" />
+            </node>
+            <node concept="15ARfc" id="hX6pW1f" role="3F10Kt">
+              <property role="3$6WeP" value="0.0" />
+            </node>
+            <node concept="VPM3Z" id="hEU$Prt" role="3F10Kt">
+              <property role="VOm3f" value="false" />
+            </node>
+            <node concept="2iRfu4" id="i2IxuQc" role="2iSdaV" />
+          </node>
+          <node concept="VPM3Z" id="hEU$PZQ" role="3F10Kt">
+            <property role="VOm3f" value="false" />
+          </node>
+          <node concept="2iRkQZ" id="i2IxuMp" role="2iSdaV" />
+        </node>
+        <node concept="15ARfc" id="hX6pS4K" role="3F10Kt">
+          <property role="3$6WeP" value="0.0" />
+        </node>
+        <node concept="VPM3Z" id="hEU$PhZ" role="3F10Kt">
+          <property role="VOm3f" value="false" />
+        </node>
+        <node concept="2iRfu4" id="i2IxuTK" role="2iSdaV" />
+      </node>
+      <node concept="2iRkQZ" id="i2IxuMz" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="5PKDVfOkPd9">
@@ -564,22 +776,6 @@
             </node>
           </node>
         </node>
-        <node concept="3F0ifn" id="1QVEC_ibSpd" role="3EZMnx">
-          <property role="3F0ifm" value="(" />
-          <ref role="1k5W1q" to="tpc5:hFCSAw$" resolve="LeftParen" />
-          <node concept="11L4FC" id="1QVEC_icXov" role="3F10Kt">
-            <property role="VOm3f" value="true" />
-          </node>
-        </node>
-        <node concept="3F2HdR" id="5PKDVfOlN1j" role="3EZMnx">
-          <property role="2czwfO" value="," />
-          <ref role="1NtTu8" to="91fu:5PKDVfOlsvY" resolve="arguments" />
-          <node concept="2iRfu4" id="5PKDVfOlN1l" role="2czzBx" />
-        </node>
-      </node>
-      <node concept="3F0ifn" id="5PKDVfOlN1$" role="3EZMnx">
-        <property role="3F0ifm" value=")" />
-        <ref role="1k5W1q" to="tpc5:hFCSUmN" resolve="RightParen" />
       </node>
       <node concept="PMmxH" id="h7TNf64" role="3EZMnx">
         <ref role="PMmxG" to="tpc5:h7TMK$j" resolve="_CloseTag" />
@@ -588,6 +784,42 @@
         </node>
       </node>
       <node concept="2iRfu4" id="i2IxuQV" role="2iSdaV" />
+    </node>
+    <node concept="3EZMnI" id="1gBmad3C98t" role="6VMZX">
+      <node concept="2iRkQZ" id="1gBmad3C98u" role="2iSdaV" />
+      <node concept="B$lHz" id="1gBmad3C98q" role="3EZMnx" />
+      <node concept="3F0ifn" id="1gBmad3ClGb" role="3EZMnx" />
+      <node concept="3EZMnI" id="3h9t8JnexrB" role="3EZMnx">
+        <node concept="3F0ifn" id="3h9t8JnexrE" role="3EZMnx">
+          <property role="3F0ifm" value="Component" />
+          <ref role="1k5W1q" to="tpc5:hF4yUZ8" resolve="header" />
+        </node>
+        <node concept="3EZMnI" id="3h9t8JnexrF" role="3EZMnx">
+          <node concept="3EZMnI" id="1gBmad3Em1t" role="3EZMnx">
+            <node concept="3F0ifn" id="3K0abI4qFqo" role="3EZMnx">
+              <property role="3F0ifm" value="arguments" />
+              <ref role="1k5W1q" to="tpc5:hF4H1c8" resolve="property" />
+            </node>
+            <node concept="3F2HdR" id="1gBmad3Ca0B" role="3EZMnx">
+              <property role="2czwfO" value="," />
+              <ref role="1NtTu8" to="91fu:5PKDVfOlsvY" resolve="arguments" />
+              <node concept="l2Vlx" id="1gBmad3EGfy" role="2czzBx" />
+              <node concept="tppnM" id="1gBmad3EGf_" role="sWeuL">
+                <node concept="pVoyu" id="1gBmad3ESoA" role="3F10Kt">
+                  <property role="VOm3f" value="true" />
+                </node>
+              </node>
+            </node>
+            <node concept="VPXOz" id="1gBmad3Em1u" role="3F10Kt">
+              <property role="VOm3f" value="true" />
+            </node>
+            <node concept="2iRfu4" id="3K0abI4qFqs" role="2iSdaV" />
+          </node>
+          <node concept="2EHx9g" id="3h9t8Jnexsx" role="2iSdaV" />
+        </node>
+        <node concept="2iRkQZ" id="3h9t8JnexrD" role="2iSdaV" />
+      </node>
+      <node concept="3F0ifn" id="1gBmad3C98z" role="3EZMnx" />
     </node>
   </node>
   <node concept="3p309x" id="5PKDVfOnfIs">

--- a/code/conditional-editor/languages/de.slisson.mps.conditionalEditor/languageModels/structure.mps
+++ b/code/conditional-editor/languages/de.slisson.mps.conditionalEditor/languageModels/structure.mps
@@ -36,6 +36,7 @@
         <property id="1071599893252" name="sourceCardinality" index="20lbJX" />
         <property id="1071599937831" name="metaClass" index="20lmBu" />
         <property id="241647608299431140" name="linkId" index="IQ2ns" />
+        <reference id="1071599698500" name="specializedLink" index="20ksaX" />
         <reference id="1071599976176" name="target" index="20lvS9" />
       </concept>
     </language>
@@ -126,6 +127,59 @@
       <property role="20lbJX" value="fLJekj4/_1" />
       <property role="IQ2ns" value="1885109890161512398" />
       <ref role="20lvS9" to="tpc2:fBEYTCT" resolve="EditorCellModel" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="5PKDVfNXREN">
+    <property role="EcuMT" value="6733065834252958387" />
+    <property role="TrG5h" value="EditorComponentDeclarationWithParameters" />
+    <property role="34LRSv" value="editor component with parameters" />
+    <property role="19KtqR" value="true" />
+    <ref role="1TJDcQ" to="tpc2:fGPKFH7" resolve="EditorComponentDeclaration" />
+    <node concept="1TJgyj" id="5PKDVfNY0qm" role="1TKVEi">
+      <property role="IQ2ns" value="6733065834252994198" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="parameters" />
+      <property role="20lbJX" value="fLJekj5/_0__n" />
+      <ref role="20lvS9" to="tpee:4k3qd$cSlJ3" resolve="BaseVariableDeclaration" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="5PKDVfOkPcZ">
+    <property role="EcuMT" value="6733065834258977599" />
+    <property role="TrG5h" value="EditorComponentParameterReference" />
+    <ref role="1TJDcQ" to="tpee:fz3vP1J" resolve="Expression" />
+    <node concept="1TJgyj" id="5PKDVfOkPd0" role="1TKVEi">
+      <property role="IQ2ns" value="6733065834258977600" />
+      <property role="20kJfa" value="parameter" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <ref role="20lvS9" to="tpee:4k3qd$cSlJ3" resolve="BaseVariableDeclaration" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="5PKDVfOlrE5">
+    <property role="EcuMT" value="6733065834259135109" />
+    <property role="TrG5h" value="CellModel_ComponentWithParameters" />
+    <property role="34LRSv" value="component with arguments" />
+    <ref role="1TJDcQ" to="tpc2:fGPMmym" resolve="CellModel_Component" />
+    <node concept="1TJgyj" id="fGPMmyn" role="1TKVEi">
+      <property role="20kJfa" value="editorComponent" />
+      <property role="20lbJX" value="fLJekj4/1" />
+      <property role="IQ2ns" value="1078939183255" />
+      <ref role="20ksaX" to="tpc2:fGPMmyn" resolve="editorComponent" />
+      <ref role="20lvS9" node="5PKDVfNXREN" resolve="EditorComponentDeclarationWithParameters" />
+    </node>
+    <node concept="1TJgyj" id="5PKDVfOlsvY" role="1TKVEi">
+      <property role="IQ2ns" value="6733065834259138558" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="arguments" />
+      <property role="20lbJX" value="fLJekj5/_0__n" />
+      <ref role="20lvS9" to="tpee:fz3vP1J" resolve="Expression" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="5PKDVfOlsvP">
+    <property role="TrG5h" value="StubCellModel_ComponentWithParameters" />
+    <property role="EcuMT" value="6733065834259138549" />
+    <ref role="1TJDcQ" node="5PKDVfOlrE5" resolve="CellModel_ComponentWithParameters" />
+    <node concept="PrWs8" id="5PKDVfOlsvR" role="PzmwI">
+      <ref role="PrY4T" to="tpck:8AYOKVCAP5" />
     </node>
   </node>
 </model>

--- a/code/conditional-editor/languages/de.slisson.mps.conditionalEditor/languageModels/structure.mps
+++ b/code/conditional-editor/languages/de.slisson.mps.conditionalEditor/languageModels/structure.mps
@@ -171,7 +171,7 @@
       <property role="20lmBu" value="fLJjDmT/aggregation" />
       <property role="20kJfa" value="arguments" />
       <property role="20lbJX" value="fLJekj5/_0__n" />
-      <ref role="20lvS9" to="tpee:fz3vP1J" resolve="Expression" />
+      <ref role="20lvS9" node="1gBmad3Feya" resolve="ComponentArgument" />
     </node>
   </node>
   <node concept="1TIwiD" id="5PKDVfOlsvP">
@@ -180,6 +180,17 @@
     <ref role="1TJDcQ" node="5PKDVfOlrE5" resolve="CellModel_ComponentWithParameters" />
     <node concept="PrWs8" id="5PKDVfOlsvR" role="PzmwI">
       <ref role="PrY4T" to="tpck:8AYOKVCAP5" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="1gBmad3Feya">
+    <property role="EcuMT" value="1452226863088593034" />
+    <property role="TrG5h" value="ComponentArgument" />
+    <ref role="1TJDcQ" to="tpee:gyVMwX8" resolve="ConceptFunction" />
+    <node concept="1TJgyj" id="1gBmad3FeJu" role="1TKVEi">
+      <property role="IQ2ns" value="1452226863088593886" />
+      <property role="20kJfa" value="variable" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <ref role="20lvS9" to="tpee:4k3qd$cSlJ3" resolve="BaseVariableDeclaration" />
     </node>
   </node>
 </model>

--- a/code/conditional-editor/languages/de.slisson.mps.conditionalEditor/languageModels/typesystem.mps
+++ b/code/conditional-editor/languages/de.slisson.mps.conditionalEditor/languageModels/typesystem.mps
@@ -15,10 +15,17 @@
     <import index="z1c3" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.project(MPS.Core/)" implicit="true" />
     <import index="w0gx" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.project.structure.modules(MPS.Core/)" implicit="true" />
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" implicit="true" />
+    <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" implicit="true" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="1239714755177" name="jetbrains.mps.baseLanguage.structure.AbstractUnaryNumberOperation" flags="nn" index="2$Kvd9">
+        <child id="1239714902950" name="expression" index="2$L3a6" />
+      </concept>
+      <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
+        <child id="1154032183016" name="body" index="2LFqv$" />
+      </concept>
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
@@ -30,6 +37,7 @@
         <property id="1070475926801" name="value" index="Xl_RC" />
       </concept>
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
+      <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
       <concept id="1070534934090" name="jetbrains.mps.baseLanguage.structure.CastExpression" flags="nn" index="10QFUN">
         <child id="1070534934091" name="type" index="10QFUM" />
         <child id="1070534934092" name="expression" index="10QFUP" />
@@ -54,6 +62,9 @@
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
+      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
+        <property id="1068580320021" name="value" index="3cmrfH" />
+      </concept>
       <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
       <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
         <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
@@ -62,6 +73,7 @@
       <concept id="1079359253375" name="jetbrains.mps.baseLanguage.structure.ParenthesizedExpression" flags="nn" index="1eOMI4">
         <child id="1079359253376" name="expression" index="1eOMHV" />
       </concept>
+      <concept id="1081506773034" name="jetbrains.mps.baseLanguage.structure.LessThanExpression" flags="nn" index="3eOVzh" />
       <concept id="1081516740877" name="jetbrains.mps.baseLanguage.structure.NotExpression" flags="nn" index="3fqX7Q">
         <child id="1081516765348" name="expression" index="3fr31v" />
       </concept>
@@ -76,12 +88,23 @@
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
+      <concept id="1214918800624" name="jetbrains.mps.baseLanguage.structure.PostfixIncrementExpression" flags="nn" index="3uNrnE" />
       <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
+      <concept id="1144230876926" name="jetbrains.mps.baseLanguage.structure.AbstractForStatement" flags="nn" index="1DupvO">
+        <child id="1144230900587" name="variable" index="1Duv9x" />
+      </concept>
+      <concept id="1144231330558" name="jetbrains.mps.baseLanguage.structure.ForStatement" flags="nn" index="1Dw8fO">
+        <child id="1144231399730" name="condition" index="1Dwp0S" />
+        <child id="1144231408325" name="iteration" index="1Dwrff" />
+      </concept>
       <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
     </language>
     <language id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem">
       <concept id="2329696648445392942" name="jetbrains.mps.lang.typesystem.structure.CheckingRuleReference" flags="ng" index="dlsrG">
         <reference id="2329696648445392943" name="declaration" index="dlsrH" />
+      </concept>
+      <concept id="1185788614172" name="jetbrains.mps.lang.typesystem.structure.NormalTypeClause" flags="ng" index="mw_s8">
+        <child id="1185788644032" name="normalType" index="mwGJk" />
       </concept>
       <concept id="1175517767210" name="jetbrains.mps.lang.typesystem.structure.ReportErrorStatement" flags="nn" index="2MkqsV">
         <child id="1175517851849" name="errorString" index="2MkJ7o" />
@@ -121,15 +144,28 @@
       <concept id="1174642788531" name="jetbrains.mps.lang.typesystem.structure.ConceptReference" flags="ig" index="1YaCAy">
         <reference id="1174642800329" name="concept" index="1YaFvo" />
       </concept>
+      <concept id="1174643105530" name="jetbrains.mps.lang.typesystem.structure.InferenceRule" flags="ig" index="1YbPZF" />
       <concept id="1174648085619" name="jetbrains.mps.lang.typesystem.structure.AbstractRule" flags="ng" index="1YuPPy">
         <child id="1174648101952" name="applicableNode" index="1YuTPh" />
       </concept>
       <concept id="1174650418652" name="jetbrains.mps.lang.typesystem.structure.ApplicableNodeReference" flags="nn" index="1YBJjd">
         <reference id="1174650432090" name="applicableNode" index="1YBMHb" />
       </concept>
+      <concept id="1174657487114" name="jetbrains.mps.lang.typesystem.structure.TypeOfExpression" flags="nn" index="1Z2H0r">
+        <child id="1174657509053" name="term" index="1Z2MuG" />
+      </concept>
+      <concept id="1174658326157" name="jetbrains.mps.lang.typesystem.structure.CreateEquationStatement" flags="nn" index="1Z5TYs" />
+      <concept id="1174660718586" name="jetbrains.mps.lang.typesystem.structure.AbstractEquationStatement" flags="nn" index="1Zf1VF">
+        <child id="1174660783413" name="leftExpression" index="1ZfhK$" />
+        <child id="1174660783414" name="rightExpression" index="1ZfhKB" />
+      </concept>
+      <concept id="1174663118805" name="jetbrains.mps.lang.typesystem.structure.CreateLessThanInequationStatement" flags="nn" index="1ZobV4" />
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
       <concept id="1143234257716" name="jetbrains.mps.lang.smodel.structure.Node_GetModelOperation" flags="nn" index="I4A8Y" />
+      <concept id="1145383075378" name="jetbrains.mps.lang.smodel.structure.SNodeListType" flags="in" index="2I9FWS">
+        <reference id="1145383142433" name="elementConcept" index="2I9WkF" />
+      </concept>
       <concept id="1145404486709" name="jetbrains.mps.lang.smodel.structure.SemanticDowncastExpression" flags="nn" index="2JrnkZ">
         <child id="1145404616321" name="leftExpression" index="2JrQYb" />
       </concept>
@@ -139,11 +175,21 @@
       <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="nn" index="3TrEf2">
         <reference id="1138056516764" name="link" index="3Tt5mk" />
       </concept>
+      <concept id="1138056282393" name="jetbrains.mps.lang.smodel.structure.SLinkListAccess" flags="nn" index="3Tsc0h">
+        <reference id="1138056546658" name="link" index="3TtcxE" />
+      </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
+    </language>
+    <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="nn" index="25WWJ4">
+        <child id="540871147943773366" name="argument" index="25WWJ7" />
+      </concept>
+      <concept id="1162934736510" name="jetbrains.mps.baseLanguage.collections.structure.GetElementOperation" flags="nn" index="34jXtK" />
+      <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
     </language>
   </registry>
   <node concept="18kY7G" id="2vJRo8gBgwd">
@@ -389,6 +435,232 @@
           </node>
         </node>
       </node>
+    </node>
+  </node>
+  <node concept="1YbPZF" id="5PKDVfOmCYw">
+    <property role="TrG5h" value="typeof_EditorComponentParameterReference" />
+    <node concept="3clFbS" id="5PKDVfOmCYx" role="18ibNy">
+      <node concept="1Z5TYs" id="5PKDVfOmD6f" role="3cqZAp">
+        <node concept="mw_s8" id="5PKDVfOmD6z" role="1ZfhKB">
+          <node concept="1Z2H0r" id="5PKDVfOmD6v" role="mwGJk">
+            <node concept="2OqwBi" id="5PKDVfOmDeB" role="1Z2MuG">
+              <node concept="1YBJjd" id="5PKDVfOmD6O" role="2Oq$k0">
+                <ref role="1YBMHb" node="5PKDVfOmCYz" resolve="reference" />
+              </node>
+              <node concept="3TrEf2" id="5PKDVfOmDnW" role="2OqNvi">
+                <ref role="3Tt5mk" to="91fu:5PKDVfOkPd0" resolve="parameter" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="mw_s8" id="5PKDVfOmD6i" role="1ZfhK$">
+          <node concept="1Z2H0r" id="5PKDVfOmCYE" role="mwGJk">
+            <node concept="1YBJjd" id="5PKDVfOmCYU" role="1Z2MuG">
+              <ref role="1YBMHb" node="5PKDVfOmCYz" resolve="reference" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1YaCAy" id="5PKDVfOmCYz" role="1YuTPh">
+      <property role="TrG5h" value="reference" />
+      <ref role="1YaFvo" to="91fu:5PKDVfOkPcZ" resolve="EditorComponentParameterReference" />
+    </node>
+  </node>
+  <node concept="1YbPZF" id="5PKDVfOmDqP">
+    <property role="TrG5h" value="typeof_CellModel_ComponentWithParameters" />
+    <node concept="3clFbS" id="5PKDVfOmDqQ" role="18ibNy">
+      <node concept="3cpWs8" id="5PKDVfOmINj" role="3cqZAp">
+        <node concept="3cpWsn" id="5PKDVfOmINk" role="3cpWs9">
+          <property role="TrG5h" value="parameters" />
+          <node concept="2I9FWS" id="5PKDVfOmINg" role="1tU5fm">
+            <ref role="2I9WkF" to="tpee:4k3qd$cSlJ3" resolve="BaseVariableDeclaration" />
+          </node>
+          <node concept="2OqwBi" id="5PKDVfOmJSJ" role="33vP2m">
+            <node concept="2OqwBi" id="5PKDVfOmINl" role="2Oq$k0">
+              <node concept="1YBJjd" id="5PKDVfOmINm" role="2Oq$k0">
+                <ref role="1YBMHb" node="5PKDVfOmDqS" resolve="cellModel_ComponentWithParameters" />
+              </node>
+              <node concept="3TrEf2" id="5PKDVfOmJw7" role="2OqNvi">
+                <ref role="3Tt5mk" to="91fu:fGPMmyn" resolve="editorComponent" />
+              </node>
+            </node>
+            <node concept="3Tsc0h" id="5PKDVfOmKoE" role="2OqNvi">
+              <ref role="3TtcxE" to="91fu:5PKDVfNY0qm" resolve="parameters" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3cpWs8" id="5PKDVfOmLsa" role="3cqZAp">
+        <node concept="3cpWsn" id="5PKDVfOmLsb" role="3cpWs9">
+          <property role="TrG5h" value="arguments" />
+          <node concept="2I9FWS" id="5PKDVfOmJUC" role="1tU5fm">
+            <ref role="2I9WkF" to="tpee:fz3vP1J" resolve="Expression" />
+          </node>
+          <node concept="2OqwBi" id="5PKDVfOmLsc" role="33vP2m">
+            <node concept="1YBJjd" id="5PKDVfOmLsd" role="2Oq$k0">
+              <ref role="1YBMHb" node="5PKDVfOmDqS" resolve="cellModel_ComponentWithParameters" />
+            </node>
+            <node concept="3Tsc0h" id="5PKDVfOmLse" role="2OqNvi">
+              <ref role="3TtcxE" to="91fu:5PKDVfOlsvY" resolve="arguments" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1Dw8fO" id="5PKDVfOmMyz" role="3cqZAp">
+        <node concept="3clFbS" id="5PKDVfOmMy_" role="2LFqv$">
+          <node concept="1ZobV4" id="1QVEC_icK0h" role="3cqZAp">
+            <node concept="mw_s8" id="1QVEC_icK0j" role="1ZfhK$">
+              <node concept="1Z2H0r" id="1QVEC_icK0k" role="mwGJk">
+                <node concept="2OqwBi" id="1QVEC_icK0l" role="1Z2MuG">
+                  <node concept="37vLTw" id="1QVEC_icK0m" role="2Oq$k0">
+                    <ref role="3cqZAo" node="5PKDVfOmLsb" resolve="arguments" />
+                  </node>
+                  <node concept="34jXtK" id="1QVEC_icK0n" role="2OqNvi">
+                    <node concept="37vLTw" id="1QVEC_icK0o" role="25WWJ7">
+                      <ref role="3cqZAo" node="5PKDVfOmMyA" resolve="i" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="mw_s8" id="1QVEC_icK0p" role="1ZfhKB">
+              <node concept="1Z2H0r" id="1QVEC_icK0q" role="mwGJk">
+                <node concept="2OqwBi" id="1QVEC_icK0r" role="1Z2MuG">
+                  <node concept="37vLTw" id="1QVEC_icK0s" role="2Oq$k0">
+                    <ref role="3cqZAo" node="5PKDVfOmINk" resolve="parameters" />
+                  </node>
+                  <node concept="34jXtK" id="1QVEC_icK0t" role="2OqNvi">
+                    <node concept="37vLTw" id="1QVEC_icK0u" role="25WWJ7">
+                      <ref role="3cqZAo" node="5PKDVfOmMyA" resolve="i" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWsn" id="5PKDVfOmMyA" role="1Duv9x">
+          <property role="TrG5h" value="i" />
+          <node concept="10Oyi0" id="5PKDVfOmMzi" role="1tU5fm" />
+          <node concept="3cmrfG" id="5PKDVfOmMzx" role="33vP2m">
+            <property role="3cmrfH" value="0" />
+          </node>
+        </node>
+        <node concept="3eOVzh" id="5PKDVfOmNpy" role="1Dwp0S">
+          <node concept="2OqwBi" id="5PKDVfOmPwe" role="3uHU7w">
+            <node concept="37vLTw" id="5PKDVfOmNpN" role="2Oq$k0">
+              <ref role="3cqZAo" node="5PKDVfOmLsb" resolve="arguments" />
+            </node>
+            <node concept="34oBXx" id="5PKDVfOmQQd" role="2OqNvi" />
+          </node>
+          <node concept="37vLTw" id="5PKDVfOmMzz" role="3uHU7B">
+            <ref role="3cqZAo" node="5PKDVfOmMyA" resolve="i" />
+          </node>
+        </node>
+        <node concept="3uNrnE" id="5PKDVfOmRDg" role="1Dwrff">
+          <node concept="37vLTw" id="5PKDVfOmRDi" role="2$L3a6">
+            <ref role="3cqZAo" node="5PKDVfOmMyA" resolve="i" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1YaCAy" id="5PKDVfOmDqS" role="1YuTPh">
+      <property role="TrG5h" value="cellModel" />
+      <ref role="1YaFvo" to="91fu:5PKDVfOlrE5" resolve="CellModel_ComponentWithParameters" />
+    </node>
+  </node>
+  <node concept="18kY7G" id="5PKDVfOoJQO">
+    <property role="TrG5h" value="check_CellModel_ComponentWithParameters" />
+    <node concept="3clFbS" id="5PKDVfOoJQP" role="18ibNy">
+      <node concept="3cpWs8" id="5PKDVfOoK5Q" role="3cqZAp">
+        <node concept="3cpWsn" id="5PKDVfOoK5R" role="3cpWs9">
+          <property role="TrG5h" value="parameters" />
+          <node concept="2I9FWS" id="5PKDVfOoK5S" role="1tU5fm">
+            <ref role="2I9WkF" to="tpee:4k3qd$cSlJ3" resolve="BaseVariableDeclaration" />
+          </node>
+          <node concept="2OqwBi" id="5PKDVfOoK5T" role="33vP2m">
+            <node concept="2OqwBi" id="5PKDVfOoK5U" role="2Oq$k0">
+              <node concept="1YBJjd" id="5PKDVfOoK5V" role="2Oq$k0">
+                <ref role="1YBMHb" node="5PKDVfOoJQR" resolve="cellModel" />
+              </node>
+              <node concept="3TrEf2" id="5PKDVfOoK5W" role="2OqNvi">
+                <ref role="3Tt5mk" to="91fu:fGPMmyn" resolve="editorComponent" />
+              </node>
+            </node>
+            <node concept="3Tsc0h" id="5PKDVfOoK5X" role="2OqNvi">
+              <ref role="3TtcxE" to="91fu:5PKDVfNY0qm" resolve="parameters" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3cpWs8" id="5PKDVfOoK5Y" role="3cqZAp">
+        <node concept="3cpWsn" id="5PKDVfOoK5Z" role="3cpWs9">
+          <property role="TrG5h" value="arguments" />
+          <node concept="2I9FWS" id="5PKDVfOoK60" role="1tU5fm">
+            <ref role="2I9WkF" to="tpee:fz3vP1J" resolve="Expression" />
+          </node>
+          <node concept="2OqwBi" id="5PKDVfOoK61" role="33vP2m">
+            <node concept="1YBJjd" id="5PKDVfOoK62" role="2Oq$k0">
+              <ref role="1YBMHb" node="5PKDVfOoJQR" resolve="cellModel" />
+            </node>
+            <node concept="3Tsc0h" id="5PKDVfOoK63" role="2OqNvi">
+              <ref role="3TtcxE" to="91fu:5PKDVfOlsvY" resolve="arguments" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbJ" id="5PKDVfOoKlH" role="3cqZAp">
+        <node concept="3clFbS" id="5PKDVfOoKlJ" role="3clFbx">
+          <node concept="2MkqsV" id="5PKDVfOoUWA" role="3cqZAp">
+            <node concept="3cpWs3" id="5PKDVfOp1G3" role="2MkJ7o">
+              <node concept="2OqwBi" id="5PKDVfOp3mY" role="3uHU7w">
+                <node concept="37vLTw" id="5PKDVfOp1HI" role="2Oq$k0">
+                  <ref role="3cqZAo" node="5PKDVfOoK5Z" resolve="arguments" />
+                </node>
+                <node concept="34oBXx" id="5PKDVfOp4I2" role="2OqNvi" />
+              </node>
+              <node concept="3cpWs3" id="5PKDVfOp1lK" role="3uHU7B">
+                <node concept="3cpWs3" id="5PKDVfOoVf0" role="3uHU7B">
+                  <node concept="Xl_RD" id="5PKDVfOoUWP" role="3uHU7B">
+                    <property role="Xl_RC" value="Expected " />
+                  </node>
+                  <node concept="2OqwBi" id="5PKDVfOoX4q" role="3uHU7w">
+                    <node concept="37vLTw" id="5PKDVfOoVfi" role="2Oq$k0">
+                      <ref role="3cqZAo" node="5PKDVfOoK5R" resolve="parameters" />
+                    </node>
+                    <node concept="34oBXx" id="5PKDVfOoYMm" role="2OqNvi" />
+                  </node>
+                </node>
+                <node concept="Xl_RD" id="5PKDVfOp1m2" role="3uHU7w">
+                  <property role="Xl_RC" value=" arguments but got " />
+                </node>
+              </node>
+            </node>
+            <node concept="1YBJjd" id="5PKDVfOp4Kl" role="1urrMF">
+              <ref role="1YBMHb" node="5PKDVfOoJQR" resolve="cellModel" />
+            </node>
+          </node>
+        </node>
+        <node concept="3y3z36" id="5PKDVfOoQVO" role="3clFbw">
+          <node concept="2OqwBi" id="5PKDVfOoT92" role="3uHU7w">
+            <node concept="37vLTw" id="5PKDVfOoRnQ" role="2Oq$k0">
+              <ref role="3cqZAo" node="5PKDVfOoK5Z" resolve="arguments" />
+            </node>
+            <node concept="34oBXx" id="5PKDVfOoUUA" role="2OqNvi" />
+          </node>
+          <node concept="2OqwBi" id="5PKDVfOoMxT" role="3uHU7B">
+            <node concept="37vLTw" id="5PKDVfOoKma" role="2Oq$k0">
+              <ref role="3cqZAo" node="5PKDVfOoK5R" resolve="parameters" />
+            </node>
+            <node concept="34oBXx" id="5PKDVfOoOfK" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1YaCAy" id="5PKDVfOoJQR" role="1YuTPh">
+      <property role="TrG5h" value="cellModel" />
+      <ref role="1YaFvo" to="91fu:5PKDVfOlrE5" resolve="CellModel_ComponentWithParameters" />
     </node>
   </node>
 </model>

--- a/code/conditional-editor/languages/de.slisson.mps.conditionalEditor/languageModels/typesystem.mps
+++ b/code/conditional-editor/languages/de.slisson.mps.conditionalEditor/languageModels/typesystem.mps
@@ -16,9 +16,17 @@
     <import index="w0gx" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.project.structure.modules(MPS.Core/)" implicit="true" />
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" implicit="true" />
     <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" implicit="true" />
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1082485599095" name="jetbrains.mps.baseLanguage.structure.BlockStatement" flags="nn" index="9aQIb">
+        <child id="1082485599096" name="statements" index="9aQI4" />
+      </concept>
+      <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
+        <child id="1068498886297" name="rValue" index="37vLTx" />
+        <child id="1068498886295" name="lValue" index="37vLTJ" />
+      </concept>
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
       <concept id="1239714755177" name="jetbrains.mps.baseLanguage.structure.AbstractUnaryNumberOperation" flags="nn" index="2$Kvd9">
         <child id="1239714902950" name="expression" index="2$L3a6" />
@@ -48,6 +56,7 @@
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
+      <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
       <concept id="1225271221393" name="jetbrains.mps.baseLanguage.structure.NPENotEqualsExpression" flags="nn" index="17QLQc" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
@@ -55,7 +64,9 @@
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
       <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
+        <child id="1082485599094" name="ifFalseStatement" index="9aQIa" />
         <child id="1068580123160" name="condition" index="3clFbw" />
         <child id="1068580123161" name="ifTrue" index="3clFbx" />
       </concept>
@@ -109,6 +120,9 @@
       <concept id="1175517767210" name="jetbrains.mps.lang.typesystem.structure.ReportErrorStatement" flags="nn" index="2MkqsV">
         <child id="1175517851849" name="errorString" index="2MkJ7o" />
       </concept>
+      <concept id="1227096620180" name="jetbrains.mps.lang.typesystem.structure.ReferenceMessageTarget" flags="ng" index="2OE7Q9">
+        <reference id="1227096645744" name="linkDeclaration" index="2OEe5H" />
+      </concept>
       <concept id="1216383170661" name="jetbrains.mps.lang.typesystem.structure.TypesystemQuickFix" flags="ng" index="Q5z_Y">
         <child id="1216383424566" name="executeBlock" index="Q6x$H" />
         <child id="1216383476350" name="quickFixArgument" index="Q6Id_" />
@@ -130,6 +144,7 @@
         <child id="2329696648448631592" name="overridenRules" index="dp_RE" />
       </concept>
       <concept id="3937244445246642777" name="jetbrains.mps.lang.typesystem.structure.AbstractReportStatement" flags="ng" index="1urrMJ">
+        <child id="3937244445246643443" name="messageTarget" index="1urrC5" />
         <child id="3937244445246643221" name="helginsIntention" index="1urrFz" />
         <child id="3937244445246642781" name="nodeToReport" index="1urrMF" />
       </concept>
@@ -162,6 +177,13 @@
       <concept id="1174663118805" name="jetbrains.mps.lang.typesystem.structure.CreateLessThanInequationStatement" flags="nn" index="1ZobV4" />
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1179168000618" name="jetbrains.mps.lang.smodel.structure.Node_GetIndexInParentOperation" flags="nn" index="2bSWHS" />
+      <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
+        <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
+      </concept>
+      <concept id="1138411891628" name="jetbrains.mps.lang.smodel.structure.SNodeOperation" flags="nn" index="eCIE_">
+        <child id="1144104376918" name="parameter" index="1xVPHs" />
+      </concept>
       <concept id="1143234257716" name="jetbrains.mps.lang.smodel.structure.Node_GetModelOperation" flags="nn" index="I4A8Y" />
       <concept id="1145383075378" name="jetbrains.mps.lang.smodel.structure.SNodeListType" flags="in" index="2I9FWS">
         <reference id="1145383142433" name="elementConcept" index="2I9WkF" />
@@ -169,8 +191,16 @@
       <concept id="1145404486709" name="jetbrains.mps.lang.smodel.structure.SemanticDowncastExpression" flags="nn" index="2JrnkZ">
         <child id="1145404616321" name="leftExpression" index="2JrQYb" />
       </concept>
+      <concept id="1171407110247" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorOperation" flags="nn" index="2Xjw5R" />
+      <concept id="1144100932627" name="jetbrains.mps.lang.smodel.structure.OperationParm_Inclusion" flags="ng" index="1xIGOp" />
+      <concept id="1144101972840" name="jetbrains.mps.lang.smodel.structure.OperationParm_Concept" flags="ng" index="1xMEDy">
+        <child id="1207343664468" name="conceptArgument" index="ri$Ld" />
+      </concept>
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
         <reference id="1138405853777" name="concept" index="ehGHo" />
+      </concept>
+      <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
+        <reference id="1138056395725" name="property" index="3TsBF5" />
       </concept>
       <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="nn" index="3TrEf2">
         <reference id="1138056516764" name="link" index="3Tt5mk" />
@@ -495,7 +525,7 @@
         <node concept="3cpWsn" id="5PKDVfOmLsb" role="3cpWs9">
           <property role="TrG5h" value="arguments" />
           <node concept="2I9FWS" id="5PKDVfOmJUC" role="1tU5fm">
-            <ref role="2I9WkF" to="tpee:fz3vP1J" resolve="Expression" />
+            <ref role="2I9WkF" to="91fu:1gBmad3Feya" resolve="ComponentArgument" />
           </node>
           <node concept="2OqwBi" id="5PKDVfOmLsc" role="33vP2m">
             <node concept="1YBJjd" id="5PKDVfOmLsd" role="2Oq$k0">
@@ -598,7 +628,7 @@
         <node concept="3cpWsn" id="5PKDVfOoK5Z" role="3cpWs9">
           <property role="TrG5h" value="arguments" />
           <node concept="2I9FWS" id="5PKDVfOoK60" role="1tU5fm">
-            <ref role="2I9WkF" to="tpee:fz3vP1J" resolve="Expression" />
+            <ref role="2I9WkF" to="91fu:1gBmad3Feya" resolve="ComponentArgument" />
           </node>
           <node concept="2OqwBi" id="5PKDVfOoK61" role="33vP2m">
             <node concept="1YBJjd" id="5PKDVfOoK62" role="2Oq$k0">
@@ -610,57 +640,337 @@
           </node>
         </node>
       </node>
-      <node concept="3clFbJ" id="5PKDVfOoKlH" role="3cqZAp">
-        <node concept="3clFbS" id="5PKDVfOoKlJ" role="3clFbx">
-          <node concept="2MkqsV" id="5PKDVfOoUWA" role="3cqZAp">
-            <node concept="3cpWs3" id="5PKDVfOp1G3" role="2MkJ7o">
-              <node concept="2OqwBi" id="5PKDVfOp3mY" role="3uHU7w">
-                <node concept="37vLTw" id="5PKDVfOp1HI" role="2Oq$k0">
+      <node concept="3clFbH" id="1gBmad3PXYH" role="3cqZAp" />
+      <node concept="3clFbJ" id="1gBmad3PY0B" role="3cqZAp">
+        <node concept="3clFbS" id="1gBmad3PY0D" role="3clFbx">
+          <node concept="2MkqsV" id="1gBmad3QaKP" role="3cqZAp">
+            <node concept="3cpWs3" id="1gBmad3QaKQ" role="2MkJ7o">
+              <node concept="2OqwBi" id="1gBmad3QaKR" role="3uHU7w">
+                <node concept="37vLTw" id="1gBmad3QaKS" role="2Oq$k0">
                   <ref role="3cqZAo" node="5PKDVfOoK5Z" resolve="arguments" />
                 </node>
-                <node concept="34oBXx" id="5PKDVfOp4I2" role="2OqNvi" />
+                <node concept="34oBXx" id="1gBmad3QaKT" role="2OqNvi" />
               </node>
-              <node concept="3cpWs3" id="5PKDVfOp1lK" role="3uHU7B">
-                <node concept="3cpWs3" id="5PKDVfOoVf0" role="3uHU7B">
-                  <node concept="Xl_RD" id="5PKDVfOoUWP" role="3uHU7B">
+              <node concept="3cpWs3" id="1gBmad3QaKU" role="3uHU7B">
+                <node concept="3cpWs3" id="1gBmad3QaKV" role="3uHU7B">
+                  <node concept="Xl_RD" id="1gBmad3QaKW" role="3uHU7B">
                     <property role="Xl_RC" value="Expected " />
                   </node>
-                  <node concept="2OqwBi" id="5PKDVfOoX4q" role="3uHU7w">
-                    <node concept="37vLTw" id="5PKDVfOoVfi" role="2Oq$k0">
+                  <node concept="2OqwBi" id="1gBmad3QaKX" role="3uHU7w">
+                    <node concept="37vLTw" id="1gBmad3QaKY" role="2Oq$k0">
                       <ref role="3cqZAo" node="5PKDVfOoK5R" resolve="parameters" />
                     </node>
-                    <node concept="34oBXx" id="5PKDVfOoYMm" role="2OqNvi" />
+                    <node concept="34oBXx" id="1gBmad3QaKZ" role="2OqNvi" />
                   </node>
                 </node>
-                <node concept="Xl_RD" id="5PKDVfOp1m2" role="3uHU7w">
+                <node concept="Xl_RD" id="1gBmad3QaL0" role="3uHU7w">
                   <property role="Xl_RC" value=" arguments but got " />
                 </node>
               </node>
             </node>
-            <node concept="1YBJjd" id="5PKDVfOp4Kl" role="1urrMF">
+            <node concept="1YBJjd" id="1gBmad3QaL3" role="1urrMF">
               <ref role="1YBMHb" node="5PKDVfOoJQR" resolve="cellModel" />
+            </node>
+            <node concept="2OE7Q9" id="1gBmad3QnNh" role="1urrC5">
+              <ref role="2OEe5H" to="91fu:fGPMmyn" resolve="editorComponent" />
             </node>
           </node>
         </node>
-        <node concept="3y3z36" id="5PKDVfOoQVO" role="3clFbw">
-          <node concept="2OqwBi" id="5PKDVfOoT92" role="3uHU7w">
-            <node concept="37vLTw" id="5PKDVfOoRnQ" role="2Oq$k0">
-              <ref role="3cqZAo" node="5PKDVfOoK5Z" resolve="arguments" />
-            </node>
-            <node concept="34oBXx" id="5PKDVfOoUUA" role="2OqNvi" />
-          </node>
-          <node concept="2OqwBi" id="5PKDVfOoMxT" role="3uHU7B">
-            <node concept="37vLTw" id="5PKDVfOoKma" role="2Oq$k0">
+        <node concept="3eOVzh" id="1gBmad3Q7IB" role="3clFbw">
+          <node concept="2OqwBi" id="1gBmad3Q8Rk" role="3uHU7w">
+            <node concept="37vLTw" id="1gBmad3Q7SI" role="2Oq$k0">
               <ref role="3cqZAo" node="5PKDVfOoK5R" resolve="parameters" />
             </node>
-            <node concept="34oBXx" id="5PKDVfOoOfK" role="2OqNvi" />
+            <node concept="34oBXx" id="1gBmad3Q9uT" role="2OqNvi" />
+          </node>
+          <node concept="2OqwBi" id="1gBmad3Q1AR" role="3uHU7B">
+            <node concept="37vLTw" id="1gBmad3PY1L" role="2Oq$k0">
+              <ref role="3cqZAo" node="5PKDVfOoK5Z" resolve="arguments" />
+            </node>
+            <node concept="34oBXx" id="1gBmad3Q490" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="9aQIb" id="1gBmad3Q9BD" role="9aQIa">
+          <node concept="3clFbS" id="1gBmad3Q9BE" role="9aQI4">
+            <node concept="1Dw8fO" id="1gBmad3NWau" role="3cqZAp">
+              <node concept="3clFbS" id="1gBmad3NWaw" role="2LFqv$">
+                <node concept="3clFbJ" id="5PKDVfOoKlH" role="3cqZAp">
+                  <node concept="3clFbS" id="5PKDVfOoKlJ" role="3clFbx">
+                    <node concept="2MkqsV" id="5PKDVfOoUWA" role="3cqZAp">
+                      <node concept="3cpWs3" id="5PKDVfOp1G3" role="2MkJ7o">
+                        <node concept="2OqwBi" id="5PKDVfOp3mY" role="3uHU7w">
+                          <node concept="37vLTw" id="5PKDVfOp1HI" role="2Oq$k0">
+                            <ref role="3cqZAo" node="5PKDVfOoK5Z" resolve="arguments" />
+                          </node>
+                          <node concept="34oBXx" id="5PKDVfOp4I2" role="2OqNvi" />
+                        </node>
+                        <node concept="3cpWs3" id="5PKDVfOp1lK" role="3uHU7B">
+                          <node concept="3cpWs3" id="5PKDVfOoVf0" role="3uHU7B">
+                            <node concept="Xl_RD" id="5PKDVfOoUWP" role="3uHU7B">
+                              <property role="Xl_RC" value="Expected " />
+                            </node>
+                            <node concept="2OqwBi" id="5PKDVfOoX4q" role="3uHU7w">
+                              <node concept="37vLTw" id="5PKDVfOoVfi" role="2Oq$k0">
+                                <ref role="3cqZAo" node="5PKDVfOoK5R" resolve="parameters" />
+                              </node>
+                              <node concept="34oBXx" id="5PKDVfOoYMm" role="2OqNvi" />
+                            </node>
+                          </node>
+                          <node concept="Xl_RD" id="5PKDVfOp1m2" role="3uHU7w">
+                            <property role="Xl_RC" value=" arguments but got " />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="2OqwBi" id="1gBmad3ObaZ" role="1urrMF">
+                        <node concept="2OqwBi" id="1gBmad3NKpc" role="2Oq$k0">
+                          <node concept="1YBJjd" id="5PKDVfOp4Kl" role="2Oq$k0">
+                            <ref role="1YBMHb" node="5PKDVfOoJQR" resolve="cellModel" />
+                          </node>
+                          <node concept="3Tsc0h" id="1gBmad3NL2v" role="2OqNvi">
+                            <ref role="3TtcxE" to="91fu:5PKDVfOlsvY" resolve="arguments" />
+                          </node>
+                        </node>
+                        <node concept="34jXtK" id="1gBmad3Oepk" role="2OqNvi">
+                          <node concept="37vLTw" id="1gBmad3OetL" role="25WWJ7">
+                            <ref role="3cqZAo" node="1gBmad3NWax" resolve="i" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3y3z36" id="5PKDVfOoQVO" role="3clFbw">
+                    <node concept="2OqwBi" id="5PKDVfOoT92" role="3uHU7w">
+                      <node concept="37vLTw" id="5PKDVfOoRnQ" role="2Oq$k0">
+                        <ref role="3cqZAo" node="5PKDVfOoK5Z" resolve="arguments" />
+                      </node>
+                      <node concept="34oBXx" id="5PKDVfOoUUA" role="2OqNvi" />
+                    </node>
+                    <node concept="2OqwBi" id="5PKDVfOoMxT" role="3uHU7B">
+                      <node concept="37vLTw" id="5PKDVfOoKma" role="2Oq$k0">
+                        <ref role="3cqZAo" node="5PKDVfOoK5R" resolve="parameters" />
+                      </node>
+                      <node concept="34oBXx" id="5PKDVfOoOfK" role="2OqNvi" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3cpWsn" id="1gBmad3NWax" role="1Duv9x">
+                <property role="TrG5h" value="i" />
+                <node concept="10Oyi0" id="1gBmad3NWbh" role="1tU5fm" />
+                <node concept="2OqwBi" id="1gBmad3NWU5" role="33vP2m">
+                  <node concept="37vLTw" id="1gBmad3NWbw" role="2Oq$k0">
+                    <ref role="3cqZAo" node="5PKDVfOoK5R" resolve="parameters" />
+                  </node>
+                  <node concept="34oBXx" id="1gBmad3NXwG" role="2OqNvi" />
+                </node>
+              </node>
+              <node concept="3eOVzh" id="1gBmad3NYn_" role="1Dwp0S">
+                <node concept="2OqwBi" id="1gBmad3O2Md" role="3uHU7w">
+                  <node concept="37vLTw" id="1gBmad3NYnQ" role="2Oq$k0">
+                    <ref role="3cqZAo" node="5PKDVfOoK5Z" resolve="arguments" />
+                  </node>
+                  <node concept="34oBXx" id="1gBmad3O5kq" role="2OqNvi" />
+                </node>
+                <node concept="37vLTw" id="1gBmad3NXxK" role="3uHU7B">
+                  <ref role="3cqZAo" node="1gBmad3NWax" resolve="i" />
+                </node>
+              </node>
+              <node concept="3uNrnE" id="1gBmad3O6gm" role="1Dwrff">
+                <node concept="37vLTw" id="1gBmad3O6go" role="2$L3a6">
+                  <ref role="3cqZAo" node="1gBmad3NWax" resolve="i" />
+                </node>
+              </node>
+            </node>
           </node>
         </node>
       </node>
+      <node concept="3clFbH" id="1gBmad3Pqii" role="3cqZAp" />
     </node>
     <node concept="1YaCAy" id="5PKDVfOoJQR" role="1YuTPh">
       <property role="TrG5h" value="cellModel" />
       <ref role="1YaFvo" to="91fu:5PKDVfOlrE5" resolve="CellModel_ComponentWithParameters" />
+    </node>
+  </node>
+  <node concept="18kY7G" id="1gBmad3OjsF">
+    <property role="TrG5h" value="check_ComponentArgument" />
+    <node concept="3clFbS" id="1gBmad3OjsG" role="18ibNy">
+      <node concept="3cpWs8" id="1gBmad3OrKu" role="3cqZAp">
+        <node concept="3cpWsn" id="1gBmad3OrKv" role="3cpWs9">
+          <property role="TrG5h" value="currentIndex" />
+          <node concept="10Oyi0" id="1gBmad3OrK0" role="1tU5fm" />
+          <node concept="2OqwBi" id="1gBmad3OrKw" role="33vP2m">
+            <node concept="1YBJjd" id="1gBmad3OrKx" role="2Oq$k0">
+              <ref role="1YBMHb" node="1gBmad3OjsI" resolve="componentArgument" />
+            </node>
+            <node concept="2bSWHS" id="1gBmad3OrKy" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbJ" id="1gBmad3OjsM" role="3cqZAp">
+        <node concept="3y3z36" id="1gBmad3Okt1" role="3clFbw">
+          <node concept="2OqwBi" id="1gBmad3OlWC" role="3uHU7w">
+            <node concept="2OqwBi" id="1gBmad3Ol7K" role="2Oq$k0">
+              <node concept="1YBJjd" id="1gBmad3OkSE" role="2Oq$k0">
+                <ref role="1YBMHb" node="1gBmad3OjsI" resolve="componentArgument" />
+              </node>
+              <node concept="3TrEf2" id="1gBmad3Ol_6" role="2OqNvi">
+                <ref role="3Tt5mk" to="91fu:1gBmad3FeJu" resolve="variable" />
+              </node>
+            </node>
+            <node concept="2bSWHS" id="1gBmad3OmsB" role="2OqNvi" />
+          </node>
+          <node concept="37vLTw" id="1gBmad3OrKz" role="3uHU7B">
+            <ref role="3cqZAo" node="1gBmad3OrKv" resolve="index" />
+          </node>
+        </node>
+        <node concept="3clFbS" id="1gBmad3OjsO" role="3clFbx">
+          <node concept="3cpWs8" id="1gBmad3OtJW" role="3cqZAp">
+            <node concept="3cpWsn" id="1gBmad3OtJX" role="3cpWs9">
+              <property role="TrG5h" value="correctVariable" />
+              <node concept="3Tqbb2" id="1gBmad3OtaC" role="1tU5fm">
+                <ref role="ehGHo" to="tpee:4k3qd$cSlJ3" resolve="BaseVariableDeclaration" />
+              </node>
+              <node concept="2OqwBi" id="1gBmad3OtJY" role="33vP2m">
+                <node concept="2OqwBi" id="1gBmad3OtJZ" role="2Oq$k0">
+                  <node concept="2OqwBi" id="1gBmad3OtK0" role="2Oq$k0">
+                    <node concept="2OqwBi" id="1gBmad3OtK1" role="2Oq$k0">
+                      <node concept="1YBJjd" id="1gBmad3OtK2" role="2Oq$k0">
+                        <ref role="1YBMHb" node="1gBmad3OjsI" resolve="componentArgument" />
+                      </node>
+                      <node concept="2Xjw5R" id="1gBmad3OtK3" role="2OqNvi">
+                        <node concept="1xMEDy" id="1gBmad3OtK4" role="1xVPHs">
+                          <node concept="chp4Y" id="1gBmad3OtK5" role="ri$Ld">
+                            <ref role="cht4Q" to="91fu:5PKDVfOlrE5" resolve="CellModel_ComponentWithParameters" />
+                          </node>
+                        </node>
+                        <node concept="1xIGOp" id="1gBmad3OtK6" role="1xVPHs" />
+                      </node>
+                    </node>
+                    <node concept="3TrEf2" id="1gBmad3OtK7" role="2OqNvi">
+                      <ref role="3Tt5mk" to="91fu:fGPMmyn" resolve="editorComponent" />
+                    </node>
+                  </node>
+                  <node concept="3Tsc0h" id="1gBmad3OtK8" role="2OqNvi">
+                    <ref role="3TtcxE" to="91fu:5PKDVfNY0qm" resolve="parameters" />
+                  </node>
+                </node>
+                <node concept="34jXtK" id="1gBmad3OtK9" role="2OqNvi">
+                  <node concept="37vLTw" id="1gBmad3OtKa" role="25WWJ7">
+                    <ref role="3cqZAo" node="1gBmad3OrKv" resolve="currentIndex" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbJ" id="1gBmad3OvDT" role="3cqZAp">
+            <node concept="3clFbS" id="1gBmad3OvDV" role="3clFbx">
+              <node concept="2MkqsV" id="1gBmad3Omtx" role="3cqZAp">
+                <node concept="3cpWs3" id="1gBmad3OmuZ" role="2MkJ7o">
+                  <node concept="2OqwBi" id="1gBmad3OxQS" role="3uHU7w">
+                    <node concept="37vLTw" id="1gBmad3OtKb" role="2Oq$k0">
+                      <ref role="3cqZAo" node="1gBmad3OtJX" resolve="correctVariable" />
+                    </node>
+                    <node concept="3TrcHB" id="1gBmad3OxSr" role="2OqNvi">
+                      <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                    </node>
+                  </node>
+                  <node concept="Xl_RD" id="1gBmad3OmtH" role="3uHU7B">
+                    <property role="Xl_RC" value="This argument must reference variable " />
+                  </node>
+                </node>
+                <node concept="1YBJjd" id="1gBmad3OxVg" role="1urrMF">
+                  <ref role="1YBMHb" node="1gBmad3OjsI" resolve="componentArgument" />
+                </node>
+                <node concept="3Cnw8n" id="1gBmad3Oz4h" role="1urrFz">
+                  <ref role="QpYPw" node="1gBmad3OxZf" resolve="ReferenceCorrectVariableInComponentArgument" />
+                  <node concept="3CnSsL" id="1gBmad3OzII" role="3Coj4f">
+                    <ref role="QkamJ" node="1gBmad3OxZN" resolve="argument" />
+                    <node concept="1YBJjd" id="1gBmad3OzLF" role="3CoRuB">
+                      <ref role="1YBMHb" node="1gBmad3OjsI" resolve="componentArgument" />
+                    </node>
+                  </node>
+                  <node concept="3CnSsL" id="1gBmad3OzLc" role="3Coj4f">
+                    <ref role="QkamJ" node="1gBmad3OxZ$" resolve="variable" />
+                    <node concept="37vLTw" id="1gBmad3O$vB" role="3CoRuB">
+                      <ref role="3cqZAo" node="1gBmad3OtJX" resolve="correctVariable" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="17QLQc" id="1gBmad3OvKw" role="3clFbw">
+              <node concept="37vLTw" id="1gBmad3Ownz" role="3uHU7w">
+                <ref role="3cqZAo" node="1gBmad3OtJX" resolve="correctVariable" />
+              </node>
+              <node concept="2OqwBi" id="1gBmad3Ox6x" role="3uHU7B">
+                <node concept="1YBJjd" id="1gBmad3OvEv" role="2Oq$k0">
+                  <ref role="1YBMHb" node="1gBmad3OjsI" resolve="componentArgument" />
+                </node>
+                <node concept="3TrEf2" id="1gBmad3OxaD" role="2OqNvi">
+                  <ref role="3Tt5mk" to="91fu:1gBmad3FeJu" resolve="variable" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1YaCAy" id="1gBmad3OjsI" role="1YuTPh">
+      <property role="TrG5h" value="componentArgument" />
+      <ref role="1YaFvo" to="91fu:1gBmad3Feya" resolve="ComponentArgument" />
+    </node>
+  </node>
+  <node concept="Q5z_Y" id="1gBmad3OxZf">
+    <property role="TrG5h" value="ReferenceCorrectVariableInComponentArgument" />
+    <node concept="Q6JDH" id="1gBmad3OxZN" role="Q6Id_">
+      <property role="TrG5h" value="argument" />
+      <node concept="3Tqbb2" id="1gBmad3OxZV" role="Q6QK4">
+        <ref role="ehGHo" to="91fu:1gBmad3Feya" resolve="ComponentArgument" />
+      </node>
+    </node>
+    <node concept="Q6JDH" id="1gBmad3OxZ$" role="Q6Id_">
+      <property role="TrG5h" value="variable" />
+      <node concept="3Tqbb2" id="1gBmad3OxZE" role="Q6QK4">
+        <ref role="ehGHo" to="tpee:4k3qd$cSlJ3" resolve="BaseVariableDeclaration" />
+      </node>
+    </node>
+    <node concept="Q5ZZ6" id="1gBmad3OxZg" role="Q6x$H">
+      <node concept="3clFbS" id="1gBmad3OxZh" role="2VODD2">
+        <node concept="3clFbF" id="1gBmad3OI0s" role="3cqZAp">
+          <node concept="37vLTI" id="1gBmad3OIda" role="3clFbG">
+            <node concept="QwW4i" id="1gBmad3OIga" role="37vLTx">
+              <ref role="QwW4h" node="1gBmad3OxZ$" resolve="variable" />
+            </node>
+            <node concept="2OqwBi" id="1gBmad3OI3z" role="37vLTJ">
+              <node concept="QwW4i" id="1gBmad3OI0r" role="2Oq$k0">
+                <ref role="QwW4h" node="1gBmad3OxZN" resolve="argument" />
+              </node>
+              <node concept="3TrEf2" id="1gBmad3OI5H" role="2OqNvi">
+                <ref role="3Tt5mk" to="91fu:1gBmad3FeJu" resolve="variable" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="QznSV" id="1gBmad3Oy04" role="QzAvj">
+      <node concept="3clFbS" id="1gBmad3Oy05" role="2VODD2">
+        <node concept="3clFbF" id="1gBmad3Oy0a" role="3cqZAp">
+          <node concept="3cpWs3" id="1gBmad3Oyac" role="3clFbG">
+            <node concept="2OqwBi" id="1gBmad3Oyqn" role="3uHU7w">
+              <node concept="QwW4i" id="1gBmad3Oyf6" role="2Oq$k0">
+                <ref role="QwW4h" node="1gBmad3OxZ$" resolve="variable" />
+              </node>
+              <node concept="3TrcHB" id="1gBmad3Oywt" role="2OqNvi">
+                <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+              </node>
+            </node>
+            <node concept="Xl_RD" id="1gBmad3Oy09" role="3uHU7B">
+              <property role="Xl_RC" value="Reference " />
+            </node>
+          </node>
+        </node>
+      </node>
     </node>
   </node>
 </model>

--- a/code/conditional-editor/solutions/de.slisson.mps.conditionalEditor.sandbox/models/de/slisson/mps/conditionalEditor/sandbox.mps
+++ b/code/conditional-editor/solutions/de.slisson.mps.conditionalEditor.sandbox/models/de/slisson/mps/conditionalEditor/sandbox.mps
@@ -174,7 +174,11 @@
     </node>
     <node concept="3Tm1VV" id="2vJRo8gBQdq" role="1B3o_S" />
   </node>
-  <node concept="2IymN2" id="5PKDVfOfiLR" />
-  <node concept="2IymN1" id="5PKDVfOrikW" />
+  <node concept="2IymN2" id="5PKDVfOfiLR">
+    <property role="TrG5h" value="ANode" />
+  </node>
+  <node concept="2IymN1" id="5PKDVfOrikW">
+    <property role="TrG5h" value="BNode" />
+  </node>
 </model>
 

--- a/code/conditional-editor/solutions/de.slisson.mps.conditionalEditor.sandbox/models/de/slisson/mps/conditionalEditor/sandbox.mps
+++ b/code/conditional-editor/solutions/de.slisson.mps.conditionalEditor.sandbox/models/de/slisson/mps/conditionalEditor/sandbox.mps
@@ -91,6 +91,8 @@
       </concept>
     </language>
     <language id="1831633c-aea1-4345-beff-4a6e7fb4f813" name="de.slisson.mps.conditionalEditor.demolang">
+      <concept id="6733065834253110130" name="de.slisson.mps.conditionalEditor.demolang.structure.B" flags="ng" index="2IymN1" />
+      <concept id="6733065834253110129" name="de.slisson.mps.conditionalEditor.demolang.structure.A" flags="ng" index="2IymN2" />
       <concept id="7172636034965390688" name="de.slisson.mps.conditionalEditor.demolang.structure.ExpressionWithInspector" flags="ng" index="3kNhso" />
     </language>
   </registry>
@@ -172,5 +174,7 @@
     </node>
     <node concept="3Tm1VV" id="2vJRo8gBQdq" role="1B3o_S" />
   </node>
+  <node concept="2IymN2" id="5PKDVfOfiLR" />
+  <node concept="2IymN1" id="5PKDVfOrikW" />
 </model>
 


### PR DESCRIPTION
The parameter information is saved in the user object of the node instead of the root editor cell. The reason is that on first editor creation, this information can't be accessed.

For updated screenshots: see last answer

# Example

## Declaration

<img width="100" alt="image" src="https://github.com/JetBrains/MPS-extensions/assets/88385944/d14359eb-f3fa-46b2-b57a-7825ea3dd38e">

<img width="100" alt="image" src="https://github.com/JetBrains/MPS-extensions/assets/88385944/5136bd38-c4da-4d0f-b2f5-2e607b955965">

## Usage

<img width="100" alt="image" src="https://github.com/JetBrains/MPS-extensions/assets/88385944/6c37b58d-6943-4f99-8908-a02e2e6697ba">
