### PR TITLE
Reimplemented ProjectViewExtension and minor fixes (for MPS 2024.1 a.k.a "master")

### DIFF
--- a/code/shadowmodels/languages/de.q60.mps.virtualinterfaces.sandboxlang/models/virtualinterfaces.mps
+++ b/code/shadowmodels/languages/de.q60.mps.virtualinterfaces.sandboxlang/models/virtualinterfaces.mps
@@ -100,7 +100,7 @@
                 <ref role="24pWH3" node="1KLm$DhRLd8" resolve="ctx" />
               </node>
               <node concept="liA8E" id="1KLm$DhQ3QU" role="2OqNvi">
-                <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String):java.lang.StringBuilder" resolve="append" />
+                <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
                 <node concept="2OqwBi" id="1KLm$DhQ4nM" role="37wK5m">
                   <node concept="24pvgE" id="1KLm$DhQ3Rl" role="2Oq$k0" />
                   <node concept="3TrcHB" id="1KLm$DhQ4AS" role="2OqNvi">

--- a/code/shadowmodels/solutions/de.q60.mps.shadowmodels.runtime/models/engine.mps
+++ b/code/shadowmodels/solutions/de.q60.mps.shadowmodels.runtime/models/engine.mps
@@ -24,7 +24,7 @@
     <import index="c9mi" ref="r:e280b60e-1e31-4362-b72e-05ea0aaad63c(de.q60.mps.shadowmodels.runtime.util.pmap)" />
     <import index="2wxy" ref="r:a64bf504-1b65-47d6-8d8c-e9aef4535e3a(de.q60.mps.incremental.runtime)" />
     <import index="3d38" ref="r:bc160b50-5a4e-4f99-ba07-a7b7116dab7a(de.q60.mps.incremental.util)" />
-    <import index="3o3z" ref="ecfb9949-7433-4db5-85de-0f84d172e4ce/java:com.google.common.collect(de.q60.mps.libs/)" />
+    <import index="3o3z" ref="ecfb9949-7433-4db5-85de-0f84d172e4ce/java:com.google.common.collect(de.q60.mps.collections.libs/)" />
     <import index="y071" ref="r:57711a24-29ad-4bd9-8062-d4259c0a2ba5(de.q60.mps.logging.runtime)" />
     <import index="kgaa" ref="r:fa847d10-a670-48b8-aa0a-425906c34683(de.q60.mps.shadowmodels.runtime.mpslike)" />
     <import index="zy2h" ref="r:ec0fe8c4-38e5-4216-9425-8861454eaf8a(de.q60.mps.util.invalidation)" />

--- a/code/shadowmodels/solutions/de.q60.mps.shadowmodels.runtime/models/plugin.mps
+++ b/code/shadowmodels/solutions/de.q60.mps.shadowmodels.runtime/models/plugin.mps
@@ -52,7 +52,13 @@
     <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="3a50" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.ide(MPS.Platform/)" />
     <import index="wyuk" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.components(MPS.Core/)" />
-    <import index="1m72" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.components(MPS.IDEA/)" implicit="true" />
+    <import index="9ti4" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.extensions(MPS.IDEA/)" />
+    <import index="bnjk" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ide.projectView(MPS.IDEA/)" />
+    <import index="rcv5" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ide.util.treeView(MPS.IDEA/)" />
+    <import index="w1kd" ref="86441d7a-e194-42da-81a5-2161ec62a379/java:jetbrains.mps.smodel(MPS.Workbench/)" />
+    <import index="zn9m" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.util(MPS.IDEA/)" />
+    <import index="v23q" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi(MPS.IDEA/)" />
+    <import index="k21q" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ide.projectView.impl(MPS.IDEA/)" implicit="true" />
     <import index="tprs" ref="r:00000000-0000-4000-0000-011c895904a4(jetbrains.mps.ide.actions)" implicit="true" />
   </imports>
   <registry>
@@ -110,27 +116,16 @@
       <concept id="7520713872864775836" name="jetbrains.mps.lang.plugin.standalone.structure.StandalonePluginDescriptor" flags="ng" index="2DaZZR" />
     </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
-      <concept id="1082485599095" name="jetbrains.mps.baseLanguage.structure.BlockStatement" flags="nn" index="9aQIb">
-        <child id="1082485599096" name="statements" index="9aQI4" />
-      </concept>
       <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
         <child id="1068498886297" name="rValue" index="37vLTx" />
         <child id="1068498886295" name="lValue" index="37vLTJ" />
       </concept>
       <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
-      <concept id="8118189177080264853" name="jetbrains.mps.baseLanguage.structure.AlternativeType" flags="ig" index="nSUau">
-        <child id="8118189177080264854" name="alternative" index="nSUat" />
-      </concept>
       <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
+      <concept id="8010275703121539591" name="jetbrains.mps.baseLanguage.structure.InferredType" flags="ng" index="2yE$l8" />
       <concept id="5279705229678483897" name="jetbrains.mps.baseLanguage.structure.FloatingPointFloatConstant" flags="nn" index="2$xPTn">
         <property id="5279705229678483899" name="value" index="2$xPTl" />
-      </concept>
-      <concept id="1076505808687" name="jetbrains.mps.baseLanguage.structure.WhileStatement" flags="nn" index="2$JKZl">
-        <child id="1076505808688" name="condition" index="2$JKZa" />
-      </concept>
-      <concept id="1239714755177" name="jetbrains.mps.baseLanguage.structure.AbstractUnaryNumberOperation" flags="nn" index="2$Kvd9">
-        <child id="1239714902950" name="expression" index="2$L3a6" />
       </concept>
       <concept id="1188207840427" name="jetbrains.mps.baseLanguage.structure.AnnotationInstance" flags="nn" index="2AHcQZ">
         <reference id="1188208074048" name="annotation" index="2AI5Lk" />
@@ -145,6 +140,7 @@
         <child id="1154032183016" name="body" index="2LFqv$" />
       </concept>
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <property id="2523873803623706117" name="isMultiline" index="hSjvv" />
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
       </concept>
@@ -163,7 +159,6 @@
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
       </concept>
-      <concept id="4952749571008284462" name="jetbrains.mps.baseLanguage.structure.CatchVariable" flags="ng" index="XOnhg" />
       <concept id="1182160077978" name="jetbrains.mps.baseLanguage.structure.AnonymousClassCreator" flags="nn" index="YeOm9">
         <child id="1182160096073" name="cls" index="YeSDq" />
       </concept>
@@ -195,6 +190,9 @@
         <property id="1176718929932" name="isFinal" index="3TUv4t" />
         <child id="1068431790190" name="initializer" index="33vP2m" />
       </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ngI" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
+      </concept>
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
@@ -220,10 +218,8 @@
       </concept>
       <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
       <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
-        <child id="1082485599094" name="ifFalseStatement" index="9aQIa" />
         <child id="1068580123160" name="condition" index="3clFbw" />
         <child id="1068580123161" name="ifTrue" index="3clFbx" />
-        <child id="1206060520071" name="elsifClauses" index="3eNLev" />
       </concept>
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
@@ -242,18 +238,11 @@
       <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
         <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
       </concept>
-      <concept id="1068581242869" name="jetbrains.mps.baseLanguage.structure.MinusExpression" flags="nn" index="3cpWsd" />
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
       <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
-      <concept id="1206060495898" name="jetbrains.mps.baseLanguage.structure.ElsifClause" flags="ng" index="3eNFk2">
-        <child id="1206060619838" name="condition" index="3eO9$A" />
-        <child id="1206060644605" name="statementList" index="3eOfB_" />
-      </concept>
       <concept id="1079359253375" name="jetbrains.mps.baseLanguage.structure.ParenthesizedExpression" flags="nn" index="1eOMI4">
         <child id="1079359253376" name="expression" index="1eOMHV" />
       </concept>
-      <concept id="1081506762703" name="jetbrains.mps.baseLanguage.structure.GreaterThanExpression" flags="nn" index="3eOSWO" />
-      <concept id="1081506773034" name="jetbrains.mps.baseLanguage.structure.LessThanExpression" flags="nn" index="3eOVzh" />
       <concept id="1081516740877" name="jetbrains.mps.baseLanguage.structure.NotExpression" flags="nn" index="3fqX7Q">
         <child id="1081516765348" name="expression" index="3fr31v" />
       </concept>
@@ -261,12 +250,12 @@
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
-      <concept id="1073063089578" name="jetbrains.mps.baseLanguage.structure.SuperMethodCall" flags="nn" index="3nyPlj" />
       <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
       <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
         <property id="521412098689998745" name="nonStatic" index="2bfB8j" />
         <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
       </concept>
+      <concept id="1171903607971" name="jetbrains.mps.baseLanguage.structure.WildCardType" flags="in" index="3qTvmN" />
       <concept id="7812454656619025412" name="jetbrains.mps.baseLanguage.structure.LocalMethodCall" flags="nn" index="1rXfSq" />
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
@@ -276,11 +265,6 @@
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
-      <concept id="1214918800624" name="jetbrains.mps.baseLanguage.structure.PostfixIncrementExpression" flags="nn" index="3uNrnE" />
-      <concept id="3093926081414150598" name="jetbrains.mps.baseLanguage.structure.MultipleCatchClause" flags="ng" index="3uVAMA">
-        <child id="8276990574895933173" name="catchBody" index="1zc67A" />
-        <child id="8276990574895933172" name="throwable" index="1zc67B" />
-      </concept>
       <concept id="8276990574909231788" name="jetbrains.mps.baseLanguage.structure.FinallyClause" flags="ng" index="1wplmZ">
         <child id="8276990574909234106" name="finallyBody" index="1wplMD" />
       </concept>
@@ -288,15 +272,7 @@
       <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
-      <concept id="1144230876926" name="jetbrains.mps.baseLanguage.structure.AbstractForStatement" flags="nn" index="1DupvO">
-        <child id="1144230900587" name="variable" index="1Duv9x" />
-      </concept>
-      <concept id="1144231330558" name="jetbrains.mps.baseLanguage.structure.ForStatement" flags="nn" index="1Dw8fO">
-        <child id="1144231399730" name="condition" index="1Dwp0S" />
-        <child id="1144231408325" name="iteration" index="1Dwrff" />
-      </concept>
       <concept id="5351203823916750322" name="jetbrains.mps.baseLanguage.structure.TryUniversalStatement" flags="nn" index="3J1_TO">
-        <child id="8276990574886367510" name="catchClause" index="1zxBo5" />
         <child id="8276990574886367509" name="finallyClause" index="1zxBo6" />
         <child id="8276990574886367508" name="body" index="1zxBo7" />
       </concept>
@@ -318,27 +294,12 @@
         <reference id="1170346070688" name="classifier" index="1Y3XeK" />
       </concept>
     </language>
-    <language id="63650c59-16c8-498a-99c8-005c7ee9515d" name="jetbrains.mps.lang.access">
-      <concept id="8974276187400348173" name="jetbrains.mps.lang.access.structure.CommandClosureLiteral" flags="nn" index="1QHqEC" />
-      <concept id="8974276187400348170" name="jetbrains.mps.lang.access.structure.BaseExecuteCommandStatement" flags="nn" index="1QHqEJ">
-        <child id="1423104411234567454" name="repo" index="ukAjM" />
-        <child id="8974276187400348171" name="commandClosureLiteral" index="1QHqEI" />
-      </concept>
-      <concept id="8974276187400348181" name="jetbrains.mps.lang.access.structure.ExecuteLightweightCommandStatement" flags="nn" index="1QHqEK" />
-    </language>
     <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
       <concept id="2524418899405758586" name="jetbrains.mps.baseLanguage.closures.structure.InferredClosureParameterDeclaration" flags="ig" index="gl6BB" />
-      <concept id="1199542442495" name="jetbrains.mps.baseLanguage.closures.structure.FunctionType" flags="in" index="1ajhzC">
-        <child id="1199542457201" name="resultType" index="1ajl9A" />
-        <child id="1199542501692" name="parameterType" index="1ajw0F" />
-      </concept>
       <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
         <property id="890797661671409019" name="forceMultiLine" index="3yWfEV" />
         <child id="1199569906740" name="parameter" index="1bW2Oz" />
         <child id="1199569916463" name="body" index="1bW5cS" />
-      </concept>
-      <concept id="1225797177491" name="jetbrains.mps.baseLanguage.closures.structure.InvokeFunctionOperation" flags="nn" index="1Bd96e">
-        <child id="1225797361612" name="parameter" index="1BdPVh" />
       </concept>
     </language>
     <language id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc">
@@ -361,13 +322,6 @@
       </concept>
       <concept id="1205756064662" name="jetbrains.mps.baseLanguage.classifiers.structure.IMemberOperation" flags="ngI" index="2WEnae">
         <reference id="1205756909548" name="member" index="2WH_rO" />
-      </concept>
-    </language>
-    <language id="760a0a8c-eabb-4521-8bfd-65db761a9ba3" name="jetbrains.mps.baseLanguage.logging">
-      <concept id="2034914114981261497" name="jetbrains.mps.baseLanguage.logging.structure.LogLowLevelStatement" flags="ng" index="RRSsy">
-        <property id="2034914114981261751" name="severity" index="RRSoG" />
-        <child id="2034914114981261755" name="throwable" index="RRSow" />
-        <child id="2034914114981261753" name="message" index="RRSoy" />
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
@@ -394,10 +348,6 @@
         <child id="540871147943773366" name="argument" index="25WWJ7" />
       </concept>
       <concept id="1204980550705" name="jetbrains.mps.baseLanguage.collections.structure.VisitAllOperation" flags="nn" index="2es0OD" />
-      <concept id="1226511727824" name="jetbrains.mps.baseLanguage.collections.structure.SetType" flags="in" index="2hMVRd">
-        <child id="1226511765987" name="elementType" index="2hN53Y" />
-      </concept>
-      <concept id="1226516258405" name="jetbrains.mps.baseLanguage.collections.structure.HashSetCreator" flags="nn" index="2i4dXS" />
       <concept id="1207233427108" name="jetbrains.mps.baseLanguage.collections.structure.MapRemoveOperation" flags="nn" index="kI3uX">
         <child id="1207233489861" name="key" index="kIiFs" />
       </concept>
@@ -416,7 +366,7 @@
         <reference id="1153944258490" name="variable" index="2Gs0qQ" />
       </concept>
       <concept id="1237721394592" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerCreator" flags="nn" index="HWqM0">
-        <child id="1237721435807" name="elementType" index="HW$YZ" />
+        <child id="1237731803878" name="copyFrom" index="I$8f6" />
       </concept>
       <concept id="1205679737078" name="jetbrains.mps.baseLanguage.collections.structure.SortOperation" flags="nn" index="2S7cBI">
         <child id="1205679832066" name="ascending" index="2S7zOq" />
@@ -427,7 +377,6 @@
         <child id="4611582986551314344" name="requestedType" index="UnYnz" />
       </concept>
       <concept id="1240325842691" name="jetbrains.mps.baseLanguage.collections.structure.AsSequenceOperation" flags="nn" index="39bAoz" />
-      <concept id="1167380149909" name="jetbrains.mps.baseLanguage.collections.structure.RemoveElementOperation" flags="nn" index="3dhRuq" />
       <concept id="1178286324487" name="jetbrains.mps.baseLanguage.collections.structure.SortDirection" flags="nn" index="1nlBCl" />
       <concept id="1197683403723" name="jetbrains.mps.baseLanguage.collections.structure.MapType" flags="in" index="3rvAFt">
         <child id="1197683466920" name="keyType" index="3rvQeY" />
@@ -443,6 +392,7 @@
         <child id="1197932505799" name="map" index="3ElQJh" />
         <child id="1197932525128" name="key" index="3ElVtu" />
       </concept>
+      <concept id="1176501494711" name="jetbrains.mps.baseLanguage.collections.structure.IsNotEmptyOperation" flags="nn" index="3GX2aA" />
     </language>
   </registry>
   <node concept="2DaZZR" id="5HQgaiNsNbn" />
@@ -960,194 +910,6 @@
         <ref role="3uigEE" to="z1c3:~Project" resolve="Project" />
       </node>
     </node>
-    <node concept="312cEg" id="115Xaa41cD5" role="jymVt">
-      <property role="TrG5h" value="shadowTreeNode" />
-      <node concept="3Tm6S6" id="115Xaa41cD6" role="1B3o_S" />
-      <node concept="3uibUv" id="115Xaa41dDU" role="1tU5fm">
-        <ref role="3uigEE" to="7e8u:~TextTreeNode" resolve="TextTreeNode" />
-      </node>
-    </node>
-    <node concept="312cEg" id="115Xaa41sOA" role="jymVt">
-      <property role="TrG5h" value="treeListener" />
-      <node concept="3Tm6S6" id="115Xaa41sOB" role="1B3o_S" />
-      <node concept="3uibUv" id="115Xaa41tS7" role="1tU5fm">
-        <ref role="3uigEE" to="gsia:~TreeModelListener" resolve="TreeModelListener" />
-      </node>
-      <node concept="2ShNRf" id="115Xaa41tZd" role="33vP2m">
-        <node concept="YeOm9" id="115Xaa41tZe" role="2ShVmc">
-          <node concept="1Y3b0j" id="115Xaa41tZf" role="YeSDq">
-            <property role="2bfB8j" value="true" />
-            <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
-            <ref role="1Y3XeK" to="gsia:~TreeModelListener" resolve="TreeModelListener" />
-            <node concept="312cEg" id="115Xaa41tZg" role="jymVt">
-              <property role="TrG5h" value="handling" />
-              <node concept="3Tm6S6" id="115Xaa41tZh" role="1B3o_S" />
-              <node concept="10P_77" id="115Xaa41tZi" role="1tU5fm" />
-            </node>
-            <node concept="3Tm1VV" id="115Xaa41tZj" role="1B3o_S" />
-            <node concept="3clFb_" id="115Xaa41tZk" role="jymVt">
-              <property role="1EzhhJ" value="false" />
-              <property role="TrG5h" value="treeNodesChanged" />
-              <property role="DiZV1" value="false" />
-              <property role="od$2w" value="false" />
-              <node concept="3Tm1VV" id="115Xaa41tZl" role="1B3o_S" />
-              <node concept="3cqZAl" id="115Xaa41tZm" role="3clF45" />
-              <node concept="37vLTG" id="115Xaa41tZn" role="3clF46">
-                <property role="TrG5h" value="p0" />
-                <node concept="3uibUv" id="115Xaa41tZo" role="1tU5fm">
-                  <ref role="3uigEE" to="gsia:~TreeModelEvent" resolve="TreeModelEvent" />
-                </node>
-              </node>
-              <node concept="3clFbS" id="115Xaa41tZp" role="3clF47">
-                <node concept="3clFbF" id="115Xaa41tZq" role="3cqZAp">
-                  <node concept="1rXfSq" id="115Xaa41tZr" role="3clFbG">
-                    <ref role="37wK5l" node="115Xaa41tZO" resolve="handle" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3clFb_" id="115Xaa41tZs" role="jymVt">
-              <property role="1EzhhJ" value="false" />
-              <property role="TrG5h" value="treeNodesInserted" />
-              <property role="DiZV1" value="false" />
-              <property role="od$2w" value="false" />
-              <node concept="3Tm1VV" id="115Xaa41tZt" role="1B3o_S" />
-              <node concept="3cqZAl" id="115Xaa41tZu" role="3clF45" />
-              <node concept="37vLTG" id="115Xaa41tZv" role="3clF46">
-                <property role="TrG5h" value="p0" />
-                <node concept="3uibUv" id="115Xaa41tZw" role="1tU5fm">
-                  <ref role="3uigEE" to="gsia:~TreeModelEvent" resolve="TreeModelEvent" />
-                </node>
-              </node>
-              <node concept="3clFbS" id="115Xaa41tZx" role="3clF47">
-                <node concept="3clFbF" id="115Xaa41tZy" role="3cqZAp">
-                  <node concept="1rXfSq" id="115Xaa41tZz" role="3clFbG">
-                    <ref role="37wK5l" node="115Xaa41tZO" resolve="handle" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3clFb_" id="115Xaa41tZ$" role="jymVt">
-              <property role="1EzhhJ" value="false" />
-              <property role="TrG5h" value="treeNodesRemoved" />
-              <property role="DiZV1" value="false" />
-              <property role="od$2w" value="false" />
-              <node concept="3Tm1VV" id="115Xaa41tZ_" role="1B3o_S" />
-              <node concept="3cqZAl" id="115Xaa41tZA" role="3clF45" />
-              <node concept="37vLTG" id="115Xaa41tZB" role="3clF46">
-                <property role="TrG5h" value="p0" />
-                <node concept="3uibUv" id="115Xaa41tZC" role="1tU5fm">
-                  <ref role="3uigEE" to="gsia:~TreeModelEvent" resolve="TreeModelEvent" />
-                </node>
-              </node>
-              <node concept="3clFbS" id="115Xaa41tZD" role="3clF47">
-                <node concept="3clFbF" id="115Xaa41tZE" role="3cqZAp">
-                  <node concept="1rXfSq" id="115Xaa41tZF" role="3clFbG">
-                    <ref role="37wK5l" node="115Xaa41tZO" resolve="handle" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3clFb_" id="115Xaa41tZG" role="jymVt">
-              <property role="1EzhhJ" value="false" />
-              <property role="TrG5h" value="treeStructureChanged" />
-              <property role="DiZV1" value="false" />
-              <property role="od$2w" value="false" />
-              <node concept="3Tm1VV" id="115Xaa41tZH" role="1B3o_S" />
-              <node concept="3cqZAl" id="115Xaa41tZI" role="3clF45" />
-              <node concept="37vLTG" id="115Xaa41tZJ" role="3clF46">
-                <property role="TrG5h" value="p0" />
-                <node concept="3uibUv" id="115Xaa41tZK" role="1tU5fm">
-                  <ref role="3uigEE" to="gsia:~TreeModelEvent" resolve="TreeModelEvent" />
-                </node>
-              </node>
-              <node concept="3clFbS" id="115Xaa41tZL" role="3clF47">
-                <node concept="3clFbF" id="115Xaa41tZM" role="3cqZAp">
-                  <node concept="1rXfSq" id="115Xaa41tZN" role="3clFbG">
-                    <ref role="37wK5l" node="115Xaa41tZO" resolve="handle" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3clFb_" id="115Xaa41tZO" role="jymVt">
-              <property role="TrG5h" value="handle" />
-              <node concept="3cqZAl" id="115Xaa41tZP" role="3clF45" />
-              <node concept="3Tm1VV" id="115Xaa41tZQ" role="1B3o_S" />
-              <node concept="3clFbS" id="115Xaa41tZR" role="3clF47">
-                <node concept="3clFbJ" id="115Xaa41u05" role="3cqZAp">
-                  <node concept="3clFbS" id="115Xaa41u06" role="3clFbx">
-                    <node concept="3cpWs6" id="115Xaa41u07" role="3cqZAp" />
-                  </node>
-                  <node concept="37vLTw" id="115Xaa41u08" role="3clFbw">
-                    <ref role="3cqZAo" node="115Xaa41tZg" resolve="handling" />
-                  </node>
-                </node>
-                <node concept="3J1_TO" id="115Xaa41u09" role="3cqZAp">
-                  <node concept="3clFbS" id="115Xaa41u0a" role="1zxBo7">
-                    <node concept="3clFbF" id="115Xaa41u0b" role="3cqZAp">
-                      <node concept="37vLTI" id="115Xaa41u0c" role="3clFbG">
-                        <node concept="3clFbT" id="115Xaa41u0d" role="37vLTx">
-                          <property role="3clFbU" value="true" />
-                        </node>
-                        <node concept="37vLTw" id="115Xaa41u0e" role="37vLTJ">
-                          <ref role="3cqZAo" node="115Xaa41tZg" resolve="handling" />
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="3clFbF" id="7zI2priWPx3" role="3cqZAp">
-                      <node concept="1rXfSq" id="7zI2priWPx4" role="3clFbG">
-                        <ref role="37wK5l" node="7zI2priU5Kn" resolve="attachShadowRootIfNotEmpty" />
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3uVAMA" id="5_qLwQsxrYZ" role="1zxBo5">
-                    <node concept="XOnhg" id="5_qLwQsxrZ0" role="1zc67B">
-                      <property role="3TUv4t" value="false" />
-                      <property role="TrG5h" value="ex" />
-                      <node concept="nSUau" id="7kh3NkgV3B6" role="1tU5fm">
-                        <node concept="3uibUv" id="5_qLwQsxsj9" role="nSUat">
-                          <ref role="3uigEE" to="wyt6:~Exception" resolve="Exception" />
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="3clFbS" id="5_qLwQsxrZ2" role="1zc67A">
-                      <node concept="RRSsy" id="5_qLwQsxtfh" role="3cqZAp">
-                        <property role="RRSoG" value="gZ5fh_4/error" />
-                        <node concept="Xl_RD" id="5_qLwQsxtfj" role="RRSoy" />
-                        <node concept="37vLTw" id="5_qLwQsxtfl" role="RRSow">
-                          <ref role="3cqZAo" node="5_qLwQsxrZ0" resolve="ex" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="1wplmZ" id="6lx465$tXfu" role="1zxBo6">
-                    <node concept="3clFbS" id="115Xaa41u0j" role="1wplMD">
-                      <node concept="3clFbF" id="115Xaa41u0k" role="3cqZAp">
-                        <node concept="37vLTI" id="115Xaa41u0l" role="3clFbG">
-                          <node concept="3clFbT" id="115Xaa41u0m" role="37vLTx">
-                            <property role="3clFbU" value="false" />
-                          </node>
-                          <node concept="37vLTw" id="115Xaa41u0n" role="37vLTJ">
-                            <ref role="3cqZAo" node="115Xaa41tZg" resolve="handling" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="312cEg" id="6EruykV8CMZ" role="jymVt">
-      <property role="TrG5h" value="treeModel" />
-      <node concept="3Tm6S6" id="6EruykV8CN0" role="1B3o_S" />
-      <node concept="3uibUv" id="6EruykV8GVe" role="1tU5fm">
-        <ref role="3uigEE" to="rgfa:~TreeModel" resolve="TreeModel" />
-      </node>
-    </node>
     <node concept="312cEg" id="6EruykV8Png" role="jymVt">
       <property role="TrG5h" value="disposed" />
       <node concept="3Tm6S6" id="6EruykV8Pnh" role="1B3o_S" />
@@ -1155,255 +917,6 @@
       <node concept="3clFbT" id="6EruykV8Ukk" role="33vP2m" />
     </node>
     <node concept="2tJIrI" id="3vsFnFV6eJQ" role="jymVt" />
