### PR TITLE
Set the the read-only flag in all property cell providers if the model is null

### DIFF
--- a/code/grammarcells/solutions/com.mbeddr.mpsutil.grammarcells.runtime/models/com/mbeddr/mpsutil/grammarcells/runtime.mps
+++ b/code/grammarcells/solutions/com.mbeddr.mpsutil.grammarcells.runtime/models/com/mbeddr/mpsutil/grammarcells/runtime.mps
@@ -315,6 +315,7 @@
         <child id="8276990574895933173" name="catchBody" index="1zc67A" />
         <child id="8276990574895933172" name="throwable" index="1zc67B" />
       </concept>
+      <concept id="7024111702304501416" name="jetbrains.mps.baseLanguage.structure.OrAssignmentExpression" flags="nn" index="3vZ8r8" />
       <concept id="8276990574909231788" name="jetbrains.mps.baseLanguage.structure.FinallyClause" flags="ng" index="1wplmZ">
         <child id="8276990574909234106" name="finallyBody" index="1wplMD" />
       </concept>
@@ -25472,6 +25473,24 @@
         </node>
       </node>
       <node concept="3clFbS" id="3pFNVizDMw4" role="3clF47">
+        <node concept="3clFbF" id="6zwr99Mojd_" role="3cqZAp">
+          <node concept="3vZ8r8" id="6zwr99MojXL" role="3clFbG">
+            <node concept="3clFbC" id="6zwr99MomH6" role="37vLTx">
+              <node concept="10Nm6u" id="6zwr99Monf8" role="3uHU7w" />
+              <node concept="2OqwBi" id="6zwr99Mom4e" role="3uHU7B">
+                <node concept="1rXfSq" id="6zwr99MolmY" role="2Oq$k0">
+                  <ref role="37wK5l" to="exr9:~AbstractCellProvider.getSNode()" resolve="getSNode" />
+                </node>
+                <node concept="liA8E" id="6zwr99Momq3" role="2OqNvi">
+                  <ref role="37wK5l" to="mhbf:~SNode.getModel()" resolve="getModel" />
+                </node>
+              </node>
+            </node>
+            <node concept="37vLTw" id="6zwr99Mojdz" role="37vLTJ">
+              <ref role="3cqZAo" to="emqf:~CellProviderWithRole.myReadOnly" resolve="myReadOnly" />
+            </node>
+          </node>
+        </node>
         <node concept="3cpWs8" id="3pFNVizDM$r" role="3cqZAp">
           <node concept="3cpWsn" id="3pFNVizDM$q" role="3cpWs9">
             <property role="3TUv4t" value="false" />

--- a/code/multiline/solutions/de.slisson.mps.editor.multiline.runtime/models/de/slisson/mps/editor/multiline/cellProviders.mps
+++ b/code/multiline/solutions/de.slisson.mps.editor.multiline.runtime/models/de/slisson/mps/editor/multiline/cellProviders.mps
@@ -14,9 +14,14 @@
     <import index="cj4x" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor(MPS.Editor/)" />
     <import index="p9jd" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.lang.editor.cellProviders(MPS.Editor/)" />
     <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" />
+    <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
+        <child id="1068498886297" name="rValue" index="37vLTx" />
+        <child id="1068498886295" name="lValue" index="37vLTJ" />
+      </concept>
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
@@ -53,9 +58,11 @@
       <concept id="1068580123165" name="jetbrains.mps.baseLanguage.structure.InstanceMethodDeclaration" flags="ig" index="3clFb_">
         <property id="1178608670077" name="isAbstract" index="1EzhhJ" />
       </concept>
+      <concept id="1068580123152" name="jetbrains.mps.baseLanguage.structure.EqualsExpression" flags="nn" index="3clFbC" />
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
@@ -80,6 +87,11 @@
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
       </concept>
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
+        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
+        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
+      </concept>
+      <concept id="7024111702304501416" name="jetbrains.mps.baseLanguage.structure.OrAssignmentExpression" flags="nn" index="3vZ8r8" />
       <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
