### PR TITLE
MPS.Thirdparty: Fixed classloading issue due to wrong packaging 

### DIFF
--- a/code/.mps/modules.xml
+++ b/code/.mps/modules.xml
@@ -192,6 +192,7 @@
       <modulePath path="$PROJECT_DIR$/tables/solutions/de.slisson.mps.testutils/de.slisson.mps.testutils.msd" folder="tables" />
       <modulePath path="$PROJECT_DIR$/tables/solutions/test.de.slisson.mps.tables/test.de.slisson.mps.tables.msd" folder="tables" />
       <modulePath path="$PROJECT_DIR$/third-party/solutions/MPS.ThirdParty/MPS.ThirdParty.msd" folder="3rd-party" />
+      <modulePath path="$PROJECT_DIR$/third-party/solutions/third.party.usage.test/third.party.usage.test.msd" folder="" />
       <modulePath path="$PROJECT_DIR$/tooltips/solutions/de.itemis.mps.tooltips.runtime/de.itemis.mps.tooltips.runtime.msd" folder="tooltips" />
       <modulePath path="$PROJECT_DIR$/treenotation/com.mbeddr.mpsutil.treenotation.runtime/com.mbeddr.mpsutil.treenotation.runtime.msd" folder="treenotation" />
       <modulePath path="$PROJECT_DIR$/treenotation/com.mbeddr.mpsutil.treenotation.sandbox/com.mbeddr.mpsutil.treenotation.sandbox.msd" folder="treenotation" />

--- a/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
+++ b/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
@@ -167,7 +167,6 @@
       </concept>
       <concept id="1265949165890536423" name="jetbrains.mps.build.mps.structure.BuildMpsLayout_ModuleJars" flags="ng" index="L2wRC">
         <reference id="1265949165890536425" name="module" index="L2wRA" />
-        <child id="4356762679305730677" name="jarLocations" index="3yL2VB" />
       </concept>
       <concept id="8971171305100238972" name="jetbrains.mps.build.mps.structure.BuildMps_ModuleDependencyTargetLanguage" flags="ng" index="Rbm2T">
         <reference id="3189788309731922643" name="language" index="1E1Vl2" />
@@ -193,10 +192,6 @@
         <property id="6535001758416941941" name="createStaticRefs" index="3Ej$Sc" />
       </concept>
       <concept id="5507251971038816436" name="jetbrains.mps.build.mps.structure.BuildMps_Generator" flags="ng" index="1yeLz9" />
-      <concept id="4356762679305675652" name="jetbrains.mps.build.mps.structure.BuildMpsLayout_ModuleXml_CustomJarLocation" flags="ng" index="3yLZsm">
-        <property id="4356762679305675654" name="packagedLocation" index="3yLZsk" />
-        <child id="4356762679305675653" name="path" index="3yLZsn" />
-      </concept>
       <concept id="4278635856200817744" name="jetbrains.mps.build.mps.structure.BuildMps_ModuleModelRoot" flags="ng" index="1BupzO">
         <property id="8137134783396907368" name="convert2binary" index="1Hdu6h" />
         <property id="8137134783396676838" name="extracted" index="1HemKv" />
@@ -14872,15 +14867,38 @@
       <node concept="m$_wl" id="2Y$Ewq9ERUo" role="39821P">
         <ref role="m_rDy" node="3$A0JaN5ezp" resolve="MPS.ThirdParty" />
         <node concept="398223" id="6_UytVTj6iE" role="39821P">
-          <node concept="L2wRC" id="2Y$Ewq9F85p" role="39821P">
-            <ref role="L2wRA" node="3$A0JaN5bpX" resolve="MPS.ThirdParty" />
-            <node concept="3yLZsm" id="2Y$Ewq9F85q" role="3yL2VB">
-              <property role="3yLZsk" value="${platform_lib}/app.jar" />
-              <node concept="398BVA" id="2Y$Ewq9F85r" role="3yLZsn">
-                <ref role="398BVh" node="5Ngh5kRcxhz" resolve="platform_lib" />
-                <node concept="2Ry0Ak" id="2Y$Ewq9F85s" role="iGT6I">
-                  <property role="2Ry0Am" value="app.jar" />
+          <node concept="3981dx" id="6dIEilsfE9K" role="39821P">
+            <node concept="398223" id="6dIEilsfEtK" role="39821P">
+              <node concept="398223" id="6dIEilsjMqT" role="39821P">
+                <node concept="3_J27D" id="6dIEilsjMqV" role="Nbhlr">
+                  <node concept="3Mxwew" id="6dIEilsjMxC" role="3MwsjC">
+                    <property role="3MwjfP" value="MPS.ThirdParty" />
+                  </node>
                 </node>
