### PR TITLE
mpsutil.editor.querylist: add support for an index expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project are documented in this file.
 
 The format is *loosely* based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) .The project does *not* follow Semantic Versioning and the changes are documented in reverse chronological order, grouped by calendar month.
 
+## October 2024
+
+### Added
+
+- *com.mbeddr.mpsutil.editor.querylist*: The expression *queryListNode* was renamed to node and a new expression *index* can now be used to refer to the index of the current queried node.
+
 ## September 2024
 
 ### Added

--- a/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
+++ b/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
@@ -13893,6 +13893,11 @@
             </node>
           </node>
         </node>
+        <node concept="1SiIV0" id="3YRpSuyY2bs" role="3bR37C">
+          <node concept="3bR9La" id="3YRpSuyY2bt" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:3MI1gu0QouH" resolve="jetbrains.mps.editor.runtime" />
+          </node>
+        </node>
       </node>
     </node>
     <node concept="m$_wf" id="TAJODzUQvo" role="3989C9">

--- a/code/querylist/com.mbeddr.mpsutil.editor.querylist.demolang/languageModels/editor.mps
+++ b/code/querylist/com.mbeddr.mpsutil.editor.querylist.demolang/languageModels/editor.mps
@@ -107,6 +107,9 @@
       <concept id="1182160077978" name="jetbrains.mps.baseLanguage.structure.AnonymousClassCreator" flags="nn" index="YeOm9">
         <child id="1182160096073" name="cls" index="YeSDq" />
       </concept>
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
+      </concept>
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
       <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
@@ -237,6 +240,7 @@
         <child id="6046489571270834038" name="foldedCellModel" index="3EmGlc" />
         <child id="6240706158490734121" name="collapseByDefaultCondition" index="3EXrW6" />
       </concept>
+      <concept id="4591252177377353906" name="com.mbeddr.mpsutil.editor.querylist.structure.QueryListIndexExpression" flags="ng" index="2tpSsP" />
       <concept id="5820306262933110156" name="com.mbeddr.mpsutil.editor.querylist.structure.Function_InsertNewNode" flags="ig" index="ARxKT" />
       <concept id="5820306262933734929" name="com.mbeddr.mpsutil.editor.querylist.structure.Parameter_AnchorNode" flags="ng" index="AS6u$" />
       <concept id="5820306262933951366" name="com.mbeddr.mpsutil.editor.querylist.structure.Paramter_insertBefore" flags="ng" index="AVj8N" />
@@ -1625,6 +1629,32 @@
             </node>
           </node>
         </node>
+        <node concept="1yz3lS" id="3YRpSuyPQgJ" role="1yzFaX">
+          <node concept="3EZMnI" id="3YRpSuyPR5H" role="2wV5jI">
+            <node concept="1HlG4h" id="3YRpSuyPR5K" role="3EZMnx">
+              <node concept="1HfYo3" id="3YRpSuyPR5M" role="1HlULh">
+                <node concept="3TQlhw" id="3YRpSuyPR5O" role="1Hhtcw">
+                  <node concept="3clFbS" id="3YRpSuyPR5Q" role="2VODD2">
+                    <node concept="3clFbF" id="3YRpSuyV2CX" role="3cqZAp">
+                      <node concept="3cpWs3" id="3YRpSuyV46D" role="3clFbG">
+                        <node concept="Xl_RD" id="3YRpSuyV46H" role="3uHU7w">
+                          <property role="Xl_RC" value=":" />
+                        </node>
+                        <node concept="2YIFZM" id="3YRpSuyPRdg" role="3uHU7B">
+                          <ref role="37wK5l" to="wyt6:~String.valueOf(int)" resolve="valueOf" />
+                          <ref role="1Pybhc" to="wyt6:~String" resolve="String" />
+                          <node concept="2tpSsP" id="3YRpSuyPRr$" role="37wK5m" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="2iRfu4" id="3YRpSuyPR5I" role="2iSdaV" />
+            <node concept="r$x8Z" id="3YRpSuyPR5F" role="3EZMnx" />
+          </node>
+        </node>
       </node>
       <node concept="3F0ifn" id="3jHPIDnh_UX" role="3EZMnx">
         <node concept="ljvvj" id="3jHPIDnh_UY" role="3F10Kt">
@@ -1746,6 +1776,32 @@
         </node>
         <node concept="xShMh" id="T_6DrkZpyE" role="3F10Kt">
           <property role="VOm3f" value="true" />
