### PR TITLE
editor.diagram: add a new option to allow boxes to set a new required minimum size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is *loosely* based on [Keep a Changelog](https://keepachangelog.com/e
 
 ### Added
 
+- *de.itemis.mps.editor.diagram*: A new option for diagrams was added to allow boxes to set a new required minimum size.
 - *de.slisson.mps.editor.multiline*: A new cell *constant multi-line* can be used to create dynamic read-only text that spans multiple lines.
 
 ### Fixed

--- a/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
+++ b/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
@@ -20850,6 +20850,11 @@
             <ref role="3bR37D" node="4be$WTb1AQa" resolve="de.itemis.mps.editor.diagram.runtime" />
           </node>
         </node>
+        <node concept="1SiIV0" id="4Dfm9e0q5f" role="3bR37C">
+          <node concept="3bR9La" id="4Dfm9e0q5g" role="1SiIV1">
+            <ref role="3bR37D" node="1sO539bGQvB" resolve="de.slisson.mps.richtext" />
+          </node>
+        </node>
       </node>
       <node concept="1E1JtA" id="6$6tsX_CJdr" role="2G$12L">
         <property role="BnDLt" value="true" />
@@ -21158,6 +21163,11 @@
         <node concept="1SiIV0" id="1mqidcyBhlq" role="3bR37C">
           <node concept="3bR9La" id="1mqidcyBhlr" role="1SiIV1">
             <ref role="3bR37D" node="6$6tsX_CISo" resolve="test.de.itemis.mps.editor.diagram.lang" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="4Dfm9e0q6Y" role="3bR37C">
+          <node concept="3bR9La" id="4Dfm9e0q6Z" role="1SiIV1">
+            <ref role="3bR37D" node="1sO539bGQvB" resolve="de.slisson.mps.richtext" />
           </node>
         </node>
       </node>

--- a/code/diagram/languages/de.itemis.mps.editor.diagram.demoentities/de.itemis.mps.editor.diagram.demoentities.mpl
+++ b/code/diagram/languages/de.itemis.mps.editor.diagram.demoentities/de.itemis.mps.editor.diagram.demoentities.mpl
@@ -18,6 +18,7 @@
     <dependency reexport="false">f7ad14aa-a3e2-4301-8822-d919845c8bcf(de.itemis.mps.editor.diagram.shapes)</dependency>
     <dependency reexport="false">fa13cc63-c476-4d46-9c96-d53670abe7bc(de.itemis.mps.editor.diagram)</dependency>
     <dependency reexport="false">aff569ad-098d-414a-aa23-96963959392c(test.de.itemis.mps.editor.diagram.lang)</dependency>
+    <dependency reexport="false">92d2ea16-5a42-4fdf-a676-c7604efe3504(de.slisson.mps.richtext)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:fa13cc63-c476-4d46-9c96-d53670abe7bc:de.itemis.mps.editor.diagram" version="1" />
@@ -79,8 +80,11 @@
     <module reference="56c81845-acaf-48a7-bcd8-e29b36c98dd7(de.itemis.mps.editor.diagram.styles)" version="0" />
     <module reference="21063c66-85ba-4e98-839b-036445b17ae2(de.itemis.mps.editor.layout)" version="0" />
     <module reference="5c13c612-0f7b-4f0a-ab8b-565186b418de(de.itemis.mps.mouselistener.runtime)" version="0" />
+    <module reference="cce85e64-7b37-4ad5-b0e6-9d18324cdfb3(de.itemis.mps.selection.runtime)" version="0" />
     <module reference="0022e9df-2136-4ef8-81b2-08650aeb1dc7(de.itemis.mps.tooltips.runtime)" version="0" />
+    <module reference="dc038ceb-b7ea-4fea-ac12-55f7400e97ba(de.slisson.mps.editor.multiline.runtime)" version="0" />
     <module reference="f0fff802-6d26-4d2e-b89d-391357265626(de.slisson.mps.hacks.editor)" version="0" />
+    <module reference="92d2ea16-5a42-4fdf-a676-c7604efe3504(de.slisson.mps.richtext)" version="0" />
     <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
     <module reference="443f4c36-fcf5-4eb6-9500-8d06ed259e3e(jetbrains.mps.baseLanguage.classifiers)" version="0" />
     <module reference="fd392034-7849-419d-9071-12563d152375(jetbrains.mps.baseLanguage.closures)" version="0" />

--- a/code/diagram/languages/de.itemis.mps.editor.diagram.demoentities/languageModels/editor.mps
+++ b/code/diagram/languages/de.itemis.mps.editor.diagram.demoentities/languageModels/editor.mps
@@ -13,6 +13,7 @@
     <import index="guwi" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.io(JDK/)" />
     <import index="tc27" ref="r:92d28f3c-6acc-431a-94ba-30cd184d2da4(de.itemis.mps.editor.diagram.runtime.substitute)" />
     <import index="wo6c" ref="r:de91083f-90a8-4dd4-83b1-8a92d65ab81d(de.itemis.mps.editor.diagram.shapes)" />
+    <import index="vgho" ref="1144260c-e9a5-49a2-9add-39a1a1a7077e/java:org.eclipse.elk.core.math(de.itemis.mps.editor.diagram.runtime/)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
     <import index="88j9" ref="r:20c4aa5c-ab36-4815-af32-01895ee9c2f5(de.itemis.mps.editor.diagram.editor)" implicit="true" />
     <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" implicit="true" />
@@ -32,6 +33,7 @@
       <concept id="1106270549637" name="jetbrains.mps.lang.editor.structure.CellLayout_Horizontal" flags="nn" index="2iRfu4" />
       <concept id="1106270571710" name="jetbrains.mps.lang.editor.structure.CellLayout_Vertical" flags="nn" index="2iRkQZ" />
       <concept id="1142886221719" name="jetbrains.mps.lang.editor.structure.QueryFunction_NodeCondition" flags="in" index="pkWqt" />
+      <concept id="1142886811589" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameter_node" flags="nn" index="pncrf" />
       <concept id="4242538589859161874" name="jetbrains.mps.lang.editor.structure.ExplicitHintsSpecification" flags="ng" index="2w$q5c">
         <child id="4242538589859162459" name="hints" index="2w$qW5" />
       </concept>
@@ -51,6 +53,9 @@
       </concept>
       <concept id="1186414860679" name="jetbrains.mps.lang.editor.structure.EditableStyleClassItem" flags="ln" index="VPxyj" />
       <concept id="1186414928363" name="jetbrains.mps.lang.editor.structure.SelectableStyleSheetItem" flags="ln" index="VPM3Z" />
+      <concept id="1186415722038" name="jetbrains.mps.lang.editor.structure.FontSizeStyleClassItem" flags="ln" index="VSNWy">
+        <property id="1221209241505" name="value" index="1lJzqX" />
+      </concept>
       <concept id="1233758997495" name="jetbrains.mps.lang.editor.structure.PunctuationLeftStyleClassItem" flags="ln" index="11L4FC" />
       <concept id="1233759184865" name="jetbrains.mps.lang.editor.structure.PunctuationRightStyleClassItem" flags="ln" index="11LMrY" />
       <concept id="1088013125922" name="jetbrains.mps.lang.editor.structure.CellModel_RefCell" flags="sg" stub="730538219795941030" index="1iCGBv">
@@ -64,6 +69,9 @@
       </concept>
       <concept id="1139848536355" name="jetbrains.mps.lang.editor.structure.CellModel_WithRole" flags="ng" index="1$h60E">
         <reference id="1140103550593" name="relationDeclaration" index="1NtTu8" />
+      </concept>
+      <concept id="1073389214265" name="jetbrains.mps.lang.editor.structure.EditorCellModel" flags="ng" index="3EYTF0">
+        <child id="1142887637401" name="renderingCondition" index="pqm2j" />
       </concept>
       <concept id="1073389446423" name="jetbrains.mps.lang.editor.structure.CellModel_Collection" flags="sn" stub="3013115976261988961" index="3EZMnI">
         <child id="1106270802874" name="cellLayout" index="2iSdaV" />
@@ -210,6 +218,7 @@
         <child id="8433227566816393050" name="layoutAlgorithm" index="35U2g" />
         <child id="1742468285817538342" name="disableNodeEditing" index="2gDVEa" />
         <child id="53713348769907228" name="autoLayoutOnChange" index="2hB_ot" />
+        <child id="2060885462441433843" name="allowElementsBelowRequiredSize" index="2F3Mqr" />
         <child id="8637411062076630380" name="connectionTypes" index="1xLlFP" />
         <child id="7858611447550199305" name="syncWithModelOnlyOnOpening" index="3y0MdK" />
         <child id="8637411062062914773" name="paletteFolder" index="1y_2dc" />
@@ -282,6 +291,7 @@
         <child id="1177027386292" name="conceptArgument" index="cj9EA" />
       </concept>
       <concept id="1171999116870" name="jetbrains.mps.lang.smodel.structure.Node_IsNullOperation" flags="nn" index="3w_OXm" />
+      <concept id="1172008320231" name="jetbrains.mps.lang.smodel.structure.Node_IsNotNullOperation" flags="nn" index="3x8VRR" />
       <concept id="1144101972840" name="jetbrains.mps.lang.smodel.structure.OperationParm_Concept" flags="ng" index="1xMEDy">
         <child id="1207343664468" name="conceptArgument" index="ri$Ld" />
       </concept>
@@ -412,6 +422,15 @@
         </node>
         <node concept="2iRfu4" id="4_qW8fWLeFi" role="2iSdaV" />
       </node>
+      <node concept="3EZMnI" id="4B5Ce8Kz3aX" role="3EZMnx">
+        <node concept="2iRfu4" id="4B5Ce8Kz3aY" role="2iSdaV" />
+        <node concept="3F0ifn" id="4B5Ce8Kz3aW" role="3EZMnx">
+          <property role="3F0ifm" value="additional description" />
+        </node>
+        <node concept="3F1sOY" id="4B5Ce8Kz3b0" role="3EZMnx">
+          <ref role="1NtTu8" to="g93z:4B5Ce8Kz36j" resolve="additionalDescription" />
+        </node>
+      </node>
       <node concept="3F0ifn" id="4_qW8fWLeFT" role="3EZMnx">
         <property role="3F0ifm" value="}" />
       </node>
@@ -476,6 +495,27 @@
               <node concept="3F2HdR" id="6OfpnAgaO4B" role="3EZMnx">
                 <ref role="1NtTu8" to="g93z:4_qW8fWLenL" resolve="attributes" />
                 <node concept="2iRkQZ" id="6OfpnAgaO4D" role="2czzBx" />
+              </node>
+            </node>
+            <node concept="3F1sOY" id="4B5Ce8Kz4$3" role="3EZMnx">
+              <ref role="1NtTu8" to="g93z:4B5Ce8Kz36j" resolve="additionalDescription" />
+              <node concept="pkWqt" id="4B5Ce8Kz4$5" role="pqm2j">
+                <node concept="3clFbS" id="4B5Ce8Kz4$6" role="2VODD2">
+                  <node concept="3clFbF" id="4B5Ce8Kz4$z" role="3cqZAp">
+                    <node concept="2OqwBi" id="4B5Ce8Kz5EV" role="3clFbG">
+                      <node concept="2OqwBi" id="4B5Ce8Kz4LP" role="2Oq$k0">
+                        <node concept="pncrf" id="4B5Ce8Kz4$y" role="2Oq$k0" />
+                        <node concept="3TrEf2" id="4B5Ce8Kz5cU" role="2OqNvi">
+                          <ref role="3Tt5mk" to="g93z:4B5Ce8Kz36j" resolve="additionalDescription" />
+                        </node>
+                      </node>
+                      <node concept="3x8VRR" id="4B5Ce8Kz6E3" role="2OqNvi" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="VSNWy" id="2PdRDsXzFgU" role="3F10Kt">
+                <property role="1lJzqX" value="10" />
               </node>
             </node>
             <node concept="2iRkQZ" id="30bR1EZs_2A" role="2iSdaV" />
@@ -826,6 +866,15 @@
         <node concept="3clFbS" id="7176I12jWID" role="2VODD2">
           <node concept="3clFbF" id="7176I12jX1b" role="3cqZAp">
             <node concept="3clFbT" id="7176I12jX1a" role="3clFbG">
+              <property role="3clFbU" value="true" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="pkWqt" id="1MpJ6ySoyzK" role="2F3Mqr">
+        <node concept="3clFbS" id="1MpJ6ySoyzL" role="2VODD2">
+          <node concept="3clFbF" id="1MpJ6ySoyON" role="3cqZAp">
+            <node concept="3clFbT" id="1MpJ6ySoyOM" role="3clFbG">
               <property role="3clFbU" value="true" />
             </node>
           </node>

--- a/code/diagram/languages/de.itemis.mps.editor.diagram.demoentities/languageModels/structure.mps
+++ b/code/diagram/languages/de.itemis.mps.editor.diagram.demoentities/languageModels/structure.mps
@@ -6,6 +6,7 @@
     <devkit ref="78434eb8-b0e5-444b-850d-e7c4ad2da9ab(jetbrains.mps.devkit.aspect.structure)" />
   </languages>
   <imports>
+    <import index="87nw" ref="r:ca2ab6bb-f6e7-4c0f-a88c-b78b9b31fff3(de.slisson.mps.richtext.structure)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
   </imports>
   <registry>
@@ -76,6 +77,12 @@
       <property role="20lbJX" value="fLJekj5/_0__n" />
       <property role="IQ2ns" value="5285801562344842739" />
       <ref role="20lvS9" node="4_qW8fWLecz" resolve="Reference" />
+    </node>
+    <node concept="1TJgyj" id="4B5Ce8Kz36j" role="1TKVEi">
+      <property role="IQ2ns" value="5315831828518285715" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="additionalDescription" />
+      <ref role="20lvS9" to="87nw:2dWzqxEB$Tx" resolve="Text" />
     </node>
     <node concept="PrWs8" id="4_qW8fWLenZ" role="PzmwI">
       <ref role="PrY4T" to="tpck:h0TrEE$" resolve="INamedConcept" />

--- a/code/diagram/languages/de.itemis.mps.editor.diagram/generator/template/main@generator.mps
+++ b/code/diagram/languages/de.itemis.mps.editor.diagram/generator/template/main@generator.mps
@@ -6137,6 +6137,31 @@
                                                   </node>
                                                 </node>
                                                 <node concept="2tJIrI" id="6OfpnAf3bW4" role="jymVt" />
+                                                <node concept="3clFb_" id="1MpJ6yS8Td9" role="jymVt">
+                                                  <property role="TrG5h" value="allowElementsBelowRequiredSize" />
+                                                  <node concept="3clFbS" id="1MpJ6yS8Tda" role="3clF47">
+                                                    <node concept="3cpWs6" id="1MpJ6yS8Tdb" role="3cqZAp">
+                                                      <node concept="3clFbT" id="1MpJ6yS8Tdc" role="3cqZAk" />
+                                                    </node>
+                                                  </node>
+                                                  <node concept="3Tm6S6" id="1MpJ6yS8Tdd" role="1B3o_S" />
+                                                  <node concept="10P_77" id="1MpJ6yS8Tde" role="3clF45" />
+                                                  <node concept="29HgVG" id="1MpJ6yS8Tdf" role="lGtFl">
+                                                    <node concept="3NFfHV" id="1MpJ6yS8Tdg" role="3NFExx">
+                                                      <node concept="3clFbS" id="1MpJ6yS8Tdh" role="2VODD2">
+                                                        <node concept="3clFbF" id="1MpJ6yS8Tdi" role="3cqZAp">
+                                                          <node concept="2OqwBi" id="1MpJ6yS8Tdj" role="3clFbG">
+                                                            <node concept="30H73N" id="1MpJ6yS8Tdk" role="2Oq$k0" />
+                                                            <node concept="3TrEf2" id="1MpJ6yS8Tdl" role="2OqNvi">
+                                                              <ref role="3Tt5mk" to="2qld:1MpJ6yR_DFN" resolve="allowElementsBelowRequiredSize" />
+                                                            </node>
+                                                          </node>
+                                                        </node>
+                                                      </node>
+                                                    </node>
+                                                  </node>
+                                                </node>
+                                                <node concept="2tJIrI" id="1MpJ6yS8QN5" role="jymVt" />
                                                 <node concept="3clFb_" id="4m$$SBGcTQF" role="jymVt">
                                                   <property role="TrG5h" value="runAutoLayoutOnInit" />
                                                   <node concept="3clFbS" id="4m$$SBGcTQI" role="3clF47">
@@ -6531,6 +6556,77 @@
                                                   </node>
                                                 </node>
                                                 <node concept="2tJIrI" id="6OfpnAf4i_w" role="jymVt" />
+                                                <node concept="3clFb_" id="1MpJ6yS9irN" role="jymVt">
+                                                  <property role="TrG5h" value="allowElementsToBeBelowRequiredSize" />
+                                                  <node concept="3clFbS" id="1MpJ6yS9irO" role="3clF47">
+                                                    <node concept="3cpWs8" id="1MpJ6yS9irP" role="3cqZAp">
+                                                      <node concept="3cpWsn" id="1MpJ6yS9irQ" role="3cpWs9">
+                                                        <property role="TrG5h" value="flag" />
+                                                        <node concept="10P_77" id="1MpJ6yS9irR" role="1tU5fm" />
+                                                        <node concept="3clFbT" id="1MpJ6yS9irS" role="33vP2m" />
+                                                      </node>
+                                                    </node>
+                                                    <node concept="3clFbF" id="1MpJ6yS9irT" role="3cqZAp">
+                                                      <node concept="37vLTI" id="1MpJ6yS9irU" role="3clFbG">
+                                                        <node concept="37vLTw" id="1MpJ6yS9irV" role="37vLTJ">
+                                                          <ref role="3cqZAo" node="1MpJ6yS9irQ" resolve="flag" />
+                                                        </node>
+                                                        <node concept="1rXfSq" id="1MpJ6yS9irW" role="37vLTx">
+                                                          <ref role="37wK5l" node="1MpJ6yS8Td9" resolve="allowElementsBelowRequiredSize" />
+                                                          <node concept="1ZhdrF" id="1MpJ6yS9irX" role="lGtFl">
+                                                            <property role="2qtEX8" value="baseMethodDeclaration" />
+                                                            <property role="P3scX" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1204053956946/1068499141037" />
+                                                            <node concept="3$xsQk" id="1MpJ6yS9irY" role="3$ytzL">
+                                                              <node concept="3clFbS" id="1MpJ6yS9irZ" role="2VODD2">
+                                                                <node concept="3clFbF" id="1MpJ6yS9is0" role="3cqZAp">
+                                                                  <node concept="2OqwBi" id="1MpJ6yS9is1" role="3clFbG">
+                                                                    <node concept="1iwH70" id="1MpJ6yS9is2" role="2OqNvi">
+                                                                      <ref role="1iwH77" to="tpc3:hG092go" resolve="query_method" />
+                                                                      <node concept="2OqwBi" id="1MpJ6yS9is3" role="1iwH7V">
+                                                                        <node concept="30H73N" id="1MpJ6yS9is4" role="2Oq$k0" />
+                                                                        <node concept="3TrEf2" id="1MpJ6yS9is5" role="2OqNvi">
+                                                                          <ref role="3Tt5mk" to="2qld:1MpJ6yR_DFN" resolve="allowElementsBelowRequiredSize" />
+                                                                        </node>
+                                                                      </node>
+                                                                    </node>
+                                                                    <node concept="1iwH7S" id="1MpJ6yS9is6" role="2Oq$k0" />
+                                                                  </node>
+                                                                </node>
+                                                              </node>
+                                                            </node>
+                                                          </node>
+                                                        </node>
+                                                      </node>
+                                                      <node concept="1W57fq" id="1MpJ6yS9is7" role="lGtFl">
+                                                        <node concept="3IZrLx" id="1MpJ6yS9is8" role="3IZSJc">
+                                                          <node concept="3clFbS" id="1MpJ6yS9is9" role="2VODD2">
+                                                            <node concept="3clFbF" id="1MpJ6yS9isa" role="3cqZAp">
+                                                              <node concept="3y3z36" id="1MpJ6yS9isb" role="3clFbG">
+                                                                <node concept="10Nm6u" id="1MpJ6yS9isc" role="3uHU7w" />
+                                                                <node concept="2OqwBi" id="1MpJ6yS9isd" role="3uHU7B">
+                                                                  <node concept="30H73N" id="1MpJ6yS9ise" role="2Oq$k0" />
+                                                                  <node concept="3TrEf2" id="1MpJ6yS9isf" role="2OqNvi">
+                                                                    <ref role="3Tt5mk" to="2qld:1MpJ6yR_DFN" resolve="allowElementsBelowRequiredSize" />
+                                                                  </node>
+                                                                </node>
+                                                              </node>
+                                                            </node>
+                                                          </node>
+                                                        </node>
+                                                      </node>
+                                                    </node>
+                                                    <node concept="3cpWs6" id="1MpJ6yS9isg" role="3cqZAp">
+                                                      <node concept="37vLTw" id="1MpJ6yS9ish" role="3cqZAk">
+                                                        <ref role="3cqZAo" node="1MpJ6yS9irQ" resolve="flag" />
+                                                      </node>
+                                                    </node>
+                                                  </node>
+                                                  <node concept="3Tm1VV" id="1MpJ6yS9isi" role="1B3o_S" />
+                                                  <node concept="10P_77" id="1MpJ6yS9isj" role="3clF45" />
+                                                  <node concept="2AHcQZ" id="1MpJ6yS9isk" role="2AJF6D">
+                                                    <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                                                  </node>
+                                                </node>
                                               </node>
                                             </node>
                                           </node>

--- a/code/diagram/languages/de.itemis.mps.editor.diagram/generator/template/main@generator.mps
+++ b/code/diagram/languages/de.itemis.mps.editor.diagram/generator/template/main@generator.mps
@@ -16526,39 +16526,6 @@
         </node>
         <node concept="raruj" id="5ZBOFE3$Ik2" role="lGtFl" />
       </node>
-      <node concept="3clFbF" id="2ZU2kH0oSTj" role="3cqZAp">
-        <node concept="2OqwBi" id="2ZU2kH0oSTk" role="3clFbG">
-          <node concept="37vLTw" id="2ZU2kH0oSTl" role="2Oq$k0">
-            <ref role="3cqZAo" node="5ZBOFE3$Ijz" resolve="styleDiagram" />
-          </node>
-          <node concept="liA8E" id="2ZU2kH0oSTm" role="2OqNvi">
-            <ref role="37wK5l" to="hox0:~Style.set(jetbrains.mps.openapi.editor.style.StyleAttribute,java.lang.Object)" resolve="set" />
-            <node concept="1Z6Ecs" id="2ZU2kH0oSTn" role="37wK5m">
-              <ref role="1Z6EpT" to="swi3:4bryhcrFmRC" resolve="__move-to-diagram-viewer-button" />
-            </node>
-            <node concept="3clFbT" id="2ZU2kH0oSTo" role="37wK5m">
-              <property role="3clFbU" value="true" />
-              <node concept="17Uvod" id="2ZU2kH0oSTp" role="lGtFl">
-                <property role="P4ACc" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123137/1068580123138" />
-                <property role="2qtEX9" value="value" />
-                <node concept="3zFVjK" id="2ZU2kH0oSTq" role="3zH0cK">
-                  <node concept="3clFbS" id="2ZU2kH0oSTr" role="2VODD2">
-                    <node concept="3clFbF" id="2ZU2kH0oSTs" role="3cqZAp">
-                      <node concept="2OqwBi" id="2ZU2kH0oSTt" role="3clFbG">
-                        <node concept="30H73N" id="2ZU2kH0oSTu" role="2Oq$k0" />
-                        <node concept="3TrcHB" id="2ZU2kH0oSTv" role="2OqNvi">
-                          <ref role="3TsBF5" to="2qld:2ZU2kH0jA_x" resolve="hasMoveToViewerButton" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="raruj" id="2ZU2kH0oSTw" role="lGtFl" />
-      </node>
       <node concept="3clFbF" id="5ZBOFE3$Ikh" role="3cqZAp">
         <node concept="2OqwBi" id="5ZBOFE3$Iki" role="3clFbG">
           <node concept="37vLTw" id="5ZBOFE3$Ikj" role="2Oq$k0">

--- a/code/diagram/languages/de.itemis.mps.editor.diagram/languageModels/behavior.mps
+++ b/code/diagram/languages/de.itemis.mps.editor.diagram/languageModels/behavior.mps
@@ -10249,51 +10249,6 @@
                     </node>
                   </node>
                 </node>
-                <node concept="3clFbF" id="74e51Ji6cHy" role="3cqZAp">
-                  <node concept="2OqwBi" id="74e51Ji6duY" role="3clFbG">
-                    <node concept="37vLTw" id="74e51Ji6cHw" role="2Oq$k0">
-                      <ref role="3cqZAo" node="74e51Ji6bH0" resolve="buttons" />
-                    </node>
-                    <node concept="TSZUe" id="74e51Ji6egN" role="2OqNvi">
-                      <node concept="2ShNRf" id="74e51Ji6eKA" role="25WWJ7">
-                        <node concept="1pGfFk" id="74e51Ji6eKB" role="2ShVmc">
-                          <ref role="37wK5l" to="r3rm:4bryhcrFn2E" resolve="MoveToViewerButton" />
-                          <node concept="2OqwBi" id="74e51Ji6eKC" role="37wK5m">
-                            <node concept="37vLTw" id="74e51Ji6eKD" role="2Oq$k0">
-                              <ref role="3cqZAo" to="r3rm:2ZU2kH0_fvO" resolve="editorContext" />
-                              <node concept="2c44te" id="74e51Ji6PvX" role="lGtFl">
-                                <node concept="2ShNRf" id="74e51Ji6PBU" role="2c44t1">
-                                  <node concept="3zrR0B" id="74e51Ji6Q5s" role="2ShVmc">
-                                    <node concept="3Tqbb2" id="74e51Ji6Q5u" role="3zrR0E">
-                                      <ref role="ehGHo" to="tpc2:gTQ80DJ" resolve="ConceptFunctionParameter_editorContext" />
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                            <node concept="liA8E" id="74e51Ji6eKE" role="2OqNvi">
-                              <ref role="37wK5l" to="cj4x:~EditorContext.getRepository()" resolve="getRepository" />
-                            </node>
-                          </node>
-                          <node concept="10M0yZ" id="74e51Ji6eKF" role="37wK5m">
-                            <ref role="3cqZAo" to="r3rm:17I5kyiXMqc" resolve="DEFAULT_BUTTON_SIZE" />
-                            <ref role="1PxDUh" to="r3rm:2KWY$Um6wZH" resolve="ContextButton" />
-                          </node>
-                          <node concept="37vLTw" id="74e51Ji6eKG" role="37wK5m">
-                            <ref role="3cqZAo" to="r3rm:45TnPEv7YRN" resolve="mxCellState" />
-                            <node concept="2c44te" id="74e51Ji7g2u" role="lGtFl">
-                              <node concept="2pJPEk" id="74e51Jj5ymK" role="2c44t1">
-                                <node concept="2pJPED" id="74e51Jj5ymM" role="2pJPEn">
-                                  <ref role="2pJxaS" to="2qld:gTQ80DJ" resolve="ConceptFunctionParameter_mxCellState" />
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
                 <node concept="3clFbF" id="74e51Ji6la9" role="3cqZAp">
                   <node concept="2OqwBi" id="74e51Ji6m0N" role="3clFbG">
                     <node concept="37vLTw" id="74e51Ji6la7" role="2Oq$k0">

--- a/code/diagram/languages/de.itemis.mps.editor.diagram/languageModels/editor.mps
+++ b/code/diagram/languages/de.itemis.mps.editor.diagram/languageModels/editor.mps
@@ -1166,6 +1166,19 @@
               <property role="VOm3f" value="true" />
             </node>
           </node>
+          <node concept="3EZMnI" id="1MpJ6yS8GU4" role="3EZMnx">
+            <node concept="2iRfu4" id="1MpJ6yS8GU5" role="2iSdaV" />
+            <node concept="3F0ifn" id="1MpJ6yS8GU6" role="3EZMnx">
+              <property role="3F0ifm" value="ignore elements' minimum size restriction (indent layout) " />
+            </node>
+            <node concept="3F1sOY" id="1MpJ6yS8Hfy" role="3EZMnx">
+              <ref role="1NtTu8" to="2qld:1MpJ6yR_DFN" resolve="allowElementsBelowRequiredSize" />
+            </node>
+            <node concept="VPM3Z" id="1MpJ6yS8GU9" role="3F10Kt" />
+            <node concept="VPXOz" id="1MpJ6yS8GUa" role="3F10Kt">
+              <property role="VOm3f" value="true" />
+            </node>
+          </node>
         </node>
         <node concept="2iRfu4" id="5qgNcfDnGw9" role="2iSdaV" />
         <node concept="3F0ifn" id="5qgNcfDnGxf" role="3EZMnx" />

--- a/code/diagram/languages/de.itemis.mps.editor.diagram/languageModels/editor.mps
+++ b/code/diagram/languages/de.itemis.mps.editor.diagram/languageModels/editor.mps
@@ -5670,25 +5670,6 @@
           </node>
         </node>
       </node>
-      <node concept="3gTLQM" id="5ZBOFE3vyye" role="3EZMnx">
-        <node concept="3Fmcul" id="5ZBOFE3vyyf" role="3FoqZy">
-          <node concept="3clFbS" id="5ZBOFE3vyyg" role="2VODD2">
-            <node concept="3cpWs6" id="5ZBOFE3vyyh" role="3cqZAp">
-              <node concept="2OqwBi" id="5ZBOFE3vyyi" role="3cqZAk">
-                <node concept="pncrf" id="5ZBOFE3vyyj" role="2Oq$k0" />
-                <node concept="2qgKlT" id="5ZBOFE3vyyk" role="2OqNvi">
-                  <ref role="37wK5l" to="nh7q:4h7S3973QQF" resolve="getBooleanPropertyCheckBox" />
-                  <node concept="1Q80Hx" id="5ZBOFE3vyyl" role="37wK5m" />
-                  <node concept="355D3s" id="5ZBOFE3vyym" role="37wK5m">
-                    <ref role="355D3t" to="2qld:5ZBOFE3vobP" resolve="DiagramButtonConfig" />
-                    <ref role="355D3u" to="2qld:2ZU2kH0jA_x" resolve="hasMoveToViewerButton" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
       <node concept="3gTLQM" id="2ZU2kH0oQNe" role="3EZMnx">
         <node concept="3Fmcul" id="2ZU2kH0oQNf" role="3FoqZy">
           <node concept="3clFbS" id="2ZU2kH0oQNg" role="2VODD2">

--- a/code/diagram/languages/de.itemis.mps.editor.diagram/languageModels/structure.mps
+++ b/code/diagram/languages/de.itemis.mps.editor.diagram/languageModels/structure.mps
@@ -210,6 +210,12 @@
       <property role="20kJfa" value="syncWithModelOnlyOnOpening" />
       <ref role="20lvS9" to="tpc2:gCpkWun" resolve="QueryFunction_NodeCondition" />
     </node>
+    <node concept="1TJgyj" id="1MpJ6yR_DFN" role="1TKVEi">
+      <property role="IQ2ns" value="2060885462441433843" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="allowElementsBelowRequiredSize" />
+      <ref role="20lvS9" to="tpc2:gCpkWun" resolve="QueryFunction_NodeCondition" />
+    </node>
     <node concept="1TJgyj" id="5qgNcfDnbtd" role="1TKVEi">
       <property role="20lmBu" value="fLJjDmT/aggregation" />
       <property role="20kJfa" value="contentQuery" />

--- a/code/diagram/languages/de.itemis.mps.editor.diagram/languageModels/structure.mps
+++ b/code/diagram/languages/de.itemis.mps.editor.diagram/languageModels/structure.mps
@@ -2154,11 +2154,6 @@
       <ref role="AX2Wp" to="tpck:fKAQMTB" resolve="boolean" />
       <node concept="asaX9" id="2ZU2kH0jA8r" role="lGtFl" />
     </node>
-    <node concept="1TJgyi" id="2ZU2kH0jA_x" role="1TKVEl">
-      <property role="IQ2nx" value="3457085882766354785" />
-      <property role="TrG5h" value="hasMoveToViewerButton" />
-      <ref role="AX2Wp" to="tpck:fKAQMTB" resolve="boolean" />
-    </node>
     <node concept="1TJgyi" id="5ZBOFE3vtwH" role="1TKVEl">
       <property role="IQ2nx" value="6910723851735128109" />
       <property role="TrG5h" value="hasMaximizeDiagramButton" />

--- a/code/diagram/languages/test.de.itemis.mps.editor.diagram.lang/languageModels/behavior.mps
+++ b/code/diagram/languages/test.de.itemis.mps.editor.diagram.lang/languageModels/behavior.mps
@@ -31,6 +31,10 @@
       <concept id="1225194691553" name="jetbrains.mps.lang.behavior.structure.ThisNodeExpression" flags="nn" index="13iPFW" />
     </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
+        <child id="1068498886297" name="rValue" index="37vLTx" />
+        <child id="1068498886295" name="lValue" index="37vLTJ" />
+      </concept>
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
       <concept id="8118189177080264853" name="jetbrains.mps.baseLanguage.structure.AlternativeType" flags="ig" index="nSUau">
         <child id="8118189177080264854" name="alternative" index="nSUat" />
@@ -68,6 +72,7 @@
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
       <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
+      <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
       <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
@@ -154,7 +159,27 @@
   <node concept="13h7C7" id="24zrZPPzdZr">
     <ref role="13h7C2" to="7nxb:24zrZPPzcAY" resolve="Port" />
     <node concept="13hLZK" id="24zrZPPzdZs" role="13h7CW">
-      <node concept="3clFbS" id="24zrZPPzdZt" role="2VODD2" />
+      <node concept="3clFbS" id="24zrZPPzdZt" role="2VODD2">
+        <node concept="3clFbF" id="2PdRDsX_182" role="3cqZAp">
+          <node concept="37vLTI" id="2PdRDsX_2CT" role="3clFbG">
+            <node concept="3cpWs3" id="2PdRDsX_2VU" role="37vLTx">
+              <node concept="2YIFZM" id="2PdRDsX_38Q" role="3uHU7w">
+                <ref role="37wK5l" to="wyt6:~Math.random()" resolve="random" />
+                <ref role="1Pybhc" to="wyt6:~Math" resolve="Math" />
+              </node>
+              <node concept="Xl_RD" id="2PdRDsX_2Db" role="3uHU7B">
+                <property role="Xl_RC" value="Port" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="2PdRDsX_1jM" role="37vLTJ">
+              <node concept="13iPFW" id="2PdRDsX_181" role="2Oq$k0" />
+              <node concept="3TrcHB" id="2PdRDsX_1ww" role="2OqNvi">
+                <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
     </node>
     <node concept="13i0hz" id="24zrZPPzdZv" role="13h7CS">
       <property role="TrG5h" value="getPositionX" />

--- a/code/diagram/languages/test.de.itemis.mps.editor.diagram.lang/languageModels/editor.mps
+++ b/code/diagram/languages/test.de.itemis.mps.editor.diagram.lang/languageModels/editor.mps
@@ -36,6 +36,9 @@
       <concept id="1237303669825" name="jetbrains.mps.lang.editor.structure.CellLayout_Indent" flags="nn" index="l2Vlx" />
       <concept id="1237307900041" name="jetbrains.mps.lang.editor.structure.IndentLayoutIndentStyleClassItem" flags="ln" index="lj46D" />
       <concept id="1237308012275" name="jetbrains.mps.lang.editor.structure.IndentLayoutNewLineStyleClassItem" flags="ln" index="ljvvj" />
+      <concept id="7651593722933768974" name="jetbrains.mps.lang.editor.structure.MaxWidthStyleClassItem" flags="ln" index="nf9zX">
+        <property id="7651593722933768975" name="value" index="nf9zW" />
+      </concept>
       <concept id="1237375020029" name="jetbrains.mps.lang.editor.structure.IndentLayoutNewLineChildrenStyleClassItem" flags="ln" index="pj6Ft" />
       <concept id="1142886221719" name="jetbrains.mps.lang.editor.structure.QueryFunction_NodeCondition" flags="in" index="pkWqt" />
       <concept id="1142886811589" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameter_node" flags="nn" index="pncrf" />
@@ -76,7 +79,9 @@
         <child id="3982520150122341379" name="query" index="3tD6jU" />
       </concept>
       <concept id="1139848536355" name="jetbrains.mps.lang.editor.structure.CellModel_WithRole" flags="ng" index="1$h60E">
+        <property id="1139852716018" name="noTargetText" index="1$x2rV" />
         <property id="1140017977771" name="readOnly" index="1Intyy" />
+        <property id="1140114345053" name="allowEmptyText" index="1O74Pk" />
         <reference id="1140103550593" name="relationDeclaration" index="1NtTu8" />
       </concept>
       <concept id="1073389446423" name="jetbrains.mps.lang.editor.structure.CellModel_Collection" flags="sn" stub="3013115976261988961" index="3EZMnI">
@@ -279,6 +284,7 @@
         <child id="53713348769907228" name="autoLayoutOnChange" index="2hB_ot" />
         <child id="8316481512155640329" name="saveLayout" index="qiu7m" />
         <child id="5018298105379062639" name="autoLayoutOnInit" index="2Dxx3A" />
+        <child id="2060885462441433843" name="allowElementsBelowRequiredSize" index="2F3Mqr" />
         <child id="6910723851735171798" name="buttonConfig" index="3sAl1G" />
         <child id="8637411062076630380" name="connectionTypes" index="1xLlFP" />
         <child id="7858611447550199305" name="syncWithModelOnlyOnOpening" index="3y0MdK" />
@@ -937,8 +943,16 @@
   </node>
   <node concept="24kQdi" id="24zrZPP$0Pk">
     <ref role="1XX52x" to="7nxb:24zrZPPz$8d" resolve="TextBoxContent" />
-    <node concept="3F0A7n" id="21ib$h2_aLB" role="2wV5jI">
-      <ref role="1NtTu8" to="7nxb:24zrZPPz$8l" resolve="value" />
+    <node concept="3EZMnI" id="2PdRDsXByHw" role="2wV5jI">
+      <node concept="l2Vlx" id="2PdRDsXByHx" role="2iSdaV" />
+      <node concept="3F0A7n" id="21ib$h2_aLB" role="3EZMnx">
+        <ref role="1NtTu8" to="7nxb:24zrZPPz$8l" resolve="value1" />
+      </node>
+      <node concept="3F0A7n" id="2PdRDsXByHz" role="3EZMnx">
+        <property role="1$x2rV" value=" " />
+        <property role="1O74Pk" value="true" />
+        <ref role="1NtTu8" to="7nxb:2PdRDsXByHv" resolve="value2" />
+      </node>
     </node>
   </node>
   <node concept="24kQdi" id="24zrZPP$0Q6">
@@ -2511,6 +2525,34 @@
           </node>
           <node concept="3clFbF" id="1mqidcvKIWM" role="3cqZAp">
             <node concept="3clFbT" id="1mqidcvKIWL" role="3clFbG">
+              <property role="3clFbU" value="true" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="pkWqt" id="1MpJ6ySnYcO" role="2F3Mqr">
+        <node concept="3clFbS" id="1MpJ6ySnYcP" role="2VODD2">
+          <node concept="RRSsy" id="1MpJ6ySnYsA" role="3cqZAp">
+            <node concept="3cpWs3" id="1MpJ6ySnYsB" role="RRSoy">
+              <node concept="1Q80Hx" id="1MpJ6ySnYsC" role="3uHU7w" />
+              <node concept="Xl_RD" id="1MpJ6ySnYsD" role="3uHU7B">
+                <property role="Xl_RC" value="editor context:" />
+              </node>
+            </node>
+          </node>
+          <node concept="RRSsy" id="1MpJ6ySnYsE" role="3cqZAp">
+            <node concept="3cpWs3" id="1MpJ6ySnYsF" role="RRSoy">
+              <node concept="2OqwBi" id="1MpJ6ySnYsG" role="3uHU7w">
+                <node concept="pncrf" id="1MpJ6ySnYsH" role="2Oq$k0" />
+                <node concept="2Iv5rx" id="1MpJ6ySnYsI" role="2OqNvi" />
+              </node>
+              <node concept="Xl_RD" id="1MpJ6ySnYsJ" role="3uHU7B">
+                <property role="Xl_RC" value="node:" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="1MpJ6ySnYsK" role="3cqZAp">
+            <node concept="3clFbT" id="1MpJ6ySnYsL" role="3clFbG">
               <property role="3clFbU" value="true" />
             </node>
           </node>
@@ -5310,6 +5352,81 @@
     <node concept="3Tm1VV" id="5UUX0AoLQa$" role="1B3o_S" />
     <node concept="3uibUv" id="5UUX0AoLQIc" role="1zkMxy">
       <ref role="3uigEE" to="nkm5:5BPceOJSo9l" resolve="SNodeConnectionType" />
+    </node>
+  </node>
+  <node concept="24kQdi" id="2PdRDsXzRa6">
+    <property role="3GE5qa" value="testDiagrams" />
+    <ref role="1XX52x" to="7nxb:2PdRDsXzQMw" resolve="DiagramSmallerThanRequiredSize" />
+    <node concept="3EZMnI" id="2PdRDsXzRa8" role="2wV5jI">
+      <node concept="3EZMnI" id="2PdRDsXzRa9" role="3EZMnx">
+        <node concept="2iRfu4" id="2PdRDsXzRaa" role="2iSdaV" />
+        <node concept="3F0ifn" id="2PdRDsXzRab" role="3EZMnx">
+          <property role="3F0ifm" value="smaller than required size" />
+        </node>
+        <node concept="3F0A7n" id="2PdRDsXzRac" role="3EZMnx">
+          <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
+        </node>
+      </node>
+      <node concept="2iRkQZ" id="2PdRDsXzRad" role="2iSdaV" />
+      <node concept="27vDVx" id="2PdRDsXzRae" role="3EZMnx">
+        <node concept="1xLmZY" id="2PdRDsXzRaf" role="1xLlFP">
+          <node concept="3clFbS" id="2PdRDsXzRag" role="2VODD2">
+            <node concept="3clFbF" id="2PdRDsXzRah" role="3cqZAp">
+              <node concept="2ShNRf" id="2PdRDsXzRai" role="3clFbG">
+                <node concept="Tc6Ow" id="2PdRDsXzRaj" role="2ShVmc">
+                  <node concept="3uibUv" id="2PdRDsXzRak" role="HW$YZ">
+                    <ref role="3uigEE" to="nkm5:7vufT$m5fkU" resolve="IConnectionType" />
+                  </node>
+                  <node concept="2ShNRf" id="2PdRDsXzRal" role="HW$Y0">
+                    <node concept="1pGfFk" id="2PdRDsXzRam" role="2ShVmc">
+                      <property role="373rjd" value="true" />
+                      <ref role="37wK5l" node="5UUX0AoLQLI" resolve="PortToPortConnector" />
+                      <node concept="2ZN8Hh" id="2PdRDsXzRan" role="37wK5m" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="aDKH9" id="2PdRDsXzRao" role="aCds2">
+          <ref role="aDKIf" to="7nxb:24zrZPPzcAP" resolve="elements" />
+        </node>
+        <node concept="1RuTs0" id="2PdRDsXzRap" role="1RuSHk">
+          <ref role="1RuSHD" to="7nxb:24zrZPPzcAP" resolve="elements" />
+        </node>
+        <node concept="39fpm" id="2PdRDsXzRaq" role="35U2g">
+          <property role="1NdBj4" value="6Bd7VwqYQAT/RIGHT" />
+        </node>
+        <node concept="pkWqt" id="2PdRDsXzRvT" role="2F3Mqr">
+          <node concept="3clFbS" id="2PdRDsXzRvU" role="2VODD2">
+            <node concept="3clFbF" id="2PdRDsXzRxY" role="3cqZAp">
+              <node concept="3clFbT" id="2PdRDsXzRxX" role="3clFbG">
+                <property role="3clFbU" value="true" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2w$q5c" id="2PdRDsXzRav" role="2whIAn" />
+    </node>
+    <node concept="PMmxH" id="2PdRDsX$org" role="6VMZX">
+      <ref role="PMmxG" node="1mqidcwdDvj" resolve="DiagramInspector" />
+    </node>
+  </node>
+  <node concept="24kQdi" id="2PdRDsXC_op">
+    <ref role="1XX52x" to="7nxb:2PdRDsXC_h7" resolve="TextTextBoxContent" />
+    <node concept="3F1sOY" id="2PdRDsXC_or" role="2wV5jI">
+      <ref role="1NtTu8" to="7nxb:2PdRDsXC_hc" resolve="text" />
+    </node>
+  </node>
+  <node concept="24kQdi" id="2PdRDsXC_ow">
+    <ref role="1XX52x" to="7nxb:2PdRDsXC_ot" resolve="TextMaxWithTextBoxContent" />
+    <node concept="3F1sOY" id="2PdRDsXC_oy" role="2wV5jI">
+      <ref role="1NtTu8" to="7nxb:2PdRDsXC_ov" resolve="text" />
+      <node concept="nf9zX" id="2PdRDsXC_o$" role="3F10Kt">
+        <property role="nf9zW" value="200" />
+      </node>
     </node>
   </node>
 </model>

--- a/code/diagram/languages/test.de.itemis.mps.editor.diagram.lang/languageModels/structure.mps
+++ b/code/diagram/languages/test.de.itemis.mps.editor.diagram.lang/languageModels/structure.mps
@@ -8,6 +8,7 @@
   <imports>
     <import index="tpc2" ref="r:00000000-0000-4000-0000-011c8959029e(jetbrains.mps.lang.editor.structure)" />
     <import index="2qld" ref="r:24bac084-437d-402d-b9a3-49599b18a0d1(de.itemis.mps.editor.diagram.structure)" />
+    <import index="87nw" ref="r:ca2ab6bb-f6e7-4c0f-a88c-b78b9b31fff3(de.slisson.mps.richtext.structure)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
     <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" implicit="true" />
   </imports>
@@ -172,8 +173,13 @@
     <property role="EcuMT" value="2387875361826161165" />
     <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
     <node concept="1TJgyi" id="24zrZPPz$8l" role="1TKVEl">
-      <property role="TrG5h" value="value" />
+      <property role="TrG5h" value="value1" />
       <property role="IQ2nx" value="2387875361826161173" />
+      <ref role="AX2Wp" to="tpck:fKAOsGN" resolve="string" />
+    </node>
+    <node concept="1TJgyi" id="2PdRDsXByHv" role="1TKVEl">
+      <property role="IQ2nx" value="3264510046068681567" />
+      <property role="TrG5h" value="value2" />
       <ref role="AX2Wp" to="tpck:fKAOsGN" resolve="string" />
     </node>
     <node concept="PrWs8" id="24zrZPPz$8e" role="PzmwI">
@@ -331,6 +337,45 @@
       <property role="20kJfa" value="subDiagrams" />
       <property role="20lbJX" value="fLJekj5/_0__n" />
       <ref role="20lvS9" node="21ib$h2$w$t" resolve="BaseDiagram" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="2PdRDsXzQMw">
+    <property role="EcuMT" value="3264510046067715232" />
+    <property role="TrG5h" value="DiagramSmallerThanRequiredSize" />
+    <property role="19KtqR" value="true" />
+    <property role="3GE5qa" value="testDiagrams" />
+    <ref role="1TJDcQ" node="21ib$h2$w$t" resolve="BaseDiagram" />
+  </node>
+  <node concept="1TIwiD" id="2PdRDsXC_h7">
+    <property role="TrG5h" value="TextTextBoxContent" />
+    <property role="34LRSv" value="text (Text)" />
+    <property role="EcuMT" value="3264510046068954183" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+    <node concept="PrWs8" id="2PdRDsXC_ha" role="PzmwI">
+      <ref role="PrY4T" node="24zrZPPzcB8" resolve="IBoxContent" />
+    </node>
+    <node concept="1TJgyj" id="2PdRDsXC_hc" role="1TKVEi">
+      <property role="IQ2ns" value="3264510046068954188" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="text" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <ref role="20lvS9" to="87nw:2dWzqxEB$Tx" resolve="Text" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="2PdRDsXC_ot">
+    <property role="TrG5h" value="TextMaxWithTextBoxContent" />
+    <property role="34LRSv" value="text (Text maxWidth=200)" />
+    <property role="EcuMT" value="3264510046068954653" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+    <node concept="PrWs8" id="2PdRDsXC_ou" role="PzmwI">
+      <ref role="PrY4T" node="24zrZPPzcB8" resolve="IBoxContent" />
+    </node>
+    <node concept="1TJgyj" id="2PdRDsXC_ov" role="1TKVEi">
+      <property role="IQ2ns" value="3264510046068954655" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="text" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <ref role="20lvS9" to="87nw:2dWzqxEB$Tx" resolve="Text" />
     </node>
   </node>
 </model>

--- a/code/diagram/languages/test.de.itemis.mps.editor.diagram.lang/test.de.itemis.mps.editor.diagram.lang.mpl
+++ b/code/diagram/languages/test.de.itemis.mps.editor.diagram.lang/test.de.itemis.mps.editor.diagram.lang.mpl
@@ -19,6 +19,7 @@
     <dependency reexport="false">f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)</dependency>
     <dependency reexport="false">fa13cc63-c476-4d46-9c96-d53670abe7bc(de.itemis.mps.editor.diagram)</dependency>
     <dependency reexport="true">1144260c-e9a5-49a2-9add-39a1a1a7077e(de.itemis.mps.editor.diagram.runtime)</dependency>
