### PR TITLE
com.mbeddr.mpsutil.editor.querylist: don't force the element's concept

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The project does _not_ follow Semantic Versioning and the changes are documented
 
 - com.mbeddr.mpsutil.projectview: Class reloading of project views now works.
 - com.mbeddr.mpsutil.editor.querylist: Query lists now support model checking for non-dynamically generated nodes and `collapse by default` is generated correctly.
+- com.mbeddr.mpsutil.editor.querylist: The element's concept is not automatically forced anymore but is now rather a suggestion.
 - de.slisson.mps.reflection: To fix the compilatation issues, the language is now generated earlier in the generation plan.
 - de.slisson.mps.richtext: The duplicate action that overwrites the MPS action was added back and now duplicating lines should work again.
 

--- a/code/querylist/com.mbeddr.mpsutil.editor.querylist/generator/template/main@generator.mps
+++ b/code/querylist/com.mbeddr.mpsutil.editor.querylist/generator/template/main@generator.mps
@@ -5217,41 +5217,26 @@
                     </node>
                   </node>
                 </node>
-              </node>
-            </node>
-            <node concept="3cpWs6" id="heOoiHh" role="3cqZAp">
-              <node concept="1W57fq" id="heOoiHm" role="lGtFl">
-                <node concept="3IZrLx" id="heOoiHn" role="3IZSJc">
-                  <node concept="3clFbS" id="heOoiHo" role="2VODD2">
-                    <node concept="3clFbF" id="heOoiHp" role="3cqZAp">
-                      <node concept="3clFbC" id="heOoiHq" role="3clFbG">
-                        <node concept="10Nm6u" id="heOoiHr" role="3uHU7w" />
-                        <node concept="2OqwBi" id="hxx$VWA" role="3uHU7B">
-                          <node concept="3TrEf2" id="8dI1zL60F6" role="2OqNvi">
-                            <ref role="3Tt5mk" to="bbp5:h84_6ER" resolve="nodeFactory" />
-                          </node>
-                          <node concept="30H73N" id="heOoiHt" role="2Oq$k0" />
+                <node concept="gft3U" id="6TSlAOGKYgv" role="UU_$l">
+                  <node concept="3cpWs6" id="heOoiHh" role="gfFT$">
+                    <node concept="2YIFZM" id="3Km1Pf7cimB" role="3cqZAk">
+                      <ref role="37wK5l" to="zce0:~NodeFactoryManager.createNode(org.jetbrains.mps.openapi.model.SNode,jetbrains.mps.openapi.editor.EditorContext,java.lang.String)" resolve="createNode" />
+                      <ref role="1Pybhc" to="zce0:~NodeFactoryManager" resolve="NodeFactoryManager" />
+                      <node concept="37vLTw" id="3GM_nagTBmC" role="37wK5m">
+                        <ref role="3cqZAo" node="heOoiH0" resolve="listOwner" />
+                      </node>
+                      <node concept="37vLTw" id="2BHiRxghfAu" role="37wK5m">
+                        <ref role="3cqZAo" node="heOoiHw" resolve="editorContext" />
+                      </node>
+                      <node concept="2OqwBi" id="4glh_DcqKYP" role="37wK5m">
+                        <node concept="3nyPlj" id="3Km1Pf7cimE" role="2Oq$k0">
+                          <ref role="37wK5l" to="p9jd:~RefNodeListHandler.getElementSRole()" resolve="getElementSRole" />
+                        </node>
+                        <node concept="liA8E" id="4glh_DcqNMg" role="2OqNvi">
+                          <ref role="37wK5l" to="c17a:~SNamedElement.getName()" resolve="getName" />
                         </node>
                       </node>
                     </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="2YIFZM" id="3Km1Pf7cimB" role="3cqZAk">