+        </node>
+        <node concept="1yz3lS" id="3YRpSuyW0XT" role="1yzFaX">
+          <node concept="3EZMnI" id="3YRpSuyW7ZR" role="2wV5jI">
+            <node concept="1HlG4h" id="3YRpSuyWivq" role="3EZMnx">
+              <node concept="1HfYo3" id="3YRpSuyWivr" role="1HlULh">
+                <node concept="3TQlhw" id="3YRpSuyWivs" role="1Hhtcw">
+                  <node concept="3clFbS" id="3YRpSuyWivt" role="2VODD2">
+                    <node concept="3clFbF" id="3YRpSuyWivu" role="3cqZAp">
+                      <node concept="3cpWs3" id="3YRpSuyWivv" role="3clFbG">
+                        <node concept="Xl_RD" id="3YRpSuyWivw" role="3uHU7w">
+                          <property role="Xl_RC" value=":" />
+                        </node>
+                        <node concept="2YIFZM" id="3YRpSuyWivx" role="3uHU7B">
+                          <ref role="37wK5l" to="wyt6:~String.valueOf(int)" resolve="valueOf" />
+                          <ref role="1Pybhc" to="wyt6:~String" resolve="String" />
+                          <node concept="2tpSsP" id="3YRpSuyWivy" role="37wK5m" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="2iRfu4" id="3YRpSuyW7ZS" role="2iSdaV" />
+            <node concept="r$x8Z" id="3YRpSuyW4ue" role="3EZMnx" />
+          </node>
         </node>
       </node>
       <node concept="3F0ifn" id="lPJxikeccu" role="3EZMnx">

--- a/code/querylist/com.mbeddr.mpsutil.editor.querylist.runtime/models/com/mbeddr/mpsutil/editor/querylist/runtime.mps
+++ b/code/querylist/com.mbeddr.mpsutil.editor.querylist.runtime/models/com/mbeddr/mpsutil/editor/querylist/runtime.mps
@@ -1667,6 +1667,18 @@
             </node>
           </node>
         </node>
+        <node concept="3clFbH" id="3YRpSuyNeis" role="3cqZAp" />
+        <node concept="3clFbF" id="3YRpSuySwi2" role="3cqZAp">
+          <node concept="2OqwBi" id="3YRpSuyS$6M" role="3clFbG">
+            <node concept="2YIFZM" id="3YRpSuyPEcz" role="2Oq$k0">
+              <ref role="37wK5l" node="1WjrBsNI5cO" resolve="getCurrentContext" />
+              <ref role="1Pybhc" node="1WjrBsNHO$4" resolve="QueryListContext" />
+            </node>
+            <node concept="liA8E" id="3YRpSuyS_Mk" role="2OqNvi">
+              <ref role="37wK5l" node="3YRpSuySk4Z" resolve="increaseIndex" />
+            </node>
+          </node>
+        </node>
         <node concept="3cpWs6" id="C$q8A2Nx$b" role="3cqZAp">
           <node concept="37vLTw" id="C$q8A2Nzs0" role="3cqZAk">
             <ref role="3cqZAo" node="C$q8A2NgmE" resolve="cell" />
@@ -3811,6 +3823,14 @@
       <node concept="3Tm6S6" id="1WjrBsNIckg" role="1B3o_S" />
       <node concept="3Tqbb2" id="1WjrBsNIc$F" role="1tU5fm" />
     </node>
+    <node concept="312cEg" id="3YRpSuyShEm" role="jymVt">
+      <property role="TrG5h" value="currentIndex" />
+      <node concept="3Tm6S6" id="3YRpSuySgXl" role="1B3o_S" />
+      <node concept="10Oyi0" id="3YRpSuyShx6" role="1tU5fm" />
+      <node concept="3cmrfG" id="3YRpSuySifm" role="33vP2m">
+        <property role="3cmrfH" value="0" />
+      </node>
+    </node>
     <node concept="2tJIrI" id="1WjrBsNIc45" role="jymVt" />
     <node concept="3clFbW" id="1WjrBsNI9Ji" role="jymVt">
       <node concept="37vLTG" id="1WjrBsNIc3$" role="3clF46">
@@ -3844,6 +3864,34 @@
           </node>
         </node>
       </node>
+    </node>
+    <node concept="2tJIrI" id="3YRpSuyO$Ud" role="jymVt" />
+    <node concept="3clFb_" id="3YRpSuySk4Z" role="jymVt">
+      <property role="TrG5h" value="increaseIndex" />
+      <node concept="3clFbS" id="3YRpSuySk52" role="3clF47">
+        <node concept="3clFbF" id="3YRpSuySmJU" role="3cqZAp">
+          <node concept="3uNrnE" id="3YRpSuySo8y" role="3clFbG">
+            <node concept="37vLTw" id="3YRpSuySo8$" role="2$L3a6">
+              <ref role="3cqZAo" node="3YRpSuyShEm" resolve="currentIndex" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="3YRpSuySjo2" role="1B3o_S" />
+      <node concept="3cqZAl" id="3YRpSuySjVJ" role="3clF45" />
+    </node>
+    <node concept="2tJIrI" id="3YRpSuyOEvU" role="jymVt" />
+    <node concept="3clFb_" id="3YRpSuyOFjn" role="jymVt">
+      <property role="TrG5h" value="getIndex" />
+      <node concept="3clFbS" id="3YRpSuyOFjq" role="3clF47">
+        <node concept="3clFbF" id="3YRpSuySp4X" role="3cqZAp">
+          <node concept="37vLTw" id="3YRpSuySp4W" role="3clFbG">
+            <ref role="3cqZAo" node="3YRpSuyShEm" resolve="currentIndex" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="3YRpSuyOEYF" role="1B3o_S" />
+      <node concept="10Oyi0" id="3YRpSuyOFhH" role="3clF45" />
     </node>
     <node concept="2tJIrI" id="1WjrBsNI9w0" role="jymVt" />
     <node concept="3clFb_" id="1WjrBsNI3Qi" role="jymVt">

