### PR TITLE
keep typesystem checker computation mode alive inside querylist

### DIFF
--- a/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
+++ b/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
@@ -112,7 +112,7 @@
       <concept id="8654221991637384182" name="jetbrains.mps.build.structure.BuildFileIncludesSelector" flags="ng" index="3qWCbU">
         <property id="8654221991637384184" name="pattern" index="3qWCbO" />
       </concept>
-      <concept id="4701820937132344003" name="jetbrains.mps.build.structure.BuildLayout_Container" flags="ng" index="1y1bJS">
+      <concept id="4701820937132344003" name="jetbrains.mps.build.structure.BuildLayout_Container" flags="ngI" index="1y1bJS">
         <child id="7389400916848037006" name="children" index="39821P" />
       </concept>
       <concept id="5610619299014309452" name="jetbrains.mps.build.structure.BuildSource_JavaExternalJarRef" flags="ng" index="3yrxFa">
@@ -131,7 +131,7 @@
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
-      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
     </language>
@@ -12903,82 +12903,6 @@
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="6bkzxtWPIpv" role="3bR37C">
-          <node concept="1BurEX" id="6bkzxtWPIpw" role="1SiIV1">
-            <node concept="398BVA" id="6bkzxtWPIpk" role="1BurEY">
-              <ref role="398BVh" node="2fo8bJE$D4t" resolve="extensions.code" />
-              <node concept="2Ry0Ak" id="6bkzxtWPIpl" role="iGT6I">
-                <property role="2Ry0Am" value="batik" />
-                <node concept="2Ry0Ak" id="6bkzxtWPIpm" role="2Ry0An">
-                  <property role="2Ry0Am" value="solutions" />
-                  <node concept="2Ry0Ak" id="6bkzxtWPIpn" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="6bkzxtWPIpo" role="2Ry0An">
-                      <property role="2Ry0Am" value="commons-io.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="6bkzxtWPIpG" role="3bR37C">
-          <node concept="1BurEX" id="6bkzxtWPIpH" role="1SiIV1">
-            <node concept="398BVA" id="6bkzxtWPIpx" role="1BurEY">
-              <ref role="398BVh" node="2fo8bJE$D4t" resolve="extensions.code" />
-              <node concept="2Ry0Ak" id="6bkzxtWPIpy" role="iGT6I">
-                <property role="2Ry0Am" value="batik" />
-                <node concept="2Ry0Ak" id="6bkzxtWPIpz" role="2Ry0An">
-                  <property role="2Ry0Am" value="solutions" />
-                  <node concept="2Ry0Ak" id="6bkzxtWPIp$" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="6bkzxtWPIp_" role="2Ry0An">
-                      <property role="2Ry0Am" value="commons-logging.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="6bkzxtWPIpT" role="3bR37C">
-          <node concept="1BurEX" id="6bkzxtWPIpU" role="1SiIV1">
-            <node concept="398BVA" id="6bkzxtWPIpI" role="1BurEY">
-              <ref role="398BVh" node="2fo8bJE$D4t" resolve="extensions.code" />
-              <node concept="2Ry0Ak" id="6bkzxtWPIpJ" role="iGT6I">
-                <property role="2Ry0Am" value="batik" />
-                <node concept="2Ry0Ak" id="6bkzxtWPIpK" role="2Ry0An">
-                  <property role="2Ry0Am" value="solutions" />
-                  <node concept="2Ry0Ak" id="6bkzxtWPIpL" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="6bkzxtWPIpM" role="2Ry0An">
-                      <property role="2Ry0Am" value="xml-apis-ext.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="6bkzxtWPIq6" role="3bR37C">
-          <node concept="1BurEX" id="6bkzxtWPIq7" role="1SiIV1">
-            <node concept="398BVA" id="6bkzxtWPIpV" role="1BurEY">
-              <ref role="398BVh" node="2fo8bJE$D4t" resolve="extensions.code" />
-              <node concept="2Ry0Ak" id="6bkzxtWPIpW" role="iGT6I">
-                <property role="2Ry0Am" value="batik" />
-                <node concept="2Ry0Ak" id="6bkzxtWPIpX" role="2Ry0An">
-                  <property role="2Ry0Am" value="solutions" />
-                  <node concept="2Ry0Ak" id="6bkzxtWPIpY" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="6bkzxtWPIpZ" role="2Ry0An">
-                      <property role="2Ry0Am" value="xml-apis.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
         <node concept="1SiIV0" id="6bkzxtWPIqj" role="3bR37C">
           <node concept="1BurEX" id="6bkzxtWPIqk" role="1SiIV1">
             <node concept="398BVA" id="6bkzxtWPIq8" role="1BurEY">
@@ -13938,6 +13862,11 @@
         <node concept="1SiIV0" id="76bI8XWtuxR" role="3bR37C">
           <node concept="3bR9La" id="76bI8XWtuxS" role="1SiIV1">
             <ref role="3bR37D" node="2Xjt3l57hht" resolve="de.slisson.mps.reflection.runtime" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="3E4xQE1ElQo" role="3bR37C">
+          <node concept="3bR9La" id="3E4xQE1ElQp" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:7Kfy9QB6Lh7" resolve="jetbrains.mps.typesystemEngine" />
           </node>
         </node>
       </node>

--- a/code/querylist/com.mbeddr.mpsutil.editor.querylist.demolang/languageModels/typesystem.mps
+++ b/code/querylist/com.mbeddr.mpsutil.editor.querylist.demolang/languageModels/typesystem.mps
@@ -4,7 +4,64 @@
   <languages>
     <devkit ref="00000000-0000-4000-0000-1de82b3a4936(jetbrains.mps.devkit.aspect.typesystem)" />
   </languages>
-  <imports />
-  <registry />
+  <imports>
+    <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+    </language>
+    <language id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem">
+      <concept id="1175517767210" name="jetbrains.mps.lang.typesystem.structure.ReportErrorStatement" flags="nn" index="2MkqsV">
+        <child id="1175517851849" name="errorString" index="2MkJ7o" />
+      </concept>
+      <concept id="1195213580585" name="jetbrains.mps.lang.typesystem.structure.AbstractCheckingRule" flags="ig" index="18hYwZ">
+        <child id="1195213635060" name="body" index="18ibNy" />
+      </concept>
+      <concept id="1195214364922" name="jetbrains.mps.lang.typesystem.structure.NonTypesystemRule" flags="ig" index="18kY7G">
+        <property id="7181286126212894140" name="doNotApplyOnTheFly" index="1$Xk0j" />
+      </concept>
+      <concept id="3937244445246642777" name="jetbrains.mps.lang.typesystem.structure.AbstractReportStatement" flags="ng" index="1urrMJ">
+        <child id="3937244445246642781" name="nodeToReport" index="1urrMF" />
+      </concept>
+      <concept id="1174642788531" name="jetbrains.mps.lang.typesystem.structure.ConceptReference" flags="ig" index="1YaCAy">
+        <reference id="1174642800329" name="concept" index="1YaFvo" />
+      </concept>
+      <concept id="1174648085619" name="jetbrains.mps.lang.typesystem.structure.AbstractRule" flags="ng" index="1YuPPy">
+        <child id="1174648101952" name="applicableNode" index="1YuTPh" />
+      </concept>
+      <concept id="1174650418652" name="jetbrains.mps.lang.typesystem.structure.ApplicableNodeReference" flags="nn" index="1YBJjd">
+        <reference id="1174650432090" name="applicableNode" index="1YBMHb" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="18kY7G" id="7zv1GjB9a8g">
+    <property role="TrG5h" value="nonOnTheFlyTargetRule" />
+    <property role="1$Xk0j" value="true" />
+    <node concept="3clFbS" id="7zv1GjB9a8h" role="18ibNy">
+      <node concept="2MkqsV" id="7zv1GjB9cGm" role="3cqZAp">
+        <node concept="Xl_RD" id="7zv1GjB9cGy" role="2MkJ7o">
+          <property role="Xl_RC" value="on the fly" />
+        </node>
+        <node concept="1YBJjd" id="7zv1GjB9cGZ" role="1urrMF">
+          <ref role="1YBMHb" node="7zv1GjB9cG8" resolve="localVariableDeclaration" />
+        </node>
+      </node>
+    </node>
+    <node concept="1YaCAy" id="7zv1GjB9cG8" role="1YuTPh">
+      <property role="TrG5h" value="localVariableDeclaration" />
+      <ref role="1YaFvo" to="tpee:fzcpWvJ" resolve="LocalVariableDeclaration" />
+    </node>
+  </node>
 </model>
 