-    <node concept="312cEg" id="6AlUJyrx6h8" role="jymVt">
-      <property role="TrG5h" value="repositoryListener" />
-      <node concept="3Tm6S6" id="6AlUJyrx6h9" role="1B3o_S" />
-      <node concept="3uibUv" id="6AlUJyrx8tx" role="1tU5fm">
-        <ref role="3uigEE" to="lui2:~SRepositoryListener" resolve="SRepositoryListener" />
-      </node>
-      <node concept="2ShNRf" id="6AlUJyrx8z4" role="33vP2m">
-        <node concept="YeOm9" id="6AlUJyrxacn" role="2ShVmc">
-          <node concept="1Y3b0j" id="6AlUJyrxacq" role="YeSDq">
-            <property role="2bfB8j" value="true" />
-            <ref role="1Y3XeK" to="lui2:~SRepositoryListenerBase" resolve="SRepositoryListenerBase" />
-            <ref role="37wK5l" to="lui2:~SRepositoryListenerBase.&lt;init&gt;()" resolve="SRepositoryListenerBase" />
-            <node concept="312cEg" id="6AlUJyrxjKY" role="jymVt">
-              <property role="TrG5h" value="modulesDirty" />
-              <node concept="3Tm6S6" id="6AlUJyrxjKZ" role="1B3o_S" />
-              <node concept="3uibUv" id="6AlUJyrxmah" role="1tU5fm">
-                <ref role="3uigEE" to="i5cy:~AtomicBoolean" resolve="AtomicBoolean" />
-              </node>
-              <node concept="2ShNRf" id="6AlUJyrxmkZ" role="33vP2m">
-                <node concept="1pGfFk" id="6AlUJyrxmfZ" role="2ShVmc">
-                  <ref role="37wK5l" to="i5cy:~AtomicBoolean.&lt;init&gt;(boolean)" resolve="AtomicBoolean" />
-                  <node concept="3clFbT" id="6AlUJyrxmqp" role="37wK5m">
-                    <property role="3clFbU" value="true" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3Tm1VV" id="6AlUJyrxacr" role="1B3o_S" />
-            <node concept="3clFb_" id="6AlUJyrxacs" role="jymVt">
-              <property role="1EzhhJ" value="false" />
-              <property role="TrG5h" value="moduleAdded" />
-              <property role="DiZV1" value="false" />
-              <property role="od$2w" value="false" />
-              <node concept="3Tm1VV" id="6AlUJyrxact" role="1B3o_S" />
-              <node concept="3cqZAl" id="6AlUJyrxacv" role="3clF45" />
-              <node concept="37vLTG" id="6AlUJyrxacw" role="3clF46">
-                <property role="TrG5h" value="m" />
-                <node concept="3uibUv" id="6AlUJyrxacx" role="1tU5fm">
-                  <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-                </node>
-                <node concept="2AHcQZ" id="6AlUJyrxacy" role="2AJF6D">
-                  <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
-                </node>
-              </node>
-              <node concept="3clFbS" id="6AlUJyrxacz" role="3clF47">
-                <node concept="3clFbJ" id="6AlUJyrxIWx" role="3cqZAp">
-                  <node concept="3clFbS" id="6AlUJyrxIWz" role="3clFbx">
-                    <node concept="3clFbF" id="3vsFnFV68ph" role="3cqZAp">
-                      <node concept="2OqwBi" id="3vsFnFV68uO" role="3clFbG">
-                        <node concept="37vLTw" id="3vsFnFV68pf" role="2Oq$k0">
-                          <ref role="3cqZAo" node="6AlUJyrxacw" resolve="m" />
-                        </node>
-                        <node concept="liA8E" id="3vsFnFV68Kb" role="2OqNvi">
-                          <ref role="37wK5l" to="lui2:~SModule.addModuleListener(org.jetbrains.mps.openapi.module.SModuleListener)" resolve="addModuleListener" />
-                          <node concept="37vLTw" id="3vsFnFV69gb" role="37wK5m">
-                            <ref role="3cqZAo" node="3vsFnFV62C7" resolve="moduleListener" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="3clFbF" id="6AlUJyrxuGG" role="3cqZAp">
-                      <node concept="1rXfSq" id="6AlUJyrxuGF" role="3clFbG">
-                        <ref role="37wK5l" node="6AlUJyrxrXK" resolve="queueUpdate" />
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="2ZW3vV" id="6AlUJyrxJsh" role="3clFbw">
-                    <node concept="3uibUv" id="6AlUJyrxJLy" role="2ZW6by">
-                      <ref role="3uigEE" to="l6bp:115Xaa43tZI" resolve="SM_ShadowModule" />
-                    </node>
-                    <node concept="37vLTw" id="6AlUJyrxJc3" role="2ZW6bz">
-                      <ref role="3cqZAo" node="6AlUJyrxacw" resolve="m" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3clFb_" id="6AlUJyrxacI" role="jymVt">
-              <property role="1EzhhJ" value="false" />
-              <property role="TrG5h" value="moduleRemoved" />
-              <property role="DiZV1" value="false" />
-              <property role="od$2w" value="false" />
-              <node concept="3Tm1VV" id="6AlUJyrxacJ" role="1B3o_S" />
-              <node concept="3cqZAl" id="6AlUJyrxacL" role="3clF45" />
-              <node concept="37vLTG" id="6AlUJyrxacM" role="3clF46">
-                <property role="TrG5h" value="m" />
-                <node concept="3uibUv" id="6AlUJyrxacN" role="1tU5fm">
-                  <ref role="3uigEE" to="lui2:~SModuleReference" resolve="SModuleReference" />
-                </node>
-                <node concept="2AHcQZ" id="6AlUJyrxacO" role="2AJF6D">
-                  <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
-                </node>
-              </node>
-              <node concept="3clFbS" id="6AlUJyrxacP" role="3clF47">
-                <node concept="3clFbF" id="6AlUJyrxtUV" role="3cqZAp">
-                  <node concept="1rXfSq" id="6AlUJyrxtUU" role="3clFbG">
-                    <ref role="37wK5l" node="6AlUJyrxrXK" resolve="queueUpdate" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3clFb_" id="6AlUJyrxrXK" role="jymVt">
-              <property role="TrG5h" value="queueUpdate" />
-              <node concept="3cqZAl" id="6AlUJyrxrXM" role="3clF45" />
-              <node concept="3Tm1VV" id="6AlUJyrxrXN" role="1B3o_S" />
-              <node concept="3clFbS" id="6AlUJyrxrXO" role="3clF47">
-                <node concept="3clFbF" id="6AlUJyrxs_F" role="3cqZAp">
-                  <node concept="2OqwBi" id="6AlUJyrxs_G" role="3clFbG">
-                    <node concept="37vLTw" id="6AlUJyrxs_H" role="2Oq$k0">
-                      <ref role="3cqZAo" node="6AlUJyrxjKY" resolve="modulesDirty" />
-                    </node>
-                    <node concept="liA8E" id="6AlUJyrxs_I" role="2OqNvi">
-                      <ref role="37wK5l" to="i5cy:~AtomicBoolean.set(boolean)" resolve="set" />
-                      <node concept="3clFbT" id="6AlUJyrxs_J" role="37wK5m">
-                        <property role="3clFbU" value="true" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="3clFbF" id="6AlUJyrxs_K" role="3cqZAp">
-                  <node concept="2OqwBi" id="6AlUJyrxs_L" role="3clFbG">
-                    <node concept="2YIFZM" id="6AlUJyrxs_M" role="2Oq$k0">
-                      <ref role="1Pybhc" to="bd8o:~ApplicationManager" resolve="ApplicationManager" />
-                      <ref role="37wK5l" to="bd8o:~ApplicationManager.getApplication()" resolve="getApplication" />
-                    </node>
-                    <node concept="liA8E" id="6AlUJyrxs_N" role="2OqNvi">
-                      <ref role="37wK5l" to="bd8o:~Application.invokeLater(java.lang.Runnable)" resolve="invokeLater" />
-                      <node concept="1bVj0M" id="6AlUJyrxs_O" role="37wK5m">
-                        <node concept="3clFbS" id="6AlUJyrxs_P" role="1bW5cS">
-                          <node concept="3clFbJ" id="6AlUJyrxviB" role="3cqZAp">
-                            <node concept="3clFbS" id="6AlUJyrxviD" role="3clFbx">
-                              <node concept="3clFbF" id="6AlUJyrxs_Q" role="3cqZAp">
-                                <node concept="1rXfSq" id="6AlUJyrxs_R" role="3clFbG">
-                                  <ref role="37wK5l" node="6AlUJyrwjTk" resolve="updateModules" />
-                                </node>
-                              </node>
-                            </node>
-                            <node concept="2OqwBi" id="6AlUJyrxwcx" role="3clFbw">
-                              <node concept="37vLTw" id="6AlUJyrxvLV" role="2Oq$k0">
-                                <ref role="3cqZAo" node="6AlUJyrxjKY" resolve="modulesDirty" />
-                              </node>
-                              <node concept="liA8E" id="6AlUJyrxwp$" role="2OqNvi">
-                                <ref role="37wK5l" to="i5cy:~AtomicBoolean.getAndSet(boolean)" resolve="getAndSet" />
-                                <node concept="3clFbT" id="6AlUJyrxxKn" role="37wK5m">
-                                  <property role="3clFbU" value="false" />
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="312cEg" id="3vsFnFV62C7" role="jymVt">
-      <property role="TrG5h" value="moduleListener" />
-      <node concept="3Tm6S6" id="3vsFnFV62C8" role="1B3o_S" />
-      <node concept="3uibUv" id="3vsFnFV65d_" role="1tU5fm">
-        <ref role="3uigEE" to="lui2:~SModuleListener" resolve="SModuleListener" />
-      </node>
-      <node concept="2ShNRf" id="3vsFnFV65jq" role="33vP2m">
-        <node concept="YeOm9" id="3vsFnFV66fV" role="2ShVmc">
-          <node concept="1Y3b0j" id="3vsFnFV66fY" role="YeSDq">
-            <property role="2bfB8j" value="true" />
-            <ref role="1Y3XeK" to="lui2:~SModuleListenerBase" resolve="SModuleListenerBase" />
-            <ref role="37wK5l" to="lui2:~SModuleListenerBase.&lt;init&gt;()" resolve="SModuleListenerBase" />
-            <node concept="3Tm1VV" id="3vsFnFV66fZ" role="1B3o_S" />
-            <node concept="3clFb_" id="3vsFnFV66mo" role="jymVt">
-              <property role="1EzhhJ" value="false" />
-              <property role="TrG5h" value="modelAdded" />
-              <property role="DiZV1" value="false" />
-              <property role="od$2w" value="false" />
-              <node concept="3Tm1VV" id="3vsFnFV66mp" role="1B3o_S" />
-              <node concept="3cqZAl" id="3vsFnFV66mr" role="3clF45" />
-              <node concept="37vLTG" id="3vsFnFV66ms" role="3clF46">
-                <property role="TrG5h" value="module" />
-                <node concept="3uibUv" id="3vsFnFV66mt" role="1tU5fm">
-                  <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-                </node>
-              </node>
-              <node concept="37vLTG" id="3vsFnFV66mu" role="3clF46">
-                <property role="TrG5h" value="model" />
-                <node concept="3uibUv" id="3vsFnFV66mv" role="1tU5fm">
-                  <ref role="3uigEE" to="mhbf:~SModel" resolve="SModel" />
-                </node>
-              </node>
-              <node concept="3clFbS" id="3vsFnFV66mx" role="3clF47">
-                <node concept="3clFbF" id="3vsFnFV66mA" role="3cqZAp">
-                  <node concept="3nyPlj" id="3vsFnFV66m_" role="3clFbG">
-                    <ref role="37wK5l" to="lui2:~SModuleListenerBase.modelAdded(org.jetbrains.mps.openapi.module.SModule,org.jetbrains.mps.openapi.model.SModel)" resolve="modelAdded" />
-                    <node concept="37vLTw" id="3vsFnFV66mz" role="37wK5m">
-                      <ref role="3cqZAo" node="3vsFnFV66ms" resolve="module" />
-                    </node>
-                    <node concept="37vLTw" id="3vsFnFV66m$" role="37wK5m">
-                      <ref role="3cqZAo" node="3vsFnFV66mu" resolve="model" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="2AHcQZ" id="3vsFnFV66my" role="2AJF6D">
-                <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-              </node>
-            </node>
-            <node concept="3clFb_" id="3vsFnFV66mB" role="jymVt">
-              <property role="1EzhhJ" value="false" />
-              <property role="TrG5h" value="modelRemoved" />
-              <property role="DiZV1" value="false" />
-              <property role="od$2w" value="false" />
-              <node concept="3Tm1VV" id="3vsFnFV66mC" role="1B3o_S" />
-              <node concept="3cqZAl" id="3vsFnFV66mE" role="3clF45" />
-              <node concept="37vLTG" id="3vsFnFV66mF" role="3clF46">
-                <property role="TrG5h" value="module" />
-                <node concept="3uibUv" id="3vsFnFV66mG" role="1tU5fm">
-                  <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-                </node>
-              </node>
-              <node concept="37vLTG" id="3vsFnFV66mH" role="3clF46">
-                <property role="TrG5h" value="ref" />
-                <node concept="3uibUv" id="3vsFnFV66mI" role="1tU5fm">
-                  <ref role="3uigEE" to="mhbf:~SModelReference" resolve="SModelReference" />
-                </node>
-              </node>
-              <node concept="3clFbS" id="3vsFnFV66mK" role="3clF47">
-                <node concept="3clFbF" id="3vsFnFV66mP" role="3cqZAp">
-                  <node concept="3nyPlj" id="3vsFnFV66mO" role="3clFbG">
-                    <ref role="37wK5l" to="lui2:~SModuleListenerBase.modelRemoved(org.jetbrains.mps.openapi.module.SModule,org.jetbrains.mps.openapi.model.SModelReference)" resolve="modelRemoved" />
-                    <node concept="37vLTw" id="3vsFnFV66mM" role="37wK5m">
-                      <ref role="3cqZAo" node="3vsFnFV66mF" resolve="module" />
-                    </node>
-                    <node concept="37vLTw" id="3vsFnFV66mN" role="37wK5m">
-                      <ref role="3cqZAo" node="3vsFnFV66mH" resolve="ref" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="2AHcQZ" id="3vsFnFV66mL" role="2AJF6D">
-                <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-    </node>
     <node concept="312cEg" id="5b2TV0XEYrI" role="jymVt">
       <property role="TrG5h" value="invalidatable" />
       <node concept="3Tm6S6" id="5b2TV0XEYrJ" role="1B3o_S" />
@@ -1434,9 +947,21 @@
                       <node concept="1bVj0M" id="5b2TV0XF41O" role="37wK5m">
                         <property role="3yWfEV" value="true" />
                         <node concept="3clFbS" id="5b2TV0XF41P" role="1bW5cS">
-                          <node concept="3clFbF" id="5b2TV0XF41Q" role="3cqZAp">
-                            <node concept="1rXfSq" id="5b2TV0XF6nq" role="3clFbG">
-                              <ref role="37wK5l" node="56YPHTokZqG" resolve="forceUpdate" />
+                          <node concept="3clFbF" id="5rSmnqxll_Y" role="3cqZAp">
+                            <node concept="2OqwBi" id="5rSmnqxlDHu" role="3clFbG">
+                              <node concept="2YIFZM" id="5rSmnqxlqLN" role="2Oq$k0">
+                                <ref role="37wK5l" to="rvbb:~ProjectPane.getInstance(jetbrains.mps.project.Project)" resolve="getInstance" />
+                                <ref role="1Pybhc" to="rvbb:~ProjectPane" resolve="ProjectPane" />
+                                <node concept="37vLTw" id="5rSmnqxlxYK" role="37wK5m">
+                                  <ref role="3cqZAo" node="115Xaa3Z2NL" resolve="project" />
+                                </node>
+                              </node>
+                              <node concept="liA8E" id="5rSmnqxlK6L" role="2OqNvi">
+                                <ref role="37wK5l" to="k21q:~AbstractProjectViewPaneWithAsyncSupport.updateFromRoot(boolean)" resolve="updateFromRoot" />
+                                <node concept="3clFbT" id="5rSmnqxlQ0S" role="37wK5m">
+                                  <property role="3clFbU" value="true" />
+                                </node>
+                              </node>
                             </node>
                           </node>
                         </node>
@@ -1512,510 +1037,89 @@
       <node concept="3cqZAl" id="115Xaa3Zj8O" role="3clF45" />
       <node concept="3Tm1VV" id="115Xaa3Zj8P" role="1B3o_S" />
       <node concept="3clFbS" id="115Xaa3Zj8Q" role="3clF47">
-        <node concept="3clFbF" id="115Xaa41ewz" role="3cqZAp">
-          <node concept="37vLTI" id="115Xaa41fKf" role="3clFbG">
-            <node concept="2ShNRf" id="115Xaa41g0h" role="37vLTx">
-              <node concept="1pGfFk" id="115Xaa41hE$" role="2ShVmc">
-                <ref role="37wK5l" to="7e8u:~TextTreeNode.&lt;init&gt;(java.lang.String)" resolve="TextTreeNode" />
-                <node concept="Xl_RD" id="115Xaa41hIY" role="37wK5m">
-                  <property role="Xl_RC" value="Shadow" />
-                </node>
-              </node>
+        <node concept="3cpWs8" id="2nMt2sky4h7" role="3cqZAp">
+          <node concept="3cpWsn" id="2nMt2sky4h8" role="3cpWs9">
+            <property role="TrG5h" value="ideaProject" />
+            <node concept="3uibUv" id="2nMt2sky2A$" role="1tU5fm">
+              <ref role="3uigEE" to="4nm9:~Project" resolve="Project" />
             </node>
-            <node concept="37vLTw" id="115Xaa41ewx" role="37vLTJ">
-              <ref role="3cqZAo" node="115Xaa41cD5" resolve="shadowTreeNode" />
+            <node concept="1rXfSq" id="5rSmnqx1Lrk" role="33vP2m">
+              <ref role="37wK5l" node="5rSmnqx0OJK" resolve="getIdeaProject" />
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="3Ezg1fN0dhi" role="3cqZAp">
-          <node concept="2OqwBi" id="3Ezg1fN0dX6" role="3clFbG">
-            <node concept="37vLTw" id="3Ezg1fN0dhg" role="2Oq$k0">
-              <ref role="3cqZAo" node="115Xaa41cD5" resolve="shadowTreeNode" />
+        <node concept="3cpWs8" id="2nMt2skxJLD" role="3cqZAp">
+          <node concept="3cpWsn" id="2nMt2skxJLE" role="3cpWs9">
+            <property role="TrG5h" value="epoint" />
+            <node concept="3uibUv" id="2nMt2skxI0v" role="1tU5fm">
+              <ref role="3uigEE" to="9ti4:~ExtensionPoint" resolve="ExtensionPoint" />
+              <node concept="3uibUv" id="2nMt2skxI0y" role="11_B2D">
+                <ref role="3uigEE" to="bnjk:~TreeStructureProvider" resolve="TreeStructureProvider" />
+              </node>
             </node>
-            <node concept="liA8E" id="3Ezg1fN0fia" role="2OqNvi">
-              <ref role="37wK5l" to="7e8u:~MPSTreeNode.setIcon(javax.swing.Icon)" resolve="setIcon" />
-              <node concept="37vLTw" id="4NO8rntTnzG" role="37wK5m">
-                <ref role="3cqZAo" node="4NO8rntTnzD" resolve="ROOT_ICON" />
+            <node concept="2OqwBi" id="2nMt2skxJLF" role="33vP2m">
+              <node concept="10M0yZ" id="2nMt2skxJLG" role="2Oq$k0">
+                <ref role="3cqZAo" to="bnjk:~TreeStructureProvider.EP" resolve="EP" />
+                <ref role="1PxDUh" to="bnjk:~TreeStructureProvider" resolve="TreeStructureProvider" />
+              </node>
+              <node concept="liA8E" id="2nMt2skxJLH" role="2OqNvi">
+                <ref role="37wK5l" to="9ti4:~ProjectExtensionPointName.getPoint(com.intellij.openapi.extensions.AreaInstance)" resolve="getPoint" />
+                <node concept="37vLTw" id="2nMt2sky4hf" role="37wK5m">
+                  <ref role="3cqZAo" node="2nMt2sky4h8" resolve="ideaProject" />
+                </node>
               </node>
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="1cRLf1A02sa" role="3cqZAp">
-          <node concept="1rXfSq" id="1cRLf1A02s8" role="3clFbG">
-            <ref role="37wK5l" node="1cRLf1_Y6nE" resolve="waitForProjectTree" />
-            <node concept="1bVj0M" id="1cRLf1A03eW" role="37wK5m">
-              <node concept="37vLTG" id="1cRLf1A03hn" role="1bW2Oz">
-                <property role="TrG5h" value="tree" />
-                <node concept="3uibUv" id="1cRLf1A03Jc" role="1tU5fm">
-                  <ref role="3uigEE" to="paf:~ProjectTree" resolve="ProjectTree" />
+        <node concept="3clFbF" id="2nMt2skxrrc" role="3cqZAp">
+          <node concept="2OqwBi" id="2nMt2skxPLD" role="3clFbG">
+            <node concept="37vLTw" id="2nMt2skxJLO" role="2Oq$k0">
+              <ref role="3cqZAo" node="2nMt2skxJLE" resolve="epoint" />
+            </node>
+            <node concept="liA8E" id="2nMt2skxT5R" role="2OqNvi">
+              <ref role="37wK5l" to="9ti4:~ExtensionPoint.registerExtension(java.lang.Object,com.intellij.openapi.Disposable)" resolve="registerExtension" />
+              <node concept="2ShNRf" id="5rSmnqwmYx8" role="37wK5m">
+                <node concept="HV5vD" id="5rSmnqwnudB" role="2ShVmc">
+                  <property role="373rjd" value="true" />
+                  <ref role="HV5vE" node="2nMt2skySM5" resolve="ProjectViewExtension.ShadowRootTreeStructureProvider" />
                 </node>
               </node>
-              <node concept="3clFbS" id="1cRLf1A03eX" role="1bW5cS">
-                <node concept="3clFbJ" id="6EruykV8UEt" role="3cqZAp">
-                  <node concept="3clFbS" id="6EruykV8UEv" role="3clFbx">
-                    <node concept="3cpWs6" id="6EruykV8Vm$" role="3cqZAp" />
-                  </node>
-                  <node concept="37vLTw" id="6EruykV8V06" role="3clFbw">
-                    <ref role="3cqZAo" node="6EruykV8Png" resolve="disposed" />
-                  </node>
+              <node concept="37vLTw" id="5rSmnqxn$PX" role="37wK5m">
+                <ref role="3cqZAo" node="2nMt2sky4h8" resolve="ideaProject" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="2nMt2skyJFD" role="jymVt" />
+    <node concept="3clFb_" id="5rSmnqx0OJK" role="jymVt">
+      <property role="TrG5h" value="getIdeaProject" />
+      <node concept="3uibUv" id="5rSmnqx234h" role="3clF45">
+        <ref role="3uigEE" to="4nm9:~Project" resolve="Project" />
+      </node>
+      <node concept="3Tm6S6" id="5rSmnqx1Ei6" role="1B3o_S" />
+      <node concept="3clFbS" id="5rSmnqx0OJO" role="3clF47">
+        <node concept="3clFbF" id="5rSmnqx1yzA" role="3cqZAp">
+          <node concept="2OqwBi" id="5rSmnqx1yzC" role="3clFbG">
+            <node concept="1eOMI4" id="5rSmnqx1yzD" role="2Oq$k0">
+              <node concept="10QFUN" id="5rSmnqx1yzE" role="1eOMHV">
+                <node concept="3uibUv" id="5rSmnqx1yzF" role="10QFUM">
+                  <ref role="3uigEE" to="z1c4:~MPSProject" resolve="MPSProject" />
                 </node>
-                <node concept="3clFbF" id="6EruykV8HPf" role="3cqZAp">
-                  <node concept="37vLTI" id="6EruykV8HPh" role="3clFbG">
-                    <node concept="2OqwBi" id="6EruykV8HhG" role="37vLTx">
-                      <node concept="37vLTw" id="6EruykV8HhH" role="2Oq$k0">
-                        <ref role="3cqZAo" node="1cRLf1A03hn" resolve="tree" />
-                      </node>
-                      <node concept="liA8E" id="6EruykV8HhI" role="2OqNvi">
-                        <ref role="37wK5l" to="7e8u:~MPSTree.getModel()" resolve="getModel" />
-                      </node>
-                    </node>
-                    <node concept="37vLTw" id="6EruykV8HPl" role="37vLTJ">
-                      <ref role="3cqZAo" node="6EruykV8CMZ" resolve="treeModel" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="3clFbF" id="7YhLqbpA$qR" role="3cqZAp">
-                  <node concept="2OqwBi" id="7YhLqbpAUTl" role="3clFbG">
-                    <node concept="liA8E" id="7YhLqbpB9HX" role="2OqNvi">
-                      <ref role="37wK5l" to="rgfa:~TreeModel.addTreeModelListener(javax.swing.event.TreeModelListener)" resolve="addTreeModelListener" />
-                      <node concept="37vLTw" id="115Xaa41yNQ" role="37wK5m">
-                        <ref role="3cqZAo" node="115Xaa41sOA" resolve="treeListener" />
-                      </node>
-                    </node>
-                    <node concept="37vLTw" id="6EruykV8Ixp" role="2Oq$k0">
-                      <ref role="3cqZAo" node="6EruykV8CMZ" resolve="treeModel" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="3clFbF" id="6AlUJyrx1JC" role="3cqZAp">
-                  <node concept="2OqwBi" id="6AlUJyrx3sj" role="3clFbG">
-                    <node concept="2OqwBi" id="6AlUJyrx2EZ" role="2Oq$k0">
-                      <node concept="37vLTw" id="6AlUJyrx1JA" role="2Oq$k0">
-                        <ref role="3cqZAo" node="115Xaa3Z2NL" resolve="project" />
-                      </node>
-                      <node concept="liA8E" id="6AlUJyrx3gg" role="2OqNvi">
-                        <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
-                      </node>
-                    </node>
-                    <node concept="liA8E" id="6AlUJyrx41M" role="2OqNvi">
-                      <ref role="37wK5l" to="lui2:~SRepository.addRepositoryListener(org.jetbrains.mps.openapi.module.SRepositoryListener)" resolve="addRepositoryListener" />
-                      <node concept="37vLTw" id="6AlUJyrxaSe" role="37wK5m">
-                        <ref role="3cqZAo" node="6AlUJyrx6h8" resolve="repositoryListener" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="3clFbF" id="6AlUJyrx0Jj" role="3cqZAp">
-                  <node concept="1rXfSq" id="6AlUJyrx0Jh" role="3clFbG">
-                    <ref role="37wK5l" node="6AlUJyrwjTk" resolve="updateModules" />
-                  </node>
+                <node concept="37vLTw" id="5rSmnqx1yzG" role="10QFUP">
+                  <ref role="3cqZAo" node="115Xaa3Z2NL" resolve="project" />
                 </node>
               </node>
+            </node>
+            <node concept="liA8E" id="5rSmnqx1yzH" role="2OqNvi">
+              <ref role="37wK5l" to="z1c4:~MPSProject.getProject()" resolve="getProject" />
             </node>
           </node>
         </node>
       </node>
     </node>
     <node concept="2tJIrI" id="1cRLf1_XYvQ" role="jymVt" />