--- a/code/querylist/com.mbeddr.mpsutil.editor.querylist/com.mbeddr.mpsutil.editor.querylist.mpl
+++ b/code/querylist/com.mbeddr.mpsutil.editor.querylist/com.mbeddr.mpsutil.editor.querylist.mpl
@@ -110,6 +110,7 @@
     <dependency reexport="false">94b17d5e-87d9-4868-8101-157e83e33243(com.mbeddr.mpsutil.editor.querylist.runtime)</dependency>
     <dependency reexport="false">2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)</dependency>
     <dependency reexport="false">c72da2b9-7cce-4447-8389-f407dc1158b7(jetbrains.mps.lang.structure)</dependency>
+    <dependency reexport="false">34e84b8f-afa8-4364-abcd-a279fddddbe7(jetbrains.mps.editor.runtime)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
@@ -158,6 +159,7 @@
     <module reference="fd392034-7849-419d-9071-12563d152375(jetbrains.mps.baseLanguage.closures)" version="0" />
     <module reference="83888646-71ce-4f1c-9c53-c54016f6ad4f(jetbrains.mps.baseLanguage.collections)" version="0" />
     <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
+    <module reference="34e84b8f-afa8-4364-abcd-a279fddddbe7(jetbrains.mps.editor.runtime)" version="0" />
     <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
     <module reference="d936855b-48da-4812-a8a0-2bfddd633ac5(jetbrains.mps.lang.behavior.api)" version="0" />
     <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />

--- a/code/querylist/com.mbeddr.mpsutil.editor.querylist/generator/template/main@generator.mps
+++ b/code/querylist/com.mbeddr.mpsutil.editor.querylist/generator/template/main@generator.mps
@@ -769,6 +769,20 @@
         </node>
       </node>
     </node>
+    <node concept="3aamgX" id="3YRpSuyPEcv" role="3acgRq">
+      <ref role="30HIoZ" to="bbp5:3YRpSuyOe2M" resolve="QueryListIndexExpression" />
+      <node concept="gft3U" id="3YRpSuyPEcw" role="1lVwrX">
+        <node concept="2OqwBi" id="3YRpSuyPEcy" role="gfFT$">
+          <node concept="2YIFZM" id="3YRpSuyPEcz" role="2Oq$k0">
+            <ref role="37wK5l" to="d2zl:1WjrBsNI5cO" resolve="getCurrentContext" />
+            <ref role="1Pybhc" to="d2zl:1WjrBsNHO$4" resolve="QueryListContext" />
+          </node>
+          <node concept="liA8E" id="3YRpSuyPEtr" role="2OqNvi">
+            <ref role="37wK5l" to="d2zl:3YRpSuyOFjn" resolve="getIndex" />
+          </node>
+        </node>
+      </node>
+    </node>
   </node>
   <node concept="13MO4I" id="fYh_sBt">
     <property role="TrG5h" value="reduce_CellModel_QueryList" />
@@ -847,7 +861,6 @@
                       </node>
                     </node>
                   </node>
-                  <node concept="3clFbH" id="1WjrBsNI_nE" role="3cqZAp" />
                   <node concept="3cpWs8" id="1WjrBsNI_nF" role="3cqZAp">
                     <node concept="3cpWsn" id="1WjrBsNI_nG" role="3cpWs9">
                       <property role="TrG5h" value="editorCell" />

--- a/code/querylist/com.mbeddr.mpsutil.editor.querylist/languageModels/behavior.mps
+++ b/code/querylist/com.mbeddr.mpsutil.editor.querylist/languageModels/behavior.mps
@@ -58,6 +58,7 @@
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
       </concept>
+      <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
       <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <child id="1068431790190" name="initializer" index="33vP2m" />
@@ -238,6 +239,9 @@
             <node concept="Tc6Ow" id="5oklODadYw5" role="2ShVmc">
               <node concept="35c_gC" id="1zqEQG3WoH4" role="HW$Y0">
                 <ref role="35c_gD" to="tpc2:gCpncv5" resolve="ConceptFunctionParameter_node" />
+              </node>
+              <node concept="35c_gC" id="3YRpSuyxXFY" role="HW$Y0">
+                <ref role="35c_gD" to="bbp5:3YRpSuyxXqU" resolve="Parameter_Index" />
               </node>
               <node concept="35c_gC" id="1zqEQG3WoH5" role="HW$Y0">
                 <ref role="35c_gD" to="tpc2:gTQ80DJ" resolve="ConceptFunctionParameter_editorContext" />
@@ -1538,6 +1542,29 @@
           </node>
         </node>
       </node>