--- a/code/querylist/com.mbeddr.mpsutil.editor.querylist.runtime/com.mbeddr.mpsutil.editor.querylist.runtime.msd
+++ b/code/querylist/com.mbeddr.mpsutil.editor.querylist.runtime/com.mbeddr.mpsutil.editor.querylist.runtime.msd
@@ -24,6 +24,7 @@
     <dependency reexport="false">ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)</dependency>
     <dependency reexport="false">707c4fde-f79a-44b5-b3d7-b5cef8844ccf(jetbrains.mps.lang.test.runtime)</dependency>
     <dependency reexport="false">7037b32c-9607-4f8e-81bd-1f028a4c117b(de.slisson.mps.reflection.runtime)</dependency>
+    <dependency reexport="false">20c6e580-bdc5-4067-8049-d7e3265a86de(jetbrains.mps.typesystemEngine)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:654422bf-e75f-44dc-936d-188890a746ce:de.slisson.mps.reflection" version="0" />
@@ -73,6 +74,7 @@
     <module reference="8585453e-6bfb-4d80-98de-b16074f1d86c(jetbrains.mps.lang.test)" version="0" />
     <module reference="707c4fde-f79a-44b5-b3d7-b5cef8844ccf(jetbrains.mps.lang.test.runtime)" version="0" />
     <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
+    <module reference="20c6e580-bdc5-4067-8049-d7e3265a86de(jetbrains.mps.typesystemEngine)" version="0" />
   </dependencyVersions>
 </solution>
 

--- a/code/querylist/com.mbeddr.mpsutil.editor.querylist.runtime/models/com.mbeddr.mpsutil.editor.querylist.runtime.plugin.mps
+++ b/code/querylist/com.mbeddr.mpsutil.editor.querylist.runtime/models/com.mbeddr.mpsutil.editor.querylist.runtime.plugin.mps
@@ -55,6 +55,9 @@
     <import index="jmi8" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ide.util(MPS.IDEA/)" />
     <import index="28m1" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.time(JDK/)" />
     <import index="5zyv" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util.concurrent(JDK/)" />
+    <import index="k8ev" ref="r:f39afe13-666a-48f2-9d7c-2f9366f78fe5(jetbrains.mps.typesystemEngine.checker)" />
+    <import index="ev0w" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.typechecking.backend(MPS.Core/)" />
+    <import index="ntri" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.newTypesystem.context.typechecking(MPS.Core/)" />
   </imports>
   <registry>
     <language id="28f9e497-3b42-4291-aeba-0a1039153ab1" name="jetbrains.mps.lang.plugin">
@@ -90,6 +93,9 @@
       </concept>
       <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="1732176556423009631" name="jetbrains.mps.baseLanguage.structure.MultiLineComment" flags="ng" index="2lOVwT">
+        <child id="1732176556423038857" name="lines" index="2lOMFJ" />
+      </concept>
       <concept id="8118189177080264853" name="jetbrains.mps.baseLanguage.structure.AlternativeType" flags="ig" index="nSUau">
         <child id="8118189177080264854" name="alternative" index="nSUat" />
       </concept>
@@ -99,6 +105,9 @@
       </concept>
       <concept id="1188208481402" name="jetbrains.mps.baseLanguage.structure.HasAnnotation" flags="ngI" index="2AJDlI">
         <child id="1188208488637" name="annotation" index="2AJF6D" />
+      </concept>
+      <concept id="2820489544401957797" name="jetbrains.mps.baseLanguage.structure.DefaultClassCreator" flags="nn" index="HV5vD">
+        <reference id="2820489544401957798" name="classifier" index="HV5vE" />
       </concept>
       <concept id="4678410916365116210" name="jetbrains.mps.baseLanguage.structure.DefaultModifier" flags="ng" index="2JFqV2" />
       <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
@@ -133,6 +142,10 @@
       <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
       </concept>
+      <concept id="1081256982272" name="jetbrains.mps.baseLanguage.structure.InstanceOfExpression" flags="nn" index="2ZW3vV">
+        <child id="1081256993305" name="classType" index="2ZW6by" />
+        <child id="1081256993304" name="leftExpression" index="2ZW6bz" />
+      </concept>
       <concept id="1070533707846" name="jetbrains.mps.baseLanguage.structure.StaticFieldReference" flags="nn" index="10M0yZ">
         <reference id="1144433057691" name="classifier" index="1PxDUh" />
       </concept>
@@ -164,12 +177,15 @@
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
       <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <property id="1181808852946" name="isFinal" index="DiZV1" />
         <child id="1164879685961" name="throwsItem" index="Sfmx6" />
         <child id="1068580123133" name="returnType" index="3clF45" />
         <child id="1068580123134" name="parameter" index="3clF46" />
         <child id="1068580123135" name="body" index="3clF47" />
       </concept>
-      <concept id="1068580123165" name="jetbrains.mps.baseLanguage.structure.InstanceMethodDeclaration" flags="ig" index="3clFb_" />
+      <concept id="1068580123165" name="jetbrains.mps.baseLanguage.structure.InstanceMethodDeclaration" flags="ig" index="3clFb_">
+        <property id="1178608670077" name="isAbstract" index="1EzhhJ" />
+      </concept>
       <concept id="1068580123152" name="jetbrains.mps.baseLanguage.structure.EqualsExpression" flags="nn" index="3clFbC" />
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
@@ -216,6 +232,10 @@
         <property id="521412098689998745" name="nonStatic" index="2bfB8j" />
         <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
       </concept>
+      <concept id="1171903607971" name="jetbrains.mps.baseLanguage.structure.WildCardType" flags="in" index="3qTvmN" />
+      <concept id="1171903916106" name="jetbrains.mps.baseLanguage.structure.UpperBoundType" flags="in" index="3qUE_q">
+        <child id="1171903916107" name="bound" index="3qUE_r" />
+      </concept>
       <concept id="7812454656619025412" name="jetbrains.mps.baseLanguage.structure.LocalMethodCall" flags="nn" index="1rXfSq" />
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
@@ -237,11 +257,20 @@
       <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
+      <concept id="1144226303539" name="jetbrains.mps.baseLanguage.structure.ForeachStatement" flags="nn" index="1DcWWT">
+        <child id="1144226360166" name="iterable" index="1DdaDG" />
+      </concept>
+      <concept id="1144230876926" name="jetbrains.mps.baseLanguage.structure.AbstractForStatement" flags="nn" index="1DupvO">
+        <child id="1144230900587" name="variable" index="1Duv9x" />
+      </concept>
       <concept id="1107796713796" name="jetbrains.mps.baseLanguage.structure.Interface" flags="ig" index="3HP615" />
       <concept id="5351203823916750322" name="jetbrains.mps.baseLanguage.structure.TryUniversalStatement" flags="nn" index="3J1_TO">
         <child id="8276990574886367510" name="catchClause" index="1zxBo5" />
         <child id="8276990574886367509" name="finallyClause" index="1zxBo6" />
         <child id="8276990574886367508" name="body" index="1zxBo7" />
