### PR TITLE
editor.diagram: add support for grid snapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is *loosely* based on [Keep a Changelog](https://keepachangelog.com/e
 
 ### Added
 
+- *de.itemis.mps.editor.diagram*: Diagrams can now show a grid that is used for snapping elements to it. It can be configured (visibility, grid snapping, grid color/size) in the editor definition of the diagram itself.
 - A module stub solution *MPS.Kotlin* was added to support referencing Kotlin classes and libraries from MPS.ThirdParty.
 
 ## August 2024

--- a/code/diagram/languages/de.itemis.mps.editor.diagram.demoentities/languageModels/editor.mps
+++ b/code/diagram/languages/de.itemis.mps.editor.diagram.demoentities/languageModels/editor.mps
@@ -14,6 +14,7 @@
     <import index="tc27" ref="r:92d28f3c-6acc-431a-94ba-30cd184d2da4(de.itemis.mps.editor.diagram.runtime.substitute)" />
     <import index="wo6c" ref="r:de91083f-90a8-4dd4-83b1-8a92d65ab81d(de.itemis.mps.editor.diagram.shapes)" />
     <import index="vgho" ref="1144260c-e9a5-49a2-9add-39a1a1a7077e/java:org.eclipse.elk.core.math(de.itemis.mps.editor.diagram.runtime/)" />
+    <import index="z60i" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt(JDK/)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
     <import index="88j9" ref="r:20c4aa5c-ab36-4815-af32-01895ee9c2f5(de.itemis.mps.editor.diagram.editor)" implicit="true" />
     <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" implicit="true" />
@@ -58,6 +59,7 @@
       </concept>
       <concept id="1233758997495" name="jetbrains.mps.lang.editor.structure.PunctuationLeftStyleClassItem" flags="ln" index="11L4FC" />
       <concept id="1233759184865" name="jetbrains.mps.lang.editor.structure.PunctuationRightStyleClassItem" flags="ln" index="11LMrY" />
+      <concept id="1221057094638" name="jetbrains.mps.lang.editor.structure.QueryFunction_Integer" flags="in" index="1cFabM" />
       <concept id="1088013125922" name="jetbrains.mps.lang.editor.structure.CellModel_RefCell" flags="sg" stub="730538219795941030" index="1iCGBv">
         <child id="1088186146602" name="editorComponent" index="1sWHZn" />
       </concept>
@@ -93,6 +95,7 @@
       <concept id="1166049232041" name="jetbrains.mps.lang.editor.structure.AbstractComponent" flags="ng" index="1XWOmA">
         <reference id="1166049300910" name="conceptDeclaration" index="1XX52x" />
       </concept>
+      <concept id="1176809959526" name="jetbrains.mps.lang.editor.structure.QueryFunction_Color" flags="in" index="3ZlJ5R" />
     </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
       <concept id="1080223426719" name="jetbrains.mps.baseLanguage.structure.OrExpression" flags="nn" index="22lmx$" />
@@ -123,6 +126,9 @@
       </concept>
       <concept id="1164991038168" name="jetbrains.mps.baseLanguage.structure.ThrowStatement" flags="nn" index="YS8fn">
         <child id="1164991057263" name="throwable" index="YScLw" />
+      </concept>
+      <concept id="1070533707846" name="jetbrains.mps.baseLanguage.structure.StaticFieldReference" flags="nn" index="10M0yZ">
+        <reference id="1144433057691" name="classifier" index="1PxDUh" />
       </concept>
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
       <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
@@ -161,6 +167,9 @@
       </concept>
       <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
         <property id="1068580123138" name="value" index="3clFbU" />
+      </concept>
+      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
+        <property id="1068580320021" name="value" index="3cmrfH" />
       </concept>
       <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6" />
       <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
@@ -219,6 +228,10 @@
         <child id="1742468285817538342" name="disableNodeEditing" index="2gDVEa" />
         <child id="53713348769907228" name="autoLayoutOnChange" index="2hB_ot" />
         <child id="2060885462441433843" name="allowElementsBelowRequiredSize" index="2F3Mqr" />
+        <child id="3401785396303280005" name="gridColor" index="1bWipe" />
+        <child id="7349833668006295675" name="gridSize" index="3ehQaW" />
+        <child id="5128117196760806289" name="useGridSnapping" index="3wlkzU" />
+        <child id="5128117196760806288" name="showGrid" index="3wlkzV" />
         <child id="8637411062076630380" name="connectionTypes" index="1xLlFP" />
         <child id="7858611447550199305" name="syncWithModelOnlyOnOpening" index="3y0MdK" />
         <child id="8637411062062914773" name="paletteFolder" index="1y_2dc" />
@@ -876,6 +889,43 @@
           <node concept="3clFbF" id="1MpJ6ySoyON" role="3cqZAp">
             <node concept="3clFbT" id="1MpJ6ySoyOM" role="3clFbG">
               <property role="3clFbU" value="true" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1cFabM" id="6nZQGuFTYEq" role="3ehQaW">
+        <node concept="3clFbS" id="6nZQGuFTYEr" role="2VODD2">
+          <node concept="3clFbF" id="6nZQGuFTZ5W" role="3cqZAp">
+            <node concept="3cmrfG" id="6nZQGuFTZBR" role="3clFbG">
+              <property role="3cmrfH" value="5" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="pkWqt" id="6nZQGuG5umb" role="3wlkzV">
+        <node concept="3clFbS" id="6nZQGuG5umc" role="2VODD2">
+          <node concept="3clFbF" id="6nZQGuG5uzJ" role="3cqZAp">
+            <node concept="3clFbT" id="6nZQGuG5uzI" role="3clFbG">
+              <property role="3clFbU" value="true" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="pkWqt" id="6nZQGuG5Fj1" role="3wlkzU">
+        <node concept="3clFbS" id="6nZQGuG5Fj2" role="2VODD2">
+          <node concept="3clFbF" id="6nZQGuG5F$_" role="3cqZAp">
+            <node concept="3clFbT" id="6nZQGuG5F$$" role="3clFbG">
+              <property role="3clFbU" value="true" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3ZlJ5R" id="2WP$sH_3F$E" role="1bWipe">
+        <node concept="3clFbS" id="2WP$sH_3F$F" role="2VODD2">
+          <node concept="3clFbF" id="2WP$sH_3Ght" role="3cqZAp">
+            <node concept="10M0yZ" id="2WP$sH_3GlE" role="3clFbG">
+              <ref role="3cqZAo" to="z60i:~Color.BLUE" resolve="BLUE" />
+              <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
             </node>
           </node>
         </node>

--- a/code/diagram/languages/de.itemis.mps.editor.diagram.demoentities/languageModels/editor.mps
+++ b/code/diagram/languages/de.itemis.mps.editor.diagram.demoentities/languageModels/editor.mps
@@ -224,6 +224,7 @@
       </concept>
       <concept id="6554619382999975769" name="de.itemis.mps.editor.diagram.structure.Content_GenericElementQuery_OuterNode" flags="ng" index="23r2z0" />
       <concept id="1110129820007229393" name="de.itemis.mps.editor.diagram.structure.CellModel_Diagram" flags="ng" index="27vDVx">
+        <property id="1259410080007702445" name="gridStyle" index="2s7plA" />
         <child id="8433227566816393050" name="layoutAlgorithm" index="35U2g" />
         <child id="1742468285817538342" name="disableNodeEditing" index="2gDVEa" />
         <child id="53713348769907228" name="autoLayoutOnChange" index="2hB_ot" />
@@ -490,6 +491,7 @@
     <property role="3GE5qa" value="diagram" />
     <ref role="1XX52x" to="g93z:4_qW8fWLMYX" resolve="EntityDiagram" />
     <node concept="27vDVx" id="4_qW8fWLOPi" role="2wV5jI">
+      <property role="2s7plA" value="15UkGIdpWfA/GRID_STYLE_LINE" />
       <node concept="ahg9e" id="30bR1EZsvUl" role="aCds2">
         <node concept="238au4" id="30bR1EZsvUn" role="23bJyd">
           <node concept="3EZMnI" id="30bR1EZs_2z" role="2wV5jI">
@@ -896,8 +898,8 @@
       <node concept="1cFabM" id="6nZQGuFTYEq" role="3ehQaW">
         <node concept="3clFbS" id="6nZQGuFTYEr" role="2VODD2">
           <node concept="3clFbF" id="6nZQGuFTZ5W" role="3cqZAp">
-            <node concept="3cmrfG" id="6nZQGuFTZBR" role="3clFbG">
-              <property role="3cmrfH" value="5" />
+            <node concept="3cmrfG" id="15UkGIdCPvn" role="3clFbG">
+              <property role="3cmrfH" value="20" />
             </node>
           </node>
         </node>

--- a/code/diagram/languages/de.itemis.mps.editor.diagram.styles/languageModels/editor.mps
+++ b/code/diagram/languages/de.itemis.mps.editor.diagram.styles/languageModels/editor.mps
@@ -469,6 +469,20 @@
         <property role="3clFbU" value="true" />
       </node>
     </node>
+    <node concept="3t5Usi" id="4sEIQIBKTSa" role="V601i">
+      <property role="TrG5h" value="__show-grid-button" />
+      <node concept="10P_77" id="4sEIQIBKTSb" role="3t5Oan" />
+      <node concept="3clFbT" id="4sEIQIBKTSc" role="3t49C2">
+        <property role="3clFbU" value="true" />
+      </node>
+    </node>
+    <node concept="3t5Usi" id="4sEIQIBKU2v" role="V601i">
+      <property role="TrG5h" value="__use_grid-snapping-button" />
+      <node concept="10P_77" id="4sEIQIBKU2w" role="3t5Oan" />
+      <node concept="3clFbT" id="4sEIQIBKU2x" role="3t49C2">
+        <property role="3clFbU" value="true" />
+      </node>
+    </node>
     <node concept="3t5Usi" id="74e51JhIQfJ" role="V601i">
       <property role="TrG5h" value="__root-button-creator" />
       <node concept="1ajhzC" id="74e51JhIQiK" role="3t5Oan">

--- a/code/diagram/languages/de.itemis.mps.editor.diagram/generator/template/main@generator.mps
+++ b/code/diagram/languages/de.itemis.mps.editor.diagram/generator/template/main@generator.mps
@@ -68,7 +68,9 @@
     <import index="4nm9" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.project(MPS.IDEA/)" />
     <import index="1njx" ref="1144260c-e9a5-49a2-9add-39a1a1a7077e/java:com.mxgraph.view(de.itemis.mps.editor.diagram.runtime/)" />
     <import index="tpce" ref="r:00000000-0000-4000-0000-011c89590292(jetbrains.mps.lang.structure.structure)" />
+    <import index="p8va" ref="1144260c-e9a5-49a2-9add-39a1a1a7077e/java:com.mxgraph.swing(de.itemis.mps.editor.diagram.runtime/)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
+    <import index="t6h5" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang.reflect(JDK/)" implicit="true" />
   </imports>
   <registry>
     <language id="a247e09e-2435-45ba-b8d2-07e93feba96a" name="jetbrains.mps.baseLanguage.tuples">
@@ -101,6 +103,9 @@
       <concept id="1215695189714" name="jetbrains.mps.baseLanguage.structure.PlusAssignmentExpression" flags="nn" index="d57v9" />
       <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="8118189177080264853" name="jetbrains.mps.baseLanguage.structure.AlternativeType" flags="ig" index="nSUau">
+        <child id="8118189177080264854" name="alternative" index="nSUat" />
+      </concept>
       <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
       <concept id="5279705229678483897" name="jetbrains.mps.baseLanguage.structure.FloatingPointFloatConstant" flags="nn" index="2$xPTn">
         <property id="5279705229678483899" name="value" index="2$xPTl" />
@@ -140,6 +145,7 @@
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
       </concept>
+      <concept id="4952749571008284462" name="jetbrains.mps.baseLanguage.structure.CatchVariable" flags="ng" index="XOnhg" />
       <concept id="1182160077978" name="jetbrains.mps.baseLanguage.structure.AnonymousClassCreator" flags="nn" index="YeOm9">
         <child id="1182160096073" name="cls" index="YeSDq" />
       </concept>
@@ -265,6 +271,10 @@
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
+      <concept id="3093926081414150598" name="jetbrains.mps.baseLanguage.structure.MultipleCatchClause" flags="ng" index="3uVAMA">
+        <child id="8276990574895933173" name="catchBody" index="1zc67A" />
+        <child id="8276990574895933172" name="throwable" index="1zc67B" />
+      </concept>
       <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
       <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
@@ -274,6 +284,10 @@
       </concept>
       <concept id="1144230876926" name="jetbrains.mps.baseLanguage.structure.AbstractForStatement" flags="nn" index="1DupvO">
         <child id="1144230900587" name="variable" index="1Duv9x" />
+      </concept>
+      <concept id="5351203823916750322" name="jetbrains.mps.baseLanguage.structure.TryUniversalStatement" flags="nn" index="3J1_TO">
+        <child id="8276990574886367510" name="catchClause" index="1zxBo5" />
+        <child id="8276990574886367508" name="body" index="1zxBo7" />
       </concept>
       <concept id="1163668896201" name="jetbrains.mps.baseLanguage.structure.TernaryOperatorExpression" flags="nn" index="3K4zz7">
         <child id="1163668914799" name="condition" index="3K4Cdx" />
@@ -6875,6 +6889,79 @@
                                                     <node concept="3cpWs6" id="6nZQGuFJWd9" role="3cqZAp">
                                                       <node concept="37vLTw" id="6nZQGuFK294" role="3cqZAk">
                                                         <ref role="3cqZAo" node="6nZQGuFJ0UI" resolve="size" />
+                                                      </node>
+                                                    </node>
+                                                  </node>
+                                                </node>
+                                                <node concept="2tJIrI" id="15UkGIdq$PJ" role="jymVt" />
+                                                <node concept="2tJIrI" id="15UkGIdqBEP" role="jymVt" />
+                                                <node concept="3clFb_" id="15UkGIdqECW" role="jymVt">
+                                                  <property role="TrG5h" value="getGridStyle" />
+                                                  <node concept="3Tm1VV" id="15UkGIdqECX" role="1B3o_S" />
+                                                  <node concept="10Oyi0" id="15UkGIdqECY" role="3clF45" />
+                                                  <node concept="2AHcQZ" id="15UkGIdqED2" role="2AJF6D">
+                                                    <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                                                  </node>
+                                                  <node concept="3clFbS" id="15UkGIdqED4" role="3clF47">
+                                                    <node concept="3J1_TO" id="15UkGIds5EJ" role="3cqZAp">
+                                                      <node concept="3uVAMA" id="15UkGIds8x4" role="1zxBo5">
+                                                        <node concept="XOnhg" id="15UkGIds8x5" role="1zc67B">
+                                                          <property role="TrG5h" value="ex" />
+                                                          <node concept="nSUau" id="15UkGIds8x6" role="1tU5fm">
+                                                            <node concept="3uibUv" id="15UkGIdsbwE" role="nSUat">
+                                                              <ref role="3uigEE" to="wyt6:~Exception" resolve="Exception" />
+                                                            </node>
+                                                          </node>
+                                                        </node>
+                                                        <node concept="3clFbS" id="15UkGIds8x7" role="1zc67A">
+                                                          <node concept="3cpWs6" id="15UkGIdsjrt" role="3cqZAp">
+                                                            <node concept="3cmrfG" id="15UkGIdsmUU" role="3cqZAk">
+                                                              <property role="3cmrfH" value="0" />
+                                                            </node>
+                                                          </node>
+                                                        </node>
+                                                      </node>
+                                                      <node concept="3clFbS" id="15UkGIds5EK" role="1zxBo7">
+                                                        <node concept="3cpWs6" id="15UkGIdsAaD" role="3cqZAp">
+                                                          <node concept="2OqwBi" id="15UkGIdrRQx" role="3cqZAk">
+                                                            <node concept="2OqwBi" id="15UkGIdr4P4" role="2Oq$k0">
+                                                              <node concept="3VsKOn" id="15UkGIdr33i" role="2Oq$k0">
+                                                                <ref role="3VsUkX" to="p8va:~mxGraphComponent" resolve="mxGraphComponent" />
+                                                              </node>
+                                                              <node concept="liA8E" id="15UkGIdr9Ht" role="2OqNvi">
+                                                                <ref role="37wK5l" to="wyt6:~Class.getDeclaredField(java.lang.String)" resolve="getDeclaredField" />
+                                                                <node concept="Xl_RD" id="15UkGIdrtOu" role="37wK5m">
+                                                                  <property role="Xl_RC" value="GRID_STYLE_DOT" />
+                                                                  <node concept="17Uvod" id="15UkGIdr_hb" role="lGtFl">
+                                                                    <property role="2qtEX9" value="value" />
+                                                                    <property role="P4ACc" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1070475926800/1070475926801" />
+                                                                    <node concept="3zFVjK" id="15UkGIdr_hc" role="3zH0cK">
+                                                                      <node concept="3clFbS" id="15UkGIdr_hd" role="2VODD2">
+                                                                        <node concept="3clFbF" id="15UkGIdrErK" role="3cqZAp">
+                                                                          <node concept="2OqwBi" id="15UkGIdrLBB" role="3clFbG">
+                                                                            <node concept="2OqwBi" id="15UkGIdrGlI" role="2Oq$k0">
+                                                                              <node concept="30H73N" id="15UkGIdrErJ" role="2Oq$k0" />
+                                                                              <node concept="3TrcHB" id="15UkGIdrJOx" role="2OqNvi">
+                                                                                <ref role="3TsBF5" to="2qld:15UkGIdpWuH" resolve="gridStyle" />
+                                                                              </node>
+                                                                            </node>
+                                                                            <node concept="liA8E" id="15UkGIdrODa" role="2OqNvi">
+                                                                              <ref role="37wK5l" to="c17a:~SEnumerationLiteral.getName()" resolve="getName" />
+                                                                            </node>
+                                                                          </node>
+                                                                        </node>
+                                                                      </node>
+                                                                    </node>
+                                                                  </node>
+                                                                </node>
+                                                              </node>
+                                                            </node>
+                                                            <node concept="liA8E" id="15UkGIdrV4z" role="2OqNvi">
+                                                              <ref role="37wK5l" to="t6h5:~Field.getInt(java.lang.Object)" resolve="getInt" />
+                                                              <node concept="10Nm6u" id="15UkGIdrZj0" role="37wK5m" />
+                                                            </node>
+                                                          </node>
+                                                        </node>
                                                       </node>
                                                     </node>
                                                   </node>

--- a/code/diagram/languages/de.itemis.mps.editor.diagram/generator/template/main@generator.mps
+++ b/code/diagram/languages/de.itemis.mps.editor.diagram/generator/template/main@generator.mps
@@ -6161,6 +6161,112 @@
                                                     </node>
                                                   </node>
                                                 </node>
+                                                <node concept="2tJIrI" id="4sEIQIBwHcp" role="jymVt" />
+                                                <node concept="3clFb_" id="4sEIQIBwIXv" role="jymVt">
+                                                  <property role="TrG5h" value="showTheGrid" />
+                                                  <node concept="3clFbS" id="4sEIQIBwIXw" role="3clF47">
+                                                    <node concept="3cpWs6" id="4sEIQIBwIXx" role="3cqZAp">
+                                                      <node concept="3clFbT" id="4sEIQIBwIXy" role="3cqZAk" />
+                                                    </node>
+                                                  </node>
+                                                  <node concept="3Tm6S6" id="4sEIQIBwIXz" role="1B3o_S" />
+                                                  <node concept="10P_77" id="4sEIQIBwIX$" role="3clF45" />
+                                                  <node concept="29HgVG" id="4sEIQIBwIX_" role="lGtFl">
+                                                    <node concept="3NFfHV" id="4sEIQIBwIXA" role="3NFExx">
+                                                      <node concept="3clFbS" id="4sEIQIBwIXB" role="2VODD2">
+                                                        <node concept="3clFbF" id="4sEIQIBwIXC" role="3cqZAp">
+                                                          <node concept="2OqwBi" id="4sEIQIBwIXD" role="3clFbG">
+                                                            <node concept="30H73N" id="4sEIQIBwIXE" role="2Oq$k0" />
+                                                            <node concept="3TrEf2" id="4sEIQIBwIXF" role="2OqNvi">
+                                                              <ref role="3Tt5mk" to="2qld:4sEIQIBvZeh" resolve="useGridSnapping" />
+                                                            </node>
+                                                          </node>
+                                                        </node>
+                                                      </node>
+                                                    </node>
+                                                  </node>
+                                                </node>
+                                                <node concept="2tJIrI" id="6nZQGuFIEKf" role="jymVt" />
+                                                <node concept="3clFb_" id="6nZQGuFIBcj" role="jymVt">
+                                                  <property role="TrG5h" value="getTheGridSize" />
+                                                  <node concept="3clFbS" id="6nZQGuFIBck" role="3clF47">
+                                                    <node concept="3cpWs6" id="6nZQGuFIBcl" role="3cqZAp">
+                                                      <node concept="3cmrfG" id="6nZQGuFIUld" role="3cqZAk">
+                                                        <property role="3cmrfH" value="0" />
+                                                      </node>
+                                                    </node>
+                                                  </node>
+                                                  <node concept="3Tm6S6" id="6nZQGuFIBcn" role="1B3o_S" />
+                                                  <node concept="10Oyi0" id="6nZQGuFIR16" role="3clF45" />
+                                                  <node concept="29HgVG" id="6nZQGuFIBcp" role="lGtFl">
+                                                    <ref role="2rW$FS" to="tpc3:hG092go" resolve="query_method" />
+                                                    <node concept="3NFfHV" id="6nZQGuFIBcq" role="3NFExx">
+                                                      <node concept="3clFbS" id="6nZQGuFIBcr" role="2VODD2">
+                                                        <node concept="3clFbF" id="6nZQGuFIBcs" role="3cqZAp">
+                                                          <node concept="2OqwBi" id="6nZQGuFIBct" role="3clFbG">
+                                                            <node concept="30H73N" id="6nZQGuFIBcu" role="2Oq$k0" />
+                                                            <node concept="3TrEf2" id="6nZQGuFIBcv" role="2OqNvi">
+                                                              <ref role="3Tt5mk" to="2qld:6nZQGuFIbxV" resolve="gridSize" />
+                                                            </node>
+                                                          </node>
+                                                        </node>
+                                                      </node>
+                                                    </node>
+                                                  </node>
+                                                </node>
+                                                <node concept="2tJIrI" id="2WP$sH$LpBs" role="jymVt" />
+                                                <node concept="3clFb_" id="2WP$sH$LjQX" role="jymVt">
+                                                  <property role="TrG5h" value="getTheGridColor" />
+                                                  <node concept="3clFbS" id="2WP$sH$LjQY" role="3clF47">
+                                                    <node concept="3cpWs6" id="2WP$sH$LjQZ" role="3cqZAp">
+                                                      <node concept="10Nm6u" id="2WP$sH$LzVC" role="3cqZAk" />
+                                                    </node>
+                                                  </node>
+                                                  <node concept="3Tm6S6" id="2WP$sH$LjR1" role="1B3o_S" />
+                                                  <node concept="3uibUv" id="2WP$sH$LtkB" role="3clF45">
+                                                    <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
+                                                  </node>
+                                                  <node concept="29HgVG" id="2WP$sH$LjR3" role="lGtFl">
+                                                    <ref role="2rW$FS" to="tpc3:hG092go" resolve="query_method" />
+                                                    <node concept="3NFfHV" id="2WP$sH$LjR4" role="3NFExx">
+                                                      <node concept="3clFbS" id="2WP$sH$LjR5" role="2VODD2">
+                                                        <node concept="3clFbF" id="2WP$sH$LjR6" role="3cqZAp">
+                                                          <node concept="2OqwBi" id="2WP$sH$LjR7" role="3clFbG">
+                                                            <node concept="30H73N" id="2WP$sH$LjR8" role="2Oq$k0" />
+                                                            <node concept="3TrEf2" id="2WP$sH$LjR9" role="2OqNvi">
+                                                              <ref role="3Tt5mk" to="2qld:2WP$sH$Lbu5" resolve="gridColor" />
+                                                            </node>
+                                                          </node>
+                                                        </node>
+                                                      </node>
+                                                    </node>
+                                                  </node>
+                                                </node>
+                                                <node concept="2tJIrI" id="4sEIQIBwHcq" role="jymVt" />
+                                                <node concept="3clFb_" id="4sEIQIBwWNH" role="jymVt">
+                                                  <property role="TrG5h" value="useTheGridSnapping" />
+                                                  <node concept="3clFbS" id="4sEIQIBwWNI" role="3clF47">
+                                                    <node concept="3cpWs6" id="4sEIQIBwWNJ" role="3cqZAp">
+                                                      <node concept="3clFbT" id="4sEIQIBwWNK" role="3cqZAk" />
+                                                    </node>
+                                                  </node>
+                                                  <node concept="3Tm6S6" id="4sEIQIBwWNL" role="1B3o_S" />
+                                                  <node concept="10P_77" id="4sEIQIBwWNM" role="3clF45" />
+                                                  <node concept="29HgVG" id="4sEIQIBwWNN" role="lGtFl">
+                                                    <node concept="3NFfHV" id="4sEIQIBwWNO" role="3NFExx">
+                                                      <node concept="3clFbS" id="4sEIQIBwWNP" role="2VODD2">
+                                                        <node concept="3clFbF" id="4sEIQIBwWNQ" role="3cqZAp">
+                                                          <node concept="2OqwBi" id="4sEIQIBwWNR" role="3clFbG">
+                                                            <node concept="30H73N" id="4sEIQIBwWNS" role="2Oq$k0" />
+                                                            <node concept="3TrEf2" id="4sEIQIBwWNT" role="2OqNvi">
+                                                              <ref role="3Tt5mk" to="2qld:4sEIQIBvZeg" resolve="showGrid" />
+                                                            </node>
+                                                          </node>
+                                                        </node>
+                                                      </node>
+                                                    </node>
+                                                  </node>
+                                                </node>
                                                 <node concept="2tJIrI" id="1MpJ6yS8QN5" role="jymVt" />
                                                 <node concept="3clFb_" id="4m$$SBGcTQF" role="jymVt">
                                                   <property role="TrG5h" value="runAutoLayoutOnInit" />
@@ -6624,6 +6730,300 @@
                                                   <node concept="3Tm1VV" id="1MpJ6yS9isi" role="1B3o_S" />
                                                   <node concept="10P_77" id="1MpJ6yS9isj" role="3clF45" />
                                                   <node concept="2AHcQZ" id="1MpJ6yS9isk" role="2AJF6D">
+                                                    <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                                                  </node>
+                                                </node>
+                                                <node concept="2tJIrI" id="4sEIQIBw6Xw" role="jymVt" />
+                                                <node concept="3clFb_" id="4sEIQIBwdfN" role="jymVt">
+                                                  <property role="TrG5h" value="showGrid" />
+                                                  <node concept="3clFbS" id="4sEIQIBwdfO" role="3clF47">
+                                                    <node concept="3cpWs8" id="4sEIQIBwdfP" role="3cqZAp">
+                                                      <node concept="3cpWsn" id="4sEIQIBwdfQ" role="3cpWs9">
+                                                        <property role="TrG5h" value="flag" />
+                                                        <node concept="10P_77" id="4sEIQIBwdfR" role="1tU5fm" />
+                                                        <node concept="3clFbT" id="4sEIQIBwdfS" role="33vP2m" />
+                                                      </node>
+                                                    </node>
+                                                    <node concept="3clFbF" id="4sEIQIBwdfT" role="3cqZAp">
+                                                      <node concept="37vLTI" id="4sEIQIBwdfU" role="3clFbG">
+                                                        <node concept="37vLTw" id="4sEIQIBwdfV" role="37vLTJ">
+                                                          <ref role="3cqZAo" node="4sEIQIBwdfQ" resolve="flag" />
+                                                        </node>
+                                                        <node concept="1rXfSq" id="4sEIQIBxInr" role="37vLTx">
+                                                          <ref role="37wK5l" node="4sEIQIBwIXv" resolve="showTheGrid" />
+                                                          <node concept="1ZhdrF" id="4sEIQIBxLl$" role="lGtFl">
+                                                            <property role="2qtEX8" value="baseMethodDeclaration" />
+                                                            <property role="P3scX" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1204053956946/1068499141037" />
+                                                            <node concept="3$xsQk" id="4sEIQIBxLl_" role="3$ytzL">
+                                                              <node concept="3clFbS" id="4sEIQIBxLlA" role="2VODD2">
+                                                                <node concept="3clFbF" id="4sEIQIBxPyR" role="3cqZAp">
+                                                                  <node concept="2OqwBi" id="4sEIQIBxPyS" role="3clFbG">
+                                                                    <node concept="1iwH70" id="4sEIQIBxPyT" role="2OqNvi">
+                                                                      <ref role="1iwH77" to="tpc3:hG092go" resolve="query_method" />
+                                                                      <node concept="2OqwBi" id="4sEIQIBxPyU" role="1iwH7V">
+                                                                        <node concept="30H73N" id="4sEIQIBxPyV" role="2Oq$k0" />
+                                                                        <node concept="3TrEf2" id="4sEIQIBxPyW" role="2OqNvi">
+                                                                          <ref role="3Tt5mk" to="2qld:4sEIQIBvZeg" resolve="showGrid" />
+                                                                        </node>
+                                                                      </node>
+                                                                    </node>
+                                                                    <node concept="1iwH7S" id="4sEIQIBxPyX" role="2Oq$k0" />
+                                                                  </node>
+                                                                </node>
+                                                              </node>
+                                                            </node>
+                                                          </node>
+                                                        </node>
+                                                      </node>
+                                                      <node concept="1W57fq" id="4sEIQIBwdg7" role="lGtFl">
+                                                        <node concept="3IZrLx" id="4sEIQIBwdg8" role="3IZSJc">
+                                                          <node concept="3clFbS" id="4sEIQIBwdg9" role="2VODD2">
+                                                            <node concept="3clFbF" id="4sEIQIBwdga" role="3cqZAp">
+                                                              <node concept="3y3z36" id="4sEIQIBwdgb" role="3clFbG">
+                                                                <node concept="10Nm6u" id="4sEIQIBwdgc" role="3uHU7w" />
+                                                                <node concept="2OqwBi" id="4sEIQIBwdgd" role="3uHU7B">
+                                                                  <node concept="30H73N" id="4sEIQIBwdge" role="2Oq$k0" />
+                                                                  <node concept="3TrEf2" id="4sEIQIBwdgf" role="2OqNvi">
+                                                                    <ref role="3Tt5mk" to="2qld:4sEIQIBvZeg" resolve="showGrid" />
+                                                                  </node>
+                                                                </node>
+                                                              </node>
+                                                            </node>
+                                                          </node>
+                                                        </node>
+                                                      </node>
+                                                    </node>
+                                                    <node concept="3cpWs6" id="4sEIQIBwdgg" role="3cqZAp">
+                                                      <node concept="37vLTw" id="4sEIQIBwdgh" role="3cqZAk">
+                                                        <ref role="3cqZAo" node="4sEIQIBwdfQ" resolve="flag" />
+                                                      </node>
+                                                    </node>
+                                                  </node>
+                                                  <node concept="3Tm1VV" id="4sEIQIBwdgi" role="1B3o_S" />
+                                                  <node concept="10P_77" id="4sEIQIBwdgj" role="3clF45" />
+                                                  <node concept="2AHcQZ" id="4sEIQIBwdgk" role="2AJF6D">
+                                                    <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                                                  </node>
+                                                </node>
+                                                <node concept="2tJIrI" id="6nZQGuFIvOK" role="jymVt" />
+                                                <node concept="3clFb_" id="6nZQGuFH4RH" role="jymVt">
+                                                  <property role="TrG5h" value="getGridSize" />
+                                                  <node concept="3Tm1VV" id="6nZQGuFH4RI" role="1B3o_S" />
+                                                  <node concept="10Oyi0" id="6nZQGuFH4RJ" role="3clF45" />
+                                                  <node concept="2AHcQZ" id="6nZQGuFH4RN" role="2AJF6D">
+                                                    <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                                                  </node>
+                                                  <node concept="3clFbS" id="6nZQGuFH4RP" role="3clF47">
+                                                    <node concept="3cpWs8" id="6nZQGuFJ0UF" role="3cqZAp">
+                                                      <node concept="3cpWsn" id="6nZQGuFJ0UI" role="3cpWs9">
+                                                        <property role="TrG5h" value="size" />
+                                                        <node concept="10Oyi0" id="6nZQGuFJ0UE" role="1tU5fm" />
+                                                        <node concept="3cmrfG" id="6nZQGuFJ7Hg" role="33vP2m">
+                                                          <property role="3cmrfH" value="10" />
+                                                        </node>
+                                                      </node>
+                                                    </node>
+                                                    <node concept="3clFbF" id="6nZQGuFJsP0" role="3cqZAp">
+                                                      <node concept="37vLTI" id="6nZQGuFJy3s" role="3clFbG">
+                                                        <node concept="1rXfSq" id="6nZQGuFJAG_" role="37vLTx">
+                                                          <ref role="37wK5l" node="6nZQGuFIBcj" resolve="getTheGridSize" />
+                                                          <node concept="1ZhdrF" id="6nZQGuFJD$7" role="lGtFl">
+                                                            <property role="2qtEX8" value="baseMethodDeclaration" />
+                                                            <property role="P3scX" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1204053956946/1068499141037" />
+                                                            <node concept="3$xsQk" id="6nZQGuFJD$8" role="3$ytzL">
+                                                              <node concept="3clFbS" id="6nZQGuFJD$9" role="2VODD2">
+                                                                <node concept="3clFbF" id="6nZQGuFJGhr" role="3cqZAp">
+                                                                  <node concept="2OqwBi" id="6nZQGuFJGhs" role="3clFbG">
+                                                                    <node concept="1iwH70" id="6nZQGuFJGht" role="2OqNvi">
+                                                                      <ref role="1iwH77" to="tpc3:hG092go" resolve="query_method" />
+                                                                      <node concept="2OqwBi" id="6nZQGuFJGhu" role="1iwH7V">
+                                                                        <node concept="30H73N" id="6nZQGuFJGhv" role="2Oq$k0" />
+                                                                        <node concept="3TrEf2" id="6nZQGuFJGhw" role="2OqNvi">
+                                                                          <ref role="3Tt5mk" to="2qld:6nZQGuFIbxV" resolve="gridSize" />
+                                                                        </node>
+                                                                      </node>
+                                                                    </node>
+                                                                    <node concept="1iwH7S" id="6nZQGuFJGhx" role="2Oq$k0" />
+                                                                  </node>
+                                                                </node>
+                                                              </node>
+                                                            </node>
+                                                          </node>
+                                                        </node>
+                                                        <node concept="37vLTw" id="6nZQGuFJsOY" role="37vLTJ">
+                                                          <ref role="3cqZAo" node="6nZQGuFJ0UI" resolve="size" />
+                                                        </node>
+                                                      </node>
+                                                      <node concept="1W57fq" id="6nZQGuFK6JN" role="lGtFl">
+                                                        <node concept="3IZrLx" id="6nZQGuFK6JQ" role="3IZSJc">
+                                                          <node concept="3clFbS" id="6nZQGuFK6JR" role="2VODD2">
+                                                            <node concept="3clFbF" id="6nZQGuFK6JX" role="3cqZAp">
+                                                              <node concept="3y3z36" id="6nZQGuFKpZr" role="3clFbG">
+                                                                <node concept="10Nm6u" id="6nZQGuFKu4M" role="3uHU7w" />
+                                                                <node concept="2OqwBi" id="6nZQGuFKha$" role="3uHU7B">
+                                                                  <node concept="30H73N" id="6nZQGuFKfGL" role="2Oq$k0" />
+                                                                  <node concept="3TrEf2" id="6nZQGuFKk$_" role="2OqNvi">
+                                                                    <ref role="3Tt5mk" to="2qld:6nZQGuFIbxV" resolve="gridSize" />
+                                                                  </node>
+                                                                </node>
+                                                              </node>
+                                                            </node>
+                                                          </node>
+                                                        </node>
+                                                      </node>
+                                                    </node>
+                                                    <node concept="3cpWs6" id="6nZQGuFJWd9" role="3cqZAp">
+                                                      <node concept="37vLTw" id="6nZQGuFK294" role="3cqZAk">
+                                                        <ref role="3cqZAo" node="6nZQGuFJ0UI" resolve="size" />
+                                                      </node>
+                                                    </node>
+                                                  </node>
+                                                </node>
+                                                <node concept="2tJIrI" id="2WP$sH$LMTP" role="jymVt" />
+                                                <node concept="3clFb_" id="2WP$sH$LDMx" role="jymVt">
+                                                  <property role="TrG5h" value="getGridColor" />
+                                                  <node concept="3Tm1VV" id="2WP$sH$LDMy" role="1B3o_S" />
+                                                  <node concept="2AHcQZ" id="2WP$sH$LDM$" role="2AJF6D">
+                                                    <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                                                  </node>
+                                                  <node concept="3clFbS" id="2WP$sH$LDM_" role="3clF47">
+                                                    <node concept="3cpWs8" id="2WP$sH$LDMA" role="3cqZAp">
+                                                      <node concept="3cpWsn" id="2WP$sH$LDMB" role="3cpWs9">
+                                                        <property role="TrG5h" value="color" />
+                                                        <node concept="3uibUv" id="2WP$sH$LUHX" role="1tU5fm">
+                                                          <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
+                                                        </node>
+                                                        <node concept="10Nm6u" id="2WP$sH$M3DV" role="33vP2m" />
+                                                      </node>
+                                                    </node>
+                                                    <node concept="3clFbF" id="2WP$sH$LDME" role="3cqZAp">
+                                                      <node concept="37vLTI" id="2WP$sH$LDMF" role="3clFbG">
+                                                        <node concept="37vLTw" id="2WP$sH$LDMR" role="37vLTJ">
+                                                          <ref role="3cqZAo" node="2WP$sH$LDMB" resolve="size" />
+                                                        </node>
+                                                        <node concept="1rXfSq" id="2WP$sH$M9xS" role="37vLTx">
+                                                          <ref role="37wK5l" node="2WP$sH$LjQX" resolve="getTheGridColor" />
+                                                          <node concept="1ZhdrF" id="2WP$sH$MeqY" role="lGtFl">
+                                                            <property role="2qtEX8" value="baseMethodDeclaration" />
+                                                            <property role="P3scX" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1204053956946/1068499141037" />
+                                                            <node concept="3$xsQk" id="2WP$sH$MeqZ" role="3$ytzL">
+                                                              <node concept="3clFbS" id="2WP$sH$Mer0" role="2VODD2">
+                                                                <node concept="3clFbF" id="2WP$sH$Mm3k" role="3cqZAp">
+                                                                  <node concept="2OqwBi" id="2WP$sH$Mm3l" role="3clFbG">
+                                                                    <node concept="1iwH70" id="2WP$sH$Mm3m" role="2OqNvi">
+                                                                      <ref role="1iwH77" to="tpc3:hG092go" resolve="query_method" />
+                                                                      <node concept="2OqwBi" id="2WP$sH$Mm3n" role="1iwH7V">
+                                                                        <node concept="30H73N" id="2WP$sH$Mm3o" role="2Oq$k0" />
+                                                                        <node concept="3TrEf2" id="2WP$sH$Mm3p" role="2OqNvi">
+                                                                          <ref role="3Tt5mk" to="2qld:2WP$sH$Lbu5" resolve="gridColor" />
+                                                                        </node>
+                                                                      </node>
+                                                                    </node>
+                                                                    <node concept="1iwH7S" id="2WP$sH$Mm3q" role="2Oq$k0" />
+                                                                  </node>
+                                                                </node>
+                                                              </node>
+                                                            </node>
+                                                          </node>
+                                                        </node>
+                                                      </node>
+                                                      <node concept="1W57fq" id="2WP$sH$LDMS" role="lGtFl">
+                                                        <node concept="3IZrLx" id="2WP$sH$LDMT" role="3IZSJc">
+                                                          <node concept="3clFbS" id="2WP$sH$LDMU" role="2VODD2">
+                                                            <node concept="3clFbF" id="2WP$sH$LDMV" role="3cqZAp">
+                                                              <node concept="3y3z36" id="2WP$sH$LDMW" role="3clFbG">
+                                                                <node concept="10Nm6u" id="2WP$sH$LDMX" role="3uHU7w" />
+                                                                <node concept="2OqwBi" id="2WP$sH$LDMY" role="3uHU7B">
+                                                                  <node concept="30H73N" id="2WP$sH$LDMZ" role="2Oq$k0" />
+                                                                  <node concept="3TrEf2" id="2WP$sH$LDN0" role="2OqNvi">
+                                                                    <ref role="3Tt5mk" to="2qld:2WP$sH$Lbu5" resolve="gridColor" />
+                                                                  </node>
+                                                                </node>
+                                                              </node>
+                                                            </node>
+                                                          </node>
+                                                        </node>
+                                                      </node>
+                                                    </node>
+                                                    <node concept="3cpWs6" id="2WP$sH$LDN1" role="3cqZAp">
+                                                      <node concept="37vLTw" id="2WP$sH$LDN2" role="3cqZAk">
+                                                        <ref role="3cqZAo" node="2WP$sH$LDMB" resolve="size" />
+                                                      </node>
+                                                    </node>
+                                                  </node>
+                                                  <node concept="3uibUv" id="2WP$sH$MxS6" role="3clF45">
+                                                    <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
+                                                  </node>
+                                                </node>
+                                                <node concept="2tJIrI" id="4sEIQIBwtCH" role="jymVt" />
+                                                <node concept="3clFb_" id="4sEIQIBwvBX" role="jymVt">
+                                                  <property role="TrG5h" value="useGridSnapping" />
+                                                  <node concept="3clFbS" id="4sEIQIBwvBY" role="3clF47">
+                                                    <node concept="3cpWs8" id="4sEIQIBwvBZ" role="3cqZAp">
+                                                      <node concept="3cpWsn" id="4sEIQIBwvC0" role="3cpWs9">
+                                                        <property role="TrG5h" value="flag" />
+                                                        <node concept="10P_77" id="4sEIQIBwvC1" role="1tU5fm" />
+                                                        <node concept="3clFbT" id="4sEIQIBwvC2" role="33vP2m" />
+                                                      </node>
+                                                    </node>
+                                                    <node concept="3clFbF" id="4sEIQIBwvC3" role="3cqZAp">
+                                                      <node concept="37vLTI" id="4sEIQIBwvC4" role="3clFbG">
+                                                        <node concept="37vLTw" id="4sEIQIBwvC5" role="37vLTJ">
+                                                          <ref role="3cqZAo" node="4sEIQIBwvC0" resolve="flag" />
+                                                        </node>
+                                                        <node concept="1rXfSq" id="4sEIQIBxsFz" role="37vLTx">
+                                                          <ref role="37wK5l" node="4sEIQIBwWNH" resolve="useTheGridSnapping" />
+                                                          <node concept="1ZhdrF" id="4sEIQIBxvlp" role="lGtFl">
+                                                            <property role="2qtEX8" value="baseMethodDeclaration" />
+                                                            <property role="P3scX" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1204053956946/1068499141037" />
+                                                            <node concept="3$xsQk" id="4sEIQIBxvlq" role="3$ytzL">
+                                                              <node concept="3clFbS" id="4sEIQIBxvlr" role="2VODD2">
+                                                                <node concept="3clFbF" id="4sEIQIBxy6a" role="3cqZAp">
+                                                                  <node concept="2OqwBi" id="4sEIQIBxy6b" role="3clFbG">
+                                                                    <node concept="1iwH70" id="4sEIQIBxy6c" role="2OqNvi">
+                                                                      <ref role="1iwH77" to="tpc3:hG092go" resolve="query_method" />
+                                                                      <node concept="2OqwBi" id="4sEIQIBxy6d" role="1iwH7V">
+                                                                        <node concept="30H73N" id="4sEIQIBxy6e" role="2Oq$k0" />
+                                                                        <node concept="3TrEf2" id="4sEIQIBxy6f" role="2OqNvi">
+                                                                          <ref role="3Tt5mk" to="2qld:4sEIQIBvZeh" resolve="useGridSnapping" />
+                                                                        </node>
+                                                                      </node>
+                                                                    </node>
+                                                                    <node concept="1iwH7S" id="4sEIQIBxy6g" role="2Oq$k0" />
+                                                                  </node>
+                                                                </node>
+                                                              </node>
+                                                            </node>
+                                                          </node>
+                                                        </node>
+                                                      </node>
+                                                      <node concept="1W57fq" id="4sEIQIBwvCh" role="lGtFl">
+                                                        <node concept="3IZrLx" id="4sEIQIBwvCi" role="3IZSJc">
+                                                          <node concept="3clFbS" id="4sEIQIBwvCj" role="2VODD2">
+                                                            <node concept="3clFbF" id="4sEIQIBwvCk" role="3cqZAp">
+                                                              <node concept="3y3z36" id="4sEIQIBwvCl" role="3clFbG">
+                                                                <node concept="10Nm6u" id="4sEIQIBwvCm" role="3uHU7w" />
+                                                                <node concept="2OqwBi" id="4sEIQIBwvCn" role="3uHU7B">
+                                                                  <node concept="30H73N" id="4sEIQIBwvCo" role="2Oq$k0" />
+                                                                  <node concept="3TrEf2" id="4sEIQIBwvCp" role="2OqNvi">
+                                                                    <ref role="3Tt5mk" to="2qld:4sEIQIBvZeh" resolve="useGridSnapping" />
+                                                                  </node>
+                                                                </node>
+                                                              </node>
+                                                            </node>
+                                                          </node>
+                                                        </node>
+                                                      </node>
+                                                    </node>
+                                                    <node concept="3cpWs6" id="4sEIQIBwvCq" role="3cqZAp">
+                                                      <node concept="37vLTw" id="4sEIQIBwvCr" role="3cqZAk">
+                                                        <ref role="3cqZAo" node="4sEIQIBwvC0" resolve="flag" />
+                                                      </node>
+                                                    </node>
+                                                  </node>
+                                                  <node concept="3Tm1VV" id="4sEIQIBwvCs" role="1B3o_S" />
+                                                  <node concept="10P_77" id="4sEIQIBwvCt" role="3clF45" />
+                                                  <node concept="2AHcQZ" id="4sEIQIBwvCu" role="2AJF6D">
                                                     <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
                                                   </node>
                                                 </node>
@@ -16789,6 +17189,72 @@
           </node>
         </node>
         <node concept="raruj" id="2ZU2kH0jCRx" role="lGtFl" />
+      </node>
+      <node concept="3clFbF" id="4sEIQIBNCAb" role="3cqZAp">
+        <node concept="2OqwBi" id="4sEIQIBNCAc" role="3clFbG">
+          <node concept="37vLTw" id="4sEIQIBNCAd" role="2Oq$k0">
+            <ref role="3cqZAo" node="5ZBOFE3$Ijz" resolve="styleDiagram" />
+          </node>
+          <node concept="liA8E" id="4sEIQIBNCAe" role="2OqNvi">
+            <ref role="37wK5l" to="hox0:~Style.set(jetbrains.mps.openapi.editor.style.StyleAttribute,java.lang.Object)" resolve="set" />
+            <node concept="1Z6Ecs" id="4sEIQIBNCAf" role="37wK5m">
+              <ref role="1Z6EpT" to="swi3:4sEIQIBKTSa" resolve="__show-grid-button" />
+            </node>
+            <node concept="3clFbT" id="4sEIQIBNCAg" role="37wK5m">
+              <property role="3clFbU" value="true" />
+              <node concept="17Uvod" id="4sEIQIBNCAh" role="lGtFl">
+                <property role="P4ACc" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123137/1068580123138" />
+                <property role="2qtEX9" value="value" />
+                <node concept="3zFVjK" id="4sEIQIBNCAi" role="3zH0cK">
+                  <node concept="3clFbS" id="4sEIQIBNCAj" role="2VODD2">
+                    <node concept="3clFbF" id="4sEIQIBNCAk" role="3cqZAp">
+                      <node concept="2OqwBi" id="4sEIQIBNCAl" role="3clFbG">
+                        <node concept="30H73N" id="4sEIQIBNCAm" role="2Oq$k0" />
+                        <node concept="3TrcHB" id="4sEIQIBNCAn" role="2OqNvi">
+                          <ref role="3TsBF5" to="2qld:4sEIQIBNARD" resolve="hasShowGridButton" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="raruj" id="4sEIQIBNCAo" role="lGtFl" />
+      </node>
+      <node concept="3clFbF" id="4sEIQIBND5H" role="3cqZAp">
+        <node concept="2OqwBi" id="4sEIQIBND5I" role="3clFbG">
+          <node concept="37vLTw" id="4sEIQIBND5J" role="2Oq$k0">
+            <ref role="3cqZAo" node="5ZBOFE3$Ijz" resolve="styleDiagram" />
+          </node>
+          <node concept="liA8E" id="4sEIQIBND5K" role="2OqNvi">
+            <ref role="37wK5l" to="hox0:~Style.set(jetbrains.mps.openapi.editor.style.StyleAttribute,java.lang.Object)" resolve="set" />
+            <node concept="1Z6Ecs" id="4sEIQIBND5L" role="37wK5m">
+              <ref role="1Z6EpT" to="swi3:4sEIQIBKU2v" resolve="__use_grid-snapping-button" />
+            </node>
+            <node concept="3clFbT" id="4sEIQIBND5M" role="37wK5m">
+              <property role="3clFbU" value="true" />
+              <node concept="17Uvod" id="4sEIQIBND5N" role="lGtFl">
+                <property role="P4ACc" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123137/1068580123138" />
+                <property role="2qtEX9" value="value" />
+                <node concept="3zFVjK" id="4sEIQIBND5O" role="3zH0cK">
+                  <node concept="3clFbS" id="4sEIQIBND5P" role="2VODD2">
+                    <node concept="3clFbF" id="4sEIQIBND5Q" role="3cqZAp">
+                      <node concept="2OqwBi" id="4sEIQIBND5R" role="3clFbG">
+                        <node concept="30H73N" id="4sEIQIBND5S" role="2Oq$k0" />
+                        <node concept="3TrcHB" id="4sEIQIBND5T" role="2OqNvi">
+                          <ref role="3TsBF5" to="2qld:4sEIQIBNAVE" resolve="hasUseGridSnappingButton" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="raruj" id="4sEIQIBND5U" role="lGtFl" />
       </node>
       <node concept="3clFbF" id="2ZU2kH0jEIM" role="3cqZAp">
         <node concept="2OqwBi" id="2ZU2kH0jEIN" role="3clFbG">

--- a/code/diagram/languages/de.itemis.mps.editor.diagram/generator/template/main@generator.mps
+++ b/code/diagram/languages/de.itemis.mps.editor.diagram/generator/template/main@generator.mps
@@ -6899,7 +6899,7 @@
                                                     <node concept="3clFbF" id="2WP$sH$LDME" role="3cqZAp">
                                                       <node concept="37vLTI" id="2WP$sH$LDMF" role="3clFbG">
                                                         <node concept="37vLTw" id="2WP$sH$LDMR" role="37vLTJ">
-                                                          <ref role="3cqZAo" node="2WP$sH$LDMB" resolve="size" />
+                                                          <ref role="3cqZAo" node="2WP$sH$LDMB" resolve="color" />
                                                         </node>
                                                         <node concept="1rXfSq" id="2WP$sH$M9xS" role="37vLTx">
                                                           <ref role="37wK5l" node="2WP$sH$LjQX" resolve="getTheGridColor" />
@@ -6947,7 +6947,7 @@
                                                     </node>
                                                     <node concept="3cpWs6" id="2WP$sH$LDN1" role="3cqZAp">
                                                       <node concept="37vLTw" id="2WP$sH$LDN2" role="3cqZAk">
-                                                        <ref role="3cqZAo" node="2WP$sH$LDMB" resolve="size" />
+                                                        <ref role="3cqZAo" node="2WP$sH$LDMB" resolve="color" />
                                                       </node>
                                                     </node>
                                                   </node>

--- a/code/diagram/languages/de.itemis.mps.editor.diagram/languageModels/behavior.mps
+++ b/code/diagram/languages/de.itemis.mps.editor.diagram/languageModels/behavior.mps
@@ -10473,6 +10473,64 @@
                     </node>
                   </node>
                 </node>
+                <node concept="3clFbF" id="4sEIQIBNL$4" role="3cqZAp">
+                  <node concept="2OqwBi" id="4sEIQIBNL$5" role="3clFbG">
+                    <node concept="37vLTw" id="4sEIQIBNL$6" role="2Oq$k0">
+                      <ref role="3cqZAo" node="74e51Ji6bH0" resolve="buttons" />
+                    </node>
+                    <node concept="TSZUe" id="4sEIQIBNL$7" role="2OqNvi">
+                      <node concept="2ShNRf" id="4sEIQIBNL$8" role="25WWJ7">
+                        <node concept="1pGfFk" id="4sEIQIBNL$9" role="2ShVmc">
+                          <property role="373rjd" value="true" />
+                          <ref role="37wK5l" to="r3rm:4sEIQIBu97K" resolve="ToggleGridDiagramButton" />
+                          <node concept="10M0yZ" id="4sEIQIBNL$c" role="37wK5m">
+                            <ref role="1PxDUh" to="r3rm:2KWY$Um6wZH" resolve="ContextButton" />
+                            <ref role="3cqZAo" to="r3rm:17I5kyiXMqc" resolve="DEFAULT_BUTTON_SIZE" />
+                          </node>
+                          <node concept="37vLTw" id="4sEIQIBNL$e" role="37wK5m">
+                            <ref role="3cqZAo" to="r3rm:45TnPEv7YRN" resolve="mxCellState" />
+                            <node concept="2c44te" id="4sEIQIBNL$f" role="lGtFl">
+                              <node concept="2pJPEk" id="4sEIQIBNL$g" role="2c44t1">
+                                <node concept="2pJPED" id="4sEIQIBNL$h" role="2pJPEn">
+                                  <ref role="2pJxaS" to="2qld:gTQ80DJ" resolve="ConceptFunctionParameter_mxCellState" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbF" id="4sEIQIBNLF8" role="3cqZAp">
+                  <node concept="2OqwBi" id="4sEIQIBNLF9" role="3clFbG">
+                    <node concept="37vLTw" id="4sEIQIBNLFa" role="2Oq$k0">
+                      <ref role="3cqZAo" node="74e51Ji6bH0" resolve="buttons" />
+                    </node>
+                    <node concept="TSZUe" id="4sEIQIBNLFb" role="2OqNvi">
+                      <node concept="2ShNRf" id="4sEIQIBNLFc" role="25WWJ7">
+                        <node concept="1pGfFk" id="4sEIQIBNLFd" role="2ShVmc">
+                          <property role="373rjd" value="true" />
+                          <ref role="37wK5l" to="r3rm:4sEIQIBMnTa" resolve="ToggleGridSnappingDiagramButton" />
+                          <node concept="10M0yZ" id="4sEIQIBNLFg" role="37wK5m">
+                            <ref role="1PxDUh" to="r3rm:2KWY$Um6wZH" resolve="ContextButton" />
+                            <ref role="3cqZAo" to="r3rm:17I5kyiXMqc" resolve="DEFAULT_BUTTON_SIZE" />
+                          </node>
+                          <node concept="37vLTw" id="4sEIQIBNLFi" role="37wK5m">
+                            <ref role="3cqZAo" to="r3rm:45TnPEv7YRN" resolve="mxCellState" />
+                            <node concept="2c44te" id="4sEIQIBNLFj" role="lGtFl">
+                              <node concept="2pJPEk" id="4sEIQIBNLFk" role="2c44t1">
+                                <node concept="2pJPED" id="4sEIQIBNLFl" role="2pJPEn">
+                                  <ref role="2pJxaS" to="2qld:gTQ80DJ" resolve="ConceptFunctionParameter_mxCellState" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
                 <node concept="3clFbF" id="74e51Ji6nNI" role="3cqZAp">
                   <node concept="2OqwBi" id="74e51Ji6nNJ" role="3clFbG">
                     <node concept="37vLTw" id="74e51Ji6nNK" role="2Oq$k0">

--- a/code/diagram/languages/de.itemis.mps.editor.diagram/languageModels/editor.mps
+++ b/code/diagram/languages/de.itemis.mps.editor.diagram/languageModels/editor.mps
@@ -1222,6 +1222,19 @@
               <property role="VOm3f" value="true" />
             </node>
           </node>
+          <node concept="3EZMnI" id="15UkGIdpXuW" role="3EZMnx">
+            <node concept="2iRfu4" id="15UkGIdpXuX" role="2iSdaV" />
+            <node concept="3F0ifn" id="15UkGIdpXuY" role="3EZMnx">
+              <property role="3F0ifm" value="grid style" />
+            </node>
+            <node concept="3F0A7n" id="15UkGIdpXQT" role="3EZMnx">
+              <ref role="1NtTu8" to="2qld:15UkGIdpWuH" resolve="gridStyle" />
+            </node>
+            <node concept="VPM3Z" id="15UkGIdpXv0" role="3F10Kt" />
+            <node concept="VPXOz" id="15UkGIdpXv1" role="3F10Kt">
+              <property role="VOm3f" value="true" />
+            </node>
+          </node>
           <node concept="3EZMnI" id="4sEIQIBw07n" role="3EZMnx">
             <node concept="2iRfu4" id="4sEIQIBw07o" role="2iSdaV" />
             <node concept="3F0ifn" id="4sEIQIBw07p" role="3EZMnx">

--- a/code/diagram/languages/de.itemis.mps.editor.diagram/languageModels/editor.mps
+++ b/code/diagram/languages/de.itemis.mps.editor.diagram/languageModels/editor.mps
@@ -1179,6 +1179,63 @@
               <property role="VOm3f" value="true" />
             </node>
           </node>
+          <node concept="3EZMnI" id="4sEIQIBw07g" role="3EZMnx">
+            <node concept="2iRfu4" id="4sEIQIBw07h" role="2iSdaV" />
+            <node concept="3F0ifn" id="4sEIQIBw07i" role="3EZMnx">
+              <property role="3F0ifm" value="show grid" />
+            </node>
+            <node concept="3F1sOY" id="4sEIQIBw07j" role="3EZMnx">
+              <property role="1$x2rV" value="false" />
+              <ref role="1NtTu8" to="2qld:4sEIQIBvZeg" resolve="showGrid" />
+              <node concept="VPXOz" id="4sEIQIBw07k" role="3F10Kt">
+                <property role="VOm3f" value="true" />
+              </node>
+            </node>
+            <node concept="VPM3Z" id="4sEIQIBw07l" role="3F10Kt" />
+            <node concept="VPXOz" id="4sEIQIBw07m" role="3F10Kt">
+              <property role="VOm3f" value="true" />
+            </node>
+          </node>
+          <node concept="3EZMnI" id="6nZQGuFIkLk" role="3EZMnx">
+            <node concept="2iRfu4" id="6nZQGuFIkLl" role="2iSdaV" />
+            <node concept="3F0ifn" id="6nZQGuFIkLm" role="3EZMnx">
+              <property role="3F0ifm" value="grid size" />
+            </node>
+            <node concept="3F1sOY" id="6nZQGuFIm7_" role="3EZMnx">
+              <ref role="1NtTu8" to="2qld:6nZQGuFIbxV" resolve="gridSize" />
+            </node>
+            <node concept="VPM3Z" id="6nZQGuFIkLo" role="3F10Kt" />
+            <node concept="VPXOz" id="6nZQGuFIkLp" role="3F10Kt">
+              <property role="VOm3f" value="true" />
+            </node>
+          </node>
+          <node concept="3EZMnI" id="2WP$sH$Lcw7" role="3EZMnx">
+            <node concept="2iRfu4" id="2WP$sH$Lcw8" role="2iSdaV" />
+            <node concept="3F0ifn" id="2WP$sH$Lcw9" role="3EZMnx">
+              <property role="3F0ifm" value="grid color" />
+            </node>
+            <node concept="3F1sOY" id="2WP$sH$Lcwa" role="3EZMnx">
+              <ref role="1NtTu8" to="2qld:2WP$sH$Lbu5" resolve="gridColor" />
+            </node>
+            <node concept="VPM3Z" id="2WP$sH$Lcwb" role="3F10Kt" />
+            <node concept="VPXOz" id="2WP$sH$Lcwc" role="3F10Kt">
+              <property role="VOm3f" value="true" />
+            </node>
+          </node>
+          <node concept="3EZMnI" id="4sEIQIBw07n" role="3EZMnx">
+            <node concept="2iRfu4" id="4sEIQIBw07o" role="2iSdaV" />
+            <node concept="3F0ifn" id="4sEIQIBw07p" role="3EZMnx">
+              <property role="3F0ifm" value="use grid snapping" />
+            </node>
+            <node concept="3F1sOY" id="4sEIQIBw07q" role="3EZMnx">
+              <ref role="1NtTu8" to="2qld:4sEIQIBvZeh" resolve="useGridSnapping" />
+            </node>
+            <node concept="VPM3Z" id="4sEIQIBw07r" role="3F10Kt" />
+            <node concept="VPXOz" id="4sEIQIBw07s" role="3F10Kt">
+              <property role="VOm3f" value="true" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="4sEIQIBw07f" role="3EZMnx" />
         </node>
         <node concept="2iRfu4" id="5qgNcfDnGw9" role="2iSdaV" />
         <node concept="3F0ifn" id="5qgNcfDnGxf" role="3EZMnx" />
@@ -5815,6 +5872,44 @@
                   <node concept="355D3s" id="2ZU2kH0oPyu" role="37wK5m">
                     <ref role="355D3t" to="2qld:5ZBOFE3vobP" resolve="DiagramButtonConfig" />
                     <ref role="355D3u" to="2qld:2ZU2kH0jAMG" resolve="hasTranslateToOriginButton" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3gTLQM" id="4sEIQIBNBov" role="3EZMnx">
+        <node concept="3Fmcul" id="4sEIQIBNBow" role="3FoqZy">
+          <node concept="3clFbS" id="4sEIQIBNBox" role="2VODD2">
+            <node concept="3cpWs6" id="4sEIQIBNBoy" role="3cqZAp">
+              <node concept="2OqwBi" id="4sEIQIBNBoz" role="3cqZAk">
+                <node concept="pncrf" id="4sEIQIBNBo$" role="2Oq$k0" />
+                <node concept="2qgKlT" id="4sEIQIBNBo_" role="2OqNvi">
+                  <ref role="37wK5l" to="nh7q:4h7S3973QQF" resolve="getBooleanPropertyCheckBox" />
+                  <node concept="1Q80Hx" id="4sEIQIBNBoA" role="37wK5m" />
+                  <node concept="355D3s" id="4sEIQIBNBoB" role="37wK5m">
+                    <ref role="355D3t" to="2qld:5ZBOFE3vobP" resolve="DiagramButtonConfig" />
+                    <ref role="355D3u" to="2qld:4sEIQIBNARD" resolve="hasShowGridButton" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3gTLQM" id="4sEIQIBNB_f" role="3EZMnx">
+        <node concept="3Fmcul" id="4sEIQIBNB_g" role="3FoqZy">
+          <node concept="3clFbS" id="4sEIQIBNB_h" role="2VODD2">
+            <node concept="3cpWs6" id="4sEIQIBNB_i" role="3cqZAp">
+              <node concept="2OqwBi" id="4sEIQIBNB_j" role="3cqZAk">
+                <node concept="pncrf" id="4sEIQIBNB_k" role="2Oq$k0" />
+                <node concept="2qgKlT" id="4sEIQIBNB_l" role="2OqNvi">
+                  <ref role="37wK5l" to="nh7q:4h7S3973QQF" resolve="getBooleanPropertyCheckBox" />
+                  <node concept="1Q80Hx" id="4sEIQIBNB_m" role="37wK5m" />
+                  <node concept="355D3s" id="4sEIQIBNB_n" role="37wK5m">
+                    <ref role="355D3t" to="2qld:5ZBOFE3vobP" resolve="DiagramButtonConfig" />
+                    <ref role="355D3u" to="2qld:4sEIQIBNAVE" resolve="hasUseGridSnappingButton" />
                   </node>
                 </node>
               </node>

--- a/code/diagram/languages/de.itemis.mps.editor.diagram/languageModels/structure.mps
+++ b/code/diagram/languages/de.itemis.mps.editor.diagram/languageModels/structure.mps
@@ -216,6 +216,30 @@
       <property role="20kJfa" value="allowElementsBelowRequiredSize" />
       <ref role="20lvS9" to="tpc2:gCpkWun" resolve="QueryFunction_NodeCondition" />
     </node>
+    <node concept="1TJgyj" id="4sEIQIBvZeg" role="1TKVEi">
+      <property role="IQ2ns" value="5128117196760806288" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="showGrid" />
+      <ref role="20lvS9" to="tpc2:gCpkWun" resolve="QueryFunction_NodeCondition" />
+    </node>
+    <node concept="1TJgyj" id="6nZQGuFIbxV" role="1TKVEi">
+      <property role="IQ2ns" value="7349833668006295675" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="gridSize" />
+      <ref role="20lvS9" to="tpc2:hLcFafI" resolve="QueryFunction_Integer" />
+    </node>
+    <node concept="1TJgyj" id="2WP$sH$Lbu5" role="1TKVEi">
+      <property role="IQ2ns" value="3401785396303280005" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="gridColor" />
+      <ref role="20lvS9" to="tpc2:h7ZlJ1A" resolve="QueryFunction_Color" />
+    </node>
+    <node concept="1TJgyj" id="4sEIQIBvZeh" role="1TKVEi">
+      <property role="IQ2ns" value="5128117196760806289" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="useGridSnapping" />
+      <ref role="20lvS9" to="tpc2:gCpkWun" resolve="QueryFunction_NodeCondition" />
+    </node>
     <node concept="1TJgyj" id="5qgNcfDnbtd" role="1TKVEi">
       <property role="20lmBu" value="fLJjDmT/aggregation" />
       <property role="20kJfa" value="contentQuery" />
@@ -2192,6 +2216,16 @@
     <node concept="1TJgyi" id="2ZU2kH0jAMG" role="1TKVEl">
       <property role="IQ2nx" value="3457085882766355628" />
       <property role="TrG5h" value="hasTranslateToOriginButton" />
+      <ref role="AX2Wp" to="tpck:fKAQMTB" resolve="boolean" />
+    </node>
+    <node concept="1TJgyi" id="4sEIQIBNARD" role="1TKVEl">
+      <property role="IQ2nx" value="5128117196765949417" />
+      <property role="TrG5h" value="hasShowGridButton" />
+      <ref role="AX2Wp" to="tpck:fKAQMTB" resolve="boolean" />
+    </node>
+    <node concept="1TJgyi" id="4sEIQIBNAVE" role="1TKVEl">
+      <property role="IQ2nx" value="5128117196765949674" />
+      <property role="TrG5h" value="hasUseGridSnappingButton" />
       <ref role="AX2Wp" to="tpck:fKAQMTB" resolve="boolean" />
     </node>
     <node concept="1TJgyi" id="2ZU2kH0jB7A" role="1TKVEl">

--- a/code/diagram/languages/de.itemis.mps.editor.diagram/languageModels/structure.mps
+++ b/code/diagram/languages/de.itemis.mps.editor.diagram/languageModels/structure.mps
@@ -124,6 +124,11 @@
       <property role="TrG5h" value="connectBoxesWithoutDummyPort" />
       <ref role="AX2Wp" to="tpck:fKAQMTB" resolve="boolean" />
     </node>
+    <node concept="1TJgyi" id="15UkGIdpWuH" role="1TKVEl">
+      <property role="IQ2nx" value="1259410080007702445" />
+      <property role="TrG5h" value="gridStyle" />
+      <ref role="AX2Wp" node="15UkGIdpWax" resolve="GridStyle" />
+    </node>
     <node concept="1TJgyj" id="6actlYi6UMa" role="1TKVEi">
       <property role="20lmBu" value="fLJjDmT/aggregation" />
       <property role="20kJfa" value="diagramID" />
@@ -5094,6 +5099,31 @@
     <property role="TrG5h" value="Function_GetNode" />
     <property role="EcuMT" value="6237710625716701263" />
     <ref role="1TJDcQ" to="tpee:gyVMwX8" resolve="ConceptFunction" />
+  </node>
+  <node concept="25R3W" id="15UkGIdpWax">
+    <property role="3F6X1D" value="1259410080007701153" />
+    <property role="TrG5h" value="GridStyle" />
+    <ref role="1H5jkz" node="15UkGIdpWay" resolve="GRID_STYLE_DOT" />
+    <node concept="25R33" id="15UkGIdpWay" role="25R1y">
+      <property role="3tVfz5" value="1259410080007701154" />
+      <property role="TrG5h" value="GRID_STYLE_DOT" />
+      <property role="1L1pqM" value="dot" />
+    </node>
+    <node concept="25R33" id="15UkGIdpWe4" role="25R1y">
+      <property role="3tVfz5" value="1259410080007701380" />
+      <property role="TrG5h" value="GRID_STYLE_CROSS" />
+      <property role="1L1pqM" value="cross" />
+    </node>
+    <node concept="25R33" id="15UkGIdpWfA" role="25R1y">
+      <property role="3tVfz5" value="1259410080007701478" />
+      <property role="TrG5h" value="GRID_STYLE_LINE" />
+      <property role="1L1pqM" value="line" />
+    </node>
+    <node concept="25R33" id="15UkGIdpWiD" role="25R1y">
+      <property role="3tVfz5" value="1259410080007701673" />
+      <property role="TrG5h" value="GRID_STYLE_DASHED" />
+      <property role="1L1pqM" value="dashed" />
+    </node>
   </node>
 </model>
 

--- a/code/diagram/solutions/de.itemis.mps.editor.diagram.demoentities.sandbox/models/de/itemis/mps/editor/diagram/demoentities/sandbox.mps
+++ b/code/diagram/solutions/de.itemis.mps.editor.diagram.demoentities.sandbox/models/de/itemis/mps/editor/diagram/demoentities/sandbox.mps
@@ -488,11 +488,11 @@
                 </node>
               </node>
             </node>
-            <node concept="2VclrF" id="1MpJ6yR4V35" role="2Vcluh">
+            <node concept="2VclrF" id="2WP$sH_4coA" role="2Vcluh">
               <property role="2Vclpx" value="1096.00048828125" />
               <property role="2Vclpz" value="481.00005" />
             </node>
-            <node concept="2VclrF" id="1MpJ6yR4V36" role="2Vcluh">
+            <node concept="2VclrF" id="2WP$sH_4coB" role="2Vcluh">
               <property role="2Vclpx" value="1096.00048828125" />
               <property role="2Vclpz" value="332.00005" />
             </node>

--- a/code/diagram/solutions/de.itemis.mps.editor.diagram.runtime/models/de/itemis/mps/editor/diagram/runtime/model.mps
+++ b/code/diagram/solutions/de.itemis.mps.editor.diagram.runtime/models/de/itemis/mps/editor/diagram/runtime/model.mps
@@ -17592,6 +17592,33 @@
       <node concept="3Tm1VV" id="1MpJ6ySdrhg" role="1B3o_S" />
       <node concept="10P_77" id="1MpJ6ySdrcu" role="3clF45" />
     </node>
+    <node concept="2tJIrI" id="1HGmlJVAqgT" role="jymVt" />
+    <node concept="3clFb_" id="1HGmlJVAqBb" role="jymVt">
+      <property role="TrG5h" value="useGridSnapping" />
+      <node concept="3clFbS" id="1HGmlJVAqBe" role="3clF47" />
+      <node concept="3Tm1VV" id="1HGmlJVAqBf" role="1B3o_S" />
+      <node concept="10P_77" id="1HGmlJVAqvG" role="3clF45" />
+    </node>
+    <node concept="3clFb_" id="1HGmlJVAr8P" role="jymVt">
+      <property role="TrG5h" value="showGrid" />
+      <node concept="3clFbS" id="1HGmlJVAr8S" role="3clF47" />
+      <node concept="3Tm1VV" id="1HGmlJVAr8T" role="1B3o_S" />
+      <node concept="10P_77" id="1HGmlJVAr2_" role="3clF45" />
+    </node>
+    <node concept="3clFb_" id="6nZQGuFEBnv" role="jymVt">
+      <property role="TrG5h" value="getGridSize" />
+      <node concept="3clFbS" id="6nZQGuFEBny" role="3clF47" />
+      <node concept="3Tm1VV" id="6nZQGuFEBnz" role="1B3o_S" />
+      <node concept="10Oyi0" id="6nZQGuFEBgY" role="3clF45" />
+    </node>
+    <node concept="3clFb_" id="2WP$sH$Jy7Y" role="jymVt">
+      <property role="TrG5h" value="getGridColor" />
+      <node concept="3clFbS" id="2WP$sH$Jy81" role="3clF47" />
+      <node concept="3Tm1VV" id="2WP$sH$Jy82" role="1B3o_S" />
+      <node concept="3uibUv" id="2WP$sH$Jy0G" role="3clF45">
+        <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
+      </node>
+    </node>
   </node>
   <node concept="3HP615" id="4teJTSBx0$0">
     <property role="3GE5qa" value="accessor" />
@@ -29401,6 +29428,80 @@
       </node>
       <node concept="3Tm1VV" id="1MpJ6yS97u3" role="1B3o_S" />
       <node concept="10P_77" id="1MpJ6yS98ok" role="3clF45" />
+    </node>
+    <node concept="2tJIrI" id="1HGmlJVAs0B" role="jymVt" />
+    <node concept="3clFb_" id="1HGmlJVAsBi" role="jymVt">
+      <property role="TrG5h" value="showGrid" />
+      <node concept="3Tm1VV" id="1HGmlJVAsBk" role="1B3o_S" />
+      <node concept="10P_77" id="1HGmlJVAsBl" role="3clF45" />
+      <node concept="3clFbS" id="1HGmlJVAsBm" role="3clF47">
+        <node concept="3clFbF" id="1HGmlJVAsBp" role="3cqZAp">
+          <node concept="3clFbT" id="1HGmlJVAsBo" role="3clFbG" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="1HGmlJVAsBn" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="1HGmlJVAuxT" role="jymVt" />
+    <node concept="3clFb_" id="1HGmlJVAsBq" role="jymVt">
+      <property role="TrG5h" value="useGridSnapping" />
+      <node concept="3Tm1VV" id="1HGmlJVAsBs" role="1B3o_S" />
+      <node concept="10P_77" id="1HGmlJVAsBt" role="3clF45" />
+      <node concept="3clFbS" id="1HGmlJVAsBu" role="3clF47">
+        <node concept="3clFbF" id="1HGmlJVAsBx" role="3cqZAp">
+          <node concept="3clFbT" id="1HGmlJVAsBw" role="3clFbG" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="1HGmlJVAsBv" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6nZQGuFEI4G" role="jymVt" />
+    <node concept="3clFb_" id="6nZQGuFEIKn" role="jymVt">
+      <property role="TrG5h" value="getGridSize" />
+      <node concept="3Tm1VV" id="6nZQGuFEIKp" role="1B3o_S" />
+      <node concept="10Oyi0" id="6nZQGuFEIKq" role="3clF45" />
+      <node concept="3clFbS" id="6nZQGuFEIKr" role="3clF47">
+        <node concept="3clFbF" id="6nZQGuFEIKu" role="3cqZAp">
+          <node concept="3cmrfG" id="6nZQGuFEIKt" role="3clFbG">
+            <property role="3cmrfH" value="10" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="6nZQGuFEIKs" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="2WP$sH$KKxy" role="jymVt" />
+    <node concept="3clFb_" id="2WP$sH$KLc_" role="jymVt">
+      <property role="TrG5h" value="getGridColor" />
+      <node concept="3Tm1VV" id="2WP$sH$KLcB" role="1B3o_S" />
+      <node concept="3uibUv" id="2WP$sH$KLcC" role="3clF45">
+        <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
+      </node>
+      <node concept="3clFbS" id="2WP$sH$KLcD" role="3clF47">
+        <node concept="3clFbF" id="2WP$sH$KNGS" role="3cqZAp">
+          <node concept="2ShNRf" id="2WP$sH$KNGQ" role="3clFbG">
+            <node concept="1pGfFk" id="2WP$sH$L6Kf" role="2ShVmc">
+              <property role="373rjd" value="true" />
+              <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
+              <node concept="3cmrfG" id="2WP$sH$L7vD" role="37wK5m">
+                <property role="3cmrfH" value="192" />
+              </node>
+              <node concept="3cmrfG" id="2WP$sH$L8LK" role="37wK5m">
+                <property role="3cmrfH" value="192" />
+              </node>
+              <node concept="3cmrfG" id="2WP$sH$L9q_" role="37wK5m">
+                <property role="3cmrfH" value="192" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="2WP$sH$KLcE" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" />
+      </node>
     </node>
   </node>
   <node concept="312cEu" id="63AkbuPiu1I">

--- a/code/diagram/solutions/de.itemis.mps.editor.diagram.runtime/models/de/itemis/mps/editor/diagram/runtime/model.mps
+++ b/code/diagram/solutions/de.itemis.mps.editor.diagram.runtime/models/de/itemis/mps/editor/diagram/runtime/model.mps
@@ -54,6 +54,7 @@
     <import index="1njx" ref="1144260c-e9a5-49a2-9add-39a1a1a7077e/java:com.mxgraph.view(de.itemis.mps.editor.diagram.runtime/)" />
     <import index="xggr" ref="r:12584d60-2d80-4ca9-9c6e-b79d499da0cf(de.itemis.mps.editor.celllayout.layout)" />
     <import index="5ueo" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.editor.runtime.style(MPS.Editor/)" />
+    <import index="p8va" ref="1144260c-e9a5-49a2-9add-39a1a1a7077e/java:com.mxgraph.swing(de.itemis.mps.editor.diagram.runtime/)" />
     <import index="lui2" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.module(MPS.OpenAPI/)" implicit="true" />
     <import index="lwvz" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.selection(MPS.Editor/)" implicit="true" />
     <import index="22ra" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.update(MPS.Editor/)" implicit="true" />
@@ -17611,6 +17612,12 @@
       <node concept="3Tm1VV" id="6nZQGuFEBnz" role="1B3o_S" />
       <node concept="10Oyi0" id="6nZQGuFEBgY" role="3clF45" />
     </node>
+    <node concept="3clFb_" id="15UkGIdqaGq" role="jymVt">
+      <property role="TrG5h" value="getGridStyle" />
+      <node concept="3clFbS" id="15UkGIdqaGt" role="3clF47" />
+      <node concept="3Tm1VV" id="15UkGIdqaGu" role="1B3o_S" />
+      <node concept="10Oyi0" id="15UkGIdqa$R" role="3clF45" />
+    </node>
     <node concept="3clFb_" id="2WP$sH$Jy7Y" role="jymVt">
       <property role="TrG5h" value="getGridColor" />
       <node concept="3clFbS" id="2WP$sH$Jy81" role="3clF47" />
@@ -29470,6 +29477,24 @@
         </node>
       </node>
       <node concept="2AHcQZ" id="6nZQGuFEIKs" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="15UkGIdqg2J" role="jymVt" />
+    <node concept="2tJIrI" id="15UkGIdqg2K" role="jymVt" />
+    <node concept="3clFb_" id="15UkGIdqgPI" role="jymVt">
+      <property role="TrG5h" value="getGridStyle" />
+      <node concept="3Tm1VV" id="15UkGIdqgPK" role="1B3o_S" />
+      <node concept="10Oyi0" id="15UkGIdqgPL" role="3clF45" />
+      <node concept="3clFbS" id="15UkGIdqgPM" role="3clF47">
+        <node concept="3clFbF" id="15UkGIdqjCr" role="3cqZAp">
+          <node concept="10M0yZ" id="15UkGIdqkjA" role="3clFbG">
+            <ref role="3cqZAo" to="p8va:~mxGraphComponent.GRID_STYLE_DOT" resolve="GRID_STYLE_DOT" />
+            <ref role="1PxDUh" to="p8va:~mxGraphComponent" resolve="mxGraphComponent" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="15UkGIdqgPN" role="2AJF6D">
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>

--- a/code/diagram/solutions/de.itemis.mps.editor.diagram.runtime/models/de/itemis/mps/editor/diagram/runtime/model.mps
+++ b/code/diagram/solutions/de.itemis.mps.editor.diagram.runtime/models/de/itemis/mps/editor/diagram/runtime/model.mps
@@ -29440,7 +29440,7 @@
         </node>
       </node>
       <node concept="2AHcQZ" id="1HGmlJVAsBn" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" />
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
     <node concept="2tJIrI" id="1HGmlJVAuxT" role="jymVt" />
@@ -29454,7 +29454,7 @@
         </node>
       </node>
       <node concept="2AHcQZ" id="1HGmlJVAsBv" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" />
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
     <node concept="2tJIrI" id="6nZQGuFEI4G" role="jymVt" />
@@ -29470,7 +29470,7 @@
         </node>
       </node>
       <node concept="2AHcQZ" id="6nZQGuFEIKs" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" />
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
     <node concept="2tJIrI" id="2WP$sH$KKxy" role="jymVt" />
@@ -29500,7 +29500,7 @@
         </node>
       </node>
       <node concept="2AHcQZ" id="2WP$sH$KLcE" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" />
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
   </node>

--- a/code/solutions/de.itemis.mps.extensions.changelog/models/de.itemis.mps.extensions.changelog.mps
+++ b/code/solutions/de.itemis.mps.extensions.changelog/models/de.itemis.mps.extensions.changelog.mps
@@ -234,6 +234,116 @@
       </node>
       <node concept="15bAme" id="2IcGFIaJNN1" role="15bAlL">
         <property role="15bAli" value="Po4Z58tnOE/added" />
+        <node concept="2DRihI" id="2WP$sH_4cFB" role="15bAlk">
+          <node concept="2hgSXJ" id="2WP$sH_4cKO" role="1PaTwD">
+            <node concept="1PaTwC" id="2WP$sH_4cKP" role="2hiFM$">
+              <node concept="15Ami3" id="2WP$sH_4cKQ" role="1PaTwD">
+                <node concept="37shsh" id="2WP$sH_4cKR" role="15Aodc">
+                  <node concept="1dCxOk" id="2WP$sH_4cKS" role="37shsm">
+                    <property role="1XweGW" value="fa13cc63-c476-4d46-9c96-d53670abe7bc" />
+                    <property role="1XxBO9" value="de.itemis.mps.editor.diagram" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3oM_SD" id="2WP$sH_4cKT" role="1PaTwD">
+                <property role="3oM_SC" value=":" />
+              </node>
+            </node>
+          </node>
+          <node concept="3oM_SD" id="2WP$sH_4cLt" role="1PaTwD">
+            <property role="3oM_SC" value="Diagrams" />
+          </node>
+          <node concept="3oM_SD" id="2WP$sH_4cQy" role="1PaTwD">
+            <property role="3oM_SC" value="can" />
+          </node>
+          <node concept="3oM_SD" id="2WP$sH_4cS_" role="1PaTwD">
+            <property role="3oM_SC" value="now" />
+          </node>
+          <node concept="3oM_SD" id="2WP$sH_4cXH" role="1PaTwD">
+            <property role="3oM_SC" value="show" />
+          </node>
+          <node concept="3oM_SD" id="2WP$sH_4cU6" role="1PaTwD">
+            <property role="3oM_SC" value="a" />
+          </node>
+          <node concept="3oM_SD" id="2WP$sH_4cU7" role="1PaTwD">
+            <property role="3oM_SC" value="grid" />
+          </node>
+          <node concept="3oM_SD" id="2WP$sH_4cUC" role="1PaTwD">
+            <property role="3oM_SC" value="that" />
+          </node>
+          <node concept="3oM_SD" id="2WP$sH_4cW9" role="1PaTwD">
+            <property role="3oM_SC" value="is" />
+          </node>
+          <node concept="3oM_SD" id="2WP$sH_4cWa" role="1PaTwD">
+            <property role="3oM_SC" value="used" />
+          </node>
+          <node concept="3oM_SD" id="2WP$sH_4cWF" role="1PaTwD">
+            <property role="3oM_SC" value="for" />
+          </node>
+          <node concept="3oM_SD" id="2WP$sH_4cWG" role="1PaTwD">
+            <property role="3oM_SC" value="snapping" />
+          </node>
+          <node concept="3oM_SD" id="2WP$sH_4cYI" role="1PaTwD">
+            <property role="3oM_SC" value="elements" />
+          </node>
+          <node concept="3oM_SD" id="2WP$sH_4cZf" role="1PaTwD">
+            <property role="3oM_SC" value="to" />
+          </node>
+          <node concept="3oM_SD" id="2WP$sH_4cZK" role="1PaTwD">
+            <property role="3oM_SC" value="it." />
+          </node>
+          <node concept="3oM_SD" id="2WP$sH_4d0h" role="1PaTwD">
+            <property role="3oM_SC" value="It" />
+          </node>
+          <node concept="3oM_SD" id="2WP$sH_4d0M" role="1PaTwD">
+            <property role="3oM_SC" value="can" />
+          </node>
+          <node concept="3oM_SD" id="2WP$sH_4d0N" role="1PaTwD">
+            <property role="3oM_SC" value="be" />
+          </node>
+          <node concept="3oM_SD" id="2WP$sH_4d1k" role="1PaTwD">
+            <property role="3oM_SC" value="configured" />
+          </node>
+          <node concept="3oM_SD" id="2WP$sH_4d5X" role="1PaTwD">
+            <property role="3oM_SC" value="(visibility," />
+          </node>
+          <node concept="3oM_SD" id="2WP$sH_4d6Y" role="1PaTwD">
+            <property role="3oM_SC" value="grid" />
+          </node>
+          <node concept="3oM_SD" id="2WP$sH_4d7v" role="1PaTwD">
+            <property role="3oM_SC" value="snapping," />
+          </node>
+          <node concept="3oM_SD" id="2WP$sH_4d8w" role="1PaTwD">
+            <property role="3oM_SC" value="grid" />
+          </node>
+          <node concept="3oM_SD" id="2WP$sH_4d91" role="1PaTwD">
+            <property role="3oM_SC" value="color/size)" />
+          </node>
+          <node concept="3oM_SD" id="2WP$sH_4d1P" role="1PaTwD">
+            <property role="3oM_SC" value="in" />
+          </node>
+          <node concept="3oM_SD" id="2WP$sH_4d2m" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="2WP$sH_4d2n" role="1PaTwD">
+            <property role="3oM_SC" value="editor" />
+          </node>
+          <node concept="3oM_SD" id="2WP$sH_4d2S" role="1PaTwD">
+            <property role="3oM_SC" value="definition" />
+          </node>
+          <node concept="3oM_SD" id="2WP$sH_4d3p" role="1PaTwD">
+            <property role="3oM_SC" value="of" />
+          </node>
+          <node concept="3oM_SD" id="2WP$sH_4d3U" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="2WP$sH_4d3V" role="1PaTwD">
+            <property role="3oM_SC" value="diagram" />
+          </node>
+          <node concept="3oM_SD" id="2WP$sH_4d4s" role="1PaTwD">
+            <property role="3oM_SC" value="itself." />
+          </node>
+        </node>
         <node concept="2DRihI" id="2IcGFIaJNN2" role="15bAlk">
           <node concept="3oM_SD" id="2IcGFIaJNP4" role="1PaTwD">
             <property role="3oM_SC" value="A" />


### PR DESCRIPTION
Diagrams can now show a grid that is used for snapping elements to it. It can be configured (visibility, grid snapping, grid color/size/style) in the editor definition of the diagram itself:

<img width="755" alt="Screenshot 2024-09-16 at 09 20 29" src="https://github.com/user-attachments/assets/926c3f89-f316-4433-a98d-19fc71cb10db">


The elements sometimes don't snap to the grid itself but that seems to be an issue in the library itself. Taken from https://github.com/jgraph/mxgraph/blob/ff141aab158417bd866e2dfebd06c61d40773cd2/java/src/com/mxgraph/swing/handler/mxGraphHandler.java#L1105: 

> Drag image _size_ depends on the initial position and may sometimes
> not align with the grid when dragging. This is because the rounding of the width
> and height at the initial position may be different than that at the current
> position as the left and bottom side of the shape must align to the grid lines.
>  Only fix is a full repaint of the drag cells at each new mouse location.