+    <dependency reexport="false">92d2ea16-5a42-4fdf-a676-c7604efe3504(de.slisson.mps.richtext)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:fa13cc63-c476-4d46-9c96-d53670abe7bc:de.itemis.mps.editor.diagram" version="1" />
@@ -69,8 +70,11 @@
     <module reference="1144260c-e9a5-49a2-9add-39a1a1a7077e(de.itemis.mps.editor.diagram.runtime)" version="0" />
     <module reference="56c81845-acaf-48a7-bcd8-e29b36c98dd7(de.itemis.mps.editor.diagram.styles)" version="0" />
     <module reference="5c13c612-0f7b-4f0a-ab8b-565186b418de(de.itemis.mps.mouselistener.runtime)" version="0" />
+    <module reference="cce85e64-7b37-4ad5-b0e6-9d18324cdfb3(de.itemis.mps.selection.runtime)" version="0" />
     <module reference="0022e9df-2136-4ef8-81b2-08650aeb1dc7(de.itemis.mps.tooltips.runtime)" version="0" />
+    <module reference="dc038ceb-b7ea-4fea-ac12-55f7400e97ba(de.slisson.mps.editor.multiline.runtime)" version="0" />
     <module reference="f0fff802-6d26-4d2e-b89d-391357265626(de.slisson.mps.hacks.editor)" version="0" />
+    <module reference="92d2ea16-5a42-4fdf-a676-c7604efe3504(de.slisson.mps.richtext)" version="0" />
     <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
     <module reference="443f4c36-fcf5-4eb6-9500-8d06ed259e3e(jetbrains.mps.baseLanguage.classifiers)" version="0" />
     <module reference="fd392034-7849-419d-9071-12563d152375(jetbrains.mps.baseLanguage.closures)" version="0" />

--- a/code/diagram/solutions/de.itemis.mps.editor.diagram.demoentities.sandbox/models/de/itemis/mps/editor/diagram/demoentities/sandbox.mps
+++ b/code/diagram/solutions/de.itemis.mps.editor.diagram.demoentities.sandbox/models/de/itemis/mps/editor/diagram/demoentities/sandbox.mps
@@ -7,6 +7,14 @@
   </languages>
   <imports />
   <registry>
+    <language id="92d2ea16-5a42-4fdf-a676-c7604efe3504" name="de.slisson.mps.richtext">
+      <concept id="2557074442922380897" name="de.slisson.mps.richtext.structure.Text" flags="ng" index="19SGf9">
+        <child id="2557074442922392302" name="words" index="19SJt6" />
+      </concept>
+      <concept id="2557074442922438156" name="de.slisson.mps.richtext.structure.Word" flags="ng" index="19SUe$">
+        <property id="2557074442922438158" name="escapedValue" index="19SUeA" />
+      </concept>
+    </language>
     <language id="46b1f1f4-3955-4255-af94-7acb92d5711a" name="de.itemis.mps.editor.diagram.demoentities">
       <concept id="5285801562344992701" name="de.itemis.mps.editor.diagram.demoentities.structure.EntityDiagram" flags="ng" index="2PBtWY" />
       <concept id="5285801562344842019" name="de.itemis.mps.editor.diagram.demoentities.structure.Reference" flags="ng" index="2PBxew">
@@ -22,6 +30,7 @@
         <reference id="5285801562344842742" name="supertype" index="2PBxlP" />
         <child id="5285801562344842739" name="references" index="2PBxlK" />
         <child id="5285801562344842737" name="attributes" index="2PBxlM" />
+        <child id="5315831828518285715" name="additionalDescription" index="1Tip5L" />
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
@@ -416,50 +425,50 @@
         <node concept="37mRIm" id="6OfpnAgaoxx" role="37mRID">
           <property role="37mO49" value="7858611447568891607" />
           <node concept="gqqVs" id="6OfpnAgaoxw" role="37mO4d">
-            <property role="gqqTZ" value="386.0002831054687" />
-            <property role="gqqTW" value="177.0" />
-            <property role="gqqTX" value="154.0" />
-            <property role="gqqTy" value="94.0" />
+            <property role="gqqTZ" value="574.000344140625" />
+            <property role="gqqTW" value="409.0" />
+            <property role="gqqTX" value="290.0" />
+            <property role="gqqTy" value="142.0" />
             <property role="TgtnS" value="1.0;0.0;0.0;1.0;0.0;0.0" />
           </node>
         </node>
         <node concept="37mRIm" id="6OfpnAgaoxz" role="37mRID">
           <property role="37mO49" value="7858611447568893985" />
           <node concept="gqqVs" id="6OfpnAgaoxy" role="37mO4d">
-            <property role="gqqTZ" value="792.0004662109375" />
-            <property role="gqqTW" value="187.5" />
-            <property role="gqqTX" value="170.0" />
-            <property role="gqqTy" value="73.0" />
+            <property role="gqqTZ" value="1116.00058828125" />
+            <property role="gqqTW" value="262.5" />
+            <property role="gqqTX" value="308.0" />
+            <property role="gqqTy" value="137.0" />
             <property role="TgtnS" value="1.0;0.0;0.0;1.0;0.0;0.0" />
           </node>
         </node>
         <node concept="37mRIm" id="6OfpnAgaox_" role="37mRID">
           <property role="37mO49" value="7858611447568893988" />
           <node concept="gqqVs" id="6OfpnAgaox$" role="37mO4d">