+                <node concept="2HvfSZ" id="6dIEilsfEYU" role="39821P">
+                  <node concept="398BVA" id="6dIEilsfF5A" role="2HvfZ0">
+                    <ref role="398BVh" node="2fo8bJE$D4t" resolve="extensions.code" />
+                    <node concept="2Ry0Ak" id="6dIEilsfFcg" role="iGT6I">
+                      <property role="2Ry0Am" value="third-party" />
+                      <node concept="2Ry0Ak" id="6dIEilsfFcl" role="2Ry0An">
+                        <property role="2Ry0Am" value="solutions" />
+                        <node concept="2Ry0Ak" id="6dIEilsfFcq" role="2Ry0An">
+                          <property role="2Ry0Am" value="MPS.ThirdParty" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3_J27D" id="6dIEilsfEtM" role="Nbhlr">
+                <node concept="3Mxwew" id="6dIEilsfE$u" role="3MwsjC">
+                  <property role="3MwjfP" value="modules" />
+                </node>
+              </node>
+            </node>
+            <node concept="3_J27D" id="6dIEilsfE9M" role="Nbhlr">
+              <node concept="3Mxwew" id="6dIEilsfEgu" role="3MwsjC">
+                <property role="3MwjfP" value="MPS.ThirdParty.jar" />
               </node>
             </node>
           </node>

--- a/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
+++ b/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
@@ -107,6 +107,9 @@
       <concept id="4701820937132344003" name="jetbrains.mps.build.structure.BuildLayout_Container" flags="ng" index="1y1bJS">
         <child id="7389400916848037006" name="children" index="39821P" />
       </concept>
+      <concept id="5610619299014309452" name="jetbrains.mps.build.structure.BuildSource_JavaExternalJarRef" flags="ng" index="3yrxFa">
+        <reference id="5610619299014309453" name="jar" index="3yrxFb" />
+      </concept>
       <concept id="841011766566059607" name="jetbrains.mps.build.structure.BuildStringNotEmpty" flags="ng" index="3_J27D" />
       <concept id="5248329904287794596" name="jetbrains.mps.build.structure.BuildInputFiles" flags="ng" index="3LXTmp">
         <child id="5248329904287794598" name="dir" index="3LXTmr" />
@@ -201,6 +204,7 @@
         <child id="8137134783396676835" name="location" index="1HemKq" />
       </concept>
       <concept id="4278635856200826393" name="jetbrains.mps.build.mps.structure.BuildMps_ModuleDependencyJar" flags="ng" index="1BurEX">
+        <child id="2798275735916344703" name="customLocation" index="2gdwQb" />
         <child id="4278635856200826394" name="path" index="1BurEY" />
       </concept>
       <concept id="4278635856200794926" name="jetbrains.mps.build.mps.structure.BuildMps_ModuleDependencyExtendLanguage" flags="ng" index="1Busua">
@@ -912,10 +916,10 @@
     <node concept="2G$12M" id="3$A0JaN5ae8" role="3989C9">
       <property role="TrG5h" value="third-party" />
       <node concept="1E1JtA" id="3$A0JaN5bpX" role="2G$12L">
-        <property role="BnDLt" value="true" />
         <property role="TrG5h" value="MPS.ThirdParty" />
         <property role="3LESm3" value="39983771-4e9b-401b-a1a9-1da6c777c843" />
         <property role="2GAjPV" value="true" />
+        <property role="BnDLt" value="true" />
         <node concept="398BVA" id="3$A0JaN5bwY" role="3LF7KH">
           <ref role="398BVh" node="2fo8bJE$D4t" resolve="extensions.code" />
           <node concept="2Ry0Ak" id="3$A0JaN5chM" role="iGT6I">
@@ -952,6 +956,19 @@
                   </node>
                 </node>
               </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="28qbqxxOALs" role="3bR37C">
+          <node concept="1BurEX" id="28qbqxxOALt" role="1SiIV1">
+            <node concept="398BVA" id="28qbqxxOALn" role="1BurEY">
+              <ref role="398BVh" node="5Ngh5kRcxhz" resolve="platform_lib" />
+              <node concept="2Ry0Ak" id="28qbqxxOALo" role="iGT6I">
+                <property role="2Ry0Am" value="app.jar" />
+              </node>
+            </node>
+            <node concept="3yrxFa" id="56z5W63g4Cc" role="2gdwQb">
+              <ref role="3yrxFb" to="ffeo:4LdE6kxkp0J" />
             </node>
           </node>
         </node>
