### PR TITLE
mpsutil.blutil: introduce named groups and refer to them from named back references

### DIFF
--- a/code/blutil/languages/com.mbeddr.mpsutil.blutil/languageModels/behavior.mps
+++ b/code/blutil/languages/com.mbeddr.mpsutil.blutil/languageModels/behavior.mps
@@ -2745,20 +2745,25 @@
       <ref role="13i0hy" to="tpfs:hMuDF1A" resolve="getString" />
       <node concept="3clFbS" id="45$ooctt7k9" role="3clF47">
         <node concept="3cpWs6" id="45$ooctt7ka" role="3cqZAp">
-          <node concept="3cpWs3" id="45$ooctt7kb" role="3cqZAk">
-            <node concept="2OqwBi" id="45$ooctt8ei" role="3uHU7w">
-              <node concept="2OqwBi" id="45$ooctt7kc" role="2Oq$k0">
-                <node concept="13iPFW" id="45$ooctt7kd" role="2Oq$k0" />
-                <node concept="3TrEf2" id="45$ooctt82F" role="2OqNvi">
-                  <ref role="3Tt5mk" to="hba4:45$ooctt21r" resolve="group" />
+          <node concept="3cpWs3" id="46RgPUMrLT5" role="3cqZAk">
+            <node concept="Xl_RD" id="46RgPUMrLT8" role="3uHU7w">
+              <property role="Xl_RC" value="&gt;" />
+            </node>
+            <node concept="3cpWs3" id="45$ooctt7kb" role="3uHU7B">
+              <node concept="Xl_RD" id="45$ooctt7kf" role="3uHU7B">
+                <property role="Xl_RC" value="\\k&lt;" />
+              </node>
+              <node concept="2OqwBi" id="45$ooctt8ei" role="3uHU7w">
+                <node concept="2OqwBi" id="45$ooctt7kc" role="2Oq$k0">
+                  <node concept="13iPFW" id="45$ooctt7kd" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="45$ooctt82F" role="2OqNvi">
+                    <ref role="3Tt5mk" to="hba4:45$ooctt21r" resolve="group" />
+                  </node>
+                </node>
+                <node concept="3TrcHB" id="46RgPUMrKCG" role="2OqNvi">
+                  <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
                 </node>
               </node>
-              <node concept="2qgKlT" id="45$ooctt8$v" role="2OqNvi">
-                <ref role="37wK5l" to="tpfs:hNm3Btp" resolve="getIndex" />
-              </node>
-            </node>
-            <node concept="Xl_RD" id="45$ooctt7kf" role="3uHU7B">
-              <property role="Xl_RC" value="\\" />
             </node>
           </node>
         </node>
@@ -2774,6 +2779,67 @@
     </node>
     <node concept="13hLZK" id="45$ooctt7jy" role="13h7CW">
       <node concept="3clFbS" id="45$ooctt7jz" role="2VODD2" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="46RgPUMtyr9">
