### PR TITLE
Fix EditorComponentCreationListener uses

### DIFF
--- a/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
+++ b/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
@@ -2313,11 +2313,6 @@
             <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
           </node>
         </node>
-        <node concept="1SiIV0" id="2hz1PZpEco5" role="3bR37C">
-          <node concept="3bR9La" id="2hz1PZpEco6" role="1SiIV1">
-            <ref role="3bR37D" node="64TsoMQT2qP" resolve="de.slisson.mps.hacks.editor" />
-          </node>
-        </node>
         <node concept="3rtmxn" id="3xFG3bj5MoU" role="3bR31x">
           <node concept="3LXTmp" id="3xFG3bj5MoV" role="3rtmxm">
             <node concept="3qWCbU" id="3xFG3bj5MoW" role="3LXTna">
@@ -6352,12 +6347,6 @@
                 </node>
               </node>
             </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="6SVXTgIekIm" role="3bR37C">
-          <node concept="3bR9La" id="6SVXTgIekIn" role="1SiIV1">
-            <property role="3bR36h" value="true" />
-            <ref role="3bR37D" node="64TsoMQT2qP" resolve="de.slisson.mps.hacks.editor" />
           </node>
         </node>
         <node concept="1SiIV0" id="6SVXTgIekIo" role="3bR37C">

--- a/code/celllayout/solutions/de.slisson.mps.editor.celllayout.runtime/de.itemis.mps.editor.celllayout.runtime.msd
+++ b/code/celllayout/solutions/de.slisson.mps.editor.celllayout.runtime/de.itemis.mps.editor.celllayout.runtime.msd
@@ -13,7 +13,6 @@
   <dependencies>
     <dependency reexport="true">1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)</dependency>
     <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
-    <dependency reexport="true">f0fff802-6d26-4d2e-b89d-391357265626(de.slisson.mps.hacks.editor)</dependency>
     <dependency reexport="true">24c96a96-b7a1-4f30-82da-0f8e279a2661(de.itemis.mps.editor.celllayout.styles)</dependency>
   </dependencies>
   <languageVersions>
@@ -48,7 +47,6 @@
     <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
     <module reference="848ef45d-e560-4e35-853c-f35a64cc135c(de.itemis.mps.editor.celllayout.runtime)" version="0" />
     <module reference="24c96a96-b7a1-4f30-82da-0f8e279a2661(de.itemis.mps.editor.celllayout.styles)" version="0" />
-    <module reference="f0fff802-6d26-4d2e-b89d-391357265626(de.slisson.mps.hacks.editor)" version="0" />
     <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
   </dependencyVersions>
 </solution>

--- a/code/celllayout/solutions/de.slisson.mps.editor.celllayout.runtime/models/de/itemis/mps/editor/celllayout/runtime/plugin.mps
+++ b/code/celllayout/solutions/de.slisson.mps.editor.celllayout.runtime/models/de/itemis/mps/editor/celllayout/runtime/plugin.mps
@@ -9,13 +9,15 @@
   <imports>
     <import index="k3nr" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.ide.editor(MPS.Editor/)" />
     <import index="qxi4" ref="r:45c19b6d-dd9a-4f15-973f-0267c5e76303(de.itemis.mps.editor.celllayout.runtime)" />
-    <import index="kvq8" ref="r:2e938759-cfd0-47cd-9046-896d85204f59(de.slisson.mps.hacks.editor)" />
     <import index="exr9" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor(MPS.Editor/)" />
     <import index="22ra" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.update(MPS.Editor/)" />
     <import index="cj4x" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor(MPS.Editor/)" />
     <import index="f4zo" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.cells(MPS.Editor/)" />
     <import index="z60i" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt(JDK/)" />
+    <import index="wvnl" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.extensions(MPS.Editor/)" />
+    <import index="mhfm" ref="3f233e7f-b8a6-46d2-a57f-795d56775243/java:org.jetbrains.annotations(Annotations/)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
+    <import index="z1c3" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.project(MPS.Platform/)" implicit="true" />
   </imports>
   <registry>
     <language id="28f9e497-3b42-4291-aeba-0a1039153ab1" name="jetbrains.mps.lang.plugin">
@@ -53,6 +55,7 @@
         <child id="1068498886295" name="lValue" index="37vLTJ" />
       </concept>
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
       <concept id="1188207840427" name="jetbrains.mps.baseLanguage.structure.AnnotationInstance" flags="nn" index="2AHcQZ">
         <reference id="1188208074048" name="annotation" index="2AI5Lk" />
       </concept>
@@ -79,11 +82,21 @@
       <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
       </concept>
+      <concept id="1081256982272" name="jetbrains.mps.baseLanguage.structure.InstanceOfExpression" flags="nn" index="2ZW3vV">
+        <child id="1081256993305" name="classType" index="2ZW6by" />
+        <child id="1081256993304" name="leftExpression" index="2ZW6bz" />
+      </concept>
+      <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
       <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
+      <concept id="1070534934090" name="jetbrains.mps.baseLanguage.structure.CastExpression" flags="nn" index="10QFUN">
+        <child id="1070534934091" name="type" index="10QFUM" />
+        <child id="1070534934092" name="expression" index="10QFUP" />
+      </concept>
       <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu">
         <child id="1165602531693" name="superclass" index="1zkMxy" />
       </concept>
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <property id="1176718929932" name="isFinal" index="3TUv4t" />
         <child id="1068431790190" name="initializer" index="33vP2m" />
       </concept>
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
@@ -138,6 +151,9 @@
       </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
       <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
+      <concept id="1116615150612" name="jetbrains.mps.baseLanguage.structure.ClassifierClassExpression" flags="nn" index="3VsKOn">
+        <reference id="1116615189566" name="classifier" index="3VsUkX" />
+      </concept>
       <concept id="1170345865475" name="jetbrains.mps.baseLanguage.structure.AnonymousClass" flags="ig" index="1Y3b0j">
         <reference id="1170346070688" name="classifier" index="1Y3XeK" />
       </concept>
@@ -202,10 +218,10 @@
   <node concept="2uRRBy" id="3Osd_yxgjRl">
     <property role="TrG5h" value="ProjectPlugin" />
     <node concept="2BZ0e9" id="3Osd_yxgk0e" role="2uRRBA">
-      <property role="TrG5h" value="myEditorComponentCreationListener" />
+      <property role="TrG5h" value="myEditorComponentExtension" />
       <node concept="3Tm6S6" id="3Osd_yxgk0f" role="1B3o_S" />
       <node concept="3uibUv" id="3Osd_yxgk6i" role="1tU5fm">
-        <ref role="3uigEE" to="kvq8:2WlJ6VKPQcy" resolve="EditorComponentCreationListener" />
+        <ref role="3uigEE" to="wvnl:~EditorExtension" resolve="EditorExtension" />
       </node>
     </node>
     <node concept="2BZ0e9" id="3Osd_yxgsW8" role="2uRRBA">
@@ -330,26 +346,75 @@
               <node concept="YeOm9" id="3Osd_yxgp5B" role="2ShVmc">
                 <node concept="1Y3b0j" id="3Osd_yxgp5E" role="YeSDq">
                   <property role="2bfB8j" value="true" />
-                  <ref role="1Y3XeK" to="kvq8:2WlJ6VKPQcy" resolve="EditorComponentCreationListener" />
-                  <ref role="37wK5l" to="kvq8:3pwG8PSjV93" resolve="EditorComponentCreationListener" />
+                  <ref role="1Y3XeK" to="wvnl:~EditorExtension" resolve="EditorExtension" />
+                  <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" />
+                  <node concept="2tJIrI" id="DrREDhoOkU" role="jymVt" />
                   <node concept="3Tm1VV" id="3Osd_yxgp5F" role="1B3o_S" />
-                  <node concept="3clFb_" id="3Osd_yxgp5G" role="jymVt">
-                    <property role="TrG5h" value="editorComponentCreate" />
-                    <property role="1EzhhJ" value="false" />
-                    <node concept="37vLTG" id="3Osd_yxgp5H" role="3clF46">
-                      <property role="TrG5h" value="editorComponent" />
-                      <node concept="3uibUv" id="3Osd_yxgp5I" role="1tU5fm">
-                        <ref role="3uigEE" to="exr9:~EditorComponent" resolve="EditorComponent" />
+                  <node concept="3clFb_" id="DrREDhoPlv" role="jymVt">
+                    <property role="TrG5h" value="isApplicable" />
+                    <node concept="3Tm1VV" id="DrREDhoPlw" role="1B3o_S" />
+                    <node concept="10P_77" id="DrREDhoPly" role="3clF45" />
+                    <node concept="37vLTG" id="DrREDhoPlz" role="3clF46">
+                      <property role="TrG5h" value="component" />
+                      <node concept="3uibUv" id="DrREDhoPl$" role="1tU5fm">
+                        <ref role="3uigEE" to="cj4x:~EditorComponent" resolve="EditorComponent" />
+                      </node>
+                      <node concept="2AHcQZ" id="DrREDhoPl_" role="2AJF6D">
+                        <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
                       </node>
                     </node>