+      </concept>
+      <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
+        <child id="8356039341262087992" name="line" index="1aUNEU" />
       </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
       <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
@@ -277,12 +306,22 @@
       </concept>
     </language>
     <language id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc">
+      <concept id="2546654756694997551" name="jetbrains.mps.baseLanguage.javadoc.structure.LinkInlineDocTag" flags="ng" index="92FcH">
+        <child id="2546654756694997556" name="reference" index="92FcQ" />
+        <child id="3106559687488913694" name="line" index="2XjZqd" />
+      </concept>
       <concept id="5349172909345501395" name="jetbrains.mps.baseLanguage.javadoc.structure.BaseDocComment" flags="ng" index="P$AiS">
         <child id="8465538089690331502" name="body" index="TZ5H$" />
       </concept>
       <concept id="5349172909345532724" name="jetbrains.mps.baseLanguage.javadoc.structure.MethodDocComment" flags="ng" index="P$JXv" />
       <concept id="8465538089690331500" name="jetbrains.mps.baseLanguage.javadoc.structure.CommentLine" flags="ng" index="TZ5HA">
         <child id="8970989240999019149" name="part" index="1dT_Ay" />
+      </concept>
+      <concept id="2217234381367530195" name="jetbrains.mps.baseLanguage.javadoc.structure.MethodDocReference" flags="ng" index="VXe0Z">
+        <reference id="2217234381367530196" name="methodDeclaration" index="VXe0S" />
+      </concept>
+      <concept id="8970989240999019145" name="jetbrains.mps.baseLanguage.javadoc.structure.InlineTagCommentLinePart" flags="ng" index="1dT_AA">
+        <child id="6962838954693749192" name="tag" index="qph3F" />
       </concept>
       <concept id="8970989240999019143" name="jetbrains.mps.baseLanguage.javadoc.structure.TextCommentLinePart" flags="ng" index="1dT_AC">
         <property id="8970989240999019144" name="text" index="1dT_AB" />
@@ -326,6 +365,21 @@
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
+      <concept id="709746936026466394" name="jetbrains.mps.lang.core.structure.ChildAttribute" flags="ng" index="3VBwX9">
+        <property id="709746936026609031" name="linkId" index="3V$3ak" />
+        <property id="709746936026609029" name="role_DebugInfo" index="3V$3am" />
+      </concept>
+      <concept id="4452961908202556907" name="jetbrains.mps.lang.core.structure.BaseCommentAttribute" flags="ng" index="1X3_iC">
+        <child id="3078666699043039389" name="commentedNode" index="8Wnug" />
+      </concept>
+    </language>
+    <language id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text">
+      <concept id="155656958578482948" name="jetbrains.mps.lang.text.structure.Word" flags="nn" index="3oM_SD">
+        <property id="155656958578482949" name="value" index="3oM_SC" />
+      </concept>
+      <concept id="2535923850359271782" name="jetbrains.mps.lang.text.structure.Line" flags="nn" index="1PaTwC">
+        <child id="2535923850359271783" name="elements" index="1PaTwD" />
+      </concept>
     </language>
     <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
       <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
@@ -365,10 +419,16 @@
       <concept id="4611582986551314327" name="jetbrains.mps.baseLanguage.collections.structure.OfTypeOperation" flags="nn" index="UnYns">
         <child id="4611582986551314344" name="requestedType" index="UnYnz" />
       </concept>
+      <concept id="1171391069720" name="jetbrains.mps.baseLanguage.collections.structure.GetIndexOfOperation" flags="nn" index="2WmjW8" />
       <concept id="1201792049884" name="jetbrains.mps.baseLanguage.collections.structure.TranslateOperation" flags="nn" index="3goQfb" />
       <concept id="1178286324487" name="jetbrains.mps.baseLanguage.collections.structure.SortDirection" flags="nn" index="1nlBCl" />
       <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
       <concept id="7125221305512719026" name="jetbrains.mps.baseLanguage.collections.structure.CollectionType" flags="in" index="3vKaQO" />
+      <concept id="1225711141656" name="jetbrains.mps.baseLanguage.collections.structure.ListElementAccessExpression" flags="nn" index="1y4W85">
+        <child id="1225711182005" name="list" index="1y566C" />
+        <child id="1225711191269" name="index" index="1y58nS" />
+      </concept>
+      <concept id="1225727723840" name="jetbrains.mps.baseLanguage.collections.structure.FindFirstOperation" flags="nn" index="1z4cxt" />
       <concept id="1202120902084" name="jetbrains.mps.baseLanguage.collections.structure.WhereOperation" flags="nn" index="3zZkjj" />
       <concept id="1202128969694" name="jetbrains.mps.baseLanguage.collections.structure.SelectOperation" flags="nn" index="3$u5V9" />
       <concept id="1172254888721" name="jetbrains.mps.baseLanguage.collections.structure.ContainsOperation" flags="nn" index="3JPx81" />
@@ -1371,10 +1431,9 @@
               </node>
               <node concept="liA8E" id="T_6DrlXBR4" role="2OqNvi">
                 <ref role="37wK5l" to="wsw7:6bXa3O$aFCh" resolve="createChecker" />
-                <node concept="2YIFZM" id="T_6DrlXBR5" role="37wK5m">
-                  <ref role="1Pybhc" to="tp6m:18jf_F1WDsS" resolve="NodeCheckerUtil" />
-                  <ref role="37wK5l" to="tp6m:fM_JX6vi$E" resolve="getStandardCheckers" />
-                  <node concept="37vLTw" id="T_6DrlXBR6" role="37wK5m">
+                <node concept="1rXfSq" id="7zv1GjB757n" role="37wK5m">
+                  <ref role="37wK5l" node="7zv1GjB757f" resolve="getCheckers" />
+                  <node concept="37vLTw" id="7zv1GjB757m" role="37wK5m">
                     <ref role="3cqZAo" node="T_6DrlXBRU" resolve="host" />
                   </node>
                 </node>
@@ -1574,6 +1633,144 @@
         <node concept="TZ5HA" id="T_6DrlXBS5" role="TZ5H$">
           <node concept="1dT_AC" id="T_6DrlXBS6" role="1dT_Ay">
             <property role="1dT_AB" value="based on NodeCheckerUtil#checkForNodeMessages" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="7zv1GjB78J2" role="jymVt" />