-                <ref role="37wK5l" to="zce0:~NodeFactoryManager.createNode(org.jetbrains.mps.openapi.model.SNode,jetbrains.mps.openapi.editor.EditorContext,java.lang.String)" resolve="createNode" />
-                <ref role="1Pybhc" to="zce0:~NodeFactoryManager" resolve="NodeFactoryManager" />
-                <node concept="37vLTw" id="3GM_nagTBmC" role="37wK5m">
-                  <ref role="3cqZAo" node="heOoiH0" resolve="listOwner" />
-                </node>
-                <node concept="37vLTw" id="2BHiRxghfAu" role="37wK5m">
-                  <ref role="3cqZAo" node="heOoiHw" resolve="editorContext" />
-                </node>
-                <node concept="2OqwBi" id="4glh_DcqKYP" role="37wK5m">
-                  <node concept="3nyPlj" id="3Km1Pf7cimE" role="2Oq$k0">
-                    <ref role="37wK5l" to="p9jd:~RefNodeListHandler.getElementSRole()" resolve="getElementSRole" />
-                  </node>
-                  <node concept="liA8E" id="4glh_DcqNMg" role="2OqNvi">
-                    <ref role="37wK5l" to="c17a:~SNamedElement.getName()" resolve="getName" />
                   </node>
                 </node>
               </node>

--- a/code/querylist/com.mbeddr.mpsutil.editor.querylist/languageModels/behavior.mps
+++ b/code/querylist/com.mbeddr.mpsutil.editor.querylist/languageModels/behavior.mps
@@ -5,6 +5,7 @@
     <use id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior" version="2" />
     <use id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem" version="5" />
     <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
+    <use id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc" version="2" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -177,7 +178,6 @@
       <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="nn" index="3TrEf2">
         <reference id="1138056516764" name="link" index="3Tt5mk" />
       </concept>
-      <concept id="1172420572800" name="jetbrains.mps.lang.smodel.structure.ConceptNodeType" flags="in" index="3THzug" />
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
@@ -653,7 +653,6 @@
         <node concept="3cpWs8" id="C$q8A2yC7M" role="3cqZAp">
           <node concept="3cpWsn" id="C$q8A2yC7N" role="3cpWs9">
             <property role="TrG5h" value="concept" />
-            <node concept="3THzug" id="C$q8A2yC7O" role="1tU5fm" />
             <node concept="2OqwBi" id="C$q8A2yC7P" role="33vP2m">
               <node concept="37vLTw" id="C$q8A2yC7Q" role="2Oq$k0">
                 <ref role="3cqZAo" node="C$q8A2yC7F" resolve="nodeType" />
@@ -661,6 +660,9 @@
               <node concept="3TrEf2" id="C$q8A2yC7R" role="2OqNvi">
                 <ref role="3Tt5mk" to="tp25:g$ehGDh" resolve="concept" />
               </node>
+            </node>
+            <node concept="3Tqbb2" id="6TSlAOGJC9Z" role="1tU5fm">
+              <ref role="ehGHo" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
             </node>
           </node>
         </node>
@@ -675,7 +677,7 @@
       <property role="13i0iv" value="false" />
       <property role="13i0it" value="false" />
       <property role="TrG5h" value="getConceptForInlineComponent" />
-      <ref role="13i0hy" node="Op$R499ptZ" resolve="getConceptForInlineComponent" />
+      <ref role="13i0hy" node="6TSlAOGJCRe" resolve="getConceptForInlineComponent" />
       <node concept="3Tm1VV" id="Op$R499qqW" role="1B3o_S" />
       <node concept="3clFbS" id="Op$R499qqZ" role="3clF47">
         <node concept="3clFbF" id="Op$R499qwp" role="3cqZAp">
@@ -687,7 +689,9 @@
           </node>
         </node>
       </node>
-      <node concept="3THzug" id="Op$R499qr0" role="3clF45" />
+      <node concept="3Tqbb2" id="6TSlAOGJDN8" role="3clF45">
+        <ref role="ehGHo" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
+      </node>
     </node>
     <node concept="13hLZK" id="5oklODagIfC" role="13h7CW">
       <node concept="3clFbS" id="5oklODagIfD" role="2VODD2" />
@@ -1021,12 +1025,14 @@
               </node>
             </node>
             <node concept="2qgKlT" id="Op$R499s4G" role="2OqNvi">
