### PR TITLE
mps.conditionalEditor: removed broken model dep. in generator model

### DIFF
--- a/code/conditional-editor/languages/de.slisson.mps.conditionalEditor/generator/template/main@generator.mps
+++ b/code/conditional-editor/languages/de.slisson.mps.conditionalEditor/generator/template/main@generator.mps
@@ -27,7 +27,6 @@
     <import index="iwf0" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.descriptor(MPS.Editor/)" />
     <import index="6f4m" ref="528ff3b9-5fc4-40dd-931f-c6ce3650640e/r:f69c3fa1-0e30-4980-84e2-190ae44e4c3d(jetbrains.mps.lang.migration.runtime/jetbrains.mps.lang.migration.runtime.base)" />
     <import index="fwk" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.textgen.trace(MPS.Core/)" />
-    <import index="ao3" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.text(MPS.Core/)" />
     <import index="qvne" ref="r:8ff33705-85bf-4855-805c-06d68fbe233c(jetbrains.mps.editor.runtime.descriptor)" />
     <import index="91fu" ref="r:8d20232d-87e2-425b-b4d7-a9790e401b85(de.slisson.mps.conditionalEditor.structure)" implicit="true" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />


### PR DESCRIPTION
This broken dep. is now gone: 
<img width="352" alt="grafik" src="https://github.com/JetBrains/MPS-extensions/assets/16648247/f790b57e-622c-4804-9fbc-c69b3201fd5d">
