### PR TITLE
only re-export Annotations in MPS.Kotlin

### DIFF
--- a/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
+++ b/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
@@ -893,9 +893,6 @@
       <node concept="m$_yC" id="3$A0JaN5ijM" role="m$_yJ">
         <ref role="m$_y1" to="ffeo:5HVSRHdVm9a" resolve="jetbrains.mps.build" />
       </node>
-      <node concept="m$_yC" id="2IcGFIb0y8T" role="m$_yJ">
-        <ref role="m$_y1" node="2IcGFIaJU8j" resolve="MPS.Kotlin" />
-      </node>
       <node concept="3_J27D" id="3$A0JaN5ezr" role="m$_yQ">
         <node concept="3Mxwew" id="3$A0JaN5gnC" role="3MwsjC">
           <property role="3MwjfP" value="Stubs for the third party libraries in MPS" />
@@ -922,6 +919,9 @@
       <node concept="2iUeEo" id="3$A0JaN5j9p" role="2iVFfd">
         <property role="2iUeEu" value="https://www.itemis.com/en/it-services/methods-and-tools/mps" />
         <property role="2iUeEt" value="itemis AG" />
+      </node>
+      <node concept="m$_yC" id="2IcGFIb0y8T" role="m$_yJ">
+        <ref role="m$_y1" node="2IcGFIaJU8j" resolve="MPS.Kotlin" />
       </node>
     </node>
     <node concept="2G$12M" id="3$A0JaN5ae8" role="3989C9">
@@ -1011,9 +1011,6 @@
       <node concept="m$_yC" id="2IcGFIaJU8l" role="m$_yJ">
         <ref role="m$_y1" to="ffeo:5HVSRHdVm9a" resolve="jetbrains.mps.build" />
       </node>
-      <node concept="m$_yC" id="2IcGFIb0yI0" role="m$_yJ">
-        <ref role="m$_y1" node="3$A0JaN5ezp" resolve="MPS.ThirdParty" />
-      </node>
       <node concept="3_J27D" id="2IcGFIaJU8m" role="m$_yQ">
         <node concept="3Mxwew" id="2IcGFIaJU8n" role="3MwsjC">
           <property role="3MwjfP" value="Stubs for the Kotlin libraries in MPS" />
@@ -1081,12 +1078,6 @@
                 </node>
               </node>
             </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2IcGFIaJUND" role="3bR37C">
-          <node concept="3bR9La" id="2IcGFIaJUNE" role="1SiIV1">
-            <property role="3bR36h" value="true" />
-            <ref role="3bR37D" node="3$A0JaN5bpX" resolve="MPS.ThirdParty" />
           </node>
         </node>
         <node concept="1SiIV0" id="2PSVZXMBj4h" role="3bR37C">
@@ -1175,6 +1166,12 @@
             <node concept="3yrxFa" id="2PSVZXMBkou" role="2gdwQb">
               <ref role="3yrxFb" to="ffeo:2I9TXtJz75K" />
             </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2VwBI6iTzXI" role="3bR37C">
+          <node concept="3bR9La" id="2VwBI6iTzXJ" role="1SiIV1">
+            <property role="3bR36h" value="true" />
+            <ref role="3bR37D" to="ffeo:44LXwdzyvTi" resolve="Annotations" />
           </node>
         </node>
       </node>
@@ -16551,6 +16548,11 @@
         <node concept="1SiIV0" id="2PSVZXMynSg" role="3bR37C">
           <node concept="3bR9La" id="2PSVZXMynSh" role="1SiIV1">
             <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2VwBI6iTHh0" role="3bR37C">
+          <node concept="3bR9La" id="2VwBI6iTHh1" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:44LXwdzyvTi" resolve="Annotations" />
           </node>
         </node>
       </node>

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells.sandboxlang/models/com/mbeddr/mpsutil/grammarcells/sandboxlang/constraints.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells.sandboxlang/models/com/mbeddr/mpsutil/grammarcells/sandboxlang/constraints.mps
@@ -64,8 +64,10 @@
       <concept id="4303308395523096213" name="jetbrains.mps.lang.constraints.structure.ConstraintFunctionParameter_childConcept" flags="ng" index="2DD5aU" />
       <concept id="1147467115080" name="jetbrains.mps.lang.constraints.structure.NodePropertyConstraint" flags="ng" index="EnEH3">
         <reference id="1147467295099" name="applicableProperty" index="EomxK" />