-    <node concept="3clFb_" id="1cRLf1_Y6nE" role="jymVt">
-      <property role="TrG5h" value="waitForProjectTree" />
-      <node concept="3cqZAl" id="1cRLf1_Y6nG" role="3clF45" />
-      <node concept="3Tm6S6" id="1cRLf1_YzMO" role="1B3o_S" />
-      <node concept="3clFbS" id="1cRLf1_Y6nI" role="3clF47">
-        <node concept="3cpWs8" id="1cRLf1_ZoFF" role="3cqZAp">
-          <node concept="3cpWsn" id="1cRLf1_ZoFG" role="3cpWs9">
-            <property role="TrG5h" value="tree" />
-            <node concept="3uibUv" id="1cRLf1_ZoFE" role="1tU5fm">
-              <ref role="3uigEE" to="paf:~ProjectTree" resolve="ProjectTree" />
-            </node>
-            <node concept="1rXfSq" id="1cRLf1_ZoFH" role="33vP2m">
-              <ref role="37wK5l" node="1cRLf1_YMsl" resolve="getProjectTree" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbJ" id="1cRLf1_ZoYB" role="3cqZAp">
-          <node concept="3clFbS" id="1cRLf1_ZoYD" role="3clFbx">
-            <node concept="3clFbF" id="1cRLf1_ZqIV" role="3cqZAp">
-              <node concept="2OqwBi" id="1cRLf1_ZqQ9" role="3clFbG">
-                <node concept="37vLTw" id="1cRLf1_ZqIT" role="2Oq$k0">
-                  <ref role="3cqZAo" node="1cRLf1_Yv7K" resolve="callback" />
-                </node>
-                <node concept="1Bd96e" id="1cRLf1_Zru4" role="2OqNvi">
-                  <node concept="37vLTw" id="1cRLf1_Zr_i" role="1BdPVh">
-                    <ref role="3cqZAo" node="1cRLf1_ZoFG" resolve="tree" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3y3z36" id="1cRLf1_Zqog" role="3clFbw">
-            <node concept="10Nm6u" id="1cRLf1_ZqtT" role="3uHU7w" />
-            <node concept="37vLTw" id="1cRLf1_Zp4D" role="3uHU7B">
-              <ref role="3cqZAo" node="1cRLf1_ZoFG" resolve="tree" />
-            </node>
-          </node>
-          <node concept="9aQIb" id="1cRLf1_ZrIQ" role="9aQIa">
-            <node concept="3clFbS" id="1cRLf1_ZrIR" role="9aQI4">
-              <node concept="3cpWs8" id="1cRLf1_Zs3j" role="3cqZAp">
-                <node concept="3cpWsn" id="1cRLf1_Zs3k" role="3cpWs9">
-                  <property role="TrG5h" value="timer" />
-                  <node concept="3uibUv" id="1cRLf1_Zs3l" role="1tU5fm">
-                    <ref role="3uigEE" to="dxuu:~Timer" resolve="Timer" />
-                  </node>
-                  <node concept="10Nm6u" id="1cRLf1_ZUhR" role="33vP2m" />
-                </node>
-              </node>
-              <node concept="3clFbF" id="1cRLf1_ZTdB" role="3cqZAp">
-                <node concept="37vLTI" id="1cRLf1_ZTdD" role="3clFbG">
-                  <node concept="2ShNRf" id="1cRLf1_Zsf8" role="37vLTx">
-                    <node concept="1pGfFk" id="1cRLf1_Zs9Q" role="2ShVmc">
-                      <ref role="37wK5l" to="dxuu:~Timer.&lt;init&gt;(int,java.awt.event.ActionListener)" resolve="Timer" />
-                      <node concept="3cmrfG" id="1cRLf1_ZsUV" role="37wK5m">
-                        <property role="3cmrfH" value="1000" />
-                      </node>
-                      <node concept="1bVj0M" id="1cRLf1_ZtbC" role="37wK5m">
-                        <node concept="37vLTG" id="1cRLf1_Zv69" role="1bW2Oz">
-                          <property role="TrG5h" value="e" />
-                          <node concept="3uibUv" id="1cRLf1_ZvOz" role="1tU5fm">
-                            <ref role="3uigEE" to="hyam:~ActionEvent" resolve="ActionEvent" />
-                          </node>
-                        </node>
-                        <node concept="3clFbS" id="1cRLf1_ZtbE" role="1bW5cS">
-                          <node concept="3cpWs8" id="1cRLf1_ZFM7" role="3cqZAp">
-                            <node concept="3cpWsn" id="1cRLf1_ZFM8" role="3cpWs9">
-                              <property role="TrG5h" value="tree" />
-                              <node concept="3uibUv" id="1cRLf1_ZFM6" role="1tU5fm">
-                                <ref role="3uigEE" to="paf:~ProjectTree" resolve="ProjectTree" />
-                              </node>
-                              <node concept="1rXfSq" id="1cRLf1_ZFM9" role="33vP2m">
-                                <ref role="37wK5l" node="1cRLf1_YMsl" resolve="getProjectTree" />
-                              </node>
-                            </node>
-                          </node>
-                          <node concept="3clFbJ" id="1cRLf1_ZFhb" role="3cqZAp">
-                            <node concept="3clFbS" id="1cRLf1_ZFhd" role="3clFbx">
-                              <node concept="3clFbF" id="1cRLf1_ZIkg" role="3cqZAp">
-                                <node concept="2OqwBi" id="1cRLf1_ZIty" role="3clFbG">
-                                  <node concept="37vLTw" id="1cRLf1_ZIke" role="2Oq$k0">
-                                    <ref role="3cqZAo" node="1cRLf1_Yv7K" resolve="callback" />
-                                  </node>
-                                  <node concept="1Bd96e" id="1cRLf1_ZJ78" role="2OqNvi">
-                                    <node concept="37vLTw" id="1cRLf1_ZJgp" role="1BdPVh">
-                                      <ref role="3cqZAo" node="1cRLf1_ZFM8" resolve="tree" />
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                              <node concept="3clFbF" id="1cRLf1_ZycD" role="3cqZAp">
-                                <node concept="2OqwBi" id="1cRLf1_Zysj" role="3clFbG">
-                                  <node concept="37vLTw" id="1cRLf1_ZycB" role="2Oq$k0">
-                                    <ref role="3cqZAo" node="1cRLf1_Zs3k" resolve="timer" />
-                                  </node>
-                                  <node concept="liA8E" id="1cRLf1_ZBUL" role="2OqNvi">
-                                    <ref role="37wK5l" to="dxuu:~Timer.stop()" resolve="stop" />
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                            <node concept="3y3z36" id="1cRLf1_ZHTZ" role="3clFbw">
-                              <node concept="10Nm6u" id="1cRLf1_ZI1o" role="3uHU7w" />
-                              <node concept="37vLTw" id="1cRLf1_ZFMa" role="3uHU7B">
-                                <ref role="3cqZAo" node="1cRLf1_ZFM8" resolve="tree" />
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="37vLTw" id="1cRLf1_ZTdH" role="37vLTJ">
-                    <ref role="3cqZAo" node="1cRLf1_Zs3k" resolve="timer" />
-                  </node>
-                </node>
-              </node>
-              <node concept="3clFbF" id="1cRLf1_ZCcH" role="3cqZAp">
-                <node concept="2OqwBi" id="1cRLf1_ZCry" role="3clFbG">
-                  <node concept="37vLTw" id="1cRLf1_ZCcF" role="2Oq$k0">
-                    <ref role="3cqZAo" node="1cRLf1_Zs3k" resolve="timer" />
-                  </node>
-                  <node concept="liA8E" id="1cRLf1_ZF8d" role="2OqNvi">
-                    <ref role="37wK5l" to="dxuu:~Timer.start()" resolve="start" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="37vLTG" id="1cRLf1_Yv7K" role="3clF46">
-        <property role="TrG5h" value="callback" />
-        <property role="3TUv4t" value="true" />
-        <node concept="1ajhzC" id="1cRLf1_Yv7I" role="1tU5fm">
-          <node concept="3uibUv" id="1cRLf1_YzkM" role="1ajw0F">
-            <ref role="3uigEE" to="paf:~ProjectTree" resolve="ProjectTree" />
-          </node>
-          <node concept="3cqZAl" id="1cRLf1_Yz$p" role="1ajl9A" />
-        </node>
-      </node>
-    </node>
-    <node concept="2tJIrI" id="1cRLf1_YHRj" role="jymVt" />
-    <node concept="3clFb_" id="1cRLf1_YMsl" role="jymVt">
-      <property role="TrG5h" value="getProjectTree" />
-      <node concept="3uibUv" id="1cRLf1_YQRO" role="3clF45">
-        <ref role="3uigEE" to="paf:~ProjectTree" resolve="ProjectTree" />
-      </node>
-      <node concept="3Tm6S6" id="1cRLf1_Z1L1" role="1B3o_S" />
-      <node concept="3clFbS" id="1cRLf1_YMsp" role="3clF47">
-        <node concept="3clFbJ" id="2wBC8Z9fyz_" role="3cqZAp">
-          <node concept="3clFbS" id="2wBC8Z9fyzB" role="3clFbx">
-            <node concept="3cpWs6" id="2wBC8Z9fESZ" role="3cqZAp">
-              <node concept="10Nm6u" id="2wBC8Z9fEZ4" role="3cqZAk" />
-            </node>
-          </node>
-          <node concept="2OqwBi" id="2wBC8Z9fCbG" role="3clFbw">
-            <node concept="37vLTw" id="2wBC8Z9fBIw" role="2Oq$k0">
-              <ref role="3cqZAo" node="115Xaa3Z2NL" resolve="project" />
-            </node>
-            <node concept="liA8E" id="2wBC8Z9fE_b" role="2OqNvi">
-              <ref role="37wK5l" to="z1c3:~Project.isDisposed()" resolve="isDisposed" />
-            </node>
-          </node>
-          <node concept="3eNFk2" id="2BBR7lu9A9U" role="3eNLev">
-            <node concept="1Wc70l" id="2BBR7lu9IQi" role="3eO9$A">
-              <node concept="2OqwBi" id="2BBR7lu9LkQ" role="3uHU7w">
-                <node concept="2OqwBi" id="2BBR7lu9Kg4" role="2Oq$k0">
-                  <node concept="1eOMI4" id="2BBR7lu9J8o" role="2Oq$k0">
-                    <node concept="10QFUN" id="2BBR7lu9J8l" role="1eOMHV">
-                      <node concept="3uibUv" id="2BBR7lu9JlD" role="10QFUM">
-                        <ref role="3uigEE" to="z1c4:~MPSProject" resolve="MPSProject" />
-                      </node>
-                      <node concept="37vLTw" id="2BBR7lu9JEO" role="10QFUP">
-                        <ref role="3cqZAo" node="115Xaa3Z2NL" resolve="project" />
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="liA8E" id="2BBR7lu9KX2" role="2OqNvi">
-                    <ref role="37wK5l" to="z1c4:~MPSProject.getProject()" resolve="getProject" />
-                  </node>
-                </node>
-                <node concept="liA8E" id="2BBR7lu9LLp" role="2OqNvi">
-                  <ref role="37wK5l" to="1m72:~ComponentManager.isDisposed()" resolve="isDisposed" />
-                </node>
-              </node>
-              <node concept="1eOMI4" id="2BBR7lu9ItQ" role="3uHU7B">
-                <node concept="2ZW3vV" id="2BBR7lu9H_O" role="1eOMHV">
-                  <node concept="3uibUv" id="2BBR7lu9HTx" role="2ZW6by">
-                    <ref role="3uigEE" to="z1c4:~MPSProject" resolve="MPSProject" />
-                  </node>
-                  <node concept="37vLTw" id="2BBR7lu9H5n" role="2ZW6bz">
-                    <ref role="3cqZAo" node="115Xaa3Z2NL" resolve="project" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbS" id="2BBR7lu9A9W" role="3eOfB_">
-              <node concept="3SKdUt" id="2BBR7luac4U" role="3cqZAp">
-                <node concept="1PaTwC" id="2BBR7luac4V" role="1aUNEU">
-                  <node concept="3oM_SD" id="2BBR7luac4W" role="1PaTwD">
-                    <property role="3oM_SC" value="In" />
-                  </node>
-                  <node concept="3oM_SD" id="2BBR7luafXD" role="1PaTwD">
-                    <property role="3oM_SC" value="certain" />
-                  </node>
-                  <node concept="3oM_SD" id="2BBR7luafYH" role="1PaTwD">
-                    <property role="3oM_SC" value="cases," />
-                  </node>
-                  <node concept="3oM_SD" id="2BBR7luag0C" role="1PaTwD">
-                    <property role="3oM_SC" value="it" />
-                  </node>
-                  <node concept="3oM_SD" id="2BBR7luag0P" role="1PaTwD">
-                    <property role="3oM_SC" value="can" />
-                  </node>
-                  <node concept="3oM_SD" id="2BBR7luag0V" role="1PaTwD">
-                    <property role="3oM_SC" value="actually" />
-                  </node>
-                  <node concept="3oM_SD" id="2BBR7luag1S" role="1PaTwD">
-                    <property role="3oM_SC" value="happen" />
-                  </node>
-                  <node concept="3oM_SD" id="2BBR7luag2Q" role="1PaTwD">
-                    <property role="3oM_SC" value="that" />
-                  </node>
-                  <node concept="3oM_SD" id="2BBR7luag2Z" role="1PaTwD">
-                    <property role="3oM_SC" value="the" />
-                  </node>
-                  <node concept="3oM_SD" id="2BBR7luag39" role="1PaTwD">
-                    <property role="3oM_SC" value="idea" />
-                  </node>
-                  <node concept="3oM_SD" id="2BBR7luag4a" role="1PaTwD">
-                    <property role="3oM_SC" value="project" />
-                  </node>
-                  <node concept="3oM_SD" id="2BBR7luag4m" role="1PaTwD">
-                    <property role="3oM_SC" value="is" />
-                  </node>
-                  <node concept="3oM_SD" id="2BBR7luag4z" role="1PaTwD">
-                    <property role="3oM_SC" value="already" />
-                  </node>
-                  <node concept="3oM_SD" id="2BBR7luag5B" role="1PaTwD">
-                    <property role="3oM_SC" value="disposed," />
-                  </node>
-                  <node concept="3oM_SD" id="2BBR7luag6G" role="1PaTwD">
-                    <property role="3oM_SC" value="" />
-                  </node>
-                </node>
-              </node>
-              <node concept="3SKdUt" id="2BBR7luagdS" role="3cqZAp">
-                <node concept="1PaTwC" id="2BBR7luagdR" role="1aUNEU">
-                  <node concept="3oM_SD" id="2BBR7luagdQ" role="1PaTwD">
-                    <property role="3oM_SC" value="but" />
-                  </node>
-                  <node concept="3oM_SD" id="2BBR7luag88" role="1PaTwD">
-                    <property role="3oM_SC" value="the" />
-                  </node>
-                  <node concept="3oM_SD" id="2BBR7luag8p" role="1PaTwD">
-                    <property role="3oM_SC" value="MPS" />
-                  </node>
-                  <node concept="3oM_SD" id="2BBR7luag9G" role="1PaTwD">
-                    <property role="3oM_SC" value="project" />
-                  </node>
-                  <node concept="3oM_SD" id="2BBR7luag9Z" role="1PaTwD">
-                    <property role="3oM_SC" value="is" />
-                  </node>
-                  <node concept="3oM_SD" id="2BBR7luagaj" role="1PaTwD">
-                    <property role="3oM_SC" value="not" />
-                  </node>
-                  <node concept="3oM_SD" id="2BBR7luagbD" role="1PaTwD">
-                    <property role="3oM_SC" value="yet." />
-                  </node>
-                  <node concept="3oM_SD" id="2BBR7luajUX" role="1PaTwD">
-                    <property role="3oM_SC" value="This" />
-                  </node>
-                  <node concept="3oM_SD" id="2BBR7luajWi" role="1PaTwD">
-                    <property role="3oM_SC" value="situation" />
-                  </node>
-                  <node concept="3oM_SD" id="2BBR7luajXC" role="1PaTwD">
-                    <property role="3oM_SC" value="can" />
-                  </node>
-                  <node concept="3oM_SD" id="2BBR7luajXN" role="1PaTwD">
-                    <property role="3oM_SC" value="still" />
-                  </node>
-                  <node concept="3oM_SD" id="2BBR7luajYP" role="1PaTwD">
-                    <property role="3oM_SC" value="lead" />
-                  </node>
-                  <node concept="3oM_SD" id="2BBR7luajZa" role="1PaTwD">
-                    <property role="3oM_SC" value="to" />
-                  </node>
-                  <node concept="3oM_SD" id="2BBR7luajZo" role="1PaTwD">
-                    <property role="3oM_SC" value="errors" />
-                  </node>
-                  <node concept="3oM_SD" id="2BBR7luak1D" role="1PaTwD">
-                    <property role="3oM_SC" value="when" />
-                  </node>
-                  <node concept="3oM_SD" id="2BBR7luak2J" role="1PaTwD">
-                    <property role="3oM_SC" value="trying" />
-                  </node>
-                  <node concept="3oM_SD" id="2BBR7luak41" role="1PaTwD">
-                    <property role="3oM_SC" value="to" />
-                  </node>
-                  <node concept="3oM_SD" id="2BBR7luak4j" role="1PaTwD">
-                    <property role="3oM_SC" value="" />
-                  </node>
-                </node>
-              </node>
-              <node concept="3SKdUt" id="2BBR7luaozz" role="3cqZAp">
-                <node concept="1PaTwC" id="2BBR7luaoz$" role="1aUNEU">
-                  <node concept="3oM_SD" id="2BBR7luaoz_" role="1PaTwD">
-                    <property role="3oM_SC" value="get" />
-                  </node>
-                  <node concept="3oM_SD" id="2BBR7luasHd" role="1PaTwD">
-                    <property role="3oM_SC" value="the" />
-                  </node>
-                  <node concept="3oM_SD" id="2BBR7luasHg" role="1PaTwD">
-                    <property role="3oM_SC" value="project" />
-                  </node>
-                  <node concept="3oM_SD" id="2BBR7luasIa" role="1PaTwD">
-                    <property role="3oM_SC" value="pane." />
-                  </node>
-                  <node concept="3oM_SD" id="2BBR7luasIf" role="1PaTwD">
-                    <property role="3oM_SC" value="Let's" />
-                  </node>
-                  <node concept="3oM_SD" id="2BBR7luasKc" role="1PaTwD">
-                    <property role="3oM_SC" value="guard" />
-                  </node>
-                  <node concept="3oM_SD" id="2BBR7luasLk" role="1PaTwD">
-                    <property role="3oM_SC" value="against" />
-                  </node>
-                  <node concept="3oM_SD" id="2BBR7luasMi" role="1PaTwD">
-                    <property role="3oM_SC" value="this" />
-                  </node>
-                  <node concept="3oM_SD" id="2BBR7luasMr" role="1PaTwD">
-                    <property role="3oM_SC" value="case," />
-                  </node>
-                  <node concept="3oM_SD" id="2BBR7luasNr" role="1PaTwD">
-                    <property role="3oM_SC" value="as" />
-                  </node>
-                  <node concept="3oM_SD" id="2BBR7luasNL" role="1PaTwD">
-                    <property role="3oM_SC" value="well." />
-                  </node>
-                  <node concept="3oM_SD" id="2BBR7luasON" role="1PaTwD">
-                    <property role="3oM_SC" value="" />
-                  </node>
-                </node>
-              </node>
-              <node concept="3cpWs6" id="2BBR7lu9LQ8" role="3cqZAp">
-                <node concept="10Nm6u" id="2BBR7lu9LQ9" role="3cqZAk" />
-              </node>
-            </node>
-          </node>
-          <node concept="9aQIb" id="2BBR7lu9LRu" role="9aQIa">
-            <node concept="3clFbS" id="2BBR7lu9LRv" role="9aQI4">
-              <node concept="3cpWs8" id="1cRLf1_Z67F" role="3cqZAp">
-                <node concept="3cpWsn" id="1cRLf1_Z67G" role="3cpWs9">
-                  <property role="TrG5h" value="pane" />
-                  <node concept="3uibUv" id="1cRLf1_Z67H" role="1tU5fm">
-                    <ref role="3uigEE" to="rvbb:~ProjectPane" resolve="ProjectPane" />
-                  </node>
-                  <node concept="2YIFZM" id="1cRLf1_Z67I" role="33vP2m">
-                    <ref role="1Pybhc" to="rvbb:~ProjectPane" resolve="ProjectPane" />
-                    <ref role="37wK5l" to="rvbb:~ProjectPane.getInstance(jetbrains.mps.project.Project)" resolve="getInstance" />
-                    <node concept="37vLTw" id="1cRLf1_Z67J" role="37wK5m">
-                      <ref role="3cqZAo" node="115Xaa3Z2NL" resolve="project" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3clFbJ" id="1cRLf1_Z6yv" role="3cqZAp">
-                <node concept="3clFbS" id="1cRLf1_Z6yx" role="3clFbx">
-                  <node concept="3cpWs6" id="1cRLf1_Z7qe" role="3cqZAp">
-                    <node concept="10Nm6u" id="1cRLf1_Z7vF" role="3cqZAk" />
-                  </node>
-                </node>
-                <node concept="3clFbC" id="1cRLf1_Z7bh" role="3clFbw">
-                  <node concept="10Nm6u" id="1cRLf1_Z7gv" role="3uHU7w" />
-                  <node concept="37vLTw" id="1cRLf1_Z6Ch" role="3uHU7B">
-                    <ref role="3cqZAo" node="1cRLf1_Z67G" resolve="pane" />
-                  </node>
-                </node>
-                <node concept="9aQIb" id="2BBR7lu9U7q" role="9aQIa">
-                  <node concept="3clFbS" id="2BBR7lu9U7r" role="9aQI4">
-                    <node concept="3cpWs6" id="2BBR7lua1Fm" role="3cqZAp">
-                      <node concept="2OqwBi" id="2BBR7lua1Kk" role="3cqZAk">
-                        <node concept="37vLTw" id="2BBR7lua1Kl" role="2Oq$k0">
-                          <ref role="3cqZAo" node="1cRLf1_Z67G" resolve="pane" />
-                        </node>
-                        <node concept="liA8E" id="2BBR7lua1Km" role="2OqNvi">
-                          <ref role="37wK5l" to="rvbb:~ProjectPane.getTree()" resolve="getTree" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="2tJIrI" id="115Xaa3Zjn2" role="jymVt" />
     <node concept="3clFb_" id="115Xaa3Zj_d" role="jymVt">
       <property role="TrG5h" value="dispose" />
       <node concept="3cqZAl" id="115Xaa3Zj_f" role="3clF45" />
@@ -2028,55 +1132,6 @@
             </node>
             <node concept="37vLTw" id="6EruykV8VRA" role="37vLTJ">
               <ref role="3cqZAo" node="6EruykV8Png" resolve="disposed" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="6AlUJyrxb7H" role="3cqZAp">
-          <node concept="2OqwBi" id="6AlUJyrxb7I" role="3clFbG">
-            <node concept="2OqwBi" id="6AlUJyrxb7J" role="2Oq$k0">
-              <node concept="37vLTw" id="6AlUJyrxb7K" role="2Oq$k0">
-                <ref role="3cqZAo" node="115Xaa3Z2NL" resolve="project" />
-              </node>
-              <node concept="liA8E" id="6AlUJyrxb7L" role="2OqNvi">
-                <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
-              </node>
-            </node>
-            <node concept="liA8E" id="6AlUJyrxb7M" role="2OqNvi">
-              <ref role="37wK5l" to="lui2:~SRepository.removeRepositoryListener(org.jetbrains.mps.openapi.module.SRepositoryListener)" resolve="removeRepositoryListener" />
-              <node concept="37vLTw" id="6AlUJyrxb7N" role="37wK5m">
-                <ref role="3cqZAo" node="6AlUJyrx6h8" resolve="repositoryListener" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbJ" id="6EruykV8J6S" role="3cqZAp">
-          <node concept="3clFbS" id="6EruykV8J6U" role="3clFbx">
-            <node concept="3clFbF" id="6EruykV8KcB" role="3cqZAp">
-              <node concept="2OqwBi" id="6EruykV8Ks1" role="3clFbG">
-                <node concept="37vLTw" id="6EruykV8Kc_" role="2Oq$k0">
-                  <ref role="3cqZAo" node="6EruykV8CMZ" resolve="treeModel" />
-                </node>
-                <node concept="liA8E" id="6EruykV8KI1" role="2OqNvi">
-                  <ref role="37wK5l" to="rgfa:~TreeModel.removeTreeModelListener(javax.swing.event.TreeModelListener)" resolve="removeTreeModelListener" />
-                  <node concept="37vLTw" id="6EruykV8KV5" role="37wK5m">
-                    <ref role="3cqZAo" node="115Xaa41sOA" resolve="treeListener" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbF" id="1Yk_YbD6Clz" role="3cqZAp">
-              <node concept="37vLTI" id="1Yk_YbD6CAf" role="3clFbG">
-                <node concept="10Nm6u" id="1Yk_YbD6CGU" role="37vLTx" />
-                <node concept="37vLTw" id="1Yk_YbD6Clx" role="37vLTJ">
-                  <ref role="3cqZAo" node="6EruykV8CMZ" resolve="treeModel" />
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3y3z36" id="6EruykV8JKU" role="3clFbw">
-            <node concept="10Nm6u" id="6EruykV8JQI" role="3uHU7w" />
-            <node concept="37vLTw" id="6EruykV8JrE" role="3uHU7B">
-              <ref role="3cqZAo" node="6EruykV8CMZ" resolve="treeModel" />
             </node>
           </node>
         </node>
@@ -2108,1370 +1163,739 @@
         </node>
       </node>
     </node>