-            <property role="gqqTZ" value="402.0002831054687" />
-            <property role="gqqTW" value="291.0" />
-            <property role="gqqTX" value="138.0" />
-            <property role="gqqTy" value="52.0" />
+            <property role="gqqTZ" value="566.000344140625" />
+            <property role="gqqTW" value="273.0" />
+            <property role="gqqTX" value="298.0" />
+            <property role="gqqTy" value="116.0" />
             <property role="TgtnS" value="1.0;0.0;0.0;1.0;0.0;0.0" />
           </node>
         </node>
         <node concept="37mRIm" id="6OfpnAgaoxB" role="37mRID">
           <property role="37mO49" value="7858611447568893992" />
           <node concept="gqqVs" id="6OfpnAgaoxA" role="37mO4d">
-            <property role="gqqTZ" value="406.0002831054687" />
-            <property role="gqqTW" value="84.0" />
-            <property role="gqqTX" value="114.0" />
-            <property role="gqqTy" value="73.0" />
+            <property role="gqqTZ" value="558.000344140625" />
+            <property role="gqqTW" value="132.0" />
+            <property role="gqqTX" value="306.0" />
+            <property role="gqqTy" value="121.0" />
             <property role="TgtnS" value="1.0;0.0;0.0;1.0;0.0;0.0" />
           </node>
         </node>
         <node concept="37mRIm" id="6OfpnAgaoxD" role="37mRID">
           <property role="37mO49" value="7858611447568893997" />
           <node concept="gqqVs" id="6OfpnAgaoxC" role="37mO4d">
-            <property role="gqqTZ" value="12.000100000000003" />
-            <property role="gqqTW" value="84.0" />
-            <property role="gqqTX" value="122.0" />
-            <property role="gqqTy" value="73.0" />
+            <property role="gqqTZ" value="12.000099999999975" />
+            <property role="gqqTW" value="132.0" />
+            <property role="gqqTX" value="294.0" />
+            <property role="gqqTy" value="121.0" />
             <property role="TgtnS" value="1.0;0.0;0.0;1.0;0.0;0.0" />
           </node>
         </node>
@@ -470,14 +479,22 @@
               <property role="3ul5GH" value="label" />
               <node concept="3wpmZ1" id="6OfpnAgaoxH" role="3ul5Gz">
                 <node concept="2VclrF" id="6OfpnAgaoxI" role="3wpmZR">
-                  <property role="2Vclpx" value="568.0003662109375" />
-                  <property role="2Vclpz" value="214.00005" />
+                  <property role="2Vclpx" value="892.0004272460938" />
+                  <property role="2Vclpz" value="470.00005" />
                 </node>
                 <node concept="2VclrF" id="6OfpnAgaoxJ" role="3wpmZP">
                   <property role="2Vclpx" value="0.0" />
                   <property role="2Vclpz" value="0.0" />
                 </node>
               </node>
+            </node>
+            <node concept="2VclrF" id="1MpJ6yR4V35" role="2Vcluh">
+              <property role="2Vclpx" value="1096.00048828125" />
+              <property role="2Vclpz" value="481.00005" />
+            </node>
+            <node concept="2VclrF" id="1MpJ6yR4V36" role="2Vcluh">
+              <property role="2Vclpx" value="1096.00048828125" />
+              <property role="2Vclpz" value="332.00005" />
             </node>
           </node>
         </node>
@@ -488,8 +505,8 @@
               <property role="3ul5GH" value="label" />
               <node concept="3wpmZ1" id="6OfpnAgaoxN" role="3ul5Gz">
                 <node concept="2VclrF" id="6OfpnAgaoxO" role="3wpmZR">
-                  <property role="2Vclpx" value="560.0003662109375" />
-                  <property role="2Vclpz" value="352.0" />
+                  <property role="2Vclpx" value="884.0004272460938" />
+                  <property role="2Vclpz" value="560.0" />
                 </node>
                 <node concept="2VclrF" id="6OfpnAgaoxP" role="3wpmZP">
                   <property role="2Vclpx" value="0.0" />
@@ -498,28 +515,28 @@
               </node>
             </node>
             <node concept="2VclrF" id="6OfpnAgao_r" role="2Vcluh">
-              <property role="2Vclpx" value="982.0005493164062" />
-              <property role="2Vclpz" value="225.00005" />
+              <property role="2Vclpx" value="1444.000732421875" />
+              <property role="2Vclpz" value="332.00005" />
             </node>
             <node concept="2VclrF" id="6OfpnAgao_s" role="2Vcluh">
-              <property role="2Vclpx" value="982.0005493164062" />
-              <property role="2Vclpz" value="363.0" />
+              <property role="2Vclpx" value="1444.000732421875" />
+              <property role="2Vclpz" value="571.0" />
             </node>
             <node concept="2VclrF" id="6OfpnAgao_t" role="2Vcluh">
-              <property role="2Vclpx" value="877.0004662109375" />
-              <property role="2Vclpz" value="363.0" />
+              <property role="2Vclpx" value="1270.00058828125" />
+              <property role="2Vclpz" value="571.0" />
             </node>
             <node concept="2VclrF" id="6OfpnAgao_u" role="2Vcluh">
-              <property role="2Vclpx" value="463.0002831054687" />
-              <property role="2Vclpz" value="363.0" />
+              <property role="2Vclpx" value="711.000344140625" />
+              <property role="2Vclpz" value="571.0" />
             </node>
             <node concept="2VclrF" id="6OfpnAgao_v" role="2Vcluh">
-              <property role="2Vclpx" value="366.00018310546875" />
-              <property role="2Vclpz" value="363.0" />
+              <property role="2Vclpx" value="538.0002136230469" />
+              <property role="2Vclpz" value="571.0" />
             </node>
             <node concept="2VclrF" id="6OfpnAgao_w" role="2Vcluh">
-              <property role="2Vclpx" value="366.00018310546875" />
-              <property role="2Vclpz" value="225.00005" />
+              <property role="2Vclpx" value="538.0002136230469" />
+              <property role="2Vclpz" value="481.00005" />
             </node>
           </node>
         </node>
@@ -530,22 +547,14 @@
               <property role="3ul5GH" value="label" />
               <node concept="3wpmZ1" id="6OfpnAgaoxT" role="3ul5Gz">
                 <node concept="2VclrF" id="6OfpnAgaoxU" role="3wpmZR">
-                  <property role="2Vclpx" value="568.0003662109375" />
-                  <property role="2Vclpz" value="307.00005" />
+                  <property role="2Vclpx" value="892.0004272460938" />
+                  <property role="2Vclpz" value="321.00005" />
                 </node>
                 <node concept="2VclrF" id="6OfpnAgaoxV" role="3wpmZP">
                   <property role="2Vclpx" value="0.0" />
                   <property role="2Vclpz" value="0.0" />
                 </node>
               </node>
-            </node>
-            <node concept="2VclrF" id="1mqidcyBgJT" role="2Vcluh">
-              <property role="2Vclpx" value="772.0003662109375" />
-              <property role="2Vclpz" value="318.00005" />
-            </node>
-            <node concept="2VclrF" id="1mqidcyBgJU" role="2Vcluh">
-              <property role="2Vclpx" value="772.0003662109375" />
-              <property role="2Vclpz" value="225.00005" />
             </node>
           </node>
         </node>
@@ -556,8 +565,8 @@
               <property role="3ul5GH" value="label" />
               <node concept="3wpmZ1" id="6OfpnAgaoxZ" role="3ul5Gz">
                 <node concept="2VclrF" id="6OfpnAgaoy0" role="3wpmZR">
-                  <property role="2Vclpx" value="560.0003662109375" />
-                  <property role="2Vclpz" value="110.50004999999999" />
+                  <property role="2Vclpx" value="884.0004272460938" />
+                  <property role="2Vclpz" value="182.50005" />
                 </node>
                 <node concept="2VclrF" id="6OfpnAgaoy1" role="3wpmZP">
                   <property role="2Vclpx" value="0.0" />
@@ -566,12 +575,12 @@
               </node>
             </node>
             <node concept="2VclrF" id="6OfpnAgao_z" role="2Vcluh">
-              <property role="2Vclpx" value="772.0003662109375" />
-              <property role="2Vclpz" value="121.50004999999999" />
+              <property role="2Vclpx" value="1096.00048828125" />
+              <property role="2Vclpz" value="193.50005" />
             </node>
             <node concept="2VclrF" id="6OfpnAgao_$" role="2Vcluh">
-              <property role="2Vclpx" value="772.0003662109375" />
-              <property role="2Vclpz" value="225.00005" />
+              <property role="2Vclpx" value="1096.00048828125" />
+              <property role="2Vclpz" value="332.00005" />
             </node>
           </node>
         </node>
@@ -582,8 +591,8 @@
               <property role="3ul5GH" value="label" />
               <node concept="3wpmZ1" id="6OfpnAgaoy5" role="3ul5Gz">
                 <node concept="2VclrF" id="6OfpnAgaoy6" role="3wpmZR">
-                  <property role="2Vclpx" value="154.0001983642578" />
-                  <property role="2Vclpz" value="110.50004999999999" />
+                  <property role="2Vclpx" value="326.0002136230469" />
+                  <property role="2Vclpz" value="182.50005" />
                 </node>
                 <node concept="2VclrF" id="6OfpnAgaoy7" role="3wpmZP">
                   <property role="2Vclpx" value="0.0" />
@@ -596,10 +605,10 @@
         <node concept="37mRIm" id="6OfpnAgaoAe" role="37mRID">
           <property role="37mO49" value="7858611447568894324" />
           <node concept="gqqVs" id="6OfpnAgaoAd" role="37mO4d">
-            <property role="gqqTZ" value="12.000100000000003" />
+            <property role="gqqTZ" value="12.000099999999975" />
             <property role="gqqTW" value="12.0" />
-            <property role="gqqTX" value="106.0" />
-            <property role="gqqTy" value="52.0" />
+            <property role="gqqTX" value="266.0" />
+            <property role="gqqTy" value="100.0" />
             <property role="TgtnS" value="1.0;0.0;0.0;1.0;0.0;0.0" />
           </node>
         </node>
@@ -620,6 +629,11 @@
         <property role="TrG5h" value="contains" />
         <ref role="2PBxlG" node="6OfpnAgaowx" resolve="Department" />
       </node>
+      <node concept="19SGf9" id="4B5Ce8KzrjW" role="1Tip5L">
+        <node concept="19SUe$" id="4B5Ce8KzrjX" role="19SJt6">
+          <property role="19SUeA" value=" A university is a high-level educational institution where students study for degrees, and academic research is conducted." />
+        </node>
+      </node>
     </node>
     <node concept="2PBybn" id="6OfpnAgaowx" role="2PBxlY">
       <property role="TrG5h" value="Department" />
@@ -634,11 +648,21 @@
         <property role="TrG5h" value="belongs to" />
         <ref role="2PBxlG" node="6OfpnAganVn" resolve="University" />
       </node>
+      <node concept="19SGf9" id="4B5Ce8Kzrk0" role="1Tip5L">
+        <node concept="19SUe$" id="4B5Ce8Kzrk1" role="19SJt6">
+          <property role="19SUeA" value=" A department is a division within a large organization (such as a government, university, or business) that deals with a specific area of activity." />
+        </node>
+      </node>
     </node>
     <node concept="2PBybn" id="6OfpnAgao_O" role="2PBxlY">
       <property role="TrG5h" value="Human" />
       <node concept="2PBxex" id="6OfpnAgaox9" role="2PBxlM">
         <property role="TrG5h" value="name" />
+      </node>
+      <node concept="19SGf9" id="4B5Ce8Kzrk4" role="1Tip5L">
+        <node concept="19SUe$" id="4B5Ce8Kzrk5" role="19SJt6">
+          <property role="19SUeA" value="Human: A human refers to a person or individual, belonging to the species Homo sapiens. " />
+        </node>
       </node>
     </node>
     <node concept="2PBybn" id="6OfpnAgaow$" role="2PBxlY">
@@ -649,6 +673,11 @@
       <node concept="2PBxew" id="6OfpnAgaoxq" role="2PBxlK">
         <property role="TrG5h" value="works in" />
         <ref role="2PBxlG" node="6OfpnAgaowx" resolve="Department" />
+      </node>
+      <node concept="19SGf9" id="4B5Ce8Kzrk8" role="1Tip5L">
+        <node concept="19SUe$" id="4B5Ce8Kzrk9" role="19SJt6">
+          <property role="19SUeA" value=" A professor is an academic rank at universities and other post-secondary institutions, usually an expert in their field and a teacher of the highest rank" />
+        </node>
       </node>
     </node>
     <node concept="2PBybn" id="6OfpnAgaowC" role="2PBxlY">
@@ -664,6 +693,11 @@
         <property role="2PBxlI" value="4_qW8fWLecA/composition" />
         <ref role="2PBxlG" node="6OfpnAgaowx" resolve="Department" />
       </node>
+      <node concept="19SGf9" id="4B5Ce8Kzrkc" role="1Tip5L">
+        <node concept="19SUe$" id="4B5Ce8Kzrkd" role="19SJt6">
+          <property role="19SUeA" value=" A course is a set of classes or a plan of study on a particular subject, often leading to an exam or qualification" />
+        </node>
+      </node>
     </node>
     <node concept="2PBybn" id="6OfpnAgaowH" role="2PBxlY">
       <property role="TrG5h" value="Student" />
@@ -677,6 +711,11 @@
       <node concept="2PBxew" id="6OfpnAgaoxu" role="2PBxlK">
         <property role="TrG5h" value="enrolls in" />
         <ref role="2PBxlG" node="6OfpnAgaowC" resolve="Course" />
+      </node>
+      <node concept="19SGf9" id="4B5Ce8Kzrkg" role="1Tip5L">
+        <node concept="19SUe$" id="4B5Ce8Kzrkh" role="19SJt6">
+          <property role="19SUeA" value=" A student is an individual enrolled in an educational institution, pursuing learning and academic goals" />
+        </node>
       </node>
     </node>
   </node>

--- a/code/diagram/solutions/de.itemis.mps.editor.diagram.runtime/models/de/itemis/mps/editor/diagram/runtime/model.mps
+++ b/code/diagram/solutions/de.itemis.mps.editor.diagram.runtime/models/de/itemis/mps/editor/diagram/runtime/model.mps
@@ -17585,6 +17585,13 @@
       <node concept="3Tm1VV" id="6OfpnAf3O9n" role="1B3o_S" />
       <node concept="10P_77" id="6OfpnAf3DUb" role="3clF45" />
     </node>
+    <node concept="2tJIrI" id="1MpJ6ySdqVj" role="jymVt" />
+    <node concept="3clFb_" id="1MpJ6ySdrhc" role="jymVt">
+      <property role="TrG5h" value="allowElementsToBeBelowRequiredSize" />
+      <node concept="3clFbS" id="1MpJ6ySdrhf" role="3clF47" />
+      <node concept="3Tm1VV" id="1MpJ6ySdrhg" role="1B3o_S" />
+      <node concept="10P_77" id="1MpJ6ySdrcu" role="3clF45" />
+    </node>
   </node>
   <node concept="3HP615" id="4teJTSBx0$0">
     <property role="3GE5qa" value="accessor" />
@@ -29383,6 +29390,17 @@
           <node concept="3clFbT" id="6OfpnAf4swk" role="3cqZAk" />
         </node>
       </node>
+    </node>
+    <node concept="2tJIrI" id="1MpJ6yS963Z" role="jymVt" />
+    <node concept="3clFb_" id="1MpJ6yS98Ax" role="jymVt">
+      <property role="TrG5h" value="allowElementsToBeBelowRequiredSize" />
+      <node concept="3clFbS" id="1MpJ6yS98A$" role="3clF47">
+        <node concept="3cpWs6" id="1MpJ6yS9ag3" role="3cqZAp">
+          <node concept="3clFbT" id="1MpJ6yS9b9_" role="3cqZAk" />
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="1MpJ6yS97u3" role="1B3o_S" />
+      <node concept="10P_77" id="1MpJ6yS98ok" role="3clF45" />
     </node>
   </node>
   <node concept="312cEu" id="63AkbuPiu1I">

--- a/code/diagram/solutions/test.de.itemis.mps.editor.diagram.solution/models/test/de/itemis/mps/editor/diagram/solution@tests.mps
+++ b/code/diagram/solutions/test.de.itemis.mps.editor.diagram.solution/models/test/de/itemis/mps/editor/diagram/solution@tests.mps
@@ -11880,8 +11880,8 @@
               <node concept="3b6qkQ" id="1mqidcvkJEr" role="37wK5m">
                 <property role="$nhwW" value="12.0" />
               </node>
-              <node concept="3b6qkQ" id="1mqidcvkJEs" role="37wK5m">
-                <property role="$nhwW" value="52.0" />
+              <node concept="3b6qkQ" id="2$oRW7vI7JS" role="37wK5m">
+                <property role="$nhwW" value="68.0" />
               </node>
               <node concept="3b6qkQ" id="1mqidcvkJEt" role="37wK5m">
                 <property role="$nhwW" value="33.0" />
@@ -12248,8 +12248,8 @@
           <node concept="1pGfFk" id="1mqidcwe9eg" role="2ShVmc">
             <property role="373rjd" value="true" />
             <ref role="37wK5l" to="4io5:~Vector2D.&lt;init&gt;(double,double)" resolve="Vector2D" />
-            <node concept="3b6qkQ" id="1mqidcwfpY7" role="37wK5m">
-              <property role="$nhwW" value="138.0" />
+            <node concept="3cmrfG" id="4Dfm9e2RIX" role="37wK5m">
+              <property role="3cmrfH" value="154" />
             </node>
             <node concept="37vLTw" id="1mqidcwfQYl" role="37wK5m">
               <ref role="3cqZAo" node="1mqidcwfOeK" resolve="boxY" />
@@ -12271,7 +12271,7 @@
             <property role="373rjd" value="true" />
             <ref role="37wK5l" to="4io5:~Vector2D.&lt;init&gt;(double,double)" resolve="Vector2D" />
             <node concept="3cmrfG" id="1mqidcwfLgf" role="37wK5m">
-              <property role="3cmrfH" value="232" />
+              <property role="3cmrfH" value="264" />
             </node>
             <node concept="37vLTw" id="1mqidcwfQZ3" role="37wK5m">
               <ref role="3cqZAo" node="1mqidcwfOeK" resolve="boxY" />
@@ -12418,149 +12418,90 @@
                   </node>
                 </node>
               </node>
-              <node concept="3SKdUt" id="1mqidcwmLwa" role="3cqZAp">
-                <node concept="1PaTwC" id="1mqidcwmLwb" role="1aUNEU">
-                  <node concept="3oM_SD" id="1mqidcwmLy1" role="1PaTwD">
-                    <property role="3oM_SC" value="FIXME" />
+              <node concept="3vlDli" id="1mqidcwf3$Y" role="3cqZAp">
+                <node concept="2OqwBi" id="1mqidcwf3$Z" role="3tpDZA">
+                  <node concept="37vLTw" id="1mqidcwf3_0" role="2Oq$k0">
+                    <ref role="3cqZAo" node="1mqidcwe9dE" resolve="box1" />
                   </node>
-                  <node concept="3oM_SD" id="1mqidcwmL_D" role="1PaTwD">
-                    <property role="3oM_SC" value="not" />
-                  </node>
-                  <node concept="3oM_SD" id="1mqidcwmLAR" role="1PaTwD">
-                    <property role="3oM_SC" value="working" />
-                  </node>
-                  <node concept="3oM_SD" id="1mqidcwmLAS" role="1PaTwD">
-                    <property role="3oM_SC" value="because" />
-                  </node>
-                  <node concept="3oM_SD" id="1mqidcwmLC6" role="1PaTwD">
-                    <property role="3oM_SC" value="the" />
-                  </node>
-                  <node concept="3oM_SD" id="1mqidcwmLG4" role="1PaTwD">
-                    <property role="3oM_SC" value="tests" />
-                  </node>
-                  <node concept="3oM_SD" id="1mqidcwmLG5" role="1PaTwD">
-                    <property role="3oM_SC" value="doesn't" />
-                  </node>
-                  <node concept="3oM_SD" id="1mqidcwmLIw" role="1PaTwD">
-                    <property role="3oM_SC" value="wait" />
-                  </node>
-                  <node concept="3oM_SD" id="1mqidcwmLIx" role="1PaTwD">
-                    <property role="3oM_SC" value="for" />
-                  </node>
-                  <node concept="3oM_SD" id="1mqidcwmLIy" role="1PaTwD">
-                    <property role="3oM_SC" value="the" />
-                  </node>
-                  <node concept="3oM_SD" id="1mqidcwmLIz" role="1PaTwD">
-                    <property role="3oM_SC" value="layouter" />
-                  </node>
-                  <node concept="3oM_SD" id="1mqidcwmLJL" role="1PaTwD">
-                    <property role="3oM_SC" value="to" />
-                  </node>
-                  <node concept="3oM_SD" id="1mqidcwmLJM" role="1PaTwD">
-                    <property role="3oM_SC" value="finish" />
+                  <node concept="AQDAd" id="1mqidcwf3_1" role="2OqNvi">
+                    <ref role="37wK5l" to="r3rm:1zuRb1e784W" resolve="getPosition" />
                   </node>
                 </node>
-              </node>
-              <node concept="1X3_iC" id="1mqidcwmLgV" role="lGtFl">
-                <property role="3V$3am" value="statement" />
-                <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-                <node concept="3vlDli" id="1mqidcwf3$Y" role="8Wnug">
-                  <node concept="2OqwBi" id="1mqidcwf3$Z" role="3tpDZA">
-                    <node concept="37vLTw" id="1mqidcwf3_0" role="2Oq$k0">
-                      <ref role="3cqZAo" node="1mqidcwe9dE" resolve="box1" />
+                <node concept="2ShNRf" id="1mqidcwf3_2" role="3tpDZB">
+                  <node concept="1pGfFk" id="1mqidcwf3_3" role="2ShVmc">
+                    <property role="373rjd" value="true" />
+                    <ref role="37wK5l" to="4io5:~Vector2D.&lt;init&gt;(double,double)" resolve="Vector2D" />
+                    <node concept="3cmrfG" id="4Dfm9e2qJ5" role="37wK5m">
+                      <property role="3cmrfH" value="154" />
                     </node>
-                    <node concept="AQDAd" id="1mqidcwf3_1" role="2OqNvi">
-                      <ref role="37wK5l" to="r3rm:1zuRb1e784W" resolve="getPosition" />
-                    </node>
-                  </node>
-                  <node concept="2ShNRf" id="1mqidcwf3_2" role="3tpDZB">
-                    <node concept="1pGfFk" id="1mqidcwf3_3" role="2ShVmc">
-                      <property role="373rjd" value="true" />
-                      <ref role="37wK5l" to="4io5:~Vector2D.&lt;init&gt;(double,double)" resolve="Vector2D" />
-                      <node concept="3b6qkQ" id="1mqidcwgLFC" role="37wK5m">
-                        <property role="$nhwW" value="138.0" />
-                      </node>
-                      <node concept="37vLTw" id="1mqidcwfRe7" role="37wK5m">
-                        <ref role="3cqZAo" node="1mqidcwfOeK" resolve="boxY" />
-                      </node>
+                    <node concept="37vLTw" id="1mqidcwfRe7" role="37wK5m">
+                      <ref role="3cqZAo" node="1mqidcwfOeK" resolve="boxY" />
                     </node>
                   </node>
                 </node>
               </node>
-              <node concept="1X3_iC" id="1mqidcwmLgW" role="lGtFl">
-                <property role="3V$3am" value="statement" />
-                <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-                <node concept="3vlDli" id="1mqidcwf3_8" role="8Wnug">
-                  <node concept="2OqwBi" id="1mqidcwf3_9" role="3tpDZA">
-                    <node concept="37vLTw" id="1mqidcwf3_a" role="2Oq$k0">
-                      <ref role="3cqZAo" node="1mqidcwenJ$" resolve="box2" />
-                    </node>
-                    <node concept="AQDAd" id="1mqidcwf3_b" role="2OqNvi">
-                      <ref role="37wK5l" to="r3rm:1zuRb1e784W" resolve="getPosition" />
-                    </node>
+              <node concept="3vlDli" id="1mqidcwf3_8" role="3cqZAp">
+                <node concept="2OqwBi" id="1mqidcwf3_9" role="3tpDZA">
+                  <node concept="37vLTw" id="1mqidcwf3_a" role="2Oq$k0">
+                    <ref role="3cqZAo" node="1mqidcwenJ$" resolve="box2" />
                   </node>
-                  <node concept="2ShNRf" id="1mqidcwf3_c" role="3tpDZB">
-                    <node concept="1pGfFk" id="1mqidcwf3_d" role="2ShVmc">
-                      <property role="373rjd" value="true" />
-                      <ref role="37wK5l" to="4io5:~Vector2D.&lt;init&gt;(double,double)" resolve="Vector2D" />
-                      <node concept="3cmrfG" id="1mqidcwgLGH" role="37wK5m">
-                        <property role="3cmrfH" value="232" />
-                      </node>
-                      <node concept="37vLTw" id="1mqidcwfReP" role="37wK5m">
-                        <ref role="3cqZAo" node="1mqidcwfOeK" resolve="boxY" />
-                      </node>
+                  <node concept="AQDAd" id="1mqidcwf3_b" role="2OqNvi">
+                    <ref role="37wK5l" to="r3rm:1zuRb1e784W" resolve="getPosition" />
+                  </node>
+                </node>
+                <node concept="2ShNRf" id="1mqidcwf3_c" role="3tpDZB">
+                  <node concept="1pGfFk" id="1mqidcwf3_d" role="2ShVmc">
+                    <property role="373rjd" value="true" />
+                    <ref role="37wK5l" to="4io5:~Vector2D.&lt;init&gt;(double,double)" resolve="Vector2D" />
+                    <node concept="3cmrfG" id="1mqidcwgLGH" role="37wK5m">
+                      <property role="3cmrfH" value="264" />
+                    </node>
+                    <node concept="37vLTw" id="1mqidcwfReP" role="37wK5m">
+                      <ref role="3cqZAo" node="1mqidcwfOeK" resolve="boxY" />
                     </node>
                   </node>
                 </node>
               </node>
-              <node concept="1X3_iC" id="1mqidcwmLgX" role="lGtFl">
-                <property role="3V$3am" value="statement" />
-                <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-                <node concept="3vlDli" id="1mqidcwf3_i" role="8Wnug">
-                  <node concept="2OqwBi" id="1mqidcwf3_j" role="3tpDZA">
-                    <node concept="37vLTw" id="1mqidcwf3_k" role="2Oq$k0">
-                      <ref role="3cqZAo" node="1mqidcweo_5" resolve="box3" />
-                    </node>
-                    <node concept="AQDAd" id="1mqidcwf3_l" role="2OqNvi">
-                      <ref role="37wK5l" to="r3rm:1zuRb1e784W" resolve="getPosition" />
-                    </node>
+              <node concept="3vlDli" id="1mqidcwf3_i" role="3cqZAp">
+                <node concept="2OqwBi" id="1mqidcwf3_j" role="3tpDZA">
+                  <node concept="37vLTw" id="1mqidcwf3_k" role="2Oq$k0">
+                    <ref role="3cqZAo" node="1mqidcweo_5" resolve="box3" />
                   </node>