+    <property role="3GE5qa" value="regexp" />
+    <ref role="13h7C2" to="hba4:46RgPUMrFAF" resolve="NamedGroupRegexp" />
+    <node concept="13hLZK" id="46RgPUMtyra" role="13h7CW">
+      <node concept="3clFbS" id="46RgPUMtyrb" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="46RgPUMtzre" role="13h7CS">
+      <property role="TrG5h" value="getString" />
+      <property role="13i0it" value="true" />
+      <ref role="13i0hy" to="tpfs:hMuDF1A" resolve="getString" />
+      <node concept="3clFbS" id="46RgPUMtzrf" role="3clF47">
+        <node concept="3cpWs6" id="46RgPUMtzrg" role="3cqZAp">
+          <node concept="3cpWs3" id="46RgPUMtzrh" role="3cqZAk">
+            <node concept="Xl_RD" id="46RgPUMtzri" role="3uHU7w">
+              <property role="Xl_RC" value=")" />
+            </node>
+            <node concept="3cpWs3" id="46RgPUMt$Qi" role="3uHU7B">
+              <node concept="3cpWs3" id="46RgPUMtBGH" role="3uHU7B">
+                <node concept="Xl_RD" id="46RgPUMtBGK" role="3uHU7w">
+                  <property role="Xl_RC" value="&gt;" />
+                </node>
+                <node concept="3cpWs3" id="46RgPUMtBbi" role="3uHU7B">
+                  <node concept="Xl_RD" id="46RgPUMtzrk" role="3uHU7B">
+                    <property role="Xl_RC" value="(?&lt;" />
+                  </node>
+                  <node concept="2OqwBi" id="46RgPUMtBnV" role="3uHU7w">
+                    <node concept="13iPFW" id="46RgPUMtBcl" role="2Oq$k0" />
+                    <node concept="3TrcHB" id="46RgPUMtBEz" role="2OqNvi">
+                      <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="2OqwBi" id="46RgPUMtzrl" role="3uHU7w">
+                <node concept="2OqwBi" id="46RgPUMtzrm" role="2Oq$k0">
+                  <node concept="13iPFW" id="46RgPUMtzrn" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="46RgPUMtzro" role="2OqNvi">
+                    <ref role="3Tt5mk" to="tpfo:h5P8htV" resolve="expr" />
+                  </node>
+                </node>
+                <node concept="2qgKlT" id="46RgPUMtzrp" role="2OqNvi">
+                  <ref role="37wK5l" to="tpfs:hMuDF1A" resolve="getString" />
+                  <node concept="37vLTw" id="46RgPUMtzrq" role="37wK5m">
+                    <ref role="3cqZAo" node="46RgPUMtzrr" resolve="vars" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="46RgPUMtzrr" role="3clF46">
+        <property role="TrG5h" value="vars" />
+        <node concept="2I9FWS" id="46RgPUMtzrs" role="1tU5fm">
+          <ref role="2I9WkF" to="tpfo:h5Tukr7" resolve="MatchParensRegexp" />
+        </node>
+      </node>
+      <node concept="17QB3L" id="46RgPUMtzrt" role="3clF45" />
+      <node concept="3Tm1VV" id="46RgPUMtzru" role="1B3o_S" />
     </node>
   </node>
 </model>

--- a/code/blutil/languages/com.mbeddr.mpsutil.blutil/languageModels/editor.mps
+++ b/code/blutil/languages/com.mbeddr.mpsutil.blutil/languageModels/editor.mps
@@ -126,6 +126,9 @@
         <reference id="1078939183255" name="editorComponent" index="PMmxG" />
       </concept>
       <concept id="1149850725784" name="jetbrains.mps.lang.editor.structure.CellModel_AttributedNodeCell" flags="ng" index="2SsqMj" />
+      <concept id="1164914519156" name="jetbrains.mps.lang.editor.structure.CellMenuPart_ReplaceNode_CustomNodeConcept" flags="ng" index="UkePV">
+        <reference id="1164914727930" name="replacementConcept" index="Ul1FP" />
+      </concept>
       <concept id="1214317859050" name="jetbrains.mps.lang.editor.structure.LayoutConstraintStyleClassItem" flags="ln" index="2UZ17K">
         <property id="1214317859051" name="layoutConstraint" index="2UZ17L" />
       </concept>
@@ -459,6 +462,11 @@
     <language id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem">
       <concept id="1176544042499" name="jetbrains.mps.lang.typesystem.structure.Node_TypeOperation" flags="nn" index="3JvlWi" />
     </language>
+    <language id="aee9cad2-acd4-4608-aef2-0004f6a1cdbd" name="jetbrains.mps.lang.actions">
+      <concept id="7776141288922801652" name="jetbrains.mps.lang.actions.structure.NF_Concept_NewInstance" flags="nn" index="q_SaT">
+        <child id="3757480014665178932" name="prototype" index="1wAxWu" />
+      </concept>
+    </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
       <concept id="1204851882688" name="jetbrains.mps.lang.smodel.structure.LinkRefQualifier" flags="ng" index="26LbJo">
         <reference id="1204851882689" name="link" index="26LbJp" />
@@ -478,9 +486,13 @@
       <concept id="7835263205327057228" name="jetbrains.mps.lang.smodel.structure.Node_GetChildrenAndChildAttributesOperation" flags="ng" index="Bykcj" />
       <concept id="1139184414036" name="jetbrains.mps.lang.smodel.structure.LinkList_AddNewChildOperation" flags="nn" index="WFELt" />
       <concept id="1171407110247" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorOperation" flags="nn" index="2Xjw5R" />