-                    <node concept="3cqZAl" id="3Osd_yxgp5J" role="3clF45" />
-                    <node concept="3Tm1VV" id="3Osd_yxgp5K" role="1B3o_S" />
-                    <node concept="3clFbS" id="3Osd_yxgp5M" role="3clF47">
+                    <node concept="3clFbS" id="DrREDhoPlB" role="3clF47">
+                      <node concept="3clFbF" id="DrREDhpYbJ" role="3cqZAp">
+                        <node concept="2ZW3vV" id="DrREDhpYT5" role="3clFbG">
+                          <node concept="3uibUv" id="DrREDhq0fk" role="2ZW6by">
+                            <ref role="3uigEE" to="exr9:~EditorComponent" resolve="EditorComponent" />
+                          </node>
+                          <node concept="37vLTw" id="DrREDhpYbG" role="2ZW6bz">
+                            <ref role="3cqZAo" node="DrREDhoPlz" resolve="component" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2AHcQZ" id="DrREDhoPlC" role="2AJF6D">
+                      <ref role="2AI5Lk" to="wyt6:~Override" />
+                    </node>
+                  </node>
+                  <node concept="3clFb_" id="DrREDhoPlF" role="jymVt">
+                    <property role="TrG5h" value="install" />
+                    <node concept="3Tm1VV" id="DrREDhoPlG" role="1B3o_S" />
+                    <node concept="3cqZAl" id="DrREDhoPlI" role="3clF45" />
+                    <node concept="37vLTG" id="DrREDhoPlJ" role="3clF46">
+                      <property role="TrG5h" value="component" />
+                      <node concept="3uibUv" id="DrREDhoPlK" role="1tU5fm">
+                        <ref role="3uigEE" to="cj4x:~EditorComponent" resolve="EditorComponent" />
+                      </node>
+                      <node concept="2AHcQZ" id="DrREDhoPlL" role="2AJF6D">
+                        <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+                      </node>
+                    </node>
+                    <node concept="3clFbS" id="DrREDhoPlN" role="3clF47">
+                      <node concept="3cpWs8" id="DrREDhpexR" role="3cqZAp">
+                        <node concept="3cpWsn" id="DrREDhpexS" role="3cpWs9">
+                          <property role="TrG5h" value="editorComponent" />
+                          <property role="3TUv4t" value="true" />
+                          <node concept="3uibUv" id="DrREDhpexT" role="1tU5fm">
+                            <ref role="3uigEE" to="exr9:~EditorComponent" resolve="EditorComponent" />
+                          </node>
+                          <node concept="10QFUN" id="DrREDhpexU" role="33vP2m">
+                            <node concept="3uibUv" id="DrREDhpexV" role="10QFUM">
+                              <ref role="3uigEE" to="exr9:~EditorComponent" resolve="EditorComponent" />
+                            </node>
+                            <node concept="37vLTw" id="DrREDhpexW" role="10QFUP">
+                              <ref role="3cqZAo" node="DrREDhoPlJ" resolve="component" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
                       <node concept="3clFbF" id="3Osd_yxgqD4" role="3cqZAp">
                         <node concept="2OqwBi" id="3Osd_yxgrY9" role="3clFbG">
                           <node concept="2OqwBi" id="3Osd_yxgqI6" role="2Oq$k0">
                             <node concept="37vLTw" id="3Osd_yxgqD3" role="2Oq$k0">
-                              <ref role="3cqZAo" node="3Osd_yxgp5H" resolve="editorComponent" />
+                              <ref role="3cqZAo" node="DrREDhpexS" resolve="editorComponent" />
                             </node>
                             <node concept="liA8E" id="3Osd_yxgrUt" role="2OqNvi">
                               <ref role="37wK5l" to="exr9:~EditorComponent.getUpdater()" resolve="getUpdater" />
@@ -382,14 +447,14 @@
                             </node>
                           </node>
                           <node concept="37vLTw" id="6IJAP0oQhwN" role="2Oq$k0">
-                            <ref role="3cqZAo" node="3Osd_yxgp5H" resolve="editorComponent" />
+                            <ref role="3cqZAo" node="DrREDhpexS" resolve="editorComponent" />
                           </node>
                         </node>
                       </node>
                       <node concept="3clFbF" id="6SVXTgIaykH" role="3cqZAp">
                         <node concept="2OqwBi" id="6SVXTgIaykI" role="3clFbG">
                           <node concept="37vLTw" id="6SVXTgIaykJ" role="2Oq$k0">
-                            <ref role="3cqZAo" node="3Osd_yxgp5H" resolve="editorComponent" />
+                            <ref role="3cqZAo" node="DrREDhpexS" resolve="editorComponent" />
                           </node>
                           <node concept="liA8E" id="6SVXTgIaykK" role="2OqNvi">
                             <ref role="37wK5l" to="exr9:~EditorComponent.addAdditionalPainter(jetbrains.mps.nodeEditor.AdditionalPainter)" resolve="addAdditionalPainter" />
@@ -412,7 +477,7 @@
                             <ref role="37wK5l" to="qxi4:3ATi8gIzat4" resolve="installWhereRequired" />
                             <ref role="1Pybhc" to="qxi4:3Osd_yxgaDz" resolve="LayoutInterceptor" />
                             <node concept="37vLTw" id="3ATi8gI_7KY" role="37wK5m">
-                              <ref role="3cqZAo" node="3Osd_yxgp5H" resolve="editorComponent" />
+                              <ref role="3cqZAo" node="DrREDhpexS" resolve="editorComponent" />
                             </node>
                           </node>
                         </node>
@@ -425,7 +490,7 @@
                               <ref role="37wK5l" to="qxi4:2hEgJWEwRPU" resolve="invalidateAllCells" />
                               <node concept="2OqwBi" id="2hEgJWEwT5t" role="37wK5m">
                                 <node concept="37vLTw" id="2hEgJWEx7O5" role="2Oq$k0">
-                                  <ref role="3cqZAo" node="3Osd_yxgp5H" resolve="editorComponent" />
+                                  <ref role="3cqZAo" node="DrREDhpexS" resolve="editorComponent" />
                                 </node>
                                 <node concept="liA8E" id="2hEgJWEwT5v" role="2OqNvi">
                                   <ref role="37wK5l" to="exr9:~EditorComponent.getRootCell()" resolve="getRootCell" />
@@ -439,7 +504,7 @@
                                 <ref role="37wK5l" to="exr9:~EditorComponent.relayout()" resolve="relayout" />
                               </node>
                               <node concept="37vLTw" id="2hEgJWExc8z" role="2Oq$k0">
-                                <ref role="3cqZAo" node="3Osd_yxgp5H" resolve="editorComponent" />
+                                <ref role="3cqZAo" node="DrREDhpexS" resolve="editorComponent" />
                               </node>
                             </node>
                           </node>
@@ -449,23 +514,45 @@
                         </node>
                       </node>
                     </node>
+                    <node concept="2AHcQZ" id="DrREDhoPlO" role="2AJF6D">
+                      <ref role="2AI5Lk" to="wyt6:~Override" />
+                    </node>
                   </node>
-                  <node concept="3clFb_" id="3Osd_yxgp5O" role="jymVt">
-                    <property role="TrG5h" value="editorComponentDisposed" />
-                    <property role="1EzhhJ" value="false" />
-                    <node concept="37vLTG" id="3Osd_yxgp5P" role="3clF46">
-                      <property role="TrG5h" value="editorComponent" />
-                      <node concept="3uibUv" id="3Osd_yxgp5Q" role="1tU5fm">
-                        <ref role="3uigEE" to="exr9:~EditorComponent" resolve="EditorComponent" />
+                  <node concept="3clFb_" id="DrREDhoPlP" role="jymVt">
+                    <property role="TrG5h" value="uninstall" />
+                    <node concept="3Tm1VV" id="DrREDhoPlQ" role="1B3o_S" />
+                    <node concept="3cqZAl" id="DrREDhoPlS" role="3clF45" />
+                    <node concept="37vLTG" id="DrREDhoPlT" role="3clF46">
+                      <property role="TrG5h" value="component" />
+                      <node concept="3uibUv" id="DrREDhoPlU" role="1tU5fm">
+                        <ref role="3uigEE" to="cj4x:~EditorComponent" resolve="EditorComponent" />
+                      </node>
+                      <node concept="2AHcQZ" id="DrREDhoPlV" role="2AJF6D">
+                        <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
                       </node>
                     </node>
-                    <node concept="3cqZAl" id="3Osd_yxgp5R" role="3clF45" />
-                    <node concept="3Tm1VV" id="3Osd_yxgp5S" role="1B3o_S" />
-                    <node concept="3clFbS" id="3Osd_yxgp5U" role="3clF47">
+                    <node concept="3clFbS" id="DrREDhoPlX" role="3clF47">
+                      <node concept="3cpWs8" id="DrREDhp0Ek" role="3cqZAp">
+                        <node concept="3cpWsn" id="DrREDhp0El" role="3cpWs9">
+                          <property role="TrG5h" value="editorComponent" />
+                          <property role="3TUv4t" value="true" />
+                          <node concept="3uibUv" id="DrREDhp0Em" role="1tU5fm">
+                            <ref role="3uigEE" to="exr9:~EditorComponent" resolve="EditorComponent" />
+                          </node>
+                          <node concept="10QFUN" id="DrREDhp6iU" role="33vP2m">
+                            <node concept="3uibUv" id="DrREDhp7sa" role="10QFUM">
+                              <ref role="3uigEE" to="exr9:~EditorComponent" resolve="EditorComponent" />
+                            </node>
+                            <node concept="37vLTw" id="DrREDhp58I" role="10QFUP">
+                              <ref role="3cqZAo" node="DrREDhoPlT" resolve="component" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
                       <node concept="3clFbF" id="6SVXTgIayr8" role="3cqZAp">
                         <node concept="2OqwBi" id="6SVXTgIayr9" role="3clFbG">
                           <node concept="37vLTw" id="6SVXTgIayra" role="2Oq$k0">
-                            <ref role="3cqZAo" node="3Osd_yxgp5P" resolve="editorComponent" />
+                            <ref role="3cqZAo" node="DrREDhp0El" resolve="editorComponent" />
                           </node>
                           <node concept="liA8E" id="6SVXTgIayrb" role="2OqNvi">
                             <ref role="37wK5l" to="exr9:~EditorComponent.removeAdditionalPainter(jetbrains.mps.nodeEditor.AdditionalPainter)" resolve="removeAdditionalPainter" />