-                  <node concept="2ShNRf" id="1mqidcwf3_m" role="3tpDZB">
-                    <node concept="1pGfFk" id="1mqidcwf3_n" role="2ShVmc">
-                      <property role="373rjd" value="true" />
-                      <ref role="37wK5l" to="4io5:~Vector2D.&lt;init&gt;(double,double)" resolve="Vector2D" />
-                      <node concept="3cmrfG" id="1mqidcwgLII" role="37wK5m">
-                        <property role="3cmrfH" value="44" />
-                      </node>
-                      <node concept="37vLTw" id="1mqidcwfRfz" role="37wK5m">
-                        <ref role="3cqZAo" node="1mqidcwfOeK" resolve="boxY" />
-                      </node>
+                  <node concept="AQDAd" id="1mqidcwf3_l" role="2OqNvi">
+                    <ref role="37wK5l" to="r3rm:1zuRb1e784W" resolve="getPosition" />
+                  </node>
+                </node>
+                <node concept="2ShNRf" id="1mqidcwf3_m" role="3tpDZB">
+                  <node concept="1pGfFk" id="1mqidcwf3_n" role="2ShVmc">
+                    <property role="373rjd" value="true" />
+                    <ref role="37wK5l" to="4io5:~Vector2D.&lt;init&gt;(double,double)" resolve="Vector2D" />
+                    <node concept="3cmrfG" id="1mqidcwgLII" role="37wK5m">
+                      <property role="3cmrfH" value="44" />
+                    </node>
+                    <node concept="37vLTw" id="1mqidcwfRfz" role="37wK5m">
+                      <ref role="3cqZAo" node="1mqidcwfOeK" resolve="boxY" />
                     </node>
                   </node>
                 </node>
               </node>
-              <node concept="1X3_iC" id="1mqidcwmLgY" role="lGtFl">
-                <property role="3V$3am" value="statement" />
-                <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-                <node concept="3vlDli" id="1mqidcwf5tj" role="8Wnug">
-                  <node concept="2OqwBi" id="1mqidcwf5tk" role="3tpDZA">
-                    <node concept="37vLTw" id="1mqidcwf5tl" role="2Oq$k0">
-                      <ref role="3cqZAo" node="1mqidcweZdh" resolve="box1Copy" />
-                    </node>
-                    <node concept="AQDAd" id="1mqidcwf5tm" role="2OqNvi">
-                      <ref role="37wK5l" to="r3rm:1zuRb1e784W" resolve="getPosition" />
-                    </node>
+              <node concept="3vlDli" id="1mqidcwf5tj" role="3cqZAp">
+                <node concept="2OqwBi" id="1mqidcwf5tk" role="3tpDZA">
+                  <node concept="37vLTw" id="1mqidcwf5tl" role="2Oq$k0">
+                    <ref role="3cqZAo" node="1mqidcweZdh" resolve="box1Copy" />
                   </node>
-                  <node concept="2ShNRf" id="1mqidcwf5tn" role="3tpDZB">
-                    <node concept="1pGfFk" id="1mqidcwf5to" role="2ShVmc">
-                      <property role="373rjd" value="true" />
-                      <ref role="37wK5l" to="4io5:~Vector2D.&lt;init&gt;(double,double)" resolve="Vector2D" />
-                      <node concept="3cmrfG" id="1mqidcwgLKJ" role="37wK5m">
-                        <property role="3cmrfH" value="0" />
-                      </node>
-                      <node concept="3cmrfG" id="1mqidcwhE7n" role="37wK5m">
-                        <property role="3cmrfH" value="0" />
-                      </node>
+                  <node concept="AQDAd" id="1mqidcwf5tm" role="2OqNvi">
+                    <ref role="37wK5l" to="r3rm:1zuRb1e784W" resolve="getPosition" />
+                  </node>
+                </node>
+                <node concept="2ShNRf" id="1mqidcwf5tn" role="3tpDZB">
+                  <node concept="1pGfFk" id="1mqidcwf5to" role="2ShVmc">
+                    <property role="373rjd" value="true" />
+                    <ref role="37wK5l" to="4io5:~Vector2D.&lt;init&gt;(double,double)" resolve="Vector2D" />
+                    <node concept="3cmrfG" id="1mqidcwgLKJ" role="37wK5m">
+                      <property role="3cmrfH" value="0" />
+                    </node>
+                    <node concept="3cmrfG" id="1mqidcwhE7n" role="37wK5m">
+                      <property role="3cmrfH" value="0" />
                     </node>
                   </node>
                 </node>
@@ -13364,20 +13305,6 @@
                     </node>
                   </node>
                 </node>
-                <node concept="3clFbH" id="ir_Dm4eQZX" role="3cqZAp" />
-                <node concept="3clFbF" id="1laJE2$nbqV" role="3cqZAp">
-                  <node concept="2YIFZM" id="1laJE2$nbqX" role="3clFbG">
-                    <ref role="37wK5l" to="r3rm:YGA9S4RKB$" resolve="fitSizeAll" />
-                    <ref role="1Pybhc" to="r3rm:YGA9S4Rvy7" resolve="DiagramActionsUtil" />
-                    <node concept="2OqwBi" id="1laJE2$nbqY" role="37wK5m">
-                      <node concept="369mXd" id="1laJE2$nbqZ" role="2Oq$k0" />
-                      <node concept="liA8E" id="1laJE2$nbr0" role="2OqNvi">
-                        <ref role="37wK5l" to="exr9:~EditorComponent.getEditorContext()" resolve="getEditorContext" />
-                      </node>
-                    </node>
-                    <node concept="3clFbT" id="1laJE2$nbr1" role="37wK5m" />
-                  </node>
-                </node>
               </node>
             </node>
           </node>
@@ -13409,6 +13336,30 @@
         </node>
       </node>
       <node concept="3clFbH" id="ir_Dm46HVm" role="3cqZAp" />
+      <node concept="3clFbF" id="4Dfm9dY0vo" role="3cqZAp">
+        <node concept="2YIFZM" id="4Dfm9dY1Q3" role="3clFbG">
+          <ref role="37wK5l" to="3a50:~ThreadUtils.runInUIThreadAndWait(java.lang.Runnable)" resolve="runInUIThreadAndWait" />
+          <ref role="1Pybhc" to="3a50:~ThreadUtils" resolve="ThreadUtils" />
+          <node concept="1bVj0M" id="4Dfm9dY24$" role="37wK5m">
+            <node concept="3clFbS" id="4Dfm9dY24_" role="1bW5cS">
+              <node concept="3clFbF" id="1laJE2$nbqV" role="3cqZAp">
+                <node concept="2YIFZM" id="1laJE2$nbqX" role="3clFbG">
+                  <ref role="37wK5l" to="r3rm:YGA9S4RKB$" resolve="fitSizeAll" />
+                  <ref role="1Pybhc" to="r3rm:YGA9S4Rvy7" resolve="DiagramActionsUtil" />
+                  <node concept="2OqwBi" id="1laJE2$nbqY" role="37wK5m">
+                    <node concept="369mXd" id="1laJE2$nbqZ" role="2Oq$k0" />
+                    <node concept="liA8E" id="1laJE2$nbr0" role="2OqNvi">
+                      <ref role="37wK5l" to="exr9:~EditorComponent.getEditorContext()" resolve="getEditorContext" />
+                    </node>
+                  </node>
+                  <node concept="3clFbT" id="1laJE2$nbr1" role="37wK5m" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbH" id="4Dfm9dXYNQ" role="3cqZAp" />
       <node concept="3vlDli" id="1mqidcvpvr$" role="3cqZAp">
         <node concept="2OqwBi" id="1mqidcvpvr_" role="3tpDZA">
           <node concept="37vLTw" id="1mqidcvpvrA" role="2Oq$k0">
@@ -14303,8 +14254,8 @@
               <node concept="3b6qkQ" id="1mqidcwn4ei" role="37wK5m">
                 <property role="$nhwW" value="12.0" />
               </node>
-              <node concept="3b6qkQ" id="1mqidcwn4ej" role="37wK5m">
-                <property role="$nhwW" value="52.0" />
+              <node concept="3b6qkQ" id="2$oRW7vJ3Qj" role="37wK5m">
+                <property role="$nhwW" value="68.0" />
               </node>
               <node concept="3b6qkQ" id="1mqidcwn4ek" role="37wK5m">
                 <property role="$nhwW" value="33.0" />
@@ -18803,7 +18754,7 @@
             <property role="373rjd" value="true" />
             <ref role="37wK5l" to="4io5:~Vector2D.&lt;init&gt;(double,double)" resolve="Vector2D" />
             <node concept="3b6qkQ" id="1mqidcxMb_d" role="37wK5m">
-              <property role="$nhwW" value="101.5" />
+              <property role="$nhwW" value="109.5" />
             </node>
             <node concept="3b6qkQ" id="1mqidcxMb_e" role="37wK5m">
               <property role="$nhwW" value="12.0" />
@@ -18847,7 +18798,7 @@
             <property role="373rjd" value="true" />
             <ref role="37wK5l" to="4io5:~Vector2D.&lt;init&gt;(double,double)" resolve="Vector2D" />
             <node concept="3cmrfG" id="1mqidcxMb_t" role="37wK5m">
-              <property role="3cmrfH" value="158" />
+              <property role="3cmrfH" value="174" />
             </node>
             <node concept="3cmrfG" id="1mqidcxMb_u" role="37wK5m">
               <property role="3cmrfH" value="154" />
@@ -18997,8 +18948,8 @@
           <node concept="1pGfFk" id="1mqidcxMbAp" role="2ShVmc">
             <property role="373rjd" value="true" />
             <ref role="37wK5l" to="4io5:~Vector2D.&lt;init&gt;(double,double)" resolve="Vector2D" />
-            <node concept="3b6qkQ" id="1mqidcxMbAq" role="37wK5m">
-              <property role="$nhwW" value="138.0" />
+            <node concept="3cmrfG" id="2$oRW7vJZya" role="37wK5m">
+              <property role="3cmrfH" value="154" />
             </node>
             <node concept="3b6qkQ" id="1mqidcxMbAr" role="37wK5m">
               <property role="$nhwW" value="12.0" />
@@ -19019,8 +18970,8 @@
           <node concept="1pGfFk" id="1mqidcxMbAx" role="2ShVmc">
             <property role="373rjd" value="true" />
             <ref role="37wK5l" to="4io5:~Vector2D.&lt;init&gt;(double,double)" resolve="Vector2D" />
-            <node concept="3b6qkQ" id="1mqidcxMbAy" role="37wK5m">
-              <property role="$nhwW" value="232.0" />
+            <node concept="3cmrfG" id="2$oRW7vKrmr" role="37wK5m">
+              <property role="3cmrfH" value="264" />
             </node>
             <node concept="3b6qkQ" id="1mqidcxMbAz" role="37wK5m">
               <property role="$nhwW" value="12.0" />
@@ -19123,7 +19074,7 @@
             <property role="373rjd" value="true" />
             <ref role="37wK5l" to="4io5:~Vector2D.&lt;init&gt;(double,double)" resolve="Vector2D" />
             <node concept="3b6qkQ" id="1mqidcxMbBd" role="37wK5m">
-              <property role="$nhwW" value="101.5" />
+              <property role="$nhwW" value="109.5" />
             </node>
             <node concept="3b6qkQ" id="1mqidcxMbBe" role="37wK5m">
               <property role="$nhwW" value="12.0" />
@@ -19167,7 +19118,7 @@
             <property role="373rjd" value="true" />
             <ref role="37wK5l" to="4io5:~Vector2D.&lt;init&gt;(double,double)" resolve="Vector2D" />
             <node concept="3cmrfG" id="1mqidcxMbBt" role="37wK5m">
-              <property role="3cmrfH" value="158" />
+              <property role="3cmrfH" value="174" />
             </node>
             <node concept="3cmrfG" id="1mqidcxMbBu" role="37wK5m">
               <property role="3cmrfH" value="154" />
@@ -23012,7 +22963,7 @@
         <node concept="gqqVs" id="naXaFmvZ_l" role="37mO4d">
           <property role="gqqTZ" value="44.0" />
           <property role="gqqTW" value="12.0" />
-          <property role="gqqTX" value="50.0" />
+          <property role="gqqTX" value="66.0" />
           <property role="gqqTy" value="31.0" />
           <property role="TgtnS" value="1.0;0.0;0.0;1.0;0.0;0.0" />
           <node concept="1pa3jb" id="naXaFmvZ_n" role="1pap1a">
@@ -23028,9 +22979,9 @@
       <node concept="37mRIm" id="naXaFmvZ_q" role="37mRID">
         <property role="37mO49" value="1817672572875630824" />
         <node concept="gqqVs" id="naXaFmvZ_p" role="37mO4d">
-          <property role="gqqTZ" value="138.0" />
+          <property role="gqqTZ" value="154.0" />
           <property role="gqqTW" value="12.0" />
-          <property role="gqqTX" value="50.0" />
+          <property role="gqqTX" value="66.0" />
           <property role="gqqTy" value="31.0" />
           <property role="TgtnS" value="1.0;0.0;0.0;1.0;0.0;0.0" />
           <node concept="1pa3jb" id="naXaFmvZ_r" role="1pap1a">
@@ -23046,9 +22997,9 @@
       <node concept="37mRIm" id="naXaFmvZ_u" role="37mRID">
         <property role="37mO49" value="1817672572875630830" />
         <node concept="gqqVs" id="naXaFmvZ_t" role="37mO4d">
-          <property role="gqqTZ" value="232.0" />
+          <property role="gqqTZ" value="264.0" />
           <property role="gqqTW" value="12.0" />
-          <property role="gqqTX" value="50.0" />
+          <property role="gqqTX" value="66.0" />
           <property role="gqqTy" value="31.0" />
           <property role="TgtnS" value="1.0;0.0;0.0;1.0;0.0;0.0" />
           <node concept="1pa3jb" id="naXaFmvZ_v" role="1pap1a">
@@ -23073,23 +23024,23 @@
         <property role="37mO49" value="7093298676114956980" />
         <node concept="2VclpC" id="naXaFmvZ__" role="37mO4d">
           <node concept="2VclrF" id="naXaFmvZ_B" role="2Vcluh">
-            <property role="2Vclpx" value="314.0" />
+            <property role="2Vclpx" value="362.0" />
             <property role="2Vclpz" value="28.5" />
           </node>
           <node concept="2VclrF" id="naXaFmvZ_C" role="2Vcluh">
-            <property role="2Vclpx" value="314.0" />
+            <property role="2Vclpx" value="362.0" />
             <property role="2Vclpz" value="63.0" />
           </node>
           <node concept="2VclrF" id="naXaFmvZ_D" role="2Vcluh">
-            <property role="2Vclpx" value="257.0" />
+            <property role="2Vclpx" value="297.0" />
             <property role="2Vclpz" value="63.0" />
           </node>
           <node concept="2VclrF" id="naXaFmvZ_E" role="2Vcluh">
-            <property role="2Vclpx" value="163.0" />
+            <property role="2Vclpx" value="187.0" />
             <property role="2Vclpz" value="63.0" />
           </node>
           <node concept="2VclrF" id="naXaFmvZ_F" role="2Vcluh">
-            <property role="2Vclpx" value="69.0" />
+            <property role="2Vclpx" value="77.0" />
             <property role="2Vclpz" value="63.0" />
           </node>
           <node concept="2VclrF" id="naXaFmvZ_G" role="2Vcluh">
@@ -23189,9 +23140,9 @@
       <node concept="37mRIm" id="1mqidcwe7Lx" role="37mRID">
         <property role="37mO49" value="1556636692825799748" />
         <node concept="gqqVs" id="1mqidcwe7Lv" role="37mO4d">
-          <property role="gqqTZ" value="138.0" />
+          <property role="gqqTZ" value="154.0" />
           <property role="gqqTW" value="12.0" />
-          <property role="gqqTX" value="50.0" />
+          <property role="gqqTX" value="66.0" />
           <property role="gqqTy" value="31.0" />
           <property role="TgtnS" value="1.0;0.0;0.0;1.0;0.0;0.0" />
           <node concept="1pa3jb" id="1mqidcwe7Ly" role="1pap1a">
@@ -23207,9 +23158,9 @@
       <node concept="37mRIm" id="1mqidcwe7L_" role="37mRID">
         <property role="37mO49" value="1556636692825799754" />
         <node concept="gqqVs" id="1mqidcwe7L$" role="37mO4d">
-          <property role="gqqTZ" value="232.0" />
+          <property role="gqqTZ" value="264.0" />
           <property role="gqqTW" value="12.0" />
-          <property role="gqqTX" value="50.0" />
+          <property role="gqqTX" value="66.0" />
           <property role="gqqTy" value="31.0" />
           <property role="TgtnS" value="1.0;0.0;0.0;1.0;0.0;0.0" />
           <node concept="1pa3jb" id="1mqidcwe7LA" role="1pap1a">
@@ -23227,7 +23178,7 @@
         <node concept="gqqVs" id="1mqidcwe7LC" role="37mO4d">
           <property role="gqqTZ" value="44.0" />
           <property role="gqqTW" value="12.0" />
-          <property role="gqqTX" value="50.0" />
+          <property role="gqqTX" value="66.0" />
           <property role="gqqTy" value="31.0" />
           <property role="TgtnS" value="1.0;0.0;0.0;1.0;0.0;0.0" />
           <node concept="1pa3jb" id="1mqidcwe7LE" role="1pap1a">
@@ -23248,23 +23199,23 @@
         <property role="37mO49" value="1556636692825799769" />
         <node concept="2VclpC" id="1mqidcwe7LI" role="37mO4d">
           <node concept="2VclrF" id="1mqidcwe7LM" role="2Vcluh">
-            <property role="2Vclpx" value="314.0" />
+            <property role="2Vclpx" value="362.0" />
             <property role="2Vclpz" value="28.5" />
           </node>
           <node concept="2VclrF" id="1mqidcwe7LN" role="2Vcluh">
-            <property role="2Vclpx" value="314.0" />
+            <property role="2Vclpx" value="362.0" />
             <property role="2Vclpz" value="63.0" />
           </node>
           <node concept="2VclrF" id="1mqidcwe7LO" role="2Vcluh">
-            <property role="2Vclpx" value="257.0" />
+            <property role="2Vclpx" value="297.0" />
             <property role="2Vclpz" value="63.0" />
           </node>
           <node concept="2VclrF" id="1mqidcwe7LP" role="2Vcluh">
-            <property role="2Vclpx" value="163.0" />
+            <property role="2Vclpx" value="187.0" />
             <property role="2Vclpz" value="63.0" />
           </node>
           <node concept="2VclrF" id="1mqidcwe7LQ" role="2Vcluh">
-            <property role="2Vclpx" value="69.0" />
+            <property role="2Vclpx" value="77.0" />
             <property role="2Vclpz" value="63.0" />
           </node>
           <node concept="2VclrF" id="1mqidcwe7LR" role="2Vcluh">

--- a/code/diagram/solutions/test.de.itemis.mps.editor.diagram.solution/models/test/de/itemis/mps/editor/diagram/solution@tests.mps
+++ b/code/diagram/solutions/test.de.itemis.mps.editor.diagram.solution/models/test/de/itemis/mps/editor/diagram/solution@tests.mps
@@ -316,6 +316,14 @@
       </concept>
       <concept id="8974276187400348181" name="jetbrains.mps.lang.access.structure.ExecuteLightweightCommandStatement" flags="nn" index="1QHqEK" />
     </language>
+    <language id="92d2ea16-5a42-4fdf-a676-c7604efe3504" name="de.slisson.mps.richtext">
+      <concept id="2557074442922380897" name="de.slisson.mps.richtext.structure.Text" flags="ng" index="19SGf9">
+        <child id="2557074442922392302" name="words" index="19SJt6" />
+      </concept>
+      <concept id="2557074442922438156" name="de.slisson.mps.richtext.structure.Word" flags="ng" index="19SUe$">
+        <property id="2557074442922438158" name="escapedValue" index="19SUeA" />
+      </concept>
+    </language>
     <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
       <concept id="1235746970280" name="jetbrains.mps.baseLanguage.closures.structure.CompactInvokeFunctionExpression" flags="nn" index="2Sg_IR">
         <child id="1235746996653" name="function" index="2SgG2M" />
@@ -342,6 +350,13 @@
     </language>
     <language id="aff569ad-098d-414a-aa23-96963959392c" name="test.de.itemis.mps.editor.diagram.lang">
       <concept id="1556636692819439989" name="test.de.itemis.mps.editor.diagram.lang.structure.DiagramDontSynchronizeChanges" flags="ng" index="ajjAA" />
+      <concept id="3264510046067715232" name="test.de.itemis.mps.editor.diagram.lang.structure.DiagramSmallerThanRequiredSize" flags="ng" index="gKF8R" />
+      <concept id="3264510046068954653" name="test.de.itemis.mps.editor.diagram.lang.structure.TextMaxWithTextBoxContent" flags="ng" index="gVSya">
+        <child id="3264510046068954655" name="text" index="gVSy8" />
+      </concept>
+      <concept id="3264510046068954183" name="test.de.itemis.mps.editor.diagram.lang.structure.TextTextBoxContent" flags="ng" index="gVSFg">
+        <child id="3264510046068954188" name="text" index="gVSFr" />
+      </concept>
       <concept id="5356444056661139986" name="test.de.itemis.mps.editor.diagram.lang.structure.DiagramReference" flags="ng" index="yRWHJ">
         <reference id="5356444056661139987" name="diagram" index="yRWHI" />
       </concept>
@@ -355,7 +370,8 @@
         <child id="2387875361826216583" name="from" index="1kF7lU" />
       </concept>
       <concept id="2387875361826161165" name="test.de.itemis.mps.editor.diagram.lang.structure.TextBoxContent" flags="ng" index="1kFiRK">
-        <property id="2387875361826161173" name="value" index="1kFiRC" />
+        <property id="3264510046068681567" name="value2" index="gOZn8" />
+        <property id="2387875361826161173" name="value1" index="1kFiRC" />
       </concept>
       <concept id="2387875361826064830" name="test.de.itemis.mps.editor.diagram.lang.structure.Port" flags="ng" index="1kFUp3">
         <child id="2387875361826064887" name="positionX" index="1kFUoa" />
@@ -414,6 +430,7 @@
         <reference id="5285801562344842742" name="supertype" index="2PBxlP" />
         <child id="5285801562344842739" name="references" index="2PBxlK" />
         <child id="5285801562344842737" name="attributes" index="2PBxlM" />
+        <child id="5315831828518285715" name="additionalDescription" index="1Tip5L" />
       </concept>
     </language>
     <language id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation">
@@ -23638,40 +23655,40 @@
         <node concept="37mRIm" id="6OfpnAgaoxx" role="37mRID">
           <property role="37mO49" value="7858611447568891607" />
           <node concept="gqqVs" id="6OfpnAgaoxw" role="37mO4d">
-            <property role="gqqTZ" value="386.0002831054687" />
-            <property role="gqqTW" value="177.0" />
-            <property role="gqqTX" value="154.0" />
-            <property role="gqqTy" value="94.0" />
+            <property role="gqqTZ" value="388.0002831054687" />
+            <property role="gqqTW" value="473.0" />
+            <property role="gqqTX" value="172.0" />
+            <property role="gqqTy" value="176.0" />
             <property role="TgtnS" value="1.0;0.0;0.0;1.0;0.0;0.0" />
           </node>
         </node>
         <node concept="37mRIm" id="6OfpnAgaoxz" role="37mRID">
           <property role="37mO49" value="7858611447568893985" />
           <node concept="gqqVs" id="6OfpnAgaoxy" role="37mO4d">
-            <property role="gqqTZ" value="792.0004662109375" />
-            <property role="gqqTW" value="187.5" />
-            <property role="gqqTX" value="170.0" />
-            <property role="gqqTy" value="73.0" />
+            <property role="gqqTZ" value="810.0004662109375" />
+            <property role="gqqTW" value="310.5" />
+            <property role="gqqTX" value="172.0" />
+            <property role="gqqTy" value="155.0" />
             <property role="TgtnS" value="1.0;0.0;0.0;1.0;0.0;0.0" />
           </node>
         </node>
         <node concept="37mRIm" id="6OfpnAgaox_" role="37mRID">
           <property role="37mO49" value="7858611447568893988" />
           <node concept="gqqVs" id="6OfpnAgaox$" role="37mO4d">
-            <property role="gqqTZ" value="402.0002831054687" />
-            <property role="gqqTW" value="291.0" />
-            <property role="gqqTX" value="138.0" />
-            <property role="gqqTy" value="52.0" />
+            <property role="gqqTZ" value="390.0002831054687" />
+            <property role="gqqTW" value="321.0" />
+            <property role="gqqTX" value="170.0" />
+            <property role="gqqTy" value="134.0" />
             <property role="TgtnS" value="1.0;0.0;0.0;1.0;0.0;0.0" />
           </node>
         </node>
         <node concept="37mRIm" id="6OfpnAgaoxB" role="37mRID">
           <property role="37mO49" value="7858611447568893992" />
           <node concept="gqqVs" id="6OfpnAgaoxA" role="37mO4d">
-            <property role="gqqTZ" value="406.0002831054687" />
-            <property role="gqqTW" value="84.0" />
-            <property role="gqqTX" value="114.0" />
-            <property role="gqqTy" value="73.0" />
+            <property role="gqqTZ" value="410.0002831054687" />
+            <property role="gqqTW" value="132.0" />
+            <property role="gqqTX" value="128.0" />
+            <property role="gqqTy" value="171.0" />
             <property role="TgtnS" value="1.0;0.0;0.0;1.0;0.0;0.0" />
           </node>
         </node>
@@ -23679,9 +23696,9 @@
           <property role="37mO49" value="7858611447568893997" />
           <node concept="gqqVs" id="6OfpnAgaoxC" role="37mO4d">
             <property role="gqqTZ" value="12.000100000000003" />
-            <property role="gqqTW" value="84.0" />
-            <property role="gqqTX" value="122.0" />
-            <property role="gqqTy" value="73.0" />
+            <property role="gqqTW" value="140.0" />
+            <property role="gqqTX" value="126.0" />
+            <property role="gqqTy" value="155.0" />
             <property role="TgtnS" value="1.0;0.0;0.0;1.0;0.0;0.0" />
           </node>
         </node>
@@ -23692,14 +23709,22 @@
               <property role="3ul5GH" value="label" />
               <node concept="3wpmZ1" id="6OfpnAgaoxH" role="3ul5Gz">
                 <node concept="2VclrF" id="6OfpnAgaoxI" role="3wpmZR">
-                  <property role="2Vclpx" value="568.0003662109375" />
-                  <property role="2Vclpz" value="214.00005" />
+                  <property role="2Vclpx" value="586.0003662109375" />
+                  <property role="2Vclpz" value="550.00005" />
                 </node>
                 <node concept="2VclrF" id="6OfpnAgaoxJ" role="3wpmZP">
                   <property role="2Vclpx" value="0.0" />
                   <property role="2Vclpz" value="0.0" />
                 </node>
               </node>