-              <ref role="37wK5l" node="Op$R499ptZ" resolve="getConceptForInlineComponent" />
+              <ref role="37wK5l" node="6TSlAOGJCRe" resolve="getConceptForInlineComponent" />
             </node>
           </node>
         </node>
       </node>
-      <node concept="3THzug" id="6hPjX46YofF" role="3clF45" />
+      <node concept="3Tqbb2" id="6TSlAOGJHT_" role="3clF45">
+        <ref role="ehGHo" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
+      </node>
     </node>
   </node>
   <node concept="13h7C7" id="Op$R494ArD">
@@ -1142,7 +1148,7 @@
       <property role="13i0iv" value="false" />
       <property role="13i0it" value="false" />
       <property role="TrG5h" value="getConceptForInlineComponent" />
-      <ref role="13i0hy" node="Op$R499ptZ" resolve="getConceptForInlineComponent" />
+      <ref role="13i0hy" node="6TSlAOGJCRe" resolve="getConceptForInlineComponent" />
       <node concept="3Tm1VV" id="Op$R499r2L" role="1B3o_S" />
       <node concept="3clFbS" id="Op$R499r2O" role="3clF47">
         <node concept="3cpWs6" id="Op$R499rlB" role="3cqZAp">
@@ -1154,7 +1160,9 @@
           </node>
         </node>
       </node>
-      <node concept="3THzug" id="Op$R499r2P" role="3clF45" />
+      <node concept="3Tqbb2" id="6TSlAOGJGnt" role="3clF45">
+        <ref role="ehGHo" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
+      </node>
     </node>
     <node concept="13hLZK" id="Op$R496zMA" role="13h7CW">
       <node concept="3clFbS" id="Op$R496zMB" role="2VODD2" />
@@ -1165,13 +1173,15 @@
     <node concept="13hLZK" id="Op$R499ptX" role="13h7CW">
       <node concept="3clFbS" id="Op$R499ptY" role="2VODD2" />
     </node>
-    <node concept="13i0hz" id="Op$R499ptZ" role="13h7CS">
+    <node concept="13i0hz" id="6TSlAOGJCRe" role="13h7CS">
       <property role="13i0iv" value="true" />
       <property role="13i0it" value="true" />
       <property role="TrG5h" value="getConceptForInlineComponent" />
-      <node concept="3Tm1VV" id="Op$R499pu0" role="1B3o_S" />
-      <node concept="3THzug" id="Op$R499q4u" role="3clF45" />
-      <node concept="3clFbS" id="Op$R499pu2" role="3clF47" />
+      <node concept="3Tm1VV" id="6TSlAOGJCRf" role="1B3o_S" />
+      <node concept="3Tqbb2" id="6TSlAOGJCUY" role="3clF45">
+        <ref role="ehGHo" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
+      </node>
+      <node concept="3clFbS" id="6TSlAOGJCRh" role="3clF47" />
     </node>
   </node>
   <node concept="13h7C7" id="8dI1zL1C6y">

--- a/code/querylist/com.mbeddr.mpsutil.editor.querylist/languageModels/editor.mps
+++ b/code/querylist/com.mbeddr.mpsutil.editor.querylist/languageModels/editor.mps
@@ -335,7 +335,7 @@
             <property role="VOm3f" value="true" />
           </node>
           <node concept="3F0ifn" id="C$q8A2yzqr" role="3EZMnx">
-            <property role="3F0ifm" value="elements concept" />
+            <property role="3F0ifm" value="element's concept" />
             <ref role="1k5W1q" to="tpc5:hF4H1c8" resolve="property" />
           </node>
           <node concept="1iCGBv" id="C$q8A2y_cM" role="3EZMnx">

--- a/code/querylist/com.mbeddr.mpsutil.editor.querylist/languageModels/typesystem.mps
+++ b/code/querylist/com.mbeddr.mpsutil.editor.querylist/languageModels/typesystem.mps
@@ -12,6 +12,7 @@
     <import index="tpcb" ref="r:00000000-0000-4000-0000-011c89590297(jetbrains.mps.lang.editor.behavior)" />
     <import index="tpce" ref="r:00000000-0000-4000-0000-011c89590292(jetbrains.mps.lang.structure.structure)" implicit="true" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