@@ -483,7 +570,7 @@
                       <node concept="3clFbF" id="6IJAP0oQk0j" role="3cqZAp">
                         <node concept="2OqwBi" id="6IJAP0oQk8d" role="3clFbG">
                           <node concept="37vLTw" id="6IJAP0oQk0h" role="2Oq$k0">
-                            <ref role="3cqZAo" node="3Osd_yxgp5P" resolve="editorComponent" />
+                            <ref role="3cqZAo" node="DrREDhp0El" resolve="editorComponent" />
                           </node>
                           <node concept="liA8E" id="6IJAP0oQlVI" role="2OqNvi">
                             <ref role="37wK5l" to="exr9:~EditorComponent.removeAdditionalPainter(jetbrains.mps.nodeEditor.AdditionalPainter)" resolve="removeAdditionalPainter" />
@@ -502,7 +589,7 @@
                         <node concept="2OqwBi" id="3Osd_yxgtA5" role="3clFbG">
                           <node concept="2OqwBi" id="3Osd_yxgtA6" role="2Oq$k0">
                             <node concept="37vLTw" id="3Osd_yxgtA7" role="2Oq$k0">
-                              <ref role="3cqZAo" node="3Osd_yxgp5P" resolve="editorComponent" />
+                              <ref role="3cqZAo" node="DrREDhp0El" resolve="editorComponent" />
                             </node>
                             <node concept="liA8E" id="3Osd_yxgtA8" role="2OqNvi">
                               <ref role="37wK5l" to="exr9:~EditorComponent.getUpdater()" resolve="getUpdater" />
@@ -526,13 +613,15 @@
                           <ref role="37wK5l" to="qxi4:3oUU9KDF3kp" resolve="uninstall" />
                           <ref role="1Pybhc" to="qxi4:3Osd_yxgaDz" resolve="LayoutInterceptor" />
                           <node concept="37vLTw" id="3oUU9KDF3BD" role="37wK5m">
-                            <ref role="3cqZAo" node="3Osd_yxgp5P" resolve="editorComponent" />
+                            <ref role="3cqZAo" node="DrREDhp0El" resolve="editorComponent" />
                           </node>
                         </node>
                       </node>
                     </node>
+                    <node concept="2AHcQZ" id="DrREDhoPlY" role="2AJF6D">
+                      <ref role="2AI5Lk" to="wyt6:~Override" />
+                    </node>
                   </node>
-                  <node concept="1KvdUw" id="3Osd_yxgqlh" role="37wK5m" />
                 </node>
               </node>
             </node>
@@ -544,18 +633,24 @@
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="3Osd_yxgq38" role="3cqZAp">
-          <node concept="2OqwBi" id="3Osd_yxgq78" role="3clFbG">
-            <node concept="2OqwBi" id="3Osd_yxgq32" role="2Oq$k0">
-              <node concept="2WthIp" id="3Osd_yxgq35" role="2Oq$k0" />
-              <node concept="2BZ7hE" id="3Osd_yxgq37" role="2OqNvi">
-                <ref role="2WH_rO" node="3Osd_yxgk0e" resolve="myEditorComponentCreationListener" />
+        <node concept="3clFbF" id="2BYLcdcOEca" role="3cqZAp">
+          <node concept="2OqwBi" id="2BYLcdcOFbX" role="3clFbG">
+            <node concept="2OqwBi" id="2BYLcdcOEvN" role="2Oq$k0">
+              <node concept="liA8E" id="2BYLcdcOEIo" role="2OqNvi">
+                <ref role="37wK5l" to="z1c3:~MPSProject.getComponent(java.lang.Class)" resolve="getComponent" />
+                <node concept="3VsKOn" id="2BYLcdcOF5v" role="37wK5m">
+                  <ref role="3VsUkX" to="wvnl:~EditorExtensionRegistry" resolve="EditorExtensionRegistry" />
+                </node>
               </node>
+              <node concept="1KvdUw" id="DrREDhoKSp" role="2Oq$k0" />
             </node>
-            <node concept="liA8E" id="3Osd_yxgq9Y" role="2OqNvi">
-              <ref role="37wK5l" to="kvq8:2WlJ6VKQR6W" resolve="start" />
-              <node concept="3clFbT" id="3Osd_yxgqbj" role="37wK5m">
-                <property role="3clFbU" value="true" />
+            <node concept="liA8E" id="2BYLcdcOFk_" role="2OqNvi">
+              <ref role="37wK5l" to="wvnl:~EditorExtensionRegistry.registerExtension(jetbrains.mps.openapi.editor.extensions.EditorExtension)" resolve="registerExtension" />
+              <node concept="2OqwBi" id="DrREDhoL2P" role="37wK5m">
+                <node concept="2WthIp" id="DrREDhoL2S" role="2Oq$k0" />
+                <node concept="2BZ7hE" id="DrREDhoL2U" role="2OqNvi">
+                  <ref role="2WH_rO" node="3Osd_yxgk0e" resolve="myEditorComponentExtension" />
+                </node>
               </node>
             </node>
           </node>
@@ -564,16 +659,36 @@
     </node>
     <node concept="2uRRBN" id="3Osd_yxgpHW" role="2uRRB_">
       <node concept="3clFbS" id="3Osd_yxgpHX" role="2VODD2">
-        <node concept="3clFbF" id="3Osd_yxgpPZ" role="3cqZAp">
-          <node concept="2OqwBi" id="3Osd_yxgpRX" role="3clFbG">
-            <node concept="2OqwBi" id="3Osd_yxgpPT" role="2Oq$k0">
-              <node concept="2WthIp" id="3Osd_yxgpPW" role="2Oq$k0" />
-              <node concept="2BZ7hE" id="3Osd_yxgpPY" role="2OqNvi">
-                <ref role="2WH_rO" node="3Osd_yxgk0e" resolve="myEditorComponentCreationListener" />
+        <node concept="3clFbF" id="DrREDhoL8f" role="3cqZAp">
+          <node concept="2OqwBi" id="DrREDhoL8g" role="3clFbG">
+            <node concept="2OqwBi" id="DrREDhoL8h" role="2Oq$k0">
+              <node concept="liA8E" id="DrREDhoL8i" role="2OqNvi">
+                <ref role="37wK5l" to="z1c3:~MPSProject.getComponent(java.lang.Class)" resolve="getComponent" />
+                <node concept="3VsKOn" id="DrREDhoL8j" role="37wK5m">
+                  <ref role="3VsUkX" to="wvnl:~EditorExtensionRegistry" resolve="EditorExtensionRegistry" />
+                </node>
+              </node>
+              <node concept="1KvdUw" id="DrREDhoL8k" role="2Oq$k0" />
+            </node>
+            <node concept="liA8E" id="DrREDhoL8l" role="2OqNvi">
+              <ref role="37wK5l" to="wvnl:~EditorExtensionRegistry.unregisterExtension(jetbrains.mps.openapi.editor.extensions.EditorExtension)" resolve="unregisterExtension" />
+              <node concept="2OqwBi" id="DrREDhoL8m" role="37wK5m">
+                <node concept="2WthIp" id="DrREDhoL8n" role="2Oq$k0" />
+                <node concept="2BZ7hE" id="DrREDhoL8o" role="2OqNvi">
+                  <ref role="2WH_rO" node="3Osd_yxgk0e" resolve="myEditorComponentExtension" />
+                </node>
               </node>
             </node>
-            <node concept="liA8E" id="3Osd_yxgpTA" role="2OqNvi">
-              <ref role="37wK5l" to="kvq8:2WlJ6VKQRx4" resolve="stop" />
+          </node>
+        </node>
+        <node concept="3clFbF" id="3Osd_yxgpPZ" role="3cqZAp">
+          <node concept="37vLTI" id="DrREDhoLXp" role="3clFbG">
+            <node concept="10Nm6u" id="DrREDhoM4V" role="37vLTx" />
+            <node concept="2OqwBi" id="3Osd_yxgpPT" role="37vLTJ">
+              <node concept="2WthIp" id="3Osd_yxgpPW" role="2Oq$k0" />
+              <node concept="2BZ7hE" id="3Osd_yxgpPY" role="2OqNvi">
+                <ref role="2WH_rO" node="3Osd_yxgk0e" resolve="myEditorComponentExtension" />
+              </node>
             </node>
           </node>
         </node>

--- a/code/hacks/solutions/de.slisson.mps.hacks.editor/models/de/slisson/mps/hacks/editor.mps
+++ b/code/hacks/solutions/de.slisson.mps.hacks.editor/models/de/slisson/mps/hacks/editor.mps
@@ -847,10 +847,10 @@
     <property role="1sVAO0" value="true" />
     <node concept="2tJIrI" id="2WlJ6VKPQeq" role="jymVt" />
     <node concept="312cEg" id="2WlJ6VKPQi6" role="jymVt">
-      <property role="TrG5h" value="myIdeaProject" />
+      <property role="TrG5h" value="myProject" />
       <node concept="3Tm6S6" id="2WlJ6VKPQi7" role="1B3o_S" />
       <node concept="3uibUv" id="2WlJ6VKQO3B" role="1tU5fm">
-        <ref role="3uigEE" to="4nm9:~Project" resolve="Project" />
+        <ref role="3uigEE" to="z1c3:~Project" resolve="Project" />
       </node>
     </node>
     <node concept="2tJIrI" id="2WlJ6VKQQft" role="jymVt" />
@@ -858,13 +858,13 @@
       <node concept="3cqZAl" id="3pwG8PSjV95" role="3clF45" />
       <node concept="3Tm1VV" id="3pwG8PSjV96" role="1B3o_S" />
       <node concept="3clFbS" id="3pwG8PSjV97" role="3clF47">