+            </node>
+            <node concept="2VclrF" id="2PdRDsY5$Mq" role="2Vcluh">
+              <property role="2Vclpx" value="790.0003662109375" />
+              <property role="2Vclpz" value="561.00005" />
+            </node>
+            <node concept="2VclrF" id="2PdRDsY5$Mr" role="2Vcluh">
+              <property role="2Vclpx" value="790.0003662109375" />
+              <property role="2Vclpz" value="388.00005" />
             </node>
           </node>
         </node>
@@ -23710,8 +23735,8 @@
               <property role="3ul5GH" value="label" />
               <node concept="3wpmZ1" id="6OfpnAgaoxN" role="3ul5Gz">
                 <node concept="2VclrF" id="6OfpnAgaoxO" role="3wpmZR">
-                  <property role="2Vclpx" value="560.0003662109375" />
-                  <property role="2Vclpz" value="352.0" />
+                  <property role="2Vclpx" value="578.0003662109375" />
+                  <property role="2Vclpz" value="656.0" />
                 </node>
                 <node concept="2VclrF" id="6OfpnAgaoxP" role="3wpmZP">
                   <property role="2Vclpx" value="0.0" />
@@ -23720,28 +23745,28 @@
               </node>
             </node>
             <node concept="2VclrF" id="6OfpnAgao_r" role="2Vcluh">
-              <property role="2Vclpx" value="982.0005493164062" />
-              <property role="2Vclpz" value="225.00005" />
+              <property role="2Vclpx" value="1000.0005493164062" />
+              <property role="2Vclpz" value="388.00005" />
             </node>
             <node concept="2VclrF" id="6OfpnAgao_s" role="2Vcluh">
-              <property role="2Vclpx" value="982.0005493164062" />
-              <property role="2Vclpz" value="363.0" />
+              <property role="2Vclpx" value="1000.0005493164062" />
+              <property role="2Vclpz" value="667.0" />
             </node>
             <node concept="2VclrF" id="6OfpnAgao_t" role="2Vcluh">
-              <property role="2Vclpx" value="877.0004662109375" />
-              <property role="2Vclpz" value="363.0" />
+              <property role="2Vclpx" value="895.0004662109375" />
+              <property role="2Vclpz" value="667.0" />
             </node>
             <node concept="2VclrF" id="6OfpnAgao_u" role="2Vcluh">
-              <property role="2Vclpx" value="463.0002831054687" />
-              <property role="2Vclpz" value="363.0" />
+              <property role="2Vclpx" value="473.0002831054687" />
+              <property role="2Vclpz" value="667.0" />
             </node>
             <node concept="2VclrF" id="6OfpnAgao_v" role="2Vcluh">
-              <property role="2Vclpx" value="366.00018310546875" />
-              <property role="2Vclpz" value="363.0" />
+              <property role="2Vclpx" value="368.00018310546875" />
+              <property role="2Vclpz" value="667.0" />
             </node>
             <node concept="2VclrF" id="6OfpnAgao_w" role="2Vcluh">
-              <property role="2Vclpx" value="366.00018310546875" />
-              <property role="2Vclpz" value="225.00005" />
+              <property role="2Vclpx" value="368.00018310546875" />
+              <property role="2Vclpz" value="561.00005" />
             </node>
           </node>
         </node>
@@ -23752,22 +23777,14 @@
               <property role="3ul5GH" value="label" />
               <node concept="3wpmZ1" id="6OfpnAgaoxT" role="3ul5Gz">
                 <node concept="2VclrF" id="6OfpnAgaoxU" role="3wpmZR">
-                  <property role="2Vclpx" value="568.0003662109375" />
-                  <property role="2Vclpz" value="307.00005" />
+                  <property role="2Vclpx" value="586.0003662109375" />
+                  <property role="2Vclpz" value="377.00005" />
                 </node>
                 <node concept="2VclrF" id="6OfpnAgaoxV" role="3wpmZP">
                   <property role="2Vclpx" value="0.0" />
                   <property role="2Vclpz" value="0.0" />
                 </node>
               </node>
-            </node>
-            <node concept="2VclrF" id="3yqOawE4r94" role="2Vcluh">
-              <property role="2Vclpx" value="772.0003662109375" />
-              <property role="2Vclpz" value="318.00005" />
-            </node>
-            <node concept="2VclrF" id="3yqOawE4r95" role="2Vcluh">
-              <property role="2Vclpx" value="772.0003662109375" />
-              <property role="2Vclpz" value="225.00005" />
             </node>
           </node>
         </node>
@@ -23778,8 +23795,8 @@
               <property role="3ul5GH" value="label" />
               <node concept="3wpmZ1" id="6OfpnAgaoxZ" role="3ul5Gz">
                 <node concept="2VclrF" id="6OfpnAgaoy0" role="3wpmZR">
-                  <property role="2Vclpx" value="560.0003662109375" />
-                  <property role="2Vclpz" value="110.50004999999999" />
+                  <property role="2Vclpx" value="578.0003662109375" />
+                  <property role="2Vclpz" value="206.50005" />
                 </node>
                 <node concept="2VclrF" id="6OfpnAgaoy1" role="3wpmZP">
                   <property role="2Vclpx" value="0.0" />
@@ -23788,12 +23805,12 @@
               </node>
             </node>
             <node concept="2VclrF" id="6OfpnAgao_z" role="2Vcluh">
-              <property role="2Vclpx" value="772.0003662109375" />
-              <property role="2Vclpz" value="121.50004999999999" />
+              <property role="2Vclpx" value="790.0003662109375" />
+              <property role="2Vclpz" value="217.50005" />
             </node>
             <node concept="2VclrF" id="6OfpnAgao_$" role="2Vcluh">
-              <property role="2Vclpx" value="772.0003662109375" />
-              <property role="2Vclpz" value="225.00005" />
+              <property role="2Vclpx" value="790.0003662109375" />
+              <property role="2Vclpz" value="388.00005" />
             </node>
           </node>
         </node>
@@ -23804,8 +23821,8 @@
               <property role="3ul5GH" value="label" />
               <node concept="3wpmZ1" id="6OfpnAgaoy5" role="3ul5Gz">
                 <node concept="2VclrF" id="6OfpnAgaoy6" role="3wpmZR">
-                  <property role="2Vclpx" value="154.0001983642578" />
-                  <property role="2Vclpz" value="110.50004999999999" />
+                  <property role="2Vclpx" value="156.0001983642578" />
+                  <property role="2Vclpz" value="206.50005" />
                 </node>
                 <node concept="2VclrF" id="6OfpnAgaoy7" role="3wpmZP">
                   <property role="2Vclpx" value="0.0" />
@@ -23818,10 +23835,10 @@
         <node concept="37mRIm" id="6OfpnAgaoAe" role="37mRID">
           <property role="37mO49" value="7858611447568894324" />
           <node concept="gqqVs" id="6OfpnAgaoAd" role="37mO4d">
-            <property role="gqqTZ" value="12.000100000000003" />
+            <property role="gqqTZ" value="12.000099999999975" />
             <property role="gqqTW" value="12.0" />
-            <property role="gqqTX" value="106.0" />
-            <property role="gqqTy" value="52.0" />
+            <property role="gqqTX" value="270.0" />
+            <property role="gqqTy" value="102.0" />
             <property role="TgtnS" value="1.0;0.0;0.0;1.0;0.0;0.0" />
           </node>
         </node>
@@ -23842,6 +23859,11 @@
         <property role="TrG5h" value="contains" />
         <ref role="2PBxlG" node="6OfpnAgaowx" resolve="Department" />
       </node>
+      <node concept="19SGf9" id="2PdRDsY5$Mm" role="1Tip5L">
+        <node concept="19SUe$" id="2PdRDsY5$Mn" role="19SJt6">
+          <property role="19SUeA" value=" A high-level educational institution where students study for degrees and academic research is conducted." />
+        </node>
+      </node>
     </node>
     <node concept="2PBybn" id="6OfpnAgaowx" role="2PBxlY">
       <property role="TrG5h" value="Department" />
@@ -23856,11 +23878,21 @@
         <property role="TrG5h" value="belongs to" />
         <ref role="2PBxlG" node="6OfpnAganVn" resolve="University" />
       </node>
+      <node concept="19SGf9" id="2PdRDsY5$Ms" role="1Tip5L">
+        <node concept="19SUe$" id="2PdRDsY5$Mt" role="19SJt6">
+          <property role="19SUeA" value=" A high-level educational institution where students study for degrees and academic research is conducted" />
+        </node>
+      </node>
     </node>
     <node concept="2PBybn" id="6OfpnAgao_O" role="2PBxlY">
       <property role="TrG5h" value="Human" />
       <node concept="2PBxex" id="6OfpnAgaox9" role="2PBxlM">
         <property role="TrG5h" value="name" />
+      </node>
+      <node concept="19SGf9" id="2PdRDsY5$Mw" role="1Tip5L">
+        <node concept="19SUe$" id="2PdRDsY5$Mx" role="19SJt6">
+          <property role="19SUeA" value=" A member of the species Homo sapiens, characterized by intelligence, bipedalism, and hairlessness" />
+        </node>
       </node>
     </node>
     <node concept="2PBybn" id="6OfpnAgaow$" role="2PBxlY">
@@ -23871,6 +23903,11 @@
       <node concept="2PBxew" id="6OfpnAgaoxq" role="2PBxlK">
         <property role="TrG5h" value="works in" />
         <ref role="2PBxlG" node="6OfpnAgaowx" resolve="Department" />
+      </node>
+      <node concept="19SGf9" id="2PdRDsY5$M$" role="1Tip5L">
+        <node concept="19SUe$" id="2PdRDsY5$M_" role="19SJt6">
+          <property role="19SUeA" value=" An academic rank at universities, usually an expert in their field and a teacher of the highest rank" />
+        </node>
       </node>
     </node>
     <node concept="2PBybn" id="6OfpnAgaowC" role="2PBxlY">
@@ -23886,6 +23923,11 @@
         <property role="2PBxlI" value="4_qW8fWLecA/composition" />
         <ref role="2PBxlG" node="6OfpnAgaowx" resolve="Department" />
       </node>
+      <node concept="19SGf9" id="2PdRDsY5$MC" role="1Tip5L">
+        <node concept="19SUe$" id="2PdRDsY5$MD" role="19SJt6">
+          <property role="19SUeA" value=" A set of classes or a plan of study on a particular subject, often leading to an exam or qualification" />
+        </node>
+      </node>
     </node>
     <node concept="2PBybn" id="6OfpnAgaowH" role="2PBxlY">
       <property role="TrG5h" value="Student" />
@@ -23899,6 +23941,11 @@
       <node concept="2PBxew" id="6OfpnAgaoxu" role="2PBxlK">
         <property role="TrG5h" value="enrolls in" />
         <ref role="2PBxlG" node="6OfpnAgaowC" resolve="Course" />
+      </node>
+      <node concept="19SGf9" id="2PdRDsY5$MG" role="1Tip5L">
+        <node concept="19SUe$" id="2PdRDsY5$MH" role="19SJt6">
+          <property role="19SUeA" value=" A person enrolled in an educational institution, pursuing learning and academic goals" />
+        </node>
       </node>
     </node>
   </node>
@@ -24627,6 +24674,1589 @@
       </node>
       <node concept="3uibUv" id="ir_Dm4lwGO" role="aoRGl">
         <ref role="3uigEE" to="r3rm:6mIiWXPO0l0" resolve="BaseDCell" />