+      <concept id="2644386474300074836" name="jetbrains.mps.lang.smodel.structure.ConceptIdRefExpression" flags="nn" index="35c_gC">
+        <reference id="2644386474300074837" name="conceptDeclaration" index="35c_gD" />
+      </concept>
       <concept id="5168775467716640652" name="jetbrains.mps.lang.smodel.structure.OperationParm_LinkQualifier" flags="ng" index="1aIX9F">
         <child id="5168775467716640653" name="linkQualifier" index="1aIX9E" />
       </concept>
+      <concept id="6677504323281689838" name="jetbrains.mps.lang.smodel.structure.SConceptType" flags="in" index="3bZ5Sz" />
       <concept id="1139613262185" name="jetbrains.mps.lang.smodel.structure.Node_GetParentOperation" flags="nn" index="1mfA1w" />
       <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
         <child id="1177027386292" name="conceptArgument" index="cj9EA" />
@@ -526,6 +538,17 @@
       <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
         <child id="1204796294226" name="closure" index="23t8la" />
       </concept>
+      <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="nn" index="25WWJ4">
+        <child id="540871147943773366" name="argument" index="25WWJ7" />
+      </concept>
+      <concept id="1151688443754" name="jetbrains.mps.baseLanguage.collections.structure.ListType" flags="in" index="_YKpA">
+        <child id="1151688676805" name="elementType" index="_ZDj9" />
+      </concept>
+      <concept id="1237721394592" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerCreator" flags="nn" index="HWqM0">
+        <child id="1237721435807" name="elementType" index="HW$YZ" />
+      </concept>
+      <concept id="1227008614712" name="jetbrains.mps.baseLanguage.collections.structure.LinkedListCreator" flags="nn" index="2Jqq0_" />
+      <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
       <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
       <concept id="5232196642625575054" name="jetbrains.mps.baseLanguage.collections.structure.TailListOperation" flags="nn" index="1eb2uI">
         <child id="5232196642625575056" name="fromIndex" index="1eb2uK" />
@@ -4061,7 +4084,7 @@
     <node concept="3EZMnI" id="45$ooctt6CH" role="2wV5jI">
       <ref role="1ERwB7" to="tpfu:1eaRHy5sj$D" resolve="RegexpSequenceByEnter" />
       <node concept="3F0ifn" id="45$ooctt6CI" role="3EZMnx">
-        <property role="3F0ifm" value="\" />
+        <property role="3F0ifm" value="k\&lt;" />
         <node concept="11LMrY" id="45$ooctt6CJ" role="3F10Kt">
           <property role="VOm3f" value="true" />
         </node>
@@ -4075,7 +4098,146 @@
           </node>
         </node>
       </node>
+      <node concept="3F0ifn" id="46RgPUMu0$W" role="3EZMnx">
+        <property role="3F0ifm" value="&gt;" />
+        <node concept="11L4FC" id="46RgPUMu0$Y" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
       <node concept="l2Vlx" id="45$ooctt6CL" role="2iSdaV" />