@@ -163,6 +175,25 @@
         </node>
       </node>
       <node concept="3clFbS" id="7Pi_Fu5SfIA" role="3clF47">
+        <node concept="3clFbF" id="6zwr99Mojd_" role="3cqZAp">
+          <node concept="3vZ8r8" id="6zwr99MojXL" role="3clFbG">
+            <node concept="3clFbC" id="6zwr99MomH6" role="37vLTx">
+              <node concept="10Nm6u" id="6zwr99Monf8" role="3uHU7w" />
+              <node concept="2OqwBi" id="6zwr99Mom4e" role="3uHU7B">
+                <node concept="1rXfSq" id="6zwr99MolmY" role="2Oq$k0">
+                  <ref role="37wK5l" to="exr9:~AbstractCellProvider.getSNode()" resolve="getSNode" />
+                </node>
+                <node concept="liA8E" id="6zwr99Momq3" role="2OqNvi">
+                  <ref role="37wK5l" to="mhbf:~SNode.getModel()" resolve="getModel" />
+                </node>
+              </node>
+            </node>
+            <node concept="37vLTw" id="6zwr99Mojdz" role="37vLTJ">
+              <ref role="3cqZAo" to="emqf:~CellProviderWithRole.myReadOnly" resolve="myReadOnly" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6zwr99Mqjm2" role="3cqZAp" />
         <node concept="3cpWs8" id="7Pi_Fu5Sqnd" role="3cqZAp">
           <node concept="3cpWsn" id="7Pi_Fu5Sqne" role="3cpWs9">
             <property role="TrG5h" value="propertyAccessor" />

--- a/code/widgets/languages/de.itemis.mps.editor.enumeration/runtime/models/de.itemis.mps.editor.enumeration.runtime.mps
+++ b/code/widgets/languages/de.itemis.mps.editor.enumeration/runtime/models/de.itemis.mps.editor.enumeration.runtime.mps
@@ -202,6 +202,7 @@
         <child id="8276990574895933173" name="catchBody" index="1zc67A" />
         <child id="8276990574895933172" name="throwable" index="1zc67B" />
       </concept>
+      <concept id="7024111702304501416" name="jetbrains.mps.baseLanguage.structure.OrAssignmentExpression" flags="nn" index="3vZ8r8" />
       <concept id="8276990574909231788" name="jetbrains.mps.baseLanguage.structure.FinallyClause" flags="ng" index="1wplmZ">
         <child id="8276990574909234106" name="finallyBody" index="1wplMD" />
       </concept>
@@ -3210,6 +3211,25 @@
         </node>
       </node>
       <node concept="3clFbS" id="4g2H4r3Ws9o" role="3clF47">
+        <node concept="3clFbF" id="6zwr99Mojd_" role="3cqZAp">
+          <node concept="3vZ8r8" id="6zwr99MojXL" role="3clFbG">
+            <node concept="3clFbC" id="6zwr99MomH6" role="37vLTx">
+              <node concept="10Nm6u" id="6zwr99Monf8" role="3uHU7w" />
+              <node concept="2OqwBi" id="6zwr99Mom4e" role="3uHU7B">
+                <node concept="1rXfSq" id="6zwr99MolmY" role="2Oq$k0">
+                  <ref role="37wK5l" to="exr9:~AbstractCellProvider.getSNode()" resolve="getSNode" />
+                </node>
+                <node concept="liA8E" id="6zwr99Momq3" role="2OqNvi">
+                  <ref role="37wK5l" to="mhbf:~SNode.getModel()" resolve="getModel" />
+                </node>
+              </node>
+            </node>
+            <node concept="37vLTw" id="6zwr99Mojdz" role="37vLTJ">
+              <ref role="3cqZAo" to="emqf:~CellProviderWithRole.myReadOnly" resolve="myReadOnly" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6zwr99Mqi_n" role="3cqZAp" />
         <node concept="3cpWs8" id="4g2H4r3Ws9q" role="3cqZAp">
           <node concept="3cpWsn" id="4g2H4r3Ws9p" role="3cpWs9">
             <property role="3TUv4t" value="false" />