+    </node>
+  </node>
+  <node concept="13h7C7" id="3YRpSuyxXtP">
+    <ref role="13h7C2" to="bbp5:3YRpSuyxXqU" resolve="Parameter_Index" />
+    <node concept="13i0hz" id="3YRpSuyxXu8" role="13h7CS">
+      <property role="TrG5h" value="getType" />
+      <property role="13i0it" value="false" />
+      <property role="13i0iv" value="false" />
+      <ref role="13i0hy" to="tpek:27DJnJtIQ9C" resolve="getType" />
+      <node concept="3Tm1VV" id="3YRpSuyxXu9" role="1B3o_S" />
+      <node concept="3clFbS" id="3YRpSuyxXua" role="3clF47">
+        <node concept="3clFbF" id="3YRpSuyxXub" role="3cqZAp">
+          <node concept="2c44tf" id="3YRpSuyxXuc" role="3clFbG">
+            <node concept="10Oyi0" id="3YRpSuyxXzl" role="2c44tc" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tqbb2" id="3YRpSuyxXue" role="3clF45">
+        <ref role="ehGHo" to="tpee:fz3vP1H" resolve="Type" />
+      </node>
+    </node>
+    <node concept="13hLZK" id="3YRpSuyxXtQ" role="13h7CW">
+      <node concept="3clFbS" id="3YRpSuyxXtR" role="2VODD2" />
     </node>
   </node>
 </model>

--- a/code/querylist/com.mbeddr.mpsutil.editor.querylist/languageModels/constraints.mps
+++ b/code/querylist/com.mbeddr.mpsutil.editor.querylist/languageModels/constraints.mps
@@ -92,5 +92,28 @@
       </node>
     </node>
   </node>
+  <node concept="1M2fIO" id="3YRpSuyOedA">
+    <ref role="1M2myG" to="bbp5:3YRpSuyOe2M" resolve="QueryListIndexExpression" />
+    <node concept="9S07l" id="3YRpSuyOedB" role="9Vyp8">
+      <node concept="3clFbS" id="3YRpSuyOedC" role="2VODD2">
+        <node concept="3clFbF" id="3YRpSuyOeis" role="3cqZAp">
+          <node concept="2OqwBi" id="3YRpSuyOeit" role="3clFbG">
+            <node concept="2OqwBi" id="3YRpSuyOeiu" role="2Oq$k0">
+              <node concept="nLn13" id="3YRpSuyOeiv" role="2Oq$k0" />
+              <node concept="2Xjw5R" id="3YRpSuyOeiw" role="2OqNvi">
+                <node concept="1xMEDy" id="3YRpSuyOeix" role="1xVPHs">
+                  <node concept="chp4Y" id="3YRpSuyOeiy" role="ri$Ld">
+                    <ref role="cht4Q" to="bbp5:5oklODadopi" resolve="CellModel_QueryList" />
+                  </node>
+                </node>
+                <node concept="1xIGOp" id="3YRpSuyOeiz" role="1xVPHs" />
+              </node>
+            </node>
+            <node concept="3x8VRR" id="3YRpSuyOei$" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
 </model>
 

--- a/code/querylist/com.mbeddr.mpsutil.editor.querylist/languageModels/editor.mps
+++ b/code/querylist/com.mbeddr.mpsutil.editor.querylist/languageModels/editor.mps
@@ -18,6 +18,11 @@
     <import index="tpce" ref="r:00000000-0000-4000-0000-011c89590292(jetbrains.mps.lang.structure.structure)" implicit="true" />
     <import index="tpcn" ref="r:00000000-0000-4000-0000-011c8959028b(jetbrains.mps.lang.structure.behavior)" implicit="true" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
+    <import index="tpco" ref="r:00000000-0000-4000-0000-011c89590284(jetbrains.mps.lang.core.editor)" implicit="true" />
+    <import index="tpen" ref="r:00000000-0000-4000-0000-011c895902c3(jetbrains.mps.baseLanguage.editor)" implicit="true" />
+    <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" implicit="true" />
+    <import index="fulz" ref="r:6f792c44-2a5d-40e8-9f05-33f7d4ae26ec(jetbrains.mps.editor.runtime.completion)" implicit="true" />
+    <import index="av1m" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.menus.style(MPS.Editor/)" implicit="true" />
   </imports>
   <registry>
     <language id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor">
@@ -37,6 +42,10 @@
         <child id="1080736633877" name="cellModel" index="2wV5jI" />
       </concept>
       <concept id="1239814640496" name="jetbrains.mps.lang.editor.structure.CellLayout_VerticalGrid" flags="nn" index="2EHx9g" />
+      <concept id="7250830207897895674" name="jetbrains.mps.lang.editor.structure.CompletionCustomizationContextSpecificator_Concept" flags="ng" index="KNhPi">
+        <reference id="9115396979021131941" name="conceptDeclaration" index="2RIln$" />
+      </concept>
+      <concept id="7250830207897895678" name="jetbrains.mps.lang.editor.structure.CompletionCustomizationConceptCreatingSpecificator" flags="ng" index="KNhPm" />
       <concept id="1160493135005" name="jetbrains.mps.lang.editor.structure.CellMenuPart_PropertyValues_GetValues" flags="in" index="MLZmj" />
       <concept id="1164824717996" name="jetbrains.mps.lang.editor.structure.CellMenuDescriptor" flags="ng" index="OXEIz">
         <child id="1164824815888" name="cellMenuPart" index="OY2wv" />
@@ -52,16 +61,23 @@
         <property id="1186403713874" name="color" index="Vb096" />
         <child id="1186403803051" name="query" index="VblUZ" />
       </concept>