@@ -13439,11 +13456,6 @@
         <node concept="1E0d5M" id="52ZF9D3h0uS" role="1E1XAP">
           <ref role="1E0d5P" node="52ZF9D3gLhJ" resolve="com.mbeddr.mpsutil.modellisteners.runtime" />
         </node>
-        <node concept="1SiIV0" id="52ZF9D3h0uT" role="3bR37C">
-          <node concept="1Busua" id="52ZF9D3h0uU" role="1SiIV1">
-            <ref role="1Busuk" to="ffeo:7Kfy9QB6LaO" resolve="jetbrains.mps.lang.structure" />
-          </node>
-        </node>
         <node concept="1yeLz9" id="52ZF9D3h0uV" role="1TViLv">
           <property role="TrG5h" value="com.mbeddr.mpsutil.modellisteners#5818559022136673503" />
           <property role="3LESm3" value="37132e31-f64c-4798-8f65-d49942f5121d" />
@@ -13482,6 +13494,11 @@
                 <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
               </node>
             </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="52ZF9D3h0uT" role="3bR37C">
+          <node concept="1Busua" id="52ZF9D3h0uU" role="1SiIV1">
+            <ref role="1Busuk" to="ffeo:7Kfy9QB6LaO" resolve="jetbrains.mps.lang.structure" />
           </node>
         </node>
         <node concept="1SiIV0" id="3AI_UIpOEou" role="3bR37C">
@@ -15249,6 +15266,53 @@
       <property role="1wNuhe" value="true" />
       <property role="1wNuhh" value="16" />
       <property role="1wOHq$" value="true" />
+    </node>
+    <node concept="2G$12M" id="6wECU8wtgAW" role="3989C9">
+      <property role="TrG5h" value="mps-thirdparty-classloading" />
+      <node concept="1E1JtA" id="6wECU8wth18" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="third.party.usage.test" />
+        <property role="3LESm3" value="0cca457a-289f-4811-b49b-c3b096dbf72a" />
+        <node concept="398BVA" id="6wECU8wth2R" role="3LF7KH">
+          <ref role="398BVh" node="6wECU8wth1R" resolve="thirdPartyUsage.home" />
+          <node concept="2Ry0Ak" id="6wECU8wth2X" role="iGT6I">
+            <property role="2Ry0Am" value="solutions" />
+            <node concept="2Ry0Ak" id="6wECU8wth32" role="2Ry0An">
+              <property role="2Ry0Am" value="third.party.usage.test" />
+              <node concept="2Ry0Ak" id="6wECU8wth37" role="2Ry0An">
+                <property role="2Ry0Am" value="third.party.usage.test.msd" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="6wECU8wth39" role="3bR37C">
+          <node concept="3bR9La" id="6wECU8wth3a" role="1SiIV1">
+            <ref role="3bR37D" node="3$A0JaN5bpX" resolve="MPS.ThirdParty" />
+          </node>
+        </node>
+        <node concept="1BupzO" id="6wECU8wth3w" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="6wECU8wth3x" role="1HemKq">
+            <node concept="398BVA" id="6wECU8wth3b" role="3LXTmr">
+              <ref role="398BVh" node="6wECU8wth1R" resolve="thirdPartyUsage.home" />
+              <node concept="2Ry0Ak" id="6wECU8wth3c" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="6wECU8wth3d" role="2Ry0An">
+                  <property role="2Ry0Am" value="third.party.usage.test" />
+                  <node concept="2Ry0Ak" id="6wECU8wth3e" role="2Ry0An">
+                    <property role="2Ry0Am" value="models" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="6wECU8wth3y" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+      </node>
     </node>
     <node concept="2G$12M" id="6$6tsX_CIRQ" role="3989C9">
       <property role="TrG5h" value="de.slisson.mps.all.tests" />
@@ -20241,6 +20305,16 @@
         </node>
       </node>
     </node>
+    <node concept="398rNT" id="6wECU8wth1R" role="1l3spd">
+      <property role="TrG5h" value="thirdPartyUsage.home" />
+      <node concept="398BVA" id="6wECU8wth2z" role="398pKh">
+        <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+        <node concept="2Ry0Ak" id="6wECU8wth2C" role="iGT6I">
+          <property role="2Ry0Am" value="third-party" />
+          <node concept="2Ry0Ak" id="6wECU8wth2H" role="2Ry0An" />
+        </node>
+      </node>
+    </node>
     <node concept="398rNT" id="6$6tsX_CF7m" role="1l3spd">
       <property role="TrG5h" value="diagram.home" />
       <node concept="398BVA" id="1QLFoGON23R" role="398pKh">