+    <node concept="3clFb_" id="7zv1GjB757f" role="jymVt">
+      <property role="TrG5h" value="getCheckers" />
+      <node concept="3Tm6S6" id="7zv1GjB757g" role="1B3o_S" />
+      <node concept="_YKpA" id="7zv1GjB757h" role="3clF45">
+        <node concept="3uibUv" id="7zv1GjB757i" role="_ZDj9">
+          <ref role="3uigEE" to="wsw7:4r$i1_aEwSg" resolve="IChecker" />
+          <node concept="3qTvmN" id="7zv1GjB757j" role="11_B2D" />
+          <node concept="3qUE_q" id="7zv1GjB757k" role="11_B2D">
+            <node concept="3uibUv" id="7zv1GjB757l" role="3qUE_r">
+              <ref role="3uigEE" to="d6hs:~IssueKindReportItem" resolve="IssueKindReportItem" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="7zv1GjB753q" role="3clF46">
+        <property role="TrG5h" value="host" />
+        <node concept="3uibUv" id="7zv1GjB753r" role="1tU5fm">
+          <ref role="3uigEE" to="wyuk:~ComponentHost" resolve="ComponentHost" />
+        </node>
+        <node concept="2AHcQZ" id="7zv1GjB7bR7" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="7zv1GjB753m" role="3clF47">
+        <node concept="3cpWs8" id="7zv1GjB7gfN" role="3cqZAp">
+          <node concept="3cpWsn" id="7zv1GjB7gfO" role="3cpWs9">
+            <property role="TrG5h" value="standardCheckers" />
+            <node concept="_YKpA" id="7zv1GjB7eZz" role="1tU5fm">
+              <node concept="3uibUv" id="7zv1GjB7eZO" role="_ZDj9">
+                <ref role="3uigEE" to="wsw7:4r$i1_aEwSg" resolve="IChecker" />
+                <node concept="3qTvmN" id="7zv1GjB7eZP" role="11_B2D" />
+                <node concept="3qUE_q" id="7zv1GjB7eZQ" role="11_B2D">
+                  <node concept="3uibUv" id="7zv1GjB7eZR" role="3qUE_r">
+                    <ref role="3uigEE" to="d6hs:~IssueKindReportItem" resolve="IssueKindReportItem" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="2YIFZM" id="7zv1GjB7gfP" role="33vP2m">
+              <ref role="1Pybhc" to="tp6m:18jf_F1WDsS" resolve="NodeCheckerUtil" />
+              <ref role="37wK5l" to="tp6m:fM_JX6vi$E" resolve="getStandardCheckers" />
+              <node concept="37vLTw" id="7zv1GjB7gfQ" role="37wK5m">
+                <ref role="3cqZAo" node="7zv1GjB753q" resolve="host" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="7zv1GjB7GSw" role="3cqZAp">
+          <node concept="3cpWsn" id="7zv1GjB7GSx" role="3cpWs9">
+            <property role="TrG5h" value="nonTypesystemChecker" />
+            <node concept="3uibUv" id="7zv1GjB7FDF" role="1tU5fm">
+              <ref role="3uigEE" to="wsw7:4r$i1_aEwSg" resolve="IChecker" />
+              <node concept="3qTvmN" id="7zv1GjB7FDO" role="11_B2D" />
+              <node concept="3qUE_q" id="7zv1GjB7FDP" role="11_B2D">
+                <node concept="3uibUv" id="7zv1GjB7FDQ" role="3qUE_r">
+                  <ref role="3uigEE" to="d6hs:~IssueKindReportItem" resolve="IssueKindReportItem" />
+                </node>
+              </node>
+            </node>
+            <node concept="2OqwBi" id="7zv1GjB7GSy" role="33vP2m">
+              <node concept="37vLTw" id="7zv1GjB7GSz" role="2Oq$k0">
+                <ref role="3cqZAo" node="7zv1GjB7gfO" resolve="standardCheckers" />
+              </node>
+              <node concept="1z4cxt" id="7zv1GjB7GS$" role="2OqNvi">
+                <node concept="1bVj0M" id="7zv1GjB7GS_" role="23t8la">
+                  <node concept="3clFbS" id="7zv1GjB7GSA" role="1bW5cS">
+                    <node concept="3clFbF" id="7zv1GjB7GSB" role="3cqZAp">
+                      <node concept="2ZW3vV" id="7zv1GjB7GSC" role="3clFbG">
+                        <node concept="3uibUv" id="7zv1GjB7GSD" role="2ZW6by">
+                          <ref role="3uigEE" to="k8ev:mDYNhtw$3r" resolve="NonTypesystemChecker" />
+                        </node>
+                        <node concept="37vLTw" id="7zv1GjB7GSE" role="2ZW6bz">
+                          <ref role="3cqZAo" node="7zv1GjB7GSF" resolve="it" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="gl6BB" id="7zv1GjB7GSF" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="7zv1GjB7GSG" role="1tU5fm" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="7zv1GjB7U0T" role="3cqZAp">
+          <node concept="3clFbS" id="7zv1GjB7U0V" role="3clFbx">
+            <node concept="3cpWs8" id="7zv1GjB8iNw" role="3cqZAp">
+              <node concept="3cpWsn" id="7zv1GjB8iNx" role="3cpWs9">
+                <property role="TrG5h" value="index" />
+                <node concept="10Oyi0" id="7zv1GjB8hsI" role="1tU5fm" />
+                <node concept="2OqwBi" id="7zv1GjB8iNy" role="33vP2m">
+                  <node concept="37vLTw" id="7zv1GjB8iNz" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7zv1GjB7gfO" resolve="standardCheckers" />
+                  </node>
+                  <node concept="2WmjW8" id="7zv1GjB8iN$" role="2OqNvi">
+                    <node concept="37vLTw" id="7zv1GjB8iN_" role="25WWJ7">
+                      <ref role="3cqZAo" node="7zv1GjB7GSx" resolve="nonTypesystemChecker" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="7zv1GjB8sb9" role="3cqZAp">
+              <node concept="37vLTI" id="7zv1GjB8H8f" role="3clFbG">
+                <node concept="2ShNRf" id="7zv1GjB8K_n" role="37vLTx">
+                  <node concept="HV5vD" id="7zv1GjB8Pdv" role="2ShVmc">
+                    <property role="373rjd" value="true" />
+                    <ref role="HV5vE" node="7zv1GjB3gDA" resolve="ComputationModePreservingNonTypesystemChecker" />
+                  </node>
+                </node>
+                <node concept="1y4W85" id="7zv1GjB8AUQ" role="37vLTJ">
+                  <node concept="37vLTw" id="7zv1GjB8DR_" role="1y58nS">
+                    <ref role="3cqZAo" node="7zv1GjB8iNx" resolve="index" />
+                  </node>
+                  <node concept="37vLTw" id="7zv1GjB8sb6" role="1y566C">
+                    <ref role="3cqZAo" node="7zv1GjB7gfO" resolve="standardCheckers" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3y3z36" id="7zv1GjB7ZFr" role="3clFbw">
+            <node concept="10Nm6u" id="7zv1GjB82wg" role="3uHU7w" />
+            <node concept="37vLTw" id="7zv1GjB7WW6" role="3uHU7B">
+              <ref role="3cqZAo" node="7zv1GjB7GSx" resolve="nonTypesystemChecker" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="7zv1GjB753n" role="3cqZAp">
+          <node concept="37vLTw" id="7zv1GjB7gfR" role="3cqZAk">
+            <ref role="3cqZAo" node="7zv1GjB7gfO" resolve="standardCheckers" />
           </node>
         </node>
       </node>
@@ -1947,6 +2144,467 @@
           </node>
         </node>
       </node>