-      <concept id="1186403751766" name="jetbrains.mps.lang.editor.structure.FontStyleStyleClassItem" flags="ln" index="Vb9p2" />
+      <concept id="1186403751766" name="jetbrains.mps.lang.editor.structure.FontStyleStyleClassItem" flags="ln" index="Vb9p2">
+        <property id="1186403771423" name="style" index="Vbekb" />
+      </concept>
       <concept id="1186404574412" name="jetbrains.mps.lang.editor.structure.BackgroundColorStyleClassItem" flags="ln" index="Veino" />
       <concept id="1186414536763" name="jetbrains.mps.lang.editor.structure.BooleanStyleSheetItem" flags="ln" index="VOi$J">
         <property id="1186414551515" name="flag" index="VOm3f" />
         <child id="1223387335081" name="query" index="3n$kyP" />
       </concept>
       <concept id="1186414928363" name="jetbrains.mps.lang.editor.structure.SelectableStyleSheetItem" flags="ln" index="VPM3Z" />
+      <concept id="1186414949600" name="jetbrains.mps.lang.editor.structure.AutoDeletableStyleClassItem" flags="ln" index="VPRnO" />
       <concept id="1186414976055" name="jetbrains.mps.lang.editor.structure.DrawBorderStyleClassItem" flags="ln" index="VPXOz" />
       <concept id="1214406454886" name="jetbrains.mps.lang.editor.structure.TextBackgroundColorStyleClassItem" flags="ln" index="30gYXW" />
       <concept id="1214406466686" name="jetbrains.mps.lang.editor.structure.TextBackgroundColorSelectedStyleClassItem" flags="ln" index="30h1P$" />
+      <concept id="7818019076292260194" name="jetbrains.mps.lang.editor.structure.CompletionStyling" flags="ig" index="3dRTYf">
+        <child id="7250830207897909099" name="specificator" index="KNiz3" />
+        <child id="772883491827840107" name="customizeFunction" index="3l$a4r" />
+      </concept>
       <concept id="1165253627126" name="jetbrains.mps.lang.editor.structure.CellMenuPart_AbstractGroup" flags="ng" index="1exORT">
         <property id="1165254125954" name="presentation" index="1ezIyd" />
         <child id="1165253890469" name="parameterObjectType" index="1eyP2E" />
@@ -74,6 +90,9 @@
       <concept id="1381004262292414836" name="jetbrains.mps.lang.editor.structure.ICellStyle" flags="ng" index="1k5N5V">
         <reference id="1381004262292426837" name="parentStyleClass" index="1k5W1q" />
       </concept>
+      <concept id="772883491827578824" name="jetbrains.mps.lang.editor.structure.CompletionCustomization_CustomizeFunction" flags="ig" index="3lBaaS" />
+      <concept id="772883491827671409" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameterCustomize_CompletionItemInformation" flags="ng" index="3lBNg1" />
+      <concept id="772883491827671446" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameterCustomize_Style" flags="ng" index="3lBNjA" />
       <concept id="1223387125302" name="jetbrains.mps.lang.editor.structure.QueryFunction_Boolean" flags="in" index="3nzxsE" />
       <concept id="1165420413719" name="jetbrains.mps.lang.editor.structure.CellMenuPart_Generic_Group" flags="ng" index="1ou48o">
         <child id="1165420413721" name="handlerFunction" index="1ou48m" />
@@ -128,6 +147,7 @@
       <concept id="1176809959526" name="jetbrains.mps.lang.editor.structure.QueryFunction_Color" flags="in" index="3ZlJ5R" />
     </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1080223426719" name="jetbrains.mps.baseLanguage.structure.OrExpression" flags="nn" index="22lmx$" />
       <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
         <child id="1068498886297" name="rValue" index="37vLTx" />
         <child id="1068498886295" name="lValue" index="37vLTJ" />
@@ -171,6 +191,7 @@
       <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
       <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
       <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
+      <concept id="1225271283259" name="jetbrains.mps.baseLanguage.structure.NPEEqualsExpression" flags="nn" index="17R0WA" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
@@ -187,6 +208,10 @@
       <concept id="1068580123152" name="jetbrains.mps.baseLanguage.structure.EqualsExpression" flags="nn" index="3clFbC" />
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
+        <child id="1068580123160" name="condition" index="3clFbw" />
+        <child id="1068580123161" name="ifTrue" index="3clFbx" />
       </concept>
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
@@ -244,6 +269,9 @@
         <child id="1140725362529" name="linkTarget" index="2oxUTC" />
       </concept>
       <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
+      <concept id="2644386474300074836" name="jetbrains.mps.lang.smodel.structure.ConceptIdRefExpression" flags="nn" index="35c_gC">
+        <reference id="2644386474300074837" name="conceptDeclaration" index="35c_gD" />
+      </concept>
       <concept id="1171999116870" name="jetbrains.mps.lang.smodel.structure.Node_IsNullOperation" flags="nn" index="3w_OXm" />
       <concept id="1180636770613" name="jetbrains.mps.lang.smodel.structure.SNodeCreator" flags="nn" index="3zrR0B">
         <child id="1180636770616" name="createdType" index="3zrR0E" />