-    <node concept="2tJIrI" id="115Xaa41EuW" role="jymVt" />
-    <node concept="3clFb_" id="115Xaa41jby" role="jymVt">
-      <property role="TrG5h" value="attachShadowRoot" />
-      <node concept="3cqZAl" id="115Xaa41jb$" role="3clF45" />
-      <node concept="3Tm1VV" id="115Xaa41jb_" role="1B3o_S" />
-      <node concept="3clFbS" id="115Xaa41jbA" role="3clF47">
-        <node concept="3cpWs8" id="115Xaa41HDe" role="3cqZAp">
-          <node concept="3cpWsn" id="115Xaa41HDf" role="3cpWs9">
-            <property role="TrG5h" value="projectPane" />
-            <node concept="3uibUv" id="115Xaa41HDd" role="1tU5fm">
-              <ref role="3uigEE" to="rvbb:~ProjectPane" resolve="ProjectPane" />
-            </node>
-            <node concept="2YIFZM" id="115Xaa41HDg" role="33vP2m">
-              <ref role="1Pybhc" to="rvbb:~ProjectPane" resolve="ProjectPane" />
-              <ref role="37wK5l" to="rvbb:~ProjectPane.getInstance(jetbrains.mps.project.Project)" resolve="getInstance" />
-              <node concept="37vLTw" id="115Xaa41HDh" role="37wK5m">
-                <ref role="3cqZAo" node="115Xaa3Z2NL" resolve="project" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3cpWs8" id="7YhLqbpvh8r" role="3cqZAp">
-          <node concept="3cpWsn" id="7YhLqbpvh8s" role="3cpWs9">
-            <property role="TrG5h" value="root" />
-            <node concept="3uibUv" id="151UdFuXpId" role="1tU5fm">
-              <ref role="3uigEE" to="7e8u:~MPSTreeNode" resolve="MPSTreeNode" />
-            </node>
-            <node concept="2OqwBi" id="7YhLqbpvh8t" role="33vP2m">
-              <node concept="2OqwBi" id="7YhLqbpvh8u" role="2Oq$k0">
-                <node concept="37vLTw" id="7YhLqbpvh8v" role="2Oq$k0">
-                  <ref role="3cqZAo" node="115Xaa41HDf" resolve="projectPane" />
-                </node>
-                <node concept="liA8E" id="7YhLqbpvh8w" role="2OqNvi">
-                  <ref role="37wK5l" to="rvbb:~ProjectPane.getTree()" resolve="getTree" />
-                </node>
-              </node>
-              <node concept="liA8E" id="7YhLqbpvh8x" role="2OqNvi">
-                <ref role="37wK5l" to="7e8u:~MPSTree.getRootNode()" resolve="getRootNode" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbJ" id="7uScH4fNtSl" role="3cqZAp">
-          <node concept="3clFbS" id="7uScH4fNtSn" role="3clFbx">
-            <node concept="3cpWs6" id="7uScH4fNwVV" role="3cqZAp" />
-          </node>
-          <node concept="3clFbC" id="7uScH4fNwas" role="3clFbw">
-            <node concept="10Nm6u" id="7uScH4fNwaP" role="3uHU7w" />
-            <node concept="37vLTw" id="7uScH4fNuIQ" role="3uHU7B">
-              <ref role="3cqZAo" node="7YhLqbpvh8s" resolve="root" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbH" id="3HhbiV6en6O" role="3cqZAp" />
-        <node concept="3cpWs8" id="7YhLqbpzWN5" role="3cqZAp">
-          <node concept="3cpWsn" id="7YhLqbpzWN6" role="3cpWs9">
-            <property role="TrG5h" value="model" />
-            <node concept="3uibUv" id="7YhLqbpzWM2" role="1tU5fm">
-              <ref role="3uigEE" to="rgfa:~DefaultTreeModel" resolve="DefaultTreeModel" />
-            </node>
-            <node concept="2OqwBi" id="7YhLqbpzWN7" role="33vP2m">
-              <node concept="2OqwBi" id="7YhLqbpzWN8" role="2Oq$k0">
-                <node concept="37vLTw" id="7YhLqbpzWN9" role="2Oq$k0">
-                  <ref role="3cqZAo" node="115Xaa41HDf" resolve="projectPane" />
-                </node>
-                <node concept="liA8E" id="7YhLqbpzWNa" role="2OqNvi">
-                  <ref role="37wK5l" to="rvbb:~ProjectPane.getTree()" resolve="getTree" />
-                </node>
-              </node>
-              <node concept="liA8E" id="2Ko4lD9zcmv" role="2OqNvi">
-                <ref role="37wK5l" to="7e8u:~MPSTree.getDFTreeModel()" resolve="getDFTreeModel" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbH" id="115Xaa42Gcw" role="3cqZAp" />
-        <node concept="3SKdUt" id="115Xaa42WuJ" role="3cqZAp">
-          <node concept="1PaTwC" id="7WTFIQIcYcS" role="1aUNEU">
-            <node concept="3oM_SD" id="7WTFIQIcYcT" role="1PaTwD">
-              <property role="3oM_SC" value="wrong" />
-            </node>
-            <node concept="3oM_SD" id="7WTFIQIcYcU" role="1PaTwD">
-              <property role="3oM_SC" value="parent" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbJ" id="7YhLqbpF_Ey" role="3cqZAp">
-          <node concept="3clFbS" id="7YhLqbpF_E$" role="3clFbx">
-            <node concept="3clFbF" id="7YhLqbpQ3u1" role="3cqZAp">
-              <node concept="2OqwBi" id="7YhLqbpQ3u2" role="3clFbG">
-                <node concept="37vLTw" id="7YhLqbpQ3u3" role="2Oq$k0">
-                  <ref role="3cqZAo" node="7YhLqbpzWN6" resolve="model" />
-                </node>
-                <node concept="liA8E" id="7YhLqbpQ3u4" role="2OqNvi">
-                  <ref role="37wK5l" to="rgfa:~DefaultTreeModel.removeNodeFromParent(javax.swing.tree.MutableTreeNode)" resolve="removeNodeFromParent" />
-                  <node concept="37vLTw" id="115Xaa41Lm8" role="37wK5m">
-                    <ref role="3cqZAo" node="115Xaa41cD5" resolve="shadowTreeNode" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="1Wc70l" id="115Xaa42MFG" role="3clFbw">
-            <node concept="3y3z36" id="115Xaa42QiC" role="3uHU7B">
-              <node concept="10Nm6u" id="115Xaa42Qjd" role="3uHU7w" />
-              <node concept="2OqwBi" id="115Xaa42OsO" role="3uHU7B">
-                <node concept="37vLTw" id="115Xaa42NP3" role="2Oq$k0">
-                  <ref role="3cqZAo" node="115Xaa41cD5" resolve="shadowTreeNode" />
-                </node>
-                <node concept="liA8E" id="115Xaa42PIj" role="2OqNvi">
-                  <ref role="37wK5l" to="rgfa:~DefaultMutableTreeNode.getParent()" resolve="getParent" />
-                </node>
-              </node>
-            </node>
-            <node concept="3y3z36" id="7YhLqbpSrYE" role="3uHU7w">
-              <node concept="37vLTw" id="115Xaa42J_8" role="3uHU7w">
-                <ref role="3cqZAo" node="7YhLqbpvh8s" resolve="root" />
-              </node>
-              <node concept="2OqwBi" id="7YhLqbpShMr" role="3uHU7B">
-                <node concept="37vLTw" id="115Xaa41Lc_" role="2Oq$k0">
-                  <ref role="3cqZAo" node="115Xaa41cD5" resolve="shadowTreeNode" />
-                </node>
-                <node concept="liA8E" id="115Xaa42J2g" role="2OqNvi">
-                  <ref role="37wK5l" to="rgfa:~DefaultMutableTreeNode.getParent()" resolve="getParent" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbH" id="115Xaa42JD$" role="3cqZAp" />
-        <node concept="3SKdUt" id="115Xaa42XAq" role="3cqZAp">
-          <node concept="1PaTwC" id="7WTFIQIcYcV" role="1aUNEU">
-            <node concept="3oM_SD" id="7WTFIQIcYcW" role="1PaTwD">
-              <property role="3oM_SC" value="wrong" />
-            </node>
-            <node concept="3oM_SD" id="7WTFIQIcYcX" role="1PaTwD">
-              <property role="3oM_SC" value="position" />
-            </node>
-          </node>
-        </node>
-        <node concept="3cpWs8" id="151UdFuXT7m" role="3cqZAp">
-          <node concept="3cpWsn" id="151UdFuXT7n" role="3cpWs9">
-            <property role="TrG5h" value="preferedIndex" />
-            <node concept="10Oyi0" id="151UdFuXT7g" role="1tU5fm" />
-            <node concept="3cmrfG" id="151UdFuYcAz" role="33vP2m">
-              <property role="3cmrfH" value="2" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbJ" id="7YhLqbpPDEy" role="3cqZAp">
-          <node concept="3clFbS" id="7YhLqbpPDE$" role="3clFbx">
-            <node concept="3clFbF" id="7YhLqbpKECV" role="3cqZAp">
-              <node concept="2OqwBi" id="7YhLqbpKFZs" role="3clFbG">
-                <node concept="37vLTw" id="7YhLqbpKECT" role="2Oq$k0">
-                  <ref role="3cqZAo" node="7YhLqbpzWN6" resolve="model" />
-                </node>
-                <node concept="liA8E" id="7YhLqbpKHeU" role="2OqNvi">
-                  <ref role="37wK5l" to="rgfa:~DefaultTreeModel.removeNodeFromParent(javax.swing.tree.MutableTreeNode)" resolve="removeNodeFromParent" />
-                  <node concept="37vLTw" id="115Xaa41NI$" role="37wK5m">
-                    <ref role="3cqZAo" node="115Xaa41cD5" resolve="shadowTreeNode" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="1Wc70l" id="115Xaa42TpQ" role="3clFbw">
-            <node concept="3y3z36" id="115Xaa42TpR" role="3uHU7B">
-              <node concept="10Nm6u" id="115Xaa42TpS" role="3uHU7w" />
-              <node concept="2OqwBi" id="115Xaa42TpT" role="3uHU7B">
-                <node concept="37vLTw" id="115Xaa42TpU" role="2Oq$k0">
-                  <ref role="3cqZAo" node="115Xaa41cD5" resolve="shadowTreeNode" />
-                </node>
-                <node concept="liA8E" id="115Xaa42TpV" role="2OqNvi">
-                  <ref role="37wK5l" to="rgfa:~DefaultMutableTreeNode.getParent()" resolve="getParent" />
-                </node>
-              </node>
-            </node>
-            <node concept="3y3z36" id="151UdFuXXob" role="3uHU7w">
-              <node concept="2OqwBi" id="115Xaa42TpX" role="3uHU7B">
-                <node concept="2OqwBi" id="115Xaa42TpY" role="2Oq$k0">
-                  <node concept="37vLTw" id="115Xaa42TpZ" role="2Oq$k0">
-                    <ref role="3cqZAo" node="115Xaa41cD5" resolve="shadowTreeNode" />
-                  </node>
-                  <node concept="liA8E" id="115Xaa42Tq0" role="2OqNvi">
-                    <ref role="37wK5l" to="rgfa:~DefaultMutableTreeNode.getParent()" resolve="getParent" />
-                  </node>
-                </node>
-                <node concept="liA8E" id="115Xaa42Tq1" role="2OqNvi">
-                  <ref role="37wK5l" to="rgfa:~TreeNode.getIndex(javax.swing.tree.TreeNode)" resolve="getIndex" />
-                  <node concept="37vLTw" id="115Xaa42Tq2" role="37wK5m">
-                    <ref role="3cqZAo" node="115Xaa41cD5" resolve="shadowTreeNode" />
-                  </node>
-                </node>
-              </node>
-              <node concept="2YIFZM" id="151UdFuY8YW" role="3uHU7w">
-                <ref role="1Pybhc" to="wyt6:~Math" resolve="Math" />
-                <ref role="37wK5l" to="wyt6:~Math.min(int,int)" resolve="min" />
-                <node concept="3cpWsd" id="151UdFuY8YX" role="37wK5m">
-                  <node concept="3cmrfG" id="151UdFuY8YY" role="3uHU7w">
-                    <property role="3cmrfH" value="1" />
-                  </node>
-                  <node concept="2OqwBi" id="151UdFuY8YZ" role="3uHU7B">
-                    <node concept="2OqwBi" id="151UdFuY8Z0" role="2Oq$k0">
-                      <node concept="37vLTw" id="151UdFuY8Z1" role="2Oq$k0">
-                        <ref role="3cqZAo" node="115Xaa41cD5" resolve="shadowTreeNode" />
-                      </node>
-                      <node concept="liA8E" id="151UdFuY8Z2" role="2OqNvi">
-                        <ref role="37wK5l" to="rgfa:~DefaultMutableTreeNode.getParent()" resolve="getParent" />
-                      </node>
-                    </node>
-                    <node concept="liA8E" id="151UdFuY8Z3" role="2OqNvi">
-                      <ref role="37wK5l" to="rgfa:~TreeNode.getChildCount()" resolve="getChildCount" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="37vLTw" id="151UdFuYdcn" role="37wK5m">
-                  <ref role="3cqZAo" node="151UdFuXT7n" resolve="preferedIndex" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbH" id="115Xaa430i3" role="3cqZAp" />
-        <node concept="3clFbJ" id="7YhLqbpO2IX" role="3cqZAp">
-          <node concept="3clFbS" id="7YhLqbpO2IZ" role="3clFbx">
-            <node concept="3clFbF" id="7YhLqbpJI1b" role="3cqZAp">
-              <node concept="2OqwBi" id="7YhLqbpJI1c" role="3clFbG">
-                <node concept="37vLTw" id="7YhLqbpJI1d" role="2Oq$k0">
-                  <ref role="3cqZAo" node="7YhLqbpzWN6" resolve="model" />
-                </node>
-                <node concept="liA8E" id="7YhLqbpJI1e" role="2OqNvi">
-                  <ref role="37wK5l" to="rgfa:~DefaultTreeModel.insertNodeInto(javax.swing.tree.MutableTreeNode,javax.swing.tree.MutableTreeNode,int)" resolve="insertNodeInto" />
-                  <node concept="37vLTw" id="115Xaa41OaV" role="37wK5m">
-                    <ref role="3cqZAo" node="115Xaa41cD5" resolve="shadowTreeNode" />
-                  </node>
-                  <node concept="37vLTw" id="7YhLqbpJI1g" role="37wK5m">
-                    <ref role="3cqZAo" node="7YhLqbpvh8s" resolve="root" />
-                  </node>
-                  <node concept="2YIFZM" id="151UdFuYahp" role="37wK5m">
-                    <ref role="1Pybhc" to="wyt6:~Math" resolve="Math" />
-                    <ref role="37wK5l" to="wyt6:~Math.min(int,int)" resolve="min" />
-                    <node concept="2OqwBi" id="151UdFuYahs" role="37wK5m">
-                      <node concept="37vLTw" id="5_qLwQsxlmn" role="2Oq$k0">
-                        <ref role="3cqZAo" node="7YhLqbpvh8s" resolve="root" />
-                      </node>
-                      <node concept="liA8E" id="151UdFuYahw" role="2OqNvi">
-                        <ref role="37wK5l" to="rgfa:~DefaultMutableTreeNode.getChildCount()" resolve="getChildCount" />
-                      </node>
-                    </node>
-                    <node concept="37vLTw" id="151UdFuYdWI" role="37wK5m">
-                      <ref role="3cqZAo" node="151UdFuXT7n" resolve="preferedIndex" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3clFbC" id="115Xaa430PP" role="3clFbw">
-            <node concept="2OqwBi" id="7YhLqbpP9Bm" role="3uHU7B">
-              <node concept="37vLTw" id="115Xaa41Mgd" role="2Oq$k0">
-                <ref role="3cqZAo" node="115Xaa41cD5" resolve="shadowTreeNode" />
-              </node>
-              <node concept="liA8E" id="7YhLqbpPbFj" role="2OqNvi">
-                <ref role="37wK5l" to="rgfa:~DefaultMutableTreeNode.getParent()" resolve="getParent" />
-              </node>
-            </node>
-            <node concept="10Nm6u" id="7YhLqbpPgC8" role="3uHU7w" />
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="2tJIrI" id="7zI2priU0Lo" role="jymVt" />
-    <node concept="3clFb_" id="7zI2priU5Kn" role="jymVt">
-      <property role="TrG5h" value="attachShadowRootIfNotEmpty" />
-      <node concept="3cqZAl" id="7zI2priU5Kp" role="3clF45" />
-      <node concept="3Tm1VV" id="7zI2priU5Kq" role="1B3o_S" />
-      <node concept="3clFbS" id="7zI2priU5Kr" role="3clF47">
-        <node concept="3clFbJ" id="7zI2priUQE1" role="3cqZAp">
-          <node concept="3clFbS" id="7zI2priUQE3" role="3clFbx">
-            <node concept="3clFbJ" id="7zI2priUU4y" role="3cqZAp">
-              <node concept="1Wc70l" id="7zI2priWtpc" role="3clFbw">
-                <node concept="3y3z36" id="7zI2priWFH3" role="3uHU7w">
-                  <node concept="10Nm6u" id="7zI2priWGD$" role="3uHU7w" />
-                  <node concept="2OqwBi" id="7zI2priWvc_" role="3uHU7B">
-                    <node concept="37vLTw" id="7zI2priWuw6" role="2Oq$k0">
-                      <ref role="3cqZAo" node="115Xaa41cD5" resolve="shadowTreeNode" />
-                    </node>
-                    <node concept="liA8E" id="7zI2priWE5H" role="2OqNvi">
-                      <ref role="37wK5l" to="7e8u:~MPSTreeNode.getTree()" resolve="getTree" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="3y3z36" id="7zI2priV6Wa" role="3uHU7B">
-                  <node concept="2OqwBi" id="7zI2priUVsY" role="3uHU7B">
-                    <node concept="37vLTw" id="7zI2priUUeZ" role="2Oq$k0">
-                      <ref role="3cqZAo" node="115Xaa41cD5" resolve="shadowTreeNode" />
-                    </node>
-                    <node concept="liA8E" id="7zI2priV66s" role="2OqNvi">
-                      <ref role="37wK5l" to="rgfa:~DefaultMutableTreeNode.getParent()" resolve="getParent" />
-                    </node>
-                  </node>
-                  <node concept="10Nm6u" id="7zI2priV7Fq" role="3uHU7w" />
-                </node>
-              </node>
-              <node concept="3clFbS" id="7zI2priUU4$" role="3clFbx">
-                <node concept="3clFbF" id="7zI2priVx$v" role="3cqZAp">
-                  <node concept="2OqwBi" id="7zI2priWhlQ" role="3clFbG">
-                    <node concept="2OqwBi" id="7zI2priVV0b" role="2Oq$k0">
-                      <node concept="2OqwBi" id="7zI2priVyh6" role="2Oq$k0">
-                        <node concept="37vLTw" id="7zI2priVx$t" role="2Oq$k0">
-                          <ref role="3cqZAo" node="115Xaa41cD5" resolve="shadowTreeNode" />
-                        </node>
-                        <node concept="liA8E" id="7zI2priVTDz" role="2OqNvi">
-                          <ref role="37wK5l" to="7e8u:~MPSTreeNode.getTree()" resolve="getTree" />
-                        </node>
-                      </node>
-                      <node concept="liA8E" id="7zI2priWcO4" role="2OqNvi">
-                        <ref role="37wK5l" to="7e8u:~MPSTree.getDFTreeModel()" resolve="getDFTreeModel" />
-                      </node>
-                    </node>
-                    <node concept="liA8E" id="7zI2priWtbV" role="2OqNvi">
-                      <ref role="37wK5l" to="rgfa:~DefaultTreeModel.removeNodeFromParent(javax.swing.tree.MutableTreeNode)" resolve="removeNodeFromParent" />
-                      <node concept="37vLTw" id="7zI2priWGT9" role="37wK5m">
-                        <ref role="3cqZAo" node="115Xaa41cD5" resolve="shadowTreeNode" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3clFbC" id="7zI2priUSkf" role="3clFbw">
-            <node concept="3cmrfG" id="7zI2priUSTF" role="3uHU7w">
-              <property role="3cmrfH" value="0" />
-            </node>
-            <node concept="2OqwBi" id="7zI2priUO6U" role="3uHU7B">
-              <node concept="37vLTw" id="7zI2priUN6N" role="2Oq$k0">
-                <ref role="3cqZAo" node="115Xaa41cD5" resolve="shadowTreeNode" />
-              </node>
-              <node concept="liA8E" id="7zI2priUPht" role="2OqNvi">
-                <ref role="37wK5l" to="rgfa:~DefaultMutableTreeNode.getChildCount()" resolve="getChildCount" />
-              </node>
-            </node>
-          </node>
-          <node concept="9aQIb" id="7zI2priVbmy" role="9aQIa">
-            <node concept="3clFbS" id="7zI2priVbmz" role="9aQI4">
-              <node concept="3clFbF" id="7zI2priVdYM" role="3cqZAp">
-                <node concept="1rXfSq" id="7zI2priVdYL" role="3clFbG">
-                  <ref role="37wK5l" node="115Xaa41jby" resolve="attachShadowRoot" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="2tJIrI" id="115Xaa44GIW" role="jymVt" />
-    <node concept="3clFb_" id="56YPHTokZqG" role="jymVt">
-      <property role="TrG5h" value="forceUpdate" />
-      <node concept="3cqZAl" id="56YPHTokZqI" role="3clF45" />
-      <node concept="3Tm1VV" id="56YPHTokZqJ" role="1B3o_S" />
-      <node concept="3clFbS" id="56YPHTokZqK" role="3clF47">
-        <node concept="2$JKZl" id="56YPHTolpXd" role="3cqZAp">
-          <node concept="3clFbS" id="56YPHTolpXf" role="2LFqv$">
-            <node concept="3cpWs8" id="56YPHTom8yC" role="3cqZAp">
-              <node concept="3cpWsn" id="56YPHTom8yD" role="3cpWs9">
-                <property role="TrG5h" value="moduleTreeNode" />
-                <node concept="3uibUv" id="56YPHTom8y_" role="1tU5fm">
-                  <ref role="3uigEE" node="7YhLqbpW_Qz" resolve="ProjectViewExtension.ShadowModuleTreeNode" />
-                </node>
-                <node concept="10QFUN" id="56YPHTom8yE" role="33vP2m">
-                  <node concept="2OqwBi" id="56YPHTom8yF" role="10QFUP">
-                    <node concept="37vLTw" id="56YPHTom8yG" role="2Oq$k0">
-                      <ref role="3cqZAo" node="115Xaa41cD5" resolve="shadowTreeNode" />
-                    </node>
-                    <node concept="liA8E" id="56YPHTom8yH" role="2OqNvi">
-                      <ref role="37wK5l" to="rgfa:~DefaultMutableTreeNode.getChildAt(int)" resolve="getChildAt" />
-                      <node concept="3cmrfG" id="56YPHTom8yI" role="37wK5m">
-                        <property role="3cmrfH" value="0" />
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3uibUv" id="56YPHTom8yJ" role="10QFUM">
-                    <ref role="3uigEE" node="7YhLqbpW_Qz" resolve="ProjectViewExtension.ShadowModuleTreeNode" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbF" id="56YPHTolKx3" role="3cqZAp">
-              <node concept="2OqwBi" id="56YPHTolKZh" role="3clFbG">
-                <node concept="2OqwBi" id="56YPHTolKx5" role="2Oq$k0">
-                  <node concept="1rXfSq" id="56YPHTolKx6" role="2Oq$k0">
-                    <ref role="37wK5l" node="1cRLf1_YMsl" resolve="getProjectTree" />
-                  </node>
-                  <node concept="liA8E" id="2Ko4lD9yWzh" role="2OqNvi">
-                    <ref role="37wK5l" to="7e8u:~MPSTree.getDFTreeModel()" resolve="getDFTreeModel" />
-                  </node>
-                </node>
-                <node concept="liA8E" id="56YPHTolLsC" role="2OqNvi">
-                  <ref role="37wK5l" to="rgfa:~DefaultTreeModel.removeNodeFromParent(javax.swing.tree.MutableTreeNode)" resolve="removeNodeFromParent" />
-                  <node concept="37vLTw" id="56YPHTom8yK" role="37wK5m">
-                    <ref role="3cqZAo" node="56YPHTom8yD" resolve="moduleTreeNode" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbF" id="56YPHTomaMC" role="3cqZAp">
-              <node concept="2OqwBi" id="56YPHTombN7" role="3clFbG">
-                <node concept="37vLTw" id="56YPHTomaMA" role="2Oq$k0">
-                  <ref role="3cqZAo" node="56YPHTom8yD" resolve="moduleTreeNode" />
-                </node>
-                <node concept="liA8E" id="56YPHTomnS$" role="2OqNvi">
-                  <ref role="37wK5l" node="5tQmAwPF6qd" resolve="dispose" />
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3eOSWO" id="56YPHTolHy1" role="2$JKZa">
-            <node concept="3cmrfG" id="56YPHTolHB7" role="3uHU7w">
-              <property role="3cmrfH" value="0" />
-            </node>
-            <node concept="2OqwBi" id="56YPHTolrnU" role="3uHU7B">
-              <node concept="37vLTw" id="56YPHTolqde" role="2Oq$k0">
-                <ref role="3cqZAo" node="115Xaa41cD5" resolve="shadowTreeNode" />
-              </node>
-              <node concept="liA8E" id="56YPHTolG6U" role="2OqNvi">
-                <ref role="37wK5l" to="rgfa:~DefaultMutableTreeNode.getChildCount()" resolve="getChildCount" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="56YPHTom09r" role="3cqZAp">
-          <node concept="1rXfSq" id="56YPHTom09p" role="3clFbG">
-            <ref role="37wK5l" node="6AlUJyrwjTk" resolve="updateModules" />
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="2tJIrI" id="56YPHTokUoI" role="jymVt" />
-    <node concept="3clFb_" id="6AlUJyrwjTk" role="jymVt">
-      <property role="TrG5h" value="updateModules" />
-      <node concept="3cqZAl" id="6AlUJyrwjTm" role="3clF45" />
-      <node concept="3Tm1VV" id="6AlUJyrwjTn" role="1B3o_S" />
-      <node concept="3clFbS" id="6AlUJyrwjTo" role="3clF47">
-        <node concept="3cpWs8" id="7tcNvKICWv3" role="3cqZAp">
-          <node concept="3cpWsn" id="7tcNvKICWv4" role="3cpWs9">
-            <property role="TrG5h" value="projectTree" />
-            <node concept="3uibUv" id="7tcNvKICWet" role="1tU5fm">
-              <ref role="3uigEE" to="paf:~ProjectTree" resolve="ProjectTree" />
-            </node>
-            <node concept="1rXfSq" id="7tcNvKICWv5" role="33vP2m">
-              <ref role="37wK5l" node="1cRLf1_YMsl" resolve="getProjectTree" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbJ" id="7tcNvKICZyh" role="3cqZAp">
-          <node concept="3clFbS" id="7tcNvKICZyj" role="3clFbx">
-            <node concept="3cpWs6" id="7tcNvKID3jb" role="3cqZAp" />
-          </node>
-          <node concept="3clFbC" id="7tcNvKID2vu" role="3clFbw">
-            <node concept="10Nm6u" id="7tcNvKID39S" role="3uHU7w" />
-            <node concept="37vLTw" id="7tcNvKID0YM" role="3uHU7B">
-              <ref role="3cqZAo" node="7tcNvKICWv4" resolve="projectTree" />
-            </node>
-          </node>
-        </node>
-        <node concept="3cpWs8" id="6AlUJyrwIaJ" role="3cqZAp">
-          <node concept="3cpWsn" id="6AlUJyrwIaK" role="3cpWs9">
-            <property role="TrG5h" value="root" />
-            <property role="3TUv4t" value="true" />
-            <node concept="3uibUv" id="6AlUJyrwIaL" role="1tU5fm">
-              <ref role="3uigEE" to="7e8u:~MPSTreeNode" resolve="MPSTreeNode" />
-            </node>
-            <node concept="2OqwBi" id="6AlUJyrwIaM" role="33vP2m">
-              <node concept="37vLTw" id="7tcNvKICWv6" role="2Oq$k0">
-                <ref role="3cqZAo" node="7tcNvKICWv4" resolve="projectTree" />
-              </node>
-              <node concept="liA8E" id="6AlUJyrwIaQ" role="2OqNvi">
-                <ref role="37wK5l" to="7e8u:~MPSTree.getRootNode()" resolve="getRootNode" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbJ" id="6AlUJyrwIaR" role="3cqZAp">
-          <node concept="3clFbS" id="6AlUJyrwIaS" role="3clFbx">
-            <node concept="3cpWs6" id="6AlUJyrwIaT" role="3cqZAp" />
-          </node>
-          <node concept="3clFbC" id="6AlUJyrwIaU" role="3clFbw">
-            <node concept="10Nm6u" id="6AlUJyrwIaV" role="3uHU7w" />
-            <node concept="37vLTw" id="6AlUJyrwIaW" role="3uHU7B">
-              <ref role="3cqZAo" node="6AlUJyrwIaK" resolve="root" />
-            </node>
-          </node>
-        </node>
-        <node concept="3cpWs8" id="6AlUJyrwIaX" role="3cqZAp">
-          <node concept="3cpWsn" id="6AlUJyrwIaY" role="3cpWs9">
-            <property role="TrG5h" value="treeModel" />
-            <property role="3TUv4t" value="true" />
-            <node concept="3uibUv" id="6AlUJyrwIaZ" role="1tU5fm">
-              <ref role="3uigEE" to="rgfa:~DefaultTreeModel" resolve="DefaultTreeModel" />
-            </node>
-            <node concept="2OqwBi" id="6AlUJyrwIb0" role="33vP2m">
-              <node concept="37vLTw" id="7tcNvKICWv7" role="2Oq$k0">
-                <ref role="3cqZAo" node="7tcNvKICWv4" resolve="projectTree" />
-              </node>
-              <node concept="liA8E" id="2Ko4lD9zoYk" role="2OqNvi">
-                <ref role="37wK5l" to="7e8u:~MPSTree.getDFTreeModel()" resolve="getDFTreeModel" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbJ" id="7tcNvKID5pc" role="3cqZAp">
-          <node concept="3clFbS" id="7tcNvKID5pe" role="3clFbx">
-            <node concept="3cpWs6" id="7tcNvKID7OI" role="3cqZAp" />
-          </node>
-          <node concept="3clFbC" id="7tcNvKID7yO" role="3clFbw">
-            <node concept="10Nm6u" id="7tcNvKID7DN" role="3uHU7w" />
-            <node concept="37vLTw" id="7tcNvKID7cn" role="3uHU7B">
-              <ref role="3cqZAo" node="6AlUJyrwIaY" resolve="treeModel" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbH" id="6AlUJyrwI4P" role="3cqZAp" />
-        <node concept="3cpWs8" id="7tcNvKID7Qm" role="3cqZAp">
-          <node concept="3cpWsn" id="7tcNvKID7Qn" role="3cpWs9">
-            <property role="TrG5h" value="repository" />
-            <node concept="3uibUv" id="7tcNvKID6YZ" role="1tU5fm">
-              <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
-            </node>
-            <node concept="2OqwBi" id="7tcNvKID7Qo" role="33vP2m">
-              <node concept="37vLTw" id="7tcNvKID7Qp" role="2Oq$k0">
-                <ref role="3cqZAo" node="115Xaa3Z2NL" resolve="project" />
-              </node>
-              <node concept="liA8E" id="7tcNvKID7Qq" role="2OqNvi">
-                <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1QHqEK" id="115Xaa46mqS" role="3cqZAp">
-          <node concept="1QHqEC" id="115Xaa46mqU" role="1QHqEI">
-            <node concept="3clFbS" id="115Xaa46mqW" role="1bW5cS">
-              <node concept="3cpWs8" id="115Xaa44zdv" role="3cqZAp">
-                <node concept="3cpWsn" id="115Xaa44zdw" role="3cpWs9">
-                  <property role="TrG5h" value="modules" />
-                  <node concept="A3Dl8" id="115Xaa44$8M" role="1tU5fm">
-                    <node concept="3uibUv" id="115Xaa44$8O" role="A3Ik2">
-                      <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-                    </node>
-                  </node>
-                  <node concept="2OqwBi" id="115Xaa44zdx" role="33vP2m">
-                    <node concept="37vLTw" id="7tcNvKID7Qr" role="2Oq$k0">
-                      <ref role="3cqZAo" node="7tcNvKID7Qn" resolve="repository" />
-                    </node>
-                    <node concept="liA8E" id="115Xaa44zd_" role="2OqNvi">
-                      <ref role="37wK5l" to="lui2:~SRepository.getModules()" resolve="getModules" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3cpWs8" id="115Xaa452o7" role="3cqZAp">
-                <node concept="3cpWsn" id="115Xaa452o8" role="3cpWs9">
-                  <property role="TrG5h" value="module2treeNode" />
-                  <node concept="3rvAFt" id="115Xaa452nT" role="1tU5fm">
-                    <node concept="3uibUv" id="115Xaa452nZ" role="3rvQeY">
-                      <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-                    </node>
-                    <node concept="3uibUv" id="115Xaa452nY" role="3rvSg0">
-                      <ref role="3uigEE" node="7YhLqbpW_Qz" resolve="ProjectViewExtension.ShadowModuleTreeNode" />
-                    </node>
-                  </node>
-                  <node concept="2ShNRf" id="115Xaa452o9" role="33vP2m">
-                    <node concept="3rGOSV" id="115Xaa452oa" role="2ShVmc">
-                      <node concept="3uibUv" id="115Xaa452ob" role="3rHrn6">
-                        <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-                      </node>
-                      <node concept="3uibUv" id="115Xaa452oc" role="3rHtpV">
-                        <ref role="3uigEE" node="7YhLqbpW_Qz" resolve="ProjectViewExtension.ShadowModuleTreeNode" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3cpWs8" id="U8fLbAo41B" role="3cqZAp">
-                <node concept="3cpWsn" id="U8fLbAo41E" role="3cpWs9">
-                  <property role="TrG5h" value="treeNodesToRemove" />
-                  <node concept="2hMVRd" id="U8fLbAo41z" role="1tU5fm">
-                    <node concept="3uibUv" id="U8fLbAo5ee" role="2hN53Y">
-                      <ref role="3uigEE" node="7YhLqbpW_Qz" resolve="ProjectViewExtension.ShadowModuleTreeNode" />
-                    </node>
-                  </node>
-                  <node concept="2ShNRf" id="U8fLbAocLm" role="33vP2m">
-                    <node concept="2i4dXS" id="U8fLbAocGe" role="2ShVmc">
-                      <node concept="3uibUv" id="U8fLbAocGf" role="HW$YZ">
-                        <ref role="3uigEE" node="7YhLqbpW_Qz" resolve="ProjectViewExtension.ShadowModuleTreeNode" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3clFbF" id="115Xaa453NW" role="3cqZAp">
-                <node concept="2OqwBi" id="115Xaa454I9" role="3clFbG">
-                  <node concept="2OqwBi" id="115Xaa453NY" role="2Oq$k0">
-                    <node concept="1rXfSq" id="115Xaa453NZ" role="2Oq$k0">
-                      <ref role="37wK5l" node="115Xaa44KEi" resolve="getChildren" />
-                      <node concept="37vLTw" id="115Xaa453O0" role="37wK5m">
-                        <ref role="3cqZAo" node="115Xaa41cD5" resolve="shadowTreeNode" />
-                      </node>
-                    </node>
-                    <node concept="UnYns" id="115Xaa453O1" role="2OqNvi">
-                      <node concept="3uibUv" id="115Xaa453O2" role="UnYnz">
-                        <ref role="3uigEE" node="7YhLqbpW_Qz" resolve="ProjectViewExtension.ShadowModuleTreeNode" />
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="2es0OD" id="115Xaa455MZ" role="2OqNvi">
-                    <node concept="1bVj0M" id="115Xaa455N1" role="23t8la">
-                      <node concept="3clFbS" id="115Xaa455N2" role="1bW5cS">
-                        <node concept="3clFbF" id="U8fLbAofum" role="3cqZAp">
-                          <node concept="2OqwBi" id="U8fLbAoheJ" role="3clFbG">
-                            <node concept="37vLTw" id="U8fLbAofuk" role="2Oq$k0">
-                              <ref role="3cqZAo" node="U8fLbAo41E" resolve="treeNodesToRemove" />
-                            </node>
-                            <node concept="TSZUe" id="U8fLbAolf6" role="2OqNvi">
-                              <node concept="37vLTw" id="U8fLbAomsQ" role="25WWJ7">
-                                <ref role="3cqZAo" node="7Z$RfkF7J9P" resolve="it" />
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="3clFbF" id="115Xaa4566X" role="3cqZAp">
-                          <node concept="37vLTI" id="115Xaa45brg" role="3clFbG">
-                            <node concept="37vLTw" id="115Xaa45bCN" role="37vLTx">
-                              <ref role="3cqZAo" node="7Z$RfkF7J9P" resolve="it" />
-                            </node>
-                            <node concept="3EllGN" id="115Xaa456Di" role="37vLTJ">
-                              <node concept="2OqwBi" id="115Xaa457Kd" role="3ElVtu">
-                                <node concept="37vLTw" id="115Xaa456Qu" role="2Oq$k0">
-                                  <ref role="3cqZAo" node="7Z$RfkF7J9P" resolve="it" />
-                                </node>
-                                <node concept="liA8E" id="115Xaa459_G" role="2OqNvi">
-                                  <ref role="37wK5l" to="kxvg:~ProjectModuleTreeNode.getModule()" resolve="getModule" />
-                                </node>
-                              </node>
-                              <node concept="37vLTw" id="115Xaa4566W" role="3ElQJh">
-                                <ref role="3cqZAo" node="115Xaa452o8" resolve="module2treeNode" />
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="gl6BB" id="7Z$RfkF7J9P" role="1bW2Oz">
-                        <property role="TrG5h" value="it" />
-                        <node concept="2jxLKc" id="7Z$RfkF7J9Q" role="1tU5fm" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3cpWs8" id="5_qLwQsyTB6" role="3cqZAp">
-                <node concept="3cpWsn" id="5_qLwQsyTB9" role="3cpWs9">
-                  <property role="TrG5h" value="insertAt" />
-                  <node concept="10Oyi0" id="5_qLwQsyTB4" role="1tU5fm" />
-                  <node concept="3cmrfG" id="5_qLwQsyX1m" role="33vP2m">
-                    <property role="3cmrfH" value="0" />
-                  </node>
-                </node>
-              </node>
-              <node concept="2Gpval" id="115Xaa44_zR" role="3cqZAp">
-                <node concept="2GrKxI" id="115Xaa44_zT" role="2Gsz3X">
-                  <property role="TrG5h" value="shadowModule" />
-                </node>
-                <node concept="3clFbS" id="115Xaa44_zX" role="2LFqv$">
-                  <node concept="3cpWs8" id="115Xaa45h80" role="3cqZAp">
-                    <node concept="3cpWsn" id="115Xaa45h81" role="3cpWs9">
-                      <property role="TrG5h" value="moduleTreeNode" />
-                      <node concept="3uibUv" id="115Xaa45h7V" role="1tU5fm">
-                        <ref role="3uigEE" node="7YhLqbpW_Qz" resolve="ProjectViewExtension.ShadowModuleTreeNode" />
-                      </node>
-                      <node concept="3EllGN" id="115Xaa45h82" role="33vP2m">
-                        <node concept="2GrUjf" id="115Xaa45h83" role="3ElVtu">
-                          <ref role="2Gs0qQ" node="115Xaa44_zT" resolve="shadowModule" />
-                        </node>
-                        <node concept="37vLTw" id="115Xaa45h84" role="3ElQJh">
-                          <ref role="3cqZAo" node="115Xaa452o8" resolve="module2treeNode" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3clFbJ" id="115Xaa45iWt" role="3cqZAp">
-                    <node concept="3clFbS" id="115Xaa45iWv" role="3clFbx">
-                      <node concept="3clFbF" id="115Xaa44FRA" role="3cqZAp">
-                        <node concept="2OqwBi" id="115Xaa44G2S" role="3clFbG">
-                          <node concept="37vLTw" id="115Xaa44FR_" role="2Oq$k0">
-                            <ref role="3cqZAo" node="6AlUJyrwIaY" resolve="treeModel" />
-                          </node>
-                          <node concept="liA8E" id="115Xaa44GwH" role="2OqNvi">
-                            <ref role="37wK5l" to="rgfa:~DefaultTreeModel.insertNodeInto(javax.swing.tree.MutableTreeNode,javax.swing.tree.MutableTreeNode,int)" resolve="insertNodeInto" />
-                            <node concept="2ShNRf" id="115Xaa45on0" role="37wK5m">
-                              <node concept="1pGfFk" id="115Xaa45p2M" role="2ShVmc">
-                                <ref role="37wK5l" node="7YhLqbpWBIq" resolve="ProjectViewExtension.ShadowModuleTreeNode" />
-                                <node concept="2GrUjf" id="115Xaa45psb" role="37wK5m">
-                                  <ref role="2Gs0qQ" node="115Xaa44_zT" resolve="shadowModule" />
-                                </node>
-                              </node>
-                            </node>
-                            <node concept="37vLTw" id="115Xaa45tfT" role="37wK5m">
-                              <ref role="3cqZAo" node="115Xaa41cD5" resolve="shadowTreeNode" />
-                            </node>
-                            <node concept="37vLTw" id="5_qLwQsyYoX" role="37wK5m">
-                              <ref role="3cqZAo" node="5_qLwQsyTB9" resolve="insertAt" />
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="3clFbF" id="5_qLwQsyZJB" role="3cqZAp">
-                        <node concept="3uNrnE" id="5_qLwQsz124" role="3clFbG">
-                          <node concept="37vLTw" id="5_qLwQsz126" role="2$L3a6">
-                            <ref role="3cqZAo" node="5_qLwQsyTB9" resolve="insertAt" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="3clFbC" id="115Xaa45mcW" role="3clFbw">
-                      <node concept="10Nm6u" id="115Xaa45mmt" role="3uHU7w" />
-                      <node concept="37vLTw" id="115Xaa45jdS" role="3uHU7B">
-                        <ref role="3cqZAo" node="115Xaa45h81" resolve="moduleTreeNode" />
-                      </node>
-                    </node>
-                    <node concept="9aQIb" id="5_qLwQsyyaG" role="9aQIa">
-                      <node concept="3clFbS" id="5_qLwQsyyaH" role="9aQI4">
-                        <node concept="3clFbF" id="5_qLwQsz85U" role="3cqZAp">
-                          <node concept="37vLTI" id="5_qLwQsz9Iu" role="3clFbG">
-                            <node concept="3cpWs3" id="5_qLwQszIoA" role="37vLTx">
-                              <node concept="3cmrfG" id="5_qLwQszItC" role="3uHU7w">
-                                <property role="3cmrfH" value="1" />
-                              </node>
-                              <node concept="2OqwBi" id="5_qLwQszlpw" role="3uHU7B">
-                                <node concept="2OqwBi" id="5_qLwQszdcQ" role="2Oq$k0">
-                                  <node concept="37vLTw" id="5_qLwQszaC_" role="2Oq$k0">
-                                    <ref role="3cqZAo" node="115Xaa45h81" resolve="moduleTreeNode" />
-                                  </node>
-                                  <node concept="liA8E" id="5_qLwQszh2g" role="2OqNvi">
-                                    <ref role="37wK5l" to="rgfa:~DefaultMutableTreeNode.getParent()" resolve="getParent" />
-                                  </node>
-                                </node>
-                                <node concept="liA8E" id="5_qLwQsz$aN" role="2OqNvi">
-                                  <ref role="37wK5l" to="rgfa:~TreeNode.getIndex(javax.swing.tree.TreeNode)" resolve="getIndex" />
-                                  <node concept="37vLTw" id="5_qLwQszCv8" role="37wK5m">
-                                    <ref role="3cqZAo" node="115Xaa45h81" resolve="moduleTreeNode" />
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                            <node concept="37vLTw" id="5_qLwQsz85S" role="37vLTJ">
-                              <ref role="3cqZAo" node="5_qLwQsyTB9" resolve="insertAt" />
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="3clFbF" id="5_qLwQsyyZo" role="3cqZAp">
-                          <node concept="2OqwBi" id="5_qLwQsyzUv" role="3clFbG">
-                            <node concept="37vLTw" id="5_qLwQsyyZn" role="2Oq$k0">
-                              <ref role="3cqZAo" node="115Xaa452o8" resolve="module2treeNode" />
-                            </node>
-                            <node concept="kI3uX" id="5_qLwQsy_d3" role="2OqNvi">
-                              <node concept="2GrUjf" id="5_qLwQsy_Wp" role="kIiFs">
-                                <ref role="2Gs0qQ" node="115Xaa44_zT" resolve="shadowModule" />
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="3clFbF" id="U8fLbAopct" role="3cqZAp">
-                          <node concept="2OqwBi" id="U8fLbAoqV4" role="3clFbG">
-                            <node concept="37vLTw" id="U8fLbAopcr" role="2Oq$k0">
-                              <ref role="3cqZAo" node="U8fLbAo41E" resolve="treeNodesToRemove" />
-                            </node>
-                            <node concept="3dhRuq" id="U8fLbAouX7" role="2OqNvi">
-                              <node concept="37vLTw" id="U8fLbAowLf" role="25WWJ7">
-                                <ref role="3cqZAo" node="115Xaa45h81" resolve="moduleTreeNode" />
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="2OqwBi" id="5_qLwQsz1Qm" role="2GsD0m">
-                  <node concept="2OqwBi" id="115Xaa44y2z" role="2Oq$k0">
-                    <node concept="37vLTw" id="115Xaa44zdA" role="2Oq$k0">
-                      <ref role="3cqZAo" node="115Xaa44zdw" resolve="modules" />
-                    </node>
-                    <node concept="UnYns" id="115Xaa44$Do" role="2OqNvi">
-                      <node concept="3uibUv" id="115Xaa45hRw" role="UnYnz">
-                        <ref role="3uigEE" to="l6bp:115Xaa43tZI" resolve="SM_ShadowModule" />
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="2S7cBI" id="5_qLwQsz2L3" role="2OqNvi">
-                    <node concept="1bVj0M" id="5_qLwQsz2L5" role="23t8la">
-                      <node concept="3clFbS" id="5_qLwQsz2L6" role="1bW5cS">
-                        <node concept="3clFbF" id="5_qLwQsz3vJ" role="3cqZAp">
-                          <node concept="2OqwBi" id="5_qLwQsz4r7" role="3clFbG">
-                            <node concept="37vLTw" id="5_qLwQsz3vI" role="2Oq$k0">
-                              <ref role="3cqZAo" node="7Z$RfkF7J9R" resolve="it" />
-                            </node>
-                            <node concept="liA8E" id="5_qLwQsz5KA" role="2OqNvi">
-                              <ref role="37wK5l" to="z1c3:~AbstractModule.getModuleName()" resolve="getModuleName" />
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="gl6BB" id="7Z$RfkF7J9R" role="1bW2Oz">
-                        <property role="TrG5h" value="it" />
-                        <node concept="2jxLKc" id="7Z$RfkF7J9S" role="1tU5fm" />
-                      </node>
-                    </node>
-                    <node concept="1nlBCl" id="5_qLwQsz2L9" role="2S7zOq">
-                      <property role="3clFbU" value="true" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3clFbF" id="5_qLwQsyBqE" role="3cqZAp">
-                <node concept="2OqwBi" id="5_qLwQsyEMP" role="3clFbG">
-                  <node concept="37vLTw" id="U8fLbAoyBX" role="2Oq$k0">
-                    <ref role="3cqZAo" node="U8fLbAo41E" resolve="treeNodesToRemove" />
-                  </node>
-                  <node concept="2es0OD" id="5_qLwQsyGH_" role="2OqNvi">
-                    <node concept="1bVj0M" id="5_qLwQsyGHB" role="23t8la">
-                      <node concept="3clFbS" id="5_qLwQsyGHC" role="1bW5cS">
-                        <node concept="3clFbF" id="5_qLwQsyHA2" role="3cqZAp">
-                          <node concept="2OqwBi" id="5_qLwQsyIvG" role="3clFbG">
-                            <node concept="37vLTw" id="5_qLwQsyHA1" role="2Oq$k0">
-                              <ref role="3cqZAo" node="6AlUJyrwIaY" resolve="treeModel" />
-                            </node>
-                            <node concept="liA8E" id="5_qLwQsyJxb" role="2OqNvi">
-                              <ref role="37wK5l" to="rgfa:~DefaultTreeModel.removeNodeFromParent(javax.swing.tree.MutableTreeNode)" resolve="removeNodeFromParent" />
-                              <node concept="37vLTw" id="5_qLwQsyKkJ" role="37wK5m">
-                                <ref role="3cqZAo" node="7Z$RfkF7J9T" resolve="it" />
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="3clFbF" id="5tQmAwPGew7" role="3cqZAp">
-                          <node concept="2OqwBi" id="5tQmAwPGg3E" role="3clFbG">
-                            <node concept="37vLTw" id="5tQmAwPGew5" role="2Oq$k0">
-                              <ref role="3cqZAo" node="7Z$RfkF7J9T" resolve="it" />
-                            </node>
-                            <node concept="liA8E" id="5tQmAwPGiCO" role="2OqNvi">
-                              <ref role="37wK5l" node="5tQmAwPF6qd" resolve="dispose" />
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="gl6BB" id="7Z$RfkF7J9T" role="1bW2Oz">
-                        <property role="TrG5h" value="it" />
-                        <node concept="2jxLKc" id="7Z$RfkF7J9U" role="1tU5fm" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3clFbF" id="7zI2priWMwH" role="3cqZAp">
-                <node concept="1rXfSq" id="7zI2priWMwF" role="3clFbG">
-                  <ref role="37wK5l" node="7zI2priU5Kn" resolve="attachShadowRootIfNotEmpty" />
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="37vLTw" id="7tcNvKIDvel" role="ukAjM">
-            <ref role="3cqZAo" node="7tcNvKID7Qn" resolve="repository" />
-          </node>
-        </node>
-      </node>
-    </node>
     <node concept="2tJIrI" id="6AlUJyrwhPW" role="jymVt" />