+    </node>
+  </node>
+  <node concept="312cEu" id="7zv1GjB3gDA">
+    <property role="TrG5h" value="ComputationModePreservingNonTypesystemChecker" />
+    <node concept="2tJIrI" id="7zv1GjB3vd2" role="jymVt" />
+    <node concept="3clFb_" id="mDYNhtw$3w" role="jymVt">
+      <property role="1EzhhJ" value="false" />
+      <property role="TrG5h" value="getErrors" />
+      <property role="DiZV1" value="false" />
+      <node concept="3clFbS" id="mDYNhtw$3x" role="3clF47">
+        <node concept="3clFbF" id="obyZJhYbx9" role="3cqZAp">
+          <node concept="2OqwBi" id="obyZJhYd2l" role="3clFbG">
+            <node concept="2YIFZM" id="obyZJhYchv" role="2Oq$k0">
+              <ref role="37wK5l" to="1ka:~TypecheckingFacade.getFromContext()" resolve="getFromContext" />
+              <ref role="1Pybhc" to="1ka:~TypecheckingFacade" resolve="TypecheckingFacade" />
+            </node>
+            <node concept="liA8E" id="obyZJhYdUd" role="2OqNvi">
+              <ref role="37wK5l" to="ev0w:~TypecheckingSessionHandler.computeIsolated(jetbrains.mps.typechecking.TypecheckingSession$Flags,java.util.function.Function)" resolve="computeIsolated" />
+              <node concept="2OqwBi" id="obyZJhYdVA" role="37wK5m">
+                <node concept="2YIFZM" id="obyZJhYdVB" role="2Oq$k0">
+                  <ref role="37wK5l" to="1ka:~TypecheckingSession$Flags.forRoot(org.jetbrains.mps.openapi.model.SNode)" resolve="forRoot" />
+                  <ref role="1Pybhc" to="1ka:~TypecheckingSession$Flags" resolve="Flags" />
+                  <node concept="37vLTw" id="obyZJhYdVC" role="37wK5m">
+                    <ref role="3cqZAo" node="mDYNhtw$46" resolve="root" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="obyZJhYdVD" role="2OqNvi">
+                  <ref role="37wK5l" to="1ka:~TypecheckingSession$Flags.incremental()" resolve="incremental" />
+                </node>
+              </node>
+              <node concept="1bVj0M" id="obyZJhYe7r" role="37wK5m">
+                <node concept="37vLTG" id="obyZJhYebs" role="1bW2Oz">
+                  <property role="TrG5h" value="session" />
+                  <node concept="3uibUv" id="obyZJhYejU" role="1tU5fm">
+                    <ref role="3uigEE" to="1ka:~TypecheckingSession" resolve="TypecheckingSession" />
+                  </node>
+                </node>
+                <node concept="3clFbS" id="obyZJhYe7t" role="1bW5cS">
+                  <node concept="3clFbH" id="obyZJhYk3X" role="3cqZAp" />
+                  <node concept="3cpWs8" id="mDYNhtw$3y" role="3cqZAp">
+                    <node concept="3cpWsn" id="mDYNhtw$3z" role="3cpWs9">
+                      <property role="TrG5h" value="errors" />
+                      <node concept="2hMVRd" id="mDYNhtw$3$" role="1tU5fm">
+                        <node concept="3uibUv" id="mDYNhtw$3_" role="2hN53Y">
+                          <ref role="3uigEE" to="d6hs:~NodeReportItem" resolve="NodeReportItem" />
+                        </node>
+                      </node>
+                      <node concept="2ShNRf" id="mDYNhtw$3A" role="33vP2m">
+                        <node concept="2i4dXS" id="mDYNhtw$3B" role="2ShVmc">
+                          <node concept="3uibUv" id="mDYNhtw$3C" role="HW$YZ">
+                            <ref role="3uigEE" to="d6hs:~NodeReportItem" resolve="NodeReportItem" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbH" id="obyZJhYeBt" role="3cqZAp" />
+                  <node concept="3cpWs8" id="EYcDysMYbD" role="3cqZAp">
+                    <node concept="3cpWsn" id="EYcDysMYbE" role="3cpWs9">
+                      <property role="TrG5h" value="typecheckingQueries" />
+                      <node concept="3uibUv" id="EYcDysMXQu" role="1tU5fm">
+                        <ref role="3uigEE" to="1ka:~TypecheckingQueries" resolve="TypecheckingQueries" />
+                      </node>
+                      <node concept="2OqwBi" id="EYcDysMYbF" role="33vP2m">
+                        <node concept="37vLTw" id="EYcDysMYbG" role="2Oq$k0">
+                          <ref role="3cqZAo" node="obyZJhYebs" resolve="session" />
+                        </node>
+                        <node concept="liA8E" id="EYcDysMYbH" role="2OqNvi">
+                          <ref role="37wK5l" to="1ka:~TypecheckingSession.getQueries(org.jetbrains.mps.openapi.model.SNode)" resolve="getQueries" />
+                          <node concept="37vLTw" id="EYcDysMYbI" role="37wK5m">
+                            <ref role="3cqZAo" node="mDYNhtw$46" resolve="root" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3SKdUt" id="mDYNhtwSsp" role="3cqZAp">
+                    <node concept="1PaTwC" id="mDYNhtwSsq" role="1aUNEU">
+                      <node concept="3oM_SD" id="mDYNhtwSx0" role="1PaTwD">
+                        <property role="3oM_SC" value="FIXME" />
+                      </node>
+                      <node concept="3oM_SD" id="mDYNhtwSy1" role="1PaTwD">
+                        <property role="3oM_SC" value="" />
+                      </node>
+                      <node concept="3oM_SD" id="mDYNhtwSx2" role="1PaTwD">
+                        <property role="3oM_SC" value="assuming" />
+                      </node>
+                      <node concept="3oM_SD" id="mDYNhtwSx5" role="1PaTwD">
+                        <property role="3oM_SC" value="it's" />
+                      </node>
+                      <node concept="3oM_SD" id="mDYNhtwSx9" role="1PaTwD">
+                        <property role="3oM_SC" value="safe" />
+                      </node>
+                      <node concept="3oM_SD" id="mDYNhtwSxe" role="1PaTwD">
+                        <property role="3oM_SC" value="to" />
+                      </node>
+                      <node concept="3oM_SD" id="mDYNhtwSxk" role="1PaTwD">
+                        <property role="3oM_SC" value="access" />
+                      </node>
+                      <node concept="3oM_SD" id="mDYNhtwSxr" role="1PaTwD">
+                        <property role="3oM_SC" value="the" />
+                      </node>
+                      <node concept="3oM_SD" id="mDYNhtwSxz" role="1PaTwD">
+                        <property role="3oM_SC" value="underlying" />
+                      </node>
+                      <node concept="3oM_SD" id="mDYNhtwSxG" role="1PaTwD">
+                        <property role="3oM_SC" value="legacy" />
+                      </node>
+                      <node concept="3oM_SD" id="mDYNhtwSxQ" role="1PaTwD">
+                        <property role="3oM_SC" value="provider" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3cpWs8" id="mDYNhtwSk_" role="3cqZAp">
+                    <node concept="3cpWsn" id="mDYNhtwSkA" role="3cpWs9">
+                      <property role="TrG5h" value="legacyTypecheckingQueries" />
+                      <node concept="3uibUv" id="mDYNhtwSk9" role="1tU5fm">
+                        <ref role="3uigEE" to="h83j:~LegacyTypecheckingQueries" resolve="LegacyTypecheckingQueries" />
+                      </node>
+                      <node concept="2OqwBi" id="mDYNhtwSkB" role="33vP2m">
+                        <node concept="37vLTw" id="obyZJhYmGX" role="2Oq$k0">
+                          <ref role="3cqZAo" node="obyZJhYebs" resolve="session" />
+                        </node>
+                        <node concept="liA8E" id="mDYNhtwSkD" role="2OqNvi">
+                          <ref role="37wK5l" to="1ka:~TypecheckingSession.getQueries(java.lang.Class)" resolve="getQueries" />
+                          <node concept="3VsKOn" id="mDYNhtwSkE" role="37wK5m">
+                            <ref role="3VsUkX" to="h83j:~LegacyTypecheckingQueries" resolve="LegacyTypecheckingQueries" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbJ" id="EYcDysNudp" role="3cqZAp">
+                    <node concept="3clFbS" id="EYcDysNudr" role="3clFbx">
+                      <node concept="3cpWs6" id="EYcDysNDNg" role="3cqZAp">
+                        <node concept="2YIFZM" id="EYcDysNJ8D" role="3cqZAk">
+                          <ref role="37wK5l" to="33ny:~Collections.emptySet()" resolve="emptySet" />
+                          <ref role="1Pybhc" to="33ny:~Collections" resolve="Collections" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="22lmx$" id="EYcDysNyh7" role="3clFbw">
+                      <node concept="3clFbC" id="EYcDysNBcJ" role="3uHU7w">
+                        <node concept="10Nm6u" id="EYcDysNCy8" role="3uHU7w" />
+                        <node concept="37vLTw" id="EYcDysN_e3" role="3uHU7B">
+                          <ref role="3cqZAo" node="mDYNhtwSkA" resolve="legacyTypecheckingQueries" />
+                        </node>
+                      </node>
+                      <node concept="3clFbC" id="EYcDysNx5d" role="3uHU7B">
+                        <node concept="37vLTw" id="EYcDysNvwM" role="3uHU7B">
+                          <ref role="3cqZAo" node="EYcDysMYbE" resolve="typecheckingQueries" />
+                        </node>
+                        <node concept="10Nm6u" id="EYcDysNx5Y" role="3uHU7w" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3cpWs8" id="mDYNhtwT1f" role="3cqZAp">
+                    <node concept="3cpWsn" id="mDYNhtwT1g" role="3cpWs9">
+                      <property role="TrG5h" value="context" />
+                      <node concept="3uibUv" id="mDYNhtwT0Z" role="1tU5fm">
+                        <ref role="3uigEE" to="u78q:~TypeCheckingContext" resolve="TypeCheckingContext" />
+                      </node>
+                      <node concept="2OqwBi" id="mDYNhtwT1h" role="33vP2m">
+                        <node concept="37vLTw" id="mDYNhtwT1i" role="2Oq$k0">
+                          <ref role="3cqZAo" node="mDYNhtwSkA" resolve="legacyTypecheckingQueries" />
+                        </node>
+                        <node concept="liA8E" id="mDYNhtwT1j" role="2OqNvi">
+                          <ref role="37wK5l" to="h83j:~LegacyTypecheckingQueries.getTypeCheckingContext()" resolve="getTypeCheckingContext" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3cpWs8" id="mDYNhtwU2p" role="3cqZAp">
+                    <node concept="3cpWsn" id="mDYNhtwU2q" role="3cpWs9">
+                      <property role="TrG5h" value="typesComponent" />
+                      <node concept="3uibUv" id="mDYNhtwU2c" role="1tU5fm">
+                        <ref role="3uigEE" to="ntri:~IncrementalTypechecking" resolve="IncrementalTypechecking" />
+                      </node>
+                      <node concept="2OqwBi" id="mDYNhtwU2r" role="33vP2m">
+                        <node concept="37vLTw" id="mDYNhtwU2s" role="2Oq$k0">
+                          <ref role="3cqZAo" node="mDYNhtwT1g" resolve="context" />
+                        </node>
+                        <node concept="liA8E" id="mDYNhtwU2t" role="2OqNvi">
+                          <ref role="37wK5l" to="u78q:~TypeCheckingContext.getBaseNodeTypesComponent()" resolve="getBaseNodeTypesComponent" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbH" id="mDYNhtwUe$" role="3cqZAp" />
+                  <node concept="3SKdUt" id="mDYNhtwUQd" role="3cqZAp">
+                    <node concept="1PaTwC" id="mDYNhtwUQe" role="1aUNEU">
+                      <node concept="3oM_SD" id="mDYNhtwUWs" role="1PaTwD">
+                        <property role="3oM_SC" value="update" />
+                      </node>
+                      <node concept="3oM_SD" id="mDYNhtwUWu" role="1PaTwD">
+                        <property role="3oM_SC" value="the" />
+                      </node>
+                      <node concept="3oM_SD" id="mDYNhtwUWx" role="1PaTwD">
+                        <property role="3oM_SC" value="types" />
+                      </node>
+                      <node concept="3oM_SD" id="mDYNhtwUW_" role="1PaTwD">
+                        <property role="3oM_SC" value="first" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbF" id="EYcDysN4hh" role="3cqZAp">
+                    <node concept="2OqwBi" id="EYcDysN6cm" role="3clFbG">
+                      <node concept="37vLTw" id="EYcDysN4hf" role="2Oq$k0">
+                        <ref role="3cqZAo" node="EYcDysMYbE" resolve="typecheckingQueries" />
+                      </node>
+                      <node concept="liA8E" id="EYcDysN7xU" role="2OqNvi">
+                        <ref role="37wK5l" to="1ka:~TypecheckingQueries.checkRecursively(org.jetbrains.mps.openapi.model.SNode,java.util.function.Consumer)" resolve="checkRecursively" />
+                        <node concept="37vLTw" id="EYcDysNa9N" role="37wK5m">
+                          <ref role="3cqZAo" node="mDYNhtw$46" resolve="root" />
+                        </node>
+                        <node concept="1bVj0M" id="EYcDysNbCg" role="37wK5m">
+                          <node concept="37vLTG" id="EYcDysNd5l" role="1bW2Oz">
+                            <property role="TrG5h" value="nodeReportItem" />
+                            <node concept="3uibUv" id="EYcDysNemE" role="1tU5fm">
+                              <ref role="3uigEE" to="d6hs:~NodeReportItem" resolve="NodeReportItem" />
+                            </node>
+                          </node>
+                          <node concept="3clFbS" id="EYcDysNbCi" role="1bW5cS">
+                            <node concept="2lOVwT" id="EYcDysNhwL" role="3cqZAp">
+                              <node concept="1PaTwC" id="EYcDysNhwM" role="2lOMFJ">
+                                <node concept="3oM_SD" id="EYcDysNhwN" role="1PaTwD">
+                                  <property role="3oM_SC" value="NOP" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbH" id="7zv1GjB4uCK" role="3cqZAp" />
+                  <node concept="3J1_TO" id="mDYNhtwUXY" role="3cqZAp">
+                    <node concept="3clFbS" id="mDYNhtwUY0" role="1zxBo7">
+                      <node concept="3SKdUt" id="7zv1GjB4Q5g" role="3cqZAp">
+                        <node concept="1PaTwC" id="7zv1GjB4Q5h" role="1aUNEU">
+                          <node concept="3oM_SD" id="7zv1GjB51QN" role="1PaTwD">
+                            <property role="3oM_SC" value="!!!" />
+                          </node>
+                          <node concept="3oM_SD" id="7zv1GjB59kM" role="1PaTwD">
+                            <property role="3oM_SC" value="Change" />
+                          </node>
+                          <node concept="3oM_SD" id="7zv1GjB59kP" role="1PaTwD">
+                            <property role="3oM_SC" value="starts" />
+                          </node>
+                          <node concept="3oM_SD" id="7zv1GjB59kT" role="1PaTwD">
+                            <property role="3oM_SC" value="here" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="1X3_iC" id="7zv1GjB5z3i" role="lGtFl">
+                        <property role="3V$3am" value="statement" />
+                        <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+                        <node concept="3clFbF" id="mDYNhtwV4Z" role="8Wnug">
+                          <node concept="2OqwBi" id="mDYNhtwVa2" role="3clFbG">
+                            <node concept="37vLTw" id="mDYNhtwV4X" role="2Oq$k0">
+                              <ref role="3cqZAo" node="mDYNhtwT1g" resolve="context" />
+                            </node>
+                            <node concept="liA8E" id="4VpcCIwXRkf" role="2OqNvi">
+                              <ref role="37wK5l" to="u78q:~TypeCheckingContext.setNonTypesystemComputationMode(jetbrains.mps.typesystem.inference.TypeCheckingContext$NonTypesystemComputationMode)" resolve="setNonTypesystemComputationMode" />
+                              <node concept="Rm8GO" id="4VpcCIwXVON" role="37wK5m">
+                                <ref role="Rm8GQ" to="u78q:~TypeCheckingContext$NonTypesystemComputationMode.NORMAL" resolve="NORMAL" />
+                                <ref role="1Px2BO" to="u78q:~TypeCheckingContext$NonTypesystemComputationMode" resolve="NonTypesystemComputationMode" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3SKdUt" id="7zv1GjB5Uza" role="3cqZAp">
+                        <node concept="1PaTwC" id="7zv1GjB5Uzb" role="1aUNEU">
+                          <node concept="3oM_SD" id="7zv1GjB5Uzx" role="1PaTwD">
+                            <property role="3oM_SC" value="!!!" />
+                          </node>
+                          <node concept="3oM_SD" id="7zv1GjB6hOa" role="1PaTwD">
+                            <property role="3oM_SC" value="Change" />
+                          </node>
+                          <node concept="3oM_SD" id="7zv1GjB6tpr" role="1PaTwD">
+                            <property role="3oM_SC" value="ends" />
+                          </node>
+                          <node concept="3oM_SD" id="7zv1GjB6D4p" role="1PaTwD">
+                            <property role="3oM_SC" value="here" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="mDYNhtwVjM" role="3cqZAp">
+                        <node concept="2OqwBi" id="mDYNhtwV$q" role="3clFbG">
+                          <node concept="37vLTw" id="mDYNhtwVjK" role="2Oq$k0">
+                            <ref role="3cqZAo" node="mDYNhtwU2q" resolve="typesComponent" />
+                          </node>
+                          <node concept="liA8E" id="mDYNhtwWeO" role="2OqNvi">
+                            <ref role="37wK5l" to="ntri:~BaseTypechecking.applyNonTypesystemRulesToRoot(jetbrains.mps.typesystem.inference.TypeCheckingContext)" resolve="applyNonTypesystemRulesToRoot" />
+                            <node concept="37vLTw" id="mDYNhtwWhq" role="37wK5m">
+                              <ref role="3cqZAo" node="mDYNhtwT1g" resolve="context" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="1wplmZ" id="xvs04dGAo_" role="1zxBo6">
+                      <node concept="3clFbS" id="mDYNhtwUY1" role="1wplMD">
+                        <node concept="3clFbF" id="4VpcCIwXWAI" role="3cqZAp">
+                          <node concept="2OqwBi" id="4VpcCIwXWAJ" role="3clFbG">
+                            <node concept="37vLTw" id="4VpcCIwXWAK" role="2Oq$k0">
+                              <ref role="3cqZAo" node="mDYNhtwT1g" resolve="context" />
+                            </node>
+                            <node concept="liA8E" id="4VpcCIwXWAL" role="2OqNvi">
+                              <ref role="37wK5l" to="u78q:~TypeCheckingContext.setNonTypesystemComputationMode(jetbrains.mps.typesystem.inference.TypeCheckingContext$NonTypesystemComputationMode)" resolve="setNonTypesystemComputationMode" />
+                              <node concept="Rm8GO" id="4VpcCIwXYKa" role="37wK5m">
+                                <ref role="Rm8GQ" to="u78q:~TypeCheckingContext$NonTypesystemComputationMode.OFF" resolve="OFF" />
+                                <ref role="1Px2BO" to="u78q:~TypeCheckingContext$NonTypesystemComputationMode" resolve="NonTypesystemComputationMode" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbH" id="mDYNhtwXjO" role="3cqZAp" />
+                  <node concept="3cpWs8" id="mDYNhtwYBx" role="3cqZAp">
+                    <node concept="3cpWsn" id="mDYNhtwYBy" role="3cpWs9">
+                      <property role="TrG5h" value="nodesWithErrors" />
+                      <node concept="3uibUv" id="mDYNhtwYAZ" role="1tU5fm">
+                        <ref role="3uigEE" to="33ny:~Set" resolve="Set" />
+                        <node concept="3uibUv" id="mDYNhtwYBg" role="11_B2D">
+                          <ref role="3uigEE" to="18ew:~Pair" resolve="Pair" />
+                          <node concept="3uibUv" id="mDYNhtwYBh" role="11_B2D">
+                            <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
+                          </node>
+                          <node concept="3uibUv" id="mDYNhtwYBi" role="11_B2D">
+                            <ref role="3uigEE" to="33ny:~List" resolve="List" />
+                            <node concept="3uibUv" id="mDYNhtwYBj" role="11_B2D">
+                              <ref role="3uigEE" to="2gg1:~IErrorReporter" resolve="IErrorReporter" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="2OqwBi" id="mDYNhtwYBz" role="33vP2m">
+                        <node concept="37vLTw" id="mDYNhtwYB$" role="2Oq$k0">
+                          <ref role="3cqZAo" node="mDYNhtwT1g" resolve="context" />
+                        </node>
+                        <node concept="liA8E" id="mDYNhtwYB_" role="2OqNvi">
+                          <ref role="37wK5l" to="u78q:~TypeCheckingContext.getNodesWithErrors(boolean)" resolve="getNodesWithErrors" />
+                          <node concept="3clFbT" id="mDYNhtwYBA" role="37wK5m" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="1DcWWT" id="mDYNhtwYVQ" role="3cqZAp">
+                    <node concept="3clFbS" id="mDYNhtwYVT" role="2LFqv$">
+                      <node concept="1DcWWT" id="mDYNhtx1OE" role="3cqZAp">
+                        <node concept="3clFbS" id="mDYNhtx1OH" role="2LFqv$">
+                          <node concept="3clFbF" id="mDYNhtwZVE" role="3cqZAp">
+                            <node concept="2OqwBi" id="mDYNhtx0pm" role="3clFbG">
+                              <node concept="37vLTw" id="mDYNhtwZVD" role="2Oq$k0">
+                                <ref role="3cqZAo" node="mDYNhtw$3z" resolve="errors" />
+                              </node>
+                              <node concept="TSZUe" id="mDYNhtx0Sf" role="2OqNvi">
+                                <node concept="2ShNRf" id="mDYNhtx2Br" role="25WWJ7">
+                                  <node concept="1pGfFk" id="mDYNhtx5$i" role="2ShVmc">
+                                    <ref role="37wK5l" to="d6hs:~TypesystemReportItemAdapter.&lt;init&gt;(jetbrains.mps.errors.IErrorReporter)" resolve="TypesystemReportItemAdapter" />
+                                    <node concept="37vLTw" id="mDYNhtx5Rm" role="37wK5m">
+                                      <ref role="3cqZAo" node="mDYNhtx1OI" resolve="ier" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3cpWsn" id="mDYNhtx1OI" role="1Duv9x">
+                          <property role="TrG5h" value="ier" />
+                          <node concept="3uibUv" id="mDYNhtx1OM" role="1tU5fm">
+                            <ref role="3uigEE" to="2gg1:~IErrorReporter" resolve="IErrorReporter" />
+                          </node>
+                        </node>
+                        <node concept="2OqwBi" id="mDYNhtx1ON" role="1DdaDG">
+                          <node concept="37vLTw" id="mDYNhtx1OO" role="2Oq$k0">
+                            <ref role="3cqZAo" node="mDYNhtwYVU" resolve="p" />
+                          </node>
+                          <node concept="2OwXpG" id="mDYNhtx1OP" role="2OqNvi">
+                            <ref role="2Oxat5" to="18ew:~Pair.o2" resolve="o2" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3cpWsn" id="mDYNhtwYVU" role="1Duv9x">
+                      <property role="TrG5h" value="p" />
+                      <node concept="3uibUv" id="mDYNhtwYVY" role="1tU5fm">
+                        <ref role="3uigEE" to="18ew:~Pair" resolve="Pair" />
+                        <node concept="3uibUv" id="mDYNhtwYVZ" role="11_B2D">
+                          <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
+                        </node>
+                        <node concept="3uibUv" id="mDYNhtwYW0" role="11_B2D">
+                          <ref role="3uigEE" to="33ny:~List" resolve="List" />
+                          <node concept="3uibUv" id="mDYNhtwYW1" role="11_B2D">
+                            <ref role="3uigEE" to="2gg1:~IErrorReporter" resolve="IErrorReporter" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="37vLTw" id="mDYNhtwYW2" role="1DdaDG">
+                      <ref role="3cqZAo" node="mDYNhtwYBy" resolve="nodesWithErrors" />
+                    </node>
+                  </node>
+                  <node concept="3clFbH" id="mDYNhtw$43" role="3cqZAp" />
+                  <node concept="3cpWs6" id="mDYNhtw$44" role="3cqZAp">
+                    <node concept="37vLTw" id="mDYNhtw$45" role="3cqZAk">
+                      <ref role="3cqZAo" node="mDYNhtw$3z" resolve="errors" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="mDYNhtw$46" role="3clF46">
+        <property role="TrG5h" value="root" />
+        <node concept="3uibUv" id="mDYNhtw$47" role="1tU5fm">
+          <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="mDYNhtw$48" role="3clF46">
+        <property role="TrG5h" value="repository" />
+        <node concept="3uibUv" id="mDYNhtw$49" role="1tU5fm">
+          <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="mDYNhtw$4a" role="1B3o_S" />
+      <node concept="2hMVRd" id="mDYNhtw$4b" role="3clF45">
+        <node concept="3uibUv" id="mDYNhtw$4c" role="2hN53Y">
+          <ref role="3uigEE" to="d6hs:~NodeReportItem" resolve="NodeReportItem" />
+        </node>
+      </node>
+      <node concept="P$JXv" id="7zv1GjB3Nt_" role="lGtFl">
+        <node concept="TZ5HA" id="7zv1GjB3NtA" role="TZ5H$">
+          <node concept="1dT_AC" id="7zv1GjB3NtB" role="1dT_Ay">
+            <property role="1dT_AB" value="Copy of " />
+          </node>
+          <node concept="1dT_AA" id="7zv1GjB3Zem" role="1dT_Ay">
+            <node concept="92FcH" id="7zv1GjB3ZeG" role="qph3F">
+              <node concept="TZ5HA" id="7zv1GjB3ZeI" role="2XjZqd" />
+              <node concept="VXe0Z" id="7zv1GjB4g$_" role="92FcQ">
+                <ref role="VXe0S" to="k8ev:mDYNhtw$3w" resolve="getErrors" />
+              </node>
+            </node>
+          </node>
+          <node concept="1dT_AC" id="7zv1GjB3Zel" role="1dT_Ay">
+            <property role="1dT_AB" value="" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="7zv1GjB3vdA" role="jymVt" />
+    <node concept="3Tm1VV" id="7zv1GjB3gDB" role="1B3o_S" />
+    <node concept="3uibUv" id="7zv1GjB3gYc" role="1zkMxy">
+      <ref role="3uigEE" to="k8ev:mDYNhtw$3r" resolve="NonTypesystemChecker" />
     </node>
   </node>
 </model>