-        <node concept="1VxSAg" id="3pwG8PSjXP3" role="3cqZAp">
-          <ref role="37wK5l" node="2WlJ6VKQQJ7" resolve="EditorComponentCreationListener" />
-          <node concept="2YIFZM" id="3pwG8PSjXQ8" role="37wK5m">
-            <ref role="37wK5l" to="alof:~ProjectHelper.toIdeaProject(jetbrains.mps.project.Project)" resolve="toIdeaProject" />
-            <ref role="1Pybhc" to="alof:~ProjectHelper" resolve="ProjectHelper" />
-            <node concept="37vLTw" id="3pwG8PSjXRm" role="37wK5m">
+        <node concept="3clFbF" id="DrREDhnysd" role="3cqZAp">
+          <node concept="37vLTI" id="DrREDhn$dp" role="3clFbG">
+            <node concept="37vLTw" id="DrREDhn_6m" role="37vLTx">
               <ref role="3cqZAo" node="3pwG8PSjXGn" resolve="project" />
+            </node>
+            <node concept="37vLTw" id="DrREDhnysb" role="37vLTJ">
+              <ref role="3cqZAo" node="2WlJ6VKPQi6" resolve="myProject" />
             </node>
           </node>
         </node>
@@ -882,12 +882,12 @@
       <node concept="3cqZAl" id="2WlJ6VKQQJ8" role="3clF45" />
       <node concept="3Tm1VV" id="2WlJ6VKQQJ9" role="1B3o_S" />
       <node concept="3clFbS" id="2WlJ6VKQQJb" role="3clF47">
-        <node concept="3clFbF" id="2WlJ6VKQQJf" role="3cqZAp">
-          <node concept="37vLTI" id="2WlJ6VKQQJh" role="3clFbG">
-            <node concept="37vLTw" id="2WlJ6VKQQJl" role="37vLTJ">
-              <ref role="3cqZAo" node="2WlJ6VKPQi6" resolve="myIdeaProject" />
-            </node>
-            <node concept="37vLTw" id="2WlJ6VKQQJm" role="37vLTx">
+        <node concept="1VxSAg" id="DrREDhnDk4" role="3cqZAp">
+          <ref role="37wK5l" node="3pwG8PSjV93" resolve="EditorComponentCreationListener" />
+          <node concept="2YIFZM" id="DrREDhn_xo" role="37wK5m">
+            <ref role="37wK5l" to="alof:~ProjectHelper.fromIdeaProject(com.intellij.openapi.project.Project)" resolve="fromIdeaProject" />
+            <ref role="1Pybhc" to="alof:~ProjectHelper" resolve="ProjectHelper" />
+            <node concept="37vLTw" id="DrREDhn_xp" role="37wK5m">
               <ref role="3cqZAo" node="2WlJ6VKQQJe" resolve="ideaProject" />
             </node>
           </node>
@@ -999,12 +999,73 @@
     <node concept="3clFb_" id="2WlJ6VKQR6W" role="jymVt">
       <property role="TrG5h" value="start" />
       <node concept="37vLTG" id="2WlJ6VKQWQ$" role="3clF46">
-        <property role="TrG5h" value="eventForExisting" />
+        <property role="TrG5h" value="ignored_eventForExisting" />
         <node concept="10P_77" id="2WlJ6VKQX0w" role="1tU5fm" />
       </node>
       <node concept="3cqZAl" id="2WlJ6VKQR6Y" role="3clF45" />
       <node concept="3Tm1VV" id="2WlJ6VKQR6Z" role="1B3o_S" />
       <node concept="3clFbS" id="2WlJ6VKQR70" role="3clF47">
+        <node concept="3SKdUt" id="DrREDhnFwc" role="3cqZAp">
+          <node concept="1PaTwC" id="DrREDhnFwd" role="1aUNEU">
+            <node concept="3oM_SD" id="DrREDhnFHG" role="1PaTwD">
+              <property role="3oM_SC" value="EditorExtensionRegistry" />
+            </node>
+            <node concept="3oM_SD" id="DrREDhnFHX" role="1PaTwD">
+              <property role="3oM_SC" value="is" />
+            </node>
+            <node concept="3oM_SD" id="DrREDhnFIP" role="1PaTwD">
+              <property role="3oM_SC" value="MPS" />
+            </node>
+            <node concept="3oM_SD" id="DrREDhnFOl" role="1PaTwD">
+              <property role="3oM_SC" value="CoreComponent" />
+            </node>
+            <node concept="3oM_SD" id="DrREDhnFLy" role="1PaTwD">
+              <property role="3oM_SC" value="since" />
+            </node>
+            <node concept="3oM_SD" id="DrREDhnFT$" role="1PaTwD">
+              <property role="3oM_SC" value="2024.1," />
+            </node>
+            <node concept="3oM_SD" id="DrREDhnFVb" role="1PaTwD">
+              <property role="3oM_SC" value="use" />
+            </node>
+            <node concept="3oM_SD" id="DrREDhnFX8" role="1PaTwD">
+              <property role="3oM_SC" value="MPS" />
+            </node>
+            <node concept="3oM_SD" id="DrREDhnFXp" role="1PaTwD">
+              <property role="3oM_SC" value="project" />
+            </node>
+            <node concept="3oM_SD" id="DrREDhnFZQ" role="1PaTwD">
+              <property role="3oM_SC" value="to" />
+            </node>
+            <node concept="3oM_SD" id="DrREDhnFZR" role="1PaTwD">
+              <property role="3oM_SC" value="access" />
+            </node>
+            <node concept="3oM_SD" id="DrREDhnG0I" role="1PaTwD">
+              <property role="3oM_SC" value="component" />
+            </node>
+            <node concept="3oM_SD" id="DrREDhnG0J" role="1PaTwD">
+              <property role="3oM_SC" value="instance" />
+            </node>
+            <node concept="3oM_SD" id="DrREDhnG1Q" role="1PaTwD">
+              <property role="3oM_SC" value="(backward" />
+            </node>
+            <node concept="3oM_SD" id="DrREDhnG5p" role="1PaTwD">
+              <property role="3oM_SC" value="compatible" />
+            </node>
+            <node concept="3oM_SD" id="DrREDhnG7m" role="1PaTwD">
+              <property role="3oM_SC" value="with" />
+            </node>
+            <node concept="3oM_SD" id="DrREDhnG9N" role="1PaTwD">
+              <property role="3oM_SC" value="earlier" />
+            </node>
+            <node concept="3oM_SD" id="DrREDhnGba" role="1PaTwD">
+              <property role="3oM_SC" value="MPS" />
+            </node>
+            <node concept="3oM_SD" id="DrREDhnGch" role="1PaTwD">
+              <property role="3oM_SC" value="versions)" />
+            </node>
+          </node>
+        </node>
         <node concept="3clFbF" id="2BYLcdcOEca" role="3cqZAp">
           <node concept="2OqwBi" id="2BYLcdcOFbX" role="3clFbG">
             <node concept="2OqwBi" id="2BYLcdcOEvN" role="2Oq$k0">
@@ -1012,7 +1073,7 @@
                 <ref role="3cqZAo" node="2WlJ6VKPQi6" resolve="myIdeaProject" />
               </node>
               <node concept="liA8E" id="2BYLcdcOEIo" role="2OqNvi">
-                <ref role="37wK5l" to="1m72:~ComponentManager.getComponent(java.lang.Class)" resolve="getComponent" />
+                <ref role="37wK5l" to="z1c3:~Project.getComponent(java.lang.Class)" resolve="getComponent" />
                 <node concept="3VsKOn" id="2BYLcdcOF5v" role="37wK5m">
                   <ref role="3VsUkX" to="wvnl:~EditorExtensionRegistry" resolve="EditorExtensionRegistry" />
                 </node>
@@ -1039,7 +1100,7 @@
                 <ref role="3cqZAo" node="2WlJ6VKPQi6" resolve="myIdeaProject" />
               </node>
               <node concept="liA8E" id="2BYLcdcOVTA" role="2OqNvi">
-                <ref role="37wK5l" to="1m72:~ComponentManager.getComponent(java.lang.Class)" resolve="getComponent" />
+                <ref role="37wK5l" to="z1c3:~Project.getComponent(java.lang.Class)" resolve="getComponent" />
                 <node concept="3VsKOn" id="2BYLcdcOVTB" role="37wK5m">
                   <ref role="3VsUkX" to="wvnl:~EditorExtensionRegistry" resolve="EditorExtensionRegistry" />
                 </node>

--- a/code/tooltips/solutions/de.itemis.mps.tooltips.runtime/models/de/itemis/mps/tooltips/runtime/plugin.mps
+++ b/code/tooltips/solutions/de.itemis.mps.tooltips.runtime/models/de/itemis/mps/tooltips/runtime/plugin.mps
@@ -51,9 +51,6 @@
       <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
       </concept>
-      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
-        <child id="1068431790190" name="initializer" index="33vP2m" />
-      </concept>
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
@@ -80,10 +77,6 @@
       <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
         <property id="1068580123138" name="value" index="3clFbU" />
       </concept>
-      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
-        <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
-      </concept>
-      <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
       <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
@@ -133,13 +126,6 @@
   <node concept="2DaZZR" id="2vJRo8g$$xe" />
   <node concept="2uRRBy" id="2vJRo8g$$xf">
     <property role="TrG5h" value="ProjectPlugin" />
-    <node concept="2BZ0e9" id="2vJRo8g$$xg" role="2uRRBA">
-      <property role="TrG5h" value="myConnection" />
-      <node concept="3Tm6S6" id="2vJRo8g$$xh" role="1B3o_S" />
-      <node concept="3uibUv" id="2vJRo8g$$xi" role="1tU5fm">
-        <ref role="3uigEE" to="4b2m:~MessageBusConnection" resolve="MessageBusConnection" />
-      </node>
-    </node>
     <node concept="2BZ0e9" id="5VSAssGMyfR" role="2uRRBA">
       <property role="TrG5h" value="myCreateListener" />
       <node concept="3Tm6S6" id="5VSAssGMyfS" role="1B3o_S" />