--- a/code/widgets/solutions/de.itemis.mps.editor.bool.runtime/models/de/itemis/mps/editor/bool/runtime.mps
+++ b/code/widgets/solutions/de.itemis.mps.editor.bool.runtime/models/de/itemis/mps/editor/bool/runtime.mps
@@ -209,6 +209,7 @@
         <child id="8276990574895933173" name="catchBody" index="1zc67A" />
         <child id="8276990574895933172" name="throwable" index="1zc67B" />
       </concept>
+      <concept id="7024111702304501416" name="jetbrains.mps.baseLanguage.structure.OrAssignmentExpression" flags="nn" index="3vZ8r8" />
       <concept id="8276990574909231788" name="jetbrains.mps.baseLanguage.structure.FinallyClause" flags="ng" index="1wplmZ">
         <child id="8276990574909234106" name="finallyBody" index="1wplMD" />
       </concept>
@@ -1466,6 +1467,25 @@
         </node>
       </node>
       <node concept="3clFbS" id="4g2H4r3Ws9o" role="3clF47">
+        <node concept="3clFbF" id="6zwr99MqhLl" role="3cqZAp">
+          <node concept="3vZ8r8" id="6zwr99MqhLm" role="3clFbG">
+            <node concept="3clFbC" id="6zwr99MqhLn" role="37vLTx">
+              <node concept="10Nm6u" id="6zwr99MqhLo" role="3uHU7w" />
+              <node concept="2OqwBi" id="6zwr99MqhLp" role="3uHU7B">
+                <node concept="1rXfSq" id="6zwr99MqhLq" role="2Oq$k0">
+                  <ref role="37wK5l" to="exr9:~AbstractCellProvider.getSNode()" resolve="getSNode" />
+                </node>
+                <node concept="liA8E" id="6zwr99MqhLr" role="2OqNvi">
+                  <ref role="37wK5l" to="mhbf:~SNode.getModel()" resolve="getModel" />
+                </node>
+              </node>
+            </node>
+            <node concept="37vLTw" id="6zwr99MqhLs" role="37vLTJ">
+              <ref role="3cqZAo" to="emqf:~CellProviderWithRole.myReadOnly" resolve="myReadOnly" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6zwr99MqhBm" role="3cqZAp" />
         <node concept="3cpWs8" id="4g2H4r3Ws9q" role="3cqZAp">
           <node concept="3cpWsn" id="4g2H4r3Ws9p" role="3cpWs9">
             <property role="3TUv4t" value="false" />
@@ -3539,6 +3559,25 @@
         </node>
       </node>
       <node concept="3clFbS" id="6bmIkNC7z3y" role="3clF47">
+        <node concept="3clFbF" id="6zwr99Mojd_" role="3cqZAp">
+          <node concept="3vZ8r8" id="6zwr99MojXL" role="3clFbG">
+            <node concept="3clFbC" id="6zwr99MomH6" role="37vLTx">
+              <node concept="10Nm6u" id="6zwr99Monf8" role="3uHU7w" />
+              <node concept="2OqwBi" id="6zwr99Mom4e" role="3uHU7B">
+                <node concept="1rXfSq" id="6zwr99MolmY" role="2Oq$k0">
+                  <ref role="37wK5l" to="exr9:~AbstractCellProvider.getSNode()" resolve="getSNode" />
+                </node>
+                <node concept="liA8E" id="6zwr99Momq3" role="2OqNvi">
+                  <ref role="37wK5l" to="mhbf:~SNode.getModel()" resolve="getModel" />
+                </node>
+              </node>
+            </node>
+            <node concept="37vLTw" id="6zwr99Mojdz" role="37vLTJ">
+              <ref role="3cqZAo" to="emqf:~CellProviderWithRole.myReadOnly" resolve="myReadOnly" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6zwr99MqfLh" role="3cqZAp" />
         <node concept="3cpWs8" id="6bmIkNC7z3$" role="3cqZAp">
           <node concept="3cpWsn" id="6bmIkNC7z3z" role="3cpWs9">
             <property role="3TUv4t" value="false" />


### PR DESCRIPTION
It can happen when showing dynamically generated nodes in query lists that the model is null.