+    <import index="tpcn" ref="r:00000000-0000-4000-0000-011c8959028b(jetbrains.mps.lang.structure.behavior)" implicit="true" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
@@ -58,14 +59,17 @@
         <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
       </concept>
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1081516740877" name="jetbrains.mps.baseLanguage.structure.NotExpression" flags="nn" index="3fqX7Q">
+        <child id="1081516765348" name="expression" index="3fr31v" />
+      </concept>
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
       <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
-      <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
     </language>
     <language id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation">
       <concept id="1196350785110" name="jetbrains.mps.lang.quotation.structure.AbstractAntiquotation" flags="ng" index="2c44t0">
@@ -77,11 +81,11 @@
       </concept>
     </language>
     <language id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem">
+      <concept id="1207055528241" name="jetbrains.mps.lang.typesystem.structure.WarningStatement" flags="nn" index="a7r0C">
+        <child id="1207055552304" name="warningText" index="a7wSD" />
+      </concept>
       <concept id="1185788614172" name="jetbrains.mps.lang.typesystem.structure.NormalTypeClause" flags="ng" index="mw_s8">
         <child id="1185788644032" name="normalType" index="mwGJk" />
-      </concept>
-      <concept id="1175517767210" name="jetbrains.mps.lang.typesystem.structure.ReportErrorStatement" flags="nn" index="2MkqsV">
-        <child id="1175517851849" name="errorString" index="2MkJ7o" />
       </concept>
       <concept id="1216383170661" name="jetbrains.mps.lang.typesystem.structure.TypesystemQuickFix" flags="ng" index="Q5z_Y">
         <child id="1216383424566" name="executeBlock" index="Q6x$H" />
@@ -105,7 +109,6 @@
         <child id="3937244445246642781" name="nodeToReport" index="1urrMF" />
       </concept>
       <concept id="1210784285454" name="jetbrains.mps.lang.typesystem.structure.TypesystemIntention" flags="ng" index="3Cnw8n">
-        <property id="1216127910019" name="applyImmediately" index="ARO6o" />
         <reference id="1216388525179" name="quickFix" index="QpYPw" />
         <child id="1210784493590" name="actualArgument" index="3Coj4f" />
       </concept>
@@ -135,14 +138,14 @@
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
       <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
       <concept id="8866923313515890008" name="jetbrains.mps.lang.smodel.structure.AsNodeOperation" flags="nn" index="FGMqu" />
+      <concept id="2644386474300074836" name="jetbrains.mps.lang.smodel.structure.ConceptIdRefExpression" flags="nn" index="35c_gC">
+        <reference id="2644386474300074837" name="conceptDeclaration" index="35c_gD" />
+      </concept>
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
         <reference id="1138405853777" name="concept" index="ehGHo" />
       </concept>
       <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="nn" index="3TrEf2">
         <reference id="1138056516764" name="link" index="3Tt5mk" />
-      </concept>
-      <concept id="1172424058054" name="jetbrains.mps.lang.smodel.structure.ConceptRefExpression" flags="nn" index="3TUQnm">
-        <reference id="1172424100906" name="conceptDeclaration" index="3TV0OU" />
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
@@ -183,11 +186,14 @@
         <node concept="3clFbS" id="3jHPIDnhgHV" role="3clFbx">
           <node concept="3clFbF" id="3jHPIDnhgYN" role="3cqZAp">
             <node concept="37vLTI" id="3jHPIDnhh3g" role="3clFbG">
-              <node concept="3TUQnm" id="3jHPIDnhh64" role="37vLTx">
-                <ref role="3TV0OU" to="tpck:gw2VY9q" resolve="BaseConcept" />
-              </node>
               <node concept="37vLTw" id="3jHPIDnhgYM" role="37vLTJ">
                 <ref role="3cqZAo" node="C$q8A2yNtq" resolve="actual" />