@@ -149,19 +135,6 @@
     </node>
     <node concept="2uRRBT" id="2vJRo8g$$xj" role="2uRRB$">
       <node concept="3clFbS" id="2vJRo8g$$xk" role="2VODD2">
-        <node concept="3cpWs8" id="2vJRo8g$$xl" role="3cqZAp">
-          <node concept="3cpWsn" id="2vJRo8g$$xm" role="3cpWs9">
-            <property role="TrG5h" value="ideaProject" />
-            <node concept="3uibUv" id="2vJRo8g$$xn" role="1tU5fm">
-              <ref role="3uigEE" to="4nm9:~Project" resolve="Project" />
-            </node>
-            <node concept="2YIFZM" id="2vJRo8g$$xo" role="33vP2m">
-              <ref role="37wK5l" to="alof:~ProjectHelper.toIdeaProject(jetbrains.mps.project.Project)" resolve="toIdeaProject" />
-              <ref role="1Pybhc" to="alof:~ProjectHelper" resolve="ProjectHelper" />
-              <node concept="1KvdUw" id="2vJRo8g$$xp" role="37wK5m" />
-            </node>
-          </node>
-        </node>
         <node concept="3clFbH" id="5VSAssGMnPV" role="3cqZAp" />
         <node concept="3clFbF" id="5VSAssGMySi" role="3cqZAp">
           <node concept="37vLTI" id="5VSAssGMz1G" role="3clFbG">

--- a/code/tooltips/solutions/de.itemis.mps.tooltips.runtime/models/de/itemis/mps/tooltips/runtime/plugin.mps
+++ b/code/tooltips/solutions/de.itemis.mps.tooltips.runtime/models/de/itemis/mps/tooltips/runtime/plugin.mps
@@ -9,11 +9,12 @@
   </languages>
   <imports>
     <import index="exr9" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor(MPS.Editor/)" />
-    <import index="4b2m" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.util.messages(MPS.IDEA/)" />
-    <import index="alof" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.ide.project(MPS.Platform/)" />
-    <import index="4nm9" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.project(MPS.IDEA/)" />
     <import index="5usg" ref="r:3838bb8b-fecd-4f7c-841e-325717a43980(de.itemis.mps.tooltips.runtime)" />
-    <import index="kvq8" ref="r:2e938759-cfd0-47cd-9046-896d85204f59(de.slisson.mps.hacks.editor)" />
+    <import index="wvnl" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.extensions(MPS.Editor/)" />
+    <import index="cj4x" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor(MPS.Editor/)" />
+    <import index="mhfm" ref="3f233e7f-b8a6-46d2-a57f-795d56775243/java:org.jetbrains.annotations(Annotations/)" />
+    <import index="z1c3" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.project(MPS.Platform/)" />
+    <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
   </imports>
   <registry>
     <language id="28f9e497-3b42-4291-aeba-0a1039153ab1" name="jetbrains.mps.lang.plugin">
@@ -35,6 +36,12 @@
         <child id="1068498886295" name="lValue" index="37vLTJ" />
       </concept>
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="1188207840427" name="jetbrains.mps.baseLanguage.structure.AnnotationInstance" flags="nn" index="2AHcQZ">
+        <reference id="1188208074048" name="annotation" index="2AI5Lk" />
+      </concept>
+      <concept id="1188208481402" name="jetbrains.mps.baseLanguage.structure.HasAnnotation" flags="ngI" index="2AJDlI">
+        <child id="1188208488637" name="annotation" index="2AJF6D" />
+      </concept>
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
@@ -51,6 +58,16 @@
       <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
       </concept>
+      <concept id="1081256982272" name="jetbrains.mps.baseLanguage.structure.InstanceOfExpression" flags="nn" index="2ZW3vV">
+        <child id="1081256993305" name="classType" index="2ZW6by" />
+        <child id="1081256993304" name="leftExpression" index="2ZW6bz" />
+      </concept>
+      <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
+      <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
+      <concept id="1070534934090" name="jetbrains.mps.baseLanguage.structure.CastExpression" flags="nn" index="10QFUN">
+        <child id="1070534934091" name="type" index="10QFUM" />
+        <child id="1070534934092" name="expression" index="10QFUP" />
+      </concept>
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
@@ -64,18 +81,13 @@
         <child id="1068580123134" name="parameter" index="3clF46" />
         <child id="1068580123135" name="body" index="3clF47" />
       </concept>
-      <concept id="1068580123165" name="jetbrains.mps.baseLanguage.structure.InstanceMethodDeclaration" flags="ig" index="3clFb_">
-        <property id="1178608670077" name="isAbstract" index="1EzhhJ" />
-      </concept>
+      <concept id="1068580123165" name="jetbrains.mps.baseLanguage.structure.InstanceMethodDeclaration" flags="ig" index="3clFb_" />
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
       <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
-      </concept>
-      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
-        <property id="1068580123138" name="value" index="3clFbU" />
       </concept>
       <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
@@ -97,6 +109,9 @@
       </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
       <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
+      <concept id="1116615150612" name="jetbrains.mps.baseLanguage.structure.ClassifierClassExpression" flags="nn" index="3VsKOn">
+        <reference id="1116615189566" name="classifier" index="3VsUkX" />
+      </concept>
       <concept id="1170345865475" name="jetbrains.mps.baseLanguage.structure.AnonymousClass" flags="ig" index="1Y3b0j">
         <reference id="1170346070688" name="classifier" index="1Y3XeK" />
       </concept>
@@ -130,7 +145,7 @@
       <property role="TrG5h" value="myCreateListener" />
       <node concept="3Tm6S6" id="5VSAssGMyfS" role="1B3o_S" />
       <node concept="3uibUv" id="5VSAssGMyrH" role="1tU5fm">
-        <ref role="3uigEE" to="kvq8:2WlJ6VKPQcy" resolve="EditorComponentCreationListener" />
+        <ref role="3uigEE" to="wvnl:~EditorExtension" resolve="EditorExtension" />
       </node>
     </node>
     <node concept="2uRRBT" id="2vJRo8g$$xj" role="2uRRB$">
@@ -148,21 +163,52 @@
               <node concept="YeOm9" id="5VSAssGMz5A" role="2ShVmc">
                 <node concept="1Y3b0j" id="5VSAssGMz5B" role="YeSDq">
                   <property role="2bfB8j" value="true" />
-                  <ref role="1Y3XeK" to="kvq8:2WlJ6VKPQcy" resolve="EditorComponentCreationListener" />
-                  <ref role="37wK5l" to="kvq8:3pwG8PSjV93" resolve="EditorComponentCreationListener" />
+                  <ref role="1Y3XeK" to="wvnl:~EditorExtension" resolve="EditorExtension" />
+                  <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" />
                   <node concept="3Tm1VV" id="5VSAssGMz5C" role="1B3o_S" />
-                  <node concept="3clFb_" id="5VSAssGMz5D" role="jymVt">
-                    <property role="TrG5h" value="editorComponentCreate" />
-                    <property role="1EzhhJ" value="false" />
-                    <node concept="37vLTG" id="5VSAssGMz5E" role="3clF46">
-                      <property role="TrG5h" value="editorComponent" />
-                      <node concept="3uibUv" id="5VSAssGMz5F" role="1tU5fm">
-                        <ref role="3uigEE" to="exr9:~EditorComponent" resolve="EditorComponent" />
+                  <node concept="3clFb_" id="DrREDhpAx9" role="jymVt">
+                    <property role="TrG5h" value="isApplicable" />
+                    <node concept="3Tm1VV" id="DrREDhpAxa" role="1B3o_S" />
+                    <node concept="10P_77" id="DrREDhpAxc" role="3clF45" />
+                    <node concept="37vLTG" id="DrREDhpAxd" role="3clF46">
+                      <property role="TrG5h" value="component" />
+                      <node concept="3uibUv" id="DrREDhpAxe" role="1tU5fm">
+                        <ref role="3uigEE" to="cj4x:~EditorComponent" resolve="EditorComponent" />
+                      </node>
+                      <node concept="2AHcQZ" id="DrREDhpAxf" role="2AJF6D">
+                        <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
                       </node>
                     </node>
-                    <node concept="3cqZAl" id="5VSAssGMz5G" role="3clF45" />
-                    <node concept="3Tm1VV" id="5VSAssGMz5H" role="1B3o_S" />
-                    <node concept="3clFbS" id="5VSAssGMz5I" role="3clF47">
+                    <node concept="3clFbS" id="DrREDhpAxh" role="3clF47">
+                      <node concept="3clFbF" id="DrREDhpSZm" role="3cqZAp">
+                        <node concept="2ZW3vV" id="DrREDhpTh0" role="3clFbG">
+                          <node concept="3uibUv" id="DrREDhpTT5" role="2ZW6by">
+                            <ref role="3uigEE" to="exr9:~EditorComponent" resolve="EditorComponent" />
+                          </node>
+                          <node concept="37vLTw" id="DrREDhpSZj" role="2ZW6bz">
+                            <ref role="3cqZAo" node="DrREDhpAxd" resolve="component" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2AHcQZ" id="DrREDhpAxi" role="2AJF6D">
+                      <ref role="2AI5Lk" to="wyt6:~Override" />
+                    </node>
+                  </node>
+                  <node concept="3clFb_" id="DrREDhpAxl" role="jymVt">
+                    <property role="TrG5h" value="install" />
+                    <node concept="3Tm1VV" id="DrREDhpAxm" role="1B3o_S" />
+                    <node concept="3cqZAl" id="DrREDhpAxo" role="3clF45" />
+                    <node concept="37vLTG" id="DrREDhpAxp" role="3clF46">
+                      <property role="TrG5h" value="component" />
+                      <node concept="3uibUv" id="DrREDhpAxq" role="1tU5fm">
+                        <ref role="3uigEE" to="cj4x:~EditorComponent" resolve="EditorComponent" />
+                      </node>
+                      <node concept="2AHcQZ" id="DrREDhpAxr" role="2AJF6D">
+                        <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+                      </node>
+                    </node>
+                    <node concept="3clFbS" id="DrREDhpAxt" role="3clF47">
                       <node concept="3SKdUt" id="5$X36HXsNPY" role="3cqZAp">
                         <node concept="1PaTwC" id="7WTFIQIcYoO" role="1aUNEU">
                           <node concept="3oM_SD" id="7WTFIQIcYoP" role="1PaTwD">