-    <node concept="2YIFZL" id="115Xaa44KEi" role="jymVt">
-      <property role="TrG5h" value="getChildren" />
-      <property role="DiZV1" value="false" />
-      <property role="od$2w" value="false" />
-      <node concept="37vLTG" id="115Xaa44LUf" role="3clF46">
-        <property role="TrG5h" value="parent" />
-        <node concept="3uibUv" id="115Xaa44LYu" role="1tU5fm">
-          <ref role="3uigEE" to="rgfa:~TreeNode" resolve="TreeNode" />
-        </node>
-      </node>
-      <node concept="3clFbS" id="115Xaa44I1C" role="3clF47">
-        <node concept="3cpWs8" id="115Xaa44MN9" role="3cqZAp">
-          <node concept="3cpWsn" id="115Xaa44MNa" role="3cpWs9">
-            <property role="TrG5h" value="result" />
-            <node concept="_YKpA" id="115Xaa44MN5" role="1tU5fm">
-              <node concept="3uibUv" id="115Xaa44MN8" role="_ZDj9">
-                <ref role="3uigEE" to="rgfa:~TreeNode" resolve="TreeNode" />
-              </node>
-            </node>
-            <node concept="2ShNRf" id="115Xaa44MNb" role="33vP2m">
-              <node concept="Tc6Ow" id="115Xaa44MNc" role="2ShVmc">
-                <node concept="3uibUv" id="115Xaa44MNd" role="HW$YZ">
-                  <ref role="3uigEE" to="rgfa:~TreeNode" resolve="TreeNode" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1Dw8fO" id="115Xaa44MYg" role="3cqZAp">
-          <node concept="3clFbS" id="115Xaa44MYi" role="2LFqv$">
-            <node concept="3clFbF" id="115Xaa44Ptp" role="3cqZAp">
-              <node concept="2OqwBi" id="115Xaa44Q5N" role="3clFbG">
-                <node concept="37vLTw" id="115Xaa44Ptn" role="2Oq$k0">
-                  <ref role="3cqZAo" node="115Xaa44MNa" resolve="result" />
-                </node>
-                <node concept="TSZUe" id="115Xaa44RER" role="2OqNvi">
-                  <node concept="2OqwBi" id="115Xaa44ROK" role="25WWJ7">
-                    <node concept="37vLTw" id="115Xaa44RHZ" role="2Oq$k0">
-                      <ref role="3cqZAo" node="115Xaa44LUf" resolve="parent" />
-                    </node>
-                    <node concept="liA8E" id="115Xaa44S5g" role="2OqNvi">
-                      <ref role="37wK5l" to="rgfa:~TreeNode.getChildAt(int)" resolve="getChildAt" />
-                      <node concept="37vLTw" id="115Xaa44SaH" role="37wK5m">
-                        <ref role="3cqZAo" node="115Xaa44MYj" resolve="i" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3cpWsn" id="115Xaa44MYj" role="1Duv9x">
-            <property role="TrG5h" value="i" />
-            <node concept="10Oyi0" id="115Xaa44N2l" role="1tU5fm" />
-            <node concept="3cmrfG" id="115Xaa44N3Z" role="33vP2m">
-              <property role="3cmrfH" value="0" />
-            </node>
-          </node>
-          <node concept="3eOVzh" id="115Xaa44NSJ" role="1Dwp0S">
-            <node concept="2OqwBi" id="115Xaa44OdW" role="3uHU7w">
-              <node concept="37vLTw" id="115Xaa44NT8" role="2Oq$k0">
-                <ref role="3cqZAo" node="115Xaa44LUf" resolve="parent" />
-              </node>
-              <node concept="liA8E" id="115Xaa44OlC" role="2OqNvi">
-                <ref role="37wK5l" to="rgfa:~TreeNode.getChildCount()" resolve="getChildCount" />
-              </node>
-            </node>
-            <node concept="37vLTw" id="115Xaa44N4I" role="3uHU7B">
-              <ref role="3cqZAo" node="115Xaa44MYj" resolve="i" />
-            </node>
-          </node>
-          <node concept="3uNrnE" id="115Xaa44Plv" role="1Dwrff">
-            <node concept="37vLTw" id="115Xaa44Plx" role="2$L3a6">
-              <ref role="3cqZAo" node="115Xaa44MYj" resolve="i" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="115Xaa44M5b" role="3cqZAp">
-          <node concept="37vLTw" id="115Xaa44MNe" role="3clFbG">
-            <ref role="3cqZAo" node="115Xaa44MNa" resolve="result" />
-          </node>
-        </node>
-      </node>
-      <node concept="A3Dl8" id="115Xaa44LLD" role="3clF45">
-        <node concept="3uibUv" id="115Xaa44LRP" role="A3Ik2">
-          <ref role="3uigEE" to="rgfa:~TreeNode" resolve="TreeNode" />
-        </node>
-      </node>
-      <node concept="3Tm6S6" id="115Xaa44JTk" role="1B3o_S" />
-    </node>
-    <node concept="2tJIrI" id="115Xaa3ZoqC" role="jymVt" />
     <node concept="312cEu" id="7YhLqbpW_Qz" role="jymVt">
       <property role="2bfB8j" value="false" />