+              </node>
+              <node concept="2OqwBi" id="6TSlAOGL4Uo" role="37vLTx">
+                <node concept="35c_gC" id="6TSlAOGL4rj" role="2Oq$k0">
+                  <ref role="35c_gD" to="tpck:gw2VY9q" resolve="BaseConcept" />
+                </node>
+                <node concept="FGMqu" id="6TSlAOGL5pv" role="2OqNvi" />
               </node>
             </node>
           </node>
@@ -201,76 +207,55 @@
       </node>
       <node concept="3clFbJ" id="C$q8A2yMfL" role="3cqZAp">
         <node concept="3clFbS" id="C$q8A2yMfM" role="3clFbx">
-          <node concept="2MkqsV" id="C$q8A2yOMm" role="3cqZAp">
-            <node concept="3cpWs3" id="C$q8A2ySNf" role="2MkJ7o">
-              <node concept="2OqwBi" id="C$q8A2yT6B" role="3uHU7w">
-                <node concept="37vLTw" id="C$q8A2ySUI" role="2Oq$k0">
+          <node concept="a7r0C" id="6TSlAOGL4fb" role="3cqZAp">
+            <node concept="3cpWs3" id="6TSlAOGL4fd" role="a7wSD">
+              <node concept="2OqwBi" id="6TSlAOGL4fe" role="3uHU7w">
+                <node concept="37vLTw" id="6TSlAOGL4ff" role="2Oq$k0">
                   <ref role="3cqZAo" node="C$q8A2yNtq" resolve="actual" />
                 </node>
-                <node concept="2qgKlT" id="C$q8A2yTqy" role="2OqNvi">
+                <node concept="2qgKlT" id="6TSlAOGL4fg" role="2OqNvi">
                   <ref role="37wK5l" to="tpcu:hEwIO9y" resolve="getFqName" />
                 </node>
               </node>
-              <node concept="3cpWs3" id="C$q8A2ySyS" role="3uHU7B">
-                <node concept="3cpWs3" id="C$q8A2yOWD" role="3uHU7B">
-                  <node concept="Xl_RD" id="C$q8A2yOMF" role="3uHU7B">
-                    <property role="Xl_RC" value="expecting elements of type " />
-                  </node>
-                  <node concept="2OqwBi" id="C$q8A2yS4Y" role="3uHU7w">
-                    <node concept="2OqwBi" id="C$q8A2yRkz" role="2Oq$k0">
-                      <node concept="1YBJjd" id="C$q8A2yRfI" role="2Oq$k0">
-                        <ref role="1YBMHb" node="C$q8A2yAjT" resolve="node" />
-                      </node>
-                      <node concept="3TrEf2" id="C$q8A2yRIR" role="2OqNvi">
-                        <ref role="3Tt5mk" to="bbp5:C$q8A2yeI6" resolve="elementsConcept" />
-                      </node>
-                    </node>
-                    <node concept="2qgKlT" id="C$q8A2ySk1" role="2OqNvi">
-                      <ref role="37wK5l" to="tpcu:hEwIO9y" resolve="getFqName" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="Xl_RD" id="C$q8A2ySyV" role="3uHU7w">
-                  <property role="Xl_RC" value="but found " />
-                </node>
+              <node concept="Xl_RD" id="6TSlAOGL4fj" role="3uHU7B">
+                <property role="Xl_RC" value="the element's concept should be a subconcept of " />
               </node>
             </node>
-            <node concept="2OqwBi" id="C$q8A2yTAE" role="1urrMF">
-              <node concept="1YBJjd" id="C$q8A2yTtL" role="2Oq$k0">
-                <ref role="1YBMHb" node="C$q8A2yAjT" resolve="node" />
-              </node>
-              <node concept="3TrEf2" id="C$q8A2yTWG" role="2OqNvi">
-                <ref role="3Tt5mk" to="bbp5:5oklODae9g3" resolve="query" />
-              </node>
+            <node concept="1YBJjd" id="6TSlAOGL4fr" role="1urrMF">
+              <ref role="1YBMHb" node="C$q8A2yAjT" resolve="node" />
             </node>