@@ -198,54 +244,77 @@
                         <node concept="2YIFZM" id="5$X36HXsNHg" role="3clFbG">
                           <ref role="37wK5l" to="5usg:7XU1fOGmqyH" resolve="getInstance" />
                           <ref role="1Pybhc" to="5usg:7XU1fOGm9dY" resolve="TooltipManager" />
-                          <node concept="37vLTw" id="5$X36HXsNIK" role="37wK5m">
-                            <ref role="3cqZAo" node="5VSAssGMz5E" resolve="editorComponent" />
+                          <node concept="10QFUN" id="DrREDhpyzr" role="37wK5m">
+                            <node concept="3uibUv" id="DrREDhpzc5" role="10QFUM">
+                              <ref role="3uigEE" to="exr9:~EditorComponent" resolve="EditorComponent" />
+                            </node>
+                            <node concept="37vLTw" id="2mjECGQOIgN" role="10QFUP">
+                              <ref role="3cqZAo" node="DrREDhpAxp" resolve="component" />
+                            </node>
                           </node>
                         </node>
                       </node>
                     </node>
+                    <node concept="2AHcQZ" id="DrREDhpAxu" role="2AJF6D">
+                      <ref role="2AI5Lk" to="wyt6:~Override" />
+                    </node>
                   </node>
-                  <node concept="3clFb_" id="5VSAssGMz5J" role="jymVt">
-                    <property role="TrG5h" value="editorComponentDisposed" />
-                    <property role="1EzhhJ" value="false" />
-                    <node concept="37vLTG" id="5VSAssGMz5K" role="3clF46">
-                      <property role="TrG5h" value="editorComponent" />
-                      <node concept="3uibUv" id="5VSAssGMz5L" role="1tU5fm">
-                        <ref role="3uigEE" to="exr9:~EditorComponent" resolve="EditorComponent" />
+                  <node concept="3clFb_" id="DrREDhpAxv" role="jymVt">
+                    <property role="TrG5h" value="uninstall" />
+                    <node concept="3Tm1VV" id="DrREDhpAxw" role="1B3o_S" />
+                    <node concept="3cqZAl" id="DrREDhpAxy" role="3clF45" />
+                    <node concept="37vLTG" id="DrREDhpAxz" role="3clF46">
+                      <property role="TrG5h" value="component" />
+                      <node concept="3uibUv" id="DrREDhpAx$" role="1tU5fm">
+                        <ref role="3uigEE" to="cj4x:~EditorComponent" resolve="EditorComponent" />
+                      </node>
+                      <node concept="2AHcQZ" id="DrREDhpAx_" role="2AJF6D">
+                        <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
                       </node>
                     </node>
-                    <node concept="3cqZAl" id="5VSAssGMz5M" role="3clF45" />
-                    <node concept="3Tm1VV" id="5VSAssGMz5N" role="1B3o_S" />
-                    <node concept="3clFbS" id="5VSAssGMz5O" role="3clF47">
+                    <node concept="3clFbS" id="DrREDhpAxB" role="3clF47">
                       <node concept="3clFbF" id="5VSAssGMPzg" role="3cqZAp">
                         <node concept="2YIFZM" id="5VSAssGMP_9" role="3clFbG">
                           <ref role="37wK5l" to="5usg:5VSAssGMMTT" resolve="disposeInstance" />
                           <ref role="1Pybhc" to="5usg:7XU1fOGm9dY" resolve="TooltipManager" />
-                          <node concept="37vLTw" id="5VSAssGMPA6" role="37wK5m">
-                            <ref role="3cqZAo" node="5VSAssGMz5K" resolve="editorComponent" />
+                          <node concept="10QFUN" id="DrREDhq12a" role="37wK5m">
+                            <node concept="3uibUv" id="DrREDhq12b" role="10QFUM">
+                              <ref role="3uigEE" to="exr9:~EditorComponent" resolve="EditorComponent" />
+                            </node>
+                            <node concept="37vLTw" id="DrREDhq12c" role="10QFUP">
+                              <ref role="3cqZAo" node="DrREDhpAxz" resolve="component" />
+                            </node>
                           </node>
                         </node>
                       </node>
                     </node>
+                    <node concept="2AHcQZ" id="DrREDhpAxC" role="2AJF6D">
+                      <ref role="2AI5Lk" to="wyt6:~Override" />
+                    </node>
                   </node>
-                  <node concept="1KvdUw" id="5VSAssGMz5P" role="37wK5m" />
                 </node>
               </node>
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="5VSAssGMzLv" role="3cqZAp">
-          <node concept="2OqwBi" id="5VSAssGMzVj" role="3clFbG">
-            <node concept="2OqwBi" id="5VSAssGMzLp" role="2Oq$k0">
-              <node concept="2WthIp" id="5VSAssGMzLs" role="2Oq$k0" />
-              <node concept="2BZ7hE" id="5VSAssGMzLu" role="2OqNvi">
-                <ref role="2WH_rO" node="5VSAssGMyfR" resolve="myCreateListener" />
+        <node concept="3clFbF" id="DrREDhq1Kk" role="3cqZAp">
+          <node concept="2OqwBi" id="DrREDhq3QX" role="3clFbG">
+            <node concept="2OqwBi" id="DrREDhq2$p" role="2Oq$k0">
+              <node concept="1KvdUw" id="DrREDhq1Kj" role="2Oq$k0" />
+              <node concept="liA8E" id="DrREDhq3yB" role="2OqNvi">
+                <ref role="37wK5l" to="z1c3:~MPSProject.getComponent(java.lang.Class)" resolve="getComponent" />
+                <node concept="3VsKOn" id="DrREDhq3De" role="37wK5m">
+                  <ref role="3VsUkX" to="wvnl:~EditorExtensionRegistry" resolve="EditorExtensionRegistry" />
+                </node>
               </node>
             </node>
-            <node concept="liA8E" id="5VSAssGMzYH" role="2OqNvi">
-              <ref role="37wK5l" to="kvq8:2WlJ6VKQR6W" resolve="start" />
-              <node concept="3clFbT" id="5VSAssGM$1z" role="37wK5m">
-                <property role="3clFbU" value="true" />
+            <node concept="liA8E" id="DrREDhq44d" role="2OqNvi">
+              <ref role="37wK5l" to="wvnl:~EditorExtensionRegistry.registerExtension(jetbrains.mps.openapi.editor.extensions.EditorExtension)" resolve="registerExtension" />
+              <node concept="2OqwBi" id="DrREDhq47K" role="37wK5m">
+                <node concept="2WthIp" id="DrREDhq47N" role="2Oq$k0" />
+                <node concept="2BZ7hE" id="DrREDhq47P" role="2OqNvi">
+                  <ref role="2WH_rO" node="5VSAssGMyfR" resolve="myCreateListener" />
+                </node>
               </node>
             </node>
           </node>
@@ -254,16 +323,36 @@
     </node>
     <node concept="2uRRBN" id="2vJRo8g$$y0" role="2uRRB_">
       <node concept="3clFbS" id="2vJRo8g$$y1" role="2VODD2">
-        <node concept="3clFbF" id="5VSAssGMzss" role="3cqZAp">
-          <node concept="2OqwBi" id="5VSAssGMzvp" role="3clFbG">
-            <node concept="2OqwBi" id="5VSAssGMzsm" role="2Oq$k0">
-              <node concept="2WthIp" id="5VSAssGMzsp" role="2Oq$k0" />
-              <node concept="2BZ7hE" id="5VSAssGMzsr" role="2OqNvi">
-                <ref role="2WH_rO" node="5VSAssGMyfR" resolve="myCreateListener" />
+        <node concept="3clFbF" id="DrREDhq4f0" role="3cqZAp">
+          <node concept="2OqwBi" id="DrREDhq4f1" role="3clFbG">
+            <node concept="2OqwBi" id="DrREDhq4f2" role="2Oq$k0">
+              <node concept="1KvdUw" id="DrREDhq4f3" role="2Oq$k0" />
+              <node concept="liA8E" id="DrREDhq4f4" role="2OqNvi">
+                <ref role="37wK5l" to="z1c3:~MPSProject.getComponent(java.lang.Class)" resolve="getComponent" />
+                <node concept="3VsKOn" id="DrREDhq4f5" role="37wK5m">
+                  <ref role="3VsUkX" to="wvnl:~EditorExtensionRegistry" resolve="EditorExtensionRegistry" />
+                </node>
               </node>
             </node>