+    </node>
+  </node>
+  <node concept="24kQdi" id="46RgPUMrIWV">
+    <property role="3GE5qa" value="regexp" />
+    <ref role="1XX52x" to="hba4:46RgPUMrFAF" resolve="NamedGroupRegexp" />
+    <node concept="3EZMnI" id="h5P8kpv" role="2wV5jI">
+      <ref role="1ERwB7" to="tpfu:1eaRHy5sj$D" resolve="RegexpSequenceByEnter" />
+      <node concept="3F0ifn" id="h5P8kYR" role="3EZMnx">
+        <property role="3F0ifm" value="(?&lt;" />
+        <ref role="1ERwB7" to="tpfu:h6dDp4N" resolve="ParensRegexp_Actions" />
+        <ref role="1k5W1q" to="tpfu:4uWsyBq9tox" resolve="LeftRegexpBrace" />
+        <node concept="OXEIz" id="7BLlDyibQCU" role="P5bDN">
+          <node concept="UkePV" id="7BLlDyicFQi" role="OY2wv">
+            <ref role="Ul1FP" to="tpfo:h5P8g6K" resolve="ParensRegexp" />
+          </node>
+          <node concept="ZEniJ" id="7BLlDyibQD4" role="OY2wv">
+            <property role="1ezIyd" value="gWZP3tU/custom" />
+            <node concept="3GJtP1" id="7BLlDyibQD5" role="ZF_Y3">
+              <node concept="3clFbS" id="7BLlDyibQD6" role="2VODD2">
+                <node concept="3cpWs8" id="7BLlDyibQD7" role="3cqZAp">
+                  <node concept="3cpWsn" id="7BLlDyibQD8" role="3cpWs9">
+                    <property role="TrG5h" value="res" />
+                    <node concept="_YKpA" id="7BLlDyibQD9" role="1tU5fm">
+                      <node concept="3bZ5Sz" id="7Ift4HfJx89" role="_ZDj9" />
+                    </node>
+                    <node concept="2ShNRf" id="7BLlDyibQDb" role="33vP2m">
+                      <node concept="2Jqq0_" id="7BLlDyibQDc" role="2ShVmc">
+                        <node concept="3bZ5Sz" id="7Ift4HfJzdt" role="HW$YZ" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbF" id="7BLlDyibQDe" role="3cqZAp">
+                  <node concept="2OqwBi" id="7BLlDyibQDf" role="3clFbG">
+                    <node concept="37vLTw" id="3GM_nagT$dL" role="2Oq$k0">
+                      <ref role="3cqZAo" node="7BLlDyibQD8" resolve="res" />
+                    </node>
+                    <node concept="TSZUe" id="7BLlDyibQDh" role="2OqNvi">
+                      <node concept="35c_gC" id="7Ift4HfJ$Lb" role="25WWJ7">
+                        <ref role="35c_gD" to="tpfo:h6dSv$P" resolve="NegativeLookAheadRegexp" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbF" id="7BLlDyibQDE" role="3cqZAp">
+                  <node concept="2OqwBi" id="7BLlDyibQDG" role="3clFbG">
+                    <node concept="37vLTw" id="3GM_nagTw00" role="2Oq$k0">
+                      <ref role="3cqZAo" node="7BLlDyibQD8" resolve="res" />
+                    </node>
+                    <node concept="TSZUe" id="7BLlDyibQDK" role="2OqNvi">
+                      <node concept="35c_gC" id="7Ift4HfJ_Os" role="25WWJ7">
+                        <ref role="35c_gD" to="tpfo:h6dTIfQ" resolve="NegativeLookBehindRegexp" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbF" id="7BLlDyibQDW" role="3cqZAp">
+                  <node concept="2OqwBi" id="7BLlDyibQDY" role="3clFbG">
+                    <node concept="37vLTw" id="3GM_nagTz5r" role="2Oq$k0">
+                      <ref role="3cqZAo" node="7BLlDyibQD8" resolve="res" />
+                    </node>
+                    <node concept="TSZUe" id="7BLlDyibQE2" role="2OqNvi">
+                      <node concept="35c_gC" id="7Ift4HfJAPu" role="25WWJ7">
+                        <ref role="35c_gD" to="tpfo:h6dRV_N" resolve="PositiveLookAheadRegexp" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbF" id="7BLlDyibQEe" role="3cqZAp">
+                  <node concept="2OqwBi" id="7BLlDyibQEf" role="3clFbG">
+                    <node concept="37vLTw" id="3GM_nagTvN$" role="2Oq$k0">
+                      <ref role="3cqZAo" node="7BLlDyibQD8" resolve="res" />
+                    </node>
+                    <node concept="TSZUe" id="7BLlDyibQEh" role="2OqNvi">
+                      <node concept="35c_gC" id="7Ift4HfJBQd" role="25WWJ7">
+                        <ref role="35c_gD" to="tpfo:h6dTBgJ" resolve="PositiveLookBehindRegexp" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbF" id="7BLlDyibQDj" role="3cqZAp">
+                  <node concept="2OqwBi" id="7BLlDyibQDk" role="3clFbG">
+                    <node concept="37vLTw" id="3GM_nagTxll" role="2Oq$k0">
+                      <ref role="3cqZAo" node="7BLlDyibQD8" resolve="res" />
+                    </node>
+                    <node concept="TSZUe" id="7BLlDyibQDm" role="2OqNvi">
+                      <node concept="35c_gC" id="7Ift4HfJCRc" role="25WWJ7">
+                        <ref role="35c_gD" to="tpfo:h5Tukr7" resolve="MatchParensRegexp" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbF" id="7BLlDyibQDo" role="3cqZAp">
+                  <node concept="37vLTw" id="3GM_nagTual" role="3clFbG">
+                    <ref role="3cqZAo" node="7BLlDyibQD8" resolve="res" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3GJPmD" id="7BLlDyibQDq" role="ZF_Y2">
+              <node concept="3clFbS" id="7BLlDyibQDr" role="2VODD2">
+                <node concept="3clFbF" id="7BLlDyibQDs" role="3cqZAp">
+                  <node concept="2OqwBi" id="7BLlDyibQDt" role="3clFbG">
+                    <node concept="3GLrbK" id="7BLlDyibQDu" role="2Oq$k0" />
+                    <node concept="q_SaT" id="2b3Tt7jqktm" role="2OqNvi">
+                      <node concept="3GMtW1" id="2b3Tt7jqktn" role="1wAxWu" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3bZ5Sz" id="19B7r35He1" role="1eyP2E" />
+          </node>
+        </node>
+      </node>
+      <node concept="3F0A7n" id="46RgPUMrJuu" role="3EZMnx">
+        <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
+      </node>
+      <node concept="3F0ifn" id="46RgPUMrJuX" role="3EZMnx">
+        <property role="3F0ifm" value="&gt;" />
+        <node concept="11L4FC" id="46RgPUMrJwd" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="3F1sOY" id="h5P8lMU" role="3EZMnx">
+        <ref role="1NtTu8" to="tpfo:h5P8htV" resolve="expr" />
+      </node>
+      <node concept="3F0ifn" id="h5P8mE7" role="3EZMnx">
+        <property role="3F0ifm" value=")" />
+        <ref role="1ERwB7" to="tpfu:h6dDp4N" resolve="ParensRegexp_Actions" />
+        <ref role="1k5W1q" to="tpfu:4uWsyBq9toC" resolve="RightRegexpBrace" />
+      </node>
+      <node concept="l2Vlx" id="i0MCu6Q" role="2iSdaV" />
     </node>
   </node>
 </model>

