### PR TITLE
Add a language to describe CHANGELOG.md files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,95 +2,98 @@
 
 All notable changes to this project are documented in this file.
 
-Format of the log is _loosely_ based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). 
-The project does _not_ follow Semantic Versioning and the changes are documented in reverse chronological order, grouped by calendar month.
+The format is *loosely* based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) .The project does *not* follow Semantic Versioning and the changes are documented in reverse chronological order, grouped by calendar month.
 
 ## April 2024
 
 ### Fixed
 
-- com.mbeddr.mpsutil.projectview: Class reloading of project views now works.
-- com.mbeddr.mpsutil.editor.querylist: Query lists now support model checking for non-dynamically generated nodes and `collapse by default` is generated correctly.
-- de.slisson.mps.reflection: To fix the compilatation issues, the language is now generated earlier in the generation plan.
+- *com.mbeddr.mpsutil.projectview*: Class reloading of project views now works.
+- *com.mbeddr.mpsutil.editor.querylist*: Query lists now support model checking for non-dynamically generated nodes and collapse by default is generated correctly.
+- *de.slisson.mps.reflection*: To fix the compilation issues, the language is now generated earlier in the generation plan.
+
+### Added
+
+- A new language *de.itemis.mps.changelog* was added to describe *CHANGELOG.md* files. This file is generated with this language.
 
 ## March 2024
 
 ### Added
 
-- de.slisson.mps.conditionalEditor: Support for editor components with parameters was added.
-- com.mbeddr.mpsutil.grammarcells: Read-only model accessory cells can now also be used in places where constant cells are supported.
+- *de.slisson.mps.conditionalEditor*: Support for editor components with parameters was added.
+- *com.mbeddr.mpsutil.grammarcells*: Read-only model accessory cells can now also be used in places where constant cells are supported.
 
 ### Fixed
 
-- com.mbeddr.mpsutil.editor.querylist: return null in the query shows the empty cell again (regression).
+- *com.mbeddr.mpsutil.editor.querylist*: Returning null in the query shows the empty cell again (regression).
 
 ## February 2024
 
 ### Changed
 
-- com.mbeddr.mpsutil.editor.querylist: Dynamic generated nodes (without a model) can now be used in query lists if `read-only` is set to true.
-- The language `de.slisson.mps.structurecheck` was renamed to `de.itemis.mps.structurecheck`.
-- The stubs `com.mbeddr.mpsutil.serializer.xml` were renamed to `de.itemis.mps.utils.serializer.xml`.
-- The language `de.slisson.mps.hacks.xmodelgen` was renamed to `de.itemis.mps.hacks.xmodelgen`.
+- *com.mbeddr.mpsutil.editor.querylist*: Dynamic generated nodes (without a model) can now be used in query lists if read-only is set to true.
+- The language `de.slisson.mps.structurecheck` was renamed to *de.itemis.mps.structurecheck* .
+- The stubs `com.mbeddr.mpsutil.serializer.xml` were renamed to *de.itemis.mps.utils.serializer.xml* .
+- The language `de.slisson.mps.hacks.xmodelgen` was renamed to *de.itemis.mps.hacks.xmodelgen* .
 
 ### Deprecated
 
-- MethodLineDoc is now deprecated and an automatic migration is provided to migrate to `jetbrains.mps.baseLanguage.javadoc`.
+- [MethodLineDoc](http://127.0.0.1:63320/node?ref=63e0e566-5131-447e-90e3-12ea330e1a00%2Fr%3Af5bd2ad9-cd54-4408-b815-07f9f306f074%28com.mbeddr.mpsutil.blutil%2Fcom.mbeddr.mpsutil.blutil.structure%29%2F6451706574539345403) is now deprecated and an automatic migration is provided to migrate to `jetbrains.mps.baseLanguage.javadoc` .
 
 ### Fixed
 
-- de.slisson.mps.editor.multiline.runtime: An issue was fixed where pressing shift+enter didn't enter a new line in the current text but in the next collection in the editor.
+- *de.slisson.mps.editor.multiline.runtime*: An issue was fixed where pressing `shift+enter` didn't enter a new line in the current text but in the next collection in the editor.
 
 ## January 2024
 
 ### Fixed
 
-- com.mbeddr.mpsutil.modellisteners: The newly supported interface listeners are now backward compatible and doesn't require regenerating the listener aspects anymore.
+- *com.mbeddr.mpsutil.modellisteners*: The newly supported interface listeners are now backward compatible and doesn't require regenerating the listener aspects anymore.
 
 ## December 2023
 
 ### Added
 
-- A new language `de.itemis.mps.statistics` was added that adds a new menu `MPS Statistics` to the `Tools`  menu. The containing action writes a file `dependencies.txt` to the root folder. It contains all the used dependencies of the current project. 
-- de.slisson.mps.tables: tables now support a new property `column UI actions (experimental)`: This property adds actions to the MPS toolbar to add a new column above/below the current column or to delete the current column. These actions only work for simple tables that are based on rows (default: *false*).
+- A new language *de.itemis.mps.statistics* was added that adds a new menu *MPS Statistics* to the *Tools* menu. The containing action writes a file dependencies.txt to the root folder. It contains all the used dependencies of the current project.
+- *de.slisson.mps.tables* tables now support a new property column UI actions (experimental): This property adds actions to the MPS toolbar to add a new column above/below the current column or to delete the current column. These actions only work for simple tables that are based on rows (default: false).
 
 ### Fixed
 
-- The performance of the language `de.itemis.mps.linenumbers` was improved.
+- The performance of the language *de.itemis.mps.linenumbers* was improved.
 
 ### Changed
 
-- mpsutil.intentions: Intentions available in read-only cells are not available anymore when the annotation showIntentionInReadyOnlyCell is not added.
+- *com.mbeddr.mpsutil.intentions*: Intentions available in read-only cells are not available anymore when the annotation showIntentionInReadyOnlyCell is not added.
 
 ## November 2023
 
 ### Changed
 
-- mpsutil.modellisteners: listeners on interface concepts are now supported.
-- `@NotNull` annotations in the code are now checked at run time (the `javac2` compiler is used).
-- de.itemis.editor.diagram: Edge labels can now be annotated with the attribute editors of the edges. Previously they were floating in the diagram as external boxes. A new flag "use annotations from parent in label" is used to customize the behavior.
+- *com.mbeddr.mpsutil.modellisteners* listeners on interface concepts are now supported.
+- [NotNull](http://127.0.0.1:63320/node?ref=3f233e7f-b8a6-46d2-a57f-795d56775243%2Fjava%3Aorg.jetbrains.annotations%28Annotations%2F%29%2F~NotNull) annotations in the code are now checked at run time (the *javac2* compiler is used).
+- *de.itemis.mps.editor.diagram*: Edge labels can now be annotated with the attribute editors of the edges. Previously they were floating in the diagram as external boxes. A new flag *use annotations from parent in label* is used to customize the behavior.
 
 ### Added
 
-- mpsutil.intentions: a new style attribute `intentions-in-read-only-cell` is now available to allow intentions in read-only cells. Single intentions can also be enabled or disabled in those cells through the intention "Toggle Show Intention In Read-Only Cell Annotation".
-- com.mbeddr.mpsutil.editor.querylist: Default editor cells now support style attributes.
-- de.slisson.mps.tables: tables now support a new property `row UI actions (experimental)`: This property adds actions to the MPS toolbar to add a new row above/below the current row or to delete the current row. These actions only work for simple tables that are based on rows (default: *false*).
+- *com.mbeddr.mpsutil.intentions*: A new style attribute *intentions-in-read-only-cell* is now available to allow intentions in read-only cells. Single intentions can also be enabled or disabled in those cells through the intention *Toggle Show Intention In Read-Only Cell Annotation* *.*
+- *com.mbeddr.mpsutil.editor.querylist*: Default editor cells now support style attributes.
+- *de.slisson.mps.tables*: Tables now support a new property row UI actions (experimental): This property adds actions to the MPS toolbar to add a new row above/below the current row or to delete the current row. These actions only work for simple tables that are based on rows (default: *false* ).
 
 ## October 2023
 
 ### Added
 
-- There is a new dsl called pagination, it provides an editor cell paginate which given an editor cell collection it displays the collection in multiple pages, with swing components to move between pages and show the current page.
+- There is a new DSL called pagination, it provides an editor cell paginate which given an editor cell collection it displays the collection in multiple pages, with swing components to move between pages and show the current page.
 
 ## September 2023
 
 ### Changed
 
-- The grammar cells grammar.wrap cell now checks constraints from the containing node when combined with grammar.rule.
+- The grammar cells *grammar.wrap* cell now checks constraints from the containing node when combined with *grammar.rule.*
 
 ## July 2023
 
 ### Changed
 
-- The auto-completion for a WrapperCell, where the wrapping node is not created yet, shows entries for possible wrapped nodes with the description of the wrapped nodes concept and not the description of the wrapping nodes concept.  
-- The auto-completion for an OptionalCell without a dedicated description shows no description anymore, instead of using the description of the concept which is using the OptionalCell.  
+- The auto-completion for a [WrapperCell](http://127.0.0.1:63320/node?ref=r%3A96165ed2-ef22-48c7-bfe5-8fce083cbabb%28com.mbeddr.mpsutil.grammarcells.structure%29%2F7363578995839435357) where the wrapping node is not created yet, shows entries for possible wrapped nodes with the description of the wrapped nodes concept and not the description of the wrapping nodes concept.
+- The auto-completion for an [OptionalCell](http://127.0.0.1:63320/node?ref=r%3A96165ed2-ef22-48c7-bfe5-8fce083cbabb%28com.mbeddr.mpsutil.grammarcells.structure%29%2F5083944728298846680) without a dedicated description shows no description anymore, instead of using the description of the concept which is using the [OptionalCell](http://127.0.0.1:63320/node?ref=r%3A96165ed2-ef22-48c7-bfe5-8fce083cbabb%28com.mbeddr.mpsutil.grammarcells.structure%29%2F5083944728298846680) .

--- a/build.gradle
+++ b/build.gradle
@@ -221,7 +221,13 @@ task build_allScripts(type: BuildLanguages, dependsOn: [
     script "$rootDir/scripts/build.xml"
 }
 
-task build_languages(type: BuildLanguages, dependsOn: [build_allScripts]) {
+task copyReadme(type: Copy) {
+    from "$rootDir/code/solutions/de.itemis.mps.extensions.changelog/source_gen/de/itemis/mps/extensions/changelog"
+    into "$rootDir"
+    include "*.md"
+}
+
+task build_languages(type: BuildLanguages, dependsOn: [build_allScripts, copyReadme]) {
     script scriptFile('languages/build.xml')
 }
 

--- a/code/.mps/modules.xml
+++ b/code/.mps/modules.xml
@@ -21,6 +21,9 @@
       <modulePath path="$PROJECT_DIR$/celllayout/solutions/de.itemis.mps.editor.celllayout.sandbox/de.itemis.mps.editor.celllayout.sandbox.msd" folder="celllayout" />
       <modulePath path="$PROJECT_DIR$/celllayout/solutions/de.slisson.mps.editor.celllayout.runtime/de.itemis.mps.editor.celllayout.runtime.msd" folder="celllayout" />
       <modulePath path="$PROJECT_DIR$/celllayout/solutions/test.de.itemis.mps.editor.celllayout.runtime/test.de.itemis.mps.editor.celllayout.msd" folder="celllayout" />
+      <modulePath path="$PROJECT_DIR$/changelog/de.itemis.mps.changelog.sandbox/de.itemis.mps.changelog.sandbox.msd" folder="changelog" />
+      <modulePath path="$PROJECT_DIR$/changelog/de.itemis.mps.changelog.tests/de.itemis.mps.changelog.tests.msd" folder="changelog" />
+      <modulePath path="$PROJECT_DIR$/changelog/de.itemis.mps.changelog/de.itemis.mps.changelog.mpl" folder="changelog" />
       <modulePath path="$PROJECT_DIR$/conditional-editor/languages/de.slisson.mps.conditionalEditor.demolang/de.slisson.mps.conditionalEditor.demolang.mpl" folder="conditional-editor" />
       <modulePath path="$PROJECT_DIR$/conditional-editor/languages/de.slisson.mps.conditionalEditor.hints/de.slisson.mps.conditionalEditor.hints.mpl" folder="conditional-editor" />
       <modulePath path="$PROJECT_DIR$/conditional-editor/languages/de.slisson.mps.conditionalEditor/de.slisson.mps.conditionalEditor.mpl" folder="conditional-editor" />
@@ -177,6 +180,7 @@
       <modulePath path="$PROJECT_DIR$/solutions/de.itemis.model.merge.simple.demo/de.itemis.model.merge.simple.demo.msd" folder="modelmerger2" />
       <modulePath path="$PROJECT_DIR$/solutions/de.itemis.model.merge.test.integration/de.itemis.model.merge.test.integration.msd" folder="modelmerger2" />
       <modulePath path="$PROJECT_DIR$/solutions/de.itemis.model.merge.test/de.itemis.model.merge.test.msd" folder="modelmerger2" />
+      <modulePath path="$PROJECT_DIR$/solutions/de.itemis.mps.extensions.changelog/de.itemis.mps.extensions.changelog.msd" folder="build" />
       <modulePath path="$PROJECT_DIR$/statistics/de.itemis.mps.statistics.mpl" folder="statistics" />
       <modulePath path="$PROJECT_DIR$/structurecheck/languages/de.itemis.mps.structurecheck/de.itemis.mps.structurecheck.mpl" folder="structurecheck" />
       <modulePath path="$PROJECT_DIR$/structurecheck/solutions/de.itemis.mps.structurecheck.runtime/de.itemis.mps.structurecheck.runtime.msd" folder="structurecheck" />

--- a/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
+++ b/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
@@ -14556,6 +14556,202 @@
         </node>
       </node>
     </node>
+    <node concept="m$_wf" id="1$KnWE8eXEs" role="3989C9">
+      <property role="m$_wk" value="de.itemis.mps.changelog" />
+      <node concept="3_J27D" id="1$KnWE8eXEt" role="m$_yQ">
+        <node concept="3Mxwew" id="1$KnWE8eXEu" role="3MwsjC">
+          <property role="3MwjfP" value="MPS Changelog language" />
+        </node>
+      </node>
+      <node concept="3_J27D" id="1$KnWE8eXEv" role="m_cZH">
+        <node concept="3Mxwew" id="1$KnWE8eXEw" role="3MwsjC">
+          <property role="3MwjfP" value="de.itemis.mps.changelog" />
+        </node>
+      </node>
+      <node concept="3_J27D" id="1$KnWE8eXEx" role="m$_w8">
+        <node concept="3Mxwey" id="1$KnWE8eXEy" role="3MwsjC">
+          <ref role="3Mxwex" node="4MKCCgA1ncQ" resolve="versionNumber" />
+        </node>
+      </node>
+      <node concept="2iUeEo" id="1$KnWE8eXEz" role="2iVFfd">
+        <property role="2iUeEt" value="itemis AG" />
+        <property role="2iUeEu" value="https://www.itemis.com/en/it-services/methods-and-tools/mps" />
+      </node>
+      <node concept="m$f5U" id="1$KnWE8eXE$" role="m$_yh">
+        <ref role="m$f5T" node="1$KnWE8eXEC" />
+      </node>
+      <node concept="m$_yC" id="1$KnWE8eXE_" role="m$_yJ">
+        <ref role="m$_y1" to="ffeo:4k71ibbKLe8" resolve="jetbrains.mps.core" />
+      </node>
+      <node concept="m$_yC" id="1$KnWE8eXEA" role="m$_yJ">
+        <ref role="m$_y1" node="2Xjt3l57iTJ" resolve="de.slisson.mps.hacks" />
+      </node>
+      <node concept="m$_yC" id="1$KnWE8eXEB" role="m$_yJ">
+        <ref role="m$_y1" node="6SVXTgIe8wD" resolve="de.itemis.mps.celllayout" />
+      </node>
+      <node concept="m$_yC" id="1$KnWE8H8oh" role="m$_yJ">
+        <ref role="m$_y1" to="ffeo:5xhjlkpPhJu" resolve="jetbrains.mps.ide.httpsupport" />
+      </node>
+    </node>
+    <node concept="2G$12M" id="1$KnWE8eXEC" role="3989C9">
+      <property role="TrG5h" value="de.itemis.mps.changelog" />
+      <node concept="1E1JtD" id="1$KnWE8eXED" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="de.itemis.mps.changelog" />
+        <property role="3LESm3" value="638c9345-2613-49dc-b2ae-8ceadef24141" />
+        <node concept="398BVA" id="1$KnWE8eXEE" role="3LF7KH">
+          <ref role="398BVh" node="2fo8bJE$D4t" resolve="extensions.code" />
+          <node concept="2Ry0Ak" id="1$KnWE8eXEF" role="iGT6I">
+            <property role="2Ry0Am" value="changelog" />
+            <node concept="2Ry0Ak" id="1$KnWE8eXEH" role="2Ry0An">
+              <property role="2Ry0Am" value="de.itemis.mps.changelog" />
+              <node concept="2Ry0Ak" id="1$KnWE8eZJR" role="2Ry0An">
+                <property role="2Ry0Am" value="de.itemis.mps.changelog.mpl" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="1$KnWE8eXEJ" role="3bR37C">
+          <node concept="3bR9La" id="1$KnWE8eXEK" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:7Kfy9QB6L4X" resolve="jetbrains.mps.lang.editor" />
+          </node>
+        </node>
+        <node concept="1BupzO" id="1$KnWE8eXEL" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="1$KnWE8f0u1" role="1HemKq">
+            <node concept="398BVA" id="1$KnWE8f0tS" role="3LXTmr">
+              <ref role="398BVh" node="2fo8bJE$D4t" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="1$KnWE8f0tT" role="iGT6I">
+                <property role="2Ry0Am" value="changelog" />
+                <node concept="2Ry0Ak" id="1$KnWE8f0tU" role="2Ry0An">
+                  <property role="2Ry0Am" value="de.itemis.mps.changelog" />
+                  <node concept="2Ry0Ak" id="1$KnWE8f0tV" role="2Ry0An">
+                    <property role="2Ry0Am" value="models" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="1$KnWE8f0u2" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+        <node concept="1yeLz9" id="1$KnWE8eXEV" role="1TViLv">
+          <property role="TrG5h" value="de.itemis.mps.changelog.generator" />
+          <property role="3LESm3" value="8a65cbd6-c224-4e7a-a5e8-1c272d28e755" />
+          <node concept="1SiIV0" id="1$KnWE8eXF0" role="3bR37C">
+            <node concept="3bR9La" id="1$KnWE8eXF1" role="1SiIV1">
+              <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
+            </node>
+          </node>
+          <node concept="1BupzO" id="1$KnWE8eXF6" role="3bR31x">
+            <property role="3ZfqAx" value="generator/templates" />
+            <property role="1Hdu6h" value="true" />
+            <property role="1HemKv" value="true" />
+            <node concept="3LXTmp" id="1$KnWE8f0ug" role="1HemKq">
+              <node concept="398BVA" id="1$KnWE8f0u5" role="3LXTmr">
+                <ref role="398BVh" node="2fo8bJE$D4t" resolve="extensions.code" />
+                <node concept="2Ry0Ak" id="1$KnWE8f0u6" role="iGT6I">
+                  <property role="2Ry0Am" value="changelog" />
+                  <node concept="2Ry0Ak" id="1$KnWE8f0u7" role="2Ry0An">
+                    <property role="2Ry0Am" value="de.itemis.mps.changelog" />
+                    <node concept="2Ry0Ak" id="1$KnWE8f0u8" role="2Ry0An">
+                      <property role="2Ry0Am" value="generator" />
+                      <node concept="2Ry0Ak" id="1$KnWE8f0u9" role="2Ry0An">
+                        <property role="2Ry0Am" value="templates" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3qWCbU" id="1$KnWE8f0uh" role="3LXTna">
+                <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3rtmxn" id="1$KnWE8eXFh" role="3bR31x">
+          <node concept="3LXTmp" id="1$KnWE8eXFi" role="3rtmxm">
+            <node concept="398BVA" id="1$KnWE8eXFj" role="3LXTmr">
+              <ref role="398BVh" node="2fo8bJE$D4t" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="1$KnWE8eXFk" role="iGT6I">
+                <property role="2Ry0Am" value="htmlcell" />
+                <node concept="2Ry0Ak" id="1$KnWE8eXFl" role="2Ry0An">
+                  <property role="2Ry0Am" value="languages" />
+                  <node concept="2Ry0Ak" id="1$KnWE8eXFm" role="2Ry0An">
+                    <property role="2Ry0Am" value="de.itemis.mps.editor.htmlcell" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="1$KnWE8eXFn" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+          </node>
+        </node>
+        <node concept="1E0d5M" id="1$KnWE8eXFo" role="1E1XAP">
+          <ref role="1E0d5P" node="31kgwP4hem3" resolve="de.itemis.mps.editor.htmlcell.runtime" />
+        </node>
+        <node concept="1SiIV0" id="1$KnWE8f0tC" role="3bR37C">
+          <node concept="3bR9La" id="1$KnWE8f0tD" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:3HV74$ebibC" resolve="jetbrains.mps.lang.text" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="1$KnWE8f0tE" role="3bR37C">
+          <node concept="3bR9La" id="1$KnWE8f0tF" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="1$KnWE8f0tG" role="3bR37C">
+          <node concept="3bR9La" id="1$KnWE8f0tH" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:7Kfy9QB6KXW" resolve="jetbrains.mps.lang.core" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="1$KnWE8f0tI" role="3bR37C">
+          <node concept="3bR9La" id="1$KnWE8f0tJ" role="1SiIV1">
+            <property role="3bR36h" value="true" />
+            <ref role="3bR37D" to="ffeo:4SM2EuqHUPF" resolve="jetbrains.mps.lang.modelapi" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="1$KnWE8f0tK" role="3bR37C">
+          <node concept="3bR9La" id="1$KnWE8f0tL" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1TaHNgiIbIZ" resolve="MPS.Editor" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="1$KnWE8f0tM" role="3bR37C">
+          <node concept="3bR9La" id="1$KnWE8f0tN" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:7Kfy9QB6L9O" resolve="jetbrains.mps.lang.smodel" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="1$KnWE8f0tO" role="3bR37C">
+          <node concept="3bR9La" id="1$KnWE8f0tP" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1TaHNgiIbIQ" resolve="MPS.Core" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="1$KnWE8f0tQ" role="3bR37C">
+          <node concept="3bR9La" id="1$KnWE8f0tR" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:5cCcm$KATVz" resolve="jetbrains.mps.lang.migration.runtime" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="1$KnWE8f0u3" role="3bR37C">
+          <node concept="1Busua" id="1$KnWE8f0u4" role="1SiIV1">
+            <ref role="1Busuk" to="ffeo:3HV74$ebibC" resolve="jetbrains.mps.lang.text" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="1$KnWE8rcDl" role="3bR37C">
+          <node concept="3bR9La" id="1$KnWE8rcDm" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:xSXmQZAqVi" resolve="jetbrains.mps.ide.httpsupport.runtime" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="1$KnWE8DYUo" role="3bR37C">
+          <node concept="3bR9La" id="1$KnWE8DYUp" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1H905DlDUSw" resolve="MPS.OpenAPI" />
+          </node>
+        </node>
+      </node>
+    </node>
     <node concept="2_Ic$z" id="5KXebfcSw7" role="3989C9">
       <property role="2_Ic$$" value="true" />
       <property role="TZNOO" value="11" />
@@ -15003,6 +15199,10 @@
       <node concept="m$_wl" id="31kgwP4hion" role="39821P">
         <ref role="m_rDy" node="31kgwP4h7R3" resolve="de.itemis.mps.htmlcell" />
         <node concept="pUk6x" id="31kgwP4hiC1" role="pUk7w" />
+      </node>
+      <node concept="m$_wl" id="1$KnWE8f0_$" role="39821P">
+        <ref role="m_rDy" node="1$KnWE8eXEs" resolve="de.itemis.mps.changelog" />
+        <node concept="pUk6x" id="1$KnWE8f0__" role="pUk7w" />
       </node>
     </node>
   </node>

--- a/code/changelog/de.itemis.mps.changelog.sandbox/de.itemis.mps.changelog.sandbox.msd
+++ b/code/changelog/de.itemis.mps.changelog.sandbox/de.itemis.mps.changelog.sandbox.msd
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<solution name="de.itemis.mps.changelog.sandbox" uuid="79221974-0531-46e7-a1ba-808ced0829a4" moduleVersion="0" compileInMPS="true">
+  <models>
+    <modelRoot contentPath="${module}" type="default">
+      <sourceRoot location="models" />
+    </modelRoot>
+  </models>
+  <facets>
+    <facet type="java">
+      <classes generated="true" path="${module}/classes_gen" />
+    </facet>
+  </facets>
+  <sourcePath />
+  <dependencies>
+    <dependency reexport="false">3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)</dependency>
+    <dependency reexport="false">9d69e719-78c8-4286-90db-fb19c107d049(com.mbeddr.mpsutil.grammarcells)</dependency>
+  </dependencies>
+  <languageVersions>
+    <language slang="l:638c9345-2613-49dc-b2ae-8ceadef24141:de.itemis.mps.changelog" version="0" />
+    <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
+    <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
+  </languageVersions>
+  <dependencyVersions>
+    <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
+    <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
+    <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
+    <module reference="1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)" version="0" />
+    <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
+    <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+    <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
+    <module reference="9d69e719-78c8-4286-90db-fb19c107d049(com.mbeddr.mpsutil.grammarcells)" version="0" />
+    <module reference="7ac49bcb-77fb-4f0f-9036-e31b86b854b2(com.mbeddr.mpsutil.grammarcells.runtime)" version="0" />
+    <module reference="b4f35ed8-45af-4efa-abe4-00ac26956e69(com.mbeddr.mpsutil.grammarcells.runtimelang)" version="0" />
+    <module reference="79221974-0531-46e7-a1ba-808ced0829a4(de.itemis.mps.changelog.sandbox)" version="0" />
+    <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
+    <module reference="443f4c36-fcf5-4eb6-9500-8d06ed259e3e(jetbrains.mps.baseLanguage.classifiers)" version="0" />
+    <module reference="fd392034-7849-419d-9071-12563d152375(jetbrains.mps.baseLanguage.closures)" version="0" />
+    <module reference="83888646-71ce-4f1c-9c53-c54016f6ad4f(jetbrains.mps.baseLanguage.collections)" version="0" />
+    <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
+    <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
+    <module reference="d936855b-48da-4812-a8a0-2bfddd633ac5(jetbrains.mps.lang.behavior.api)" version="0" />
+    <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
+    <module reference="18bc6592-03a6-4e29-a83a-7ff23bde13ba(jetbrains.mps.lang.editor)" version="0" />
+    <module reference="446c26eb-2b7b-4bf0-9b35-f83fa582753e(jetbrains.mps.lang.modelapi)" version="0" />
+    <module reference="d7eb0a2a-bd50-4576-beae-e4a89db35f20(jetbrains.mps.lang.scopes.runtime)" version="0" />
+    <module reference="7866978e-a0f0-4cc7-81bc-4d213d9375e1(jetbrains.mps.lang.smodel)" version="1" />
+    <module reference="c72da2b9-7cce-4447-8389-f407dc1158b7(jetbrains.mps.lang.structure)" version="0" />
+    <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
+  </dependencyVersions>
+</solution>
+

--- a/code/changelog/de.itemis.mps.changelog.sandbox/models/de.itemis.mps.changelog.sandbox.mps
+++ b/code/changelog/de.itemis.mps.changelog.sandbox/models/de.itemis.mps.changelog.sandbox.mps
@@ -1,0 +1,636 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:b77354cc-89a7-42fb-9e37-075b26b92174(de.itemis.mps.changelog.sandbox)">
+  <persistence version="9" />
+  <languages>
+    <use id="638c9345-2613-49dc-b2ae-8ceadef24141" name="de.itemis.mps.changelog" version="0" />
+  </languages>
+  <imports />
+  <registry>
+    <language id="638c9345-2613-49dc-b2ae-8ceadef24141" name="de.itemis.mps.changelog">
+      <concept id="961540447467216844" name="de.itemis.mps.changelog.structure.Changelog" flags="ng" index="15b0KX">
+        <property id="1815055973306615526" name="ext" index="2hl1$G" />
+        <property id="961540447471754729" name="headerType" index="15SkSo" />
+        <child id="961540447467306265" name="releases" index="15bmVC" />
+        <child id="961540447467301035" name="header" index="15bnHq" />
+      </concept>
+      <concept id="961540447467306315" name="de.itemis.mps.changelog.structure.VersionDateReleaseHeader" flags="ng" index="15bmUU">
+        <property id="961540447467306316" name="timeStamp" index="15bmUX" />
+        <child id="961540447467320141" name="version" index="15bq2W" />
+      </concept>
+      <concept id="961540447467306318" name="de.itemis.mps.changelog.structure.SemanticVersion" flags="ng" index="15bmUZ">
+        <property id="961540447467306321" name="minor" index="15bmUw" />
+        <property id="961540447467306324" name="patch" index="15bmU_" />
+        <property id="961540447467306328" name="preRelease" index="15bmUD" />
+        <property id="961540447467306319" name="major" index="15bmUY" />
+      </concept>
+      <concept id="961540447467306264" name="de.itemis.mps.changelog.structure.Release" flags="ng" index="15bmVD">
+        <child id="961540447467320143" name="header" index="15bq2Y" />
+        <child id="961540447467370112" name="sections" index="15bAlL" />
+      </concept>
+      <concept id="961540447467370111" name="de.itemis.mps.changelog.structure.ChangeSection" flags="ng" index="15bAme">
+        <property id="961540447467370147" name="type" index="15bAli" />
+        <child id="961540447467370149" name="changes" index="15bAlk" />
+      </concept>
+      <concept id="961540447471733133" name="de.itemis.mps.changelog.structure.MonthYearReleaseHeader" flags="ng" index="15ShDW">
+        <property id="961540447471733137" name="year" index="15ShDw" />
+        <property id="961540447471733135" name="month" index="15ShDY" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+    <language id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text">
+      <concept id="1094247804558289146" name="jetbrains.mps.lang.text.structure.BulletLine" flags="ng" index="2DRihI" />
+      <concept id="5106752179536586436" name="jetbrains.mps.lang.text.structure.IndentedPoint" flags="ng" index="2RT3b8">
+        <property id="5106752179536586491" name="indentation" index="2RT3bR" />
+      </concept>
+      <concept id="155656958578482948" name="jetbrains.mps.lang.text.structure.Word" flags="nn" index="3oM_SD">
+        <property id="155656958578482949" name="value" index="3oM_SC" />
+        <property id="6328114375520539781" name="url" index="1X82VU" />
+      </concept>
+      <concept id="2535923850359206929" name="jetbrains.mps.lang.text.structure.Text" flags="nn" index="1Pa9Pv">
+        <child id="2535923850359210936" name="lines" index="1PaQFQ" />
+      </concept>
+      <concept id="2535923850359271782" name="jetbrains.mps.lang.text.structure.Line" flags="nn" index="1PaTwC">
+        <child id="2535923850359271783" name="elements" index="1PaTwD" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="15b0KX" id="Po4Z58vHYh">
+    <property role="TrG5h" value="ChangelogDemo" />
+    <property role="2hl1$G" value="md" />
+    <node concept="1Pa9Pv" id="Po4Z58vHYi" role="15bnHq">
+      <node concept="1PaTwC" id="Po4Z58vHYj" role="1PaQFQ">
+        <node concept="3oM_SD" id="Po4Z58vHYk" role="1PaTwD">
+          <property role="3oM_SC" value="All" />
+        </node>
+        <node concept="3oM_SD" id="Po4Z58vHYl" role="1PaTwD">
+          <property role="3oM_SC" value="notable" />
+        </node>
+        <node concept="3oM_SD" id="Po4Z58vHYm" role="1PaTwD">
+          <property role="3oM_SC" value="changes" />
+        </node>
+        <node concept="3oM_SD" id="Po4Z58vHYn" role="1PaTwD">
+          <property role="3oM_SC" value="to" />
+        </node>
+        <node concept="3oM_SD" id="Po4Z58vHYo" role="1PaTwD">
+          <property role="3oM_SC" value="this" />
+        </node>
+        <node concept="3oM_SD" id="Po4Z58vHYp" role="1PaTwD">
+          <property role="3oM_SC" value="project" />
+        </node>
+        <node concept="3oM_SD" id="Po4Z58vHYq" role="1PaTwD">
+          <property role="3oM_SC" value="will" />
+        </node>
+        <node concept="3oM_SD" id="Po4Z58vHYr" role="1PaTwD">
+          <property role="3oM_SC" value="be" />
+        </node>
+        <node concept="3oM_SD" id="Po4Z58vHYs" role="1PaTwD">
+          <property role="3oM_SC" value="documented" />
+        </node>
+        <node concept="3oM_SD" id="Po4Z58vHYt" role="1PaTwD">
+          <property role="3oM_SC" value="in" />
+        </node>
+        <node concept="3oM_SD" id="Po4Z58vHYu" role="1PaTwD">
+          <property role="3oM_SC" value="this" />
+        </node>
+        <node concept="3oM_SD" id="Po4Z58vHYv" role="1PaTwD">
+          <property role="3oM_SC" value="file." />
+        </node>
+      </node>
+      <node concept="1PaTwC" id="Po4Z58vHYw" role="1PaQFQ">
+        <node concept="3oM_SD" id="Po4Z58vHYx" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+      </node>
+      <node concept="1PaTwC" id="Po4Z58vHYy" role="1PaQFQ">
+        <node concept="3oM_SD" id="Po4Z58vHYz" role="1PaTwD">
+          <property role="3oM_SC" value="The" />
+        </node>
+        <node concept="3oM_SD" id="Po4Z58vHY$" role="1PaTwD">
+          <property role="3oM_SC" value="format" />
+        </node>
+        <node concept="3oM_SD" id="Po4Z58vHY_" role="1PaTwD">
+          <property role="3oM_SC" value="is" />
+        </node>
+        <node concept="3oM_SD" id="Po4Z58vHYA" role="1PaTwD">
+          <property role="3oM_SC" value="based" />
+        </node>
+        <node concept="3oM_SD" id="Po4Z58vHYB" role="1PaTwD">
+          <property role="3oM_SC" value="on" />
+        </node>
+        <node concept="3oM_SD" id="1$KnWE8sWZy" role="1PaTwD">
+          <property role="3oM_SC" value="Keep a Changelog" />
+          <property role="1X82VU" value="https://keepachangelog.com/en/1.0.0/" />
+        </node>
+        <node concept="3oM_SD" id="1$KnWE8sX0d" role="1PaTwD">
+          <property role="3oM_SC" value="and" />
+        </node>
+        <node concept="3oM_SD" id="Po4Z58vHYG" role="1PaTwD">
+          <property role="3oM_SC" value="this" />
+        </node>
+        <node concept="3oM_SD" id="Po4Z58vHYH" role="1PaTwD">
+          <property role="3oM_SC" value="project" />
+        </node>
+        <node concept="3oM_SD" id="Po4Z58vHYI" role="1PaTwD">
+          <property role="3oM_SC" value="adheres" />
+        </node>
+        <node concept="3oM_SD" id="Po4Z58vHYJ" role="1PaTwD">
+          <property role="3oM_SC" value="to" />
+        </node>
+        <node concept="3oM_SD" id="XbadXSkzeU" role="1PaTwD">
+          <property role="3oM_SC" value="Semantic Versioning" />
+          <property role="1X82VU" value="https://semver.org/spec/v2.0.0.html" />
+        </node>
+        <node concept="3oM_SD" id="Po4Z58vHYL" role="1PaTwD">
+          <property role="3oM_SC" value="." />
+        </node>
+      </node>
+      <node concept="1PaTwC" id="Po4Z58vHYM" role="1PaQFQ">
+        <node concept="3oM_SD" id="Po4Z58vHYN" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+      </node>
+    </node>
+    <node concept="15bmVD" id="Po4Z58wkAf" role="15bmVC">
+      <node concept="15bmUU" id="Po4Z58wkAg" role="15bq2Y">
+        <property role="15bmUX" value="1598400000" />
+        <node concept="15bmUZ" id="Po4Z58wkAh" role="15bq2W">
+          <property role="15bmUY" value="2" />
+          <property role="15bmUw" value="0" />
+          <property role="15bmU_" value="0" />
+          <property role="15bmUD" value="rc123" />
+        </node>
+      </node>
+      <node concept="15bAme" id="Po4Z58wkAi" role="15bAlL">
+        <property role="15bAli" value="Po4Z58tnOE/added" />
+        <node concept="2DRihI" id="Po4Z58wkAj" role="15bAlk">
+          <node concept="3oM_SD" id="Po4Z58$EWI" role="1PaTwD">
+            <property role="3oM_SC" value="Added" />
+          </node>
+          <node concept="3oM_SD" id="Po4Z58$EWK" role="1PaTwD">
+            <property role="3oM_SC" value="a" />
+          </node>
+          <node concept="3oM_SD" id="Po4Z58$EWN" role="1PaTwD">
+            <property role="3oM_SC" value="line." />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="15bmVD" id="Po4Z58yFtC" role="15bmVC">
+      <node concept="15bmUU" id="Po4Z58yFtD" role="15bq2Y">
+        <property role="15bmUX" value="1598313600" />
+        <node concept="15bmUZ" id="Po4Z58yFtE" role="15bq2W">
+          <property role="15bmUY" value="1" />
+          <property role="15bmUw" value="0" />
+          <property role="15bmU_" value="0" />
+          <property role="15bmUD" value="alpha" />
+        </node>
+      </node>
+      <node concept="15bAme" id="Po4Z58yFtF" role="15bAlL">
+        <property role="15bAli" value="Po4Z58tnOE/added" />
+        <node concept="2DRihI" id="Po4Z58yFtG" role="15bAlk">
+          <node concept="3oM_SD" id="Po4Z58_8ut" role="1PaTwD">
+            <property role="3oM_SC" value="Added" />
+          </node>
+          <node concept="3oM_SD" id="Po4Z58_8uv" role="1PaTwD">
+            <property role="3oM_SC" value="a" />
+          </node>
+          <node concept="3oM_SD" id="Po4Z58_8uy" role="1PaTwD">
+            <property role="3oM_SC" value="thing." />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="15bmVD" id="Po4Z58_8uA" role="15bmVC">
+      <node concept="15bmUU" id="Po4Z58_8uB" role="15bq2Y">
+        <property role="15bmUX" value="1598220000" />
+        <node concept="15bmUZ" id="Po4Z58_8uC" role="15bq2W">
+          <property role="15bmUY" value="1" />
+          <property role="15bmUw" value="0" />
+          <property role="15bmU_" value="0" />
+          <property role="15bmUD" value="alpha.1" />
+        </node>
+      </node>
+      <node concept="15bAme" id="Po4Z58_8uD" role="15bAlL">
+        <property role="15bAli" value="Po4Z58tnOE/added" />
+        <node concept="2DRihI" id="Po4Z58_8uE" role="15bAlk">
+          <node concept="3oM_SD" id="Po4Z58_8v1" role="1PaTwD">
+            <property role="3oM_SC" value="Added" />
+          </node>
+          <node concept="3oM_SD" id="Po4Z58_8v3" role="1PaTwD">
+            <property role="3oM_SC" value="a" />
+          </node>
+          <node concept="3oM_SD" id="Po4Z58_8v6" role="1PaTwD">
+            <property role="3oM_SC" value="thing." />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="15bmVD" id="Po4Z58AjdB" role="15bmVC">
+      <node concept="15bmUU" id="Po4Z58AjdC" role="15bq2Y">
+        <property role="15bmUX" value="1598133600" />
+        <node concept="15bmUZ" id="Po4Z58AjdD" role="15bq2W">
+          <property role="15bmUY" value="1" />
+          <property role="15bmUw" value="0" />
+          <property role="15bmU_" value="0" />
+          <property role="15bmUD" value="0.3.7" />
+        </node>
+      </node>
+      <node concept="15bAme" id="Po4Z58AjdE" role="15bAlL">
+        <property role="15bAli" value="Po4Z58tnOE/added" />
+        <node concept="2DRihI" id="Po4Z58AjdF" role="15bAlk">
+          <node concept="3oM_SD" id="Po4Z58Amj8" role="1PaTwD">
+            <property role="3oM_SC" value="Added" />
+          </node>
+          <node concept="3oM_SD" id="Po4Z58Amja" role="1PaTwD">
+            <property role="3oM_SC" value="a" />
+          </node>
+          <node concept="3oM_SD" id="Po4Z58Amjd" role="1PaTwD">
+            <property role="3oM_SC" value="thing." />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="15bmVD" id="Po4Z58AmjV" role="15bmVC">
+      <node concept="15bmUU" id="Po4Z58AmjW" role="15bq2Y">
+        <property role="15bmUX" value="1597960800" />
+        <node concept="15bmUZ" id="Po4Z58AmjX" role="15bq2W">
+          <property role="15bmUY" value="1" />
+          <property role="15bmUw" value="0" />
+          <property role="15bmU_" value="0" />
+          <property role="15bmUD" value="x.y.z" />
+        </node>
+      </node>
+      <node concept="15bAme" id="Po4Z58AmjY" role="15bAlL">
+        <property role="15bAli" value="Po4Z58tnOE/added" />
+        <node concept="2DRihI" id="Po4Z58AmjZ" role="15bAlk">
+          <node concept="3oM_SD" id="Po4Z58Amk0" role="1PaTwD">
+            <property role="3oM_SC" value="Added" />
+          </node>
+          <node concept="3oM_SD" id="Po4Z58Amk1" role="1PaTwD">
+            <property role="3oM_SC" value="a" />
+          </node>
+          <node concept="3oM_SD" id="Po4Z58Amk2" role="1PaTwD">
+            <property role="3oM_SC" value="thing." />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="15bmVD" id="Po4Z58AmkF" role="15bmVC">
+      <node concept="15bmUU" id="Po4Z58AmkG" role="15bq2Y">
+        <property role="15bmUX" value="1546473600" />
+        <node concept="15bmUZ" id="Po4Z58AmkH" role="15bq2W">
+          <property role="15bmUY" value="1" />
+          <property role="15bmUw" value="0" />
+          <property role="15bmU_" value="0" />
+        </node>
+      </node>
+      <node concept="15bAme" id="Po4Z58AmkI" role="15bAlL">
+        <property role="15bAli" value="Po4Z58tnOI/deprecated" />
+        <node concept="2DRihI" id="Po4Z58AmkJ" role="15bAlk">
+          <node concept="3oM_SD" id="Po4Z58Amop" role="1PaTwD">
+            <property role="3oM_SC" value="Some" />
+          </node>
+          <node concept="3oM_SD" id="Po4Z58Amor" role="1PaTwD">
+            <property role="3oM_SC" value="things" />
+          </node>
+          <node concept="3oM_SD" id="Po4Z58Amou" role="1PaTwD">
+            <property role="3oM_SC" value="were" />
+          </node>
+          <node concept="3oM_SD" id="XbadXRRbKC" role="1PaTwD">
+            <property role="3oM_SC" value="deprecated." />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="15b0KX" id="Po4Z58E89I">
+    <property role="TrG5h" value="ChangelogDemo2" />
+    <property role="2hl1$G" value="md" />
+    <node concept="1Pa9Pv" id="Po4Z58E89J" role="15bnHq">
+      <node concept="1PaTwC" id="Po4Z58E89K" role="1PaQFQ">
+        <node concept="3oM_SD" id="Po4Z58E89L" role="1PaTwD">
+          <property role="3oM_SC" value="All" />
+        </node>
+        <node concept="3oM_SD" id="Po4Z58E89M" role="1PaTwD">
+          <property role="3oM_SC" value="notable" />
+        </node>
+        <node concept="3oM_SD" id="Po4Z58E89N" role="1PaTwD">
+          <property role="3oM_SC" value="changes" />
+        </node>
+        <node concept="3oM_SD" id="Po4Z58E89O" role="1PaTwD">
+          <property role="3oM_SC" value="to" />
+        </node>
+        <node concept="3oM_SD" id="Po4Z58E89P" role="1PaTwD">
+          <property role="3oM_SC" value="this" />
+        </node>
+        <node concept="3oM_SD" id="Po4Z58E89Q" role="1PaTwD">
+          <property role="3oM_SC" value="project" />
+        </node>
+        <node concept="3oM_SD" id="Po4Z58E89R" role="1PaTwD">
+          <property role="3oM_SC" value="will" />
+        </node>
+        <node concept="3oM_SD" id="Po4Z58E89S" role="1PaTwD">
+          <property role="3oM_SC" value="be" />
+        </node>
+        <node concept="3oM_SD" id="Po4Z58E89T" role="1PaTwD">
+          <property role="3oM_SC" value="documented" />
+        </node>
+        <node concept="3oM_SD" id="Po4Z58E89U" role="1PaTwD">
+          <property role="3oM_SC" value="in" />
+        </node>
+        <node concept="3oM_SD" id="Po4Z58E89V" role="1PaTwD">
+          <property role="3oM_SC" value="this" />
+        </node>
+        <node concept="3oM_SD" id="Po4Z58E89W" role="1PaTwD">
+          <property role="3oM_SC" value="file." />
+        </node>
+      </node>
+      <node concept="1PaTwC" id="Po4Z58E89X" role="1PaQFQ">
+        <node concept="3oM_SD" id="Po4Z58E89Y" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+      </node>
+      <node concept="1PaTwC" id="Po4Z58E89Z" role="1PaQFQ">
+        <node concept="3oM_SD" id="Po4Z58E8a0" role="1PaTwD">
+          <property role="3oM_SC" value="The" />
+        </node>
+        <node concept="3oM_SD" id="Po4Z58E8a1" role="1PaTwD">
+          <property role="3oM_SC" value="format" />
+        </node>
+        <node concept="3oM_SD" id="Po4Z58E8a2" role="1PaTwD">
+          <property role="3oM_SC" value="is" />
+        </node>
+        <node concept="3oM_SD" id="Po4Z58E8a3" role="1PaTwD">
+          <property role="3oM_SC" value="based" />
+        </node>
+        <node concept="3oM_SD" id="Po4Z58E8a4" role="1PaTwD">
+          <property role="3oM_SC" value="on" />
+        </node>
+        <node concept="3oM_SD" id="43oF0KsRzTP" role="1PaTwD">
+          <property role="3oM_SC" value="Keep a Changelog" />
+          <property role="1X82VU" value="https://keepachangelog.com/en/1.0.0/" />
+        </node>
+        <node concept="3oM_SD" id="1$KnWE8sX0r" role="1PaTwD">
+          <property role="3oM_SC" value="and" />
+        </node>
+        <node concept="3oM_SD" id="Po4Z58E8a9" role="1PaTwD">
+          <property role="3oM_SC" value="this" />
+        </node>
+        <node concept="3oM_SD" id="Po4Z58E8aa" role="1PaTwD">
+          <property role="3oM_SC" value="project" />
+        </node>
+        <node concept="3oM_SD" id="Po4Z58E8ab" role="1PaTwD">
+          <property role="3oM_SC" value="adheres" />
+        </node>
+        <node concept="3oM_SD" id="Po4Z58E8ac" role="1PaTwD">
+          <property role="3oM_SC" value="to" />
+        </node>
+        <node concept="3oM_SD" id="XbadXRRbL5" role="1PaTwD">
+          <property role="3oM_SC" value="Semantic Versioning" />
+          <property role="1X82VU" value="https://semver.org/spec/v2.0.0.html" />
+        </node>
+        <node concept="3oM_SD" id="XbadXRRbLd" role="1PaTwD">
+          <property role="3oM_SC" value="." />
+        </node>
+      </node>
+    </node>
+    <node concept="15bmVD" id="Po4Z58E8a_" role="15bmVC">
+      <node concept="15bmUU" id="Po4Z58E8aA" role="15bq2Y">
+        <property role="15bmUX" value="1546473600" />
+        <node concept="15bmUZ" id="Po4Z58E8aB" role="15bq2W">
+          <property role="15bmUY" value="1" />
+          <property role="15bmUw" value="0" />
+          <property role="15bmU_" value="0" />
+        </node>
+      </node>
+      <node concept="15bAme" id="Po4Z58E8aC" role="15bAlL">
+        <property role="15bAli" value="Po4Z58tnOI/deprecated" />
+        <node concept="2DRihI" id="Po4Z58E8aD" role="15bAlk">
+          <node concept="3oM_SD" id="Po4Z58E8aJ" role="1PaTwD">
+            <property role="3oM_SC" value="Some" />
+          </node>
+          <node concept="3oM_SD" id="Po4Z58E8aL" role="1PaTwD">
+            <property role="3oM_SC" value="things" />
+          </node>
+          <node concept="3oM_SD" id="Po4Z58E8aM" role="1PaTwD">
+            <property role="3oM_SC" value="were" />
+          </node>
+          <node concept="3oM_SD" id="Po4Z58E8aN" role="1PaTwD">
+            <property role="3oM_SC" value="deprecated." />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="15bmVD" id="Po4Z58E8aS" role="15bmVC">
+      <node concept="15bmUU" id="Po4Z58E8aT" role="15bq2Y">
+        <property role="15bmUX" value="1543363200" />
+        <node concept="15bmUZ" id="Po4Z58E8aU" role="15bq2W">
+          <property role="15bmUY" value="0" />
+          <property role="15bmUw" value="1" />
+          <property role="15bmU_" value="0" />
+        </node>
+      </node>
+      <node concept="15bAme" id="Po4Z58E8aV" role="15bAlL">
+        <property role="15bAli" value="Po4Z58tnOM/removed" />
+        <node concept="2DRihI" id="Po4Z58E8aW" role="15bAlk">
+          <node concept="3oM_SD" id="Po4Z58E8bb" role="1PaTwD">
+            <property role="3oM_SC" value="Removed" />
+          </node>
+          <node concept="3oM_SD" id="Po4Z58E8bd" role="1PaTwD">
+            <property role="3oM_SC" value="all" />
+          </node>
+          <node concept="3oM_SD" id="Po4Z58E8bg" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="Po4Z58E8bk" role="1PaTwD">
+            <property role="3oM_SC" value="things." />
+          </node>
+        </node>
+      </node>
+      <node concept="15bAme" id="Po4Z58E8bp" role="15bAlL">
+        <node concept="2DRihI" id="Po4Z58E8bq" role="15bAlk">
+          <node concept="3oM_SD" id="Po4Z58E8bz" role="1PaTwD">
+            <property role="3oM_SC" value="Fixed" />
+          </node>
+          <node concept="3oM_SD" id="Po4Z58E8b_" role="1PaTwD">
+            <property role="3oM_SC" value="all" />
+          </node>
+          <node concept="3oM_SD" id="Po4Z58E8bA" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="Po4Z58E8bB" role="1PaTwD">
+            <property role="3oM_SC" value="bugs" />
+          </node>
+          <node concept="3oM_SD" id="Po4Z58E8bC" role="1PaTwD">
+            <property role="3oM_SC" value="from" />
+          </node>
+          <node concept="3oM_SD" id="Po4Z58E8bD" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="Po4Z58E8bE" role="1PaTwD">
+            <property role="3oM_SC" value="non-existent" />
+          </node>
+          <node concept="3oM_SD" id="Po4Z58E8bF" role="1PaTwD">
+            <property role="3oM_SC" value="previous" />
+          </node>
+          <node concept="3oM_SD" id="Po4Z58E8bG" role="1PaTwD">
+            <property role="3oM_SC" value="release." />
+          </node>
+        </node>
+      </node>
+      <node concept="15bAme" id="Po4Z58E8bQ" role="15bAlL">
+        <property role="15bAli" value="Po4Z58tnOX/security" />
+        <node concept="2DRihI" id="Po4Z58E8bR" role="15bAlk">
+          <node concept="3oM_SD" id="Po4Z58E8cb" role="1PaTwD">
+            <property role="3oM_SC" value="We" />
+          </node>
+          <node concept="3oM_SD" id="Po4Z58E8cd" role="1PaTwD">
+            <property role="3oM_SC" value="are" />
+          </node>
+          <node concept="3oM_SD" id="Po4Z58E8ce" role="1PaTwD">
+            <property role="3oM_SC" value="so" />
+          </node>
+          <node concept="3oM_SD" id="Po4Z58E8cf" role="1PaTwD">
+            <property role="3oM_SC" value="secure" />
+          </node>
+          <node concept="3oM_SD" id="Po4Z58E8cg" role="1PaTwD">
+            <property role="3oM_SC" value="now." />
+          </node>
+        </node>
+        <node concept="2DRihI" id="Po4Z58E8cn" role="15bAlk">
+          <property role="2RT3bR" value="0" />
+          <node concept="3oM_SD" id="Po4Z58E8cG" role="1PaTwD">
+            <property role="3oM_SC" value="The" />
+          </node>
+          <node concept="3oM_SD" id="Po4Z58E8cH" role="1PaTwD">
+            <property role="3oM_SC" value="securest." />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="15b0KX" id="43oF0KsR_xa">
+    <property role="TrG5h" value="ChangelogDemo3" />
+    <property role="15SkSo" value="Po4Z58IlRA/monthYear" />
+    <property role="2hl1$G" value="md" />
+    <node concept="1Pa9Pv" id="43oF0KsR_xb" role="15bnHq">
+      <node concept="1PaTwC" id="43oF0KsR_xc" role="1PaQFQ">
+        <node concept="3oM_SD" id="43oF0KsR_xd" role="1PaTwD">
+          <property role="3oM_SC" value="All" />
+        </node>
+        <node concept="3oM_SD" id="43oF0KsR_xe" role="1PaTwD">
+          <property role="3oM_SC" value="notable" />
+        </node>
+        <node concept="3oM_SD" id="43oF0KsR_xf" role="1PaTwD">
+          <property role="3oM_SC" value="changes" />
+        </node>
+        <node concept="3oM_SD" id="43oF0KsR_xg" role="1PaTwD">
+          <property role="3oM_SC" value="to" />
+        </node>
+        <node concept="3oM_SD" id="43oF0KsR_xh" role="1PaTwD">
+          <property role="3oM_SC" value="this" />
+        </node>
+        <node concept="3oM_SD" id="43oF0KsR_xi" role="1PaTwD">
+          <property role="3oM_SC" value="project" />
+        </node>
+        <node concept="3oM_SD" id="43oF0KsR_xj" role="1PaTwD">
+          <property role="3oM_SC" value="will" />
+        </node>
+        <node concept="3oM_SD" id="43oF0KsR_xk" role="1PaTwD">
+          <property role="3oM_SC" value="be" />
+        </node>
+        <node concept="3oM_SD" id="43oF0KsR_xl" role="1PaTwD">
+          <property role="3oM_SC" value="documented" />
+        </node>
+        <node concept="3oM_SD" id="43oF0KsR_xm" role="1PaTwD">
+          <property role="3oM_SC" value="in" />
+        </node>
+        <node concept="3oM_SD" id="43oF0KsR_xn" role="1PaTwD">
+          <property role="3oM_SC" value="this" />
+        </node>
+        <node concept="3oM_SD" id="43oF0KsR_xo" role="1PaTwD">
+          <property role="3oM_SC" value="file." />
+        </node>
+      </node>
+      <node concept="1PaTwC" id="43oF0KsR_xp" role="1PaQFQ">
+        <node concept="3oM_SD" id="43oF0KsR_xq" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+      </node>
+      <node concept="1PaTwC" id="43oF0KsR_xr" role="1PaQFQ">
+        <node concept="3oM_SD" id="43oF0KsR_xs" role="1PaTwD">
+          <property role="3oM_SC" value="The" />
+        </node>
+        <node concept="3oM_SD" id="43oF0KsR_xt" role="1PaTwD">
+          <property role="3oM_SC" value="format" />
+        </node>
+        <node concept="3oM_SD" id="43oF0KsR_xu" role="1PaTwD">
+          <property role="3oM_SC" value="is" />
+        </node>
+        <node concept="3oM_SD" id="43oF0KsR_xv" role="1PaTwD">
+          <property role="3oM_SC" value="based" />
+        </node>
+        <node concept="3oM_SD" id="43oF0KsR_xw" role="1PaTwD">
+          <property role="3oM_SC" value="on" />
+        </node>
+        <node concept="3oM_SD" id="43oF0KsR_xx" role="1PaTwD">
+          <property role="3oM_SC" value="Keep a Changelog" />
+          <property role="1X82VU" value="https://keepachangelog.com/en/1.0.0/" />
+        </node>
+        <node concept="3oM_SD" id="43oF0KsR_xy" role="1PaTwD">
+          <property role="3oM_SC" value="." />
+        </node>
+      </node>
+    </node>
+    <node concept="15bmVD" id="43oF0KsR_xK" role="15bmVC">
+      <node concept="15ShDW" id="43oF0KsR_xH" role="15bq2Y">
+        <property role="15ShDY" value="Po4Z58IgAt/April" />
+        <property role="15ShDw" value="2024" />
+      </node>
+      <node concept="15bAme" id="43oF0KsR_xI" role="15bAlL">
+        <node concept="2DRihI" id="43oF0KsR_xJ" role="15bAlk">
+          <node concept="3oM_SD" id="43oF0KsR_y1" role="1PaTwD">
+            <property role="3oM_SC" value="Something" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsR_y3" role="1PaTwD">
+            <property role="3oM_SC" value="that" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsR_y6" role="1PaTwD">
+            <property role="3oM_SC" value="I" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsR_ya" role="1PaTwD">
+            <property role="3oM_SC" value="fixed." />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="15bmVD" id="43oF0KsR_xS" role="15bmVC">
+      <node concept="15ShDW" id="43oF0KsR_xP" role="15bq2Y">
+        <property role="15ShDY" value="Po4Z58IgAp/March" />
+        <property role="15ShDw" value="2024" />
+      </node>
+      <node concept="15bAme" id="43oF0KsR_xQ" role="15bAlL">
+        <property role="15bAli" value="Po4Z58tnOF/changed" />
+        <node concept="2DRihI" id="43oF0KsR_xR" role="15bAlk">
+          <node concept="3oM_SD" id="43oF0KsR_yf" role="1PaTwD">
+            <property role="3oM_SC" value="Something" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsR_yh" role="1PaTwD">
+            <property role="3oM_SC" value="that" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsR_yk" role="1PaTwD">
+            <property role="3oM_SC" value="I" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsR_yo" role="1PaTwD">
+            <property role="3oM_SC" value="changed." />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/code/changelog/de.itemis.mps.changelog/de.itemis.mps.changelog.mpl
+++ b/code/changelog/de.itemis.mps.changelog/de.itemis.mps.changelog.mpl
@@ -1,0 +1,183 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<language namespace="de.itemis.mps.changelog" uuid="638c9345-2613-49dc-b2ae-8ceadef24141" languageVersion="0" moduleVersion="0">
+  <models>
+    <modelRoot contentPath="${module}" type="default">
+      <sourceRoot location="models" />
+    </modelRoot>
+  </models>
+  <facets>
+    <facet type="java">
+      <classes generated="true" path="${module}/classes_gen" />
+    </facet>
+  </facets>
+  <accessoryModels />
+  <generators>
+    <generator alias="main" namespace="de.itemis.mps.changelog.generator" uuid="8a65cbd6-c224-4e7a-a5e8-1c272d28e755">
+      <models>
+        <modelRoot contentPath="${module}/generator" type="default">
+          <sourceRoot location="templates" />
+        </modelRoot>
+      </models>
+      <facets>
+        <facet type="java">
+          <classes generated="true" path="${module}/generator/classes_gen" />
+        </facet>
+      </facets>
+      <external-templates />
+      <dependencies>
+        <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
+        <dependency reexport="false" scope="design">2bdcefec-ba49-4b32-ab50-ebc7a41d5090(jetbrains.mps.lang.smodel#1139186730696)</dependency>
+        <dependency reexport="false" scope="design">736153ab-0665-4767-a720-756ab69c61f0(com.dslfoundry.plaintextflow#01)</dependency>
+      </dependencies>
+      <languageVersions>
+        <language slang="l:cf681fc9-c798-4f89-af38-ba3c0ac342d9:com.dslfoundry.plaintextflow" version="0" />
+        <language slang="l:990507d3-3527-4c54-bfe9-0ca3c9c6247a:com.dslfoundry.plaintextgen" version="0" />
+        <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
+        <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
+        <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
+        <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
+        <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
+        <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
+        <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
+        <language slang="l:b401a680-8325-4110-8fd3-84331ff25bef:jetbrains.mps.lang.generator" version="4" />
+        <language slang="l:d7706f63-9be2-479c-a3da-ae92af1e64d5:jetbrains.mps.lang.generator.generationContext" version="2" />
+        <language slang="l:289fcc83-6543-41e8-a5ca-768235715ce4:jetbrains.mps.lang.generator.generationParameters" version="0" />
+        <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
+        <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
+        <language slang="l:13744753-c81f-424a-9c1b-cf8943bf4e86:jetbrains.mps.lang.sharedConcepts" version="0" />
+        <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
+        <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
+        <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
+      </languageVersions>
+      <dependencyVersions>
+        <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
+        <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
+        <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
+        <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+        <module reference="736153ab-0665-4767-a720-756ab69c61f0(com.dslfoundry.plaintextflow#01)" version="0" />
+        <module reference="638c9345-2613-49dc-b2ae-8ceadef24141(de.itemis.mps.changelog)" version="0" />
+        <module reference="8a65cbd6-c224-4e7a-a5e8-1c272d28e755(de.itemis.mps.changelog.generator)" version="0" />
+        <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
+        <module reference="446c26eb-2b7b-4bf0-9b35-f83fa582753e(jetbrains.mps.lang.modelapi)" version="0" />
+        <module reference="2bdcefec-ba49-4b32-ab50-ebc7a41d5090(jetbrains.mps.lang.smodel#1139186730696)" version="0" />
+        <module reference="c7fb639f-be78-4307-89b0-b5959c3fa8c8(jetbrains.mps.lang.text)" version="0" />
+      </dependencyVersions>
+      <mapping-priorities>
+        <mapping-priority-rule kind="strictly_before">
+          <greater-priority-mapping>
+            <generator generatorUID="8a65cbd6-c224-4e7a-a5e8-1c272d28e755(de.itemis.mps.changelog.generator)" />
+            <external-mapping>
+              <mapping-node modelUID="r:0a21c1b4-c18b-41e1-8692-688b5601ff61(de.itemis.mps.changelog.generator@generator)" nodeID="1815055973304997939" />
+            </external-mapping>
+          </greater-priority-mapping>
+          <lesser-priority-mapping>
+            <generator generatorUID="2bdcefec-ba49-4b32-ab50-ebc7a41d5090(jetbrains.mps.lang.smodel#1139186730696)" />
+            <external-mapping>
+              <all-local-mappings />
+            </external-mapping>
+          </lesser-priority-mapping>
+        </mapping-priority-rule>
+        <mapping-priority-rule kind="strictly_before">
+          <greater-priority-mapping>
+            <generator generatorUID="8a65cbd6-c224-4e7a-a5e8-1c272d28e755(de.itemis.mps.changelog.generator)" />
+            <external-mapping>
+              <mapping-node modelUID="r:0a21c1b4-c18b-41e1-8692-688b5601ff61(de.itemis.mps.changelog.generator@generator)" nodeID="1815055973304997939" />
+            </external-mapping>
+          </greater-priority-mapping>
+          <lesser-priority-mapping>
+            <generator generatorUID="736153ab-0665-4767-a720-756ab69c61f0(com.dslfoundry.plaintextflow#01)" />
+            <external-mapping>
+              <mapping-node modelUID="r:e0611dee-93ac-4e51-aacc-8ac9535cad7e(main@generator)" nodeID="7578858899714625060" />
+            </external-mapping>
+          </lesser-priority-mapping>
+        </mapping-priority-rule>
+      </mapping-priorities>
+    </generator>
+  </generators>
+  <sourcePath />
+  <dependencies>
+    <dependency reexport="false">c7fb639f-be78-4307-89b0-b5959c3fa8c8(jetbrains.mps.lang.text)</dependency>
+    <dependency reexport="false">7866978e-a0f0-4cc7-81bc-4d213d9375e1(jetbrains.mps.lang.smodel)</dependency>
+    <dependency reexport="true">446c26eb-2b7b-4bf0-9b35-f83fa582753e(jetbrains.mps.lang.modelapi)</dependency>
+    <dependency reexport="false">1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)</dependency>
+    <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
+    <dependency reexport="false">ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)</dependency>
+    <dependency reexport="false">6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)</dependency>
+    <dependency reexport="false">528ff3b9-5fc4-40dd-931f-c6ce3650640e(jetbrains.mps.lang.migration.runtime)</dependency>
+    <dependency reexport="false">18bc6592-03a6-4e29-a83a-7ff23bde13ba(jetbrains.mps.lang.editor)</dependency>
+    <dependency reexport="false">ae6d8005-36be-4cb6-945b-8c8cfc033c51(jetbrains.mps.ide.httpsupport.runtime)</dependency>
+    <dependency reexport="false">8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)</dependency>
+  </dependencies>
+  <languageVersions>
+    <language slang="l:9d69e719-78c8-4286-90db-fb19c107d049:com.mbeddr.mpsutil.grammarcells" version="2" />
+    <language slang="l:b4f35ed8-45af-4efa-abe4-00ac26956e69:com.mbeddr.mpsutil.grammarcells.runtimelang" version="0" />
+    <language slang="l:05f762a9-99f5-4971-a9ed-5a6481dc2be4:de.itemis.mps.selection.intentions" version="0" />
+    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
+    <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />
+    <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
+    <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
+    <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
+    <language slang="l:c7d5b9dd-a05f-4be2-bc73-f2e16994cc67:jetbrains.mps.baseLanguage.lightweightdsl" version="1" />
+    <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
+    <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
+    <language slang="l:aee9cad2-acd4-4608-aef2-0004f6a1cdbd:jetbrains.mps.lang.actions" version="4" />
+    <language slang="l:af65afd8-f0dd-4942-87d9-63a55f2a9db1:jetbrains.mps.lang.behavior" version="2" />
+    <language slang="l:3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1:jetbrains.mps.lang.constraints" version="6" />
+    <language slang="l:e51810c5-7308-4642-bcb6-469e61b5dd18:jetbrains.mps.lang.constraints.msg.specification" version="0" />
+    <language slang="l:47257bf3-78d3-470b-89d9-8c3261a61d15:jetbrains.mps.lang.constraints.rules" version="0" />
+    <language slang="l:5dae8159-ab99-46bb-a40d-0cee30ee7018:jetbrains.mps.lang.constraints.rules.kinds" version="0" />
+    <language slang="l:134c38d4-e3af-4d9e-b069-1c7df0a4005d:jetbrains.mps.lang.constraints.rules.skeleton" version="0" />
+    <language slang="l:3ad5badc-1d9c-461c-b7b1-fa2fcd0a0ae7:jetbrains.mps.lang.context" version="0" />
+    <language slang="l:ea3159bf-f48e-4720-bde2-86dba75f0d34:jetbrains.mps.lang.context.defs" version="0" />
+    <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
+    <language slang="l:f4ad079d-bc71-4ffb-9600-9328705cf998:jetbrains.mps.lang.descriptor" version="0" />
+    <language slang="l:18bc6592-03a6-4e29-a83a-7ff23bde13ba:jetbrains.mps.lang.editor" version="14" />
+    <language slang="l:d7a92d38-f7db-40d0-8431-763b0c3c9f20:jetbrains.mps.lang.intentions" version="1" />
+    <language slang="l:ad93155d-79b2-4759-b10c-55123e763903:jetbrains.mps.lang.messages" version="0" />
+    <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
+    <language slang="l:d4615e3b-d671-4ba9-af01-2b78369b0ba7:jetbrains.mps.lang.pattern" version="2" />
+    <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
+    <language slang="l:982eb8df-2c96-4bd7-9963-11712ea622e5:jetbrains.mps.lang.resources" version="2" />
+    <language slang="l:b3551702-269c-4f05-ba61-58060cef4292:jetbrains.mps.lang.rulesAndMessages" version="0" />
+    <language slang="l:d8f591ec-4d86-4af2-9f92-a9e93c803ffa:jetbrains.mps.lang.scopes" version="0" />
+    <language slang="l:13744753-c81f-424a-9c1b-cf8943bf4e86:jetbrains.mps.lang.sharedConcepts" version="0" />
+    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
+    <language slang="l:c72da2b9-7cce-4447-8389-f407dc1158b7:jetbrains.mps.lang.structure" version="9" />
+    <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
+    <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
+    <language slang="l:7a5dda62-9140-4668-ab76-d5ed1746f2b2:jetbrains.mps.lang.typesystem" version="5" />
+  </languageVersions>
+  <dependencyVersions>
+    <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
+    <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
+    <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
+    <module reference="1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)" version="0" />
+    <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
+    <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+    <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
+    <module reference="638c9345-2613-49dc-b2ae-8ceadef24141(de.itemis.mps.changelog)" version="0" />
+    <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
+    <module reference="443f4c36-fcf5-4eb6-9500-8d06ed259e3e(jetbrains.mps.baseLanguage.classifiers)" version="0" />
+    <module reference="fd392034-7849-419d-9071-12563d152375(jetbrains.mps.baseLanguage.closures)" version="0" />
+    <module reference="83888646-71ce-4f1c-9c53-c54016f6ad4f(jetbrains.mps.baseLanguage.collections)" version="0" />
+    <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
+    <module reference="23865718-e2ed-41b5-a132-0da1d04e266d(jetbrains.mps.ide.httpsupport.manager)" version="0" />
+    <module reference="ae6d8005-36be-4cb6-945b-8c8cfc033c51(jetbrains.mps.ide.httpsupport.runtime)" version="0" />
+    <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
+    <module reference="d936855b-48da-4812-a8a0-2bfddd633ac5(jetbrains.mps.lang.behavior.api)" version="0" />
+    <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
+    <module reference="a9e4c532-c5f5-4bb7-99ef-42abb73bbb70(jetbrains.mps.lang.descriptor.aspects)" version="0" />
+    <module reference="18bc6592-03a6-4e29-a83a-7ff23bde13ba(jetbrains.mps.lang.editor)" version="0" />
+    <module reference="528ff3b9-5fc4-40dd-931f-c6ce3650640e(jetbrains.mps.lang.migration.runtime)" version="0" />
+    <module reference="446c26eb-2b7b-4bf0-9b35-f83fa582753e(jetbrains.mps.lang.modelapi)" version="0" />
+    <module reference="d7eb0a2a-bd50-4576-beae-e4a89db35f20(jetbrains.mps.lang.scopes.runtime)" version="0" />
+    <module reference="7866978e-a0f0-4cc7-81bc-4d213d9375e1(jetbrains.mps.lang.smodel)" version="1" />
+    <module reference="c72da2b9-7cce-4447-8389-f407dc1158b7(jetbrains.mps.lang.structure)" version="0" />
+    <module reference="c7fb639f-be78-4307-89b0-b5959c3fa8c8(jetbrains.mps.lang.text)" version="0" />
+    <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
+  </dependencyVersions>
+  <extendedLanguages>
+    <extendedLanguage>c7fb639f-be78-4307-89b0-b5959c3fa8c8(jetbrains.mps.lang.text)</extendedLanguage>
+  </extendedLanguages>
+</language>
+

--- a/code/changelog/de.itemis.mps.changelog/generator/templates/de.itemis.mps.changelog.generator@generator.mps
+++ b/code/changelog/de.itemis.mps.changelog/generator/templates/de.itemis.mps.changelog.generator@generator.mps
@@ -1,0 +1,841 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:0a21c1b4-c18b-41e1-8692-688b5601ff61(de.itemis.mps.changelog.generator@generator)">
+  <persistence version="9" />
+  <languages>
+    <use id="cf681fc9-c798-4f89-af38-ba3c0ac342d9" name="com.dslfoundry.plaintextflow" version="0" />
+    <use id="b401a680-8325-4110-8fd3-84331ff25bef" name="jetbrains.mps.lang.generator" version="4" />
+    <use id="13744753-c81f-424a-9c1b-cf8943bf4e86" name="jetbrains.mps.lang.sharedConcepts" version="0" />
+    <devkit ref="a2eb3a43-fcc2-4200-80dc-c60110c4862d(jetbrains.mps.devkit.templates)" />
+  </languages>
+  <imports>
+    <import index="b7vt" ref="r:86cc19c0-126f-473b-92c6-29dba75c1e89(de.itemis.mps.changelog.structure)" />
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
+    <import index="vdrq" ref="r:85354f47-14fd-40e6-a7cc-2d1aa842c4cd(jetbrains.mps.lang.text.behavior)" implicit="true" />
+    <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" implicit="true" />
+    <import index="zqge" ref="r:59e90602-6655-4552-86eb-441a42a9a0e4(jetbrains.mps.lang.text.structure)" implicit="true" />
+    <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="13744753-c81f-424a-9c1b-cf8943bf4e86" name="jetbrains.mps.lang.sharedConcepts">
+      <concept id="1161622665029" name="jetbrains.mps.lang.sharedConcepts.structure.ConceptFunctionParameter_model" flags="nn" index="1Q6Npb" />
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
+        <child id="1068498886297" name="rValue" index="37vLTx" />
+        <child id="1068498886295" name="lValue" index="37vLTJ" />
+      </concept>
+      <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
+        <child id="1137022507850" name="body" index="2VODD2" />
+      </concept>
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
+      </concept>
+      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
+      <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
+      <concept id="1225271408483" name="jetbrains.mps.baseLanguage.structure.IsNotEmptyOperation" flags="nn" index="17RvpY" />
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
+      <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
+        <child id="1068580123160" name="condition" index="3clFbw" />
+        <child id="1068580123161" name="ifTrue" index="3clFbx" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
+      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
+        <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
+      </concept>
+      <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
+        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
+        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
+      </concept>
+    </language>
+    <language id="b401a680-8325-4110-8fd3-84331ff25bef" name="jetbrains.mps.lang.generator">
+      <concept id="1114706874351" name="jetbrains.mps.lang.generator.structure.CopySrcNodeMacro" flags="ln" index="29HgVG">
+        <child id="1168024447342" name="sourceNodeQuery" index="3NFExx" />
+      </concept>
+      <concept id="1114729360583" name="jetbrains.mps.lang.generator.structure.CopySrcListMacro" flags="ln" index="2b32R4">
+        <child id="1168278589236" name="sourceNodesQuery" index="2P8S$" />
+      </concept>
+      <concept id="1095416546421" name="jetbrains.mps.lang.generator.structure.MappingConfiguration" flags="ig" index="bUwia">
+        <child id="1167328349397" name="reductionMappingRule" index="3acgRq" />
+        <child id="1167514678247" name="rootMappingRule" index="3lj3bC" />
+        <child id="1195502100749" name="preMappingScript" index="1puA0r" />
+      </concept>
+      <concept id="1168559333462" name="jetbrains.mps.lang.generator.structure.TemplateDeclarationReference" flags="ln" index="j$656" />
+      <concept id="1168619357332" name="jetbrains.mps.lang.generator.structure.RootTemplateAnnotation" flags="lg" index="n94m4">
+        <reference id="1168619429071" name="applicableConcept" index="n9lRv" />
+      </concept>
+      <concept id="1095672379244" name="jetbrains.mps.lang.generator.structure.TemplateFragment" flags="ng" index="raruj" />
+      <concept id="1722980698497626400" name="jetbrains.mps.lang.generator.structure.ITemplateCall" flags="ng" index="v9R3L">
+        <reference id="1722980698497626483" name="template" index="v9R2y" />
+      </concept>
+      <concept id="1167169188348" name="jetbrains.mps.lang.generator.structure.TemplateFunctionParameter_sourceNode" flags="nn" index="30H73N" />
+      <concept id="1167169308231" name="jetbrains.mps.lang.generator.structure.BaseMappingRule" flags="ng" index="30H$t8">
+        <property id="1167272244852" name="applyToConceptInheritors" index="36QftV" />
+        <reference id="1167169349424" name="applicableConcept" index="30HIoZ" />
+      </concept>
+      <concept id="1092059087312" name="jetbrains.mps.lang.generator.structure.TemplateDeclaration" flags="ig" index="13MO4I">
+        <reference id="1168285871518" name="applicableConcept" index="3gUMe" />
+        <child id="1092060348987" name="contentNode" index="13RCb5" />
+      </concept>
+      <concept id="1087833241328" name="jetbrains.mps.lang.generator.structure.PropertyMacro" flags="ln" index="17Uvod">
+        <child id="1167756362303" name="propertyValueFunction" index="3zH0cK" />
+      </concept>
+      <concept id="1167327847730" name="jetbrains.mps.lang.generator.structure.Reduction_MappingRule" flags="lg" index="3aamgX">
+        <child id="1169672767469" name="ruleConsequence" index="1lVwrX" />
+      </concept>
+      <concept id="1167514355419" name="jetbrains.mps.lang.generator.structure.Root_MappingRule" flags="lg" index="3lhOvk">
+        <reference id="1167514355421" name="template" index="3lhOvi" />
+      </concept>
+      <concept id="1195499912406" name="jetbrains.mps.lang.generator.structure.MappingScript" flags="lg" index="1pmfR0">
+        <property id="1195595592106" name="scriptKind" index="1v3f2W" />
+        <property id="1195595611951" name="modifiesModel" index="1v3jST" />
+        <child id="1195501105008" name="codeBlock" index="1pqMTA" />
+      </concept>
+      <concept id="1195500722856" name="jetbrains.mps.lang.generator.structure.MappingScript_CodeBlock" flags="in" index="1pplIY" />
+      <concept id="1195502151594" name="jetbrains.mps.lang.generator.structure.MappingScriptReference" flags="lg" index="1puMqW">
+        <reference id="1195502167610" name="mappingScript" index="1puQsG" />
+      </concept>
+      <concept id="1167756080639" name="jetbrains.mps.lang.generator.structure.PropertyMacro_GetPropertyValue" flags="in" index="3zFVjK" />
+      <concept id="1167951910403" name="jetbrains.mps.lang.generator.structure.SourceSubstituteMacro_SourceNodesQuery" flags="in" index="3JmXsc" />
+      <concept id="1168024337012" name="jetbrains.mps.lang.generator.structure.SourceSubstituteMacro_SourceNodeQuery" flags="in" index="3NFfHV" />
+    </language>
+    <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
+      <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
+        <child id="1199569906740" name="parameter" index="1bW2Oz" />
+        <child id="1199569916463" name="body" index="1bW5cS" />
+      </concept>
+    </language>
+    <language id="990507d3-3527-4c54-bfe9-0ca3c9c6247a" name="com.dslfoundry.plaintextgen">
+      <concept id="5082088080656902716" name="com.dslfoundry.plaintextgen.structure.NewlineMarker" flags="ng" index="2EixSi" />
+      <concept id="1145195647825954804" name="com.dslfoundry.plaintextgen.structure.word" flags="ng" index="356sEF" />
+      <concept id="1145195647825954799" name="com.dslfoundry.plaintextgen.structure.Line" flags="ng" index="356sEK">
+        <child id="5082088080656976323" name="newlineMarker" index="2EinRH" />
+        <child id="1145195647825954802" name="words" index="356sEH" />
+      </concept>
+      <concept id="1145195647825954788" name="com.dslfoundry.plaintextgen.structure.TextgenText" flags="ng" index="356sEV">
+        <property id="5407518469085446424" name="ext" index="3Le9LX" />
+        <child id="1145195647826100986" name="content" index="356KY_" />
+      </concept>
+      <concept id="1145195647826084325" name="com.dslfoundry.plaintextgen.structure.VerticalLines" flags="ng" index="356WMU" />
+      <concept id="7214912913997260680" name="com.dslfoundry.plaintextgen.structure.IVerticalGroup" flags="ng" index="383Yap">
+        <child id="7214912913997260696" name="lines" index="383Ya9" />
+      </concept>
+    </language>
+    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
+        <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
+      </concept>
+      <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
+      <concept id="1883223317721008708" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfStatement" flags="nn" index="Jncv_">
+        <reference id="1883223317721008712" name="nodeConcept" index="JncvD" />
+        <child id="1883223317721008709" name="body" index="Jncv$" />
+        <child id="1883223317721008711" name="variable" index="JncvA" />
+        <child id="1883223317721008710" name="nodeExpression" index="JncvB" />
+      </concept>
+      <concept id="1883223317721008713" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfVariable" flags="ng" index="JncvC" />
+      <concept id="1171323947159" name="jetbrains.mps.lang.smodel.structure.Model_NodesOperation" flags="nn" index="2SmgA7">
+        <child id="1758937410080001570" name="conceptArgument" index="1dBWTz" />
+      </concept>
+      <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
+        <reference id="1138056395725" name="property" index="3TsBF5" />
+      </concept>
+      <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="nn" index="3TrEf2">
+        <reference id="1138056516764" name="link" index="3Tt5mk" />
+      </concept>
+      <concept id="1138056282393" name="jetbrains.mps.lang.smodel.structure.SLinkListAccess" flags="nn" index="3Tsc0h">
+        <reference id="1138056546658" name="link" index="3TtcxE" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="3364660638048049750" name="jetbrains.mps.lang.core.structure.PropertyAttribute" flags="ng" index="A9Btg">
+        <property id="1757699476691236117" name="name_DebugInfo" index="2qtEX9" />
+        <property id="1341860900487648621" name="propertyId" index="P4ACc" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+    <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
+        <child id="1204796294226" name="closure" index="23t8la" />
+      </concept>
+      <concept id="1204980550705" name="jetbrains.mps.baseLanguage.collections.structure.VisitAllOperation" flags="nn" index="2es0OD" />
+      <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
+      <concept id="1240687580870" name="jetbrains.mps.baseLanguage.collections.structure.JoinOperation" flags="nn" index="3uJxvA">
+        <child id="1240687658305" name="delimiter" index="3uJOhx" />
+      </concept>
+      <concept id="1202128969694" name="jetbrains.mps.baseLanguage.collections.structure.SelectOperation" flags="nn" index="3$u5V9" />
+    </language>
+  </registry>
+  <node concept="bUwia" id="1$KnWE8iTwN">
+    <property role="TrG5h" value="main" />
+    <node concept="3aamgX" id="1$KnWE8j079" role="3acgRq">
+      <property role="36QftV" value="true" />
+      <ref role="30HIoZ" to="b7vt:Po4Z58Iad0" resolve="IReleaseHeader" />
+      <node concept="j$656" id="1$KnWE8j07h" role="1lVwrX">
+        <ref role="v9R2y" node="1$KnWE8j07f" resolve="reduce_VersionDateReleaseHeader" />
+      </node>
+    </node>
+    <node concept="3aamgX" id="1$KnWE8j2hb" role="3acgRq">
+      <property role="36QftV" value="true" />
+      <ref role="30HIoZ" to="b7vt:Po4Z58tnOo" resolve="Release" />
+      <node concept="j$656" id="1$KnWE8j2hj" role="1lVwrX">
+        <ref role="v9R2y" node="1$KnWE8j2hh" resolve="reduce_Release" />
+      </node>
+    </node>
+    <node concept="3aamgX" id="1$KnWE8j2zz" role="3acgRq">
+      <property role="36QftV" value="true" />
+      <ref role="30HIoZ" to="b7vt:Po4Z58tBpZ" resolve="ChangeSection" />
+      <node concept="j$656" id="1$KnWE8j2zH" role="1lVwrX">
+        <ref role="v9R2y" node="1$KnWE8j2zF" resolve="reduce_ChangeSection" />
+      </node>
+    </node>
+    <node concept="3lhOvk" id="1$KnWE8iTwO" role="3lj3bC">
+      <ref role="30HIoZ" to="b7vt:Po4Z58t1Zc" resolve="Changelog" />
+      <ref role="3lhOvi" node="1$KnWE8iTBq" resolve="map_Changelog" />
+    </node>
+    <node concept="1puMqW" id="1$KnWE8jinB" role="1puA0r">
+      <ref role="1puQsG" node="1$KnWE8jins" resolve="preprocessWords" />
+    </node>
+  </node>
+  <node concept="356sEV" id="1$KnWE8iTBq">
+    <property role="TrG5h" value="map_Changelog" />
+    <property role="3Le9LX" value=".md" />
+    <node concept="356WMU" id="1$KnWE8iTBr" role="356KY_">
+      <node concept="356sEK" id="1$KnWE8p3SJ" role="383Ya9">
+        <node concept="356sEF" id="1$KnWE8p4f1" role="356sEH">
+          <property role="TrG5h" value="# " />
+        </node>
+        <node concept="356sEF" id="1$KnWE8p3SK" role="356sEH">
+          <property role="TrG5h" value="Changelog" />
+          <node concept="17Uvod" id="1$KnWE8p4jK" role="lGtFl">
+            <property role="2qtEX9" value="name" />
+            <property role="P4ACc" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c/1169194658468/1169194664001" />
+            <node concept="3zFVjK" id="1$KnWE8p4jN" role="3zH0cK">
+              <node concept="3clFbS" id="1$KnWE8p4jO" role="2VODD2">
+                <node concept="3clFbF" id="1$KnWE8p4jU" role="3cqZAp">
+                  <node concept="2OqwBi" id="1$KnWE8p4jP" role="3clFbG">
+                    <node concept="3TrcHB" id="1$KnWE8p4jS" role="2OqNvi">
+                      <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                    </node>
+                    <node concept="30H73N" id="1$KnWE8p4jT" role="2Oq$k0" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2EixSi" id="1$KnWE8p3SL" role="2EinRH" />
+      </node>
+      <node concept="356sEK" id="1$KnWE8pIrs" role="383Ya9">
+        <node concept="2EixSi" id="1$KnWE8pIru" role="2EinRH" />
+      </node>
+      <node concept="356sEK" id="1$KnWE8iUk4" role="383Ya9">
+        <node concept="356sEF" id="1$KnWE8lp7B" role="356sEH">
+          <property role="TrG5h" value="header" />
+          <node concept="17Uvod" id="1$KnWE8lp7D" role="lGtFl">
+            <property role="2qtEX9" value="name" />
+            <property role="P4ACc" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c/1169194658468/1169194664001" />
+            <node concept="3zFVjK" id="1$KnWE8lp7E" role="3zH0cK">
+              <node concept="3clFbS" id="1$KnWE8lp7F" role="2VODD2">
+                <node concept="3clFbF" id="1$KnWE8lpcm" role="3cqZAp">
+                  <node concept="2OqwBi" id="1$KnWE8luq0" role="3clFbG">
+                    <node concept="2OqwBi" id="1$KnWE8lrXR" role="2Oq$k0">
+                      <node concept="2OqwBi" id="1$KnWE8lqhl" role="2Oq$k0">
+                        <node concept="2OqwBi" id="1$KnWE8lppA" role="2Oq$k0">
+                          <node concept="30H73N" id="1$KnWE8lpcl" role="2Oq$k0" />
+                          <node concept="3TrEf2" id="1$KnWE8lp$_" role="2OqNvi">
+                            <ref role="3Tt5mk" to="b7vt:Po4Z58tmyF" resolve="header" />
+                          </node>
+                        </node>
+                        <node concept="2qgKlT" id="1$KnWE8lqyb" role="2OqNvi">
+                          <ref role="37wK5l" to="vdrq:6GJhO0n1Xys" resolve="getLines" />
+                        </node>
+                      </node>
+                      <node concept="3$u5V9" id="1$KnWE8lts2" role="2OqNvi">
+                        <node concept="1bVj0M" id="1$KnWE8lts4" role="23t8la">
+                          <node concept="3clFbS" id="1$KnWE8lts5" role="1bW5cS">
+                            <node concept="3clFbF" id="1$KnWE8ltsf" role="3cqZAp">
+                              <node concept="2OqwBi" id="1$KnWE8ltIt" role="3clFbG">
+                                <node concept="37vLTw" id="1$KnWE8ltse" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="1$KnWE8lts6" resolve="it" />
+                                </node>
+                                <node concept="2qgKlT" id="1$KnWE8lu7i" role="2OqNvi">
+                                  <ref role="37wK5l" to="vdrq:2iG$EWuTXv2" resolve="representAsText" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="Rh6nW" id="1$KnWE8lts6" role="1bW2Oz">
+                            <property role="TrG5h" value="it" />
+                            <node concept="2jxLKc" id="1$KnWE8lts7" role="1tU5fm" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3uJxvA" id="1$KnWE8lv9L" role="2OqNvi">
+                      <node concept="Xl_RD" id="1$KnWE8lvQw" role="3uJOhx">
+                        <property role="Xl_RC" value="\n" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2EixSi" id="1$KnWE8iUk6" role="2EinRH" />
+      </node>
+      <node concept="356sEK" id="1$KnWE8pIMs" role="383Ya9">
+        <node concept="2EixSi" id="1$KnWE8pIMu" role="2EinRH" />
+      </node>
+      <node concept="356WMU" id="1$KnWE8iUp9" role="383Ya9">
+        <node concept="2b32R4" id="1$KnWE8iUpZ" role="lGtFl">
+          <node concept="3JmXsc" id="1$KnWE8iUq2" role="2P8S$">
+            <node concept="3clFbS" id="1$KnWE8iUq3" role="2VODD2">
+              <node concept="3clFbF" id="1$KnWE8iUq9" role="3cqZAp">
+                <node concept="2OqwBi" id="1$KnWE8iUq4" role="3clFbG">
+                  <node concept="3Tsc0h" id="1$KnWE8iUq7" role="2OqNvi">
+                    <ref role="3TtcxE" to="b7vt:Po4Z58tnOp" resolve="releases" />
+                  </node>
+                  <node concept="30H73N" id="1$KnWE8iUq8" role="2Oq$k0" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="n94m4" id="1$KnWE8iTBs" role="lGtFl">
+      <ref role="n9lRv" to="b7vt:Po4Z58t1Zc" resolve="Changelog" />
+    </node>
+    <node concept="17Uvod" id="1$KnWE8iTBu" role="lGtFl">
+      <property role="2qtEX9" value="name" />
+      <property role="P4ACc" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c/1169194658468/1169194664001" />
+      <node concept="3zFVjK" id="1$KnWE8iTBv" role="3zH0cK">
+        <node concept="3clFbS" id="1$KnWE8iTBw" role="2VODD2">
+          <node concept="3clFbF" id="1$KnWE8iTGc" role="3cqZAp">
+            <node concept="2OqwBi" id="1$KnWE8iTTs" role="3clFbG">
+              <node concept="30H73N" id="1$KnWE8iTGb" role="2Oq$k0" />
+              <node concept="3TrcHB" id="1$KnWE8iU8I" role="2OqNvi">
+                <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="17Uvod" id="1$KnWE8p6ma" role="lGtFl">
+      <property role="2qtEX9" value="ext" />
+      <property role="P4ACc" value="990507d3-3527-4c54-bfe9-0ca3c9c6247a/1145195647825954788/5407518469085446424" />
+      <node concept="3zFVjK" id="1$KnWE8p6md" role="3zH0cK">
+        <node concept="3clFbS" id="1$KnWE8p6me" role="2VODD2">
+          <node concept="3clFbF" id="1$KnWE8p6mk" role="3cqZAp">
+            <node concept="3cpWs3" id="1$KnWE8p6t3" role="3clFbG">
+              <node concept="Xl_RD" id="1$KnWE8p6tf" role="3uHU7B">
+                <property role="Xl_RC" value="." />
+              </node>
+              <node concept="2OqwBi" id="1$KnWE8p6mf" role="3uHU7w">
+                <node concept="3TrcHB" id="1$KnWE8p6mi" role="2OqNvi">
+                  <ref role="3TsBF5" to="b7vt:1$KnWE8p4rA" resolve="ext" />
+                </node>
+                <node concept="30H73N" id="1$KnWE8p6mj" role="2Oq$k0" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="13MO4I" id="1$KnWE8j07f">
+    <property role="TrG5h" value="reduce_ReleaseHeader" />
+    <ref role="3gUMe" to="b7vt:Po4Z58Iad0" resolve="IReleaseHeader" />
+    <node concept="356sEK" id="1$KnWE8j1H8" role="13RCb5">
+      <node concept="356sEK" id="1$KnWE8j1H9" role="356sEH">
+        <node concept="2EixSi" id="1$KnWE8j1Ha" role="2EinRH" />
+        <node concept="356sEF" id="1$KnWE8j1Hb" role="356sEH">
+          <property role="TrG5h" value="## " />
+        </node>
+        <node concept="356sEF" id="1$KnWE8j1Hc" role="356sEH">
+          <property role="TrG5h" value="text" />
+          <node concept="17Uvod" id="1$KnWE8j1Hd" role="lGtFl">
+            <property role="2qtEX9" value="name" />
+            <property role="P4ACc" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c/1169194658468/1169194664001" />
+            <node concept="3zFVjK" id="1$KnWE8j1He" role="3zH0cK">
+              <node concept="3clFbS" id="1$KnWE8j1Hf" role="2VODD2">
+                <node concept="3clFbF" id="1$KnWE8j1Hg" role="3cqZAp">
+                  <node concept="2OqwBi" id="1$KnWE8j1Hh" role="3clFbG">
+                    <node concept="3TrcHB" id="1$KnWE8j1Hi" role="2OqNvi">
+                      <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                    </node>
+                    <node concept="30H73N" id="1$KnWE8j1Hj" role="2Oq$k0" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2EixSi" id="1$KnWE8j1Hk" role="2EinRH" />
+      <node concept="raruj" id="1$KnWE8j1Hl" role="lGtFl" />
+    </node>
+  </node>
+  <node concept="13MO4I" id="1$KnWE8j2hh">
+    <property role="TrG5h" value="reduce_Release" />
+    <ref role="3gUMe" to="b7vt:Po4Z58tnOo" resolve="Release" />
+    <node concept="356WMU" id="1$KnWE8j2hm" role="13RCb5">
+      <node concept="356sEK" id="1$KnWE8j2ho" role="383Ya9">
+        <node concept="356sEF" id="1$KnWE8j2hp" role="356sEH">
+          <property role="TrG5h" value="header" />
+          <node concept="29HgVG" id="1$KnWE8j2hw" role="lGtFl">
+            <node concept="3NFfHV" id="1$KnWE8j2hx" role="3NFExx">
+              <node concept="3clFbS" id="1$KnWE8j2hy" role="2VODD2">
+                <node concept="3clFbF" id="1$KnWE8j2hC" role="3cqZAp">
+                  <node concept="2OqwBi" id="1$KnWE8j2hz" role="3clFbG">
+                    <node concept="3TrEf2" id="1$KnWE8j2hA" role="2OqNvi">
+                      <ref role="3Tt5mk" to="b7vt:Po4Z58trdf" resolve="header" />
+                    </node>
+                    <node concept="30H73N" id="1$KnWE8j2hB" role="2Oq$k0" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2EixSi" id="1$KnWE8j2hq" role="2EinRH" />
+      </node>
+      <node concept="356sEK" id="1$KnWE8mFXG" role="383Ya9">
+        <node concept="2EixSi" id="1$KnWE8mFXI" role="2EinRH" />
+      </node>
+      <node concept="356WMU" id="1$KnWE8j2rg" role="383Ya9">
+        <node concept="356sEK" id="1$KnWE8j2qt" role="383Ya9">
+          <node concept="356sEF" id="1$KnWE8j2qu" role="356sEH" />
+          <node concept="2EixSi" id="1$KnWE8j2qv" role="2EinRH" />
+        </node>
+        <node concept="2b32R4" id="1$KnWE8j2vJ" role="lGtFl">
+          <node concept="3JmXsc" id="1$KnWE8j2vM" role="2P8S$">
+            <node concept="3clFbS" id="1$KnWE8j2vN" role="2VODD2">
+              <node concept="3clFbF" id="1$KnWE8j2vT" role="3cqZAp">
+                <node concept="2OqwBi" id="1$KnWE8j2vO" role="3clFbG">
+                  <node concept="3Tsc0h" id="1$KnWE8j2vR" role="2OqNvi">
+                    <ref role="3TtcxE" to="b7vt:Po4Z58tBq0" resolve="sections" />
+                  </node>
+                  <node concept="30H73N" id="1$KnWE8j2vS" role="2Oq$k0" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="raruj" id="1$KnWE8j2m8" role="lGtFl" />
+    </node>
+  </node>
+  <node concept="13MO4I" id="1$KnWE8j2zF">
+    <property role="TrG5h" value="reduce_ChangeSection" />
+    <ref role="3gUMe" to="b7vt:Po4Z58tBpZ" resolve="ChangeSection" />
+    <node concept="356WMU" id="1$KnWE8j2zK" role="13RCb5">
+      <node concept="356sEK" id="1$KnWE8j2Ah" role="383Ya9">
+        <node concept="356sEF" id="1$KnWE8j2Ai" role="356sEH">
+          <property role="TrG5h" value="### " />
+        </node>
+        <node concept="356sEF" id="1$KnWE8j2An" role="356sEH">
+          <property role="TrG5h" value="changeType" />
+          <node concept="17Uvod" id="1$KnWE8j2Ar" role="lGtFl">
+            <property role="2qtEX9" value="name" />
+            <property role="P4ACc" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c/1169194658468/1169194664001" />
+            <node concept="3zFVjK" id="1$KnWE8j2Au" role="3zH0cK">
+              <node concept="3clFbS" id="1$KnWE8j2Av" role="2VODD2">
+                <node concept="3clFbF" id="1$KnWE8j2A_" role="3cqZAp">
+                  <node concept="2OqwBi" id="1$KnWE8j3UA" role="3clFbG">
+                    <node concept="2OqwBi" id="1$KnWE8j2Aw" role="2Oq$k0">
+                      <node concept="30H73N" id="1$KnWE8j2A$" role="2Oq$k0" />
+                      <node concept="3TrcHB" id="1$KnWE8j3Ad" role="2OqNvi">
+                        <ref role="3TsBF5" to="b7vt:Po4Z58tBqz" resolve="type" />
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="1$KnWE8j48k" role="2OqNvi">
+                      <ref role="37wK5l" to="c17a:~SEnumerationLiteral.getPresentation()" resolve="getPresentation" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2EixSi" id="1$KnWE8j2Aj" role="2EinRH" />
+      </node>
+      <node concept="356sEK" id="1$KnWE8j4tN" role="383Ya9">
+        <node concept="2EixSi" id="1$KnWE8j4tP" role="2EinRH" />
+      </node>
+      <node concept="356sEK" id="1$KnWE8j5ld" role="383Ya9">
+        <node concept="356sEF" id="1$KnWE8j5le" role="356sEH">
+          <property role="TrG5h" value="changes" />
+          <node concept="17Uvod" id="1$KnWE8j5m_" role="lGtFl">
+            <property role="2qtEX9" value="name" />
+            <property role="P4ACc" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c/1169194658468/1169194664001" />
+            <node concept="3zFVjK" id="1$KnWE8j5mA" role="3zH0cK">
+              <node concept="3clFbS" id="1$KnWE8j5mB" role="2VODD2">
+                <node concept="3clFbF" id="1$KnWE8j5mZ" role="3cqZAp">
+                  <node concept="2OqwBi" id="1$KnWE8jgZ0" role="3clFbG">
+                    <node concept="2OqwBi" id="1$KnWE8j78v" role="2Oq$k0">
+                      <node concept="2OqwBi" id="1$KnWE8j5zp" role="2Oq$k0">
+                        <node concept="30H73N" id="1$KnWE8j5mY" role="2Oq$k0" />
+                        <node concept="3Tsc0h" id="1$KnWE8j5KI" role="2OqNvi">
+                          <ref role="3TtcxE" to="b7vt:Po4Z58tBq_" resolve="changes" />
+                        </node>
+                      </node>
+                      <node concept="3$u5V9" id="1$KnWE8j8wN" role="2OqNvi">
+                        <node concept="1bVj0M" id="1$KnWE8j8wP" role="23t8la">
+                          <node concept="3clFbS" id="1$KnWE8j8wQ" role="1bW5cS">
+                            <node concept="3cpWs8" id="1$KnWE8jbN_" role="3cqZAp">
+                              <node concept="3cpWsn" id="1$KnWE8jbNA" role="3cpWs9">
+                                <property role="TrG5h" value="text" />
+                                <node concept="17QB3L" id="1$KnWE8jbG3" role="1tU5fm" />
+                                <node concept="2OqwBi" id="1$KnWE8jbNB" role="33vP2m">
+                                  <node concept="37vLTw" id="1$KnWE8jbNC" role="2Oq$k0">
+                                    <ref role="3cqZAo" node="1$KnWE8j8wR" resolve="it" />
+                                  </node>
+                                  <node concept="2qgKlT" id="1$KnWE8jbND" role="2OqNvi">
+                                    <ref role="37wK5l" to="vdrq:2iG$EWuTXv2" resolve="representAsText" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="Jncv_" id="1$KnWE8jc$M" role="3cqZAp">
+                              <ref role="JncvD" to="zqge:WJz9iAWEzU" resolve="BulletLine" />
+                              <node concept="37vLTw" id="1$KnWE8jcMD" role="JncvB">
+                                <ref role="3cqZAo" node="1$KnWE8j8wR" resolve="it" />
+                              </node>
+                              <node concept="3clFbS" id="1$KnWE8jc$Q" role="Jncv$">
+                                <node concept="3clFbF" id="1$KnWE8jfN_" role="3cqZAp">
+                                  <node concept="37vLTI" id="1$KnWE8jgho" role="3clFbG">
+                                    <node concept="37vLTw" id="1$KnWE8jfN$" role="37vLTJ">
+                                      <ref role="3cqZAo" node="1$KnWE8jbNA" resolve="text" />
+                                    </node>
+                                    <node concept="2OqwBi" id="1$KnWE8jdUU" role="37vLTx">
+                                      <node concept="37vLTw" id="1$KnWE8jdpE" role="2Oq$k0">
+                                        <ref role="3cqZAo" node="1$KnWE8jbNA" resolve="text" />
+                                      </node>
+                                      <node concept="liA8E" id="1$KnWE8jedl" role="2OqNvi">
+                                        <ref role="37wK5l" to="wyt6:~String.replaceFirst(java.lang.String,java.lang.String)" resolve="replaceFirst" />
+                                        <node concept="Xl_RD" id="1$KnWE8jedp" role="37wK5m">
+                                          <property role="Xl_RC" value="\\*" />
+                                        </node>
+                                        <node concept="Xl_RD" id="1$KnWE8jeWp" role="37wK5m">
+                                          <property role="Xl_RC" value="-" />
+                                        </node>
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                              <node concept="JncvC" id="1$KnWE8jc$S" role="JncvA">
+                                <property role="TrG5h" value="bulletLine" />
+                                <node concept="2jxLKc" id="1$KnWE8jc$T" role="1tU5fm" />
+                              </node>
+                            </node>
+                            <node concept="3clFbF" id="1$KnWE8jb1F" role="3cqZAp">
+                              <node concept="37vLTw" id="1$KnWE8jbNE" role="3clFbG">
+                                <ref role="3cqZAo" node="1$KnWE8jbNA" resolve="text" />
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="Rh6nW" id="1$KnWE8j8wR" role="1bW2Oz">
+                            <property role="TrG5h" value="it" />
+                            <node concept="2jxLKc" id="1$KnWE8j8wS" role="1tU5fm" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3uJxvA" id="1$KnWE8jhuv" role="2OqNvi">
+                      <node concept="Xl_RD" id="1$KnWE8ji3l" role="3uJOhx">
+                        <property role="Xl_RC" value="\n" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2EixSi" id="1$KnWE8j5lf" role="2EinRH" />
+      </node>
+      <node concept="356sEK" id="1$KnWE8otIa" role="383Ya9">
+        <node concept="2EixSi" id="1$KnWE8otIc" role="2EinRH" />
+      </node>
+      <node concept="raruj" id="1$KnWE8j4i4" role="lGtFl" />
+    </node>
+  </node>
+  <node concept="1pmfR0" id="1$KnWE8jins">
+    <property role="TrG5h" value="preprocessWords" />
+    <property role="1v3f2W" value="hpv1Zf2/pre_processing" />
+    <property role="1v3jST" value="true" />
+    <node concept="1pplIY" id="1$KnWE8jint" role="1pqMTA">
+      <node concept="3clFbS" id="1$KnWE8jinu" role="2VODD2">
+        <node concept="3clFbF" id="1$KnWE8jinE" role="3cqZAp">
+          <node concept="2OqwBi" id="1$KnWE8jkhb" role="3clFbG">
+            <node concept="2OqwBi" id="1$KnWE8jiuK" role="2Oq$k0">
+              <node concept="1Q6Npb" id="1$KnWE8jinD" role="2Oq$k0" />
+              <node concept="2SmgA7" id="1$KnWE8jizR" role="2OqNvi">
+                <node concept="chp4Y" id="1$KnWE8jiEi" role="1dBWTz">
+                  <ref role="cht4Q" to="zqge:8D0iRqSPW4" resolve="Word" />
+                </node>
+              </node>
+            </node>
+            <node concept="2es0OD" id="1$KnWE8jlN2" role="2OqNvi">
+              <node concept="1bVj0M" id="1$KnWE8jlN4" role="23t8la">
+                <node concept="3clFbS" id="1$KnWE8jlN5" role="1bW5cS">
+                  <node concept="3clFbJ" id="1$KnWE8jquV" role="3cqZAp">
+                    <node concept="3clFbS" id="1$KnWE8jquX" role="3clFbx">
+                      <node concept="3clFbF" id="1$KnWE8jsUV" role="3cqZAp">
+                        <node concept="37vLTI" id="1$KnWE8jtUE" role="3clFbG">
+                          <node concept="2OqwBi" id="1$KnWE8jt7t" role="37vLTJ">
+                            <node concept="37vLTw" id="1$KnWE8jsUT" role="2Oq$k0">
+                              <ref role="3cqZAo" node="1$KnWE8jlN6" resolve="it" />
+                            </node>
+                            <node concept="3TrcHB" id="1$KnWE8jtfx" role="2OqNvi">
+                              <ref role="3TsBF5" to="zqge:8D0iRqSPW5" resolve="value" />
+                            </node>
+                          </node>
+                          <node concept="2YIFZM" id="1$KnWE8junG" role="37vLTx">
+                            <ref role="1Pybhc" to="wyt6:~String" resolve="String" />
+                            <ref role="37wK5l" to="wyt6:~String.format(java.lang.String,java.lang.Object...)" resolve="format" />
+                            <node concept="Xl_RD" id="1$KnWE8juxH" role="37wK5m">
+                              <property role="Xl_RC" value="[%s](%s)" />
+                            </node>
+                            <node concept="2OqwBi" id="1$KnWE8jvBY" role="37wK5m">
+                              <node concept="37vLTw" id="1$KnWE8jviA" role="2Oq$k0">
+                                <ref role="3cqZAo" node="1$KnWE8jlN6" resolve="it" />
+                              </node>
+                              <node concept="3TrcHB" id="1$KnWE8jw9s" role="2OqNvi">
+                                <ref role="3TsBF5" to="zqge:8D0iRqSPW5" resolve="value" />
+                              </node>
+                            </node>
+                            <node concept="2OqwBi" id="1$KnWE8jwTg" role="37wK5m">
+                              <node concept="37vLTw" id="1$KnWE8jw_b" role="2Oq$k0">
+                                <ref role="3cqZAo" node="1$KnWE8jlN6" resolve="it" />
+                              </node>
+                              <node concept="3TrcHB" id="1$KnWE8jxsz" role="2OqNvi">
+                                <ref role="3TsBF5" to="zqge:5vhYBWEWti5" resolve="url" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2OqwBi" id="1$KnWE8jsr9" role="3clFbw">
+                      <node concept="2OqwBi" id="1$KnWE8jqUS" role="2Oq$k0">
+                        <node concept="37vLTw" id="1$KnWE8jqFe" role="2Oq$k0">
+                          <ref role="3cqZAo" node="1$KnWE8jlN6" resolve="it" />
+                        </node>
+                        <node concept="3TrcHB" id="1$KnWE8jrcm" role="2OqNvi">
+                          <ref role="3TsBF5" to="zqge:5vhYBWEWti5" resolve="url" />
+                        </node>
+                      </node>
+                      <node concept="17RvpY" id="1$KnWE8jsPA" role="2OqNvi" />
+                    </node>
+                  </node>
+                  <node concept="3clFbH" id="1$KnWE8jrBC" role="3cqZAp" />
+                  <node concept="3clFbJ" id="1$KnWE8jm0$" role="3cqZAp">
+                    <node concept="3clFbS" id="1$KnWE8jm0A" role="3clFbx">
+                      <node concept="3clFbF" id="1$KnWE8jmxV" role="3cqZAp">
+                        <node concept="37vLTI" id="1$KnWE8jnuF" role="3clFbG">
+                          <node concept="3cpWs3" id="1$KnWE8joyl" role="37vLTx">
+                            <node concept="Xl_RD" id="1$KnWE8joyo" role="3uHU7w">
+                              <property role="Xl_RC" value="**" />
+                            </node>
+                            <node concept="3cpWs3" id="1$KnWE8jnAE" role="3uHU7B">
+                              <node concept="Xl_RD" id="1$KnWE8jnxo" role="3uHU7B">
+                                <property role="Xl_RC" value="**" />
+                              </node>
+                              <node concept="2OqwBi" id="1$KnWE8jnPF" role="3uHU7w">
+                                <node concept="37vLTw" id="1$KnWE8jnAL" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="1$KnWE8jlN6" resolve="it" />
+                                </node>
+                                <node concept="3TrcHB" id="1$KnWE8jo6H" role="2OqNvi">
+                                  <ref role="3TsBF5" to="zqge:8D0iRqSPW5" resolve="value" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="2OqwBi" id="1$KnWE8jmzA" role="37vLTJ">
+                            <node concept="37vLTw" id="1$KnWE8jmxT" role="2Oq$k0">
+                              <ref role="3cqZAo" node="1$KnWE8jlN6" resolve="it" />
+                            </node>
+                            <node concept="3TrcHB" id="1$KnWE8jn5J" role="2OqNvi">
+                              <ref role="3TsBF5" to="zqge:8D0iRqSPW5" resolve="value" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2OqwBi" id="1$KnWE8jmeU" role="3clFbw">
+                      <node concept="37vLTw" id="1$KnWE8jm2R" role="2Oq$k0">
+                        <ref role="3cqZAo" node="1$KnWE8jlN6" resolve="it" />
+                      </node>
+                      <node concept="3TrcHB" id="1$KnWE8jmtx" role="2OqNvi">
+                        <ref role="3TsBF5" to="zqge:5vhYBWEWthY" resolve="bold" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbJ" id="1$KnWE8joPl" role="3cqZAp">
+                    <node concept="3clFbS" id="1$KnWE8joPm" role="3clFbx">
+                      <node concept="3clFbF" id="1$KnWE8joPn" role="3cqZAp">
+                        <node concept="37vLTI" id="1$KnWE8joPo" role="3clFbG">
+                          <node concept="3cpWs3" id="1$KnWE8joPp" role="37vLTx">
+                            <node concept="Xl_RD" id="1$KnWE8joPq" role="3uHU7w">
+                              <property role="Xl_RC" value="*" />
+                            </node>
+                            <node concept="3cpWs3" id="1$KnWE8joPr" role="3uHU7B">
+                              <node concept="Xl_RD" id="1$KnWE8joPs" role="3uHU7B">
+                                <property role="Xl_RC" value="*" />
+                              </node>
+                              <node concept="2OqwBi" id="1$KnWE8joPt" role="3uHU7w">
+                                <node concept="37vLTw" id="1$KnWE8joPu" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="1$KnWE8jlN6" resolve="it" />
+                                </node>
+                                <node concept="3TrcHB" id="1$KnWE8joPv" role="2OqNvi">
+                                  <ref role="3TsBF5" to="zqge:8D0iRqSPW5" resolve="value" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="2OqwBi" id="1$KnWE8joPw" role="37vLTJ">
+                            <node concept="37vLTw" id="1$KnWE8joPx" role="2Oq$k0">
+                              <ref role="3cqZAo" node="1$KnWE8jlN6" resolve="it" />
+                            </node>
+                            <node concept="3TrcHB" id="1$KnWE8joPy" role="2OqNvi">
+                              <ref role="3TsBF5" to="zqge:8D0iRqSPW5" resolve="value" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2OqwBi" id="1$KnWE8joPz" role="3clFbw">
+                      <node concept="37vLTw" id="1$KnWE8joP$" role="2Oq$k0">
+                        <ref role="3cqZAo" node="1$KnWE8jlN6" resolve="it" />
+                      </node>
+                      <node concept="3TrcHB" id="1$KnWE8joP_" role="2OqNvi">
+                        <ref role="3TsBF5" to="zqge:5vhYBWEWti1" resolve="italic" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbJ" id="1$KnWE8jp3p" role="3cqZAp">
+                    <node concept="3clFbS" id="1$KnWE8jp3q" role="3clFbx">
+                      <node concept="3clFbF" id="1$KnWE8jp3r" role="3cqZAp">
+                        <node concept="37vLTI" id="1$KnWE8jp3s" role="3clFbG">
+                          <node concept="3cpWs3" id="1$KnWE8jp3t" role="37vLTx">
+                            <node concept="Xl_RD" id="1$KnWE8jp3u" role="3uHU7w">
+                              <property role="Xl_RC" value="&lt;/u&gt;" />
+                            </node>
+                            <node concept="3cpWs3" id="1$KnWE8jp3v" role="3uHU7B">
+                              <node concept="Xl_RD" id="1$KnWE8jp3w" role="3uHU7B">
+                                <property role="Xl_RC" value="&lt;u&gt;" />
+                              </node>
+                              <node concept="2OqwBi" id="1$KnWE8jp3x" role="3uHU7w">
+                                <node concept="37vLTw" id="1$KnWE8jp3y" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="1$KnWE8jlN6" resolve="it" />
+                                </node>
+                                <node concept="3TrcHB" id="1$KnWE8jp3z" role="2OqNvi">
+                                  <ref role="3TsBF5" to="zqge:8D0iRqSPW5" resolve="value" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="2OqwBi" id="1$KnWE8jp3$" role="37vLTJ">
+                            <node concept="37vLTw" id="1$KnWE8jp3_" role="2Oq$k0">
+                              <ref role="3cqZAo" node="1$KnWE8jlN6" resolve="it" />
+                            </node>
+                            <node concept="3TrcHB" id="1$KnWE8jp3A" role="2OqNvi">
+                              <ref role="3TsBF5" to="zqge:8D0iRqSPW5" resolve="value" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2OqwBi" id="1$KnWE8jp3B" role="3clFbw">
+                      <node concept="37vLTw" id="1$KnWE8jp3C" role="2Oq$k0">
+                        <ref role="3cqZAo" node="1$KnWE8jlN6" resolve="it" />
+                      </node>
+                      <node concept="3TrcHB" id="1$KnWE8jp3D" role="2OqNvi">
+                        <ref role="3TsBF5" to="zqge:5vhYBWEWtik" resolve="underlined" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbH" id="1$KnWE8jxBp" role="3cqZAp" />
+                  <node concept="3clFbF" id="1$KnWE8jxQE" role="3cqZAp">
+                    <node concept="37vLTI" id="1$KnWE8jzJV" role="3clFbG">
+                      <node concept="2OqwBi" id="1$KnWE8j_qU" role="37vLTx">
+                        <node concept="2OqwBi" id="1$KnWE8j$rq" role="2Oq$k0">
+                          <node concept="37vLTw" id="1$KnWE8jzUA" role="2Oq$k0">
+                            <ref role="3cqZAo" node="1$KnWE8jlN6" resolve="it" />
+                          </node>
+                          <node concept="3TrcHB" id="1$KnWE8j$$R" role="2OqNvi">
+                            <ref role="3TsBF5" to="zqge:8D0iRqSPW5" resolve="value" />
+                          </node>
+                        </node>
+                        <node concept="liA8E" id="1$KnWE8j_PQ" role="2OqNvi">
+                          <ref role="37wK5l" to="wyt6:~String.replaceAll(java.lang.String,java.lang.String)" resolve="replaceAll" />
+                          <node concept="Xl_RD" id="1$KnWE8j_Xq" role="37wK5m">
+                            <property role="Xl_RC" value=" " />
+                          </node>
+                          <node concept="Xl_RD" id="1$KnWE8jAb8" role="37wK5m">
+                            <property role="Xl_RC" value=" " />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="2OqwBi" id="1$KnWE8jyaN" role="37vLTJ">
+                        <node concept="37vLTw" id="1$KnWE8jxQC" role="2Oq$k0">
+                          <ref role="3cqZAo" node="1$KnWE8jlN6" resolve="it" />
+                        </node>
+                        <node concept="3TrcHB" id="1$KnWE8jy_W" role="2OqNvi">
+                          <ref role="3TsBF5" to="zqge:8D0iRqSPW5" resolve="value" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="Rh6nW" id="1$KnWE8jlN6" role="1bW2Oz">
+                  <property role="TrG5h" value="it" />
+                  <node concept="2jxLKc" id="1$KnWE8jlN7" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/code/changelog/de.itemis.mps.changelog/models/de.itemis.mps.changelog.behavior.mps
+++ b/code/changelog/de.itemis.mps.changelog/models/de.itemis.mps.changelog.behavior.mps
@@ -20,6 +20,7 @@
     <import index="vdrq" ref="r:85354f47-14fd-40e6-a7cc-2d1aa842c4cd(jetbrains.mps.lang.text.behavior)" implicit="true" />
     <import index="tp25" ref="r:00000000-0000-4000-0000-011c89590301(jetbrains.mps.lang.smodel.structure)" implicit="true" />
     <import index="xlb7" ref="r:cf42fd0a-68d2-493b-8b77-961658617704(jetbrains.mps.lang.modelapi.behavior)" implicit="true" />
+    <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" implicit="true" />
     <import index="wyuk" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.components(MPS.Core/)" implicit="true" />
     <import index="zqge" ref="r:59e90602-6655-4552-86eb-441a42a9a0e4(jetbrains.mps.lang.text.structure)" implicit="true" />
   </imports>
@@ -33,6 +34,8 @@
       </concept>
       <concept id="1225194413805" name="jetbrains.mps.lang.behavior.structure.ConceptConstructorDeclaration" flags="in" index="13hLZK" />
       <concept id="1225194472830" name="jetbrains.mps.lang.behavior.structure.ConceptMethodDeclaration" flags="ng" index="13i0hz">
+        <property id="1225194472832" name="isVirtual" index="13i0it" />
+        <property id="1225194472834" name="isAbstract" index="13i0iv" />
         <reference id="1225194472831" name="overriddenMethod" index="13i0hy" />
       </concept>
       <concept id="1225194628440" name="jetbrains.mps.lang.behavior.structure.SuperNodeExpression" flags="nn" index="13iAh5" />
@@ -66,12 +69,14 @@
       </concept>
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
       <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
+      <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <child id="1068431790190" name="initializer" index="33vP2m" />
       </concept>
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
+      <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
       <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
       <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
       <concept id="1225271369338" name="jetbrains.mps.baseLanguage.structure.IsEmptyOperation" flags="nn" index="17RlXB" />
@@ -80,8 +85,10 @@
       </concept>
       <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
         <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123134" name="parameter" index="3clF46" />
         <child id="1068580123135" name="body" index="3clF47" />
       </concept>
+      <concept id="1068580123152" name="jetbrains.mps.baseLanguage.structure.EqualsExpression" flags="nn" index="3clFbC" />
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
@@ -93,6 +100,9 @@
       </concept>
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
+        <property id="1068580123138" name="value" index="3clFbU" />
       </concept>
       <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
       <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
@@ -107,6 +117,7 @@
         <child id="1206060619838" name="condition" index="3eO9$A" />
         <child id="1206060644605" name="statementList" index="3eOfB_" />
       </concept>
+      <concept id="1081506762703" name="jetbrains.mps.baseLanguage.structure.GreaterThanExpression" flags="nn" index="3eOSWO" />
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
@@ -121,10 +132,14 @@
       <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
+      <concept id="5497648299878491908" name="jetbrains.mps.baseLanguage.structure.BaseVariableReference" flags="nn" index="1M0zk4">
+        <reference id="5497648299878491909" name="baseVariableDeclaration" index="1M0zk5" />
+      </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
       <concept id="1116615150612" name="jetbrains.mps.baseLanguage.structure.ClassifierClassExpression" flags="nn" index="3VsKOn">
         <reference id="1116615189566" name="classifier" index="3VsUkX" />
       </concept>
+      <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
     </language>
     <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
       <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
@@ -162,6 +177,14 @@
         <reference id="4705942098322467736" name="decl" index="21nZrZ" />
       </concept>
       <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
+      <concept id="1883223317721008708" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfStatement" flags="nn" index="Jncv_">
+        <reference id="1883223317721008712" name="nodeConcept" index="JncvD" />
+        <child id="1883223317721008709" name="body" index="Jncv$" />
+        <child id="1883223317721008711" name="variable" index="JncvA" />
+        <child id="1883223317721008710" name="nodeExpression" index="JncvB" />
+      </concept>
+      <concept id="1883223317721008713" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfVariable" flags="ng" index="JncvC" />
+      <concept id="1883223317721107059" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfVarReference" flags="nn" index="Jnkvi" />
       <concept id="1145404486709" name="jetbrains.mps.lang.smodel.structure.SemanticDowncastExpression" flags="nn" index="2JrnkZ">
         <child id="1145404616321" name="leftExpression" index="2JrQYb" />
       </concept>
@@ -226,10 +249,30 @@
   <node concept="13h7C7" id="2r0ijgcUaz7">
     <ref role="13h7C2" to="b7vt:Po4Z58tnPb" resolve="VersionDateReleaseHeader" />
     <node concept="13i0hz" id="2r0ijgcUaDV" role="13h7CS">
-      <property role="TrG5h" value="getDate" />
+      <property role="TrG5h" value="getDateAsString" />
       <node concept="3Tm1VV" id="2r0ijgcUaDW" role="1B3o_S" />
       <node concept="17QB3L" id="2r0ijgcUdzK" role="3clF45" />
       <node concept="3clFbS" id="2r0ijgcUaDY" role="3clF47">
+        <node concept="3cpWs6" id="2r0ijgcUCa4" role="3cqZAp">
+          <node concept="2OqwBi" id="2r0ijgcUDjz" role="3cqZAk">
+            <node concept="liA8E" id="2r0ijgcUDOh" role="2OqNvi">
+              <ref role="37wK5l" to="28m1:~LocalDate.format(java.time.format.DateTimeFormatter)" resolve="format" />
+              <node concept="10M0yZ" id="2r0ijgcUElU" role="37wK5m">
+                <ref role="3cqZAo" to="6t7w:~DateTimeFormatter.ISO_LOCAL_DATE" resolve="ISO_LOCAL_DATE" />
+                <ref role="1PxDUh" to="6t7w:~DateTimeFormatter" resolve="DateTimeFormatter" />
+              </node>
+            </node>
+            <node concept="BsUDl" id="6aVQm8WgqLy" role="2Oq$k0">
+              <ref role="37wK5l" node="6aVQm8WgoJy" resolve="getDate" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="13i0hz" id="6aVQm8WgoJy" role="13h7CS">
+      <property role="TrG5h" value="getDate" />
+      <node concept="3Tm1VV" id="6aVQm8WgoJz" role="1B3o_S" />
+      <node concept="3clFbS" id="6aVQm8WgoJ_" role="3clF47">
         <node concept="3clFbJ" id="43oF0KsRjiv" role="3cqZAp">
           <node concept="3clFbS" id="43oF0KsRjix" role="3clFbx">
             <node concept="3cpWs6" id="43oF0KsRlaT" role="3cqZAp">
@@ -252,8 +295,8 @@
             <property role="TrG5h" value="unixTimeStamp" />
             <node concept="3cpWsb" id="2r0ijgcUAS0" role="1tU5fm" />
             <node concept="2YIFZM" id="2r0ijgcUATa" role="33vP2m">
-              <ref role="37wK5l" to="wyt6:~Long.valueOf(java.lang.String)" resolve="valueOf" />
               <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
+              <ref role="37wK5l" to="wyt6:~Long.valueOf(java.lang.String)" resolve="valueOf" />
               <node concept="2OqwBi" id="2r0ijgcUBcW" role="37wK5m">
                 <node concept="13iPFW" id="2r0ijgcUAVD" role="2Oq$k0" />
                 <node concept="3TrcHB" id="2r0ijgcUBFn" role="2OqNvi">
@@ -270,47 +313,30 @@
               <ref role="3uigEE" to="28m1:~Instant" resolve="Instant" />
             </node>
             <node concept="2YIFZM" id="2r0ijgcUC2r" role="33vP2m">
-              <ref role="37wK5l" to="28m1:~Instant.ofEpochSecond(long)" resolve="ofEpochSecond" />
               <ref role="1Pybhc" to="28m1:~Instant" resolve="Instant" />
+              <ref role="37wK5l" to="28m1:~Instant.ofEpochSecond(long)" resolve="ofEpochSecond" />
               <node concept="37vLTw" id="2r0ijgcUC7K" role="37wK5m">
                 <ref role="3cqZAo" node="2r0ijgcUAS4" resolve="unixTimeStamp" />
               </node>
             </node>
           </node>
         </node>
-        <node concept="3cpWs8" id="2r0ijgcUCo1" role="3cqZAp">
-          <node concept="3cpWsn" id="2r0ijgcUCo2" role="3cpWs9">
-            <property role="TrG5h" value="ld" />
-            <node concept="3uibUv" id="2r0ijgcUCo3" role="1tU5fm">
-              <ref role="3uigEE" to="28m1:~LocalDate" resolve="LocalDate" />
+        <node concept="3cpWs6" id="6aVQm8Wgr20" role="3cqZAp">
+          <node concept="2YIFZM" id="2r0ijgcUC_N" role="3cqZAk">
+            <ref role="37wK5l" to="28m1:~LocalDate.ofInstant(java.time.Instant,java.time.ZoneId)" resolve="ofInstant" />
+            <ref role="1Pybhc" to="28m1:~LocalDate" resolve="LocalDate" />
+            <node concept="37vLTw" id="2r0ijgcUCB9" role="37wK5m">
+              <ref role="3cqZAo" node="2r0ijgcUBPt" resolve="instant" />
             </node>
-            <node concept="2YIFZM" id="2r0ijgcUC_N" role="33vP2m">
-              <ref role="37wK5l" to="28m1:~LocalDate.ofInstant(java.time.Instant,java.time.ZoneId)" resolve="ofInstant" />
-              <ref role="1Pybhc" to="28m1:~LocalDate" resolve="LocalDate" />
-              <node concept="37vLTw" id="2r0ijgcUCB9" role="37wK5m">
-                <ref role="3cqZAo" node="2r0ijgcUBPt" resolve="instant" />
-              </node>
-              <node concept="10M0yZ" id="2r0ijgcUCIE" role="37wK5m">
-                <ref role="3cqZAo" to="28m1:~ZoneOffset.UTC" resolve="UTC" />
-                <ref role="1PxDUh" to="28m1:~ZoneOffset" resolve="ZoneOffset" />
-              </node>
+            <node concept="10M0yZ" id="2r0ijgcUCIE" role="37wK5m">
+              <ref role="3cqZAo" to="28m1:~ZoneOffset.UTC" resolve="UTC" />
+              <ref role="1PxDUh" to="28m1:~ZoneOffset" resolve="ZoneOffset" />
             </node>
           </node>
         </node>
-        <node concept="3cpWs6" id="2r0ijgcUCa4" role="3cqZAp">
-          <node concept="2OqwBi" id="2r0ijgcUDjz" role="3cqZAk">
-            <node concept="37vLTw" id="2r0ijgcUCQg" role="2Oq$k0">
-              <ref role="3cqZAo" node="2r0ijgcUCo2" resolve="ld" />
-            </node>
-            <node concept="liA8E" id="2r0ijgcUDOh" role="2OqNvi">
-              <ref role="37wK5l" to="28m1:~LocalDate.format(java.time.format.DateTimeFormatter)" resolve="format" />
-              <node concept="10M0yZ" id="2r0ijgcUElU" role="37wK5m">
-                <ref role="3cqZAo" to="6t7w:~DateTimeFormatter.ISO_LOCAL_DATE" resolve="ISO_LOCAL_DATE" />
-                <ref role="1PxDUh" to="6t7w:~DateTimeFormatter" resolve="DateTimeFormatter" />
-              </node>
-            </node>
-          </node>
-        </node>
+      </node>
+      <node concept="3uibUv" id="6aVQm8WgqtB" role="3clF45">
+        <ref role="3uigEE" to="28m1:~LocalDate" resolve="LocalDate" />
       </node>
     </node>
     <node concept="13hLZK" id="2r0ijgcUaz8" role="13h7CW">
@@ -333,6 +359,54 @@
           </node>
         </node>
       </node>
+    </node>
+    <node concept="13i0hz" id="6aVQm8Wgor_" role="13h7CS">
+      <property role="TrG5h" value="isAfter" />
+      <ref role="13i0hy" node="6aVQm8Wg3U3" resolve="isBefore" />
+      <node concept="3Tm1VV" id="6aVQm8WgorA" role="1B3o_S" />
+      <node concept="3clFbS" id="6aVQm8WgorF" role="3clF47">
+        <node concept="Jncv_" id="6aVQm8Wgrj1" role="3cqZAp">
+          <ref role="JncvD" to="b7vt:Po4Z58tnPb" resolve="VersionDateReleaseHeader" />
+          <node concept="37vLTw" id="6aVQm8WgrjH" role="JncvB">
+            <ref role="3cqZAo" node="6aVQm8WgorG" resolve="header" />
+          </node>
+          <node concept="3clFbS" id="6aVQm8Wgrj5" role="Jncv$">
+            <node concept="3cpWs6" id="6aVQm8WgrlF" role="3cqZAp">
+              <node concept="2OqwBi" id="6aVQm8WgrRL" role="3cqZAk">
+                <node concept="BsUDl" id="6aVQm8Wgrmv" role="2Oq$k0">
+                  <ref role="37wK5l" node="6aVQm8WgoJy" resolve="getDate" />
+                </node>
+                <node concept="liA8E" id="6aVQm8Wgsjn" role="2OqNvi">
+                  <ref role="37wK5l" to="28m1:~LocalDate.isAfter(java.time.chrono.ChronoLocalDate)" resolve="isAfter" />
+                  <node concept="2OqwBi" id="6aVQm8Wgw74" role="37wK5m">
+                    <node concept="Jnkvi" id="6aVQm8Wgskm" role="2Oq$k0">
+                      <ref role="1M0zk5" node="6aVQm8Wgrj7" resolve="otherHeader" />
+                    </node>
+                    <node concept="2qgKlT" id="6aVQm8WgwzC" role="2OqNvi">
+                      <ref role="37wK5l" node="6aVQm8WgoJy" resolve="getDate" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="JncvC" id="6aVQm8Wgrj7" role="JncvA">
+            <property role="TrG5h" value="otherHeader" />
+            <node concept="2jxLKc" id="6aVQm8Wgrj8" role="1tU5fm" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="6aVQm8WgriG" role="3cqZAp" />
+        <node concept="3clFbF" id="6aVQm8Wgrgy" role="3cqZAp">
+          <node concept="3clFbT" id="6aVQm8Wgrgx" role="3clFbG" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="6aVQm8WgorG" role="3clF46">
+        <property role="TrG5h" value="header" />
+        <node concept="3Tqbb2" id="6aVQm8WgorH" role="1tU5fm">
+          <ref role="ehGHo" to="b7vt:Po4Z58Iad0" resolve="IReleaseHeader" />
+        </node>
+      </node>
+      <node concept="10P_77" id="6aVQm8WgorI" role="3clF45" />
     </node>
   </node>
   <node concept="13h7C7" id="2r0ijgcUr49">
@@ -507,6 +581,107 @@
           </node>
         </node>
       </node>
+    </node>
+    <node concept="13i0hz" id="6aVQm8Wge9B" role="13h7CS">
+      <property role="TrG5h" value="isAfter" />
+      <ref role="13i0hy" node="6aVQm8Wg3U3" resolve="isBefore" />
+      <node concept="3Tm1VV" id="6aVQm8Wge9C" role="1B3o_S" />
+      <node concept="3clFbS" id="6aVQm8Wge9H" role="3clF47">
+        <node concept="Jncv_" id="6aVQm8Wgf58" role="3cqZAp">
+          <ref role="JncvD" to="b7vt:Po4Z58IgAd" resolve="MonthYearReleaseHeader" />
+          <node concept="37vLTw" id="6aVQm8Wgf5O" role="JncvB">
+            <ref role="3cqZAo" node="6aVQm8Wge9I" resolve="header" />
+          </node>
+          <node concept="3clFbS" id="6aVQm8Wgf5c" role="Jncv$">
+            <node concept="3clFbJ" id="6aVQm8Wi4Lw" role="3cqZAp">
+              <node concept="3clFbS" id="6aVQm8Wi4Ly" role="3clFbx">
+                <node concept="3cpWs6" id="6aVQm8Wi7ys" role="3cqZAp">
+                  <node concept="3clFbT" id="6aVQm8Wi7y_" role="3cqZAk">
+                    <property role="3clFbU" value="true" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3eOSWO" id="6aVQm8Wi6uN" role="3clFbw">
+                <node concept="2OqwBi" id="6aVQm8Wi7ao" role="3uHU7w">
+                  <node concept="Jnkvi" id="6aVQm8Wi6Dj" role="2Oq$k0">
+                    <ref role="1M0zk5" node="6aVQm8Wgf5e" resolve="otherHeader" />
+                  </node>
+                  <node concept="3TrcHB" id="6aVQm8Wi7vB" role="2OqNvi">
+                    <ref role="3TsBF5" to="b7vt:Po4Z58IgAh" resolve="year" />
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="6aVQm8Wi5fI" role="3uHU7B">
+                  <node concept="13iPFW" id="6aVQm8Wi4Wx" role="2Oq$k0" />
+                  <node concept="3TrcHB" id="6aVQm8Wi5An" role="2OqNvi">
+                    <ref role="3TsBF5" to="b7vt:Po4Z58IgAh" resolve="year" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs6" id="6aVQm8WggpY" role="3cqZAp">
+              <node concept="1Wc70l" id="6aVQm8WgjyH" role="3cqZAk">
+                <node concept="3eOSWO" id="6aVQm8Wgx0k" role="3uHU7w">
+                  <node concept="2OqwBi" id="6aVQm8Wgm2D" role="3uHU7B">
+                    <node concept="2OqwBi" id="6aVQm8WgjQP" role="2Oq$k0">
+                      <node concept="13iPFW" id="6aVQm8Wgj$f" role="2Oq$k0" />
+                      <node concept="3TrcHB" id="6aVQm8WgkcH" role="2OqNvi">
+                        <ref role="3TsBF5" to="b7vt:Po4Z58IgAf" resolve="month" />
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="6aVQm8Wgmjl" role="2OqNvi">
+                      <ref role="37wK5l" to="c17a:~SEnumerationLiteral.getOrdinal()" resolve="getOrdinal" />
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="6aVQm8WgmXg" role="3uHU7w">
+                    <node concept="2OqwBi" id="6aVQm8WgllF" role="2Oq$k0">
+                      <node concept="Jnkvi" id="6aVQm8WgkX_" role="2Oq$k0">
+                        <ref role="1M0zk5" node="6aVQm8Wgf5e" resolve="otherHeader" />
+                      </node>
+                      <node concept="3TrcHB" id="6aVQm8WglFZ" role="2OqNvi">
+                        <ref role="3TsBF5" to="b7vt:Po4Z58IgAf" resolve="month" />
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="6aVQm8Wgney" role="2OqNvi">
+                      <ref role="37wK5l" to="c17a:~SEnumerationLiteral.getOrdinal()" resolve="getOrdinal" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbC" id="6aVQm8Wi7HB" role="3uHU7B">
+                  <node concept="2OqwBi" id="6aVQm8WggAM" role="3uHU7B">
+                    <node concept="13iPFW" id="6aVQm8WggqI" role="2Oq$k0" />
+                    <node concept="3TrcHB" id="6aVQm8Wgh1o" role="2OqNvi">
+                      <ref role="3TsBF5" to="b7vt:Po4Z58IgAh" resolve="year" />
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="6aVQm8WgisJ" role="3uHU7w">
+                    <node concept="Jnkvi" id="6aVQm8WghXn" role="2Oq$k0">
+                      <ref role="1M0zk5" node="6aVQm8Wgf5e" resolve="otherHeader" />
+                    </node>
+                    <node concept="3TrcHB" id="6aVQm8WgiFP" role="2OqNvi">
+                      <ref role="3TsBF5" to="b7vt:Po4Z58IgAh" resolve="year" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="JncvC" id="6aVQm8Wgf5e" role="JncvA">
+            <property role="TrG5h" value="otherHeader" />
+            <node concept="2jxLKc" id="6aVQm8Wgf5f" role="1tU5fm" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="6aVQm8Wgexd" role="3cqZAp" />
+        <node concept="3clFbF" id="6aVQm8Wge9M" role="3cqZAp">
+          <node concept="3clFbT" id="6aVQm8Wge9L" role="3clFbG" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="6aVQm8Wge9I" role="3clF46">
+        <property role="TrG5h" value="header" />
+        <node concept="3Tqbb2" id="6aVQm8Wge9J" role="1tU5fm">
+          <ref role="ehGHo" to="b7vt:Po4Z58Iad0" resolve="IReleaseHeader" />
+        </node>
+      </node>
+      <node concept="10P_77" id="6aVQm8Wge9K" role="3clF45" />
     </node>
   </node>
   <node concept="13h7C7" id="2r0ijgcUN8H">
@@ -940,6 +1115,26 @@
         </node>
       </node>
       <node concept="17QB3L" id="1$KnWE8sX3f" role="3clF45" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="6aVQm8Wg3TS">
+    <ref role="13h7C2" to="b7vt:Po4Z58Iad0" resolve="IReleaseHeader" />
+    <node concept="13i0hz" id="6aVQm8Wg3U3" role="13h7CS">
+      <property role="13i0iv" value="true" />
+      <property role="13i0it" value="true" />
+      <property role="TrG5h" value="isAfter" />
+      <node concept="3Tm1VV" id="6aVQm8Wg3U4" role="1B3o_S" />
+      <node concept="10P_77" id="6aVQm8Wge2f" role="3clF45" />
+      <node concept="3clFbS" id="6aVQm8Wg3U6" role="3clF47" />
+      <node concept="37vLTG" id="6aVQm8Wge2V" role="3clF46">
+        <property role="TrG5h" value="header" />
+        <node concept="3Tqbb2" id="6aVQm8Wge2U" role="1tU5fm">
+          <ref role="ehGHo" to="b7vt:Po4Z58Iad0" resolve="IReleaseHeader" />
+        </node>
+      </node>
+    </node>
+    <node concept="13hLZK" id="6aVQm8Wg3TT" role="13h7CW">
+      <node concept="3clFbS" id="6aVQm8Wg3TU" role="2VODD2" />
     </node>
   </node>
 </model>

--- a/code/changelog/de.itemis.mps.changelog/models/de.itemis.mps.changelog.behavior.mps
+++ b/code/changelog/de.itemis.mps.changelog/models/de.itemis.mps.changelog.behavior.mps
@@ -1,0 +1,946 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:44801727-1f82-4e97-98b6-460b3dc79dca(de.itemis.mps.changelog.behavior)">
+  <persistence version="9" />
+  <languages>
+    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
+    <use id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior" version="2" />
+    <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
+  </languages>
+  <imports>
+    <import index="28m1" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.time(JDK/)" />
+    <import index="b7vt" ref="r:86cc19c0-126f-473b-92c6-29dba75c1e89(de.itemis.mps.changelog.structure)" />
+    <import index="lui2" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.module(MPS.OpenAPI/)" />
+    <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
+    <import index="6t7w" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.time.format(JDK/)" />
+    <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" />
+    <import index="3a50" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.ide(MPS.Platform/)" />
+    <import index="w1kc" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel(MPS.Core/)" />
+    <import index="ciba" ref="r:11b7cdb2-cc58-456e-bb9a-ce45b78edd2f(jetbrains.mps.ide.httpsupport.runtime.base)" />
+    <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
+    <import index="vdrq" ref="r:85354f47-14fd-40e6-a7cc-2d1aa842c4cd(jetbrains.mps.lang.text.behavior)" implicit="true" />
+    <import index="tp25" ref="r:00000000-0000-4000-0000-011c89590301(jetbrains.mps.lang.smodel.structure)" implicit="true" />
+    <import index="xlb7" ref="r:cf42fd0a-68d2-493b-8b77-961658617704(jetbrains.mps.lang.modelapi.behavior)" implicit="true" />
+    <import index="wyuk" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.components(MPS.Core/)" implicit="true" />
+    <import index="zqge" ref="r:59e90602-6655-4552-86eb-441a42a9a0e4(jetbrains.mps.lang.text.structure)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior">
+      <concept id="6496299201655527393" name="jetbrains.mps.lang.behavior.structure.LocalBehaviorMethodCall" flags="nn" index="BsUDl" />
+      <concept id="1225194240794" name="jetbrains.mps.lang.behavior.structure.ConceptBehavior" flags="ng" index="13h7C7">
+        <reference id="1225194240799" name="concept" index="13h7C2" />
+        <child id="1225194240805" name="method" index="13h7CS" />
+        <child id="1225194240801" name="constructor" index="13h7CW" />
+      </concept>
+      <concept id="1225194413805" name="jetbrains.mps.lang.behavior.structure.ConceptConstructorDeclaration" flags="in" index="13hLZK" />
+      <concept id="1225194472830" name="jetbrains.mps.lang.behavior.structure.ConceptMethodDeclaration" flags="ng" index="13i0hz">
+        <reference id="1225194472831" name="overriddenMethod" index="13i0hy" />
+      </concept>
+      <concept id="1225194628440" name="jetbrains.mps.lang.behavior.structure.SuperNodeExpression" flags="nn" index="13iAh5" />
+      <concept id="1225194691553" name="jetbrains.mps.lang.behavior.structure.ThisNodeExpression" flags="nn" index="13iPFW" />
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
+        <child id="1068498886297" name="rValue" index="37vLTx" />
+        <child id="1068498886295" name="lValue" index="37vLTJ" />
+      </concept>
+      <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
+        <child id="1145553007750" name="creator" index="2ShVmc" />
+      </concept>
+      <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
+        <child id="1137022507850" name="body" index="2VODD2" />
+      </concept>
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
+      </concept>
+      <concept id="1070533707846" name="jetbrains.mps.baseLanguage.structure.StaticFieldReference" flags="nn" index="10M0yZ">
+        <reference id="1144433057691" name="classifier" index="1PxDUh" />
+      </concept>
+      <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
+      <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
+      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
+      <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
+      <concept id="1225271369338" name="jetbrains.mps.baseLanguage.structure.IsEmptyOperation" flags="nn" index="17RlXB" />
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123135" name="body" index="3clF47" />
+      </concept>
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
+      <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
+        <child id="1068580123160" name="condition" index="3clFbw" />
+        <child id="1068580123161" name="ifTrue" index="3clFbx" />
+        <child id="1206060520071" name="elsifClauses" index="3eNLev" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
+      <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
+        <child id="1068581517676" name="expression" index="3cqZAk" />
+      </concept>
+      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
+        <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
+      </concept>
+      <concept id="1068581242867" name="jetbrains.mps.baseLanguage.structure.LongType" flags="in" index="3cpWsb" />
+      <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1206060495898" name="jetbrains.mps.baseLanguage.structure.ElsifClause" flags="ng" index="3eNFk2">
+        <child id="1206060619838" name="condition" index="3eO9$A" />
+        <child id="1206060644605" name="statementList" index="3eOfB_" />
+      </concept>
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+        <reference id="1107535924139" name="classifier" index="3uigEE" />
+      </concept>
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
+        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
+        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
+      </concept>
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
+        <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+      <concept id="1116615150612" name="jetbrains.mps.baseLanguage.structure.ClassifierClassExpression" flags="nn" index="3VsKOn">
+        <reference id="1116615189566" name="classifier" index="3VsUkX" />
+      </concept>
+    </language>
+    <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
+      <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
+        <child id="1199569906740" name="parameter" index="1bW2Oz" />
+        <child id="1199569916463" name="body" index="1bW5cS" />
+      </concept>
+    </language>
+    <language id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation">
+      <concept id="1196350785113" name="jetbrains.mps.lang.quotation.structure.Quotation" flags="nn" index="2c44tf">
+        <child id="1196350785114" name="quotedNode" index="2c44tc" />
+      </concept>
+      <concept id="5455284157994012186" name="jetbrains.mps.lang.quotation.structure.NodeBuilderInitLink" flags="ng" index="2pIpSj">
+        <reference id="5455284157994012188" name="link" index="2pIpSl" />
+        <child id="1595412875168045827" name="initValue" index="28nt2d" />
+      </concept>
+      <concept id="5455284157993863837" name="jetbrains.mps.lang.quotation.structure.NodeBuilder" flags="nn" index="2pJPEk">
+        <child id="5455284157993863838" name="quotedNode" index="2pJPEn" />
+      </concept>
+      <concept id="5455284157993863840" name="jetbrains.mps.lang.quotation.structure.NodeBuilderNode" flags="nn" index="2pJPED">
+        <reference id="5455284157993910961" name="concept" index="2pJxaS" />
+        <child id="5455284157993911099" name="values" index="2pJxcM" />
+      </concept>
+      <concept id="8182547171709738802" name="jetbrains.mps.lang.quotation.structure.NodeBuilderList" flags="nn" index="36be1Y">
+        <child id="8182547171709738803" name="nodes" index="36be1Z" />
+      </concept>
+      <concept id="8182547171709752110" name="jetbrains.mps.lang.quotation.structure.NodeBuilderExpression" flags="nn" index="36biLy">
+        <child id="8182547171709752112" name="expression" index="36biLW" />
+      </concept>
+    </language>
+    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="4705942098322609812" name="jetbrains.mps.lang.smodel.structure.EnumMember_IsOperation" flags="ng" index="21noJN">
+        <child id="4705942098322609813" name="member" index="21noJM" />
+      </concept>
+      <concept id="4705942098322467729" name="jetbrains.mps.lang.smodel.structure.EnumMemberReference" flags="ng" index="21nZrQ">
+        <reference id="4705942098322467736" name="decl" index="21nZrZ" />
+      </concept>
+      <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
+      <concept id="1145404486709" name="jetbrains.mps.lang.smodel.structure.SemanticDowncastExpression" flags="nn" index="2JrnkZ">
+        <child id="1145404616321" name="leftExpression" index="2JrQYb" />
+      </concept>
+      <concept id="1966870290088668520" name="jetbrains.mps.lang.smodel.structure.Enum_MembersOperation" flags="ng" index="2ViDtN" />
+      <concept id="1139184414036" name="jetbrains.mps.lang.smodel.structure.LinkList_AddNewChildOperation" flags="nn" index="WFELt">
+        <reference id="1139877738879" name="concept" index="1A0vxQ" />
+      </concept>
+      <concept id="1180636770613" name="jetbrains.mps.lang.smodel.structure.SNodeCreator" flags="nn" index="3zrR0B">
+        <child id="1180636770616" name="createdType" index="3zrR0E" />
+      </concept>
+      <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
+        <reference id="1138405853777" name="concept" index="ehGHo" />
+      </concept>
+      <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
+        <reference id="1138056395725" name="property" index="3TsBF5" />
+      </concept>
+      <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="nn" index="3TrEf2">
+        <reference id="1138056516764" name="link" index="3Tt5mk" />
+      </concept>
+      <concept id="1138056282393" name="jetbrains.mps.lang.smodel.structure.SLinkListAccess" flags="nn" index="3Tsc0h">
+        <reference id="1138056546658" name="link" index="3TtcxE" />
+      </concept>
+      <concept id="5779574625830813396" name="jetbrains.mps.lang.smodel.structure.EnumerationIdRefExpression" flags="ng" index="1XH99k">
+        <reference id="5779574625830813397" name="enumDeclaration" index="1XH99l" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+    <language id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text">
+      <concept id="155656958578482948" name="jetbrains.mps.lang.text.structure.Word" flags="nn" index="3oM_SD">
+        <property id="155656958578482949" name="value" index="3oM_SC" />
+        <property id="6328114375520539781" name="url" index="1X82VU" />
+      </concept>
+      <concept id="2535923850359206929" name="jetbrains.mps.lang.text.structure.Text" flags="nn" index="1Pa9Pv">
+        <child id="2535923850359210936" name="lines" index="1PaQFQ" />
+      </concept>
+      <concept id="2535923850359271782" name="jetbrains.mps.lang.text.structure.Line" flags="nn" index="1PaTwC">
+        <child id="2535923850359271783" name="elements" index="1PaTwD" />
+      </concept>
+    </language>
+    <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
+        <child id="1204796294226" name="closure" index="23t8la" />
+      </concept>
+      <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="nn" index="25WWJ4">
+        <child id="540871147943773366" name="argument" index="25WWJ7" />
+      </concept>
+      <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
+      <concept id="1162934736510" name="jetbrains.mps.baseLanguage.collections.structure.GetElementOperation" flags="nn" index="34jXtK" />
+      <concept id="1240687580870" name="jetbrains.mps.baseLanguage.collections.structure.JoinOperation" flags="nn" index="3uJxvA">
+        <child id="1240687658305" name="delimiter" index="3uJOhx" />
+      </concept>
+      <concept id="1202128969694" name="jetbrains.mps.baseLanguage.collections.structure.SelectOperation" flags="nn" index="3$u5V9" />
+    </language>
+  </registry>
+  <node concept="13h7C7" id="2r0ijgcUaz7">
+    <ref role="13h7C2" to="b7vt:Po4Z58tnPb" resolve="VersionDateReleaseHeader" />
+    <node concept="13i0hz" id="2r0ijgcUaDV" role="13h7CS">
+      <property role="TrG5h" value="getDate" />
+      <node concept="3Tm1VV" id="2r0ijgcUaDW" role="1B3o_S" />
+      <node concept="17QB3L" id="2r0ijgcUdzK" role="3clF45" />
+      <node concept="3clFbS" id="2r0ijgcUaDY" role="3clF47">
+        <node concept="3clFbJ" id="43oF0KsRjiv" role="3cqZAp">
+          <node concept="3clFbS" id="43oF0KsRjix" role="3clFbx">
+            <node concept="3cpWs6" id="43oF0KsRlaT" role="3cqZAp">
+              <node concept="10Nm6u" id="43oF0KsRlb2" role="3cqZAk" />
+            </node>
+          </node>
+          <node concept="2OqwBi" id="43oF0KsRkER" role="3clFbw">
+            <node concept="2OqwBi" id="43oF0KsRjVw" role="2Oq$k0">
+              <node concept="13iPFW" id="43oF0KsRjxV" role="2Oq$k0" />
+              <node concept="3TrcHB" id="43oF0KsRkij" role="2OqNvi">
+                <ref role="3TsBF5" to="b7vt:Po4Z58tnPc" resolve="timeStamp" />
+              </node>
+            </node>
+            <node concept="17RlXB" id="43oF0KsRl8A" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="43oF0KsRjfQ" role="3cqZAp" />
+        <node concept="3cpWs8" id="2r0ijgcUAS1" role="3cqZAp">
+          <node concept="3cpWsn" id="2r0ijgcUAS4" role="3cpWs9">
+            <property role="TrG5h" value="unixTimeStamp" />
+            <node concept="3cpWsb" id="2r0ijgcUAS0" role="1tU5fm" />
+            <node concept="2YIFZM" id="2r0ijgcUATa" role="33vP2m">
+              <ref role="37wK5l" to="wyt6:~Long.valueOf(java.lang.String)" resolve="valueOf" />
+              <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
+              <node concept="2OqwBi" id="2r0ijgcUBcW" role="37wK5m">
+                <node concept="13iPFW" id="2r0ijgcUAVD" role="2Oq$k0" />
+                <node concept="3TrcHB" id="2r0ijgcUBFn" role="2OqNvi">
+                  <ref role="3TsBF5" to="b7vt:Po4Z58tnPc" resolve="timeStamp" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="2r0ijgcUBPs" role="3cqZAp">
+          <node concept="3cpWsn" id="2r0ijgcUBPt" role="3cpWs9">
+            <property role="TrG5h" value="instant" />
+            <node concept="3uibUv" id="2r0ijgcUBPu" role="1tU5fm">
+              <ref role="3uigEE" to="28m1:~Instant" resolve="Instant" />
+            </node>
+            <node concept="2YIFZM" id="2r0ijgcUC2r" role="33vP2m">
+              <ref role="37wK5l" to="28m1:~Instant.ofEpochSecond(long)" resolve="ofEpochSecond" />
+              <ref role="1Pybhc" to="28m1:~Instant" resolve="Instant" />
+              <node concept="37vLTw" id="2r0ijgcUC7K" role="37wK5m">
+                <ref role="3cqZAo" node="2r0ijgcUAS4" resolve="unixTimeStamp" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="2r0ijgcUCo1" role="3cqZAp">
+          <node concept="3cpWsn" id="2r0ijgcUCo2" role="3cpWs9">
+            <property role="TrG5h" value="ld" />
+            <node concept="3uibUv" id="2r0ijgcUCo3" role="1tU5fm">
+              <ref role="3uigEE" to="28m1:~LocalDate" resolve="LocalDate" />
+            </node>
+            <node concept="2YIFZM" id="2r0ijgcUC_N" role="33vP2m">
+              <ref role="37wK5l" to="28m1:~LocalDate.ofInstant(java.time.Instant,java.time.ZoneId)" resolve="ofInstant" />
+              <ref role="1Pybhc" to="28m1:~LocalDate" resolve="LocalDate" />
+              <node concept="37vLTw" id="2r0ijgcUCB9" role="37wK5m">
+                <ref role="3cqZAo" node="2r0ijgcUBPt" resolve="instant" />
+              </node>
+              <node concept="10M0yZ" id="2r0ijgcUCIE" role="37wK5m">
+                <ref role="3cqZAo" to="28m1:~ZoneOffset.UTC" resolve="UTC" />
+                <ref role="1PxDUh" to="28m1:~ZoneOffset" resolve="ZoneOffset" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="2r0ijgcUCa4" role="3cqZAp">
+          <node concept="2OqwBi" id="2r0ijgcUDjz" role="3cqZAk">
+            <node concept="37vLTw" id="2r0ijgcUCQg" role="2Oq$k0">
+              <ref role="3cqZAo" node="2r0ijgcUCo2" resolve="ld" />
+            </node>
+            <node concept="liA8E" id="2r0ijgcUDOh" role="2OqNvi">
+              <ref role="37wK5l" to="28m1:~LocalDate.format(java.time.format.DateTimeFormatter)" resolve="format" />
+              <node concept="10M0yZ" id="2r0ijgcUElU" role="37wK5m">
+                <ref role="3cqZAo" to="6t7w:~DateTimeFormatter.ISO_LOCAL_DATE" resolve="ISO_LOCAL_DATE" />
+                <ref role="1PxDUh" to="6t7w:~DateTimeFormatter" resolve="DateTimeFormatter" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="13hLZK" id="2r0ijgcUaz8" role="13h7CW">
+      <node concept="3clFbS" id="2r0ijgcUaz9" role="2VODD2">
+        <node concept="3clFbF" id="43oF0KsRnBX" role="3cqZAp">
+          <node concept="37vLTI" id="43oF0KsRoo7" role="3clFbG">
+            <node concept="2ShNRf" id="43oF0KsRooQ" role="37vLTx">
+              <node concept="3zrR0B" id="43oF0KsRp7X" role="2ShVmc">
+                <node concept="3Tqbb2" id="43oF0KsRp7Z" role="3zrR0E">
+                  <ref role="ehGHo" to="b7vt:Po4Z58tnPe" resolve="SemanticVersion" />
+                </node>
+              </node>
+            </node>
+            <node concept="2OqwBi" id="43oF0KsRnLD" role="37vLTJ">
+              <node concept="13iPFW" id="43oF0KsRnBW" role="2Oq$k0" />
+              <node concept="3TrEf2" id="43oF0KsRnY_" role="2OqNvi">
+                <ref role="3Tt5mk" to="b7vt:Po4Z58trdd" resolve="version" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="13h7C7" id="2r0ijgcUr49">
+    <property role="3GE5qa" value="textElements" />
+    <ref role="13h7C2" to="b7vt:XbadXS8vkr" resolve="CodeWord" />
+    <node concept="13hLZK" id="2r0ijgcUr4a" role="13h7CW">
+      <node concept="3clFbS" id="2r0ijgcUr4b" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="2r0ijgcUr4k" role="13h7CS">
+      <property role="TrG5h" value="getTextualRepresentation" />
+      <ref role="13i0hy" to="vdrq:fB3l81it7u" resolve="getTextualRepresentation" />
+      <node concept="3Tm1VV" id="2r0ijgcUr4l" role="1B3o_S" />
+      <node concept="3clFbS" id="2r0ijgcUr4z" role="3clF47">
+        <node concept="3cpWs6" id="2r0ijgcUreK" role="3cqZAp">
+          <node concept="3cpWs3" id="2r0ijgcUsxO" role="3cqZAk">
+            <node concept="Xl_RD" id="2r0ijgcUsEZ" role="3uHU7w">
+              <property role="Xl_RC" value="`" />
+            </node>
+            <node concept="3cpWs3" id="2r0ijgcUs2E" role="3uHU7B">
+              <node concept="Xl_RD" id="2r0ijgcUs4u" role="3uHU7B">
+                <property role="Xl_RC" value="`" />
+              </node>
+              <node concept="2OqwBi" id="2r0ijgcUreM" role="3uHU7w">
+                <node concept="13iAh5" id="2r0ijgcUreN" role="2Oq$k0" />
+                <node concept="2qgKlT" id="2r0ijgcUreO" role="2OqNvi">
+                  <ref role="37wK5l" to="vdrq:fB3l81it7u" resolve="getTextualRepresentation" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="2r0ijgcUr4$" role="3clF45" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="2r0ijgcUt0f">
+    <property role="3GE5qa" value="textElements" />
+    <ref role="13h7C2" to="b7vt:Po4Z58KntM" resolve="ModuleReference" />
+    <node concept="13hLZK" id="2r0ijgcUt0g" role="13h7CW">
+      <node concept="3clFbS" id="2r0ijgcUt0h" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="2r0ijgcUt0q" role="13h7CS">
+      <property role="TrG5h" value="getTextualRepresentation" />
+      <ref role="13i0hy" to="vdrq:fB3l81it7u" resolve="getTextualRepresentation" />
+      <node concept="3Tm1VV" id="2r0ijgcUt0r" role="1B3o_S" />
+      <node concept="3clFbS" id="2r0ijgcUt0u" role="3clF47">
+        <node concept="3cpWs8" id="2r0ijgcUuTu" role="3cqZAp">
+          <node concept="3cpWsn" id="2r0ijgcUuTv" role="3cpWs9">
+            <property role="TrG5h" value="moduleReference" />
+            <node concept="3uibUv" id="2r0ijgcUuOO" role="1tU5fm">
+              <ref role="3uigEE" to="lui2:~SModuleReference" resolve="SModuleReference" />
+            </node>
+            <node concept="2OqwBi" id="2r0ijgcUuTw" role="33vP2m">
+              <node concept="2OqwBi" id="2r0ijgcUuTx" role="2Oq$k0">
+                <node concept="2OqwBi" id="2r0ijgcUuTy" role="2Oq$k0">
+                  <node concept="13iPFW" id="2r0ijgcUuTz" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="2r0ijgcUuT$" role="2OqNvi">
+                    <ref role="3Tt5mk" to="b7vt:Po4Z58Kp2X" resolve="expression" />
+                  </node>
+                </node>
+                <node concept="3TrEf2" id="2r0ijgcUuT_" role="2OqNvi">
+                  <ref role="3Tt5mk" to="tp25:1t9FffgebJ_" resolve="moduleId" />
+                </node>
+              </node>
+              <node concept="2qgKlT" id="2r0ijgcUuTA" role="2OqNvi">
+                <ref role="37wK5l" to="xlb7:1Bs_61$mqDd" resolve="toModuleReference" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="2r0ijgcUvoH" role="3cqZAp">
+          <node concept="3cpWs3" id="2r0ijgcUwfY" role="3cqZAk">
+            <node concept="Xl_RD" id="2r0ijgcUwh4" role="3uHU7w">
+              <property role="Xl_RC" value="*" />
+            </node>
+            <node concept="3cpWs3" id="2r0ijgcUvOS" role="3uHU7B">
+              <node concept="Xl_RD" id="2r0ijgcUvxk" role="3uHU7B">
+                <property role="Xl_RC" value="*" />
+              </node>
+              <node concept="2OqwBi" id="2r0ijgcUw$N" role="3uHU7w">
+                <node concept="37vLTw" id="2r0ijgcUvXr" role="2Oq$k0">
+                  <ref role="3cqZAo" node="2r0ijgcUuTv" resolve="moduleReference" />
+                </node>
+                <node concept="liA8E" id="2r0ijgcUwFD" role="2OqNvi">
+                  <ref role="37wK5l" to="lui2:~SModuleReference.getModuleName()" resolve="getModuleName" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="2r0ijgcUt0v" role="3clF45" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="2r0ijgcUwHa">
+    <ref role="13h7C2" to="b7vt:Po4Z58IgAd" resolve="MonthYearReleaseHeader" />
+    <node concept="13hLZK" id="2r0ijgcUwHb" role="13h7CW">
+      <node concept="3clFbS" id="2r0ijgcUwHc" role="2VODD2">
+        <node concept="3cpWs8" id="2r0ijgcUwHm" role="3cqZAp">
+          <node concept="3cpWsn" id="2r0ijgcUwHp" role="3cpWs9">
+            <property role="TrG5h" value="month" />
+            <node concept="10Oyi0" id="2r0ijgcUwHl" role="1tU5fm" />
+            <node concept="2OqwBi" id="2r0ijgcUx4Y" role="33vP2m">
+              <node concept="2YIFZM" id="2r0ijgcUwIt" role="2Oq$k0">
+                <ref role="37wK5l" to="33ny:~Calendar.getInstance()" resolve="getInstance" />
+                <ref role="1Pybhc" to="33ny:~Calendar" resolve="Calendar" />
+              </node>
+              <node concept="liA8E" id="2r0ijgcUxo5" role="2OqNvi">
+                <ref role="37wK5l" to="33ny:~Calendar.get(int)" resolve="get" />
+                <node concept="10M0yZ" id="2r0ijgcUxpK" role="37wK5m">
+                  <ref role="3cqZAo" to="33ny:~Calendar.MONTH" resolve="MONTH" />
+                  <ref role="1PxDUh" to="33ny:~Calendar" resolve="Calendar" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="2r0ijgcUxsB" role="3cqZAp">
+          <node concept="37vLTI" id="2r0ijgcUy9G" role="3clFbG">
+            <node concept="2OqwBi" id="2r0ijgcUzO3" role="37vLTx">
+              <node concept="2OqwBi" id="2r0ijgcUyEl" role="2Oq$k0">
+                <node concept="1XH99k" id="2r0ijgcUyeo" role="2Oq$k0">
+                  <ref role="1XH99l" to="b7vt:Po4Z58IgAk" resolve="Month" />
+                </node>
+                <node concept="2ViDtN" id="2r0ijgcUyTi" role="2OqNvi" />
+              </node>
+              <node concept="34jXtK" id="2r0ijgcU$uL" role="2OqNvi">
+                <node concept="37vLTw" id="2r0ijgcU$wu" role="25WWJ7">
+                  <ref role="3cqZAo" node="2r0ijgcUwHp" resolve="month" />
+                </node>
+              </node>
+            </node>
+            <node concept="2OqwBi" id="2r0ijgcUxAM" role="37vLTJ">
+              <node concept="13iPFW" id="2r0ijgcUxs_" role="2Oq$k0" />
+              <node concept="3TrcHB" id="2r0ijgcUxOd" role="2OqNvi">
+                <ref role="3TsBF5" to="b7vt:Po4Z58IgAf" resolve="month" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="2r0ijgcU$zm" role="3cqZAp" />
+        <node concept="3cpWs8" id="2r0ijgcU$Et" role="3cqZAp">
+          <node concept="3cpWsn" id="2r0ijgcU$Ew" role="3cpWs9">
+            <property role="TrG5h" value="year" />
+            <node concept="10Oyi0" id="2r0ijgcU$Er" role="1tU5fm" />
+            <node concept="2OqwBi" id="2r0ijgcU$Hh" role="33vP2m">
+              <node concept="2YIFZM" id="2r0ijgcU$Hi" role="2Oq$k0">
+                <ref role="1Pybhc" to="33ny:~Calendar" resolve="Calendar" />
+                <ref role="37wK5l" to="33ny:~Calendar.getInstance()" resolve="getInstance" />
+              </node>
+              <node concept="liA8E" id="2r0ijgcU$Hj" role="2OqNvi">
+                <ref role="37wK5l" to="33ny:~Calendar.get(int)" resolve="get" />
+                <node concept="10M0yZ" id="2r0ijgcU$Im" role="37wK5m">
+                  <ref role="3cqZAo" to="33ny:~Calendar.YEAR" resolve="YEAR" />
+                  <ref role="1PxDUh" to="33ny:~Calendar" resolve="Calendar" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="2r0ijgcU$P8" role="3cqZAp">
+          <node concept="37vLTI" id="2r0ijgcUAdL" role="3clFbG">
+            <node concept="37vLTw" id="2r0ijgcUAgm" role="37vLTx">
+              <ref role="3cqZAo" node="2r0ijgcU$Ew" resolve="year" />
+            </node>
+            <node concept="2OqwBi" id="2r0ijgcU_1g" role="37vLTJ">
+              <node concept="13iPFW" id="2r0ijgcU$P6" role="2Oq$k0" />
+              <node concept="3TrcHB" id="2r0ijgcU_gF" role="2OqNvi">
+                <ref role="3TsBF5" to="b7vt:Po4Z58IgAh" resolve="year" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="13h7C7" id="2r0ijgcUN8H">
+    <property role="3GE5qa" value="textElements" />
+    <ref role="13h7C2" to="b7vt:Po4Z58Lv7f" resolve="ModelReference" />
+    <node concept="13i0hz" id="2r0ijgcUN8S" role="13h7CS">
+      <property role="TrG5h" value="getTextualRepresentation" />
+      <ref role="13i0hy" to="vdrq:fB3l81it7u" resolve="getTextualRepresentation" />
+      <node concept="3Tm1VV" id="2r0ijgcUN8T" role="1B3o_S" />
+      <node concept="3clFbS" id="2r0ijgcUN8U" role="3clF47">
+        <node concept="3cpWs8" id="2r0ijgcUN8V" role="3cqZAp">
+          <node concept="3cpWsn" id="2r0ijgcUN8W" role="3cpWs9">
+            <property role="TrG5h" value="modelReference" />
+            <node concept="3uibUv" id="2r0ijgcUN8X" role="1tU5fm">
+              <ref role="3uigEE" to="mhbf:~SModelReference" resolve="SModelReference" />
+            </node>
+            <node concept="2OqwBi" id="2r0ijgcUN8Y" role="33vP2m">
+              <node concept="2OqwBi" id="2r0ijgcUN8Z" role="2Oq$k0">
+                <node concept="2OqwBi" id="2r0ijgcUN90" role="2Oq$k0">
+                  <node concept="13iPFW" id="2r0ijgcUN91" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="2r0ijgcUN92" role="2OqNvi">
+                    <ref role="3Tt5mk" to="b7vt:Po4Z58Lv7g" resolve="expression" />
+                  </node>
+                </node>
+                <node concept="3TrEf2" id="2r0ijgcUN93" role="2OqNvi">
+                  <ref role="3Tt5mk" to="tp25:1Bs_61$ngwB" resolve="modelRef" />
+                </node>
+              </node>
+              <node concept="2qgKlT" id="2r0ijgcUN94" role="2OqNvi">
+                <ref role="37wK5l" to="xlb7:1Bs_61$mvvu" resolve="toModelReference" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="2r0ijgcUN95" role="3cqZAp">
+          <node concept="3cpWs3" id="2r0ijgcUN96" role="3cqZAk">
+            <node concept="Xl_RD" id="2r0ijgcUN97" role="3uHU7w">
+              <property role="Xl_RC" value="*" />
+            </node>
+            <node concept="3cpWs3" id="2r0ijgcUN98" role="3uHU7B">
+              <node concept="Xl_RD" id="2r0ijgcUN99" role="3uHU7B">
+                <property role="Xl_RC" value="*" />
+              </node>
+              <node concept="2OqwBi" id="2r0ijgcUOPV" role="3uHU7w">
+                <node concept="2OqwBi" id="2r0ijgcUN9a" role="2Oq$k0">
+                  <node concept="37vLTw" id="2r0ijgcUN9b" role="2Oq$k0">
+                    <ref role="3cqZAo" node="2r0ijgcUN8W" resolve="modelReference" />
+                  </node>
+                  <node concept="liA8E" id="2r0ijgcUN9c" role="2OqNvi">
+                    <ref role="37wK5l" to="mhbf:~SModelReference.getName()" resolve="getName" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="2r0ijgcUP69" role="2OqNvi">
+                  <ref role="37wK5l" to="mhbf:~SModelName.toString()" resolve="toString" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="2r0ijgcUN9d" role="3clF45" />
+    </node>
+    <node concept="13hLZK" id="2r0ijgcUN8I" role="13h7CW">
+      <node concept="3clFbS" id="2r0ijgcUN8J" role="2VODD2" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="2r0ijgcUPcD">
+    <property role="3GE5qa" value="textElements" />
+    <ref role="13h7C2" to="b7vt:Po4Z58LQTj" resolve="NodeReference" />
+    <node concept="13hLZK" id="2r0ijgcUPcE" role="13h7CW">
+      <node concept="3clFbS" id="2r0ijgcUPcF" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="2r0ijgcUPcO" role="13h7CS">
+      <property role="TrG5h" value="getTextualRepresentation" />
+      <ref role="13i0hy" to="vdrq:fB3l81it7u" resolve="getTextualRepresentation" />
+      <node concept="3Tm1VV" id="2r0ijgcUPcP" role="1B3o_S" />
+      <node concept="3clFbS" id="2r0ijgcUPcS" role="3clF47">
+        <node concept="3cpWs8" id="2r0ijgcUPij" role="3cqZAp">
+          <node concept="3cpWsn" id="2r0ijgcUPik" role="3cpWs9">
+            <property role="TrG5h" value="nodeReference" />
+            <node concept="3uibUv" id="2r0ijgcUPil" role="1tU5fm">
+              <ref role="3uigEE" to="mhbf:~SNodeReference" resolve="SNodeReference" />
+            </node>
+            <node concept="2OqwBi" id="2r0ijgcUPim" role="33vP2m">
+              <node concept="2OqwBi" id="2r0ijgcUPin" role="2Oq$k0">
+                <node concept="2OqwBi" id="2r0ijgcUPio" role="2Oq$k0">
+                  <node concept="13iPFW" id="2r0ijgcUPip" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="2r0ijgcUPiq" role="2OqNvi">
+                    <ref role="3Tt5mk" to="b7vt:Po4Z58LQTk" resolve="expression" />
+                  </node>
+                </node>
+                <node concept="3TrEf2" id="2r0ijgcUPir" role="2OqNvi">
+                  <ref role="3Tt5mk" to="tp25:6qMaajV39im" resolve="ref" />
+                </node>
+              </node>
+              <node concept="2qgKlT" id="2r0ijgcUQdf" role="2OqNvi">
+                <ref role="37wK5l" to="xlb7:4nxIQVLmsc4" resolve="toNodeReference" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="2r0ijgcUTA9" role="3cqZAp">
+          <node concept="3cpWsn" id="2r0ijgcUTAa" role="3cpWs9">
+            <property role="TrG5h" value="repository" />
+            <node concept="3uibUv" id="2r0ijgcUTwg" role="1tU5fm">
+              <ref role="3uigEE" to="w1kc:~MPSModuleRepository" resolve="MPSModuleRepository" />
+            </node>
+            <node concept="2OqwBi" id="2r0ijgcUTAb" role="33vP2m">
+              <node concept="2OqwBi" id="2r0ijgcUTAc" role="2Oq$k0">
+                <node concept="2YIFZM" id="2r0ijgcUTAd" role="2Oq$k0">
+                  <ref role="37wK5l" to="3a50:~MPSCoreComponents.getInstance()" resolve="getInstance" />
+                  <ref role="1Pybhc" to="3a50:~MPSCoreComponents" resolve="MPSCoreComponents" />
+                </node>
+                <node concept="liA8E" id="2r0ijgcUTAe" role="2OqNvi">
+                  <ref role="37wK5l" to="3a50:~MPSCoreComponents.getPlatform()" resolve="getPlatform" />
+                </node>
+              </node>
+              <node concept="liA8E" id="2r0ijgcUTAf" role="2OqNvi">
+                <ref role="37wK5l" to="wyuk:~ComponentHost.findComponent(java.lang.Class)" resolve="findComponent" />
+                <node concept="3VsKOn" id="2r0ijgcUTAg" role="37wK5m">
+                  <ref role="3VsUkX" to="w1kc:~MPSModuleRepository" resolve="MPSModuleRepository" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="1$KnWE8r0Mk" role="3cqZAp">
+          <node concept="3cpWsn" id="1$KnWE8r0Ml" role="3cpWs9">
+            <property role="TrG5h" value="node" />
+            <node concept="3Tqbb2" id="1$KnWE8r1me" role="1tU5fm" />
+            <node concept="2OqwBi" id="1$KnWE8r0Mm" role="33vP2m">
+              <node concept="37vLTw" id="1$KnWE8r0Mn" role="2Oq$k0">
+                <ref role="3cqZAo" node="2r0ijgcUPik" resolve="nodeReference" />
+              </node>
+              <node concept="liA8E" id="1$KnWE8r0Mo" role="2OqNvi">
+                <ref role="37wK5l" to="mhbf:~SNodeReference.resolve(org.jetbrains.mps.openapi.module.SRepository)" resolve="resolve" />
+                <node concept="37vLTw" id="1$KnWE8r0Mp" role="37wK5m">
+                  <ref role="3cqZAo" node="2r0ijgcUTAa" resolve="repository" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="1$KnWE8qXp1" role="3cqZAp">
+          <node concept="2YIFZM" id="1$KnWE8qYcd" role="3cqZAk">
+            <ref role="1Pybhc" to="wyt6:~String" resolve="String" />
+            <ref role="37wK5l" to="wyt6:~String.format(java.lang.String,java.lang.Object...)" resolve="format" />
+            <node concept="Xl_RD" id="1$KnWE8qYjF" role="37wK5m">
+              <property role="Xl_RC" value="[%s](%s)" />
+            </node>
+            <node concept="2OqwBi" id="2r0ijgcUPiy" role="37wK5m">
+              <node concept="2JrnkZ" id="1$KnWE8r2zm" role="2Oq$k0">
+                <node concept="37vLTw" id="1$KnWE8r0Mq" role="2JrQYb">
+                  <ref role="3cqZAo" node="1$KnWE8r0Ml" resolve="f" />
+                </node>
+              </node>
+              <node concept="liA8E" id="2r0ijgcUPiA" role="2OqNvi">
+                <ref role="37wK5l" to="mhbf:~SNode.getName()" resolve="getName" />
+              </node>
+            </node>
+            <node concept="2YIFZM" id="1$KnWE8rbAT" role="37wK5m">
+              <ref role="37wK5l" to="ciba:1_yOWEXenNM" resolve="getURL" />
+              <ref role="1Pybhc" to="ciba:3OrGkZCn9ZQ" resolve="HttpSupportUtil" />
+              <node concept="37vLTw" id="1$KnWE8rc1$" role="37wK5m">
+                <ref role="3cqZAo" node="1$KnWE8r0Ml" resolve="node" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="2r0ijgcUPcT" role="3clF45" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="2r0ijgcUUGH">
+    <ref role="13h7C2" to="b7vt:Po4Z58t1Zc" resolve="Changelog" />
+    <node concept="13i0hz" id="2r0ijgcUUGS" role="13h7CS">
+      <property role="TrG5h" value="createNewRelease" />
+      <node concept="3Tm1VV" id="2r0ijgcUUGT" role="1B3o_S" />
+      <node concept="3Tqbb2" id="2r0ijgcUUH8" role="3clF45">
+        <ref role="ehGHo" to="b7vt:Po4Z58tnOo" resolve="Release" />
+      </node>
+      <node concept="3clFbS" id="2r0ijgcUUGV" role="3clF47">
+        <node concept="3clFbF" id="43oF0KsQTSF" role="3cqZAp">
+          <node concept="2pJPEk" id="43oF0KsQTSD" role="3clFbG">
+            <node concept="2pJPED" id="43oF0KsQTSE" role="2pJPEn">
+              <ref role="2pJxaS" to="b7vt:Po4Z58tnOo" resolve="Release" />
+              <node concept="2pIpSj" id="43oF0KsRdcI" role="2pJxcM">
+                <ref role="2pIpSl" to="b7vt:Po4Z58trdf" resolve="header" />
+                <node concept="36biLy" id="43oF0KsRdd5" role="28nt2d">
+                  <node concept="BsUDl" id="43oF0KsRg7R" role="36biLW">
+                    <ref role="37wK5l" node="43oF0KsRddw" resolve="createReleaseHeader" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2pIpSj" id="43oF0KsRg8V" role="2pJxcM">
+                <ref role="2pIpSl" to="b7vt:Po4Z58tBq0" resolve="sections" />
+                <node concept="36be1Y" id="43oF0KsRgbm" role="28nt2d">
+                  <node concept="36biLy" id="43oF0KsRgeG" role="36be1Z">
+                    <node concept="2ShNRf" id="43oF0KsRgfj" role="36biLW">
+                      <node concept="3zrR0B" id="43oF0KsRhLH" role="2ShVmc">
+                        <node concept="3Tqbb2" id="43oF0KsRhLJ" role="3zrR0E">
+                          <ref role="ehGHo" to="b7vt:Po4Z58tBpZ" resolve="ChangeSection" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="13i0hz" id="43oF0KsRddw" role="13h7CS">
+      <property role="TrG5h" value="createReleaseHeader" />
+      <node concept="3Tm1VV" id="43oF0KsRddx" role="1B3o_S" />
+      <node concept="3Tqbb2" id="43oF0KsRdea" role="3clF45">
+        <ref role="ehGHo" to="b7vt:Po4Z58Iad0" resolve="IReleaseHeader" />
+      </node>
+      <node concept="3clFbS" id="43oF0KsRddz" role="3clF47">
+        <node concept="3clFbJ" id="43oF0KsRdMr" role="3cqZAp">
+          <node concept="2OqwBi" id="43oF0KsRehG" role="3clFbw">
+            <node concept="2OqwBi" id="43oF0KsRdXt" role="2Oq$k0">
+              <node concept="13iPFW" id="43oF0KsRdMJ" role="2Oq$k0" />
+              <node concept="3TrcHB" id="43oF0KsRe8f" role="2OqNvi">
+                <ref role="3TsBF5" to="b7vt:Po4Z58IlRD" resolve="headerType" />
+              </node>
+            </node>
+            <node concept="21noJN" id="43oF0KsRerj" role="2OqNvi">
+              <node concept="21nZrQ" id="43oF0KsRerl" role="21noJM">
+                <ref role="21nZrZ" to="b7vt:Po4Z58IlRA" resolve="monthYear" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbS" id="43oF0KsRdMt" role="3clFbx">
+            <node concept="3cpWs6" id="43oF0KsReuo" role="3cqZAp">
+              <node concept="2ShNRf" id="43oF0KsRev_" role="3cqZAk">
+                <node concept="3zrR0B" id="43oF0KsRevz" role="2ShVmc">
+                  <node concept="3Tqbb2" id="43oF0KsRev$" role="3zrR0E">
+                    <ref role="ehGHo" to="b7vt:Po4Z58IgAd" resolve="MonthYearReleaseHeader" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3eNFk2" id="43oF0KsReH9" role="3eNLev">
+            <node concept="2OqwBi" id="43oF0KsRfi7" role="3eO9$A">
+              <node concept="2OqwBi" id="43oF0KsReTV" role="2Oq$k0">
+                <node concept="13iPFW" id="43oF0KsReHR" role="2Oq$k0" />
+                <node concept="3TrcHB" id="43oF0KsRf8i" role="2OqNvi">
+                  <ref role="3TsBF5" to="b7vt:Po4Z58IlRD" resolve="headerType" />
+                </node>
+              </node>
+              <node concept="21noJN" id="43oF0KsRft6" role="2OqNvi">
+                <node concept="21nZrQ" id="43oF0KsRft8" role="21noJM">
+                  <ref role="21nZrZ" to="b7vt:Po4Z58IlR_" resolve="versionDate" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbS" id="43oF0KsReHb" role="3eOfB_">
+              <node concept="3cpWs6" id="43oF0KsRfuM" role="3cqZAp">
+                <node concept="2ShNRf" id="43oF0KsRfvQ" role="3cqZAk">
+                  <node concept="3zrR0B" id="43oF0KsRfvO" role="2ShVmc">
+                    <node concept="3Tqbb2" id="43oF0KsRfvP" role="3zrR0E">
+                      <ref role="ehGHo" to="b7vt:Po4Z58tnPb" resolve="VersionDateReleaseHeader" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="43oF0KsRfAj" role="3cqZAp">
+          <node concept="10Nm6u" id="43oF0KsRfG4" role="3cqZAk" />
+        </node>
+      </node>
+    </node>
+    <node concept="13hLZK" id="2r0ijgcUUGI" role="13h7CW">
+      <node concept="3clFbS" id="2r0ijgcUUGJ" role="2VODD2">
+        <node concept="3clFbF" id="43oF0KsRybk" role="3cqZAp">
+          <node concept="37vLTI" id="43oF0KsRzEH" role="3clFbG">
+            <node concept="2c44tf" id="43oF0KsRzJM" role="37vLTx">
+              <node concept="1Pa9Pv" id="43oF0KsRzLZ" role="2c44tc">
+                <node concept="1PaTwC" id="43oF0KsRzM0" role="1PaQFQ">
+                  <node concept="3oM_SD" id="43oF0KsRzOL" role="1PaTwD">
+                    <property role="3oM_SC" value="All" />
+                  </node>
+                  <node concept="3oM_SD" id="43oF0KsRzOM" role="1PaTwD">
+                    <property role="3oM_SC" value="notable" />
+                  </node>
+                  <node concept="3oM_SD" id="43oF0KsRzON" role="1PaTwD">
+                    <property role="3oM_SC" value="changes" />
+                  </node>
+                  <node concept="3oM_SD" id="43oF0KsRzOO" role="1PaTwD">
+                    <property role="3oM_SC" value="to" />
+                  </node>
+                  <node concept="3oM_SD" id="43oF0KsRzOP" role="1PaTwD">
+                    <property role="3oM_SC" value="this" />
+                  </node>
+                  <node concept="3oM_SD" id="43oF0KsRzOQ" role="1PaTwD">
+                    <property role="3oM_SC" value="project" />
+                  </node>
+                  <node concept="3oM_SD" id="1$KnWE8qVGr" role="1PaTwD">
+                    <property role="3oM_SC" value="are" />
+                  </node>
+                  <node concept="3oM_SD" id="43oF0KsRzOT" role="1PaTwD">
+                    <property role="3oM_SC" value="documented" />
+                  </node>
+                  <node concept="3oM_SD" id="43oF0KsRzOU" role="1PaTwD">
+                    <property role="3oM_SC" value="in" />
+                  </node>
+                  <node concept="3oM_SD" id="43oF0KsRzOV" role="1PaTwD">
+                    <property role="3oM_SC" value="this" />
+                  </node>
+                  <node concept="3oM_SD" id="43oF0KsRzOW" role="1PaTwD">
+                    <property role="3oM_SC" value="file." />
+                  </node>
+                </node>
+                <node concept="1PaTwC" id="43oF0KsRzOY" role="1PaQFQ">
+                  <node concept="3oM_SD" id="43oF0KsRzOZ" role="1PaTwD">
+                    <property role="3oM_SC" value="" />
+                  </node>
+                </node>
+                <node concept="1PaTwC" id="43oF0KsRzP0" role="1PaQFQ">
+                  <node concept="3oM_SD" id="43oF0KsRzP1" role="1PaTwD">
+                    <property role="3oM_SC" value="The" />
+                  </node>
+                  <node concept="3oM_SD" id="43oF0KsRzP2" role="1PaTwD">
+                    <property role="3oM_SC" value="format" />
+                  </node>
+                  <node concept="3oM_SD" id="43oF0KsRzP3" role="1PaTwD">
+                    <property role="3oM_SC" value="is" />
+                  </node>
+                  <node concept="3oM_SD" id="43oF0KsRzP4" role="1PaTwD">
+                    <property role="3oM_SC" value="based" />
+                  </node>
+                  <node concept="3oM_SD" id="43oF0KsRzP5" role="1PaTwD">
+                    <property role="3oM_SC" value="on" />
+                  </node>
+                  <node concept="3oM_SD" id="43oF0KsRzP6" role="1PaTwD">
+                    <property role="3oM_SC" value="Keep a Changelog" />
+                    <property role="1X82VU" value="https://keepachangelog.com/en/1.0.0/" />
+                  </node>
+                  <node concept="3oM_SD" id="43oF0KsRzP7" role="1PaTwD">
+                    <property role="3oM_SC" value="." />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="2OqwBi" id="43oF0KsRyk4" role="37vLTJ">
+              <node concept="13iPFW" id="43oF0KsRybj" role="2Oq$k0" />
+              <node concept="3TrEf2" id="43oF0KsRyuO" role="2OqNvi">
+                <ref role="3Tt5mk" to="b7vt:Po4Z58tmyF" resolve="header" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="13h7C7" id="43oF0KsRq$c">
+    <ref role="13h7C2" to="b7vt:Po4Z58tBpZ" resolve="ChangeSection" />
+    <node concept="13hLZK" id="43oF0KsRq$d" role="13h7CW">
+      <node concept="3clFbS" id="43oF0KsRq$e" role="2VODD2">
+        <node concept="3clFbF" id="43oF0KsRq$o" role="3cqZAp">
+          <node concept="2OqwBi" id="43oF0KsRscB" role="3clFbG">
+            <node concept="2OqwBi" id="43oF0KsRqGi" role="2Oq$k0">
+              <node concept="13iPFW" id="43oF0KsRq$n" role="2Oq$k0" />
+              <node concept="3Tsc0h" id="43oF0KsRqP5" role="2OqNvi">
+                <ref role="3TtcxE" to="b7vt:Po4Z58tBq_" resolve="changes" />
+              </node>
+            </node>
+            <node concept="WFELt" id="43oF0KsRt$P" role="2OqNvi">
+              <ref role="1A0vxQ" to="zqge:WJz9iAWEzU" resolve="BulletLine" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="13h7C7" id="1$KnWE8sX2O">
+    <property role="3GE5qa" value="textElements" />
+    <ref role="13h7C2" to="b7vt:1$KnWE8sX2_" resolve="CombinedElements" />
+    <node concept="13hLZK" id="1$KnWE8sX2P" role="13h7CW">
+      <node concept="3clFbS" id="1$KnWE8sX2Q" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="1$KnWE8sX2Z" role="13h7CS">
+      <property role="TrG5h" value="getTextualRepresentation" />
+      <ref role="13i0hy" to="vdrq:fB3l81it7u" resolve="getTextualRepresentation" />
+      <node concept="3Tm1VV" id="1$KnWE8sX30" role="1B3o_S" />
+      <node concept="3clFbS" id="1$KnWE8sX3e" role="3clF47">
+        <node concept="3clFbF" id="1$KnWE8uSLH" role="3cqZAp">
+          <node concept="2OqwBi" id="1$KnWE8uS2m" role="3clFbG">
+            <node concept="2OqwBi" id="1$KnWE8uQUh" role="2Oq$k0">
+              <node concept="2OqwBi" id="1$KnWE8uJaf" role="2Oq$k0">
+                <node concept="2OqwBi" id="1$KnWE8uILn" role="2Oq$k0">
+                  <node concept="13iPFW" id="1$KnWE8uIAD" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="1$KnWE8uJ01" role="2OqNvi">
+                    <ref role="3Tt5mk" to="b7vt:1$KnWE8uIdI" resolve="line" />
+                  </node>
+                </node>
+                <node concept="2qgKlT" id="1$KnWE8uQGB" role="2OqNvi">
+                  <ref role="37wK5l" to="vdrq:WJz9iATjyN" resolve="getTextElements" />
+                </node>
+              </node>
+              <node concept="3$u5V9" id="1$KnWE8uRcJ" role="2OqNvi">
+                <node concept="1bVj0M" id="1$KnWE8uRcL" role="23t8la">
+                  <node concept="3clFbS" id="1$KnWE8uRcM" role="1bW5cS">
+                    <node concept="3clFbF" id="1$KnWE8uRcV" role="3cqZAp">
+                      <node concept="2OqwBi" id="1$KnWE8uRoD" role="3clFbG">
+                        <node concept="37vLTw" id="1$KnWE8uRcU" role="2Oq$k0">
+                          <ref role="3cqZAo" node="1$KnWE8uRcN" resolve="it" />
+                        </node>
+                        <node concept="2qgKlT" id="1$KnWE8uRHI" role="2OqNvi">
+                          <ref role="37wK5l" to="vdrq:fB3l81it7u" resolve="getTextualRepresentation" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Rh6nW" id="1$KnWE8uRcN" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="1$KnWE8uRcO" role="1tU5fm" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3uJxvA" id="1$KnWE8uSAl" role="2OqNvi">
+              <node concept="Xl_RD" id="1$KnWE8vrzM" role="3uJOhx" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="1$KnWE8sX3f" role="3clF45" />
+    </node>
+  </node>
+</model>
+

--- a/code/changelog/de.itemis.mps.changelog/models/de.itemis.mps.changelog.constraints.mps
+++ b/code/changelog/de.itemis.mps.changelog/models/de.itemis.mps.changelog.constraints.mps
@@ -174,7 +174,7 @@
               <node concept="2OqwBi" id="XbadXRL1Nl" role="3uHU7w">
                 <node concept="EsrRn" id="XbadXRNkSb" role="2Oq$k0" />
                 <node concept="2qgKlT" id="XbadXRL28w" role="2OqNvi">
-                  <ref role="37wK5l" to="j2b5:2r0ijgcUaDV" resolve="getDate" />
+                  <ref role="37wK5l" to="j2b5:2r0ijgcUaDV" resolve="getDateAsString" />
                 </node>
               </node>
               <node concept="3cpWs3" id="XbadXRKViV" role="3uHU7B">

--- a/code/changelog/de.itemis.mps.changelog/models/de.itemis.mps.changelog.constraints.mps
+++ b/code/changelog/de.itemis.mps.changelog/models/de.itemis.mps.changelog.constraints.mps
@@ -1,0 +1,353 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:5224e1e2-6a4b-4b44-839f-f30ff2a8c3b8(de.itemis.mps.changelog.constraints)">
+  <persistence version="9" />
+  <languages>
+    <use id="5dae8159-ab99-46bb-a40d-0cee30ee7018" name="jetbrains.mps.lang.constraints.rules.kinds" version="0" />
+    <use id="ea3159bf-f48e-4720-bde2-86dba75f0d34" name="jetbrains.mps.lang.context.defs" version="0" />
+    <use id="e51810c5-7308-4642-bcb6-469e61b5dd18" name="jetbrains.mps.lang.constraints.msg.specification" version="0" />
+    <use id="134c38d4-e3af-4d9e-b069-1c7df0a4005d" name="jetbrains.mps.lang.constraints.rules.skeleton" version="0" />
+    <use id="b3551702-269c-4f05-ba61-58060cef4292" name="jetbrains.mps.lang.rulesAndMessages" version="0" />
+    <use id="3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1" name="jetbrains.mps.lang.constraints" version="6" />
+    <use id="13744753-c81f-424a-9c1b-cf8943bf4e86" name="jetbrains.mps.lang.sharedConcepts" version="0" />
+    <use id="3ad5badc-1d9c-461c-b7b1-fa2fcd0a0ae7" name="jetbrains.mps.lang.context" version="0" />
+    <use id="ad93155d-79b2-4759-b10c-55123e763903" name="jetbrains.mps.lang.messages" version="0" />
+    <use id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior" version="2" />
+    <devkit ref="00000000-0000-4000-0000-5604ebd4f22c(jetbrains.mps.devkit.aspect.constraints)" />
+  </languages>
+  <imports>
+    <import index="b7vt" ref="r:86cc19c0-126f-473b-92c6-29dba75c1e89(de.itemis.mps.changelog.structure)" />
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
+    <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" implicit="true" />
+    <import index="j2b5" ref="r:44801727-1f82-4e97-98b6-460b3dc79dca(de.itemis.mps.changelog.behavior)" implicit="true" />
+    <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1153417849900" name="jetbrains.mps.baseLanguage.structure.GreaterThanOrEqualsExpression" flags="nn" index="2d3UOw" />
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
+        <child id="1145553007750" name="creator" index="2ShVmc" />
+      </concept>
+      <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
+        <child id="1137022507850" name="body" index="2VODD2" />
+      </concept>
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ng" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
+      </concept>
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="1225271408483" name="jetbrains.mps.baseLanguage.structure.IsNotEmptyOperation" flags="nn" index="17RvpY" />
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
+        <child id="1068580123160" name="condition" index="3clFbw" />
+        <child id="1068580123161" name="ifTrue" index="3clFbx" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
+        <property id="1068580320021" name="value" index="3cmrfH" />
+      </concept>
+      <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
+      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
+        <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
+      </concept>
+      <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+        <reference id="1107535924139" name="classifier" index="3uigEE" />
+      </concept>
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
+        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
+        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
+      </concept>
+    </language>
+    <language id="3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1" name="jetbrains.mps.lang.constraints">
+      <concept id="1147467115080" name="jetbrains.mps.lang.constraints.structure.NodePropertyConstraint" flags="ng" index="EnEH3">
+        <reference id="1147467295099" name="applicableProperty" index="EomxK" />
+        <child id="1147468630220" name="propertyGetter" index="EtsB7" />
+        <child id="1212097481299" name="propertyValidator" index="QCWH9" />
+      </concept>
+      <concept id="1147467790433" name="jetbrains.mps.lang.constraints.structure.ConstraintFunction_PropertyGetter" flags="in" index="Eqf_E" />
+      <concept id="1147468365020" name="jetbrains.mps.lang.constraints.structure.ConstraintsFunctionParameter_node" flags="nn" index="EsrRn" />
+      <concept id="1212096972063" name="jetbrains.mps.lang.constraints.structure.ConstraintFunction_PropertyValidator" flags="in" index="QB0g5" />
+      <concept id="1213093968558" name="jetbrains.mps.lang.constraints.structure.ConceptConstraints" flags="ng" index="1M2fIO">
+        <reference id="1213093996982" name="concept" index="1M2myG" />
+        <child id="1213098023997" name="property" index="1MhHOB" />
+      </concept>
+      <concept id="1153138554286" name="jetbrains.mps.lang.constraints.structure.ConstraintsFunctionParameter_propertyValue" flags="nn" index="1Wqviy" />
+    </language>
+    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
+      <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
+        <reference id="1138056395725" name="property" index="3TsBF5" />
+      </concept>
+      <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="nn" index="3TrEf2">
+        <reference id="1138056516764" name="link" index="3Tt5mk" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="1M2fIO" id="Po4Z58KgJU">
+    <ref role="1M2myG" to="b7vt:Po4Z58IgAd" resolve="MonthYearReleaseHeader" />
+    <node concept="EnEH3" id="Po4Z58KgJV" role="1MhHOB">
+      <ref role="EomxK" to="b7vt:Po4Z58IgAh" resolve="year" />
+      <node concept="QB0g5" id="Po4Z58KgJX" role="QCWH9">
+        <node concept="3clFbS" id="Po4Z58KgJY" role="2VODD2">
+          <node concept="3clFbF" id="Po4Z58Kjlp" role="3cqZAp">
+            <node concept="2d3UOw" id="Po4Z58Km4M" role="3clFbG">
+              <node concept="3cmrfG" id="Po4Z58Km91" role="3uHU7w">
+                <property role="3cmrfH" value="0" />
+              </node>
+              <node concept="1Wqviy" id="Po4Z58Kjlo" role="3uHU7B" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="EnEH3" id="XbadXRLY9s" role="1MhHOB">
+      <ref role="EomxK" to="tpck:h0TrG11" resolve="name" />
+      <node concept="Eqf_E" id="XbadXRLYCV" role="EtsB7">
+        <node concept="3clFbS" id="XbadXRLYCW" role="2VODD2">
+          <node concept="3clFbF" id="XbadXRKMwX" role="3cqZAp">
+            <node concept="3cpWs3" id="XbadXRKNiY" role="3clFbG">
+              <node concept="2OqwBi" id="XbadXRKNvJ" role="3uHU7w">
+                <node concept="EsrRn" id="XbadXRM20W" role="2Oq$k0" />
+                <node concept="3TrcHB" id="XbadXRKNLL" role="2OqNvi">
+                  <ref role="3TsBF5" to="b7vt:Po4Z58IgAh" resolve="year" />
+                </node>
+              </node>
+              <node concept="3cpWs3" id="XbadXRKNcr" role="3uHU7B">
+                <node concept="2OqwBi" id="XbadXRLZgY" role="3uHU7B">
+                  <node concept="2OqwBi" id="XbadXRKMO3" role="2Oq$k0">
+                    <node concept="EsrRn" id="XbadXRM0x8" role="2Oq$k0" />
+                    <node concept="3TrcHB" id="XbadXRKN1V" role="2OqNvi">
+                      <ref role="3TsBF5" to="b7vt:Po4Z58IgAf" resolve="month" />
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="XbadXRLZuJ" role="2OqNvi">
+                    <ref role="37wK5l" to="c17a:~SEnumerationLiteral.getPresentation()" resolve="getPresentation" />
+                  </node>
+                </node>
+                <node concept="Xl_RD" id="XbadXRKNcA" role="3uHU7w">
+                  <property role="Xl_RC" value=" " />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1M2fIO" id="XbadXRM4SN">
+    <ref role="1M2myG" to="b7vt:Po4Z58tnPb" resolve="VersionDateReleaseHeader" />
+    <node concept="EnEH3" id="XbadXRM4SO" role="1MhHOB">
+      <ref role="EomxK" to="tpck:h0TrG11" resolve="name" />
+      <node concept="Eqf_E" id="XbadXRM4SQ" role="EtsB7">
+        <node concept="3clFbS" id="XbadXRM4SR" role="2VODD2">
+          <node concept="3clFbF" id="XbadXRKUzK" role="3cqZAp">
+            <node concept="3cpWs3" id="XbadXRL1vY" role="3clFbG">
+              <node concept="2OqwBi" id="XbadXRL1Nl" role="3uHU7w">
+                <node concept="EsrRn" id="XbadXRNkSb" role="2Oq$k0" />
+                <node concept="2qgKlT" id="XbadXRL28w" role="2OqNvi">
+                  <ref role="37wK5l" to="j2b5:2r0ijgcUaDV" resolve="getDate" />
+                </node>
+              </node>
+              <node concept="3cpWs3" id="XbadXRKViV" role="3uHU7B">
+                <node concept="2OqwBi" id="XbadXRL2Cu" role="3uHU7B">
+                  <node concept="2OqwBi" id="XbadXRKUG_" role="2Oq$k0">
+                    <node concept="EsrRn" id="XbadXRM73Q" role="2Oq$k0" />
+                    <node concept="3TrEf2" id="XbadXRKUTi" role="2OqNvi">
+                      <ref role="3Tt5mk" to="b7vt:Po4Z58trdd" resolve="version" />
+                    </node>
+                  </node>
+                  <node concept="3TrcHB" id="XbadXRM8pt" role="2OqNvi">
+                    <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                  </node>
+                </node>
+                <node concept="Xl_RD" id="XbadXRKVj6" role="3uHU7w">
+                  <property role="Xl_RC" value=" - " />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1M2fIO" id="XbadXRMbXc">
+    <ref role="1M2myG" to="b7vt:Po4Z58tnPe" resolve="SemanticVersion" />
+    <node concept="EnEH3" id="XbadXRMbXd" role="1MhHOB">
+      <ref role="EomxK" to="tpck:h0TrG11" resolve="name" />
+      <node concept="Eqf_E" id="XbadXRMbXf" role="EtsB7">
+        <node concept="3clFbS" id="XbadXRMbXg" role="2VODD2">
+          <node concept="3cpWs8" id="XbadXRL9V9" role="3cqZAp">
+            <node concept="3cpWsn" id="XbadXRL9Va" role="3cpWs9">
+              <property role="TrG5h" value="builder" />
+              <node concept="3uibUv" id="XbadXRL9Vb" role="1tU5fm">
+                <ref role="3uigEE" to="wyt6:~StringBuilder" resolve="StringBuilder" />
+              </node>
+              <node concept="2ShNRf" id="XbadXRLaIN" role="33vP2m">
+                <node concept="1pGfFk" id="XbadXRLbCB" role="2ShVmc">
+                  <property role="373rjd" value="true" />
+                  <ref role="37wK5l" to="wyt6:~StringBuilder.&lt;init&gt;()" resolve="StringBuilder" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="XbadXRLfwl" role="3cqZAp">
+            <node concept="2OqwBi" id="XbadXRLg1E" role="3clFbG">
+              <node concept="37vLTw" id="XbadXRLfwj" role="2Oq$k0">
+                <ref role="3cqZAo" node="XbadXRL9Va" resolve="builder" />
+              </node>
+              <node concept="liA8E" id="XbadXRLhab" role="2OqNvi">
+                <ref role="37wK5l" to="wyt6:~StringBuilder.append(int)" resolve="append" />
+                <node concept="2OqwBi" id="XbadXRLiM9" role="37wK5m">
+                  <node concept="EsrRn" id="XbadXRMdlQ" role="2Oq$k0" />
+                  <node concept="3TrcHB" id="XbadXRLjKc" role="2OqNvi">
+                    <ref role="3TsBF5" to="b7vt:Po4Z58tnPf" resolve="major" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="XbadXRLlAW" role="3cqZAp">
+            <node concept="2OqwBi" id="XbadXRLlYQ" role="3clFbG">
+              <node concept="37vLTw" id="XbadXRLlAU" role="2Oq$k0">
+                <ref role="3cqZAo" node="XbadXRL9Va" resolve="builder" />
+              </node>
+              <node concept="liA8E" id="XbadXRLmFO" role="2OqNvi">
+                <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
+                <node concept="Xl_RD" id="XbadXRLnrw" role="37wK5m">
+                  <property role="Xl_RC" value="." />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="XbadXRLoRc" role="3cqZAp">
+            <node concept="2OqwBi" id="XbadXRLoY8" role="3clFbG">
+              <node concept="37vLTw" id="XbadXRLoRa" role="2Oq$k0">
+                <ref role="3cqZAo" node="XbadXRL9Va" resolve="builder" />
+              </node>
+              <node concept="liA8E" id="XbadXRLpO_" role="2OqNvi">
+                <ref role="37wK5l" to="wyt6:~StringBuilder.append(int)" resolve="append" />
+                <node concept="2OqwBi" id="XbadXRLr7Q" role="37wK5m">
+                  <node concept="EsrRn" id="XbadXRMewx" role="2Oq$k0" />
+                  <node concept="3TrcHB" id="XbadXRLsgh" role="2OqNvi">
+                    <ref role="3TsBF5" to="b7vt:Po4Z58tnPh" resolve="minor" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="XbadXRLvqA" role="3cqZAp">
+            <node concept="2OqwBi" id="XbadXRLvyf" role="3clFbG">
+              <node concept="37vLTw" id="XbadXRLvq$" role="2Oq$k0">
+                <ref role="3cqZAo" node="XbadXRL9Va" resolve="builder" />
+              </node>
+              <node concept="liA8E" id="XbadXRLvBS" role="2OqNvi">
+                <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
+                <node concept="Xl_RD" id="XbadXRLwzK" role="37wK5m">
+                  <property role="Xl_RC" value="." />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="XbadXRLxVN" role="3cqZAp">
+            <node concept="2OqwBi" id="XbadXRLy3T" role="3clFbG">
+              <node concept="37vLTw" id="XbadXRLxVL" role="2Oq$k0">
+                <ref role="3cqZAo" node="XbadXRL9Va" resolve="builder" />
+              </node>
+              <node concept="liA8E" id="XbadXRLyXg" role="2OqNvi">
+                <ref role="37wK5l" to="wyt6:~StringBuilder.append(int)" resolve="append" />
+                <node concept="2OqwBi" id="XbadXRLznO" role="37wK5m">
+                  <node concept="EsrRn" id="XbadXRMfFc" role="2Oq$k0" />
+                  <node concept="3TrcHB" id="XbadXRL$y_" role="2OqNvi">
+                    <ref role="3TsBF5" to="b7vt:Po4Z58tnPk" resolve="patch" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbJ" id="XbadXRLAE0" role="3cqZAp">
+            <node concept="3clFbS" id="XbadXRLAE2" role="3clFbx">
+              <node concept="3clFbF" id="XbadXRLEo_" role="3cqZAp">
+                <node concept="2OqwBi" id="XbadXRLEwN" role="3clFbG">
+                  <node concept="37vLTw" id="XbadXRLEoz" role="2Oq$k0">
+                    <ref role="3cqZAo" node="XbadXRL9Va" resolve="builder" />
+                  </node>
+                  <node concept="liA8E" id="XbadXRLFqD" role="2OqNvi">
+                    <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
+                    <node concept="Xl_RD" id="XbadXRLGjc" role="37wK5m">
+                      <property role="Xl_RC" value="-" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbF" id="XbadXRLHEw" role="3cqZAp">
+                <node concept="2OqwBi" id="XbadXRLHNb" role="3clFbG">
+                  <node concept="37vLTw" id="XbadXRLHEu" role="2Oq$k0">
+                    <ref role="3cqZAo" node="XbadXRL9Va" resolve="builder" />
+                  </node>
+                  <node concept="liA8E" id="XbadXRLII9" role="2OqNvi">
+                    <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
+                    <node concept="2OqwBi" id="XbadXRLMfK" role="37wK5m">
+                      <node concept="EsrRn" id="XbadXRMhVS" role="2Oq$k0" />
+                      <node concept="3TrcHB" id="XbadXRLM$m" role="2OqNvi">
+                        <ref role="3TsBF5" to="b7vt:Po4Z58tnPo" resolve="preRelease" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="2OqwBi" id="XbadXRLDbN" role="3clFbw">
+              <node concept="2OqwBi" id="XbadXRLAW6" role="2Oq$k0">
+                <node concept="EsrRn" id="XbadXRMgK9" role="2Oq$k0" />
+                <node concept="3TrcHB" id="XbadXRLC0Z" role="2OqNvi">
+                  <ref role="3TsBF5" to="b7vt:Po4Z58tnPo" resolve="preRelease" />
+                </node>
+              </node>
+              <node concept="17RvpY" id="XbadXRLEj5" role="2OqNvi" />
+            </node>
+          </node>
+          <node concept="3clFbF" id="XbadXRLOuK" role="3cqZAp">
+            <node concept="2OqwBi" id="XbadXRLPAN" role="3clFbG">
+              <node concept="37vLTw" id="XbadXRLOuI" role="2Oq$k0">
+                <ref role="3cqZAo" node="XbadXRL9Va" resolve="builder" />
+              </node>
+              <node concept="liA8E" id="XbadXRLPK3" role="2OqNvi">
+                <ref role="37wK5l" to="wyt6:~StringBuilder.toString()" resolve="toString" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/code/changelog/de.itemis.mps.changelog/models/de.itemis.mps.changelog.editor.mps
+++ b/code/changelog/de.itemis.mps.changelog/models/de.itemis.mps.changelog.editor.mps
@@ -1,0 +1,1509 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:59d0704b-fe11-45f5-812e-d1676afe357e(de.itemis.mps.changelog.editor)">
+  <persistence version="9" />
+  <languages>
+    <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="14" />
+    <use id="9d69e719-78c8-4286-90db-fb19c107d049" name="com.mbeddr.mpsutil.grammarcells" version="2" />
+    <use id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior" version="2" />
+    <use id="aee9cad2-acd4-4608-aef2-0004f6a1cdbd" name="jetbrains.mps.lang.actions" version="4" />
+    <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
+  </languages>
+  <imports>
+    <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
+    <import index="25x5" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.text(JDK/)" />
+    <import index="6t7w" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.time.format(JDK/)" />
+    <import index="28m1" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.time(JDK/)" />
+    <import index="b7vt" ref="r:86cc19c0-126f-473b-92c6-29dba75c1e89(de.itemis.mps.changelog.structure)" />
+    <import index="25zl" ref="r:7bd127a5-e641-4c13-b150-b9c9b96f76ae(jetbrains.mps.lang.modelapi.editor)" />
+    <import index="tpc5" ref="r:00000000-0000-4000-0000-011c89590299(jetbrains.mps.lang.editor.editor)" />
+    <import index="zqge" ref="r:59e90602-6655-4552-86eb-441a42a9a0e4(jetbrains.mps.lang.text.structure)" />
+    <import index="lwvz" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.selection(MPS.Editor/)" />
+    <import index="cj4x" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor(MPS.Editor/)" />
+    <import index="b8lf" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor.selection(MPS.Editor/)" />
+    <import index="f4zo" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.cells(MPS.Editor/)" />
+    <import index="2u9v" ref="r:ad87c166-8161-4e40-b79b-3d7ba4070d9e(jetbrains.mps.lang.text.editor)" />
+    <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" />
+    <import index="t6h5" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang.reflect(JDK/)" />
+    <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" />
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
+    <import index="j2b5" ref="r:44801727-1f82-4e97-98b6-460b3dc79dca(de.itemis.mps.changelog.behavior)" implicit="true" />
+    <import index="tpen" ref="r:00000000-0000-4000-0000-011c895902c3(jetbrains.mps.baseLanguage.editor)" implicit="true" />
+    <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
+    <import index="7fo8" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.time.chrono(JDK/)" implicit="true" />
+    <import index="tpch" ref="r:00000000-0000-4000-0000-011c8959028d(jetbrains.mps.lang.structure.editor)" implicit="true" />
+    <import index="tpco" ref="r:00000000-0000-4000-0000-011c89590284(jetbrains.mps.lang.core.editor)" implicit="true" />
+    <import index="tp25" ref="r:00000000-0000-4000-0000-011c89590301(jetbrains.mps.lang.smodel.structure)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor">
+      <concept id="1402906326896143883" name="jetbrains.mps.lang.editor.structure.CellKeyMap_FunctionParm_selectedNode" flags="nn" index="0GJ7k" />
+      <concept id="5991739802479784073" name="jetbrains.mps.lang.editor.structure.MenuTypeDefault" flags="ng" index="22hDWj" />
+      <concept id="2000375450116454183" name="jetbrains.mps.lang.editor.structure.ISubstituteMenu" flags="ng" index="22mbnS">
+        <child id="414384289274416996" name="parts" index="3ft7WO" />
+      </concept>
+      <concept id="2000375450116423800" name="jetbrains.mps.lang.editor.structure.SubstituteMenu" flags="ng" index="22mcaB" />
+      <concept id="1071666914219" name="jetbrains.mps.lang.editor.structure.ConceptEditorDeclaration" flags="ig" index="24kQdi">
+        <child id="1078153129734" name="inspectedCellModel" index="6VMZX" />
+      </concept>
+      <concept id="1176897764478" name="jetbrains.mps.lang.editor.structure.QueryFunction_NodeFactory" flags="in" index="4$FPG" />
+      <concept id="1140524381322" name="jetbrains.mps.lang.editor.structure.CellModel_ListWithRole" flags="ng" index="2czfm3">
+        <child id="1176897874615" name="nodeFactory" index="4_6I_" />
+        <child id="1140524464360" name="cellLayout" index="2czzBx" />
+      </concept>
+      <concept id="1106270549637" name="jetbrains.mps.lang.editor.structure.CellLayout_Horizontal" flags="nn" index="2iRfu4" />
+      <concept id="1106270571710" name="jetbrains.mps.lang.editor.structure.CellLayout_Vertical" flags="nn" index="2iRkQZ" />
+      <concept id="1237303669825" name="jetbrains.mps.lang.editor.structure.CellLayout_Indent" flags="nn" index="l2Vlx" />
+      <concept id="1142886811589" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameter_node" flags="nn" index="pncrf" />
+      <concept id="1177327570013" name="jetbrains.mps.lang.editor.structure.QueryFunction_SubstituteMenu_Substitute" flags="in" index="ucgPf" />
+      <concept id="1080736578640" name="jetbrains.mps.lang.editor.structure.BaseEditorComponent" flags="ig" index="2wURMF">
+        <child id="1080736633877" name="cellModel" index="2wV5jI" />
+      </concept>
+      <concept id="6718020819487620873" name="jetbrains.mps.lang.editor.structure.TransformationMenuReference_Named" flags="ng" index="A1WHu">
+        <reference id="6718020819487620874" name="menu" index="A1WHt" />
+      </concept>
+      <concept id="3547227755871693971" name="jetbrains.mps.lang.editor.structure.PredefinedSelector" flags="ng" index="2B6iha" />
+      <concept id="8383079901754291618" name="jetbrains.mps.lang.editor.structure.CellModel_NextEditor" flags="ng" index="B$lHz" />
+      <concept id="1239814640496" name="jetbrains.mps.lang.editor.structure.CellLayout_VerticalGrid" flags="nn" index="2EHx9g" />
+      <concept id="1136916919141" name="jetbrains.mps.lang.editor.structure.CellKeyMapItem" flags="lg" index="2PxR9H">
+        <property id="1141091278922" name="caretPolicy" index="2IlM53" />
+        <child id="1136916998332" name="keystroke" index="2PyaAO" />
+        <child id="1136917325338" name="isApplicableFunction" index="2Pzqsi" />
+        <child id="1136920925604" name="executeFunction" index="2PL9iG" />
+      </concept>
+      <concept id="1136916976737" name="jetbrains.mps.lang.editor.structure.CellKeyMapKeystroke" flags="ng" index="2Py5lD">
+        <property id="1136923970223" name="modifiers" index="2PWKIB" />
+        <property id="1136923970224" name="keycode" index="2PWKIS" />
+      </concept>
+      <concept id="1136917249679" name="jetbrains.mps.lang.editor.structure.CellKeyMap_IsApplicableFunction" flags="in" index="2Pz7Y7" />
+      <concept id="1136917288805" name="jetbrains.mps.lang.editor.structure.CellKeyMap_ExecuteFunction" flags="in" index="2PzhpH" />
+      <concept id="1078938745671" name="jetbrains.mps.lang.editor.structure.EditorComponentDeclaration" flags="ig" index="PKFIW" />
+      <concept id="1078939183254" name="jetbrains.mps.lang.editor.structure.CellModel_Component" flags="sg" stub="3162947552742194261" index="PMmxH">
+        <reference id="1078939183255" name="editorComponent" index="PMmxG" />
+      </concept>
+      <concept id="1186403694788" name="jetbrains.mps.lang.editor.structure.ColorStyleClassItem" flags="ln" index="VaVBg">
+        <property id="1186403713874" name="color" index="Vb096" />
+        <child id="1186403803051" name="query" index="VblUZ" />
+      </concept>
+      <concept id="1186403751766" name="jetbrains.mps.lang.editor.structure.FontStyleStyleClassItem" flags="ln" index="Vb9p2">
+        <property id="1186403771423" name="style" index="Vbekb" />
+      </concept>
+      <concept id="1186404549998" name="jetbrains.mps.lang.editor.structure.ForegroundColorStyleClassItem" flags="ln" index="VechU" />
+      <concept id="1186404574412" name="jetbrains.mps.lang.editor.structure.BackgroundColorStyleClassItem" flags="ln" index="Veino" />
+      <concept id="1186414536763" name="jetbrains.mps.lang.editor.structure.BooleanStyleSheetItem" flags="ln" index="VOi$J">
+        <property id="1186414551515" name="flag" index="VOm3f" />
+      </concept>
+      <concept id="1186414928363" name="jetbrains.mps.lang.editor.structure.SelectableStyleSheetItem" flags="ln" index="VPM3Z" />
+      <concept id="1186414976055" name="jetbrains.mps.lang.editor.structure.DrawBorderStyleClassItem" flags="ln" index="VPXOz" />
+      <concept id="1186415722038" name="jetbrains.mps.lang.editor.structure.FontSizeStyleClassItem" flags="ln" index="VSNWy">
+        <property id="1221209241505" name="value" index="1lJzqX" />
+      </concept>
+      <concept id="1074767920765" name="jetbrains.mps.lang.editor.structure.CellModel_ModelAccess" flags="sg" stub="8104358048506729357" index="XafU7">
+        <child id="1176718152741" name="modelAcessor" index="3TRxkO" />
+      </concept>
+      <concept id="1630016958697344083" name="jetbrains.mps.lang.editor.structure.IMenu_Concept" flags="ng" index="2ZABuq">
+        <reference id="6591946374543067572" name="conceptDeclaration" index="aqKnT" />
+        <child id="5991739802479788259" name="type" index="22hAXT" />
+      </concept>
+      <concept id="1233758997495" name="jetbrains.mps.lang.editor.structure.PunctuationLeftStyleClassItem" flags="ln" index="11L4FC" />
+      <concept id="1233759184865" name="jetbrains.mps.lang.editor.structure.PunctuationRightStyleClassItem" flags="ln" index="11LMrY" />
+      <concept id="1081293058843" name="jetbrains.mps.lang.editor.structure.CellKeyMapDeclaration" flags="ig" index="325Ffw">
+        <reference id="1139445935125" name="applicableConcept" index="1chiOs" />
+        <child id="1136930944870" name="item" index="2QnnpI" />
+      </concept>
+      <concept id="1214472762472" name="jetbrains.mps.lang.editor.structure.DefaultCaretPositionStyleClassItem" flags="ln" index="34dVlM">
+        <property id="1214472762473" name="position" index="34dVlN" />
+      </concept>
+      <concept id="1154465273778" name="jetbrains.mps.lang.editor.structure.QueryFunctionParameter_SubstituteMenu_ParentNode" flags="nn" index="3bvxqY" />
+      <concept id="7342352913006985483" name="jetbrains.mps.lang.editor.structure.SubstituteMenuPart_Action" flags="ng" index="3eGOop">
+        <child id="8612453216082699922" name="substituteHandler" index="3aKz83" />
+      </concept>
+      <concept id="1088013125922" name="jetbrains.mps.lang.editor.structure.CellModel_RefCell" flags="sg" stub="730538219795941030" index="1iCGBv">
+        <child id="1088186146602" name="editorComponent" index="1sWHZn" />
+      </concept>
+      <concept id="1225456267680" name="jetbrains.mps.lang.editor.structure.RGBColor" flags="ng" index="1iSF2X">
+        <property id="1225456424731" name="value" index="1iTho6" />
+      </concept>
+      <concept id="1381004262292414836" name="jetbrains.mps.lang.editor.structure.ICellStyle" flags="ng" index="1k5N5V">
+        <reference id="1381004262292426837" name="parentStyleClass" index="1k5W1q" />
+      </concept>
+      <concept id="1236262245656" name="jetbrains.mps.lang.editor.structure.MatchingLabelStyleClassItem" flags="ln" index="3mYdg7">
+        <property id="1238091709220" name="labelName" index="1413C4" />
+      </concept>
+      <concept id="1088185857835" name="jetbrains.mps.lang.editor.structure.InlineEditorComponent" flags="ig" index="1sVBvm" />
+      <concept id="1215007762405" name="jetbrains.mps.lang.editor.structure.FloatStyleClassItem" flags="ln" index="3$6MrZ">
+        <property id="1215007802031" name="value" index="3$6WeP" />
+      </concept>
+      <concept id="1215007897487" name="jetbrains.mps.lang.editor.structure.PaddingRightStyleClassItem" flags="ln" index="3$7jql" />
+      <concept id="1139848536355" name="jetbrains.mps.lang.editor.structure.CellModel_WithRole" flags="ng" index="1$h60E">
+        <reference id="1140103550593" name="relationDeclaration" index="1NtTu8" />
+      </concept>
+      <concept id="1073389214265" name="jetbrains.mps.lang.editor.structure.EditorCellModel" flags="ng" index="3EYTF0">
+        <reference id="1081339532145" name="keyMap" index="34QXea" />
+        <child id="4202667662392416064" name="transformationMenu" index="3vIgyS" />
+      </concept>
+      <concept id="1073389446423" name="jetbrains.mps.lang.editor.structure.CellModel_Collection" flags="sn" stub="3013115976261988961" index="3EZMnI">
+        <property id="1160590353935" name="usesFolding" index="S$Qs1" />
+        <child id="1106270802874" name="cellLayout" index="2iSdaV" />
+        <child id="7723470090030138869" name="foldedCellModel" index="AHCbl" />
+        <child id="1073389446424" name="childCellModel" index="3EZMnx" />
+      </concept>
+      <concept id="1073389577006" name="jetbrains.mps.lang.editor.structure.CellModel_Constant" flags="sn" stub="3610246225209162225" index="3F0ifn">
+        <property id="1073389577007" name="text" index="3F0ifm" />
+      </concept>
+      <concept id="1073389658414" name="jetbrains.mps.lang.editor.structure.CellModel_Property" flags="sg" stub="730538219796134133" index="3F0A7n" />
+      <concept id="1219418625346" name="jetbrains.mps.lang.editor.structure.IStyleContainer" flags="ng" index="3F0Thp">
+        <child id="1219418656006" name="styleItem" index="3F10Kt" />
+      </concept>
+      <concept id="1073389882823" name="jetbrains.mps.lang.editor.structure.CellModel_RefNode" flags="sg" stub="730538219795960754" index="3F1sOY" />
+      <concept id="1073390211982" name="jetbrains.mps.lang.editor.structure.CellModel_RefNodeList" flags="sg" stub="2794558372793454595" index="3F2HdR" />
+      <concept id="3647146066980922272" name="jetbrains.mps.lang.editor.structure.SelectInEditorOperation" flags="nn" index="1OKiuA">
+        <child id="1948540814633499358" name="editorContext" index="lBI5i" />
+        <child id="1948540814635895774" name="cellSelector" index="lGT1i" />
+        <child id="3604384757217586546" name="selectionStart" index="3dN3m$" />
+      </concept>
+      <concept id="1161622981231" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameter_editorContext" flags="nn" index="1Q80Hx" />
+      <concept id="1176717779940" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameter_text" flags="nn" index="3TQ6bP" />
+      <concept id="1176717841777" name="jetbrains.mps.lang.editor.structure.QueryFunction_ModelAccess_Getter" flags="in" index="3TQlhw" />
+      <concept id="1176717871254" name="jetbrains.mps.lang.editor.structure.QueryFunction_ModelAccess_Setter" flags="in" index="3TQsA7" />
+      <concept id="1176717888428" name="jetbrains.mps.lang.editor.structure.QueryFunction_ModelAccess_Validator" flags="in" index="3TQwEX" />
+      <concept id="1176717996748" name="jetbrains.mps.lang.editor.structure.ModelAccessor" flags="ng" index="3TQVft">
+        <child id="1176718001874" name="getter" index="3TQWv3" />
+        <child id="1176718007938" name="setter" index="3TQXYj" />
+        <child id="1176718014393" name="validator" index="3TQZqC" />
+      </concept>
+      <concept id="1198256887712" name="jetbrains.mps.lang.editor.structure.CellModel_Indent" flags="ng" index="3XFhqQ" />
+      <concept id="1166049232041" name="jetbrains.mps.lang.editor.structure.AbstractComponent" flags="ng" index="1XWOmA">
+        <reference id="1166049300910" name="conceptDeclaration" index="1XX52x" />
+      </concept>
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="4564374268190696673" name="jetbrains.mps.baseLanguage.structure.PrimitiveClassExpression" flags="nn" index="229OVn">
+        <child id="4564374268190696674" name="primitiveType" index="229OVk" />
+      </concept>
+      <concept id="1082485599095" name="jetbrains.mps.baseLanguage.structure.BlockStatement" flags="nn" index="9aQIb">
+        <child id="1082485599096" name="statements" index="9aQI4" />
+      </concept>
+      <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
+        <child id="1068498886297" name="rValue" index="37vLTx" />
+        <child id="1068498886295" name="lValue" index="37vLTJ" />
+      </concept>
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="8118189177080264853" name="jetbrains.mps.baseLanguage.structure.AlternativeType" flags="ig" index="nSUau">
+        <child id="8118189177080264854" name="alternative" index="nSUat" />
+      </concept>
+      <concept id="1239714755177" name="jetbrains.mps.baseLanguage.structure.AbstractUnaryNumberOperation" flags="nn" index="2$Kvd9">
+        <child id="1239714902950" name="expression" index="2$L3a6" />
+      </concept>
+      <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
+        <child id="1154032183016" name="body" index="2LFqv$" />
+      </concept>
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
+        <child id="1145553007750" name="creator" index="2ShVmc" />
+      </concept>
+      <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
+        <child id="1137022507850" name="body" index="2VODD2" />
+      </concept>
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="4952749571008284462" name="jetbrains.mps.baseLanguage.structure.CatchVariable" flags="ng" index="XOnhg" />
+      <concept id="1081236700938" name="jetbrains.mps.baseLanguage.structure.StaticMethodDeclaration" flags="ig" index="2YIFZL" />
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
+      </concept>
+      <concept id="1081256982272" name="jetbrains.mps.baseLanguage.structure.InstanceOfExpression" flags="nn" index="2ZW3vV">
+        <child id="1081256993305" name="classType" index="2ZW6by" />
+        <child id="1081256993304" name="leftExpression" index="2ZW6bz" />
+      </concept>
+      <concept id="1070533707846" name="jetbrains.mps.baseLanguage.structure.StaticFieldReference" flags="nn" index="10M0yZ">
+        <reference id="1144433057691" name="classifier" index="1PxDUh" />
+      </concept>
+      <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
+      <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
+      <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
+      <concept id="1070534934090" name="jetbrains.mps.baseLanguage.structure.CastExpression" flags="nn" index="10QFUN">
+        <child id="1070534934091" name="type" index="10QFUM" />
+        <child id="1070534934092" name="expression" index="10QFUP" />
+      </concept>
+      <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu" />
+      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
+      <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123134" name="parameter" index="3clF46" />
+        <child id="1068580123135" name="body" index="3clF47" />
+      </concept>
+      <concept id="1068580123152" name="jetbrains.mps.baseLanguage.structure.EqualsExpression" flags="nn" index="3clFbC" />
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
+      <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
+        <child id="1082485599094" name="ifFalseStatement" index="9aQIa" />
+        <child id="1068580123160" name="condition" index="3clFbw" />
+        <child id="1068580123161" name="ifTrue" index="3clFbx" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
+        <property id="1068580123138" name="value" index="3clFbU" />
+      </concept>
+      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
+        <property id="1068580320021" name="value" index="3cmrfH" />
+      </concept>
+      <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
+        <child id="1068581517676" name="expression" index="3cqZAk" />
+      </concept>
+      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
+        <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
+      </concept>
+      <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
+      <concept id="1079359253375" name="jetbrains.mps.baseLanguage.structure.ParenthesizedExpression" flags="nn" index="1eOMI4">
+        <child id="1079359253376" name="expression" index="1eOMHV" />
+      </concept>
+      <concept id="1081506773034" name="jetbrains.mps.baseLanguage.structure.LessThanExpression" flags="nn" index="3eOVzh" />
+      <concept id="1081516740877" name="jetbrains.mps.baseLanguage.structure.NotExpression" flags="nn" index="3fqX7Q">
+        <child id="1081516765348" name="expression" index="3fr31v" />
+      </concept>
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+      <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
+        <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
+      </concept>
+      <concept id="1171903607971" name="jetbrains.mps.baseLanguage.structure.WildCardType" flags="in" index="3qTvmN" />
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+        <reference id="1107535924139" name="classifier" index="3uigEE" />
+        <child id="1109201940907" name="parameter" index="11_B2D" />
+      </concept>
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
+        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
+        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
+      </concept>
+      <concept id="1214918800624" name="jetbrains.mps.baseLanguage.structure.PostfixIncrementExpression" flags="nn" index="3uNrnE" />
+      <concept id="3093926081414150598" name="jetbrains.mps.baseLanguage.structure.MultipleCatchClause" flags="ng" index="3uVAMA">
+        <child id="8276990574895933173" name="catchBody" index="1zc67A" />
+        <child id="8276990574895933172" name="throwable" index="1zc67B" />
+      </concept>
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
+        <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="1144230876926" name="jetbrains.mps.baseLanguage.structure.AbstractForStatement" flags="nn" index="1DupvO">
+        <child id="1144230900587" name="variable" index="1Duv9x" />
+      </concept>
+      <concept id="1144231330558" name="jetbrains.mps.baseLanguage.structure.ForStatement" flags="nn" index="1Dw8fO">
+        <child id="1144231399730" name="condition" index="1Dwp0S" />
+        <child id="1144231408325" name="iteration" index="1Dwrff" />
+      </concept>
+      <concept id="5351203823916750322" name="jetbrains.mps.baseLanguage.structure.TryUniversalStatement" flags="nn" index="3J1_TO">
+        <child id="8276990574886367510" name="catchClause" index="1zxBo5" />
+        <child id="8276990574886367508" name="body" index="1zxBo7" />
+      </concept>
+      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+      <concept id="1116615150612" name="jetbrains.mps.baseLanguage.structure.ClassifierClassExpression" flags="nn" index="3VsKOn">
+        <reference id="1116615189566" name="classifier" index="3VsUkX" />
+      </concept>
+      <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
+    </language>
+    <language id="9d69e719-78c8-4286-90db-fb19c107d049" name="com.mbeddr.mpsutil.grammarcells">
+      <concept id="5083944728298846680" name="com.mbeddr.mpsutil.grammarcells.structure.OptionalCell" flags="ng" index="_tjkj">
+        <child id="5083944728298846681" name="option" index="_tjki" />
+      </concept>
+    </language>
+    <language id="760a0a8c-eabb-4521-8bfd-65db761a9ba3" name="jetbrains.mps.baseLanguage.logging">
+      <concept id="6332851714983831325" name="jetbrains.mps.baseLanguage.logging.structure.MsgStatement" flags="ng" index="2xdQw9">
+        <property id="6332851714983843871" name="severity" index="2xdLsb" />
+        <child id="5721587534047265374" name="message" index="9lYJi" />
+        <child id="5721587534047265375" name="throwable" index="9lYJj" />
+      </concept>
+    </language>
+    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
+        <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
+      </concept>
+      <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
+      <concept id="2396822768958367367" name="jetbrains.mps.lang.smodel.structure.AbstractTypeCastExpression" flags="nn" index="$5XWr">
+        <child id="6733348108486823193" name="leftExpression" index="1m5AlR" />
+        <child id="3906496115198199033" name="conceptArgument" index="3oSUPX" />
+      </concept>
+      <concept id="1143511969223" name="jetbrains.mps.lang.smodel.structure.Node_GetPrevSiblingOperation" flags="nn" index="YBYNd" />
+      <concept id="1143512015885" name="jetbrains.mps.lang.smodel.structure.Node_GetNextSiblingOperation" flags="nn" index="YCak7" />
+      <concept id="1139613262185" name="jetbrains.mps.lang.smodel.structure.Node_GetParentOperation" flags="nn" index="1mfA1w" />
+      <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
+        <child id="1177027386292" name="conceptArgument" index="cj9EA" />
+      </concept>
+      <concept id="1171999116870" name="jetbrains.mps.lang.smodel.structure.Node_IsNullOperation" flags="nn" index="3w_OXm" />
+      <concept id="1180636770613" name="jetbrains.mps.lang.smodel.structure.SNodeCreator" flags="nn" index="3zrR0B">
+        <child id="1180636770616" name="createdType" index="3zrR0E" />
+      </concept>
+      <concept id="1140137987495" name="jetbrains.mps.lang.smodel.structure.SNodeTypeCastExpression" flags="nn" index="1PxgMI">
+        <property id="1238684351431" name="asCast" index="1BlNFB" />
+      </concept>
+      <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
+        <reference id="1138405853777" name="concept" index="ehGHo" />
+      </concept>
+      <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
+        <reference id="1138056395725" name="property" index="3TsBF5" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+      <concept id="709746936026466394" name="jetbrains.mps.lang.core.structure.ChildAttribute" flags="ng" index="3VBwX9">
+        <property id="709746936026609031" name="linkId" index="3V$3ak" />
+        <property id="709746936026609029" name="role_DebugInfo" index="3V$3am" />
+      </concept>
+      <concept id="4452961908202556907" name="jetbrains.mps.lang.core.structure.BaseCommentAttribute" flags="ng" index="1X3_iC">
+        <child id="3078666699043039389" name="commentedNode" index="8Wnug" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="24kQdi" id="Po4Z58tlhm">
+    <ref role="1XX52x" to="b7vt:Po4Z58t1Zc" resolve="Changelog" />
+    <node concept="3EZMnI" id="Po4Z58tlht" role="2wV5jI">
+      <node concept="2iRkQZ" id="Po4Z58tlhu" role="2iSdaV" />
+      <node concept="3EZMnI" id="Po4Z58vNk9" role="3EZMnx">
+        <node concept="2iRfu4" id="Po4Z58vNka" role="2iSdaV" />
+        <node concept="3F0A7n" id="Po4Z58vNkt" role="3EZMnx">
+          <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
+          <node concept="VSNWy" id="Po4Z58tlhr" role="3F10Kt">
+            <property role="1lJzqX" value="16" />
+          </node>
+          <node concept="Vb9p2" id="XbadXSkdNg" role="3F10Kt">
+            <property role="Vbekb" value="g1_k_vY/BOLD" />
+          </node>
+        </node>
+        <node concept="3EZMnI" id="1$KnWE8p4zp" role="3EZMnx">
+          <node concept="2iRfu4" id="1$KnWE8p4zq" role="2iSdaV" />
+          <node concept="3F0ifn" id="1$KnWE8p4zj" role="3EZMnx">
+            <property role="3F0ifm" value="." />
+            <node concept="VSNWy" id="1$KnWE8p5nd" role="3F10Kt">
+              <property role="1lJzqX" value="16" />
+            </node>
+            <node concept="11L4FC" id="1$KnWE8p5gD" role="3F10Kt">
+              <property role="VOm3f" value="true" />
+            </node>
+            <node concept="11LMrY" id="1$KnWE8p5gI" role="3F10Kt">
+              <property role="VOm3f" value="true" />
+            </node>
+          </node>
+          <node concept="3F0A7n" id="1$KnWE8p4z_" role="3EZMnx">
+            <ref role="1NtTu8" to="b7vt:1$KnWE8p4rA" resolve="ext" />
+            <node concept="VSNWy" id="1$KnWE8p5nb" role="3F10Kt">
+              <property role="1lJzqX" value="16" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3F1sOY" id="Po4Z58tmDl" role="3EZMnx">
+        <ref role="1NtTu8" to="b7vt:Po4Z58tmyF" resolve="header" />
+      </node>
+      <node concept="3F0ifn" id="Po4Z58A4mO" role="3EZMnx" />
+      <node concept="3F2HdR" id="Po4Z58tnOx" role="3EZMnx">
+        <ref role="1NtTu8" to="b7vt:Po4Z58tnOp" resolve="releases" />
+        <node concept="2iRkQZ" id="Po4Z58tnOz" role="2czzBx" />
+        <node concept="4$FPG" id="Po4Z58Ibdg" role="4_6I_">
+          <node concept="3clFbS" id="Po4Z58Ibdh" role="2VODD2">
+            <node concept="3clFbF" id="Po4Z58IJXq" role="3cqZAp">
+              <node concept="2OqwBi" id="Po4Z58IK95" role="3clFbG">
+                <node concept="pncrf" id="Po4Z58IJXp" role="2Oq$k0" />
+                <node concept="2qgKlT" id="Po4Z58IKo4" role="2OqNvi">
+                  <ref role="37wK5l" to="j2b5:2r0ijgcUUGS" resolve="createNewRelease" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3EZMnI" id="Po4Z58Imt2" role="6VMZX">
+      <node concept="3F0ifn" id="XbadXSjQ1E" role="3EZMnx">
+        <property role="3F0ifm" value="Changelog" />
+        <ref role="1k5W1q" to="tpc5:hF4yUZ8" resolve="header" />
+      </node>
+      <node concept="3EZMnI" id="XbadXSjQmP" role="3EZMnx">
+        <node concept="VPM3Z" id="XbadXSjQzH" role="3F10Kt">
+          <property role="VOm3f" value="false" />
+        </node>
+        <node concept="VPXOz" id="XbadXSjQzI" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+        <node concept="2EHx9g" id="XbadXSjQp2" role="2iSdaV" />
+        <node concept="3EZMnI" id="Po4Z58ImtK" role="3EZMnx">
+          <node concept="VPM3Z" id="XbadXSjQRb" role="3F10Kt">
+            <property role="VOm3f" value="false" />
+          </node>
+          <node concept="VPXOz" id="XbadXSjQRc" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+          <node concept="2iRfu4" id="Po4Z58ImtL" role="2iSdaV" />
+          <node concept="3F0ifn" id="Po4Z58ImtM" role="3EZMnx">
+            <property role="3F0ifm" value="header type:" />
+            <ref role="1k5W1q" to="tpc5:hF4H1c8" resolve="property" />
+          </node>
+          <node concept="3F0A7n" id="Po4Z58ImtN" role="3EZMnx">
+            <ref role="1NtTu8" to="b7vt:Po4Z58IlRD" resolve="headerType" />
+          </node>
+        </node>
+      </node>
+      <node concept="2iRkQZ" id="Po4Z58Imt3" role="2iSdaV" />
+      <node concept="3F0ifn" id="XbadXShqc2" role="3EZMnx" />
+      <node concept="3F0ifn" id="XbadXShqm7" role="3EZMnx">
+        <property role="3F0ifm" value="Shortcuts" />
+        <ref role="1k5W1q" to="tpc5:hF4yUZ8" resolve="header" />
+      </node>
+      <node concept="3EZMnI" id="XbadXShqSr" role="3EZMnx">
+        <node concept="VPM3Z" id="hEU$Px_" role="3F10Kt">
+          <property role="VOm3f" value="false" />
+        </node>
+        <node concept="VPXOz" id="hEUNSL$" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+        <node concept="2EHx9g" id="XbadXShr2G" role="2iSdaV" />
+        <node concept="3EZMnI" id="XbadXShqIe" role="3EZMnx">
+          <node concept="VPM3Z" id="hEU$PZ7" role="3F10Kt">
+            <property role="VOm3f" value="false" />
+          </node>
+          <node concept="VPXOz" id="hEUNStH" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+          <node concept="2iRfu4" id="XbadXShqIf" role="2iSdaV" />
+          <node concept="3F0ifn" id="XbadXShqxT" role="3EZMnx">
+            <property role="3F0ifm" value="cmd/ctrl + i " />
+            <ref role="1k5W1q" to="tpc5:hF4H1c8" resolve="property" />
+          </node>
+          <node concept="3F0ifn" id="XbadXShr2M" role="3EZMnx">
+            <property role="3F0ifm" value="italic" />
+            <node concept="Vb9p2" id="XbadXShr2Q" role="3F10Kt" />
+          </node>
+        </node>
+        <node concept="3EZMnI" id="XbadXShr2S" role="3EZMnx">
+          <node concept="VPM3Z" id="XbadXSjx31" role="3F10Kt">
+            <property role="VOm3f" value="false" />
+          </node>
+          <node concept="VPXOz" id="XbadXSjx32" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+          <node concept="2iRfu4" id="XbadXShr2T" role="2iSdaV" />
+          <node concept="3F0ifn" id="XbadXShr2U" role="3EZMnx">
+            <property role="3F0ifm" value="cmd/ctrl + u " />
+            <ref role="1k5W1q" to="tpc5:hF4H1c8" resolve="property" />
+          </node>
+          <node concept="3F0ifn" id="XbadXShr2V" role="3EZMnx">
+            <property role="3F0ifm" value="underline" />
+            <node concept="Vb9p2" id="XbadXShr2W" role="3F10Kt" />
+          </node>
+        </node>
+        <node concept="3EZMnI" id="XbadXShr37" role="3EZMnx">
+          <node concept="VPM3Z" id="XbadXSjx35" role="3F10Kt">
+            <property role="VOm3f" value="false" />
+          </node>
+          <node concept="VPXOz" id="XbadXSjx36" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+          <node concept="2iRfu4" id="XbadXShr38" role="2iSdaV" />
+          <node concept="3F0ifn" id="XbadXShr39" role="3EZMnx">
+            <property role="3F0ifm" value="cmd/ctrl + b " />
+            <ref role="1k5W1q" to="tpc5:hF4H1c8" resolve="property" />
+          </node>
+          <node concept="3F0ifn" id="XbadXShr3a" role="3EZMnx">
+            <property role="3F0ifm" value="bold" />
+            <node concept="Vb9p2" id="XbadXShr3b" role="3F10Kt" />
+          </node>
+        </node>
+      </node>
+      <node concept="3F0ifn" id="XbadXShrdL" role="3EZMnx" />
+      <node concept="3F0ifn" id="XbadXShrew" role="3EZMnx">
+        <property role="3F0ifm" value="To apply formatting or links to multiple words, use the intention &quot;Merge Into One Word&quot; first." />
+        <node concept="Vb9p2" id="XbadXShroT" role="3F10Kt">
+          <property role="Vbekb" value="g1_kEg4/ITALIC" />
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="24kQdi" id="Po4Z58tnP$">
+    <ref role="1XX52x" to="b7vt:Po4Z58tnPe" resolve="SemanticVersion" />
+    <node concept="3EZMnI" id="Po4Z58tnPD" role="2wV5jI">
+      <node concept="2iRfu4" id="Po4Z58tnPE" role="2iSdaV" />
+      <node concept="3F0A7n" id="Po4Z58tnPA" role="3EZMnx">
+        <ref role="1NtTu8" to="b7vt:Po4Z58tnPf" resolve="major" />
+      </node>
+      <node concept="3F0ifn" id="Po4Z58tnPM" role="3EZMnx">
+        <property role="3F0ifm" value="." />
+        <node concept="11L4FC" id="Po4Z58tnPQ" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+        <node concept="11LMrY" id="Po4Z58tnPV" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="3F0A7n" id="Po4Z58tnQ5" role="3EZMnx">
+        <ref role="1NtTu8" to="b7vt:Po4Z58tnPh" resolve="minor" />
+      </node>
+      <node concept="3F0ifn" id="Po4Z58tnQj" role="3EZMnx">
+        <property role="3F0ifm" value="." />
+        <node concept="11L4FC" id="Po4Z58tnQr" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+        <node concept="11LMrY" id="Po4Z58tnQw" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="3F0A7n" id="Po4Z58tnQI" role="3EZMnx">
+        <ref role="1NtTu8" to="b7vt:Po4Z58tnPk" resolve="patch" />
+      </node>
+      <node concept="_tjkj" id="Po4Z58wqHD" role="3EZMnx">
+        <node concept="3EZMnI" id="Po4Z58wqHU" role="_tjki">
+          <node concept="3F0ifn" id="Po4Z58wqI4" role="3EZMnx">
+            <property role="3F0ifm" value="-" />
+            <node concept="11L4FC" id="Po4Z58x36u" role="3F10Kt">
+              <property role="VOm3f" value="true" />
+            </node>
+            <node concept="11LMrY" id="Po4Z58x36z" role="3F10Kt">
+              <property role="VOm3f" value="true" />
+            </node>
+          </node>
+          <node concept="2iRfu4" id="Po4Z58wqHV" role="2iSdaV" />
+          <node concept="3F0A7n" id="Po4Z58tnRX" role="3EZMnx">
+            <ref role="1NtTu8" to="b7vt:Po4Z58tnPo" resolve="preRelease" />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="24kQdi" id="Po4Z58tBqa">
+    <ref role="1XX52x" to="b7vt:Po4Z58tnOo" resolve="Release" />
+    <node concept="3EZMnI" id="Po4Z58tBqf" role="2wV5jI">
+      <property role="S$Qs1" value="true" />
+      <node concept="2iRkQZ" id="Po4Z58tBqg" role="2iSdaV" />
+      <node concept="3EZMnI" id="Po4Z58xhMj" role="3EZMnx">
+        <node concept="2iRfu4" id="Po4Z58xhMk" role="2iSdaV" />
+        <node concept="3F1sOY" id="Po4Z58tBqc" role="3EZMnx">
+          <ref role="1NtTu8" to="b7vt:Po4Z58trdf" resolve="header" />
+        </node>
+        <node concept="3F0ifn" id="Po4Z58xhMv" role="3EZMnx">
+          <property role="3F0ifm" value="{" />
+          <node concept="3mYdg7" id="Po4Z58xhMz" role="3F10Kt">
+            <property role="1413C4" value="curly_brace" />
+          </node>
+        </node>
+      </node>
+      <node concept="3EZMnI" id="Po4Z58xwwB" role="3EZMnx">
+        <node concept="2iRfu4" id="Po4Z58xwwC" role="2iSdaV" />
+        <node concept="3XFhqQ" id="Po4Z58xwws" role="3EZMnx" />
+        <node concept="3F2HdR" id="Po4Z58tBqs" role="3EZMnx">
+          <ref role="1NtTu8" to="b7vt:Po4Z58tBq0" resolve="sections" />
+          <node concept="2iRkQZ" id="Po4Z58tBqu" role="2czzBx" />
+        </node>
+      </node>
+      <node concept="3F0ifn" id="Po4Z58xhM_" role="3EZMnx">
+        <property role="3F0ifm" value="}" />
+        <node concept="3mYdg7" id="Po4Z58xhMJ" role="3F10Kt">
+          <property role="1413C4" value="curly_brace" />
+        </node>
+      </node>
+      <node concept="3EZMnI" id="1$KnWE8ryZD" role="AHCbl">
+        <node concept="2iRfu4" id="1$KnWE8ryZE" role="2iSdaV" />
+        <node concept="3F1sOY" id="1$KnWE8ryZB" role="3EZMnx">
+          <ref role="1NtTu8" to="b7vt:Po4Z58trdf" resolve="header" />
+        </node>
+        <node concept="3F0ifn" id="1$KnWE8rzBN" role="3EZMnx">
+          <property role="3F0ifm" value="{...}" />
+          <ref role="1k5W1q" to="tpen:4vxLnq9T43C" resolve="FoldedCell" />
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="24kQdi" id="Po4Z58tBqI">
+    <ref role="1XX52x" to="b7vt:Po4Z58tBpZ" resolve="ChangeSection" />
+    <node concept="3EZMnI" id="Po4Z58tPMU" role="2wV5jI">
+      <property role="S$Qs1" value="true" />
+      <node concept="2iRkQZ" id="Po4Z58tPMV" role="2iSdaV" />
+      <node concept="3EZMnI" id="Po4Z58tBqN" role="3EZMnx">
+        <node concept="2iRfu4" id="Po4Z58tBqO" role="2iSdaV" />
+        <node concept="3F0A7n" id="Po4Z58tBqK" role="3EZMnx">
+          <ref role="1NtTu8" to="b7vt:Po4Z58tBqz" resolve="type" />
+          <node concept="Vb9p2" id="Po4Z58tPMS" role="3F10Kt">
+            <property role="Vbekb" value="g1_k_vY/BOLD" />
+          </node>
+          <node concept="34dVlM" id="Po4Z58$THV" role="3F10Kt">
+            <property role="34dVlN" value="hrC1nx$/FIRST" />
+          </node>
+        </node>
+        <node concept="3F0ifn" id="Po4Z58xwwZ" role="3EZMnx">
+          <property role="3F0ifm" value="{" />
+          <node concept="3mYdg7" id="Po4Z58xwx4" role="3F10Kt">
+            <property role="1413C4" value="curly_brace" />
+          </node>
+        </node>
+      </node>
+      <node concept="3EZMnI" id="Po4Z58xwxN" role="3EZMnx">
+        <node concept="2iRfu4" id="Po4Z58xwxO" role="2iSdaV" />
+        <node concept="3XFhqQ" id="Po4Z58xwxB" role="3EZMnx" />
+        <node concept="3F2HdR" id="Po4Z58tPYd" role="3EZMnx">
+          <ref role="1NtTu8" to="b7vt:Po4Z58tBq_" resolve="changes" />
+          <node concept="2iRkQZ" id="Po4Z58tPYf" role="2czzBx" />
+          <node concept="4$FPG" id="Po4Z58MB1w" role="4_6I_">
+            <node concept="3clFbS" id="Po4Z58MB1x" role="2VODD2">
+              <node concept="3clFbF" id="Po4Z58MB1B" role="3cqZAp">
+                <node concept="2ShNRf" id="Po4Z58MB1_" role="3clFbG">
+                  <node concept="3zrR0B" id="Po4Z58MB$U" role="2ShVmc">
+                    <node concept="3Tqbb2" id="Po4Z58MB$W" role="3zrR0E">
+                      <ref role="ehGHo" to="zqge:WJz9iAWEzU" resolve="BulletLine" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3F0ifn" id="Po4Z58xwx6" role="3EZMnx">
+        <property role="3F0ifm" value="}" />
+        <node concept="3mYdg7" id="Po4Z58xwxh" role="3F10Kt">
+          <property role="1413C4" value="curly_brace" />
+        </node>
+      </node>
+      <node concept="3EZMnI" id="1$KnWE8rPTs" role="AHCbl">
+        <node concept="2iRfu4" id="1$KnWE8rPTt" role="2iSdaV" />
+        <node concept="3F0A7n" id="1$KnWE8rPT_" role="3EZMnx">
+          <ref role="1NtTu8" to="b7vt:Po4Z58tBqz" resolve="type" />
+          <node concept="Vb9p2" id="1$KnWE8rPTA" role="3F10Kt">
+            <property role="Vbekb" value="g1_k_vY/BOLD" />
+          </node>
+          <node concept="34dVlM" id="1$KnWE8rPTB" role="3F10Kt">
+            <property role="34dVlN" value="hrC1nx$/FIRST" />
+          </node>
+        </node>
+        <node concept="3F0ifn" id="1$KnWE8rPTq" role="3EZMnx">
+          <property role="3F0ifm" value="{...}" />
+          <ref role="1k5W1q" to="tpen:4vxLnq9T43C" resolve="FoldedCell" />
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="24kQdi" id="Po4Z58vyis">
+    <ref role="1XX52x" to="b7vt:Po4Z58tnPb" resolve="VersionDateReleaseHeader" />
+    <node concept="3EZMnI" id="Po4Z58vyix" role="2wV5jI">
+      <node concept="2iRfu4" id="Po4Z58vyiy" role="2iSdaV" />
+      <node concept="3F1sOY" id="Po4Z58vyiu" role="3EZMnx">
+        <ref role="1NtTu8" to="b7vt:Po4Z58trdd" resolve="version" />
+        <node concept="VechU" id="Po4Z58AmoH" role="3F10Kt">
+          <property role="Vb096" value="fLwANPu/blue" />
+        </node>
+      </node>
+      <node concept="3F0ifn" id="Po4Z58vyiE" role="3EZMnx">
+        <property role="3F0ifm" value="-" />
+      </node>
+      <node concept="XafU7" id="Po4Z58yX3P" role="3EZMnx">
+        <node concept="VechU" id="Po4Z58B2M2" role="3F10Kt">
+          <property role="Vb096" value="fLJRk5A/lightGray" />
+        </node>
+        <node concept="3TQVft" id="Po4Z58yX3R" role="3TRxkO">
+          <node concept="3TQlhw" id="Po4Z58yX3T" role="3TQWv3">
+            <node concept="3clFbS" id="Po4Z58yX3V" role="2VODD2">
+              <node concept="3clFbF" id="XbadXRL06H" role="3cqZAp">
+                <node concept="2OqwBi" id="XbadXRL0jX" role="3clFbG">
+                  <node concept="pncrf" id="XbadXRL06G" role="2Oq$k0" />
+                  <node concept="2qgKlT" id="XbadXRL0_B" role="2OqNvi">
+                    <ref role="37wK5l" to="j2b5:2r0ijgcUaDV" resolve="getDate" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3TQsA7" id="Po4Z58yX3X" role="3TQXYj">
+            <node concept="3clFbS" id="Po4Z58yX3Z" role="2VODD2">
+              <node concept="3J1_TO" id="Po4Z58z3eW" role="3cqZAp">
+                <node concept="3uVAMA" id="Po4Z58z3eX" role="1zxBo5">
+                  <node concept="XOnhg" id="Po4Z58z3eY" role="1zc67B">
+                    <property role="TrG5h" value="e" />
+                    <node concept="nSUau" id="Po4Z58z3eZ" role="1tU5fm">
+                      <node concept="3uibUv" id="Po4Z58z3f0" role="nSUat">
+                        <ref role="3uigEE" to="wyt6:~Exception" resolve="Exception" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbS" id="Po4Z58z3f1" role="1zc67A" />
+                </node>
+                <node concept="3clFbS" id="Po4Z58z3f4" role="1zxBo7">
+                  <node concept="3cpWs8" id="Po4Z58B$DS" role="3cqZAp">
+                    <node concept="3cpWsn" id="Po4Z58B$DT" role="3cpWs9">
+                      <property role="TrG5h" value="date" />
+                      <node concept="3uibUv" id="Po4Z58B$zz" role="1tU5fm">
+                        <ref role="3uigEE" to="28m1:~LocalDate" resolve="LocalDate" />
+                      </node>
+                      <node concept="2YIFZM" id="Po4Z58B$DU" role="33vP2m">
+                        <ref role="1Pybhc" to="28m1:~LocalDate" resolve="LocalDate" />
+                        <ref role="37wK5l" to="28m1:~LocalDate.parse(java.lang.CharSequence)" resolve="parse" />
+                        <node concept="3TQ6bP" id="Po4Z58B$DV" role="37wK5m" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbF" id="Po4Z58z4Dn" role="3cqZAp">
+                    <node concept="37vLTI" id="Po4Z58z5ks" role="3clFbG">
+                      <node concept="2OqwBi" id="Po4Z58z4LN" role="37vLTJ">
+                        <node concept="pncrf" id="Po4Z58z4Dm" role="2Oq$k0" />
+                        <node concept="3TrcHB" id="Po4Z58z4Yn" role="2OqNvi">
+                          <ref role="3TsBF5" to="b7vt:Po4Z58tnPc" resolve="timeStamp" />
+                        </node>
+                      </node>
+                      <node concept="2YIFZM" id="Po4Z58z8iB" role="37vLTx">
+                        <ref role="1Pybhc" to="wyt6:~String" resolve="String" />
+                        <ref role="37wK5l" to="wyt6:~String.valueOf(long)" resolve="valueOf" />
+                        <node concept="2OqwBi" id="Po4Z58DaB1" role="37wK5m">
+                          <node concept="2OqwBi" id="Po4Z58BBGq" role="2Oq$k0">
+                            <node concept="37vLTw" id="Po4Z58BB3T" role="2Oq$k0">
+                              <ref role="3cqZAo" node="Po4Z58B$DT" resolve="date" />
+                            </node>
+                            <node concept="liA8E" id="Po4Z58Da0g" role="2OqNvi">
+                              <ref role="37wK5l" to="28m1:~LocalDate.atStartOfDay()" resolve="atStartOfDay" />
+                            </node>
+                          </node>
+                          <node concept="liA8E" id="Po4Z58Dbti" role="2OqNvi">
+                            <ref role="37wK5l" to="7fo8:~ChronoLocalDateTime.toEpochSecond(java.time.ZoneOffset)" resolve="toEpochSecond" />
+                            <node concept="10M0yZ" id="Po4Z58DcF4" role="37wK5m">
+                              <ref role="3cqZAo" to="28m1:~ZoneOffset.UTC" resolve="UTC" />
+                              <ref role="1PxDUh" to="28m1:~ZoneOffset" resolve="ZoneOffset" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3TQwEX" id="Po4Z58yX41" role="3TQZqC">
+            <node concept="3clFbS" id="Po4Z58yX43" role="2VODD2">
+              <node concept="3J1_TO" id="Po4Z58BFs_" role="3cqZAp">
+                <node concept="3uVAMA" id="Po4Z58BFsA" role="1zxBo5">
+                  <node concept="XOnhg" id="Po4Z58BFsB" role="1zc67B">
+                    <property role="TrG5h" value="e" />
+                    <node concept="nSUau" id="Po4Z58BFsC" role="1tU5fm">
+                      <node concept="3uibUv" id="Po4Z58BFsD" role="nSUat">
+                        <ref role="3uigEE" to="wyt6:~Exception" resolve="Exception" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbS" id="Po4Z58BFsE" role="1zc67A">
+                    <node concept="3cpWs6" id="Po4Z58BGTz" role="3cqZAp">
+                      <node concept="3clFbT" id="Po4Z58BGTN" role="3cqZAk" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbS" id="Po4Z58BFsF" role="1zxBo7">
+                  <node concept="3clFbF" id="Po4Z58BG_n" role="3cqZAp">
+                    <node concept="2YIFZM" id="Po4Z58BFsJ" role="3clFbG">
+                      <ref role="1Pybhc" to="28m1:~LocalDate" resolve="LocalDate" />
+                      <ref role="37wK5l" to="28m1:~LocalDate.parse(java.lang.CharSequence)" resolve="parse" />
+                      <node concept="3TQ6bP" id="Po4Z58BFsK" role="37wK5m" />
+                    </node>
+                  </node>
+                  <node concept="3cpWs6" id="Po4Z58BGQY" role="3cqZAp">
+                    <node concept="3clFbT" id="Po4Z58BGRh" role="3cqZAk">
+                      <property role="3clFbU" value="true" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="PKFIW" id="Po4Z58wqHS">
+    <property role="TrG5h" value="DummyForGrammarCells" />
+    <ref role="1XX52x" to="tpck:gw2VY9q" />
+    <node concept="3F0ifn" id="Po4Z58wqHT" role="2wV5jI">
+      <property role="3F0ifm" value="Workaround to fix contributions to BaseConcept generated by grammarCells." />
+    </node>
+  </node>
+  <node concept="24kQdi" id="Po4Z58IgBP">
+    <ref role="1XX52x" to="b7vt:Po4Z58IgAd" resolve="MonthYearReleaseHeader" />
+    <node concept="3EZMnI" id="Po4Z58IgBU" role="2wV5jI">
+      <node concept="2iRfu4" id="Po4Z58IgBV" role="2iSdaV" />
+      <node concept="3F0A7n" id="Po4Z58IgBR" role="3EZMnx">
+        <ref role="1NtTu8" to="b7vt:Po4Z58IgAf" resolve="month" />
+        <node concept="VSNWy" id="Po4Z58Nqhw" role="3F10Kt">
+          <property role="1lJzqX" value="14" />
+        </node>
+        <node concept="Vb9p2" id="Po4Z58NqhB" role="3F10Kt">
+          <property role="Vbekb" value="g1_k_vY/BOLD" />
+        </node>
+        <node concept="34dVlM" id="XbadXRS4Dj" role="3F10Kt">
+          <property role="34dVlN" value="hrC1nx$/FIRST" />
+        </node>
+      </node>
+      <node concept="3F0A7n" id="Po4Z58IgC3" role="3EZMnx">
+        <ref role="1NtTu8" to="b7vt:Po4Z58IgAh" resolve="year" />
+        <node concept="VSNWy" id="Po4Z58Nqhy" role="3F10Kt">
+          <property role="1lJzqX" value="14" />
+        </node>
+        <node concept="Vb9p2" id="Po4Z58NqhF" role="3F10Kt">
+          <property role="Vbekb" value="g1_k_vY/BOLD" />
+        </node>
+        <node concept="34dVlM" id="XbadXRSqeK" role="3F10Kt">
+          <property role="34dVlN" value="hrC1ovA/LAST" />
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="22mcaB" id="Po4Z58JHPh">
+    <ref role="aqKnT" to="b7vt:Po4Z58tnOo" resolve="Release" />
+    <node concept="22hDWj" id="Po4Z58JHPi" role="22hAXT" />
+    <node concept="3eGOop" id="Po4Z58JHRx" role="3ft7WO">
+      <node concept="ucgPf" id="Po4Z58JHRy" role="3aKz83">
+        <node concept="3clFbS" id="Po4Z58JHRz" role="2VODD2">
+          <node concept="3clFbF" id="Po4Z58JYW3" role="3cqZAp">
+            <node concept="2OqwBi" id="Po4Z58JZp8" role="3clFbG">
+              <node concept="1PxgMI" id="Po4Z58JZ9X" role="2Oq$k0">
+                <property role="1BlNFB" value="true" />
+                <node concept="chp4Y" id="Po4Z58JZaK" role="3oSUPX">
+                  <ref role="cht4Q" to="b7vt:Po4Z58t1Zc" resolve="Changelog" />
+                </node>
+                <node concept="3bvxqY" id="Po4Z58JYW2" role="1m5AlR" />
+              </node>
+              <node concept="2qgKlT" id="Po4Z58JZEY" role="2OqNvi">
+                <ref role="37wK5l" to="j2b5:2r0ijgcUUGS" resolve="createNewRelease" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="24kQdi" id="Po4Z58Kpb8">
+    <property role="3GE5qa" value="textElements" />
+    <ref role="1XX52x" to="b7vt:Po4Z58KntM" resolve="ModuleReference" />
+    <node concept="3EZMnI" id="1t9Fffgecfx" role="2wV5jI">
+      <node concept="PMmxH" id="1t9FffgecpJ" role="3EZMnx">
+        <ref role="1k5W1q" to="tpch:24YP6ZDyde4" resolve="Keyword" />
+        <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
+        <node concept="3$7jql" id="3WF9HwF0$Oa" role="3F10Kt">
+          <property role="3$6WeP" value="0" />
+        </node>
+      </node>
+      <node concept="3F0ifn" id="1t9FffgecpQ" role="3EZMnx">
+        <property role="3F0ifm" value="(" />
+        <ref role="1k5W1q" to="tpen:hY9fg1G" resolve="LeftParenAfterName" />
+      </node>
+      <node concept="1iCGBv" id="Po4Z58LdxB" role="3EZMnx">
+        <ref role="1NtTu8" to="b7vt:Po4Z58Kp2X" resolve="expression" />
+        <node concept="1sVBvm" id="Po4Z58LdxD" role="1sWHZn">
+          <node concept="3F1sOY" id="Po4Z58LdxO" role="2wV5jI">
+            <ref role="1NtTu8" to="tp25:1t9FffgebJ_" resolve="moduleId" />
+            <ref role="34QXea" node="8D0iRqYy6v" resolve="SpecialElement_KeyMap" />
+            <node concept="A1WHu" id="5ZqXG2mZI$k" role="3vIgyS">
+              <ref role="A1WHt" to="25zl:7k$14oQs2hn" resolve="ContextRepositoryModules_TM" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3F0ifn" id="1t9FffgecGX" role="3EZMnx">
+        <property role="3F0ifm" value=")" />
+        <ref role="1k5W1q" to="tpen:hFCSUmN" resolve="RightParen" />
+      </node>
+      <node concept="l2Vlx" id="1t9FffgecpE" role="2iSdaV" />
+    </node>
+  </node>
+  <node concept="24kQdi" id="Po4Z58Lv8T">
+    <property role="3GE5qa" value="textElements" />
+    <ref role="1XX52x" to="b7vt:Po4Z58Lv7f" resolve="ModelReference" />
+    <node concept="3EZMnI" id="Po4Z58Lv8V" role="2wV5jI">
+      <ref role="34QXea" node="8D0iRqYy6v" resolve="SpecialElement_KeyMap" />
+      <node concept="PMmxH" id="Po4Z58Lv8W" role="3EZMnx">
+        <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
+        <ref role="1k5W1q" to="tpch:24YP6ZDyde4" resolve="Keyword" />
+        <node concept="3$7jql" id="Po4Z58Lv8X" role="3F10Kt">
+          <property role="3$6WeP" value="0" />
+        </node>
+      </node>
+      <node concept="3F0ifn" id="Po4Z58Lv8Y" role="3EZMnx">
+        <property role="3F0ifm" value="(" />
+        <ref role="1k5W1q" to="tpen:hY9fg1G" resolve="LeftParenAfterName" />
+      </node>
+      <node concept="1iCGBv" id="Po4Z58Lv8Z" role="3EZMnx">
+        <ref role="1NtTu8" to="b7vt:Po4Z58Lv7g" resolve="expression" />
+        <node concept="1sVBvm" id="Po4Z58Lv90" role="1sWHZn">
+          <node concept="3F1sOY" id="Po4Z58Lv91" role="2wV5jI">
+            <ref role="1NtTu8" to="tp25:1Bs_61$ngwB" resolve="modelRef" />
+            <node concept="A1WHu" id="Po4Z58Lv92" role="3vIgyS">
+              <ref role="A1WHt" to="25zl:7cODfNsrd5u" resolve="AllRepositoryModels_TM" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3F0ifn" id="Po4Z58Lv93" role="3EZMnx">
+        <property role="3F0ifm" value=")" />
+        <ref role="1k5W1q" to="tpen:hFCSUmN" resolve="RightParen" />
+      </node>
+      <node concept="l2Vlx" id="Po4Z58Lv94" role="2iSdaV" />
+    </node>
+  </node>
+  <node concept="24kQdi" id="Po4Z58LQTs">
+    <property role="3GE5qa" value="textElements" />
+    <ref role="1XX52x" to="b7vt:Po4Z58LQTj" resolve="NodeReference" />
+    <node concept="3EZMnI" id="Po4Z58LQTu" role="2wV5jI">
+      <ref role="34QXea" node="8D0iRqYy6v" resolve="SpecialElement_KeyMap" />
+      <node concept="PMmxH" id="Po4Z58LQTv" role="3EZMnx">
+        <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
+        <ref role="1k5W1q" to="tpch:24YP6ZDyde4" resolve="Keyword" />
+        <node concept="3$7jql" id="Po4Z58LQTw" role="3F10Kt">
+          <property role="3$6WeP" value="0" />
+        </node>
+      </node>
+      <node concept="3F0ifn" id="Po4Z58LQTx" role="3EZMnx">
+        <property role="3F0ifm" value="(" />
+        <ref role="1k5W1q" to="tpen:hY9fg1G" resolve="LeftParenAfterName" />
+      </node>
+      <node concept="1iCGBv" id="Po4Z58LQTy" role="3EZMnx">
+        <ref role="1NtTu8" to="b7vt:Po4Z58LQTk" resolve="expression" />
+        <node concept="1sVBvm" id="Po4Z58LQTz" role="1sWHZn">
+          <node concept="3F1sOY" id="Po4Z58LQT$" role="2wV5jI">
+            <ref role="1NtTu8" to="tp25:6qMaajV39im" resolve="ref" />
+          </node>
+        </node>
+      </node>
+      <node concept="3F0ifn" id="Po4Z58LQTA" role="3EZMnx">
+        <property role="3F0ifm" value=")" />
+        <ref role="1k5W1q" to="tpen:hFCSUmN" resolve="RightParen" />
+      </node>
+      <node concept="l2Vlx" id="Po4Z58LQTB" role="2iSdaV" />
+    </node>
+  </node>
+  <node concept="24kQdi" id="XbadXS8vkz">
+    <property role="3GE5qa" value="textElements" />
+    <ref role="1XX52x" to="b7vt:XbadXS8vkr" resolve="CodeWord" />
+    <node concept="B$lHz" id="XbadXScZAN" role="2wV5jI">
+      <ref role="34QXea" to="2u9v:8D0iRqYy6v" resolve="Word_KeyMap" />
+      <node concept="Veino" id="XbadXScZAQ" role="3F10Kt">
+        <property role="Vb096" value="fLJRk5A/lightGray" />
+        <node concept="1iSF2X" id="XbadXSowxN" role="VblUZ">
+          <property role="1iTho6" value="f1f1f1" />
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="24kQdi" id="1$KnWE8sX2J">
+    <property role="3GE5qa" value="textElements" />
+    <ref role="1XX52x" to="b7vt:1$KnWE8sX2_" resolve="CombinedElements" />
+    <node concept="3EZMnI" id="1$KnWE8w2YI" role="2wV5jI">
+      <ref role="34QXea" node="8D0iRqYy6v" resolve="SpecialElement_KeyMap" />
+      <node concept="3F0ifn" id="1$KnWE8w2YR" role="3EZMnx">
+        <property role="3F0ifm" value="[" />
+        <node concept="11LMrY" id="1$KnWE8w2Z6" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="2iRfu4" id="1$KnWE8w2YJ" role="2iSdaV" />
+      <node concept="3F1sOY" id="1$KnWE8v6Vj" role="3EZMnx">
+        <ref role="1NtTu8" to="b7vt:1$KnWE8uIdI" resolve="line" />
+      </node>
+      <node concept="3F0ifn" id="1$KnWE8w2YZ" role="3EZMnx">
+        <property role="3F0ifm" value="]" />
+        <node concept="11L4FC" id="1$KnWE8w2Z4" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="325Ffw" id="8D0iRqYy6v">
+    <property role="3GE5qa" value="textElements" />
+    <property role="TrG5h" value="SpecialElement_KeyMap" />
+    <ref role="1chiOs" to="zqge:8D0iRqSPVB" resolve="TextElement" />
+    <node concept="2PxR9H" id="8D0iRqYy6w" role="2QnnpI">
+      <property role="2IlM53" value="gAIlx3c/caret_at_last_position" />
+      <node concept="2Py5lD" id="8D0iRqYy6x" role="2PyaAO">
+        <property role="2PWKIS" value=" " />
+      </node>
+      <node concept="2PzhpH" id="8D0iRqYy6y" role="2PL9iG">
+        <node concept="3clFbS" id="8D0iRqYy6z" role="2VODD2">
+          <node concept="3clFbF" id="1$KnWE8F9ow" role="3cqZAp">
+            <node concept="2YIFZM" id="1$KnWE8F9ox" role="3clFbG">
+              <ref role="37wK5l" node="1$KnWE8Dv2W" resolve="execute" />
+              <ref role="1Pybhc" node="1$KnWE8DuVK" resolve="NewElementStrategyFactoryWrapper" />
+              <node concept="0GJ7k" id="1$KnWE8F9oy" role="37wK5m" />
+              <node concept="1Q80Hx" id="1$KnWE8F9oz" role="37wK5m" />
+              <node concept="3clFbT" id="1$KnWE8F9o$" role="37wK5m" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2PxR9H" id="4k0apfI_EeL" role="2QnnpI">
+      <node concept="2Py5lD" id="4k0apfI_EeM" role="2PyaAO">
+        <property role="2PWKIS" value=" " />
+      </node>
+      <node concept="2PzhpH" id="4k0apfI_EeN" role="2PL9iG">
+        <node concept="3clFbS" id="4k0apfI_EeO" role="2VODD2">
+          <node concept="3clFbF" id="1$KnWE8DDLA" role="3cqZAp">
+            <node concept="2YIFZM" id="1$KnWE8DDMe" role="3clFbG">
+              <ref role="37wK5l" node="1$KnWE8Dv2W" resolve="execute" />
+              <ref role="1Pybhc" node="1$KnWE8DuVK" resolve="NewElementStrategyFactoryWrapper" />
+              <node concept="0GJ7k" id="1$KnWE8DDMz" role="37wK5m" />
+              <node concept="1Q80Hx" id="1$KnWE8DDV2" role="37wK5m" />
+              <node concept="3clFbT" id="1$KnWE8DDXC" role="37wK5m" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2Pz7Y7" id="4k0apfI_WQE" role="2Pzqsi">
+        <node concept="3clFbS" id="4k0apfI_WQF" role="2VODD2">
+          <node concept="3clFbF" id="4k0apfI_WYh" role="3cqZAp">
+            <node concept="3fqX7Q" id="4k0apfI_Zdd" role="3clFbG">
+              <node concept="2ZW3vV" id="4k0apfI_Zdf" role="3fr31v">
+                <node concept="3uibUv" id="4k0apfI_Zdg" role="2ZW6by">
+                  <ref role="3uigEE" to="b8lf:~EditorCellLabelSelection" resolve="EditorCellLabelSelection" />
+                </node>
+                <node concept="2OqwBi" id="4k0apfI_Zdh" role="2ZW6bz">
+                  <node concept="2OqwBi" id="4k0apfI_Zdi" role="2Oq$k0">
+                    <node concept="1Q80Hx" id="4k0apfI_Zdj" role="2Oq$k0" />
+                    <node concept="liA8E" id="4k0apfI_Zdk" role="2OqNvi">
+                      <ref role="37wK5l" to="cj4x:~EditorContext.getSelectionManager()" resolve="getSelectionManager" />
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="4k0apfI_Zdl" role="2OqNvi">
+                    <ref role="37wK5l" to="lwvz:~SelectionManager.getSelection()" resolve="getSelection" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2PxR9H" id="3cya7SwzEMt" role="2QnnpI">
+      <property role="2IlM53" value="gAIlo0M/caret_at_first_position" />
+      <node concept="2Py5lD" id="3cya7SwzEMu" role="2PyaAO">
+        <property role="2PWKIS" value=" " />
+      </node>
+      <node concept="2PzhpH" id="3cya7SwzEMv" role="2PL9iG">
+        <node concept="3clFbS" id="3cya7SwzEMw" role="2VODD2">
+          <node concept="3clFbF" id="1$KnWE8DDYV" role="3cqZAp">
+            <node concept="2YIFZM" id="1$KnWE8DDYW" role="3clFbG">
+              <ref role="1Pybhc" node="1$KnWE8DuVK" resolve="NewElementStrategyFactoryWrapper" />
+              <ref role="37wK5l" node="1$KnWE8Dv2W" resolve="execute" />
+              <node concept="0GJ7k" id="1$KnWE8DDYX" role="37wK5m" />
+              <node concept="1Q80Hx" id="1$KnWE8DDYY" role="37wK5m" />
+              <node concept="3clFbT" id="1$KnWE8DE89" role="37wK5m">
+                <property role="3clFbU" value="true" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2PxR9H" id="62tSVkRFJPX" role="2QnnpI">
+      <property role="2IlM53" value="gD2iXe_/caret_at_intermediate_position" />
+      <node concept="2Py5lD" id="62tSVkRFJPY" role="2PyaAO">
+        <property role="2PWKIS" value=" " />
+      </node>
+      <node concept="2PzhpH" id="62tSVkRFJPZ" role="2PL9iG">
+        <node concept="3clFbS" id="62tSVkRFJQ0" role="2VODD2">
+          <node concept="3clFbF" id="1$KnWE8DEab" role="3cqZAp">
+            <node concept="2YIFZM" id="1$KnWE8DEac" role="3clFbG">
+              <ref role="1Pybhc" node="1$KnWE8DuVK" resolve="NewElementStrategyFactoryWrapper" />
+              <ref role="37wK5l" node="1$KnWE8Dv2W" resolve="execute" />
+              <node concept="0GJ7k" id="1$KnWE8DEad" role="37wK5m" />
+              <node concept="1Q80Hx" id="1$KnWE8DEae" role="37wK5m" />
+              <node concept="3clFbT" id="1$KnWE8DEaf" role="37wK5m" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2PxR9H" id="2J_7GX59bG4" role="2QnnpI">
+      <node concept="2Py5lD" id="2J_7GX59bG5" role="2PyaAO">
+        <property role="2PWKIS" value="VK_TAB" />
+        <property role="2PWKIB" value="none" />
+      </node>
+      <node concept="2PzhpH" id="2J_7GX59bG6" role="2PL9iG">
+        <node concept="3clFbS" id="2J_7GX59bG7" role="2VODD2">
+          <node concept="3clFbJ" id="2J_7GX59bGj" role="3cqZAp">
+            <node concept="3clFbS" id="2J_7GX59bGk" role="3clFbx">
+              <node concept="3clFbF" id="2J_7GX59bGl" role="3cqZAp">
+                <node concept="3uNrnE" id="2J_7GX59bGm" role="3clFbG">
+                  <node concept="2OqwBi" id="2J_7GX59bGn" role="2$L3a6">
+                    <node concept="1PxgMI" id="2J_7GX59bGo" role="2Oq$k0">
+                      <property role="1BlNFB" value="true" />
+                      <node concept="chp4Y" id="2J_7GX59bGp" role="3oSUPX">
+                        <ref role="cht4Q" to="zqge:4ruP0NLeIr4" resolve="IndentedPoint" />
+                      </node>
+                      <node concept="2OqwBi" id="2J_7GX59bGq" role="1m5AlR">
+                        <node concept="0GJ7k" id="2J_7GX59bGr" role="2Oq$k0" />
+                        <node concept="1mfA1w" id="2J_7GX59bGs" role="2OqNvi" />
+                      </node>
+                    </node>
+                    <node concept="3TrcHB" id="2J_7GX59bGt" role="2OqNvi">
+                      <ref role="3TsBF5" to="zqge:4ruP0NLeIrV" resolve="indentation" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="1Wc70l" id="2J_7GX59bGy" role="3clFbw">
+              <node concept="2OqwBi" id="2J_7GX59bGz" role="3uHU7B">
+                <node concept="2OqwBi" id="2J_7GX59bG$" role="2Oq$k0">
+                  <node concept="0GJ7k" id="2J_7GX59bG_" role="2Oq$k0" />
+                  <node concept="1mfA1w" id="2J_7GX59bGA" role="2OqNvi" />
+                </node>
+                <node concept="1mIQ4w" id="2J_7GX59bGB" role="2OqNvi">
+                  <node concept="chp4Y" id="2J_7GX59bGC" role="cj9EA">
+                    <ref role="cht4Q" to="zqge:4ruP0NLeIr4" resolve="IndentedPoint" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2OqwBi" id="2J_7GX59bGD" role="3uHU7w">
+                <node concept="2OqwBi" id="2J_7GX59bGE" role="2Oq$k0">
+                  <node concept="0GJ7k" id="2J_7GX59bGF" role="2Oq$k0" />
+                  <node concept="YBYNd" id="2J_7GX59bGG" role="2OqNvi" />
+                </node>
+                <node concept="3w_OXm" id="2J_7GX59bGH" role="2OqNvi" />
+              </node>
+            </node>
+            <node concept="9aQIb" id="2J_7GX59bGI" role="9aQIa">
+              <node concept="3clFbS" id="2J_7GX59bGJ" role="9aQI4">
+                <node concept="3cpWs8" id="2J_7GX59bGK" role="3cqZAp">
+                  <node concept="3cpWsn" id="2J_7GX59bGL" role="3cpWs9">
+                    <property role="TrG5h" value="currentNode" />
+                    <node concept="3Tqbb2" id="2J_7GX59bGM" role="1tU5fm">
+                      <ref role="ehGHo" to="zqge:8D0iRqSPVB" resolve="TextElement" />
+                    </node>
+                    <node concept="0GJ7k" id="2J_7GX59bGN" role="33vP2m" />
+                  </node>
+                </node>
+                <node concept="1Dw8fO" id="2J_7GX59bGO" role="3cqZAp">
+                  <node concept="3clFbS" id="2J_7GX59bGP" role="2LFqv$">
+                    <node concept="3clFbF" id="1$KnWE8DEcF" role="3cqZAp">
+                      <node concept="2YIFZM" id="1$KnWE8DEcG" role="3clFbG">
+                        <ref role="1Pybhc" node="1$KnWE8DuVK" resolve="NewElementStrategyFactoryWrapper" />
+                        <ref role="37wK5l" node="1$KnWE8Dv2W" resolve="execute" />
+                        <node concept="0GJ7k" id="1$KnWE8DEcH" role="37wK5m" />
+                        <node concept="1Q80Hx" id="1$KnWE8DEcI" role="37wK5m" />
+                        <node concept="3clFbT" id="1$KnWE8DEcJ" role="37wK5m" />
+                      </node>
+                    </node>
+                    <node concept="3clFbF" id="1Xw9fLTaHJD" role="3cqZAp">
+                      <node concept="37vLTI" id="1Xw9fLTaHXd" role="3clFbG">
+                        <node concept="1PxgMI" id="1Xw9fLTaIQo" role="37vLTx">
+                          <property role="1BlNFB" value="true" />
+                          <node concept="chp4Y" id="1Xw9fLTaIRK" role="3oSUPX">
+                            <ref role="cht4Q" to="zqge:8D0iRqSPVB" resolve="TextElement" />
+                          </node>
+                          <node concept="2OqwBi" id="1Xw9fLTaI22" role="1m5AlR">
+                            <node concept="37vLTw" id="1Xw9fLTaHZD" role="2Oq$k0">
+                              <ref role="3cqZAo" node="2J_7GX59bGL" resolve="currentNode" />
+                            </node>
+                            <node concept="YCak7" id="1Xw9fLTaIHJ" role="2OqNvi" />
+                          </node>
+                        </node>
+                        <node concept="37vLTw" id="1Xw9fLTaHJB" role="37vLTJ">
+                          <ref role="3cqZAo" node="2J_7GX59bGL" resolve="currentNode" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3cpWsn" id="2J_7GX59bHn" role="1Duv9x">
+                    <property role="TrG5h" value="i" />
+                    <node concept="10Oyi0" id="2J_7GX59bHo" role="1tU5fm" />
+                    <node concept="3cmrfG" id="2J_7GX59bHp" role="33vP2m">
+                      <property role="3cmrfH" value="0" />
+                    </node>
+                  </node>
+                  <node concept="3eOVzh" id="2J_7GX59bHq" role="1Dwp0S">
+                    <node concept="3cmrfG" id="2J_7GX59bHr" role="3uHU7w">
+                      <property role="3cmrfH" value="4" />
+                    </node>
+                    <node concept="37vLTw" id="2J_7GX59bHs" role="3uHU7B">
+                      <ref role="3cqZAo" node="2J_7GX59bHn" resolve="i" />
+                    </node>
+                  </node>
+                  <node concept="3uNrnE" id="2J_7GX59bHt" role="1Dwrff">
+                    <node concept="37vLTw" id="2J_7GX59bHu" role="2$L3a6">
+                      <ref role="3cqZAo" node="2J_7GX59bHn" resolve="i" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbF" id="2J_7GX59bHE" role="3cqZAp">
+                  <node concept="2OqwBi" id="2J_7GX59bHF" role="3clFbG">
+                    <node concept="37vLTw" id="2J_7GX59bHG" role="2Oq$k0">
+                      <ref role="3cqZAo" node="2J_7GX59bGL" resolve="currentNode" />
+                    </node>
+                    <node concept="1OKiuA" id="2J_7GX59bHH" role="2OqNvi">
+                      <node concept="1Q80Hx" id="2J_7GX59bHI" role="lBI5i" />
+                      <node concept="2B6iha" id="1Xw9fLTbt5Z" role="lGT1i" />
+                      <node concept="3cmrfG" id="1Xw9fLTbt96" role="3dN3m$">
+                        <property role="3cmrfH" value="0" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2Pz7Y7" id="2J_7GX5c$WZ" role="2Pzqsi">
+        <node concept="3clFbS" id="2J_7GX5c$X0" role="2VODD2">
+          <node concept="1X3_iC" id="1Xw9fLT8g9b" role="lGtFl">
+            <property role="3V$3am" value="statement" />
+            <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+            <node concept="3clFbF" id="2J_7GX5c_83" role="8Wnug">
+              <node concept="3clFbC" id="2J_7GX5c_85" role="3clFbG">
+                <node concept="3cmrfG" id="2J_7GX5c_86" role="3uHU7w">
+                  <property role="3cmrfH" value="0" />
+                </node>
+                <node concept="2OqwBi" id="2J_7GX5c_87" role="3uHU7B">
+                  <node concept="1eOMI4" id="2J_7GX5c_88" role="2Oq$k0">
+                    <node concept="10QFUN" id="2J_7GX5c_89" role="1eOMHV">
+                      <node concept="3uibUv" id="2J_7GX5c_8a" role="10QFUM">
+                        <ref role="3uigEE" to="f4zo:~EditorCell_Label" resolve="EditorCell_Label" />
+                      </node>
+                      <node concept="2OqwBi" id="2J_7GX5c_8b" role="10QFUP">
+                        <node concept="1Q80Hx" id="2J_7GX5c_8c" role="2Oq$k0" />
+                        <node concept="liA8E" id="2J_7GX5c_8d" role="2OqNvi">
+                          <ref role="37wK5l" to="cj4x:~EditorContext.getSelectedCell()" resolve="getSelectedCell" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="2J_7GX5c_8e" role="2OqNvi">
+                    <ref role="37wK5l" to="f4zo:~EditorCell_Label.getCaretPosition()" resolve="getCaretPosition" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="1Xw9fLT8ge8" role="3cqZAp">
+            <node concept="3clFbT" id="1Xw9fLT8ge7" role="3clFbG">
+              <property role="3clFbU" value="true" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="312cEu" id="1$KnWE8DuVK">
+    <property role="3GE5qa" value="textElements" />
+    <property role="TrG5h" value="NewElementStrategyFactoryWrapper" />
+    <node concept="2YIFZL" id="1$KnWE8Dv2W" role="jymVt">
+      <property role="TrG5h" value="execute" />
+      <node concept="3clFbS" id="1$KnWE8Dv2Z" role="3clF47">
+        <node concept="3J1_TO" id="1$KnWE8DAO2" role="3cqZAp">
+          <node concept="3uVAMA" id="1$KnWE8DAO3" role="1zxBo5">
+            <node concept="XOnhg" id="1$KnWE8DAO4" role="1zc67B">
+              <property role="TrG5h" value="e" />
+              <node concept="nSUau" id="1$KnWE8DAO5" role="1tU5fm">
+                <node concept="3uibUv" id="1$KnWE8DAO6" role="nSUat">
+                  <ref role="3uigEE" to="wyt6:~Exception" resolve="Exception" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbS" id="1$KnWE8DAO7" role="1zc67A">
+              <node concept="2xdQw9" id="1$KnWE8DAO8" role="3cqZAp">
+                <property role="2xdLsb" value="gZ5fh_4/error" />
+                <node concept="Xl_RD" id="1$KnWE8DAO9" role="9lYJi">
+                  <property role="Xl_RC" value="Error" />
+                </node>
+                <node concept="37vLTw" id="1$KnWE8DAOa" role="9lYJj">
+                  <ref role="3cqZAo" node="1$KnWE8DAO4" resolve="e" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbS" id="1$KnWE8DAOb" role="1zxBo7">
+            <node concept="3cpWs8" id="1$KnWE8DAOc" role="3cqZAp">
+              <node concept="3cpWsn" id="1$KnWE8DAOd" role="3cpWs9">
+                <property role="TrG5h" value="newElementsStrategyFactoryCls" />
+                <node concept="3uibUv" id="1$KnWE8DAOe" role="1tU5fm">
+                  <ref role="3uigEE" to="wyt6:~Class" resolve="Class" />
+                  <node concept="3qTvmN" id="1$KnWE8DAOf" role="11_B2D" />
+                </node>
+                <node concept="2YIFZM" id="1$KnWE8DAOg" role="33vP2m">
+                  <ref role="37wK5l" to="wyt6:~Class.forName(java.lang.String)" resolve="forName" />
+                  <ref role="1Pybhc" to="wyt6:~Class" resolve="Class" />
+                  <node concept="Xl_RD" id="1$KnWE8DAOh" role="37wK5m">
+                    <property role="Xl_RC" value="jetbrains.mps.lang.text.editor.NewElementStrategyFactory" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs8" id="1$KnWE8DAOi" role="3cqZAp">
+              <node concept="3cpWsn" id="1$KnWE8DAOj" role="3cpWs9">
+                <property role="TrG5h" value="createNewElementStrategyMethod" />
+                <node concept="3uibUv" id="1$KnWE8DAOk" role="1tU5fm">
+                  <ref role="3uigEE" to="t6h5:~Method" resolve="Method" />
+                </node>
+                <node concept="2OqwBi" id="1$KnWE8DAOl" role="33vP2m">
+                  <node concept="37vLTw" id="1$KnWE8DAOm" role="2Oq$k0">
+                    <ref role="3cqZAo" node="1$KnWE8DAOd" resolve="newElementsStrategyFactoryCls" />
+                  </node>
+                  <node concept="liA8E" id="1$KnWE8DAOn" role="2OqNvi">
+                    <ref role="37wK5l" to="wyt6:~Class.getDeclaredMethod(java.lang.String,java.lang.Class...)" resolve="getDeclaredMethod" />
+                    <node concept="Xl_RD" id="1$KnWE8DAOo" role="37wK5m">
+                      <property role="Xl_RC" value="createNewElementStrategy" />
+                    </node>
+                    <node concept="3VsKOn" id="1$KnWE8DAOp" role="37wK5m">
+                      <ref role="3VsUkX" to="mhbf:~SNode" resolve="SNode" />
+                    </node>
+                    <node concept="3VsKOn" id="1$KnWE8DAOq" role="37wK5m">
+                      <ref role="3VsUkX" to="cj4x:~EditorContext" resolve="EditorContext" />
+                    </node>
+                    <node concept="229OVn" id="1$KnWE8FxYO" role="37wK5m">
+                      <node concept="10P_77" id="1$KnWE8FxYM" role="229OVk" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="1$KnWE8DAOt" role="3cqZAp">
+              <node concept="2OqwBi" id="1$KnWE8DAOu" role="3clFbG">
+                <node concept="37vLTw" id="1$KnWE8DAOv" role="2Oq$k0">
+                  <ref role="3cqZAo" node="1$KnWE8DAOj" resolve="method" />
+                </node>
+                <node concept="liA8E" id="1$KnWE8DAOw" role="2OqNvi">
+                  <ref role="37wK5l" to="t6h5:~Method.setAccessible(boolean)" resolve="setAccessible" />
+                  <node concept="3clFbT" id="1$KnWE8DAOx" role="37wK5m">
+                    <property role="3clFbU" value="true" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs8" id="1$KnWE8DAOy" role="3cqZAp">
+              <node concept="3cpWsn" id="1$KnWE8DAOz" role="3cpWs9">
+                <property role="TrG5h" value="result" />
+                <node concept="3uibUv" id="1$KnWE8DAO$" role="1tU5fm">
+                  <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+                </node>
+                <node concept="2OqwBi" id="1$KnWE8DAO_" role="33vP2m">
+                  <node concept="37vLTw" id="1$KnWE8DAOA" role="2Oq$k0">
+                    <ref role="3cqZAo" node="1$KnWE8DAOj" resolve="method" />
+                  </node>
+                  <node concept="liA8E" id="1$KnWE8DAOB" role="2OqNvi">
+                    <ref role="37wK5l" to="t6h5:~Method.invoke(java.lang.Object,java.lang.Object...)" resolve="invoke" />
+                    <node concept="10Nm6u" id="1$KnWE8FQKX" role="37wK5m" />
+                    <node concept="37vLTw" id="1$KnWE8DBeK" role="37wK5m">
+                      <ref role="3cqZAo" node="1$KnWE8Dv8S" resolve="node" />
+                    </node>
+                    <node concept="37vLTw" id="1$KnWE8DCHk" role="37wK5m">
+                      <ref role="3cqZAo" node="1$KnWE8Dv9g" resolve="editorContext" />
+                    </node>
+                    <node concept="37vLTw" id="1$KnWE8DDrn" role="37wK5m">
+                      <ref role="3cqZAo" node="1$KnWE8DvOy" resolve="isFirstPosition" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs8" id="1$KnWE8DAOF" role="3cqZAp">
+              <node concept="3cpWsn" id="1$KnWE8DAOG" role="3cpWs9">
+                <property role="TrG5h" value="textStrategyCls" />
+                <node concept="3uibUv" id="1$KnWE8DAOH" role="1tU5fm">
+                  <ref role="3uigEE" to="wyt6:~Class" resolve="Class" />
+                  <node concept="3qTvmN" id="1$KnWE8DAOI" role="11_B2D" />
+                </node>
+                <node concept="2YIFZM" id="1$KnWE8DAOJ" role="33vP2m">
+                  <ref role="1Pybhc" to="wyt6:~Class" resolve="Class" />
+                  <ref role="37wK5l" to="wyt6:~Class.forName(java.lang.String)" resolve="forName" />
+                  <node concept="Xl_RD" id="1$KnWE8DAOK" role="37wK5m">
+                    <property role="Xl_RC" value="jetbrains.mps.lang.text.editor.TextStrategy" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs8" id="1$KnWE8DAOL" role="3cqZAp">
+              <node concept="3cpWsn" id="1$KnWE8DAOM" role="3cpWs9">
+                <property role="TrG5h" value="executeMethod" />
+                <node concept="3uibUv" id="1$KnWE8DAON" role="1tU5fm">
+                  <ref role="3uigEE" to="t6h5:~Method" resolve="Method" />
+                </node>
+                <node concept="2OqwBi" id="1$KnWE8DAOO" role="33vP2m">
+                  <node concept="37vLTw" id="1$KnWE8DAOP" role="2Oq$k0">
+                    <ref role="3cqZAo" node="1$KnWE8DAOG" resolve="textStrategyCls" />
+                  </node>
+                  <node concept="liA8E" id="1$KnWE8DAOQ" role="2OqNvi">
+                    <ref role="37wK5l" to="wyt6:~Class.getDeclaredMethod(java.lang.String,java.lang.Class...)" resolve="getDeclaredMethod" />
+                    <node concept="Xl_RD" id="1$KnWE8DAOR" role="37wK5m">
+                      <property role="Xl_RC" value="execute" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="1$KnWE8DAOS" role="3cqZAp">
+              <node concept="2OqwBi" id="1$KnWE8DAOT" role="3clFbG">
+                <node concept="37vLTw" id="1$KnWE8DAOU" role="2Oq$k0">
+                  <ref role="3cqZAo" node="1$KnWE8DAOM" resolve="method2" />
+                </node>
+                <node concept="liA8E" id="1$KnWE8DAOV" role="2OqNvi">
+                  <ref role="37wK5l" to="t6h5:~Method.setAccessible(boolean)" resolve="setAccessible" />
+                  <node concept="3clFbT" id="1$KnWE8DAOW" role="37wK5m">
+                    <property role="3clFbU" value="true" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="1$KnWE8DAOX" role="3cqZAp">
+              <node concept="2OqwBi" id="1$KnWE8DAOY" role="3clFbG">
+                <node concept="37vLTw" id="1$KnWE8DAOZ" role="2Oq$k0">
+                  <ref role="3cqZAo" node="1$KnWE8DAOM" resolve="method2" />
+                </node>
+                <node concept="liA8E" id="1$KnWE8DAP0" role="2OqNvi">
+                  <ref role="37wK5l" to="t6h5:~Method.invoke(java.lang.Object,java.lang.Object...)" resolve="invoke" />
+                  <node concept="37vLTw" id="1$KnWE8DAP1" role="37wK5m">
+                    <ref role="3cqZAo" node="1$KnWE8DAOz" resolve="result" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbH" id="1$KnWE8DAP2" role="3cqZAp" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="1$KnWE8Dv2p" role="1B3o_S" />
+      <node concept="3cqZAl" id="1$KnWE8Dv2L" role="3clF45" />
+      <node concept="37vLTG" id="1$KnWE8Dv8S" role="3clF46">
+        <property role="TrG5h" value="node" />
+        <node concept="3Tqbb2" id="1$KnWE8Dv8R" role="1tU5fm">
+          <ref role="ehGHo" to="zqge:8D0iRqSPVB" resolve="TextElement" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="1$KnWE8Dv9g" role="3clF46">
+        <property role="TrG5h" value="editorContext" />
+        <node concept="3uibUv" id="1$KnWE8Dv9G" role="1tU5fm">
+          <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="1$KnWE8DvOy" role="3clF46">
+        <property role="TrG5h" value="isFirstPosition" />
+        <node concept="10P_77" id="1$KnWE8DvP2" role="1tU5fm" />
+      </node>
+    </node>
+    <node concept="3Tm1VV" id="1$KnWE8DuVL" role="1B3o_S" />
+  </node>
+</model>
+

--- a/code/changelog/de.itemis.mps.changelog/models/de.itemis.mps.changelog.editor.mps
+++ b/code/changelog/de.itemis.mps.changelog/models/de.itemis.mps.changelog.editor.mps
@@ -466,6 +466,22 @@
             <ref role="1NtTu8" to="b7vt:Po4Z58IlRD" resolve="headerType" />
           </node>
         </node>
+        <node concept="3EZMnI" id="6aVQm8Wic1Z" role="3EZMnx">
+          <node concept="VPM3Z" id="6aVQm8Wic20" role="3F10Kt">
+            <property role="VOm3f" value="false" />
+          </node>
+          <node concept="VPXOz" id="6aVQm8Wic21" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+          <node concept="2iRfu4" id="6aVQm8Wic22" role="2iSdaV" />
+          <node concept="3F0ifn" id="6aVQm8Wic23" role="3EZMnx">
+            <property role="3F0ifm" value="chronological order:" />
+            <ref role="1k5W1q" to="tpc5:hF4H1c8" resolve="property" />
+          </node>
+          <node concept="3F0A7n" id="6aVQm8Wic24" role="3EZMnx">
+            <ref role="1NtTu8" to="b7vt:6aVQm8WibTZ" resolve="chronologicalOrder" />
+          </node>
+        </node>
       </node>
       <node concept="2iRkQZ" id="Po4Z58Imt3" role="2iSdaV" />
       <node concept="3F0ifn" id="XbadXShqc2" role="3EZMnx" />
@@ -727,7 +743,7 @@
                 <node concept="2OqwBi" id="XbadXRL0jX" role="3clFbG">
                   <node concept="pncrf" id="XbadXRL06G" role="2Oq$k0" />
                   <node concept="2qgKlT" id="XbadXRL0_B" role="2OqNvi">
-                    <ref role="37wK5l" to="j2b5:2r0ijgcUaDV" resolve="getDate" />
+                    <ref role="37wK5l" to="j2b5:2r0ijgcUaDV" resolve="getDateAsString" />
                   </node>
                 </node>
               </node>

--- a/code/changelog/de.itemis.mps.changelog/models/de.itemis.mps.changelog.intentions.mps
+++ b/code/changelog/de.itemis.mps.changelog/models/de.itemis.mps.changelog.intentions.mps
@@ -1,0 +1,892 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:522c8b6a-14e0-4f36-a3df-8cb7e042db6f(de.itemis.mps.changelog.intentions)">
+  <persistence version="9" />
+  <languages>
+    <use id="d7a92d38-f7db-40d0-8431-763b0c3c9f20" name="jetbrains.mps.lang.intentions" version="1" />
+    <use id="05f762a9-99f5-4971-a9ed-5a6481dc2be4" name="de.itemis.mps.selection.intentions" version="0" />
+    <engage id="d7a92d38-f7db-40d0-8431-763b0c3c9f20" name="jetbrains.mps.lang.intentions" />
+    <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
+  </languages>
+  <imports>
+    <import index="2u9v" ref="r:ad87c166-8161-4e40-b79b-3d7ba4070d9e(jetbrains.mps.lang.text.editor)" />
+    <import index="6f4m" ref="528ff3b9-5fc4-40dd-931f-c6ce3650640e/r:f69c3fa1-0e30-4980-84e2-190ae44e4c3d(jetbrains.mps.lang.migration.runtime/jetbrains.mps.lang.migration.runtime.base)" />
+    <import index="b8lf" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor.selection(MPS.Editor/)" implicit="true" />
+    <import index="zqge" ref="r:59e90602-6655-4552-86eb-441a42a9a0e4(jetbrains.mps.lang.text.structure)" implicit="true" />
+    <import index="vdrq" ref="r:85354f47-14fd-40e6-a7cc-2d1aa842c4cd(jetbrains.mps.lang.text.behavior)" implicit="true" />
+    <import index="cj4x" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor(MPS.Editor/)" implicit="true" />
+    <import index="b7vt" ref="r:86cc19c0-126f-473b-92c6-29dba75c1e89(de.itemis.mps.changelog.structure)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1080223426719" name="jetbrains.mps.baseLanguage.structure.OrExpression" flags="nn" index="22lmx$" />
+      <concept id="1082485599095" name="jetbrains.mps.baseLanguage.structure.BlockStatement" flags="nn" index="9aQIb">
+        <child id="1082485599096" name="statements" index="9aQI4" />
+      </concept>
+      <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
+        <child id="1137022507850" name="body" index="2VODD2" />
+      </concept>
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
+      </concept>
+      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
+        <child id="1082485599094" name="ifFalseStatement" index="9aQIa" />
+        <child id="1068580123160" name="condition" index="3clFbw" />
+        <child id="1068580123161" name="ifTrue" index="3clFbx" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
+        <property id="1068580320021" name="value" index="3cmrfH" />
+      </concept>
+      <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
+        <child id="1068581517676" name="expression" index="3cqZAk" />
+      </concept>
+      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
+        <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
+      </concept>
+      <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1081506762703" name="jetbrains.mps.baseLanguage.structure.GreaterThanExpression" flags="nn" index="3eOSWO" />
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+        <reference id="1107535924139" name="classifier" index="3uigEE" />
+      </concept>
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
+        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
+        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
+      </concept>
+      <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
+    </language>
+    <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
+      <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
+        <child id="1199569906740" name="parameter" index="1bW2Oz" />
+        <child id="1199569916463" name="body" index="1bW5cS" />
+      </concept>
+    </language>
+    <language id="d7a92d38-f7db-40d0-8431-763b0c3c9f20" name="jetbrains.mps.lang.intentions">
+      <concept id="1192794744107" name="jetbrains.mps.lang.intentions.structure.IntentionDeclaration" flags="ig" index="2S6QgY" />
+      <concept id="1192794782375" name="jetbrains.mps.lang.intentions.structure.DescriptionBlock" flags="in" index="2S6ZIM" />
+      <concept id="1192795771125" name="jetbrains.mps.lang.intentions.structure.IsApplicableBlock" flags="in" index="2SaL7w" />
+      <concept id="1192795911897" name="jetbrains.mps.lang.intentions.structure.ExecuteBlock" flags="in" index="2Sbjvc" />
+      <concept id="1192796902958" name="jetbrains.mps.lang.intentions.structure.ConceptFunctionParameter_node" flags="nn" index="2Sf5sV" />
+      <concept id="2522969319638091381" name="jetbrains.mps.lang.intentions.structure.BaseIntentionDeclaration" flags="ig" index="2ZfUlf">
+        <reference id="2522969319638198290" name="forConcept" index="2ZfgGC" />
+        <child id="2522969319638198291" name="executeFunction" index="2ZfgGD" />
+        <child id="2522969319638093995" name="isApplicableFunction" index="2ZfVeh" />
+        <child id="2522969319638093993" name="descriptionFunction" index="2ZfVej" />
+      </concept>
+    </language>
+    <language id="05f762a9-99f5-4971-a9ed-5a6481dc2be4" name="de.itemis.mps.selection.intentions">
+      <concept id="6009478650970401999" name="de.itemis.mps.selection.intentions.structure.Description" flags="ig" index="71TwL" />
+      <concept id="6009478650970402176" name="de.itemis.mps.selection.intentions.structure.Parameter_Selection" flags="ng" index="71T_Y" />
+      <concept id="6009478650970402162" name="de.itemis.mps.selection.intentions.structure.Execute" flags="ig" index="71TAc" />
+      <concept id="6009478650970402067" name="de.itemis.mps.selection.intentions.structure.IsApplicable" flags="ig" index="71TBH" />
+      <concept id="6009478650970401247" name="de.itemis.mps.selection.intentions.structure.SelectionIntention" flags="ng" index="71TOx">
+        <child id="6009478650970402171" name="execute" index="71TA5" />
+        <child id="6009478650970402167" name="isApplicable" index="71TA9" />
+        <child id="6009478650970402164" name="description" index="71TAa" />
+        <child id="6009478650970401248" name="selectionType" index="71TOu" />
+      </concept>
+    </language>
+    <language id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation">
+      <concept id="5455284157994012186" name="jetbrains.mps.lang.quotation.structure.NodeBuilderInitLink" flags="ng" index="2pIpSj">
+        <reference id="5455284157994012188" name="link" index="2pIpSl" />
+        <child id="1595412875168045827" name="initValue" index="28nt2d" />
+      </concept>
+      <concept id="5455284157993911077" name="jetbrains.mps.lang.quotation.structure.NodeBuilderInitProperty" flags="ng" index="2pJxcG">
+        <reference id="5455284157993911078" name="property" index="2pJxcJ" />
+        <child id="1595412875168045201" name="initValue" index="28ntcv" />
+      </concept>
+      <concept id="5455284157993863837" name="jetbrains.mps.lang.quotation.structure.NodeBuilder" flags="nn" index="2pJPEk">
+        <child id="5455284157993863838" name="quotedNode" index="2pJPEn" />
+      </concept>
+      <concept id="5455284157993863840" name="jetbrains.mps.lang.quotation.structure.NodeBuilderNode" flags="nn" index="2pJPED">
+        <reference id="5455284157993910961" name="concept" index="2pJxaS" />
+        <child id="5455284157993911099" name="values" index="2pJxcM" />
+      </concept>
+      <concept id="6985522012210254362" name="jetbrains.mps.lang.quotation.structure.NodeBuilderPropertyExpression" flags="nn" index="WxPPo">
+        <child id="6985522012210254363" name="expression" index="WxPPp" />
+      </concept>
+      <concept id="8182547171709752110" name="jetbrains.mps.lang.quotation.structure.NodeBuilderExpression" flags="nn" index="36biLy">
+        <child id="8182547171709752112" name="expression" index="36biLW" />
+      </concept>
+    </language>
+    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
+        <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
+      </concept>
+      <concept id="1138411891628" name="jetbrains.mps.lang.smodel.structure.SNodeOperation" flags="nn" index="eCIE_">
+        <child id="1144104376918" name="parameter" index="1xVPHs" />
+      </concept>
+      <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
+      <concept id="7453996997717780434" name="jetbrains.mps.lang.smodel.structure.Node_GetSConceptOperation" flags="nn" index="2yIwOk" />
+      <concept id="2396822768958367367" name="jetbrains.mps.lang.smodel.structure.AbstractTypeCastExpression" flags="nn" index="$5XWr">
+        <child id="6733348108486823193" name="leftExpression" index="1m5AlR" />
+        <child id="3906496115198199033" name="conceptArgument" index="3oSUPX" />
+      </concept>
+      <concept id="1171407110247" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorOperation" flags="nn" index="2Xjw5R" />
+      <concept id="2644386474300074836" name="jetbrains.mps.lang.smodel.structure.ConceptIdRefExpression" flags="nn" index="35c_gC">
+        <reference id="2644386474300074837" name="conceptDeclaration" index="35c_gD" />
+      </concept>
+      <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
+        <child id="1177027386292" name="conceptArgument" index="cj9EA" />
+      </concept>
+      <concept id="1144101972840" name="jetbrains.mps.lang.smodel.structure.OperationParm_Concept" flags="ng" index="1xMEDy">
+        <child id="1207343664468" name="conceptArgument" index="ri$Ld" />
+      </concept>
+      <concept id="1144146199828" name="jetbrains.mps.lang.smodel.structure.Node_CopyOperation" flags="nn" index="1$rogu" />
+      <concept id="1172326502327" name="jetbrains.mps.lang.smodel.structure.Concept_IsExactlyOperation" flags="nn" index="3O6GUB">
+        <child id="1206733650006" name="conceptArgument" index="3QVz_e" />
+      </concept>
+      <concept id="1140131837776" name="jetbrains.mps.lang.smodel.structure.Node_ReplaceWithAnotherOperation" flags="nn" index="1P9Npp">
+        <child id="1140131861877" name="replacementNode" index="1P9ThW" />
+      </concept>
+      <concept id="1140137987495" name="jetbrains.mps.lang.smodel.structure.SNodeTypeCastExpression" flags="nn" index="1PxgMI">
+        <property id="1238684351431" name="asCast" index="1BlNFB" />
+      </concept>
+      <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
+        <reference id="1138405853777" name="concept" index="ehGHo" />
+      </concept>
+      <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="nn" index="3TrEf2">
+        <reference id="1138056516764" name="link" index="3Tt5mk" />
+      </concept>
+      <concept id="1228341669568" name="jetbrains.mps.lang.smodel.structure.Node_DetachOperation" flags="nn" index="3YRAZt" />
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+    <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
+        <child id="1204796294226" name="closure" index="23t8la" />
+      </concept>
+      <concept id="1172650591544" name="jetbrains.mps.baseLanguage.collections.structure.SkipOperation" flags="nn" index="7r0gD">
+        <child id="1172658456740" name="elementsToSkip" index="7T0AP" />
+      </concept>
+      <concept id="1204980550705" name="jetbrains.mps.baseLanguage.collections.structure.VisitAllOperation" flags="nn" index="2es0OD" />
+      <concept id="1151688443754" name="jetbrains.mps.baseLanguage.collections.structure.ListType" flags="in" index="_YKpA">
+        <child id="1151688676805" name="elementType" index="_ZDj9" />
+      </concept>
+      <concept id="1151702311717" name="jetbrains.mps.baseLanguage.collections.structure.ToListOperation" flags="nn" index="ANE8D" />
+      <concept id="1235566831861" name="jetbrains.mps.baseLanguage.collections.structure.AllOperation" flags="nn" index="2HxqBE" />
+      <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
+      <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
+      <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
+      <concept id="1240687580870" name="jetbrains.mps.baseLanguage.collections.structure.JoinOperation" flags="nn" index="3uJxvA">
+        <child id="1240687658305" name="delimiter" index="3uJOhx" />
+      </concept>
+      <concept id="1202128969694" name="jetbrains.mps.baseLanguage.collections.structure.SelectOperation" flags="nn" index="3$u5V9" />
+    </language>
+  </registry>
+  <node concept="71TOx" id="XbadXRF6RY">
+    <property role="TrG5h" value="MergeIntoOneWord" />
+    <node concept="3uibUv" id="XbadXRF872" role="71TOu">
+      <ref role="3uigEE" to="2u9v:4tfWvd2gXHJ" resolve="WordRangeSelection" />
+    </node>
+    <node concept="71TwL" id="XbadXRF6S0" role="71TAa">
+      <node concept="3clFbS" id="XbadXRF6S1" role="2VODD2">
+        <node concept="3clFbF" id="XbadXRF878" role="3cqZAp">
+          <node concept="Xl_RD" id="XbadXRF877" role="3clFbG">
+            <property role="Xl_RC" value="Merge Into One Word" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="71TAc" id="XbadXRF6S2" role="71TA5">
+      <node concept="3clFbS" id="XbadXRF6S3" role="2VODD2">
+        <node concept="3cpWs8" id="XbadXRHVLK" role="3cqZAp">
+          <node concept="3cpWsn" id="XbadXRHVLL" role="3cpWs9">
+            <property role="TrG5h" value="selectedNodes" />
+            <node concept="_YKpA" id="XbadXRHVLM" role="1tU5fm">
+              <node concept="3Tqbb2" id="XbadXRHVLN" role="_ZDj9" />
+            </node>
+            <node concept="2OqwBi" id="XbadXRHVLO" role="33vP2m">
+              <node concept="71T_Y" id="XbadXRHVLP" role="2Oq$k0" />
+              <node concept="liA8E" id="XbadXRHVLQ" role="2OqNvi">
+                <ref role="37wK5l" to="b8lf:~AbstractMultipleSelection.getSelectedNodes()" resolve="getSelectedNodes" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="XbadXRGgfV" role="3cqZAp">
+          <node concept="3cpWsn" id="XbadXRGgfY" role="3cpWs9">
+            <property role="TrG5h" value="selectedWords" />
+            <node concept="_YKpA" id="XbadXRGgfR" role="1tU5fm">
+              <node concept="3Tqbb2" id="XbadXRGglF" role="_ZDj9">
+                <ref role="ehGHo" to="zqge:8D0iRqSPW4" resolve="Word" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="XbadXRHYA_" role="33vP2m">
+              <node concept="2OqwBi" id="XbadXRHWYJ" role="2Oq$k0">
+                <node concept="37vLTw" id="XbadXRHVUh" role="2Oq$k0">
+                  <ref role="3cqZAo" node="XbadXRHVLL" resolve="selectedNodes" />
+                </node>
+                <node concept="3$u5V9" id="XbadXRHXSB" role="2OqNvi">
+                  <node concept="1bVj0M" id="XbadXRHXSD" role="23t8la">
+                    <node concept="3clFbS" id="XbadXRHXSE" role="1bW5cS">
+                      <node concept="3clFbF" id="XbadXRHXY6" role="3cqZAp">
+                        <node concept="1PxgMI" id="XbadXRHYht" role="3clFbG">
+                          <property role="1BlNFB" value="true" />
+                          <node concept="chp4Y" id="XbadXRHYkF" role="3oSUPX">
+                            <ref role="cht4Q" to="zqge:8D0iRqSPW4" resolve="Word" />
+                          </node>
+                          <node concept="37vLTw" id="XbadXRHXY5" role="1m5AlR">
+                            <ref role="3cqZAo" node="XbadXRHXSF" resolve="it" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="Rh6nW" id="XbadXRHXSF" role="1bW2Oz">
+                      <property role="TrG5h" value="it" />
+                      <node concept="2jxLKc" id="XbadXRHXSG" role="1tU5fm" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="ANE8D" id="XbadXRHYXG" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="XbadXRI3S2" role="3cqZAp">
+          <node concept="3cpWsn" id="XbadXRI3S5" role="3cpWs9">
+            <property role="TrG5h" value="newText" />
+            <node concept="17QB3L" id="XbadXRI3S0" role="1tU5fm" />
+            <node concept="2OqwBi" id="XbadXRI85j" role="33vP2m">
+              <node concept="2OqwBi" id="XbadXRI5KE" role="2Oq$k0">
+                <node concept="37vLTw" id="XbadXRI3Zw" role="2Oq$k0">
+                  <ref role="3cqZAo" node="XbadXRGgfY" resolve="selectedWords" />
+                </node>
+                <node concept="3$u5V9" id="XbadXRI79U" role="2OqNvi">
+                  <node concept="1bVj0M" id="XbadXRI79W" role="23t8la">
+                    <node concept="3clFbS" id="XbadXRI79X" role="1bW5cS">
+                      <node concept="3clFbF" id="XbadXRI7gj" role="3cqZAp">
+                        <node concept="2OqwBi" id="XbadXRI7uX" role="3clFbG">
+                          <node concept="37vLTw" id="XbadXRI7gi" role="2Oq$k0">
+                            <ref role="3cqZAo" node="XbadXRI79Y" resolve="it" />
+                          </node>
+                          <node concept="2qgKlT" id="XbadXRI7K7" role="2OqNvi">
+                            <ref role="37wK5l" to="vdrq:fB3l81it7u" resolve="getTextualRepresentation" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="Rh6nW" id="XbadXRI79Y" role="1bW2Oz">
+                      <property role="TrG5h" value="it" />
+                      <node concept="2jxLKc" id="XbadXRI79Z" role="1tU5fm" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3uJxvA" id="XbadXRI8FY" role="2OqNvi">
+                <node concept="Xl_RD" id="XbadXRI9aP" role="3uJOhx">
+                  <property role="Xl_RC" value=" " />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="XbadXRI9O9" role="3cqZAp">
+          <node concept="3cpWsn" id="XbadXRI9Oc" role="3cpWs9">
+            <property role="TrG5h" value="newWord" />
+            <node concept="3Tqbb2" id="XbadXRI9O7" role="1tU5fm">
+              <ref role="ehGHo" to="zqge:8D0iRqSPW4" resolve="Word" />
+            </node>
+            <node concept="2pJPEk" id="XbadXRIa92" role="33vP2m">
+              <node concept="2pJPED" id="XbadXRIa94" role="2pJPEn">
+                <ref role="2pJxaS" to="zqge:8D0iRqSPW4" resolve="Word" />
+                <node concept="2pJxcG" id="XbadXRIabi" role="2pJxcM">
+                  <ref role="2pJxcJ" to="zqge:8D0iRqSPW5" resolve="value" />
+                  <node concept="WxPPo" id="XbadXRIabO" role="28ntcv">
+                    <node concept="37vLTw" id="XbadXRIabM" role="WxPPp">
+                      <ref role="3cqZAo" node="XbadXRI3S5" resolve="newText" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="XbadXRIaww" role="3cqZAp">
+          <node concept="2OqwBi" id="XbadXRIeF7" role="3clFbG">
+            <node concept="2OqwBi" id="XbadXRIcl_" role="2Oq$k0">
+              <node concept="37vLTw" id="XbadXRIawu" role="2Oq$k0">
+                <ref role="3cqZAo" node="XbadXRGgfY" resolve="selectedWords" />
+              </node>
+              <node concept="1uHKPH" id="XbadXRIdUt" role="2OqNvi" />
+            </node>
+            <node concept="1P9Npp" id="XbadXRIeV2" role="2OqNvi">
+              <node concept="37vLTw" id="XbadXRIeXo" role="1P9ThW">
+                <ref role="3cqZAo" node="XbadXRI9Oc" resolve="newWord" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="XbadXRIfpf" role="3cqZAp">
+          <node concept="2OqwBi" id="XbadXRIiiU" role="3clFbG">
+            <node concept="2OqwBi" id="XbadXRIhkr" role="2Oq$k0">
+              <node concept="37vLTw" id="XbadXRIfpd" role="2Oq$k0">
+                <ref role="3cqZAo" node="XbadXRGgfY" resolve="selectedWords" />
+              </node>
+              <node concept="7r0gD" id="XbadXRIi5V" role="2OqNvi">
+                <node concept="3cmrfG" id="XbadXRIi61" role="7T0AP">
+                  <property role="3cmrfH" value="1" />
+                </node>
+              </node>
+            </node>
+            <node concept="2es0OD" id="XbadXRIix9" role="2OqNvi">
+              <node concept="1bVj0M" id="XbadXRIixb" role="23t8la">
+                <node concept="3clFbS" id="XbadXRIixc" role="1bW5cS">
+                  <node concept="3clFbF" id="XbadXRIiyU" role="3cqZAp">
+                    <node concept="2OqwBi" id="XbadXRIiIl" role="3clFbG">
+                      <node concept="37vLTw" id="XbadXRIiyT" role="2Oq$k0">
+                        <ref role="3cqZAo" node="XbadXRIixd" resolve="it" />
+                      </node>
+                      <node concept="3YRAZt" id="XbadXRIjaK" role="2OqNvi" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="Rh6nW" id="XbadXRIixd" role="1bW2Oz">
+                  <property role="TrG5h" value="it" />
+                  <node concept="2jxLKc" id="XbadXRIixe" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="XbadXRIpmY" role="3cqZAp">
+          <node concept="2OqwBi" id="XbadXRIqpS" role="3clFbG">
+            <node concept="2OqwBi" id="XbadXRIqbY" role="2Oq$k0">
+              <node concept="2OqwBi" id="XbadXRIpYP" role="2Oq$k0">
+                <node concept="71T_Y" id="XbadXRIpmX" role="2Oq$k0" />
+                <node concept="liA8E" id="XbadXRIq5J" role="2OqNvi">
+                  <ref role="37wK5l" to="b8lf:~AbstractSelection.getEditorComponent()" resolve="getEditorComponent" />
+                </node>
+              </node>
+              <node concept="liA8E" id="XbadXRIqjg" role="2OqNvi">
+                <ref role="37wK5l" to="cj4x:~EditorComponent.getEditorContext()" resolve="getEditorContext" />
+              </node>
+            </node>
+            <node concept="liA8E" id="XbadXRIqyl" role="2OqNvi">
+              <ref role="37wK5l" to="cj4x:~EditorContext.selectWRTFocusPolicy(org.jetbrains.mps.openapi.model.SNode)" resolve="selectWRTFocusPolicy" />
+              <node concept="37vLTw" id="XbadXRIq$4" role="37wK5m">
+                <ref role="3cqZAo" node="XbadXRI9Oc" resolve="newWord" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="71TBH" id="XbadXRHPK$" role="71TA9">
+      <node concept="3clFbS" id="XbadXRHPK_" role="2VODD2">
+        <node concept="3cpWs8" id="XbadXRHPPJ" role="3cqZAp">
+          <node concept="3cpWsn" id="XbadXRHPPK" role="3cpWs9">
+            <property role="TrG5h" value="selectedNodes" />
+            <node concept="_YKpA" id="XbadXRHPPL" role="1tU5fm">
+              <node concept="3Tqbb2" id="XbadXRHPPM" role="_ZDj9" />
+            </node>
+            <node concept="2OqwBi" id="XbadXRHPPN" role="33vP2m">
+              <node concept="71T_Y" id="XbadXRHPPO" role="2Oq$k0" />
+              <node concept="liA8E" id="XbadXRHPPP" role="2OqNvi">
+                <ref role="37wK5l" to="b8lf:~AbstractMultipleSelection.getSelectedNodes()" resolve="getSelectedNodes" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="XbadXRHQ1x" role="3cqZAp">
+          <node concept="1Wc70l" id="XbadXRIwgc" role="3clFbG">
+            <node concept="3eOSWO" id="XbadXRI$eK" role="3uHU7w">
+              <node concept="3cmrfG" id="XbadXRI$BY" role="3uHU7w">
+                <property role="3cmrfH" value="1" />
+              </node>
+              <node concept="2OqwBi" id="XbadXRIxP_" role="3uHU7B">
+                <node concept="37vLTw" id="XbadXRIwyt" role="2Oq$k0">
+                  <ref role="3cqZAo" node="XbadXRHPPK" resolve="selectedNodes" />
+                </node>
+                <node concept="34oBXx" id="XbadXRIz0G" role="2OqNvi" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="XbadXRHRfF" role="3uHU7B">
+              <node concept="37vLTw" id="XbadXRHQ1v" role="2Oq$k0">
+                <ref role="3cqZAo" node="XbadXRHPPK" resolve="selectedNodes" />
+              </node>
+              <node concept="2HxqBE" id="XbadXRHSj4" role="2OqNvi">
+                <node concept="1bVj0M" id="XbadXRHSj6" role="23t8la">
+                  <node concept="3clFbS" id="XbadXRHSj7" role="1bW5cS">
+                    <node concept="3clFbF" id="XbadXRHSoj" role="3cqZAp">
+                      <node concept="2OqwBi" id="XbadXRHSH4" role="3clFbG">
+                        <node concept="37vLTw" id="XbadXRHSoi" role="2Oq$k0">
+                          <ref role="3cqZAo" node="XbadXRHSj8" resolve="it" />
+                        </node>
+                        <node concept="1mIQ4w" id="XbadXRHT6c" role="2OqNvi">
+                          <node concept="chp4Y" id="XbadXRHTfk" role="cj9EA">
+                            <ref role="cht4Q" to="zqge:8D0iRqSPW4" resolve="Word" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Rh6nW" id="XbadXRHSj8" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="XbadXRHSj9" role="1tU5fm" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="2S6QgY" id="XbadXS8Rhv">
+    <property role="TrG5h" value="ChangeCodeFormatting" />
+    <ref role="2ZfgGC" to="zqge:8D0iRqSPW4" resolve="Word" />
+    <node concept="2S6ZIM" id="XbadXS8Rhw" role="2ZfVej">
+      <node concept="3clFbS" id="XbadXS8Rhx" role="2VODD2">
+        <node concept="3clFbJ" id="XbadXSdmX0" role="3cqZAp">
+          <node concept="3clFbS" id="XbadXSdmX2" role="3clFbx">
+            <node concept="3cpWs6" id="XbadXSdn84" role="3cqZAp">
+              <node concept="Xl_RD" id="XbadXS8RmE" role="3cqZAk">
+                <property role="Xl_RC" value="Add Code Formatting" />
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="XbadXSdmXL" role="3clFbw">
+            <node concept="2OqwBi" id="XbadXSdmXM" role="2Oq$k0">
+              <node concept="2Sf5sV" id="XbadXSdmXN" role="2Oq$k0" />
+              <node concept="2yIwOk" id="XbadXSdmXO" role="2OqNvi" />
+            </node>
+            <node concept="3O6GUB" id="XbadXSdmXP" role="2OqNvi">
+              <node concept="chp4Y" id="XbadXSdmXQ" role="3QVz_e">
+                <ref role="cht4Q" to="zqge:8D0iRqSPW4" resolve="Word" />
+              </node>
+            </node>
+          </node>
+          <node concept="9aQIb" id="XbadXSdnhk" role="9aQIa">
+            <node concept="3clFbS" id="XbadXSdnhl" role="9aQI4">
+              <node concept="3cpWs6" id="XbadXSdnid" role="3cqZAp">
+                <node concept="Xl_RD" id="XbadXSdnil" role="3cqZAk">
+                  <property role="Xl_RC" value="Remove Code Formatting" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2Sbjvc" id="XbadXS8Rhy" role="2ZfgGD">
+      <node concept="3clFbS" id="XbadXS8Rhz" role="2VODD2">
+        <node concept="3clFbJ" id="XbadXSdnCx" role="3cqZAp">
+          <node concept="3clFbS" id="XbadXSdnCz" role="3clFbx">
+            <node concept="3clFbF" id="XbadXS8TAk" role="3cqZAp">
+              <node concept="2OqwBi" id="XbadXS8TJ4" role="3clFbG">
+                <node concept="2Sf5sV" id="XbadXS8TAj" role="2Oq$k0" />
+                <node concept="1P9Npp" id="XbadXS8TU0" role="2OqNvi">
+                  <node concept="2YIFZM" id="XbadXS8VWD" role="1P9ThW">
+                    <ref role="37wK5l" to="6f4m:6gEjUfBKG6M" resolve="replaceWithNewConcept" />
+                    <ref role="1Pybhc" to="6f4m:4dr7st0kFTM" resolve="RefactoringRuntime" />
+                    <node concept="2Sf5sV" id="XbadXS8VXE" role="37wK5m" />
+                    <node concept="35c_gC" id="XbadXS8Wbz" role="37wK5m">
+                      <ref role="35c_gD" to="b7vt:XbadXS8vkr" resolve="CodeWord" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="XbadXSdnGA" role="3clFbw">
+            <node concept="2OqwBi" id="XbadXSdnGB" role="2Oq$k0">
+              <node concept="2Sf5sV" id="XbadXSdnGC" role="2Oq$k0" />
+              <node concept="2yIwOk" id="XbadXSdnGD" role="2OqNvi" />
+            </node>
+            <node concept="3O6GUB" id="XbadXSdnGE" role="2OqNvi">
+              <node concept="chp4Y" id="XbadXSdnGF" role="3QVz_e">
+                <ref role="cht4Q" to="zqge:8D0iRqSPW4" resolve="Word" />
+              </node>
+            </node>
+          </node>
+          <node concept="9aQIb" id="XbadXSdnRp" role="9aQIa">
+            <node concept="3clFbS" id="XbadXSdnRq" role="9aQI4">
+              <node concept="3clFbF" id="XbadXSdnWj" role="3cqZAp">
+                <node concept="2OqwBi" id="XbadXSdnWk" role="3clFbG">
+                  <node concept="2Sf5sV" id="XbadXSdnWl" role="2Oq$k0" />
+                  <node concept="1P9Npp" id="XbadXSdnWm" role="2OqNvi">
+                    <node concept="2YIFZM" id="XbadXSdnWn" role="1P9ThW">
+                      <ref role="1Pybhc" to="6f4m:4dr7st0kFTM" resolve="RefactoringRuntime" />
+                      <ref role="37wK5l" to="6f4m:6gEjUfBKG6M" resolve="replaceWithNewConcept" />
+                      <node concept="2Sf5sV" id="XbadXSdnWo" role="37wK5m" />
+                      <node concept="35c_gC" id="XbadXSdnWp" role="37wK5m">
+                        <ref role="35c_gD" to="zqge:8D0iRqSPW4" resolve="Word" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2SaL7w" id="XbadXS8Rw$" role="2ZfVeh">
+      <node concept="3clFbS" id="XbadXS8Rw_" role="2VODD2">
+        <node concept="3clFbF" id="XbadXS8R$D" role="3cqZAp">
+          <node concept="22lmx$" id="XbadXSdl5N" role="3clFbG">
+            <node concept="2OqwBi" id="XbadXSdm0F" role="3uHU7w">
+              <node concept="2OqwBi" id="XbadXSdlm8" role="2Oq$k0">
+                <node concept="2Sf5sV" id="XbadXSdl7f" role="2Oq$k0" />
+                <node concept="2yIwOk" id="XbadXSdlGS" role="2OqNvi" />
+              </node>
+              <node concept="3O6GUB" id="XbadXSdmxw" role="2OqNvi">
+                <node concept="chp4Y" id="XbadXSdmA_" role="3QVz_e">
+                  <ref role="cht4Q" to="b7vt:XbadXS8vkr" resolve="CodeWord" />
+                </node>
+              </node>
+            </node>
+            <node concept="2OqwBi" id="XbadXS8SMG" role="3uHU7B">
+              <node concept="2OqwBi" id="XbadXS8RNa" role="2Oq$k0">
+                <node concept="2Sf5sV" id="XbadXS8R$C" role="2Oq$k0" />
+                <node concept="2yIwOk" id="XbadXS8Srr" role="2OqNvi" />
+              </node>
+              <node concept="3O6GUB" id="XbadXS8T7G" role="2OqNvi">
+                <node concept="chp4Y" id="XbadXS8TfZ" role="3QVz_e">
+                  <ref role="cht4Q" to="zqge:8D0iRqSPW4" resolve="Word" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="71TOx" id="1$KnWE8t36A">
+    <property role="TrG5h" value="CombineElements" />
+    <node concept="3uibUv" id="1$KnWE8t36B" role="71TOu">
+      <ref role="3uigEE" to="2u9v:4tfWvd2gXHJ" resolve="WordRangeSelection" />
+    </node>
+    <node concept="71TwL" id="1$KnWE8t36C" role="71TAa">
+      <node concept="3clFbS" id="1$KnWE8t36D" role="2VODD2">
+        <node concept="3clFbF" id="1$KnWE8t36E" role="3cqZAp">
+          <node concept="Xl_RD" id="1$KnWE8t36F" role="3clFbG">
+            <property role="Xl_RC" value="Combine Multiple Elements Without Spaces" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="71TAc" id="1$KnWE8t36G" role="71TA5">
+      <node concept="3clFbS" id="1$KnWE8t36H" role="2VODD2">
+        <node concept="3cpWs8" id="1$KnWE8t36I" role="3cqZAp">
+          <node concept="3cpWsn" id="1$KnWE8t36J" role="3cpWs9">
+            <property role="TrG5h" value="selectedNodes" />
+            <node concept="_YKpA" id="1$KnWE8t36K" role="1tU5fm">
+              <node concept="3Tqbb2" id="1$KnWE8t36L" role="_ZDj9" />
+            </node>
+            <node concept="2OqwBi" id="1$KnWE8t36M" role="33vP2m">
+              <node concept="71T_Y" id="1$KnWE8t36N" role="2Oq$k0" />
+              <node concept="liA8E" id="1$KnWE8t36O" role="2OqNvi">
+                <ref role="37wK5l" to="b8lf:~AbstractMultipleSelection.getSelectedNodes()" resolve="getSelectedNodes" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="1$KnWE8t36P" role="3cqZAp">
+          <node concept="3cpWsn" id="1$KnWE8t36Q" role="3cpWs9">
+            <property role="TrG5h" value="selectedElements" />
+            <node concept="_YKpA" id="1$KnWE8t36R" role="1tU5fm">
+              <node concept="3Tqbb2" id="1$KnWE8t36S" role="_ZDj9">
+                <ref role="ehGHo" to="zqge:8D0iRqSPVB" resolve="TextElement" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="1$KnWE8t36T" role="33vP2m">
+              <node concept="2OqwBi" id="1$KnWE8t36U" role="2Oq$k0">
+                <node concept="37vLTw" id="1$KnWE8t36V" role="2Oq$k0">
+                  <ref role="3cqZAo" node="1$KnWE8t36J" resolve="selectedNodes" />
+                </node>
+                <node concept="3$u5V9" id="1$KnWE8t36W" role="2OqNvi">
+                  <node concept="1bVj0M" id="1$KnWE8t36X" role="23t8la">
+                    <node concept="3clFbS" id="1$KnWE8t36Y" role="1bW5cS">
+                      <node concept="3clFbF" id="1$KnWE8t36Z" role="3cqZAp">
+                        <node concept="1PxgMI" id="1$KnWE8t370" role="3clFbG">
+                          <property role="1BlNFB" value="true" />
+                          <node concept="chp4Y" id="1$KnWE8t371" role="3oSUPX">
+                            <ref role="cht4Q" to="zqge:8D0iRqSPVB" resolve="TextElement" />
+                          </node>
+                          <node concept="37vLTw" id="1$KnWE8t372" role="1m5AlR">
+                            <ref role="3cqZAo" node="1$KnWE8t373" resolve="it" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="Rh6nW" id="1$KnWE8t373" role="1bW2Oz">
+                      <property role="TrG5h" value="it" />
+                      <node concept="2jxLKc" id="1$KnWE8t374" role="1tU5fm" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="ANE8D" id="1$KnWE8t375" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="1$KnWE8t37n" role="3cqZAp">
+          <node concept="3cpWsn" id="1$KnWE8t37o" role="3cpWs9">
+            <property role="TrG5h" value="newWord" />
+            <node concept="3Tqbb2" id="1$KnWE8t37p" role="1tU5fm">
+              <ref role="ehGHo" to="b7vt:1$KnWE8sX2_" resolve="CombinedElements" />
+            </node>
+            <node concept="2pJPEk" id="1$KnWE8t37q" role="33vP2m">
+              <node concept="2pJPED" id="1$KnWE8t37r" role="2pJPEn">
+                <ref role="2pJxaS" to="b7vt:1$KnWE8sX2_" resolve="CombinedElements" />
+                <node concept="2pIpSj" id="1$KnWE8t5XT" role="2pJxcM">
+                  <ref role="2pIpSl" to="b7vt:1$KnWE8uIdI" resolve="line" />
+                  <node concept="2pJPED" id="1$KnWE8uTmZ" role="28nt2d">
+                    <ref role="2pJxaS" to="zqge:2cLqkTm6J5A" resolve="Line" />
+                    <node concept="2pIpSj" id="1$KnWE8uTnd" role="2pJxcM">
+                      <ref role="2pIpSl" to="zqge:2cLqkTm6J5B" resolve="elements" />
+                      <node concept="36biLy" id="1$KnWE8uTSX" role="28nt2d">
+                        <node concept="2OqwBi" id="1$KnWE8t8dT" role="36biLW">
+                          <node concept="37vLTw" id="1$KnWE8t6jU" role="2Oq$k0">
+                            <ref role="3cqZAo" node="1$KnWE8t36Q" resolve="selectedElements" />
+                          </node>
+                          <node concept="3$u5V9" id="1$KnWE8t9TG" role="2OqNvi">
+                            <node concept="1bVj0M" id="1$KnWE8t9TI" role="23t8la">
+                              <node concept="3clFbS" id="1$KnWE8t9TJ" role="1bW5cS">
+                                <node concept="3clFbF" id="1$KnWE8t9Y7" role="3cqZAp">
+                                  <node concept="2OqwBi" id="1$KnWE8ta9K" role="3clFbG">
+                                    <node concept="37vLTw" id="1$KnWE8t9Y6" role="2Oq$k0">
+                                      <ref role="3cqZAo" node="1$KnWE8t9TK" resolve="it" />
+                                    </node>
+                                    <node concept="1$rogu" id="1$KnWE8tapi" role="2OqNvi" />
+                                  </node>
+                                </node>
+                              </node>
+                              <node concept="Rh6nW" id="1$KnWE8t9TK" role="1bW2Oz">
+                                <property role="TrG5h" value="it" />
+                                <node concept="2jxLKc" id="1$KnWE8t9TL" role="1tU5fm" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="1$KnWE8t37v" role="3cqZAp">
+          <node concept="2OqwBi" id="1$KnWE8t37w" role="3clFbG">
+            <node concept="2OqwBi" id="1$KnWE8t37x" role="2Oq$k0">
+              <node concept="37vLTw" id="1$KnWE8t37y" role="2Oq$k0">
+                <ref role="3cqZAo" node="1$KnWE8t36Q" resolve="selectedWords" />
+              </node>
+              <node concept="1uHKPH" id="1$KnWE8t37z" role="2OqNvi" />
+            </node>
+            <node concept="1P9Npp" id="1$KnWE8t37$" role="2OqNvi">
+              <node concept="37vLTw" id="1$KnWE8t37_" role="1P9ThW">
+                <ref role="3cqZAo" node="1$KnWE8t37o" resolve="newWord" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="1$KnWE8t37A" role="3cqZAp">
+          <node concept="2OqwBi" id="1$KnWE8t37B" role="3clFbG">
+            <node concept="2OqwBi" id="1$KnWE8t37C" role="2Oq$k0">
+              <node concept="37vLTw" id="1$KnWE8t37D" role="2Oq$k0">
+                <ref role="3cqZAo" node="1$KnWE8t36Q" resolve="selectedWords" />
+              </node>
+              <node concept="7r0gD" id="1$KnWE8t37E" role="2OqNvi">
+                <node concept="3cmrfG" id="1$KnWE8t37F" role="7T0AP">
+                  <property role="3cmrfH" value="1" />
+                </node>
+              </node>
+            </node>
+            <node concept="2es0OD" id="1$KnWE8t37G" role="2OqNvi">
+              <node concept="1bVj0M" id="1$KnWE8t37H" role="23t8la">
+                <node concept="3clFbS" id="1$KnWE8t37I" role="1bW5cS">
+                  <node concept="3clFbF" id="1$KnWE8t37J" role="3cqZAp">
+                    <node concept="2OqwBi" id="1$KnWE8t37K" role="3clFbG">
+                      <node concept="37vLTw" id="1$KnWE8t37L" role="2Oq$k0">
+                        <ref role="3cqZAo" node="1$KnWE8t37N" resolve="it" />
+                      </node>
+                      <node concept="3YRAZt" id="1$KnWE8t37M" role="2OqNvi" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="Rh6nW" id="1$KnWE8t37N" role="1bW2Oz">
+                  <property role="TrG5h" value="it" />
+                  <node concept="2jxLKc" id="1$KnWE8t37O" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="1$KnWE8t37P" role="3cqZAp">
+          <node concept="2OqwBi" id="1$KnWE8t37Q" role="3clFbG">
+            <node concept="2OqwBi" id="1$KnWE8t37R" role="2Oq$k0">
+              <node concept="2OqwBi" id="1$KnWE8t37S" role="2Oq$k0">
+                <node concept="71T_Y" id="1$KnWE8t37T" role="2Oq$k0" />
+                <node concept="liA8E" id="1$KnWE8t37U" role="2OqNvi">
+                  <ref role="37wK5l" to="b8lf:~AbstractSelection.getEditorComponent()" resolve="getEditorComponent" />
+                </node>
+              </node>
+              <node concept="liA8E" id="1$KnWE8t37V" role="2OqNvi">
+                <ref role="37wK5l" to="cj4x:~EditorComponent.getEditorContext()" resolve="getEditorContext" />
+              </node>
+            </node>
+            <node concept="liA8E" id="1$KnWE8t37W" role="2OqNvi">
+              <ref role="37wK5l" to="cj4x:~EditorContext.selectWRTFocusPolicy(org.jetbrains.mps.openapi.model.SNode)" resolve="selectWRTFocusPolicy" />
+              <node concept="37vLTw" id="1$KnWE8t37X" role="37wK5m">
+                <ref role="3cqZAo" node="1$KnWE8t37o" resolve="newWord" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="71TBH" id="1$KnWE8t37Y" role="71TA9">
+      <node concept="3clFbS" id="1$KnWE8t37Z" role="2VODD2">
+        <node concept="3cpWs8" id="1$KnWE8t380" role="3cqZAp">
+          <node concept="3cpWsn" id="1$KnWE8t381" role="3cpWs9">
+            <property role="TrG5h" value="selectedNodes" />
+            <node concept="_YKpA" id="1$KnWE8t382" role="1tU5fm">
+              <node concept="3Tqbb2" id="1$KnWE8t383" role="_ZDj9" />
+            </node>
+            <node concept="2OqwBi" id="1$KnWE8t384" role="33vP2m">
+              <node concept="71T_Y" id="1$KnWE8t385" role="2Oq$k0" />
+              <node concept="liA8E" id="1$KnWE8t386" role="2OqNvi">
+                <ref role="37wK5l" to="b8lf:~AbstractMultipleSelection.getSelectedNodes()" resolve="getSelectedNodes" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="1$KnWE8t387" role="3cqZAp">
+          <node concept="1Wc70l" id="1$KnWE8t388" role="3clFbG">
+            <node concept="3eOSWO" id="1$KnWE8t389" role="3uHU7w">
+              <node concept="3cmrfG" id="1$KnWE8t38a" role="3uHU7w">
+                <property role="3cmrfH" value="1" />
+              </node>
+              <node concept="2OqwBi" id="1$KnWE8t38b" role="3uHU7B">
+                <node concept="37vLTw" id="1$KnWE8t38c" role="2Oq$k0">
+                  <ref role="3cqZAo" node="1$KnWE8t381" resolve="selectedNodes" />
+                </node>
+                <node concept="34oBXx" id="1$KnWE8t38d" role="2OqNvi" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="1$KnWE8t38e" role="3uHU7B">
+              <node concept="37vLTw" id="1$KnWE8t38f" role="2Oq$k0">
+                <ref role="3cqZAo" node="1$KnWE8t381" resolve="selectedNodes" />
+              </node>
+              <node concept="2HxqBE" id="1$KnWE8t38g" role="2OqNvi">
+                <node concept="1bVj0M" id="1$KnWE8t38h" role="23t8la">
+                  <node concept="3clFbS" id="1$KnWE8t38i" role="1bW5cS">
+                    <node concept="3clFbF" id="1$KnWE8t38j" role="3cqZAp">
+                      <node concept="2OqwBi" id="1$KnWE8t38k" role="3clFbG">
+                        <node concept="37vLTw" id="1$KnWE8t38l" role="2Oq$k0">
+                          <ref role="3cqZAo" node="1$KnWE8t38o" resolve="it" />
+                        </node>
+                        <node concept="1mIQ4w" id="1$KnWE8t38m" role="2OqNvi">
+                          <node concept="chp4Y" id="1$KnWE8t38n" role="cj9EA">
+                            <ref role="cht4Q" to="zqge:8D0iRqSPVB" resolve="TextElement" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Rh6nW" id="1$KnWE8t38o" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="1$KnWE8t38p" role="1tU5fm" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="2S6QgY" id="1$KnWE8vy2x">
+    <property role="TrG5h" value="SeparateCombinedElements" />
+    <ref role="2ZfgGC" to="b7vt:1$KnWE8sX2_" resolve="CombinedElements" />
+    <node concept="2S6ZIM" id="1$KnWE8vy2y" role="2ZfVej">
+      <node concept="3clFbS" id="1$KnWE8vy2z" role="2VODD2">
+        <node concept="3clFbF" id="1$KnWE8vy3o" role="3cqZAp">
+          <node concept="Xl_RD" id="1$KnWE8vy3n" role="3clFbG">
+            <property role="Xl_RC" value="Separate Combined Elements" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2Sbjvc" id="1$KnWE8vy2$" role="2ZfgGD">
+      <node concept="3clFbS" id="1$KnWE8vy2_" role="2VODD2">
+        <node concept="3cpWs8" id="1$KnWE8v$li" role="3cqZAp">
+          <node concept="3cpWsn" id="1$KnWE8v$ll" role="3cpWs9">
+            <property role="TrG5h" value="line" />
+            <node concept="3Tqbb2" id="1$KnWE8v$lh" role="1tU5fm">
+              <ref role="ehGHo" to="zqge:2cLqkTm6J5A" resolve="Line" />
+            </node>
+            <node concept="2OqwBi" id="1$KnWE8v$xu" role="33vP2m">
+              <node concept="2Sf5sV" id="1$KnWE8v$mH" role="2Oq$k0" />
+              <node concept="2Xjw5R" id="1$KnWE8v$Gj" role="2OqNvi">
+                <node concept="1xMEDy" id="1$KnWE8v$Gl" role="1xVPHs">
+                  <node concept="chp4Y" id="1$KnWE8v$IG" role="ri$Ld">
+                    <ref role="cht4Q" to="zqge:2cLqkTm6J5A" resolve="Line" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="1$KnWE8vCpY" role="3cqZAp">
+          <node concept="2OqwBi" id="1$KnWE8vCT8" role="3clFbG">
+            <node concept="37vLTw" id="1$KnWE8vMxN" role="2Oq$k0">
+              <ref role="3cqZAo" node="1$KnWE8v$ll" resolve="line" />
+            </node>
+            <node concept="2qgKlT" id="1$KnWE8vD3V" role="2OqNvi">
+              <ref role="37wK5l" to="vdrq:1YnOZxAMHtO" resolve="merge" />
+              <node concept="2OqwBi" id="1$KnWE8vS3v" role="37wK5m">
+                <node concept="2Sf5sV" id="1$KnWE8vRSE" role="2Oq$k0" />
+                <node concept="3TrEf2" id="1$KnWE8vSi9" role="2OqNvi">
+                  <ref role="3Tt5mk" to="b7vt:1$KnWE8uIdI" resolve="line" />
+                </node>
+              </node>
+              <node concept="2Sf5sV" id="1$KnWE8vStU" role="37wK5m" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="1$KnWE8wmTK" role="3cqZAp">
+          <node concept="2OqwBi" id="1$KnWE8wn3Z" role="3clFbG">
+            <node concept="2Sf5sV" id="1$KnWE8wmTJ" role="2Oq$k0" />
+            <node concept="3YRAZt" id="1$KnWE8wnme" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/code/changelog/de.itemis.mps.changelog/models/de.itemis.mps.changelog.structure.mps
+++ b/code/changelog/de.itemis.mps.changelog/models/de.itemis.mps.changelog.structure.mps
@@ -1,0 +1,384 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:86cc19c0-126f-473b-92c6-29dba75c1e89(de.itemis.mps.changelog.structure)">
+  <persistence version="9" />
+  <languages>
+    <use id="c72da2b9-7cce-4447-8389-f407dc1158b7" name="jetbrains.mps.lang.structure" version="9" />
+    <devkit ref="78434eb8-b0e5-444b-850d-e7c4ad2da9ab(jetbrains.mps.devkit.aspect.structure)" />
+  </languages>
+  <imports>
+    <import index="zqge" ref="r:59e90602-6655-4552-86eb-441a42a9a0e4(jetbrains.mps.lang.text.structure)" />
+    <import index="tp25" ref="r:00000000-0000-4000-0000-011c89590301(jetbrains.mps.lang.smodel.structure)" />
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="c72da2b9-7cce-4447-8389-f407dc1158b7" name="jetbrains.mps.lang.structure">
+      <concept id="3348158742936976480" name="jetbrains.mps.lang.structure.structure.EnumerationMemberDeclaration" flags="ng" index="25R33">
+        <property id="1421157252384165432" name="memberId" index="3tVfz5" />
+        <property id="672037151186491528" name="presentation" index="1L1pqM" />
+      </concept>
+      <concept id="3348158742936976479" name="jetbrains.mps.lang.structure.structure.EnumerationDeclaration" flags="ng" index="25R3W">
+        <reference id="1075010451642646892" name="defaultMember" index="1H5jkz" />
+        <child id="3348158742936976577" name="members" index="25R1y" />
+      </concept>
+      <concept id="1082978164218" name="jetbrains.mps.lang.structure.structure.DataTypeDeclaration" flags="ng" index="AxPO6">
+        <property id="7791109065626895363" name="datatypeId" index="3F6X1D" />
+      </concept>
+      <concept id="1082978499127" name="jetbrains.mps.lang.structure.structure.ConstrainedDataTypeDeclaration" flags="ng" index="Az7Fb">
+        <property id="1083066089218" name="constraint" index="FLfZY" />
+      </concept>
+      <concept id="1169125787135" name="jetbrains.mps.lang.structure.structure.AbstractConceptDeclaration" flags="ig" index="PkWjJ">
+        <property id="6714410169261853888" name="conceptId" index="EcuMT" />
+        <property id="4628067390765907488" name="conceptShortDescription" index="R4oN_" />
+        <property id="5092175715804935370" name="conceptAlias" index="34LRSv" />
+        <child id="1071489727083" name="linkDeclaration" index="1TKVEi" />
+        <child id="1071489727084" name="propertyDeclaration" index="1TKVEl" />
+      </concept>
+      <concept id="1169125989551" name="jetbrains.mps.lang.structure.structure.InterfaceConceptDeclaration" flags="ig" index="PlHQZ">
+        <child id="1169127546356" name="extends" index="PrDN$" />
+      </concept>
+      <concept id="1169127622168" name="jetbrains.mps.lang.structure.structure.InterfaceConceptReference" flags="ig" index="PrWs8">
+        <reference id="1169127628841" name="intfc" index="PrY4T" />
+      </concept>
+      <concept id="1071489090640" name="jetbrains.mps.lang.structure.structure.ConceptDeclaration" flags="ig" index="1TIwiD">
+        <property id="1096454100552" name="rootable" index="19KtqR" />
+        <reference id="1071489389519" name="extends" index="1TJDcQ" />
+        <child id="1169129564478" name="implements" index="PzmwI" />
+      </concept>
+      <concept id="1071489288299" name="jetbrains.mps.lang.structure.structure.PropertyDeclaration" flags="ig" index="1TJgyi">
+        <property id="241647608299431129" name="propertyId" index="IQ2nx" />
+        <reference id="1082985295845" name="dataType" index="AX2Wp" />
+      </concept>
+      <concept id="1071489288298" name="jetbrains.mps.lang.structure.structure.LinkDeclaration" flags="ig" index="1TJgyj">
+        <property id="1071599776563" name="role" index="20kJfa" />
+        <property id="1071599893252" name="sourceCardinality" index="20lbJX" />
+        <property id="1071599937831" name="metaClass" index="20lmBu" />
+        <property id="241647608299431140" name="linkId" index="IQ2ns" />
+        <reference id="1071599976176" name="target" index="20lvS9" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="1TIwiD" id="Po4Z58t1Zc">
+    <property role="EcuMT" value="961540447467216844" />
+    <property role="TrG5h" value="Changelog" />
+    <property role="19KtqR" value="true" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" />
+    <node concept="1TJgyi" id="Po4Z58IlRD" role="1TKVEl">
+      <property role="IQ2nx" value="961540447471754729" />
+      <property role="TrG5h" value="headerType" />
+      <ref role="AX2Wp" node="Po4Z58IlR$" resolve="HeaderType" />
+    </node>
+    <node concept="1TJgyi" id="1$KnWE8p4rA" role="1TKVEl">
+      <property role="IQ2nx" value="1815055973306615526" />
+      <property role="TrG5h" value="ext" />
+      <ref role="AX2Wp" to="tpck:fKAOsGN" resolve="string" />
+    </node>
+    <node concept="1TJgyj" id="Po4Z58tmyF" role="1TKVEi">
+      <property role="IQ2ns" value="961540447467301035" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="header" />
+      <ref role="20lvS9" to="zqge:2cLqkTm6vgh" resolve="Text" />
+    </node>
+    <node concept="1TJgyj" id="Po4Z58tnOp" role="1TKVEi">
+      <property role="IQ2ns" value="961540447467306265" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="releases" />
+      <property role="20lbJX" value="fLJekj5/_0__n" />
+      <ref role="20lvS9" node="Po4Z58tnOo" resolve="Release" />
+    </node>
+    <node concept="PrWs8" id="Po4Z58tlh3" role="PzmwI">
+      <ref role="PrY4T" to="tpck:h0TrEE$" resolve="INamedConcept" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="Po4Z58tnOo">
+    <property role="EcuMT" value="961540447467306264" />
+    <property role="TrG5h" value="Release" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" />
+    <node concept="1TJgyj" id="Po4Z58trdf" role="1TKVEi">
+      <property role="IQ2ns" value="961540447467320143" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="header" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <ref role="20lvS9" node="Po4Z58Iad0" resolve="IReleaseHeader" />
+    </node>
+    <node concept="1TJgyj" id="Po4Z58tBq0" role="1TKVEi">
+      <property role="IQ2ns" value="961540447467370112" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="sections" />
+      <property role="20lbJX" value="fLJekj6/_1__n" />
+      <ref role="20lvS9" node="Po4Z58tBpZ" resolve="ChangeSection" />
+    </node>
+  </node>
+  <node concept="25R3W" id="Po4Z58tnOD">
+    <property role="3F6X1D" value="961540447467306281" />
+    <property role="TrG5h" value="ChangeType" />
+    <ref role="1H5jkz" node="Po4Z58tnOR" resolve="fixed" />
+    <node concept="25R33" id="Po4Z58tnOE" role="25R1y">
+      <property role="3tVfz5" value="961540447467306282" />
+      <property role="TrG5h" value="added" />
+      <property role="1L1pqM" value="Added" />
+    </node>
+    <node concept="25R33" id="Po4Z58tnOF" role="25R1y">
+      <property role="3tVfz5" value="961540447467306283" />
+      <property role="TrG5h" value="changed" />
+      <property role="1L1pqM" value="Changed" />
+    </node>
+    <node concept="25R33" id="Po4Z58tnOI" role="25R1y">
+      <property role="3tVfz5" value="961540447467306286" />
+      <property role="TrG5h" value="deprecated" />
+      <property role="1L1pqM" value="Deprecated" />
+    </node>
+    <node concept="25R33" id="Po4Z58tnOM" role="25R1y">
+      <property role="3tVfz5" value="961540447467306290" />
+      <property role="TrG5h" value="removed" />
+      <property role="1L1pqM" value="Removed" />
+    </node>
+    <node concept="25R33" id="Po4Z58tnOR" role="25R1y">
+      <property role="3tVfz5" value="961540447467306295" />
+      <property role="TrG5h" value="fixed" />
+      <property role="1L1pqM" value="Fixed" />
+    </node>
+    <node concept="25R33" id="Po4Z58tnOX" role="25R1y">
+      <property role="3tVfz5" value="961540447467306301" />
+      <property role="TrG5h" value="security" />
+      <property role="1L1pqM" value="Security" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="Po4Z58tnPb">
+    <property role="EcuMT" value="961540447467306315" />
+    <property role="TrG5h" value="VersionDateReleaseHeader" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" />
+    <node concept="1TJgyj" id="Po4Z58trdd" role="1TKVEi">
+      <property role="IQ2ns" value="961540447467320141" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="version" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <ref role="20lvS9" node="Po4Z58tnPe" resolve="SemanticVersion" />
+    </node>
+    <node concept="1TJgyi" id="Po4Z58tnPc" role="1TKVEl">
+      <property role="IQ2nx" value="961540447467306316" />
+      <property role="TrG5h" value="timeStamp" />
+      <ref role="AX2Wp" to="tpck:fKAOsGN" resolve="string" />
+    </node>
+    <node concept="PrWs8" id="Po4Z58Iad1" role="PzmwI">
+      <ref role="PrY4T" node="Po4Z58Iad0" resolve="IReleaseHeader" />
+    </node>
+    <node concept="PrWs8" id="XbadXRM4SI" role="PzmwI">
+      <ref role="PrY4T" to="tpck:h0TrEE$" resolve="INamedConcept" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="Po4Z58tnPe">
+    <property role="EcuMT" value="961540447467306318" />
+    <property role="TrG5h" value="SemanticVersion" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" />
+    <node concept="1TJgyi" id="Po4Z58tnPf" role="1TKVEl">
+      <property role="IQ2nx" value="961540447467306319" />
+      <property role="TrG5h" value="major" />
+      <ref role="AX2Wp" to="tpck:fKAQMTA" resolve="integer" />
+    </node>
+    <node concept="1TJgyi" id="Po4Z58tnPh" role="1TKVEl">
+      <property role="IQ2nx" value="961540447467306321" />
+      <property role="TrG5h" value="minor" />
+      <ref role="AX2Wp" to="tpck:fKAQMTA" resolve="integer" />
+    </node>
+    <node concept="1TJgyi" id="Po4Z58tnPk" role="1TKVEl">
+      <property role="IQ2nx" value="961540447467306324" />
+      <property role="TrG5h" value="patch" />
+      <ref role="AX2Wp" to="tpck:fKAQMTA" resolve="integer" />
+    </node>
+    <node concept="1TJgyi" id="Po4Z58tnPo" role="1TKVEl">
+      <property role="IQ2nx" value="961540447467306328" />
+      <property role="TrG5h" value="preRelease" />
+      <ref role="AX2Wp" node="XbadXSlbry" resolve="Prelease" />
+    </node>
+    <node concept="PrWs8" id="XbadXRM7y_" role="PzmwI">
+      <ref role="PrY4T" to="tpck:h0TrEE$" resolve="INamedConcept" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="Po4Z58tBpZ">
+    <property role="EcuMT" value="961540447467370111" />
+    <property role="TrG5h" value="ChangeSection" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" />
+    <node concept="1TJgyj" id="Po4Z58tBq_" role="1TKVEi">
+      <property role="IQ2ns" value="961540447467370149" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="changes" />
+      <property role="20lbJX" value="fLJekj6/_1__n" />
+      <ref role="20lvS9" to="zqge:2cLqkTm6J5A" resolve="Line" />
+    </node>
+    <node concept="1TJgyi" id="Po4Z58tBqz" role="1TKVEl">
+      <property role="IQ2nx" value="961540447467370147" />
+      <property role="TrG5h" value="type" />
+      <ref role="AX2Wp" node="Po4Z58tnOD" resolve="ChangeType" />
+    </node>
+  </node>
+  <node concept="PlHQZ" id="Po4Z58Iad0">
+    <property role="EcuMT" value="961540447471706944" />
+    <property role="TrG5h" value="IReleaseHeader" />
+    <node concept="PrWs8" id="XbadXRLXZN" role="PrDN$">
+      <ref role="PrY4T" to="tpck:h0TrEE$" resolve="INamedConcept" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="Po4Z58IgAd">
+    <property role="EcuMT" value="961540447471733133" />
+    <property role="TrG5h" value="MonthYearReleaseHeader" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+    <node concept="1TJgyi" id="Po4Z58IgAf" role="1TKVEl">
+      <property role="IQ2nx" value="961540447471733135" />
+      <property role="TrG5h" value="month" />
+      <ref role="AX2Wp" node="Po4Z58IgAk" resolve="Month" />
+    </node>
+    <node concept="1TJgyi" id="Po4Z58IgAh" role="1TKVEl">
+      <property role="IQ2nx" value="961540447471733137" />
+      <property role="TrG5h" value="year" />
+      <ref role="AX2Wp" to="tpck:fKAQMTA" resolve="integer" />
+    </node>
+    <node concept="PrWs8" id="Po4Z58IgAg" role="PzmwI">
+      <ref role="PrY4T" node="Po4Z58Iad0" resolve="IReleaseHeader" />
+    </node>
+  </node>
+  <node concept="25R3W" id="Po4Z58IgAk">
+    <property role="3F6X1D" value="961540447471733140" />
+    <property role="TrG5h" value="Month" />
+    <node concept="25R33" id="Po4Z58IgAl" role="25R1y">
+      <property role="3tVfz5" value="961540447471733141" />
+      <property role="TrG5h" value="January" />
+    </node>
+    <node concept="25R33" id="Po4Z58IgAm" role="25R1y">
+      <property role="3tVfz5" value="961540447471733142" />
+      <property role="TrG5h" value="February" />
+    </node>
+    <node concept="25R33" id="Po4Z58IgAp" role="25R1y">
+      <property role="3tVfz5" value="961540447471733145" />
+      <property role="TrG5h" value="March" />
+    </node>
+    <node concept="25R33" id="Po4Z58IgAt" role="25R1y">
+      <property role="3tVfz5" value="961540447471733149" />
+      <property role="TrG5h" value="April" />
+    </node>
+    <node concept="25R33" id="Po4Z58IgAy" role="25R1y">
+      <property role="3tVfz5" value="961540447471733154" />
+      <property role="TrG5h" value="May" />
+    </node>
+    <node concept="25R33" id="Po4Z58IgAC" role="25R1y">
+      <property role="3tVfz5" value="961540447471733160" />
+      <property role="TrG5h" value="June" />
+    </node>
+    <node concept="25R33" id="Po4Z58IgAJ" role="25R1y">
+      <property role="3tVfz5" value="961540447471733167" />
+      <property role="TrG5h" value="July" />
+    </node>
+    <node concept="25R33" id="Po4Z58IgAR" role="25R1y">
+      <property role="3tVfz5" value="961540447471733175" />
+      <property role="TrG5h" value="August" />
+    </node>
+    <node concept="25R33" id="Po4Z58IgB0" role="25R1y">
+      <property role="3tVfz5" value="961540447471733184" />
+      <property role="TrG5h" value="September" />
+    </node>
+    <node concept="25R33" id="Po4Z58IgBa" role="25R1y">
+      <property role="3tVfz5" value="961540447471733194" />
+      <property role="TrG5h" value="October" />
+    </node>
+    <node concept="25R33" id="Po4Z58IgBl" role="25R1y">
+      <property role="3tVfz5" value="961540447471733205" />
+      <property role="TrG5h" value="November" />
+    </node>
+    <node concept="25R33" id="Po4Z58IgBx" role="25R1y">
+      <property role="3tVfz5" value="961540447471733217" />
+      <property role="TrG5h" value="December" />
+    </node>
+  </node>
+  <node concept="25R3W" id="Po4Z58IlR$">
+    <property role="3F6X1D" value="961540447471754724" />
+    <property role="TrG5h" value="HeaderType" />
+    <ref role="1H5jkz" node="Po4Z58IlR_" resolve="versionDate" />
+    <node concept="25R33" id="Po4Z58IlR_" role="25R1y">
+      <property role="3tVfz5" value="961540447471754725" />
+      <property role="TrG5h" value="versionDate" />
+      <property role="1L1pqM" value="version and date" />
+    </node>
+    <node concept="25R33" id="Po4Z58IlRA" role="25R1y">
+      <property role="3tVfz5" value="961540447471754726" />
+      <property role="TrG5h" value="monthYear" />
+      <property role="1L1pqM" value="month and year" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="Po4Z58KntM">
+    <property role="EcuMT" value="961540447472285554" />
+    <property role="TrG5h" value="ModuleReference" />
+    <property role="34LRSv" value="@module" />
+    <property role="3GE5qa" value="textElements" />
+    <ref role="1TJDcQ" to="zqge:8D0iRqSPVB" resolve="TextElement" />
+    <node concept="1TJgyj" id="Po4Z58Kp2X" role="1TKVEi">
+      <property role="IQ2ns" value="961540447472292029" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="expression" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <ref role="20lvS9" to="tp25:1t9FffgebJy" resolve="ModuleRefExpression" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="Po4Z58Lv7f">
+    <property role="EcuMT" value="961540447472579023" />
+    <property role="TrG5h" value="ModelReference" />
+    <property role="34LRSv" value="@model" />
+    <property role="3GE5qa" value="textElements" />
+    <ref role="1TJDcQ" to="zqge:8D0iRqSPVB" resolve="TextElement" />
+    <node concept="1TJgyj" id="Po4Z58Lv7g" role="1TKVEi">
+      <property role="IQ2ns" value="961540447472579024" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="expression" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <ref role="20lvS9" to="tp25:1Bs_61$nfRn" resolve="ModelPointerExpression" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="Po4Z58LQTj">
+    <property role="EcuMT" value="961540447472676435" />
+    <property role="TrG5h" value="NodeReference" />
+    <property role="34LRSv" value="@node" />
+    <property role="3GE5qa" value="textElements" />
+    <ref role="1TJDcQ" to="zqge:8D0iRqSPVB" resolve="TextElement" />
+    <node concept="1TJgyj" id="Po4Z58LQTk" role="1TKVEi">
+      <property role="IQ2ns" value="961540447472676436" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="expression" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <ref role="20lvS9" to="tp25:6qMaajV39gP" resolve="NodePointerExpression" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="XbadXS8vkr">
+    <property role="EcuMT" value="1102019474080527643" />
+    <property role="3GE5qa" value="textElements" />
+    <property role="TrG5h" value="CodeWord" />
+    <property role="34LRSv" value="`" />
+    <property role="R4oN_" value="text formatted as code" />
+    <ref role="1TJDcQ" to="zqge:8D0iRqSPW4" resolve="Word" />
+  </node>
+  <node concept="Az7Fb" id="XbadXSlbry">
+    <property role="3F6X1D" value="1102019474083854050" />
+    <property role="TrG5h" value="Prelease" />
+    <property role="FLfZY" value="[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*" />
+  </node>
+  <node concept="1TIwiD" id="1$KnWE8sX2_">
+    <property role="EcuMT" value="1815055973307633829" />
+    <property role="3GE5qa" value="textElements" />
+    <property role="TrG5h" value="CombinedElements" />
+    <property role="34LRSv" value="combine multiple elements without spaces" />
+    <ref role="1TJDcQ" to="zqge:8D0iRqSPVB" resolve="TextElement" />
+    <node concept="1TJgyj" id="1$KnWE8uIdI" role="1TKVEi">
+      <property role="IQ2ns" value="1815055973308097390" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="line" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <ref role="20lvS9" to="zqge:2cLqkTm6J5A" resolve="Line" />
+    </node>
+  </node>
+</model>
+

--- a/code/changelog/de.itemis.mps.changelog/models/de.itemis.mps.changelog.structure.mps
+++ b/code/changelog/de.itemis.mps.changelog/models/de.itemis.mps.changelog.structure.mps
@@ -80,6 +80,11 @@
       <property role="TrG5h" value="ext" />
       <ref role="AX2Wp" to="tpck:fKAOsGN" resolve="string" />
     </node>
+    <node concept="1TJgyi" id="6aVQm8WibTZ" role="1TKVEl">
+      <property role="IQ2nx" value="7114519052303253119" />
+      <property role="TrG5h" value="chronologicalOrder" />
+      <ref role="AX2Wp" to="tpck:fKAQMTB" resolve="boolean" />
+    </node>
     <node concept="1TJgyj" id="Po4Z58tmyF" role="1TKVEi">
       <property role="IQ2ns" value="961540447467301035" />
       <property role="20lmBu" value="fLJjDmT/aggregation" />

--- a/code/changelog/de.itemis.mps.changelog/models/de.itemis.mps.changelog.typesystem.mps
+++ b/code/changelog/de.itemis.mps.changelog/models/de.itemis.mps.changelog.typesystem.mps
@@ -1,0 +1,759 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:5929cd51-847d-4474-b113-e4584f35fa06(de.itemis.mps.changelog.typesystem)">
+  <persistence version="9" />
+  <languages>
+    <use id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem" version="5" />
+    <devkit ref="00000000-0000-4000-0000-1de82b3a4936(jetbrains.mps.devkit.aspect.typesystem)" />
+  </languages>
+  <imports>
+    <import index="b7vt" ref="r:86cc19c0-126f-473b-92c6-29dba75c1e89(de.itemis.mps.changelog.structure)" />
+    <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" />
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" />
+    <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
+        <child id="1154032183016" name="body" index="2LFqv$" />
+      </concept>
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
+        <child id="1145553007750" name="creator" index="2ShVmc" />
+      </concept>
+      <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
+        <child id="1137022507850" name="body" index="2VODD2" />
+      </concept>
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
+      </concept>
+      <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
+      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
+      <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
+      <concept id="1225271283259" name="jetbrains.mps.baseLanguage.structure.NPEEqualsExpression" flags="nn" index="17R0WA" />
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
+      <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
+        <child id="1068580123160" name="condition" index="3clFbw" />
+        <child id="1068580123161" name="ifTrue" index="3clFbx" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
+        <property id="1068580320021" name="value" index="3cmrfH" />
+      </concept>
+      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
+        <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
+      </concept>
+      <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1081506762703" name="jetbrains.mps.baseLanguage.structure.GreaterThanExpression" flags="nn" index="3eOSWO" />
+      <concept id="1081506773034" name="jetbrains.mps.baseLanguage.structure.LessThanExpression" flags="nn" index="3eOVzh" />
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
+        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
+        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
+      </concept>
+    </language>
+    <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
+      <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
+        <child id="1199569906740" name="parameter" index="1bW2Oz" />
+        <child id="1199569916463" name="body" index="1bW5cS" />
+      </concept>
+    </language>
+    <language id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem">
+      <concept id="1175517767210" name="jetbrains.mps.lang.typesystem.structure.ReportErrorStatement" flags="nn" index="2MkqsV">
+        <child id="1175517851849" name="errorString" index="2MkJ7o" />
+      </concept>
+      <concept id="1227096498176" name="jetbrains.mps.lang.typesystem.structure.PropertyMessageTarget" flags="ng" index="2ODE4t">
+        <reference id="1227096521710" name="propertyDeclaration" index="2ODJFN" />
+      </concept>
+      <concept id="1216383170661" name="jetbrains.mps.lang.typesystem.structure.TypesystemQuickFix" flags="ng" index="Q5z_Y">
+        <child id="1216383424566" name="executeBlock" index="Q6x$H" />
+        <child id="1216383476350" name="quickFixArgument" index="Q6Id_" />
+        <child id="1216391046856" name="descriptionBlock" index="QzAvj" />
+      </concept>
+      <concept id="1216383287005" name="jetbrains.mps.lang.typesystem.structure.QuickFixExecuteBlock" flags="in" index="Q5ZZ6" />
+      <concept id="1216383482742" name="jetbrains.mps.lang.typesystem.structure.QuickFixArgument" flags="ng" index="Q6JDH">
+        <child id="1216383511839" name="argumentType" index="Q6QK4" />
+      </concept>
+      <concept id="1216390348809" name="jetbrains.mps.lang.typesystem.structure.QuickFixArgumentReference" flags="nn" index="QwW4i">
+        <reference id="1216390348810" name="quickFixArgument" index="QwW4h" />
+      </concept>
+      <concept id="1216390987552" name="jetbrains.mps.lang.typesystem.structure.QuickFixDescriptionBlock" flags="in" index="QznSV" />
+      <concept id="1195213580585" name="jetbrains.mps.lang.typesystem.structure.AbstractCheckingRule" flags="ig" index="18hYwZ">
+        <child id="1195213635060" name="body" index="18ibNy" />
+      </concept>
+      <concept id="1195214364922" name="jetbrains.mps.lang.typesystem.structure.NonTypesystemRule" flags="ig" index="18kY7G" />
+      <concept id="3937244445246642777" name="jetbrains.mps.lang.typesystem.structure.AbstractReportStatement" flags="ng" index="1urrMJ">
+        <child id="3937244445246643443" name="messageTarget" index="1urrC5" />
+        <child id="3937244445246643221" name="helginsIntention" index="1urrFz" />
+        <child id="3937244445246642781" name="nodeToReport" index="1urrMF" />
+      </concept>
+      <concept id="1210784285454" name="jetbrains.mps.lang.typesystem.structure.TypesystemIntention" flags="ng" index="3Cnw8n">
+        <reference id="1216388525179" name="quickFix" index="QpYPw" />
+        <child id="1210784493590" name="actualArgument" index="3Coj4f" />
+      </concept>
+      <concept id="1210784384552" name="jetbrains.mps.lang.typesystem.structure.TypesystemIntentionArgument" flags="ng" index="3CnSsL">
+        <reference id="1216386999476" name="quickFixArgument" index="QkamJ" />
+        <child id="1210784642750" name="value" index="3CoRuB" />
+      </concept>
+      <concept id="1174642788531" name="jetbrains.mps.lang.typesystem.structure.ConceptReference" flags="ig" index="1YaCAy">
+        <reference id="1174642800329" name="concept" index="1YaFvo" />
+      </concept>
+      <concept id="1174648085619" name="jetbrains.mps.lang.typesystem.structure.AbstractRule" flags="ng" index="1YuPPy">
+        <child id="1174648101952" name="applicableNode" index="1YuTPh" />
+      </concept>
+      <concept id="1174650418652" name="jetbrains.mps.lang.typesystem.structure.ApplicableNodeReference" flags="nn" index="1YBJjd">
+        <reference id="1174650432090" name="applicableNode" index="1YBMHb" />
+      </concept>
+    </language>
+    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
+        <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
+      </concept>
+      <concept id="1138411891628" name="jetbrains.mps.lang.smodel.structure.SNodeOperation" flags="nn" index="eCIE_">
+        <child id="1144104376918" name="parameter" index="1xVPHs" />
+      </concept>
+      <concept id="1145383075378" name="jetbrains.mps.lang.smodel.structure.SNodeListType" flags="in" index="2I9FWS">
+        <reference id="1145383142433" name="elementConcept" index="2I9WkF" />
+      </concept>
+      <concept id="1171305280644" name="jetbrains.mps.lang.smodel.structure.Node_GetDescendantsOperation" flags="nn" index="2Rf3mk" />
+      <concept id="1240170042401" name="jetbrains.mps.lang.smodel.structure.SEnumerationMemberType" flags="in" index="2ZThk1">
+        <reference id="1240170836027" name="enum" index="2ZWj4r" />
+      </concept>
+      <concept id="1144101972840" name="jetbrains.mps.lang.smodel.structure.OperationParm_Concept" flags="ng" index="1xMEDy">
+        <child id="1207343664468" name="conceptArgument" index="ri$Ld" />
+      </concept>
+      <concept id="1180636770613" name="jetbrains.mps.lang.smodel.structure.SNodeCreator" flags="nn" index="3zrR0B">
+        <child id="1180636770616" name="createdType" index="3zrR0E" />
+      </concept>
+      <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
+        <reference id="1138405853777" name="concept" index="ehGHo" />
+      </concept>
+      <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
+        <reference id="1138056395725" name="property" index="3TsBF5" />
+      </concept>
+      <concept id="1138056282393" name="jetbrains.mps.lang.smodel.structure.SLinkListAccess" flags="nn" index="3Tsc0h">
+        <reference id="1138056546658" name="link" index="3TtcxE" />
+      </concept>
+      <concept id="1228341669568" name="jetbrains.mps.lang.smodel.structure.Node_DetachOperation" flags="nn" index="3YRAZt" />
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+    <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
+        <child id="1204796294226" name="closure" index="23t8la" />
+      </concept>
+      <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="nn" index="25WWJ4">
+        <child id="540871147943773366" name="argument" index="25WWJ7" />
+      </concept>
+      <concept id="1204980550705" name="jetbrains.mps.baseLanguage.collections.structure.VisitAllOperation" flags="nn" index="2es0OD" />
+      <concept id="1226511727824" name="jetbrains.mps.baseLanguage.collections.structure.SetType" flags="in" index="2hMVRd">
+        <child id="1226511765987" name="elementType" index="2hN53Y" />
+      </concept>
+      <concept id="1226516258405" name="jetbrains.mps.baseLanguage.collections.structure.HashSetCreator" flags="nn" index="2i4dXS" />
+      <concept id="1153943597977" name="jetbrains.mps.baseLanguage.collections.structure.ForEachStatement" flags="nn" index="2Gpval">
+        <child id="1153944400369" name="variable" index="2Gsz3X" />
+        <child id="1153944424730" name="inputSequence" index="2GsD0m" />
+      </concept>
+      <concept id="1153944193378" name="jetbrains.mps.baseLanguage.collections.structure.ForEachVariable" flags="nr" index="2GrKxI" />
+      <concept id="1153944233411" name="jetbrains.mps.baseLanguage.collections.structure.ForEachVariableReference" flags="nn" index="2GrUjf">
+        <reference id="1153944258490" name="variable" index="2Gs0qQ" />
+      </concept>
+      <concept id="1235566554328" name="jetbrains.mps.baseLanguage.collections.structure.AnyOperation" flags="nn" index="2HwmR7" />
+      <concept id="1237721394592" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerCreator" flags="nn" index="HWqM0">
+        <child id="1237721435807" name="elementType" index="HW$YZ" />
+      </concept>
+      <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
+      <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
+      <concept id="1160666733551" name="jetbrains.mps.baseLanguage.collections.structure.AddAllElementsOperation" flags="nn" index="X8dFx" />
+      <concept id="1197683403723" name="jetbrains.mps.baseLanguage.collections.structure.MapType" flags="in" index="3rvAFt">
+        <child id="1197683466920" name="keyType" index="3rvQeY" />
+        <child id="1197683475734" name="valueType" index="3rvSg0" />
+      </concept>
+      <concept id="1197686869805" name="jetbrains.mps.baseLanguage.collections.structure.HashMapCreator" flags="nn" index="3rGOSV">
+        <child id="1197687026896" name="keyType" index="3rHrn6" />
+        <child id="1197687035757" name="valueType" index="3rHtpV" />
+      </concept>
+      <concept id="1202120902084" name="jetbrains.mps.baseLanguage.collections.structure.WhereOperation" flags="nn" index="3zZkjj" />
+      <concept id="1240824834947" name="jetbrains.mps.baseLanguage.collections.structure.ValueAccessOperation" flags="nn" index="3AV6Ez" />
+      <concept id="1240825616499" name="jetbrains.mps.baseLanguage.collections.structure.KeyAccessOperation" flags="nn" index="3AY5_j" />
+      <concept id="1172254888721" name="jetbrains.mps.baseLanguage.collections.structure.ContainsOperation" flags="nn" index="3JPx81" />
+      <concept id="1228228912534" name="jetbrains.mps.baseLanguage.collections.structure.DowncastExpression" flags="nn" index="3S9uib">
+        <child id="1228228959951" name="expression" index="3S9DZi" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="18kY7G" id="43oF0KsRB5y">
+    <property role="TrG5h" value="check_Changelog" />
+    <node concept="3clFbS" id="43oF0KsRB5z" role="18ibNy">
+      <node concept="3cpWs8" id="43oF0KsRBdP" role="3cqZAp">
+        <node concept="3cpWsn" id="43oF0KsRBdS" role="3cpWs9">
+          <property role="TrG5h" value="names" />
+          <node concept="2hMVRd" id="43oF0KsRBdL" role="1tU5fm">
+            <node concept="17QB3L" id="43oF0KsRBgs" role="2hN53Y" />
+          </node>
+          <node concept="2ShNRf" id="43oF0KsRBhR" role="33vP2m">
+            <node concept="2i4dXS" id="43oF0KsRBhM" role="2ShVmc">
+              <node concept="17QB3L" id="43oF0KsRBhN" role="HW$YZ" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3cpWs8" id="43oF0KsRBVf" role="3cqZAp">
+        <node concept="3cpWsn" id="43oF0KsRBVg" role="3cpWs9">
+          <property role="TrG5h" value="une" />
+          <node concept="2I9FWS" id="43oF0KsRBNE" role="1tU5fm">
+            <ref role="2I9WkF" to="b7vt:Po4Z58Iad0" resolve="IReleaseHeader" />
+          </node>
+          <node concept="2OqwBi" id="43oF0KsRBVh" role="33vP2m">
+            <node concept="1YBJjd" id="43oF0KsRBVi" role="2Oq$k0">
+              <ref role="1YBMHb" node="43oF0KsRB5_" resolve="changelog" />
+            </node>
+            <node concept="2Rf3mk" id="43oF0KsRBVj" role="2OqNvi">
+              <node concept="1xMEDy" id="43oF0KsRBVk" role="1xVPHs">
+                <node concept="chp4Y" id="43oF0KsRBVl" role="ri$Ld">
+                  <ref role="cht4Q" to="b7vt:Po4Z58Iad0" resolve="IReleaseHeader" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2Gpval" id="43oF0KsREOT" role="3cqZAp">
+        <node concept="2GrKxI" id="43oF0KsREOV" role="2Gsz3X">
+          <property role="TrG5h" value="e" />
+        </node>
+        <node concept="37vLTw" id="43oF0KsRESo" role="2GsD0m">
+          <ref role="3cqZAo" node="43oF0KsRBVg" resolve="une" />
+        </node>
+        <node concept="3clFbS" id="43oF0KsREOZ" role="2LFqv$">
+          <node concept="3cpWs8" id="43oF0KsRESO" role="3cqZAp">
+            <node concept="3cpWsn" id="43oF0KsRESR" role="3cpWs9">
+              <property role="TrG5h" value="name" />
+              <node concept="17QB3L" id="43oF0KsRESN" role="1tU5fm" />
+              <node concept="2OqwBi" id="43oF0KsRF1Q" role="33vP2m">
+                <node concept="2GrUjf" id="43oF0KsRET9" role="2Oq$k0">
+                  <ref role="2Gs0qQ" node="43oF0KsREOV" resolve="e" />
+                </node>
+                <node concept="3TrcHB" id="43oF0KsRFfw" role="2OqNvi">
+                  <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbJ" id="43oF0KsRFiq" role="3cqZAp">
+            <node concept="3clFbS" id="43oF0KsRFis" role="3clFbx">
+              <node concept="2MkqsV" id="43oF0KsRGB4" role="3cqZAp">
+                <node concept="Xl_RD" id="43oF0KsRGBj" role="2MkJ7o">
+                  <property role="Xl_RC" value="duplicate release header" />
+                </node>
+                <node concept="2GrUjf" id="43oF0KsRGBB" role="1urrMF">
+                  <ref role="2Gs0qQ" node="43oF0KsREOV" resolve="e" />
+                </node>
+              </node>
+            </node>
+            <node concept="2OqwBi" id="43oF0KsRFYY" role="3clFbw">
+              <node concept="37vLTw" id="43oF0KsRFiJ" role="2Oq$k0">
+                <ref role="3cqZAo" node="43oF0KsRBdS" resolve="names" />
+              </node>
+              <node concept="3JPx81" id="43oF0KsRGzH" role="2OqNvi">
+                <node concept="37vLTw" id="43oF0KsRG_p" role="25WWJ7">
+                  <ref role="3cqZAo" node="43oF0KsRESR" resolve="name" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="43oF0KsRGD5" role="3cqZAp">
+            <node concept="2OqwBi" id="43oF0KsRHiz" role="3clFbG">
+              <node concept="37vLTw" id="43oF0KsRGD3" role="2Oq$k0">
+                <ref role="3cqZAo" node="43oF0KsRBdS" resolve="names" />
+              </node>
+              <node concept="TSZUe" id="43oF0KsRHRe" role="2OqNvi">
+                <node concept="37vLTw" id="43oF0KsRIiG" role="25WWJ7">
+                  <ref role="3cqZAo" node="43oF0KsRESR" resolve="name" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1YaCAy" id="43oF0KsRB5_" role="1YuTPh">
+      <property role="TrG5h" value="changelog" />
+      <ref role="1YaFvo" to="b7vt:Po4Z58t1Zc" resolve="Changelog" />
+    </node>
+  </node>
+  <node concept="Q5z_Y" id="43oF0KsRKLm">
+    <property role="TrG5h" value="MergeSameChangeTypes" />
+    <node concept="Q6JDH" id="43oF0KsSYJ7" role="Q6Id_">
+      <property role="TrG5h" value="release" />
+      <node concept="3Tqbb2" id="43oF0KsSYLt" role="Q6QK4">
+        <ref role="ehGHo" to="b7vt:Po4Z58tnOo" resolve="Release" />
+      </node>
+    </node>
+    <node concept="Q6JDH" id="43oF0KsSYLA" role="Q6Id_">
+      <property role="TrG5h" value="countMap" />
+      <node concept="3rvAFt" id="43oF0KsSYQQ" role="Q6QK4">
+        <node concept="2ZThk1" id="43oF0KsSYR7" role="3rvQeY">
+          <ref role="2ZWj4r" to="b7vt:Po4Z58tnOD" resolve="ChangeType" />
+        </node>
+        <node concept="10Oyi0" id="43oF0KsSYRq" role="3rvSg0" />
+      </node>
+    </node>
+    <node concept="Q5ZZ6" id="43oF0KsRKLn" role="Q6x$H">
+      <node concept="3clFbS" id="43oF0KsRKLo" role="2VODD2">
+        <node concept="3clFbF" id="43oF0KsRLF7" role="3cqZAp">
+          <node concept="2OqwBi" id="43oF0KsROA4" role="3clFbG">
+            <node concept="2OqwBi" id="43oF0KsRLZQ" role="2Oq$k0">
+              <node concept="QwW4i" id="43oF0KsT0ow" role="2Oq$k0">
+                <ref role="QwW4h" node="43oF0KsSYLA" resolve="countMap" />
+              </node>
+              <node concept="3zZkjj" id="43oF0KsRMmp" role="2OqNvi">
+                <node concept="1bVj0M" id="43oF0KsRMmr" role="23t8la">
+                  <node concept="3clFbS" id="43oF0KsRMms" role="1bW5cS">
+                    <node concept="3clFbF" id="43oF0KsRMt4" role="3cqZAp">
+                      <node concept="3eOSWO" id="43oF0KsRO6k" role="3clFbG">
+                        <node concept="3cmrfG" id="43oF0KsRO6w" role="3uHU7w">
+                          <property role="3cmrfH" value="1" />
+                        </node>
+                        <node concept="2OqwBi" id="43oF0KsRMIo" role="3uHU7B">
+                          <node concept="37vLTw" id="43oF0KsRMt3" role="2Oq$k0">
+                            <ref role="3cqZAo" node="43oF0KsRMmt" resolve="it" />
+                          </node>
+                          <node concept="3AV6Ez" id="43oF0KsRN3c" role="2OqNvi" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Rh6nW" id="43oF0KsRMmt" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="43oF0KsRMmu" role="1tU5fm" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="2es0OD" id="43oF0KsRP46" role="2OqNvi">
+              <node concept="1bVj0M" id="43oF0KsRP48" role="23t8la">
+                <node concept="3clFbS" id="43oF0KsRP49" role="1bW5cS">
+                  <node concept="3cpWs8" id="43oF0KsRP9i" role="3cqZAp">
+                    <node concept="3cpWsn" id="43oF0KsRP9l" role="3cpWs9">
+                      <property role="TrG5h" value="newSection" />
+                      <node concept="3Tqbb2" id="43oF0KsRP9h" role="1tU5fm">
+                        <ref role="ehGHo" to="b7vt:Po4Z58tBpZ" resolve="ChangeSection" />
+                      </node>
+                      <node concept="2ShNRf" id="43oF0KsRPQS" role="33vP2m">
+                        <node concept="3zrR0B" id="43oF0KsRPQQ" role="2ShVmc">
+                          <node concept="3Tqbb2" id="43oF0KsRPQR" role="3zrR0E">
+                            <ref role="ehGHo" to="b7vt:Po4Z58tBpZ" resolve="ChangeSection" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbF" id="43oF0KsRQd2" role="3cqZAp">
+                    <node concept="2OqwBi" id="43oF0KsRZ69" role="3clFbG">
+                      <node concept="2OqwBi" id="43oF0KsRSBP" role="2Oq$k0">
+                        <node concept="2OqwBi" id="43oF0KsRQxX" role="2Oq$k0">
+                          <node concept="QwW4i" id="43oF0KsT2wb" role="2Oq$k0">
+                            <ref role="QwW4h" node="43oF0KsSYJ7" resolve="release" />
+                          </node>
+                          <node concept="3Tsc0h" id="43oF0KsRQOL" role="2OqNvi">
+                            <ref role="3TtcxE" to="b7vt:Po4Z58tBq0" resolve="sections" />
+                          </node>
+                        </node>
+                        <node concept="3zZkjj" id="43oF0KsRU6y" role="2OqNvi">
+                          <node concept="1bVj0M" id="43oF0KsRU6$" role="23t8la">
+                            <node concept="3clFbS" id="43oF0KsRU6_" role="1bW5cS">
+                              <node concept="3clFbF" id="43oF0KsRUpE" role="3cqZAp">
+                                <node concept="17R0WA" id="43oF0KsRVFr" role="3clFbG">
+                                  <node concept="2OqwBi" id="43oF0KsRUNL" role="3uHU7B">
+                                    <node concept="37vLTw" id="43oF0KsRUpD" role="2Oq$k0">
+                                      <ref role="3cqZAo" node="43oF0KsRU6A" resolve="it" />
+                                    </node>
+                                    <node concept="3TrcHB" id="43oF0KsRVgB" role="2OqNvi">
+                                      <ref role="3TsBF5" to="b7vt:Po4Z58tBqz" resolve="type" />
+                                    </node>
+                                  </node>
+                                  <node concept="2OqwBi" id="43oF0KsRXJY" role="3uHU7w">
+                                    <node concept="37vLTw" id="43oF0KsRXmW" role="2Oq$k0">
+                                      <ref role="3cqZAo" node="43oF0KsRP4a" resolve="mapping" />
+                                    </node>
+                                    <node concept="3AY5_j" id="43oF0KsRYEq" role="2OqNvi" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="Rh6nW" id="43oF0KsRU6A" role="1bW2Oz">
+                              <property role="TrG5h" value="it" />
+                              <node concept="2jxLKc" id="43oF0KsRU6B" role="1tU5fm" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="2es0OD" id="43oF0KsRZDL" role="2OqNvi">
+                        <node concept="1bVj0M" id="43oF0KsRZDN" role="23t8la">
+                          <node concept="3clFbS" id="43oF0KsRZDO" role="1bW5cS">
+                            <node concept="3clFbF" id="43oF0KsRZSQ" role="3cqZAp">
+                              <node concept="2OqwBi" id="43oF0KsS2m4" role="3clFbG">
+                                <node concept="2OqwBi" id="43oF0KsS0kA" role="2Oq$k0">
+                                  <node concept="37vLTw" id="43oF0KsRZSP" role="2Oq$k0">
+                                    <ref role="3cqZAo" node="43oF0KsRP9l" resolve="newSection" />
+                                  </node>
+                                  <node concept="3Tsc0h" id="43oF0KsS0KQ" role="2OqNvi">
+                                    <ref role="3TtcxE" to="b7vt:Po4Z58tBq_" resolve="changes" />
+                                  </node>
+                                </node>
+                                <node concept="X8dFx" id="43oF0KsS43j" role="2OqNvi">
+                                  <node concept="2OqwBi" id="43oF0KsSl4A" role="25WWJ7">
+                                    <node concept="37vLTw" id="43oF0KsSiOg" role="2Oq$k0">
+                                      <ref role="3cqZAo" node="43oF0KsRZDP" resolve="section" />
+                                    </node>
+                                    <node concept="3Tsc0h" id="43oF0KsSmnU" role="2OqNvi">
+                                      <ref role="3TtcxE" to="b7vt:Po4Z58tBq_" resolve="changes" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="3clFbF" id="43oF0KsSnAP" role="3cqZAp">
+                              <node concept="2OqwBi" id="43oF0KsSo8V" role="3clFbG">
+                                <node concept="37vLTw" id="43oF0KsSnAN" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="43oF0KsRZDP" resolve="section" />
+                                </node>
+                                <node concept="3YRAZt" id="43oF0KsSr$z" role="2OqNvi" />
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="Rh6nW" id="43oF0KsRZDP" role="1bW2Oz">
+                            <property role="TrG5h" value="section" />
+                            <node concept="2jxLKc" id="43oF0KsRZDQ" role="1tU5fm" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbF" id="43oF0KsSvBe" role="3cqZAp">
+                    <node concept="2OqwBi" id="43oF0KsS$HL" role="3clFbG">
+                      <node concept="2OqwBi" id="43oF0KsSxdU" role="2Oq$k0">
+                        <node concept="QwW4i" id="43oF0KsT56h" role="2Oq$k0">
+                          <ref role="QwW4h" node="43oF0KsSYJ7" resolve="release" />
+                        </node>
+                        <node concept="3Tsc0h" id="43oF0KsSxPl" role="2OqNvi">
+                          <ref role="3TtcxE" to="b7vt:Po4Z58tBq0" resolve="sections" />
+                        </node>
+                      </node>
+                      <node concept="TSZUe" id="43oF0KsSC9T" role="2OqNvi">
+                        <node concept="37vLTw" id="43oF0KsSCDN" role="25WWJ7">
+                          <ref role="3cqZAo" node="43oF0KsRP9l" resolve="newSection" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="Rh6nW" id="43oF0KsRP4a" role="1bW2Oz">
+                  <property role="TrG5h" value="mapping" />
+                  <node concept="2jxLKc" id="43oF0KsRP4b" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="QznSV" id="43oF0KsRKLD" role="QzAvj">
+      <node concept="3clFbS" id="43oF0KsRKLE" role="2VODD2">
+        <node concept="3clFbF" id="43oF0KsRKQk" role="3cqZAp">
+          <node concept="Xl_RD" id="43oF0KsRKQj" role="3clFbG">
+            <property role="Xl_RC" value="Merge Changes With the Same Type" />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="18kY7G" id="43oF0KsSDKz">
+    <property role="TrG5h" value="check_Release" />
+    <node concept="3clFbS" id="43oF0KsSDK$" role="18ibNy">
+      <node concept="3cpWs8" id="43oF0KsSE6V" role="3cqZAp">
+        <node concept="3cpWsn" id="43oF0KsSE6Y" role="3cpWs9">
+          <property role="TrG5h" value="countMap" />
+          <node concept="3rvAFt" id="43oF0KsSE6P" role="1tU5fm">
+            <node concept="2ZThk1" id="43oF0KsSE7l" role="3rvQeY">
+              <ref role="2ZWj4r" to="b7vt:Po4Z58tnOD" resolve="ChangeType" />
+            </node>
+            <node concept="10Oyi0" id="43oF0KsSE7C" role="3rvSg0" />
+          </node>
+          <node concept="2ShNRf" id="43oF0KsSE9b" role="33vP2m">
+            <node concept="3rGOSV" id="43oF0KsSEdE" role="2ShVmc">
+              <node concept="2ZThk1" id="43oF0KsSEkO" role="3rHrn6">
+                <ref role="2ZWj4r" to="b7vt:Po4Z58tnOD" resolve="ChangeType" />
+              </node>
+              <node concept="10Oyi0" id="43oF0KsSEuH" role="3rHtpV" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbF" id="43oF0KsSEvR" role="3cqZAp">
+        <node concept="2OqwBi" id="43oF0KsSGac" role="3clFbG">
+          <node concept="2OqwBi" id="43oF0KsSEBT" role="2Oq$k0">
+            <node concept="1YBJjd" id="43oF0KsSEvP" role="2Oq$k0">
+              <ref role="1YBMHb" node="43oF0KsSDKA" resolve="release" />
+            </node>
+            <node concept="3Tsc0h" id="43oF0KsSEKE" role="2OqNvi">
+              <ref role="3TtcxE" to="b7vt:Po4Z58tBq0" resolve="sections" />
+            </node>
+          </node>
+          <node concept="2es0OD" id="43oF0KsSHBz" role="2OqNvi">
+            <node concept="1bVj0M" id="43oF0KsSHB_" role="23t8la">
+              <node concept="3clFbS" id="43oF0KsSHBA" role="1bW5cS">
+                <node concept="3cpWs8" id="43oF0KsSKky" role="3cqZAp">
+                  <node concept="3cpWsn" id="43oF0KsSKk_" role="3cpWs9">
+                    <property role="TrG5h" value="key" />
+                    <node concept="2ZThk1" id="43oF0KsSKkw" role="1tU5fm">
+                      <ref role="2ZWj4r" to="b7vt:Po4Z58tnOD" resolve="ChangeType" />
+                    </node>
+                    <node concept="2OqwBi" id="43oF0KsSKOp" role="33vP2m">
+                      <node concept="37vLTw" id="43oF0KsSKBO" role="2Oq$k0">
+                        <ref role="3cqZAo" node="43oF0KsSHBB" resolve="it" />
+                      </node>
+                      <node concept="3TrcHB" id="43oF0KsSL6Z" role="2OqNvi">
+                        <ref role="3TsBF5" to="b7vt:Po4Z58tBqz" resolve="type" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbF" id="43oF0KsSHEZ" role="3cqZAp">
+                  <node concept="2OqwBi" id="43oF0KsSIOX" role="3clFbG">
+                    <node concept="3S9uib" id="43oF0KsSIxh" role="2Oq$k0">
+                      <node concept="37vLTw" id="43oF0KsSHEY" role="3S9DZi">
+                        <ref role="3cqZAo" node="43oF0KsSE6Y" resolve="map" />
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="43oF0KsSJTN" role="2OqNvi">
+                      <ref role="37wK5l" to="33ny:~Map.merge(java.lang.Object,java.lang.Object,java.util.function.BiFunction)" resolve="merge" />
+                      <node concept="37vLTw" id="43oF0KsSLfz" role="37wK5m">
+                        <ref role="3cqZAo" node="43oF0KsSKk_" resolve="key" />
+                      </node>
+                      <node concept="3cmrfG" id="43oF0KsSLFJ" role="37wK5m">
+                        <property role="3cmrfH" value="1" />
+                      </node>
+                      <node concept="1bVj0M" id="43oF0KsSO7_" role="37wK5m">
+                        <node concept="3clFbS" id="43oF0KsSO7B" role="1bW5cS">
+                          <node concept="3clFbF" id="43oF0KsSPz2" role="3cqZAp">
+                            <node concept="2YIFZM" id="43oF0KsSPYM" role="3clFbG">
+                              <ref role="37wK5l" to="wyt6:~Integer.sum(int,int)" resolve="sum" />
+                              <ref role="1Pybhc" to="wyt6:~Integer" resolve="Integer" />
+                              <node concept="37vLTw" id="43oF0KsSQ8S" role="37wK5m">
+                                <ref role="3cqZAo" node="43oF0KsSOoJ" resolve="a" />
+                              </node>
+                              <node concept="37vLTw" id="43oF0KsSQ_0" role="37wK5m">
+                                <ref role="3cqZAo" node="43oF0KsSOKh" resolve="b" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="37vLTG" id="43oF0KsSOoJ" role="1bW2Oz">
+                          <property role="TrG5h" value="a" />
+                          <node concept="10Oyi0" id="43oF0KsSOoI" role="1tU5fm" />
+                        </node>
+                        <node concept="37vLTG" id="43oF0KsSOKh" role="1bW2Oz">
+                          <property role="TrG5h" value="b" />
+                          <node concept="10Oyi0" id="43oF0KsSP7c" role="1tU5fm" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="Rh6nW" id="43oF0KsSHBB" role="1bW2Oz">
+                <property role="TrG5h" value="it" />
+                <node concept="2jxLKc" id="43oF0KsSHBC" role="1tU5fm" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbJ" id="43oF0KsSSMh" role="3cqZAp">
+        <node concept="3clFbS" id="43oF0KsSSMj" role="3clFbx">
+          <node concept="2MkqsV" id="43oF0KsSWbu" role="3cqZAp">
+            <node concept="Xl_RD" id="43oF0KsSWbI" role="2MkJ7o">
+              <property role="Xl_RC" value="Multiple sections with the same category" />
+            </node>
+            <node concept="1YBJjd" id="43oF0KsSWcy" role="1urrMF">
+              <ref role="1YBMHb" node="43oF0KsSDKA" resolve="release" />
+            </node>
+            <node concept="3Cnw8n" id="43oF0KsSWdI" role="1urrFz">
+              <ref role="QpYPw" node="43oF0KsRKLm" resolve="MergeSameChangeTypes" />
+              <node concept="3CnSsL" id="43oF0KsSWEu" role="3Coj4f">
+                <ref role="QkamJ" node="43oF0KsSYJ7" resolve="release" />
+                <node concept="1YBJjd" id="43oF0KsT7Ve" role="3CoRuB">
+                  <ref role="1YBMHb" node="43oF0KsSDKA" resolve="release" />
+                </node>
+              </node>
+              <node concept="3CnSsL" id="43oF0KsT7Vh" role="3Coj4f">
+                <ref role="QkamJ" node="43oF0KsSYLA" resolve="countMap" />
+                <node concept="37vLTw" id="43oF0KsT7Wh" role="3CoRuB">
+                  <ref role="3cqZAo" node="43oF0KsSE6Y" resolve="countMap" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2OqwBi" id="43oF0KsSTUO" role="3clFbw">
+          <node concept="37vLTw" id="43oF0KsSSUH" role="2Oq$k0">
+            <ref role="3cqZAo" node="43oF0KsSE6Y" resolve="countMap" />
+          </node>
+          <node concept="2HwmR7" id="43oF0KsSUf7" role="2OqNvi">
+            <node concept="1bVj0M" id="43oF0KsSUf9" role="23t8la">
+              <node concept="3clFbS" id="43oF0KsSUfa" role="1bW5cS">
+                <node concept="3clFbF" id="43oF0KsSUl5" role="3cqZAp">
+                  <node concept="3eOSWO" id="43oF0KsSVYq" role="3clFbG">
+                    <node concept="3cmrfG" id="43oF0KsSW37" role="3uHU7w">
+                      <property role="3cmrfH" value="1" />
+                    </node>
+                    <node concept="2OqwBi" id="43oF0KsSUvn" role="3uHU7B">
+                      <node concept="37vLTw" id="43oF0KsSUl4" role="2Oq$k0">
+                        <ref role="3cqZAo" node="43oF0KsSUfb" resolve="it" />
+                      </node>
+                      <node concept="3AV6Ez" id="43oF0KsSUV5" role="2OqNvi" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="Rh6nW" id="43oF0KsSUfb" role="1bW2Oz">
+                <property role="TrG5h" value="it" />
+                <node concept="2jxLKc" id="43oF0KsSUfc" role="1tU5fm" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1YaCAy" id="43oF0KsSDKA" role="1YuTPh">
+      <property role="TrG5h" value="release" />
+      <ref role="1YaFvo" to="b7vt:Po4Z58tnOo" resolve="Release" />
+    </node>
+  </node>
+  <node concept="18kY7G" id="43oF0KsTh0F">
+    <property role="TrG5h" value="check_SemanticVersion" />
+    <node concept="3clFbS" id="43oF0KsTh0G" role="18ibNy">
+      <node concept="3clFbJ" id="43oF0KsTh0R" role="3cqZAp">
+        <node concept="3eOVzh" id="43oF0KsTiod" role="3clFbw">
+          <node concept="3cmrfG" id="43oF0KsTiog" role="3uHU7w">
+            <property role="3cmrfH" value="0" />
+          </node>
+          <node concept="2OqwBi" id="43oF0KsThbK" role="3uHU7B">
+            <node concept="1YBJjd" id="43oF0KsTh13" role="2Oq$k0">
+              <ref role="1YBMHb" node="43oF0KsTh0I" resolve="semanticVersion" />
+            </node>
+            <node concept="3TrcHB" id="43oF0KsThmw" role="2OqNvi">
+              <ref role="3TsBF5" to="b7vt:Po4Z58tnPf" resolve="major" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbS" id="43oF0KsTh0T" role="3clFbx">
+          <node concept="2MkqsV" id="43oF0KsTir3" role="3cqZAp">
+            <node concept="Xl_RD" id="43oF0KsTirf" role="2MkJ7o">
+              <property role="Xl_RC" value="the version must not be negative" />
+            </node>
+            <node concept="1YBJjd" id="43oF0KsTisF" role="1urrMF">
+              <ref role="1YBMHb" node="43oF0KsTh0I" resolve="semanticVersion" />
+            </node>
+            <node concept="2ODE4t" id="43oF0KsTja1" role="1urrC5">
+              <ref role="2ODJFN" to="b7vt:Po4Z58tnPf" resolve="major" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbH" id="43oF0KsTitZ" role="3cqZAp" />
+      <node concept="3clFbJ" id="43oF0KsTiuo" role="3cqZAp">
+        <node concept="3eOVzh" id="43oF0KsTiup" role="3clFbw">
+          <node concept="3cmrfG" id="43oF0KsTiuq" role="3uHU7w">
+            <property role="3cmrfH" value="0" />
+          </node>
+          <node concept="2OqwBi" id="43oF0KsTiur" role="3uHU7B">
+            <node concept="1YBJjd" id="43oF0KsTius" role="2Oq$k0">
+              <ref role="1YBMHb" node="43oF0KsTh0I" resolve="semanticVersion" />
+            </node>
+            <node concept="3TrcHB" id="43oF0KsTiut" role="2OqNvi">
+              <ref role="3TsBF5" to="b7vt:Po4Z58tnPh" resolve="minor" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbS" id="43oF0KsTiuu" role="3clFbx">
+          <node concept="2MkqsV" id="43oF0KsTiuv" role="3cqZAp">
+            <node concept="Xl_RD" id="43oF0KsTiuw" role="2MkJ7o">
+              <property role="Xl_RC" value="the version must not be negative" />
+            </node>
+            <node concept="1YBJjd" id="43oF0KsTiux" role="1urrMF">
+              <ref role="1YBMHb" node="43oF0KsTh0I" resolve="semanticVersion" />
+            </node>
+            <node concept="2ODE4t" id="43oF0KsTjbM" role="1urrC5">
+              <ref role="2ODJFN" to="b7vt:Po4Z58tnPh" resolve="minor" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbH" id="43oF0KsTiub" role="3cqZAp" />
+      <node concept="3clFbJ" id="43oF0KsTiD7" role="3cqZAp">
+        <node concept="3eOVzh" id="43oF0KsTiD8" role="3clFbw">
+          <node concept="3cmrfG" id="43oF0KsTiD9" role="3uHU7w">
+            <property role="3cmrfH" value="0" />
+          </node>
+          <node concept="2OqwBi" id="43oF0KsTiDa" role="3uHU7B">
+            <node concept="1YBJjd" id="43oF0KsTiDb" role="2Oq$k0">
+              <ref role="1YBMHb" node="43oF0KsTh0I" resolve="semanticVersion" />
+            </node>
+            <node concept="3TrcHB" id="43oF0KsTiDc" role="2OqNvi">
+              <ref role="3TsBF5" to="b7vt:Po4Z58tnPk" resolve="patch" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbS" id="43oF0KsTiDd" role="3clFbx">
+          <node concept="2MkqsV" id="43oF0KsTiDe" role="3cqZAp">
+            <node concept="Xl_RD" id="43oF0KsTiDf" role="2MkJ7o">
+              <property role="Xl_RC" value="the version must not be negative" />
+            </node>
+            <node concept="1YBJjd" id="43oF0KsTiDg" role="1urrMF">
+              <ref role="1YBMHb" node="43oF0KsTh0I" resolve="semanticVersion" />
+            </node>
+            <node concept="2ODE4t" id="43oF0KsTjgQ" role="1urrC5">
+              <ref role="2ODJFN" to="b7vt:Po4Z58tnPk" resolve="patch" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbH" id="43oF0KsTiCJ" role="3cqZAp" />
+    </node>
+    <node concept="1YaCAy" id="43oF0KsTh0I" role="1YuTPh">
+      <property role="TrG5h" value="semanticVersion" />
+      <ref role="1YaFvo" to="b7vt:Po4Z58tnPe" resolve="SemanticVersion" />
+    </node>
+  </node>
+</model>
+

--- a/code/changelog/de.itemis.mps.changelog/models/de.itemis.mps.changelog.typesystem.mps
+++ b/code/changelog/de.itemis.mps.changelog/models/de.itemis.mps.changelog.typesystem.mps
@@ -9,10 +9,15 @@
     <import index="b7vt" ref="r:86cc19c0-126f-473b-92c6-29dba75c1e89(de.itemis.mps.changelog.structure)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" />
+    <import index="j2b5" ref="r:44801727-1f82-4e97-98b6-460b3dc79dca(de.itemis.mps.changelog.behavior)" implicit="true" />
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" implicit="true" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
+        <child id="1068498886297" name="rValue" index="37vLTx" />
+        <child id="1068498886295" name="lValue" index="37vLTJ" />
+      </concept>
       <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
       <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
@@ -34,7 +39,9 @@
       <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
       </concept>
+      <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
       <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
+      <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <child id="1068431790190" name="initializer" index="33vP2m" />
       </concept>
@@ -42,6 +49,7 @@
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
       <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
+      <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
       <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
       <concept id="1225271283259" name="jetbrains.mps.baseLanguage.structure.NPEEqualsExpression" flags="nn" index="17R0WA" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
@@ -54,6 +62,7 @@
       <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
         <child id="1068580123160" name="condition" index="3clFbw" />
         <child id="1068580123161" name="ifTrue" index="3clFbx" />
+        <child id="1206060520071" name="elsifClauses" index="3eNLev" />
       </concept>
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
@@ -61,12 +70,23 @@
       <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
         <property id="1068580320021" name="value" index="3cmrfH" />
       </concept>
+      <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
       <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
         <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
       </concept>
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1206060495898" name="jetbrains.mps.baseLanguage.structure.ElsifClause" flags="ng" index="3eNFk2">
+        <child id="1206060619838" name="condition" index="3eO9$A" />
+        <child id="1206060644605" name="statementList" index="3eOfB_" />
+      </concept>
+      <concept id="1079359253375" name="jetbrains.mps.baseLanguage.structure.ParenthesizedExpression" flags="nn" index="1eOMI4">
+        <child id="1079359253376" name="expression" index="1eOMHV" />
+      </concept>
       <concept id="1081506762703" name="jetbrains.mps.baseLanguage.structure.GreaterThanExpression" flags="nn" index="3eOSWO" />
       <concept id="1081506773034" name="jetbrains.mps.baseLanguage.structure.LessThanExpression" flags="nn" index="3eOVzh" />
+      <concept id="1081516740877" name="jetbrains.mps.baseLanguage.structure.NotExpression" flags="nn" index="3fqX7Q">
+        <child id="1081516765348" name="expression" index="3fr31v" />
+      </concept>
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
@@ -74,6 +94,11 @@
       <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
+      </concept>
+      <concept id="1163668896201" name="jetbrains.mps.baseLanguage.structure.TernaryOperatorExpression" flags="nn" index="3K4zz7">
+        <child id="1163668914799" name="condition" index="3K4Cdx" />
+        <child id="1163668922816" name="ifTrue" index="3K4E3e" />
+        <child id="1163668934364" name="ifFalse" index="3K4GZi" />
       </concept>
     </language>
     <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
@@ -136,6 +161,7 @@
       <concept id="1138411891628" name="jetbrains.mps.lang.smodel.structure.SNodeOperation" flags="nn" index="eCIE_">
         <child id="1144104376918" name="parameter" index="1xVPHs" />
       </concept>
+      <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
       <concept id="1145383075378" name="jetbrains.mps.lang.smodel.structure.SNodeListType" flags="in" index="2I9FWS">
         <reference id="1145383142433" name="elementConcept" index="2I9WkF" />
       </concept>
@@ -143,6 +169,7 @@
       <concept id="1240170042401" name="jetbrains.mps.lang.smodel.structure.SEnumerationMemberType" flags="in" index="2ZThk1">
         <reference id="1240170836027" name="enum" index="2ZWj4r" />
       </concept>
+      <concept id="1172008320231" name="jetbrains.mps.lang.smodel.structure.Node_IsNotNullOperation" flags="nn" index="3x8VRR" />
       <concept id="1144101972840" name="jetbrains.mps.lang.smodel.structure.OperationParm_Concept" flags="ng" index="1xMEDy">
         <child id="1207343664468" name="conceptArgument" index="ri$Ld" />
       </concept>
@@ -245,6 +272,15 @@
           </node>
         </node>
       </node>
+      <node concept="3cpWs8" id="6aVQm8WgyBQ" role="3cqZAp">
+        <node concept="3cpWsn" id="6aVQm8WgyBT" role="3cpWs9">
+          <property role="TrG5h" value="lastHeader" />
+          <node concept="3Tqbb2" id="6aVQm8WgyBO" role="1tU5fm">
+            <ref role="ehGHo" to="b7vt:Po4Z58Iad0" resolve="IReleaseHeader" />
+          </node>
+          <node concept="10Nm6u" id="6aVQm8WgyD4" role="33vP2m" />
+        </node>
+      </node>
       <node concept="2Gpval" id="43oF0KsREOT" role="3cqZAp">
         <node concept="2GrKxI" id="43oF0KsREOV" role="2Gsz3X">
           <property role="TrG5h" value="e" />
@@ -286,6 +322,105 @@
                 <node concept="37vLTw" id="43oF0KsRG_p" role="25WWJ7">
                   <ref role="3cqZAo" node="43oF0KsRESR" resolve="name" />
                 </node>
+              </node>
+            </node>
+            <node concept="3eNFk2" id="6aVQm8Wh_RB" role="3eNLev">
+              <node concept="3clFbS" id="6aVQm8Wh_RD" role="3eOfB_">
+                <node concept="3cpWs8" id="6aVQm8Wiet7" role="3cqZAp">
+                  <node concept="3cpWsn" id="6aVQm8Wieta" role="3cpWs9">
+                    <property role="TrG5h" value="orderCheck" />
+                    <node concept="10P_77" id="6aVQm8Wiet5" role="1tU5fm" />
+                    <node concept="2OqwBi" id="6aVQm8WieCh" role="33vP2m">
+                      <node concept="2GrUjf" id="6aVQm8WieCi" role="2Oq$k0">
+                        <ref role="2Gs0qQ" node="43oF0KsREOV" resolve="e" />
+                      </node>
+                      <node concept="2qgKlT" id="6aVQm8WieCj" role="2OqNvi">
+                        <ref role="37wK5l" to="j2b5:6aVQm8Wg3U3" resolve="isAfter" />
+                        <node concept="37vLTw" id="6aVQm8WieCk" role="37wK5m">
+                          <ref role="3cqZAo" node="6aVQm8WgyBT" resolve="lastHeader" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbJ" id="6aVQm8Wif2Q" role="3cqZAp">
+                  <node concept="3clFbS" id="6aVQm8Wif2S" role="3clFbx">
+                    <node concept="3clFbF" id="6aVQm8WifS6" role="3cqZAp">
+                      <node concept="37vLTI" id="6aVQm8Wigau" role="3clFbG">
+                        <node concept="3fqX7Q" id="6aVQm8WigaI" role="37vLTx">
+                          <node concept="37vLTw" id="6aVQm8Wigb5" role="3fr31v">
+                            <ref role="3cqZAo" node="6aVQm8Wieta" resolve="orderCheck" />
+                          </node>
+                        </node>
+                        <node concept="37vLTw" id="6aVQm8WifS4" role="37vLTJ">
+                          <ref role="3cqZAo" node="6aVQm8Wieta" resolve="orderCheck" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="6aVQm8Wifph" role="3clFbw">
+                    <node concept="1YBJjd" id="6aVQm8Wife$" role="2Oq$k0">
+                      <ref role="1YBMHb" node="43oF0KsRB5_" resolve="changelog" />
+                    </node>
+                    <node concept="3TrcHB" id="6aVQm8WifJd" role="2OqNvi">
+                      <ref role="3TsBF5" to="b7vt:6aVQm8WibTZ" resolve="chronologicalOrder" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbJ" id="6aVQm8Wgzip" role="3cqZAp">
+                  <node concept="3clFbS" id="6aVQm8Wgzir" role="3clFbx">
+                    <node concept="2MkqsV" id="6aVQm8Wg$ll" role="3cqZAp">
+                      <node concept="3cpWs3" id="6aVQm8WihBS" role="2MkJ7o">
+                        <node concept="Xl_RD" id="6aVQm8WigVT" role="3uHU7w">
+                          <property role="Xl_RC" value="chronological order" />
+                        </node>
+                        <node concept="3cpWs3" id="6aVQm8WigVL" role="3uHU7B">
+                          <node concept="Xl_RD" id="6aVQm8WigVR" role="3uHU7B">
+                            <property role="Xl_RC" value="entry is not in " />
+                          </node>
+                          <node concept="1eOMI4" id="6aVQm8WilHZ" role="3uHU7w">
+                            <node concept="3K4zz7" id="6aVQm8WihTV" role="1eOMHV">
+                              <node concept="2OqwBi" id="6aVQm8Wiixh" role="3K4Cdx">
+                                <node concept="1YBJjd" id="6aVQm8WiifH" role="2Oq$k0">
+                                  <ref role="1YBMHb" node="43oF0KsRB5_" resolve="changelog" />
+                                </node>
+                                <node concept="3TrcHB" id="6aVQm8WiiTg" role="2OqNvi">
+                                  <ref role="3TsBF5" to="b7vt:6aVQm8WibTZ" resolve="chronologicalOrder" />
+                                </node>
+                              </node>
+                              <node concept="Xl_RD" id="6aVQm8WijUe" role="3K4E3e" />
+                              <node concept="Xl_RD" id="6aVQm8Wikmx" role="3K4GZi">
+                                <property role="Xl_RC" value="reverse " />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="2GrUjf" id="6aVQm8Wg$m_" role="1urrMF">
+                        <ref role="2Gs0qQ" node="43oF0KsREOV" resolve="e" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="37vLTw" id="6aVQm8WigvN" role="3clFbw">
+                    <ref role="3cqZAo" node="6aVQm8Wieta" resolve="orderCheck" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2OqwBi" id="6aVQm8WgyPg" role="3eO9$A">
+                <node concept="37vLTw" id="6aVQm8WgyEE" role="2Oq$k0">
+                  <ref role="3cqZAo" node="6aVQm8WgyBT" resolve="lastHeader" />
+                </node>
+                <node concept="3x8VRR" id="6aVQm8WgyZG" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="6aVQm8Wgz4N" role="3cqZAp">
+            <node concept="37vLTI" id="6aVQm8WgzdV" role="3clFbG">
+              <node concept="2GrUjf" id="6aVQm8Wgzgc" role="37vLTx">
+                <ref role="2Gs0qQ" node="43oF0KsREOV" resolve="e" />
+              </node>
+              <node concept="37vLTw" id="6aVQm8Wgz4L" role="37vLTJ">
+                <ref role="3cqZAo" node="6aVQm8WgyBT" resolve="lastHeader" />
               </node>
             </node>
           </node>

--- a/code/changelog/de.itemis.mps.changelog/sandbox/de.itemis.mps.changelog.sandbox.msd
+++ b/code/changelog/de.itemis.mps.changelog/sandbox/de.itemis.mps.changelog.sandbox.msd
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<solution name="de.itemis.mps.changelog.sandbox" uuid="79221974-0531-46e7-a1ba-808ced0829a4" moduleVersion="0" compileInMPS="true">
+  <models>
+    <modelRoot contentPath="${module}" type="default">
+      <sourceRoot location="models" />
+    </modelRoot>
+  </models>
+  <facets>
+    <facet type="java">
+      <classes generated="true" path="${module}/classes_gen" />
+    </facet>
+  </facets>
+  <sourcePath />
+  <dependencies>
+    <dependency reexport="false">3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)</dependency>
+    <dependency reexport="false">9d69e719-78c8-4286-90db-fb19c107d049(com.mbeddr.mpsutil.grammarcells)</dependency>
+  </dependencies>
+  <languageVersions>
+    <language slang="l:638c9345-2613-49dc-b2ae-8ceadef24141:de.itemis.mps.changelog" version="0" />
+    <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
+    <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
+  </languageVersions>
+  <dependencyVersions>
+    <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
+    <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
+    <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
+    <module reference="1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)" version="0" />
+    <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
+    <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+    <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
+    <module reference="9d69e719-78c8-4286-90db-fb19c107d049(com.mbeddr.mpsutil.grammarcells)" version="0" />
+    <module reference="7ac49bcb-77fb-4f0f-9036-e31b86b854b2(com.mbeddr.mpsutil.grammarcells.runtime)" version="0" />
+    <module reference="b4f35ed8-45af-4efa-abe4-00ac26956e69(com.mbeddr.mpsutil.grammarcells.runtimelang)" version="0" />
+    <module reference="79221974-0531-46e7-a1ba-808ced0829a4(de.itemis.mps.changelog.sandbox)" version="0" />
+    <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
+    <module reference="443f4c36-fcf5-4eb6-9500-8d06ed259e3e(jetbrains.mps.baseLanguage.classifiers)" version="0" />
+    <module reference="fd392034-7849-419d-9071-12563d152375(jetbrains.mps.baseLanguage.closures)" version="0" />
+    <module reference="83888646-71ce-4f1c-9c53-c54016f6ad4f(jetbrains.mps.baseLanguage.collections)" version="0" />
+    <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
+    <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
+    <module reference="d936855b-48da-4812-a8a0-2bfddd633ac5(jetbrains.mps.lang.behavior.api)" version="0" />
+    <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
+    <module reference="18bc6592-03a6-4e29-a83a-7ff23bde13ba(jetbrains.mps.lang.editor)" version="0" />
+    <module reference="446c26eb-2b7b-4bf0-9b35-f83fa582753e(jetbrains.mps.lang.modelapi)" version="0" />
+    <module reference="d7eb0a2a-bd50-4576-beae-e4a89db35f20(jetbrains.mps.lang.scopes.runtime)" version="0" />
+    <module reference="7866978e-a0f0-4cc7-81bc-4d213d9375e1(jetbrains.mps.lang.smodel)" version="1" />
+    <module reference="c72da2b9-7cce-4447-8389-f407dc1158b7(jetbrains.mps.lang.structure)" version="0" />
+    <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
+  </dependencyVersions>
+</solution>
+

--- a/code/changelog/de.itemis.mps.changelog/sandbox/models/de.itemis.mps.changelog.sandbox.mps
+++ b/code/changelog/de.itemis.mps.changelog/sandbox/models/de.itemis.mps.changelog.sandbox.mps
@@ -1,0 +1,522 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:b77354cc-89a7-42fb-9e37-075b26b92174(de.itemis.mps.changelog.sandbox)">
+  <persistence version="9" />
+  <languages>
+    <use id="638c9345-2613-49dc-b2ae-8ceadef24141" name="de.itemis.mps.changelog" version="0" />
+  </languages>
+  <imports />
+  <registry>
+    <language id="638c9345-2613-49dc-b2ae-8ceadef24141" name="de.itemis.mps.changelog">
+      <concept id="961540447467216844" name="de.itemis.mps.changelog.structure.Changelog" flags="ng" index="15b0KX">
+        <property id="961540447467429783" name="path" index="15bOLA" />
+        <child id="961540447467306265" name="releases" index="15bmVC" />
+        <child id="961540447467301035" name="header" index="15bnHq" />
+      </concept>
+      <concept id="961540447467306315" name="de.itemis.mps.changelog.structure.VersionDateReleaseHeader" flags="ng" index="15bmUU">
+        <property id="961540447467306316" name="timeStamp" index="15bmUX" />
+        <child id="961540447467320141" name="version" index="15bq2W" />
+      </concept>
+      <concept id="961540447467306318" name="de.itemis.mps.changelog.structure.SemanticVersion" flags="ng" index="15bmUZ">
+        <property id="961540447467306321" name="minor" index="15bmUw" />
+        <property id="961540447467306324" name="patch" index="15bmU_" />
+        <property id="961540447467306328" name="label" index="15bmUD" />
+        <property id="961540447467306319" name="major" index="15bmUY" />
+      </concept>
+      <concept id="961540447467306264" name="de.itemis.mps.changelog.structure.Release" flags="ng" index="15bmVD">
+        <child id="961540447467320143" name="header" index="15bq2Y" />
+        <child id="961540447467370112" name="sections" index="15bAlL" />
+      </concept>
+      <concept id="961540447467370111" name="de.itemis.mps.changelog.structure.ChangeSection" flags="ng" index="15bAme">
+        <property id="961540447467370147" name="type" index="15bAli" />
+        <child id="961540447467370149" name="changes" index="15bAlk" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+    <language id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text">
+      <concept id="1094247804558289146" name="jetbrains.mps.lang.text.structure.BulletLine" flags="ng" index="2DRihI" />
+      <concept id="5106752179536586436" name="jetbrains.mps.lang.text.structure.IndentedPoint" flags="ng" index="2RT3b8">
+        <property id="5106752179536586491" name="indentation" index="2RT3bR" />
+      </concept>
+      <concept id="155656958578482948" name="jetbrains.mps.lang.text.structure.Word" flags="nn" index="3oM_SD">
+        <property id="155656958578482949" name="value" index="3oM_SC" />
+        <property id="6328114375520539781" name="url" index="1X82VU" />
+      </concept>
+      <concept id="2535923850359206929" name="jetbrains.mps.lang.text.structure.Text" flags="nn" index="1Pa9Pv">
+        <child id="2535923850359210936" name="lines" index="1PaQFQ" />
+      </concept>
+      <concept id="2535923850359271782" name="jetbrains.mps.lang.text.structure.Line" flags="nn" index="1PaTwC">
+        <child id="2535923850359271783" name="elements" index="1PaTwD" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="15b0KX" id="Po4Z58vHYh">
+    <property role="TrG5h" value="ChangelogDemo" />
+    <property role="15bOLA" value="." />
+    <node concept="1Pa9Pv" id="Po4Z58vHYi" role="15bnHq">
+      <node concept="1PaTwC" id="Po4Z58vHYj" role="1PaQFQ">
+        <node concept="3oM_SD" id="Po4Z58vHYk" role="1PaTwD">
+          <property role="3oM_SC" value="All" />
+        </node>
+        <node concept="3oM_SD" id="Po4Z58vHYl" role="1PaTwD">
+          <property role="3oM_SC" value="notable" />
+        </node>
+        <node concept="3oM_SD" id="Po4Z58vHYm" role="1PaTwD">
+          <property role="3oM_SC" value="changes" />
+        </node>
+        <node concept="3oM_SD" id="Po4Z58vHYn" role="1PaTwD">
+          <property role="3oM_SC" value="to" />
+        </node>
+        <node concept="3oM_SD" id="Po4Z58vHYo" role="1PaTwD">
+          <property role="3oM_SC" value="this" />
+        </node>
+        <node concept="3oM_SD" id="Po4Z58vHYp" role="1PaTwD">
+          <property role="3oM_SC" value="project" />
+        </node>
+        <node concept="3oM_SD" id="Po4Z58vHYq" role="1PaTwD">
+          <property role="3oM_SC" value="will" />
+        </node>
+        <node concept="3oM_SD" id="Po4Z58vHYr" role="1PaTwD">
+          <property role="3oM_SC" value="be" />
+        </node>
+        <node concept="3oM_SD" id="Po4Z58vHYs" role="1PaTwD">
+          <property role="3oM_SC" value="documented" />
+        </node>
+        <node concept="3oM_SD" id="Po4Z58vHYt" role="1PaTwD">
+          <property role="3oM_SC" value="in" />
+        </node>
+        <node concept="3oM_SD" id="Po4Z58vHYu" role="1PaTwD">
+          <property role="3oM_SC" value="this" />
+        </node>
+        <node concept="3oM_SD" id="Po4Z58vHYv" role="1PaTwD">
+          <property role="3oM_SC" value="file." />
+        </node>
+      </node>
+      <node concept="1PaTwC" id="Po4Z58vHYw" role="1PaQFQ">
+        <node concept="3oM_SD" id="Po4Z58vHYx" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+      </node>
+      <node concept="1PaTwC" id="Po4Z58vHYy" role="1PaQFQ">
+        <node concept="3oM_SD" id="Po4Z58vHYz" role="1PaTwD">
+          <property role="3oM_SC" value="The" />
+        </node>
+        <node concept="3oM_SD" id="Po4Z58vHY$" role="1PaTwD">
+          <property role="3oM_SC" value="format" />
+        </node>
+        <node concept="3oM_SD" id="Po4Z58vHY_" role="1PaTwD">
+          <property role="3oM_SC" value="is" />
+        </node>
+        <node concept="3oM_SD" id="Po4Z58vHYA" role="1PaTwD">
+          <property role="3oM_SC" value="based" />
+        </node>
+        <node concept="3oM_SD" id="Po4Z58vHYB" role="1PaTwD">
+          <property role="3oM_SC" value="on" />
+        </node>
+        <node concept="3oM_SD" id="XbadXSkzeM" role="1PaTwD">
+          <property role="3oM_SC" value="Keep a Changelog" />
+          <property role="1X82VU" value="https://keepachangelog.com/en/1.0.0/" />
+        </node>
+        <node concept="3oM_SD" id="Po4Z58vHYD" role="1PaTwD">
+          <property role="3oM_SC" value="." />
+        </node>
+      </node>
+      <node concept="1PaTwC" id="Po4Z58vHYE" role="1PaQFQ">
+        <node concept="3oM_SD" id="Po4Z58vHYF" role="1PaTwD">
+          <property role="3oM_SC" value="and" />
+        </node>
+        <node concept="3oM_SD" id="Po4Z58vHYG" role="1PaTwD">
+          <property role="3oM_SC" value="this" />
+        </node>
+        <node concept="3oM_SD" id="Po4Z58vHYH" role="1PaTwD">
+          <property role="3oM_SC" value="project" />
+        </node>
+        <node concept="3oM_SD" id="Po4Z58vHYI" role="1PaTwD">
+          <property role="3oM_SC" value="adheres" />
+        </node>
+        <node concept="3oM_SD" id="Po4Z58vHYJ" role="1PaTwD">
+          <property role="3oM_SC" value="to" />
+        </node>
+        <node concept="3oM_SD" id="XbadXSkzeU" role="1PaTwD">
+          <property role="3oM_SC" value="Semantic Versioning" />
+          <property role="1X82VU" value="https://semver.org/spec/v2.0.0.html" />
+        </node>
+        <node concept="3oM_SD" id="Po4Z58vHYL" role="1PaTwD">
+          <property role="3oM_SC" value="." />
+        </node>
+      </node>
+      <node concept="1PaTwC" id="Po4Z58vHYM" role="1PaQFQ">
+        <node concept="3oM_SD" id="Po4Z58vHYN" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+      </node>
+    </node>
+    <node concept="15bmVD" id="Po4Z58wkAf" role="15bmVC">
+      <node concept="15bmUU" id="Po4Z58wkAg" role="15bq2Y">
+        <property role="15bmUX" value="1598400000" />
+        <node concept="15bmUZ" id="Po4Z58wkAh" role="15bq2W">
+          <property role="15bmUY" value="2" />
+          <property role="15bmUw" value="0" />
+          <property role="15bmU_" value="0" />
+          <property role="15bmUD" value="rc123" />
+        </node>
+      </node>
+      <node concept="15bAme" id="Po4Z58wkAi" role="15bAlL">
+        <property role="15bAli" value="Po4Z58tnOE/added" />
+        <node concept="2DRihI" id="Po4Z58wkAj" role="15bAlk">
+          <node concept="3oM_SD" id="Po4Z58$EWI" role="1PaTwD">
+            <property role="3oM_SC" value="Added" />
+          </node>
+          <node concept="3oM_SD" id="Po4Z58$EWK" role="1PaTwD">
+            <property role="3oM_SC" value="a" />
+          </node>
+          <node concept="3oM_SD" id="Po4Z58$EWN" role="1PaTwD">
+            <property role="3oM_SC" value="line." />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="15bmVD" id="Po4Z58yFtC" role="15bmVC">
+      <node concept="15bmUU" id="Po4Z58yFtD" role="15bq2Y">
+        <property role="15bmUX" value="1598313600" />
+        <node concept="15bmUZ" id="Po4Z58yFtE" role="15bq2W">
+          <property role="15bmUY" value="1" />
+          <property role="15bmUw" value="0" />
+          <property role="15bmU_" value="0" />
+          <property role="15bmUD" value="alpha" />
+        </node>
+      </node>
+      <node concept="15bAme" id="Po4Z58yFtF" role="15bAlL">
+        <property role="15bAli" value="Po4Z58tnOE/added" />
+        <node concept="2DRihI" id="Po4Z58yFtG" role="15bAlk">
+          <node concept="3oM_SD" id="Po4Z58_8ut" role="1PaTwD">
+            <property role="3oM_SC" value="Added" />
+          </node>
+          <node concept="3oM_SD" id="Po4Z58_8uv" role="1PaTwD">
+            <property role="3oM_SC" value="a" />
+          </node>
+          <node concept="3oM_SD" id="Po4Z58_8uy" role="1PaTwD">
+            <property role="3oM_SC" value="thing." />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="15bmVD" id="Po4Z58_8uA" role="15bmVC">
+      <node concept="15bmUU" id="Po4Z58_8uB" role="15bq2Y">
+        <property role="15bmUX" value="1598220000" />
+        <node concept="15bmUZ" id="Po4Z58_8uC" role="15bq2W">
+          <property role="15bmUY" value="1" />
+          <property role="15bmUw" value="0" />
+          <property role="15bmU_" value="0" />
+          <property role="15bmUD" value="alpha.1" />
+        </node>
+      </node>
+      <node concept="15bAme" id="Po4Z58_8uD" role="15bAlL">
+        <property role="15bAli" value="Po4Z58tnOE/added" />
+        <node concept="2DRihI" id="Po4Z58_8uE" role="15bAlk">
+          <node concept="3oM_SD" id="Po4Z58_8v1" role="1PaTwD">
+            <property role="3oM_SC" value="Added" />
+          </node>
+          <node concept="3oM_SD" id="Po4Z58_8v3" role="1PaTwD">
+            <property role="3oM_SC" value="a" />
+          </node>
+          <node concept="3oM_SD" id="Po4Z58_8v6" role="1PaTwD">
+            <property role="3oM_SC" value="thing." />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="15bmVD" id="Po4Z58AjdB" role="15bmVC">
+      <node concept="15bmUU" id="Po4Z58AjdC" role="15bq2Y">
+        <property role="15bmUX" value="1598133600" />
+        <node concept="15bmUZ" id="Po4Z58AjdD" role="15bq2W">
+          <property role="15bmUY" value="1" />
+          <property role="15bmUw" value="0" />
+          <property role="15bmU_" value="0" />
+          <property role="15bmUD" value="0.3.7" />
+        </node>
+      </node>
+      <node concept="15bAme" id="Po4Z58AjdE" role="15bAlL">
+        <property role="15bAli" value="Po4Z58tnOE/added" />
+        <node concept="2DRihI" id="Po4Z58AjdF" role="15bAlk">
+          <node concept="3oM_SD" id="Po4Z58Amj8" role="1PaTwD">
+            <property role="3oM_SC" value="Added" />
+          </node>
+          <node concept="3oM_SD" id="Po4Z58Amja" role="1PaTwD">
+            <property role="3oM_SC" value="a" />
+          </node>
+          <node concept="3oM_SD" id="Po4Z58Amjd" role="1PaTwD">
+            <property role="3oM_SC" value="thing." />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="15bmVD" id="Po4Z58AmjV" role="15bmVC">
+      <node concept="15bmUU" id="Po4Z58AmjW" role="15bq2Y">
+        <property role="15bmUX" value="1597960800" />
+        <node concept="15bmUZ" id="Po4Z58AmjX" role="15bq2W">
+          <property role="15bmUY" value="1" />
+          <property role="15bmUw" value="0" />
+          <property role="15bmU_" value="0" />
+          <property role="15bmUD" value="x.y.z" />
+        </node>
+      </node>
+      <node concept="15bAme" id="Po4Z58AmjY" role="15bAlL">
+        <property role="15bAli" value="Po4Z58tnOE/added" />
+        <node concept="2DRihI" id="Po4Z58AmjZ" role="15bAlk">
+          <node concept="3oM_SD" id="Po4Z58Amk0" role="1PaTwD">
+            <property role="3oM_SC" value="Added" />
+          </node>
+          <node concept="3oM_SD" id="Po4Z58Amk1" role="1PaTwD">
+            <property role="3oM_SC" value="a" />
+          </node>
+          <node concept="3oM_SD" id="Po4Z58Amk2" role="1PaTwD">
+            <property role="3oM_SC" value="thing." />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="15bmVD" id="Po4Z58AmkF" role="15bmVC">
+      <node concept="15bmUU" id="Po4Z58AmkG" role="15bq2Y">
+        <property role="15bmUX" value="1546473600" />
+        <node concept="15bmUZ" id="Po4Z58AmkH" role="15bq2W">
+          <property role="15bmUY" value="1" />
+          <property role="15bmUw" value="0" />
+          <property role="15bmU_" value="0" />
+        </node>
+      </node>
+      <node concept="15bAme" id="Po4Z58AmkI" role="15bAlL">
+        <property role="15bAli" value="Po4Z58tnOI/deprecated" />
+        <node concept="2DRihI" id="Po4Z58AmkJ" role="15bAlk">
+          <node concept="3oM_SD" id="Po4Z58Amop" role="1PaTwD">
+            <property role="3oM_SC" value="Some" />
+          </node>
+          <node concept="3oM_SD" id="Po4Z58Amor" role="1PaTwD">
+            <property role="3oM_SC" value="things" />
+          </node>
+          <node concept="3oM_SD" id="Po4Z58Amou" role="1PaTwD">
+            <property role="3oM_SC" value="were" />
+          </node>
+          <node concept="3oM_SD" id="XbadXRRbKC" role="1PaTwD">
+            <property role="3oM_SC" value="deprecated." />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="15b0KX" id="Po4Z58E89I">
+    <property role="TrG5h" value="ChangelogDemo2" />
+    <property role="15bOLA" value="." />
+    <node concept="1Pa9Pv" id="Po4Z58E89J" role="15bnHq">
+      <node concept="1PaTwC" id="Po4Z58E89K" role="1PaQFQ">
+        <node concept="3oM_SD" id="Po4Z58E89L" role="1PaTwD">
+          <property role="3oM_SC" value="All" />
+        </node>
+        <node concept="3oM_SD" id="Po4Z58E89M" role="1PaTwD">
+          <property role="3oM_SC" value="notable" />
+        </node>
+        <node concept="3oM_SD" id="Po4Z58E89N" role="1PaTwD">
+          <property role="3oM_SC" value="changes" />
+        </node>
+        <node concept="3oM_SD" id="Po4Z58E89O" role="1PaTwD">
+          <property role="3oM_SC" value="to" />
+        </node>
+        <node concept="3oM_SD" id="Po4Z58E89P" role="1PaTwD">
+          <property role="3oM_SC" value="this" />
+        </node>
+        <node concept="3oM_SD" id="Po4Z58E89Q" role="1PaTwD">
+          <property role="3oM_SC" value="project" />
+        </node>
+        <node concept="3oM_SD" id="Po4Z58E89R" role="1PaTwD">
+          <property role="3oM_SC" value="will" />
+        </node>
+        <node concept="3oM_SD" id="Po4Z58E89S" role="1PaTwD">
+          <property role="3oM_SC" value="be" />
+        </node>
+        <node concept="3oM_SD" id="Po4Z58E89T" role="1PaTwD">
+          <property role="3oM_SC" value="documented" />
+        </node>
+        <node concept="3oM_SD" id="Po4Z58E89U" role="1PaTwD">
+          <property role="3oM_SC" value="in" />
+        </node>
+        <node concept="3oM_SD" id="Po4Z58E89V" role="1PaTwD">
+          <property role="3oM_SC" value="this" />
+        </node>
+        <node concept="3oM_SD" id="Po4Z58E89W" role="1PaTwD">
+          <property role="3oM_SC" value="file." />
+        </node>
+      </node>
+      <node concept="1PaTwC" id="Po4Z58E89X" role="1PaQFQ">
+        <node concept="3oM_SD" id="Po4Z58E89Y" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+      </node>
+      <node concept="1PaTwC" id="Po4Z58E89Z" role="1PaQFQ">
+        <node concept="3oM_SD" id="Po4Z58E8a0" role="1PaTwD">
+          <property role="3oM_SC" value="The" />
+        </node>
+        <node concept="3oM_SD" id="Po4Z58E8a1" role="1PaTwD">
+          <property role="3oM_SC" value="format" />
+        </node>
+        <node concept="3oM_SD" id="Po4Z58E8a2" role="1PaTwD">
+          <property role="3oM_SC" value="is" />
+        </node>
+        <node concept="3oM_SD" id="Po4Z58E8a3" role="1PaTwD">
+          <property role="3oM_SC" value="based" />
+        </node>
+        <node concept="3oM_SD" id="Po4Z58E8a4" role="1PaTwD">
+          <property role="3oM_SC" value="on" />
+        </node>
+        <node concept="3oM_SD" id="XbadXRRbKH" role="1PaTwD">
+          <property role="3oM_SC" value="Keep a Changelog" />
+          <property role="1X82VU" value="https://keepachangelog.com/en/1.0.0/" />
+        </node>
+        <node concept="3oM_SD" id="Po4Z58E8a6" role="1PaTwD">
+          <property role="3oM_SC" value="." />
+        </node>
+      </node>
+      <node concept="1PaTwC" id="Po4Z58E8a7" role="1PaQFQ">
+        <node concept="3oM_SD" id="Po4Z58E8a8" role="1PaTwD">
+          <property role="3oM_SC" value="and" />
+        </node>
+        <node concept="3oM_SD" id="Po4Z58E8a9" role="1PaTwD">
+          <property role="3oM_SC" value="this" />
+        </node>
+        <node concept="3oM_SD" id="Po4Z58E8aa" role="1PaTwD">
+          <property role="3oM_SC" value="project" />
+        </node>
+        <node concept="3oM_SD" id="Po4Z58E8ab" role="1PaTwD">
+          <property role="3oM_SC" value="adheres" />
+        </node>
+        <node concept="3oM_SD" id="Po4Z58E8ac" role="1PaTwD">
+          <property role="3oM_SC" value="to" />
+        </node>
+        <node concept="3oM_SD" id="XbadXRRbL5" role="1PaTwD">
+          <property role="3oM_SC" value="Semantic Versioning" />
+          <property role="1X82VU" value="https://semver.org/spec/v2.0.0.html" />
+        </node>
+        <node concept="3oM_SD" id="XbadXRRbLd" role="1PaTwD">
+          <property role="3oM_SC" value="." />
+        </node>
+      </node>
+    </node>
+    <node concept="15bmVD" id="Po4Z58E8a_" role="15bmVC">
+      <node concept="15bmUU" id="Po4Z58E8aA" role="15bq2Y">
+        <property role="15bmUX" value="1546473600" />
+        <node concept="15bmUZ" id="Po4Z58E8aB" role="15bq2W">
+          <property role="15bmUY" value="1" />
+          <property role="15bmUw" value="0" />
+          <property role="15bmU_" value="0" />
+        </node>
+      </node>
+      <node concept="15bAme" id="Po4Z58E8aC" role="15bAlL">
+        <property role="15bAli" value="Po4Z58tnOI/deprecated" />
+        <node concept="2DRihI" id="Po4Z58E8aD" role="15bAlk">
+          <node concept="3oM_SD" id="Po4Z58E8aJ" role="1PaTwD">
+            <property role="3oM_SC" value="Some" />
+          </node>
+          <node concept="3oM_SD" id="Po4Z58E8aL" role="1PaTwD">
+            <property role="3oM_SC" value="things" />
+          </node>
+          <node concept="3oM_SD" id="Po4Z58E8aM" role="1PaTwD">
+            <property role="3oM_SC" value="were" />
+          </node>
+          <node concept="3oM_SD" id="Po4Z58E8aN" role="1PaTwD">
+            <property role="3oM_SC" value="deprecated." />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="15bmVD" id="Po4Z58E8aS" role="15bmVC">
+      <node concept="15bmUU" id="Po4Z58E8aT" role="15bq2Y">
+        <property role="15bmUX" value="1543363200" />
+        <node concept="15bmUZ" id="Po4Z58E8aU" role="15bq2W">
+          <property role="15bmUY" value="0" />
+          <property role="15bmUw" value="1" />
+          <property role="15bmU_" value="0" />
+        </node>
+      </node>
+      <node concept="15bAme" id="Po4Z58E8aV" role="15bAlL">
+        <property role="15bAli" value="Po4Z58tnOM/removed" />
+        <node concept="2DRihI" id="Po4Z58E8aW" role="15bAlk">
+          <node concept="3oM_SD" id="Po4Z58E8bb" role="1PaTwD">
+            <property role="3oM_SC" value="Removed" />
+          </node>
+          <node concept="3oM_SD" id="Po4Z58E8bd" role="1PaTwD">
+            <property role="3oM_SC" value="all" />
+          </node>
+          <node concept="3oM_SD" id="Po4Z58E8bg" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="Po4Z58E8bk" role="1PaTwD">
+            <property role="3oM_SC" value="things." />
+          </node>
+        </node>
+      </node>
+      <node concept="15bAme" id="Po4Z58E8bp" role="15bAlL">
+        <node concept="2DRihI" id="Po4Z58E8bq" role="15bAlk">
+          <node concept="3oM_SD" id="Po4Z58E8bz" role="1PaTwD">
+            <property role="3oM_SC" value="Fixed" />
+          </node>
+          <node concept="3oM_SD" id="Po4Z58E8b_" role="1PaTwD">
+            <property role="3oM_SC" value="all" />
+          </node>
+          <node concept="3oM_SD" id="Po4Z58E8bA" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="Po4Z58E8bB" role="1PaTwD">
+            <property role="3oM_SC" value="bugs" />
+          </node>
+          <node concept="3oM_SD" id="Po4Z58E8bC" role="1PaTwD">
+            <property role="3oM_SC" value="from" />
+          </node>
+          <node concept="3oM_SD" id="Po4Z58E8bD" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="Po4Z58E8bE" role="1PaTwD">
+            <property role="3oM_SC" value="non-existent" />
+          </node>
+          <node concept="3oM_SD" id="Po4Z58E8bF" role="1PaTwD">
+            <property role="3oM_SC" value="previous" />
+          </node>
+          <node concept="3oM_SD" id="Po4Z58E8bG" role="1PaTwD">
+            <property role="3oM_SC" value="release." />
+          </node>
+        </node>
+      </node>
+      <node concept="15bAme" id="Po4Z58E8bQ" role="15bAlL">
+        <property role="15bAli" value="Po4Z58tnOX/security" />
+        <node concept="2DRihI" id="Po4Z58E8bR" role="15bAlk">
+          <node concept="3oM_SD" id="Po4Z58E8cb" role="1PaTwD">
+            <property role="3oM_SC" value="We" />
+          </node>
+          <node concept="3oM_SD" id="Po4Z58E8cd" role="1PaTwD">
+            <property role="3oM_SC" value="are" />
+          </node>
+          <node concept="3oM_SD" id="Po4Z58E8ce" role="1PaTwD">
+            <property role="3oM_SC" value="so" />
+          </node>
+          <node concept="3oM_SD" id="Po4Z58E8cf" role="1PaTwD">
+            <property role="3oM_SC" value="secure" />
+          </node>
+          <node concept="3oM_SD" id="Po4Z58E8cg" role="1PaTwD">
+            <property role="3oM_SC" value="now." />
+          </node>
+        </node>
+        <node concept="2DRihI" id="Po4Z58E8cn" role="15bAlk">
+          <property role="2RT3bR" value="0" />
+          <node concept="3oM_SD" id="Po4Z58E8cG" role="1PaTwD">
+            <property role="3oM_SC" value="The" />
+          </node>
+          <node concept="3oM_SD" id="Po4Z58E8cH" role="1PaTwD">
+            <property role="3oM_SC" value="securest." />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/code/solutions/de.itemis.mps.extensions.changelog/de.itemis.mps.extensions.changelog.msd
+++ b/code/solutions/de.itemis.mps.extensions.changelog/de.itemis.mps.extensions.changelog.msd
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<solution name="de.itemis.mps.extensions.changelog" uuid="12cc529a-5bc1-40a0-b44a-d814ba237eae" moduleVersion="0" compileInMPS="true">
+  <models>
+    <modelRoot contentPath="${module}" type="default">
+      <sourceRoot location="models" />
+    </modelRoot>
+  </models>
+  <facets>
+    <facet type="java">
+      <classes generated="true" path="${module}/classes_gen" />
+    </facet>
+  </facets>
+  <sourcePath />
+  <dependencies>
+    <dependency reexport="false">63e0e566-5131-447e-90e3-12ea330e1a00(com.mbeddr.mpsutil.blutil)</dependency>
+    <dependency reexport="false">9d69e719-78c8-4286-90db-fb19c107d049(com.mbeddr.mpsutil.grammarcells)</dependency>
+  </dependencies>
+  <languageVersions>
+    <language slang="l:638c9345-2613-49dc-b2ae-8ceadef24141:de.itemis.mps.changelog" version="0" />
+    <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
+    <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
+    <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
+  </languageVersions>
+  <dependencyVersions>
+    <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
+    <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
+    <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
+    <module reference="1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)" version="0" />
+    <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
+    <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+    <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
+    <module reference="63e0e566-5131-447e-90e3-12ea330e1a00(com.mbeddr.mpsutil.blutil)" version="0" />
+    <module reference="9d69e719-78c8-4286-90db-fb19c107d049(com.mbeddr.mpsutil.grammarcells)" version="0" />
+    <module reference="7ac49bcb-77fb-4f0f-9036-e31b86b854b2(com.mbeddr.mpsutil.grammarcells.runtime)" version="0" />
+    <module reference="b4f35ed8-45af-4efa-abe4-00ac26956e69(com.mbeddr.mpsutil.grammarcells.runtimelang)" version="0" />
+    <module reference="12cc529a-5bc1-40a0-b44a-d814ba237eae(de.itemis.mps.extensions.changelog)" version="0" />
+    <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
+    <module reference="443f4c36-fcf5-4eb6-9500-8d06ed259e3e(jetbrains.mps.baseLanguage.classifiers)" version="0" />
+    <module reference="fd392034-7849-419d-9071-12563d152375(jetbrains.mps.baseLanguage.closures)" version="0" />
+    <module reference="83888646-71ce-4f1c-9c53-c54016f6ad4f(jetbrains.mps.baseLanguage.collections)" version="0" />
+    <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
+    <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
+    <module reference="d936855b-48da-4812-a8a0-2bfddd633ac5(jetbrains.mps.lang.behavior.api)" version="0" />
+    <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
+    <module reference="18bc6592-03a6-4e29-a83a-7ff23bde13ba(jetbrains.mps.lang.editor)" version="0" />
+    <module reference="446c26eb-2b7b-4bf0-9b35-f83fa582753e(jetbrains.mps.lang.modelapi)" version="0" />
+    <module reference="d7eb0a2a-bd50-4576-beae-e4a89db35f20(jetbrains.mps.lang.scopes.runtime)" version="0" />
+    <module reference="7866978e-a0f0-4cc7-81bc-4d213d9375e1(jetbrains.mps.lang.smodel)" version="1" />
+    <module reference="c72da2b9-7cce-4447-8389-f407dc1158b7(jetbrains.mps.lang.structure)" version="0" />
+    <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
+  </dependencyVersions>
+</solution>
+

--- a/code/solutions/de.itemis.mps.extensions.changelog/models/de.itemis.mps.extensions.changelog.mps
+++ b/code/solutions/de.itemis.mps.extensions.changelog/models/de.itemis.mps.extensions.changelog.mps
@@ -1,0 +1,2338 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:c2a03117-d7bb-4287-be70-b5591cc02c98(de.itemis.mps.extensions.changelog)">
+  <persistence version="9" />
+  <languages>
+    <use id="638c9345-2613-49dc-b2ae-8ceadef24141" name="de.itemis.mps.changelog" version="0" />
+    <use id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi" version="0" />
+    <use id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text" version="0" />
+  </languages>
+  <imports>
+    <import index="hba4" ref="63e0e566-5131-447e-90e3-12ea330e1a00/r:f5bd2ad9-cd54-4408-b815-07f9f306f074(com.mbeddr.mpsutil.blutil/com.mbeddr.mpsutil.blutil.structure)" />
+    <import index="mhfm" ref="3f233e7f-b8a6-46d2-a57f-795d56775243/java:org.jetbrains.annotations(Annotations/)" />
+    <import index="teg0" ref="r:96165ed2-ef22-48c7-bfe5-8fce083cbabb(com.mbeddr.mpsutil.grammarcells.structure)" />
+  </imports>
+  <registry>
+    <language id="638c9345-2613-49dc-b2ae-8ceadef24141" name="de.itemis.mps.changelog">
+      <concept id="1815055973307633829" name="de.itemis.mps.changelog.structure.CombinedElements" flags="ng" index="2hgSXJ">
+        <child id="1815055973308097390" name="line" index="2hiFM$" />
+      </concept>
+      <concept id="961540447467216844" name="de.itemis.mps.changelog.structure.Changelog" flags="ng" index="15b0KX">
+        <property id="1815055973306615526" name="ext" index="2hl1$G" />
+        <property id="961540447471754729" name="headerType" index="15SkSo" />
+        <child id="961540447467306265" name="releases" index="15bmVC" />
+        <child id="961540447467301035" name="header" index="15bnHq" />
+      </concept>
+      <concept id="961540447467306264" name="de.itemis.mps.changelog.structure.Release" flags="ng" index="15bmVD">
+        <child id="961540447467320143" name="header" index="15bq2Y" />
+        <child id="961540447467370112" name="sections" index="15bAlL" />
+      </concept>
+      <concept id="961540447467370111" name="de.itemis.mps.changelog.structure.ChangeSection" flags="ng" index="15bAme">
+        <property id="961540447467370147" name="type" index="15bAli" />
+        <child id="961540447467370149" name="changes" index="15bAlk" />
+      </concept>
+      <concept id="961540447472285554" name="de.itemis.mps.changelog.structure.ModuleReference" flags="ng" index="15Ami3">
+        <child id="961540447472292029" name="expression" index="15Aodc" />
+      </concept>
+      <concept id="961540447472676435" name="de.itemis.mps.changelog.structure.NodeReference" flags="ng" index="15BRQy">
+        <child id="961540447472676436" name="expression" index="15BRQ_" />
+      </concept>
+      <concept id="961540447471733133" name="de.itemis.mps.changelog.structure.MonthYearReleaseHeader" flags="ng" index="15ShDW">
+        <property id="961540447471733137" name="year" index="15ShDw" />
+        <property id="961540447471733135" name="month" index="15ShDY" />
+      </concept>
+      <concept id="1102019474080527643" name="de.itemis.mps.changelog.structure.CodeWord" flags="ng" index="1RqHR4" />
+    </language>
+    <language id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi">
+      <concept id="4733039728785194814" name="jetbrains.mps.lang.modelapi.structure.NamedNodeReference" flags="ng" index="ZC_QK">
+        <reference id="7256306938026143658" name="target" index="2aWVGs" />
+      </concept>
+      <concept id="361130699826193249" name="jetbrains.mps.lang.modelapi.structure.ModulePointer" flags="ng" index="1dCxOk">
+        <property id="1863527487546097500" name="moduleId" index="1XweGW" />
+        <property id="1863527487545993577" name="moduleName" index="1XxBO9" />
+      </concept>
+    </language>
+    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="7400021826774799413" name="jetbrains.mps.lang.smodel.structure.NodePointerExpression" flags="ng" index="2tJFMh">
+        <child id="7400021826774799510" name="ref" index="2tJFKM" />
+      </concept>
+      <concept id="1678062499342629858" name="jetbrains.mps.lang.smodel.structure.ModuleRefExpression" flags="ng" index="37shsh">
+        <child id="1678062499342629861" name="moduleId" index="37shsm" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+    <language id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text">
+      <concept id="1094247804558289146" name="jetbrains.mps.lang.text.structure.BulletLine" flags="ng" index="2DRihI" />
+      <concept id="5106752179536586436" name="jetbrains.mps.lang.text.structure.IndentedPoint" flags="ng" index="2RT3b8">
+        <property id="5106752179536586491" name="indentation" index="2RT3bR" />
+      </concept>
+      <concept id="155656958578482948" name="jetbrains.mps.lang.text.structure.Word" flags="nn" index="3oM_SD">
+        <property id="155656958578482949" name="value" index="3oM_SC" />
+        <property id="6328114375520539781" name="url" index="1X82VU" />
+        <property id="6328114375520539777" name="italic" index="1X82VY" />
+      </concept>
+      <concept id="2535923850359206929" name="jetbrains.mps.lang.text.structure.Text" flags="nn" index="1Pa9Pv">
+        <child id="2535923850359210936" name="lines" index="1PaQFQ" />
+      </concept>
+      <concept id="2535923850359271782" name="jetbrains.mps.lang.text.structure.Line" flags="nn" index="1PaTwC">
+        <child id="2535923850359271783" name="elements" index="1PaTwD" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="15b0KX" id="43oF0KsR_J_">
+    <property role="TrG5h" value="Changelog" />
+    <property role="15SkSo" value="Po4Z58IlRA/monthYear" />
+    <property role="2hl1$G" value="md" />
+    <node concept="1Pa9Pv" id="43oF0KsR_JA" role="15bnHq">
+      <node concept="1PaTwC" id="43oF0KsR_JB" role="1PaQFQ">
+        <node concept="3oM_SD" id="43oF0KsR_JC" role="1PaTwD">
+          <property role="3oM_SC" value="All" />
+        </node>
+        <node concept="3oM_SD" id="43oF0KsR_JD" role="1PaTwD">
+          <property role="3oM_SC" value="notable" />
+        </node>
+        <node concept="3oM_SD" id="43oF0KsR_JE" role="1PaTwD">
+          <property role="3oM_SC" value="changes" />
+        </node>
+        <node concept="3oM_SD" id="43oF0KsR_JF" role="1PaTwD">
+          <property role="3oM_SC" value="to" />
+        </node>
+        <node concept="3oM_SD" id="43oF0KsR_JG" role="1PaTwD">
+          <property role="3oM_SC" value="this" />
+        </node>
+        <node concept="3oM_SD" id="43oF0KsR_JH" role="1PaTwD">
+          <property role="3oM_SC" value="project" />
+        </node>
+        <node concept="3oM_SD" id="1$KnWE8qVGJ" role="1PaTwD">
+          <property role="3oM_SC" value="are" />
+        </node>
+        <node concept="3oM_SD" id="43oF0KsR_JK" role="1PaTwD">
+          <property role="3oM_SC" value="documented" />
+        </node>
+        <node concept="3oM_SD" id="43oF0KsR_JL" role="1PaTwD">
+          <property role="3oM_SC" value="in" />
+        </node>
+        <node concept="3oM_SD" id="43oF0KsR_JM" role="1PaTwD">
+          <property role="3oM_SC" value="this" />
+        </node>
+        <node concept="3oM_SD" id="43oF0KsR_JN" role="1PaTwD">
+          <property role="3oM_SC" value="file." />
+        </node>
+      </node>
+      <node concept="1PaTwC" id="43oF0KsR_JO" role="1PaQFQ">
+        <node concept="3oM_SD" id="43oF0KsR_JP" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+      </node>
+      <node concept="1PaTwC" id="43oF0KsR_JQ" role="1PaQFQ">
+        <node concept="3oM_SD" id="43oF0KsR_JR" role="1PaTwD">
+          <property role="3oM_SC" value="The" />
+        </node>
+        <node concept="3oM_SD" id="43oF0KsR_JS" role="1PaTwD">
+          <property role="3oM_SC" value="format" />
+        </node>
+        <node concept="3oM_SD" id="43oF0KsR_JT" role="1PaTwD">
+          <property role="3oM_SC" value="is" />
+        </node>
+        <node concept="3oM_SD" id="43oF0KsR_JU" role="1PaTwD">
+          <property role="3oM_SC" value="loosely" />
+          <property role="1X82VY" value="true" />
+        </node>
+        <node concept="3oM_SD" id="1$KnWE8iTny" role="1PaTwD">
+          <property role="3oM_SC" value="based" />
+        </node>
+        <node concept="3oM_SD" id="43oF0KsR_JV" role="1PaTwD">
+          <property role="3oM_SC" value="on" />
+        </node>
+        <node concept="3oM_SD" id="43oF0KsR_JW" role="1PaTwD">
+          <property role="3oM_SC" value="Keep a Changelog" />
+          <property role="1X82VU" value="https://keepachangelog.com/en/1.0.0/" />
+        </node>
+        <node concept="3oM_SD" id="1$KnWE8iTo_" role="1PaTwD">
+          <property role="3oM_SC" value=".The" />
+        </node>
+        <node concept="3oM_SD" id="1$KnWE8iTnQ" role="1PaTwD">
+          <property role="3oM_SC" value="project" />
+        </node>
+        <node concept="3oM_SD" id="1$KnWE8iTnR" role="1PaTwD">
+          <property role="3oM_SC" value="does" />
+        </node>
+        <node concept="3oM_SD" id="1$KnWE8iTnS" role="1PaTwD">
+          <property role="3oM_SC" value="not" />
+          <property role="1X82VY" value="true" />
+        </node>
+        <node concept="3oM_SD" id="1$KnWE8iTnT" role="1PaTwD">
+          <property role="3oM_SC" value="follow" />
+        </node>
+        <node concept="3oM_SD" id="1$KnWE8iTnU" role="1PaTwD">
+          <property role="3oM_SC" value="Semantic" />
+        </node>
+        <node concept="3oM_SD" id="1$KnWE8iTnV" role="1PaTwD">
+          <property role="3oM_SC" value="Versioning" />
+        </node>
+        <node concept="3oM_SD" id="1$KnWE8iTnW" role="1PaTwD">
+          <property role="3oM_SC" value="and" />
+        </node>
+        <node concept="3oM_SD" id="1$KnWE8iTnX" role="1PaTwD">
+          <property role="3oM_SC" value="the" />
+        </node>
+        <node concept="3oM_SD" id="1$KnWE8iTnY" role="1PaTwD">
+          <property role="3oM_SC" value="changes" />
+        </node>
+        <node concept="3oM_SD" id="1$KnWE8iTnZ" role="1PaTwD">
+          <property role="3oM_SC" value="are" />
+        </node>
+        <node concept="3oM_SD" id="1$KnWE8iTo0" role="1PaTwD">
+          <property role="3oM_SC" value="documented" />
+        </node>
+        <node concept="3oM_SD" id="1$KnWE8iTo1" role="1PaTwD">
+          <property role="3oM_SC" value="in" />
+        </node>
+        <node concept="3oM_SD" id="1$KnWE8iTo2" role="1PaTwD">
+          <property role="3oM_SC" value="reverse" />
+        </node>
+        <node concept="3oM_SD" id="1$KnWE8iTo3" role="1PaTwD">
+          <property role="3oM_SC" value="chronological" />
+        </node>
+        <node concept="3oM_SD" id="1$KnWE8iTo4" role="1PaTwD">
+          <property role="3oM_SC" value="order," />
+        </node>
+        <node concept="3oM_SD" id="1$KnWE8iTo5" role="1PaTwD">
+          <property role="3oM_SC" value="grouped" />
+        </node>
+        <node concept="3oM_SD" id="1$KnWE8iTo6" role="1PaTwD">
+          <property role="3oM_SC" value="by" />
+        </node>
+        <node concept="3oM_SD" id="1$KnWE8iTo7" role="1PaTwD">
+          <property role="3oM_SC" value="calendar" />
+        </node>
+        <node concept="3oM_SD" id="1$KnWE8iTo8" role="1PaTwD">
+          <property role="3oM_SC" value="month." />
+        </node>
+      </node>
+    </node>
+    <node concept="15bmVD" id="43oF0KsR_Kl" role="15bmVC">
+      <node concept="15ShDW" id="43oF0KsR_Ki" role="15bq2Y">
+        <property role="15ShDY" value="Po4Z58IgAt/April" />
+        <property role="15ShDw" value="2024" />
+      </node>
+      <node concept="15bAme" id="43oF0KsR_Oc" role="15bAlL">
+        <node concept="2DRihI" id="43oF0KsTgzM" role="15bAlk">
+          <node concept="2hgSXJ" id="1$KnWE8wwSH" role="1PaTwD">
+            <node concept="1PaTwC" id="1$KnWE8wwSI" role="2hiFM$">
+              <node concept="15Ami3" id="1$KnWE8wwSJ" role="1PaTwD">
+                <node concept="37shsh" id="1$KnWE8wwSK" role="15Aodc">
+                  <node concept="1dCxOk" id="1$KnWE8wwSL" role="37shsm">
+                    <property role="1XweGW" value="1f1b4a81-113d-4b88-9b67-2bae3e4f8128" />
+                    <property role="1XxBO9" value="com.mbeddr.mpsutil.projectview" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3oM_SD" id="1$KnWE8wwSM" role="1PaTwD">
+                <property role="3oM_SC" value=":" />
+              </node>
+            </node>
+          </node>
+          <node concept="3oM_SD" id="1$KnWE8eAQ2" role="1PaTwD">
+            <property role="3oM_SC" value="Class" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg_E" role="1PaTwD">
+            <property role="3oM_SC" value="reloading" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg_F" role="1PaTwD">
+            <property role="3oM_SC" value="of" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg_G" role="1PaTwD">
+            <property role="3oM_SC" value="project" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg_H" role="1PaTwD">
+            <property role="3oM_SC" value="views" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg_I" role="1PaTwD">
+            <property role="3oM_SC" value="now" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg_J" role="1PaTwD">
+            <property role="3oM_SC" value="works." />
+          </node>
+        </node>
+        <node concept="2DRihI" id="43oF0KsTg$F" role="15bAlk">
+          <property role="2RT3bR" value="0" />
+          <node concept="2hgSXJ" id="1$KnWE8wwT3" role="1PaTwD">
+            <node concept="1PaTwC" id="1$KnWE8wwT4" role="2hiFM$">
+              <node concept="15Ami3" id="1$KnWE8wwT5" role="1PaTwD">
+                <node concept="37shsh" id="1$KnWE8wwT6" role="15Aodc">
+                  <node concept="1dCxOk" id="1$KnWE8wwT7" role="37shsm">
+                    <property role="1XweGW" value="120e1c9d-4e27-4478-b2af-b2c3bd3850b0" />
+                    <property role="1XxBO9" value="com.mbeddr.mpsutil.editor.querylist" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3oM_SD" id="1$KnWE8wwT8" role="1PaTwD">
+                <property role="3oM_SC" value=":" />
+              </node>
+            </node>
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg$7" role="1PaTwD">
+            <property role="3oM_SC" value="Query" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg$8" role="1PaTwD">
+            <property role="3oM_SC" value="lists" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg$9" role="1PaTwD">
+            <property role="3oM_SC" value="now" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg$a" role="1PaTwD">
+            <property role="3oM_SC" value="support" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg$b" role="1PaTwD">
+            <property role="3oM_SC" value="model" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg$c" role="1PaTwD">
+            <property role="3oM_SC" value="checking" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg$d" role="1PaTwD">
+            <property role="3oM_SC" value="for" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg$e" role="1PaTwD">
+            <property role="3oM_SC" value="non-dynamically" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg$f" role="1PaTwD">
+            <property role="3oM_SC" value="generated" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg$g" role="1PaTwD">
+            <property role="3oM_SC" value="nodes" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg$h" role="1PaTwD">
+            <property role="3oM_SC" value="and" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg$i" role="1PaTwD">
+            <property role="3oM_SC" value="collapse" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg$j" role="1PaTwD">
+            <property role="3oM_SC" value="by" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg$k" role="1PaTwD">
+            <property role="3oM_SC" value="default" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg$l" role="1PaTwD">
+            <property role="3oM_SC" value="is" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg$m" role="1PaTwD">
+            <property role="3oM_SC" value="generated" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg$n" role="1PaTwD">
+            <property role="3oM_SC" value="correctly." />
+          </node>
+        </node>
+        <node concept="2DRihI" id="43oF0KsR_Od" role="15bAlk">
+          <node concept="2hgSXJ" id="1$KnWE8wwTz" role="1PaTwD">
+            <node concept="1PaTwC" id="1$KnWE8wwT$" role="2hiFM$">
+              <node concept="15Ami3" id="1$KnWE8wwT_" role="1PaTwD">
+                <node concept="37shsh" id="1$KnWE8wwTA" role="15Aodc">
+                  <node concept="1dCxOk" id="1$KnWE8wwTB" role="37shsm">
+                    <property role="1XweGW" value="654422bf-e75f-44dc-936d-188890a746ce" />
+                    <property role="1XxBO9" value="de.slisson.mps.reflection" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3oM_SD" id="1$KnWE8wwTC" role="1PaTwD">
+                <property role="3oM_SC" value=":" />
+              </node>
+            </node>
+          </node>
+          <node concept="3oM_SD" id="1$KnWE8eARn" role="1PaTwD">
+            <property role="3oM_SC" value="To" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgzk" role="1PaTwD">
+            <property role="3oM_SC" value="fix" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgzl" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgzm" role="1PaTwD">
+            <property role="3oM_SC" value="compilation" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgzn" role="1PaTwD">
+            <property role="3oM_SC" value="issues," />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgzo" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgzp" role="1PaTwD">
+            <property role="3oM_SC" value="language" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgzq" role="1PaTwD">
+            <property role="3oM_SC" value="is" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgzr" role="1PaTwD">
+            <property role="3oM_SC" value="now" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgzs" role="1PaTwD">
+            <property role="3oM_SC" value="generated" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgzt" role="1PaTwD">
+            <property role="3oM_SC" value="earlier" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgzu" role="1PaTwD">
+            <property role="3oM_SC" value="in" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgzv" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgzw" role="1PaTwD">
+            <property role="3oM_SC" value="generation" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgzx" role="1PaTwD">
+            <property role="3oM_SC" value="plan." />
+          </node>
+        </node>
+      </node>
+      <node concept="15bAme" id="1$KnWE8reRA" role="15bAlL">
+        <property role="15bAli" value="Po4Z58tnOE/added" />
+        <node concept="2DRihI" id="1$KnWE8reRB" role="15bAlk">
+          <node concept="3oM_SD" id="1$KnWE8reSx" role="1PaTwD">
+            <property role="3oM_SC" value="A" />
+          </node>
+          <node concept="3oM_SD" id="1$KnWE8reSz" role="1PaTwD">
+            <property role="3oM_SC" value="new" />
+          </node>
+          <node concept="3oM_SD" id="1$KnWE8reSA" role="1PaTwD">
+            <property role="3oM_SC" value="language" />
+          </node>
+          <node concept="15Ami3" id="1$KnWE8reSJ" role="1PaTwD">
+            <node concept="37shsh" id="1$KnWE8reSL" role="15Aodc">
+              <node concept="1dCxOk" id="1$KnWE8reSX" role="37shsm">
+                <property role="1XweGW" value="638c9345-2613-49dc-b2ae-8ceadef24141" />
+                <property role="1XxBO9" value="de.itemis.mps.changelog" />
+              </node>
+            </node>
+          </node>
+          <node concept="3oM_SD" id="1$KnWE8reTa" role="1PaTwD">
+            <property role="3oM_SC" value="was" />
+          </node>
+          <node concept="3oM_SD" id="1$KnWE8reTi" role="1PaTwD">
+            <property role="3oM_SC" value="added" />
+          </node>
+          <node concept="3oM_SD" id="1$KnWE8reTr" role="1PaTwD">
+            <property role="3oM_SC" value="to" />
+          </node>
+          <node concept="3oM_SD" id="1$KnWE8reT_" role="1PaTwD">
+            <property role="3oM_SC" value="describe" />
+          </node>
+          <node concept="3oM_SD" id="1$KnWE8reTK" role="1PaTwD">
+            <property role="3oM_SC" value="CHANGELOG.md" />
+            <property role="1X82VY" value="true" />
+          </node>
+          <node concept="3oM_SD" id="1$KnWE8reTW" role="1PaTwD">
+            <property role="3oM_SC" value="files." />
+          </node>
+          <node concept="3oM_SD" id="1$KnWE8reU9" role="1PaTwD">
+            <property role="3oM_SC" value="This" />
+          </node>
+          <node concept="3oM_SD" id="1$KnWE8reUn" role="1PaTwD">
+            <property role="3oM_SC" value="file" />
+          </node>
+          <node concept="3oM_SD" id="1$KnWE8reUA" role="1PaTwD">
+            <property role="3oM_SC" value="is" />
+          </node>
+          <node concept="3oM_SD" id="1$KnWE8reUQ" role="1PaTwD">
+            <property role="3oM_SC" value="generated" />
+          </node>
+          <node concept="3oM_SD" id="1$KnWE8reV7" role="1PaTwD">
+            <property role="3oM_SC" value="with" />
+          </node>
+          <node concept="3oM_SD" id="1$KnWE8reVp" role="1PaTwD">
+            <property role="3oM_SC" value="this" />
+          </node>
+          <node concept="3oM_SD" id="1$KnWE8reVG" role="1PaTwD">
+            <property role="3oM_SC" value="language." />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="15bmVD" id="43oF0KsR_Kt" role="15bmVC">
+      <node concept="15ShDW" id="43oF0KsR_Kq" role="15bq2Y">
+        <property role="15ShDY" value="Po4Z58IgAp/March" />
+        <property role="15ShDw" value="2024" />
+      </node>
+      <node concept="15bAme" id="43oF0KsTg2m" role="15bAlL">
+        <property role="15bAli" value="Po4Z58tnOE/added" />
+        <node concept="2DRihI" id="43oF0KsTg2n" role="15bAlk">
+          <node concept="2hgSXJ" id="1$KnWE8wwU1" role="1PaTwD">
+            <node concept="1PaTwC" id="1$KnWE8wwU2" role="2hiFM$">
+              <node concept="15Ami3" id="1$KnWE8wwU3" role="1PaTwD">
+                <node concept="37shsh" id="1$KnWE8wwU4" role="15Aodc">
+                  <node concept="1dCxOk" id="1$KnWE8wwU5" role="37shsm">
+                    <property role="1XweGW" value="b8bb702e-43ed-4090-a902-d180d3e5f292" />
+                    <property role="1XxBO9" value="de.slisson.mps.conditionalEditor" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3oM_SD" id="1$KnWE8wwU6" role="1PaTwD">
+                <property role="3oM_SC" value=":" />
+              </node>
+            </node>
+          </node>
+          <node concept="3oM_SD" id="1$KnWE8eASr" role="1PaTwD">
+            <property role="3oM_SC" value="Support" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgz1" role="1PaTwD">
+            <property role="3oM_SC" value="for" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgz2" role="1PaTwD">
+            <property role="3oM_SC" value="editor" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgz3" role="1PaTwD">
+            <property role="3oM_SC" value="components" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgz4" role="1PaTwD">
+            <property role="3oM_SC" value="with" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgz5" role="1PaTwD">
+            <property role="3oM_SC" value="parameters" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgz6" role="1PaTwD">
+            <property role="3oM_SC" value="was" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgz7" role="1PaTwD">
+            <property role="3oM_SC" value="added." />
+          </node>
+        </node>
+        <node concept="2DRihI" id="43oF0KsTgyl" role="15bAlk">
+          <property role="2RT3bR" value="0" />
+          <node concept="2hgSXJ" id="1$KnWE8wwUo" role="1PaTwD">
+            <node concept="1PaTwC" id="1$KnWE8wwUp" role="2hiFM$">
+              <node concept="15Ami3" id="1$KnWE8wwUq" role="1PaTwD">
+                <node concept="37shsh" id="1$KnWE8wwUr" role="15Aodc">
+                  <node concept="1dCxOk" id="1$KnWE8wwUs" role="37shsm">
+                    <property role="1XweGW" value="9d69e719-78c8-4286-90db-fb19c107d049" />
+                    <property role="1XxBO9" value="com.mbeddr.mpsutil.grammarcells" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3oM_SD" id="1$KnWE8wwUt" role="1PaTwD">
+                <property role="3oM_SC" value=":" />
+              </node>
+            </node>
+          </node>
+          <node concept="3oM_SD" id="1$KnWE8eATK" role="1PaTwD">
+            <property role="3oM_SC" value="Read-only" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgxO" role="1PaTwD">
+            <property role="3oM_SC" value="model" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgxP" role="1PaTwD">
+            <property role="3oM_SC" value="accessory" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgxQ" role="1PaTwD">
+            <property role="3oM_SC" value="cells" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgxR" role="1PaTwD">
+            <property role="3oM_SC" value="can" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgxS" role="1PaTwD">
+            <property role="3oM_SC" value="now" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgxT" role="1PaTwD">
+            <property role="3oM_SC" value="also" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgxU" role="1PaTwD">
+            <property role="3oM_SC" value="be" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgxV" role="1PaTwD">
+            <property role="3oM_SC" value="used" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgxW" role="1PaTwD">
+            <property role="3oM_SC" value="in" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgxX" role="1PaTwD">
+            <property role="3oM_SC" value="places" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgxY" role="1PaTwD">
+            <property role="3oM_SC" value="where" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgxZ" role="1PaTwD">
+            <property role="3oM_SC" value="constant" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgy0" role="1PaTwD">
+            <property role="3oM_SC" value="cells" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgy1" role="1PaTwD">
+            <property role="3oM_SC" value="are" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgy2" role="1PaTwD">
+            <property role="3oM_SC" value="supported." />
+          </node>
+        </node>
+      </node>
+      <node concept="15bAme" id="43oF0KsTg2b" role="15bAlL">
+        <node concept="2DRihI" id="43oF0KsTg2c" role="15bAlk">
+          <node concept="2hgSXJ" id="1$KnWE8wwX8" role="1PaTwD">
+            <node concept="1PaTwC" id="1$KnWE8wwX9" role="2hiFM$">
+              <node concept="15Ami3" id="1$KnWE8wwXa" role="1PaTwD">
+                <node concept="37shsh" id="1$KnWE8wwXb" role="15Aodc">
+                  <node concept="1dCxOk" id="1$KnWE8wwXc" role="37shsm">
+                    <property role="1XweGW" value="120e1c9d-4e27-4478-b2af-b2c3bd3850b0" />
+                    <property role="1XxBO9" value="com.mbeddr.mpsutil.editor.querylist" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3oM_SD" id="1$KnWE8wwXd" role="1PaTwD">
+                <property role="3oM_SC" value=":" />
+              </node>
+            </node>
+          </node>
+          <node concept="3oM_SD" id="1$KnWE8eAUX" role="1PaTwD">
+            <property role="3oM_SC" value="Returning" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgxr" role="1PaTwD">
+            <property role="3oM_SC" value="null" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgxs" role="1PaTwD">
+            <property role="3oM_SC" value="in" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgxt" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgxu" role="1PaTwD">
+            <property role="3oM_SC" value="query" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgxv" role="1PaTwD">
+            <property role="3oM_SC" value="shows" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgxw" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgxx" role="1PaTwD">
+            <property role="3oM_SC" value="empty" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgxy" role="1PaTwD">
+            <property role="3oM_SC" value="cell" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgxz" role="1PaTwD">
+            <property role="3oM_SC" value="again" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgx$" role="1PaTwD">
+            <property role="3oM_SC" value="(regression)." />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="15bmVD" id="43oF0KsR_KD" role="15bmVC">
+      <node concept="15ShDW" id="43oF0KsR_KA" role="15bq2Y">
+        <property role="15ShDY" value="Po4Z58IgAm/February" />
+        <property role="15ShDw" value="2024" />
+      </node>
+      <node concept="15bAme" id="43oF0KsR_KB" role="15bAlL">
+        <property role="15bAli" value="Po4Z58tnOF/changed" />
+        <node concept="2DRihI" id="43oF0KsR_KC" role="15bAlk">
+          <node concept="2hgSXJ" id="1$KnWE8wwXy" role="1PaTwD">
+            <node concept="1PaTwC" id="1$KnWE8wwXz" role="2hiFM$">
+              <node concept="15Ami3" id="1$KnWE8wwX$" role="1PaTwD">
+                <node concept="37shsh" id="1$KnWE8wwX_" role="15Aodc">
+                  <node concept="1dCxOk" id="1$KnWE8wwXA" role="37shsm">
+                    <property role="1XweGW" value="120e1c9d-4e27-4478-b2af-b2c3bd3850b0" />
+                    <property role="1XxBO9" value="com.mbeddr.mpsutil.editor.querylist" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3oM_SD" id="1$KnWE8wwXB" role="1PaTwD">
+                <property role="3oM_SC" value=":" />
+              </node>
+            </node>
+          </node>
+          <node concept="3oM_SD" id="1$KnWE8eAWt" role="1PaTwD">
+            <property role="3oM_SC" value="Dynamic" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgwM" role="1PaTwD">
+            <property role="3oM_SC" value="generated" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgwN" role="1PaTwD">
+            <property role="3oM_SC" value="nodes" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgwO" role="1PaTwD">
+            <property role="3oM_SC" value="(without" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgwP" role="1PaTwD">
+            <property role="3oM_SC" value="a" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgwQ" role="1PaTwD">
+            <property role="3oM_SC" value="model)" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgwR" role="1PaTwD">
+            <property role="3oM_SC" value="can" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgwS" role="1PaTwD">
+            <property role="3oM_SC" value="now" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgwT" role="1PaTwD">
+            <property role="3oM_SC" value="be" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgwU" role="1PaTwD">
+            <property role="3oM_SC" value="used" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgwV" role="1PaTwD">
+            <property role="3oM_SC" value="in" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgwW" role="1PaTwD">
+            <property role="3oM_SC" value="query" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgwX" role="1PaTwD">
+            <property role="3oM_SC" value="lists" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgwY" role="1PaTwD">
+            <property role="3oM_SC" value="if" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgwZ" role="1PaTwD">
+            <property role="3oM_SC" value="read-only" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgx0" role="1PaTwD">
+            <property role="3oM_SC" value="is" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgx1" role="1PaTwD">
+            <property role="3oM_SC" value="set" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgx2" role="1PaTwD">
+            <property role="3oM_SC" value="to" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgx3" role="1PaTwD">
+            <property role="3oM_SC" value="true." />
+          </node>
+        </node>
+        <node concept="2DRihI" id="43oF0KsTgwa" role="15bAlk">
+          <property role="2RT3bR" value="0" />
+          <node concept="3oM_SD" id="43oF0KsTgw9" role="1PaTwD">
+            <property role="3oM_SC" value="The" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgvW" role="1PaTwD">
+            <property role="3oM_SC" value="language" />
+          </node>
+          <node concept="1RqHR4" id="43oF0KsTgvX" role="1PaTwD">
+            <property role="3oM_SC" value="de.slisson.mps.structurecheck" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgvY" role="1PaTwD">
+            <property role="3oM_SC" value="was" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgvZ" role="1PaTwD">
+            <property role="3oM_SC" value="renamed" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgw0" role="1PaTwD">
+            <property role="3oM_SC" value="to" />
+          </node>
+          <node concept="15Ami3" id="1$KnWE8eAX6" role="1PaTwD">
+            <node concept="37shsh" id="1$KnWE8eAX8" role="15Aodc">
+              <node concept="1dCxOk" id="1$KnWE8eAXo" role="37shsm">
+                <property role="1XweGW" value="c6cfed73-685b-4891-8bdd-b38a1dcb107a" />
+                <property role="1XxBO9" value="de.itemis.mps.structurecheck" />
+              </node>
+            </node>
+          </node>
+          <node concept="3oM_SD" id="1$KnWE8eAXL" role="1PaTwD">
+            <property role="3oM_SC" value="." />
+          </node>
+        </node>
+        <node concept="2DRihI" id="43oF0KsTgvt" role="15bAlk">
+          <property role="2RT3bR" value="0" />
+          <node concept="3oM_SD" id="43oF0KsTgvs" role="1PaTwD">
+            <property role="3oM_SC" value="The" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgvf" role="1PaTwD">
+            <property role="3oM_SC" value="stubs" />
+          </node>
+          <node concept="1RqHR4" id="43oF0KsTgvg" role="1PaTwD">
+            <property role="3oM_SC" value="com.mbeddr.mpsutil.serializer.xml" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgvh" role="1PaTwD">
+            <property role="3oM_SC" value="were" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgvi" role="1PaTwD">
+            <property role="3oM_SC" value="renamed" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgvj" role="1PaTwD">
+            <property role="3oM_SC" value="to" />
+          </node>
+          <node concept="15Ami3" id="1$KnWE8eAYd" role="1PaTwD">
+            <node concept="37shsh" id="1$KnWE8eAYf" role="15Aodc">
+              <node concept="1dCxOk" id="1$KnWE8eAYv" role="37shsm">
+                <property role="1XweGW" value="5454dbfd-2075-4de0-b85e-fa645eb6957e" />
+                <property role="1XxBO9" value="de.itemis.mps.utils.serializer.xml" />
+              </node>
+            </node>
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgvk" role="1PaTwD">
+            <property role="3oM_SC" value="." />
+          </node>
+        </node>
+        <node concept="2DRihI" id="43oF0KsTgur" role="15bAlk">
+          <property role="2RT3bR" value="0" />
+          <node concept="3oM_SD" id="43oF0KsTguq" role="1PaTwD">
+            <property role="3oM_SC" value="The" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgud" role="1PaTwD">
+            <property role="3oM_SC" value="language" />
+          </node>
+          <node concept="1RqHR4" id="43oF0KsTgue" role="1PaTwD">
+            <property role="3oM_SC" value="de.slisson.mps.hacks.xmodelgen" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTguf" role="1PaTwD">
+            <property role="3oM_SC" value="was" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgug" role="1PaTwD">
+            <property role="3oM_SC" value="renamed" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTguh" role="1PaTwD">
+            <property role="3oM_SC" value="to" />
+          </node>
+          <node concept="15Ami3" id="1$KnWE8eAYP" role="1PaTwD">
+            <node concept="37shsh" id="1$KnWE8eAYR" role="15Aodc">
+              <node concept="1dCxOk" id="1$KnWE8eAZ7" role="37shsm">
+                <property role="1XweGW" value="c5eeb6dc-2f3d-45ae-a7be-929daeb6bda1" />
+                <property role="1XxBO9" value="de.itemis.mps.hacks.xmodelgen" />
+              </node>
+            </node>
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgui" role="1PaTwD">
+            <property role="3oM_SC" value="." />
+          </node>
+        </node>
+      </node>
+      <node concept="15bAme" id="43oF0KsR_NY" role="15bAlL">
+        <property role="15bAli" value="Po4Z58tnOI/deprecated" />
+        <node concept="2DRihI" id="43oF0KsR_NZ" role="15bAlk">
+          <node concept="15BRQy" id="1$KnWE8eAZc" role="1PaTwD">
+            <node concept="2tJFMh" id="1$KnWE8eAZe" role="15BRQ_">
+              <node concept="ZC_QK" id="1$KnWE8eAZ$" role="2tJFKM">
+                <ref role="2aWVGs" to="hba4:5A94f9Eu4RV" resolve="MethodLineDoc" />
+              </node>
+            </node>
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgtK" role="1PaTwD">
+            <property role="3oM_SC" value="is" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgtL" role="1PaTwD">
+            <property role="3oM_SC" value="now" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgtM" role="1PaTwD">
+            <property role="3oM_SC" value="deprecated" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgtN" role="1PaTwD">
+            <property role="3oM_SC" value="and" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgtO" role="1PaTwD">
+            <property role="3oM_SC" value="an" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgtP" role="1PaTwD">
+            <property role="3oM_SC" value="automatic" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgtQ" role="1PaTwD">
+            <property role="3oM_SC" value="migration" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgtR" role="1PaTwD">
+            <property role="3oM_SC" value="is" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgtS" role="1PaTwD">
+            <property role="3oM_SC" value="provided" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgtT" role="1PaTwD">
+            <property role="3oM_SC" value="to" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgtU" role="1PaTwD">
+            <property role="3oM_SC" value="migrate" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgtV" role="1PaTwD">
+            <property role="3oM_SC" value="to" />
+          </node>
+          <node concept="1RqHR4" id="1$KnWE8eXyM" role="1PaTwD">
+            <property role="3oM_SC" value="jetbrains.mps.baseLanguage.javadoc" />
+          </node>
+          <node concept="3oM_SD" id="1$KnWE8eXzk" role="1PaTwD">
+            <property role="3oM_SC" value="." />
+          </node>
+        </node>
+      </node>
+      <node concept="15bAme" id="43oF0KsR_O4" role="15bAlL">
+        <node concept="2DRihI" id="43oF0KsR_O5" role="15bAlk">
+          <node concept="2hgSXJ" id="1$KnWE8wwY4" role="1PaTwD">
+            <node concept="1PaTwC" id="1$KnWE8wwY5" role="2hiFM$">
+              <node concept="15Ami3" id="1$KnWE8wwY6" role="1PaTwD">
+                <node concept="37shsh" id="1$KnWE8wwY7" role="15Aodc">
+                  <node concept="1dCxOk" id="1$KnWE8wwY8" role="37shsm">
+                    <property role="1XweGW" value="dc038ceb-b7ea-4fea-ac12-55f7400e97ba" />
+                    <property role="1XxBO9" value="de.slisson.mps.editor.multiline.runtime" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3oM_SD" id="1$KnWE8wwY9" role="1PaTwD">
+                <property role="3oM_SC" value=":" />
+              </node>
+            </node>
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgsX" role="1PaTwD">
+            <property role="3oM_SC" value="An" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgsY" role="1PaTwD">
+            <property role="3oM_SC" value="issue" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgsZ" role="1PaTwD">
+            <property role="3oM_SC" value="was" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgt0" role="1PaTwD">
+            <property role="3oM_SC" value="fixed" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgt1" role="1PaTwD">
+            <property role="3oM_SC" value="where" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgt2" role="1PaTwD">
+            <property role="3oM_SC" value="pressing" />
+          </node>
+          <node concept="1RqHR4" id="43oF0KsTgt3" role="1PaTwD">
+            <property role="3oM_SC" value="shift+enter" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgt4" role="1PaTwD">
+            <property role="3oM_SC" value="didn't" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgt5" role="1PaTwD">
+            <property role="3oM_SC" value="enter" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgt6" role="1PaTwD">
+            <property role="3oM_SC" value="a" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgt7" role="1PaTwD">
+            <property role="3oM_SC" value="new" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgt8" role="1PaTwD">
+            <property role="3oM_SC" value="line" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgt9" role="1PaTwD">
+            <property role="3oM_SC" value="in" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgta" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgtb" role="1PaTwD">
+            <property role="3oM_SC" value="current" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgtc" role="1PaTwD">
+            <property role="3oM_SC" value="text" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgtd" role="1PaTwD">
+            <property role="3oM_SC" value="but" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgte" role="1PaTwD">
+            <property role="3oM_SC" value="in" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgtf" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgtg" role="1PaTwD">
+            <property role="3oM_SC" value="next" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgth" role="1PaTwD">
+            <property role="3oM_SC" value="collection" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgti" role="1PaTwD">
+            <property role="3oM_SC" value="in" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgtj" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgtk" role="1PaTwD">
+            <property role="3oM_SC" value="editor." />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="15bmVD" id="43oF0KsR_KT" role="15bmVC">
+      <node concept="15ShDW" id="43oF0KsR_KQ" role="15bq2Y">
+        <property role="15ShDY" value="Po4Z58IgAl/January" />
+        <property role="15ShDw" value="2024" />
+      </node>
+      <node concept="15bAme" id="43oF0KsR_KR" role="15bAlL">
+        <node concept="2DRihI" id="43oF0KsR_KS" role="15bAlk">
+          <node concept="2hgSXJ" id="1$KnWE8wwYF" role="1PaTwD">
+            <node concept="1PaTwC" id="1$KnWE8wwYG" role="2hiFM$">
+              <node concept="15Ami3" id="1$KnWE8wwYH" role="1PaTwD">
+                <node concept="37shsh" id="1$KnWE8wwYI" role="15Aodc">
+                  <node concept="1dCxOk" id="1$KnWE8wwYJ" role="37shsm">
+                    <property role="1XweGW" value="309e0004-4976-4416-b947-ec02ae4ecef2" />
+                    <property role="1XxBO9" value="com.mbeddr.mpsutil.modellisteners" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3oM_SD" id="1$KnWE8wwYK" role="1PaTwD">
+                <property role="3oM_SC" value=":" />
+              </node>
+            </node>
+          </node>
+          <node concept="3oM_SD" id="1$KnWE8eBcc" role="1PaTwD">
+            <property role="3oM_SC" value="The" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgsp" role="1PaTwD">
+            <property role="3oM_SC" value="newly" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgsq" role="1PaTwD">
+            <property role="3oM_SC" value="supported" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgsr" role="1PaTwD">
+            <property role="3oM_SC" value="interface" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgss" role="1PaTwD">
+            <property role="3oM_SC" value="listeners" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgst" role="1PaTwD">
+            <property role="3oM_SC" value="are" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgsu" role="1PaTwD">
+            <property role="3oM_SC" value="now" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgsv" role="1PaTwD">
+            <property role="3oM_SC" value="backward" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgsw" role="1PaTwD">
+            <property role="3oM_SC" value="compatible" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgsx" role="1PaTwD">
+            <property role="3oM_SC" value="and" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgsy" role="1PaTwD">
+            <property role="3oM_SC" value="doesn't" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgsz" role="1PaTwD">
+            <property role="3oM_SC" value="require" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgs$" role="1PaTwD">
+            <property role="3oM_SC" value="regenerating" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgs_" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgsA" role="1PaTwD">
+            <property role="3oM_SC" value="listener" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgsB" role="1PaTwD">
+            <property role="3oM_SC" value="aspects" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgsC" role="1PaTwD">
+            <property role="3oM_SC" value="anymore." />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="15bmVD" id="43oF0KsR_Ld" role="15bmVC">
+      <node concept="15ShDW" id="43oF0KsR_La" role="15bq2Y">
+        <property role="15ShDY" value="Po4Z58IgBx/December" />
+        <property role="15ShDw" value="2023" />
+      </node>
+      <node concept="15bAme" id="43oF0KsR_Lb" role="15bAlL">
+        <property role="15bAli" value="Po4Z58tnOE/added" />
+        <node concept="2DRihI" id="43oF0KsR_Lc" role="15bAlk">
+          <node concept="3oM_SD" id="43oF0KsTgra" role="1PaTwD">
+            <property role="3oM_SC" value="A" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgrb" role="1PaTwD">
+            <property role="3oM_SC" value="new" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgrc" role="1PaTwD">
+            <property role="3oM_SC" value="language" />
+          </node>
+          <node concept="15Ami3" id="1$KnWE8eBda" role="1PaTwD">
+            <node concept="37shsh" id="1$KnWE8eBdc" role="15Aodc">
+              <node concept="1dCxOk" id="1$KnWE8eBdV" role="37shsm">
+                <property role="1XweGW" value="72570c50-58ae-43ff-a0b7-71d2b3908271" />
+                <property role="1XxBO9" value="de.itemis.mps.statistics" />
+              </node>
+            </node>
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgre" role="1PaTwD">
+            <property role="3oM_SC" value="was" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgrf" role="1PaTwD">
+            <property role="3oM_SC" value="added" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgrg" role="1PaTwD">
+            <property role="3oM_SC" value="that" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgrh" role="1PaTwD">
+            <property role="3oM_SC" value="adds" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgri" role="1PaTwD">
+            <property role="3oM_SC" value="a" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgrj" role="1PaTwD">
+            <property role="3oM_SC" value="new" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgrk" role="1PaTwD">
+            <property role="3oM_SC" value="menu" />
+          </node>
+          <node concept="3oM_SD" id="1$KnWE8eBeC" role="1PaTwD">
+            <property role="3oM_SC" value="MPS Statistics" />
+            <property role="1X82VY" value="true" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgrn" role="1PaTwD">
+            <property role="3oM_SC" value="to" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgro" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgrp" role="1PaTwD">
+            <property role="3oM_SC" value="Tools" />
+            <property role="1X82VY" value="true" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgrq" role="1PaTwD">
+            <property role="3oM_SC" value="menu." />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgrr" role="1PaTwD">
+            <property role="3oM_SC" value="The" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgrs" role="1PaTwD">
+            <property role="3oM_SC" value="containing" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgrt" role="1PaTwD">
+            <property role="3oM_SC" value="action" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgru" role="1PaTwD">
+            <property role="3oM_SC" value="writes" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgrv" role="1PaTwD">
+            <property role="3oM_SC" value="a" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgrw" role="1PaTwD">
+            <property role="3oM_SC" value="file" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgrx" role="1PaTwD">
+            <property role="3oM_SC" value="dependencies.txt" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgry" role="1PaTwD">
+            <property role="3oM_SC" value="to" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgrz" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgr$" role="1PaTwD">
+            <property role="3oM_SC" value="root" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgr_" role="1PaTwD">
+            <property role="3oM_SC" value="folder." />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgrA" role="1PaTwD">
+            <property role="3oM_SC" value="It" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgrB" role="1PaTwD">
+            <property role="3oM_SC" value="contains" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgrC" role="1PaTwD">
+            <property role="3oM_SC" value="all" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgrD" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgrE" role="1PaTwD">
+            <property role="3oM_SC" value="used" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgrF" role="1PaTwD">
+            <property role="3oM_SC" value="dependencies" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgrG" role="1PaTwD">
+            <property role="3oM_SC" value="of" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgrH" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgrI" role="1PaTwD">
+            <property role="3oM_SC" value="current" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgrJ" role="1PaTwD">
+            <property role="3oM_SC" value="project." />
+          </node>
+        </node>
+        <node concept="2DRihI" id="43oF0KsTgpy" role="15bAlk">
+          <property role="2RT3bR" value="0" />
+          <node concept="15Ami3" id="1$KnWE8eBg2" role="1PaTwD">
+            <node concept="37shsh" id="1$KnWE8eBg4" role="15Aodc">
+              <node concept="1dCxOk" id="1$KnWE8eBgX" role="37shsm">
+                <property role="1XweGW" value="7e450f4e-1ac3-41ef-a851-4598161bdb94" />
+                <property role="1XxBO9" value="de.slisson.mps.tables" />
+              </node>
+            </node>
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgo2" role="1PaTwD">
+            <property role="3oM_SC" value="tables" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgo3" role="1PaTwD">
+            <property role="3oM_SC" value="now" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgo4" role="1PaTwD">
+            <property role="3oM_SC" value="support" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgo5" role="1PaTwD">
+            <property role="3oM_SC" value="a" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgo6" role="1PaTwD">
+            <property role="3oM_SC" value="new" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgo7" role="1PaTwD">
+            <property role="3oM_SC" value="property" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgo8" role="1PaTwD">
+            <property role="3oM_SC" value="column" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgo9" role="1PaTwD">
+            <property role="3oM_SC" value="UI" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgoa" role="1PaTwD">
+            <property role="3oM_SC" value="actions" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgob" role="1PaTwD">
+            <property role="3oM_SC" value="(experimental):" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgoc" role="1PaTwD">
+            <property role="3oM_SC" value="This" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgod" role="1PaTwD">
+            <property role="3oM_SC" value="property" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgoe" role="1PaTwD">
+            <property role="3oM_SC" value="adds" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgof" role="1PaTwD">
+            <property role="3oM_SC" value="actions" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgog" role="1PaTwD">
+            <property role="3oM_SC" value="to" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgoh" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgoi" role="1PaTwD">
+            <property role="3oM_SC" value="MPS" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgoj" role="1PaTwD">
+            <property role="3oM_SC" value="toolbar" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgok" role="1PaTwD">
+            <property role="3oM_SC" value="to" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgol" role="1PaTwD">
+            <property role="3oM_SC" value="add" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgom" role="1PaTwD">
+            <property role="3oM_SC" value="a" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgon" role="1PaTwD">
+            <property role="3oM_SC" value="new" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgoo" role="1PaTwD">
+            <property role="3oM_SC" value="column" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgop" role="1PaTwD">
+            <property role="3oM_SC" value="above/below" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgoq" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgor" role="1PaTwD">
+            <property role="3oM_SC" value="current" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgos" role="1PaTwD">
+            <property role="3oM_SC" value="column" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgot" role="1PaTwD">
+            <property role="3oM_SC" value="or" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgou" role="1PaTwD">
+            <property role="3oM_SC" value="to" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgov" role="1PaTwD">
+            <property role="3oM_SC" value="delete" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgow" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgox" role="1PaTwD">
+            <property role="3oM_SC" value="current" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgoy" role="1PaTwD">
+            <property role="3oM_SC" value="column." />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgoz" role="1PaTwD">
+            <property role="3oM_SC" value="These" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgo$" role="1PaTwD">
+            <property role="3oM_SC" value="actions" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgo_" role="1PaTwD">
+            <property role="3oM_SC" value="only" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgoA" role="1PaTwD">
+            <property role="3oM_SC" value="work" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgoB" role="1PaTwD">
+            <property role="3oM_SC" value="for" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgoC" role="1PaTwD">
+            <property role="3oM_SC" value="simple" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgoD" role="1PaTwD">
+            <property role="3oM_SC" value="tables" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgoE" role="1PaTwD">
+            <property role="3oM_SC" value="that" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgoF" role="1PaTwD">
+            <property role="3oM_SC" value="are" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgoG" role="1PaTwD">
+            <property role="3oM_SC" value="based" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgoH" role="1PaTwD">
+            <property role="3oM_SC" value="on" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgoI" role="1PaTwD">
+            <property role="3oM_SC" value="rows" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgoJ" role="1PaTwD">
+            <property role="3oM_SC" value="(default:" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgoK" role="1PaTwD">
+            <property role="3oM_SC" value="false)." />
+          </node>
+        </node>
+      </node>
+      <node concept="15bAme" id="43oF0KsR_NK" role="15bAlL">
+        <node concept="2DRihI" id="43oF0KsR_NL" role="15bAlk">
+          <node concept="3oM_SD" id="43oF0KsTgnJ" role="1PaTwD">
+            <property role="3oM_SC" value="The" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgnL" role="1PaTwD">
+            <property role="3oM_SC" value="performance" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgnM" role="1PaTwD">
+            <property role="3oM_SC" value="of" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgnN" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgnO" role="1PaTwD">
+            <property role="3oM_SC" value="language" />
+          </node>
+          <node concept="15Ami3" id="1$KnWE8eBhY" role="1PaTwD">
+            <node concept="37shsh" id="1$KnWE8eBi0" role="15Aodc">
+              <node concept="1dCxOk" id="1$KnWE8eBih" role="37shsm">
+                <property role="1XweGW" value="dc309acc-7f3e-4ca9-bee5-a61c7c599f59" />
+                <property role="1XxBO9" value="de.itemis.mps.linenumbers" />
+              </node>
+            </node>
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgnQ" role="1PaTwD">
+            <property role="3oM_SC" value="was" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgnR" role="1PaTwD">
+            <property role="3oM_SC" value="improved." />
+          </node>
+        </node>
+      </node>
+      <node concept="15bAme" id="43oF0KsR_NQ" role="15bAlL">
+        <property role="15bAli" value="Po4Z58tnOF/changed" />
+        <node concept="2DRihI" id="43oF0KsR_NR" role="15bAlk">
+          <node concept="2hgSXJ" id="1$KnWE8wwZb" role="1PaTwD">
+            <node concept="1PaTwC" id="1$KnWE8wwZc" role="2hiFM$">
+              <node concept="15Ami3" id="1$KnWE8wwZd" role="1PaTwD">
+                <node concept="37shsh" id="1$KnWE8wwZe" role="15Aodc">
+                  <node concept="1dCxOk" id="1$KnWE8wwZf" role="37shsm">
+                    <property role="1XweGW" value="b92f861d-0184-446d-b88b-6dcf0e070241" />
+                    <property role="1XxBO9" value="com.mbeddr.mpsutil.intentions" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3oM_SD" id="1$KnWE8wwZg" role="1PaTwD">
+                <property role="3oM_SC" value=":" />
+              </node>
+            </node>
+          </node>
+          <node concept="3oM_SD" id="1$KnWE8eBkP" role="1PaTwD">
+            <property role="3oM_SC" value="Intentions" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgj_" role="1PaTwD">
+            <property role="3oM_SC" value="available" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgjA" role="1PaTwD">
+            <property role="3oM_SC" value="in" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgjB" role="1PaTwD">
+            <property role="3oM_SC" value="read-only" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgjC" role="1PaTwD">
+            <property role="3oM_SC" value="cells" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgjD" role="1PaTwD">
+            <property role="3oM_SC" value="are" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgjE" role="1PaTwD">
+            <property role="3oM_SC" value="not" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgjF" role="1PaTwD">
+            <property role="3oM_SC" value="available" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgjG" role="1PaTwD">
+            <property role="3oM_SC" value="anymore" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgjH" role="1PaTwD">
+            <property role="3oM_SC" value="when" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgjI" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgjJ" role="1PaTwD">
+            <property role="3oM_SC" value="annotation" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgjK" role="1PaTwD">
+            <property role="3oM_SC" value="showIntentionInReadyOnlyCell" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgjL" role="1PaTwD">
+            <property role="3oM_SC" value="is" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgjM" role="1PaTwD">
+            <property role="3oM_SC" value="not" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgnb" role="1PaTwD">
+            <property role="3oM_SC" value="added." />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="15bmVD" id="43oF0KsR_L_" role="15bmVC">
+      <node concept="15ShDW" id="43oF0KsR_Ly" role="15bq2Y">
+        <property role="15ShDY" value="Po4Z58IgBl/November" />
+        <property role="15ShDw" value="2023" />
+      </node>
+      <node concept="15bAme" id="43oF0KsR_Lz" role="15bAlL">
+        <property role="15bAli" value="Po4Z58tnOF/changed" />
+        <node concept="2DRihI" id="43oF0KsR_L$" role="15bAlk">
+          <node concept="15Ami3" id="1$KnWE8eBlk" role="1PaTwD">
+            <node concept="37shsh" id="1$KnWE8eBlm" role="15Aodc">
+              <node concept="1dCxOk" id="1$KnWE8eBlB" role="37shsm">
+                <property role="1XweGW" value="309e0004-4976-4416-b947-ec02ae4ecef2" />
+                <property role="1XxBO9" value="com.mbeddr.mpsutil.modellisteners" />
+              </node>
+            </node>
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgg6" role="1PaTwD">
+            <property role="3oM_SC" value="listeners" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgg7" role="1PaTwD">
+            <property role="3oM_SC" value="on" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgg8" role="1PaTwD">
+            <property role="3oM_SC" value="interface" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgg9" role="1PaTwD">
+            <property role="3oM_SC" value="concepts" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgga" role="1PaTwD">
+            <property role="3oM_SC" value="are" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTggb" role="1PaTwD">
+            <property role="3oM_SC" value="now" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTggc" role="1PaTwD">
+            <property role="3oM_SC" value="supported." />
+          </node>
+        </node>
+        <node concept="2DRihI" id="43oF0KsTggm" role="15bAlk">
+          <property role="2RT3bR" value="0" />
+          <node concept="15BRQy" id="1$KnWE8eBm8" role="1PaTwD">
+            <node concept="2tJFMh" id="1$KnWE8eBma" role="15BRQ_">
+              <node concept="ZC_QK" id="1$KnWE8eBpM" role="2tJFKM">
+                <ref role="2aWVGs" to="mhfm:~NotNull" resolve="NotNull" />
+              </node>
+            </node>
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTggP" role="1PaTwD">
+            <property role="3oM_SC" value="annotations" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTggQ" role="1PaTwD">
+            <property role="3oM_SC" value="in" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTggR" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTggS" role="1PaTwD">
+            <property role="3oM_SC" value="code" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTggT" role="1PaTwD">
+            <property role="3oM_SC" value="are" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTggU" role="1PaTwD">
+            <property role="3oM_SC" value="now" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTggV" role="1PaTwD">
+            <property role="3oM_SC" value="checked" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTggW" role="1PaTwD">
+            <property role="3oM_SC" value="at" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTggX" role="1PaTwD">
+            <property role="3oM_SC" value="run" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTggY" role="1PaTwD">
+            <property role="3oM_SC" value="time" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTggZ" role="1PaTwD">
+            <property role="3oM_SC" value="(the" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgh0" role="1PaTwD">
+            <property role="3oM_SC" value="javac2" />
+            <property role="1X82VY" value="true" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgh1" role="1PaTwD">
+            <property role="3oM_SC" value="compiler" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgh2" role="1PaTwD">
+            <property role="3oM_SC" value="is" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgh3" role="1PaTwD">
+            <property role="3oM_SC" value="used)." />
+          </node>
+        </node>
+        <node concept="2DRihI" id="43oF0KsTghl" role="15bAlk">
+          <property role="2RT3bR" value="0" />
+          <node concept="2hgSXJ" id="1$KnWE8wwZE" role="1PaTwD">
+            <node concept="1PaTwC" id="1$KnWE8wwZF" role="2hiFM$">
+              <node concept="15Ami3" id="1$KnWE8wwZG" role="1PaTwD">
+                <node concept="37shsh" id="1$KnWE8wwZH" role="15Aodc">
+                  <node concept="1dCxOk" id="1$KnWE8wwZI" role="37shsm">
+                    <property role="1XweGW" value="fa13cc63-c476-4d46-9c96-d53670abe7bc" />
+                    <property role="1XxBO9" value="de.itemis.mps.editor.diagram" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3oM_SD" id="1$KnWE8wwZJ" role="1PaTwD">
+                <property role="3oM_SC" value=":" />
+              </node>
+            </node>
+          </node>
+          <node concept="3oM_SD" id="1$KnWE8eBwV" role="1PaTwD">
+            <property role="3oM_SC" value="Edge" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgim" role="1PaTwD">
+            <property role="3oM_SC" value="labels" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgin" role="1PaTwD">
+            <property role="3oM_SC" value="can" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgio" role="1PaTwD">
+            <property role="3oM_SC" value="now" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgip" role="1PaTwD">
+            <property role="3oM_SC" value="be" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgiq" role="1PaTwD">
+            <property role="3oM_SC" value="annotated" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgir" role="1PaTwD">
+            <property role="3oM_SC" value="with" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgis" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgit" role="1PaTwD">
+            <property role="3oM_SC" value="attribute" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgiu" role="1PaTwD">
+            <property role="3oM_SC" value="editors" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgiv" role="1PaTwD">
+            <property role="3oM_SC" value="of" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgiw" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgix" role="1PaTwD">
+            <property role="3oM_SC" value="edges." />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgiy" role="1PaTwD">
+            <property role="3oM_SC" value="Previously" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgiz" role="1PaTwD">
+            <property role="3oM_SC" value="they" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgi$" role="1PaTwD">
+            <property role="3oM_SC" value="were" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgi_" role="1PaTwD">
+            <property role="3oM_SC" value="floating" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgiA" role="1PaTwD">
+            <property role="3oM_SC" value="in" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgiB" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgiC" role="1PaTwD">
+            <property role="3oM_SC" value="diagram" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgiD" role="1PaTwD">
+            <property role="3oM_SC" value="as" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgiE" role="1PaTwD">
+            <property role="3oM_SC" value="external" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgiF" role="1PaTwD">
+            <property role="3oM_SC" value="boxes." />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgiG" role="1PaTwD">
+            <property role="3oM_SC" value="A" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgiH" role="1PaTwD">
+            <property role="3oM_SC" value="new" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgiI" role="1PaTwD">
+            <property role="3oM_SC" value="flag" />
+          </node>
+          <node concept="3oM_SD" id="1$KnWE8eBxA" role="1PaTwD">
+            <property role="3oM_SC" value="use annotations from parent in label" />
+            <property role="1X82VY" value="true" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgiP" role="1PaTwD">
+            <property role="3oM_SC" value="is" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgiQ" role="1PaTwD">
+            <property role="3oM_SC" value="used" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgiR" role="1PaTwD">
+            <property role="3oM_SC" value="to" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgiS" role="1PaTwD">
+            <property role="3oM_SC" value="customize" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgiT" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgiU" role="1PaTwD">
+            <property role="3oM_SC" value="behavior." />
+          </node>
+        </node>
+      </node>
+      <node concept="15bAme" id="43oF0KsR_NE" role="15bAlL">
+        <property role="15bAli" value="Po4Z58tnOE/added" />
+        <node concept="2DRihI" id="43oF0KsR_NF" role="15bAlk">
+          <node concept="2hgSXJ" id="1$KnWE8wx0q" role="1PaTwD">
+            <node concept="1PaTwC" id="1$KnWE8wx0r" role="2hiFM$">
+              <node concept="15Ami3" id="1$KnWE8wx0s" role="1PaTwD">
+                <node concept="37shsh" id="1$KnWE8wx0t" role="15Aodc">
+                  <node concept="1dCxOk" id="1$KnWE8wx0u" role="37shsm">
+                    <property role="1XweGW" value="b92f861d-0184-446d-b88b-6dcf0e070241" />
+                    <property role="1XxBO9" value="com.mbeddr.mpsutil.intentions" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3oM_SD" id="1$KnWE8wx0v" role="1PaTwD">
+                <property role="3oM_SC" value=":" />
+              </node>
+            </node>
+          </node>
+          <node concept="3oM_SD" id="1$KnWE8eB$c" role="1PaTwD">
+            <property role="3oM_SC" value="A" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgan" role="1PaTwD">
+            <property role="3oM_SC" value="new" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgao" role="1PaTwD">
+            <property role="3oM_SC" value="style" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgap" role="1PaTwD">
+            <property role="3oM_SC" value="attribute" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgaq" role="1PaTwD">
+            <property role="3oM_SC" value="intentions-in-read-only-cell" />
+            <property role="1X82VY" value="true" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgar" role="1PaTwD">
+            <property role="3oM_SC" value="is" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgas" role="1PaTwD">
+            <property role="3oM_SC" value="now" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgat" role="1PaTwD">
+            <property role="3oM_SC" value="available" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgau" role="1PaTwD">
+            <property role="3oM_SC" value="to" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgav" role="1PaTwD">
+            <property role="3oM_SC" value="allow" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgaw" role="1PaTwD">
+            <property role="3oM_SC" value="intentions" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgax" role="1PaTwD">
+            <property role="3oM_SC" value="in" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgay" role="1PaTwD">
+            <property role="3oM_SC" value="read-only" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgaz" role="1PaTwD">
+            <property role="3oM_SC" value="cells." />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTga$" role="1PaTwD">
+            <property role="3oM_SC" value="Single" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTga_" role="1PaTwD">
+            <property role="3oM_SC" value="intentions" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgaA" role="1PaTwD">
+            <property role="3oM_SC" value="can" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgaB" role="1PaTwD">
+            <property role="3oM_SC" value="also" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgaC" role="1PaTwD">
+            <property role="3oM_SC" value="be" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgaD" role="1PaTwD">
+            <property role="3oM_SC" value="enabled" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgaE" role="1PaTwD">
+            <property role="3oM_SC" value="or" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgaF" role="1PaTwD">
+            <property role="3oM_SC" value="disabled" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgaG" role="1PaTwD">
+            <property role="3oM_SC" value="in" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgaH" role="1PaTwD">
+            <property role="3oM_SC" value="those" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgaI" role="1PaTwD">
+            <property role="3oM_SC" value="cells" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgaJ" role="1PaTwD">
+            <property role="3oM_SC" value="through" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgaK" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgaL" role="1PaTwD">
+            <property role="3oM_SC" value="intention" />
+          </node>
+          <node concept="3oM_SD" id="1$KnWE8eB$O" role="1PaTwD">
+            <property role="3oM_SC" value="Toggle Show Intention In Read-Only Cell Annotation" />
+            <property role="1X82VY" value="true" />
+          </node>
+          <node concept="3oM_SD" id="1$KnWE8eBDm" role="1PaTwD">
+            <property role="3oM_SC" value="." />
+            <property role="1X82VY" value="true" />
+          </node>
+        </node>
+        <node concept="2DRihI" id="43oF0KsTgbu" role="15bAlk">
+          <property role="2RT3bR" value="0" />
+          <node concept="2hgSXJ" id="1$KnWE8wx17" role="1PaTwD">
+            <node concept="1PaTwC" id="1$KnWE8wx18" role="2hiFM$">
+              <node concept="15Ami3" id="1$KnWE8wx19" role="1PaTwD">
+                <node concept="37shsh" id="1$KnWE8wx1a" role="15Aodc">
+                  <node concept="1dCxOk" id="1$KnWE8wx1b" role="37shsm">
+                    <property role="1XweGW" value="120e1c9d-4e27-4478-b2af-b2c3bd3850b0" />
+                    <property role="1XxBO9" value="com.mbeddr.mpsutil.editor.querylist" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3oM_SD" id="1$KnWE8wx1c" role="1PaTwD">
+                <property role="3oM_SC" value=":" />
+              </node>
+            </node>
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgdh" role="1PaTwD">
+            <property role="3oM_SC" value="Default" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgdi" role="1PaTwD">
+            <property role="3oM_SC" value="editor" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgdj" role="1PaTwD">
+            <property role="3oM_SC" value="cells" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgdk" role="1PaTwD">
+            <property role="3oM_SC" value="now" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgdl" role="1PaTwD">
+            <property role="3oM_SC" value="support" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgdm" role="1PaTwD">
+            <property role="3oM_SC" value="style" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgdn" role="1PaTwD">
+            <property role="3oM_SC" value="attributes." />
+          </node>
+        </node>
+        <node concept="2DRihI" id="43oF0KsTgdx" role="15bAlk">
+          <property role="2RT3bR" value="0" />
+          <node concept="2hgSXJ" id="1$KnWE8wx1t" role="1PaTwD">
+            <node concept="1PaTwC" id="1$KnWE8wx1u" role="2hiFM$">
+              <node concept="15Ami3" id="1$KnWE8wx1v" role="1PaTwD">
+                <node concept="37shsh" id="1$KnWE8wx1w" role="15Aodc">
+                  <node concept="1dCxOk" id="1$KnWE8wx1x" role="37shsm">
+                    <property role="1XweGW" value="7e450f4e-1ac3-41ef-a851-4598161bdb94" />
+                    <property role="1XxBO9" value="de.slisson.mps.tables" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3oM_SD" id="1$KnWE8wx1y" role="1PaTwD">
+                <property role="3oM_SC" value=":" />
+              </node>
+            </node>
+          </node>
+          <node concept="3oM_SD" id="1$KnWE8eBH0" role="1PaTwD">
+            <property role="3oM_SC" value="Tables" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgeA" role="1PaTwD">
+            <property role="3oM_SC" value="now" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgeB" role="1PaTwD">
+            <property role="3oM_SC" value="support" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgeC" role="1PaTwD">
+            <property role="3oM_SC" value="a" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgeD" role="1PaTwD">
+            <property role="3oM_SC" value="new" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgeE" role="1PaTwD">
+            <property role="3oM_SC" value="property" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgeF" role="1PaTwD">
+            <property role="3oM_SC" value="row" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgeG" role="1PaTwD">
+            <property role="3oM_SC" value="UI" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgeH" role="1PaTwD">
+            <property role="3oM_SC" value="actions" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgeI" role="1PaTwD">
+            <property role="3oM_SC" value="(experimental):" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgeJ" role="1PaTwD">
+            <property role="3oM_SC" value="This" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgeK" role="1PaTwD">
+            <property role="3oM_SC" value="property" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgeL" role="1PaTwD">
+            <property role="3oM_SC" value="adds" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgeM" role="1PaTwD">
+            <property role="3oM_SC" value="actions" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgeN" role="1PaTwD">
+            <property role="3oM_SC" value="to" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgeO" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgeP" role="1PaTwD">
+            <property role="3oM_SC" value="MPS" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgeQ" role="1PaTwD">
+            <property role="3oM_SC" value="toolbar" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgeR" role="1PaTwD">
+            <property role="3oM_SC" value="to" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgeS" role="1PaTwD">
+            <property role="3oM_SC" value="add" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgeT" role="1PaTwD">
+            <property role="3oM_SC" value="a" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgeU" role="1PaTwD">
+            <property role="3oM_SC" value="new" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgeV" role="1PaTwD">
+            <property role="3oM_SC" value="row" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgeW" role="1PaTwD">
+            <property role="3oM_SC" value="above/below" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgeX" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgeY" role="1PaTwD">
+            <property role="3oM_SC" value="current" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgeZ" role="1PaTwD">
+            <property role="3oM_SC" value="row" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgf0" role="1PaTwD">
+            <property role="3oM_SC" value="or" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgf1" role="1PaTwD">
+            <property role="3oM_SC" value="to" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgf2" role="1PaTwD">
+            <property role="3oM_SC" value="delete" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgf3" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgf4" role="1PaTwD">
+            <property role="3oM_SC" value="current" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgf5" role="1PaTwD">
+            <property role="3oM_SC" value="row." />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgf6" role="1PaTwD">
+            <property role="3oM_SC" value="These" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgf7" role="1PaTwD">
+            <property role="3oM_SC" value="actions" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgf8" role="1PaTwD">
+            <property role="3oM_SC" value="only" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgf9" role="1PaTwD">
+            <property role="3oM_SC" value="work" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgfa" role="1PaTwD">
+            <property role="3oM_SC" value="for" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgfb" role="1PaTwD">
+            <property role="3oM_SC" value="simple" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgfc" role="1PaTwD">
+            <property role="3oM_SC" value="tables" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgfd" role="1PaTwD">
+            <property role="3oM_SC" value="that" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgfe" role="1PaTwD">
+            <property role="3oM_SC" value="are" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgff" role="1PaTwD">
+            <property role="3oM_SC" value="based" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgfg" role="1PaTwD">
+            <property role="3oM_SC" value="on" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgfh" role="1PaTwD">
+            <property role="3oM_SC" value="rows" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgfi" role="1PaTwD">
+            <property role="3oM_SC" value="(default:" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTgfj" role="1PaTwD">
+            <property role="3oM_SC" value="false" />
+            <property role="1X82VY" value="true" />
+          </node>
+          <node concept="3oM_SD" id="1$KnWE8eBHO" role="1PaTwD">
+            <property role="3oM_SC" value=")." />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="15bmVD" id="43oF0KsR_M1" role="15bmVC">
+      <node concept="15ShDW" id="43oF0KsR_LY" role="15bq2Y">
+        <property role="15ShDY" value="Po4Z58IgBa/October" />
+        <property role="15ShDw" value="2023" />
+      </node>
+      <node concept="15bAme" id="43oF0KsR_LZ" role="15bAlL">
+        <property role="15bAli" value="Po4Z58tnOE/added" />
+        <node concept="2DRihI" id="43oF0KsR_M0" role="15bAlk">
+          <node concept="3oM_SD" id="43oF0KsTg97" role="1PaTwD">
+            <property role="3oM_SC" value="There" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg99" role="1PaTwD">
+            <property role="3oM_SC" value="is" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg9a" role="1PaTwD">
+            <property role="3oM_SC" value="a" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg9b" role="1PaTwD">
+            <property role="3oM_SC" value="new" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg9c" role="1PaTwD">
+            <property role="3oM_SC" value="DSL" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg9d" role="1PaTwD">
+            <property role="3oM_SC" value="called" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg9e" role="1PaTwD">
+            <property role="3oM_SC" value="pagination," />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg9f" role="1PaTwD">
+            <property role="3oM_SC" value="it" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg9g" role="1PaTwD">
+            <property role="3oM_SC" value="provides" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg9h" role="1PaTwD">
+            <property role="3oM_SC" value="an" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg9i" role="1PaTwD">
+            <property role="3oM_SC" value="editor" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg9j" role="1PaTwD">
+            <property role="3oM_SC" value="cell" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg9k" role="1PaTwD">
+            <property role="3oM_SC" value="paginate" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg9l" role="1PaTwD">
+            <property role="3oM_SC" value="which" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg9m" role="1PaTwD">
+            <property role="3oM_SC" value="given" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg9n" role="1PaTwD">
+            <property role="3oM_SC" value="an" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg9o" role="1PaTwD">
+            <property role="3oM_SC" value="editor" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg9p" role="1PaTwD">
+            <property role="3oM_SC" value="cell" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg9q" role="1PaTwD">
+            <property role="3oM_SC" value="collection" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg9r" role="1PaTwD">
+            <property role="3oM_SC" value="it" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg9s" role="1PaTwD">
+            <property role="3oM_SC" value="displays" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg9t" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg9u" role="1PaTwD">
+            <property role="3oM_SC" value="collection" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg9v" role="1PaTwD">
+            <property role="3oM_SC" value="in" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg9w" role="1PaTwD">
+            <property role="3oM_SC" value="multiple" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg9x" role="1PaTwD">
+            <property role="3oM_SC" value="pages," />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg9y" role="1PaTwD">
+            <property role="3oM_SC" value="with" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg9z" role="1PaTwD">
+            <property role="3oM_SC" value="swing" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg9$" role="1PaTwD">
+            <property role="3oM_SC" value="components" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg9_" role="1PaTwD">
+            <property role="3oM_SC" value="to" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg9A" role="1PaTwD">
+            <property role="3oM_SC" value="move" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg9B" role="1PaTwD">
+            <property role="3oM_SC" value="between" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg9C" role="1PaTwD">
+            <property role="3oM_SC" value="pages" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg9D" role="1PaTwD">
+            <property role="3oM_SC" value="and" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg9E" role="1PaTwD">
+            <property role="3oM_SC" value="show" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg9F" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg9G" role="1PaTwD">
+            <property role="3oM_SC" value="current" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg9H" role="1PaTwD">
+            <property role="3oM_SC" value="page." />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="15bmVD" id="43oF0KsR_Mx" role="15bmVC">
+      <node concept="15ShDW" id="43oF0KsR_Mu" role="15bq2Y">
+        <property role="15ShDY" value="Po4Z58IgB0/September" />
+        <property role="15ShDw" value="2023" />
+      </node>
+      <node concept="15bAme" id="43oF0KsR_Mv" role="15bAlL">
+        <property role="15bAli" value="Po4Z58tnOF/changed" />
+        <node concept="2DRihI" id="43oF0KsR_Mw" role="15bAlk">
+          <node concept="3oM_SD" id="43oF0KsTg8A" role="1PaTwD">
+            <property role="3oM_SC" value="The" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg8C" role="1PaTwD">
+            <property role="3oM_SC" value="grammar" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg8D" role="1PaTwD">
+            <property role="3oM_SC" value="cells" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg8E" role="1PaTwD">
+            <property role="3oM_SC" value="grammar.wrap" />
+            <property role="1X82VY" value="true" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg8F" role="1PaTwD">
+            <property role="3oM_SC" value="cell" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg8G" role="1PaTwD">
+            <property role="3oM_SC" value="now" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg8H" role="1PaTwD">
+            <property role="3oM_SC" value="checks" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg8I" role="1PaTwD">
+            <property role="3oM_SC" value="constraints" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg8J" role="1PaTwD">
+            <property role="3oM_SC" value="from" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg8K" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg8L" role="1PaTwD">
+            <property role="3oM_SC" value="containing" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg8M" role="1PaTwD">
+            <property role="3oM_SC" value="node" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg8N" role="1PaTwD">
+            <property role="3oM_SC" value="when" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg8O" role="1PaTwD">
+            <property role="3oM_SC" value="combined" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg8P" role="1PaTwD">
+            <property role="3oM_SC" value="with" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg8Q" role="1PaTwD">
+            <property role="3oM_SC" value="grammar.rule." />
+            <property role="1X82VY" value="true" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="15bmVD" id="43oF0KsR_N5" role="15bmVC">
+      <node concept="15ShDW" id="43oF0KsR_N2" role="15bq2Y">
+        <property role="15ShDY" value="Po4Z58IgAJ/July" />
+        <property role="15ShDw" value="2023" />
+      </node>
+      <node concept="15bAme" id="43oF0KsR_N3" role="15bAlL">
+        <property role="15bAli" value="Po4Z58tnOF/changed" />
+        <node concept="2DRihI" id="43oF0KsR_N4" role="15bAlk">
+          <node concept="3oM_SD" id="43oF0KsTg2s" role="1PaTwD">
+            <property role="3oM_SC" value="The" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg2u" role="1PaTwD">
+            <property role="3oM_SC" value="auto-completion" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg2v" role="1PaTwD">
+            <property role="3oM_SC" value="for" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg2w" role="1PaTwD">
+            <property role="3oM_SC" value="a" />
+          </node>
+          <node concept="15BRQy" id="1$KnWE8eBJf" role="1PaTwD">
+            <node concept="2tJFMh" id="1$KnWE8eBJh" role="15BRQ_">
+              <node concept="ZC_QK" id="1$KnWE8eXiR" role="2tJFKM">
+                <ref role="2aWVGs" to="teg0:6oKG1kMyo9t" resolve="WrapperCell" />
+              </node>
+            </node>
+          </node>
+          <node concept="3oM_SD" id="1$KnWE8eXqB" role="1PaTwD">
+            <property role="3oM_SC" value="where" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg2z" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg2$" role="1PaTwD">
+            <property role="3oM_SC" value="wrapping" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg2_" role="1PaTwD">
+            <property role="3oM_SC" value="node" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg2A" role="1PaTwD">
+            <property role="3oM_SC" value="is" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg2B" role="1PaTwD">
+            <property role="3oM_SC" value="not" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg2C" role="1PaTwD">
+            <property role="3oM_SC" value="created" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg2D" role="1PaTwD">
+            <property role="3oM_SC" value="yet," />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg2E" role="1PaTwD">
+            <property role="3oM_SC" value="shows" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg2F" role="1PaTwD">
+            <property role="3oM_SC" value="entries" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg2G" role="1PaTwD">
+            <property role="3oM_SC" value="for" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg2H" role="1PaTwD">
+            <property role="3oM_SC" value="possible" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg2I" role="1PaTwD">
+            <property role="3oM_SC" value="wrapped" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg2J" role="1PaTwD">
+            <property role="3oM_SC" value="nodes" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg2K" role="1PaTwD">
+            <property role="3oM_SC" value="with" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg2L" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg2M" role="1PaTwD">
+            <property role="3oM_SC" value="description" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg2N" role="1PaTwD">
+            <property role="3oM_SC" value="of" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg2O" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg2P" role="1PaTwD">
+            <property role="3oM_SC" value="wrapped" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg2Q" role="1PaTwD">
+            <property role="3oM_SC" value="nodes" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg2R" role="1PaTwD">
+            <property role="3oM_SC" value="concept" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg2S" role="1PaTwD">
+            <property role="3oM_SC" value="and" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg2T" role="1PaTwD">
+            <property role="3oM_SC" value="not" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg2U" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg2V" role="1PaTwD">
+            <property role="3oM_SC" value="description" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg2W" role="1PaTwD">
+            <property role="3oM_SC" value="of" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg2X" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg2Y" role="1PaTwD">
+            <property role="3oM_SC" value="wrapping" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg2Z" role="1PaTwD">
+            <property role="3oM_SC" value="nodes" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg30" role="1PaTwD">
+            <property role="3oM_SC" value="concept." />
+          </node>
+        </node>
+        <node concept="2DRihI" id="43oF0KsTg60" role="15bAlk">
+          <property role="2RT3bR" value="0" />
+          <node concept="3oM_SD" id="43oF0KsTg7M" role="1PaTwD">
+            <property role="3oM_SC" value="The" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg7N" role="1PaTwD">
+            <property role="3oM_SC" value="auto-completion" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg7O" role="1PaTwD">
+            <property role="3oM_SC" value="for" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg7P" role="1PaTwD">
+            <property role="3oM_SC" value="an" />
+          </node>
+          <node concept="15BRQy" id="1$KnWE8eXrE" role="1PaTwD">
+            <node concept="2tJFMh" id="1$KnWE8eXrG" role="15BRQ_">
+              <node concept="ZC_QK" id="1$KnWE8eXsf" role="2tJFKM">
+                <ref role="2aWVGs" to="teg0:4qdNcHzYfBo" resolve="OptionalCell" />
+              </node>
+            </node>
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg7R" role="1PaTwD">
+            <property role="3oM_SC" value="without" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg7S" role="1PaTwD">
+            <property role="3oM_SC" value="a" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg7T" role="1PaTwD">
+            <property role="3oM_SC" value="dedicated" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg7U" role="1PaTwD">
+            <property role="3oM_SC" value="description" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg7V" role="1PaTwD">
+            <property role="3oM_SC" value="shows" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg7W" role="1PaTwD">
+            <property role="3oM_SC" value="no" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg7X" role="1PaTwD">
+            <property role="3oM_SC" value="description" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg7Y" role="1PaTwD">
+            <property role="3oM_SC" value="anymore," />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg7Z" role="1PaTwD">
+            <property role="3oM_SC" value="instead" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg80" role="1PaTwD">
+            <property role="3oM_SC" value="of" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg81" role="1PaTwD">
+            <property role="3oM_SC" value="using" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg82" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg83" role="1PaTwD">
+            <property role="3oM_SC" value="description" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg84" role="1PaTwD">
+            <property role="3oM_SC" value="of" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg85" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg86" role="1PaTwD">
+            <property role="3oM_SC" value="concept" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg87" role="1PaTwD">
+            <property role="3oM_SC" value="which" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg88" role="1PaTwD">
+            <property role="3oM_SC" value="is" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg89" role="1PaTwD">
+            <property role="3oM_SC" value="using" />
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg8a" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="15BRQy" id="1$KnWE8eXtf" role="1PaTwD">
+            <node concept="2tJFMh" id="1$KnWE8eXth" role="15BRQ_">
+              <node concept="ZC_QK" id="1$KnWE8eXtQ" role="2tJFKM">
+                <ref role="2aWVGs" to="teg0:4qdNcHzYfBo" resolve="OptionalCell" />
+              </node>
+            </node>
+          </node>
+          <node concept="3oM_SD" id="43oF0KsTg8b" role="1PaTwD">
+            <property role="3oM_SC" value="." />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+


### PR DESCRIPTION
It is based on `jetbrains.mps.lang.text` and not `de.slisson.mps.richtext` and uses `com.dslfoundry.plaintextflow` for generating the Markdown file. There is some additional documentation in the inspector of the _Changelog_ concept:

<img width="768" alt="Screenshot 2024-04-28 at 23 45 38" src="https://github.com/JetBrains/MPS-extensions/assets/88385944/b7e6224b-5d87-42e2-8f99-75f72d05514f">

The generated file is currently copied to the root directory with the Gradle task _copyReadme_ which should be improved. The language supports the change headers _formats version + date_ and _month + year_:

**First format:**

<img width="1174" alt="Screenshot 2024-04-28 at 23 39 03" src="https://github.com/JetBrains/MPS-extensions/assets/88385944/8101afe9-d91b-4a54-84c7-b57afc403757">

<img width="1174" alt="Screenshot 2024-04-28 at 23 40 53" src="https://github.com/JetBrains/MPS-extensions/assets/88385944/4bcf84c5-beb5-4f60-9826-0a9c6f813d5c">

**Second format:**

<img width="1174" alt="Screenshot 2024-04-28 at 23 39 15" src="https://github.com/JetBrains/MPS-extensions/assets/88385944/41033146-319e-49cc-bc85-1073c7ec6499">