-            <node concept="liA8E" id="5VSAssGMzxz" role="2OqNvi">
-              <ref role="37wK5l" to="kvq8:2WlJ6VKQRx4" resolve="stop" />
+            <node concept="liA8E" id="DrREDhq4f6" role="2OqNvi">
+              <ref role="37wK5l" to="wvnl:~EditorExtensionRegistry.unregisterExtension(jetbrains.mps.openapi.editor.extensions.EditorExtension)" resolve="unregisterExtension" />
+              <node concept="2OqwBi" id="DrREDhq4f7" role="37wK5m">
+                <node concept="2WthIp" id="DrREDhq4f8" role="2Oq$k0" />
+                <node concept="2BZ7hE" id="DrREDhq4f9" role="2OqNvi">
+                  <ref role="2WH_rO" node="5VSAssGMyfR" resolve="myCreateListener" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="DrREDhq4WM" role="3cqZAp">
+          <node concept="37vLTI" id="DrREDhq58O" role="3clFbG">
+            <node concept="10Nm6u" id="DrREDhq5aS" role="37vLTx" />
+            <node concept="2OqwBi" id="DrREDhq4WG" role="37vLTJ">
+              <node concept="2WthIp" id="DrREDhq4WJ" role="2Oq$k0" />
+              <node concept="2BZ7hE" id="DrREDhq4WL" role="2OqNvi">
+                <ref role="2WH_rO" node="5VSAssGMyfR" resolve="myCreateListener" />
+              </node>
             </node>
           </node>
         </node>

--- a/code/widgets/solutions/de.itemis.mps.mouselistener.runtime/de.itemis.mps.mouselistener.runtime.msd
+++ b/code/widgets/solutions/de.itemis.mps.mouselistener.runtime/de.itemis.mps.mouselistener.runtime.msd
@@ -14,7 +14,6 @@
     <dependency reexport="false">1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)</dependency>
     <dependency reexport="false">3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)</dependency>
     <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
-    <dependency reexport="false">f0fff802-6d26-4d2e-b89d-391357265626(de.slisson.mps.hacks.editor)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
@@ -43,7 +42,6 @@
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
     <module reference="5c13c612-0f7b-4f0a-ab8b-565186b418de(de.itemis.mps.mouselistener.runtime)" version="0" />
-    <module reference="f0fff802-6d26-4d2e-b89d-391357265626(de.slisson.mps.hacks.editor)" version="0" />
   </dependencyVersions>
 </solution>
 

--- a/code/widgets/solutions/de.itemis.mps.mouselistener.runtime/models/de/itemis/mps/mouselistener/runtime/plugin.mps
+++ b/code/widgets/solutions/de.itemis.mps.mouselistener.runtime/models/de/itemis/mps/mouselistener/runtime/plugin.mps
@@ -17,8 +17,10 @@
     <import index="exr9" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor(MPS.Editor/)" />
     <import index="f4zo" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.cells(MPS.Editor/)" />
     <import index="py4t" ref="r:4e973dcf-7005-4515-8904-9c030ef293d4(de.itemis.mps.mouselistener.runtime)" />
-    <import index="kvq8" ref="r:2e938759-cfd0-47cd-9046-896d85204f59(de.slisson.mps.hacks.editor)" />
     <import index="mpcv" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang.ref(JDK/)" />
+    <import index="wvnl" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.extensions(MPS.Editor/)" />
+    <import index="z1c3" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.project(MPS.Platform/)" />
+    <import index="cj4x" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor(MPS.Editor/)" />
     <import index="z8iw" ref="r:dfdf3542-dbcf-43df-870a-3c3504b3c840(jetbrains.mps.baseLanguage.collections.custom)" implicit="true" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
   </imports>
@@ -85,6 +87,7 @@
         <reference id="1144433057691" name="classifier" index="1PxDUh" />
       </concept>
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
+      <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
       <concept id="1070534934090" name="jetbrains.mps.baseLanguage.structure.CastExpression" flags="nn" index="10QFUN">
         <child id="1070534934091" name="type" index="10QFUM" />
         <child id="1070534934092" name="expression" index="10QFUP" />
@@ -137,9 +140,6 @@
       </concept>
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
-      </concept>
-      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
-        <property id="1068580123138" name="value" index="3clFbU" />
       </concept>
       <concept id="1068580123140" name="jetbrains.mps.baseLanguage.structure.ConstructorDeclaration" flags="ig" index="3clFbW" />
       <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
@@ -1476,7 +1476,7 @@
       <property role="TrG5h" value="myListener" />
       <node concept="3Tm6S6" id="2vJRo8g$$xh" role="1B3o_S" />
       <node concept="3uibUv" id="2mjECGQOqrW" role="1tU5fm">
-        <ref role="3uigEE" to="kvq8:2WlJ6VKPQcy" resolve="EditorComponentCreationListener" />
+        <ref role="3uigEE" to="wvnl:~EditorExtension" resolve="EditorExtension" />
       </node>
     </node>
     <node concept="2uRRBT" id="2vJRo8g$$xj" role="2uRRB$">
@@ -1487,28 +1487,64 @@
               <node concept="YeOm9" id="2mjECGQOG54" role="2ShVmc">
                 <node concept="1Y3b0j" id="2mjECGQOG57" role="YeSDq">
                   <property role="2bfB8j" value="true" />
-                  <ref role="1Y3XeK" to="kvq8:2WlJ6VKPQcy" resolve="EditorComponentCreationListener" />
-                  <ref role="37wK5l" to="kvq8:3pwG8PSjV93" resolve="EditorComponentCreationListener" />
+                  <ref role="1Y3XeK" to="wvnl:~EditorExtension" resolve="EditorExtension" />
+                  <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" />
                   <node concept="3Tm1VV" id="2mjECGQOG58" role="1B3o_S" />
-                  <node concept="3clFb_" id="2mjECGQOG59" role="jymVt">
-                    <property role="TrG5h" value="editorComponentCreate" />
-                    <property role="1EzhhJ" value="false" />
-                    <node concept="37vLTG" id="2mjECGQOG5a" role="3clF46">
-                      <property role="TrG5h" value="editorComponent" />
-                      <node concept="3uibUv" id="2mjECGQOG5b" role="1tU5fm">
-                        <ref role="3uigEE" to="exr9:~EditorComponent" resolve="EditorComponent" />
+                  <node concept="3clFb_" id="DrREDhpmfz" role="jymVt">
+                    <property role="TrG5h" value="isApplicable" />
+                    <node concept="3Tm1VV" id="DrREDhpmf$" role="1B3o_S" />
+                    <node concept="10P_77" id="DrREDhpmfA" role="3clF45" />
+                    <node concept="37vLTG" id="DrREDhpmfB" role="3clF46">
+                      <property role="TrG5h" value="component" />
+                      <node concept="3uibUv" id="DrREDhpmfC" role="1tU5fm">
+                        <ref role="3uigEE" to="cj4x:~EditorComponent" resolve="EditorComponent" />
+                      </node>
+                      <node concept="2AHcQZ" id="DrREDhpmfD" role="2AJF6D">
+                        <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
                       </node>
                     </node>
-                    <node concept="3cqZAl" id="2mjECGQOG5c" role="3clF45" />
-                    <node concept="3Tm1VV" id="2mjECGQOG5d" role="1B3o_S" />
-                    <node concept="3clFbS" id="2mjECGQOG5f" role="3clF47">
+                    <node concept="3clFbS" id="DrREDhpmfF" role="3clF47">
+                      <node concept="3clFbF" id="DrREDhpUFH" role="3cqZAp">
+                        <node concept="2ZW3vV" id="DrREDhpUVe" role="3clFbG">
+                          <node concept="3uibUv" id="DrREDhpVDp" role="2ZW6by">
+                            <ref role="3uigEE" to="exr9:~EditorComponent" resolve="EditorComponent" />
+                          </node>
+                          <node concept="37vLTw" id="DrREDhpUFE" role="2ZW6bz">
+                            <ref role="3cqZAo" node="DrREDhpmfB" resolve="component" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2AHcQZ" id="DrREDhpmfG" role="2AJF6D">
+                      <ref role="2AI5Lk" to="wyt6:~Override" />
+                    </node>
+                  </node>
+                  <node concept="3clFb_" id="DrREDhpmfJ" role="jymVt">
+                    <property role="TrG5h" value="install" />
+                    <node concept="3Tm1VV" id="DrREDhpmfK" role="1B3o_S" />
+                    <node concept="3cqZAl" id="DrREDhpmfM" role="3clF45" />
+                    <node concept="37vLTG" id="DrREDhpmfN" role="3clF46">
+                      <property role="TrG5h" value="component" />
+                      <node concept="3uibUv" id="DrREDhpmfO" role="1tU5fm">
+                        <ref role="3uigEE" to="cj4x:~EditorComponent" resolve="EditorComponent" />
+                      </node>
+                      <node concept="2AHcQZ" id="DrREDhpmfP" role="2AJF6D">
+                        <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+                      </node>
+                    </node>
+                    <node concept="3clFbS" id="DrREDhpmfR" role="3clF47">
                       <node concept="3clFbF" id="80_psBV2bR" role="3cqZAp">
                         <node concept="2OqwBi" id="80_psBV2kq" role="3clFbG">
                           <node concept="2YIFZM" id="80_psBV2cZ" role="2Oq$k0">
                             <ref role="1Pybhc" node="80_psBSjpC" resolve="DelegatingMouseListener" />
                             <ref role="37wK5l" node="80_psBTXzh" resolve="getOrCreateInstance" />
-                            <node concept="37vLTw" id="2mjECGQOIgN" role="37wK5m">
-                              <ref role="3cqZAo" node="2mjECGQOG5a" resolve="editorComponent" />
+                            <node concept="10QFUN" id="DrREDhpyzr" role="37wK5m">
+                              <node concept="3uibUv" id="DrREDhpzc5" role="10QFUM">
+                                <ref role="3uigEE" to="exr9:~EditorComponent" resolve="EditorComponent" />
+                              </node>
+                              <node concept="37vLTw" id="2mjECGQOIgN" role="10QFUP">
+                                <ref role="3cqZAo" node="DrREDhpmfN" resolve="component" />
+                              </node>
                             </node>
                           </node>
                           <node concept="liA8E" id="80_psBV3mD" role="2OqNvi">