@@ -20469,6 +20543,9 @@
       </node>
       <node concept="L2wRC" id="7NiuBZ$i0Mf" role="39821P">
         <ref role="L2wRA" node="7NiuBZ$i0jE" resolve="de.itemis.mps.editor.pagination.test" />
+      </node>
+      <node concept="L2wRC" id="6wECU8wthq9" role="39821P">
+        <ref role="L2wRA" node="6wECU8wth18" resolve="third.party.usage.test" />
       </node>
     </node>
     <node concept="22LTRH" id="6yXTMcTWb7V" role="1hWBAP">

--- a/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
+++ b/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
@@ -935,11 +935,6 @@
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="qsyhYeUL3T" role="3bR37C">
-          <node concept="3bR9La" id="qsyhYeUL3U" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
-          </node>
-        </node>
         <node concept="3rtmxn" id="7LJ_vJOlQ5R" role="3bR31x">
           <node concept="3LXTmp" id="7LJ_vJOlQ5S" role="3rtmxm">
             <node concept="3qWCbU" id="7LJ_vJOlQ5T" role="3LXTna">
@@ -959,15 +954,21 @@
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="28qbqxxOALs" role="3bR37C">
-          <node concept="1BurEX" id="28qbqxxOALt" role="1SiIV1">
-            <node concept="398BVA" id="28qbqxxOALn" role="1BurEY">
+        <node concept="1SiIV0" id="6U$p2g0plT7" role="3bR37C">
+          <node concept="3bR9La" id="6U$p2g0plT8" role="1SiIV1">
+            <property role="3bR36h" value="true" />
+            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="39MFrfLw32H" role="3bR37C">
+          <node concept="1BurEX" id="39MFrfLw3d2" role="1SiIV1">
+            <node concept="398BVA" id="39MFrfLw3nl" role="1BurEY">
               <ref role="398BVh" node="5Ngh5kRcxhz" resolve="platform_lib" />
-              <node concept="2Ry0Ak" id="28qbqxxOALo" role="iGT6I">
+              <node concept="2Ry0Ak" id="1w78goyRUDB" role="iGT6I">
                 <property role="2Ry0Am" value="app.jar" />
               </node>
             </node>
-            <node concept="3yrxFa" id="56z5W63g4Cc" role="2gdwQb">
+            <node concept="3yrxFa" id="39MFrfLw4kI" role="2gdwQb">
               <ref role="3yrxFb" to="ffeo:4LdE6kxkp0J" />
             </node>
           </node>

--- a/code/third-party/solutions/MPS.ThirdParty/MPS.ThirdParty.msd
+++ b/code/third-party/solutions/MPS.ThirdParty/MPS.ThirdParty.msd
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<solution name="MPS.ThirdParty" uuid="39983771-4e9b-401b-a1a9-1da6c777c843" moduleVersion="0" compileInMPS="true">
+<solution name="MPS.ThirdParty" uuid="39983771-4e9b-401b-a1a9-1da6c777c843" moduleVersion="0" compileInMPS="false">
   <models>
     <modelRoot contentPath="${platform_lib}" type="java_classes">
       <sourceRoot location="app.jar" />
     </modelRoot>
   </models>
   <facets>
-    <facet type="java" languageLevel="JAVA_8">
-      <classes generated="true" path="${module}/classes_gen" />
+    <facet type="java">
+      <classes generated="true" />
     </facet>
     <facet pluginId="com.intellij" type="ideaPlugin" />
   </facets>
@@ -16,7 +16,7 @@
   </stubModelEntries>
   <sourcePath />
   <dependencies>
-    <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
+    <dependency reexport="true">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />

--- a/code/third-party/solutions/third.party.usage.test/models/third.party.usage.test.mdl.mps
+++ b/code/third-party/solutions/third.party.usage.test/models/third.party.usage.test.mdl.mps
@@ -9,7 +9,6 @@
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
-      <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
       <concept id="1068390468200" name="jetbrains.mps.baseLanguage.structure.FieldDeclaration" flags="ig" index="312cEg" />
       <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
@@ -17,6 +16,9 @@
       </concept>
       <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
         <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
+      </concept>
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+        <reference id="1107535924139" name="classifier" index="3uigEE" />
       </concept>
       <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
@@ -34,7 +36,9 @@
     <node concept="312cEg" id="6wECU8wtfTh" role="jymVt">
       <property role="TrG5h" value="jacksonStuff" />
       <node concept="3Tm1VV" id="6wECU8wtfSU" role="1B3o_S" />