-      <property role="TrG5h" value="ShadowModuleTreeNode" />
-      <node concept="312cEg" id="4QZGLsL_Wl0" role="jymVt">
-        <property role="TrG5h" value="myInitialized" />
-        <node concept="3Tm6S6" id="4QZGLsL_Wl1" role="1B3o_S" />
-        <node concept="10P_77" id="4QZGLsL_X0B" role="1tU5fm" />
-        <node concept="3clFbT" id="4QZGLsL_X9B" role="33vP2m">
-          <property role="3clFbU" value="false" />
-        </node>
-      </node>
-      <node concept="312cEg" id="5tQmAwPFXRQ" role="jymVt">
-        <property role="TrG5h" value="moduleListener" />
-        <property role="3TUv4t" value="false" />
-        <node concept="3Tm6S6" id="5tQmAwPFXRR" role="1B3o_S" />
-        <node concept="3uibUv" id="5tQmAwPFRZP" role="1tU5fm">
-          <ref role="3uigEE" to="lui2:~SModuleListenerBase" resolve="SModuleListenerBase" />
-        </node>
-        <node concept="2ShNRf" id="5tQmAwPG4al" role="33vP2m">
-          <node concept="YeOm9" id="5tQmAwPG4am" role="2ShVmc">
-            <node concept="1Y3b0j" id="5tQmAwPG4an" role="YeSDq">
-              <property role="2bfB8j" value="true" />
-              <ref role="37wK5l" to="lui2:~SModuleListenerBase.&lt;init&gt;()" resolve="SModuleListenerBase" />
-              <ref role="1Y3XeK" to="lui2:~SModuleListenerBase" resolve="SModuleListenerBase" />
-              <node concept="3Tm1VV" id="5tQmAwPG4ao" role="1B3o_S" />
-              <node concept="3clFb_" id="5tQmAwPG4ap" role="jymVt">
-                <property role="1EzhhJ" value="false" />
-                <property role="TrG5h" value="modelAdded" />
-                <property role="DiZV1" value="false" />
-                <property role="od$2w" value="false" />
-                <node concept="3Tm1VV" id="5tQmAwPG4aq" role="1B3o_S" />
-                <node concept="3cqZAl" id="5tQmAwPG4ar" role="3clF45" />
-                <node concept="37vLTG" id="5tQmAwPG4as" role="3clF46">
-                  <property role="TrG5h" value="module" />
-                  <node concept="3uibUv" id="5tQmAwPG4at" role="1tU5fm">
-                    <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-                  </node>
-                </node>
-                <node concept="37vLTG" id="5tQmAwPG4au" role="3clF46">
-                  <property role="TrG5h" value="model" />
-                  <node concept="3uibUv" id="5tQmAwPG4av" role="1tU5fm">
-                    <ref role="3uigEE" to="mhbf:~SModel" resolve="SModel" />
-                  </node>
-                </node>
-                <node concept="3clFbS" id="5tQmAwPG4aw" role="3clF47">
-                  <node concept="3clFbF" id="5tQmAwPG4ax" role="3cqZAp">
-                    <node concept="1rXfSq" id="5tQmAwPG4ay" role="3clFbG">
-                      <ref role="37wK5l" to="7e8u:~MPSTreeNode.update()" resolve="update" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="2AHcQZ" id="5tQmAwPG4az" role="2AJF6D">
-                  <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-                </node>
-              </node>
-              <node concept="3clFb_" id="5tQmAwPG4a$" role="jymVt">
-                <property role="1EzhhJ" value="false" />
-                <property role="TrG5h" value="modelRemoved" />
-                <property role="DiZV1" value="false" />
-                <property role="od$2w" value="false" />
-                <node concept="3Tm1VV" id="5tQmAwPG4a_" role="1B3o_S" />
-                <node concept="3cqZAl" id="5tQmAwPG4aA" role="3clF45" />
-                <node concept="37vLTG" id="5tQmAwPG4aB" role="3clF46">
-                  <property role="TrG5h" value="module" />
-                  <node concept="3uibUv" id="5tQmAwPG4aC" role="1tU5fm">
-                    <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-                  </node>
-                </node>
-                <node concept="37vLTG" id="5tQmAwPG4aD" role="3clF46">
-                  <property role="TrG5h" value="ref" />
-                  <node concept="3uibUv" id="5tQmAwPG4aE" role="1tU5fm">
-                    <ref role="3uigEE" to="mhbf:~SModelReference" resolve="SModelReference" />
-                  </node>
-                </node>
-                <node concept="3clFbS" id="5tQmAwPG4aF" role="3clF47">
-                  <node concept="3clFbF" id="5tQmAwPG4aG" role="3cqZAp">
-                    <node concept="1rXfSq" id="5tQmAwPG4aH" role="3clFbG">
-                      <ref role="37wK5l" to="7e8u:~MPSTreeNode.update()" resolve="update" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="2AHcQZ" id="5tQmAwPG4aI" role="2AJF6D">
-                  <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-                </node>
-              </node>
-            </node>
+      <property role="TrG5h" value="ShadowModuleProjectViewNode" />
+      <node concept="3clFbW" id="5rSmnqwvTkf" role="jymVt">
+        <node concept="37vLTG" id="5rSmnqwmccu" role="3clF46">
+          <property role="TrG5h" value="project" />
+          <node concept="3uibUv" id="5rSmnqwmcct" role="1tU5fm">
+            <ref role="3uigEE" to="4nm9:~Project" resolve="Project" />
           </node>
         </node>
-      </node>
-      <node concept="3Tm1VV" id="7YhLqbpW_Q$" role="1B3o_S" />
-      <node concept="3uibUv" id="7YhLqbpWBFW" role="1zkMxy">
-        <ref role="3uigEE" to="kxvg:~ProjectModuleTreeNode" resolve="ProjectModuleTreeNode" />
-      </node>
-      <node concept="3clFbW" id="7YhLqbpWBIq" role="jymVt">
-        <node concept="3cqZAl" id="7YhLqbpWBIr" role="3clF45" />
-        <node concept="3Tm1VV" id="7YhLqbpWBIs" role="1B3o_S" />
-        <node concept="3clFbS" id="7YhLqbpWBIu" role="3clF47">
-          <node concept="XkiVB" id="7YhLqbpWBIw" role="3cqZAp">
-            <ref role="37wK5l" to="kxvg:~ProjectModuleTreeNode.&lt;init&gt;(org.jetbrains.mps.openapi.module.SModule)" resolve="ProjectModuleTreeNode" />
-            <node concept="37vLTw" id="7YhLqbpWBI_" role="37wK5m">
-              <ref role="3cqZAo" node="7YhLqbpWBIx" resolve="module" />
-            </node>
-          </node>
-          <node concept="3clFbF" id="7YhLqbpYgbv" role="3cqZAp">
-            <node concept="1rXfSq" id="7YhLqbpYgbt" role="3clFbG">
-              <ref role="37wK5l" to="7e8u:~MPSTreeNode.setNodeIdentifier(java.lang.String)" resolve="setNodeIdentifier" />
-              <node concept="2OqwBi" id="7YhLqbpYivf" role="37wK5m">
-                <node concept="2OqwBi" id="7YhLqbpYi9d" role="2Oq$k0">
-                  <node concept="37vLTw" id="7YhLqbpYhti" role="2Oq$k0">
-                    <ref role="3cqZAo" node="7YhLqbpWBIx" resolve="module" />
-                  </node>
-                  <node concept="liA8E" id="7YhLqbpYio1" role="2OqNvi">
-                    <ref role="37wK5l" to="lui2:~SModule.getModuleId()" resolve="getModuleId" />
-                  </node>
-                </node>
-                <node concept="liA8E" id="7YhLqbpYiKu" role="2OqNvi">
-                  <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3clFbF" id="7YhLqbpYksz" role="3cqZAp">
-            <node concept="1rXfSq" id="7YhLqbpYksx" role="3clFbG">
-              <ref role="37wK5l" to="7e8u:~MPSTreeNode.setIcon(javax.swing.Icon)" resolve="setIcon" />
-              <node concept="37vLTw" id="4NO8rntTrXc" role="37wK5m">
-                <ref role="3cqZAo" node="4NO8rntTrX3" resolve="MODULE_ICON" />
-              </node>
-            </node>
-          </node>
-          <node concept="3clFbF" id="5tQmAwPFzfG" role="3cqZAp">
-            <node concept="2OqwBi" id="5tQmAwPFzVA" role="3clFbG">
-              <node concept="37vLTw" id="5tQmAwPFzfE" role="2Oq$k0">
-                <ref role="3cqZAo" node="7YhLqbpWBIx" resolve="module" />
-              </node>
-              <node concept="liA8E" id="5tQmAwPF$bS" role="2OqNvi">
-                <ref role="37wK5l" to="lui2:~SModule.addModuleListener(org.jetbrains.mps.openapi.module.SModuleListener)" resolve="addModuleListener" />
-                <node concept="37vLTw" id="5tQmAwPG3IR" role="37wK5m">
-                  <ref role="3cqZAo" node="5tQmAwPFXRQ" resolve="moduleListener" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="37vLTG" id="7YhLqbpWBIx" role="3clF46">
-          <property role="TrG5h" value="module" />
-          <node concept="3uibUv" id="7YhLqbpWBIz" role="1tU5fm">
+        <node concept="37vLTG" id="5rSmnqwmccw" role="3clF46">
+          <property role="TrG5h" value="value" />
+          <node concept="3uibUv" id="5rSmnqwzCjy" role="1tU5fm">
             <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
           </node>
-          <node concept="2AHcQZ" id="7YhLqbpWBI$" role="2AJF6D">
+          <node concept="2AHcQZ" id="5rSmnqwmccx" role="2AJF6D">
             <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
           </node>
         </node>
-      </node>
-      <node concept="3clFb_" id="7YhLqbpWBMo" role="jymVt">
-        <property role="1EzhhJ" value="false" />
-        <property role="TrG5h" value="getModuleText" />
-        <property role="DiZV1" value="false" />
-        <property role="od$2w" value="false" />
-        <node concept="3Tm1VV" id="7YhLqbpWBMp" role="1B3o_S" />
-        <node concept="17QB3L" id="7YhLqbpWC3E" role="3clF45" />
-        <node concept="3clFbS" id="7YhLqbpWBMy" role="3clF47">
-          <node concept="3clFbF" id="7YhLqbpWJHj" role="3cqZAp">
-            <node concept="2OqwBi" id="115Xaa45rSA" role="3clFbG">
-              <node concept="1rXfSq" id="115Xaa45rGM" role="2Oq$k0">
-                <ref role="37wK5l" to="kxvg:~ProjectModuleTreeNode.getModule()" resolve="getModule" />
-              </node>
-              <node concept="liA8E" id="115Xaa45sbW" role="2OqNvi">
-                <ref role="37wK5l" to="lui2:~SModule.getModuleName()" resolve="getModuleName" />
-              </node>
-            </node>
+        <node concept="37vLTG" id="5rSmnqwmccz" role="3clF46">
+          <property role="TrG5h" value="viewSettings" />
+          <node concept="3uibUv" id="5rSmnqwmccy" role="1tU5fm">
+            <ref role="3uigEE" to="bnjk:~ViewSettings" resolve="ViewSettings" />
           </node>
         </node>
-        <node concept="2AHcQZ" id="7YhLqbpWBMz" role="2AJF6D">
-          <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-        </node>
-      </node>
-      <node concept="3clFb_" id="4QZGLsL_Xct" role="jymVt">
-        <property role="1EzhhJ" value="false" />
-        <property role="TrG5h" value="isInitialized" />
-        <property role="DiZV1" value="false" />
-        <property role="od$2w" value="false" />
-        <node concept="3Tm1VV" id="4QZGLsL_Xcu" role="1B3o_S" />
-        <node concept="10P_77" id="4QZGLsL_Xcw" role="3clF45" />
-        <node concept="3clFbS" id="4QZGLsL_Xc$" role="3clF47">
-          <node concept="3clFbF" id="4QZGLsL_YaV" role="3cqZAp">
-            <node concept="37vLTw" id="4QZGLsL_YaU" role="3clFbG">
-              <ref role="3cqZAo" node="4QZGLsL_Wl0" resolve="myInitialized" />
+        <node concept="3cqZAl" id="5rSmnqwvTkh" role="3clF45" />
+        <node concept="3Tm1VV" id="5rSmnqwvTki" role="1B3o_S" />
+        <node concept="3clFbS" id="5rSmnqwvTkj" role="3clF47">
+          <node concept="XkiVB" id="5rSmnqwwfEN" role="3cqZAp">
+            <ref role="37wK5l" to="paf:~BaseModuleProjectViewNode.&lt;init&gt;(com.intellij.openapi.project.Project,org.jetbrains.mps.openapi.module.SModule,com.intellij.ide.projectView.ViewSettings)" resolve="BaseModuleProjectViewNode" />
+            <node concept="37vLTw" id="5rSmnqwwmHb" role="37wK5m">
+              <ref role="3cqZAo" node="5rSmnqwmccu" resolve="project" />
+            </node>
+            <node concept="37vLTw" id="5rSmnqwwt10" role="37wK5m">
+              <ref role="3cqZAo" node="5rSmnqwmccw" resolve="value" />
+            </node>
+            <node concept="37vLTw" id="5rSmnqwwvRQ" role="37wK5m">
+              <ref role="3cqZAo" node="5rSmnqwmccz" resolve="viewSettings" />
             </node>
           </node>
-        </node>
-        <node concept="2AHcQZ" id="4QZGLsL_Xc_" role="2AJF6D">
-          <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
         </node>
       </node>
-      <node concept="2tJIrI" id="4QZGLsL_Yg4" role="jymVt" />
-      <node concept="3clFb_" id="4QZGLsL_YWp" role="jymVt">
-        <property role="1EzhhJ" value="false" />
-        <property role="TrG5h" value="doInit" />
-        <property role="DiZV1" value="false" />
-        <property role="od$2w" value="false" />
-        <node concept="3Tmbuc" id="4QZGLsL_YWq" role="1B3o_S" />
-        <node concept="3cqZAl" id="4QZGLsL_YWs" role="3clF45" />
-        <node concept="3clFbS" id="4QZGLsL_YWw" role="3clF47">
-          <node concept="3clFbF" id="4QZGLsLA5cI" role="3cqZAp">
-            <node concept="1rXfSq" id="4QZGLsLA5cG" role="3clFbG">
-              <ref role="37wK5l" node="4QZGLsLA1sm" resolve="populate" />
-            </node>
-          </node>
-          <node concept="3clFbF" id="4QZGLsL_ZZa" role="3cqZAp">
-            <node concept="37vLTI" id="4QZGLsLA0pm" role="3clFbG">
-              <node concept="3clFbT" id="4QZGLsLA0sm" role="37vLTx">
-                <property role="3clFbU" value="true" />
-              </node>
-              <node concept="37vLTw" id="4QZGLsL_ZZ9" role="37vLTJ">
-                <ref role="3cqZAo" node="4QZGLsL_Wl0" resolve="myInitialized" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="2AHcQZ" id="4QZGLsL_YWx" role="2AJF6D">
-          <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      <node concept="2tJIrI" id="5rSmnqwvO0b" role="jymVt" />
+      <node concept="3Tm1VV" id="7YhLqbpW_Q$" role="1B3o_S" />
+      <node concept="3uibUv" id="5rSmnqwvqKo" role="1zkMxy">
+        <ref role="3uigEE" to="paf:~BaseModuleProjectViewNode" resolve="BaseModuleProjectViewNode" />
+        <node concept="3uibUv" id="5rSmnqwzs3G" role="11_B2D">
+          <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
         </node>
       </node>
-      <node concept="2tJIrI" id="4QZGLsLA0Ce" role="jymVt" />
-      <node concept="3clFb_" id="4QZGLsLA1sm" role="jymVt">
-        <property role="TrG5h" value="populate" />
-        <node concept="3cqZAl" id="4QZGLsLA1so" role="3clF45" />
-        <node concept="3Tmbuc" id="4QZGLsLA5kE" role="1B3o_S" />
-        <node concept="3clFbS" id="4QZGLsLA1sq" role="3clF47">
-          <node concept="3cpWs8" id="4QZGLsLAa2G" role="3cqZAp">
-            <node concept="3cpWsn" id="4QZGLsLAa2H" role="3cpWs9">
-              <property role="TrG5h" value="models" />
-              <node concept="A3Dl8" id="4QZGLsLAaNV" role="1tU5fm">
-                <node concept="3uibUv" id="4QZGLsLAaNX" role="A3Ik2">
-                  <ref role="3uigEE" to="mhbf:~SModel" resolve="SModel" />
-                </node>
-              </node>
-              <node concept="2OqwBi" id="4QZGLsLAa2I" role="33vP2m">
-                <node concept="1rXfSq" id="4QZGLsLAa2J" role="2Oq$k0">
-                  <ref role="37wK5l" to="kxvg:~ProjectModuleTreeNode.getModule()" resolve="getModule" />
-                </node>
-                <node concept="liA8E" id="4QZGLsLAa2K" role="2OqNvi">
-                  <ref role="37wK5l" to="lui2:~SModule.getModels()" resolve="getModels" />
-                </node>
-              </node>
+      <node concept="3clFb_" id="5rSmnqw$aLM" role="jymVt">
+        <property role="TrG5h" value="getModule" />
+        <node concept="3uibUv" id="5rSmnqw$iuW" role="3clF45">
+          <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
+        </node>
+        <node concept="3Tm1VV" id="5rSmnqw$aLP" role="1B3o_S" />
+        <node concept="3clFbS" id="5rSmnqw$aLQ" role="3clF47">
+          <node concept="3cpWs6" id="5rSmnqw$DiC" role="3cqZAp">
+            <node concept="1rXfSq" id="5rSmnqw$R2R" role="3cqZAk">
+              <ref role="37wK5l" to="rcv5:~AbstractTreeNode.getValue()" resolve="getValue" />
             </node>
           </node>
-          <node concept="2Gpval" id="4NO8rntRRq3" role="3cqZAp">
-            <node concept="2GrKxI" id="4NO8rntRRq5" role="2Gsz3X">
-              <property role="TrG5h" value="model" />
-            </node>
-            <node concept="2OqwBi" id="4NO8rntSbBC" role="2GsD0m">
-              <node concept="37vLTw" id="4NO8rntRSL2" role="2Oq$k0">
-                <ref role="3cqZAo" node="4QZGLsLAa2H" resolve="models" />
+        </node>
+      </node>
+      <node concept="2tJIrI" id="5rSmnqw_wsL" role="jymVt" />
+      <node concept="3clFb_" id="5rSmnqw_G2u" role="jymVt">
+        <property role="TrG5h" value="containsSObject" />
+        <node concept="3Tmbuc" id="5rSmnqw_G2v" role="1B3o_S" />
+        <node concept="10P_77" id="5rSmnqw_G2x" role="3clF45" />
+        <node concept="37vLTG" id="5rSmnqw_G2y" role="3clF46">
+          <property role="TrG5h" value="sObject" />
+          <node concept="3uibUv" id="5rSmnqw_G2z" role="1tU5fm">
+            <ref role="3uigEE" to="w1kd:~SObject" resolve="SObject" />
+          </node>
+        </node>
+        <node concept="3clFbS" id="5rSmnqw_G2E" role="3clF47">
+          <node concept="3clFbF" id="5rSmnqwMtSE" role="3cqZAp">
+            <node concept="2OqwBi" id="5rSmnqwMyt9" role="3clFbG">
+              <node concept="37vLTw" id="5rSmnqwMtSD" role="2Oq$k0">
+                <ref role="3cqZAo" node="5rSmnqw_G2y" resolve="sObject" />
               </node>
-              <node concept="2S7cBI" id="4NO8rntSmtZ" role="2OqNvi">
-                <node concept="1bVj0M" id="4NO8rntSmu1" role="23t8la">
-                  <node concept="3clFbS" id="4NO8rntSmu2" role="1bW5cS">
-                    <node concept="3clFbF" id="4NO8rntSn7S" role="3cqZAp">
-                      <node concept="2OqwBi" id="4NO8rntSxEl" role="3clFbG">
-                        <node concept="2OqwBi" id="4NO8rntSpgP" role="2Oq$k0">
-                          <node concept="37vLTw" id="4NO8rntSoXH" role="2Oq$k0">
-                            <ref role="3cqZAo" node="7Z$RfkF7J9V" resolve="it" />
-                          </node>
-                          <node concept="liA8E" id="4NO8rntSxlh" role="2OqNvi">
-                            <ref role="37wK5l" to="mhbf:~SModel.getName()" resolve="getName" />
-                          </node>
+              <node concept="liA8E" id="5rSmnqwMRhz" role="2OqNvi">
+                <ref role="37wK5l" to="w1kd:~SObject.testIfHasSModule(java.util.function.Predicate)" resolve="testIfHasSModule" />
+                <node concept="1bVj0M" id="5rSmnqwMYyE" role="37wK5m">
+                  <node concept="gl6BB" id="5rSmnqwMYyW" role="1bW2Oz">
+                    <property role="TrG5h" value="mod" />
+                    <node concept="2jxLKc" id="5rSmnqwMYyX" role="1tU5fm" />
+                  </node>
+                  <node concept="3clFbS" id="5rSmnqwMY$y" role="1bW5cS">
+                    <node concept="3clFbF" id="5rSmnqwNlNz" role="3cqZAp">
+                      <node concept="2YIFZM" id="5rSmnqwNlN_" role="3clFbG">
+                        <ref role="37wK5l" to="33ny:~Objects.equals(java.lang.Object,java.lang.Object)" resolve="equals" />
+                        <ref role="1Pybhc" to="33ny:~Objects" resolve="Objects" />
+                        <node concept="37vLTw" id="5rSmnqwNlNA" role="37wK5m">
+                          <ref role="3cqZAo" node="5rSmnqwMYyW" resolve="mod" />
                         </node>
-                        <node concept="liA8E" id="4NO8rntSxYC" role="2OqNvi">
-                          <ref role="37wK5l" to="mhbf:~SModelName.getLongName()" resolve="getLongName" />
+                        <node concept="1rXfSq" id="5rSmnqwNlNB" role="37wK5m">
+                          <ref role="37wK5l" node="5rSmnqw$aLM" resolve="getModule" />
                         </node>
                       </node>
                     </node>
                   </node>
-                  <node concept="gl6BB" id="7Z$RfkF7J9V" role="1bW2Oz">
-                    <property role="TrG5h" value="it" />
-                    <node concept="2jxLKc" id="7Z$RfkF7J9W" role="1tU5fm" />
-                  </node>
-                </node>
-                <node concept="1nlBCl" id="4NO8rntSmu5" role="2S7zOq">
-                  <property role="3clFbU" value="true" />
                 </node>
               </node>
             </node>
-            <node concept="3clFbS" id="4NO8rntRRq9" role="2LFqv$">
-              <node concept="3cpWs8" id="4NO8rntSGcR" role="3cqZAp">
-                <node concept="3cpWsn" id="4NO8rntSGcS" role="3cpWs9">
-                  <property role="TrG5h" value="tn" />
-                  <node concept="3uibUv" id="4NO8rntSGce" role="1tU5fm">
-                    <ref role="3uigEE" to="xr52:~SModelTreeNode" resolve="SModelTreeNode" />
-                  </node>
-                  <node concept="2ShNRf" id="4NO8rntSGcT" role="33vP2m">
-                    <node concept="1pGfFk" id="4NO8rntSGcU" role="2ShVmc">
-                      <ref role="37wK5l" to="xr52:~SModelTreeNode.&lt;init&gt;(org.jetbrains.mps.openapi.model.SModel)" resolve="SModelTreeNode" />
-                      <node concept="2GrUjf" id="4NO8rntSGcV" role="37wK5m">
-                        <ref role="2Gs0qQ" node="4NO8rntRRq5" resolve="model" />
+          </node>
+        </node>
+        <node concept="2AHcQZ" id="5rSmnqw_G2F" role="2AJF6D">
+          <ref role="2AI5Lk" to="wyt6:~Override" />
+        </node>
+      </node>
+      <node concept="2tJIrI" id="5rSmnqwBSSr" role="jymVt" />
+      <node concept="3clFb_" id="5rSmnqwHkJ4" role="jymVt">
+        <property role="TrG5h" value="canRepresentSObject" />
+        <node concept="3Tmbuc" id="5rSmnqwHkJ5" role="1B3o_S" />
+        <node concept="10P_77" id="5rSmnqwHkJ7" role="3clF45" />
+        <node concept="37vLTG" id="5rSmnqwHkJ8" role="3clF46">
+          <property role="TrG5h" value="sObject" />
+          <node concept="3uibUv" id="5rSmnqwHkJ9" role="1tU5fm">
+            <ref role="3uigEE" to="w1kd:~SObject" resolve="SObject" />
+          </node>
+        </node>
+        <node concept="3clFbS" id="5rSmnqwHkJg" role="3clF47">
+          <node concept="3clFbF" id="5rSmnqwHU5p" role="3cqZAp">
+            <node concept="1Wc70l" id="5rSmnqwICnd" role="3clFbG">
+              <node concept="2OqwBi" id="5rSmnqwJcAR" role="3uHU7w">
+                <node concept="37vLTw" id="5rSmnqwIRxn" role="2Oq$k0">
+                  <ref role="3cqZAo" node="5rSmnqwHkJ8" resolve="sObject" />
+                </node>
+                <node concept="liA8E" id="5rSmnqwJvCx" role="2OqNvi">
+                  <ref role="37wK5l" to="w1kd:~SObject.testIfHasSModule(java.util.function.Predicate)" resolve="testIfHasSModule" />
+                  <node concept="1bVj0M" id="5rSmnqwJC7M" role="37wK5m">
+                    <node concept="gl6BB" id="5rSmnqwJC84" role="1bW2Oz">
+                      <property role="TrG5h" value="mod" />
+                      <node concept="2jxLKc" id="5rSmnqwJC85" role="1tU5fm" />
+                    </node>
+                    <node concept="3clFbS" id="5rSmnqwJC9E" role="1bW5cS">
+                      <node concept="3clFbF" id="5rSmnqwKhNk" role="3cqZAp">
+                        <node concept="2YIFZM" id="5rSmnqwKvDh" role="3clFbG">
+                          <ref role="37wK5l" to="33ny:~Objects.equals(java.lang.Object,java.lang.Object)" resolve="equals" />
+                          <ref role="1Pybhc" to="33ny:~Objects" resolve="Objects" />
+                          <node concept="37vLTw" id="5rSmnqwKFnx" role="37wK5m">
+                            <ref role="3cqZAo" node="5rSmnqwJC84" resolve="mod" />
+                          </node>
+                          <node concept="1rXfSq" id="5rSmnqwL1kX" role="37wK5m">
+                            <ref role="37wK5l" node="5rSmnqw$aLM" resolve="getModule" />
+                          </node>
+                        </node>
                       </node>
                     </node>
                   </node>
                 </node>
               </node>
-              <node concept="3clFbF" id="4NO8rntSH_9" role="3cqZAp">
-                <node concept="2OqwBi" id="4NO8rntSIQf" role="3clFbG">
-                  <node concept="37vLTw" id="4NO8rntSH_7" role="2Oq$k0">
-                    <ref role="3cqZAo" node="4NO8rntSGcS" resolve="tn" />
+              <node concept="3fqX7Q" id="5rSmnqwHU5n" role="3uHU7B">
+                <node concept="2OqwBi" id="5rSmnqwIaJj" role="3fr31v">
+                  <node concept="37vLTw" id="5rSmnqwI5Sk" role="2Oq$k0">
+                    <ref role="3cqZAo" node="5rSmnqwHkJ8" resolve="sObject" />
                   </node>