+        <child id="1147468630220" name="propertyGetter" index="EtsB7" />
         <child id="1212097481299" name="propertyValidator" index="QCWH9" />
       </concept>
+      <concept id="1147467790433" name="jetbrains.mps.lang.constraints.structure.ConstraintFunction_PropertyGetter" flags="in" index="Eqf_E" />
       <concept id="6738154313879680265" name="jetbrains.mps.lang.constraints.structure.ConstraintFunctionParameter_childNode" flags="nn" index="2H4GUG" />
       <concept id="1212096972063" name="jetbrains.mps.lang.constraints.structure.ConstraintFunction_PropertyValidator" flags="in" index="QB0g5" />
       <concept id="5564765827938091039" name="jetbrains.mps.lang.constraints.structure.ConstraintFunction_ReferentSearchScope_Scope" flags="ig" index="3dgokm" />
@@ -282,6 +284,21 @@
               <node concept="chp4Y" id="6sxj0_UzcBF" role="2Zo12j">
                 <ref role="cht4Q" to="ibwz:3Lzx5Pf0k5B" resolve="BType" />
               </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1M2fIO" id="5mI4pZCf5xd">
+    <ref role="1M2myG" to="ibwz:6oKG1kMxn82" resolve="LocalVariableDeclaration" />
+    <node concept="EnEH3" id="5mI4pZCf5ye" role="1MhHOB">
+      <ref role="EomxK" to="ibwz:qT5MFml3Gb" resolve="static" />
+      <node concept="Eqf_E" id="5mI4pZCfVIT" role="EtsB7">
+        <node concept="3clFbS" id="5mI4pZCfVIU" role="2VODD2">
+          <node concept="3clFbF" id="5mI4pZCfVQ7" role="3cqZAp">
+            <node concept="3clFbT" id="5mI4pZCfVQ6" role="3clFbG">
+              <property role="3clFbU" value="true" />
             </node>
           </node>
         </node>

--- a/code/kotlin/solutions/MPS.Kotlin/MPS.Kotlin.msd
+++ b/code/kotlin/solutions/MPS.Kotlin/MPS.Kotlin.msd
@@ -21,7 +21,7 @@
   </stubModelEntries>
   <sourcePath />
   <dependencies>
-    <dependency reexport="true">39983771-4e9b-401b-a1a9-1da6c777c843(MPS.ThirdParty)</dependency>
+    <dependency reexport="true">3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
@@ -32,9 +32,7 @@
   <dependencyVersions>
     <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
     <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
-    <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
     <module reference="47198eff-d292-4dcd-85af-227f983426b5(MPS.Kotlin)" version="0" />
-    <module reference="39983771-4e9b-401b-a1a9-1da6c777c843(MPS.ThirdParty)" version="0" />
   </dependencyVersions>
 </solution>
 

--- a/code/kotlin/solutions/kotlin.usage.test/kotlin.usage.test.msd
+++ b/code/kotlin/solutions/kotlin.usage.test/kotlin.usage.test.msd
@@ -14,6 +14,7 @@
   <dependencies>
     <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
     <dependency reexport="false">47198eff-d292-4dcd-85af-227f983426b5(MPS.Kotlin)</dependency>
+    <dependency reexport="false">3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
@@ -23,9 +24,7 @@
   <dependencyVersions>
     <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
     <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
-    <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
     <module reference="47198eff-d292-4dcd-85af-227f983426b5(MPS.Kotlin)" version="0" />
-    <module reference="39983771-4e9b-401b-a1a9-1da6c777c843(MPS.ThirdParty)" version="0" />
     <module reference="4105d28f-d96e-442e-9491-3eaac1128b0c(kotlin.usage.test)" version="0" />
   </dependencyVersions>
 </solution>


### PR DESCRIPTION
If MPS.Kotlin depends on MPS.Thirdparty and vice versa, we have a cyclic dependency that can't be resolved in tests. This commit is cherry picked from the last 20232 merge commit where we first saw this issue.