+      </node>
+    </node>
+  </node>
+  <node concept="gKF8R" id="2PdRDsX$nLS">
+    <property role="3GE5qa" value="testDiagrams" />
+    <property role="TrG5h" value="Boxes smaller than required size" />
+    <node concept="1kFUpA" id="2PdRDsX$R_$" role="1kFUp8">
+      <property role="TrG5h" value="box1" />
+      <node concept="1kFiRK" id="2PdRDsX_0r1" role="1kFiS3">
+        <property role="1kFiRC" value="A long content of box 1 (normal text)" />
+        <property role="gOZn8" value="second value" />
+      </node>
+      <node concept="1kFUp3" id="2PdRDsX$R_A" role="1kFUp2">
+        <property role="TrG5h" value="box1.port" />
+        <node concept="3cmrfG" id="2PdRDsX_4lX" role="1kFUoa">
+          <property role="3cmrfH" value="1" />
+        </node>
+      </node>
+    </node>
+    <node concept="1kFUpA" id="2PdRDsX_0r4" role="1kFUp8">
+      <property role="TrG5h" value="box2" />
+      <node concept="1kFiRK" id="2PdRDsX_0r7" role="1kFiS3">
+        <property role="1kFiRC" value="A long content of box 2 (normal text)" />
+        <property role="gOZn8" value="second value" />
+      </node>
+      <node concept="1kFUp3" id="2PdRDsX_4lw" role="1kFUp2">
+        <property role="TrG5h" value="box2.port" />
+      </node>
+    </node>
+    <node concept="1kFiQP" id="2PdRDsX_4m3" role="1kFUp8">
+      <node concept="1kFiQa" id="2PdRDsX_4m6" role="1kF7lU">
+        <ref role="1kF7lA" node="2PdRDsX$R_A" resolve="box1.port" />
+      </node>
+      <node concept="1kFiQa" id="2PdRDsX_4m7" role="1kF7lN">
+        <ref role="1kF7lA" node="2PdRDsX_4lw" resolve="box2.port" />
+      </node>
+    </node>
+    <node concept="1kFUpA" id="2PdRDsXE5PJ" role="1kFUp8">
+      <property role="TrG5h" value="box3" />
+      <node concept="gVSFg" id="2PdRDsXE5PR" role="1kFiS3">
+        <node concept="19SGf9" id="2PdRDsXE5PT" role="gVSFr">
+          <node concept="19SUe$" id="2PdRDsXE5PU" role="19SJt6">
+            <property role="19SUeA" value="long content of box 3 (Text)&#10;second value" />
+          </node>
+        </node>
+      </node>
+      <node concept="1kFUp3" id="2PdRDsXE5PM" role="1kFUp2">
+        <property role="TrG5h" value="box3.port" />
+        <node concept="3cmrfG" id="2PdRDsXE5PN" role="1kFUoa">
+          <property role="3cmrfH" value="1" />
+        </node>
+      </node>
+    </node>
+    <node concept="1kFUpA" id="2PdRDsXE5PZ" role="1kFUp8">
+      <property role="TrG5h" value="box4" />
+      <node concept="gVSya" id="2PdRDsXE5Q7" role="1kFiS3">
+        <node concept="19SGf9" id="2PdRDsXE5Q9" role="gVSy8">
+          <node concept="19SUe$" id="2PdRDsXE5Qa" role="19SJt6">
+            <property role="19SUeA" value=" long content of box 4 (Text maxWidth=200)&#10;second value" />
+          </node>
+        </node>
+      </node>
+      <node concept="1kFUp3" id="2PdRDsXE5Q2" role="1kFUp2">
+        <property role="TrG5h" value="box4.port" />
+        <node concept="3cmrfG" id="2PdRDsXE5Q3" role="1kFUoa">
+          <property role="3cmrfH" value="0" />
+        </node>
+      </node>
+    </node>
+    <node concept="1kFiQP" id="2PdRDsXE5Qe" role="1kFUp8">
+      <node concept="1kFiQa" id="2PdRDsXE5Qh" role="1kF7lU">
+        <ref role="1kF7lA" node="2PdRDsXE5PM" resolve="box3.port" />
+      </node>
+      <node concept="1kFiQa" id="2PdRDsXE5Qi" role="1kF7lN">
+        <ref role="1kF7lA" node="2PdRDsXE5Q2" resolve="box4.port" />
+      </node>
+    </node>
+    <node concept="37mRI7" id="2PdRDsY5xOy" role="lGtFl">
+      <node concept="37mRIm" id="1O8ZajhS$ql" role="37mRID">
+        <property role="37mO49" value="3264510046067980644" />
+        <node concept="gqqVs" id="1O8ZajhS$qk" role="37mO4d">
+          <property role="gqqTZ" value="12.0" />
+          <property role="gqqTW" value="105.0" />
+          <property role="gqqTX" value="306.0" />
+          <property role="gqqTy" value="52.0" />
+          <property role="TgtnS" value="1.0;0.0;0.0;1.0;0.0;0.0" />
+          <node concept="1pa3jb" id="1O8ZajhS$qm" role="1pap1a">
+            <property role="1pa3iD" value="box1.port" />
+            <property role="2gRgW$" value="1407876972" />
+          </node>
+        </node>
+      </node>
+      <node concept="37mRIm" id="1O8ZajhS$qo" role="37mRID">
+        <property role="37mO49" value="3264510046068016836" />
+        <node concept="gqqVs" id="1O8ZajhS$qn" role="37mO4d">
+          <property role="gqqTZ" value="362.0" />
+          <property role="gqqTW" value="115.5" />
+          <property role="gqqTX" value="410.0" />
+          <property role="gqqTy" value="31.0" />
+          <property role="TgtnS" value="1.0;0.0;0.0;1.0;0.0;0.0" />
+          <node concept="1pa3jb" id="1O8ZajhS$qp" role="1pap1a">
+            <property role="1pa3iD" value="box2.port" />
+            <property role="2gRgW$" value="569740559" />
+          </node>
+        </node>
+      </node>
+      <node concept="37mRIm" id="1O8ZajhS$qr" role="37mRID">
+        <property role="37mO49" value="3264510046069349743" />
+        <node concept="gqqVs" id="1O8ZajhS$qq" role="37mO4d">
+          <property role="gqqTZ" value="12.0" />
+          <property role="gqqTW" value="22.5" />
+          <property role="gqqTX" value="234.0" />
+          <property role="gqqTy" value="52.0" />
+          <property role="TgtnS" value="1.0;0.0;0.0;1.0;0.0;0.0" />
+          <node concept="1pa3jb" id="1O8ZajhS$qs" role="1pap1a">
+            <property role="1pa3iD" value="box3.port" />
+            <property role="2gRgW$" value="1590728626" />
+          </node>
+        </node>
+      </node>
+      <node concept="37mRIm" id="1O8ZajhS$qu" role="37mRID">
+        <property role="37mO49" value="3264510046069349759" />
+        <node concept="gqqVs" id="1O8ZajhS$qt" role="37mO4d">
+          <property role="gqqTZ" value="290.0" />
+          <property role="gqqTW" value="12.0" />
+          <property role="gqqTX" value="186.0" />
+          <property role="gqqTy" value="73.0" />
+          <property role="TgtnS" value="1.0;0.0;0.0;1.0;0.0;0.0" />
+          <node concept="1pa3jb" id="1O8ZajhS$qv" role="1pap1a">
+            <property role="1pa3iD" value="box4.port" />
+            <property role="2gRgW$" value="522554353" />
+          </node>
+        </node>
+      </node>
+      <node concept="37mRIm" id="1O8ZajhS$qx" role="37mRID">
+        <property role="37mO49" value="3264510046068032899" />
+        <node concept="2VclpC" id="1O8ZajhS$qw" role="37mO4d" />
+      </node>
+      <node concept="37mRIm" id="1O8ZajhS$qz" role="37mRID">
+        <property role="37mO49" value="3264510046069349774" />
+        <node concept="2VclpC" id="1O8ZajhS$qy" role="37mO4d" />
+      </node>
+    </node>
+  </node>
+  <node concept="LiM7Y" id="2PdRDsXE5Qn">
+    <property role="TrG5h" value="BoxesSmallerThanRequiredSize" />
+    <property role="3GE5qa" value="actions" />
+    <node concept="3clFbS" id="2PdRDsXE5Qo" role="LjaKd">
+      <node concept="3clFbJ" id="5$DDoDSLvLz" role="3cqZAp">
+        <node concept="3clFbS" id="5$DDoDSLvL$" role="3clFbx">
+          <node concept="3cpWs6" id="5$DDoDSLvL_" role="3cqZAp" />
+        </node>
+        <node concept="2OqwBi" id="5$DDoDSLvLA" role="3clFbw">
+          <node concept="2YIFZM" id="5$DDoDSLvLB" role="2Oq$k0">
+            <ref role="37wK5l" to="bd8o:~ApplicationManager.getApplication()" resolve="getApplication" />
+            <ref role="1Pybhc" to="bd8o:~ApplicationManager" resolve="ApplicationManager" />
+          </node>
+          <node concept="liA8E" id="5$DDoDSLvLC" role="2OqNvi">
+            <ref role="37wK5l" to="bd8o:~Application.isHeadlessEnvironment()" resolve="isHeadlessEnvironment" />
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbH" id="5$DDoDSLqkR" role="3cqZAp" />
+      <node concept="3cpWs8" id="2PdRDsXE5Qp" role="3cqZAp">
+        <node concept="3cpWsn" id="2PdRDsXE5Qq" role="3cpWs9">
+          <property role="TrG5h" value="diagramECell" />
+          <node concept="2OqwBi" id="2PdRDsXE5Qr" role="33vP2m">
+            <node concept="2YIFZM" id="2PdRDsXE5Qs" role="2Oq$k0">
+              <ref role="1Pybhc" to="2o4v:1sJnak6wM3n" resolve="EditorUtil" />
+              <ref role="37wK5l" to="2o4v:1sJnak6wM46" resolve="descendants" />
+              <node concept="2OqwBi" id="2PdRDsXE5Qt" role="37wK5m">
+                <node concept="liA8E" id="2PdRDsXE5Qu" role="2OqNvi">
+                  <ref role="37wK5l" to="exr9:~EditorComponent.getRootCell()" resolve="getRootCell" />
+                </node>
+                <node concept="369mXd" id="2PdRDsXE5Qv" role="2Oq$k0" />
+              </node>
+              <node concept="3VsKOn" id="2PdRDsXE5Qw" role="37wK5m">
+                <ref role="3VsUkX" to="r3rm:4KKQOHIOe6F" resolve="RootDiagramECell" />
+              </node>
+            </node>
+            <node concept="liA8E" id="2PdRDsXE5Qx" role="2OqNvi">
+              <ref role="37wK5l" to="33ny:~List.get(int)" resolve="get" />
+              <node concept="3cmrfG" id="2PdRDsXE5Qy" role="37wK5m">
+                <property role="3cmrfH" value="0" />
+              </node>
+            </node>
+          </node>
+          <node concept="3uibUv" id="2PdRDsXE5Qz" role="1tU5fm">
+            <ref role="3uigEE" to="r3rm:4KKQOHIOe6F" resolve="RootDiagramECell" />
+          </node>
+        </node>
+      </node>
+      <node concept="3cpWs8" id="2PdRDsXE5Q$" role="3cqZAp">
+        <node concept="3cpWsn" id="2PdRDsXE5Q_" role="3cpWs9">
+          <property role="TrG5h" value="diagramDCell" />
+          <node concept="3uibUv" id="2PdRDsXE5QA" role="1tU5fm">
+            <ref role="3uigEE" to="99ht:~mxCell" resolve="mxCell" />
+          </node>
+          <node concept="2OqwBi" id="2PdRDsXE5QB" role="33vP2m">
+            <node concept="37vLTw" id="2PdRDsXE5QC" role="2Oq$k0">
+              <ref role="3cqZAo" node="2PdRDsXE5Qq" resolve="diagramECell" />
+            </node>
+            <node concept="liA8E" id="2PdRDsXE5QD" role="2OqNvi">
+              <ref role="37wK5l" to="r3rm:1M7dGa3$9rX" resolve="getDCell" />
+              <node concept="2OqwBi" id="2PdRDsXE5QE" role="37wK5m">
+                <node concept="37vLTw" id="2PdRDsXE5QF" role="2Oq$k0">
+                  <ref role="3cqZAo" node="2PdRDsXE5Qq" resolve="diagramECell" />
+                </node>
+                <node concept="liA8E" id="2PdRDsXE5QG" role="2OqNvi">
+                  <ref role="37wK5l" to="r3rm:4dus55SGE6v" resolve="getGraph" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3cpWs8" id="2PdRDsY0jil" role="3cqZAp">
+        <node concept="3cpWsn" id="2PdRDsY0jim" role="3cpWs9">
+          <property role="TrG5h" value="graph" />
+          <node concept="3uibUv" id="2PdRDsXZDEv" role="1tU5fm">
+            <ref role="3uigEE" to="r3rm:190K99KhFiz" resolve="MyGraph" />
+          </node>
+          <node concept="2OqwBi" id="2PdRDsY0jin" role="33vP2m">
+            <node concept="37vLTw" id="2PdRDsY0jio" role="2Oq$k0">
+              <ref role="3cqZAo" node="2PdRDsXE5Qq" resolve="diagramECell" />
+            </node>
+            <node concept="liA8E" id="2PdRDsY0jip" role="2OqNvi">
+              <ref role="37wK5l" to="r3rm:4dus55SGE6v" resolve="getGraph" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbH" id="2PdRDsXE5QH" role="3cqZAp" />
+      <node concept="3cpWs8" id="2PdRDsXEnR9" role="3cqZAp">
+        <node concept="3cpWsn" id="2PdRDsXEnRa" role="3cpWs9">
+          <property role="TrG5h" value="children" />
+          <node concept="_YKpA" id="2PdRDsXEnkM" role="1tU5fm">
+            <node concept="3uibUv" id="2PdRDsXEnkP" role="_ZDj9">
+              <ref role="3uigEE" to="99ht:~mxCell" resolve="mxCell" />
+            </node>
+          </node>
+          <node concept="2OqwBi" id="2PdRDsXEnRb" role="33vP2m">
+            <node concept="37vLTw" id="2PdRDsXEnRc" role="2Oq$k0">
+              <ref role="3cqZAo" node="2PdRDsXE5Q_" resolve="diagramDCell" />
+            </node>
+            <node concept="AQDAd" id="2PdRDsXEnRd" role="2OqNvi">
+              <ref role="37wK5l" node="l6SLw4iT8J" resolve="getChildren" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3cpWs8" id="2PdRDsXEoMi" role="3cqZAp">
+        <node concept="3cpWsn" id="2PdRDsXEoMj" role="3cpWs9">
+          <property role="TrG5h" value="box1" />
+          <node concept="3uibUv" id="2PdRDsXEoMk" role="1tU5fm">
+            <ref role="3uigEE" to="r3rm:f4v_NgJPyX" resolve="BoxDCell" />
+          </node>
+          <node concept="0kSF2" id="2PdRDsXEBWi" role="33vP2m">
+            <node concept="3uibUv" id="2PdRDsXEBWl" role="0kSFW">
+              <ref role="3uigEE" to="r3rm:f4v_NgJPyX" resolve="BoxDCell" />
+            </node>
+            <node concept="2OqwBi" id="2PdRDsXEpLZ" role="0kSFX">
+              <node concept="37vLTw" id="2PdRDsXEoZO" role="2Oq$k0">
+                <ref role="3cqZAo" node="2PdRDsXEnRa" resolve="children" />
+              </node>
+              <node concept="34jXtK" id="2PdRDsXEsAl" role="2OqNvi">
+                <node concept="3cmrfG" id="2PdRDsXEsBN" role="25WWJ7">
+                  <property role="3cmrfH" value="0" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3cpWs8" id="2PdRDsXEHxd" role="3cqZAp">
+        <node concept="3cpWsn" id="2PdRDsXEHxe" role="3cpWs9">
+          <property role="TrG5h" value="originalBox1Bounds" />
+          <node concept="3uibUv" id="2PdRDsXEBkv" role="1tU5fm">
+            <ref role="3uigEE" to="4io5:~Vector2D" resolve="Vector2D" />
+          </node>
+          <node concept="2ShNRf" id="2PdRDsXEHxf" role="33vP2m">
+            <node concept="1pGfFk" id="2PdRDsXEHxg" role="2ShVmc">
+              <property role="373rjd" value="true" />
+              <ref role="37wK5l" to="4io5:~Vector2D.&lt;init&gt;(double,double)" resolve="Vector2D" />
+              <node concept="3cmrfG" id="2PdRDsXEHxh" role="37wK5m">
+                <property role="3cmrfH" value="308" />
+              </node>
+              <node concept="3cmrfG" id="2PdRDsXEHxi" role="37wK5m">
+                <property role="3cmrfH" value="54" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3vlDli" id="2PdRDsXEsQU" role="3cqZAp">
+        <node concept="37vLTw" id="2PdRDsXEHxj" role="3tpDZB">
+          <ref role="3cqZAo" node="2PdRDsXEHxe" resolve="d" />
+        </node>
+        <node concept="2OqwBi" id="2PdRDsXEtFu" role="3tpDZA">
+          <node concept="37vLTw" id="2PdRDsXEt4v" role="2Oq$k0">
+            <ref role="3cqZAo" node="2PdRDsXEoMj" resolve="box1" />
+          </node>
+          <node concept="AQDAd" id="2PdRDsXEuPZ" role="2OqNvi">
+            <ref role="37wK5l" to="r3rm:1mqidcvpTcD" resolve="getSize" />
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbH" id="2PdRDsXEC1V" role="3cqZAp" />
+      <node concept="3cpWs8" id="2PdRDsXEC1X" role="3cqZAp">
+        <node concept="3cpWsn" id="2PdRDsXEC1Y" role="3cpWs9">
+          <property role="TrG5h" value="box2" />
+          <node concept="3uibUv" id="2PdRDsXEC1Z" role="1tU5fm">
+            <ref role="3uigEE" to="r3rm:f4v_NgJPyX" resolve="BoxDCell" />
+          </node>
+          <node concept="0kSF2" id="2PdRDsXEC20" role="33vP2m">
+            <node concept="3uibUv" id="2PdRDsXEC21" role="0kSFW">
+              <ref role="3uigEE" to="r3rm:f4v_NgJPyX" resolve="BoxDCell" />
+            </node>
+            <node concept="2OqwBi" id="2PdRDsXEC22" role="0kSFX">
+              <node concept="37vLTw" id="2PdRDsXEC23" role="2Oq$k0">
+                <ref role="3cqZAo" node="2PdRDsXEnRa" resolve="children" />
+              </node>
+              <node concept="34jXtK" id="2PdRDsXEC24" role="2OqNvi">
+                <node concept="3cmrfG" id="2PdRDsXEEmr" role="25WWJ7">
+                  <property role="3cmrfH" value="1" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3cpWs8" id="2PdRDsXEI7D" role="3cqZAp">
+        <node concept="3cpWsn" id="2PdRDsXEI7E" role="3cpWs9">
+          <property role="TrG5h" value="originalBox2Bounds" />
+          <node concept="3uibUv" id="2PdRDsXECMH" role="1tU5fm">
+            <ref role="3uigEE" to="4io5:~Vector2D" resolve="Vector2D" />
+          </node>
+          <node concept="2ShNRf" id="2PdRDsXEI7F" role="33vP2m">
+            <node concept="1pGfFk" id="2PdRDsXEI7G" role="2ShVmc">
+              <property role="373rjd" value="true" />
+              <ref role="37wK5l" to="4io5:~Vector2D.&lt;init&gt;(double,double)" resolve="Vector2D" />
+              <node concept="3cmrfG" id="2PdRDsXEI7H" role="37wK5m">
+                <property role="3cmrfH" value="412" />
+              </node>
+              <node concept="3cmrfG" id="2PdRDsXEI7I" role="37wK5m">
+                <property role="3cmrfH" value="33" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3vlDli" id="2PdRDsXEC26" role="3cqZAp">
+        <node concept="37vLTw" id="2PdRDsXEI7J" role="3tpDZB">
+          <ref role="3cqZAo" node="2PdRDsXEI7E" resolve="d" />
+        </node>
+        <node concept="2OqwBi" id="2PdRDsXEC2b" role="3tpDZA">
+          <node concept="37vLTw" id="2PdRDsXEC2c" role="2Oq$k0">
+            <ref role="3cqZAo" node="2PdRDsXEC1Y" resolve="box1" />
+          </node>
+          <node concept="AQDAd" id="2PdRDsXEC2d" role="2OqNvi">
+            <ref role="37wK5l" to="r3rm:1mqidcvpTcD" resolve="getSize" />
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbH" id="2PdRDsXEDiJ" role="3cqZAp" />
+      <node concept="3cpWs8" id="2PdRDsXEDC3" role="3cqZAp">
+        <node concept="3cpWsn" id="2PdRDsXEDC4" role="3cpWs9">
+          <property role="TrG5h" value="box3" />
+          <node concept="3uibUv" id="2PdRDsXEDC5" role="1tU5fm">
+            <ref role="3uigEE" to="r3rm:f4v_NgJPyX" resolve="BoxDCell" />
+          </node>
+          <node concept="0kSF2" id="2PdRDsXEDC6" role="33vP2m">
+            <node concept="3uibUv" id="2PdRDsXEDC7" role="0kSFW">
+              <ref role="3uigEE" to="r3rm:f4v_NgJPyX" resolve="BoxDCell" />
+            </node>
+            <node concept="2OqwBi" id="2PdRDsXEDC8" role="0kSFX">
+              <node concept="37vLTw" id="2PdRDsXEDC9" role="2Oq$k0">
+                <ref role="3cqZAo" node="2PdRDsXEnRa" resolve="children" />
+              </node>
+              <node concept="34jXtK" id="2PdRDsXEDCa" role="2OqNvi">
+                <node concept="3cmrfG" id="2PdRDsXEEn_" role="25WWJ7">
+                  <property role="3cmrfH" value="2" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3cpWs8" id="2PdRDsXEJ7O" role="3cqZAp">
+        <node concept="3cpWsn" id="2PdRDsXEJ7P" role="3cpWs9">
+          <property role="TrG5h" value="originalBox3Bounds" />
+          <node concept="3uibUv" id="2PdRDsXEJ0x" role="1tU5fm">
+            <ref role="3uigEE" to="4io5:~Vector2D" resolve="Vector2D" />
+          </node>
+          <node concept="2ShNRf" id="2PdRDsXEJ7Q" role="33vP2m">
+            <node concept="1pGfFk" id="2PdRDsXEJ7R" role="2ShVmc">
+              <property role="373rjd" value="true" />
+              <ref role="37wK5l" to="4io5:~Vector2D.&lt;init&gt;(double,double)" resolve="Vector2D" />
+              <node concept="3cmrfG" id="2PdRDsXEJ7S" role="37wK5m">
+                <property role="3cmrfH" value="236" />
+              </node>
+              <node concept="3cmrfG" id="2PdRDsXEJ7T" role="37wK5m">
+                <property role="3cmrfH" value="54" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3vlDli" id="2PdRDsXEDCc" role="3cqZAp">
+        <node concept="37vLTw" id="2PdRDsXEJ7U" role="3tpDZB">
+          <ref role="3cqZAo" node="2PdRDsXEJ7P" resolve="d" />
+        </node>
+        <node concept="2OqwBi" id="2PdRDsXEDCh" role="3tpDZA">
+          <node concept="37vLTw" id="2PdRDsXEDCi" role="2Oq$k0">
+            <ref role="3cqZAo" node="2PdRDsXEDC4" resolve="box1" />
+          </node>
+          <node concept="AQDAd" id="2PdRDsXEDCj" role="2OqNvi">
+            <ref role="37wK5l" to="r3rm:1mqidcvpTcD" resolve="getSize" />
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbH" id="2PdRDsXEDXw" role="3cqZAp" />
+      <node concept="3cpWs8" id="2PdRDsXEDXy" role="3cqZAp">
+        <node concept="3cpWsn" id="2PdRDsXEDXz" role="3cpWs9">
+          <property role="TrG5h" value="box4" />
+          <node concept="3uibUv" id="2PdRDsXEDX$" role="1tU5fm">
+            <ref role="3uigEE" to="r3rm:f4v_NgJPyX" resolve="BoxDCell" />
+          </node>
+          <node concept="0kSF2" id="2PdRDsXEDX_" role="33vP2m">
+            <node concept="3uibUv" id="2PdRDsXEDXA" role="0kSFW">
+              <ref role="3uigEE" to="r3rm:f4v_NgJPyX" resolve="BoxDCell" />
+            </node>
+            <node concept="2OqwBi" id="2PdRDsXEDXB" role="0kSFX">
+              <node concept="37vLTw" id="2PdRDsXEDXC" role="2Oq$k0">
+                <ref role="3cqZAo" node="2PdRDsXEnRa" resolve="children" />
+              </node>
+              <node concept="34jXtK" id="2PdRDsXEDXD" role="2OqNvi">
+                <node concept="3cmrfG" id="2PdRDsXEEoJ" role="25WWJ7">
+                  <property role="3cmrfH" value="3" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3cpWs8" id="2PdRDsXEJDB" role="3cqZAp">
+        <node concept="3cpWsn" id="2PdRDsXEJDC" role="3cpWs9">
+          <property role="TrG5h" value="originalBox4Bounds" />
+          <node concept="3uibUv" id="2PdRDsXEE73" role="1tU5fm">
+            <ref role="3uigEE" to="4io5:~Vector2D" resolve="Vector2D" />
+          </node>
+          <node concept="2ShNRf" id="2PdRDsXEJDD" role="33vP2m">
+            <node concept="1pGfFk" id="2PdRDsXEJDE" role="2ShVmc">
+              <property role="373rjd" value="true" />
+              <ref role="37wK5l" to="4io5:~Vector2D.&lt;init&gt;(double,double)" resolve="Vector2D" />
+              <node concept="3cmrfG" id="2PdRDsXEJDF" role="37wK5m">
+                <property role="3cmrfH" value="188" />
+              </node>
+              <node concept="3cmrfG" id="2PdRDsXEJDG" role="37wK5m">
+                <property role="3cmrfH" value="75" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3vlDli" id="2PdRDsXEDXF" role="3cqZAp">
+        <node concept="37vLTw" id="2PdRDsXEJDH" role="3tpDZB">
+          <ref role="3cqZAo" node="2PdRDsXEJDC" resolve="d" />
+        </node>
+        <node concept="2OqwBi" id="2PdRDsXEDXK" role="3tpDZA">
+          <node concept="37vLTw" id="2PdRDsXEDXL" role="2Oq$k0">
+            <ref role="3cqZAo" node="2PdRDsXEDXz" resolve="box1" />
+          </node>
+          <node concept="AQDAd" id="2PdRDsXEDXM" role="2OqNvi">
+            <ref role="37wK5l" to="r3rm:1mqidcvpTcD" resolve="getSize" />
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbH" id="2PdRDsXEGmK" role="3cqZAp" />
+      <node concept="3clFbF" id="2PdRDsXEGTs" role="3cqZAp">
+        <node concept="2YIFZM" id="2PdRDsXEGTu" role="3clFbG">
+          <ref role="37wK5l" to="3a50:~ThreadUtils.runInUIThreadAndWait(java.lang.Runnable)" resolve="runInUIThreadAndWait" />
+          <ref role="1Pybhc" to="3a50:~ThreadUtils" resolve="ThreadUtils" />
+          <node concept="1bVj0M" id="2PdRDsXEGTv" role="37wK5m">
+            <node concept="3clFbS" id="2PdRDsXEGTw" role="1bW5cS">
+              <node concept="3clFbF" id="2PdRDsXEGTx" role="3cqZAp">
+                <node concept="2OqwBi" id="2PdRDsXEGTy" role="3clFbG">
+                  <node concept="2OqwBi" id="2PdRDsXEGTz" role="2Oq$k0">
+                    <node concept="2OqwBi" id="2PdRDsXEGT$" role="2Oq$k0">
+                      <node concept="37vLTw" id="2PdRDsXEGT_" role="2Oq$k0">
+                        <ref role="3cqZAo" node="2PdRDsXE5Qq" resolve="diagramECell" />
+                      </node>
+                      <node concept="liA8E" id="2PdRDsXEGTA" role="2OqNvi">
+                        <ref role="37wK5l" to="r3rm:5S8_I2GeiUe" resolve="getDiagramModel" />
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="2PdRDsXEGTB" role="2OqNvi">
+                      <ref role="37wK5l" to="nkm5:7k8PWDQhok1" resolve="getLayouter" />
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="2PdRDsXEGTC" role="2OqNvi">
+                    <ref role="37wK5l" to="r3rm:xqQxwstVRr" resolve="layout" />
+                    <node concept="2OqwBi" id="2PdRDsXEGTD" role="37wK5m">
+                      <node concept="37vLTw" id="2PdRDsXEGTE" role="2Oq$k0">
+                        <ref role="3cqZAo" node="2PdRDsXE5Qq" resolve="diagramECell" />
+                      </node>
+                      <node concept="liA8E" id="2PdRDsXEGTF" role="2OqNvi">
+                        <ref role="37wK5l" to="r3rm:4dus55SGE6v" resolve="getGraph" />
+                      </node>
+                    </node>
+                    <node concept="2ShNRf" id="2PdRDsXEGTG" role="37wK5m">
+                      <node concept="1pGfFk" id="2PdRDsXEGTH" role="2ShVmc">
+                        <property role="373rjd" value="true" />
+                        <ref role="37wK5l" to="xygl:~EmptyProgressIndicator.&lt;init&gt;()" resolve="EmptyProgressIndicator" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbH" id="2PdRDsXEGmL" role="3cqZAp" />
+      <node concept="3vlDli" id="2PdRDsXEK8M" role="3cqZAp">
+        <node concept="37vLTw" id="2PdRDsXELqA" role="3tpDZB">
+          <ref role="3cqZAo" node="2PdRDsXEHxe" resolve="originalBox1Bounds" />
+        </node>
+        <node concept="2OqwBi" id="2PdRDsXEMlK" role="3tpDZA">
+          <node concept="37vLTw" id="2PdRDsXELCq" role="2Oq$k0">
+            <ref role="3cqZAo" node="2PdRDsXEoMj" resolve="box1" />
+          </node>
+          <node concept="AQDAd" id="2PdRDsXENIU" role="2OqNvi">
+            <ref role="37wK5l" to="r3rm:1mqidcvpTcD" resolve="getSize" />
+          </node>
+        </node>
+      </node>
+      <node concept="3vlDli" id="2PdRDsXENK2" role="3cqZAp">
+        <node concept="37vLTw" id="2PdRDsXENK3" role="3tpDZB">
+          <ref role="3cqZAo" node="2PdRDsXEI7E" resolve="originalBox2Bounds" />
+        </node>
+        <node concept="2OqwBi" id="2PdRDsXENK4" role="3tpDZA">
+          <node concept="37vLTw" id="2PdRDsXENK5" role="2Oq$k0">
+            <ref role="3cqZAo" node="2PdRDsXEC1Y" resolve="box2" />
+          </node>
+          <node concept="AQDAd" id="2PdRDsXENK6" role="2OqNvi">
+            <ref role="37wK5l" to="r3rm:1mqidcvpTcD" resolve="getSize" />
+          </node>
+        </node>
+      </node>
+      <node concept="3vlDli" id="2PdRDsXEO$z" role="3cqZAp">
+        <node concept="37vLTw" id="2PdRDsXEO$$" role="3tpDZB">
+          <ref role="3cqZAo" node="2PdRDsXEJ7P" resolve="originalBox3Bounds" />
+        </node>
+        <node concept="2OqwBi" id="2PdRDsXEO$_" role="3tpDZA">
+          <node concept="37vLTw" id="2PdRDsXEO$A" role="2Oq$k0">
+            <ref role="3cqZAo" node="2PdRDsXEDC4" resolve="box3" />
+          </node>
+          <node concept="AQDAd" id="2PdRDsXEO$B" role="2OqNvi">
+            <ref role="37wK5l" to="r3rm:1mqidcvpTcD" resolve="getSize" />
+          </node>
+        </node>
+      </node>
+      <node concept="3vlDli" id="2PdRDsXEPeC" role="3cqZAp">
+        <node concept="37vLTw" id="2PdRDsXEPeD" role="3tpDZB">
+          <ref role="3cqZAo" node="2PdRDsXEJDC" resolve="originalBox4Bounds" />
+        </node>
+        <node concept="2OqwBi" id="2PdRDsXEPeE" role="3tpDZA">
+          <node concept="37vLTw" id="2PdRDsXEPeF" role="2Oq$k0">
+            <ref role="3cqZAo" node="2PdRDsXEDXz" resolve="box4" />
+          </node>
+          <node concept="AQDAd" id="2PdRDsXEPeG" role="2OqNvi">
+            <ref role="37wK5l" to="r3rm:1mqidcvpTcD" resolve="getSize" />
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbH" id="2PdRDsXGTUB" role="3cqZAp" />
+      <node concept="3clFbF" id="2PdRDsXGUoG" role="3cqZAp">
+        <node concept="2YIFZM" id="2PdRDsXGUoI" role="3clFbG">
+          <ref role="37wK5l" to="3a50:~ThreadUtils.runInUIThreadAndWait(java.lang.Runnable)" resolve="runInUIThreadAndWait" />
+          <ref role="1Pybhc" to="3a50:~ThreadUtils" resolve="ThreadUtils" />
+          <node concept="1bVj0M" id="2PdRDsXGUoJ" role="37wK5m">
+            <node concept="3clFbS" id="2PdRDsXGUoK" role="1bW5cS">
+              <node concept="3clFbF" id="2PdRDsXGUoL" role="3cqZAp">
+                <node concept="2YIFZM" id="2PdRDsXGVcA" role="3clFbG">
+                  <ref role="37wK5l" to="r3rm:YGA9S4Ry00" resolve="fitSizeAll" />
+                  <ref role="1Pybhc" to="r3rm:YGA9S4Rvy7" resolve="DiagramActionsUtil" />
+                  <node concept="2OqwBi" id="2PdRDsXGXpC" role="37wK5m">
+                    <node concept="37vLTw" id="2PdRDsXGWtM" role="2Oq$k0">
+                      <ref role="3cqZAo" node="2PdRDsXE5Qq" resolve="diagramECell" />
+                    </node>
+                    <node concept="liA8E" id="2PdRDsXGYXL" role="2OqNvi">
+                      <ref role="37wK5l" to="r3rm:4dus55SGE6v" resolve="getGraph" />
+                    </node>
+                  </node>
+                  <node concept="3clFbT" id="2PdRDsXH5Yd" role="37wK5m" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbH" id="2PdRDsXGTUC" role="3cqZAp" />
+      <node concept="3vlDli" id="2PdRDsXH6Nc" role="3cqZAp">
+        <node concept="37vLTw" id="2PdRDsXH6Nd" role="3tpDZB">
+          <ref role="3cqZAo" node="2PdRDsXEHxe" resolve="originalBox1Bounds" />
+        </node>
+        <node concept="2OqwBi" id="2PdRDsXH6Ne" role="3tpDZA">
+          <node concept="37vLTw" id="2PdRDsXH6Nf" role="2Oq$k0">
+            <ref role="3cqZAo" node="2PdRDsXEoMj" resolve="box1" />
+          </node>
+          <node concept="AQDAd" id="2PdRDsXH6Ng" role="2OqNvi">
+            <ref role="37wK5l" to="r3rm:1mqidcvpTcD" resolve="getSize" />
+          </node>
+        </node>
+      </node>
+      <node concept="3vlDli" id="2PdRDsXH6Nh" role="3cqZAp">
+        <node concept="37vLTw" id="2PdRDsXH6Ni" role="3tpDZB">
+          <ref role="3cqZAo" node="2PdRDsXEI7E" resolve="originalBox2Bounds" />
+        </node>
+        <node concept="2OqwBi" id="2PdRDsXH6Nj" role="3tpDZA">
+          <node concept="37vLTw" id="2PdRDsXH6Nk" role="2Oq$k0">
+            <ref role="3cqZAo" node="2PdRDsXEC1Y" resolve="box2" />
+          </node>
+          <node concept="AQDAd" id="2PdRDsXH6Nl" role="2OqNvi">
+            <ref role="37wK5l" to="r3rm:1mqidcvpTcD" resolve="getSize" />
+          </node>
+        </node>
+      </node>
+      <node concept="3vlDli" id="2PdRDsXH6Nm" role="3cqZAp">
+        <node concept="37vLTw" id="2PdRDsXH6Nn" role="3tpDZB">
+          <ref role="3cqZAo" node="2PdRDsXEJ7P" resolve="originalBox3Bounds" />
+        </node>
+        <node concept="2OqwBi" id="2PdRDsXH6No" role="3tpDZA">
+          <node concept="37vLTw" id="2PdRDsXH6Np" role="2Oq$k0">
+            <ref role="3cqZAo" node="2PdRDsXEDC4" resolve="box3" />
+          </node>
+          <node concept="AQDAd" id="2PdRDsXH6Nq" role="2OqNvi">
+            <ref role="37wK5l" to="r3rm:1mqidcvpTcD" resolve="getSize" />
+          </node>
+        </node>
+      </node>
+      <node concept="3vlDli" id="2PdRDsXH6Nr" role="3cqZAp">
+        <node concept="37vLTw" id="2PdRDsXH6Ns" role="3tpDZB">
+          <ref role="3cqZAo" node="2PdRDsXEJDC" resolve="originalBox4Bounds" />
+        </node>
+        <node concept="2OqwBi" id="2PdRDsXH6Nt" role="3tpDZA">
+          <node concept="37vLTw" id="2PdRDsXH6Nu" role="2Oq$k0">
+            <ref role="3cqZAo" node="2PdRDsXEDXz" resolve="box4" />
+          </node>
+          <node concept="AQDAd" id="2PdRDsXH6Nv" role="2OqNvi">
+            <ref role="37wK5l" to="r3rm:1mqidcvpTcD" resolve="getSize" />
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbH" id="3QtXkNBu24Z" role="3cqZAp" />
+      <node concept="3clFbF" id="2PdRDsXOGOR" role="3cqZAp">
+        <node concept="2YIFZM" id="2PdRDsXOGOS" role="3clFbG">
+          <ref role="37wK5l" to="3a50:~ThreadUtils.runInUIThreadAndWait(java.lang.Runnable)" resolve="runInUIThreadAndWait" />
+          <ref role="1Pybhc" to="3a50:~ThreadUtils" resolve="ThreadUtils" />
+          <node concept="1bVj0M" id="2PdRDsXOGOT" role="37wK5m">
+            <node concept="3clFbS" id="2PdRDsXOGOU" role="1bW5cS">
+              <node concept="3clFbF" id="2PdRDsXOSif" role="3cqZAp">
+                <node concept="2OqwBi" id="2PdRDsXOSig" role="3clFbG">
+                  <node concept="37vLTw" id="2PdRDsY0jiq" role="2Oq$k0">
+                    <ref role="3cqZAo" node="2PdRDsY0jim" resolve="graph" />
+                  </node>
+                  <node concept="liA8E" id="2PdRDsXOSik" role="2OqNvi">
+                    <ref role="37wK5l" to="1njx:~mxGraph.resizeCell(java.lang.Object,com.mxgraph.util.mxRectangle)" resolve="resizeCell" />
+                    <node concept="37vLTw" id="2PdRDsXOSil" role="37wK5m">
+                      <ref role="3cqZAo" node="2PdRDsXEoMj" resolve="box1" />
+                    </node>
+                    <node concept="2ShNRf" id="2PdRDsXOSim" role="37wK5m">
+                      <node concept="1pGfFk" id="2PdRDsXOSin" role="2ShVmc">
+                        <property role="373rjd" value="true" />
+                        <ref role="37wK5l" to="18t6:~mxRectangle.&lt;init&gt;(double,double,double,double)" resolve="mxRectangle" />
+                        <node concept="3cmrfG" id="2PdRDsXOSio" role="37wK5m">
+                          <property role="3cmrfH" value="0" />
+                        </node>
+                        <node concept="3cmrfG" id="2PdRDsXOSip" role="37wK5m">
+                          <property role="3cmrfH" value="0" />
+                        </node>
+                        <node concept="3cpWs3" id="5$DDoDSH6F1" role="37wK5m">
+                          <node concept="2OqwBi" id="5$DDoDSH6F2" role="3uHU7B">
+                            <node concept="2OqwBi" id="5$DDoDSH6F3" role="2Oq$k0">
+                              <node concept="37vLTw" id="5$DDoDSH6F4" role="2Oq$k0">
+                                <ref role="3cqZAo" node="2PdRDsXEoMj" resolve="box1" />
+                              </node>
+                              <node concept="AQDAd" id="5$DDoDSH6F5" role="2OqNvi">
+                                <ref role="37wK5l" to="r3rm:1mqidcvpTcD" resolve="getSize" />
+                              </node>
+                            </node>
+                            <node concept="liA8E" id="5$DDoDSH6F6" role="2OqNvi">
+                              <ref role="37wK5l" to="4io5:~Vector2D.getX()" resolve="getX" />
+                            </node>
+                          </node>
+                          <node concept="17qRlL" id="5$DDoDSH6F7" role="3uHU7w">
+                            <node concept="3cmrfG" id="5$DDoDSH6F8" role="3uHU7w">
+                              <property role="3cmrfH" value="100" />
+                            </node>
+                            <node concept="2YIFZM" id="5$DDoDSH6F9" role="3uHU7B">
+                              <ref role="37wK5l" to="wyt6:~Math.random()" resolve="random" />
+                              <ref role="1Pybhc" to="wyt6:~Math" resolve="Math" />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3cpWs3" id="3ycxcpqgM79" role="37wK5m">
+                          <node concept="17qRlL" id="3ycxcpqgM7a" role="3uHU7w">
+                            <node concept="3cmrfG" id="3ycxcpqgM7b" role="3uHU7w">
+                              <property role="3cmrfH" value="100" />
+                            </node>
+                            <node concept="2YIFZM" id="3ycxcpqgM7c" role="3uHU7B">
+                              <ref role="37wK5l" to="wyt6:~Math.random()" resolve="random" />
+                              <ref role="1Pybhc" to="wyt6:~Math" resolve="Math" />
+                            </node>
+                          </node>
+                          <node concept="2OqwBi" id="3ycxcpqgM7d" role="3uHU7B">
+                            <node concept="2OqwBi" id="3ycxcpqgM7e" role="2Oq$k0">
+                              <node concept="37vLTw" id="3ycxcpqgM7f" role="2Oq$k0">
+                                <ref role="3cqZAo" node="2PdRDsXEoMj" resolve="box1" />
+                              </node>
+                              <node concept="AQDAd" id="3ycxcpqgM7g" role="2OqNvi">
+                                <ref role="37wK5l" to="r3rm:1mqidcvpTcD" resolve="getSize" />
+                              </node>
+                            </node>
+                            <node concept="liA8E" id="3ycxcpqgM7h" role="2OqNvi">
+                              <ref role="37wK5l" to="4io5:~Vector2D.getY()" resolve="getY" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbF" id="3ycxcpqi$Da" role="3cqZAp">
+                <node concept="2OqwBi" id="3ycxcpqi$Dc" role="3clFbG">
+                  <node concept="37vLTw" id="3ycxcpqi$Dd" role="2Oq$k0">
+                    <ref role="3cqZAo" node="2PdRDsY0jim" resolve="graph" />
+                  </node>
+                  <node concept="liA8E" id="3ycxcpqi$De" role="2OqNvi">
+                    <ref role="37wK5l" to="1njx:~mxGraph.resizeCell(java.lang.Object,com.mxgraph.util.mxRectangle)" resolve="resizeCell" />
+                    <node concept="37vLTw" id="3ycxcpqi$Df" role="37wK5m">
+                      <ref role="3cqZAo" node="2PdRDsXEC1Y" resolve="box2" />
+                    </node>
+                    <node concept="2ShNRf" id="3ycxcpqi$Dg" role="37wK5m">
+                      <node concept="1pGfFk" id="3ycxcpqi$Dh" role="2ShVmc">
+                        <property role="373rjd" value="true" />
+                        <ref role="37wK5l" to="18t6:~mxRectangle.&lt;init&gt;(double,double,double,double)" resolve="mxRectangle" />
+                        <node concept="3cmrfG" id="3ycxcpqi$Di" role="37wK5m">
+                          <property role="3cmrfH" value="0" />
+                        </node>
+                        <node concept="3cmrfG" id="3ycxcpqi$Dj" role="37wK5m">
+                          <property role="3cmrfH" value="0" />
+                        </node>
+                        <node concept="3cpWs3" id="3ycxcpqi$Dk" role="37wK5m">
+                          <node concept="2OqwBi" id="3ycxcpqi$Dl" role="3uHU7B">
+                            <node concept="2OqwBi" id="3ycxcpqi$Dm" role="2Oq$k0">
+                              <node concept="37vLTw" id="3ycxcpqi$Dn" role="2Oq$k0">
+                                <ref role="3cqZAo" node="2PdRDsXEC1Y" resolve="box2" />
+                              </node>
+                              <node concept="AQDAd" id="3ycxcpqi$Do" role="2OqNvi">
+                                <ref role="37wK5l" to="r3rm:1mqidcvpTcD" resolve="getSize" />
+                              </node>
+                            </node>
+                            <node concept="liA8E" id="3ycxcpqi$Dp" role="2OqNvi">
+                              <ref role="37wK5l" to="4io5:~Vector2D.getX()" resolve="getX" />
+                            </node>
+                          </node>
+                          <node concept="17qRlL" id="3ycxcpqi$Dq" role="3uHU7w">
+                            <node concept="3cmrfG" id="3ycxcpqi$Dr" role="3uHU7w">
+                              <property role="3cmrfH" value="100" />
+                            </node>
+                            <node concept="2YIFZM" id="3ycxcpqi$Ds" role="3uHU7B">
+                              <ref role="37wK5l" to="wyt6:~Math.random()" resolve="random" />
+                              <ref role="1Pybhc" to="wyt6:~Math" resolve="Math" />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3cpWs3" id="3ycxcpqi$Dt" role="37wK5m">
+                          <node concept="17qRlL" id="3ycxcpqi$Du" role="3uHU7w">
+                            <node concept="3cmrfG" id="3ycxcpqi$Dv" role="3uHU7w">
+                              <property role="3cmrfH" value="100" />
+                            </node>
+                            <node concept="2YIFZM" id="3ycxcpqi$Dw" role="3uHU7B">
+                              <ref role="37wK5l" to="wyt6:~Math.random()" resolve="random" />
+                              <ref role="1Pybhc" to="wyt6:~Math" resolve="Math" />
+                            </node>
+                          </node>
+                          <node concept="2OqwBi" id="3ycxcpqi$Dx" role="3uHU7B">
+                            <node concept="2OqwBi" id="3ycxcpqi$Dy" role="2Oq$k0">
+                              <node concept="37vLTw" id="3ycxcpqi$Dz" role="2Oq$k0">
+                                <ref role="3cqZAo" node="2PdRDsXEC1Y" resolve="box2" />
+                              </node>
+                              <node concept="AQDAd" id="3ycxcpqi$D$" role="2OqNvi">
+                                <ref role="37wK5l" to="r3rm:1mqidcvpTcD" resolve="getSize" />
+                              </node>
+                            </node>
+                            <node concept="liA8E" id="3ycxcpqi$D_" role="2OqNvi">
+                              <ref role="37wK5l" to="4io5:~Vector2D.getY()" resolve="getY" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbF" id="2PdRDsXOSlf" role="3cqZAp">
+                <node concept="2OqwBi" id="2PdRDsXOSlg" role="3clFbG">
+                  <node concept="37vLTw" id="2PdRDsY0jis" role="2Oq$k0">
+                    <ref role="3cqZAo" node="2PdRDsY0jim" resolve="graph" />
+                  </node>
+                  <node concept="liA8E" id="2PdRDsXOSlk" role="2OqNvi">
+                    <ref role="37wK5l" to="1njx:~mxGraph.resizeCell(java.lang.Object,com.mxgraph.util.mxRectangle)" resolve="resizeCell" />
+                    <node concept="37vLTw" id="2PdRDsXOSll" role="37wK5m">
+                      <ref role="3cqZAo" node="2PdRDsXEDC4" resolve="box3" />
+                    </node>
+                    <node concept="2ShNRf" id="2PdRDsXOSlm" role="37wK5m">
+                      <node concept="1pGfFk" id="2PdRDsXOSln" role="2ShVmc">
+                        <property role="373rjd" value="true" />
+                        <ref role="37wK5l" to="18t6:~mxRectangle.&lt;init&gt;(double,double,double,double)" resolve="mxRectangle" />
+                        <node concept="3cmrfG" id="2PdRDsXOSlo" role="37wK5m">
+                          <property role="3cmrfH" value="0" />
+                        </node>
+                        <node concept="3cmrfG" id="2PdRDsXOSlp" role="37wK5m">
+                          <property role="3cmrfH" value="0" />
+                        </node>
+                        <node concept="3cpWs3" id="3QtXkNBu1bl" role="37wK5m">
+                          <node concept="17qRlL" id="3QtXkNBu1bm" role="3uHU7w">
+                            <node concept="3cmrfG" id="3QtXkNBu1bn" role="3uHU7w">
+                              <property role="3cmrfH" value="100" />
+                            </node>
+                            <node concept="2YIFZM" id="3QtXkNBu1bo" role="3uHU7B">
+                              <ref role="37wK5l" to="wyt6:~Math.random()" resolve="random" />
+                              <ref role="1Pybhc" to="wyt6:~Math" resolve="Math" />
+                            </node>
+                          </node>
+                          <node concept="2OqwBi" id="3QtXkNBu1bp" role="3uHU7B">
+                            <node concept="2OqwBi" id="3QtXkNBu1bq" role="2Oq$k0">
+                              <node concept="37vLTw" id="3QtXkNBu1br" role="2Oq$k0">
+                                <ref role="3cqZAo" node="2PdRDsXEDC4" resolve="box3" />
+                              </node>
+                              <node concept="AQDAd" id="3QtXkNBu1bs" role="2OqNvi">
+                                <ref role="37wK5l" to="r3rm:1mqidcvpTcD" resolve="getSize" />
+                              </node>
+                            </node>
+                            <node concept="liA8E" id="3QtXkNBu1bt" role="2OqNvi">
+                              <ref role="37wK5l" to="4io5:~Vector2D.getX()" resolve="getX" />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3cpWs3" id="3QtXkNBu5Vr" role="37wK5m">
+                          <node concept="17qRlL" id="3QtXkNBu5Vs" role="3uHU7w">
+                            <node concept="3cmrfG" id="3QtXkNBu5Vt" role="3uHU7w">
+                              <property role="3cmrfH" value="100" />
+                            </node>
+                            <node concept="2YIFZM" id="3QtXkNBu5Vu" role="3uHU7B">
+                              <ref role="37wK5l" to="wyt6:~Math.random()" resolve="random" />
+                              <ref role="1Pybhc" to="wyt6:~Math" resolve="Math" />
+                            </node>
+                          </node>
+                          <node concept="2OqwBi" id="3QtXkNBu5Vv" role="3uHU7B">
+                            <node concept="2OqwBi" id="3QtXkNBu5Vw" role="2Oq$k0">
+                              <node concept="37vLTw" id="3QtXkNBu5Vx" role="2Oq$k0">
+                                <ref role="3cqZAo" node="2PdRDsXEDC4" resolve="box3" />
+                              </node>
+                              <node concept="AQDAd" id="3QtXkNBu5Vy" role="2OqNvi">
+                                <ref role="37wK5l" to="r3rm:1mqidcvpTcD" resolve="getSize" />
+                              </node>
+                            </node>
+                            <node concept="liA8E" id="3QtXkNBu5Vz" role="2OqNvi">
+                              <ref role="37wK5l" to="4io5:~Vector2D.getY()" resolve="getY" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbF" id="2PdRDsXOT76" role="3cqZAp">
+                <node concept="2OqwBi" id="2PdRDsXOT77" role="3clFbG">
+                  <node concept="37vLTw" id="2PdRDsY0jit" role="2Oq$k0">
+                    <ref role="3cqZAo" node="2PdRDsY0jim" resolve="graph" />
+                  </node>
+                  <node concept="liA8E" id="2PdRDsXOT7b" role="2OqNvi">
+                    <ref role="37wK5l" to="1njx:~mxGraph.resizeCell(java.lang.Object,com.mxgraph.util.mxRectangle)" resolve="resizeCell" />
+                    <node concept="37vLTw" id="2PdRDsXOT7c" role="37wK5m">
+                      <ref role="3cqZAo" node="2PdRDsXEDXz" resolve="box4" />
+                    </node>
+                    <node concept="2ShNRf" id="2PdRDsXOT7d" role="37wK5m">
+                      <node concept="1pGfFk" id="2PdRDsXOT7e" role="2ShVmc">
+                        <property role="373rjd" value="true" />
+                        <ref role="37wK5l" to="18t6:~mxRectangle.&lt;init&gt;(double,double,double,double)" resolve="mxRectangle" />
+                        <node concept="3cmrfG" id="2PdRDsXOT7f" role="37wK5m">
+                          <property role="3cmrfH" value="0" />
+                        </node>
+                        <node concept="3cmrfG" id="2PdRDsXOT7g" role="37wK5m">
+                          <property role="3cmrfH" value="0" />
+                        </node>
+                        <node concept="3cpWs3" id="2PdRDsXSKK$" role="37wK5m">
+                          <node concept="17qRlL" id="2PdRDsXOT7h" role="3uHU7w">
+                            <node concept="3cmrfG" id="2PdRDsXOT7i" role="3uHU7w">
+                              <property role="3cmrfH" value="100" />
+                            </node>
+                            <node concept="2YIFZM" id="2PdRDsXOT7j" role="3uHU7B">
+                              <ref role="37wK5l" to="wyt6:~Math.random()" resolve="random" />
+                              <ref role="1Pybhc" to="wyt6:~Math" resolve="Math" />
+                            </node>
+                          </node>
+                          <node concept="2OqwBi" id="2PdRDsXSKUJ" role="3uHU7B">
+                            <node concept="2OqwBi" id="2PdRDsXSKUK" role="2Oq$k0">
+                              <node concept="37vLTw" id="2PdRDsXSKUL" role="2Oq$k0">
+                                <ref role="3cqZAo" node="2PdRDsXEDXz" resolve="box4" />
+                              </node>
+                              <node concept="AQDAd" id="2PdRDsXSKUM" role="2OqNvi">
+                                <ref role="37wK5l" to="r3rm:1mqidcvpTcD" resolve="getSize" />
+                              </node>
+                            </node>
+                            <node concept="liA8E" id="2PdRDsXSKUN" role="2OqNvi">
+                              <ref role="37wK5l" to="4io5:~Vector2D.getX()" resolve="getX" />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3cpWs3" id="2PdRDsXSLTp" role="37wK5m">
+                          <node concept="17qRlL" id="2PdRDsXOT7k" role="3uHU7w">
+                            <node concept="3cmrfG" id="2PdRDsXOT7l" role="3uHU7w">
+                              <property role="3cmrfH" value="100" />
+                            </node>
+                            <node concept="2YIFZM" id="2PdRDsXOT7m" role="3uHU7B">
+                              <ref role="37wK5l" to="wyt6:~Math.random()" resolve="random" />
+                              <ref role="1Pybhc" to="wyt6:~Math" resolve="Math" />
+                            </node>
+                          </node>
+                          <node concept="2OqwBi" id="2PdRDsXSM4o" role="3uHU7B">
+                            <node concept="2OqwBi" id="2PdRDsXSM4p" role="2Oq$k0">
+                              <node concept="37vLTw" id="2PdRDsXSM4q" role="2Oq$k0">
+                                <ref role="3cqZAo" node="2PdRDsXEDXz" resolve="box4" />
+                              </node>
+                              <node concept="AQDAd" id="2PdRDsXSM4r" role="2OqNvi">
+                                <ref role="37wK5l" to="r3rm:1mqidcvpTcD" resolve="getSize" />
+                              </node>
+                            </node>
+                            <node concept="liA8E" id="2PdRDsXSM4s" role="2OqNvi">
+                              <ref role="37wK5l" to="4io5:~Vector2D.getY()" resolve="getY" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbH" id="2PdRDsXPw8c" role="3cqZAp" />
+      <node concept="3vFxKo" id="2PdRDsXR3km" role="3cqZAp">
+        <node concept="17R0WA" id="2PdRDsXR3kn" role="3vFALc">
+          <node concept="37vLTw" id="2PdRDsXR3ko" role="3uHU7w">
+            <ref role="3cqZAo" node="2PdRDsXEHxe" resolve="originalBox1Bounds" />
+          </node>
+          <node concept="2OqwBi" id="2PdRDsXR3kp" role="3uHU7B">
+            <node concept="37vLTw" id="2PdRDsXR3kq" role="2Oq$k0">
+              <ref role="3cqZAo" node="2PdRDsXEoMj" resolve="box1" />
+            </node>
+            <node concept="AQDAd" id="2PdRDsXR3kr" role="2OqNvi">
+              <ref role="37wK5l" to="r3rm:1mqidcvpTcD" resolve="getSize" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3vFxKo" id="3ycxcpqizyD" role="3cqZAp">
+        <node concept="17R0WA" id="3ycxcpqizyE" role="3vFALc">
+          <node concept="37vLTw" id="3ycxcpqizyF" role="3uHU7w">
+            <ref role="3cqZAo" node="2PdRDsXEI7E" resolve="originalBox2Bounds" />
+          </node>
+          <node concept="2OqwBi" id="3ycxcpqizyG" role="3uHU7B">
+            <node concept="37vLTw" id="3ycxcpqizyH" role="2Oq$k0">
+              <ref role="3cqZAo" node="2PdRDsXEC1Y" resolve="box2" />
+            </node>
+            <node concept="AQDAd" id="3ycxcpqizyI" role="2OqNvi">
+              <ref role="37wK5l" to="r3rm:1mqidcvpTcD" resolve="getSize" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3vFxKo" id="2PdRDsXR53c" role="3cqZAp">
+        <node concept="17R0WA" id="2PdRDsXR53d" role="3vFALc">
+          <node concept="37vLTw" id="2PdRDsXR53e" role="3uHU7w">
+            <ref role="3cqZAo" node="2PdRDsXEJ7P" resolve="originalBox3Bounds" />
+          </node>
+          <node concept="2OqwBi" id="2PdRDsXR53f" role="3uHU7B">
+            <node concept="37vLTw" id="2PdRDsXR53g" role="2Oq$k0">
+              <ref role="3cqZAo" node="2PdRDsXEDC4" resolve="box3" />
+            </node>
+            <node concept="AQDAd" id="2PdRDsXR53h" role="2OqNvi">
+              <ref role="37wK5l" to="r3rm:1mqidcvpTcD" resolve="getSize" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3vFxKo" id="2PdRDsXR5kt" role="3cqZAp">
+        <node concept="17R0WA" id="2PdRDsXR5ku" role="3vFALc">
+          <node concept="37vLTw" id="2PdRDsXR5kv" role="3uHU7w">
+            <ref role="3cqZAo" node="2PdRDsXEJDC" resolve="originalBox4Bounds" />
+          </node>
+          <node concept="2OqwBi" id="2PdRDsXR5kw" role="3uHU7B">
+            <node concept="37vLTw" id="2PdRDsXR5kx" role="2Oq$k0">
+              <ref role="3cqZAo" node="2PdRDsXEDXz" resolve="box4" />
+            </node>
+            <node concept="AQDAd" id="2PdRDsXR5ky" role="2OqNvi">
+              <ref role="37wK5l" to="r3rm:1mqidcvpTcD" resolve="getSize" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbH" id="3QtXkNBuqVl" role="3cqZAp" />
+      <node concept="3clFbF" id="40xMhJi_37$" role="3cqZAp">
+        <node concept="2YIFZM" id="40xMhJi_5re" role="3clFbG">
+          <ref role="37wK5l" node="1laJE2$mSGB" resolve="waitForDiagram" />
+          <ref role="1Pybhc" node="l6SLw4gYSS" resolve="TestUtils" />
+          <node concept="37vLTw" id="40xMhJi_74p" role="37wK5m">
+            <ref role="3cqZAo" node="2PdRDsXE5Qq" resolve="diagramECell" />
+          </node>
+          <node concept="1bVj0M" id="40xMhJi_7dg" role="37wK5m">
+            <node concept="3clFbS" id="40xMhJi_7di" role="1bW5cS">
+              <node concept="3clFbF" id="40xMhJi_7nx" role="3cqZAp">
+                <node concept="2YIFZM" id="3ycxcpqeCX6" role="3clFbG">
+                  <ref role="37wK5l" to="r3rm:YGA9S4Ry00" resolve="fitSizeAll" />
+                  <ref role="1Pybhc" to="r3rm:YGA9S4Rvy7" resolve="DiagramActionsUtil" />
+                  <node concept="2OqwBi" id="3ycxcpqeCX7" role="37wK5m">
+                    <node concept="37vLTw" id="3ycxcpqeCX8" role="2Oq$k0">
+                      <ref role="3cqZAo" node="2PdRDsXE5Qq" resolve="diagramECell" />
+                    </node>
+                    <node concept="liA8E" id="3ycxcpqeCX9" role="2OqNvi">
+                      <ref role="37wK5l" to="r3rm:4dus55SGE6v" resolve="getGraph" />
+                    </node>
+                  </node>
+                  <node concept="3clFbT" id="3ycxcpqeCXa" role="37wK5m" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1bVj0M" id="40xMhJi_7GC" role="37wK5m">
+            <node concept="3clFbS" id="40xMhJi_7GE" role="1bW5cS">
+              <node concept="3vlDli" id="2PdRDsXHV9u" role="3cqZAp">
+                <node concept="2OqwBi" id="2PdRDsXHV9w" role="3tpDZA">
+                  <node concept="37vLTw" id="2PdRDsXHV9x" role="2Oq$k0">
+                    <ref role="3cqZAo" node="2PdRDsXEoMj" resolve="box1" />
+                  </node>
+                  <node concept="AQDAd" id="2PdRDsXHV9y" role="2OqNvi">
+                    <ref role="37wK5l" to="r3rm:1mqidcvpTcD" resolve="getSize" />
+                  </node>
+                </node>
+                <node concept="37vLTw" id="5$DDoDSI6_z" role="3tpDZB">
+                  <ref role="3cqZAo" node="2PdRDsXEHxe" resolve="originalBox1Bounds" />
+                </node>
+              </node>
+              <node concept="3vlDli" id="2PdRDsXHV9z" role="3cqZAp">
+                <node concept="37vLTw" id="2PdRDsXHV9$" role="3tpDZB">
+                  <ref role="3cqZAo" node="2PdRDsXEI7E" resolve="originalBox2Bounds" />
+                </node>
+                <node concept="2OqwBi" id="2PdRDsXHV9_" role="3tpDZA">
+                  <node concept="37vLTw" id="2PdRDsXHV9A" role="2Oq$k0">
+                    <ref role="3cqZAo" node="2PdRDsXEC1Y" resolve="box2" />
+                  </node>
+                  <node concept="AQDAd" id="2PdRDsXHV9B" role="2OqNvi">
+                    <ref role="37wK5l" to="r3rm:1mqidcvpTcD" resolve="getSize" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3vlDli" id="2PdRDsXHV9C" role="3cqZAp">
+                <node concept="2OqwBi" id="2PdRDsXHV9E" role="3tpDZA">
+                  <node concept="37vLTw" id="2PdRDsXHV9F" role="2Oq$k0">
+                    <ref role="3cqZAo" node="2PdRDsXEDC4" resolve="box3" />
+                  </node>
+                  <node concept="AQDAd" id="2PdRDsXHV9G" role="2OqNvi">
+                    <ref role="37wK5l" to="r3rm:1mqidcvpTcD" resolve="getSize" />
+                  </node>
+                </node>
+                <node concept="37vLTw" id="5$DDoDSEh$r" role="3tpDZB">
+                  <ref role="3cqZAo" node="2PdRDsXEJ7P" resolve="originalBox3Bounds" />
+                </node>
+              </node>
+              <node concept="3vlDli" id="2PdRDsXHV9H" role="3cqZAp">
+                <node concept="37vLTw" id="2PdRDsXHV9I" role="3tpDZB">
+                  <ref role="3cqZAo" node="2PdRDsXEJDC" resolve="originalBox4Bounds" />
+                </node>
+                <node concept="2OqwBi" id="2PdRDsXHV9J" role="3tpDZA">
+                  <node concept="37vLTw" id="2PdRDsXHV9K" role="2Oq$k0">
+                    <ref role="3cqZAo" node="2PdRDsXEDXz" resolve="box4" />
+                  </node>
+                  <node concept="AQDAd" id="2PdRDsXHV9L" role="2OqNvi">
+                    <ref role="37wK5l" to="r3rm:1mqidcvpTcD" resolve="getSize" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbH" id="2PdRDsXI2am" role="3cqZAp" />
+      <node concept="3clFbF" id="5$DDoDSENjH" role="3cqZAp">
+        <node concept="2YIFZM" id="5$DDoDSENjI" role="3clFbG">
+          <ref role="37wK5l" to="3a50:~ThreadUtils.runInUIThreadAndWait(java.lang.Runnable)" resolve="runInUIThreadAndWait" />
+          <ref role="1Pybhc" to="3a50:~ThreadUtils" resolve="ThreadUtils" />
+          <node concept="1bVj0M" id="5$DDoDSENjJ" role="37wK5m">
+            <node concept="3clFbS" id="5$DDoDSENjK" role="1bW5cS">
+              <node concept="3clFbF" id="5$DDoDSENjL" role="3cqZAp">
+                <node concept="2OqwBi" id="5$DDoDSENjM" role="3clFbG">
+                  <node concept="37vLTw" id="5$DDoDSENjN" role="2Oq$k0">
+                    <ref role="3cqZAo" node="2PdRDsY0jim" resolve="graph" />
+                  </node>
+                  <node concept="liA8E" id="5$DDoDSENjO" role="2OqNvi">
+                    <ref role="37wK5l" to="1njx:~mxGraph.resizeCell(java.lang.Object,com.mxgraph.util.mxRectangle)" resolve="resizeCell" />
+                    <node concept="37vLTw" id="5$DDoDSENjP" role="37wK5m">
+                      <ref role="3cqZAo" node="2PdRDsXEoMj" resolve="box1" />
+                    </node>
+                    <node concept="2ShNRf" id="5$DDoDSENjQ" role="37wK5m">
+                      <node concept="1pGfFk" id="5$DDoDSENjR" role="2ShVmc">
+                        <property role="373rjd" value="true" />
+                        <ref role="37wK5l" to="18t6:~mxRectangle.&lt;init&gt;(double,double,double,double)" resolve="mxRectangle" />
+                        <node concept="3cmrfG" id="5$DDoDSENjS" role="37wK5m">
+                          <property role="3cmrfH" value="0" />
+                        </node>
+                        <node concept="3cmrfG" id="5$DDoDSENjT" role="37wK5m">
+                          <property role="3cmrfH" value="0" />
+                        </node>
+                        <node concept="3cpWs3" id="5$DDoDSENjU" role="37wK5m">
+                          <node concept="2OqwBi" id="5$DDoDSENjV" role="3uHU7B">
+                            <node concept="2OqwBi" id="5$DDoDSENjW" role="2Oq$k0">
+                              <node concept="37vLTw" id="5$DDoDSENjX" role="2Oq$k0">
+                                <ref role="3cqZAo" node="2PdRDsXEoMj" resolve="box1" />
+                              </node>
+                              <node concept="AQDAd" id="5$DDoDSENjY" role="2OqNvi">
+                                <ref role="37wK5l" to="r3rm:1mqidcvpTcD" resolve="getSize" />
+                              </node>
+                            </node>
+                            <node concept="liA8E" id="5$DDoDSENjZ" role="2OqNvi">
+                              <ref role="37wK5l" to="4io5:~Vector2D.getX()" resolve="getX" />
+                            </node>
+                          </node>
+                          <node concept="17qRlL" id="5$DDoDSENk0" role="3uHU7w">
+                            <node concept="3cmrfG" id="5$DDoDSENk1" role="3uHU7w">
+                              <property role="3cmrfH" value="100" />
+                            </node>
+                            <node concept="2YIFZM" id="5$DDoDSENk2" role="3uHU7B">
+                              <ref role="37wK5l" to="wyt6:~Math.random()" resolve="random" />
+                              <ref role="1Pybhc" to="wyt6:~Math" resolve="Math" />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3cpWs3" id="5$DDoDSENk3" role="37wK5m">
+                          <node concept="17qRlL" id="5$DDoDSENk4" role="3uHU7w">
+                            <node concept="3cmrfG" id="5$DDoDSENk5" role="3uHU7w">
+                              <property role="3cmrfH" value="100" />
+                            </node>
+                            <node concept="2YIFZM" id="5$DDoDSENk6" role="3uHU7B">
+                              <ref role="37wK5l" to="wyt6:~Math.random()" resolve="random" />
+                              <ref role="1Pybhc" to="wyt6:~Math" resolve="Math" />
+                            </node>
+                          </node>
+                          <node concept="2OqwBi" id="5$DDoDSENk7" role="3uHU7B">
+                            <node concept="2OqwBi" id="5$DDoDSENk8" role="2Oq$k0">
+                              <node concept="37vLTw" id="5$DDoDSENk9" role="2Oq$k0">
+                                <ref role="3cqZAo" node="2PdRDsXEoMj" resolve="box1" />
+                              </node>
+                              <node concept="AQDAd" id="5$DDoDSENka" role="2OqNvi">
+                                <ref role="37wK5l" to="r3rm:1mqidcvpTcD" resolve="getSize" />
+                              </node>
+                            </node>
+                            <node concept="liA8E" id="5$DDoDSENkb" role="2OqNvi">
+                              <ref role="37wK5l" to="4io5:~Vector2D.getY()" resolve="getY" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbF" id="5$DDoDSENkc" role="3cqZAp">
+                <node concept="2OqwBi" id="5$DDoDSENkd" role="3clFbG">
+                  <node concept="37vLTw" id="5$DDoDSENke" role="2Oq$k0">
+                    <ref role="3cqZAo" node="2PdRDsY0jim" resolve="graph" />
+                  </node>
+                  <node concept="liA8E" id="5$DDoDSENkf" role="2OqNvi">
+                    <ref role="37wK5l" to="1njx:~mxGraph.resizeCell(java.lang.Object,com.mxgraph.util.mxRectangle)" resolve="resizeCell" />
+                    <node concept="37vLTw" id="5$DDoDSENkg" role="37wK5m">
+                      <ref role="3cqZAo" node="2PdRDsXEC1Y" resolve="box2" />
+                    </node>
+                    <node concept="2ShNRf" id="5$DDoDSENkh" role="37wK5m">
+                      <node concept="1pGfFk" id="5$DDoDSENki" role="2ShVmc">
+                        <property role="373rjd" value="true" />
+                        <ref role="37wK5l" to="18t6:~mxRectangle.&lt;init&gt;(double,double,double,double)" resolve="mxRectangle" />
+                        <node concept="3cmrfG" id="5$DDoDSENkj" role="37wK5m">
+                          <property role="3cmrfH" value="0" />
+                        </node>
+                        <node concept="3cmrfG" id="5$DDoDSENkk" role="37wK5m">
+                          <property role="3cmrfH" value="0" />
+                        </node>
+                        <node concept="3cpWs3" id="5$DDoDSENkl" role="37wK5m">
+                          <node concept="2OqwBi" id="5$DDoDSENkm" role="3uHU7B">
+                            <node concept="2OqwBi" id="5$DDoDSENkn" role="2Oq$k0">
+                              <node concept="37vLTw" id="5$DDoDSENko" role="2Oq$k0">
+                                <ref role="3cqZAo" node="2PdRDsXEC1Y" resolve="box2" />
+                              </node>
+                              <node concept="AQDAd" id="5$DDoDSENkp" role="2OqNvi">
+                                <ref role="37wK5l" to="r3rm:1mqidcvpTcD" resolve="getSize" />
+                              </node>
+                            </node>
+                            <node concept="liA8E" id="5$DDoDSENkq" role="2OqNvi">
+                              <ref role="37wK5l" to="4io5:~Vector2D.getX()" resolve="getX" />
+                            </node>
+                          </node>
+                          <node concept="17qRlL" id="5$DDoDSENkr" role="3uHU7w">
+                            <node concept="3cmrfG" id="5$DDoDSENks" role="3uHU7w">
+                              <property role="3cmrfH" value="100" />
+                            </node>
+                            <node concept="2YIFZM" id="5$DDoDSENkt" role="3uHU7B">
+                              <ref role="37wK5l" to="wyt6:~Math.random()" resolve="random" />
+                              <ref role="1Pybhc" to="wyt6:~Math" resolve="Math" />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3cpWs3" id="5$DDoDSENku" role="37wK5m">
+                          <node concept="17qRlL" id="5$DDoDSENkv" role="3uHU7w">
+                            <node concept="3cmrfG" id="5$DDoDSENkw" role="3uHU7w">
+                              <property role="3cmrfH" value="100" />
+                            </node>
+                            <node concept="2YIFZM" id="5$DDoDSENkx" role="3uHU7B">
+                              <ref role="37wK5l" to="wyt6:~Math.random()" resolve="random" />
+                              <ref role="1Pybhc" to="wyt6:~Math" resolve="Math" />
+                            </node>
+                          </node>
+                          <node concept="2OqwBi" id="5$DDoDSENky" role="3uHU7B">
+                            <node concept="2OqwBi" id="5$DDoDSENkz" role="2Oq$k0">
+                              <node concept="37vLTw" id="5$DDoDSENk$" role="2Oq$k0">
+                                <ref role="3cqZAo" node="2PdRDsXEC1Y" resolve="box2" />
+                              </node>
+                              <node concept="AQDAd" id="5$DDoDSENk_" role="2OqNvi">
+                                <ref role="37wK5l" to="r3rm:1mqidcvpTcD" resolve="getSize" />
+                              </node>
+                            </node>
+                            <node concept="liA8E" id="5$DDoDSENkA" role="2OqNvi">
+                              <ref role="37wK5l" to="4io5:~Vector2D.getY()" resolve="getY" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbF" id="5$DDoDSENkB" role="3cqZAp">
+                <node concept="2OqwBi" id="5$DDoDSENkC" role="3clFbG">
+                  <node concept="37vLTw" id="5$DDoDSENkD" role="2Oq$k0">
+                    <ref role="3cqZAo" node="2PdRDsY0jim" resolve="graph" />
+                  </node>
+                  <node concept="liA8E" id="5$DDoDSENkE" role="2OqNvi">
+                    <ref role="37wK5l" to="1njx:~mxGraph.resizeCell(java.lang.Object,com.mxgraph.util.mxRectangle)" resolve="resizeCell" />
+                    <node concept="37vLTw" id="5$DDoDSENkF" role="37wK5m">
+                      <ref role="3cqZAo" node="2PdRDsXEDC4" resolve="box3" />
+                    </node>
+                    <node concept="2ShNRf" id="5$DDoDSENkG" role="37wK5m">
+                      <node concept="1pGfFk" id="5$DDoDSENkH" role="2ShVmc">
+                        <property role="373rjd" value="true" />
+                        <ref role="37wK5l" to="18t6:~mxRectangle.&lt;init&gt;(double,double,double,double)" resolve="mxRectangle" />
+                        <node concept="3cmrfG" id="5$DDoDSENkI" role="37wK5m">
+                          <property role="3cmrfH" value="0" />
+                        </node>
+                        <node concept="3cmrfG" id="5$DDoDSENkJ" role="37wK5m">
+                          <property role="3cmrfH" value="0" />
+                        </node>
+                        <node concept="3cpWs3" id="5$DDoDSJb42" role="37wK5m">
+                          <node concept="2OqwBi" id="5$DDoDSJb43" role="3uHU7B">
+                            <node concept="2OqwBi" id="5$DDoDSJb44" role="2Oq$k0">
+                              <node concept="37vLTw" id="5$DDoDSJb45" role="2Oq$k0">
+                                <ref role="3cqZAo" node="2PdRDsXEDC4" resolve="box3" />
+                              </node>
+                              <node concept="AQDAd" id="5$DDoDSJb46" role="2OqNvi">
+                                <ref role="37wK5l" to="r3rm:1mqidcvpTcD" resolve="getSize" />
+                              </node>
+                            </node>
+                            <node concept="liA8E" id="5$DDoDSJb47" role="2OqNvi">
+                              <ref role="37wK5l" to="4io5:~Vector2D.getX()" resolve="getX" />
+                            </node>
+                          </node>
+                          <node concept="17qRlL" id="5$DDoDSJb48" role="3uHU7w">
+                            <node concept="3cmrfG" id="5$DDoDSJb49" role="3uHU7w">
+                              <property role="3cmrfH" value="100" />
+                            </node>
+                            <node concept="2YIFZM" id="5$DDoDSJb4a" role="3uHU7B">
+                              <ref role="37wK5l" to="wyt6:~Math.random()" resolve="random" />
+                              <ref role="1Pybhc" to="wyt6:~Math" resolve="Math" />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3cpWs3" id="5$DDoDSJbHG" role="37wK5m">
+                          <node concept="2OqwBi" id="5$DDoDSJbHH" role="3uHU7B">
+                            <node concept="2OqwBi" id="5$DDoDSJbHI" role="2Oq$k0">
+                              <node concept="37vLTw" id="5$DDoDSJbHJ" role="2Oq$k0">
+                                <ref role="3cqZAo" node="2PdRDsXEDC4" resolve="box3" />
+                              </node>
+                              <node concept="AQDAd" id="5$DDoDSJbHK" role="2OqNvi">
+                                <ref role="37wK5l" to="r3rm:1mqidcvpTcD" resolve="getSize" />
+                              </node>
+                            </node>
+                            <node concept="liA8E" id="5$DDoDSJbHL" role="2OqNvi">
+                              <ref role="37wK5l" to="4io5:~Vector2D.getX()" resolve="getX" />
+                            </node>
+                          </node>
+                          <node concept="17qRlL" id="5$DDoDSJbHM" role="3uHU7w">
+                            <node concept="3cmrfG" id="5$DDoDSJbHN" role="3uHU7w">
+                              <property role="3cmrfH" value="100" />
+                            </node>
+                            <node concept="2YIFZM" id="5$DDoDSJbHO" role="3uHU7B">
+                              <ref role="37wK5l" to="wyt6:~Math.random()" resolve="random" />
+                              <ref role="1Pybhc" to="wyt6:~Math" resolve="Math" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbF" id="5$DDoDSENkM" role="3cqZAp">
+                <node concept="2OqwBi" id="5$DDoDSENkN" role="3clFbG">
+                  <node concept="37vLTw" id="5$DDoDSENkO" role="2Oq$k0">
+                    <ref role="3cqZAo" node="2PdRDsY0jim" resolve="graph" />
+                  </node>
+                  <node concept="liA8E" id="5$DDoDSENkP" role="2OqNvi">
+                    <ref role="37wK5l" to="1njx:~mxGraph.resizeCell(java.lang.Object,com.mxgraph.util.mxRectangle)" resolve="resizeCell" />
+                    <node concept="37vLTw" id="5$DDoDSENkQ" role="37wK5m">
+                      <ref role="3cqZAo" node="2PdRDsXEDXz" resolve="box4" />
+                    </node>
+                    <node concept="2ShNRf" id="5$DDoDSENkR" role="37wK5m">
+                      <node concept="1pGfFk" id="5$DDoDSENkS" role="2ShVmc">
+                        <property role="373rjd" value="true" />
+                        <ref role="37wK5l" to="18t6:~mxRectangle.&lt;init&gt;(double,double,double,double)" resolve="mxRectangle" />
+                        <node concept="3cmrfG" id="5$DDoDSENkT" role="37wK5m">
+                          <property role="3cmrfH" value="0" />
+                        </node>
+                        <node concept="3cmrfG" id="5$DDoDSENkU" role="37wK5m">
+                          <property role="3cmrfH" value="0" />
+                        </node>
+                        <node concept="3cpWs3" id="5$DDoDSENkV" role="37wK5m">
+                          <node concept="17qRlL" id="5$DDoDSENkW" role="3uHU7w">
+                            <node concept="3cmrfG" id="5$DDoDSENkX" role="3uHU7w">
+                              <property role="3cmrfH" value="100" />
+                            </node>
+                            <node concept="2YIFZM" id="5$DDoDSENkY" role="3uHU7B">
+                              <ref role="37wK5l" to="wyt6:~Math.random()" resolve="random" />
+                              <ref role="1Pybhc" to="wyt6:~Math" resolve="Math" />
+                            </node>
+                          </node>
+                          <node concept="2OqwBi" id="5$DDoDSENkZ" role="3uHU7B">
+                            <node concept="2OqwBi" id="5$DDoDSENl0" role="2Oq$k0">
+                              <node concept="37vLTw" id="5$DDoDSENl1" role="2Oq$k0">
+                                <ref role="3cqZAo" node="2PdRDsXEDXz" resolve="box4" />
+                              </node>
+                              <node concept="AQDAd" id="5$DDoDSENl2" role="2OqNvi">
+                                <ref role="37wK5l" to="r3rm:1mqidcvpTcD" resolve="getSize" />
+                              </node>
+                            </node>
+                            <node concept="liA8E" id="5$DDoDSENl3" role="2OqNvi">
+                              <ref role="37wK5l" to="4io5:~Vector2D.getX()" resolve="getX" />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3cpWs3" id="5$DDoDSENl4" role="37wK5m">
+                          <node concept="17qRlL" id="5$DDoDSENl5" role="3uHU7w">
+                            <node concept="3cmrfG" id="5$DDoDSENl6" role="3uHU7w">
+                              <property role="3cmrfH" value="100" />
+                            </node>
+                            <node concept="2YIFZM" id="5$DDoDSENl7" role="3uHU7B">
+                              <ref role="37wK5l" to="wyt6:~Math.random()" resolve="random" />
+                              <ref role="1Pybhc" to="wyt6:~Math" resolve="Math" />
+                            </node>
+                          </node>
+                          <node concept="2OqwBi" id="5$DDoDSENl8" role="3uHU7B">
+                            <node concept="2OqwBi" id="5$DDoDSENl9" role="2Oq$k0">
+                              <node concept="37vLTw" id="5$DDoDSENla" role="2Oq$k0">
+                                <ref role="3cqZAo" node="2PdRDsXEDXz" resolve="box4" />
+                              </node>
+                              <node concept="AQDAd" id="5$DDoDSENlb" role="2OqNvi">
+                                <ref role="37wK5l" to="r3rm:1mqidcvpTcD" resolve="getSize" />
+                              </node>
+                            </node>
+                            <node concept="liA8E" id="5$DDoDSENlc" role="2OqNvi">
+                              <ref role="37wK5l" to="4io5:~Vector2D.getY()" resolve="getY" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbH" id="5$DDoDSEQR4" role="3cqZAp" />
+      <node concept="3vFxKo" id="5$DDoDSF4UJ" role="3cqZAp">
+        <node concept="17R0WA" id="5$DDoDSF4UK" role="3vFALc">
+          <node concept="37vLTw" id="5$DDoDSF4UL" role="3uHU7w">
+            <ref role="3cqZAo" node="2PdRDsXEI7E" resolve="originalBox2Bounds" />
+          </node>
+          <node concept="2OqwBi" id="5$DDoDSF4UM" role="3uHU7B">
+            <node concept="37vLTw" id="5$DDoDSF4UN" role="2Oq$k0">
+              <ref role="3cqZAo" node="2PdRDsXEoMj" resolve="box1" />
+            </node>
+            <node concept="AQDAd" id="5$DDoDSF4UO" role="2OqNvi">
+              <ref role="37wK5l" to="r3rm:1mqidcvpTcD" resolve="getSize" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3vFxKo" id="2PdRDsXI2bv" role="3cqZAp">
+        <node concept="17R0WA" id="2PdRDsXI2bw" role="3vFALc">
+          <node concept="37vLTw" id="2PdRDsXI2bx" role="3uHU7w">
+            <ref role="3cqZAo" node="2PdRDsXEI7E" resolve="originalBox2Bounds" />
+          </node>
+          <node concept="2OqwBi" id="2PdRDsXI2by" role="3uHU7B">
+            <node concept="37vLTw" id="2PdRDsXI2bz" role="2Oq$k0">
+              <ref role="3cqZAo" node="2PdRDsXEC1Y" resolve="box2" />
+            </node>
+            <node concept="AQDAd" id="2PdRDsXI2b$" role="2OqNvi">
+              <ref role="37wK5l" to="r3rm:1mqidcvpTcD" resolve="getSize" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3vFxKo" id="2PdRDsXI2b_" role="3cqZAp">
+        <node concept="17R0WA" id="2PdRDsXI2bA" role="3vFALc">
+          <node concept="37vLTw" id="2PdRDsXI2bB" role="3uHU7w">
+            <ref role="3cqZAo" node="2PdRDsXEJ7P" resolve="originalBox3Bounds" />
+          </node>
+          <node concept="2OqwBi" id="2PdRDsXI2bC" role="3uHU7B">
+            <node concept="37vLTw" id="2PdRDsXI2bD" role="2Oq$k0">
+              <ref role="3cqZAo" node="2PdRDsXEDC4" resolve="box3" />
+            </node>
+            <node concept="AQDAd" id="2PdRDsXI2bE" role="2OqNvi">
+              <ref role="37wK5l" to="r3rm:1mqidcvpTcD" resolve="getSize" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3vFxKo" id="2PdRDsXI2bF" role="3cqZAp">
+        <node concept="17R0WA" id="2PdRDsXI2bG" role="3vFALc">
+          <node concept="37vLTw" id="2PdRDsXI2bH" role="3uHU7w">
+            <ref role="3cqZAo" node="2PdRDsXEJDC" resolve="originalBox4Bounds" />
+          </node>
+          <node concept="2OqwBi" id="2PdRDsXI2bI" role="3uHU7B">
+            <node concept="37vLTw" id="2PdRDsXI2bJ" role="2Oq$k0">
+              <ref role="3cqZAo" node="2PdRDsXEDXz" resolve="box4" />
+            </node>
+            <node concept="AQDAd" id="2PdRDsXI2bK" role="2OqNvi">
+              <ref role="37wK5l" to="r3rm:1mqidcvpTcD" resolve="getSize" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbH" id="5$DDoDSEX3a" role="3cqZAp" />
+      <node concept="3clFbF" id="5$DDoDSESKA" role="3cqZAp">
+        <node concept="2YIFZM" id="5$DDoDSEUE1" role="3clFbG">
+          <ref role="37wK5l" node="1laJE2$mSGB" resolve="waitForDiagram" />
+          <ref role="1Pybhc" node="l6SLw4gYSS" resolve="TestUtils" />
+          <node concept="37vLTw" id="5$DDoDSEVy7" role="37wK5m">
+            <ref role="3cqZAo" node="2PdRDsXE5Qq" resolve="diagramECell" />
+          </node>
+          <node concept="1bVj0M" id="5$DDoDSEVFg" role="37wK5m">
+            <node concept="3clFbS" id="5$DDoDSEVFi" role="1bW5cS">
+              <node concept="3clFbF" id="5$DDoDSEW6s" role="3cqZAp">
+                <node concept="2OqwBi" id="2PdRDsY4AP7" role="3clFbG">
+                  <node concept="2OqwBi" id="2PdRDsY4AP8" role="2Oq$k0">
+                    <node concept="2OqwBi" id="2PdRDsY4AP9" role="2Oq$k0">
+                      <node concept="37vLTw" id="2PdRDsY4APa" role="2Oq$k0">
+                        <ref role="3cqZAo" node="2PdRDsXE5Qq" resolve="diagramECell" />
+                      </node>
+                      <node concept="liA8E" id="2PdRDsY4APb" role="2OqNvi">
+                        <ref role="37wK5l" to="r3rm:5S8_I2GeiUe" resolve="getDiagramModel" />
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="2PdRDsY4APc" role="2OqNvi">
+                      <ref role="37wK5l" to="nkm5:7k8PWDQhok1" resolve="getLayouter" />
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="2PdRDsY4APd" role="2OqNvi">
+                    <ref role="37wK5l" to="r3rm:xqQxwstVRr" resolve="layout" />
+                    <node concept="2OqwBi" id="2PdRDsY4APe" role="37wK5m">
+                      <node concept="37vLTw" id="2PdRDsY4APf" role="2Oq$k0">
+                        <ref role="3cqZAo" node="2PdRDsXE5Qq" resolve="diagramECell" />
+                      </node>
+                      <node concept="liA8E" id="2PdRDsY4APg" role="2OqNvi">
+                        <ref role="37wK5l" to="r3rm:4dus55SGE6v" resolve="getGraph" />
+                      </node>
+                    </node>
+                    <node concept="2ShNRf" id="2PdRDsY4APh" role="37wK5m">
+                      <node concept="1pGfFk" id="2PdRDsY4APi" role="2ShVmc">
+                        <property role="373rjd" value="true" />
+                        <ref role="37wK5l" to="xygl:~EmptyProgressIndicator.&lt;init&gt;()" resolve="EmptyProgressIndicator" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1bVj0M" id="5$DDoDSEWE9" role="37wK5m">
+            <node concept="3clFbS" id="5$DDoDSEWEb" role="1bW5cS">
+              <node concept="3vlDli" id="5$DDoDSHB5F" role="3cqZAp">
+                <node concept="2OqwBi" id="5$DDoDSHB5K" role="3tpDZA">
+                  <node concept="37vLTw" id="5$DDoDSHB5L" role="2Oq$k0">
+                    <ref role="3cqZAo" node="2PdRDsXEoMj" resolve="box1" />
+                  </node>
+                  <node concept="AQDAd" id="5$DDoDSHB5M" role="2OqNvi">
+                    <ref role="37wK5l" to="r3rm:1mqidcvpTcD" resolve="getSize" />
+                  </node>
+                </node>
+                <node concept="37vLTw" id="5$DDoDSI$WF" role="3tpDZB">
+                  <ref role="3cqZAo" node="2PdRDsXEHxe" resolve="originalBox1Bounds" />
+                </node>
+              </node>
+              <node concept="3vlDli" id="2PdRDsXI2c4" role="3cqZAp">
+                <node concept="37vLTw" id="2PdRDsXI2c5" role="3tpDZB">
+                  <ref role="3cqZAo" node="2PdRDsXEI7E" resolve="originalBox2Bounds" />
+                </node>
+                <node concept="2OqwBi" id="2PdRDsXI2c6" role="3tpDZA">
+                  <node concept="37vLTw" id="2PdRDsXI2c7" role="2Oq$k0">
+                    <ref role="3cqZAo" node="2PdRDsXEC1Y" resolve="box2" />
+                  </node>
+                  <node concept="AQDAd" id="2PdRDsXI2c8" role="2OqNvi">
+                    <ref role="37wK5l" to="r3rm:1mqidcvpTcD" resolve="getSize" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3vlDli" id="2PdRDsXI2c9" role="3cqZAp">
+                <node concept="37vLTw" id="2PdRDsXI2ca" role="3tpDZB">
+                  <ref role="3cqZAo" node="2PdRDsXEJ7P" resolve="originalBox3Bounds" />
+                </node>
+                <node concept="2OqwBi" id="2PdRDsXI2cb" role="3tpDZA">
+                  <node concept="37vLTw" id="2PdRDsXI2cc" role="2Oq$k0">
+                    <ref role="3cqZAo" node="2PdRDsXEDC4" resolve="box3" />
+                  </node>
+                  <node concept="AQDAd" id="2PdRDsXI2cd" role="2OqNvi">
+                    <ref role="37wK5l" to="r3rm:1mqidcvpTcD" resolve="getSize" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3vlDli" id="2PdRDsXI2ce" role="3cqZAp">
+                <node concept="37vLTw" id="2PdRDsXI2cf" role="3tpDZB">
+                  <ref role="3cqZAo" node="2PdRDsXEJDC" resolve="originalBox4Bounds" />
+                </node>
+                <node concept="2OqwBi" id="2PdRDsXI2cg" role="3tpDZA">
+                  <node concept="37vLTw" id="2PdRDsXI2ch" role="2Oq$k0">
+                    <ref role="3cqZAo" node="2PdRDsXEDXz" resolve="box4" />
+                  </node>
+                  <node concept="AQDAd" id="2PdRDsXI2ci" role="2OqNvi">
+                    <ref role="37wK5l" to="r3rm:1mqidcvpTcD" resolve="getSize" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="2PdRDsXE5RE" role="25YQCW">
+      <node concept="yRWHJ" id="2PdRDsXE5RF" role="1qenE9">
+        <ref role="yRWHI" node="2PdRDsX$nLS" resolve="Boxes smaller than required size" />
+        <node concept="LIFWc" id="2PdRDsXE5RG" role="lGtFl">
+          <property role="LIFWa" value="5" />
+          <property role="OXtK3" value="true" />
+          <property role="p6zMq" value="5" />
+          <property role="p6zMs" value="5" />
+          <property role="LIFWd" value="Constant_mh2tpm_a0a" />
+        </node>
       </node>
     </node>
   </node>