@@ -2843,6 +2871,82 @@
         <ref role="1NtTu8" to="bbp5:5fDszETGVtQ" resolve="foldedCellModel" />
       </node>
       <node concept="2iRfu4" id="57wonSLZwSt" role="2iSdaV" />
+    </node>
+  </node>
+  <node concept="24kQdi" id="3YRpSuyTSH0">
+    <ref role="1XX52x" to="bbp5:3YRpSuyOe2M" resolve="QueryListIndexExpression" />
+    <node concept="PMmxH" id="3YRpSuyTSPu" role="2wV5jI">
+      <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
+      <ref role="1k5W1q" to="tpen:hgVS8CF" resolve="KeyWord" />
+      <node concept="Vb9p2" id="3YRpSuyUoTk" role="3F10Kt">
+        <property role="Vbekb" value="g1_kEg4/ITALIC" />
+      </node>
+      <node concept="VPRnO" id="3YRpSuyUoTl" role="3F10Kt">
+        <property role="VOm3f" value="true" />
+      </node>
+    </node>
+  </node>
+  <node concept="24kQdi" id="3YRpSuyTT6n">
+    <ref role="1XX52x" to="bbp5:1WjrBsNJ4Il" resolve="QueryListNodeExpression" />
+    <node concept="PMmxH" id="3YRpSuyTTeP" role="2wV5jI">
+      <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
+      <ref role="1k5W1q" to="tpen:hgVS8CF" resolve="KeyWord" />
+      <node concept="Vb9p2" id="2wdLO7KhY7b" role="3F10Kt">
+        <property role="Vbekb" value="g1_kEg4/ITALIC" />
+      </node>
+      <node concept="VPRnO" id="6FVg9o8F4Fd" role="3F10Kt">
+        <property role="VOm3f" value="true" />
+      </node>
+    </node>
+  </node>
+  <node concept="3dRTYf" id="3YRpSuyTTvI">
+    <property role="TrG5h" value="QueryListExpression" />
+    <node concept="3Tm1VV" id="3YRpSuyTTvJ" role="1B3o_S" />
+    <node concept="KNhPm" id="3YRpSuyTU2t" role="KNiz3">
+      <ref role="2RIln$" to="tpee:fz3vP1J" resolve="Expression" />
+    </node>
+    <node concept="3lBaaS" id="3YRpSuyTTvL" role="3l$a4r">
+      <node concept="3clFbS" id="3YRpSuyTTvM" role="2VODD2">
+        <node concept="3clFbJ" id="3YRpSuyTUkL" role="3cqZAp">
+          <node concept="22lmx$" id="3YRpSuyU0pg" role="3clFbw">
+            <node concept="17R0WA" id="3YRpSuyTZAd" role="3uHU7B">
+              <node concept="2OqwBi" id="3YRpSuyTULd" role="3uHU7B">
+                <node concept="3lBNg1" id="3YRpSuyTUtI" role="2Oq$k0" />
+                <node concept="liA8E" id="3YRpSuyTV5D" role="2OqNvi">
+                  <ref role="37wK5l" to="fulz:6MqJAGngeyC" resolve="getOutputConcept" />
+                </node>
+              </node>
+              <node concept="35c_gC" id="3YRpSuyTZJF" role="3uHU7w">
+                <ref role="35c_gD" to="bbp5:3YRpSuyOe2M" resolve="QueryListIndexExpression" />
+              </node>
+            </node>
+            <node concept="17R0WA" id="3YRpSuyU0zl" role="3uHU7w">
+              <node concept="2OqwBi" id="3YRpSuyU0zm" role="3uHU7B">
+                <node concept="3lBNg1" id="3YRpSuyU0zn" role="2Oq$k0" />
+                <node concept="liA8E" id="3YRpSuyU0zo" role="2OqNvi">
+                  <ref role="37wK5l" to="fulz:6MqJAGngeyC" resolve="getOutputConcept" />
+                </node>
+              </node>
+              <node concept="35c_gC" id="3YRpSuyU0zp" role="3uHU7w">
+                <ref role="35c_gD" to="bbp5:1WjrBsNJ4Il" resolve="QueryListNodeExpression" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbS" id="3YRpSuyTUkN" role="3clFbx">
+            <node concept="3clFbF" id="3YRpSuyU1ft" role="3cqZAp">
+              <node concept="2OqwBi" id="3YRpSuyU1v9" role="3clFbG">
+                <node concept="3lBNjA" id="3YRpSuyU1fs" role="2Oq$k0" />
+                <node concept="liA8E" id="3YRpSuyU1Jb" role="2OqNvi">
+                  <ref role="37wK5l" to="av1m:~EditorMenuItemStyle.setPriority(double)" resolve="setPriority" />
+                  <node concept="3cmrfG" id="3YRpSuyU1RL" role="37wK5m">
+                    <property role="3cmrfH" value="1000" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
     </node>
   </node>
 </model>

--- a/code/querylist/com.mbeddr.mpsutil.editor.querylist/languageModels/structure.mps
+++ b/code/querylist/com.mbeddr.mpsutil.editor.querylist/languageModels/structure.mps
@@ -21,6 +21,7 @@
       </concept>
       <concept id="1169125787135" name="jetbrains.mps.lang.structure.structure.AbstractConceptDeclaration" flags="ig" index="PkWjJ">
         <property id="6714410169261853888" name="conceptId" index="EcuMT" />