--- a/code/solutions/de.itemis.mps.extensions.changelog/models/de.itemis.mps.extensions.changelog.mps
+++ b/code/solutions/de.itemis.mps.extensions.changelog/models/de.itemis.mps.extensions.changelog.mps
@@ -73,13 +73,13 @@
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
-      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
     </language>
     <language id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text">
       <concept id="1094247804558289146" name="jetbrains.mps.lang.text.structure.BulletLine" flags="ng" index="2DRihI" />
-      <concept id="5106752179536586436" name="jetbrains.mps.lang.text.structure.IndentedPoint" flags="ng" index="2RT3b8">
+      <concept id="5106752179536586436" name="jetbrains.mps.lang.text.structure.IndentedPoint" flags="ngI" index="2RT3b8">
         <property id="5106752179536586491" name="indentation" index="2RT3bR" />
       </concept>
       <concept id="155656958578482948" name="jetbrains.mps.lang.text.structure.Word" flags="nn" index="3oM_SD">
@@ -294,6 +294,50 @@
           </node>
           <node concept="3oM_SD" id="76bI8XWtwjj" role="1PaTwD">
             <property role="3oM_SC" value="anymore." />
+          </node>
+        </node>
+        <node concept="2DRihI" id="3E4xQE1Em8e" role="15bAlk">
+          <node concept="2hgSXJ" id="3E4xQE1Em8f" role="1PaTwD">
+            <node concept="1PaTwC" id="3E4xQE1Em8g" role="2hiFM$">
+              <node concept="15Ami3" id="3E4xQE1Em8h" role="1PaTwD">
+                <node concept="37shsh" id="3E4xQE1Em8i" role="15Aodc">
+                  <node concept="1dCxOk" id="3E4xQE1Em9j" role="37shsm">
+                    <property role="1XweGW" value="94b17d5e-87d9-4868-8101-157e83e33243" />
+                    <property role="1XxBO9" value="com.mbeddr.mpsutil.editor.querylist.runtime" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3oM_SD" id="3E4xQE1Em8k" role="1PaTwD">
+                <property role="3oM_SC" value=":" />
+              </node>
+            </node>
+          </node>
+          <node concept="3oM_SD" id="3E4xQE1Em8l" role="1PaTwD">
+            <property role="3oM_SC" value="Querylist" />
+          </node>
+          <node concept="3oM_SD" id="3E4xQE1Ema7" role="1PaTwD">
+            <property role="3oM_SC" value="calls" />
+          </node>
+          <node concept="3oM_SD" id="3E4xQE1Emau" role="1PaTwD">
+            <property role="3oM_SC" value="model" />
+          </node>
+          <node concept="3oM_SD" id="3E4xQE1EmaQ" role="1PaTwD">
+            <property role="3oM_SC" value="checks" />
+          </node>
+          <node concept="3oM_SD" id="3E4xQE1Embf" role="1PaTwD">
+            <property role="3oM_SC" value="of" />
+          </node>
+          <node concept="3oM_SD" id="3E4xQE1EmbD" role="1PaTwD">
+            <property role="3oM_SC" value="target" />
+          </node>
+          <node concept="3oM_SD" id="3E4xQE1Emc4" role="1PaTwD">
+            <property role="3oM_SC" value="nodes" />
+          </node>
+          <node concept="3oM_SD" id="3E4xQE1Emcw" role="1PaTwD">
+            <property role="3oM_SC" value="less" />
+          </node>
+          <node concept="3oM_SD" id="3E4xQE1Emi6" role="1PaTwD">
+            <property role="3oM_SC" value="agressively." />
           </node>
         </node>
       </node>


### PR DESCRIPTION
Found another performance issue with querylist model checking: It doesn't preserve the `TypeCheckingContext.NonTypesystemComputationMode`. If we have (expensive) checks marked as `do not apply on the fly: true`, they were still executed by querylist.

Unfortunately, I didn't find a better way than to duplicate most of `NonTypesystemChecker.getErrors()`.