--- a/code/blutil/languages/com.mbeddr.mpsutil.blutil/languageModels/structure.mps
+++ b/code/blutil/languages/com.mbeddr.mpsutil.blutil/languageModels/structure.mps
@@ -1183,7 +1183,7 @@
       <property role="IQ2ns" value="4711998325899141211" />
       <property role="20lbJX" value="fLJekj4/_1" />
       <property role="20kJfa" value="group" />
-      <ref role="20lvS9" to="tpfo:h5Tukr7" resolve="MatchParensRegexp" />
+      <ref role="20lvS9" node="46RgPUMrFAF" resolve="NamedGroupRegexp" />
     </node>
   </node>
   <node concept="1TIwiD" id="45$ooctvlkR">
@@ -1193,6 +1193,19 @@
     <property role="R4oN_" value="independent, non-capturing group" />
     <property role="34LRSv" value="(?&gt;" />
     <ref role="1TJDcQ" to="tpfo:h6dSM65" resolve="LookRegexp" />
+  </node>
+  <node concept="1TIwiD" id="46RgPUMrFAF">
+    <property role="R5$K7" value="false" />
+    <property role="R5$K2" value="false" />
+    <property role="R4oN_" value="named group" />
+    <property role="TrG5h" value="NamedGroupRegexp" />
+    <property role="3GE5qa" value="regexp" />
+    <property role="34LRSv" value="(?&lt;" />
+    <property role="EcuMT" value="4735327607202953643" />
+    <ref role="1TJDcQ" to="tpfo:h5P8g6K" resolve="ParensRegexp" />
+    <node concept="PrWs8" id="46RgPUMrIWU" role="PzmwI">
+      <ref role="PrY4T" to="tpck:h0TrEE$" resolve="INamedConcept" />
+    </node>
   </node>
 </model>
 


### PR DESCRIPTION
The old implementation of named back references didn't work because `MatchParensRegexp#getIndex` has a faulty implementation.