@@ -1517,26 +1553,36 @@
                         </node>
                       </node>
                     </node>
+                    <node concept="2AHcQZ" id="DrREDhpmfS" role="2AJF6D">
+                      <ref role="2AI5Lk" to="wyt6:~Override" />
+                    </node>
                   </node>
-                  <node concept="3clFb_" id="2mjECGQOG5h" role="jymVt">
-                    <property role="TrG5h" value="editorComponentDisposed" />
-                    <property role="1EzhhJ" value="false" />
-                    <node concept="37vLTG" id="2mjECGQOG5i" role="3clF46">
-                      <property role="TrG5h" value="editorComponent" />
-                      <node concept="3uibUv" id="2mjECGQOG5j" role="1tU5fm">
-                        <ref role="3uigEE" to="exr9:~EditorComponent" resolve="EditorComponent" />
+                  <node concept="3clFb_" id="DrREDhpmfT" role="jymVt">
+                    <property role="TrG5h" value="uninstall" />
+                    <node concept="3Tm1VV" id="DrREDhpmfU" role="1B3o_S" />
+                    <node concept="3cqZAl" id="DrREDhpmfW" role="3clF45" />
+                    <node concept="37vLTG" id="DrREDhpmfX" role="3clF46">
+                      <property role="TrG5h" value="component" />
+                      <node concept="3uibUv" id="DrREDhpmfY" role="1tU5fm">
+                        <ref role="3uigEE" to="cj4x:~EditorComponent" resolve="EditorComponent" />
+                      </node>
+                      <node concept="2AHcQZ" id="DrREDhpmfZ" role="2AJF6D">
+                        <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
                       </node>
                     </node>
-                    <node concept="3cqZAl" id="2mjECGQOG5k" role="3clF45" />
-                    <node concept="3Tm1VV" id="2mjECGQOG5l" role="1B3o_S" />
-                    <node concept="3clFbS" id="2mjECGQOG5n" role="3clF47">
+                    <node concept="3clFbS" id="DrREDhpmg1" role="3clF47">
                       <node concept="3clFbF" id="80_psBV3s3" role="3cqZAp">
                         <node concept="2EnYce" id="6CcfvtYXJQB" role="3clFbG">
                           <node concept="2YIFZM" id="6CcfvtYXJOz" role="2Oq$k0">
                             <ref role="37wK5l" node="6CcfvtYXFRH" resolve="getInstance" />
                             <ref role="1Pybhc" node="80_psBSjpC" resolve="DelegatingMouseListener" />
-                            <node concept="37vLTw" id="6CcfvtYXJO$" role="37wK5m">
-                              <ref role="3cqZAo" node="2mjECGQOG5i" resolve="editorComponent" />
+                            <node concept="10QFUN" id="DrREDhpz_i" role="37wK5m">
+                              <node concept="3uibUv" id="DrREDhpzSP" role="10QFUM">
+                                <ref role="3uigEE" to="exr9:~EditorComponent" resolve="EditorComponent" />
+                              </node>
+                              <node concept="37vLTw" id="6CcfvtYXJO$" role="10QFUP">
+                                <ref role="3cqZAo" node="DrREDhpmfX" resolve="component" />
+                              </node>
                             </node>
                           </node>
                           <node concept="liA8E" id="80_psBV3s7" role="2OqNvi">
@@ -1545,8 +1591,10 @@
                         </node>
                       </node>
                     </node>
+                    <node concept="2AHcQZ" id="DrREDhpmg2" role="2AJF6D">
+                      <ref role="2AI5Lk" to="wyt6:~Override" />
+                    </node>
                   </node>
-                  <node concept="1KvdUw" id="2mjECGQOKHr" role="37wK5m" />
                 </node>
               </node>
             </node>
@@ -1558,18 +1606,24 @@
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="2mjECGQOL52" role="3cqZAp">
-          <node concept="2OqwBi" id="2mjECGQOLls" role="3clFbG">
-            <node concept="2OqwBi" id="2mjECGQOL4W" role="2Oq$k0">
-              <node concept="2WthIp" id="2mjECGQOL4Z" role="2Oq$k0" />
-              <node concept="2BZ7hE" id="2mjECGQOL51" role="2OqNvi">
-                <ref role="2WH_rO" node="2vJRo8g$$xg" resolve="myListener" />
+        <node concept="3clFbF" id="DrREDhpqa2" role="3cqZAp">
+          <node concept="2OqwBi" id="DrREDhpsm1" role="3clFbG">
+            <node concept="2OqwBi" id="DrREDhpqSe" role="2Oq$k0">
+              <node concept="1KvdUw" id="DrREDhpqa1" role="2Oq$k0" />
+              <node concept="liA8E" id="DrREDhprXJ" role="2OqNvi">
+                <ref role="37wK5l" to="z1c3:~MPSProject.getComponent(java.lang.Class)" resolve="getComponent" />
+                <node concept="3VsKOn" id="DrREDhps6I" role="37wK5m">
+                  <ref role="3VsUkX" to="wvnl:~EditorExtensionRegistry" resolve="EditorExtensionRegistry" />
+                </node>
               </node>
             </node>
-            <node concept="liA8E" id="2mjECGQOLGM" role="2OqNvi">
-              <ref role="37wK5l" to="kvq8:2WlJ6VKQR6W" resolve="start" />
-              <node concept="3clFbT" id="2mjECGQOLI9" role="37wK5m">
-                <property role="3clFbU" value="true" />
+            <node concept="liA8E" id="DrREDhpsZe" role="2OqNvi">
+              <ref role="37wK5l" to="wvnl:~EditorExtensionRegistry.registerExtension(jetbrains.mps.openapi.editor.extensions.EditorExtension)" resolve="registerExtension" />
+              <node concept="2OqwBi" id="DrREDhptax" role="37wK5m">
+                <node concept="2WthIp" id="DrREDhpta$" role="2Oq$k0" />
+                <node concept="2BZ7hE" id="DrREDhptaA" role="2OqNvi">
+                  <ref role="2WH_rO" node="2vJRo8g$$xg" resolve="myListener" />
+                </node>
               </node>
             </node>
           </node>
@@ -1578,16 +1632,36 @@
     </node>
     <node concept="2uRRBN" id="2vJRo8g$$y0" role="2uRRB_">
       <node concept="3clFbS" id="2vJRo8g$$y1" role="2VODD2">
-        <node concept="3clFbF" id="2mjECGQOM1M" role="3cqZAp">
-          <node concept="2OqwBi" id="2mjECGQOMde" role="3clFbG">
-            <node concept="2OqwBi" id="2mjECGQOM1G" role="2Oq$k0">
-              <node concept="2WthIp" id="2mjECGQOM1J" role="2Oq$k0" />
-              <node concept="2BZ7hE" id="2mjECGQOM1L" role="2OqNvi">
-                <ref role="2WH_rO" node="2vJRo8g$$xg" resolve="myListener" />
+        <node concept="3clFbF" id="DrREDhptnq" role="3cqZAp">
+          <node concept="2OqwBi" id="DrREDhptnr" role="3clFbG">
+            <node concept="2OqwBi" id="DrREDhptns" role="2Oq$k0">
+              <node concept="1KvdUw" id="DrREDhptnt" role="2Oq$k0" />
+              <node concept="liA8E" id="DrREDhptnu" role="2OqNvi">
+                <ref role="37wK5l" to="z1c3:~MPSProject.getComponent(java.lang.Class)" resolve="getComponent" />
+                <node concept="3VsKOn" id="DrREDhptnv" role="37wK5m">
+                  <ref role="3VsUkX" to="wvnl:~EditorExtensionRegistry" resolve="EditorExtensionRegistry" />
+                </node>
               </node>
             </node>
-            <node concept="liA8E" id="2mjECGQOMwS" role="2OqNvi">
-              <ref role="37wK5l" to="kvq8:2WlJ6VKQRx4" resolve="stop" />
+            <node concept="liA8E" id="DrREDhptnw" role="2OqNvi">
+              <ref role="37wK5l" to="wvnl:~EditorExtensionRegistry.unregisterExtension(jetbrains.mps.openapi.editor.extensions.EditorExtension)" resolve="unregisterExtension" />
+              <node concept="2OqwBi" id="DrREDhptnx" role="37wK5m">
+                <node concept="2WthIp" id="DrREDhptny" role="2Oq$k0" />
+                <node concept="2BZ7hE" id="DrREDhptnz" role="2OqNvi">
+                  <ref role="2WH_rO" node="2vJRo8g$$xg" resolve="myListener" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="DrREDhptOM" role="3cqZAp">
+          <node concept="37vLTI" id="DrREDhpu5a" role="3clFbG">
+            <node concept="10Nm6u" id="DrREDhpu6W" role="37vLTx" />
+            <node concept="2OqwBi" id="DrREDhptOG" role="37vLTJ">
+              <node concept="2WthIp" id="DrREDhptOJ" role="2Oq$k0" />
+              <node concept="2BZ7hE" id="DrREDhptOL" role="2OqNvi">
+                <ref role="2WH_rO" node="2vJRo8g$$xg" resolve="myListener" />
+              </node>
             </node>
           </node>
         </node>


### PR DESCRIPTION
Since 2024.1, MPS EditorExtensionRegistry become a CoreComponent (used to be IDEA ProjectComponent).
To access both IDEA and MPS components, use MPSProject.getComponent() API.
Note, this approach is necessary for compatibility between MPS 2024.1 and earlier versions as long as same MPS-extensions code is in use both in 2023.x and 24.x versions. Once there's 24.1+ only (23.3 forks to maintenance), `ProjectPlugin` parts contributing EditorExtension shall get converted into `ApplicationPlugin`, as EditorExtensionRegistry CoreComponent is application-wide (unlike IDEA's ProjectComponent it used to be up and including to 2023.3).