-                  <node concept="liA8E" id="4NO8rntTmoC" role="2OqNvi">
-                    <ref role="37wK5l" to="7e8u:~MPSTreeNode.setIcon(javax.swing.Icon)" resolve="setIcon" />
-                    <node concept="37vLTw" id="4NO8rntTFA2" role="37wK5m">
-                      <ref role="3cqZAo" node="4NO8rntTytf" resolve="MODEL_ICON" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3clFbF" id="4NO8rntTHsG" role="3cqZAp">
-                <node concept="2OqwBi" id="4NO8rntTHsH" role="3clFbG">
-                  <node concept="37vLTw" id="4NO8rntTHsI" role="2Oq$k0">
-                    <ref role="3cqZAo" node="4NO8rntSGcS" resolve="tn" />
-                  </node>
-                  <node concept="liA8E" id="4NO8rntTHsJ" role="2OqNvi">
-                    <ref role="37wK5l" to="xr52:~SModelTreeNode.setBaseIcon(javax.swing.Icon)" resolve="setBaseIcon" />
-                    <node concept="37vLTw" id="4NO8rntTHsK" role="37wK5m">
-                      <ref role="3cqZAo" node="4NO8rntTytf" resolve="MODEL_ICON" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3clFbF" id="4NO8rntRUf1" role="3cqZAp">
-                <node concept="1rXfSq" id="4NO8rntRUf0" role="3clFbG">
-                  <ref role="37wK5l" to="rgfa:~DefaultMutableTreeNode.add(javax.swing.tree.MutableTreeNode)" resolve="add" />
-                  <node concept="37vLTw" id="4NO8rntSGcW" role="37wK5m">
-                    <ref role="3cqZAo" node="4NO8rntSGcS" resolve="tn" />
+                  <node concept="liA8E" id="5rSmnqwIsiF" role="2OqNvi">
+                    <ref role="37wK5l" to="w1kd:~SObject.hasSNode()" resolve="hasSNode" />
                   </node>
                 </node>
               </node>
             </node>
           </node>
+        </node>
+        <node concept="2AHcQZ" id="5rSmnqwHkJh" role="2AJF6D">
+          <ref role="2AI5Lk" to="wyt6:~Override" />
         </node>
       </node>
-      <node concept="2tJIrI" id="5tQmAwPFFjs" role="jymVt" />
-      <node concept="3clFb_" id="5tQmAwPFGQa" role="jymVt">
-        <property role="1EzhhJ" value="false" />
-        <property role="TrG5h" value="doUpdate" />
-        <property role="DiZV1" value="false" />
-        <property role="od$2w" value="false" />
-        <node concept="3Tmbuc" id="5tQmAwPFGQb" role="1B3o_S" />
-        <node concept="3cqZAl" id="5tQmAwPFGQd" role="3clF45" />
-        <node concept="3clFbS" id="5tQmAwPFGQh" role="3clF47">
-          <node concept="3clFbF" id="5tQmAwPFGQk" role="3cqZAp">
-            <node concept="3nyPlj" id="5tQmAwPFGQj" role="3clFbG">
-              <ref role="37wK5l" to="7e8u:~MPSTreeNode.doUpdate()" resolve="doUpdate" />
-            </node>
+      <node concept="2tJIrI" id="5rSmnqwGjiq" role="jymVt" />
+      <node concept="3clFb_" id="5rSmnqwC0_x" role="jymVt">
+        <property role="TrG5h" value="update" />
+        <node concept="3Tmbuc" id="5rSmnqwC0_y" role="1B3o_S" />
+        <node concept="3cqZAl" id="5rSmnqwC0_$" role="3clF45" />
+        <node concept="37vLTG" id="5rSmnqwC0__" role="3clF46">
+          <property role="TrG5h" value="presentation" />
+          <node concept="3uibUv" id="5rSmnqwC0_A" role="1tU5fm">
+            <ref role="3uigEE" to="bnjk:~PresentationData" resolve="PresentationData" />
           </node>
-          <node concept="3clFbF" id="5tQmAwPFK42" role="3cqZAp">
-            <node concept="37vLTI" id="5tQmAwPFL2K" role="3clFbG">
-              <node concept="3clFbT" id="5tQmAwPFLCj" role="37vLTx">
-                <property role="3clFbU" value="false" />
-              </node>
-              <node concept="37vLTw" id="5tQmAwPFK40" role="37vLTJ">
-                <ref role="3cqZAo" node="4QZGLsL_Wl0" resolve="myInitialized" />
-              </node>
-            </node>
-          </node>
-          <node concept="3clFbF" id="5tQmAwPFNo9" role="3cqZAp">
-            <node concept="1rXfSq" id="5tQmAwPFNo7" role="3clFbG">
-              <ref role="37wK5l" to="rgfa:~DefaultMutableTreeNode.removeAllChildren()" resolve="removeAllChildren" />
-            </node>
+          <node concept="2AHcQZ" id="5rSmnqwC0_B" role="2AJF6D">
+            <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
           </node>
         </node>
-        <node concept="2AHcQZ" id="5tQmAwPFGQi" role="2AJF6D">
-          <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-        </node>
-      </node>
-      <node concept="2tJIrI" id="5tQmAwPF4I_" role="jymVt" />
-      <node concept="3clFb_" id="5tQmAwPF6qd" role="jymVt">
-        <property role="TrG5h" value="dispose" />
-        <node concept="3cqZAl" id="5tQmAwPF6qf" role="3clF45" />
-        <node concept="3Tm1VV" id="5tQmAwPF6qg" role="1B3o_S" />
-        <node concept="3clFbS" id="5tQmAwPF6qh" role="3clF47">
-          <node concept="3clFbF" id="5tQmAwPG8c3" role="3cqZAp">
-            <node concept="2OqwBi" id="5tQmAwPG8rA" role="3clFbG">
-              <node concept="1rXfSq" id="5tQmAwPG8c2" role="2Oq$k0">
-                <ref role="37wK5l" to="kxvg:~ProjectModuleTreeNode.getModule()" resolve="getModule" />
+        <node concept="3clFbS" id="5rSmnqwC0_I" role="3clF47">
+          <node concept="3clFbF" id="5rSmnqwCzZj" role="3cqZAp">
+            <node concept="2OqwBi" id="5rSmnqwCNrb" role="3clFbG">
+              <node concept="37vLTw" id="5rSmnqwCzZi" role="2Oq$k0">
+                <ref role="3cqZAo" node="5rSmnqwC0__" resolve="presentation" />
               </node>
-              <node concept="liA8E" id="5tQmAwPG8P4" role="2OqNvi">
-                <ref role="37wK5l" to="lui2:~SModule.removeModuleListener(org.jetbrains.mps.openapi.module.SModuleListener)" resolve="removeModuleListener" />
-                <node concept="37vLTw" id="5tQmAwPG9Zs" role="37wK5m">
-                  <ref role="3cqZAo" node="5tQmAwPFXRQ" resolve="moduleListener" />
+              <node concept="liA8E" id="5rSmnqwD11$" role="2OqNvi">
+                <ref role="37wK5l" to="bnjk:~PresentationData.setPresentableText(java.lang.String)" resolve="setPresentableText" />
+                <node concept="2OqwBi" id="5rSmnqwDtDa" role="37wK5m">
+                  <node concept="1rXfSq" id="5rSmnqwDeu_" role="2Oq$k0">
+                    <ref role="37wK5l" node="5rSmnqw$aLM" resolve="getModule" />
+                  </node>
+                  <node concept="liA8E" id="5rSmnqwDLHF" role="2OqNvi">
+                    <ref role="37wK5l" to="lui2:~SModule.getModuleName()" resolve="getModuleName" />
+                  </node>
                 </node>
               </node>
             </node>
           </node>
+          <node concept="3clFbF" id="5rSmnqwE5sO" role="3cqZAp">
+            <node concept="2OqwBi" id="5rSmnqwEoBx" role="3clFbG">
+              <node concept="37vLTw" id="5rSmnqwE5sM" role="2Oq$k0">
+                <ref role="3cqZAo" node="5rSmnqwC0__" resolve="presentation" />
+              </node>
+              <node concept="liA8E" id="5rSmnqwEAmm" role="2OqNvi">
+                <ref role="37wK5l" to="bnjk:~PresentationData.setIcon(javax.swing.Icon)" resolve="setIcon" />
+                <node concept="37vLTw" id="5rSmnqwEVb4" role="37wK5m">
+                  <ref role="3cqZAo" node="4NO8rntTrX3" resolve="MODULE_ICON" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="5rSmnqwFq_j" role="3cqZAp">
+            <node concept="1rXfSq" id="5rSmnqwFq_h" role="3clFbG">
+              <ref role="37wK5l" to="paf:~BaseModuleProjectViewNode.updateTooltip(com.intellij.ide.projectView.PresentationData)" resolve="updateTooltip" />
+              <node concept="37vLTw" id="5rSmnqwFDnZ" role="37wK5m">
+                <ref role="3cqZAo" node="5rSmnqwC0__" resolve="presentation" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2AHcQZ" id="5rSmnqwC0_J" role="2AJF6D">
+          <ref role="2AI5Lk" to="wyt6:~Override" />
         </node>
       </node>
     </node>
     <node concept="2tJIrI" id="115Xaa3Zoug" role="jymVt" />
+    <node concept="312cEu" id="5rSmnqwtZrp" role="jymVt">
+      <property role="2bfB8j" value="true" />
+      <property role="TrG5h" value="ShadowRootProjectTreeNode" />
+      <node concept="3clFbW" id="5rSmnqwu8r7" role="jymVt">
+        <node concept="37vLTG" id="5rSmnqwmcjp" role="3clF46">
+          <property role="TrG5h" value="project" />
+          <node concept="3uibUv" id="5rSmnqwmcjo" role="1tU5fm">
+            <ref role="3uigEE" to="4nm9:~Project" resolve="Project" />
+          </node>
+        </node>
+        <node concept="37vLTG" id="5rSmnqwmcjr" role="3clF46">
+          <property role="TrG5h" value="value" />
+          <node concept="3uibUv" id="5rSmnqwRuSQ" role="1tU5fm">
+            <ref role="3uigEE" to="wyt6:~String" resolve="String" />
+          </node>
+          <node concept="2AHcQZ" id="5rSmnqwmcjs" role="2AJF6D">
+            <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+          </node>
+        </node>
+        <node concept="37vLTG" id="5rSmnqwmcju" role="3clF46">
+          <property role="TrG5h" value="viewSettings" />
+          <node concept="3uibUv" id="5rSmnqwmcjt" role="1tU5fm">
+            <ref role="3uigEE" to="bnjk:~ViewSettings" resolve="ViewSettings" />
+          </node>
+        </node>
+        <node concept="3cqZAl" id="5rSmnqwu8r9" role="3clF45" />
+        <node concept="3Tm1VV" id="5rSmnqwu8ra" role="1B3o_S" />
+        <node concept="3clFbS" id="5rSmnqwu8rb" role="3clF47">
+          <node concept="XkiVB" id="5rSmnqwROJQ" role="3cqZAp">
+            <ref role="37wK5l" to="paf:~TopHierarchyProjectViewNode.&lt;init&gt;(com.intellij.openapi.project.Project,java.lang.Object,com.intellij.ide.projectView.ViewSettings)" resolve="TopHierarchyProjectViewNode" />
+            <node concept="37vLTw" id="5rSmnqwS0Yk" role="37wK5m">
+              <ref role="3cqZAo" node="5rSmnqwmcjp" resolve="project" />
+            </node>
+            <node concept="37vLTw" id="5rSmnqwSb0P" role="37wK5m">
+              <ref role="3cqZAo" node="5rSmnqwmcjr" resolve="value" />
+            </node>
+            <node concept="37vLTw" id="5rSmnqwSwwR" role="37wK5m">
+              <ref role="3cqZAo" node="5rSmnqwmcju" resolve="viewSettings" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2tJIrI" id="5rSmnqwOzwR" role="jymVt" />
+      <node concept="3Tm1VV" id="5rSmnqwtZrq" role="1B3o_S" />
+      <node concept="3uibUv" id="5rSmnqwu7ct" role="1zkMxy">
+        <ref role="3uigEE" to="paf:~TopHierarchyProjectViewNode" resolve="TopHierarchyProjectViewNode" />
+        <node concept="3uibUv" id="5rSmnqwRgZO" role="11_B2D">
+          <ref role="3uigEE" to="wyt6:~String" resolve="String" />
+        </node>
+      </node>
+      <node concept="3clFb_" id="5rSmnqx5eEB" role="jymVt">
+        <property role="TrG5h" value="containsSObject" />
+        <node concept="3Tmbuc" id="5rSmnqx5eEC" role="1B3o_S" />
+        <node concept="10P_77" id="5rSmnqx5eEE" role="3clF45" />
+        <node concept="37vLTG" id="5rSmnqx5eEF" role="3clF46">
+          <property role="TrG5h" value="sObject" />
+          <node concept="3uibUv" id="5rSmnqx5eEG" role="1tU5fm">
+            <ref role="3uigEE" to="w1kd:~SObject" resolve="SObject" />
+          </node>
+        </node>
+        <node concept="3clFbS" id="5rSmnqx5eEN" role="3clF47">
+          <node concept="3clFbF" id="5rSmnqx6hFh" role="3cqZAp">
+            <node concept="2OqwBi" id="5rSmnqx6o_d" role="3clFbG">
+              <node concept="37vLTw" id="5rSmnqx6hFf" role="2Oq$k0">
+                <ref role="3cqZAo" node="5rSmnqx5eEF" resolve="sObject" />
+              </node>
+              <node concept="liA8E" id="5rSmnqx6z71" role="2OqNvi">
+                <ref role="37wK5l" to="w1kd:~SObject.testIfHasSModule(java.util.function.Predicate)" resolve="testIfHasSModule" />
+                <node concept="1bVj0M" id="5rSmnqx6Pmi" role="37wK5m">
+                  <node concept="gl6BB" id="5rSmnqx6Pm$" role="1bW2Oz">
+                    <property role="TrG5h" value="mod" />
+                    <node concept="2jxLKc" id="5rSmnqx6Pm_" role="1tU5fm" />
+                  </node>
+                  <node concept="3clFbS" id="5rSmnqx6Po0" role="1bW5cS">
+                    <node concept="3clFbF" id="5rSmnqx78Kk" role="3cqZAp">
+                      <node concept="2ZW3vV" id="5rSmnqx7gSR" role="3clFbG">
+                        <node concept="3uibUv" id="5rSmnqx7zDY" role="2ZW6by">
+                          <ref role="3uigEE" to="l6bp:115Xaa43tZI" resolve="SM_ShadowModule" />
+                        </node>
+                        <node concept="37vLTw" id="5rSmnqx78Kj" role="2ZW6bz">
+                          <ref role="3cqZAo" node="5rSmnqx6Pm$" resolve="mod" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2AHcQZ" id="5rSmnqx5eEO" role="2AJF6D">
+          <ref role="2AI5Lk" to="wyt6:~Override" />
+        </node>
+      </node>
+      <node concept="2tJIrI" id="5rSmnqx5_x0" role="jymVt" />
+      <node concept="3clFb_" id="5rSmnqx9K3h" role="jymVt">
+        <property role="TrG5h" value="fillChildren" />
+        <node concept="3Tmbuc" id="5rSmnqx9K3i" role="1B3o_S" />
+        <node concept="3cqZAl" id="5rSmnqx9K3k" role="3clF45" />
+        <node concept="37vLTG" id="5rSmnqx9K3l" role="3clF46">
+          <property role="TrG5h" value="collection" />
+          <node concept="3uibUv" id="5rSmnqx9K3m" role="1tU5fm">
+            <ref role="3uigEE" to="33ny:~Collection" resolve="Collection" />
+            <node concept="3uibUv" id="5rSmnqx9K3n" role="11_B2D">
+              <ref role="3uigEE" to="rcv5:~AbstractTreeNode" resolve="AbstractTreeNode" />
+              <node concept="3qTvmN" id="5rSmnqx9K3o" role="11_B2D" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbS" id="5rSmnqx9K3s" role="3clF47">
+          <node concept="3cpWs8" id="5rSmnqxalqo" role="3cqZAp">
+            <node concept="3cpWsn" id="5rSmnqxalqr" role="3cpWs9">
+              <property role="TrG5h" value="repository" />
+              <node concept="3uibUv" id="5rSmnqxalqs" role="1tU5fm">
+                <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
+              </node>
+              <node concept="2OqwBi" id="5rSmnqxalqt" role="33vP2m">
+                <node concept="37vLTw" id="5rSmnqxalqu" role="2Oq$k0">
+                  <ref role="3cqZAo" node="115Xaa3Z2NL" resolve="project" />
+                </node>
+                <node concept="liA8E" id="5rSmnqxalqv" role="2OqNvi">
+                  <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="5rSmnqxayY9" role="3cqZAp">
+            <node concept="3cpWsn" id="5rSmnqxayYa" role="3cpWs9">
+              <property role="TrG5h" value="modules" />
+              <node concept="A3Dl8" id="5rSmnqxayYb" role="1tU5fm">
+                <node concept="3uibUv" id="5rSmnqxayYc" role="A3Ik2">
+                  <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
+                </node>
+              </node>
+              <node concept="2OqwBi" id="5rSmnqxayYd" role="33vP2m">
+                <node concept="37vLTw" id="5rSmnqxayYe" role="2Oq$k0">
+                  <ref role="3cqZAo" node="5rSmnqxalqr" resolve="repository" />
+                </node>
+                <node concept="liA8E" id="5rSmnqxayYf" role="2OqNvi">
+                  <ref role="37wK5l" to="lui2:~SRepository.getModules()" resolve="getModules" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="5rSmnqxaIYg" role="3cqZAp">
+            <node concept="2OqwBi" id="5rSmnqxgU4M" role="3clFbG">
+              <property role="hSjvv" value="true" />
+              <node concept="2OqwBi" id="5rSmnqxaVdv" role="2Oq$k0">
+                <property role="hSjvv" value="true" />
+                <node concept="2OqwBi" id="5rSmnqxaIYi" role="2Oq$k0">
+                  <node concept="37vLTw" id="5rSmnqxaIYj" role="2Oq$k0">
+                    <ref role="3cqZAo" node="5rSmnqxayYa" resolve="modules" />
+                  </node>
+                  <node concept="UnYns" id="5rSmnqxaIYk" role="2OqNvi">
+                    <node concept="3uibUv" id="5rSmnqxaIYl" role="UnYnz">
+                      <ref role="3uigEE" to="l6bp:115Xaa43tZI" resolve="SM_ShadowModule" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3$u5V9" id="5rSmnqxbwJj" role="2OqNvi">
+                  <node concept="1bVj0M" id="5rSmnqxbwJl" role="23t8la">
+                    <node concept="3clFbS" id="5rSmnqxbwJm" role="1bW5cS">
+                      <node concept="3clFbF" id="5rSmnqxbIrP" role="3cqZAp">
+                        <node concept="2ShNRf" id="5rSmnqxbIrN" role="3clFbG">
+                          <node concept="1pGfFk" id="5rSmnqxcg$D" role="2ShVmc">
+                            <property role="373rjd" value="true" />
+                            <ref role="37wK5l" node="5rSmnqwvTkf" resolve="ProjectViewExtension.ShadowModuleProjectViewNode" />
+                            <node concept="1rXfSq" id="5rSmnqxcBjU" role="37wK5m">
+                              <ref role="37wK5l" node="5rSmnqx0OJK" resolve="getIdeaProject" />
+                            </node>
+                            <node concept="37vLTw" id="5rSmnqxd8u8" role="37wK5m">
+                              <ref role="3cqZAo" node="5rSmnqxbwJn" resolve="it" />
+                            </node>
+                            <node concept="1rXfSq" id="5rSmnqxe7o9" role="37wK5m">
+                              <ref role="37wK5l" to="bnjk:~ProjectViewNode.getSettings()" resolve="getSettings" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="gl6BB" id="5rSmnqxbwJn" role="1bW2Oz">
+                      <property role="TrG5h" value="it" />
+                      <node concept="2jxLKc" id="5rSmnqxbwJo" role="1tU5fm" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="2es0OD" id="5rSmnqxhDv3" role="2OqNvi">
+                <node concept="1bVj0M" id="5rSmnqxhDv5" role="23t8la">
+                  <node concept="3clFbS" id="5rSmnqxhDv6" role="1bW5cS">
+                    <node concept="3clFbF" id="5rSmnqxhXZD" role="3cqZAp">
+                      <node concept="2OqwBi" id="5rSmnqxi3qx" role="3clFbG">
+                        <node concept="37vLTw" id="5rSmnqxhXZC" role="2Oq$k0">
+                          <ref role="3cqZAo" node="5rSmnqx9K3l" resolve="collection" />
+                        </node>
+                        <node concept="liA8E" id="5rSmnqxiiG1" role="2OqNvi">
+                          <ref role="37wK5l" to="33ny:~Collection.add(java.lang.Object)" resolve="add" />
+                          <node concept="37vLTw" id="5rSmnqxiv_c" role="37wK5m">
+                            <ref role="3cqZAo" node="5rSmnqxhDv7" resolve="it" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="gl6BB" id="5rSmnqxhDv7" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="5rSmnqxhDv8" role="1tU5fm" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2AHcQZ" id="5rSmnqx9K3t" role="2AJF6D">
+          <ref role="2AI5Lk" to="wyt6:~Override" />
+        </node>
+      </node>
+      <node concept="2tJIrI" id="5rSmnqxa34r" role="jymVt" />
+      <node concept="3clFb_" id="5rSmnqx7Ht7" role="jymVt">
+        <property role="TrG5h" value="getTypeSortWeight" />
+        <node concept="3Tm1VV" id="5rSmnqx7Ht8" role="1B3o_S" />
+        <node concept="10Oyi0" id="5rSmnqx7Hta" role="3clF45" />
+        <node concept="37vLTG" id="5rSmnqx7Htb" role="3clF46">
+          <property role="TrG5h" value="sortByType" />
+          <node concept="10P_77" id="5rSmnqx7Htc" role="1tU5fm" />
+        </node>
+        <node concept="3clFbS" id="5rSmnqx7Htn" role="3clF47">
+          <node concept="3clFbF" id="5rSmnqx8w$W" role="3cqZAp">
+            <node concept="3cpWs3" id="5rSmnqx9eXL" role="3clFbG">
+              <node concept="3cmrfG" id="5rSmnqx9fOe" role="3uHU7w">
+                <property role="3cmrfH" value="1" />
+              </node>
+              <node concept="10M0yZ" id="5rSmnqx8S7E" role="3uHU7B">
+                <ref role="3cqZAo" to="paf:~ProjectViewWeights.MODULES_POOL_WEIGHT" resolve="MODULES_POOL_WEIGHT" />
+                <ref role="1PxDUh" to="paf:~ProjectViewWeights" resolve="ProjectViewWeights" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2AHcQZ" id="5rSmnqx7Hto" role="2AJF6D">
+          <ref role="2AI5Lk" to="wyt6:~Override" />
+        </node>
+      </node>
+      <node concept="2tJIrI" id="5rSmnqx9qdC" role="jymVt" />
+      <node concept="3clFb_" id="5rSmnqwOBTL" role="jymVt">
+        <property role="TrG5h" value="updateInReadAction" />
+        <node concept="3Tmbuc" id="5rSmnqwOBTM" role="1B3o_S" />
+        <node concept="3cqZAl" id="5rSmnqwOBTO" role="3clF45" />
+        <node concept="37vLTG" id="5rSmnqwOBTP" role="3clF46">
+          <property role="TrG5h" value="presentation" />
+          <node concept="3uibUv" id="5rSmnqwOBTQ" role="1tU5fm">
+            <ref role="3uigEE" to="bnjk:~PresentationData" resolve="PresentationData" />
+          </node>
+        </node>
+        <node concept="3clFbS" id="5rSmnqwOBTX" role="3clF47">
+          <node concept="3clFbF" id="5rSmnqwPhEi" role="3cqZAp">
+            <node concept="2OqwBi" id="5rSmnqwPp2N" role="3clFbG">
+              <node concept="37vLTw" id="5rSmnqwPhEh" role="2Oq$k0">
+                <ref role="3cqZAo" node="5rSmnqwOBTP" resolve="presentation" />
+              </node>
+              <node concept="liA8E" id="5rSmnqwPBQR" role="2OqNvi">
+                <ref role="37wK5l" to="bnjk:~PresentationData.setPresentableText(java.lang.String)" resolve="setPresentableText" />
+                <node concept="1rXfSq" id="5rSmnqwT1K7" role="37wK5m">
+                  <ref role="37wK5l" to="rcv5:~AbstractTreeNode.getValue()" resolve="getValue" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="5rSmnqwQolk" role="3cqZAp">
+            <node concept="2OqwBi" id="5rSmnqwQEzN" role="3clFbG">
+              <node concept="37vLTw" id="5rSmnqwQoli" role="2Oq$k0">
+                <ref role="3cqZAo" node="5rSmnqwOBTP" resolve="presentation" />
+              </node>
+              <node concept="liA8E" id="5rSmnqwQSps" role="2OqNvi">
+                <ref role="37wK5l" to="bnjk:~PresentationData.setIcon(javax.swing.Icon)" resolve="setIcon" />
+                <node concept="37vLTw" id="5rSmnqwR87s" role="37wK5m">
+                  <ref role="3cqZAo" node="4NO8rntTnzD" resolve="ROOT_ICON" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2AHcQZ" id="5rSmnqwOBTY" role="2AJF6D">
+          <ref role="2AI5Lk" to="wyt6:~Override" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="5rSmnqwtPi_" role="jymVt" />
+    <node concept="312cEu" id="2nMt2skySM5" role="jymVt">
+      <property role="2bfB8j" value="true" />
+      <property role="TrG5h" value="ShadowRootTreeStructure1Provider" />
+      <node concept="3Tm1VV" id="2nMt2skySM6" role="1B3o_S" />
+      <node concept="3uibUv" id="2nMt2skyZla" role="EKbjA">
+        <ref role="3uigEE" to="bnjk:~TreeStructureProvider" resolve="TreeStructureProvider" />
+      </node>
+      <node concept="3clFb_" id="2nMt2skyZLA" role="jymVt">
+        <property role="TrG5h" value="modify" />
+        <node concept="3Tm1VV" id="2nMt2skyZLB" role="1B3o_S" />
+        <node concept="2AHcQZ" id="2nMt2skyZLD" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+        <node concept="3uibUv" id="2nMt2skyZLE" role="3clF45">
+          <ref role="3uigEE" to="33ny:~Collection" resolve="Collection" />
+          <node concept="3uibUv" id="2nMt2skyZLF" role="11_B2D">
+            <ref role="3uigEE" to="rcv5:~AbstractTreeNode" resolve="AbstractTreeNode" />
+            <node concept="3qTvmN" id="2nMt2skyZLG" role="11_B2D" />
+          </node>
+        </node>
+        <node concept="37vLTG" id="2nMt2skyZLH" role="3clF46">
+          <property role="TrG5h" value="node" />
+          <node concept="3uibUv" id="2nMt2skyZLI" role="1tU5fm">
+            <ref role="3uigEE" to="rcv5:~AbstractTreeNode" resolve="AbstractTreeNode" />
+            <node concept="3qTvmN" id="2nMt2skyZLJ" role="11_B2D" />
+          </node>
+          <node concept="2AHcQZ" id="2nMt2skyZLK" role="2AJF6D">
+            <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+          </node>
+        </node>
+        <node concept="37vLTG" id="2nMt2skyZLL" role="3clF46">
+          <property role="TrG5h" value="children" />
+          <node concept="3uibUv" id="2nMt2skyZLM" role="1tU5fm">
+            <ref role="3uigEE" to="33ny:~Collection" resolve="Collection" />
+            <node concept="3uibUv" id="2nMt2skyZLN" role="11_B2D">
+              <ref role="3uigEE" to="rcv5:~AbstractTreeNode" resolve="AbstractTreeNode" />
+              <node concept="3qTvmN" id="2nMt2skyZLO" role="11_B2D" />
+            </node>
+          </node>
+          <node concept="2AHcQZ" id="2nMt2skyZLP" role="2AJF6D">
+            <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+          </node>
+        </node>
+        <node concept="37vLTG" id="2nMt2skyZLQ" role="3clF46">
+          <property role="TrG5h" value="settings" />
+          <node concept="3uibUv" id="2nMt2skyZLR" role="1tU5fm">
+            <ref role="3uigEE" to="bnjk:~ViewSettings" resolve="ViewSettings" />
+          </node>
+        </node>
+        <node concept="3clFbS" id="2nMt2skyZLS" role="3clF47">
+          <node concept="3clFbJ" id="2nMt2skBxxP" role="3cqZAp">
+            <node concept="3clFbC" id="2nMt2skBDQZ" role="3clFbw">
+              <node concept="10Nm6u" id="2nMt2skBGpH" role="3uHU7w" />
+              <node concept="2OqwBi" id="2nMt2skB_OU" role="3uHU7B">
+                <node concept="37vLTw" id="2nMt2skBzC9" role="2Oq$k0">
+                  <ref role="3cqZAo" node="2nMt2skyZLH" resolve="node" />
+                </node>
+                <node concept="liA8E" id="2nMt2skBCb5" role="2OqNvi">
+                  <ref role="37wK5l" to="rcv5:~AbstractTreeNode.getParent()" resolve="getParent" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbS" id="2nMt2skBxxR" role="3clFbx">
+              <node concept="3cpWs8" id="5rSmnqwWvrL" role="3cqZAp">
+                <node concept="3cpWsn" id="5rSmnqwWvrM" role="3cpWs9">
+                  <property role="TrG5h" value="repository" />
+                  <node concept="3uibUv" id="5rSmnqwWq_S" role="1tU5fm">
+                    <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
+                  </node>
+                  <node concept="2OqwBi" id="5rSmnqwWvrN" role="33vP2m">
+                    <node concept="37vLTw" id="5rSmnqwWvrO" role="2Oq$k0">
+                      <ref role="3cqZAo" node="115Xaa3Z2NL" resolve="project" />
+                    </node>
+                    <node concept="liA8E" id="5rSmnqwWvrP" role="2OqNvi">
+                      <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3cpWs8" id="5rSmnqwZl7G" role="3cqZAp">
+                <node concept="3cpWsn" id="5rSmnqwZl7H" role="3cpWs9">
+                  <property role="TrG5h" value="newChildren" />
+                  <node concept="_YKpA" id="5rSmnqwZgL3" role="1tU5fm">
+                    <node concept="3uibUv" id="5rSmnqwZgLb" role="_ZDj9">
+                      <ref role="3uigEE" to="rcv5:~AbstractTreeNode" resolve="AbstractTreeNode" />
+                      <node concept="3qTvmN" id="5rSmnqwZgLc" role="11_B2D" />
+                    </node>
+                    <node concept="2yE$l8" id="5rSmnqwZgLd" role="lGtFl" />
+                  </node>
+                  <node concept="10Nm6u" id="5rSmnqy4yQQ" role="33vP2m" />
+                </node>
+              </node>
+              <node concept="3clFbF" id="5rSmnqwU4U0" role="3cqZAp">
+                <node concept="2OqwBi" id="5rSmnqwUThK" role="3clFbG">
+                  <node concept="2OqwBi" id="5rSmnqwUHwF" role="2Oq$k0">
+                    <node concept="37vLTw" id="5rSmnqwWvrQ" role="2Oq$k0">
+                      <ref role="3cqZAo" node="5rSmnqwWvrM" resolve="repository" />
+                    </node>
+                    <node concept="liA8E" id="5rSmnqwURJn" role="2OqNvi">
+                      <ref role="37wK5l" to="lui2:~SRepository.getModelAccess()" resolve="getModelAccess" />
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="5rSmnqwVrO_" role="2OqNvi">
+                    <ref role="37wK5l" to="lui2:~ModelAccess.runReadAction(java.lang.Runnable)" resolve="runReadAction" />
+                    <node concept="1bVj0M" id="5rSmnqwVAvQ" role="37wK5m">
+                      <node concept="3clFbS" id="5rSmnqwVAvT" role="1bW5cS">
+                        <node concept="3cpWs8" id="5rSmnqwWFoa" role="3cqZAp">
+                          <node concept="3cpWsn" id="5rSmnqwWFob" role="3cpWs9">
+                            <property role="TrG5h" value="modules" />
+                            <node concept="A3Dl8" id="5rSmnqwX2vE" role="1tU5fm">
+                              <node concept="3uibUv" id="5rSmnqwX2vG" role="A3Ik2">
+                                <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
+                              </node>
+                            </node>
+                            <node concept="2OqwBi" id="5rSmnqwWFoc" role="33vP2m">
+                              <node concept="37vLTw" id="5rSmnqwWFod" role="2Oq$k0">
+                                <ref role="3cqZAo" node="5rSmnqwWvrM" resolve="repository" />
+                              </node>
+                              <node concept="liA8E" id="5rSmnqwWFoe" role="2OqNvi">
+                                <ref role="37wK5l" to="lui2:~SRepository.getModules()" resolve="getModules" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3clFbJ" id="5rSmnqwY6jK" role="3cqZAp">
+                          <node concept="3clFbS" id="5rSmnqwY6jM" role="3clFbx">
+                            <node concept="3clFbF" id="5rSmnqy4mE2" role="3cqZAp">
+                              <node concept="37vLTI" id="5rSmnqy4mE4" role="3clFbG">
+                                <node concept="2ShNRf" id="5rSmnqwZl7I" role="37vLTx">
+                                  <node concept="Tc6Ow" id="5rSmnqwZl7J" role="2ShVmc">
+                                    <node concept="37vLTw" id="5rSmnqwZl7K" role="I$8f6">
+                                      <ref role="3cqZAo" node="2nMt2skyZLL" resolve="children" />
+                                    </node>
+                                  </node>
+                                </node>
+                                <node concept="37vLTw" id="5rSmnqy4mE8" role="37vLTJ">
+                                  <ref role="3cqZAo" node="5rSmnqwZl7H" resolve="newChildren" />
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="3clFbF" id="5rSmnqwYxj1" role="3cqZAp">
+                              <node concept="2OqwBi" id="5rSmnqwZHnE" role="3clFbG">
+                                <node concept="37vLTw" id="5rSmnqwZl7L" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="5rSmnqwZl7H" resolve="newChildren" />
+                                </node>
+                                <node concept="TSZUe" id="5rSmnqx007Z" role="2OqNvi">
+                                  <node concept="2ShNRf" id="5rSmnqx06CU" role="25WWJ7">
+                                    <node concept="1pGfFk" id="5rSmnqx0mgO" role="2ShVmc">
+                                      <property role="373rjd" value="true" />
+                                      <ref role="37wK5l" node="5rSmnqwu8r7" resolve="ProjectViewExtension.ShadowRootProjectTreeNode" />
+                                      <node concept="1rXfSq" id="5rSmnqx2buQ" role="37wK5m">
+                                        <ref role="37wK5l" node="5rSmnqx0OJK" resolve="getIdeaProject" />
+                                      </node>
+                                      <node concept="Xl_RD" id="5rSmnqx2H6s" role="37wK5m">
+                                        <property role="Xl_RC" value="Shadow" />
+                                      </node>
+                                      <node concept="37vLTw" id="5rSmnqx46fz" role="37wK5m">
+                                        <ref role="3cqZAo" node="2nMt2skyZLQ" resolve="settings" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="2OqwBi" id="5rSmnqwYgoV" role="3clFbw">
+                            <node concept="2OqwBi" id="5rSmnqwYgoW" role="2Oq$k0">
+                              <node concept="37vLTw" id="5rSmnqwYgoX" role="2Oq$k0">
+                                <ref role="3cqZAo" node="5rSmnqwWFob" resolve="modules" />
+                              </node>
+                              <node concept="UnYns" id="5rSmnqwYgoY" role="2OqNvi">
+                                <node concept="3uibUv" id="5rSmnqwYgoZ" role="UnYnz">
+                                  <ref role="3uigEE" to="l6bp:115Xaa43tZI" resolve="SM_ShadowModule" />
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="3GX2aA" id="5rSmnqwYgp0" role="2OqNvi" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbJ" id="5rSmnqy4MAV" role="3cqZAp">
+                <node concept="3y3z36" id="5rSmnqy509p" role="3clFbw">
+                  <node concept="10Nm6u" id="5rSmnqy58Fo" role="3uHU7w" />
+                  <node concept="37vLTw" id="5rSmnqy4UB_" role="3uHU7B">
+                    <ref role="3cqZAo" node="5rSmnqwZl7H" resolve="newChildren" />
+                  </node>
+                </node>
+                <node concept="3clFbS" id="5rSmnqy4MAX" role="3clFbx">
+                  <node concept="3cpWs6" id="5rSmnqx4s16" role="3cqZAp">
+                    <node concept="37vLTw" id="5rSmnqx4L7Z" role="3cqZAk">
+                      <ref role="3cqZAo" node="5rSmnqwZl7H" resolve="newChildren" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="5rSmnqwTzYd" role="3cqZAp">
+            <node concept="37vLTw" id="5rSmnqwTzYa" role="3clFbG">
+              <ref role="3cqZAo" node="2nMt2skyZLL" resolve="collection" />
+            </node>
+          </node>
+        </node>
+        <node concept="2AHcQZ" id="2nMt2skyZLT" role="2AJF6D">
+          <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="2nMt2skyOmF" role="jymVt" />
     <node concept="3Tm1VV" id="115Xaa3Z2Jc" role="1B3o_S" />
   </node>
   <node concept="2uRRBy" id="115Xaa3ZjNG">