+        <property id="4628067390765907488" name="conceptShortDescription" index="R4oN_" />
         <property id="5092175715804935370" name="conceptAlias" index="34LRSv" />
         <child id="1071489727083" name="linkDeclaration" index="1TKVEi" />
         <child id="1071489727084" name="propertyDeclaration" index="1TKVEl" />
@@ -509,8 +510,9 @@
   </node>
   <node concept="1TIwiD" id="1WjrBsNJ4Il">
     <property role="TrG5h" value="QueryListNodeExpression" />
-    <property role="34LRSv" value="queryListNode" />
+    <property role="34LRSv" value="node" />
     <property role="EcuMT" value="2239254897981410197" />
+    <property role="R4oN_" value="the current queried node" />
     <ref role="1TJDcQ" to="tpee:fz3vP1J" resolve="Expression" />
   </node>
   <node concept="1TIwiD" id="57wonSM3yKg">
@@ -522,6 +524,19 @@
     <property role="EcuMT" value="5899822706488913135" />
     <property role="TrG5h" value="StubCellModel_DefaultEditor" />
     <ref role="1TJDcQ" to="tpc2:CzpafHMSVi" resolve="StubEditorCellModel" />
+  </node>
+  <node concept="1TIwiD" id="3YRpSuyxXqU">
+    <property role="TrG5h" value="Parameter_Index" />
+    <property role="34LRSv" value="index" />
+    <property role="EcuMT" value="4591252177372567226" />
+    <ref role="1TJDcQ" to="tpee:g76ryKb" resolve="ConceptFunctionParameter" />
+  </node>
+  <node concept="1TIwiD" id="3YRpSuyOe2M">
+    <property role="TrG5h" value="QueryListIndexExpression" />
+    <property role="EcuMT" value="4591252177377353906" />
+    <property role="R4oN_" value="the index of the current queried node" />
+    <property role="34LRSv" value="index" />
+    <ref role="1TJDcQ" to="tpee:fz3vP1J" resolve="Expression" />
   </node>
 </model>
 

--- a/code/querylist/com.mbeddr.mpsutil.editor.querylist/languageModels/typesystem.mps
+++ b/code/querylist/com.mbeddr.mpsutil.editor.querylist/languageModels/typesystem.mps
@@ -31,6 +31,7 @@
         <property id="1070475926801" name="value" index="Xl_RC" />
       </concept>
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
+      <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <child id="1068431790190" name="initializer" index="33vP2m" />
       </concept>
@@ -356,6 +357,29 @@
     <node concept="1YaCAy" id="1WjrBsNJ4Iv" role="1YuTPh">
       <property role="TrG5h" value="node" />
       <ref role="1YaFvo" to="bbp5:1WjrBsNJ4Il" resolve="QueryListNodeExpression" />
+    </node>
+  </node>
+  <node concept="1YbPZF" id="3YRpSuyOeJn">
+    <property role="TrG5h" value="typeof_QueryListIndexExpression" />
+    <node concept="3clFbS" id="3YRpSuyOeJo" role="18ibNy">
+      <node concept="1Z5TYs" id="3YRpSuyOfbt" role="3cqZAp">
+        <node concept="mw_s8" id="3YRpSuyOfbD" role="1ZfhKB">
+          <node concept="2c44tf" id="3YRpSuyOfbS" role="mwGJk">
+            <node concept="10Oyi0" id="3YRpSuyOfce" role="2c44tc" />
+          </node>
+        </node>
+        <node concept="mw_s8" id="3YRpSuyOfbw" role="1ZfhK$">
+          <node concept="1Z2H0r" id="3YRpSuyOeJ_" role="mwGJk">
+            <node concept="1YBJjd" id="3YRpSuyOeLs" role="1Z2MuG">
+              <ref role="1YBMHb" node="3YRpSuyOeJq" resolve="expression" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1YaCAy" id="3YRpSuyOeJq" role="1YuTPh">
+      <property role="TrG5h" value="expression" />
+      <ref role="1YaFvo" to="bbp5:3YRpSuyOe2M" resolve="QueryListIndexExpression" />
     </node>
   </node>
 </model>

--- a/code/solutions/de.itemis.mps.extensions.changelog/models/de.itemis.mps.extensions.changelog.mps
+++ b/code/solutions/de.itemis.mps.extensions.changelog/models/de.itemis.mps.extensions.changelog.mps
@@ -227,6 +227,112 @@
         </node>
       </node>
     </node>