-            <node concept="3Cnw8n" id="C$q8A2C0em" role="1urrFz">
-              <property role="ARO6o" value="true" />
+            <node concept="3Cnw8n" id="6TSlAOGL4ft" role="1urrFz">
               <ref role="QpYPw" node="C$q8A2C0nH" resolve="fixChildsConcept" />
-              <node concept="3CnSsL" id="C$q8A2C2vg" role="3Coj4f">
+              <node concept="3CnSsL" id="6TSlAOGL4fu" role="3Coj4f">
                 <ref role="QkamJ" node="C$q8A2C1LB" resolve="querylist" />
-                <node concept="1YBJjd" id="C$q8A2C2vC" role="3CoRuB">
+                <node concept="1YBJjd" id="6TSlAOGL4fv" role="3CoRuB">
                   <ref role="1YBMHb" node="C$q8A2yAjT" resolve="node" />
                 </node>
               </node>
-              <node concept="3CnSsL" id="C$q8A2C2vV" role="3Coj4f">
+              <node concept="3CnSsL" id="6TSlAOGL4fw" role="3Coj4f">
                 <ref role="QkamJ" node="C$q8A2C1Sh" resolve="concept" />
-                <node concept="37vLTw" id="C$q8A2C2yH" role="3CoRuB">
+                <node concept="37vLTw" id="6TSlAOGL4fx" role="3CoRuB">
                   <ref role="3cqZAo" node="C$q8A2yNtq" resolve="actual" />
                 </node>
               </node>
             </node>
           </node>
         </node>
-        <node concept="3y3z36" id="C$q8A2yNp0" role="3clFbw">
-          <node concept="37vLTw" id="C$q8A2yOKF" role="3uHU7w">
-            <ref role="3cqZAo" node="C$q8A2yNtq" resolve="actual" />
-          </node>
-          <node concept="2OqwBi" id="C$q8A2yMll" role="3uHU7B">
-            <node concept="1YBJjd" id="C$q8A2yMgc" role="2Oq$k0">
-              <ref role="1YBMHb" node="C$q8A2yAjT" resolve="node" />
+        <node concept="3fqX7Q" id="6TSlAOGNeRF" role="3clFbw">
+          <node concept="2OqwBi" id="6TSlAOGNeRH" role="3fr31v">
+            <node concept="37vLTw" id="6TSlAOGNeRI" role="2Oq$k0">
+              <ref role="3cqZAo" node="C$q8A2yNtq" resolve="actual" />
             </node>
-            <node concept="3TrEf2" id="C$q8A2yN6W" role="2OqNvi">
-              <ref role="3Tt5mk" to="bbp5:C$q8A2yeI6" resolve="elementsConcept" />
+            <node concept="2qgKlT" id="6TSlAOGNeRJ" role="2OqNvi">
+              <ref role="37wK5l" to="tpcn:73yVtVlWOga" resolve="isSubconceptOf" />
+              <node concept="2OqwBi" id="6TSlAOGNeRK" role="37wK5m">
+                <node concept="1YBJjd" id="6TSlAOGNeRL" role="2Oq$k0">
+                  <ref role="1YBMHb" node="C$q8A2yAjT" resolve="node" />
+                </node>
+                <node concept="3TrEf2" id="6TSlAOGNeRM" role="2OqNvi">
+                  <ref role="3Tt5mk" to="bbp5:C$q8A2yeI6" resolve="elementsConcept" />
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -327,7 +312,7 @@
               </node>
             </node>
             <node concept="Xl_RD" id="C$q8A2CyMl" role="3uHU7B">
-              <property role="Xl_RC" value="Set childs concept to " />
+              <property role="Xl_RC" value="Set Child Concept to " />
             </node>
           </node>
         </node>


### PR DESCRIPTION
The automatically applied quick fix sometimes doesn't work as intended and the editor starts flickering (maybe the type calculation is non-deterministic, I couldn't reproduce it). The element's concept can now be set on your own risk. It is used in different places in MPS but doesn't seem critical to me.