@@ -4135,20 +2559,23 @@
               <node concept="1bVj0M" id="56YPHTojVy8" role="37wK5m">
                 <property role="3yWfEV" value="true" />
                 <node concept="3clFbS" id="56YPHTojVy9" role="1bW5cS">
-                  <node concept="3clFbF" id="56YPHTojVHW" role="3cqZAp">
-                    <node concept="2OqwBi" id="56YPHTokeC_" role="3clFbG">
-                      <node concept="2YIFZM" id="56YPHTojVJe" role="2Oq$k0">
-                        <ref role="1Pybhc" node="115Xaa3Z2Jb" resolve="ProjectViewExtension" />
-                        <ref role="37wK5l" node="4S3q4YkONiE" resolve="getInstance" />
-                        <node concept="2OqwBi" id="56YPHTokeaJ" role="37wK5m">
-                          <node concept="2WthIp" id="56YPHTokeaM" role="2Oq$k0" />
-                          <node concept="1DTwFV" id="56YPHTokh1A" role="2OqNvi">
+                  <node concept="3clFbF" id="5rSmnqxr5xf" role="3cqZAp">
+                    <node concept="2OqwBi" id="5rSmnqxr91z" role="3clFbG">
+                      <node concept="2YIFZM" id="5rSmnqxr5LW" role="2Oq$k0">
+                        <ref role="37wK5l" to="rvbb:~ProjectPane.getInstance(jetbrains.mps.project.Project)" resolve="getInstance" />
+                        <ref role="1Pybhc" to="rvbb:~ProjectPane" resolve="ProjectPane" />
+                        <node concept="2OqwBi" id="5rSmnqxr7dW" role="37wK5m">
+                          <node concept="2WthIp" id="5rSmnqxr5OD" role="2Oq$k0" />
+                          <node concept="1DTwFV" id="5rSmnqxr81_" role="2OqNvi">
                             <ref role="2WH_rO" node="56YPHTokgJq" resolve="project" />
                           </node>
                         </node>
                       </node>
-                      <node concept="liA8E" id="56YPHTokeLM" role="2OqNvi">
-                        <ref role="37wK5l" node="56YPHTokZqG" resolve="forceUpdate" />
+                      <node concept="liA8E" id="5rSmnqxralT" role="2OqNvi">
+                        <ref role="37wK5l" to="k21q:~AbstractProjectViewPaneWithAsyncSupport.updateFromRoot(boolean)" resolve="updateFromRoot" />
+                        <node concept="3clFbT" id="5rSmnqxrapP" role="37wK5m">
+                          <property role="3clFbU" value="true" />
+                        </node>
                       </node>
                     </node>
                   </node>

--- a/code/shadowmodels/solutions/test.de.q60.mps.shadowmodels.runtime/models/test.de.q60.mps.shadowmodels.runtime@tests.mps
+++ b/code/shadowmodels/solutions/test.de.q60.mps.shadowmodels.runtime/models/test.de.q60.mps.shadowmodels.runtime@tests.mps
@@ -21,7 +21,7 @@
     <import index="dj5d" ref="r:8bca245c-17c6-44f4-9367-ad6ce25cabf5(de.q60.mps.shadowmodels.runtimelang.structure)" />
     <import index="c9mi" ref="r:e280b60e-1e31-4362-b72e-05ea0aaad63c(de.q60.mps.shadowmodels.runtime.util.pmap)" />
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
-    <import index="gxwn" ref="ecfb9949-7433-4db5-85de-0f84d172e4ce/java:com.google.common.primitives(de.q60.mps.libs/)" />
+    <import index="gxwn" ref="ecfb9949-7433-4db5-85de-0f84d172e4ce/java:com.google.common.primitives(de.q60.mps.collections.libs/)" />
     <import index="jks5" ref="cc99dce1-49f3-4392-8dbf-e22ca47bd0af/java:org.modelix.model.api(org.modelix.model.api/)" />
     <import index="jh6v" ref="r:f2f39a18-fd23-4090-b7f2-ba8da340eec2(org.modelix.model.repositoryconcepts.structure)" />
     <import index="xxte" ref="r:a79f28f8-6055-40c6-bc5e-47a42a3b97e8(org.modelix.model.mpsadapters.mps)" />

--- a/code/solutions/de.itemis.model.merge.simple.demo/models/de.itemis.model.merge.simple.demo.test@tests.mps
+++ b/code/solutions/de.itemis.model.merge.simple.demo/models/de.itemis.model.merge.simple.demo.test@tests.mps
@@ -19,7 +19,7 @@
     <import index="yeyq" ref="r:98a265f1-4186-4e32-a289-328d37e5000c(de.itemis.model.simple.demo.property.structure)" />
     <import index="tqvn" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel.tempmodel(MPS.Core/)" />
     <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" />
-    <import index="3o3z" ref="ecfb9949-7433-4db5-85de-0f84d172e4ce/java:com.google.common.collect(de.q60.mps.libs/)" />
+    <import index="3o3z" ref="ecfb9949-7433-4db5-85de-0f84d172e4ce/java:com.google.common.collect(de.q60.mps.collections.libs/)" />
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
     <import index="hsq" ref="r:fc82e0c0-6be8-4ecf-9fa1-3d5bc168484e(de.itemis.model.simple.demo.reference.structure)" />
     <import index="u132" ref="49808fad-9d41-4b96-83fa-9231640f6b2b/java:junit.framework(JUnit/)" />

--- a/code/solutions/de.itemis.model.merge.test.integration/models/de.itemis.model.merge.test.integration.tests@tests.mps
+++ b/code/solutions/de.itemis.model.merge.test.integration/models/de.itemis.model.merge.test.integration.tests@tests.mps
@@ -21,7 +21,7 @@
     <import index="z1c3" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.project(MPS.Core/)" />
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" />
-    <import index="1xlh" ref="r:83d91843-991e-414a-ada7-28ed0de69bb1(de.itemis.model.test.integration.plugin)" />
+    <import index="1xlh" ref="r:83d91843-991e-414a-ada7-28ed0de69bb1(de.itemis.model.merge.test.integration.plugin)" />
   </imports>
   <registry>
     <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">

--- a/code/solutions/de.itemis.model.merge.test/models/de.itemis.model.merge.test.gen@tests.mps
+++ b/code/solutions/de.itemis.model.merge.test/models/de.itemis.model.merge.test.gen@tests.mps
@@ -13,7 +13,7 @@
   </languages>
   <imports>
     <import index="14sb" ref="r:798bef3e-3867-4aab-a0a7-1e9776b7e479(de.itemis.model.merge.diamond.structure)" />
-    <import index="3o3z" ref="ecfb9949-7433-4db5-85de-0f84d172e4ce/java:com.google.common.collect(de.q60.mps.libs/)" />
+    <import index="3o3z" ref="ecfb9949-7433-4db5-85de-0f84d172e4ce/java:com.google.common.collect(de.q60.mps.collections.libs/)" />
     <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" />
     <import index="gunp" ref="r:a4055897-4d16-4474-96e9-a78cf2abfe5a(de.itemis.model.merge.runtime.runtime)" />

--- a/code/solutions/de.itemis.model.merge.test/models/de.itemis.model.merge.test.test1@tests.mps
+++ b/code/solutions/de.itemis.model.merge.test/models/de.itemis.model.merge.test.test1@tests.mps
@@ -13,7 +13,7 @@
     <import index="14sb" ref="r:798bef3e-3867-4aab-a0a7-1e9776b7e479(de.itemis.model.merge.diamond.structure)" />
     <import index="sz2a" ref="r:02b6652e-c87d-4bb2-bfc0-4b5c0d5b9442(de.itemis.model.merge.typesystem)" />
     <import index="rnx3" ref="r:424d540e-f1fc-49a5-b16d-3f9264b84dee(de.itemis.model.merge.behavior)" />
-    <import index="3o3z" ref="ecfb9949-7433-4db5-85de-0f84d172e4ce/java:com.google.common.collect(de.q60.mps.libs/)" />
+    <import index="3o3z" ref="ecfb9949-7433-4db5-85de-0f84d172e4ce/java:com.google.common.collect(de.q60.mps.collections.libs/)" />
     <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" />
     <import index="tpce" ref="r:00000000-0000-4000-0000-011c89590292(jetbrains.mps.lang.structure.structure)" />
     <import index="gunp" ref="r:a4055897-4d16-4474-96e9-a78cf2abfe5a(de.itemis.model.merge.runtime.runtime)" />

--- a/code/solutions/de.itemis.model.merge.test/models/de.itemis.model.merge.test.util.mps
+++ b/code/solutions/de.itemis.model.merge.test/models/de.itemis.model.merge.test.util.mps
@@ -18,7 +18,7 @@
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
     <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" />
     <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" />
-    <import index="3o3z" ref="ecfb9949-7433-4db5-85de-0f84d172e4ce/java:com.google.common.collect(de.q60.mps.libs/)" />
+    <import index="3o3z" ref="ecfb9949-7433-4db5-85de-0f84d172e4ce/java:com.google.common.collect(de.q60.mps.collections.libs/)" />
     <import index="sz2a" ref="r:02b6652e-c87d-4bb2-bfc0-4b5c0d5b9442(de.itemis.model.merge.typesystem)" />
     <import index="14sb" ref="r:798bef3e-3867-4aab-a0a7-1e9776b7e479(de.itemis.model.merge.diamond.structure)" />
   </imports>

--- a/code/structurecheck/languages/de.itemis.mps.structurecheck/generator/template/main@generator.mps
+++ b/code/structurecheck/languages/de.itemis.mps.structurecheck/generator/template/main@generator.mps
@@ -7,7 +7,7 @@
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
-    <import index="bw13" ref="r:391e565b-f801-459c-891c-816917735d49(de.slisson.mps.structurecheck.runtime)" />
+    <import index="bw13" ref="r:391e565b-f801-459c-891c-816917735d49(de.itemis.mps.structurecheck.runtime)" />
     <import index="mhfm" ref="3f233e7f-b8a6-46d2-a57f-795d56775243/java:org.jetbrains.annotations(Annotations/)" />
     <import index="tp2g" ref="r:00000000-0000-4000-0000-011c89590334(jetbrains.mps.baseLanguage.closures.constraints)" />
     <import index="tp2q" ref="r:00000000-0000-4000-0000-011c8959032e(jetbrains.mps.baseLanguage.collections.structure)" />

--- a/scripts/build.xml
+++ b/scripts/build.xml
@@ -16,6 +16,7 @@
   <property name="mps.teamcity.buildConfName" value="${import.mps.mps.teamcity.buildConfName}" />
   <property name="mps.idea.platform.build.number" value="${import.mps.mps.idea.platform.build.number}" />
   <property name="mps.mps.build.counter" value="${import.mps.mps.mps.build.counter}" />
+  <property name="mps.runtimeBuild" value="${import.mps.mps.runtimeBuild}" />
   <property name="mpsBootstrapCore.version.major" value="${import.mps.mpsBootstrapCore.version.major}" />
   <property name="mpsBootstrapCore.version.minor" value="${import.mps.mpsBootstrapCore.version.minor}" />
   <property name="mpsBootstrapCore.version.bugfixNr" value="${import.mps.mpsBootstrapCore.version.bugfixNr}" />
@@ -78,7 +79,7 @@
       <zipfileset file="${extensions.code}/build/solutions/de.itemis.mps.extensions.build/de.itemis.mps.extensions.build.msd" prefix="module" />
       <zipfileset dir="${build.tmp}/customProcessors/copyModels/build-solutions-de.itemis.mps.extensions.build-models" prefix="module/models" />
     </jar>
-    <echo file="${build.layout}/build.properties">mps.build.number=${mps.build.number}${line.separator}mps.date=${mps.date}${line.separator}mps.build.vcs.number=${mps.build.vcs.number}${line.separator}mps.teamcity.buildConfName=${mps.teamcity.buildConfName}${line.separator}mps.idea.platform.build.number=${mps.idea.platform.build.number}${line.separator}mps.mps.build.counter=${mps.mps.build.counter}${line.separator}mpsBootstrapCore.version.major=${mpsBootstrapCore.version.major}${line.separator}mpsBootstrapCore.version.minor=${mpsBootstrapCore.version.minor}${line.separator}mpsBootstrapCore.version.bugfixNr=${mpsBootstrapCore.version.bugfixNr}${line.separator}mpsBootstrapCore.version.eap=${mpsBootstrapCore.version.eap}${line.separator}mpsBootstrapCore.version=${mpsBootstrapCore.version}</echo>
+    <echo file="${build.layout}/build.properties">mps.build.number=${mps.build.number}${line.separator}mps.date=${mps.date}${line.separator}mps.build.vcs.number=${mps.build.vcs.number}${line.separator}mps.teamcity.buildConfName=${mps.teamcity.buildConfName}${line.separator}mps.idea.platform.build.number=${mps.idea.platform.build.number}${line.separator}mps.mps.build.counter=${mps.mps.build.counter}${line.separator}mps.runtimeBuild=${mps.runtimeBuild}${line.separator}mpsBootstrapCore.version.major=${mpsBootstrapCore.version.major}${line.separator}mpsBootstrapCore.version.minor=${mpsBootstrapCore.version.minor}${line.separator}mpsBootstrapCore.version.bugfixNr=${mpsBootstrapCore.version.bugfixNr}${line.separator}mpsBootstrapCore.version.eap=${mpsBootstrapCore.version.eap}${line.separator}mpsBootstrapCore.version=${mpsBootstrapCore.version}</echo>
   </target>
   
   <target name="buildDependents" />
@@ -106,8 +107,8 @@
     <echo message="generating" />
     <generate fork="true" targetJavaVersion="1.8" logLevel="${mps.ant.log}">      
       <settings refid="m2m-0" />
-      <plugin path="${artifacts.mps}/plugins/mps-build" />
-      <plugin path="${artifacts.mps}/plugins/mps-core" />
+      <plugin path="${artifacts.mps}/plugins/mps-build" id="jetbrains.mps.build" />
+      <plugin path="${artifacts.mps}/plugins/mps-core" id="jetbrains.mps.core" />
       <library file="${artifacts.mps}/languages/baseLanguage/closures.runtime.jar" />
       <library file="${artifacts.mps}/languages/baseLanguage/collections.runtime.jar" />
       <library file="${artifacts.mps}/languages/baseLanguage/jetbrains.mps.baseLanguage.blTypes.jar" />
@@ -127,7 +128,6 @@
       <library file="${artifacts.mps}/languages/baseLanguage/jetbrains.mps.baseLanguageInternal.jar" />
       <library file="${artifacts.mps}/languages/editor/jetbrains.mps.editing.runtime.jar" />
       <library file="${artifacts.mps}/languages/editor/jetbrains.mps.editor.runtime.jar" />
-      <library file="${artifacts.mps}/languages/editor/jetbrains.mps.editorlang.runtime.jar" />
       <library file="${artifacts.mps}/languages/editor/jetbrains.mps.ide.editor.jar" />
       <library file="${artifacts.mps}/languages/editor/typesystemIntegration.jar" />
       <library file="${artifacts.mps}/languages/languageDesign/jetbrains.mps.baseLanguage.lightweightdsl.jar" />
@@ -140,6 +140,7 @@
       <library file="${artifacts.mps}/languages/languageDesign/jetbrains.mps.lang.constraints.rules.skeleton.jar" />
       <library file="${artifacts.mps}/languages/languageDesign/jetbrains.mps.lang.context.defs.jar" />
       <library file="${artifacts.mps}/languages/languageDesign/jetbrains.mps.lang.context.jar" />
+      <library file="${artifacts.mps}/languages/languageDesign/jetbrains.mps.lang.core.doc.jar" />
       <library file="${artifacts.mps}/languages/languageDesign/jetbrains.mps.lang.core.jar" />
       <library file="${artifacts.mps}/languages/languageDesign/jetbrains.mps.lang.dataFlow.jar" />
       <library file="${artifacts.mps}/languages/languageDesign/jetbrains.mps.lang.descriptor.jar" />
@@ -184,6 +185,7 @@
       <library file="${artifacts.mps}/languages/runtimes/jetbrains.mps.lang.feedback.problem.legacy-constraints.jar" />
       <library file="${artifacts.mps}/languages/runtimes/jetbrains.mps.lang.feedback.problem.rt.jar" />
       <library file="${artifacts.mps}/languages/runtimes/jetbrains.mps.lang.migration.runtime.jar" />
+      <library file="${artifacts.mps}/languages/runtimes/jetbrains.mps.lang.script.rt.jar" />
       <library file="${artifacts.mps}/languages/runtimes/jetbrains.mps.lang.smodel.query.runtime.jar" />
       <library file="${artifacts.mps}/languages/runtimes/jetbrains.mps.refactoring.runtime.jar" />
       <library file="${artifacts.mps}/languages/text/jetbrains.mps.lang.text.jar" />


### PR DESCRIPTION
This changeset comprises a reimplementation of ProjectViewExtension from "shadow models" on top of the new ProjectPane API, as well as a few minor fixes that make the project build with the latest master version of MPS. 

See [this article](https://youtrack.jetbrains.com/articles/MPS-A-216170516/ProjectPane-implementation-on-top-of-ProjectViewTree) for details. 

Note, that this pull request, although made on top of `mps/2023.3` branch, is to be merged in a branch that should correspond to the next available version of MPS, which is going to include the changes necessary for the above fixes to work, and only after these changes are merged into our (MPS) master branch. 

In short, things should happen in this order (ideally): 

1. ✅ we merge the changes that implement the new ProjectPane and test with a temporary branch of MPS-extensions (the one referred to in this pull request)
2. you introduce a new branch to track fixes necessary for compatibility with MPS 2024.1 (e.g. mps/2024.1)
3. we switch to that branch for our integration builds
4. MPS 2024.1 is released containing the new ProjectPane and MPS-extensions/mps/2024.1 is up-to-date with it.