-      <node concept="10Oyi0" id="6wECU8wtfT7" role="1tU5fm" />
+      <node concept="3uibUv" id="6yNnJSJYgI_" role="1tU5fm">
+        <ref role="3uigEE" to="lhlt:~ArrayNode" resolve="ArrayNode" />
+      </node>
     </node>
     <node concept="3Tm1VV" id="6wECU8wtfQI" role="1B3o_S" />
   </node>

--- a/code/third-party/solutions/third.party.usage.test/models/third.party.usage.test.mdl.mps
+++ b/code/third-party/solutions/third.party.usage.test/models/third.party.usage.test.mdl.mps
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:e2a5f29f-8449-40b5-9681-ed0c6911b475(third.party.usage.test.mdl)">
+  <persistence version="9" />
+  <languages>
+    <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
+  </languages>
+  <imports>
+    <import index="lhlt" ref="39983771-4e9b-401b-a1a9-1da6c777c843/java:com.fasterxml.jackson.databind.node(MPS.ThirdParty/)" />
+  </imports>
+  <registry>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
+      <concept id="1068390468200" name="jetbrains.mps.baseLanguage.structure.FieldDeclaration" flags="ig" index="312cEg" />
+      <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu" />
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
+        <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
+      </concept>
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
+        <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="312cEu" id="6wECU8wtfQH">
+    <property role="TrG5h" value="UseStuffFromAppJar" />
+    <node concept="312cEg" id="6wECU8wtfTh" role="jymVt">
+      <property role="TrG5h" value="jacksonStuff" />
+      <node concept="3Tm1VV" id="6wECU8wtfSU" role="1B3o_S" />
+      <node concept="10Oyi0" id="6wECU8wtfT7" role="1tU5fm" />
+    </node>
+    <node concept="3Tm1VV" id="6wECU8wtfQI" role="1B3o_S" />
+  </node>
+</model>
+

--- a/code/third-party/solutions/third.party.usage.test/third.party.usage.test.msd
+++ b/code/third-party/solutions/third.party.usage.test/third.party.usage.test.msd
@@ -1,32 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<solution name="MPS.ThirdParty" uuid="39983771-4e9b-401b-a1a9-1da6c777c843" moduleVersion="0" compileInMPS="true">
+<solution name="third.party.usage.test" uuid="0cca457a-289f-4811-b49b-c3b096dbf72a" moduleVersion="0" compileInMPS="true">
   <models>
-    <modelRoot contentPath="${platform_lib}" type="java_classes">
-      <sourceRoot location="app.jar" />
+    <modelRoot contentPath="${module}" type="default">
+      <sourceRoot location="models" />
     </modelRoot>
   </models>
   <facets>
-    <facet type="java" languageLevel="JAVA_8">
+    <facet type="java">
       <classes generated="true" path="${module}/classes_gen" />
     </facet>
-    <facet pluginId="com.intellij" type="ideaPlugin" />
   </facets>
-  <stubModelEntries>
-    <stubModelEntry path="${platform_lib}/app.jar" />
-  </stubModelEntries>
   <sourcePath />
   <dependencies>
-    <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
+    <dependency reexport="false">39983771-4e9b-401b-a1a9-1da6c777c843(MPS.ThirdParty)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
-    <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
     <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
   </languageVersions>
   <dependencyVersions>
-    <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
     <module reference="39983771-4e9b-401b-a1a9-1da6c777c843(MPS.ThirdParty)" version="0" />
+    <module reference="0cca457a-289f-4811-b49b-c3b096dbf72a(third.party.usage.test)" version="0" />
   </dependencyVersions>
 </solution>
 


### PR DESCRIPTION
This PR fixes #789 

The changes made, are based on the  current module properties configuration and packaging of the JAXB module solution. 

**Changes are**
- MPS.Thirdparty is confiured as an intellij plugin with the id `"com.intellij"`
- stubModelEntry and modelRoot are resolved via the `${platform_lib}` path
- Packaging was done the same way it is done for [JAXB](http://127.0.0.1:63320/node?ref=r%3A874d959d-e3b4-4d04-b931-ca849af130dd%28jetbrains.mps.ide.build%29%2F7972607346140852471)


**Simple Test**
- in addition I've added a simple test scenario
- We now have solution that uses some BL classes provided by MPS.Thirdparty
- This solution is part of the test build conflig and should be generated and compiled during CL build
- in case we have classloading issues, its compilation will fail