--- a/code/solutions/de.itemis.mps.extensions.changelog/models/de.itemis.mps.extensions.changelog.mps
+++ b/code/solutions/de.itemis.mps.extensions.changelog/models/de.itemis.mps.extensions.changelog.mps
@@ -234,6 +234,74 @@
       </node>
       <node concept="15bAme" id="1TZykZLaQqm" role="15bAlL">
         <property role="15bAli" value="Po4Z58tnOE/added" />
+        <node concept="2DRihI" id="5$DDoDSNMSJ" role="15bAlk">
+          <node concept="2hgSXJ" id="5$DDoDSNMSW" role="1PaTwD">
+            <node concept="1PaTwC" id="5$DDoDSNMSX" role="2hiFM$">
+              <node concept="15Ami3" id="5$DDoDSNMSY" role="1PaTwD">
+                <node concept="37shsh" id="5$DDoDSNMSZ" role="15Aodc">
+                  <node concept="1dCxOk" id="5$DDoDSNMT0" role="37shsm">
+                    <property role="1XweGW" value="fa13cc63-c476-4d46-9c96-d53670abe7bc" />
+                    <property role="1XxBO9" value="de.itemis.mps.editor.diagram" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3oM_SD" id="5$DDoDSNMT1" role="1PaTwD">
+                <property role="3oM_SC" value=":" />
+              </node>
+            </node>
+          </node>
+          <node concept="3oM_SD" id="5$DDoDSNMT8" role="1PaTwD">
+            <property role="3oM_SC" value="A" />
+          </node>
+          <node concept="3oM_SD" id="5$DDoDSNMT9" role="1PaTwD">
+            <property role="3oM_SC" value="new" />
+          </node>
+          <node concept="3oM_SD" id="5$DDoDSNMTa" role="1PaTwD">
+            <property role="3oM_SC" value="option" />
+          </node>
+          <node concept="3oM_SD" id="5$DDoDSNMTl" role="1PaTwD">
+            <property role="3oM_SC" value="for" />
+          </node>
+          <node concept="3oM_SD" id="5$DDoDSNMTm" role="1PaTwD">
+            <property role="3oM_SC" value="diagrams" />
+          </node>
+          <node concept="3oM_SD" id="5$DDoDSNMTn" role="1PaTwD">
+            <property role="3oM_SC" value="was" />
+          </node>
+          <node concept="3oM_SD" id="5$DDoDSNMTo" role="1PaTwD">
+            <property role="3oM_SC" value="added" />
+          </node>
+          <node concept="3oM_SD" id="5$DDoDSNMTb" role="1PaTwD">
+            <property role="3oM_SC" value="to" />
+          </node>
+          <node concept="3oM_SD" id="5$DDoDSNMTc" role="1PaTwD">
+            <property role="3oM_SC" value="allow" />
+          </node>
+          <node concept="3oM_SD" id="5$DDoDSNMTd" role="1PaTwD">
+            <property role="3oM_SC" value="boxes" />
+          </node>
+          <node concept="3oM_SD" id="5$DDoDSNMTe" role="1PaTwD">
+            <property role="3oM_SC" value="to" />
+          </node>
+          <node concept="3oM_SD" id="5$DDoDSNMTf" role="1PaTwD">
+            <property role="3oM_SC" value="set" />
+          </node>
+          <node concept="3oM_SD" id="5$DDoDSNMTg" role="1PaTwD">
+            <property role="3oM_SC" value="a" />
+          </node>
+          <node concept="3oM_SD" id="5$DDoDSNMTh" role="1PaTwD">
+            <property role="3oM_SC" value="new" />
+          </node>
+          <node concept="3oM_SD" id="5$DDoDSNMTi" role="1PaTwD">
+            <property role="3oM_SC" value="required" />
+          </node>
+          <node concept="3oM_SD" id="5$DDoDSNMTj" role="1PaTwD">
+            <property role="3oM_SC" value="minimum" />
+          </node>
+          <node concept="3oM_SD" id="5$DDoDSNMTk" role="1PaTwD">
+            <property role="3oM_SC" value="size." />
+          </node>
+        </node>
         <node concept="2DRihI" id="1TZykZLaQqn" role="15bAlk">
           <node concept="2hgSXJ" id="1TZykZLaQq$" role="1PaTwD">
             <node concept="1PaTwC" id="1TZykZLaQq_" role="2hiFM$">


### PR DESCRIPTION
The idea is that you want to sometimes shrink a diagram box to a size below the required size, so that the automatic line wrapping kicks in e.g. with Text from the richtext language. I set the max-width stylesheet item for that. Fit size all and autolayout should respect this setting. @slisson would it be possible to somehow also do this for sizes that are above the minimum size?