+    <node concept="15bmVD" id="3YRpSuyWDXu" role="15bmVC">
+      <node concept="15ShDW" id="3YRpSuyWDXr" role="15bq2Y">
+        <property role="15ShDY" value="Po4Z58IgBa/October" />
+        <property role="15ShDw" value="2024" />
+      </node>
+      <node concept="15bAme" id="3YRpSuyWDXs" role="15bAlL">
+        <property role="15bAli" value="Po4Z58tnOE/added" />
+        <node concept="2DRihI" id="3YRpSuyWDXt" role="15bAlk">
+          <node concept="2hgSXJ" id="3YRpSuyWEvr" role="1PaTwD">
+            <node concept="1PaTwC" id="3YRpSuyWEvs" role="2hiFM$">
+              <node concept="15Ami3" id="3YRpSuyWEvt" role="1PaTwD">
+                <node concept="37shsh" id="3YRpSuyWEvu" role="15Aodc">
+                  <node concept="1dCxOk" id="3YRpSuyWEvv" role="37shsm">
+                    <property role="1XweGW" value="120e1c9d-4e27-4478-b2af-b2c3bd3850b0" />
+                    <property role="1XxBO9" value="com.mbeddr.mpsutil.editor.querylist" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3oM_SD" id="3YRpSuyWEvw" role="1PaTwD">
+                <property role="3oM_SC" value=":" />
+              </node>
+            </node>
+          </node>
+          <node concept="3oM_SD" id="3YRpSuyWEC0" role="1PaTwD">
+            <property role="3oM_SC" value="The" />
+          </node>
+          <node concept="3oM_SD" id="3YRpSuyWEKt" role="1PaTwD">
+            <property role="3oM_SC" value="expression" />
+          </node>
+          <node concept="3oM_SD" id="3YRpSuyWESU" role="1PaTwD">
+            <property role="3oM_SC" value="queryListNode" />
+            <property role="1X82VY" value="true" />
+          </node>
+          <node concept="3oM_SD" id="3YRpSuyWESV" role="1PaTwD">
+            <property role="3oM_SC" value="was" />
+          </node>
+          <node concept="3oM_SD" id="3YRpSuyWF1o" role="1PaTwD">
+            <property role="3oM_SC" value="renamed" />
+          </node>
+          <node concept="3oM_SD" id="3YRpSuyWF1p" role="1PaTwD">
+            <property role="3oM_SC" value="to" />
+          </node>
+          <node concept="3oM_SD" id="3YRpSuyWFO9" role="1PaTwD">
+            <property role="3oM_SC" value="node" />
+          </node>
+          <node concept="3oM_SD" id="3YRpSuyWFWA" role="1PaTwD">
+            <property role="3oM_SC" value="and" />
+          </node>
+          <node concept="3oM_SD" id="3YRpSuyWG53" role="1PaTwD">
+            <property role="3oM_SC" value="a" />
+          </node>
+          <node concept="3oM_SD" id="3YRpSuyWG54" role="1PaTwD">
+            <property role="3oM_SC" value="new" />
+          </node>
+          <node concept="3oM_SD" id="3YRpSuyWG55" role="1PaTwD">
+            <property role="3oM_SC" value="expression" />
+          </node>
+          <node concept="3oM_SD" id="3YRpSuyWGdy" role="1PaTwD">
+            <property role="3oM_SC" value="index" />
+            <property role="1X82VY" value="true" />
+          </node>
+          <node concept="3oM_SD" id="3YRpSuyWFFG" role="1PaTwD">
+            <property role="3oM_SC" value="can" />
+          </node>
+          <node concept="3oM_SD" id="3YRpSuyWGlZ" role="1PaTwD">
+            <property role="3oM_SC" value="now" />
+          </node>
+          <node concept="3oM_SD" id="3YRpSuyWGus" role="1PaTwD">
+            <property role="3oM_SC" value="be" />
+          </node>
+          <node concept="3oM_SD" id="3YRpSuyWGut" role="1PaTwD">
+            <property role="3oM_SC" value="used" />
+          </node>
+          <node concept="3oM_SD" id="3YRpSuyWGAU" role="1PaTwD">
+            <property role="3oM_SC" value="to" />
+          </node>
+          <node concept="3oM_SD" id="3YRpSuyWGAV" role="1PaTwD">
+            <property role="3oM_SC" value="refer" />
+          </node>
+          <node concept="3oM_SD" id="3YRpSuyWGAW" role="1PaTwD">
+            <property role="3oM_SC" value="to" />
+          </node>
+          <node concept="3oM_SD" id="3YRpSuyWGAX" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="3YRpSuyWGJq" role="1PaTwD">
+            <property role="3oM_SC" value="index" />
+          </node>
+          <node concept="3oM_SD" id="3YRpSuyWGJr" role="1PaTwD">
+            <property role="3oM_SC" value="of" />
+          </node>
+          <node concept="3oM_SD" id="3YRpSuyWGJs" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="3YRpSuyWGJt" role="1PaTwD">
+            <property role="3oM_SC" value="current" />
+          </node>
+          <node concept="3oM_SD" id="3YRpSuyWGRU" role="1PaTwD">
+            <property role="3oM_SC" value="queried" />
+          </node>
+          <node concept="3oM_SD" id="3YRpSuyWH0n" role="1PaTwD">
+            <property role="3oM_SC" value="node." />
+          </node>
+        </node>
+      </node>
+    </node>
     <node concept="15bmVD" id="2IcGFIaJNN3" role="15bmVC">
       <node concept="15ShDW" id="2IcGFIaJNN0" role="15bq2Y">
         <property role="15ShDY" value="Po4Z58IgB0/September" />


### PR DESCRIPTION
Inside the query, you now have an expression `index` and `node` (previously: `queryListNode`) to refer to the queried node and the index that returns the index in the returned list of nodes.