### PR TITLE
Add support for partial model merge policy and default actions

### DIFF
--- a/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
+++ b/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
@@ -8124,9 +8124,9 @@
         </node>
       </node>
       <node concept="1E1JtA" id="5zr7Q_1BD5a" role="2G$12L">
-        <property role="BnDLt" value="true" />
         <property role="TrG5h" value="de.itemis.model.merge.runtime" />
         <property role="3LESm3" value="aa8cbd62-5e1f-4d0b-a6e2-189711774c91" />
+        <property role="BnDLt" value="true" />
         <node concept="398BVA" id="5zr7Q_1BDfe" role="3LF7KH">
           <ref role="398BVh" node="2fo8bJE$D4t" resolve="extensions.code" />
           <node concept="2Ry0Ak" id="5RxOLvL3$92" role="iGT6I">
@@ -8230,6 +8230,11 @@
         <node concept="1SiIV0" id="64IPVRJ1Bo5" role="3bR37C">
           <node concept="3bR9La" id="64IPVRJ1Bo6" role="1SiIV1">
             <ref role="3bR37D" to="ffeo:rD7wKO6k$" resolve="MPS.Generator" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="29H$Uu5tuHc" role="3bR37C">
+          <node concept="3bR9La" id="29H$Uu5tuHd" role="1SiIV1">
+            <ref role="3bR37D" node="6860Y5A00Lp" resolve="de.itemis.mps.utils.serializer.xml" />
           </node>
         </node>
       </node>

--- a/code/languages/de.itemis.model.merge/de.itemis.model.merge.mpl
+++ b/code/languages/de.itemis.model.merge/de.itemis.model.merge.mpl
@@ -103,6 +103,7 @@
   </dependencies>
   <languageVersions>
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
+    <language slang="l:774bf8a0-62e5-41e1-af63-f4812e60e48b:jetbrains.mps.baseLanguage.checkedDots" version="0" />
     <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />
     <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
     <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="2" />

--- a/code/languages/de.itemis.model.merge/models/de.itemis.model.merge.behavior.mps
+++ b/code/languages/de.itemis.model.merge/models/de.itemis.model.merge.behavior.mps
@@ -6,6 +6,7 @@
     <use id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior" version="2" />
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
     <use id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc" version="2" />
+    <use id="774bf8a0-62e5-41e1-af63-f4812e60e48b" name="jetbrains.mps.baseLanguage.checkedDots" version="0" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -53,6 +54,10 @@
       <concept id="1082485599095" name="jetbrains.mps.baseLanguage.structure.BlockStatement" flags="nn" index="9aQIb">
         <child id="1082485599096" name="statements" index="9aQI4" />
       </concept>
+      <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
+        <child id="1068498886297" name="rValue" index="37vLTx" />
+        <child id="1068498886295" name="lValue" index="37vLTJ" />
+      </concept>
       <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
       <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
@@ -94,6 +99,7 @@
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
       <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
+      <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
       <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
       <concept id="1225271283259" name="jetbrains.mps.baseLanguage.structure.NPEEqualsExpression" flags="nn" index="17R0WA" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
@@ -165,6 +171,9 @@
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
       <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
     </language>
+    <language id="774bf8a0-62e5-41e1-af63-f4812e60e48b" name="jetbrains.mps.baseLanguage.checkedDots">
+      <concept id="4079382982702596667" name="jetbrains.mps.baseLanguage.checkedDots.structure.CheckedDotExpression" flags="nn" index="2EnYce" />
+    </language>
     <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
       <concept id="2524418899405758586" name="jetbrains.mps.baseLanguage.closures.structure.InferredClosureParameterDeclaration" flags="ig" index="gl6BB" />
       <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
@@ -207,6 +216,7 @@
         <child id="4693937538533538124" name="requestedConcept" index="v3oSu" />
       </concept>
       <concept id="7453996997717780434" name="jetbrains.mps.lang.smodel.structure.Node_GetSConceptOperation" flags="nn" index="2yIwOk" />
+      <concept id="8866923313515890008" name="jetbrains.mps.lang.smodel.structure.AsNodeOperation" flags="nn" index="FGMqu" />
       <concept id="1143226024141" name="jetbrains.mps.lang.smodel.structure.SModelType" flags="in" index="H_c77" />
       <concept id="1883223317721008708" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfStatement" flags="nn" index="Jncv_">
         <reference id="1883223317721008712" name="nodeConcept" index="JncvD" />
@@ -299,6 +309,7 @@
       <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
       <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
       <concept id="1201792049884" name="jetbrains.mps.baseLanguage.collections.structure.TranslateOperation" flags="nn" index="3goQfb" />
+      <concept id="1201872418428" name="jetbrains.mps.baseLanguage.collections.structure.GetKeysOperation" flags="nn" index="3lbrtF" />
       <concept id="1197683403723" name="jetbrains.mps.baseLanguage.collections.structure.MapType" flags="in" index="3rvAFt">
         <child id="1197683466920" name="keyType" index="3rvQeY" />
         <child id="1197683475734" name="valueType" index="3rvSg0" />
@@ -2698,6 +2709,121 @@
         </node>
       </node>
     </node>
+    <node concept="13i0hz" id="2GFEb9MTMsl" role="13h7CS">
+      <property role="TrG5h" value="conceptsUsedInModel" />
+      <node concept="A3Dl8" id="2GFEb9MTNBB" role="3clF45">
+        <node concept="3Tqbb2" id="2GFEb9MTPFI" role="A3Ik2">
+          <ref role="ehGHo" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="2GFEb9MTMso" role="3clF47">
+        <node concept="3cpWs8" id="2GFEb9MWnoz" role="3cqZAp">
+          <node concept="3cpWsn" id="2GFEb9MWnoA" role="3cpWs9">
+            <property role="TrG5h" value="usedModel" />
+            <node concept="H_c77" id="2GFEb9MWnox" role="1tU5fm" />
+            <node concept="2OqwBi" id="2GFEb9MWumJ" role="33vP2m">
+              <node concept="2OqwBi" id="2GFEb9MWsLJ" role="2Oq$k0">
+                <node concept="2OqwBi" id="2GFEb9MWRuk" role="2Oq$k0">
+                  <node concept="3TrEf2" id="2GFEb9MWs3o" role="2OqNvi">
+                    <ref role="3Tt5mk" to="tp25:1Bs_61$ngwB" resolve="modelRef" />
+                  </node>
+                  <node concept="37vLTw" id="2GFEb9MZstb" role="2Oq$k0">
+                    <ref role="3cqZAo" node="2GFEb9MZlei" resolve="modelExp" />
+                  </node>
+                </node>
+                <node concept="2qgKlT" id="2GFEb9MWtDb" role="2OqNvi">
+                  <ref role="37wK5l" to="xlb7:1Bs_61$mvvu" resolve="toModelReference" />
+                </node>
+              </node>
+              <node concept="liA8E" id="2GFEb9MWvcs" role="2OqNvi">
+                <ref role="37wK5l" to="mhbf:~SModelReference.resolve(org.jetbrains.mps.openapi.module.SRepository)" resolve="resolve" />
+                <node concept="2EnYce" id="2GFEb9MWO26" role="37wK5m">
+                  <node concept="2OqwBi" id="2GFEb9MWFLQ" role="2Oq$k0">
+                    <node concept="liA8E" id="2GFEb9MWH5M" role="2OqNvi">
+                      <ref role="37wK5l" to="mhbf:~SNode.getModel()" resolve="getModel" />
+                    </node>
+                    <node concept="2JrnkZ" id="2GFEb9MWFLV" role="2Oq$k0">
+                      <node concept="13iPFW" id="2GFEb9MWBNw" role="2JrQYb" />
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="2GFEb9MWJ2O" role="2OqNvi">
+                    <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="2GFEb9MYqAf" role="3cqZAp">
+          <node concept="2OqwBi" id="2GFEb9MY4BR" role="3clFbG">
+            <node concept="2OqwBi" id="2GFEb9MWXLw" role="2Oq$k0">
+              <node concept="2OqwBi" id="2GFEb9MVuo_" role="2Oq$k0">
+                <node concept="37vLTw" id="2GFEb9MVufp" role="2Oq$k0">
+                  <ref role="3cqZAo" node="2GFEb9MWnoA" resolve="rightModel" />
+                </node>
+                <node concept="2SmgA7" id="2GFEb9MWVbQ" role="2OqNvi" />
+              </node>
+              <node concept="3$u5V9" id="2GFEb9MX1yY" role="2OqNvi">
+                <node concept="1bVj0M" id="2GFEb9MX1z0" role="23t8la">
+                  <node concept="3clFbS" id="2GFEb9MX1z1" role="1bW5cS">
+                    <node concept="3clFbF" id="2GFEb9MX2bG" role="3cqZAp">
+                      <node concept="2OqwBi" id="2GFEb9MXzSR" role="3clFbG">
+                        <node concept="2OqwBi" id="2GFEb9MX2qd" role="2Oq$k0">
+                          <node concept="37vLTw" id="2GFEb9MX2bF" role="2Oq$k0">
+                            <ref role="3cqZAo" node="2GFEb9MX1z2" resolve="it" />
+                          </node>
+                          <node concept="2yIwOk" id="2GFEb9MXx1U" role="2OqNvi" />
+                        </node>
+                        <node concept="FGMqu" id="2GFEb9MX_yG" role="2OqNvi" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="gl6BB" id="2GFEb9MX1z2" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="2GFEb9MX1z3" role="1tU5fm" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="1VAtEI" id="2GFEb9MY70a" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="2GFEb9MZlei" role="3clF46">
+        <property role="TrG5h" value="modelExp" />
+        <node concept="3Tqbb2" id="2GFEb9MZleh" role="1tU5fm">
+          <ref role="ehGHo" to="tp25:1Bs_61$nfRn" resolve="ModelPointerExpression" />
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="2GFEb9NeBtJ" role="1B3o_S" />
+    </node>
+    <node concept="13i0hz" id="2GFEb9MZQtm" role="13h7CS">
+      <property role="TrG5h" value="conceptsCoveredByPolicies" />
+      <node concept="A3Dl8" id="2GFEb9N0yvA" role="3clF45">
+        <node concept="3Tqbb2" id="2GFEb9N0z0Q" role="A3Ik2">
+          <ref role="ehGHo" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="2GFEb9MZQtp" role="3clF47">
+        <node concept="3clFbF" id="2GFEb9N0FOo" role="3cqZAp">
+          <node concept="2OqwBi" id="2GFEb9N1jr9" role="3clFbG">
+            <node concept="2OqwBi" id="2GFEb9N0H9J" role="2Oq$k0">
+              <node concept="2OqwBi" id="2GFEb9N0G1$" role="2Oq$k0">
+                <node concept="13iPFW" id="2GFEb9N0FOn" role="2Oq$k0" />
+                <node concept="3TrEf2" id="2GFEb9N0GVS" role="2OqNvi">
+                  <ref role="3Tt5mk" to="mopj:5zr7Q_1IGSD" resolve="modelMerge" />
+                </node>
+              </node>
+              <node concept="2qgKlT" id="2GFEb9N1hSa" role="2OqNvi">
+                <ref role="37wK5l" node="3xJ_LYXj1c6" resolve="conceptToDefinedMergePolicy" />
+              </node>
+            </node>
+            <node concept="3lbrtF" id="2GFEb9N1liJ" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="2GFEb9NeoZU" role="1B3o_S" />
+    </node>
     <node concept="13hLZK" id="6Ltuup4sL$6" role="13h7CW">
       <node concept="3clFbS" id="6Ltuup4sL$7" role="2VODD2" />
     </node>
@@ -2878,6 +3004,133 @@
     </node>
     <node concept="13hLZK" id="1Tugx$Uc$5" role="13h7CW">
       <node concept="3clFbS" id="1Tugx$Uc$6" role="2VODD2" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="3P8JlgmNo1p">
+    <ref role="13h7C2" to="mopj:3P8JlgmMYnQ" resolve="MergerDefaultAction" />
+    <node concept="13hLZK" id="3P8JlgmNo1q" role="13h7CW">
+      <node concept="3clFbS" id="3P8JlgmNo1r" role="2VODD2">
+        <node concept="3clFbF" id="zgvH9F14Vt" role="3cqZAp">
+          <node concept="37vLTI" id="zgvH9F16YR" role="3clFbG">
+            <node concept="2pJPEk" id="zgvH9F17yv" role="37vLTx">
+              <node concept="2pJPED" id="zgvH9F17yx" role="2pJPEn">
+                <ref role="2pJxaS" to="mopj:6zqIeMU2OVm" resolve="Right" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="zgvH9F15Aw" role="37vLTJ">
+              <node concept="13iPFW" id="zgvH9F14Vs" role="2Oq$k0" />
+              <node concept="3TrEf2" id="zgvH9F16gV" role="2OqNvi">
+                <ref role="3Tt5mk" to="mopj:zgvH9CGvYJ" resolve="propertyAction" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="zgvH9F1lDP" role="3cqZAp">
+          <node concept="37vLTI" id="zgvH9F1ogd" role="3clFbG">
+            <node concept="2pJPEk" id="zgvH9F1oNP" role="37vLTx">
+              <node concept="2pJPED" id="zgvH9F1oNR" role="2pJPEn">
+                <ref role="2pJxaS" to="mopj:7jyS5urbByR" resolve="Auto" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="zgvH9F1lQN" role="37vLTJ">
+              <node concept="13iPFW" id="zgvH9F1lGu" role="2Oq$k0" />
+              <node concept="3TrEf2" id="zgvH9F1n3l" role="2OqNvi">
+                <ref role="3Tt5mk" to="mopj:zgvH9CGxS0" resolve="singleChildAction" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="zgvH9F1pTW" role="3cqZAp">
+          <node concept="37vLTI" id="zgvH9F1pTX" role="3clFbG">
+            <node concept="2pJPEk" id="zgvH9F1pTY" role="37vLTx">
+              <node concept="2pJPED" id="zgvH9F1pTZ" role="2pJPEn">
+                <ref role="2pJxaS" to="mopj:7jyS5urbByR" resolve="Auto" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="zgvH9F1pU0" role="37vLTJ">
+              <node concept="13iPFW" id="zgvH9F1pU1" role="2Oq$k0" />
+              <node concept="3TrEf2" id="zgvH9F1pU2" role="2OqNvi">
+                <ref role="3Tt5mk" to="mopj:zgvH9CGyNu" resolve="optionalChildAction" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="zgvH9F1pV$" role="3cqZAp">
+          <node concept="37vLTI" id="zgvH9F1pV_" role="3clFbG">
+            <node concept="2pJPEk" id="zgvH9F1pVA" role="37vLTx">
+              <node concept="2pJPED" id="zgvH9F1pVB" role="2pJPEn">
+                <ref role="2pJxaS" to="mopj:7jyS5urldTF" resolve="Add" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="zgvH9F1pVC" role="37vLTJ">
+              <node concept="13iPFW" id="zgvH9F1pVD" role="2Oq$k0" />
+              <node concept="3TrEf2" id="zgvH9F1pVE" role="2OqNvi">
+                <ref role="3Tt5mk" to="mopj:zgvH9CGzp5" resolve="existsOnlyOnRightAction" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="zgvH9F1qt4" role="3cqZAp">
+          <node concept="37vLTI" id="zgvH9F1qt5" role="3clFbG">
+            <node concept="2pJPEk" id="zgvH9F1qt6" role="37vLTx">
+              <node concept="2pJPED" id="zgvH9F1qt7" role="2pJPEn">
+                <ref role="2pJxaS" to="mopj:7jyS5urbByQ" resolve="Drop" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="zgvH9F1qt8" role="37vLTJ">
+              <node concept="13iPFW" id="zgvH9F1qt9" role="2Oq$k0" />
+              <node concept="3TrEf2" id="zgvH9F1qta" role="2OqNvi">
+                <ref role="3Tt5mk" to="mopj:zgvH9CZ$22" resolve="existsOnlyOnLeftAction" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="zgvH9F1qtI" role="3cqZAp">
+          <node concept="37vLTI" id="zgvH9F1qtJ" role="3clFbG">
+            <node concept="2pJPEk" id="zgvH9F1qtK" role="37vLTx">
+              <node concept="2pJPED" id="zgvH9F1qtL" role="2pJPEn">
+                <ref role="2pJxaS" to="mopj:7jyS5urbByR" resolve="Auto" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="zgvH9F1qtM" role="37vLTJ">
+              <node concept="13iPFW" id="zgvH9F1qtN" role="2Oq$k0" />
+              <node concept="3TrEf2" id="zgvH9F1qtO" role="2OqNvi">
+                <ref role="3Tt5mk" to="mopj:zgvH9CZ$2a" resolve="elementOnBothAction" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="zgvH9F1IJl" role="3cqZAp">
+          <node concept="37vLTI" id="zgvH9F1IJm" role="3clFbG">
+            <node concept="2pJPEk" id="zgvH9F1IJn" role="37vLTx">
+              <node concept="2pJPED" id="zgvH9F1IJo" role="2pJPEn">
+                <ref role="2pJxaS" to="mopj:6zqIeMU2OVm" resolve="Right" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="zgvH9F1IJp" role="37vLTJ">
+              <node concept="13iPFW" id="zgvH9F1IJq" role="2Oq$k0" />
+              <node concept="3TrEf2" id="zgvH9F1IJr" role="2OqNvi">
+                <ref role="3Tt5mk" to="mopj:zgvH9CGX3U" resolve="singleRefAction" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="zgvH9F1IKd" role="3cqZAp">
+          <node concept="37vLTI" id="zgvH9F1IKe" role="3clFbG">
+            <node concept="2pJPEk" id="zgvH9F1IKf" role="37vLTx">
+              <node concept="2pJPED" id="zgvH9F1IKg" role="2pJPEn">
+                <ref role="2pJxaS" to="mopj:7jyS5urbByR" resolve="Auto" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="zgvH9F1IKh" role="37vLTJ">
+              <node concept="13iPFW" id="zgvH9F1IKi" role="2Oq$k0" />
+              <node concept="3TrEf2" id="zgvH9F1IKj" role="2OqNvi">
+                <ref role="3Tt5mk" to="mopj:zgvH9CH6fk" resolve="optionalRefAction" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
     </node>
   </node>
 </model>

--- a/code/languages/de.itemis.model.merge/models/de.itemis.model.merge.behavior.mps
+++ b/code/languages/de.itemis.model.merge/models/de.itemis.model.merge.behavior.mps
@@ -2759,7 +2759,7 @@
             <node concept="2OqwBi" id="2GFEb9MWXLw" role="2Oq$k0">
               <node concept="2OqwBi" id="2GFEb9MVuo_" role="2Oq$k0">
                 <node concept="37vLTw" id="2GFEb9MVufp" role="2Oq$k0">
-                  <ref role="3cqZAo" node="2GFEb9MWnoA" resolve="rightModel" />
+                  <ref role="3cqZAo" node="2GFEb9MWnoA" resolve="usedModel" />
                 </node>
                 <node concept="2SmgA7" id="2GFEb9MWVbQ" role="2OqNvi" />
               </node>

--- a/code/languages/de.itemis.model.merge/models/de.itemis.model.merge.editor.mps
+++ b/code/languages/de.itemis.model.merge/models/de.itemis.model.merge.editor.mps
@@ -193,6 +193,9 @@
       <concept id="1079359253375" name="jetbrains.mps.baseLanguage.structure.ParenthesizedExpression" flags="nn" index="1eOMI4">
         <child id="1079359253376" name="expression" index="1eOMHV" />
       </concept>
+      <concept id="1081516740877" name="jetbrains.mps.baseLanguage.structure.NotExpression" flags="nn" index="3fqX7Q">
+        <child id="1081516765348" name="expression" index="3fr31v" />
+      </concept>
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
@@ -364,8 +367,54 @@
           <node concept="2iRkQZ" id="78fCHIExZbM" role="2czzBx" />
         </node>
       </node>
+      <node concept="3EZMnI" id="zgvH9CI7NK" role="3EZMnx">
+        <node concept="3F0ifn" id="zgvH9FadIa" role="3EZMnx" />
+        <node concept="2iRkQZ" id="zgvH9CI7NL" role="2iSdaV" />
+        <node concept="3EZMnI" id="2GFEb9Mv9Px" role="3EZMnx">
+          <node concept="VPM3Z" id="2GFEb9Mv9Pz" role="3F10Kt" />
+          <node concept="3F0ifn" id="2GFEb9Mvcr3" role="3EZMnx">
+            <property role="3F0ifm" value="Using partial policies:" />
+          </node>
+          <node concept="3F0A7n" id="2GFEb9MveuU" role="3EZMnx">
+            <ref role="1NtTu8" to="mopj:2GFEb9MrdCG" resolve="partialPolicy" />
+          </node>
+          <node concept="2iRfu4" id="2GFEb9Mv9PA" role="2iSdaV" />
+        </node>
+        <node concept="3EZMnI" id="zgvH9CdXJl" role="3EZMnx">
+          <node concept="VPM3Z" id="zgvH9CdXJn" role="3F10Kt" />
+          <node concept="2iRfu4" id="zgvH9CdXJq" role="2iSdaV" />
+          <node concept="3F0ifn" id="5Ql4oYCJf6B" role="3EZMnx">
+            <property role="3F0ifm" value="Use default actions: " />
+          </node>
+          <node concept="3F0A7n" id="5Ql4oYCJeF_" role="3EZMnx">
+            <ref role="1NtTu8" to="mopj:5Ql4oYC0__d" resolve="useDefaults" />
+          </node>
+        </node>
+        <node concept="3EZMnI" id="zgvH9Fz1Un" role="3EZMnx">
+          <node concept="l2Vlx" id="zgvH9Fz1Uo" role="2iSdaV" />
+          <node concept="3F1sOY" id="zgvH9CI8ak" role="3EZMnx">
+            <ref role="1NtTu8" to="mopj:kewvT_SiLF" resolve="defaultAction" />
+            <node concept="pkWqt" id="zgvH9CI8mW" role="pqm2j">
+              <node concept="3clFbS" id="zgvH9CI8mX" role="2VODD2">
+                <node concept="3clFbF" id="zgvH9CIfJH" role="3cqZAp">
+                  <node concept="2OqwBi" id="zgvH9CIgde" role="3clFbG">
+                    <node concept="pncrf" id="zgvH9CIfJG" role="2Oq$k0" />
+                    <node concept="3TrcHB" id="zgvH9CIgEv" role="2OqNvi">
+                      <ref role="3TsBF5" to="mopj:5Ql4oYC0__d" resolve="useDefaults" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="lj46D" id="zgvH9FqK7B" role="3F10Kt">
+              <property role="VOm3f" value="true" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3F0ifn" id="5Ql4oYCeVe4" role="3EZMnx" />
       <node concept="3F2HdR" id="1EbzjT2RA56" role="3EZMnx">
-        <ref role="1NtTu8" to="mopj:1EbzjT2R$JQ" resolve="items" />
+        <ref role="1NtTu8" to="mopj:1EbzjT2R$JQ" resolve="userPolicies" />
         <node concept="2iRkQZ" id="1EbzjT2RA58" role="2czzBx" />
         <node concept="4$FPG" id="1EbzjT2RGFW" role="4_6I_">
           <node concept="3clFbS" id="1EbzjT2RGFX" role="2VODD2">
@@ -384,204 +433,6 @@
   <node concept="24kQdi" id="1EbzjT2RA67">
     <ref role="1XX52x" to="mopj:1EbzjT2RA5e" resolve="EmptyMergeItem" />
     <node concept="3F0ifn" id="1EbzjT2RA69" role="2wV5jI" />
-  </node>
-  <node concept="24kQdi" id="1EbzjT2RI8k">
-    <ref role="1XX52x" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
-    <node concept="3EZMnI" id="1EbzjT2RQ93" role="2wV5jI">
-      <node concept="3EZMnI" id="1EbzjT2RQ9a" role="3EZMnx">
-        <node concept="VPM3Z" id="1EbzjT2RQ9c" role="3F10Kt" />
-        <node concept="3F0ifn" id="1EbzjT2RQ9e" role="3EZMnx">
-          <property role="3F0ifm" value="Merge Policy:" />
-          <node concept="VSNWy" id="5zr7Q_1x5jE" role="3F10Kt">
-            <node concept="1cFabM" id="5zr7Q_1x5jG" role="1d8cEk">
-              <node concept="3clFbS" id="5zr7Q_1x5jH" role="2VODD2">
-                <node concept="3clFbF" id="5zr7Q_1x5sQ" role="3cqZAp">
-                  <node concept="3cmrfG" id="5zr7Q_1y4wW" role="3clFbG">
-                    <property role="3cmrfH" value="18" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1iCGBv" id="2dyrZ3FdMBU" role="3EZMnx">
-          <ref role="1NtTu8" to="mopj:3BP4DuXu_FH" resolve="conceptRef" />
-          <node concept="1sVBvm" id="2dyrZ3FdMBW" role="1sWHZn">
-            <node concept="3F0A7n" id="2dyrZ3FdMC4" role="2wV5jI">
-              <property role="1Intyy" value="true" />
-              <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
-              <node concept="VechU" id="5zr7Q_1wsB9" role="3F10Kt">
-                <node concept="1iSF2X" id="5zr7Q_1wsBc" role="VblUZ">
-                  <property role="1iTho6" value="4b0082" />
-                </node>
-              </node>
-              <node concept="Vb9p2" id="5zr7Q_1wKXo" role="3F10Kt">
-                <property role="Vbekb" value="g1_k_vY/BOLD" />
-              </node>
-              <node concept="VSNWy" id="5zr7Q_1yqwv" role="3F10Kt">
-                <node concept="1cFabM" id="5zr7Q_1yqw_" role="1d8cEk">
-                  <node concept="3clFbS" id="5zr7Q_1yqwA" role="2VODD2">
-                    <node concept="3clFbF" id="5zr7Q_1yqDJ" role="3cqZAp">
-                      <node concept="3cmrfG" id="5zr7Q_1yqDI" role="3clFbG">
-                        <property role="3cmrfH" value="18" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="2iRfu4" id="1EbzjT2RQ9f" role="2iSdaV" />
-      </node>
-      <node concept="3EZMnI" id="6celbXx439E" role="3EZMnx">
-        <node concept="l2Vlx" id="6celbXx439F" role="2iSdaV" />
-        <node concept="3EZMnI" id="6celbXx37E6" role="3EZMnx">
-          <node concept="VPM3Z" id="6celbXx37E8" role="3F10Kt" />
-          <node concept="3F0ifn" id="6celbXx37Ea" role="3EZMnx">
-            <property role="3F0ifm" value="ID:" />
-          </node>
-          <node concept="2iRfu4" id="6celbXx37Eb" role="2iSdaV" />
-          <node concept="3F1sOY" id="6celbXx2cCB" role="3EZMnx">
-            <ref role="1NtTu8" to="mopj:6celbXx2c94" resolve="idFunction" />
-          </node>
-          <node concept="lj46D" id="6celbXx4YyU" role="3F10Kt">
-            <property role="VOm3f" value="true" />
-          </node>
-        </node>
-      </node>
-      <node concept="3EZMnI" id="6zqIeMU2qge" role="3EZMnx">
-        <node concept="3F0ifn" id="6zqIeMU2Jid" role="3EZMnx">
-          <property role="3F0ifm" value="Properties:" />
-          <node concept="lj46D" id="6zqIeMU2M80" role="3F10Kt">
-            <property role="VOm3f" value="true" />
-          </node>
-          <node concept="Vb9p2" id="5zr7Q_1va1R" role="3F10Kt">
-            <property role="Vbekb" value="g1_tSyq/BOLD_ITALIC" />
-          </node>
-        </node>
-        <node concept="l2Vlx" id="6zqIeMU2qgf" role="2iSdaV" />
-        <node concept="3EZMnI" id="5zr7Q_1uc1Q" role="3EZMnx">
-          <node concept="l2Vlx" id="5zr7Q_1uc1R" role="2iSdaV" />
-          <node concept="3F2HdR" id="5zr7Q_1uc1S" role="3EZMnx">
-            <ref role="1NtTu8" to="mopj:1EbzjT2T4LX" resolve="propertyPolicies" />
-            <node concept="2iRkQZ" id="5zr7Q_1uc1T" role="2czzBx" />
-            <node concept="lj46D" id="5zr7Q_1uc1U" role="3F10Kt">
-              <property role="VOm3f" value="true" />
-            </node>
-          </node>
-          <node concept="lj46D" id="5zr7Q_1uc1V" role="3F10Kt">
-            <property role="VOm3f" value="true" />
-          </node>
-        </node>
-        <node concept="pj6Ft" id="6zqIeMU2sqF" role="3F10Kt">
-          <property role="VOm3f" value="true" />
-        </node>
-        <node concept="pkWqt" id="2dyrZ3FhQFl" role="pqm2j">
-          <node concept="3clFbS" id="2dyrZ3FhQFm" role="2VODD2">
-            <node concept="3clFbF" id="2dyrZ3Fhrnn" role="3cqZAp">
-              <node concept="2OqwBi" id="5zr7Q_1Vzku" role="3clFbG">
-                <node concept="2OqwBi" id="2dyrZ3Fhsl2" role="2Oq$k0">
-                  <node concept="pncrf" id="2dyrZ3FhBbH" role="2Oq$k0" />
-                  <node concept="2qgKlT" id="5zr7Q_1VyQL" role="2OqNvi">
-                    <ref role="37wK5l" to="rnx3:5zr7Q_1V6SF" resolve="allHierarchyProperties" />
-                  </node>
-                </node>
-                <node concept="3GX2aA" id="7TOowlgsccR" role="2OqNvi" />
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3EZMnI" id="7jyS5urbKXG" role="3EZMnx">
-        <node concept="3F0ifn" id="7jyS5urbKXH" role="3EZMnx">
-          <property role="3F0ifm" value="Children:" />
-          <node concept="lj46D" id="7jyS5urbKXI" role="3F10Kt">
-            <property role="VOm3f" value="true" />
-          </node>
-          <node concept="Vb9p2" id="5zr7Q_1w8gb" role="3F10Kt">
-            <property role="Vbekb" value="g1_tSyq/BOLD_ITALIC" />
-          </node>
-        </node>
-        <node concept="l2Vlx" id="7jyS5urbKXJ" role="2iSdaV" />
-        <node concept="3EZMnI" id="5zr7Q_1tQGv" role="3EZMnx">
-          <node concept="l2Vlx" id="5zr7Q_1tQGw" role="2iSdaV" />
-          <node concept="3F2HdR" id="7jyS5urbKXK" role="3EZMnx">
-            <ref role="1NtTu8" to="mopj:7jyS5urbJZ5" resolve="childPolicies" />
-            <node concept="2iRkQZ" id="7jyS5urbKXL" role="2czzBx" />
-            <node concept="lj46D" id="7jyS5urbKXM" role="3F10Kt">
-              <property role="VOm3f" value="true" />
-            </node>
-          </node>
-          <node concept="lj46D" id="5zr7Q_1tQIE" role="3F10Kt">
-            <property role="VOm3f" value="true" />
-          </node>
-        </node>
-        <node concept="pj6Ft" id="7jyS5urbKXN" role="3F10Kt">
-          <property role="VOm3f" value="true" />
-        </node>
-        <node concept="pkWqt" id="2dyrZ3FhRaL" role="pqm2j">
-          <node concept="3clFbS" id="2dyrZ3FhRaM" role="2VODD2">
-            <node concept="3clFbF" id="2dyrZ3FhRb8" role="3cqZAp">
-              <node concept="2OqwBi" id="7TOowlgr2pB" role="3clFbG">
-                <node concept="2OqwBi" id="2dyrZ3FhRbd" role="2Oq$k0">
-                  <node concept="pncrf" id="2dyrZ3FhRbe" role="2Oq$k0" />
-                  <node concept="2qgKlT" id="7TOowlgr25s" role="2OqNvi">
-                    <ref role="37wK5l" to="rnx3:5zr7Q_1WLCS" resolve="allHierarchyChildren" />
-                  </node>
-                </node>
-                <node concept="3GX2aA" id="7TOowlgr2Km" role="2OqNvi" />
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3EZMnI" id="3PLTv5jzaq_" role="3EZMnx">
-        <node concept="3F0ifn" id="3PLTv5jzaqA" role="3EZMnx">
-          <property role="3F0ifm" value="References:" />
-          <node concept="lj46D" id="3PLTv5jzaqB" role="3F10Kt">
-            <property role="VOm3f" value="true" />
-          </node>
-          <node concept="Vb9p2" id="3PLTv5jzaqC" role="3F10Kt">
-            <property role="Vbekb" value="g1_tSyq/BOLD_ITALIC" />
-          </node>
-        </node>
-        <node concept="l2Vlx" id="3PLTv5jzaqD" role="2iSdaV" />
-        <node concept="3EZMnI" id="3PLTv5jzaqE" role="3EZMnx">
-          <node concept="l2Vlx" id="3PLTv5jzaqF" role="2iSdaV" />
-          <node concept="3F2HdR" id="3PLTv5jzaqG" role="3EZMnx">
-            <ref role="1NtTu8" to="mopj:3PLTv5jwPvF" resolve="referencePolicies" />
-            <node concept="2iRkQZ" id="3PLTv5jzaqH" role="2czzBx" />
-            <node concept="lj46D" id="3PLTv5jzaqI" role="3F10Kt">
-              <property role="VOm3f" value="true" />
-            </node>
-          </node>
-          <node concept="lj46D" id="3PLTv5jzaqJ" role="3F10Kt">
-            <property role="VOm3f" value="true" />
-          </node>
-        </node>
-        <node concept="pj6Ft" id="3PLTv5jzaqK" role="3F10Kt">
-          <property role="VOm3f" value="true" />
-        </node>
-        <node concept="pkWqt" id="3PLTv5jzaqL" role="pqm2j">
-          <node concept="3clFbS" id="3PLTv5jzaqM" role="2VODD2">
-            <node concept="3clFbF" id="3PLTv5jzaqN" role="3cqZAp">
-              <node concept="2OqwBi" id="3PLTv5jzaqO" role="3clFbG">
-                <node concept="2OqwBi" id="3PLTv5jzaqP" role="2Oq$k0">
-                  <node concept="pncrf" id="3PLTv5jzaqQ" role="2Oq$k0" />
-                  <node concept="2qgKlT" id="3PLTv5j$iE1" role="2OqNvi">
-                    <ref role="37wK5l" to="rnx3:3PLTv5jznVy" resolve="allHierarchyReferences" />
-                  </node>
-                </node>
-                <node concept="3GX2aA" id="3PLTv5jzaqS" role="2OqNvi" />
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3F0ifn" id="7jyS5urbKXt" role="3EZMnx" />
-      <node concept="2iRkQZ" id="1EbzjT2RQ96" role="2iSdaV" />
-    </node>
   </node>
   <node concept="24kQdi" id="1EbzjT2T4JE">
     <property role="3GE5qa" value="elementpolicies" />
@@ -2275,6 +2126,325 @@
       </node>
     </node>
     <node concept="B$lHz" id="1Tugx$DtAg" role="6VMZX" />
+  </node>
+  <node concept="24kQdi" id="3P8JlgmNhke">
+    <ref role="1XX52x" to="mopj:3P8JlgmMYnQ" resolve="MergerDefaultAction" />
+    <node concept="3EZMnI" id="zgvH9CZtv$" role="2wV5jI">
+      <node concept="3EZMnI" id="53lMkCJCyQa" role="3EZMnx">
+        <node concept="2iRfu4" id="53lMkCJCyQb" role="2iSdaV" />
+        <node concept="3F0ifn" id="53lMkCJCyQc" role="3EZMnx">
+          <property role="3F0ifm" value="Properties: " />
+        </node>
+        <node concept="3F1sOY" id="53lMkCJCyQd" role="3EZMnx">
+          <ref role="1NtTu8" to="mopj:zgvH9CGvYJ" resolve="propertyAction" />
+        </node>
+      </node>
+      <node concept="3EZMnI" id="zgvH9CZuuO" role="3EZMnx">
+        <node concept="2iRfu4" id="zgvH9CZuuP" role="2iSdaV" />
+        <node concept="3F0ifn" id="zgvH9CZuuQ" role="3EZMnx">
+          <property role="3F0ifm" value="Single child: " />
+        </node>
+        <node concept="3F1sOY" id="zgvH9DUzcA" role="3EZMnx">
+          <ref role="1NtTu8" to="mopj:zgvH9CGxS0" resolve="singleﬁChildAction" />
+        </node>
+      </node>
+      <node concept="3EZMnI" id="zgvH9CZver" role="3EZMnx">
+        <node concept="2iRfu4" id="zgvH9CZves" role="2iSdaV" />
+        <node concept="3F0ifn" id="zgvH9CZvet" role="3EZMnx">
+          <property role="3F0ifm" value="Optional child: " />
+        </node>
+        <node concept="3F1sOY" id="zgvH9DUzm6" role="3EZMnx">
+          <ref role="1NtTu8" to="mopj:zgvH9CGyNu" resolve="optionalChildAction" />
+        </node>
+      </node>
+      <node concept="3EZMnI" id="zgvH9CZveO" role="3EZMnx">
+        <node concept="2iRfu4" id="zgvH9CZveP" role="2iSdaV" />
+        <node concept="3F0ifn" id="zgvH9CZveQ" role="3EZMnx">
+          <property role="3F0ifm" value="Multiple childen: " />
+        </node>
+      </node>
+      <node concept="3EZMnI" id="zgvH9CZxeX" role="3EZMnx">
+        <node concept="VPM3Z" id="zgvH9CZxeZ" role="3F10Kt" />
+        <node concept="3EZMnI" id="zgvH9CZxs4" role="3EZMnx">
+          <node concept="VPM3Z" id="zgvH9CZxs6" role="3F10Kt" />
+          <node concept="3EZMnI" id="zgvH9Dolw9" role="3EZMnx">
+            <node concept="2iRfu4" id="zgvH9Dolwa" role="2iSdaV" />
+            <node concept="3F0ifn" id="zgvH9DolDQ" role="3EZMnx">
+              <property role="3F0ifm" value="Element Exists Only On The Right: " />
+            </node>
+            <node concept="3F1sOY" id="zgvH9DUzCY" role="3EZMnx">
+              <ref role="1NtTu8" to="mopj:zgvH9CGzp5" resolve="existsOnlyOnRightAction" />
+            </node>
+          </node>
+          <node concept="3EZMnI" id="zgvH9Dom2W" role="3EZMnx">
+            <node concept="2iRfu4" id="zgvH9Dom2X" role="2iSdaV" />
+            <node concept="3F0ifn" id="zgvH9DomvQ" role="3EZMnx">
+              <property role="3F0ifm" value="Element Exists Only On Left Side: " />
+            </node>
+            <node concept="3F1sOY" id="zgvH9DUzSM" role="3EZMnx">
+              <ref role="1NtTu8" to="mopj:zgvH9CZ$22" resolve="existsOnlyOnLeftAction" />
+            </node>
+          </node>
+          <node concept="3EZMnI" id="zgvH9Dom6n" role="3EZMnx">
+            <node concept="2iRfu4" id="zgvH9Dom6o" role="2iSdaV" />
+            <node concept="3F0ifn" id="zgvH9DomMG" role="3EZMnx">
+              <property role="3F0ifm" value="Element Exists On Both Sides: " />
+            </node>
+            <node concept="3F1sOY" id="zgvH9DU$5u" role="3EZMnx">
+              <ref role="1NtTu8" to="mopj:zgvH9CZ$2a" resolve="elementOnBothAction" />
+            </node>
+          </node>
+          <node concept="2iRkQZ" id="zgvH9CZxs9" role="2iSdaV" />
+          <node concept="lj46D" id="zgvH9D7OA_" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+        </node>
+        <node concept="l2Vlx" id="zgvH9CZxf2" role="2iSdaV" />
+      </node>
+      <node concept="3EZMnI" id="zgvH9CZvfj" role="3EZMnx">
+        <node concept="2iRfu4" id="zgvH9CZvfk" role="2iSdaV" />
+        <node concept="3F0ifn" id="zgvH9CZvfl" role="3EZMnx">
+          <property role="3F0ifm" value="Single reference: " />
+        </node>
+        <node concept="3F1sOY" id="zgvH9DU$om" role="3EZMnx">
+          <ref role="1NtTu8" to="mopj:zgvH9CGX3U" resolve="singleRefAction" />
+        </node>
+      </node>
+      <node concept="3EZMnI" id="zgvH9D7O0e" role="3EZMnx">
+        <node concept="2iRfu4" id="zgvH9D7O0f" role="2iSdaV" />
+        <node concept="3F0ifn" id="zgvH9D7O0g" role="3EZMnx">
+          <property role="3F0ifm" value="Optional reference: " />
+        </node>
+        <node concept="3F1sOY" id="zgvH9DU$$Y" role="3EZMnx">
+          <ref role="1NtTu8" to="mopj:zgvH9CH6fk" resolve="optionalRefAction" />
+        </node>
+      </node>
+      <node concept="2iRkQZ" id="zgvH9CZtvB" role="2iSdaV" />
+    </node>
+  </node>
+  <node concept="24kQdi" id="1EbzjT2RI8k">
+    <ref role="1XX52x" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
+    <node concept="3EZMnI" id="1EbzjT2RQ93" role="2wV5jI">
+      <node concept="3EZMnI" id="1EbzjT2RQ9a" role="3EZMnx">
+        <node concept="VPM3Z" id="1EbzjT2RQ9c" role="3F10Kt" />
+        <node concept="3F0ifn" id="1EbzjT2RQ9e" role="3EZMnx">
+          <property role="3F0ifm" value="Merge Policy:" />
+          <node concept="VSNWy" id="5zr7Q_1x5jE" role="3F10Kt">
+            <node concept="1cFabM" id="5zr7Q_1x5jG" role="1d8cEk">
+              <node concept="3clFbS" id="5zr7Q_1x5jH" role="2VODD2">
+                <node concept="3clFbF" id="5zr7Q_1x5sQ" role="3cqZAp">
+                  <node concept="3cmrfG" id="5zr7Q_1y4wW" role="3clFbG">
+                    <property role="3cmrfH" value="18" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1iCGBv" id="2dyrZ3FdMBU" role="3EZMnx">
+          <ref role="1NtTu8" to="mopj:3BP4DuXu_FH" resolve="conceptRef" />
+          <node concept="1sVBvm" id="2dyrZ3FdMBW" role="1sWHZn">
+            <node concept="3F0A7n" id="2dyrZ3FdMC4" role="2wV5jI">
+              <property role="1Intyy" value="true" />
+              <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
+              <node concept="VechU" id="5zr7Q_1wsB9" role="3F10Kt">
+                <node concept="1iSF2X" id="5zr7Q_1wsBc" role="VblUZ">
+                  <property role="1iTho6" value="4b0082" />
+                </node>
+              </node>
+              <node concept="Vb9p2" id="5zr7Q_1wKXo" role="3F10Kt">
+                <property role="Vbekb" value="g1_k_vY/BOLD" />
+              </node>
+              <node concept="VSNWy" id="5zr7Q_1yqwv" role="3F10Kt">
+                <node concept="1cFabM" id="5zr7Q_1yqw_" role="1d8cEk">
+                  <node concept="3clFbS" id="5zr7Q_1yqwA" role="2VODD2">
+                    <node concept="3clFbF" id="5zr7Q_1yqDJ" role="3cqZAp">
+                      <node concept="3cmrfG" id="5zr7Q_1yqDI" role="3clFbG">
+                        <property role="3cmrfH" value="18" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2iRfu4" id="1EbzjT2RQ9f" role="2iSdaV" />
+      </node>
+      <node concept="3EZMnI" id="5xmpdH7c_F3" role="3EZMnx">
+        <node concept="2iRfu4" id="5xmpdH7c_F4" role="2iSdaV" />
+        <node concept="3F0ifn" id="5xmpdH7cwYV" role="3EZMnx">
+          <property role="3F0ifm" value="Use default actions: " />
+        </node>
+        <node concept="3F0A7n" id="5xmpdH7cBhu" role="3EZMnx">
+          <ref role="1NtTu8" to="mopj:5xmpdH7cpzi" resolve="useDefaults" />
+        </node>
+      </node>
+      <node concept="3EZMnI" id="6celbXx439E" role="3EZMnx">
+        <node concept="l2Vlx" id="6celbXx439F" role="2iSdaV" />
+        <node concept="3EZMnI" id="6celbXx37E6" role="3EZMnx">
+          <node concept="VPM3Z" id="6celbXx37E8" role="3F10Kt" />
+          <node concept="3F0ifn" id="6celbXx37Ea" role="3EZMnx">
+            <property role="3F0ifm" value="ID:" />
+          </node>
+          <node concept="2iRfu4" id="6celbXx37Eb" role="2iSdaV" />
+          <node concept="3F1sOY" id="6celbXx2cCB" role="3EZMnx">
+            <ref role="1NtTu8" to="mopj:6celbXx2c94" resolve="idFunction" />
+          </node>
+          <node concept="lj46D" id="6celbXx4YyU" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+        </node>
+      </node>
+      <node concept="3EZMnI" id="5xmpdH7cPcJ" role="3EZMnx">
+        <node concept="VPM3Z" id="5xmpdH7cPcL" role="3F10Kt" />
+        <node concept="2iRkQZ" id="5xmpdH7cPcO" role="2iSdaV" />
+        <node concept="3EZMnI" id="6zqIeMU2qge" role="3EZMnx">
+          <node concept="3F0ifn" id="6zqIeMU2Jid" role="3EZMnx">
+            <property role="3F0ifm" value="Properties:" />
+            <node concept="lj46D" id="6zqIeMU2M80" role="3F10Kt">
+              <property role="VOm3f" value="true" />
+            </node>
+            <node concept="Vb9p2" id="5zr7Q_1va1R" role="3F10Kt">
+              <property role="Vbekb" value="g1_tSyq/BOLD_ITALIC" />
+            </node>
+          </node>
+          <node concept="l2Vlx" id="6zqIeMU2qgf" role="2iSdaV" />
+          <node concept="3EZMnI" id="5zr7Q_1uc1Q" role="3EZMnx">
+            <node concept="l2Vlx" id="5zr7Q_1uc1R" role="2iSdaV" />
+            <node concept="3F2HdR" id="5zr7Q_1uc1S" role="3EZMnx">
+              <ref role="1NtTu8" to="mopj:1EbzjT2T4LX" resolve="propertyPolicies" />
+              <node concept="2iRkQZ" id="5zr7Q_1uc1T" role="2czzBx" />
+              <node concept="lj46D" id="5zr7Q_1uc1U" role="3F10Kt">
+                <property role="VOm3f" value="true" />
+              </node>
+            </node>
+            <node concept="lj46D" id="5zr7Q_1uc1V" role="3F10Kt">
+              <property role="VOm3f" value="true" />
+            </node>
+          </node>
+          <node concept="pj6Ft" id="6zqIeMU2sqF" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+          <node concept="pkWqt" id="2dyrZ3FhQFl" role="pqm2j">
+            <node concept="3clFbS" id="2dyrZ3FhQFm" role="2VODD2">
+              <node concept="3clFbF" id="2dyrZ3Fhrnn" role="3cqZAp">
+                <node concept="2OqwBi" id="5zr7Q_1Vzku" role="3clFbG">
+                  <node concept="2OqwBi" id="2dyrZ3Fhsl2" role="2Oq$k0">
+                    <node concept="pncrf" id="2dyrZ3FhBbH" role="2Oq$k0" />
+                    <node concept="2qgKlT" id="5zr7Q_1VyQL" role="2OqNvi">
+                      <ref role="37wK5l" to="rnx3:5zr7Q_1V6SF" resolve="allHierarchyProperties" />
+                    </node>
+                  </node>
+                  <node concept="3GX2aA" id="7TOowlgsccR" role="2OqNvi" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3EZMnI" id="7jyS5urbKXG" role="3EZMnx">
+          <node concept="3F0ifn" id="7jyS5urbKXH" role="3EZMnx">
+            <property role="3F0ifm" value="Children:" />
+            <node concept="lj46D" id="7jyS5urbKXI" role="3F10Kt">
+              <property role="VOm3f" value="true" />
+            </node>
+            <node concept="Vb9p2" id="5zr7Q_1w8gb" role="3F10Kt">
+              <property role="Vbekb" value="g1_tSyq/BOLD_ITALIC" />
+            </node>
+          </node>
+          <node concept="l2Vlx" id="7jyS5urbKXJ" role="2iSdaV" />
+          <node concept="3EZMnI" id="5zr7Q_1tQGv" role="3EZMnx">
+            <node concept="l2Vlx" id="5zr7Q_1tQGw" role="2iSdaV" />
+            <node concept="3F2HdR" id="7jyS5urbKXK" role="3EZMnx">
+              <ref role="1NtTu8" to="mopj:7jyS5urbJZ5" resolve="childPolicies" />
+              <node concept="2iRkQZ" id="7jyS5urbKXL" role="2czzBx" />
+              <node concept="lj46D" id="7jyS5urbKXM" role="3F10Kt">
+                <property role="VOm3f" value="true" />
+              </node>
+            </node>
+            <node concept="lj46D" id="5zr7Q_1tQIE" role="3F10Kt">
+              <property role="VOm3f" value="true" />
+            </node>
+          </node>
+          <node concept="pj6Ft" id="7jyS5urbKXN" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+          <node concept="pkWqt" id="2dyrZ3FhRaL" role="pqm2j">
+            <node concept="3clFbS" id="2dyrZ3FhRaM" role="2VODD2">
+              <node concept="3clFbF" id="2dyrZ3FhRb8" role="3cqZAp">
+                <node concept="2OqwBi" id="7TOowlgr2pB" role="3clFbG">
+                  <node concept="2OqwBi" id="2dyrZ3FhRbd" role="2Oq$k0">
+                    <node concept="pncrf" id="2dyrZ3FhRbe" role="2Oq$k0" />
+                    <node concept="2qgKlT" id="7TOowlgr25s" role="2OqNvi">
+                      <ref role="37wK5l" to="rnx3:5zr7Q_1WLCS" resolve="allHierarchyChildren" />
+                    </node>
+                  </node>
+                  <node concept="3GX2aA" id="7TOowlgr2Km" role="2OqNvi" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3EZMnI" id="3PLTv5jzaq_" role="3EZMnx">
+          <node concept="3F0ifn" id="3PLTv5jzaqA" role="3EZMnx">
+            <property role="3F0ifm" value="References:" />
+            <node concept="lj46D" id="3PLTv5jzaqB" role="3F10Kt">
+              <property role="VOm3f" value="true" />
+            </node>
+            <node concept="Vb9p2" id="3PLTv5jzaqC" role="3F10Kt">
+              <property role="Vbekb" value="g1_tSyq/BOLD_ITALIC" />
+            </node>
+          </node>
+          <node concept="l2Vlx" id="3PLTv5jzaqD" role="2iSdaV" />
+          <node concept="3EZMnI" id="3PLTv5jzaqE" role="3EZMnx">
+            <node concept="l2Vlx" id="3PLTv5jzaqF" role="2iSdaV" />
+            <node concept="3F2HdR" id="3PLTv5jzaqG" role="3EZMnx">
+              <ref role="1NtTu8" to="mopj:3PLTv5jwPvF" resolve="referencePolicies" />
+              <node concept="2iRkQZ" id="3PLTv5jzaqH" role="2czzBx" />
+              <node concept="lj46D" id="3PLTv5jzaqI" role="3F10Kt">
+                <property role="VOm3f" value="true" />
+              </node>
+            </node>
+            <node concept="lj46D" id="3PLTv5jzaqJ" role="3F10Kt">
+              <property role="VOm3f" value="true" />
+            </node>
+          </node>
+          <node concept="pj6Ft" id="3PLTv5jzaqK" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+          <node concept="pkWqt" id="3PLTv5jzaqL" role="pqm2j">
+            <node concept="3clFbS" id="3PLTv5jzaqM" role="2VODD2">
+              <node concept="3clFbF" id="3PLTv5jzaqN" role="3cqZAp">
+                <node concept="2OqwBi" id="3PLTv5jzaqO" role="3clFbG">
+                  <node concept="2OqwBi" id="3PLTv5jzaqP" role="2Oq$k0">
+                    <node concept="pncrf" id="3PLTv5jzaqQ" role="2Oq$k0" />
+                    <node concept="2qgKlT" id="3PLTv5j$iE1" role="2OqNvi">
+                      <ref role="37wK5l" to="rnx3:3PLTv5jznVy" resolve="allHierarchyReferences" />
+                    </node>
+                  </node>
+                  <node concept="3GX2aA" id="3PLTv5jzaqS" role="2OqNvi" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="pkWqt" id="5xmpdH7cTyz" role="pqm2j">
+          <node concept="3clFbS" id="5xmpdH7cTy$" role="2VODD2">
+            <node concept="3clFbF" id="5xmpdH7cWxy" role="3cqZAp">
+              <node concept="3fqX7Q" id="5xmpdH7cZUw" role="3clFbG">
+                <node concept="2OqwBi" id="5xmpdH7cZUy" role="3fr31v">
+                  <node concept="pncrf" id="5xmpdH7cZUz" role="2Oq$k0" />
+                  <node concept="3TrcHB" id="5xmpdH7cZU$" role="2OqNvi">
+                    <ref role="3TsBF5" to="mopj:5xmpdH7cpzi" resolve="useDefaults" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2iRkQZ" id="1EbzjT2RQ96" role="2iSdaV" />
+    </node>
   </node>
 </model>
 

--- a/code/languages/de.itemis.model.merge/models/de.itemis.model.merge.editor.mps
+++ b/code/languages/de.itemis.model.merge/models/de.itemis.model.merge.editor.mps
@@ -414,7 +414,7 @@
       </node>
       <node concept="3F0ifn" id="5Ql4oYCeVe4" role="3EZMnx" />
       <node concept="3F2HdR" id="1EbzjT2RA56" role="3EZMnx">
-        <ref role="1NtTu8" to="mopj:1EbzjT2R$JQ" resolve="userPolicies" />
+        <ref role="1NtTu8" to="mopj:1EbzjT2R$JQ" resolve="items" />
         <node concept="2iRkQZ" id="1EbzjT2RA58" role="2czzBx" />
         <node concept="4$FPG" id="1EbzjT2RGFW" role="4_6I_">
           <node concept="3clFbS" id="1EbzjT2RGFX" role="2VODD2">
@@ -2145,7 +2145,7 @@
           <property role="3F0ifm" value="Single child: " />
         </node>
         <node concept="3F1sOY" id="zgvH9DUzcA" role="3EZMnx">
-          <ref role="1NtTu8" to="mopj:zgvH9CGxS0" resolve="singleﬁChildAction" />
+          <ref role="1NtTu8" to="mopj:zgvH9CGxS0" resolve="singleChildAction" />
         </node>
       </node>
       <node concept="3EZMnI" id="zgvH9CZver" role="3EZMnx">

--- a/code/languages/de.itemis.model.merge/models/de.itemis.model.merge.structure.mps
+++ b/code/languages/de.itemis.model.merge/models/de.itemis.model.merge.structure.mps
@@ -66,12 +66,15 @@
     <property role="EcuMT" value="1912777765298163335" />
     <property role="TrG5h" value="ModelMerge" />
     <property role="19KtqR" value="true" />
-    <node concept="1TJgyj" id="1EbzjT2R$JQ" role="1TKVEi">
-      <property role="IQ2ns" value="1912777765298260982" />
-      <property role="20lmBu" value="fLJjDmT/aggregation" />
-      <property role="20kJfa" value="items" />
-      <property role="20lbJX" value="fLJekj5/_0__n" />
-      <ref role="20lvS9" node="1EbzjT2R$JU" resolve="ModelMergeItem" />
+    <node concept="1TJgyi" id="2GFEb9MrdCG" role="1TKVEl">
+      <property role="IQ2nx" value="3110765452006840876" />
+      <property role="TrG5h" value="partialPolicy" />
+      <ref role="AX2Wp" to="tpck:fKAQMTB" resolve="boolean" />
+    </node>
+    <node concept="1TJgyi" id="5Ql4oYC0__d" role="1TKVEl">
+      <property role="IQ2nx" value="6743315325753907533" />
+      <property role="TrG5h" value="useDefaults" />
+      <ref role="AX2Wp" to="tpck:fKAQMTB" resolve="boolean" />
     </node>
     <node concept="1TJgyj" id="1VmHfRy0Ud5" role="1TKVEi">
       <property role="IQ2ns" value="2222162468665533253" />
@@ -87,6 +90,19 @@
       <property role="20lbJX" value="fLJekj5/_0__n" />
       <ref role="20lvS9" to="tp25:3TEgbCBRn3N" resolve="LanguageRefExpression" />
     </node>
+    <node concept="1TJgyj" id="kewvT_SiLF" role="1TKVEi">
+      <property role="IQ2ns" value="364371549494520939" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="defaultAction" />
+      <ref role="20lvS9" node="3P8JlgmMYnQ" resolve="MergerDefaultAction" />
+    </node>
+    <node concept="1TJgyj" id="1EbzjT2R$JQ" role="1TKVEi">
+      <property role="IQ2ns" value="1912777765298260982" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="items" />
+      <property role="20lbJX" value="fLJekj5/_0__n" />
+      <ref role="20lvS9" node="1EbzjT2R$JU" resolve="ModelMergeItem" />
+    </node>
     <node concept="PrWs8" id="4mbxYkJdXnB" role="PzmwI">
       <ref role="PrY4T" to="tpck:h0TrEE$" resolve="INamedConcept" />
     </node>
@@ -94,6 +110,9 @@
   <node concept="1TIwiD" id="1EbzjT2R$JP">
     <property role="EcuMT" value="1912777765298260981" />
     <property role="TrG5h" value="MergePolicy" />
+    <node concept="PrWs8" id="1EbzjT2R$JV" role="PzmwI">
+      <ref role="PrY4T" node="1EbzjT2R$JU" resolve="ModelMergeItem" />
+    </node>
     <node concept="1TJgyj" id="3BP4DuXu_FH" role="1TKVEi">
       <property role="IQ2ns" value="4176264672384277229" />
       <property role="20kJfa" value="conceptRef" />
@@ -127,8 +146,10 @@
       <property role="20lbJX" value="fLJekj5/_0__n" />
       <ref role="20lvS9" node="3PLTv5jwPx8" resolve="ReferencePolicy" />
     </node>
-    <node concept="PrWs8" id="1EbzjT2R$JV" role="PzmwI">
-      <ref role="PrY4T" node="1EbzjT2R$JU" resolve="ModelMergeItem" />
+    <node concept="1TJgyi" id="5xmpdH7cpzi" role="1TKVEl">
+      <property role="IQ2nx" value="6365386016289822930" />
+      <property role="TrG5h" value="useDefaults" />
+      <ref role="AX2Wp" to="tpck:fKAQMTB" resolve="boolean" />
     </node>
   </node>
   <node concept="PlHQZ" id="1EbzjT2R$JU">
@@ -513,6 +534,67 @@
     <property role="3GE5qa" value="parameters" />
     <property role="R4oN_" value="Right Version" />
     <ref role="1TJDcQ" to="tpee:g76ryKb" resolve="ConceptFunctionParameter" />
+  </node>
+  <node concept="1TIwiD" id="3P8JlgmMYnQ">
+    <property role="EcuMT" value="4415987603494135286" />
+    <property role="TrG5h" value="MergerDefaultAction" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+    <node concept="1TJgyj" id="zgvH9CGvYJ" role="1TKVEi">
+      <property role="IQ2ns" value="635146989623967663" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="propertyAction" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <ref role="20lvS9" node="6zqIeMU2RWS" resolve="AbstractMergeAction" />
+    </node>
+    <node concept="1TJgyj" id="zgvH9CGxS0" role="1TKVEi">
+      <property role="IQ2ns" value="635146989623975424" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="singleChildAction" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <ref role="20lvS9" node="6zqIeMU2RWS" resolve="AbstractMergeAction" />
+    </node>
+    <node concept="1TJgyj" id="zgvH9CGyNu" role="1TKVEi">
+      <property role="IQ2ns" value="635146989623979230" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="optionalChildAction" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <ref role="20lvS9" node="6zqIeMU2RWS" resolve="AbstractMergeAction" />
+    </node>
+    <node concept="1TJgyj" id="zgvH9CGzp5" role="1TKVEi">
+      <property role="IQ2ns" value="635146989623981637" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="existsOnlyOnRightAction" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <ref role="20lvS9" node="6zqIeMU2RWS" resolve="AbstractMergeAction" />
+    </node>
+    <node concept="1TJgyj" id="zgvH9CZ$22" role="1TKVEi">
+      <property role="IQ2ns" value="635146989628964994" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="existsOnlyOnLeftAction" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <ref role="20lvS9" node="6zqIeMU2RWS" resolve="AbstractMergeAction" />
+    </node>
+    <node concept="1TJgyj" id="zgvH9CZ$2a" role="1TKVEi">
+      <property role="IQ2ns" value="635146989628965002" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="elementOnBothAction" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <ref role="20lvS9" node="6zqIeMU2RWS" resolve="AbstractMergeAction" />
+    </node>
+    <node concept="1TJgyj" id="zgvH9CGX3U" role="1TKVEi">
+      <property role="IQ2ns" value="635146989624086778" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="singleRefAction" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <ref role="20lvS9" node="6zqIeMU2RWS" resolve="AbstractMergeAction" />
+    </node>
+    <node concept="1TJgyj" id="zgvH9CH6fk" role="1TKVEi">
+      <property role="IQ2ns" value="635146989624124372" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <property role="20kJfa" value="optionalRefAction" />
+      <ref role="20lvS9" node="6zqIeMU2RWS" resolve="AbstractMergeAction" />
+    </node>
   </node>
 </model>
 

--- a/code/languages/de.itemis.model.merge/models/de.itemis.model.merge.typesystem.mps
+++ b/code/languages/de.itemis.model.merge/models/de.itemis.model.merge.typesystem.mps
@@ -1053,7 +1053,7 @@
             <ref role="3cqZAo" node="2GFEb9NgdMU" resolve="checker" />
           </node>
           <node concept="liA8E" id="2GFEb9Ni63$" role="2OqNvi">
-            <ref role="37wK5l" node="2GFEb9Nhs8U" resolve="areRightModelCoveredByPolicies" />
+            <ref role="37wK5l" node="2GFEb9Nhs8U" resolve="areAllModelConceptsCoveredByPolicies" />
             <node concept="2OqwBi" id="2GFEb9NjpRP" role="37wK5m">
               <node concept="1YBJjd" id="2GFEb9NjpRQ" role="2Oq$k0">
                 <ref role="1YBMHb" node="5zr7Q_1Kho0" resolve="mergeModelExecution" />
@@ -1105,7 +1105,7 @@
             <ref role="3cqZAo" node="2GFEb9NgdMU" resolve="checker" />
           </node>
           <node concept="liA8E" id="2GFEb9Njry$" role="2OqNvi">
-            <ref role="37wK5l" node="2GFEb9Nhs8U" resolve="areModelCoveredByPolicies" />
+            <ref role="37wK5l" node="2GFEb9Nhs8U" resolve="areAllModelConceptsCoveredByPolicies" />
             <node concept="2OqwBi" id="2GFEb9Njry_" role="37wK5m">
               <node concept="1YBJjd" id="2GFEb9NjryA" role="2Oq$k0">
                 <ref role="1YBMHb" node="5zr7Q_1Kho0" resolve="mergeModelExecution" />
@@ -3904,7 +3904,7 @@
                 <ref role="3cqZAo" node="2GFEb9Ndlfo" resolve="execution" />
               </node>
               <node concept="2qgKlT" id="2GFEb9NhN9v" role="2OqNvi">
-                <ref role="37wK5l" to="rnx3:2GFEb9MTMsl" resolve="usedConceptsInModel" />
+                <ref role="37wK5l" to="rnx3:2GFEb9MTMsl" resolve="conceptsUsedInModel" />
                 <node concept="37vLTw" id="2GFEb9NjlXM" role="37wK5m">
                   <ref role="3cqZAo" node="2GFEb9MZlei" resolve="modelExp" />
                 </node>

--- a/code/languages/de.itemis.model.merge/models/de.itemis.model.merge.typesystem.mps
+++ b/code/languages/de.itemis.model.merge/models/de.itemis.model.merge.typesystem.mps
@@ -55,6 +55,7 @@
       <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
         <child id="1137022507850" name="body" index="2VODD2" />
       </concept>
+      <concept id="1070475354124" name="jetbrains.mps.baseLanguage.structure.ThisExpression" flags="nn" index="Xjq3P" />
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
       </concept>
@@ -73,6 +74,7 @@
         <child id="1070534934091" name="type" index="10QFUM" />
         <child id="1070534934092" name="expression" index="10QFUP" />
       </concept>
+      <concept id="1068390468200" name="jetbrains.mps.baseLanguage.structure.FieldDeclaration" flags="ig" index="312cEg" />
       <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu" />
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <child id="1068431790190" name="initializer" index="33vP2m" />
@@ -99,6 +101,7 @@
         <child id="1068580123134" name="parameter" index="3clF46" />
         <child id="1068580123135" name="body" index="3clF47" />
       </concept>
+      <concept id="1068580123165" name="jetbrains.mps.baseLanguage.structure.InstanceMethodDeclaration" flags="ig" index="3clFb_" />
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
@@ -113,6 +116,7 @@
       <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
         <property id="1068580123138" name="value" index="3clFbU" />
       </concept>
+      <concept id="1068580123140" name="jetbrains.mps.baseLanguage.structure.ConstructorDeclaration" flags="ig" index="3clFbW" />
       <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
       <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
         <child id="1068581517676" name="expression" index="3cqZAk" />
@@ -173,6 +177,7 @@
         <child id="8356039341262087992" name="line" index="1aUNEU" />
       </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+      <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
     </language>
     <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
       <concept id="2524418899405758586" name="jetbrains.mps.baseLanguage.closures.structure.InferredClosureParameterDeclaration" flags="ig" index="gl6BB" />
@@ -392,10 +397,16 @@
       <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
       <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
       <concept id="1201792049884" name="jetbrains.mps.baseLanguage.collections.structure.TranslateOperation" flags="nn" index="3goQfb" />
+      <concept id="1197683403723" name="jetbrains.mps.baseLanguage.collections.structure.MapType" flags="in" index="3rvAFt">
+        <child id="1197683466920" name="keyType" index="3rvQeY" />
+        <child id="1197683475734" name="valueType" index="3rvSg0" />
+      </concept>
       <concept id="7125221305512719026" name="jetbrains.mps.baseLanguage.collections.structure.CollectionType" flags="in" index="3vKaQO" />
       <concept id="1225727723840" name="jetbrains.mps.baseLanguage.collections.structure.FindFirstOperation" flags="nn" index="1z4cxt" />
       <concept id="1202120902084" name="jetbrains.mps.baseLanguage.collections.structure.WhereOperation" flags="nn" index="3zZkjj" />
       <concept id="1202128969694" name="jetbrains.mps.baseLanguage.collections.structure.SelectOperation" flags="nn" index="3$u5V9" />
+      <concept id="1240824834947" name="jetbrains.mps.baseLanguage.collections.structure.ValueAccessOperation" flags="nn" index="3AV6Ez" />
+      <concept id="1240825616499" name="jetbrains.mps.baseLanguage.collections.structure.KeyAccessOperation" flags="nn" index="3AY5_j" />
       <concept id="1172254888721" name="jetbrains.mps.baseLanguage.collections.structure.ContainsOperation" flags="nn" index="3JPx81" />
       <concept id="5686963296372573083" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerType" flags="in" index="3O5elB">
         <child id="5686963296372573084" name="elementType" index="3O5elw" />
@@ -1018,6 +1029,128 @@
           </node>
         </node>
       </node>
+      <node concept="3clFbH" id="2GFEb9MT1Nj" role="3cqZAp" />
+      <node concept="3cpWs8" id="2GFEb9NgdMT" role="3cqZAp">
+        <node concept="3cpWsn" id="2GFEb9NgdMU" role="3cpWs9">
+          <property role="TrG5h" value="checker" />
+          <node concept="3uibUv" id="2GFEb9NgdMV" role="1tU5fm">
+            <ref role="3uigEE" node="2GFEb9Nd7c0" resolve="ModelMergerExecutionChecker" />
+          </node>
+          <node concept="2ShNRf" id="2GFEb9NgeQK" role="33vP2m">
+            <node concept="1pGfFk" id="2GFEb9NgeQJ" role="2ShVmc">
+              <ref role="37wK5l" node="2GFEb9NdbQU" resolve="ModelMergerExecutionChecker" />
+              <node concept="1YBJjd" id="2GFEb9NgfSS" role="37wK5m">
+                <ref role="1YBMHb" node="5zr7Q_1Kho0" resolve="mergeModelExecution" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbH" id="2GFEb9NjsRG" role="3cqZAp" />
+      <node concept="3clFbF" id="2GFEb9Ni5LU" role="3cqZAp">
+        <node concept="2OqwBi" id="2GFEb9Ni5V2" role="3clFbG">
+          <node concept="37vLTw" id="2GFEb9Ni5LS" role="2Oq$k0">
+            <ref role="3cqZAo" node="2GFEb9NgdMU" resolve="checker" />
+          </node>
+          <node concept="liA8E" id="2GFEb9Ni63$" role="2OqNvi">
+            <ref role="37wK5l" node="2GFEb9Nhs8U" resolve="areRightModelCoveredByPolicies" />
+            <node concept="2OqwBi" id="2GFEb9NjpRP" role="37wK5m">
+              <node concept="1YBJjd" id="2GFEb9NjpRQ" role="2Oq$k0">
+                <ref role="1YBMHb" node="5zr7Q_1Kho0" resolve="mergeModelExecution" />
+              </node>
+              <node concept="3TrEf2" id="2GFEb9NjpRR" role="2OqNvi">
+                <ref role="3Tt5mk" to="mopj:5zr7Q_1JULP" resolve="right" />
+              </node>
+            </node>
+            <node concept="1bVj0M" id="2GFEb9Ni6_l" role="37wK5m">
+              <node concept="37vLTG" id="2GFEb9Ni6_o" role="1bW2Oz">
+                <property role="TrG5h" value="concept" />
+                <node concept="3Tqbb2" id="2GFEb9Ni6_p" role="1tU5fm">
+                  <ref role="ehGHo" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
+                </node>
+              </node>
+              <node concept="3clFbS" id="2GFEb9Ni6_q" role="1bW5cS">
+                <node concept="2MkqsV" id="2GFEb9NrUQr" role="3cqZAp">
+                  <node concept="3cpWs3" id="2GFEb9NrWWi" role="2MkJ7o">
+                    <node concept="2OqwBi" id="2GFEb9NrWWj" role="3uHU7w">
+                      <node concept="37vLTw" id="2GFEb9NrWWk" role="2Oq$k0">
+                        <ref role="3cqZAo" node="2GFEb9Ni6_o" resolve="concept" />
+                      </node>
+                      <node concept="3TrcHB" id="2GFEb9NrWWl" role="2OqNvi">
+                        <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                      </node>
+                    </node>
+                    <node concept="Xl_RD" id="2GFEb9NrWWm" role="3uHU7B">
+                      <property role="Xl_RC" value="Right model has concepts with uncovered policies: " />
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="2GFEb9NrY0P" role="1urrMF">
+                    <node concept="1YBJjd" id="2GFEb9NrY0Q" role="2Oq$k0">
+                      <ref role="1YBMHb" node="5zr7Q_1Kho0" resolve="mergeModelExecution" />
+                    </node>
+                    <node concept="3TrEf2" id="2GFEb9NrY0R" role="2OqNvi">
+                      <ref role="3Tt5mk" to="mopj:5zr7Q_1JULP" resolve="right" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbH" id="2GFEb9Njsff" role="3cqZAp" />
+      <node concept="3clFbF" id="2GFEb9Njryx" role="3cqZAp">
+        <node concept="2OqwBi" id="2GFEb9Njryy" role="3clFbG">
+          <node concept="37vLTw" id="2GFEb9Njryz" role="2Oq$k0">
+            <ref role="3cqZAo" node="2GFEb9NgdMU" resolve="checker" />
+          </node>
+          <node concept="liA8E" id="2GFEb9Njry$" role="2OqNvi">
+            <ref role="37wK5l" node="2GFEb9Nhs8U" resolve="areModelCoveredByPolicies" />
+            <node concept="2OqwBi" id="2GFEb9Njry_" role="37wK5m">
+              <node concept="1YBJjd" id="2GFEb9NjryA" role="2Oq$k0">
+                <ref role="1YBMHb" node="5zr7Q_1Kho0" resolve="mergeModelExecution" />
+              </node>
+              <node concept="3TrEf2" id="2GFEb9NjryB" role="2OqNvi">
+                <ref role="3Tt5mk" to="mopj:5zr7Q_1JULP" resolve="right" />
+              </node>
+            </node>
+            <node concept="1bVj0M" id="2GFEb9NjryC" role="37wK5m">
+              <node concept="37vLTG" id="2GFEb9NjryD" role="1bW2Oz">
+                <property role="TrG5h" value="concept" />
+                <node concept="3Tqbb2" id="2GFEb9NjryE" role="1tU5fm">
+                  <ref role="ehGHo" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
+                </node>
+              </node>
+              <node concept="3clFbS" id="2GFEb9NjryF" role="1bW5cS">
+                <node concept="2MkqsV" id="2GFEb9Ns1JY" role="3cqZAp">
+                  <node concept="3cpWs3" id="2GFEb9Ns1JZ" role="2MkJ7o">
+                    <node concept="2OqwBi" id="2GFEb9Ns1K0" role="3uHU7w">
+                      <node concept="37vLTw" id="2GFEb9Ns1K1" role="2Oq$k0">
+                        <ref role="3cqZAo" node="2GFEb9NjryD" resolve="concept" />
+                      </node>
+                      <node concept="3TrcHB" id="2GFEb9Ns1K2" role="2OqNvi">
+                        <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                      </node>
+                    </node>
+                    <node concept="Xl_RD" id="2GFEb9Ns1K3" role="3uHU7B">
+                      <property role="Xl_RC" value="Left model has concepts with uncovered policies: " />
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="2GFEb9Ns1K4" role="1urrMF">
+                    <node concept="1YBJjd" id="2GFEb9Ns1K5" role="2Oq$k0">
+                      <ref role="1YBMHb" node="5zr7Q_1Kho0" resolve="mergeModelExecution" />
+                    </node>
+                    <node concept="3TrEf2" id="2GFEb9Ns1K6" role="2OqNvi">
+                      <ref role="3Tt5mk" to="mopj:5zr7Q_1Jvjo" resolve="left" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbH" id="2GFEb9NggV3" role="3cqZAp" />
     </node>
     <node concept="1YaCAy" id="5zr7Q_1Kho0" role="1YuTPh">
       <property role="TrG5h" value="mergeModelExecution" />
@@ -1027,1314 +1160,1419 @@
   <node concept="18kY7G" id="7TOowlgBzBR">
     <property role="TrG5h" value="check_ModelMerge" />
     <node concept="3clFbS" id="7TOowlgBzBS" role="18ibNy">
-      <node concept="3J1_TO" id="7TOowlgVHwU" role="3cqZAp">
-        <node concept="3clFbS" id="7TOowlgVHwV" role="1zxBo7">
-          <node concept="3cpWs8" id="3EHNiwz7rFr" role="3cqZAp">
-            <node concept="3cpWsn" id="3EHNiwz7rFs" role="3cpWs9">
-              <property role="TrG5h" value="mergerResolver" />
-              <node concept="3uibUv" id="3EHNiwz7rpP" role="1tU5fm">
-                <ref role="3uigEE" to="gunp:2QNuyuiL5OR" resolve="MergerResolverImpl" />
-              </node>
-              <node concept="2YIFZM" id="61HvMZcxF4P" role="33vP2m">
-                <ref role="37wK5l" to="gunp:7wnapcW0cfS" resolve="run" />
-                <ref role="1Pybhc" to="gunp:18W7Z4VeRuj" resolve="MergeResolverFromModelMerge" />
-                <node concept="1YBJjd" id="3EHNiwz7rFu" role="37wK5m">
-                  <ref role="1YBMHb" node="7TOowlgBzBU" resolve="modelMerge" />
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3clFbH" id="1trrptaIAG4" role="3cqZAp" />
-          <node concept="3cpWs8" id="ZzVzivMLGk" role="3cqZAp">
-            <node concept="3cpWsn" id="ZzVzivMLGl" role="3cpWs9">
-              <property role="TrG5h" value="repository" />
-              <node concept="3uibUv" id="ZzVzivML9J" role="1tU5fm">
-                <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
-              </node>
-              <node concept="2OqwBi" id="ZzVzivMLGm" role="33vP2m">
-                <node concept="2OqwBi" id="ZzVzivMLGn" role="2Oq$k0">
-                  <node concept="2JrnkZ" id="ZzVzivMLGo" role="2Oq$k0">
-                    <node concept="2OqwBi" id="ZzVzivMLGp" role="2JrQYb">
-                      <node concept="1YBJjd" id="ZzVzivMLGq" role="2Oq$k0">
-                        <ref role="1YBMHb" node="7TOowlgBzBU" resolve="modelMerge" />
-                      </node>
-                      <node concept="3TrEf2" id="ZzVzivMLGr" role="2OqNvi">
-                        <ref role="3Tt5mk" to="mopj:1VmHfRy0Ud5" resolve="lang" />
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="liA8E" id="ZzVzivMLGs" role="2OqNvi">
-                    <ref role="37wK5l" to="mhbf:~SNode.getModel()" resolve="getModel" />
-                  </node>
-                </node>
-                <node concept="liA8E" id="ZzVzivMLGt" role="2OqNvi">
-                  <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3clFbH" id="ZzVzivroYU" role="3cqZAp" />
-          <node concept="3clFbH" id="60iGZSKk8Po" role="3cqZAp" />
-          <node concept="3clFbH" id="60iGZSKk8Ui" role="3cqZAp" />
-          <node concept="3SKdUt" id="60iGZSKkaa7" role="3cqZAp">
-            <node concept="1PaTwC" id="60iGZSKkaa8" role="1aUNEU">
-              <node concept="3oM_SD" id="60iGZSKkaa9" role="1PaTwD">
-                <property role="3oM_SC" value="--Missing" />
-              </node>
-              <node concept="3oM_SD" id="60iGZSKkb1o" role="1PaTwD">
-                <property role="3oM_SC" value="Property" />
-              </node>
-              <node concept="3oM_SD" id="60iGZSKkdrG" role="1PaTwD">
-                <property role="3oM_SC" value="Policy" />
-              </node>
-            </node>
-          </node>
-          <node concept="3cpWs8" id="582YV7z0eIx" role="3cqZAp">
-            <node concept="3cpWsn" id="582YV7z0eIy" role="3cpWs9">
-              <property role="TrG5h" value="conceptToRelevantProperties" />
-              <node concept="1ajhzC" id="582YV7z0eIt" role="1tU5fm">
-                <node concept="3Tqbb2" id="582YV7z0eIu" role="1ajw0F">
+      <node concept="3clFbJ" id="2GFEb9NAuLl" role="3cqZAp">
+        <node concept="3clFbS" id="2GFEb9NAuLn" role="3clFbx">
+          <node concept="3cpWs8" id="2GFEb9N_A6I" role="3cqZAp">
+            <node concept="3cpWsn" id="2GFEb9N_A6L" role="3cpWs9">
+              <property role="TrG5h" value="conceptToPolicy" />
+              <node concept="3rvAFt" id="2GFEb9N_A6C" role="1tU5fm">
+                <node concept="3Tqbb2" id="2GFEb9N_DTa" role="3rvQeY">
                   <ref role="ehGHo" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
                 </node>
-                <node concept="3uibUv" id="582YV7z0eIv" role="1ajl9A">
-                  <ref role="3uigEE" to="33ny:~HashSet" resolve="HashSet" />
-                  <node concept="3Tqbb2" id="582YV7z0eIw" role="11_B2D">
-                    <ref role="ehGHo" to="tpce:f_TJgxF" resolve="PropertyDeclaration" />
-                  </node>
+                <node concept="3Tqbb2" id="2GFEb9N_Evk" role="3rvSg0">
+                  <ref role="ehGHo" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
                 </node>
               </node>
-              <node concept="1bVj0M" id="582YV7z0eIz" role="33vP2m">
-                <node concept="3clFbS" id="582YV7z0eI$" role="1bW5cS">
-                  <node concept="3cpWs8" id="582YV7z0eI_" role="3cqZAp">
-                    <node concept="3cpWsn" id="582YV7z0eIA" role="3cpWs9">
-                      <property role="TrG5h" value="forbiddenProperties" />
-                      <node concept="2OqwBi" id="582YV7z0eIB" role="33vP2m">
-                        <node concept="35c_gC" id="582YV7z0eIC" role="2Oq$k0">
-                          <ref role="35c_gD" to="tpck:gw2VY9q" resolve="BaseConcept" />
+              <node concept="2OqwBi" id="2GFEb9NA2AP" role="33vP2m">
+                <node concept="1YBJjd" id="2GFEb9NA26I" role="2Oq$k0">
+                  <ref role="1YBMHb" node="7TOowlgBzBU" resolve="modelMerge" />
+                </node>
+                <node concept="2qgKlT" id="2GFEb9NA7Ey" role="2OqNvi">
+                  <ref role="37wK5l" to="rnx3:3xJ_LYXj1c6" resolve="conceptToDefinedMergePolicy" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="2GFEb9NAeU_" role="3cqZAp">
+            <node concept="2OqwBi" id="2GFEb9NAjfv" role="3clFbG">
+              <node concept="37vLTw" id="2GFEb9NAeUz" role="2Oq$k0">
+                <ref role="3cqZAo" node="2GFEb9N_A6L" resolve="conceptToPolicy" />
+              </node>
+              <node concept="2es0OD" id="2GFEb9NAlhH" role="2OqNvi">
+                <node concept="1bVj0M" id="2GFEb9NAlhJ" role="23t8la">
+                  <node concept="3clFbS" id="2GFEb9NAlhK" role="1bW5cS">
+                    <node concept="3clFbJ" id="2GFEb9NAlzp" role="3cqZAp">
+                      <node concept="2OqwBi" id="2GFEb9NAnxF" role="3clFbw">
+                        <node concept="2OqwBi" id="2GFEb9NAnxG" role="2Oq$k0">
+                          <node concept="37vLTw" id="2GFEb9NAnxH" role="2Oq$k0">
+                            <ref role="3cqZAo" node="2GFEb9NAlhL" resolve="it" />
+                          </node>
+                          <node concept="3AV6Ez" id="2GFEb9NAnxI" role="2OqNvi" />
                         </node>
-                        <node concept="liA8E" id="582YV7z0eID" role="2OqNvi">
-                          <ref role="37wK5l" to="c17a:~SAbstractConcept.getProperties()" resolve="getProperties" />
+                        <node concept="3TrcHB" id="2GFEb9NAnxJ" role="2OqNvi">
+                          <ref role="3TsBF5" to="mopj:5xmpdH7cpzi" resolve="useDefaults" />
                         </node>
                       </node>
-                      <node concept="3vKaQO" id="582YV7z0eIE" role="1tU5fm">
-                        <node concept="3uibUv" id="582YV7z0eIF" role="3O5elw">
-                          <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
+                      <node concept="3clFbS" id="2GFEb9NAlzr" role="3clFbx">
+                        <node concept="2MkqsV" id="2GFEb9NASbQ" role="3cqZAp">
+                          <node concept="2OqwBi" id="2GFEb9NB0_g" role="1urrMF">
+                            <node concept="37vLTw" id="2GFEb9NAZMQ" role="2Oq$k0">
+                              <ref role="3cqZAo" node="2GFEb9NAlhL" resolve="it" />
+                            </node>
+                            <node concept="3AV6Ez" id="7wzAiyp_njv" role="2OqNvi" />
+                          </node>
+                          <node concept="3cpWs3" id="2GFEb9NAWg1" role="2MkJ7o">
+                            <node concept="2OqwBi" id="2GFEb9NAYpb" role="3uHU7w">
+                              <node concept="2OqwBi" id="2GFEb9NAWQh" role="2Oq$k0">
+                                <node concept="37vLTw" id="2GFEb9NAWlh" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="2GFEb9NAlhL" resolve="it" />
+                                </node>
+                                <node concept="3AY5_j" id="2GFEb9NAXR5" role="2OqNvi" />
+                              </node>
+                              <node concept="3TrcHB" id="2GFEb9NAZFr" role="2OqNvi">
+                                <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                              </node>
+                            </node>
+                            <node concept="Xl_RD" id="2GFEb9NATf2" role="3uHU7B">
+                              <property role="Xl_RC" value="Concept uses default actions, but any default is specified: " />
+                            </node>
+                          </node>
                         </node>
                       </node>
                     </node>
                   </node>
-                  <node concept="3clFbF" id="4ZputZW5ecH" role="3cqZAp">
-                    <node concept="2ShNRf" id="4ZputZW5ecD" role="3clFbG">
-                      <node concept="1pGfFk" id="4ZputZW5vO$" role="2ShVmc">
-                        <ref role="37wK5l" to="33ny:~HashSet.&lt;init&gt;(java.util.Collection)" resolve="HashSet" />
-                        <node concept="2OqwBi" id="4ZputZW5QrT" role="37wK5m">
-                          <node concept="2OqwBi" id="4ZputZW5QrU" role="2Oq$k0">
-                            <node concept="2OqwBi" id="4ZputZW5QrV" role="2Oq$k0">
-                              <node concept="37vLTw" id="4ZputZW5QrW" role="2Oq$k0">
-                                <ref role="3cqZAo" node="582YV7z0eJ5" resolve="acd" />
-                              </node>
-                              <node concept="2qgKlT" id="4ZputZW5QrX" role="2OqNvi">
-                                <ref role="37wK5l" to="tpcn:hEwILLM" resolve="getPropertyDeclarations" />
-                              </node>
+                  <node concept="gl6BB" id="2GFEb9NAlhL" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="2GFEb9NAlhM" role="1tU5fm" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbH" id="2GFEb9NAuLm" role="3cqZAp" />
+        </node>
+        <node concept="3fqX7Q" id="2GFEb9NAM0j" role="3clFbw">
+          <node concept="2OqwBi" id="2GFEb9NAM0l" role="3fr31v">
+            <node concept="1YBJjd" id="2GFEb9NAM0m" role="2Oq$k0">
+              <ref role="1YBMHb" node="7TOowlgBzBU" resolve="modelMerge" />
+            </node>
+            <node concept="3TrcHB" id="2GFEb9NAM0n" role="2OqNvi">
+              <ref role="3TsBF5" to="mopj:5Ql4oYC0__d" resolve="useDefaults" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbH" id="7wzAiypsoeS" role="3cqZAp" />
+      <node concept="3clFbJ" id="2GFEb9MruHk" role="3cqZAp">
+        <node concept="3clFbS" id="2GFEb9MruHm" role="3clFbx">
+          <node concept="3J1_TO" id="7TOowlgVHwU" role="3cqZAp">
+            <node concept="3clFbS" id="7TOowlgVHwV" role="1zxBo7">
+              <node concept="3cpWs8" id="3EHNiwz7rFr" role="3cqZAp">
+                <node concept="3cpWsn" id="3EHNiwz7rFs" role="3cpWs9">
+                  <property role="TrG5h" value="mergerResolver" />
+                  <node concept="3uibUv" id="3EHNiwz7rpP" role="1tU5fm">
+                    <ref role="3uigEE" to="gunp:2QNuyuiL5OR" resolve="MergerResolverImpl" />
+                  </node>
+                  <node concept="2YIFZM" id="61HvMZcxF4P" role="33vP2m">
+                    <ref role="37wK5l" to="gunp:7wnapcW0cfS" resolve="run" />
+                    <ref role="1Pybhc" to="gunp:18W7Z4VeRuj" resolve="MergeResolverFromModelMerge" />
+                    <node concept="1YBJjd" id="3EHNiwz7rFu" role="37wK5m">
+                      <ref role="1YBMHb" node="7TOowlgBzBU" resolve="modelMerge" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbH" id="1trrptaIAG4" role="3cqZAp" />
+              <node concept="3cpWs8" id="ZzVzivMLGk" role="3cqZAp">
+                <node concept="3cpWsn" id="ZzVzivMLGl" role="3cpWs9">
+                  <property role="TrG5h" value="repository" />
+                  <node concept="3uibUv" id="ZzVzivML9J" role="1tU5fm">
+                    <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
+                  </node>
+                  <node concept="2OqwBi" id="ZzVzivMLGm" role="33vP2m">
+                    <node concept="2OqwBi" id="ZzVzivMLGn" role="2Oq$k0">
+                      <node concept="2JrnkZ" id="ZzVzivMLGo" role="2Oq$k0">
+                        <node concept="2OqwBi" id="ZzVzivMLGp" role="2JrQYb">
+                          <node concept="1YBJjd" id="ZzVzivMLGq" role="2Oq$k0">
+                            <ref role="1YBMHb" node="7TOowlgBzBU" resolve="modelMerge" />
+                          </node>
+                          <node concept="3TrEf2" id="ZzVzivMLGr" role="2OqNvi">
+                            <ref role="3Tt5mk" to="mopj:1VmHfRy0Ud5" resolve="lang" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="liA8E" id="ZzVzivMLGs" role="2OqNvi">
+                        <ref role="37wK5l" to="mhbf:~SNode.getModel()" resolve="getModel" />
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="ZzVzivMLGt" role="2OqNvi">
+                      <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbH" id="ZzVzivroYU" role="3cqZAp" />
+              <node concept="3SKdUt" id="60iGZSKkaa7" role="3cqZAp">
+                <node concept="1PaTwC" id="60iGZSKkaa8" role="1aUNEU">
+                  <node concept="3oM_SD" id="60iGZSKkaa9" role="1PaTwD">
+                    <property role="3oM_SC" value="--Missing" />
+                  </node>
+                  <node concept="3oM_SD" id="60iGZSKkb1o" role="1PaTwD">
+                    <property role="3oM_SC" value="Property" />
+                  </node>
+                  <node concept="3oM_SD" id="60iGZSKkdrG" role="1PaTwD">
+                    <property role="3oM_SC" value="Policy" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3cpWs8" id="582YV7z0eIx" role="3cqZAp">
+                <node concept="3cpWsn" id="582YV7z0eIy" role="3cpWs9">
+                  <property role="TrG5h" value="conceptToRelevantProperties" />
+                  <node concept="1ajhzC" id="582YV7z0eIt" role="1tU5fm">
+                    <node concept="3Tqbb2" id="582YV7z0eIu" role="1ajw0F">
+                      <ref role="ehGHo" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
+                    </node>
+                    <node concept="3uibUv" id="582YV7z0eIv" role="1ajl9A">
+                      <ref role="3uigEE" to="33ny:~HashSet" resolve="HashSet" />
+                      <node concept="3Tqbb2" id="582YV7z0eIw" role="11_B2D">
+                        <ref role="ehGHo" to="tpce:f_TJgxF" resolve="PropertyDeclaration" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="1bVj0M" id="582YV7z0eIz" role="33vP2m">
+                    <node concept="3clFbS" id="582YV7z0eI$" role="1bW5cS">
+                      <node concept="3cpWs8" id="582YV7z0eI_" role="3cqZAp">
+                        <node concept="3cpWsn" id="582YV7z0eIA" role="3cpWs9">
+                          <property role="TrG5h" value="forbiddenProperties" />
+                          <node concept="2OqwBi" id="582YV7z0eIB" role="33vP2m">
+                            <node concept="35c_gC" id="582YV7z0eIC" role="2Oq$k0">
+                              <ref role="35c_gD" to="tpck:gw2VY9q" resolve="BaseConcept" />
                             </node>
-                            <node concept="3zZkjj" id="4ZputZW5QrY" role="2OqNvi">
-                              <node concept="1bVj0M" id="4ZputZW5QrZ" role="23t8la">
-                                <node concept="3clFbS" id="4ZputZW5Qs0" role="1bW5cS">
-                                  <node concept="3clFbF" id="4ZputZW5Qs1" role="3cqZAp">
-                                    <node concept="3fqX7Q" id="4ZputZW5Qs2" role="3clFbG">
-                                      <node concept="2OqwBi" id="4ZputZW5Qs3" role="3fr31v">
-                                        <node concept="37vLTw" id="4ZputZW5Qs4" role="2Oq$k0">
-                                          <ref role="3cqZAo" node="582YV7z0eIA" resolve="forbiddenProperties" />
-                                        </node>
-                                        <node concept="2HwmR7" id="4ZputZW5Qs5" role="2OqNvi">
-                                          <node concept="1bVj0M" id="4ZputZW5Qs6" role="23t8la">
-                                            <node concept="3clFbS" id="4ZputZW5Qs7" role="1bW5cS">
-                                              <node concept="3clFbF" id="4ZputZW5Qs8" role="3cqZAp">
-                                                <node concept="2OqwBi" id="4ZputZW5Qs9" role="3clFbG">
-                                                  <node concept="37vLTw" id="4ZputZW5Qsa" role="2Oq$k0">
-                                                    <ref role="3cqZAo" node="7Z$RfkF7IGb" resolve="it" />
-                                                  </node>
-                                                  <node concept="2qgKlT" id="4ZputZW5Qsb" role="2OqNvi">
-                                                    <ref role="37wK5l" to="tpcn:4MKjpUYnih4" resolve="is" />
-                                                    <node concept="37vLTw" id="4ZputZW5Qsc" role="37wK5m">
-                                                      <ref role="3cqZAo" node="7Z$RfkF7IG9" resolve="prop" />
+                            <node concept="liA8E" id="582YV7z0eID" role="2OqNvi">
+                              <ref role="37wK5l" to="c17a:~SAbstractConcept.getProperties()" resolve="getProperties" />
+                            </node>
+                          </node>
+                          <node concept="3vKaQO" id="582YV7z0eIE" role="1tU5fm">
+                            <node concept="3uibUv" id="582YV7z0eIF" role="3O5elw">
+                              <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="4ZputZW5ecH" role="3cqZAp">
+                        <node concept="2ShNRf" id="4ZputZW5ecD" role="3clFbG">
+                          <node concept="1pGfFk" id="4ZputZW5vO$" role="2ShVmc">
+                            <ref role="37wK5l" to="33ny:~HashSet.&lt;init&gt;(java.util.Collection)" resolve="HashSet" />
+                            <node concept="2OqwBi" id="4ZputZW5QrT" role="37wK5m">
+                              <node concept="2OqwBi" id="4ZputZW5QrU" role="2Oq$k0">
+                                <node concept="2OqwBi" id="4ZputZW5QrV" role="2Oq$k0">
+                                  <node concept="37vLTw" id="4ZputZW5QrW" role="2Oq$k0">
+                                    <ref role="3cqZAo" node="582YV7z0eJ5" resolve="acd" />
+                                  </node>
+                                  <node concept="2qgKlT" id="4ZputZW5QrX" role="2OqNvi">
+                                    <ref role="37wK5l" to="tpcn:hEwILLM" resolve="getPropertyDeclarations" />
+                                  </node>
+                                </node>
+                                <node concept="3zZkjj" id="4ZputZW5QrY" role="2OqNvi">
+                                  <node concept="1bVj0M" id="4ZputZW5QrZ" role="23t8la">
+                                    <node concept="3clFbS" id="4ZputZW5Qs0" role="1bW5cS">
+                                      <node concept="3clFbF" id="4ZputZW5Qs1" role="3cqZAp">
+                                        <node concept="3fqX7Q" id="4ZputZW5Qs2" role="3clFbG">
+                                          <node concept="2OqwBi" id="4ZputZW5Qs3" role="3fr31v">
+                                            <node concept="37vLTw" id="4ZputZW5Qs4" role="2Oq$k0">
+                                              <ref role="3cqZAo" node="582YV7z0eIA" resolve="forbiddenProperties" />
+                                            </node>
+                                            <node concept="2HwmR7" id="4ZputZW5Qs5" role="2OqNvi">
+                                              <node concept="1bVj0M" id="4ZputZW5Qs6" role="23t8la">
+                                                <node concept="3clFbS" id="4ZputZW5Qs7" role="1bW5cS">
+                                                  <node concept="3clFbF" id="4ZputZW5Qs8" role="3cqZAp">
+                                                    <node concept="2OqwBi" id="4ZputZW5Qs9" role="3clFbG">
+                                                      <node concept="37vLTw" id="4ZputZW5Qsa" role="2Oq$k0">
+                                                        <ref role="3cqZAo" node="7Z$RfkF7IGb" resolve="it" />
+                                                      </node>
+                                                      <node concept="2qgKlT" id="4ZputZW5Qsb" role="2OqNvi">
+                                                        <ref role="37wK5l" to="tpcn:4MKjpUYnih4" resolve="is" />
+                                                        <node concept="37vLTw" id="4ZputZW5Qsc" role="37wK5m">
+                                                          <ref role="3cqZAo" node="7Z$RfkF7IG9" resolve="prop" />
+                                                        </node>
+                                                      </node>
                                                     </node>
                                                   </node>
                                                 </node>
+                                                <node concept="gl6BB" id="7Z$RfkF7IG9" role="1bW2Oz">
+                                                  <property role="TrG5h" value="prop" />
+                                                  <node concept="2jxLKc" id="7Z$RfkF7IGa" role="1tU5fm" />
+                                                </node>
                                               </node>
-                                            </node>
-                                            <node concept="gl6BB" id="7Z$RfkF7IG9" role="1bW2Oz">
-                                              <property role="TrG5h" value="prop" />
-                                              <node concept="2jxLKc" id="7Z$RfkF7IGa" role="1tU5fm" />
                                             </node>
                                           </node>
                                         </node>
                                       </node>
                                     </node>
+                                    <node concept="gl6BB" id="7Z$RfkF7IGb" role="1bW2Oz">
+                                      <property role="TrG5h" value="it" />
+                                      <node concept="2jxLKc" id="7Z$RfkF7IGc" role="1tU5fm" />
+                                    </node>
                                   </node>
                                 </node>
-                                <node concept="gl6BB" id="7Z$RfkF7IGb" role="1bW2Oz">
-                                  <property role="TrG5h" value="it" />
-                                  <node concept="2jxLKc" id="7Z$RfkF7IGc" role="1tU5fm" />
-                                </node>
                               </node>
+                              <node concept="ANE8D" id="4ZputZW5Qsh" role="2OqNvi" />
+                            </node>
+                            <node concept="3Tqbb2" id="4ZputZW5Dbu" role="1pMfVU">
+                              <ref role="ehGHo" to="tpce:f_TJgxF" resolve="PropertyDeclaration" />
                             </node>
                           </node>
-                          <node concept="ANE8D" id="4ZputZW5Qsh" role="2OqNvi" />
                         </node>
-                        <node concept="3Tqbb2" id="4ZputZW5Dbu" role="1pMfVU">
-                          <ref role="ehGHo" to="tpce:f_TJgxF" resolve="PropertyDeclaration" />
-                        </node>
+                      </node>
+                    </node>
+                    <node concept="37vLTG" id="582YV7z0eJ5" role="1bW2Oz">
+                      <property role="TrG5h" value="acd" />
+                      <node concept="3Tqbb2" id="582YV7z0eJ6" role="1tU5fm">
+                        <ref role="ehGHo" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
                       </node>
                     </node>
                   </node>
                 </node>
-                <node concept="37vLTG" id="582YV7z0eJ5" role="1bW2Oz">
-                  <property role="TrG5h" value="acd" />
-                  <node concept="3Tqbb2" id="582YV7z0eJ6" role="1tU5fm">
-                    <ref role="ehGHo" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
+              </node>
+              <node concept="3SKdUt" id="1FQTM0rQebS" role="3cqZAp">
+                <node concept="1PaTwC" id="1FQTM0rQebT" role="1aUNEU">
+                  <node concept="3oM_SD" id="1FQTM0rQebU" role="1PaTwD">
+                    <property role="3oM_SC" value="This" />
+                  </node>
+                  <node concept="3oM_SD" id="1FQTM0rQfI4" role="1PaTwD">
+                    <property role="3oM_SC" value="warning" />
+                  </node>
+                  <node concept="3oM_SD" id="1FQTM0rQfIB" role="1PaTwD">
+                    <property role="3oM_SC" value="ensures" />
+                  </node>
+                  <node concept="3oM_SD" id="1FQTM0rQfKl" role="1PaTwD">
+                    <property role="3oM_SC" value="that" />
+                  </node>
+                  <node concept="3oM_SD" id="1FQTM0rQfMB" role="1PaTwD">
+                    <property role="3oM_SC" value="is" />
+                  </node>
+                  <node concept="3oM_SD" id="1FQTM0rQfNR" role="1PaTwD">
+                    <property role="3oM_SC" value="not" />
+                  </node>
+                  <node concept="3oM_SD" id="1FQTM0rQfNY" role="1PaTwD">
+                    <property role="3oM_SC" value="possible" />
+                  </node>
+                  <node concept="3oM_SD" id="1FQTM0rQfPA" role="1PaTwD">
+                    <property role="3oM_SC" value="that" />
+                  </node>
+                  <node concept="3oM_SD" id="1FQTM0rQfQT" role="1PaTwD">
+                    <property role="3oM_SC" value="a" />
+                  </node>
+                  <node concept="3oM_SD" id="1FQTM0rQfRz" role="1PaTwD">
+                    <property role="3oM_SC" value="Auto-Merge-Policy" />
+                  </node>
+                  <node concept="3oM_SD" id="1FQTM0rQfWS" role="1PaTwD">
+                    <property role="3oM_SC" value="is" />
+                  </node>
+                  <node concept="3oM_SD" id="1FQTM0rQfYe" role="1PaTwD">
+                    <property role="3oM_SC" value="propagated" />
+                  </node>
+                  <node concept="3oM_SD" id="1FQTM0rQfZr" role="1PaTwD">
+                    <property role="3oM_SC" value="down" />
+                  </node>
+                  <node concept="3oM_SD" id="1FQTM0rQg1j" role="1PaTwD">
+                    <property role="3oM_SC" value="to" />
                   </node>
                 </node>
               </node>
-            </node>
-          </node>
-          <node concept="3SKdUt" id="1FQTM0rQebS" role="3cqZAp">
-            <node concept="1PaTwC" id="1FQTM0rQebT" role="1aUNEU">
-              <node concept="3oM_SD" id="1FQTM0rQebU" role="1PaTwD">
-                <property role="3oM_SC" value="This" />
-              </node>
-              <node concept="3oM_SD" id="1FQTM0rQfI4" role="1PaTwD">
-                <property role="3oM_SC" value="warning" />
-              </node>
-              <node concept="3oM_SD" id="1FQTM0rQfIB" role="1PaTwD">
-                <property role="3oM_SC" value="ensures" />
-              </node>
-              <node concept="3oM_SD" id="1FQTM0rQfKl" role="1PaTwD">
-                <property role="3oM_SC" value="that" />
-              </node>
-              <node concept="3oM_SD" id="1FQTM0rQfMB" role="1PaTwD">
-                <property role="3oM_SC" value="is" />
-              </node>
-              <node concept="3oM_SD" id="1FQTM0rQfNR" role="1PaTwD">
-                <property role="3oM_SC" value="not" />
-              </node>
-              <node concept="3oM_SD" id="1FQTM0rQfNY" role="1PaTwD">
-                <property role="3oM_SC" value="possible" />
-              </node>
-              <node concept="3oM_SD" id="1FQTM0rQfPA" role="1PaTwD">
-                <property role="3oM_SC" value="that" />
-              </node>
-              <node concept="3oM_SD" id="1FQTM0rQfQT" role="1PaTwD">
-                <property role="3oM_SC" value="a" />
-              </node>
-              <node concept="3oM_SD" id="1FQTM0rQfRz" role="1PaTwD">
-                <property role="3oM_SC" value="Auto-Merge-Policy" />
-              </node>
-              <node concept="3oM_SD" id="1FQTM0rQfWS" role="1PaTwD">
-                <property role="3oM_SC" value="is" />
-              </node>
-              <node concept="3oM_SD" id="1FQTM0rQfYe" role="1PaTwD">
-                <property role="3oM_SC" value="propagated" />
-              </node>
-              <node concept="3oM_SD" id="1FQTM0rQfZr" role="1PaTwD">
-                <property role="3oM_SC" value="down" />
-              </node>
-              <node concept="3oM_SD" id="1FQTM0rQg1j" role="1PaTwD">
-                <property role="3oM_SC" value="to" />
-              </node>
-            </node>
-          </node>
-          <node concept="3SKdUt" id="1FQTM0rQh0q" role="3cqZAp">
-            <node concept="1PaTwC" id="1FQTM0rQh0r" role="1aUNEU">
-              <node concept="3oM_SD" id="1FQTM0rQh0s" role="1PaTwD">
-                <property role="3oM_SC" value="some" />
-              </node>
-              <node concept="3oM_SD" id="1FQTM0rQh$T" role="1PaTwD">
-                <property role="3oM_SC" value="leaf-Concepts." />
-              </node>
-              <node concept="3oM_SD" id="1FQTM0rQhC6" role="1PaTwD">
-                <property role="3oM_SC" value="Even" />
-              </node>
-              <node concept="3oM_SD" id="1FQTM0rQhDk" role="1PaTwD">
-                <property role="3oM_SC" value="if" />
-              </node>
-              <node concept="3oM_SD" id="1FQTM0rQhDT" role="1PaTwD">
-                <property role="3oM_SC" value="all" />
-              </node>
-              <node concept="3oM_SD" id="1FQTM0rQhGD" role="1PaTwD">
-                <property role="3oM_SC" value="children" />
-              </node>
-              <node concept="3oM_SD" id="1FQTM0rQhKx" role="1PaTwD">
-                <property role="3oM_SC" value="in" />
-              </node>
-              <node concept="3oM_SD" id="1FQTM0rQhLN" role="1PaTwD">
-                <property role="3oM_SC" value="all" />
-              </node>
-              <node concept="3oM_SD" id="1FQTM0rQhMs" role="1PaTwD">
-                <property role="3oM_SC" value="Concepts" />
-              </node>
-              <node concept="3oM_SD" id="1FQTM0rQhN6" role="1PaTwD">
-                <property role="3oM_SC" value="would" />
-              </node>
-              <node concept="3oM_SD" id="1FQTM0rQhNL" role="1PaTwD">
-                <property role="3oM_SC" value="be" />
-              </node>
-              <node concept="3oM_SD" id="1FQTM0rQhP7" role="1PaTwD">
-                <property role="3oM_SC" value="handled" />
-              </node>
-              <node concept="3oM_SD" id="1FQTM0rQhRk" role="1PaTwD">
-                <property role="3oM_SC" value="by" />
-              </node>
-              <node concept="3oM_SD" id="1FQTM0rQhSG" role="1PaTwD">
-                <property role="3oM_SC" value="Auto," />
-              </node>
-              <node concept="3oM_SD" id="1FQTM0rQhVr" role="1PaTwD">
-                <property role="3oM_SC" value="then" />
-              </node>
-              <node concept="3oM_SD" id="1FQTM0rQhYS" role="1PaTwD">
-                <property role="3oM_SC" value="it" />
-              </node>
-              <node concept="3oM_SD" id="1FQTM0rQhZD" role="1PaTwD">
-                <property role="3oM_SC" value="is" />
-              </node>
-              <node concept="3oM_SD" id="1FQTM0rQi15" role="1PaTwD">
-                <property role="3oM_SC" value="assured" />
-              </node>
-            </node>
-          </node>
-          <node concept="3SKdUt" id="1FQTM0rQj14" role="3cqZAp">
-            <node concept="1PaTwC" id="1FQTM0rQj15" role="1aUNEU">
-              <node concept="3oM_SD" id="1FQTM0rQj16" role="1PaTwD">
-                <property role="3oM_SC" value="that" />
-              </node>
-              <node concept="3oM_SD" id="1FQTM0rQjR2" role="1PaTwD">
-                <property role="3oM_SC" value="the" />
-              </node>
-              <node concept="3oM_SD" id="1FQTM0rQjTf" role="1PaTwD">
-                <property role="3oM_SC" value="defined" />
-              </node>
-              <node concept="3oM_SD" id="1FQTM0rQjXh" role="1PaTwD">
-                <property role="3oM_SC" value="Merge-Policies" />
-              </node>
-              <node concept="3oM_SD" id="1FQTM0rQk0d" role="1PaTwD">
-                <property role="3oM_SC" value="for" />
-              </node>
-              <node concept="3oM_SD" id="1FQTM0rQk3Q" role="1PaTwD">
-                <property role="3oM_SC" value="properties" />
-              </node>
-              <node concept="3oM_SD" id="1FQTM0rQk4X" role="1PaTwD">
-                <property role="3oM_SC" value="makes" />
-              </node>
-              <node concept="3oM_SD" id="1FQTM0rQk6J" role="1PaTwD">
-                <property role="3oM_SC" value="the" />
-              </node>
-              <node concept="3oM_SD" id="1FQTM0rQk7o" role="1PaTwD">
-                <property role="3oM_SC" value="ModelMerge" />
-              </node>
-              <node concept="3oM_SD" id="1FQTM0rQkac" role="1PaTwD">
-                <property role="3oM_SC" value="well" />
-              </node>
-              <node concept="3oM_SD" id="1FQTM0rQkc1" role="1PaTwD">
-                <property role="3oM_SC" value="defined." />
-              </node>
-            </node>
-          </node>
-          <node concept="3clFbF" id="ZzVzivTlPG" role="3cqZAp">
-            <node concept="2YIFZM" id="6MgS2un_soA" role="3clFbG">
-              <ref role="37wK5l" node="ZzVzivR$xp" resolve="warn" />
-              <ref role="1Pybhc" node="1trrptaK_0z" resolve="CheckinRuleUtil" />
-              <node concept="2OqwBi" id="6MgS2un_soB" role="37wK5m">
-                <node concept="1YBJjd" id="6MgS2un_soC" role="2Oq$k0">
-                  <ref role="1YBMHb" node="7TOowlgBzBU" resolve="modelMerge" />
-                </node>
-                <node concept="2qgKlT" id="6MgS2un_soD" role="2OqNvi">
-                  <ref role="37wK5l" to="rnx3:3xJ_LYXlmVz" resolve="languageConcepts" />
-                </node>
-              </node>
-              <node concept="37vLTw" id="6MgS2un_soE" role="37wK5m">
-                <ref role="3cqZAo" node="ZzVzivMLGl" resolve="repository" />
-              </node>
-              <node concept="2OqwBi" id="6MgS2unBOb7" role="37wK5m">
-                <node concept="37vLTw" id="6MgS2unBNk$" role="2Oq$k0">
-                  <ref role="3cqZAo" node="3EHNiwz7rFs" resolve="mergerResolver" />
-                </node>
-                <node concept="liA8E" id="6MgS2unBPjZ" role="2OqNvi">
-                  <ref role="37wK5l" to="gunp:6MgS2unA2UL" resolve="conceptToProperty" />
-                </node>
-              </node>
-              <node concept="37vLTw" id="6MgS2un_soJ" role="37wK5m">
-                <ref role="3cqZAo" node="582YV7z0eIy" resolve="conceptToRelevantProperties" />
-              </node>
-              <node concept="1bVj0M" id="6MgS2un_soK" role="37wK5m">
-                <node concept="37vLTG" id="6MgS2un_soL" role="1bW2Oz">
-                  <property role="TrG5h" value="sac" />
-                  <node concept="3uibUv" id="6MgS2un_soM" role="1tU5fm">
-                    <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
+              <node concept="3SKdUt" id="1FQTM0rQh0q" role="3cqZAp">
+                <node concept="1PaTwC" id="1FQTM0rQh0r" role="1aUNEU">
+                  <node concept="3oM_SD" id="1FQTM0rQh0s" role="1PaTwD">
+                    <property role="3oM_SC" value="some" />
+                  </node>
+                  <node concept="3oM_SD" id="1FQTM0rQh$T" role="1PaTwD">
+                    <property role="3oM_SC" value="leaf-Concepts." />
+                  </node>
+                  <node concept="3oM_SD" id="1FQTM0rQhC6" role="1PaTwD">
+                    <property role="3oM_SC" value="Even" />
+                  </node>
+                  <node concept="3oM_SD" id="1FQTM0rQhDk" role="1PaTwD">
+                    <property role="3oM_SC" value="if" />
+                  </node>
+                  <node concept="3oM_SD" id="1FQTM0rQhDT" role="1PaTwD">
+                    <property role="3oM_SC" value="all" />
+                  </node>
+                  <node concept="3oM_SD" id="1FQTM0rQhGD" role="1PaTwD">
+                    <property role="3oM_SC" value="children" />
+                  </node>
+                  <node concept="3oM_SD" id="1FQTM0rQhKx" role="1PaTwD">
+                    <property role="3oM_SC" value="in" />
+                  </node>
+                  <node concept="3oM_SD" id="1FQTM0rQhLN" role="1PaTwD">
+                    <property role="3oM_SC" value="all" />
+                  </node>
+                  <node concept="3oM_SD" id="1FQTM0rQhMs" role="1PaTwD">
+                    <property role="3oM_SC" value="Concepts" />
+                  </node>
+                  <node concept="3oM_SD" id="1FQTM0rQhN6" role="1PaTwD">
+                    <property role="3oM_SC" value="would" />
+                  </node>
+                  <node concept="3oM_SD" id="1FQTM0rQhNL" role="1PaTwD">
+                    <property role="3oM_SC" value="be" />
+                  </node>
+                  <node concept="3oM_SD" id="1FQTM0rQhP7" role="1PaTwD">
+                    <property role="3oM_SC" value="handled" />
+                  </node>
+                  <node concept="3oM_SD" id="1FQTM0rQhRk" role="1PaTwD">
+                    <property role="3oM_SC" value="by" />
+                  </node>
+                  <node concept="3oM_SD" id="1FQTM0rQhSG" role="1PaTwD">
+                    <property role="3oM_SC" value="Auto," />
+                  </node>
+                  <node concept="3oM_SD" id="1FQTM0rQhVr" role="1PaTwD">
+                    <property role="3oM_SC" value="then" />
+                  </node>
+                  <node concept="3oM_SD" id="1FQTM0rQhYS" role="1PaTwD">
+                    <property role="3oM_SC" value="it" />
+                  </node>
+                  <node concept="3oM_SD" id="1FQTM0rQhZD" role="1PaTwD">
+                    <property role="3oM_SC" value="is" />
+                  </node>
+                  <node concept="3oM_SD" id="1FQTM0rQi15" role="1PaTwD">
+                    <property role="3oM_SC" value="assured" />
                   </node>
                 </node>
-                <node concept="37vLTG" id="6MgS2un_soN" role="1bW2Oz">
-                  <property role="TrG5h" value="pd" />
-                  <node concept="3Tqbb2" id="6MgS2un_soO" role="1tU5fm">
-                    <ref role="ehGHo" to="tpce:f_TJgxF" resolve="PropertyDeclaration" />
+              </node>
+              <node concept="3SKdUt" id="1FQTM0rQj14" role="3cqZAp">
+                <node concept="1PaTwC" id="1FQTM0rQj15" role="1aUNEU">
+                  <node concept="3oM_SD" id="1FQTM0rQj16" role="1PaTwD">
+                    <property role="3oM_SC" value="that" />
+                  </node>
+                  <node concept="3oM_SD" id="1FQTM0rQjR2" role="1PaTwD">
+                    <property role="3oM_SC" value="the" />
+                  </node>
+                  <node concept="3oM_SD" id="1FQTM0rQjTf" role="1PaTwD">
+                    <property role="3oM_SC" value="defined" />
+                  </node>
+                  <node concept="3oM_SD" id="1FQTM0rQjXh" role="1PaTwD">
+                    <property role="3oM_SC" value="Merge-Policies" />
+                  </node>
+                  <node concept="3oM_SD" id="1FQTM0rQk0d" role="1PaTwD">
+                    <property role="3oM_SC" value="for" />
+                  </node>
+                  <node concept="3oM_SD" id="1FQTM0rQk3Q" role="1PaTwD">
+                    <property role="3oM_SC" value="properties" />
+                  </node>
+                  <node concept="3oM_SD" id="1FQTM0rQk4X" role="1PaTwD">
+                    <property role="3oM_SC" value="makes" />
+                  </node>
+                  <node concept="3oM_SD" id="1FQTM0rQk6J" role="1PaTwD">
+                    <property role="3oM_SC" value="the" />
+                  </node>
+                  <node concept="3oM_SD" id="1FQTM0rQk7o" role="1PaTwD">
+                    <property role="3oM_SC" value="ModelMerge" />
+                  </node>
+                  <node concept="3oM_SD" id="1FQTM0rQkac" role="1PaTwD">
+                    <property role="3oM_SC" value="well" />
+                  </node>
+                  <node concept="3oM_SD" id="1FQTM0rQkc1" role="1PaTwD">
+                    <property role="3oM_SC" value="defined." />
                   </node>
                 </node>
-                <node concept="3clFbS" id="6MgS2un_soP" role="1bW5cS">
-                  <node concept="a7r0C" id="6MgS2un_soQ" role="3cqZAp">
-                    <node concept="3cpWs3" id="6MgS2un_soR" role="a7wSD">
-                      <node concept="37vLTw" id="6MgS2un_soS" role="3uHU7w">
-                        <ref role="3cqZAo" node="6MgS2un_soN" resolve="pd" />
+              </node>
+              <node concept="3clFbF" id="ZzVzivTlPG" role="3cqZAp">
+                <node concept="2YIFZM" id="6MgS2un_soA" role="3clFbG">
+                  <ref role="37wK5l" node="ZzVzivR$xp" resolve="warn" />
+                  <ref role="1Pybhc" node="1trrptaK_0z" resolve="CheckinRuleUtil" />
+                  <node concept="2OqwBi" id="6MgS2un_soB" role="37wK5m">
+                    <node concept="1YBJjd" id="6MgS2un_soC" role="2Oq$k0">
+                      <ref role="1YBMHb" node="7TOowlgBzBU" resolve="modelMerge" />
+                    </node>
+                    <node concept="2qgKlT" id="6MgS2un_soD" role="2OqNvi">
+                      <ref role="37wK5l" to="rnx3:3xJ_LYXlmVz" resolve="languageConcepts" />
+                    </node>
+                  </node>
+                  <node concept="37vLTw" id="6MgS2un_soE" role="37wK5m">
+                    <ref role="3cqZAo" node="ZzVzivMLGl" resolve="repository" />
+                  </node>
+                  <node concept="2OqwBi" id="6MgS2unBOb7" role="37wK5m">
+                    <node concept="37vLTw" id="6MgS2unBNk$" role="2Oq$k0">
+                      <ref role="3cqZAo" node="3EHNiwz7rFs" resolve="mergerResolver" />
+                    </node>
+                    <node concept="liA8E" id="6MgS2unBPjZ" role="2OqNvi">
+                      <ref role="37wK5l" to="gunp:6MgS2unA2UL" resolve="conceptToProperty" />
+                    </node>
+                  </node>
+                  <node concept="37vLTw" id="6MgS2un_soJ" role="37wK5m">
+                    <ref role="3cqZAo" node="582YV7z0eIy" resolve="conceptToRelevantProperties" />
+                  </node>
+                  <node concept="1bVj0M" id="6MgS2un_soK" role="37wK5m">
+                    <node concept="37vLTG" id="6MgS2un_soL" role="1bW2Oz">
+                      <property role="TrG5h" value="sac" />
+                      <node concept="3uibUv" id="6MgS2un_soM" role="1tU5fm">
+                        <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
                       </node>
-                      <node concept="3cpWs3" id="6MgS2un_soT" role="3uHU7B">
-                        <node concept="3cpWs3" id="6MgS2un_soU" role="3uHU7B">
-                          <node concept="Xl_RD" id="6MgS2un_soV" role="3uHU7B">
-                            <property role="Xl_RC" value="concept " />
+                    </node>
+                    <node concept="37vLTG" id="6MgS2un_soN" role="1bW2Oz">
+                      <property role="TrG5h" value="pd" />
+                      <node concept="3Tqbb2" id="6MgS2un_soO" role="1tU5fm">
+                        <ref role="ehGHo" to="tpce:f_TJgxF" resolve="PropertyDeclaration" />
+                      </node>
+                    </node>
+                    <node concept="3clFbS" id="6MgS2un_soP" role="1bW5cS">
+                      <node concept="a7r0C" id="6MgS2un_soQ" role="3cqZAp">
+                        <node concept="3cpWs3" id="6MgS2un_soR" role="a7wSD">
+                          <node concept="37vLTw" id="6MgS2un_soS" role="3uHU7w">
+                            <ref role="3cqZAo" node="6MgS2un_soN" resolve="pd" />
                           </node>
-                          <node concept="37vLTw" id="6MgS2un_soW" role="3uHU7w">
+                          <node concept="3cpWs3" id="6MgS2un_soT" role="3uHU7B">
+                            <node concept="3cpWs3" id="6MgS2un_soU" role="3uHU7B">
+                              <node concept="Xl_RD" id="6MgS2un_soV" role="3uHU7B">
+                                <property role="Xl_RC" value="concept " />
+                              </node>
+                              <node concept="37vLTw" id="6MgS2un_soW" role="3uHU7w">
+                                <ref role="3cqZAo" node="6MgS2un_soL" resolve="sac" />
+                              </node>
+                            </node>
+                            <node concept="Xl_RD" id="6MgS2un_soX" role="3uHU7w">
+                              <property role="Xl_RC" value=" is missing merge policy for property " />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="2YIFZM" id="6MgS2un_soY" role="1urrMF">
+                          <ref role="37wK5l" node="582YV7yWtlM" resolve="warningNode" />
+                          <ref role="1Pybhc" node="1trrptaK_0z" resolve="CheckinRuleUtil" />
+                          <node concept="1YBJjd" id="6MgS2un_soZ" role="37wK5m">
+                            <ref role="1YBMHb" node="7TOowlgBzBU" resolve="modelMerge" />
+                          </node>
+                          <node concept="37vLTw" id="6MgS2un_sp0" role="37wK5m">
                             <ref role="3cqZAo" node="6MgS2un_soL" resolve="sac" />
                           </node>
                         </node>
-                        <node concept="Xl_RD" id="6MgS2un_soX" role="3uHU7w">
-                          <property role="Xl_RC" value=" is missing merge policy for property " />
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="2YIFZM" id="6MgS2un_soY" role="1urrMF">
-                      <ref role="37wK5l" node="582YV7yWtlM" resolve="warningNode" />
-                      <ref role="1Pybhc" node="1trrptaK_0z" resolve="CheckinRuleUtil" />
-                      <node concept="1YBJjd" id="6MgS2un_soZ" role="37wK5m">
-                        <ref role="1YBMHb" node="7TOowlgBzBU" resolve="modelMerge" />
-                      </node>
-                      <node concept="37vLTw" id="6MgS2un_sp0" role="37wK5m">
-                        <ref role="3cqZAo" node="6MgS2un_soL" resolve="sac" />
                       </node>
                     </node>
                   </node>
                 </node>
               </node>
-            </node>
-          </node>
-          <node concept="3clFbH" id="ZzVzivUfmo" role="3cqZAp" />
-          <node concept="3SKdUt" id="60iGZSKkceL" role="3cqZAp">
-            <node concept="1PaTwC" id="60iGZSKkceM" role="1aUNEU">
-              <node concept="3oM_SD" id="60iGZSKkdqu" role="1PaTwD">
-                <property role="3oM_SC" value="--Missing" />
-              </node>
-              <node concept="3oM_SD" id="60iGZSKkdtA" role="1PaTwD">
-                <property role="3oM_SC" value="Child" />
-              </node>
-              <node concept="3oM_SD" id="60iGZSKkduP" role="1PaTwD">
-                <property role="3oM_SC" value="Policy" />
-              </node>
-            </node>
-          </node>
-          <node concept="3cpWs8" id="582YV7z0meD" role="3cqZAp">
-            <node concept="3cpWsn" id="582YV7z0meE" role="3cpWs9">
-              <property role="TrG5h" value="conceptToRelevantChildren" />
-              <node concept="1ajhzC" id="582YV7z0me_" role="1tU5fm">
-                <node concept="3Tqbb2" id="582YV7z0meA" role="1ajw0F">
-                  <ref role="ehGHo" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
-                </node>
-                <node concept="3uibUv" id="582YV7z0meB" role="1ajl9A">
-                  <ref role="3uigEE" to="33ny:~HashSet" resolve="HashSet" />
-                  <node concept="3Tqbb2" id="582YV7z0meC" role="11_B2D">
-                    <ref role="ehGHo" to="tpce:f_TJgxE" resolve="LinkDeclaration" />
+              <node concept="3clFbH" id="ZzVzivUfmo" role="3cqZAp" />
+              <node concept="3SKdUt" id="60iGZSKkceL" role="3cqZAp">
+                <node concept="1PaTwC" id="60iGZSKkceM" role="1aUNEU">
+                  <node concept="3oM_SD" id="60iGZSKkdqu" role="1PaTwD">
+                    <property role="3oM_SC" value="--Missing" />
+                  </node>
+                  <node concept="3oM_SD" id="60iGZSKkdtA" role="1PaTwD">
+                    <property role="3oM_SC" value="Child" />
+                  </node>
+                  <node concept="3oM_SD" id="60iGZSKkduP" role="1PaTwD">
+                    <property role="3oM_SC" value="Policy" />
                   </node>
                 </node>
               </node>
-              <node concept="1bVj0M" id="582YV7z0meF" role="33vP2m">
-                <node concept="3clFbS" id="582YV7z0meG" role="1bW5cS">
-                  <node concept="3cpWs8" id="582YV7z0meH" role="3cqZAp">
-                    <node concept="3cpWsn" id="582YV7z0meI" role="3cpWs9">
-                      <property role="TrG5h" value="forbiddenChildren" />
-                      <node concept="3vKaQO" id="582YV7z0meJ" role="1tU5fm">
-                        <node concept="3uibUv" id="582YV7z0meK" role="3O5elw">
-                          <ref role="3uigEE" to="c17a:~SContainmentLink" resolve="SContainmentLink" />
-                        </node>
-                      </node>
-                      <node concept="2OqwBi" id="582YV7z0meL" role="33vP2m">
-                        <node concept="35c_gC" id="582YV7z0meM" role="2Oq$k0">
-                          <ref role="35c_gD" to="tpck:gw2VY9q" resolve="BaseConcept" />
-                        </node>
-                        <node concept="liA8E" id="582YV7z0meN" role="2OqNvi">
-                          <ref role="37wK5l" to="c17a:~SAbstractConcept.getContainmentLinks()" resolve="getContainmentLinks" />
-                        </node>
+              <node concept="3cpWs8" id="582YV7z0meD" role="3cqZAp">
+                <node concept="3cpWsn" id="582YV7z0meE" role="3cpWs9">
+                  <property role="TrG5h" value="conceptToRelevantChildren" />
+                  <node concept="1ajhzC" id="582YV7z0me_" role="1tU5fm">
+                    <node concept="3Tqbb2" id="582YV7z0meA" role="1ajw0F">
+                      <ref role="ehGHo" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
+                    </node>
+                    <node concept="3uibUv" id="582YV7z0meB" role="1ajl9A">
+                      <ref role="3uigEE" to="33ny:~HashSet" resolve="HashSet" />
+                      <node concept="3Tqbb2" id="582YV7z0meC" role="11_B2D">
+                        <ref role="ehGHo" to="tpce:f_TJgxE" resolve="LinkDeclaration" />
                       </node>
                     </node>
                   </node>
-                  <node concept="3clFbF" id="4ZputZW5ZW6" role="3cqZAp">
-                    <node concept="2ShNRf" id="4ZputZW5ZW2" role="3clFbG">
-                      <node concept="1pGfFk" id="4ZputZW61kK" role="2ShVmc">
-                        <ref role="37wK5l" to="33ny:~HashSet.&lt;init&gt;(java.util.Collection)" resolve="HashSet" />
-                        <node concept="2OqwBi" id="4ZputZW6g9S" role="37wK5m">
-                          <node concept="2OqwBi" id="4ZputZW6g9T" role="2Oq$k0">
-                            <node concept="2OqwBi" id="4ZputZW6g9U" role="2Oq$k0">
-                              <node concept="2OqwBi" id="4ZputZW6g9V" role="2Oq$k0">
-                                <node concept="37vLTw" id="4ZputZW6g9W" role="2Oq$k0">
-                                  <ref role="3cqZAo" node="582YV7z0mfd" resolve="acd" />
-                                </node>
-                                <node concept="2qgKlT" id="4ZputZW6g9X" role="2OqNvi">
-                                  <ref role="37wK5l" to="tpcn:hEwILKK" resolve="getLinkDeclarations" />
-                                </node>
-                              </node>
-                              <node concept="3zZkjj" id="4ZputZW6g9Y" role="2OqNvi">
-                                <node concept="1bVj0M" id="4ZputZW6g9Z" role="23t8la">
-                                  <node concept="3clFbS" id="4ZputZW6ga0" role="1bW5cS">
-                                    <node concept="3clFbF" id="4ZputZW6ga1" role="3cqZAp">
-                                      <node concept="3fqX7Q" id="4ZputZW6ga2" role="3clFbG">
-                                        <node concept="2OqwBi" id="4ZputZW6ga3" role="3fr31v">
-                                          <node concept="2OqwBi" id="4ZputZW6ga4" role="2Oq$k0">
-                                            <node concept="37vLTw" id="4ZputZW6ga5" role="2Oq$k0">
-                                              <ref role="3cqZAo" node="7Z$RfkF7IGd" resolve="it" />
-                                            </node>
-                                            <node concept="3TrcHB" id="4ZputZW6ga6" role="2OqNvi">
-                                              <ref role="3TsBF5" to="tpce:3Ftr4R6BH8$" resolve="metaClass" />
-                                            </node>
-                                          </node>
-                                          <node concept="21noJN" id="4ZputZW6ga7" role="2OqNvi">
-                                            <node concept="21nZrQ" id="4ZputZW6ga8" role="21noJM">
-                                              <ref role="21nZrZ" to="tpce:3Ftr4R6BFyn" resolve="reference" />
-                                            </node>
-                                          </node>
-                                        </node>
-                                      </node>
+                  <node concept="1bVj0M" id="582YV7z0meF" role="33vP2m">
+                    <node concept="3clFbS" id="582YV7z0meG" role="1bW5cS">
+                      <node concept="3cpWs8" id="582YV7z0meH" role="3cqZAp">
+                        <node concept="3cpWsn" id="582YV7z0meI" role="3cpWs9">
+                          <property role="TrG5h" value="forbiddenChildren" />
+                          <node concept="3vKaQO" id="582YV7z0meJ" role="1tU5fm">
+                            <node concept="3uibUv" id="582YV7z0meK" role="3O5elw">
+                              <ref role="3uigEE" to="c17a:~SContainmentLink" resolve="SContainmentLink" />
+                            </node>
+                          </node>
+                          <node concept="2OqwBi" id="582YV7z0meL" role="33vP2m">
+                            <node concept="35c_gC" id="582YV7z0meM" role="2Oq$k0">
+                              <ref role="35c_gD" to="tpck:gw2VY9q" resolve="BaseConcept" />
+                            </node>
+                            <node concept="liA8E" id="582YV7z0meN" role="2OqNvi">
+                              <ref role="37wK5l" to="c17a:~SAbstractConcept.getContainmentLinks()" resolve="getContainmentLinks" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="4ZputZW5ZW6" role="3cqZAp">
+                        <node concept="2ShNRf" id="4ZputZW5ZW2" role="3clFbG">
+                          <node concept="1pGfFk" id="4ZputZW61kK" role="2ShVmc">
+                            <ref role="37wK5l" to="33ny:~HashSet.&lt;init&gt;(java.util.Collection)" resolve="HashSet" />
+                            <node concept="2OqwBi" id="4ZputZW6g9S" role="37wK5m">
+                              <node concept="2OqwBi" id="4ZputZW6g9T" role="2Oq$k0">
+                                <node concept="2OqwBi" id="4ZputZW6g9U" role="2Oq$k0">
+                                  <node concept="2OqwBi" id="4ZputZW6g9V" role="2Oq$k0">
+                                    <node concept="37vLTw" id="4ZputZW6g9W" role="2Oq$k0">
+                                      <ref role="3cqZAo" node="582YV7z0mfd" resolve="acd" />
+                                    </node>
+                                    <node concept="2qgKlT" id="4ZputZW6g9X" role="2OqNvi">
+                                      <ref role="37wK5l" to="tpcn:hEwILKK" resolve="getLinkDeclarations" />
                                     </node>
                                   </node>
-                                  <node concept="gl6BB" id="7Z$RfkF7IGd" role="1bW2Oz">
-                                    <property role="TrG5h" value="it" />
-                                    <node concept="2jxLKc" id="7Z$RfkF7IGe" role="1tU5fm" />
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                            <node concept="3zZkjj" id="4ZputZW6gab" role="2OqNvi">
-                              <node concept="1bVj0M" id="4ZputZW6gac" role="23t8la">
-                                <node concept="3clFbS" id="4ZputZW6gad" role="1bW5cS">
-                                  <node concept="3clFbF" id="4ZputZW6gae" role="3cqZAp">
-                                    <node concept="3fqX7Q" id="4ZputZW6gaf" role="3clFbG">
-                                      <node concept="2OqwBi" id="4ZputZW6gag" role="3fr31v">
-                                        <node concept="37vLTw" id="4ZputZW6gah" role="2Oq$k0">
-                                          <ref role="3cqZAo" node="582YV7z0meI" resolve="forbiddenChildren" />
-                                        </node>
-                                        <node concept="2HwmR7" id="4ZputZW6gai" role="2OqNvi">
-                                          <node concept="1bVj0M" id="4ZputZW6gaj" role="23t8la">
-                                            <node concept="3clFbS" id="4ZputZW6gak" role="1bW5cS">
-                                              <node concept="3clFbF" id="4ZputZW6gal" role="3cqZAp">
-                                                <node concept="2OqwBi" id="4ZputZW6gam" role="3clFbG">
-                                                  <node concept="37vLTw" id="4ZputZW6gan" role="2Oq$k0">
-                                                    <ref role="3cqZAo" node="7Z$RfkF7IGh" resolve="it" />
-                                                  </node>
-                                                  <node concept="2qgKlT" id="4ZputZW6gao" role="2OqNvi">
-                                                    <ref role="37wK5l" to="tpcn:4MKjpUYniHA" resolve="is" />
-                                                    <node concept="37vLTw" id="4ZputZW6gap" role="37wK5m">
-                                                      <ref role="3cqZAo" node="7Z$RfkF7IGf" resolve="child" />
-                                                    </node>
-                                                  </node>
+                                  <node concept="3zZkjj" id="4ZputZW6g9Y" role="2OqNvi">
+                                    <node concept="1bVj0M" id="4ZputZW6g9Z" role="23t8la">
+                                      <node concept="3clFbS" id="4ZputZW6ga0" role="1bW5cS">
+                                        <node concept="3clFbF" id="4ZputZW6ga1" role="3cqZAp">
+                                          <node concept="3fqX7Q" id="4ZputZW6ga2" role="3clFbG">
+                                            <node concept="2OqwBi" id="4ZputZW6ga3" role="3fr31v">
+                                              <node concept="2OqwBi" id="4ZputZW6ga4" role="2Oq$k0">
+                                                <node concept="37vLTw" id="4ZputZW6ga5" role="2Oq$k0">
+                                                  <ref role="3cqZAo" node="7Z$RfkF7IGd" resolve="it" />
+                                                </node>
+                                                <node concept="3TrcHB" id="4ZputZW6ga6" role="2OqNvi">
+                                                  <ref role="3TsBF5" to="tpce:3Ftr4R6BH8$" resolve="metaClass" />
+                                                </node>
+                                              </node>
+                                              <node concept="21noJN" id="4ZputZW6ga7" role="2OqNvi">
+                                                <node concept="21nZrQ" id="4ZputZW6ga8" role="21noJM">
+                                                  <ref role="21nZrZ" to="tpce:3Ftr4R6BFyn" resolve="reference" />
                                                 </node>
                                               </node>
                                             </node>
-                                            <node concept="gl6BB" id="7Z$RfkF7IGf" role="1bW2Oz">
-                                              <property role="TrG5h" value="child" />
-                                              <node concept="2jxLKc" id="7Z$RfkF7IGg" role="1tU5fm" />
+                                          </node>
+                                        </node>
+                                      </node>
+                                      <node concept="gl6BB" id="7Z$RfkF7IGd" role="1bW2Oz">
+                                        <property role="TrG5h" value="it" />
+                                        <node concept="2jxLKc" id="7Z$RfkF7IGe" role="1tU5fm" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                                <node concept="3zZkjj" id="4ZputZW6gab" role="2OqNvi">
+                                  <node concept="1bVj0M" id="4ZputZW6gac" role="23t8la">
+                                    <node concept="3clFbS" id="4ZputZW6gad" role="1bW5cS">
+                                      <node concept="3clFbF" id="4ZputZW6gae" role="3cqZAp">
+                                        <node concept="3fqX7Q" id="4ZputZW6gaf" role="3clFbG">
+                                          <node concept="2OqwBi" id="4ZputZW6gag" role="3fr31v">
+                                            <node concept="37vLTw" id="4ZputZW6gah" role="2Oq$k0">
+                                              <ref role="3cqZAo" node="582YV7z0meI" resolve="forbiddenChildren" />
+                                            </node>
+                                            <node concept="2HwmR7" id="4ZputZW6gai" role="2OqNvi">
+                                              <node concept="1bVj0M" id="4ZputZW6gaj" role="23t8la">
+                                                <node concept="3clFbS" id="4ZputZW6gak" role="1bW5cS">
+                                                  <node concept="3clFbF" id="4ZputZW6gal" role="3cqZAp">
+                                                    <node concept="2OqwBi" id="4ZputZW6gam" role="3clFbG">
+                                                      <node concept="37vLTw" id="4ZputZW6gan" role="2Oq$k0">
+                                                        <ref role="3cqZAo" node="7Z$RfkF7IGh" resolve="it" />
+                                                      </node>
+                                                      <node concept="2qgKlT" id="4ZputZW6gao" role="2OqNvi">
+                                                        <ref role="37wK5l" to="tpcn:4MKjpUYniHA" resolve="is" />
+                                                        <node concept="37vLTw" id="4ZputZW6gap" role="37wK5m">
+                                                          <ref role="3cqZAo" node="7Z$RfkF7IGf" resolve="child" />
+                                                        </node>
+                                                      </node>
+                                                    </node>
+                                                  </node>
+                                                </node>
+                                                <node concept="gl6BB" id="7Z$RfkF7IGf" role="1bW2Oz">
+                                                  <property role="TrG5h" value="child" />
+                                                  <node concept="2jxLKc" id="7Z$RfkF7IGg" role="1tU5fm" />
+                                                </node>
+                                              </node>
                                             </node>
                                           </node>
                                         </node>
                                       </node>
                                     </node>
+                                    <node concept="gl6BB" id="7Z$RfkF7IGh" role="1bW2Oz">
+                                      <property role="TrG5h" value="it" />
+                                      <node concept="2jxLKc" id="7Z$RfkF7IGi" role="1tU5fm" />
+                                    </node>
                                   </node>
                                 </node>
-                                <node concept="gl6BB" id="7Z$RfkF7IGh" role="1bW2Oz">
-                                  <property role="TrG5h" value="it" />
-                                  <node concept="2jxLKc" id="7Z$RfkF7IGi" role="1tU5fm" />
-                                </node>
                               </node>
+                              <node concept="ANE8D" id="4ZputZW6gau" role="2OqNvi" />
+                            </node>
+                            <node concept="3Tqbb2" id="4ZputZW67YO" role="1pMfVU">
+                              <ref role="ehGHo" to="tpce:f_TJgxE" resolve="LinkDeclaration" />
                             </node>
                           </node>
-                          <node concept="ANE8D" id="4ZputZW6gau" role="2OqNvi" />
                         </node>
-                        <node concept="3Tqbb2" id="4ZputZW67YO" role="1pMfVU">
-                          <ref role="ehGHo" to="tpce:f_TJgxE" resolve="LinkDeclaration" />
-                        </node>
+                      </node>
+                    </node>
+                    <node concept="37vLTG" id="582YV7z0mfd" role="1bW2Oz">
+                      <property role="TrG5h" value="acd" />
+                      <node concept="3Tqbb2" id="582YV7z0mfe" role="1tU5fm">
+                        <ref role="ehGHo" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
                       </node>
                     </node>
                   </node>
                 </node>
-                <node concept="37vLTG" id="582YV7z0mfd" role="1bW2Oz">
-                  <property role="TrG5h" value="acd" />
-                  <node concept="3Tqbb2" id="582YV7z0mfe" role="1tU5fm">
-                    <ref role="ehGHo" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
+              </node>
+              <node concept="3clFbF" id="ZzVzivVFWG" role="3cqZAp">
+                <node concept="2YIFZM" id="6MgS2un_o5h" role="3clFbG">
+                  <ref role="37wK5l" node="ZzVzivR$xp" resolve="warn" />
+                  <ref role="1Pybhc" node="1trrptaK_0z" resolve="CheckinRuleUtil" />
+                  <node concept="2OqwBi" id="6MgS2un_o5i" role="37wK5m">
+                    <node concept="1YBJjd" id="6MgS2un_o5j" role="2Oq$k0">
+                      <ref role="1YBMHb" node="7TOowlgBzBU" resolve="modelMerge" />
+                    </node>
+                    <node concept="2qgKlT" id="6MgS2un_o5k" role="2OqNvi">
+                      <ref role="37wK5l" to="rnx3:3xJ_LYXlmVz" resolve="languageConcepts" />
+                    </node>
                   </node>
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3clFbF" id="ZzVzivVFWG" role="3cqZAp">
-            <node concept="2YIFZM" id="6MgS2un_o5h" role="3clFbG">
-              <ref role="37wK5l" node="ZzVzivR$xp" resolve="warn" />
-              <ref role="1Pybhc" node="1trrptaK_0z" resolve="CheckinRuleUtil" />
-              <node concept="2OqwBi" id="6MgS2un_o5i" role="37wK5m">
-                <node concept="1YBJjd" id="6MgS2un_o5j" role="2Oq$k0">
-                  <ref role="1YBMHb" node="7TOowlgBzBU" resolve="modelMerge" />
-                </node>
-                <node concept="2qgKlT" id="6MgS2un_o5k" role="2OqNvi">
-                  <ref role="37wK5l" to="rnx3:3xJ_LYXlmVz" resolve="languageConcepts" />
-                </node>
-              </node>
-              <node concept="37vLTw" id="6MgS2un_o5l" role="37wK5m">
-                <ref role="3cqZAo" node="ZzVzivMLGl" resolve="repository" />
-              </node>
-              <node concept="2OqwBi" id="6MgS2unBQcH" role="37wK5m">
-                <node concept="37vLTw" id="6MgS2unBQcI" role="2Oq$k0">
-                  <ref role="3cqZAo" node="3EHNiwz7rFs" resolve="mergerResolver" />
-                </node>
-                <node concept="liA8E" id="6MgS2unBRIA" role="2OqNvi">
-                  <ref role="37wK5l" to="gunp:6MgS2unAdH$" resolve="conceptToChildLink" />
-                </node>
-              </node>
-              <node concept="37vLTw" id="6MgS2un_o5q" role="37wK5m">
-                <ref role="3cqZAo" node="582YV7z0meE" resolve="conceptToRelevantChildren" />
-              </node>
-              <node concept="1bVj0M" id="6MgS2un_o5r" role="37wK5m">
-                <node concept="37vLTG" id="6MgS2un_o5s" role="1bW2Oz">
-                  <property role="TrG5h" value="sac" />
-                  <node concept="3uibUv" id="6MgS2un_o5t" role="1tU5fm">
-                    <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
+                  <node concept="37vLTw" id="6MgS2un_o5l" role="37wK5m">
+                    <ref role="3cqZAo" node="ZzVzivMLGl" resolve="repository" />
                   </node>
-                </node>
-                <node concept="37vLTG" id="6MgS2un_o5u" role="1bW2Oz">
-                  <property role="TrG5h" value="ld" />
-                  <node concept="3Tqbb2" id="6MgS2un_o5v" role="1tU5fm">
-                    <ref role="ehGHo" to="tpce:f_TJgxE" resolve="LinkDeclaration" />
+                  <node concept="2OqwBi" id="6MgS2unBQcH" role="37wK5m">
+                    <node concept="37vLTw" id="6MgS2unBQcI" role="2Oq$k0">
+                      <ref role="3cqZAo" node="3EHNiwz7rFs" resolve="mergerResolver" />
+                    </node>
+                    <node concept="liA8E" id="6MgS2unBRIA" role="2OqNvi">
+                      <ref role="37wK5l" to="gunp:6MgS2unAdH$" resolve="conceptToChildLink" />
+                    </node>
                   </node>
-                </node>
-                <node concept="3clFbS" id="6MgS2un_o5w" role="1bW5cS">
-                  <node concept="a7r0C" id="6MgS2un_o5x" role="3cqZAp">
-                    <node concept="3cpWs3" id="6MgS2un_o5y" role="a7wSD">
-                      <node concept="2OqwBi" id="6MgS2un_o5z" role="3uHU7w">
-                        <node concept="37vLTw" id="6MgS2un_o5$" role="2Oq$k0">
-                          <ref role="3cqZAo" node="6MgS2un_o5u" resolve="ld" />
-                        </node>
-                        <node concept="2qgKlT" id="6MgS2un_o5_" role="2OqNvi">
-                          <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
-                        </node>
+                  <node concept="37vLTw" id="6MgS2un_o5q" role="37wK5m">
+                    <ref role="3cqZAo" node="582YV7z0meE" resolve="conceptToRelevantChildren" />
+                  </node>
+                  <node concept="1bVj0M" id="6MgS2un_o5r" role="37wK5m">
+                    <node concept="37vLTG" id="6MgS2un_o5s" role="1bW2Oz">
+                      <property role="TrG5h" value="sac" />
+                      <node concept="3uibUv" id="6MgS2un_o5t" role="1tU5fm">
+                        <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
                       </node>
-                      <node concept="3cpWs3" id="6MgS2un_o5A" role="3uHU7B">
-                        <node concept="3cpWs3" id="6MgS2un_o5B" role="3uHU7B">
-                          <node concept="Xl_RD" id="6MgS2un_o5C" role="3uHU7B">
-                            <property role="Xl_RC" value="concept" />
+                    </node>
+                    <node concept="37vLTG" id="6MgS2un_o5u" role="1bW2Oz">
+                      <property role="TrG5h" value="ld" />
+                      <node concept="3Tqbb2" id="6MgS2un_o5v" role="1tU5fm">
+                        <ref role="ehGHo" to="tpce:f_TJgxE" resolve="LinkDeclaration" />
+                      </node>
+                    </node>
+                    <node concept="3clFbS" id="6MgS2un_o5w" role="1bW5cS">
+                      <node concept="a7r0C" id="6MgS2un_o5x" role="3cqZAp">
+                        <node concept="3cpWs3" id="6MgS2un_o5y" role="a7wSD">
+                          <node concept="2OqwBi" id="6MgS2un_o5z" role="3uHU7w">
+                            <node concept="37vLTw" id="6MgS2un_o5$" role="2Oq$k0">
+                              <ref role="3cqZAo" node="6MgS2un_o5u" resolve="ld" />
+                            </node>
+                            <node concept="2qgKlT" id="6MgS2un_o5_" role="2OqNvi">
+                              <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                            </node>
                           </node>
-                          <node concept="37vLTw" id="6MgS2un_o5D" role="3uHU7w">
+                          <node concept="3cpWs3" id="6MgS2un_o5A" role="3uHU7B">
+                            <node concept="3cpWs3" id="6MgS2un_o5B" role="3uHU7B">
+                              <node concept="Xl_RD" id="6MgS2un_o5C" role="3uHU7B">
+                                <property role="Xl_RC" value="concept" />
+                              </node>
+                              <node concept="37vLTw" id="6MgS2un_o5D" role="3uHU7w">
+                                <ref role="3cqZAo" node="6MgS2un_o5s" resolve="sac" />
+                              </node>
+                            </node>
+                            <node concept="Xl_RD" id="6MgS2un_o5E" role="3uHU7w">
+                              <property role="Xl_RC" value=" is missing merge policy for child " />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="2YIFZM" id="6MgS2un_o5F" role="1urrMF">
+                          <ref role="1Pybhc" node="1trrptaK_0z" resolve="CheckinRuleUtil" />
+                          <ref role="37wK5l" node="582YV7yWtlM" resolve="warningNode" />
+                          <node concept="1YBJjd" id="6MgS2un_o5G" role="37wK5m">
+                            <ref role="1YBMHb" node="7TOowlgBzBU" resolve="modelMerge" />
+                          </node>
+                          <node concept="37vLTw" id="6MgS2un_o5H" role="37wK5m">
                             <ref role="3cqZAo" node="6MgS2un_o5s" resolve="sac" />
                           </node>
                         </node>
-                        <node concept="Xl_RD" id="6MgS2un_o5E" role="3uHU7w">
-                          <property role="Xl_RC" value=" is missing merge policy for child " />
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="2YIFZM" id="6MgS2un_o5F" role="1urrMF">
-                      <ref role="1Pybhc" node="1trrptaK_0z" resolve="CheckinRuleUtil" />
-                      <ref role="37wK5l" node="582YV7yWtlM" resolve="warningNode" />
-                      <node concept="1YBJjd" id="6MgS2un_o5G" role="37wK5m">
-                        <ref role="1YBMHb" node="7TOowlgBzBU" resolve="modelMerge" />
-                      </node>
-                      <node concept="37vLTw" id="6MgS2un_o5H" role="37wK5m">
-                        <ref role="3cqZAo" node="6MgS2un_o5s" resolve="sac" />
                       </node>
                     </node>
                   </node>
                 </node>
               </node>
-            </node>
-          </node>
-          <node concept="3clFbH" id="1trrptaJ3Pf" role="3cqZAp" />
-          <node concept="3SKdUt" id="60iGZSKkdxR" role="3cqZAp">
-            <node concept="1PaTwC" id="60iGZSKkdxS" role="1aUNEU">
-              <node concept="3oM_SD" id="60iGZSKkdxT" role="1PaTwD">
-                <property role="3oM_SC" value="--Missing" />
-              </node>
-              <node concept="3oM_SD" id="60iGZSKkeH0" role="1PaTwD">
-                <property role="3oM_SC" value="Reference" />
-              </node>
-              <node concept="3oM_SD" id="60iGZSKkeJv" role="1PaTwD">
-                <property role="3oM_SC" value="Policy" />
-              </node>
-            </node>
-          </node>
-          <node concept="3cpWs8" id="3PLTv5jZpdb" role="3cqZAp">
-            <node concept="3cpWsn" id="3PLTv5jZpdc" role="3cpWs9">
-              <property role="TrG5h" value="conceptToRelevantReferences" />
-              <node concept="1ajhzC" id="3PLTv5jZpdd" role="1tU5fm">
-                <node concept="3Tqbb2" id="3PLTv5jZpde" role="1ajw0F">
-                  <ref role="ehGHo" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
-                </node>
-                <node concept="3uibUv" id="3PLTv5jZpdf" role="1ajl9A">
-                  <ref role="3uigEE" to="33ny:~HashSet" resolve="HashSet" />
-                  <node concept="3Tqbb2" id="3PLTv5jZpdg" role="11_B2D">
-                    <ref role="ehGHo" to="tpce:f_TJgxE" resolve="LinkDeclaration" />
+              <node concept="3clFbH" id="1trrptaJ3Pf" role="3cqZAp" />
+              <node concept="3SKdUt" id="60iGZSKkdxR" role="3cqZAp">
+                <node concept="1PaTwC" id="60iGZSKkdxS" role="1aUNEU">
+                  <node concept="3oM_SD" id="60iGZSKkdxT" role="1PaTwD">
+                    <property role="3oM_SC" value="--Missing" />
+                  </node>
+                  <node concept="3oM_SD" id="60iGZSKkeH0" role="1PaTwD">
+                    <property role="3oM_SC" value="Reference" />
+                  </node>
+                  <node concept="3oM_SD" id="60iGZSKkeJv" role="1PaTwD">
+                    <property role="3oM_SC" value="Policy" />
                   </node>
                 </node>
               </node>
-              <node concept="1bVj0M" id="3PLTv5jZpdh" role="33vP2m">
-                <node concept="3clFbS" id="3PLTv5jZpdi" role="1bW5cS">
-                  <node concept="3cpWs8" id="3PLTv5jZpdj" role="3cqZAp">
-                    <node concept="3cpWsn" id="3PLTv5jZpdk" role="3cpWs9">
-                      <property role="TrG5h" value="forbiddenChildren" />
-                      <node concept="3vKaQO" id="3PLTv5jZpdl" role="1tU5fm">
-                        <node concept="3uibUv" id="3PLTv5jZpdm" role="3O5elw">
-                          <ref role="3uigEE" to="c17a:~SContainmentLink" resolve="SContainmentLink" />
-                        </node>
-                      </node>
-                      <node concept="2OqwBi" id="3PLTv5jZpdn" role="33vP2m">
-                        <node concept="35c_gC" id="3PLTv5jZpdo" role="2Oq$k0">
-                          <ref role="35c_gD" to="tpck:gw2VY9q" resolve="BaseConcept" />
-                        </node>
-                        <node concept="liA8E" id="3PLTv5jZpdp" role="2OqNvi">
-                          <ref role="37wK5l" to="c17a:~SAbstractConcept.getContainmentLinks()" resolve="getContainmentLinks" />
-                        </node>
+              <node concept="3cpWs8" id="3PLTv5jZpdb" role="3cqZAp">
+                <node concept="3cpWsn" id="3PLTv5jZpdc" role="3cpWs9">
+                  <property role="TrG5h" value="conceptToRelevantReferences" />
+                  <node concept="1ajhzC" id="3PLTv5jZpdd" role="1tU5fm">
+                    <node concept="3Tqbb2" id="3PLTv5jZpde" role="1ajw0F">
+                      <ref role="ehGHo" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
+                    </node>
+                    <node concept="3uibUv" id="3PLTv5jZpdf" role="1ajl9A">
+                      <ref role="3uigEE" to="33ny:~HashSet" resolve="HashSet" />
+                      <node concept="3Tqbb2" id="3PLTv5jZpdg" role="11_B2D">
+                        <ref role="ehGHo" to="tpce:f_TJgxE" resolve="LinkDeclaration" />
                       </node>
                     </node>
                   </node>
-                  <node concept="3clFbF" id="4ZputZW6pvI" role="3cqZAp">
-                    <node concept="2ShNRf" id="4ZputZW6pvE" role="3clFbG">
-                      <node concept="1pGfFk" id="4ZputZW6rC3" role="2ShVmc">
-                        <ref role="37wK5l" to="33ny:~HashSet.&lt;init&gt;(java.util.Collection)" resolve="HashSet" />
-                        <node concept="2OqwBi" id="4ZputZW6BL4" role="37wK5m">
-                          <node concept="2OqwBi" id="4ZputZW6BL5" role="2Oq$k0">
-                            <node concept="2OqwBi" id="4ZputZW6BL6" role="2Oq$k0">
-                              <node concept="2OqwBi" id="4ZputZW6BL7" role="2Oq$k0">
-                                <node concept="37vLTw" id="4ZputZW6BL8" role="2Oq$k0">
-                                  <ref role="3cqZAo" node="3PLTv5jZpe1" resolve="acd" />
-                                </node>
-                                <node concept="2qgKlT" id="4ZputZW6BL9" role="2OqNvi">
-                                  <ref role="37wK5l" to="tpcn:hEwILKK" resolve="getLinkDeclarations" />
-                                </node>
-                              </node>
-                              <node concept="3zZkjj" id="4ZputZW6BLa" role="2OqNvi">
-                                <node concept="1bVj0M" id="4ZputZW6BLb" role="23t8la">
-                                  <node concept="3clFbS" id="4ZputZW6BLc" role="1bW5cS">
-                                    <node concept="3clFbF" id="4ZputZW6BLd" role="3cqZAp">
-                                      <node concept="2OqwBi" id="4ZputZW6BLe" role="3clFbG">
-                                        <node concept="2OqwBi" id="4ZputZW6BLf" role="2Oq$k0">
-                                          <node concept="37vLTw" id="4ZputZW6BLg" role="2Oq$k0">
-                                            <ref role="3cqZAo" node="7Z$RfkF7IGj" resolve="it" />
-                                          </node>
-                                          <node concept="3TrcHB" id="4ZputZW6BLh" role="2OqNvi">
-                                            <ref role="3TsBF5" to="tpce:3Ftr4R6BH8$" resolve="metaClass" />
-                                          </node>
-                                        </node>
-                                        <node concept="21noJN" id="4ZputZW6BLi" role="2OqNvi">
-                                          <node concept="21nZrQ" id="4ZputZW6BLj" role="21noJM">
-                                            <ref role="21nZrZ" to="tpce:3Ftr4R6BFyn" resolve="reference" />
+                  <node concept="1bVj0M" id="3PLTv5jZpdh" role="33vP2m">
+                    <node concept="3clFbS" id="3PLTv5jZpdi" role="1bW5cS">
+                      <node concept="3cpWs8" id="3PLTv5jZpdj" role="3cqZAp">
+                        <node concept="3cpWsn" id="3PLTv5jZpdk" role="3cpWs9">
+                          <property role="TrG5h" value="forbiddenChildren" />
+                          <node concept="3vKaQO" id="3PLTv5jZpdl" role="1tU5fm">
+                            <node concept="3uibUv" id="3PLTv5jZpdm" role="3O5elw">
+                              <ref role="3uigEE" to="c17a:~SContainmentLink" resolve="SContainmentLink" />
+                            </node>
+                          </node>
+                          <node concept="2OqwBi" id="3PLTv5jZpdn" role="33vP2m">
+                            <node concept="35c_gC" id="3PLTv5jZpdo" role="2Oq$k0">
+                              <ref role="35c_gD" to="tpck:gw2VY9q" resolve="BaseConcept" />
+                            </node>
+                            <node concept="liA8E" id="3PLTv5jZpdp" role="2OqNvi">
+                              <ref role="37wK5l" to="c17a:~SAbstractConcept.getContainmentLinks()" resolve="getContainmentLinks" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="4ZputZW6pvI" role="3cqZAp">
+                        <node concept="2ShNRf" id="4ZputZW6pvE" role="3clFbG">
+                          <node concept="1pGfFk" id="4ZputZW6rC3" role="2ShVmc">
+                            <ref role="37wK5l" to="33ny:~HashSet.&lt;init&gt;(java.util.Collection)" resolve="HashSet" />
+                            <node concept="2OqwBi" id="4ZputZW6BL4" role="37wK5m">
+                              <node concept="2OqwBi" id="4ZputZW6BL5" role="2Oq$k0">
+                                <node concept="2OqwBi" id="4ZputZW6BL6" role="2Oq$k0">
+                                  <node concept="2OqwBi" id="4ZputZW6BL7" role="2Oq$k0">
+                                    <node concept="37vLTw" id="4ZputZW6BL8" role="2Oq$k0">
+                                      <ref role="3cqZAo" node="3PLTv5jZpe1" resolve="acd" />
+                                    </node>
+                                    <node concept="2qgKlT" id="4ZputZW6BL9" role="2OqNvi">
+                                      <ref role="37wK5l" to="tpcn:hEwILKK" resolve="getLinkDeclarations" />
+                                    </node>
+                                  </node>
+                                  <node concept="3zZkjj" id="4ZputZW6BLa" role="2OqNvi">
+                                    <node concept="1bVj0M" id="4ZputZW6BLb" role="23t8la">
+                                      <node concept="3clFbS" id="4ZputZW6BLc" role="1bW5cS">
+                                        <node concept="3clFbF" id="4ZputZW6BLd" role="3cqZAp">
+                                          <node concept="2OqwBi" id="4ZputZW6BLe" role="3clFbG">
+                                            <node concept="2OqwBi" id="4ZputZW6BLf" role="2Oq$k0">
+                                              <node concept="37vLTw" id="4ZputZW6BLg" role="2Oq$k0">
+                                                <ref role="3cqZAo" node="7Z$RfkF7IGj" resolve="it" />
+                                              </node>
+                                              <node concept="3TrcHB" id="4ZputZW6BLh" role="2OqNvi">
+                                                <ref role="3TsBF5" to="tpce:3Ftr4R6BH8$" resolve="metaClass" />
+                                              </node>
+                                            </node>
+                                            <node concept="21noJN" id="4ZputZW6BLi" role="2OqNvi">
+                                              <node concept="21nZrQ" id="4ZputZW6BLj" role="21noJM">
+                                                <ref role="21nZrZ" to="tpce:3Ftr4R6BFyn" resolve="reference" />
+                                              </node>
+                                            </node>
                                           </node>
                                         </node>
                                       </node>
+                                      <node concept="gl6BB" id="7Z$RfkF7IGj" role="1bW2Oz">
+                                        <property role="TrG5h" value="it" />
+                                        <node concept="2jxLKc" id="7Z$RfkF7IGk" role="1tU5fm" />
+                                      </node>
                                     </node>
                                   </node>
-                                  <node concept="gl6BB" id="7Z$RfkF7IGj" role="1bW2Oz">
-                                    <property role="TrG5h" value="it" />
-                                    <node concept="2jxLKc" id="7Z$RfkF7IGk" role="1tU5fm" />
-                                  </node>
                                 </node>
-                              </node>
-                            </node>
-                            <node concept="3zZkjj" id="4ZputZW6BLm" role="2OqNvi">
-                              <node concept="1bVj0M" id="4ZputZW6BLn" role="23t8la">
-                                <node concept="3clFbS" id="4ZputZW6BLo" role="1bW5cS">
-                                  <node concept="3clFbF" id="4ZputZW6BLp" role="3cqZAp">
-                                    <node concept="3fqX7Q" id="4ZputZW6BLq" role="3clFbG">
-                                      <node concept="2OqwBi" id="4ZputZW6BLr" role="3fr31v">
-                                        <node concept="37vLTw" id="4ZputZW6BLs" role="2Oq$k0">
-                                          <ref role="3cqZAo" node="3PLTv5jZpdk" resolve="forbiddenChildren" />
-                                        </node>
-                                        <node concept="2HwmR7" id="4ZputZW6BLt" role="2OqNvi">
-                                          <node concept="1bVj0M" id="4ZputZW6BLu" role="23t8la">
-                                            <node concept="3clFbS" id="4ZputZW6BLv" role="1bW5cS">
-                                              <node concept="3clFbF" id="4ZputZW6BLw" role="3cqZAp">
-                                                <node concept="2OqwBi" id="4ZputZW6BLx" role="3clFbG">
-                                                  <node concept="37vLTw" id="4ZputZW6BLy" role="2Oq$k0">
-                                                    <ref role="3cqZAo" node="7Z$RfkF7IGn" resolve="it" />
-                                                  </node>
-                                                  <node concept="2qgKlT" id="4ZputZW6BLz" role="2OqNvi">
-                                                    <ref role="37wK5l" to="tpcn:4MKjpUYniHA" resolve="is" />
-                                                    <node concept="37vLTw" id="4ZputZW6BL$" role="37wK5m">
-                                                      <ref role="3cqZAo" node="7Z$RfkF7IGl" resolve="child" />
+                                <node concept="3zZkjj" id="4ZputZW6BLm" role="2OqNvi">
+                                  <node concept="1bVj0M" id="4ZputZW6BLn" role="23t8la">
+                                    <node concept="3clFbS" id="4ZputZW6BLo" role="1bW5cS">
+                                      <node concept="3clFbF" id="4ZputZW6BLp" role="3cqZAp">
+                                        <node concept="3fqX7Q" id="4ZputZW6BLq" role="3clFbG">
+                                          <node concept="2OqwBi" id="4ZputZW6BLr" role="3fr31v">
+                                            <node concept="37vLTw" id="4ZputZW6BLs" role="2Oq$k0">
+                                              <ref role="3cqZAo" node="3PLTv5jZpdk" resolve="forbiddenChildren" />
+                                            </node>
+                                            <node concept="2HwmR7" id="4ZputZW6BLt" role="2OqNvi">
+                                              <node concept="1bVj0M" id="4ZputZW6BLu" role="23t8la">
+                                                <node concept="3clFbS" id="4ZputZW6BLv" role="1bW5cS">
+                                                  <node concept="3clFbF" id="4ZputZW6BLw" role="3cqZAp">
+                                                    <node concept="2OqwBi" id="4ZputZW6BLx" role="3clFbG">
+                                                      <node concept="37vLTw" id="4ZputZW6BLy" role="2Oq$k0">
+                                                        <ref role="3cqZAo" node="7Z$RfkF7IGn" resolve="it" />
+                                                      </node>
+                                                      <node concept="2qgKlT" id="4ZputZW6BLz" role="2OqNvi">
+                                                        <ref role="37wK5l" to="tpcn:4MKjpUYniHA" resolve="is" />
+                                                        <node concept="37vLTw" id="4ZputZW6BL$" role="37wK5m">
+                                                          <ref role="3cqZAo" node="7Z$RfkF7IGl" resolve="child" />
+                                                        </node>
+                                                      </node>
                                                     </node>
                                                   </node>
                                                 </node>
+                                                <node concept="gl6BB" id="7Z$RfkF7IGl" role="1bW2Oz">
+                                                  <property role="TrG5h" value="child" />
+                                                  <node concept="2jxLKc" id="7Z$RfkF7IGm" role="1tU5fm" />
+                                                </node>
                                               </node>
-                                            </node>
-                                            <node concept="gl6BB" id="7Z$RfkF7IGl" role="1bW2Oz">
-                                              <property role="TrG5h" value="child" />
-                                              <node concept="2jxLKc" id="7Z$RfkF7IGm" role="1tU5fm" />
                                             </node>
                                           </node>
                                         </node>
                                       </node>
                                     </node>
+                                    <node concept="gl6BB" id="7Z$RfkF7IGn" role="1bW2Oz">
+                                      <property role="TrG5h" value="it" />
+                                      <node concept="2jxLKc" id="7Z$RfkF7IGo" role="1tU5fm" />
+                                    </node>
                                   </node>
                                 </node>
-                                <node concept="gl6BB" id="7Z$RfkF7IGn" role="1bW2Oz">
-                                  <property role="TrG5h" value="it" />
-                                  <node concept="2jxLKc" id="7Z$RfkF7IGo" role="1tU5fm" />
-                                </node>
                               </node>
+                              <node concept="ANE8D" id="4ZputZW6BLD" role="2OqNvi" />
+                            </node>
+                            <node concept="3Tqbb2" id="4ZputZW6yTV" role="1pMfVU">
+                              <ref role="ehGHo" to="tpce:f_TJgxE" resolve="LinkDeclaration" />
                             </node>
                           </node>
-                          <node concept="ANE8D" id="4ZputZW6BLD" role="2OqNvi" />
                         </node>
-                        <node concept="3Tqbb2" id="4ZputZW6yTV" role="1pMfVU">
-                          <ref role="ehGHo" to="tpce:f_TJgxE" resolve="LinkDeclaration" />
-                        </node>
+                      </node>
+                    </node>
+                    <node concept="37vLTG" id="3PLTv5jZpe1" role="1bW2Oz">
+                      <property role="TrG5h" value="acd" />
+                      <node concept="3Tqbb2" id="3PLTv5jZpe2" role="1tU5fm">
+                        <ref role="ehGHo" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
                       </node>
                     </node>
                   </node>
                 </node>
-                <node concept="37vLTG" id="3PLTv5jZpe1" role="1bW2Oz">
-                  <property role="TrG5h" value="acd" />
-                  <node concept="3Tqbb2" id="3PLTv5jZpe2" role="1tU5fm">
-                    <ref role="ehGHo" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
+              </node>
+              <node concept="3clFbH" id="3PLTv5jZnYP" role="3cqZAp" />
+              <node concept="3clFbF" id="3PLTv5jWJhA" role="3cqZAp">
+                <node concept="2YIFZM" id="6MgS2unBUCj" role="3clFbG">
+                  <ref role="37wK5l" node="ZzVzivR$xp" resolve="warn" />
+                  <ref role="1Pybhc" node="1trrptaK_0z" resolve="CheckinRuleUtil" />
+                  <node concept="2OqwBi" id="6MgS2unBUCk" role="37wK5m">
+                    <node concept="1YBJjd" id="6MgS2unBUCl" role="2Oq$k0">
+                      <ref role="1YBMHb" node="7TOowlgBzBU" resolve="modelMerge" />
+                    </node>
+                    <node concept="2qgKlT" id="6MgS2unBUCm" role="2OqNvi">
+                      <ref role="37wK5l" to="rnx3:3xJ_LYXlmVz" resolve="languageConcepts" />
+                    </node>
                   </node>
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3clFbH" id="3PLTv5jZnYP" role="3cqZAp" />
-          <node concept="3clFbF" id="3PLTv5jWJhA" role="3cqZAp">
-            <node concept="2YIFZM" id="6MgS2unBUCj" role="3clFbG">
-              <ref role="37wK5l" node="ZzVzivR$xp" resolve="warn" />
-              <ref role="1Pybhc" node="1trrptaK_0z" resolve="CheckinRuleUtil" />
-              <node concept="2OqwBi" id="6MgS2unBUCk" role="37wK5m">
-                <node concept="1YBJjd" id="6MgS2unBUCl" role="2Oq$k0">
-                  <ref role="1YBMHb" node="7TOowlgBzBU" resolve="modelMerge" />
-                </node>
-                <node concept="2qgKlT" id="6MgS2unBUCm" role="2OqNvi">
-                  <ref role="37wK5l" to="rnx3:3xJ_LYXlmVz" resolve="languageConcepts" />
-                </node>
-              </node>
-              <node concept="37vLTw" id="6MgS2unBUCn" role="37wK5m">
-                <ref role="3cqZAo" node="ZzVzivMLGl" resolve="repository" />
-              </node>
-              <node concept="2OqwBi" id="6MgS2unBUCo" role="37wK5m">
-                <node concept="37vLTw" id="6MgS2unBUCp" role="2Oq$k0">
-                  <ref role="3cqZAo" node="3EHNiwz7rFs" resolve="mergerResolver" />
-                </node>
-                <node concept="liA8E" id="6MgS2unBUCq" role="2OqNvi">
-                  <ref role="37wK5l" to="gunp:6MgS2unAqjX" resolve="conceptToReferenceLink" />
-                </node>
-              </node>
-              <node concept="37vLTw" id="6MgS2unBUCr" role="37wK5m">
-                <ref role="3cqZAo" node="3PLTv5jZpdc" resolve="conceptToRelevantReferences" />
-              </node>
-              <node concept="1bVj0M" id="6MgS2unBUCs" role="37wK5m">
-                <node concept="37vLTG" id="6MgS2unBUCt" role="1bW2Oz">
-                  <property role="TrG5h" value="sac" />
-                  <node concept="3uibUv" id="6MgS2unBUCu" role="1tU5fm">
-                    <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
+                  <node concept="37vLTw" id="6MgS2unBUCn" role="37wK5m">
+                    <ref role="3cqZAo" node="ZzVzivMLGl" resolve="repository" />
                   </node>
-                </node>
-                <node concept="37vLTG" id="6MgS2unBUCv" role="1bW2Oz">
-                  <property role="TrG5h" value="ld" />
-                  <node concept="3Tqbb2" id="6MgS2unBUCw" role="1tU5fm">
-                    <ref role="ehGHo" to="tpce:f_TJgxE" resolve="LinkDeclaration" />
+                  <node concept="2OqwBi" id="6MgS2unBUCo" role="37wK5m">
+                    <node concept="37vLTw" id="6MgS2unBUCp" role="2Oq$k0">
+                      <ref role="3cqZAo" node="3EHNiwz7rFs" resolve="mergerResolver" />
+                    </node>
+                    <node concept="liA8E" id="6MgS2unBUCq" role="2OqNvi">
+                      <ref role="37wK5l" to="gunp:6MgS2unAqjX" resolve="conceptToReferenceLink" />
+                    </node>
                   </node>
-                </node>
-                <node concept="3clFbS" id="6MgS2unBUCx" role="1bW5cS">
-                  <node concept="a7r0C" id="6MgS2unBUCy" role="3cqZAp">
-                    <node concept="3cpWs3" id="6MgS2unBUCz" role="a7wSD">
-                      <node concept="2OqwBi" id="6MgS2unBUC$" role="3uHU7w">
-                        <node concept="37vLTw" id="6MgS2unBUC_" role="2Oq$k0">
-                          <ref role="3cqZAo" node="6MgS2unBUCv" resolve="ld" />
-                        </node>
-                        <node concept="2qgKlT" id="6MgS2unBUCA" role="2OqNvi">
-                          <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
-                        </node>
+                  <node concept="37vLTw" id="6MgS2unBUCr" role="37wK5m">
+                    <ref role="3cqZAo" node="3PLTv5jZpdc" resolve="conceptToRelevantReferences" />
+                  </node>
+                  <node concept="1bVj0M" id="6MgS2unBUCs" role="37wK5m">
+                    <node concept="37vLTG" id="6MgS2unBUCt" role="1bW2Oz">
+                      <property role="TrG5h" value="sac" />
+                      <node concept="3uibUv" id="6MgS2unBUCu" role="1tU5fm">
+                        <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
                       </node>
-                      <node concept="3cpWs3" id="6MgS2unBUCB" role="3uHU7B">
-                        <node concept="3cpWs3" id="6MgS2unBUCC" role="3uHU7B">
-                          <node concept="Xl_RD" id="6MgS2unBUCD" role="3uHU7B">
-                            <property role="Xl_RC" value="concept" />
+                    </node>
+                    <node concept="37vLTG" id="6MgS2unBUCv" role="1bW2Oz">
+                      <property role="TrG5h" value="ld" />
+                      <node concept="3Tqbb2" id="6MgS2unBUCw" role="1tU5fm">
+                        <ref role="ehGHo" to="tpce:f_TJgxE" resolve="LinkDeclaration" />
+                      </node>
+                    </node>
+                    <node concept="3clFbS" id="6MgS2unBUCx" role="1bW5cS">
+                      <node concept="a7r0C" id="6MgS2unBUCy" role="3cqZAp">
+                        <node concept="3cpWs3" id="6MgS2unBUCz" role="a7wSD">
+                          <node concept="2OqwBi" id="6MgS2unBUC$" role="3uHU7w">
+                            <node concept="37vLTw" id="6MgS2unBUC_" role="2Oq$k0">
+                              <ref role="3cqZAo" node="6MgS2unBUCv" resolve="ld" />
+                            </node>
+                            <node concept="2qgKlT" id="6MgS2unBUCA" role="2OqNvi">
+                              <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                            </node>
                           </node>
-                          <node concept="37vLTw" id="6MgS2unBUCE" role="3uHU7w">
+                          <node concept="3cpWs3" id="6MgS2unBUCB" role="3uHU7B">
+                            <node concept="3cpWs3" id="6MgS2unBUCC" role="3uHU7B">
+                              <node concept="Xl_RD" id="6MgS2unBUCD" role="3uHU7B">
+                                <property role="Xl_RC" value="concept" />
+                              </node>
+                              <node concept="37vLTw" id="6MgS2unBUCE" role="3uHU7w">
+                                <ref role="3cqZAo" node="6MgS2unBUCt" resolve="sac" />
+                              </node>
+                            </node>
+                            <node concept="Xl_RD" id="6MgS2unBUCF" role="3uHU7w">
+                              <property role="Xl_RC" value=" is missing merge policy for reference " />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="2YIFZM" id="6MgS2unBUCG" role="1urrMF">
+                          <ref role="37wK5l" node="582YV7yWtlM" resolve="warningNode" />
+                          <ref role="1Pybhc" node="1trrptaK_0z" resolve="CheckinRuleUtil" />
+                          <node concept="1YBJjd" id="6MgS2unBUCH" role="37wK5m">
+                            <ref role="1YBMHb" node="7TOowlgBzBU" resolve="modelMerge" />
+                          </node>
+                          <node concept="37vLTw" id="6MgS2unBUCI" role="37wK5m">
                             <ref role="3cqZAo" node="6MgS2unBUCt" resolve="sac" />
                           </node>
                         </node>
-                        <node concept="Xl_RD" id="6MgS2unBUCF" role="3uHU7w">
-                          <property role="Xl_RC" value=" is missing merge policy for reference " />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbH" id="3PLTv5jWI4$" role="3cqZAp" />
+              <node concept="3clFbH" id="60iGZSKpnRn" role="3cqZAp" />
+              <node concept="3clFbH" id="60iGZSKpnWL" role="3cqZAp" />
+              <node concept="3SKdUt" id="60iGZSKpphR" role="3cqZAp">
+                <node concept="1PaTwC" id="60iGZSKpphS" role="1aUNEU">
+                  <node concept="3oM_SD" id="60iGZSKpphT" role="1PaTwD">
+                    <property role="3oM_SC" value="---ID" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3cpWs8" id="60iGZSKxc4G" role="3cqZAp">
+                <node concept="3cpWsn" id="60iGZSKxc4H" role="3cpWs9">
+                  <property role="TrG5h" value="conceptsWithId" />
+                  <node concept="2hMVRd" id="60iGZSKxyPI" role="1tU5fm">
+                    <node concept="3uibUv" id="60iGZSKxyPK" role="2hN53Y">
+                      <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="60iGZSKxc4I" role="33vP2m">
+                    <node concept="37vLTw" id="60iGZSKxc4J" role="2Oq$k0">
+                      <ref role="3cqZAo" node="3EHNiwz7rFs" resolve="mergerResolver" />
+                    </node>
+                    <node concept="liA8E" id="60iGZSKxc4K" role="2OqNvi">
+                      <ref role="37wK5l" to="gunp:60iGZSKw3Be" resolve="conceptsWithId" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3cpWs8" id="60iGZSKxNF0" role="3cqZAp">
+                <node concept="3cpWsn" id="60iGZSKxNF1" role="3cpWs9">
+                  <property role="TrG5h" value="isCovered" />
+                  <node concept="3uibUv" id="60iGZSKxMkS" role="1tU5fm">
+                    <ref role="3uigEE" to="33ny:~Map" resolve="Map" />
+                    <node concept="3uibUv" id="60iGZSKxMl2" role="11_B2D">
+                      <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
+                    </node>
+                    <node concept="3uibUv" id="60iGZSKxMl0" role="11_B2D">
+                      <ref role="3uigEE" to="33ny:~Set" resolve="Set" />
+                      <node concept="3uibUv" id="60iGZSKxMl1" role="11_B2D">
+                        <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2YIFZM" id="60iGZSKxNF2" role="33vP2m">
+                    <ref role="37wK5l" to="3o3z:~ImmutableMap.copyOf(java.lang.Iterable)" resolve="copyOf" />
+                    <ref role="1Pybhc" to="3o3z:~ImmutableMap" resolve="ImmutableMap" />
+                    <node concept="2OqwBi" id="60iGZSKxNF3" role="37wK5m">
+                      <node concept="37vLTw" id="60iGZSKxNF4" role="2Oq$k0">
+                        <ref role="3cqZAo" node="60iGZSKxc4H" resolve="conceptsWithId" />
+                      </node>
+                      <node concept="3$u5V9" id="60iGZSKxNF5" role="2OqNvi">
+                        <node concept="1bVj0M" id="60iGZSKxNF6" role="23t8la">
+                          <node concept="3clFbS" id="60iGZSKxNF7" role="1bW5cS">
+                            <node concept="3clFbF" id="60iGZSKxNF8" role="3cqZAp">
+                              <node concept="2YIFZM" id="60iGZSKxNF9" role="3clFbG">
+                                <ref role="37wK5l" to="1qo3:~ImmutablePair.of(java.lang.Object,java.lang.Object)" resolve="of" />
+                                <ref role="1Pybhc" to="1qo3:~ImmutablePair" resolve="ImmutablePair" />
+                                <node concept="37vLTw" id="60iGZSKxNFa" role="37wK5m">
+                                  <ref role="3cqZAo" node="7Z$RfkF7IGp" resolve="it" />
+                                </node>
+                                <node concept="2YIFZM" id="60iGZSKxNFb" role="37wK5m">
+                                  <ref role="37wK5l" to="33ny:~Collections.singleton(java.lang.Object)" resolve="singleton" />
+                                  <ref role="1Pybhc" to="33ny:~Collections" resolve="Collections" />
+                                  <node concept="37vLTw" id="60iGZSKxNFc" role="37wK5m">
+                                    <ref role="3cqZAo" node="7Z$RfkF7IGp" resolve="it" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="gl6BB" id="7Z$RfkF7IGp" role="1bW2Oz">
+                            <property role="TrG5h" value="it" />
+                            <node concept="2jxLKc" id="7Z$RfkF7IGq" role="1tU5fm" />
+                          </node>
                         </node>
                       </node>
                     </node>
-                    <node concept="2YIFZM" id="6MgS2unBUCG" role="1urrMF">
-                      <ref role="37wK5l" node="582YV7yWtlM" resolve="warningNode" />
-                      <ref role="1Pybhc" node="1trrptaK_0z" resolve="CheckinRuleUtil" />
-                      <node concept="1YBJjd" id="6MgS2unBUCH" role="37wK5m">
-                        <ref role="1YBMHb" node="7TOowlgBzBU" resolve="modelMerge" />
-                      </node>
-                      <node concept="37vLTw" id="6MgS2unBUCI" role="37wK5m">
-                        <ref role="3cqZAo" node="6MgS2unBUCt" resolve="sac" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbH" id="60iGZSKx0hz" role="3cqZAp" />
+              <node concept="3cpWs8" id="60iGZSKxZ0X" role="3cqZAp">
+                <node concept="3cpWsn" id="60iGZSKxZ0Y" role="3cpWs9">
+                  <property role="TrG5h" value="mustBeCovered" />
+                  <node concept="1ajhzC" id="60iGZSKxZ0Z" role="1tU5fm">
+                    <node concept="3Tqbb2" id="60iGZSKxZ10" role="1ajw0F">
+                      <ref role="ehGHo" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
+                    </node>
+                    <node concept="3uibUv" id="60iGZSKxZ11" role="1ajl9A">
+                      <ref role="3uigEE" to="33ny:~Set" resolve="Set" />
+                      <node concept="3uibUv" id="60iGZSKykny" role="11_B2D">
+                        <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
                       </node>
                     </node>
                   </node>
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3clFbH" id="3PLTv5jWI4$" role="3cqZAp" />
-          <node concept="3clFbH" id="60iGZSKpnRn" role="3cqZAp" />
-          <node concept="3clFbH" id="60iGZSKpnWL" role="3cqZAp" />
-          <node concept="3SKdUt" id="60iGZSKpphR" role="3cqZAp">
-            <node concept="1PaTwC" id="60iGZSKpphS" role="1aUNEU">
-              <node concept="3oM_SD" id="60iGZSKpphT" role="1PaTwD">
-                <property role="3oM_SC" value="---ID" />
-              </node>
-            </node>
-          </node>
-          <node concept="3cpWs8" id="60iGZSKxc4G" role="3cqZAp">
-            <node concept="3cpWsn" id="60iGZSKxc4H" role="3cpWs9">
-              <property role="TrG5h" value="conceptsWithId" />
-              <node concept="2hMVRd" id="60iGZSKxyPI" role="1tU5fm">
-                <node concept="3uibUv" id="60iGZSKxyPK" role="2hN53Y">
-                  <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
-                </node>
-              </node>
-              <node concept="2OqwBi" id="60iGZSKxc4I" role="33vP2m">
-                <node concept="37vLTw" id="60iGZSKxc4J" role="2Oq$k0">
-                  <ref role="3cqZAo" node="3EHNiwz7rFs" resolve="mergerResolver" />
-                </node>
-                <node concept="liA8E" id="60iGZSKxc4K" role="2OqNvi">
-                  <ref role="37wK5l" to="gunp:60iGZSKw3Be" resolve="conceptsWithId" />
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3cpWs8" id="60iGZSKxNF0" role="3cqZAp">
-            <node concept="3cpWsn" id="60iGZSKxNF1" role="3cpWs9">
-              <property role="TrG5h" value="isCovered" />
-              <node concept="3uibUv" id="60iGZSKxMkS" role="1tU5fm">
-                <ref role="3uigEE" to="33ny:~Map" resolve="Map" />
-                <node concept="3uibUv" id="60iGZSKxMl2" role="11_B2D">
-                  <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
-                </node>
-                <node concept="3uibUv" id="60iGZSKxMl0" role="11_B2D">
-                  <ref role="3uigEE" to="33ny:~Set" resolve="Set" />
-                  <node concept="3uibUv" id="60iGZSKxMl1" role="11_B2D">
-                    <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
-                  </node>
-                </node>
-              </node>
-              <node concept="2YIFZM" id="60iGZSKxNF2" role="33vP2m">
-                <ref role="37wK5l" to="3o3z:~ImmutableMap.copyOf(java.lang.Iterable)" resolve="copyOf" />
-                <ref role="1Pybhc" to="3o3z:~ImmutableMap" resolve="ImmutableMap" />
-                <node concept="2OqwBi" id="60iGZSKxNF3" role="37wK5m">
-                  <node concept="37vLTw" id="60iGZSKxNF4" role="2Oq$k0">
-                    <ref role="3cqZAo" node="60iGZSKxc4H" resolve="conceptsWithId" />
-                  </node>
-                  <node concept="3$u5V9" id="60iGZSKxNF5" role="2OqNvi">
-                    <node concept="1bVj0M" id="60iGZSKxNF6" role="23t8la">
-                      <node concept="3clFbS" id="60iGZSKxNF7" role="1bW5cS">
-                        <node concept="3clFbF" id="60iGZSKxNF8" role="3cqZAp">
-                          <node concept="2YIFZM" id="60iGZSKxNF9" role="3clFbG">
-                            <ref role="37wK5l" to="1qo3:~ImmutablePair.of(java.lang.Object,java.lang.Object)" resolve="of" />
-                            <ref role="1Pybhc" to="1qo3:~ImmutablePair" resolve="ImmutablePair" />
-                            <node concept="37vLTw" id="60iGZSKxNFa" role="37wK5m">
-                              <ref role="3cqZAo" node="7Z$RfkF7IGp" resolve="it" />
+                  <node concept="1bVj0M" id="60iGZSKxZ13" role="33vP2m">
+                    <node concept="3clFbS" id="60iGZSKxZ14" role="1bW5cS">
+                      <node concept="3cpWs8" id="60iGZSKISav" role="3cqZAp">
+                        <node concept="3cpWsn" id="60iGZSKISaw" role="3cpWs9">
+                          <property role="TrG5h" value="ignoreable" />
+                          <node concept="10P_77" id="60iGZSKIQqU" role="1tU5fm" />
+                          <node concept="22lmx$" id="W4mNzklyTz" role="33vP2m">
+                            <node concept="2OqwBi" id="W4mNzkoMBI" role="3uHU7w">
+                              <node concept="37vLTw" id="W4mNzkl_OU" role="2Oq$k0">
+                                <ref role="3cqZAo" node="60iGZSKxZ18" resolve="acd" />
+                              </node>
+                              <node concept="2qgKlT" id="W4mNzkp1ao" role="2OqNvi">
+                                <ref role="37wK5l" to="tpcn:4UTtJHK9fEJ" resolve="isSubconceptOf" />
+                                <node concept="35c_gC" id="W4mNzkpEdl" role="37wK5m">
+                                  <ref role="35c_gD" to="tpck:4uZwTti3_$T" resolve="Attribute" />
+                                </node>
+                              </node>
                             </node>
-                            <node concept="2YIFZM" id="60iGZSKxNFb" role="37wK5m">
-                              <ref role="37wK5l" to="33ny:~Collections.singleton(java.lang.Object)" resolve="singleton" />
-                              <ref role="1Pybhc" to="33ny:~Collections" resolve="Collections" />
-                              <node concept="37vLTw" id="60iGZSKxNFc" role="37wK5m">
-                                <ref role="3cqZAo" node="7Z$RfkF7IGp" resolve="it" />
+                            <node concept="2OqwBi" id="60iGZSKISax" role="3uHU7B">
+                              <node concept="37vLTw" id="60iGZSKISay" role="2Oq$k0">
+                                <ref role="3cqZAo" node="60iGZSKxZ18" resolve="acd" />
+                              </node>
+                              <node concept="1mIQ4w" id="60iGZSKISaz" role="2OqNvi">
+                                <node concept="chp4Y" id="60iGZSKISa$" role="cj9EA">
+                                  <ref role="cht4Q" to="tpce:h0PlHMJ" resolve="InterfaceConceptDeclaration" />
+                                </node>
                               </node>
                             </node>
                           </node>
                         </node>
                       </node>
-                      <node concept="gl6BB" id="7Z$RfkF7IGp" role="1bW2Oz">
-                        <property role="TrG5h" value="it" />
-                        <node concept="2jxLKc" id="7Z$RfkF7IGq" role="1tU5fm" />
+                      <node concept="3clFbF" id="60iGZSKJ67u" role="3cqZAp">
+                        <node concept="3K4zz7" id="60iGZSKJ9i1" role="3clFbG">
+                          <node concept="2YIFZM" id="60iGZSKJc0J" role="3K4E3e">
+                            <ref role="37wK5l" to="33ny:~Collections.emptySet()" resolve="emptySet" />
+                            <ref role="1Pybhc" to="33ny:~Collections" resolve="Collections" />
+                            <node concept="3uibUv" id="60iGZSKJc0K" role="3PaCim">
+                              <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
+                            </node>
+                          </node>
+                          <node concept="2YIFZM" id="60iGZSKJgr_" role="3K4GZi">
+                            <ref role="37wK5l" to="33ny:~Collections.singleton(java.lang.Object)" resolve="singleton" />
+                            <ref role="1Pybhc" to="33ny:~Collections" resolve="Collections" />
+                            <node concept="2OqwBi" id="60iGZSKJml8" role="37wK5m">
+                              <node concept="37vLTw" id="60iGZSKJjeK" role="2Oq$k0">
+                                <ref role="3cqZAo" node="60iGZSKxZ18" resolve="acd" />
+                              </node>
+                              <node concept="1rGIog" id="60iGZSKJogF" role="2OqNvi" />
+                            </node>
+                          </node>
+                          <node concept="37vLTw" id="60iGZSKJ67s" role="3K4Cdx">
+                            <ref role="3cqZAo" node="60iGZSKISaw" resolve="ignoreable" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="37vLTG" id="60iGZSKxZ18" role="1bW2Oz">
+                      <property role="TrG5h" value="acd" />
+                      <node concept="3Tqbb2" id="60iGZSKxZ19" role="1tU5fm">
+                        <ref role="ehGHo" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
                       </node>
                     </node>
                   </node>
                 </node>
               </node>
-            </node>
-          </node>
-          <node concept="3clFbH" id="60iGZSKx0hz" role="3cqZAp" />
-          <node concept="3cpWs8" id="60iGZSKxZ0X" role="3cqZAp">
-            <node concept="3cpWsn" id="60iGZSKxZ0Y" role="3cpWs9">
-              <property role="TrG5h" value="mustBeCovered" />
-              <node concept="1ajhzC" id="60iGZSKxZ0Z" role="1tU5fm">
-                <node concept="3Tqbb2" id="60iGZSKxZ10" role="1ajw0F">
-                  <ref role="ehGHo" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
-                </node>
-                <node concept="3uibUv" id="60iGZSKxZ11" role="1ajl9A">
-                  <ref role="3uigEE" to="33ny:~Set" resolve="Set" />
-                  <node concept="3uibUv" id="60iGZSKykny" role="11_B2D">
-                    <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
+              <node concept="3clFbH" id="60iGZSKxXh5" role="3cqZAp" />
+              <node concept="3clFbF" id="60iGZSKxh0J" role="3cqZAp">
+                <node concept="2YIFZM" id="60iGZSKxh0K" role="3clFbG">
+                  <ref role="37wK5l" node="ZzVzivR$xp" resolve="warn" />
+                  <ref role="1Pybhc" node="1trrptaK_0z" resolve="CheckinRuleUtil" />
+                  <node concept="2OqwBi" id="60iGZSKxh0L" role="37wK5m">
+                    <node concept="1YBJjd" id="60iGZSKxh0M" role="2Oq$k0">
+                      <ref role="1YBMHb" node="7TOowlgBzBU" resolve="modelMerge" />
+                    </node>
+                    <node concept="2qgKlT" id="60iGZSKxh0N" role="2OqNvi">
+                      <ref role="37wK5l" to="rnx3:3xJ_LYXlmVz" resolve="languageConcepts" />
+                    </node>
+                  </node>
+                  <node concept="37vLTw" id="60iGZSKxh0O" role="37wK5m">
+                    <ref role="3cqZAo" node="ZzVzivMLGl" resolve="repository" />
+                  </node>
+                  <node concept="37vLTw" id="60iGZSKxV7M" role="37wK5m">
+                    <ref role="3cqZAo" node="60iGZSKxNF1" resolve="isCovered" />
+                  </node>
+                  <node concept="37vLTw" id="60iGZSKyclt" role="37wK5m">
+                    <ref role="3cqZAo" node="60iGZSKxZ0Y" resolve="mustBeCovered" />
+                  </node>
+                  <node concept="1bVj0M" id="60iGZSK$Uci" role="37wK5m">
+                    <node concept="37vLTG" id="60iGZSK$Ucj" role="1bW2Oz">
+                      <property role="TrG5h" value="sac" />
+                      <node concept="3uibUv" id="60iGZSK$Uck" role="1tU5fm">
+                        <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
+                      </node>
+                    </node>
+                    <node concept="37vLTG" id="60iGZSK$Ucl" role="1bW2Oz">
+                      <property role="TrG5h" value="id" />
+                      <node concept="3uibUv" id="60iGZSK$V1L" role="1tU5fm">
+                        <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
+                      </node>
+                    </node>
+                    <node concept="3clFbS" id="60iGZSK$Ucn" role="1bW5cS">
+                      <node concept="a7r0C" id="60iGZSK$Uco" role="3cqZAp">
+                        <node concept="3cpWs3" id="60iGZSK$Uct" role="a7wSD">
+                          <node concept="3cpWs3" id="60iGZSK$Ucu" role="3uHU7B">
+                            <node concept="Xl_RD" id="60iGZSK$Ucv" role="3uHU7B">
+                              <property role="Xl_RC" value="concept " />
+                            </node>
+                            <node concept="37vLTw" id="60iGZSK$Ucw" role="3uHU7w">
+                              <ref role="3cqZAo" node="60iGZSK$Ucj" resolve="sac" />
+                            </node>
+                          </node>
+                          <node concept="Xl_RD" id="60iGZSK$Ucx" role="3uHU7w">
+                            <property role="Xl_RC" value=" is missing ID function " />
+                          </node>
+                        </node>
+                        <node concept="2YIFZM" id="60iGZSK$Ucy" role="1urrMF">
+                          <ref role="37wK5l" node="582YV7yWtlM" resolve="warningNode" />
+                          <ref role="1Pybhc" node="1trrptaK_0z" resolve="CheckinRuleUtil" />
+                          <node concept="1YBJjd" id="60iGZSK$Ucz" role="37wK5m">
+                            <ref role="1YBMHb" node="7TOowlgBzBU" resolve="modelMerge" />
+                          </node>
+                          <node concept="37vLTw" id="60iGZSK$Uc$" role="37wK5m">
+                            <ref role="3cqZAo" node="60iGZSK$Ucj" resolve="sac" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
                   </node>
                 </node>
               </node>
-              <node concept="1bVj0M" id="60iGZSKxZ13" role="33vP2m">
-                <node concept="3clFbS" id="60iGZSKxZ14" role="1bW5cS">
-                  <node concept="3cpWs8" id="60iGZSKISav" role="3cqZAp">
-                    <node concept="3cpWsn" id="60iGZSKISaw" role="3cpWs9">
-                      <property role="TrG5h" value="ignoreable" />
-                      <node concept="10P_77" id="60iGZSKIQqU" role="1tU5fm" />
-                      <node concept="22lmx$" id="W4mNzklyTz" role="33vP2m">
-                        <node concept="2OqwBi" id="W4mNzkoMBI" role="3uHU7w">
-                          <node concept="37vLTw" id="W4mNzkl_OU" role="2Oq$k0">
-                            <ref role="3cqZAo" node="60iGZSKxZ18" resolve="acd" />
-                          </node>
-                          <node concept="2qgKlT" id="W4mNzkp1ao" role="2OqNvi">
-                            <ref role="37wK5l" to="tpcn:4UTtJHK9fEJ" resolve="isSubconceptOf" />
-                            <node concept="35c_gC" id="W4mNzkpEdl" role="37wK5m">
-                              <ref role="35c_gD" to="tpck:4uZwTti3_$T" resolve="Attribute" />
+              <node concept="3clFbH" id="60iGZSKx0n_" role="3cqZAp" />
+              <node concept="3clFbH" id="60iGZSKx1ES" role="3cqZAp" />
+            </node>
+            <node concept="3uVAMA" id="7TOowlgVHwW" role="1zxBo5">
+              <node concept="XOnhg" id="7TOowlgVHwX" role="1zc67B">
+                <property role="TrG5h" value="e" />
+                <node concept="nSUau" id="7TOowlgVHwY" role="1tU5fm">
+                  <node concept="3uibUv" id="7TOowlgVHDe" role="nSUat">
+                    <ref role="3uigEE" to="gunp:7TOowlgU0QJ" resolve="MergePolicyConflict" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbS" id="7TOowlgVHwZ" role="1zc67A">
+                <node concept="3cpWs8" id="582YV7z8mrD" role="3cqZAp">
+                  <node concept="3cpWsn" id="582YV7z8mrG" role="3cpWs9">
+                    <property role="TrG5h" value="violationForStr" />
+                    <node concept="17QB3L" id="582YV7z8mrB" role="1tU5fm" />
+                    <node concept="2OqwBi" id="582YV7z8nEI" role="33vP2m">
+                      <node concept="2OqwBi" id="582YV7z8nhq" role="2Oq$k0">
+                        <node concept="37vLTw" id="582YV7z8n0T" role="2Oq$k0">
+                          <ref role="3cqZAo" node="7TOowlgVHwX" resolve="e" />
+                        </node>
+                        <node concept="2OwXpG" id="582YV7z8n_0" role="2OqNvi">
+                          <ref role="2Oxat5" to="gunp:7TOowlgU0V6" resolve="violationFor" />
+                        </node>
+                      </node>
+                      <node concept="liA8E" id="582YV7z8nK2" role="2OqNvi">
+                        <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbJ" id="582YV7z8hIf" role="3cqZAp">
+                  <node concept="3clFbS" id="582YV7z8hIh" role="3clFbx">
+                    <node concept="3cpWs8" id="582YV7z8kPO" role="3cqZAp">
+                      <node concept="3cpWsn" id="582YV7z8kPP" role="3cpWs9">
+                        <property role="TrG5h" value="node" />
+                        <node concept="3Tqbb2" id="582YV7z8kN8" role="1tU5fm" />
+                        <node concept="1eOMI4" id="582YV7z8kPQ" role="33vP2m">
+                          <node concept="10QFUN" id="582YV7z8kPR" role="1eOMHV">
+                            <node concept="3Tqbb2" id="582YV7z8kPS" role="10QFUM" />
+                            <node concept="2OqwBi" id="582YV7z8kPT" role="10QFUP">
+                              <node concept="37vLTw" id="582YV7z8kPU" role="2Oq$k0">
+                                <ref role="3cqZAo" node="7TOowlgVHwX" resolve="e" />
+                              </node>
+                              <node concept="2OwXpG" id="582YV7z8kPV" role="2OqNvi">
+                                <ref role="2Oxat5" to="gunp:7TOowlgU0V6" resolve="violationFor" />
+                              </node>
                             </node>
                           </node>
                         </node>
-                        <node concept="2OqwBi" id="60iGZSKISax" role="3uHU7B">
-                          <node concept="37vLTw" id="60iGZSKISay" role="2Oq$k0">
-                            <ref role="3cqZAo" node="60iGZSKxZ18" resolve="acd" />
-                          </node>
-                          <node concept="1mIQ4w" id="60iGZSKISaz" role="2OqNvi">
-                            <node concept="chp4Y" id="60iGZSKISa$" role="cj9EA">
-                              <ref role="cht4Q" to="tpce:h0PlHMJ" resolve="InterfaceConceptDeclaration" />
+                      </node>
+                    </node>
+                    <node concept="Jncv_" id="582YV7z8kUN" role="3cqZAp">
+                      <ref role="JncvD" to="tpce:f_TJgxE" resolve="LinkDeclaration" />
+                      <node concept="37vLTw" id="582YV7z8kVP" role="JncvB">
+                        <ref role="3cqZAo" node="582YV7z8kPP" resolve="node" />
+                      </node>
+                      <node concept="3clFbS" id="582YV7z8kUR" role="Jncv$">
+                        <node concept="3clFbF" id="582YV7z8o3k" role="3cqZAp">
+                          <node concept="37vLTI" id="582YV7z8opS" role="3clFbG">
+                            <node concept="37vLTw" id="582YV7z8o3j" role="37vLTJ">
+                              <ref role="3cqZAo" node="582YV7z8mrG" resolve="violationForStr" />
+                            </node>
+                            <node concept="2OqwBi" id="582YV7z8o_s" role="37vLTx">
+                              <node concept="Jnkvi" id="582YV7z8o_t" role="2Oq$k0">
+                                <ref role="1M0zk5" node="582YV7z8kUT" resolve="ld" />
+                              </node>
+                              <node concept="2qgKlT" id="582YV7z8o_u" role="2OqNvi">
+                                <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                              </node>
                             </node>
                           </node>
                         </node>
                       </node>
-                    </node>
-                  </node>
-                  <node concept="3clFbF" id="60iGZSKJ67u" role="3cqZAp">
-                    <node concept="3K4zz7" id="60iGZSKJ9i1" role="3clFbG">
-                      <node concept="2YIFZM" id="60iGZSKJc0J" role="3K4E3e">
-                        <ref role="37wK5l" to="33ny:~Collections.emptySet()" resolve="emptySet" />
-                        <ref role="1Pybhc" to="33ny:~Collections" resolve="Collections" />
-                        <node concept="3uibUv" id="60iGZSKJc0K" role="3PaCim">
-                          <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
-                        </node>
-                      </node>
-                      <node concept="2YIFZM" id="60iGZSKJgr_" role="3K4GZi">
-                        <ref role="37wK5l" to="33ny:~Collections.singleton(java.lang.Object)" resolve="singleton" />
-                        <ref role="1Pybhc" to="33ny:~Collections" resolve="Collections" />
-                        <node concept="2OqwBi" id="60iGZSKJml8" role="37wK5m">
-                          <node concept="37vLTw" id="60iGZSKJjeK" role="2Oq$k0">
-                            <ref role="3cqZAo" node="60iGZSKxZ18" resolve="acd" />
-                          </node>
-                          <node concept="1rGIog" id="60iGZSKJogF" role="2OqNvi" />
-                        </node>
-                      </node>
-                      <node concept="37vLTw" id="60iGZSKJ67s" role="3K4Cdx">
-                        <ref role="3cqZAo" node="60iGZSKISaw" resolve="ignoreable" />
+                      <node concept="JncvC" id="582YV7z8kUT" role="JncvA">
+                        <property role="TrG5h" value="ld" />
+                        <node concept="2jxLKc" id="582YV7z8kUU" role="1tU5fm" />
                       </node>
                     </node>
                   </node>
-                </node>
-                <node concept="37vLTG" id="60iGZSKxZ18" role="1bW2Oz">
-                  <property role="TrG5h" value="acd" />
-                  <node concept="3Tqbb2" id="60iGZSKxZ19" role="1tU5fm">
-                    <ref role="ehGHo" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3clFbH" id="60iGZSKxXh5" role="3cqZAp" />
-          <node concept="3clFbF" id="60iGZSKxh0J" role="3cqZAp">
-            <node concept="2YIFZM" id="60iGZSKxh0K" role="3clFbG">
-              <ref role="37wK5l" node="ZzVzivR$xp" resolve="warn" />
-              <ref role="1Pybhc" node="1trrptaK_0z" resolve="CheckinRuleUtil" />
-              <node concept="2OqwBi" id="60iGZSKxh0L" role="37wK5m">
-                <node concept="1YBJjd" id="60iGZSKxh0M" role="2Oq$k0">
-                  <ref role="1YBMHb" node="7TOowlgBzBU" resolve="modelMerge" />
-                </node>
-                <node concept="2qgKlT" id="60iGZSKxh0N" role="2OqNvi">
-                  <ref role="37wK5l" to="rnx3:3xJ_LYXlmVz" resolve="languageConcepts" />
-                </node>
-              </node>
-              <node concept="37vLTw" id="60iGZSKxh0O" role="37wK5m">
-                <ref role="3cqZAo" node="ZzVzivMLGl" resolve="repository" />
-              </node>
-              <node concept="37vLTw" id="60iGZSKxV7M" role="37wK5m">
-                <ref role="3cqZAo" node="60iGZSKxNF1" resolve="isCovered" />
-              </node>
-              <node concept="37vLTw" id="60iGZSKyclt" role="37wK5m">
-                <ref role="3cqZAo" node="60iGZSKxZ0Y" resolve="mustBeCovered" />
-              </node>
-              <node concept="1bVj0M" id="60iGZSK$Uci" role="37wK5m">
-                <node concept="37vLTG" id="60iGZSK$Ucj" role="1bW2Oz">
-                  <property role="TrG5h" value="sac" />
-                  <node concept="3uibUv" id="60iGZSK$Uck" role="1tU5fm">
-                    <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
-                  </node>
-                </node>
-                <node concept="37vLTG" id="60iGZSK$Ucl" role="1bW2Oz">
-                  <property role="TrG5h" value="id" />
-                  <node concept="3uibUv" id="60iGZSK$V1L" role="1tU5fm">
-                    <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
-                  </node>
-                </node>
-                <node concept="3clFbS" id="60iGZSK$Ucn" role="1bW5cS">
-                  <node concept="a7r0C" id="60iGZSK$Uco" role="3cqZAp">
-                    <node concept="3cpWs3" id="60iGZSK$Uct" role="a7wSD">
-                      <node concept="3cpWs3" id="60iGZSK$Ucu" role="3uHU7B">
-                        <node concept="Xl_RD" id="60iGZSK$Ucv" role="3uHU7B">
-                          <property role="Xl_RC" value="concept " />
-                        </node>
-                        <node concept="37vLTw" id="60iGZSK$Ucw" role="3uHU7w">
-                          <ref role="3cqZAo" node="60iGZSK$Ucj" resolve="sac" />
-                        </node>
-                      </node>
-                      <node concept="Xl_RD" id="60iGZSK$Ucx" role="3uHU7w">
-                        <property role="Xl_RC" value=" is missing ID function " />
-                      </node>
-                    </node>
-                    <node concept="2YIFZM" id="60iGZSK$Ucy" role="1urrMF">
-                      <ref role="37wK5l" node="582YV7yWtlM" resolve="warningNode" />
-                      <ref role="1Pybhc" node="1trrptaK_0z" resolve="CheckinRuleUtil" />
-                      <node concept="1YBJjd" id="60iGZSK$Ucz" role="37wK5m">
-                        <ref role="1YBMHb" node="7TOowlgBzBU" resolve="modelMerge" />
-                      </node>
-                      <node concept="37vLTw" id="60iGZSK$Uc$" role="37wK5m">
-                        <ref role="3cqZAo" node="60iGZSK$Ucj" resolve="sac" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3clFbH" id="60iGZSKx0n_" role="3cqZAp" />
-          <node concept="3clFbH" id="60iGZSKx1ES" role="3cqZAp" />
-        </node>
-        <node concept="3uVAMA" id="7TOowlgVHwW" role="1zxBo5">
-          <node concept="XOnhg" id="7TOowlgVHwX" role="1zc67B">
-            <property role="TrG5h" value="e" />
-            <node concept="nSUau" id="7TOowlgVHwY" role="1tU5fm">
-              <node concept="3uibUv" id="7TOowlgVHDe" role="nSUat">
-                <ref role="3uigEE" to="gunp:7TOowlgU0QJ" resolve="MergePolicyConflict" />
-              </node>
-            </node>
-          </node>
-          <node concept="3clFbS" id="7TOowlgVHwZ" role="1zc67A">
-            <node concept="3cpWs8" id="582YV7z8mrD" role="3cqZAp">
-              <node concept="3cpWsn" id="582YV7z8mrG" role="3cpWs9">
-                <property role="TrG5h" value="violationForStr" />
-                <node concept="17QB3L" id="582YV7z8mrB" role="1tU5fm" />
-                <node concept="2OqwBi" id="582YV7z8nEI" role="33vP2m">
-                  <node concept="2OqwBi" id="582YV7z8nhq" role="2Oq$k0">
-                    <node concept="37vLTw" id="582YV7z8n0T" role="2Oq$k0">
-                      <ref role="3cqZAo" node="7TOowlgVHwX" resolve="e" />
-                    </node>
-                    <node concept="2OwXpG" id="582YV7z8n_0" role="2OqNvi">
-                      <ref role="2Oxat5" to="gunp:7TOowlgU0V6" resolve="violationFor" />
-                    </node>
-                  </node>
-                  <node concept="liA8E" id="582YV7z8nK2" role="2OqNvi">
-                    <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbJ" id="582YV7z8hIf" role="3cqZAp">
-              <node concept="3clFbS" id="582YV7z8hIh" role="3clFbx">
-                <node concept="3cpWs8" id="582YV7z8kPO" role="3cqZAp">
-                  <node concept="3cpWsn" id="582YV7z8kPP" role="3cpWs9">
-                    <property role="TrG5h" value="node" />
-                    <node concept="3Tqbb2" id="582YV7z8kN8" role="1tU5fm" />
-                    <node concept="1eOMI4" id="582YV7z8kPQ" role="33vP2m">
-                      <node concept="10QFUN" id="582YV7z8kPR" role="1eOMHV">
-                        <node concept="3Tqbb2" id="582YV7z8kPS" role="10QFUM" />
-                        <node concept="2OqwBi" id="582YV7z8kPT" role="10QFUP">
-                          <node concept="37vLTw" id="582YV7z8kPU" role="2Oq$k0">
-                            <ref role="3cqZAo" node="7TOowlgVHwX" resolve="e" />
-                          </node>
-                          <node concept="2OwXpG" id="582YV7z8kPV" role="2OqNvi">
-                            <ref role="2Oxat5" to="gunp:7TOowlgU0V6" resolve="violationFor" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="Jncv_" id="582YV7z8kUN" role="3cqZAp">
-                  <ref role="JncvD" to="tpce:f_TJgxE" resolve="LinkDeclaration" />
-                  <node concept="37vLTw" id="582YV7z8kVP" role="JncvB">
-                    <ref role="3cqZAo" node="582YV7z8kPP" resolve="node" />
-                  </node>
-                  <node concept="3clFbS" id="582YV7z8kUR" role="Jncv$">
-                    <node concept="3clFbF" id="582YV7z8o3k" role="3cqZAp">
-                      <node concept="37vLTI" id="582YV7z8opS" role="3clFbG">
-                        <node concept="37vLTw" id="582YV7z8o3j" role="37vLTJ">
-                          <ref role="3cqZAo" node="582YV7z8mrG" resolve="violationForStr" />
-                        </node>
-                        <node concept="2OqwBi" id="582YV7z8o_s" role="37vLTx">
-                          <node concept="Jnkvi" id="582YV7z8o_t" role="2Oq$k0">
-                            <ref role="1M0zk5" node="582YV7z8kUT" resolve="ld" />
-                          </node>
-                          <node concept="2qgKlT" id="582YV7z8o_u" role="2OqNvi">
-                            <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="JncvC" id="582YV7z8kUT" role="JncvA">
-                    <property role="TrG5h" value="ld" />
-                    <node concept="2jxLKc" id="582YV7z8kUU" role="1tU5fm" />
-                  </node>
-                </node>
-              </node>
-              <node concept="2ZW3vV" id="582YV7z8ji7" role="3clFbw">
-                <node concept="3Tqbb2" id="582YV7z8jjW" role="2ZW6by" />
-                <node concept="2OqwBi" id="582YV7z8iHG" role="2ZW6bz">
-                  <node concept="37vLTw" id="582YV7z8iAl" role="2Oq$k0">
-                    <ref role="3cqZAo" node="7TOowlgVHwX" resolve="e" />
-                  </node>
-                  <node concept="2OwXpG" id="582YV7z8iYa" role="2OqNvi">
-                    <ref role="2Oxat5" to="gunp:7TOowlgU0V6" resolve="violationFor" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="2MkqsV" id="7TOowlgVJ6e" role="3cqZAp">
-              <node concept="3cpWs3" id="60iGZSKh7YV" role="2MkJ7o">
-                <node concept="3cpWs3" id="7TOowlgVMa_" role="3uHU7B">
-                  <node concept="3cpWs3" id="7TOowlgVKKG" role="3uHU7B">
-                    <node concept="3cpWs3" id="7TOowlgVJGd" role="3uHU7B">
-                      <node concept="3cpWs3" id="7TOowlgVJp_" role="3uHU7B">
-                        <node concept="3cpWs3" id="1trrptaDnGv" role="3uHU7B">
-                          <node concept="2OqwBi" id="1trrptaDoik" role="3uHU7B">
-                            <node concept="37vLTw" id="1trrptaDnNz" role="2Oq$k0">
-                              <ref role="3cqZAo" node="7TOowlgVHwX" resolve="e" />
-                            </node>
-                            <node concept="2OwXpG" id="1trrptaDoB7" role="2OqNvi">
-                              <ref role="2Oxat5" to="gunp:1trrptaBV8y" resolve="type" />
-                            </node>
-                          </node>
-                          <node concept="Xl_RD" id="7TOowlgVJ7c" role="3uHU7w">
-                            <property role="Xl_RC" value=" " />
-                          </node>
-                        </node>
-                        <node concept="37vLTw" id="582YV7z8p1V" role="3uHU7w">
-                          <ref role="3cqZAo" node="582YV7z8mrG" resolve="violationForStr" />
-                        </node>
-                      </node>
-                      <node concept="Xl_RD" id="7TOowlgVJGg" role="3uHU7w">
-                        <property role="Xl_RC" value=" is already defined multiple times for " />
-                      </node>
-                    </node>
-                    <node concept="2OqwBi" id="7TOowlgVLoT" role="3uHU7w">
-                      <node concept="37vLTw" id="7TOowlgVKRO" role="2Oq$k0">
+                  <node concept="2ZW3vV" id="582YV7z8ji7" role="3clFbw">
+                    <node concept="3Tqbb2" id="582YV7z8jjW" role="2ZW6by" />
+                    <node concept="2OqwBi" id="582YV7z8iHG" role="2ZW6bz">
+                      <node concept="37vLTw" id="582YV7z8iAl" role="2Oq$k0">
                         <ref role="3cqZAo" node="7TOowlgVHwX" resolve="e" />
                       </node>
-                      <node concept="2OwXpG" id="7TOowlgVLQc" role="2OqNvi">
+                      <node concept="2OwXpG" id="582YV7z8iYa" role="2OqNvi">
+                        <ref role="2Oxat5" to="gunp:7TOowlgU0V6" resolve="violationFor" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="2MkqsV" id="7TOowlgVJ6e" role="3cqZAp">
+                  <node concept="3cpWs3" id="60iGZSKh7YV" role="2MkJ7o">
+                    <node concept="3cpWs3" id="7TOowlgVMa_" role="3uHU7B">
+                      <node concept="3cpWs3" id="7TOowlgVKKG" role="3uHU7B">
+                        <node concept="3cpWs3" id="7TOowlgVJGd" role="3uHU7B">
+                          <node concept="3cpWs3" id="7TOowlgVJp_" role="3uHU7B">
+                            <node concept="3cpWs3" id="1trrptaDnGv" role="3uHU7B">
+                              <node concept="2OqwBi" id="1trrptaDoik" role="3uHU7B">
+                                <node concept="37vLTw" id="1trrptaDnNz" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="7TOowlgVHwX" resolve="e" />
+                                </node>
+                                <node concept="2OwXpG" id="1trrptaDoB7" role="2OqNvi">
+                                  <ref role="2Oxat5" to="gunp:1trrptaBV8y" resolve="type" />
+                                </node>
+                              </node>
+                              <node concept="Xl_RD" id="7TOowlgVJ7c" role="3uHU7w">
+                                <property role="Xl_RC" value=" " />
+                              </node>
+                            </node>
+                            <node concept="37vLTw" id="582YV7z8p1V" role="3uHU7w">
+                              <ref role="3cqZAo" node="582YV7z8mrG" resolve="violationForStr" />
+                            </node>
+                          </node>
+                          <node concept="Xl_RD" id="7TOowlgVJGg" role="3uHU7w">
+                            <property role="Xl_RC" value=" is already defined multiple times for " />
+                          </node>
+                        </node>
+                        <node concept="2OqwBi" id="7TOowlgVLoT" role="3uHU7w">
+                          <node concept="37vLTw" id="7TOowlgVKRO" role="2Oq$k0">
+                            <ref role="3cqZAo" node="7TOowlgVHwX" resolve="e" />
+                          </node>
+                          <node concept="2OwXpG" id="7TOowlgVLQc" role="2OqNvi">
+                            <ref role="2Oxat5" to="gunp:7TOowlgU2lk" resolve="violationConcept" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="Xl_RD" id="7TOowlgVMaC" role="3uHU7w">
+                        <property role="Xl_RC" value=" via super concepts. Provide a separate policy for " />
+                      </node>
+                    </node>
+                    <node concept="2OqwBi" id="60iGZSKh9t4" role="3uHU7w">
+                      <node concept="37vLTw" id="60iGZSKh8Tj" role="2Oq$k0">
+                        <ref role="3cqZAo" node="7TOowlgVHwX" resolve="e" />
+                      </node>
+                      <node concept="2OwXpG" id="60iGZSKh9J4" role="2OqNvi">
+                        <ref role="2Oxat5" to="gunp:1trrptaBV8y" resolve="type" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2YIFZM" id="582YV7yWK$M" role="1urrMF">
+                    <ref role="1Pybhc" node="1trrptaK_0z" resolve="CheckinRuleUtil" />
+                    <ref role="37wK5l" node="582YV7yWtlM" resolve="warningNode" />
+                    <node concept="1YBJjd" id="582YV7yWK$N" role="37wK5m">
+                      <ref role="1YBMHb" node="7TOowlgBzBU" resolve="modelMerge" />
+                    </node>
+                    <node concept="2OqwBi" id="582YV7yWQQd" role="37wK5m">
+                      <node concept="37vLTw" id="582YV7yWPvy" role="2Oq$k0">
+                        <ref role="3cqZAo" node="7TOowlgVHwX" resolve="e" />
+                      </node>
+                      <node concept="2OwXpG" id="582YV7yWU4b" role="2OqNvi">
                         <ref role="2Oxat5" to="gunp:7TOowlgU2lk" resolve="violationConcept" />
                       </node>
                     </node>
                   </node>
-                  <node concept="Xl_RD" id="7TOowlgVMaC" role="3uHU7w">
-                    <property role="Xl_RC" value=" via super concepts. Provide a separate policy for " />
-                  </node>
                 </node>
-                <node concept="2OqwBi" id="60iGZSKh9t4" role="3uHU7w">
-                  <node concept="37vLTw" id="60iGZSKh8Tj" role="2Oq$k0">
-                    <ref role="3cqZAo" node="7TOowlgVHwX" resolve="e" />
-                  </node>
-                  <node concept="2OwXpG" id="60iGZSKh9J4" role="2OqNvi">
-                    <ref role="2Oxat5" to="gunp:1trrptaBV8y" resolve="type" />
+              </node>
+            </node>
+            <node concept="3uVAMA" id="6CwG2k7Ofre" role="1zxBo5">
+              <node concept="XOnhg" id="6CwG2k7Ofrf" role="1zc67B">
+                <property role="TrG5h" value="mmp" />
+                <node concept="nSUau" id="6CwG2k7Ofrg" role="1tU5fm">
+                  <node concept="3uibUv" id="6CwG2k7OgYo" role="nSUat">
+                    <ref role="3uigEE" to="gunp:6CwG2k7NbpD" resolve="MissingMergePolicies" />
                   </node>
                 </node>
               </node>
-              <node concept="2YIFZM" id="582YV7yWK$M" role="1urrMF">
-                <ref role="1Pybhc" node="1trrptaK_0z" resolve="CheckinRuleUtil" />
-                <ref role="37wK5l" node="582YV7yWtlM" resolve="warningNode" />
-                <node concept="1YBJjd" id="582YV7yWK$N" role="37wK5m">
-                  <ref role="1YBMHb" node="7TOowlgBzBU" resolve="modelMerge" />
-                </node>
-                <node concept="2OqwBi" id="582YV7yWQQd" role="37wK5m">
-                  <node concept="37vLTw" id="582YV7yWPvy" role="2Oq$k0">
-                    <ref role="3cqZAo" node="7TOowlgVHwX" resolve="e" />
+              <node concept="3clFbS" id="6CwG2k7Ofrh" role="1zc67A">
+                <node concept="3cpWs8" id="6XR_ZZHw0a9" role="3cqZAp">
+                  <node concept="3cpWsn" id="6XR_ZZHw0aa" role="3cpWs9">
+                    <property role="TrG5h" value="msg" />
+                    <node concept="17QB3L" id="6XR_ZZHvZJK" role="1tU5fm" />
+                    <node concept="3cpWs3" id="6XR_ZZHw0ab" role="33vP2m">
+                      <node concept="2OqwBi" id="6XR_ZZHw0ac" role="3uHU7w">
+                        <node concept="2OqwBi" id="6XR_ZZHw0ad" role="2Oq$k0">
+                          <node concept="37vLTw" id="6XR_ZZHw0ae" role="2Oq$k0">
+                            <ref role="3cqZAo" node="6CwG2k7Ofrf" resolve="mmp" />
+                          </node>
+                          <node concept="liA8E" id="6XR_ZZHw0af" role="2OqNvi">
+                            <ref role="37wK5l" to="gunp:6CwG2k7NcVI" resolve="missingPoliciesFor" />
+                          </node>
+                        </node>
+                        <node concept="3$u5V9" id="6XR_ZZHw0ag" role="2OqNvi">
+                          <node concept="1bVj0M" id="6XR_ZZHw0ah" role="23t8la">
+                            <node concept="3clFbS" id="6XR_ZZHw0ai" role="1bW5cS">
+                              <node concept="3clFbF" id="6XR_ZZHw0aj" role="3cqZAp">
+                                <node concept="3cpWs3" id="6XR_ZZHw0ak" role="3clFbG">
+                                  <node concept="Xl_RD" id="6XR_ZZHw0al" role="3uHU7w">
+                                    <property role="Xl_RC" value=" " />
+                                  </node>
+                                  <node concept="2OqwBi" id="6XR_ZZHw0am" role="3uHU7B">
+                                    <node concept="37vLTw" id="6XR_ZZHw0an" role="2Oq$k0">
+                                      <ref role="3cqZAo" node="7Z$RfkF7IGr" resolve="it" />
+                                    </node>
+                                    <node concept="2qgKlT" id="6XR_ZZHw0ao" role="2OqNvi">
+                                      <ref role="37wK5l" to="tpcn:280s3ZNTXNS" resolve="getPresentation" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="gl6BB" id="7Z$RfkF7IGr" role="1bW2Oz">
+                              <property role="TrG5h" value="it" />
+                              <node concept="2jxLKc" id="7Z$RfkF7IGs" role="1tU5fm" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="Xl_RD" id="6XR_ZZHw0ar" role="3uHU7B">
+                        <property role="Xl_RC" value="MergePolicies missing for concepts: " />
+                      </node>
+                    </node>
                   </node>
-                  <node concept="2OwXpG" id="582YV7yWU4b" role="2OqNvi">
-                    <ref role="2Oxat5" to="gunp:7TOowlgU2lk" resolve="violationConcept" />
+                </node>
+                <node concept="a7r0C" id="6XR_ZZHw2EC" role="3cqZAp">
+                  <node concept="3Cnw8n" id="6XR_ZZHw5L_" role="1urrFz">
+                    <ref role="QpYPw" node="6CwG2k7XBSP" resolve="AddMissingMergePolicies" />
+                    <node concept="3CnSsL" id="6XR_ZZHw7Q_" role="3Coj4f">
+                      <ref role="QkamJ" node="6CwG2k7XCNT" resolve="modelmerge" />
+                      <node concept="1YBJjd" id="6XR_ZZHw7Sw" role="3CoRuB">
+                        <ref role="1YBMHb" node="7TOowlgBzBU" resolve="modelMerge" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="37vLTw" id="6XR_ZZHw2XT" role="a7wSD">
+                    <ref role="3cqZAo" node="6XR_ZZHw0aa" resolve="msg" />
+                  </node>
+                  <node concept="1YBJjd" id="6XR_ZZHw31j" role="1urrMF">
+                    <ref role="1YBMHb" node="7TOowlgBzBU" resolve="modelMerge" />
                   </node>
                 </node>
               </node>
             </node>
           </node>
         </node>
-        <node concept="3uVAMA" id="6CwG2k7Ofre" role="1zxBo5">
-          <node concept="XOnhg" id="6CwG2k7Ofrf" role="1zc67B">
-            <property role="TrG5h" value="mmp" />
-            <node concept="nSUau" id="6CwG2k7Ofrg" role="1tU5fm">
-              <node concept="3uibUv" id="6CwG2k7OgYo" role="nSUat">
-                <ref role="3uigEE" to="gunp:6CwG2k7NbpD" resolve="MissingMergePolicies" />
-              </node>
+        <node concept="3fqX7Q" id="2GFEb9MrFtV" role="3clFbw">
+          <node concept="2OqwBi" id="2GFEb9MrFtX" role="3fr31v">
+            <node concept="1YBJjd" id="2GFEb9MrFtY" role="2Oq$k0">
+              <ref role="1YBMHb" node="7TOowlgBzBU" resolve="modelMerge" />
             </node>
-          </node>
-          <node concept="3clFbS" id="6CwG2k7Ofrh" role="1zc67A">
-            <node concept="3cpWs8" id="6XR_ZZHw0a9" role="3cqZAp">
-              <node concept="3cpWsn" id="6XR_ZZHw0aa" role="3cpWs9">
-                <property role="TrG5h" value="msg" />
-                <node concept="17QB3L" id="6XR_ZZHvZJK" role="1tU5fm" />
-                <node concept="3cpWs3" id="6XR_ZZHw0ab" role="33vP2m">
-                  <node concept="2OqwBi" id="6XR_ZZHw0ac" role="3uHU7w">
-                    <node concept="2OqwBi" id="6XR_ZZHw0ad" role="2Oq$k0">
-                      <node concept="37vLTw" id="6XR_ZZHw0ae" role="2Oq$k0">
-                        <ref role="3cqZAo" node="6CwG2k7Ofrf" resolve="mmp" />
-                      </node>
-                      <node concept="liA8E" id="6XR_ZZHw0af" role="2OqNvi">
-                        <ref role="37wK5l" to="gunp:6CwG2k7NcVI" resolve="missingPoliciesFor" />
-                      </node>
-                    </node>
-                    <node concept="3$u5V9" id="6XR_ZZHw0ag" role="2OqNvi">
-                      <node concept="1bVj0M" id="6XR_ZZHw0ah" role="23t8la">
-                        <node concept="3clFbS" id="6XR_ZZHw0ai" role="1bW5cS">
-                          <node concept="3clFbF" id="6XR_ZZHw0aj" role="3cqZAp">
-                            <node concept="3cpWs3" id="6XR_ZZHw0ak" role="3clFbG">
-                              <node concept="Xl_RD" id="6XR_ZZHw0al" role="3uHU7w">
-                                <property role="Xl_RC" value=" " />
-                              </node>
-                              <node concept="2OqwBi" id="6XR_ZZHw0am" role="3uHU7B">
-                                <node concept="37vLTw" id="6XR_ZZHw0an" role="2Oq$k0">
-                                  <ref role="3cqZAo" node="7Z$RfkF7IGr" resolve="it" />
-                                </node>
-                                <node concept="2qgKlT" id="6XR_ZZHw0ao" role="2OqNvi">
-                                  <ref role="37wK5l" to="tpcn:280s3ZNTXNS" resolve="getPresentation" />
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="gl6BB" id="7Z$RfkF7IGr" role="1bW2Oz">
-                          <property role="TrG5h" value="it" />
-                          <node concept="2jxLKc" id="7Z$RfkF7IGs" role="1tU5fm" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="Xl_RD" id="6XR_ZZHw0ar" role="3uHU7B">
-                    <property role="Xl_RC" value="MergePolicies missing for concepts: " />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="a7r0C" id="6XR_ZZHw2EC" role="3cqZAp">
-              <node concept="3Cnw8n" id="6XR_ZZHw5L_" role="1urrFz">
-                <ref role="QpYPw" node="6CwG2k7XBSP" resolve="AddMissingMergePolicies" />
-                <node concept="3CnSsL" id="6XR_ZZHw7Q_" role="3Coj4f">
-                  <ref role="QkamJ" node="6CwG2k7XCNT" resolve="modelmerge" />
-                  <node concept="1YBJjd" id="6XR_ZZHw7Sw" role="3CoRuB">
-                    <ref role="1YBMHb" node="7TOowlgBzBU" resolve="modelMerge" />
-                  </node>
-                </node>
-              </node>
-              <node concept="37vLTw" id="6XR_ZZHw2XT" role="a7wSD">
-                <ref role="3cqZAo" node="6XR_ZZHw0aa" resolve="msg" />
-              </node>
-              <node concept="1YBJjd" id="6XR_ZZHw31j" role="1urrMF">
-                <ref role="1YBMHb" node="7TOowlgBzBU" resolve="modelMerge" />
-              </node>
+            <node concept="3TrcHB" id="2GFEb9MrFtZ" role="2OqNvi">
+              <ref role="3TsBF5" to="mopj:2GFEb9MrdCG" resolve="partialPolicy" />
             </node>
           </node>
         </node>
@@ -3613,6 +3851,145 @@
         </node>
       </node>
     </node>
+  </node>
+  <node concept="312cEu" id="2GFEb9Nd7c0">
+    <property role="TrG5h" value="ModelMergerExecutionChecker" />
+    <node concept="312cEg" id="2GFEb9Ndlfo" role="jymVt">
+      <property role="TrG5h" value="execution" />
+      <node concept="3Tqbb2" id="2GFEb9Ndjbj" role="1tU5fm">
+        <ref role="ehGHo" to="mopj:5zr7Q_1InAA" resolve="ModelMergeExecution" />
+      </node>
+      <node concept="3Tm6S6" id="2GFEb9Ndqlu" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="2GFEb9NdqRk" role="jymVt" />
+    <node concept="3clFbW" id="2GFEb9NdbQU" role="jymVt">
+      <node concept="3cqZAl" id="2GFEb9NdbQW" role="3clF45" />
+      <node concept="3Tm1VV" id="2GFEb9NdbQX" role="1B3o_S" />
+      <node concept="3clFbS" id="2GFEb9NdbQY" role="3clF47">
+        <node concept="3clFbF" id="2GFEb9NdmlL" role="3cqZAp">
+          <node concept="37vLTI" id="2GFEb9NdnDt" role="3clFbG">
+            <node concept="37vLTw" id="2GFEb9NdoK1" role="37vLTx">
+              <ref role="3cqZAo" node="2GFEb9NdcVk" resolve="modelMergerExecution" />
+            </node>
+            <node concept="2OqwBi" id="2GFEb9Ndmtd" role="37vLTJ">
+              <node concept="Xjq3P" id="2GFEb9NdmlK" role="2Oq$k0" />
+              <node concept="2OwXpG" id="2GFEb9NdngU" role="2OqNvi">
+                <ref role="2Oxat5" node="2GFEb9Ndlfo" resolve="execution" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="2GFEb9NdcVk" role="3clF46">
+        <property role="TrG5h" value="modelMergerExecution" />
+        <node concept="3Tqbb2" id="2GFEb9NdcVj" role="1tU5fm">
+          <ref role="ehGHo" to="mopj:5zr7Q_1InAA" resolve="ModelMergeExecution" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="2GFEb9NdssJ" role="jymVt" />
+    <node concept="3clFb_" id="2GFEb9Nhs8U" role="jymVt">
+      <property role="TrG5h" value="areAllModelConceptsCoveredByPolicies" />
+      <node concept="3clFbS" id="2GFEb9Nhs8V" role="3clF47">
+        <node concept="3cpWs8" id="2GFEb9NhN9p" role="3cqZAp">
+          <node concept="3cpWsn" id="2GFEb9NhN9q" role="3cpWs9">
+            <property role="TrG5h" value="modelConcepts" />
+            <node concept="A3Dl8" id="2GFEb9NhN9r" role="1tU5fm">
+              <node concept="3Tqbb2" id="2GFEb9NhN9s" role="A3Ik2">
+                <ref role="ehGHo" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="2GFEb9NhN9t" role="33vP2m">
+              <node concept="37vLTw" id="2GFEb9NhN9u" role="2Oq$k0">
+                <ref role="3cqZAo" node="2GFEb9Ndlfo" resolve="execution" />
+              </node>
+              <node concept="2qgKlT" id="2GFEb9NhN9v" role="2OqNvi">
+                <ref role="37wK5l" to="rnx3:2GFEb9MTMsl" resolve="usedConceptsInModel" />
+                <node concept="37vLTw" id="2GFEb9NjlXM" role="37wK5m">
+                  <ref role="3cqZAo" node="2GFEb9MZlei" resolve="modelExp" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="2GFEb9NhN9z" role="3cqZAp">
+          <node concept="3cpWsn" id="2GFEb9NhN9$" role="3cpWs9">
+            <property role="TrG5h" value="policyConcepts" />
+            <node concept="A3Dl8" id="2GFEb9NhN9_" role="1tU5fm">
+              <node concept="3Tqbb2" id="2GFEb9NhN9A" role="A3Ik2">
+                <ref role="ehGHo" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="2GFEb9NhN9B" role="33vP2m">
+              <node concept="37vLTw" id="2GFEb9NhN9C" role="2Oq$k0">
+                <ref role="3cqZAo" node="2GFEb9Ndlfo" resolve="execution" />
+              </node>
+              <node concept="2qgKlT" id="2GFEb9NhN9D" role="2OqNvi">
+                <ref role="37wK5l" to="rnx3:2GFEb9MZQtm" resolve="conceptsCoveredByPolicies" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="2GFEb9NhN9E" role="3cqZAp" />
+        <node concept="3clFbF" id="2GFEb9NhN9F" role="3cqZAp">
+          <node concept="2OqwBi" id="2GFEb9NizBU" role="3clFbG">
+            <node concept="2OqwBi" id="2GFEb9NhN9G" role="2Oq$k0">
+              <node concept="37vLTw" id="2GFEb9NhN9H" role="2Oq$k0">
+                <ref role="3cqZAo" node="2GFEb9NhN9q" resolve="modelConcepts" />
+              </node>
+              <node concept="66VNe" id="2GFEb9NhN9I" role="2OqNvi">
+                <node concept="37vLTw" id="2GFEb9NhN9J" role="576Qk">
+                  <ref role="3cqZAo" node="2GFEb9NhN9$" resolve="policyConcepts" />
+                </node>
+              </node>
+            </node>
+            <node concept="2es0OD" id="2GFEb9Ni_rL" role="2OqNvi">
+              <node concept="1bVj0M" id="2GFEb9Ni_rN" role="23t8la">
+                <node concept="3clFbS" id="2GFEb9Ni_rO" role="1bW5cS">
+                  <node concept="3clFbF" id="2GFEb9NiITL" role="3cqZAp">
+                    <node concept="2OqwBi" id="2GFEb9NiK3V" role="3clFbG">
+                      <node concept="37vLTw" id="2GFEb9NiITK" role="2Oq$k0">
+                        <ref role="3cqZAo" node="2GFEb9NhsaG" resolve="error" />
+                      </node>
+                      <node concept="1Bd96e" id="2GFEb9NiLn2" role="2OqNvi">
+                        <node concept="37vLTw" id="2GFEb9NiM8L" role="1BdPVh">
+                          <ref role="3cqZAo" node="2GFEb9Ni_rP" resolve="missingConcept" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="gl6BB" id="2GFEb9Ni_rP" role="1bW2Oz">
+                  <property role="TrG5h" value="missingConcept" />
+                  <node concept="2jxLKc" id="2GFEb9Ni_rQ" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3cqZAl" id="2GFEb9Nhsas" role="3clF45" />
+      <node concept="37vLTG" id="2GFEb9MZlei" role="3clF46">
+        <property role="TrG5h" value="modelExp" />
+        <node concept="3Tqbb2" id="2GFEb9MZleh" role="1tU5fm">
+          <ref role="ehGHo" to="tp25:1Bs_61$nfRn" resolve="ModelPointerExpression" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="2GFEb9NhsaG" role="3clF46">
+        <property role="TrG5h" value="error" />
+        <node concept="1ajhzC" id="2GFEb9NhsaH" role="1tU5fm">
+          <node concept="3Tqbb2" id="2GFEb9NiuZR" role="1ajw0F">
+            <ref role="ehGHo" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
+          </node>
+          <node concept="3cqZAl" id="2GFEb9NhsaK" role="1ajl9A" />
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="2GFEb9NhsaM" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="2GFEb9NhrTv" role="jymVt" />
+    <node concept="2tJIrI" id="2GFEb9NdoKT" role="jymVt" />
+    <node concept="2tJIrI" id="2GFEb9NdpiH" role="jymVt" />
+    <node concept="3Tm1VV" id="2GFEb9Nd7c1" role="1B3o_S" />
   </node>
 </model>
 

--- a/code/languages/de.itemis.model.simple.demo.children/models/de.itemis.model.simple.demo.children.editor.mps
+++ b/code/languages/de.itemis.model.simple.demo.children/models/de.itemis.model.simple.demo.children.editor.mps
@@ -8,6 +8,7 @@
   </languages>
   <imports>
     <import index="9kut" ref="r:c515cf95-0439-4376-8bc5-13a56baa0293(de.itemis.model.simple.demo.children.structure)" implicit="true" />
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
   </imports>
   <registry>
     <language id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor">
@@ -28,6 +29,7 @@
       <concept id="1073389577006" name="jetbrains.mps.lang.editor.structure.CellModel_Constant" flags="sn" stub="3610246225209162225" index="3F0ifn">
         <property id="1073389577007" name="text" index="3F0ifm" />
       </concept>
+      <concept id="1073389658414" name="jetbrains.mps.lang.editor.structure.CellModel_Property" flags="sg" stub="730538219796134133" index="3F0A7n" />
       <concept id="1219418625346" name="jetbrains.mps.lang.editor.structure.IStyleContainer" flags="ngI" index="3F0Thp">
         <child id="1219418656006" name="styleItem" index="3F10Kt" />
       </concept>
@@ -41,6 +43,16 @@
     <ref role="1XX52x" to="9kut:3pc485Vr2SQ" resolve="ChildKeeper" />
     <node concept="3EZMnI" id="3pc485Wdv$7" role="2wV5jI">
       <node concept="2iRkQZ" id="3pc485Wdv$8" role="2iSdaV" />
+      <node concept="3EZMnI" id="7wzAiypMRKZ" role="3EZMnx">
+        <node concept="VPM3Z" id="7wzAiypMRL1" role="3F10Kt" />
+        <node concept="3F0ifn" id="7wzAiypMRL5" role="3EZMnx">
+          <property role="3F0ifm" value="Name: " />
+        </node>
+        <node concept="3F0A7n" id="7wzAiypMRLa" role="3EZMnx">
+          <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
+        </node>
+        <node concept="2iRfu4" id="7wzAiypMRL4" role="2iSdaV" />
+      </node>
       <node concept="3EZMnI" id="3pc485Vr3CA" role="3EZMnx">
         <node concept="3F0ifn" id="3pc485Vr3CH" role="3EZMnx">
           <property role="3F0ifm" value="Singleton:" />

--- a/code/languages/de.itemis.model.simple.demo.children/models/de.itemis.model.simple.demo.children.structure.mps
+++ b/code/languages/de.itemis.model.simple.demo.children/models/de.itemis.model.simple.demo.children.structure.mps
@@ -14,9 +14,13 @@
         <property id="6714410169261853888" name="conceptId" index="EcuMT" />
         <child id="1071489727083" name="linkDeclaration" index="1TKVEi" />
       </concept>
+      <concept id="1169127622168" name="jetbrains.mps.lang.structure.structure.InterfaceConceptReference" flags="ig" index="PrWs8">
+        <reference id="1169127628841" name="intfc" index="PrY4T" />
+      </concept>
       <concept id="1071489090640" name="jetbrains.mps.lang.structure.structure.ConceptDeclaration" flags="ig" index="1TIwiD">
         <property id="1096454100552" name="rootable" index="19KtqR" />
         <reference id="1071489389519" name="extends" index="1TJDcQ" />
+        <child id="1169129564478" name="implements" index="PzmwI" />
       </concept>
       <concept id="1071489288298" name="jetbrains.mps.lang.structure.structure.LinkDeclaration" flags="ig" index="1TJgyj">
         <property id="1071599776563" name="role" index="20kJfa" />
@@ -49,6 +53,9 @@
       <property role="20lmBu" value="fLJjDmT/aggregation" />
       <property role="20kJfa" value="optionalChild" />
       <ref role="20lvS9" to="yeyq:32ggi2DCpGw" resolve="PropertyDummy" />
+    </node>
+    <node concept="PrWs8" id="7wzAiypKYWu" role="PzmwI">
+      <ref role="PrY4T" to="tpck:h0TrEE$" resolve="INamedConcept" />
     </node>
   </node>
 </model>

--- a/code/solutions/de.itemis.model.merge.runtime/de.itemis.model.merge.runtime.msd
+++ b/code/solutions/de.itemis.model.merge.runtime/de.itemis.model.merge.runtime.msd
@@ -22,17 +22,18 @@
     <dependency reexport="false">ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)</dependency>
     <dependency reexport="false">6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)</dependency>
     <dependency reexport="false">215c4c45-ba99-49f5-9ab7-4b6901a63cfd(MPS.Generator)</dependency>
+    <dependency reexport="false">e50b0500-6fd7-4c7f-a730-9d841358ca2b(de.itemis.model.simple.demo.property)</dependency>
+    <dependency reexport="false">5454dbfd-2075-4de0-b85e-fa645eb6957e(de.itemis.mps.utils.serializer.xml)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
     <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
     <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="2" />
     <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
-    <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
-    <language slang="l:515552c7-fcc0-4ab4-9789-2f3c49344e85:jetbrains.mps.baseLanguage.varVariable" version="0" />
     <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
     <language slang="l:c0080a47-7e37-4558-bee9-9ae18e690549:jetbrains.mps.lang.extension" version="2" />
     <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
+    <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
     <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
     <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
@@ -45,6 +46,8 @@
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="539e8939-08ef-497c-a5fd-25dd10137a55(de.itemis.model.merge)" version="0" />
     <module reference="aa8cbd62-5e1f-4d0b-a6e2-189711774c91(de.itemis.model.merge.runtime)" version="0" />
+    <module reference="e50b0500-6fd7-4c7f-a730-9d841358ca2b(de.itemis.model.simple.demo.property)" version="0" />
+    <module reference="5454dbfd-2075-4de0-b85e-fa645eb6957e(de.itemis.mps.utils.serializer.xml)" version="0" />
     <module reference="ecfb9949-7433-4db5-85de-0f84d172e4ce(de.q60.mps.collections.libs)" version="0" />
     <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
     <module reference="fd392034-7849-419d-9071-12563d152375(jetbrains.mps.baseLanguage.closures)" version="0" />

--- a/code/solutions/de.itemis.model.merge.runtime/de.itemis.model.merge.runtime.msd
+++ b/code/solutions/de.itemis.model.merge.runtime/de.itemis.model.merge.runtime.msd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <solution name="de.itemis.model.merge.runtime" uuid="aa8cbd62-5e1f-4d0b-a6e2-189711774c91" moduleVersion="0">
   <models>
-    <modelRoot contentPath="${module}" type="default">
+    <modelRoot type="default" contentPath="${module}">
       <sourceRoot location="models" />
     </modelRoot>
   </models>
@@ -22,7 +22,6 @@
     <dependency reexport="false">ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)</dependency>
     <dependency reexport="false">6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)</dependency>
     <dependency reexport="false">215c4c45-ba99-49f5-9ab7-4b6901a63cfd(MPS.Generator)</dependency>
-    <dependency reexport="false">e50b0500-6fd7-4c7f-a730-9d841358ca2b(de.itemis.model.simple.demo.property)</dependency>
     <dependency reexport="false">5454dbfd-2075-4de0-b85e-fa645eb6957e(de.itemis.mps.utils.serializer.xml)</dependency>
   </dependencies>
   <languageVersions>
@@ -46,7 +45,6 @@
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="539e8939-08ef-497c-a5fd-25dd10137a55(de.itemis.model.merge)" version="0" />
     <module reference="aa8cbd62-5e1f-4d0b-a6e2-189711774c91(de.itemis.model.merge.runtime)" version="0" />
-    <module reference="e50b0500-6fd7-4c7f-a730-9d841358ca2b(de.itemis.model.simple.demo.property)" version="0" />
     <module reference="5454dbfd-2075-4de0-b85e-fa645eb6957e(de.itemis.mps.utils.serializer.xml)" version="0" />
     <module reference="ecfb9949-7433-4db5-85de-0f84d172e4ce(de.q60.mps.collections.libs)" version="0" />
     <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />

--- a/code/solutions/de.itemis.model.merge.runtime/models/de.itemis.model.merge.runtime.runtime.mps
+++ b/code/solutions/de.itemis.model.merge.runtime/models/de.itemis.model.merge.runtime.runtime.mps
@@ -11159,20 +11159,6 @@
         </node>
       </node>
       <node concept="3clFbS" id="7F7y$3JwqQN" role="3clF47">
-        <node concept="3clFbF" id="7F7y$3LnjPN" role="3cqZAp">
-          <node concept="2OqwBi" id="7F7y$3LnjPK" role="3clFbG">
-            <node concept="10M0yZ" id="7F7y$3LnjPL" role="2Oq$k0">
-              <ref role="1PxDUh" to="wyt6:~System" resolve="System" />
-              <ref role="3cqZAo" to="wyt6:~System.out" resolve="out" />
-            </node>
-            <node concept="liA8E" id="7F7y$3LnjPM" role="2OqNvi">
-              <ref role="37wK5l" to="guwi:~PrintStream.println(java.lang.String)" resolve="println" />
-              <node concept="Xl_RD" id="7F7y$3LnnG8" role="37wK5m">
-                <property role="Xl_RC" value="== Add Default Policies" />
-              </node>
-            </node>
-          </node>
-        </node>
         <node concept="3cpWs8" id="5xmpdH79TPD" role="3cqZAp">
           <node concept="3cpWsn" id="5xmpdH79TPG" role="3cpWs9">
             <property role="TrG5h" value="conceptDeclaration" />
@@ -11213,28 +11199,6 @@
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="7F7y$3LnSWx" role="3cqZAp">
-          <node concept="2OqwBi" id="7F7y$3LnSWy" role="3clFbG">
-            <node concept="10M0yZ" id="7F7y$3LnSWz" role="2Oq$k0">
-              <ref role="1PxDUh" to="wyt6:~System" resolve="System" />
-              <ref role="3cqZAo" to="wyt6:~System.out" resolve="out" />
-            </node>
-            <node concept="liA8E" id="7F7y$3LnSW$" role="2OqNvi">
-              <ref role="37wK5l" to="guwi:~PrintStream.println(java.lang.String)" resolve="println" />
-              <node concept="3cpWs3" id="7F7y$3Lo_j9" role="37wK5m">
-                <node concept="2OqwBi" id="7F7y$3LoEFQ" role="3uHU7w">
-                  <node concept="37vLTw" id="49zGylWpePS" role="2Oq$k0">
-                    <ref role="3cqZAo" node="5xmpdH79TPG" resolve="conceptDeclaration" />
-                  </node>
-                  <node concept="2Iv5rx" id="7F7y$3LoIgy" role="2OqNvi" />
-                </node>
-                <node concept="Xl_RD" id="7F7y$3Lo7rz" role="3uHU7B">
-                  <property role="Xl_RC" value="  Create default policy for " />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
         <node concept="3clFbH" id="7F7y$3JEbk5" role="3cqZAp" />
         <node concept="2Gpval" id="7F7y$3J_IVq" role="3cqZAp">
           <node concept="2GrKxI" id="7F7y$3J_IVs" role="2Gsz3X">
@@ -11249,34 +11213,6 @@
             </node>
           </node>
           <node concept="3clFbS" id="7F7y$3J_IVw" role="2LFqv$">
-            <node concept="3clFbF" id="7F7y$3LoNnH" role="3cqZAp">
-              <node concept="2OqwBi" id="7F7y$3LoNnI" role="3clFbG">
-                <node concept="10M0yZ" id="7F7y$3LoNnJ" role="2Oq$k0">
-                  <ref role="1PxDUh" to="wyt6:~System" resolve="System" />
-                  <ref role="3cqZAo" to="wyt6:~System.out" resolve="out" />
-                </node>
-                <node concept="liA8E" id="7F7y$3LoNnK" role="2OqNvi">
-                  <ref role="37wK5l" to="guwi:~PrintStream.println(java.lang.String)" resolve="println" />
-                  <node concept="3cpWs3" id="7F7y$3LoNnL" role="37wK5m">
-                    <node concept="2OqwBi" id="7F7y$3LoNnM" role="3uHU7w">
-                      <node concept="2OqwBi" id="7F7y$3Lp7Pk" role="2Oq$k0">
-                        <node concept="2GrUjf" id="7F7y$3LoNnN" role="2Oq$k0">
-                          <ref role="2Gs0qQ" node="7F7y$3J_IVs" resolve="propertyPolicy" />
-                        </node>
-                        <node concept="3TrEf2" id="7F7y$3LpbK0" role="2OqNvi">
-                          <ref role="3Tt5mk" to="mopj:6zqIeMU2u$T" resolve="property" />
-                        </node>
-                      </node>
-                      <node concept="2Iv5rx" id="7F7y$3LoNnO" role="2OqNvi" />
-                    </node>
-                    <node concept="Xl_RD" id="7F7y$3LoNnP" role="3uHU7B">
-                      <property role="Xl_RC" value="    Create default property " />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbH" id="49zGylSLxyy" role="3cqZAp" />
             <node concept="3cpWs8" id="49zGylSKh8e" role="3cqZAp">
               <node concept="3cpWsn" id="49zGylSKh8f" role="3cpWs9">
                 <property role="TrG5h" value="propertyMerger" />
@@ -11339,34 +11275,6 @@
             </node>
           </node>
           <node concept="3clFbS" id="49zGylSuxAm" role="2LFqv$">
-            <node concept="3clFbF" id="49zGylSuxAn" role="3cqZAp">
-              <node concept="2OqwBi" id="49zGylSuxAo" role="3clFbG">
-                <node concept="10M0yZ" id="49zGylSuxAp" role="2Oq$k0">
-                  <ref role="1PxDUh" to="wyt6:~System" resolve="System" />
-                  <ref role="3cqZAo" to="wyt6:~System.out" resolve="out" />
-                </node>
-                <node concept="liA8E" id="49zGylSuxAq" role="2OqNvi">
-                  <ref role="37wK5l" to="guwi:~PrintStream.println(java.lang.String)" resolve="println" />
-                  <node concept="3cpWs3" id="49zGylSuxAr" role="37wK5m">
-                    <node concept="2OqwBi" id="49zGylSuxAs" role="3uHU7w">
-                      <node concept="2OqwBi" id="49zGylSuxAt" role="2Oq$k0">
-                        <node concept="2GrUjf" id="49zGylSuxAu" role="2Oq$k0">
-                          <ref role="2Gs0qQ" node="49zGylSuxAi" resolve="childPolicy" />
-                        </node>
-                        <node concept="2qgKlT" id="49zGylSwmm4" role="2OqNvi">
-                          <ref role="37wK5l" to="rnx3:1VmHfRx_0K2" resolve="childLink" />
-                        </node>
-                      </node>
-                      <node concept="2Iv5rx" id="49zGylSuxAw" role="2OqNvi" />
-                    </node>
-                    <node concept="Xl_RD" id="49zGylSuxAx" role="3uHU7B">
-                      <property role="Xl_RC" value="    Create default child policy for: " />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbH" id="49zGylSuxAy" role="3cqZAp" />
             <node concept="3cpWs8" id="49zGylSLgpg" role="3cqZAp">
               <node concept="3cpWsn" id="49zGylSLgph" role="3cpWs9">
                 <property role="TrG5h" value="childMerger" />

--- a/code/solutions/de.itemis.model.merge.runtime/models/de.itemis.model.merge.runtime.runtime.mps
+++ b/code/solutions/de.itemis.model.merge.runtime/models/de.itemis.model.merge.runtime.runtime.mps
@@ -9331,7 +9331,7 @@
             </node>
             <node concept="10M0yZ" id="7F7y$3JyDSf" role="37vLTJ">
               <ref role="1PxDUh" node="18W7Z4VeRuj" resolve="MergeResolverFromModelMerge" />
-              <ref role="3cqZAo" node="7F7y$3JxWSP" resolve="modelMerge" />
+              <ref role="3cqZAo" node="7F7y$3JxWSP" resolve="currentModelMerge" />
             </node>
           </node>
         </node>
@@ -11162,8 +11162,8 @@
         <node concept="3clFbF" id="7F7y$3LnjPN" role="3cqZAp">
           <node concept="2OqwBi" id="7F7y$3LnjPK" role="3clFbG">
             <node concept="10M0yZ" id="7F7y$3LnjPL" role="2Oq$k0">
-              <ref role="1PxDUh" to="wyt6:~System" />
-              <ref role="3cqZAo" to="wyt6:~System.out" />
+              <ref role="1PxDUh" to="wyt6:~System" resolve="System" />
+              <ref role="3cqZAo" to="wyt6:~System.out" resolve="out" />
             </node>
             <node concept="liA8E" id="7F7y$3LnjPM" role="2OqNvi">
               <ref role="37wK5l" to="guwi:~PrintStream.println(java.lang.String)" resolve="println" />
@@ -17246,7 +17246,7 @@
                 <ref role="1Pybhc" node="7F7y$3JJe2j" resolve="DefaultPolicyBuilder" />
                 <ref role="37wK5l" node="7F7y$3JJe3y" resolve="properties" />
                 <node concept="37vLTw" id="5xmpdH75dKM" role="37wK5m">
-                  <ref role="3cqZAo" node="5xmpdH75dKH" resolve="defaultPolicy" />
+                  <ref role="3cqZAo" node="5xmpdH75dKH" resolve="policy" />
                 </node>
                 <node concept="37vLTw" id="5xmpdH75dKY" role="37wK5m">
                   <ref role="3cqZAo" node="5xmpdH75dKJ" resolve="defaultAction" />
@@ -17257,7 +17257,7 @@
           <node concept="2OqwBi" id="5xmpdH75dK3" role="3clFbw">
             <node concept="2OqwBi" id="5xmpdH75dK4" role="2Oq$k0">
               <node concept="37vLTw" id="5xmpdH75dKU" role="2Oq$k0">
-                <ref role="3cqZAo" node="5xmpdH75dKH" resolve="defaultPolicy" />
+                <ref role="3cqZAo" node="5xmpdH75dKH" resolve="policy" />
               </node>
               <node concept="2qgKlT" id="5xmpdH75dK6" role="2OqNvi">
                 <ref role="37wK5l" to="rnx3:5zr7Q_1V6SF" resolve="allHierarchyProperties" />
@@ -17274,7 +17274,7 @@
                 <ref role="1Pybhc" node="7F7y$3JJe2j" resolve="DefaultPolicyBuilder" />
                 <ref role="37wK5l" node="7F7y$3JJe41" resolve="singletonChildren" />
                 <node concept="37vLTw" id="5xmpdH75dKW" role="37wK5m">
-                  <ref role="3cqZAo" node="5xmpdH75dKH" resolve="defaultPolicy" />
+                  <ref role="3cqZAo" node="5xmpdH75dKH" resolve="policy" />
                 </node>
                 <node concept="37vLTw" id="5xmpdH75dKZ" role="37wK5m">
                   <ref role="3cqZAo" node="5xmpdH75dKJ" resolve="defaultAction" />
@@ -17286,7 +17286,7 @@
                 <ref role="1Pybhc" node="7F7y$3JJe2j" resolve="DefaultPolicyBuilder" />
                 <ref role="37wK5l" node="7F7y$3JJe4w" resolve="OptionalChildren" />
                 <node concept="37vLTw" id="5xmpdH75dKR" role="37wK5m">
-                  <ref role="3cqZAo" node="5xmpdH75dKH" resolve="defaultPolicy" />
+                  <ref role="3cqZAo" node="5xmpdH75dKH" resolve="policy" />
                 </node>
                 <node concept="37vLTw" id="5xmpdH75dKP" role="37wK5m">
                   <ref role="3cqZAo" node="5xmpdH75dKJ" resolve="defaultAction" />
@@ -17298,7 +17298,7 @@
                 <ref role="1Pybhc" node="7F7y$3JJe2j" resolve="DefaultPolicyBuilder" />
                 <ref role="37wK5l" node="7F7y$3JJe4Z" resolve="multiChildren" />
                 <node concept="37vLTw" id="5xmpdH75dKS" role="37wK5m">
-                  <ref role="3cqZAo" node="5xmpdH75dKH" resolve="defaultPolicy" />
+                  <ref role="3cqZAo" node="5xmpdH75dKH" resolve="policy" />
                 </node>
                 <node concept="37vLTw" id="5xmpdH75dKL" role="37wK5m">
                   <ref role="3cqZAo" node="5xmpdH75dKJ" resolve="defaultAction" />
@@ -17310,7 +17310,7 @@
           <node concept="2OqwBi" id="5xmpdH75dKo" role="3clFbw">
             <node concept="2OqwBi" id="5xmpdH75dKp" role="2Oq$k0">
               <node concept="37vLTw" id="5xmpdH75dKT" role="2Oq$k0">
-                <ref role="3cqZAo" node="5xmpdH75dKH" resolve="defaultPolicy" />
+                <ref role="3cqZAo" node="5xmpdH75dKH" resolve="policy" />
               </node>
               <node concept="2qgKlT" id="5xmpdH75dKr" role="2OqNvi">
                 <ref role="37wK5l" to="rnx3:5zr7Q_1WLCS" resolve="allHierarchyChildren" />
@@ -17327,7 +17327,7 @@
                 <ref role="1Pybhc" node="7F7y$3JJe2j" resolve="DefaultPolicyBuilder" />
                 <ref role="37wK5l" node="7F7y$3JJe6o" resolve="singletonRef" />
                 <node concept="37vLTw" id="5xmpdH75dKX" role="37wK5m">
-                  <ref role="3cqZAo" node="5xmpdH75dKH" resolve="defaultPolicy" />
+                  <ref role="3cqZAo" node="5xmpdH75dKH" resolve="policy" />
                 </node>
                 <node concept="37vLTw" id="5xmpdH75dKV" role="37wK5m">
                   <ref role="3cqZAo" node="5xmpdH75dKJ" resolve="defaultAction" />
@@ -17339,7 +17339,7 @@
                 <ref role="1Pybhc" node="7F7y$3JJe2j" resolve="DefaultPolicyBuilder" />
                 <ref role="37wK5l" node="7F7y$3JJe5T" resolve="buildOptionalRef" />
                 <node concept="37vLTw" id="5xmpdH75dKN" role="37wK5m">
-                  <ref role="3cqZAo" node="5xmpdH75dKH" resolve="defaultPolicy" />
+                  <ref role="3cqZAo" node="5xmpdH75dKH" resolve="policy" />
                 </node>
                 <node concept="37vLTw" id="5xmpdH75dKO" role="37wK5m">
                   <ref role="3cqZAo" node="5xmpdH75dKJ" resolve="defaultAction" />
@@ -17350,7 +17350,7 @@
           <node concept="2OqwBi" id="5xmpdH75dKC" role="3clFbw">
             <node concept="2OqwBi" id="5xmpdH75dKD" role="2Oq$k0">
               <node concept="37vLTw" id="5xmpdH75dKQ" role="2Oq$k0">
-                <ref role="3cqZAo" node="5xmpdH75dKH" resolve="defaultPolicy" />
+                <ref role="3cqZAo" node="5xmpdH75dKH" resolve="policy" />
               </node>
               <node concept="2qgKlT" id="5xmpdH75dKF" role="2OqNvi">
                 <ref role="37wK5l" to="rnx3:3PLTv5jznVy" resolve="allHierarchyReferences" />
@@ -17369,7 +17369,7 @@
       <node concept="37vLTG" id="7F7y$3JJe3_" role="3clF46">
         <property role="TrG5h" value="defaultPolicy" />
         <node concept="3Tqbb2" id="7F7y$3JJe3A" role="1tU5fm">
-          <ref role="ehGHo" to="mopj:1EbzjT2R$JP" resolve="UserMergePolicy" />
+          <ref role="ehGHo" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
         </node>
       </node>
       <node concept="37vLTG" id="7F7y$3JJe3B" role="3clF46">
@@ -17444,7 +17444,7 @@
       <node concept="37vLTG" id="7F7y$3JJe44" role="3clF46">
         <property role="TrG5h" value="defaultPolicy" />
         <node concept="3Tqbb2" id="7F7y$3JJe45" role="1tU5fm">
-          <ref role="ehGHo" to="mopj:1EbzjT2R$JP" resolve="UserMergePolicy" />
+          <ref role="ehGHo" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
         </node>
       </node>
       <node concept="37vLTG" id="7F7y$3JJe46" role="3clF46">
@@ -17519,7 +17519,7 @@
       <node concept="37vLTG" id="7F7y$3JJe4z" role="3clF46">
         <property role="TrG5h" value="defaultPolicy" />
         <node concept="3Tqbb2" id="7F7y$3JJe4$" role="1tU5fm">
-          <ref role="ehGHo" to="mopj:1EbzjT2R$JP" resolve="UserMergePolicy" />
+          <ref role="ehGHo" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
         </node>
       </node>
       <node concept="37vLTG" id="7F7y$3JJe4_" role="3clF46">
@@ -17594,7 +17594,7 @@
       <node concept="37vLTG" id="7F7y$3JJe52" role="3clF46">
         <property role="TrG5h" value="defaultPolicy" />
         <node concept="3Tqbb2" id="7F7y$3JJe53" role="1tU5fm">
-          <ref role="ehGHo" to="mopj:1EbzjT2R$JP" resolve="UserMergePolicy" />
+          <ref role="ehGHo" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
         </node>
       </node>
       <node concept="37vLTG" id="7F7y$3JJe54" role="3clF46">
@@ -17638,12 +17638,14 @@
                             <ref role="2pJxaS" to="mopj:1VmHfRxKMgU" resolve="SubPolicyContainer" />
                             <node concept="2pJxcG" id="7F7y$3JJe5o" role="2pJxcM">
                               <ref role="2pJxcJ" to="mopj:1VmHfRxKMgV" resolve="subPolicy" />
-                              <node concept="2OqwBi" id="7F7y$3JJe5p" role="28ntcv">
-                                <node concept="1XH99k" id="7F7y$3JJe5q" role="2Oq$k0">
-                                  <ref role="1XH99l" to="mopj:1VmHfRxJEru" resolve="SubPolicy" />
-                                </node>
-                                <node concept="2ViDtV" id="7F7y$3JJe5r" role="2OqNvi">
-                                  <ref role="2ViDtZ" to="mopj:1VmHfRxJErv" resolve="NewOnRight" />
+                              <node concept="WxPPo" id="3OyZRpiA4aJ" role="28ntcv">
+                                <node concept="2OqwBi" id="7F7y$3JJe5p" role="WxPPp">
+                                  <node concept="1XH99k" id="7F7y$3JJe5q" role="2Oq$k0">
+                                    <ref role="1XH99l" to="mopj:1VmHfRxJEru" resolve="SubPolicy" />
+                                  </node>
+                                  <node concept="2ViDtV" id="7F7y$3JJe5r" role="2OqNvi">
+                                    <ref role="2ViDtZ" to="mopj:1VmHfRxJErv" resolve="NewOnRight" />
+                                  </node>
                                 </node>
                               </node>
                             </node>
@@ -17665,12 +17667,14 @@
                             <ref role="2pJxaS" to="mopj:1VmHfRxKMgU" resolve="SubPolicyContainer" />
                             <node concept="2pJxcG" id="7F7y$3JJe5y" role="2pJxcM">
                               <ref role="2pJxcJ" to="mopj:1VmHfRxKMgV" resolve="subPolicy" />
-                              <node concept="2OqwBi" id="7F7y$3JJe5z" role="28ntcv">
-                                <node concept="1XH99k" id="7F7y$3JJe5$" role="2Oq$k0">
-                                  <ref role="1XH99l" to="mopj:1VmHfRxJEru" resolve="SubPolicy" />
-                                </node>
-                                <node concept="2ViDtV" id="7F7y$3JJe5_" role="2OqNvi">
-                                  <ref role="2ViDtZ" to="mopj:1VmHfRxJErw" resolve="ExistsOnLeft" />
+                              <node concept="WxPPo" id="3OyZRpiA4aK" role="28ntcv">
+                                <node concept="2OqwBi" id="7F7y$3JJe5z" role="WxPPp">
+                                  <node concept="1XH99k" id="7F7y$3JJe5$" role="2Oq$k0">
+                                    <ref role="1XH99l" to="mopj:1VmHfRxJEru" resolve="SubPolicy" />
+                                  </node>
+                                  <node concept="2ViDtV" id="7F7y$3JJe5_" role="2OqNvi">
+                                    <ref role="2ViDtZ" to="mopj:1VmHfRxJErw" resolve="ExistsOnLeft" />
+                                  </node>
                                 </node>
                               </node>
                             </node>
@@ -17692,12 +17696,14 @@
                             <ref role="2pJxaS" to="mopj:1VmHfRxKMgU" resolve="SubPolicyContainer" />
                             <node concept="2pJxcG" id="7F7y$3JJe5G" role="2pJxcM">
                               <ref role="2pJxcJ" to="mopj:1VmHfRxKMgV" resolve="subPolicy" />
-                              <node concept="2OqwBi" id="7F7y$3JJe5H" role="28ntcv">
-                                <node concept="1XH99k" id="7F7y$3JJe5I" role="2Oq$k0">
-                                  <ref role="1XH99l" to="mopj:1VmHfRxJEru" resolve="SubPolicy" />
-                                </node>
-                                <node concept="2ViDtV" id="7F7y$3JJe5J" role="2OqNvi">
-                                  <ref role="2ViDtZ" to="mopj:1VmHfRxJErz" resolve="ElementOnBoth" />
+                              <node concept="WxPPo" id="3OyZRpiA4aL" role="28ntcv">
+                                <node concept="2OqwBi" id="7F7y$3JJe5H" role="WxPPp">
+                                  <node concept="1XH99k" id="7F7y$3JJe5I" role="2Oq$k0">
+                                    <ref role="1XH99l" to="mopj:1VmHfRxJEru" resolve="SubPolicy" />
+                                  </node>
+                                  <node concept="2ViDtV" id="7F7y$3JJe5J" role="2OqNvi">
+                                    <ref role="2ViDtZ" to="mopj:1VmHfRxJErz" resolve="ElementOnBoth" />
+                                  </node>
                                 </node>
                               </node>
                             </node>
@@ -17742,7 +17748,7 @@
       <node concept="37vLTG" id="7F7y$3JJe5W" role="3clF46">
         <property role="TrG5h" value="defaultPolicy" />
         <node concept="3Tqbb2" id="7F7y$3JJe5X" role="1tU5fm">
-          <ref role="ehGHo" to="mopj:1EbzjT2R$JP" resolve="UserMergePolicy" />
+          <ref role="ehGHo" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
         </node>
       </node>
       <node concept="37vLTG" id="7F7y$3JJe5Y" role="3clF46">
@@ -17817,7 +17823,7 @@
       <node concept="37vLTG" id="7F7y$3JJe6r" role="3clF46">
         <property role="TrG5h" value="defaultPolicy" />
         <node concept="3Tqbb2" id="7F7y$3JJe6s" role="1tU5fm">
-          <ref role="ehGHo" to="mopj:1EbzjT2R$JP" resolve="UserMergePolicy" />
+          <ref role="ehGHo" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
         </node>
       </node>
       <node concept="37vLTG" id="7F7y$3JJe6t" role="3clF46">
@@ -18107,7 +18113,7 @@
         </node>
       </node>
       <node concept="2AHcQZ" id="7F7y$3Lx5Ha" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" />
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
   </node>
@@ -18238,7 +18244,7 @@
         <node concept="Jncv_" id="49zGylU9N2t" role="3cqZAp">
           <ref role="JncvD" to="mopj:3PLTv5k2w4J" resolve="SingletonChildPolicy" />
           <node concept="37vLTw" id="49zGylU9Qh5" role="JncvB">
-            <ref role="3cqZAo" node="49zGylU9FWu" resolve="policy" />
+            <ref role="3cqZAo" node="49zGylU9FWu" resolve="childPolicy" />
           </node>
           <node concept="3clFbS" id="49zGylU9N2v" role="Jncv$">
             <node concept="3cpWs6" id="49zGylU9ZsX" role="3cqZAp">
@@ -18956,7 +18962,7 @@
                 <ref role="3uigEE" node="5lvG0vITZsP" resolve="PropertyMerger" />
               </node>
               <node concept="1rXfSq" id="49zGylU3yYo" role="37wK5m">
-                <ref role="37wK5l" node="49zGylU4uGD" resolve="propertyPolicy" />
+                <ref role="37wK5l" node="49zGylU4uGD" resolve="propertyMerger" />
                 <node concept="37vLTw" id="49zGylU3$VR" role="37wK5m">
                   <ref role="3cqZAo" node="49zGylU1S6M" resolve="itemPolicy" />
                 </node>
@@ -19097,7 +19103,7 @@
         </node>
       </node>
       <node concept="2AHcQZ" id="49zGylU1S6I" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" />
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
     <node concept="2tJIrI" id="49zGylU21u5" role="jymVt" />

--- a/code/solutions/de.itemis.model.merge.runtime/models/de.itemis.model.merge.runtime.runtime.mps
+++ b/code/solutions/de.itemis.model.merge.runtime/models/de.itemis.model.merge.runtime.runtime.mps
@@ -10,8 +10,7 @@
     <use id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc" version="2" />
     <use id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text" version="0" />
     <use id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core" version="2" />
-    <use id="760a0a8c-eabb-4521-8bfd-65db761a9ba3" name="jetbrains.mps.baseLanguage.logging" version="0" />
-    <use id="515552c7-fcc0-4ab4-9789-2f3c49344e85" name="jetbrains.mps.baseLanguage.varVariable" version="0" />
+    <use id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation" version="5" />
   </languages>
   <imports>
     <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" />
@@ -35,8 +34,11 @@
     <import index="tqvn" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel.tempmodel(MPS.Core/)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" />
     <import index="80j5" ref="215c4c45-ba99-49f5-9ab7-4b6901a63cfd/java:jetbrains.mps.generator.impl(MPS.Generator/)" />
+    <import index="pjrh" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel.adapter(MPS.Core/)" />
+    <import index="39al" ref="5454dbfd-2075-4de0-b85e-fa645eb6957e/r:5bc020f2-590a-4818-ae68-fa483b92486f(de.itemis.mps.utils.serializer.xml/de.itemis.mps.utils.serializer.xml.serializer)" />
     <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" implicit="true" />
     <import index="xlb7" ref="r:cf42fd0a-68d2-493b-8b77-961658617704(jetbrains.mps.lang.modelapi.behavior)" implicit="true" />
+    <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" implicit="true" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
@@ -89,6 +91,7 @@
       <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
         <child id="1145553007750" name="creator" index="2ShVmc" />
       </concept>
+      <concept id="1070462154015" name="jetbrains.mps.baseLanguage.structure.StaticFieldDeclaration" flags="ig" index="Wx3nA" />
       <concept id="1070475354124" name="jetbrains.mps.baseLanguage.structure.ThisExpression" flags="nn" index="Xjq3P" />
       <concept id="1070475587102" name="jetbrains.mps.baseLanguage.structure.SuperConstructorInvocation" flags="nn" index="XkiVB" />
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
@@ -122,12 +125,16 @@
       <concept id="1068390468200" name="jetbrains.mps.baseLanguage.structure.FieldDeclaration" flags="ig" index="312cEg" />
       <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu">
         <property id="1075300953594" name="abstractClass" index="1sVAO0" />
+        <property id="1221565133444" name="isFinal" index="1EXbeo" />
         <child id="1095933932569" name="implementedInterface" index="EKbjA" />
         <child id="1165602531693" name="superclass" index="1zkMxy" />
       </concept>
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <property id="1176718929932" name="isFinal" index="3TUv4t" />
         <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ngI" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
       </concept>
       <concept id="1109279763828" name="jetbrains.mps.baseLanguage.structure.TypeVariableDeclaration" flags="ng" index="16euLQ" />
       <concept id="1109279851642" name="jetbrains.mps.baseLanguage.structure.GenericDeclaration" flags="ng" index="16eOlS">
@@ -301,9 +308,38 @@
       </concept>
       <concept id="2068944020170241612" name="jetbrains.mps.baseLanguage.javadoc.structure.ClassifierDocComment" flags="ng" index="3UR2Jj" />
     </language>
+    <language id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation">
+      <concept id="5455284157994012186" name="jetbrains.mps.lang.quotation.structure.NodeBuilderInitLink" flags="ng" index="2pIpSj">
+        <reference id="5455284157994012188" name="link" index="2pIpSl" />
+        <child id="1595412875168045827" name="initValue" index="28nt2d" />
+      </concept>
+      <concept id="5455284157993911077" name="jetbrains.mps.lang.quotation.structure.NodeBuilderInitProperty" flags="ng" index="2pJxcG">
+        <reference id="5455284157993911078" name="property" index="2pJxcJ" />
+        <child id="1595412875168045201" name="initValue" index="28ntcv" />
+      </concept>
+      <concept id="5455284157993863837" name="jetbrains.mps.lang.quotation.structure.NodeBuilder" flags="nn" index="2pJPEk">
+        <child id="5455284157993863838" name="quotedNode" index="2pJPEn" />
+      </concept>
+      <concept id="5455284157993863840" name="jetbrains.mps.lang.quotation.structure.NodeBuilderNode" flags="nn" index="2pJPED">
+        <reference id="5455284157993910961" name="concept" index="2pJxaS" />
+        <child id="5455284157993911099" name="values" index="2pJxcM" />
+      </concept>
+      <concept id="6985522012210254362" name="jetbrains.mps.lang.quotation.structure.NodeBuilderPropertyExpression" flags="nn" index="WxPPo">
+        <child id="6985522012210254363" name="expression" index="WxPPp" />
+      </concept>
+      <concept id="8182547171709738802" name="jetbrains.mps.lang.quotation.structure.NodeBuilderList" flags="nn" index="36be1Y">
+        <child id="8182547171709738803" name="nodes" index="36be1Z" />
+      </concept>
+      <concept id="8182547171709752110" name="jetbrains.mps.lang.quotation.structure.NodeBuilderExpression" flags="nn" index="36biLy">
+        <child id="8182547171709752112" name="expression" index="36biLW" />
+      </concept>
+    </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
       <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
         <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
+      </concept>
+      <concept id="1138411891628" name="jetbrains.mps.lang.smodel.structure.SNodeOperation" flags="nn" index="eCIE_">
+        <child id="1144104376918" name="parameter" index="1xVPHs" />
       </concept>
       <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
       <concept id="7453996997717780434" name="jetbrains.mps.lang.smodel.structure.Node_GetSConceptOperation" flags="nn" index="2yIwOk" />
@@ -330,11 +366,18 @@
       <concept id="1181949435690" name="jetbrains.mps.lang.smodel.structure.Concept_NewInstance" flags="nn" index="LFhST" />
       <concept id="1171305280644" name="jetbrains.mps.lang.smodel.structure.Node_GetDescendantsOperation" flags="nn" index="2Rf3mk" />
       <concept id="1171323947159" name="jetbrains.mps.lang.smodel.structure.Model_NodesOperation" flags="nn" index="2SmgA7" />
+      <concept id="1966870290088668512" name="jetbrains.mps.lang.smodel.structure.Enum_MemberLiteral" flags="ng" index="2ViDtV">
+        <reference id="1966870290088668516" name="memberDeclaration" index="2ViDtZ" />
+      </concept>
+      <concept id="1171407110247" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorOperation" flags="nn" index="2Xjw5R" />
       <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
         <child id="1177027386292" name="conceptArgument" index="cj9EA" />
       </concept>
       <concept id="1171999116870" name="jetbrains.mps.lang.smodel.structure.Node_IsNullOperation" flags="nn" index="3w_OXm" />
       <concept id="1172008320231" name="jetbrains.mps.lang.smodel.structure.Node_IsNotNullOperation" flags="nn" index="3x8VRR" />
+      <concept id="1144101972840" name="jetbrains.mps.lang.smodel.structure.OperationParm_Concept" flags="ng" index="1xMEDy">
+        <child id="1207343664468" name="conceptArgument" index="ri$Ld" />
+      </concept>
       <concept id="1144146199828" name="jetbrains.mps.lang.smodel.structure.Node_CopyOperation" flags="nn" index="1$rogu" />
       <concept id="1206482823744" name="jetbrains.mps.lang.smodel.structure.Model_AddRootOperation" flags="nn" index="3BYIHo">
         <child id="1206482823746" name="nodeArgument" index="3BYIHq" />
@@ -351,6 +394,9 @@
       </concept>
       <concept id="1138056282393" name="jetbrains.mps.lang.smodel.structure.SLinkListAccess" flags="nn" index="3Tsc0h">
         <reference id="1138056546658" name="link" index="3TtcxE" />
+      </concept>
+      <concept id="5779574625830813396" name="jetbrains.mps.lang.smodel.structure.EnumerationIdRefExpression" flags="ng" index="1XH99k">
+        <reference id="5779574625830813397" name="enumDeclaration" index="1XH99l" />
       </concept>
       <concept id="1228341669568" name="jetbrains.mps.lang.smodel.structure.Node_DetachOperation" flags="nn" index="3YRAZt" />
     </language>
@@ -482,38 +528,38 @@
     <property role="1sVAO0" value="true" />
     <node concept="312cEg" id="5lvG0vITZRs" role="jymVt">
       <property role="TrG5h" value="propertyMergers" />
-      <node concept="3Tm6S6" id="5lvG0vITZPn" role="1B3o_S" />
       <node concept="_YKpA" id="5lvG0vITZPD" role="1tU5fm">
         <node concept="3uibUv" id="5lvG0vIU3mW" role="_ZDj9">
           <ref role="3uigEE" node="5lvG0vITZsP" resolve="PropertyMerger" />
         </node>
       </node>
+      <node concept="3Tm6S6" id="5lvG0vITZPn" role="1B3o_S" />
     </node>
     <node concept="312cEg" id="368jN$JXARf" role="jymVt">
       <property role="TrG5h" value="childmergers" />
-      <node concept="3Tm6S6" id="368jN$JXAMn" role="1B3o_S" />
       <node concept="_YKpA" id="368jN$JXAQX" role="1tU5fm">
         <node concept="3uibUv" id="368jN$JXARc" role="_ZDj9">
           <ref role="3uigEE" node="5lvG0vIUaC$" resolve="ConceptChildMerger" />
         </node>
       </node>
+      <node concept="3Tm6S6" id="368jN$JXAMn" role="1B3o_S" />
     </node>
     <node concept="312cEg" id="LVVqNxhCqu" role="jymVt">
       <property role="TrG5h" value="referencemergers" />
-      <node concept="3Tm6S6" id="LVVqNxhCqv" role="1B3o_S" />
       <node concept="_YKpA" id="LVVqNxhCqw" role="1tU5fm">
         <node concept="3uibUv" id="4WBgwWtgpvZ" role="_ZDj9">
           <ref role="3uigEE" node="4WBgwWtfZU9" resolve="ConceptRefMerger" />
         </node>
       </node>
+      <node concept="3Tm6S6" id="LVVqNxhCqv" role="1B3o_S" />
     </node>
     <node concept="2tJIrI" id="LVVqNxhC8n" role="jymVt" />
     <node concept="312cEg" id="5lvG0vITZTi" role="jymVt">
       <property role="TrG5h" value="concept" />
-      <node concept="3Tm6S6" id="5lvG0vITZSH" role="1B3o_S" />
       <node concept="3uibUv" id="6HsBp$ThPND" role="1tU5fm">
         <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
       </node>
+      <node concept="3Tm6S6" id="5lvG0vITZSH" role="1B3o_S" />
     </node>
     <node concept="2tJIrI" id="3Wln5KITbN0" role="jymVt" />
     <node concept="3clFbW" id="3Wln5KITc9a" role="jymVt">
@@ -8059,9 +8105,6 @@
     <property role="3GE5qa" value="child" />
     <property role="TrG5h" value="AutoChildMerger" />
     <node concept="3Tm1VV" id="3pc485W4NhN" role="1B3o_S" />
-    <node concept="3uibUv" id="3pc485W4No8" role="EKbjA">
-      <ref role="3uigEE" node="5lvG0vIUaC$" resolve="ConceptChildMerger" />
-    </node>
     <node concept="3clFbW" id="3pc485W4OlZ" role="jymVt">
       <node concept="3cqZAl" id="3pc485W4Om0" role="3clF45" />
       <node concept="3Tm1VV" id="3pc485W4Om1" role="1B3o_S" />
@@ -9099,7 +9142,38 @@
   <node concept="312cEu" id="18W7Z4VeRuj">
     <property role="TrG5h" value="MergeResolverFromModelMerge" />
     <property role="3GE5qa" value="mergetraversal" />
+    <property role="1EXbeo" value="true" />
     <node concept="2tJIrI" id="18W7Z4VeRx7" role="jymVt" />
+    <node concept="Wx3nA" id="7F7y$3Jufqf" role="jymVt">
+      <property role="TrG5h" value="missingConcepts" />
+      <node concept="3Tm6S6" id="7F7y$3Ju3iA" role="1B3o_S" />
+      <node concept="2hMVRd" id="7F7y$3JudOS" role="1tU5fm">
+        <node concept="3Tqbb2" id="7F7y$3JueYZ" role="2hN53Y">
+          <ref role="ehGHo" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
+        </node>
+      </node>
+    </node>
+    <node concept="Wx3nA" id="7F7y$3JxWSP" role="jymVt">
+      <property role="TrG5h" value="currentModelMerge" />
+      <node concept="3Tm6S6" id="7F7y$3JxH1x" role="1B3o_S" />
+      <node concept="3Tqbb2" id="7F7y$3JxUxW" role="1tU5fm">
+        <ref role="ehGHo" to="mopj:1EbzjT2RcU7" resolve="ModelMerge" />
+      </node>
+    </node>
+    <node concept="Wx3nA" id="5xmpdH72naV" role="jymVt">
+      <property role="TrG5h" value="defaultStuffFactory" />
+      <node concept="3uibUv" id="5xmpdH72naY" role="1tU5fm">
+        <ref role="3uigEE" node="32ggi2DpDWx" resolve="ContentHolderFactory" />
+      </node>
+      <node concept="2ShNRf" id="5xmpdH72naZ" role="33vP2m">
+        <node concept="HV5vD" id="5xmpdH72nb0" role="2ShVmc">
+          <property role="373rjd" value="true" />
+          <ref role="HV5vE" node="49zGylSrV3J" resolve="DefaultContentHolderFactory" />
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="5xmpdH72naX" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="5xmpdH71mcv" role="jymVt" />
     <node concept="2YIFZL" id="18W7Z4Vmw0z" role="jymVt">
       <property role="TrG5h" value="traverse" />
       <node concept="3clFbS" id="18W7Z4Vmw0G" role="3clF47">
@@ -9205,7 +9279,7 @@
       <node concept="P$JXv" id="6B0NpqHznCk" role="lGtFl">
         <node concept="TZ5HA" id="6B0NpqHznCl" role="TZ5H$">
           <node concept="1dT_AC" id="6B0NpqHznCm" role="1dT_Ay">
-            <property role="1dT_AB" value="Traverses the graph from a root to the leaf (for all roots ony by one)." />
+            <property role="1dT_AB" value="Traverses the graph from a root to the leaf (for all roots one by one)." />
           </node>
         </node>
         <node concept="TZ5HA" id="6B0NpqHzoz9" role="TZ5H$">
@@ -9250,7 +9324,18 @@
     <node concept="2YIFZL" id="2QNuyuiLuqz" role="jymVt">
       <property role="TrG5h" value="run" />
       <node concept="3clFbS" id="2QNuyuiLuqB" role="3clF47">
-        <node concept="3clFbH" id="6XtVDsmsGhp" role="3cqZAp" />
+        <node concept="3clFbF" id="7F7y$3JybuA" role="3cqZAp">
+          <node concept="37vLTI" id="7F7y$3JyiUl" role="3clFbG">
+            <node concept="37vLTw" id="7F7y$3Jyl2u" role="37vLTx">
+              <ref role="3cqZAo" node="2QNuyuiLuq_" resolve="modelMerge" />
+            </node>
+            <node concept="10M0yZ" id="7F7y$3JyDSf" role="37vLTJ">
+              <ref role="1PxDUh" node="18W7Z4VeRuj" resolve="MergeResolverFromModelMerge" />
+              <ref role="3cqZAo" node="7F7y$3JxWSP" resolve="modelMerge" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7F7y$3JymO8" role="3cqZAp" />
         <node concept="3cpWs8" id="1trrptaAwvP" role="3cqZAp">
           <node concept="3cpWsn" id="1trrptaAwvQ" role="3cpWs9">
             <property role="TrG5h" value="conceptHierarchy" />
@@ -9296,38 +9381,35 @@
           </node>
         </node>
         <node concept="3clFbH" id="1trrptaAykg" role="3cqZAp" />
-        <node concept="3cpWs8" id="6XtVDsmy$sC" role="3cqZAp">
-          <node concept="3cpWsn" id="6XtVDsmy$sD" role="3cpWs9">
-            <property role="TrG5h" value="missingConcepts" />
-            <node concept="2hMVRd" id="6XtVDsmz0ay" role="1tU5fm">
-              <node concept="3Tqbb2" id="6XtVDsmz0a$" role="2hN53Y">
-                <ref role="ehGHo" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
-              </node>
+        <node concept="3clFbF" id="7F7y$3JuD9z" role="3cqZAp">
+          <node concept="37vLTI" id="7F7y$3JuGg5" role="3clFbG">
+            <node concept="37vLTw" id="7F7y$3JuD9x" role="37vLTJ">
+              <ref role="3cqZAo" node="7F7y$3Jufqf" resolve="missingConcepts" />
             </node>
-            <node concept="2YIFZM" id="6B0NpqHsVXZ" role="33vP2m">
+            <node concept="2YIFZM" id="7F7y$3JuLd5" role="37vLTx">
               <ref role="1Pybhc" node="18W7Z4VeRuj" resolve="MergeResolverFromModelMerge" />
               <ref role="37wK5l" node="6B0NpqHsVXS" resolve="missingConcepts" />
-              <node concept="2OqwBi" id="6B0NpqHut3g" role="37wK5m">
-                <node concept="37vLTw" id="6B0NpqHut3h" role="2Oq$k0">
+              <node concept="2OqwBi" id="7F7y$3JuLd6" role="37wK5m">
+                <node concept="37vLTw" id="7F7y$3JuLd7" role="2Oq$k0">
                   <ref role="3cqZAo" node="1trrptaAwvQ" resolve="conceptHierarchy" />
                 </node>
-                <node concept="liA8E" id="6B0NpqHut3i" role="2OqNvi">
+                <node concept="liA8E" id="7F7y$3JuLd8" role="2OqNvi">
                   <ref role="37wK5l" to="agc3:~Graph.nodes()" resolve="nodes" />
                 </node>
               </node>
-              <node concept="37vLTw" id="6B0NpqHsVXX" role="37wK5m">
+              <node concept="37vLTw" id="7F7y$3JuLd9" role="37wK5m">
                 <ref role="3cqZAo" node="2QNuyuiLuq_" resolve="modelMerge" />
               </node>
-              <node concept="2OqwBi" id="6B0NpqHtN1Q" role="37wK5m">
-                <node concept="37vLTw" id="6B0NpqHtN1R" role="2Oq$k0">
+              <node concept="2OqwBi" id="7F7y$3JuLda" role="37wK5m">
+                <node concept="37vLTw" id="7F7y$3JuLdb" role="2Oq$k0">
                   <ref role="3cqZAo" node="1trrptaAyan" resolve="conceptToDefinedMergePolicy" />
                 </node>
-                <node concept="3lbrtF" id="6B0NpqHtN1S" role="2OqNvi" />
+                <node concept="3lbrtF" id="7F7y$3JuLdc" role="2OqNvi" />
               </node>
             </node>
           </node>
         </node>
-        <node concept="3clFbH" id="6XtVDsmy_h6" role="3cqZAp" />
+        <node concept="3clFbH" id="7F7y$3JuSV6" role="3cqZAp" />
         <node concept="3clFbJ" id="6XtVDsmyPZe" role="3cqZAp">
           <node concept="3clFbS" id="6XtVDsmyPZg" role="3clFbx">
             <node concept="YS8fn" id="6XtVDsmyYg8" role="3cqZAp">
@@ -9335,21 +9417,33 @@
                 <node concept="1pGfFk" id="6CwG2k7O7Aw" role="2ShVmc">
                   <ref role="37wK5l" node="6CwG2k7Nbuo" resolve="MissingMergePolicies" />
                   <node concept="37vLTw" id="6CwG2k7O7F3" role="37wK5m">
-                    <ref role="3cqZAo" node="6XtVDsmy$sD" resolve="missingConcepts" />
+                    <ref role="3cqZAo" node="7F7y$3Jufqf" resolve="missingConcepts" />
                   </node>
                 </node>
               </node>
             </node>
           </node>
-          <node concept="3eOSWO" id="6XtVDsmyWDk" role="3clFbw">
-            <node concept="3cmrfG" id="6XtVDsmyWEW" role="3uHU7w">
-              <property role="3cmrfH" value="0" />
-            </node>
-            <node concept="2OqwBi" id="6XtVDsmySJ2" role="3uHU7B">
-              <node concept="37vLTw" id="6XtVDsmyR3I" role="2Oq$k0">
-                <ref role="3cqZAo" node="6XtVDsmy$sD" resolve="missingConcepts" />
+          <node concept="1Wc70l" id="3P8JlgmPV$$" role="3clFbw">
+            <node concept="3fqX7Q" id="3P8JlgmPZ_W" role="3uHU7B">
+              <node concept="2OqwBi" id="3P8JlgmQ4JX" role="3fr31v">
+                <node concept="37vLTw" id="3P8JlgmQ342" role="2Oq$k0">
+                  <ref role="3cqZAo" node="2QNuyuiLuq_" resolve="modelMerge" />
+                </node>
+                <node concept="3TrcHB" id="2GFEb9MTBjE" role="2OqNvi">
+                  <ref role="3TsBF5" to="mopj:2GFEb9MrdCG" resolve="partialPolicy" />
+                </node>
               </node>
-              <node concept="34oBXx" id="6XtVDsmz1yR" role="2OqNvi" />
+            </node>
+            <node concept="3eOSWO" id="6XtVDsmyWDk" role="3uHU7w">
+              <node concept="3cmrfG" id="6XtVDsmyWEW" role="3uHU7w">
+                <property role="3cmrfH" value="0" />
+              </node>
+              <node concept="2OqwBi" id="6XtVDsmySJ2" role="3uHU7B">
+                <node concept="37vLTw" id="6XtVDsmyR3I" role="2Oq$k0">
+                  <ref role="3cqZAo" node="7F7y$3Jufqf" resolve="missingConcepts" />
+                </node>
+                <node concept="34oBXx" id="6XtVDsmz1yR" role="2OqNvi" />
+              </node>
             </node>
           </node>
         </node>
@@ -9875,20 +9969,53 @@
           </node>
         </node>
         <node concept="3clFbH" id="7YSeTY8c7tf" role="3cqZAp" />
-        <node concept="3clFbF" id="1FQTM0rPQwV" role="3cqZAp">
-          <node concept="1rXfSq" id="1FQTM0rPXRP" role="3clFbG">
-            <ref role="37wK5l" node="1FQTM0rPQwO" resolve="addMergePoliciesToTraversalState" />
-            <node concept="37vLTw" id="1FQTM0rPQwR" role="37wK5m">
+        <node concept="3clFbJ" id="5xmpdH7c2fu" role="3cqZAp">
+          <node concept="3clFbS" id="5xmpdH7c2fw" role="3clFbx">
+            <node concept="3clFbF" id="7F7y$3JzP3h" role="3cqZAp">
+              <node concept="1rXfSq" id="7F7y$3JzP3f" role="3clFbG">
+                <ref role="37wK5l" node="7F7y$3JwqQK" resolve="addDefaultPoliciesToTraversalState" />
+                <node concept="37vLTw" id="49zGylWrmha" role="37wK5m">
+                  <ref role="3cqZAo" node="7YSeTY81uqE" resolve="mergePolicy" />
+                </node>
+                <node concept="37vLTw" id="5xmpdH7dvYl" role="37wK5m">
+                  <ref role="3cqZAo" node="7YSeTY81l4F" resolve="matc" />
+                </node>
+                <node concept="37vLTw" id="5xmpdH7NYJB" role="37wK5m">
+                  <ref role="3cqZAo" node="7YSeTY81ad_" resolve="currentNode" />
+                </node>
+                <node concept="37vLTw" id="5xmpdH7e$xN" role="37wK5m">
+                  <ref role="3cqZAo" node="32ggi2Dz8Cx" resolve="stuffFactory" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="5xmpdH7ck99" role="3clFbw">
+            <node concept="37vLTw" id="5xmpdH7chPK" role="2Oq$k0">
               <ref role="3cqZAo" node="7YSeTY81uqE" resolve="mergePolicy" />
             </node>
-            <node concept="37vLTw" id="1FQTM0rPQwS" role="37wK5m">
-              <ref role="3cqZAo" node="7YSeTY81l4F" resolve="matc" />
+            <node concept="3TrcHB" id="5xmpdH7deyG" role="2OqNvi">
+              <ref role="3TsBF5" to="mopj:5xmpdH7cpzi" resolve="useDefaults" />
             </node>
-            <node concept="37vLTw" id="1FQTM0rPQwT" role="37wK5m">
-              <ref role="3cqZAo" node="7YSeTY81ad_" resolve="currentNode" />
-            </node>
-            <node concept="37vLTw" id="32ggi2DzaSt" role="37wK5m">
-              <ref role="3cqZAo" node="32ggi2Dz8Cx" resolve="stuffFactory" />
+          </node>
+          <node concept="9aQIb" id="5xmpdH7c5w8" role="9aQIa">
+            <node concept="3clFbS" id="5xmpdH7c5w9" role="9aQI4">
+              <node concept="3clFbF" id="1FQTM0rPQwV" role="3cqZAp">
+                <node concept="1rXfSq" id="1FQTM0rPXRP" role="3clFbG">
+                  <ref role="37wK5l" node="1FQTM0rPQwO" resolve="addMergePoliciesToTraversalState" />
+                  <node concept="37vLTw" id="1FQTM0rPQwR" role="37wK5m">
+                    <ref role="3cqZAo" node="7YSeTY81uqE" resolve="mergePolicy" />
+                  </node>
+                  <node concept="37vLTw" id="1FQTM0rPQwS" role="37wK5m">
+                    <ref role="3cqZAo" node="7YSeTY81l4F" resolve="matc" />
+                  </node>
+                  <node concept="37vLTw" id="1FQTM0rPQwT" role="37wK5m">
+                    <ref role="3cqZAo" node="7YSeTY81ad_" resolve="currentNode" />
+                  </node>
+                  <node concept="37vLTw" id="32ggi2DzaSt" role="37wK5m">
+                    <ref role="3cqZAo" node="32ggi2Dz8Cx" resolve="stuffFactory" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -11004,7 +11131,416 @@
         <node concept="3clFbH" id="3PLTv5jSYJ4" role="3cqZAp" />
       </node>
     </node>
-    <node concept="2tJIrI" id="1FQTM0rPSPF" role="jymVt" />
+    <node concept="2tJIrI" id="7F7y$3JvMx$" role="jymVt" />
+    <node concept="2YIFZL" id="7F7y$3JwqQK" role="jymVt">
+      <property role="TrG5h" value="addDefaultPoliciesToTraversalState" />
+      <node concept="37vLTG" id="5xmpdH79xEc" role="3clF46">
+        <property role="TrG5h" value="incompletePolicy" />
+        <node concept="3Tqbb2" id="5xmpdH79xEd" role="1tU5fm">
+          <ref role="ehGHo" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="7F7y$3JwG2x" role="3clF46">
+        <property role="TrG5h" value="matc" />
+        <node concept="3uibUv" id="7F7y$3JwG2y" role="1tU5fm">
+          <ref role="3uigEE" node="7YSeTY7XhnK" resolve="TraversalState" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="5xmpdH7HRHJ" role="3clF46">
+        <property role="TrG5h" value="currentConcept" />
+        <node concept="3uibUv" id="5xmpdH7HRHK" role="1tU5fm">
+          <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="5xmpdH7esWN" role="3clF46">
+        <property role="TrG5h" value="stuffFactory" />
+        <node concept="3uibUv" id="5xmpdH7esWO" role="1tU5fm">
+          <ref role="3uigEE" node="32ggi2DpDWx" resolve="ContentHolderFactory" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="7F7y$3JwqQN" role="3clF47">
+        <node concept="3clFbF" id="7F7y$3LnjPN" role="3cqZAp">
+          <node concept="2OqwBi" id="7F7y$3LnjPK" role="3clFbG">
+            <node concept="10M0yZ" id="7F7y$3LnjPL" role="2Oq$k0">
+              <ref role="1PxDUh" to="wyt6:~System" />
+              <ref role="3cqZAo" to="wyt6:~System.out" />
+            </node>
+            <node concept="liA8E" id="7F7y$3LnjPM" role="2OqNvi">
+              <ref role="37wK5l" to="guwi:~PrintStream.println(java.lang.String)" resolve="println" />
+              <node concept="Xl_RD" id="7F7y$3LnnG8" role="37wK5m">
+                <property role="Xl_RC" value="== Add Default Policies" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="5xmpdH79TPD" role="3cqZAp">
+          <node concept="3cpWsn" id="5xmpdH79TPG" role="3cpWs9">
+            <property role="TrG5h" value="conceptDeclaration" />
+            <node concept="3Tqbb2" id="5xmpdH79TPB" role="1tU5fm">
+              <ref role="ehGHo" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
+            </node>
+            <node concept="2OqwBi" id="5xmpdH7aiE0" role="33vP2m">
+              <node concept="37vLTw" id="5xmpdH7aeaJ" role="2Oq$k0">
+                <ref role="3cqZAo" node="5xmpdH79xEc" resolve="incompletePolicy" />
+              </node>
+              <node concept="3TrEf2" id="5xmpdH7angK" role="2OqNvi">
+                <ref role="3Tt5mk" to="mopj:3BP4DuXu_FH" resolve="conceptRef" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="5xmpdH7awzU" role="3cqZAp" />
+        <node concept="3cpWs8" id="7hPYDJhi8U_" role="3cqZAp">
+          <node concept="3cpWsn" id="7hPYDJhi8UA" role="3cpWs9">
+            <property role="TrG5h" value="defaultPolicy" />
+            <node concept="3Tqbb2" id="7hPYDJhi8UB" role="1tU5fm">
+              <ref role="ehGHo" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
+            </node>
+            <node concept="2YIFZM" id="7hPYDJhinZ3" role="33vP2m">
+              <ref role="37wK5l" node="7F7y$3JJe2k" resolve="build" />
+              <ref role="1Pybhc" node="7F7y$3JJe2j" resolve="DefaultPolicyBuilder" />
+              <node concept="37vLTw" id="49zGylWpbeA" role="37wK5m">
+                <ref role="3cqZAo" node="5xmpdH79TPG" resolve="conceptDeclaration" />
+              </node>
+              <node concept="2OqwBi" id="7F7y$3JyZnU" role="37wK5m">
+                <node concept="37vLTw" id="7F7y$3JyQLl" role="2Oq$k0">
+                  <ref role="3cqZAo" node="7F7y$3JxWSP" resolve="currentModelMerge" />
+                </node>
+                <node concept="3TrEf2" id="7F7y$3Jz0TM" role="2OqNvi">
+                  <ref role="3Tt5mk" to="mopj:kewvT_SiLF" resolve="defaultAction" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7F7y$3LnSWx" role="3cqZAp">
+          <node concept="2OqwBi" id="7F7y$3LnSWy" role="3clFbG">
+            <node concept="10M0yZ" id="7F7y$3LnSWz" role="2Oq$k0">
+              <ref role="1PxDUh" to="wyt6:~System" resolve="System" />
+              <ref role="3cqZAo" to="wyt6:~System.out" resolve="out" />
+            </node>
+            <node concept="liA8E" id="7F7y$3LnSW$" role="2OqNvi">
+              <ref role="37wK5l" to="guwi:~PrintStream.println(java.lang.String)" resolve="println" />
+              <node concept="3cpWs3" id="7F7y$3Lo_j9" role="37wK5m">
+                <node concept="2OqwBi" id="7F7y$3LoEFQ" role="3uHU7w">
+                  <node concept="37vLTw" id="49zGylWpePS" role="2Oq$k0">
+                    <ref role="3cqZAo" node="5xmpdH79TPG" resolve="conceptDeclaration" />
+                  </node>
+                  <node concept="2Iv5rx" id="7F7y$3LoIgy" role="2OqNvi" />
+                </node>
+                <node concept="Xl_RD" id="7F7y$3Lo7rz" role="3uHU7B">
+                  <property role="Xl_RC" value="  Create default policy for " />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7F7y$3JEbk5" role="3cqZAp" />
+        <node concept="2Gpval" id="7F7y$3J_IVq" role="3cqZAp">
+          <node concept="2GrKxI" id="7F7y$3J_IVs" role="2Gsz3X">
+            <property role="TrG5h" value="propertyPolicy" />
+          </node>
+          <node concept="2OqwBi" id="7F7y$3JA34c" role="2GsD0m">
+            <node concept="37vLTw" id="7F7y$3JA0Pr" role="2Oq$k0">
+              <ref role="3cqZAo" node="7hPYDJhi8UA" resolve="defaultPolicy" />
+            </node>
+            <node concept="3Tsc0h" id="7F7y$3JA7c2" role="2OqNvi">
+              <ref role="3TtcxE" to="mopj:1EbzjT2T4LX" resolve="propertyPolicies" />
+            </node>
+          </node>
+          <node concept="3clFbS" id="7F7y$3J_IVw" role="2LFqv$">
+            <node concept="3clFbF" id="7F7y$3LoNnH" role="3cqZAp">
+              <node concept="2OqwBi" id="7F7y$3LoNnI" role="3clFbG">
+                <node concept="10M0yZ" id="7F7y$3LoNnJ" role="2Oq$k0">
+                  <ref role="1PxDUh" to="wyt6:~System" resolve="System" />
+                  <ref role="3cqZAo" to="wyt6:~System.out" resolve="out" />
+                </node>
+                <node concept="liA8E" id="7F7y$3LoNnK" role="2OqNvi">
+                  <ref role="37wK5l" to="guwi:~PrintStream.println(java.lang.String)" resolve="println" />
+                  <node concept="3cpWs3" id="7F7y$3LoNnL" role="37wK5m">
+                    <node concept="2OqwBi" id="7F7y$3LoNnM" role="3uHU7w">
+                      <node concept="2OqwBi" id="7F7y$3Lp7Pk" role="2Oq$k0">
+                        <node concept="2GrUjf" id="7F7y$3LoNnN" role="2Oq$k0">
+                          <ref role="2Gs0qQ" node="7F7y$3J_IVs" resolve="propertyPolicy" />
+                        </node>
+                        <node concept="3TrEf2" id="7F7y$3LpbK0" role="2OqNvi">
+                          <ref role="3Tt5mk" to="mopj:6zqIeMU2u$T" resolve="property" />
+                        </node>
+                      </node>
+                      <node concept="2Iv5rx" id="7F7y$3LoNnO" role="2OqNvi" />
+                    </node>
+                    <node concept="Xl_RD" id="7F7y$3LoNnP" role="3uHU7B">
+                      <property role="Xl_RC" value="    Create default property " />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbH" id="49zGylSLxyy" role="3cqZAp" />
+            <node concept="3cpWs8" id="49zGylSKh8e" role="3cqZAp">
+              <node concept="3cpWsn" id="49zGylSKh8f" role="3cpWs9">
+                <property role="TrG5h" value="propertyMerger" />
+                <node concept="3uibUv" id="49zGylSKh8g" role="1tU5fm">
+                  <ref role="3uigEE" node="3EHNiwzf98t" resolve="ContentHolder" />
+                  <node concept="3uibUv" id="49zGylSKh8h" role="11_B2D">
+                    <ref role="3uigEE" node="5lvG0vITZsP" resolve="PropertyMerger" />
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="49zGylSKh8i" role="33vP2m">
+                  <node concept="37vLTw" id="49zGylSKh8j" role="2Oq$k0">
+                    <ref role="3cqZAo" node="5xmpdH72naV" resolve="defaultStuffFactory" />
+                  </node>
+                  <node concept="liA8E" id="49zGylSKh8k" role="2OqNvi">
+                    <ref role="37wK5l" node="32ggi2DpE6P" resolve="propertyMerger" />
+                    <node concept="2GrUjf" id="49zGylSKh8l" role="37wK5m">
+                      <ref role="2Gs0qQ" node="7F7y$3J_IVs" resolve="propertyPolicy" />
+                    </node>
+                    <node concept="37vLTw" id="5xmpdH7I5qT" role="37wK5m">
+                      <ref role="3cqZAo" node="5xmpdH7HRHJ" resolve="currentConcept" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="49zGylSKh8n" role="3cqZAp">
+              <node concept="2OqwBi" id="49zGylSKh8o" role="3clFbG">
+                <node concept="37vLTw" id="49zGylSKh8p" role="2Oq$k0">
+                  <ref role="3cqZAo" node="7F7y$3JwG2x" resolve="matc" />
+                </node>
+                <node concept="liA8E" id="49zGylSKh8q" role="2OqNvi">
+                  <ref role="37wK5l" node="32ggi2DvETK" resolve="addPropertyPolicy" />
+                  <node concept="2OqwBi" id="49zGylSKh8r" role="37wK5m">
+                    <node concept="2GrUjf" id="49zGylSKh8s" role="2Oq$k0">
+                      <ref role="2Gs0qQ" node="7F7y$3J_IVs" resolve="propertyPolicy" />
+                    </node>
+                    <node concept="3TrEf2" id="49zGylSKh8t" role="2OqNvi">
+                      <ref role="3Tt5mk" to="mopj:6zqIeMU2u$T" resolve="property" />
+                    </node>
+                  </node>
+                  <node concept="37vLTw" id="49zGylSKh8u" role="37wK5m">
+                    <ref role="3cqZAo" node="49zGylSKh8f" resolve="propertyMerger" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="49zGylSurph" role="3cqZAp" />
+        <node concept="2Gpval" id="49zGylSuxAh" role="3cqZAp">
+          <node concept="2GrKxI" id="49zGylSuxAi" role="2Gsz3X">
+            <property role="TrG5h" value="childPolicy" />
+          </node>
+          <node concept="2OqwBi" id="49zGylSuxAj" role="2GsD0m">
+            <node concept="37vLTw" id="49zGylSuxAk" role="2Oq$k0">
+              <ref role="3cqZAo" node="7hPYDJhi8UA" resolve="defaultPolicy" />
+            </node>
+            <node concept="3Tsc0h" id="49zGylSvCLf" role="2OqNvi">
+              <ref role="3TtcxE" to="mopj:7jyS5urbJZ5" resolve="childPolicies" />
+            </node>
+          </node>
+          <node concept="3clFbS" id="49zGylSuxAm" role="2LFqv$">
+            <node concept="3clFbF" id="49zGylSuxAn" role="3cqZAp">
+              <node concept="2OqwBi" id="49zGylSuxAo" role="3clFbG">
+                <node concept="10M0yZ" id="49zGylSuxAp" role="2Oq$k0">
+                  <ref role="1PxDUh" to="wyt6:~System" resolve="System" />
+                  <ref role="3cqZAo" to="wyt6:~System.out" resolve="out" />
+                </node>
+                <node concept="liA8E" id="49zGylSuxAq" role="2OqNvi">
+                  <ref role="37wK5l" to="guwi:~PrintStream.println(java.lang.String)" resolve="println" />
+                  <node concept="3cpWs3" id="49zGylSuxAr" role="37wK5m">
+                    <node concept="2OqwBi" id="49zGylSuxAs" role="3uHU7w">
+                      <node concept="2OqwBi" id="49zGylSuxAt" role="2Oq$k0">
+                        <node concept="2GrUjf" id="49zGylSuxAu" role="2Oq$k0">
+                          <ref role="2Gs0qQ" node="49zGylSuxAi" resolve="childPolicy" />
+                        </node>
+                        <node concept="2qgKlT" id="49zGylSwmm4" role="2OqNvi">
+                          <ref role="37wK5l" to="rnx3:1VmHfRx_0K2" resolve="childLink" />
+                        </node>
+                      </node>
+                      <node concept="2Iv5rx" id="49zGylSuxAw" role="2OqNvi" />
+                    </node>
+                    <node concept="Xl_RD" id="49zGylSuxAx" role="3uHU7B">
+                      <property role="Xl_RC" value="    Create default child policy for: " />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbH" id="49zGylSuxAy" role="3cqZAp" />
+            <node concept="3cpWs8" id="49zGylSLgpg" role="3cqZAp">
+              <node concept="3cpWsn" id="49zGylSLgph" role="3cpWs9">
+                <property role="TrG5h" value="childMerger" />
+                <node concept="3uibUv" id="49zGylSLgpi" role="1tU5fm">
+                  <ref role="3uigEE" node="3EHNiwzf98t" resolve="ContentHolder" />
+                  <node concept="3uibUv" id="49zGylSLgpj" role="11_B2D">
+                    <ref role="3uigEE" node="5lvG0vIUaC$" resolve="ConceptChildMerger" />
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="49zGylSLgpk" role="33vP2m">
+                  <node concept="37vLTw" id="49zGylSLgpl" role="2Oq$k0">
+                    <ref role="3cqZAo" node="5xmpdH72naV" resolve="defaultStuffFactory" />
+                  </node>
+                  <node concept="liA8E" id="49zGylSLgpm" role="2OqNvi">
+                    <ref role="37wK5l" node="32ggi2DpDYO" resolve="childMerger" />
+                    <node concept="2GrUjf" id="49zGylSLgpn" role="37wK5m">
+                      <ref role="2Gs0qQ" node="49zGylSuxAi" resolve="childPolicy" />
+                    </node>
+                    <node concept="37vLTw" id="5xmpdH7Is14" role="37wK5m">
+                      <ref role="3cqZAo" node="5xmpdH7HRHJ" resolve="currentConcept" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="49zGylSLgpx" role="3cqZAp">
+              <node concept="2OqwBi" id="49zGylSLgpy" role="3clFbG">
+                <node concept="37vLTw" id="49zGylSLgpz" role="2Oq$k0">
+                  <ref role="3cqZAo" node="7F7y$3JwG2x" resolve="matc" />
+                </node>
+                <node concept="liA8E" id="49zGylSLgp$" role="2OqNvi">
+                  <ref role="37wK5l" node="32ggi2DvZb2" resolve="addChildlink" />
+                  <node concept="2OqwBi" id="49zGylSLHZx" role="37wK5m">
+                    <node concept="2GrUjf" id="49zGylSLHZy" role="2Oq$k0">
+                      <ref role="2Gs0qQ" node="49zGylSuxAi" resolve="childPolicy" />
+                    </node>
+                    <node concept="2qgKlT" id="49zGylSLHZz" role="2OqNvi">
+                      <ref role="37wK5l" to="rnx3:1VmHfRx_0K2" resolve="childLink" />
+                    </node>
+                  </node>
+                  <node concept="37vLTw" id="49zGylSLgpA" role="37wK5m">
+                    <ref role="3cqZAo" node="49zGylSLgph" resolve="childMerger" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="49zGylSHyD$" role="3cqZAp" />
+        <node concept="2Gpval" id="49zGylSH_S5" role="3cqZAp">
+          <node concept="2GrKxI" id="49zGylSH_S6" role="2Gsz3X">
+            <property role="TrG5h" value="refPolicy" />
+          </node>
+          <node concept="3clFbS" id="49zGylSH_Sa" role="2LFqv$">
+            <node concept="3cpWs8" id="49zGylSMcyn" role="3cqZAp">
+              <node concept="3cpWsn" id="49zGylSMcyo" role="3cpWs9">
+                <property role="TrG5h" value="refMerger" />
+                <node concept="3uibUv" id="49zGylSMcyp" role="1tU5fm">
+                  <ref role="3uigEE" node="3EHNiwzf98t" resolve="ContentHolder" />
+                  <node concept="3uibUv" id="49zGylSMcyq" role="11_B2D">
+                    <ref role="3uigEE" node="4WBgwWtfZU9" resolve="ConceptRefMerger" />
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="49zGylSMcyr" role="33vP2m">
+                  <node concept="37vLTw" id="49zGylSMcys" role="2Oq$k0">
+                    <ref role="3cqZAo" node="5xmpdH72naV" resolve="defaultStuffFactory" />
+                  </node>
+                  <node concept="liA8E" id="49zGylSMcyt" role="2OqNvi">
+                    <ref role="37wK5l" node="32ggi2DpFfh" resolve="refMerger" />
+                    <node concept="2GrUjf" id="49zGylSMcyu" role="37wK5m">
+                      <ref role="2Gs0qQ" node="49zGylSH_S6" resolve="refPolicy" />
+                    </node>
+                    <node concept="37vLTw" id="5xmpdH7IP30" role="37wK5m">
+                      <ref role="3cqZAo" node="5xmpdH7HRHJ" resolve="currentConcept" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="49zGylSMcyw" role="3cqZAp">
+              <node concept="2OqwBi" id="49zGylSMcyx" role="3clFbG">
+                <node concept="37vLTw" id="49zGylSMcyy" role="2Oq$k0">
+                  <ref role="3cqZAo" node="7F7y$3JwG2x" resolve="matc" />
+                </node>
+                <node concept="liA8E" id="49zGylSMcyz" role="2OqNvi">
+                  <ref role="37wK5l" node="32ggi2Dwt2R" resolve="addRefPolicy" />
+                  <node concept="2OqwBi" id="49zGylSMcy$" role="37wK5m">
+                    <node concept="2GrUjf" id="49zGylSMcy_" role="2Oq$k0">
+                      <ref role="2Gs0qQ" node="49zGylSH_S6" resolve="refPolicy" />
+                    </node>
+                    <node concept="2qgKlT" id="49zGylSMcyA" role="2OqNvi">
+                      <ref role="37wK5l" to="rnx3:1VmHfRx_0K2" resolve="childLink" />
+                    </node>
+                  </node>
+                  <node concept="37vLTw" id="49zGylSMcyB" role="37wK5m">
+                    <ref role="3cqZAo" node="49zGylSMcyo" resolve="refMerger" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="49zGylSHFSY" role="2GsD0m">
+            <node concept="37vLTw" id="49zGylSHFSZ" role="2Oq$k0">
+              <ref role="3cqZAo" node="7hPYDJhi8UA" resolve="defaultPolicy" />
+            </node>
+            <node concept="3Tsc0h" id="49zGylSHFT0" role="2OqNvi">
+              <ref role="3TtcxE" to="mopj:3PLTv5jwPvF" resolve="referencePolicies" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="5xmpdH7dChf" role="3cqZAp" />
+        <node concept="3clFbJ" id="5xmpdH7dIg4" role="3cqZAp">
+          <node concept="3clFbS" id="5xmpdH7dIg5" role="3clFbx">
+            <node concept="3cpWs8" id="5xmpdH7dIg6" role="3cqZAp">
+              <node concept="3cpWsn" id="5xmpdH7dIg7" role="3cpWs9">
+                <property role="TrG5h" value="idOf" />
+                <node concept="3uibUv" id="5xmpdH7dIg8" role="1tU5fm">
+                  <ref role="3uigEE" node="1yAYHyQ2xCj" resolve="Identity" />
+                </node>
+                <node concept="2OqwBi" id="5xmpdH7dIg9" role="33vP2m">
+                  <node concept="37vLTw" id="5xmpdH7dIga" role="2Oq$k0">
+                    <ref role="3cqZAo" node="5xmpdH7esWN" resolve="stuffFactory" />
+                  </node>
+                  <node concept="liA8E" id="5xmpdH7dIgb" role="2OqNvi">
+                    <ref role="37wK5l" node="60iGZSJPCnZ" resolve="idOf" />
+                    <node concept="2OqwBi" id="5xmpdH7dIgc" role="37wK5m">
+                      <node concept="37vLTw" id="5xmpdH7dIgd" role="2Oq$k0">
+                        <ref role="3cqZAo" node="5xmpdH79xEc" resolve="incompletePolicy" />
+                      </node>
+                      <node concept="3TrEf2" id="5xmpdH7dIge" role="2OqNvi">
+                        <ref role="3Tt5mk" to="mopj:6celbXx2c94" resolve="idFunction" />
+                      </node>
+                    </node>
+                    <node concept="37vLTw" id="5xmpdH7JhbV" role="37wK5m">
+                      <ref role="3cqZAo" node="5xmpdH7HRHJ" resolve="currentConcept" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="5xmpdH7dIgg" role="3cqZAp">
+              <node concept="2OqwBi" id="5xmpdH7dIgh" role="3clFbG">
+                <node concept="37vLTw" id="5xmpdH7dIgi" role="2Oq$k0">
+                  <ref role="3cqZAo" node="7F7y$3JwG2x" resolve="matc" />
+                </node>
+                <node concept="liA8E" id="5xmpdH7dIgj" role="2OqNvi">
+                  <ref role="37wK5l" node="60iGZSJRV2V" resolve="setIdentity" />
+                  <node concept="37vLTw" id="5xmpdH7dIgk" role="37wK5m">
+                    <ref role="3cqZAo" node="5xmpdH7dIg7" resolve="idOf" />
+                  </node>
+                  <node concept="37vLTw" id="5xmpdH7Ju1B" role="37wK5m">
+                    <ref role="3cqZAo" node="5xmpdH7HRHJ" resolve="currentConcept" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="5xmpdH7JEw0" role="3clFbw">
+            <node concept="2OqwBi" id="5xmpdH7dIg0" role="2Oq$k0">
+              <node concept="37vLTw" id="5xmpdH7dIg1" role="2Oq$k0">
+                <ref role="3cqZAo" node="5xmpdH79xEc" resolve="incompletePolicy" />
+              </node>
+              <node concept="3TrEf2" id="5xmpdH7dIg2" role="2OqNvi">
+                <ref role="3Tt5mk" to="mopj:6celbXx2c94" resolve="idFunction" />
+              </node>
+            </node>
+            <node concept="3x8VRR" id="5xmpdH7JJ89" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="7F7y$3Jwg0o" role="1B3o_S" />
+      <node concept="3cqZAl" id="7F7y$3JwpFw" role="3clF45" />
+    </node>
+    <node concept="2tJIrI" id="5xmpdH70lfI" role="jymVt" />
     <node concept="2YIFZL" id="1FQTM0rPQwO" role="jymVt">
       <property role="TrG5h" value="addMergePoliciesToTraversalState" />
       <node concept="3Tm6S6" id="1FQTM0rPQwP" role="1B3o_S" />
@@ -11095,6 +11631,7 @@
             </node>
           </node>
         </node>
+        <node concept="3clFbH" id="7F7y$3Jve5y" role="3cqZAp" />
         <node concept="2Gpval" id="1FQTM0rPQwq" role="3cqZAp">
           <node concept="2GrKxI" id="1FQTM0rPQwr" role="2Gsz3X">
             <property role="TrG5h" value="childPolicy" />
@@ -11177,6 +11714,7 @@
             </node>
           </node>
         </node>
+        <node concept="3clFbH" id="7F7y$3Jvi8p" role="3cqZAp" />
         <node concept="2Gpval" id="3PLTv5jMDZ0" role="3cqZAp">
           <node concept="2GrKxI" id="3PLTv5jMDZ2" role="2Gsz3X">
             <property role="TrG5h" value="refPolicy" />
@@ -11239,23 +11777,6 @@
           </node>
         </node>
         <node concept="3clFbH" id="60iGZSJSDRz" role="3cqZAp" />
-        <node concept="3cpWs8" id="3Wln5KJ5g$1" role="3cqZAp">
-          <node concept="3cpWsn" id="3Wln5KJ5g$2" role="3cpWs9">
-            <property role="TrG5h" value="idFunction" />
-            <node concept="3Tqbb2" id="3Wln5KJ5gzQ" role="1tU5fm">
-              <ref role="ehGHo" to="mopj:6celbXx0_R7" resolve="IdFunction" />
-            </node>
-            <node concept="2OqwBi" id="3Wln5KJ5g$3" role="33vP2m">
-              <node concept="37vLTw" id="3Wln5KJ5g$4" role="2Oq$k0">
-                <ref role="3cqZAo" node="1FQTM0rPQwA" resolve="mergePolicy" />
-              </node>
-              <node concept="3TrEf2" id="3Wln5KJ5g$5" role="2OqNvi">
-                <ref role="3Tt5mk" to="mopj:6celbXx2c94" resolve="idFunction" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbH" id="5ahhjnc03q0" role="3cqZAp" />
         <node concept="3clFbJ" id="3Wln5KJ5j9O" role="3cqZAp">
           <node concept="3clFbS" id="3Wln5KJ5j9Q" role="3clFbx">
             <node concept="3cpWs8" id="60iGZSJUbGj" role="3cqZAp">
@@ -11303,10 +11824,15 @@
             </node>
           </node>
           <node concept="2OqwBi" id="3Wln5KJ5j_i" role="3clFbw">
-            <node concept="37vLTw" id="3Wln5KJ5jhb" role="2Oq$k0">
-              <ref role="3cqZAo" node="3Wln5KJ5g$2" resolve="idFunction" />
-            </node>
             <node concept="3x8VRR" id="3Wln5KJ5k4F" role="2OqNvi" />
+            <node concept="2OqwBi" id="3Wln5KJ5g$3" role="2Oq$k0">
+              <node concept="37vLTw" id="3Wln5KJ5g$4" role="2Oq$k0">
+                <ref role="3cqZAo" node="1FQTM0rPQwA" resolve="mergePolicy" />
+              </node>
+              <node concept="3TrEf2" id="3Wln5KJ5g$5" role="2OqNvi">
+                <ref role="3Tt5mk" to="mopj:6celbXx2c94" resolve="idFunction" />
+              </node>
+            </node>
           </node>
         </node>
       </node>
@@ -14975,6 +15501,7 @@
         </node>
       </node>
     </node>
+    <node concept="2tJIrI" id="7F7y$3JtbRz" role="jymVt" />
     <node concept="312cEg" id="3PLTv5jAPf9" role="jymVt">
       <property role="TrG5h" value="conceptMergePolicy" />
       <node concept="3Tm1VV" id="3PLTv5jAPfa" role="1B3o_S" />
@@ -15017,6 +15544,7 @@
         </node>
       </node>
     </node>
+    <node concept="2tJIrI" id="7F7y$3JtdqN" role="jymVt" />
     <node concept="312cEg" id="3PLTv5jLMuy" role="jymVt">
       <property role="TrG5h" value="referenceMergePolicy" />
       <node concept="3Tm1VV" id="3PLTv5jLMuz" role="1B3o_S" />
@@ -16569,6 +17097,2046 @@
       </node>
     </node>
     <node concept="3Tm1VV" id="2cYlIwY_fxh" role="1B3o_S" />
+  </node>
+  <node concept="312cEu" id="7F7y$3JJe2j">
+    <property role="TrG5h" value="DefaultPolicyBuilder" />
+    <node concept="2tJIrI" id="5xmpdH75_oY" role="jymVt" />
+    <node concept="2YIFZL" id="7F7y$3JJe2k" role="jymVt">
+      <property role="TrG5h" value="build" />
+      <node concept="3clFbS" id="7F7y$3JJe2l" role="3clF47">
+        <node concept="3clFbH" id="5xmpdH75mUi" role="3cqZAp" />
+        <node concept="3cpWs8" id="7F7y$3JJe2m" role="3cqZAp">
+          <node concept="3cpWsn" id="7F7y$3JJe2n" role="3cpWs9">
+            <property role="TrG5h" value="defaultPolicy" />
+            <node concept="3Tqbb2" id="7F7y$3JJe2o" role="1tU5fm">
+              <ref role="ehGHo" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
+            </node>
+            <node concept="2pJPEk" id="7F7y$3JJe2p" role="33vP2m">
+              <node concept="2pJPED" id="7F7y$3JJe2q" role="2pJPEn">
+                <ref role="2pJxaS" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
+                <node concept="2pIpSj" id="7F7y$3JJe2r" role="2pJxcM">
+                  <ref role="2pIpSl" to="mopj:3BP4DuXu_FH" resolve="conceptRef" />
+                  <node concept="36biLy" id="7F7y$3JJe2s" role="28nt2d">
+                    <node concept="37vLTw" id="7F7y$3JJe2t" role="36biLW">
+                      <ref role="3cqZAo" node="7F7y$3JJe3r" resolve="missingConcept" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="5xmpdH7UDh$" role="3cqZAp">
+          <node concept="2OqwBi" id="5xmpdH7UGpO" role="3clFbG">
+            <node concept="liA8E" id="5xmpdH7UIEJ" role="2OqNvi">
+              <ref role="37wK5l" to="mhbf:~SNode.getConcept()" resolve="getConcept" />
+            </node>
+            <node concept="2JrnkZ" id="5xmpdH7UGpX" role="2Oq$k0">
+              <node concept="2OqwBi" id="5xmpdH7UE_i" role="2JrQYb">
+                <node concept="37vLTw" id="5xmpdH7UDhy" role="2Oq$k0">
+                  <ref role="3cqZAo" node="7F7y$3JJe2n" resolve="defaultPolicy" />
+                </node>
+                <node concept="3TrEf2" id="5xmpdH7UF_W" role="2OqNvi">
+                  <ref role="3Tt5mk" to="mopj:3BP4DuXu_FH" resolve="conceptRef" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="5xmpdH75dL8" role="3cqZAp">
+          <node concept="1rXfSq" id="5xmpdH75k9G" role="3clFbG">
+            <ref role="37wK5l" node="5xmpdH75dL2" resolve="buildDefaultPolicies" />
+            <node concept="37vLTw" id="5xmpdH75dL5" role="37wK5m">
+              <ref role="3cqZAo" node="7F7y$3JJe2n" resolve="defaultPolicy" />
+            </node>
+            <node concept="37vLTw" id="5xmpdH75dL6" role="37wK5m">
+              <ref role="3cqZAo" node="7F7y$3JJe3t" resolve="defaultAction" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7F7y$3JJe3e" role="3cqZAp" />
+        <node concept="3clFbF" id="49zGylW5Mi8" role="3cqZAp">
+          <node concept="37vLTI" id="49zGylW5PHm" role="3clFbG">
+            <node concept="2OqwBi" id="49zGylW5M_E" role="37vLTJ">
+              <node concept="37vLTw" id="49zGylW5Mi6" role="2Oq$k0">
+                <ref role="3cqZAo" node="7F7y$3JJe2n" resolve="defaultPolicy" />
+              </node>
+              <node concept="3TrEf2" id="49zGylW5OS_" role="2OqNvi">
+                <ref role="3Tt5mk" to="mopj:6celbXx2c94" resolve="idFunction" />
+              </node>
+            </node>
+            <node concept="2pJPEk" id="49zGylWcTgZ" role="37vLTx">
+              <node concept="2pJPED" id="49zGylWcTh1" role="2pJPEn">
+                <ref role="2pJxaS" to="mopj:6celbXx0_R7" resolve="IdFunction" />
+                <node concept="2pIpSj" id="49zGylWcV5b" role="2pJxcM">
+                  <ref role="2pIpSl" to="tpee:gyVODHa" resolve="body" />
+                  <node concept="2pJPED" id="49zGylWcWew" role="28nt2d">
+                    <ref role="2pJxaS" to="tpee:fzclF80" resolve="StatementList" />
+                    <node concept="2pIpSj" id="49zGylWcXnN" role="2pJxcM">
+                      <ref role="2pIpSl" to="tpee:fzcqZ_x" resolve="statement" />
+                      <node concept="2pJPED" id="49zGylWcYxa" role="28nt2d">
+                        <ref role="2pJxaS" to="tpee:fzcpWvY" resolve="ReturnStatement" />
+                        <node concept="2pIpSj" id="49zGylWcZaq" role="2pJxcM">
+                          <ref role="2pIpSl" to="tpee:fzcqZ_G" resolve="expression" />
+                          <node concept="2pJPED" id="49zGylWd46Q" role="28nt2d">
+                            <ref role="2pJxaS" to="tpee:f$Xl_Og" resolve="StringLiteral" />
+                            <node concept="2pJxcG" id="49zGylWd5Tn" role="2pJxcM">
+                              <ref role="2pJxcJ" to="tpee:f$Xl_Oh" resolve="value" />
+                              <node concept="WxPPo" id="49zGylWd60W" role="28ntcv">
+                                <node concept="Xl_RD" id="49zGylWd60V" role="WxPPp">
+                                  <property role="Xl_RC" value="" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7F7y$3JJe3p" role="3cqZAp">
+          <node concept="37vLTw" id="7F7y$3JJe3q" role="3clFbG">
+            <ref role="3cqZAo" node="7F7y$3JJe2n" resolve="defaultPolicy" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="7F7y$3JJe3r" role="3clF46">
+        <property role="TrG5h" value="missingConcept" />
+        <node concept="3Tqbb2" id="7F7y$3JJe3s" role="1tU5fm">
+          <ref role="ehGHo" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="7F7y$3JJe3t" role="3clF46">
+        <property role="TrG5h" value="defaultAction" />
+        <node concept="3Tqbb2" id="7F7y$3JJe3u" role="1tU5fm">
+          <ref role="ehGHo" to="mopj:3P8JlgmMYnQ" resolve="MergerDefaultAction" />
+        </node>
+      </node>
+      <node concept="3Tqbb2" id="7F7y$3JJe3v" role="3clF45">
+        <ref role="ehGHo" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
+      </node>
+      <node concept="3Tm1VV" id="7F7y$3JJe3w" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="5xmpdH75f4t" role="jymVt" />
+    <node concept="2YIFZL" id="5xmpdH75dL2" role="jymVt">
+      <property role="TrG5h" value="buildDefaultPolicies" />
+      <node concept="3Tm6S6" id="5xmpdH75dL3" role="1B3o_S" />
+      <node concept="3cqZAl" id="5xmpdH75dL4" role="3clF45" />
+      <node concept="37vLTG" id="5xmpdH75dKH" role="3clF46">
+        <property role="TrG5h" value="policy" />
+        <node concept="3Tqbb2" id="5xmpdH75dKI" role="1tU5fm">
+          <ref role="ehGHo" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="5xmpdH75dKJ" role="3clF46">
+        <property role="TrG5h" value="defaultAction" />
+        <node concept="3Tqbb2" id="5xmpdH75dKK" role="1tU5fm">
+          <ref role="ehGHo" to="mopj:3P8JlgmMYnQ" resolve="MergerDefaultAction" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="5xmpdH75dJW" role="3clF47">
+        <node concept="3clFbJ" id="5xmpdH75dJX" role="3cqZAp">
+          <node concept="3clFbS" id="5xmpdH75dJY" role="3clFbx">
+            <node concept="3clFbF" id="5xmpdH75dJZ" role="3cqZAp">
+              <node concept="2YIFZM" id="5xmpdH75dK0" role="3clFbG">
+                <ref role="1Pybhc" node="7F7y$3JJe2j" resolve="DefaultPolicyBuilder" />
+                <ref role="37wK5l" node="7F7y$3JJe3y" resolve="properties" />
+                <node concept="37vLTw" id="5xmpdH75dKM" role="37wK5m">
+                  <ref role="3cqZAo" node="5xmpdH75dKH" resolve="defaultPolicy" />
+                </node>
+                <node concept="37vLTw" id="5xmpdH75dKY" role="37wK5m">
+                  <ref role="3cqZAo" node="5xmpdH75dKJ" resolve="defaultAction" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="5xmpdH75dK3" role="3clFbw">
+            <node concept="2OqwBi" id="5xmpdH75dK4" role="2Oq$k0">
+              <node concept="37vLTw" id="5xmpdH75dKU" role="2Oq$k0">
+                <ref role="3cqZAo" node="5xmpdH75dKH" resolve="defaultPolicy" />
+              </node>
+              <node concept="2qgKlT" id="5xmpdH75dK6" role="2OqNvi">
+                <ref role="37wK5l" to="rnx3:5zr7Q_1V6SF" resolve="allHierarchyProperties" />
+              </node>
+            </node>
+            <node concept="3GX2aA" id="5xmpdH75dK7" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="5xmpdH75dK8" role="3cqZAp" />
+        <node concept="3clFbJ" id="5xmpdH75dK9" role="3cqZAp">
+          <node concept="3clFbS" id="5xmpdH75dKa" role="3clFbx">
+            <node concept="3clFbF" id="5xmpdH75dKb" role="3cqZAp">
+              <node concept="2YIFZM" id="5xmpdH75dKc" role="3clFbG">
+                <ref role="1Pybhc" node="7F7y$3JJe2j" resolve="DefaultPolicyBuilder" />
+                <ref role="37wK5l" node="7F7y$3JJe41" resolve="singletonChildren" />
+                <node concept="37vLTw" id="5xmpdH75dKW" role="37wK5m">
+                  <ref role="3cqZAo" node="5xmpdH75dKH" resolve="defaultPolicy" />
+                </node>
+                <node concept="37vLTw" id="5xmpdH75dKZ" role="37wK5m">
+                  <ref role="3cqZAo" node="5xmpdH75dKJ" resolve="defaultAction" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="5xmpdH75dKf" role="3cqZAp">
+              <node concept="2YIFZM" id="5xmpdH75dKg" role="3clFbG">
+                <ref role="1Pybhc" node="7F7y$3JJe2j" resolve="DefaultPolicyBuilder" />
+                <ref role="37wK5l" node="7F7y$3JJe4w" resolve="OptionalChildren" />
+                <node concept="37vLTw" id="5xmpdH75dKR" role="37wK5m">
+                  <ref role="3cqZAo" node="5xmpdH75dKH" resolve="defaultPolicy" />
+                </node>
+                <node concept="37vLTw" id="5xmpdH75dKP" role="37wK5m">
+                  <ref role="3cqZAo" node="5xmpdH75dKJ" resolve="defaultAction" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="5xmpdH75dKj" role="3cqZAp">
+              <node concept="2YIFZM" id="5xmpdH75dKk" role="3clFbG">
+                <ref role="1Pybhc" node="7F7y$3JJe2j" resolve="DefaultPolicyBuilder" />
+                <ref role="37wK5l" node="7F7y$3JJe4Z" resolve="multiChildren" />
+                <node concept="37vLTw" id="5xmpdH75dKS" role="37wK5m">
+                  <ref role="3cqZAo" node="5xmpdH75dKH" resolve="defaultPolicy" />
+                </node>
+                <node concept="37vLTw" id="5xmpdH75dKL" role="37wK5m">
+                  <ref role="3cqZAo" node="5xmpdH75dKJ" resolve="defaultAction" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbH" id="5xmpdH75dKn" role="3cqZAp" />
+          </node>
+          <node concept="2OqwBi" id="5xmpdH75dKo" role="3clFbw">
+            <node concept="2OqwBi" id="5xmpdH75dKp" role="2Oq$k0">
+              <node concept="37vLTw" id="5xmpdH75dKT" role="2Oq$k0">
+                <ref role="3cqZAo" node="5xmpdH75dKH" resolve="defaultPolicy" />
+              </node>
+              <node concept="2qgKlT" id="5xmpdH75dKr" role="2OqNvi">
+                <ref role="37wK5l" to="rnx3:5zr7Q_1WLCS" resolve="allHierarchyChildren" />
+              </node>
+            </node>
+            <node concept="3GX2aA" id="5xmpdH75dKs" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="5xmpdH75dKt" role="3cqZAp" />
+        <node concept="3clFbJ" id="5xmpdH75dKu" role="3cqZAp">
+          <node concept="3clFbS" id="5xmpdH75dKv" role="3clFbx">
+            <node concept="3clFbF" id="5xmpdH75dKw" role="3cqZAp">
+              <node concept="2YIFZM" id="5xmpdH75dKx" role="3clFbG">
+                <ref role="1Pybhc" node="7F7y$3JJe2j" resolve="DefaultPolicyBuilder" />
+                <ref role="37wK5l" node="7F7y$3JJe6o" resolve="singletonRef" />
+                <node concept="37vLTw" id="5xmpdH75dKX" role="37wK5m">
+                  <ref role="3cqZAo" node="5xmpdH75dKH" resolve="defaultPolicy" />
+                </node>
+                <node concept="37vLTw" id="5xmpdH75dKV" role="37wK5m">
+                  <ref role="3cqZAo" node="5xmpdH75dKJ" resolve="defaultAction" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="5xmpdH75dK$" role="3cqZAp">
+              <node concept="2YIFZM" id="5xmpdH75dK_" role="3clFbG">
+                <ref role="1Pybhc" node="7F7y$3JJe2j" resolve="DefaultPolicyBuilder" />
+                <ref role="37wK5l" node="7F7y$3JJe5T" resolve="buildOptionalRef" />
+                <node concept="37vLTw" id="5xmpdH75dKN" role="37wK5m">
+                  <ref role="3cqZAo" node="5xmpdH75dKH" resolve="defaultPolicy" />
+                </node>
+                <node concept="37vLTw" id="5xmpdH75dKO" role="37wK5m">
+                  <ref role="3cqZAo" node="5xmpdH75dKJ" resolve="defaultAction" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="5xmpdH75dKC" role="3clFbw">
+            <node concept="2OqwBi" id="5xmpdH75dKD" role="2Oq$k0">
+              <node concept="37vLTw" id="5xmpdH75dKQ" role="2Oq$k0">
+                <ref role="3cqZAo" node="5xmpdH75dKH" resolve="defaultPolicy" />
+              </node>
+              <node concept="2qgKlT" id="5xmpdH75dKF" role="2OqNvi">
+                <ref role="37wK5l" to="rnx3:3PLTv5jznVy" resolve="allHierarchyReferences" />
+              </node>
+            </node>
+            <node concept="3GX2aA" id="5xmpdH75dKG" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="7F7y$3JJe3x" role="jymVt" />
+    <node concept="2YIFZL" id="7F7y$3JJe3y" role="jymVt">
+      <property role="TrG5h" value="properties" />
+      <node concept="3Tm6S6" id="7F7y$3JJe3z" role="1B3o_S" />
+      <node concept="3cqZAl" id="7F7y$3JJe3$" role="3clF45" />
+      <node concept="37vLTG" id="7F7y$3JJe3_" role="3clF46">
+        <property role="TrG5h" value="defaultPolicy" />
+        <node concept="3Tqbb2" id="7F7y$3JJe3A" role="1tU5fm">
+          <ref role="ehGHo" to="mopj:1EbzjT2R$JP" resolve="UserMergePolicy" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="7F7y$3JJe3B" role="3clF46">
+        <property role="TrG5h" value="defaultAction" />
+        <node concept="3Tqbb2" id="7F7y$3JJe3C" role="1tU5fm">
+          <ref role="ehGHo" to="mopj:3P8JlgmMYnQ" resolve="MergerDefaultAction" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="7F7y$3JJe3D" role="3clF47">
+        <node concept="2Gpval" id="7F7y$3JJe3E" role="3cqZAp">
+          <node concept="2GrKxI" id="7F7y$3JJe3F" role="2Gsz3X">
+            <property role="TrG5h" value="property" />
+          </node>
+          <node concept="3clFbS" id="7F7y$3JJe3G" role="2LFqv$">
+            <node concept="3clFbF" id="7F7y$3JJe3H" role="3cqZAp">
+              <node concept="2OqwBi" id="7F7y$3JJe3I" role="3clFbG">
+                <node concept="2OqwBi" id="7F7y$3JJe3J" role="2Oq$k0">
+                  <node concept="37vLTw" id="7F7y$3JJe3K" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7F7y$3JJe3_" resolve="defaultPolicy" />
+                  </node>
+                  <node concept="3Tsc0h" id="7F7y$3JJe3L" role="2OqNvi">
+                    <ref role="3TtcxE" to="mopj:1EbzjT2T4LX" resolve="propertyPolicies" />
+                  </node>
+                </node>
+                <node concept="TSZUe" id="7F7y$3JJe3M" role="2OqNvi">
+                  <node concept="2pJPEk" id="7F7y$3JJe3N" role="25WWJ7">
+                    <node concept="2pJPED" id="7F7y$3JJe3O" role="2pJPEn">
+                      <ref role="2pJxaS" to="mopj:1EbzjT2T4oC" resolve="PropertyPolicy" />
+                      <node concept="2pIpSj" id="7F7y$3JJe3P" role="2pJxcM">
+                        <ref role="2pIpSl" to="mopj:6zqIeMU2u$T" resolve="property" />
+                        <node concept="36biLy" id="7F7y$3JJe3Q" role="28nt2d">
+                          <node concept="2GrUjf" id="7F7y$3JJe3R" role="36biLW">
+                            <ref role="2Gs0qQ" node="7F7y$3JJe3F" resolve="property" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="2pIpSj" id="7F7y$3JJe3S" role="2pJxcM">
+                        <ref role="2pIpSl" to="mopj:1EbzjT2T4Jd" resolve="action" />
+                        <node concept="36biLy" id="7F7y$3JJe3T" role="28nt2d">
+                          <node concept="2OqwBi" id="7F7y$3JJe3U" role="36biLW">
+                            <node concept="37vLTw" id="7F7y$3JJe3V" role="2Oq$k0">
+                              <ref role="3cqZAo" node="7F7y$3JJe3B" resolve="defaultAction" />
+                            </node>
+                            <node concept="3TrEf2" id="7F7y$3JJe3W" role="2OqNvi">
+                              <ref role="3Tt5mk" to="mopj:zgvH9CGvYJ" resolve="propertyAction" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="7F7y$3JJe3X" role="2GsD0m">
+            <node concept="37vLTw" id="7F7y$3JJe3Y" role="2Oq$k0">
+              <ref role="3cqZAo" node="7F7y$3JJe3_" resolve="defaultPolicy" />
+            </node>
+            <node concept="2qgKlT" id="7F7y$3JJe3Z" role="2OqNvi">
+              <ref role="37wK5l" to="rnx3:5zr7Q_1V6SF" resolve="allHierarchyProperties" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="7F7y$3JJe40" role="jymVt" />
+    <node concept="2YIFZL" id="7F7y$3JJe41" role="jymVt">
+      <property role="TrG5h" value="singletonChildren" />
+      <node concept="3Tm6S6" id="7F7y$3JJe42" role="1B3o_S" />
+      <node concept="3cqZAl" id="7F7y$3JJe43" role="3clF45" />
+      <node concept="37vLTG" id="7F7y$3JJe44" role="3clF46">
+        <property role="TrG5h" value="defaultPolicy" />
+        <node concept="3Tqbb2" id="7F7y$3JJe45" role="1tU5fm">
+          <ref role="ehGHo" to="mopj:1EbzjT2R$JP" resolve="UserMergePolicy" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="7F7y$3JJe46" role="3clF46">
+        <property role="TrG5h" value="defaultAction" />
+        <node concept="3Tqbb2" id="7F7y$3JJe47" role="1tU5fm">
+          <ref role="ehGHo" to="mopj:3P8JlgmMYnQ" resolve="MergerDefaultAction" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="7F7y$3JJe48" role="3clF47">
+        <node concept="2Gpval" id="7F7y$3JJe49" role="3cqZAp">
+          <node concept="2GrKxI" id="7F7y$3JJe4a" role="2Gsz3X">
+            <property role="TrG5h" value="child" />
+          </node>
+          <node concept="3clFbS" id="7F7y$3JJe4b" role="2LFqv$">
+            <node concept="3clFbF" id="7F7y$3JJe4c" role="3cqZAp">
+              <node concept="2OqwBi" id="7F7y$3JJe4d" role="3clFbG">
+                <node concept="2OqwBi" id="7F7y$3JJe4e" role="2Oq$k0">
+                  <node concept="37vLTw" id="7F7y$3JJe4f" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7F7y$3JJe44" resolve="defaultPolicy" />
+                  </node>
+                  <node concept="3Tsc0h" id="7F7y$3JJe4g" role="2OqNvi">
+                    <ref role="3TtcxE" to="mopj:7jyS5urbJZ5" resolve="childPolicies" />
+                  </node>
+                </node>
+                <node concept="TSZUe" id="7F7y$3JJe4h" role="2OqNvi">
+                  <node concept="2pJPEk" id="7F7y$3JJe4i" role="25WWJ7">
+                    <node concept="2pJPED" id="7F7y$3JJe4j" role="2pJPEn">
+                      <ref role="2pJxaS" to="mopj:3PLTv5k2w4J" resolve="SingletonChildPolicy" />
+                      <node concept="2pIpSj" id="7F7y$3JJe4k" role="2pJxcM">
+                        <ref role="2pIpSl" to="mopj:1VmHfRxVF4J" resolve="child" />
+                        <node concept="36biLy" id="7F7y$3JJe4l" role="28nt2d">
+                          <node concept="2GrUjf" id="7F7y$3JJe4m" role="36biLW">
+                            <ref role="2Gs0qQ" node="7F7y$3JJe4a" resolve="child" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="2pIpSj" id="7F7y$3JJe4n" role="2pJxcM">
+                        <ref role="2pIpSl" to="mopj:7jyS5urbTpc" resolve="action" />
+                        <node concept="36biLy" id="7F7y$3JJe4o" role="28nt2d">
+                          <node concept="2OqwBi" id="7F7y$3JJe4p" role="36biLW">
+                            <node concept="3TrEf2" id="7F7y$3JJe4q" role="2OqNvi">
+                              <ref role="3Tt5mk" to="mopj:zgvH9CGxS0" resolve="singleChildAction" />
+                            </node>
+                            <node concept="37vLTw" id="7F7y$3JJe4r" role="2Oq$k0">
+                              <ref role="3cqZAo" node="7F7y$3JJe46" resolve="defaultAction" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="7F7y$3JJe4s" role="2GsD0m">
+            <node concept="37vLTw" id="7F7y$3JJe4t" role="2Oq$k0">
+              <ref role="3cqZAo" node="7F7y$3JJe44" resolve="defaultPolicy" />
+            </node>
+            <node concept="2qgKlT" id="7F7y$3JJe4u" role="2OqNvi">
+              <ref role="37wK5l" to="rnx3:5zr7Q_1WWCs" resolve="allHierarchySingltonChildren" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="7F7y$3JJe4v" role="jymVt" />
+    <node concept="2YIFZL" id="7F7y$3JJe4w" role="jymVt">
+      <property role="TrG5h" value="OptionalChildren" />
+      <node concept="3Tm6S6" id="7F7y$3JJe4x" role="1B3o_S" />
+      <node concept="3cqZAl" id="7F7y$3JJe4y" role="3clF45" />
+      <node concept="37vLTG" id="7F7y$3JJe4z" role="3clF46">
+        <property role="TrG5h" value="defaultPolicy" />
+        <node concept="3Tqbb2" id="7F7y$3JJe4$" role="1tU5fm">
+          <ref role="ehGHo" to="mopj:1EbzjT2R$JP" resolve="UserMergePolicy" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="7F7y$3JJe4_" role="3clF46">
+        <property role="TrG5h" value="defaultAction" />
+        <node concept="3Tqbb2" id="7F7y$3JJe4A" role="1tU5fm">
+          <ref role="ehGHo" to="mopj:3P8JlgmMYnQ" resolve="MergerDefaultAction" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="7F7y$3JJe4B" role="3clF47">
+        <node concept="2Gpval" id="7F7y$3JJe4C" role="3cqZAp">
+          <node concept="2GrKxI" id="7F7y$3JJe4D" role="2Gsz3X">
+            <property role="TrG5h" value="child" />
+          </node>
+          <node concept="3clFbS" id="7F7y$3JJe4E" role="2LFqv$">
+            <node concept="3clFbF" id="7F7y$3JJe4F" role="3cqZAp">
+              <node concept="2OqwBi" id="7F7y$3JJe4G" role="3clFbG">
+                <node concept="2OqwBi" id="7F7y$3JJe4H" role="2Oq$k0">
+                  <node concept="37vLTw" id="7F7y$3JJe4I" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7F7y$3JJe4z" resolve="defaultPolicy" />
+                  </node>
+                  <node concept="3Tsc0h" id="7F7y$3JJe4J" role="2OqNvi">
+                    <ref role="3TtcxE" to="mopj:7jyS5urbJZ5" resolve="childPolicies" />
+                  </node>
+                </node>
+                <node concept="TSZUe" id="7F7y$3JJe4K" role="2OqNvi">
+                  <node concept="2pJPEk" id="7F7y$3JJe4L" role="25WWJ7">
+                    <node concept="2pJPED" id="7F7y$3JJe4M" role="2pJPEn">
+                      <ref role="2pJxaS" to="mopj:3PLTv5k2w4M" resolve="OptionalChildPolicy" />
+                      <node concept="2pIpSj" id="7F7y$3JJe4N" role="2pJxcM">
+                        <ref role="2pIpSl" to="mopj:1VmHfRxVF4J" resolve="child" />
+                        <node concept="36biLy" id="7F7y$3JJe4O" role="28nt2d">
+                          <node concept="2GrUjf" id="7F7y$3JJe4P" role="36biLW">
+                            <ref role="2Gs0qQ" node="7F7y$3JJe4D" resolve="child" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="2pIpSj" id="7F7y$3JJe4Q" role="2pJxcM">
+                        <ref role="2pIpSl" to="mopj:7jyS5urbFnA" resolve="action" />
+                        <node concept="36biLy" id="7F7y$3JJe4R" role="28nt2d">
+                          <node concept="2OqwBi" id="7F7y$3JJe4S" role="36biLW">
+                            <node concept="3TrEf2" id="7F7y$3JJe4T" role="2OqNvi">
+                              <ref role="3Tt5mk" to="mopj:zgvH9CGyNu" resolve="optionalChildAction" />
+                            </node>
+                            <node concept="37vLTw" id="7F7y$3JJe4U" role="2Oq$k0">
+                              <ref role="3cqZAo" node="7F7y$3JJe4_" resolve="defaultAction" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="7F7y$3JJe4V" role="2GsD0m">
+            <node concept="37vLTw" id="7F7y$3JJe4W" role="2Oq$k0">
+              <ref role="3cqZAo" node="7F7y$3JJe4z" resolve="defaultPolicy" />
+            </node>
+            <node concept="2qgKlT" id="7F7y$3JJe4X" role="2OqNvi">
+              <ref role="37wK5l" to="rnx3:5zr7Q_1XJwl" resolve="allHierarchyOptionalChildren" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="7F7y$3JJe4Y" role="jymVt" />
+    <node concept="2YIFZL" id="7F7y$3JJe4Z" role="jymVt">
+      <property role="TrG5h" value="multiChildren" />
+      <node concept="3Tm6S6" id="7F7y$3JJe50" role="1B3o_S" />
+      <node concept="3cqZAl" id="7F7y$3JJe51" role="3clF45" />
+      <node concept="37vLTG" id="7F7y$3JJe52" role="3clF46">
+        <property role="TrG5h" value="defaultPolicy" />
+        <node concept="3Tqbb2" id="7F7y$3JJe53" role="1tU5fm">
+          <ref role="ehGHo" to="mopj:1EbzjT2R$JP" resolve="UserMergePolicy" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="7F7y$3JJe54" role="3clF46">
+        <property role="TrG5h" value="defaultAction" />
+        <node concept="3Tqbb2" id="7F7y$3JJe55" role="1tU5fm">
+          <ref role="ehGHo" to="mopj:3P8JlgmMYnQ" resolve="MergerDefaultAction" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="7F7y$3JJe56" role="3clF47">
+        <node concept="2Gpval" id="7F7y$3JJe57" role="3cqZAp">
+          <node concept="2GrKxI" id="7F7y$3JJe58" role="2Gsz3X">
+            <property role="TrG5h" value="child" />
+          </node>
+          <node concept="3clFbS" id="7F7y$3JJe59" role="2LFqv$">
+            <node concept="3clFbF" id="7F7y$3JJe5a" role="3cqZAp">
+              <node concept="2OqwBi" id="7F7y$3JJe5b" role="3clFbG">
+                <node concept="2OqwBi" id="7F7y$3JJe5c" role="2Oq$k0">
+                  <node concept="37vLTw" id="7F7y$3JJe5d" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7F7y$3JJe52" resolve="defaultPolicy" />
+                  </node>
+                  <node concept="3Tsc0h" id="7F7y$3JJe5e" role="2OqNvi">
+                    <ref role="3TtcxE" to="mopj:7jyS5urbJZ5" resolve="childPolicies" />
+                  </node>
+                </node>
+                <node concept="TSZUe" id="7F7y$3JJe5f" role="2OqNvi">
+                  <node concept="2pJPEk" id="7F7y$3JJe5g" role="25WWJ7">
+                    <node concept="2pJPED" id="7F7y$3JJe5h" role="2pJPEn">
+                      <ref role="2pJxaS" to="mopj:7jyS5urbTpv" resolve="MultiChildPolicy" />
+                      <node concept="2pIpSj" id="7F7y$3JJe5i" role="2pJxcM">
+                        <ref role="2pIpSl" to="mopj:1VmHfRxVF4J" resolve="child" />
+                        <node concept="36biLy" id="7F7y$3JJe5j" role="28nt2d">
+                          <node concept="2GrUjf" id="7F7y$3JJe5k" role="36biLW">
+                            <ref role="2Gs0qQ" node="7F7y$3JJe58" resolve="child" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="2pIpSj" id="7F7y$3JJe5l" role="2pJxcM">
+                        <ref role="2pIpSl" to="mopj:7jyS5urbTpw" resolve="subPolicy" />
+                        <node concept="36be1Y" id="7F7y$3JJe5m" role="28nt2d">
+                          <node concept="2pJPED" id="7F7y$3JJe5n" role="36be1Z">
+                            <ref role="2pJxaS" to="mopj:1VmHfRxKMgU" resolve="SubPolicyContainer" />
+                            <node concept="2pJxcG" id="7F7y$3JJe5o" role="2pJxcM">
+                              <ref role="2pJxcJ" to="mopj:1VmHfRxKMgV" resolve="subPolicy" />
+                              <node concept="2OqwBi" id="7F7y$3JJe5p" role="28ntcv">
+                                <node concept="1XH99k" id="7F7y$3JJe5q" role="2Oq$k0">
+                                  <ref role="1XH99l" to="mopj:1VmHfRxJEru" resolve="SubPolicy" />
+                                </node>
+                                <node concept="2ViDtV" id="7F7y$3JJe5r" role="2OqNvi">
+                                  <ref role="2ViDtZ" to="mopj:1VmHfRxJErv" resolve="NewOnRight" />
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="2pIpSj" id="7F7y$3JJe5s" role="2pJxcM">
+                              <ref role="2pIpSl" to="mopj:1VmHfRxLaon" resolve="action" />
+                              <node concept="36biLy" id="7F7y$3JJe5t" role="28nt2d">
+                                <node concept="2OqwBi" id="7F7y$3JJe5u" role="36biLW">
+                                  <node concept="3TrEf2" id="7F7y$3JJe5v" role="2OqNvi">
+                                    <ref role="3Tt5mk" to="mopj:zgvH9CGzp5" resolve="existsOnlyOnRightAction" />
+                                  </node>
+                                  <node concept="37vLTw" id="7F7y$3JJe5w" role="2Oq$k0">
+                                    <ref role="3cqZAo" node="7F7y$3JJe54" resolve="defaultAction" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="2pJPED" id="7F7y$3JJe5x" role="36be1Z">
+                            <ref role="2pJxaS" to="mopj:1VmHfRxKMgU" resolve="SubPolicyContainer" />
+                            <node concept="2pJxcG" id="7F7y$3JJe5y" role="2pJxcM">
+                              <ref role="2pJxcJ" to="mopj:1VmHfRxKMgV" resolve="subPolicy" />
+                              <node concept="2OqwBi" id="7F7y$3JJe5z" role="28ntcv">
+                                <node concept="1XH99k" id="7F7y$3JJe5$" role="2Oq$k0">
+                                  <ref role="1XH99l" to="mopj:1VmHfRxJEru" resolve="SubPolicy" />
+                                </node>
+                                <node concept="2ViDtV" id="7F7y$3JJe5_" role="2OqNvi">
+                                  <ref role="2ViDtZ" to="mopj:1VmHfRxJErw" resolve="ExistsOnLeft" />
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="2pIpSj" id="7F7y$3JJe5A" role="2pJxcM">
+                              <ref role="2pIpSl" to="mopj:1VmHfRxLaon" resolve="action" />
+                              <node concept="36biLy" id="7F7y$3JJe5B" role="28nt2d">
+                                <node concept="2OqwBi" id="7F7y$3JJe5C" role="36biLW">
+                                  <node concept="3TrEf2" id="7F7y$3JJe5D" role="2OqNvi">
+                                    <ref role="3Tt5mk" to="mopj:zgvH9CZ$22" resolve="existsOnlyOnLeftAction" />
+                                  </node>
+                                  <node concept="37vLTw" id="7F7y$3JJe5E" role="2Oq$k0">
+                                    <ref role="3cqZAo" node="7F7y$3JJe54" resolve="defaultAction" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="2pJPED" id="7F7y$3JJe5F" role="36be1Z">
+                            <ref role="2pJxaS" to="mopj:1VmHfRxKMgU" resolve="SubPolicyContainer" />
+                            <node concept="2pJxcG" id="7F7y$3JJe5G" role="2pJxcM">
+                              <ref role="2pJxcJ" to="mopj:1VmHfRxKMgV" resolve="subPolicy" />
+                              <node concept="2OqwBi" id="7F7y$3JJe5H" role="28ntcv">
+                                <node concept="1XH99k" id="7F7y$3JJe5I" role="2Oq$k0">
+                                  <ref role="1XH99l" to="mopj:1VmHfRxJEru" resolve="SubPolicy" />
+                                </node>
+                                <node concept="2ViDtV" id="7F7y$3JJe5J" role="2OqNvi">
+                                  <ref role="2ViDtZ" to="mopj:1VmHfRxJErz" resolve="ElementOnBoth" />
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="2pIpSj" id="7F7y$3JJe5K" role="2pJxcM">
+                              <ref role="2pIpSl" to="mopj:1VmHfRxLaon" resolve="action" />
+                              <node concept="36biLy" id="7F7y$3JJe5L" role="28nt2d">
+                                <node concept="2OqwBi" id="7F7y$3JJe5M" role="36biLW">
+                                  <node concept="3TrEf2" id="7F7y$3JJe5N" role="2OqNvi">
+                                    <ref role="3Tt5mk" to="mopj:zgvH9CZ$2a" resolve="elementOnBothAction" />
+                                  </node>
+                                  <node concept="37vLTw" id="7F7y$3JJe5O" role="2Oq$k0">
+                                    <ref role="3cqZAo" node="7F7y$3JJe54" resolve="defaultAction" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="7F7y$3JJe5P" role="2GsD0m">
+            <node concept="37vLTw" id="7F7y$3JJe5Q" role="2Oq$k0">
+              <ref role="3cqZAo" node="7F7y$3JJe52" resolve="defaultPolicy" />
+            </node>
+            <node concept="2qgKlT" id="7F7y$3JJe5R" role="2OqNvi">
+              <ref role="37wK5l" to="rnx3:5zr7Q_1XHDE" resolve="allHierarchyMultiChildren" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="7F7y$3JJe5S" role="jymVt" />
+    <node concept="2YIFZL" id="7F7y$3JJe5T" role="jymVt">
+      <property role="TrG5h" value="buildOptionalRef" />
+      <node concept="3Tm6S6" id="7F7y$3JJe5U" role="1B3o_S" />
+      <node concept="3cqZAl" id="7F7y$3JJe5V" role="3clF45" />
+      <node concept="37vLTG" id="7F7y$3JJe5W" role="3clF46">
+        <property role="TrG5h" value="defaultPolicy" />
+        <node concept="3Tqbb2" id="7F7y$3JJe5X" role="1tU5fm">
+          <ref role="ehGHo" to="mopj:1EbzjT2R$JP" resolve="UserMergePolicy" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="7F7y$3JJe5Y" role="3clF46">
+        <property role="TrG5h" value="defaultAction" />
+        <node concept="3Tqbb2" id="7F7y$3JJe5Z" role="1tU5fm">
+          <ref role="ehGHo" to="mopj:3P8JlgmMYnQ" resolve="MergerDefaultAction" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="7F7y$3JJe60" role="3clF47">
+        <node concept="2Gpval" id="7F7y$3JJe61" role="3cqZAp">
+          <node concept="2GrKxI" id="7F7y$3JJe62" role="2Gsz3X">
+            <property role="TrG5h" value="child" />
+          </node>
+          <node concept="3clFbS" id="7F7y$3JJe63" role="2LFqv$">
+            <node concept="3clFbF" id="7F7y$3JJe64" role="3cqZAp">
+              <node concept="2OqwBi" id="7F7y$3JJe65" role="3clFbG">
+                <node concept="2OqwBi" id="7F7y$3JJe66" role="2Oq$k0">
+                  <node concept="37vLTw" id="7F7y$3JJe67" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7F7y$3JJe5W" resolve="defaultPolicy" />
+                  </node>
+                  <node concept="3Tsc0h" id="7F7y$3JJe68" role="2OqNvi">
+                    <ref role="3TtcxE" to="mopj:3PLTv5jwPvF" resolve="referencePolicies" />
+                  </node>
+                </node>
+                <node concept="TSZUe" id="7F7y$3JJe69" role="2OqNvi">
+                  <node concept="2pJPEk" id="7F7y$3JJe6a" role="25WWJ7">
+                    <node concept="2pJPED" id="7F7y$3JJe6b" role="2pJPEn">
+                      <ref role="2pJxaS" to="mopj:3PLTv5k2w4U" resolve="OptionalRefPolicy" />
+                      <node concept="2pIpSj" id="7F7y$3JJe6c" role="2pJxcM">
+                        <ref role="2pIpSl" to="mopj:1VmHfRxVF4J" resolve="child" />
+                        <node concept="36biLy" id="7F7y$3JJe6d" role="28nt2d">
+                          <node concept="2GrUjf" id="7F7y$3JJe6e" role="36biLW">
+                            <ref role="2Gs0qQ" node="7F7y$3JJe62" resolve="child" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="2pIpSj" id="7F7y$3JJe6f" role="2pJxcM">
+                        <ref role="2pIpSl" to="mopj:7jyS5urbFnA" resolve="action" />
+                        <node concept="36biLy" id="7F7y$3JJe6g" role="28nt2d">
+                          <node concept="2OqwBi" id="7F7y$3JJe6h" role="36biLW">
+                            <node concept="3TrEf2" id="7F7y$3JJe6i" role="2OqNvi">
+                              <ref role="3Tt5mk" to="mopj:zgvH9CH6fk" resolve="optionalRefAction" />
+                            </node>
+                            <node concept="37vLTw" id="7F7y$3JJe6j" role="2Oq$k0">
+                              <ref role="3cqZAo" node="7F7y$3JJe5Y" resolve="defaultAction" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="7F7y$3JJe6k" role="2GsD0m">
+            <node concept="37vLTw" id="7F7y$3JJe6l" role="2Oq$k0">
+              <ref role="3cqZAo" node="7F7y$3JJe5W" resolve="defaultPolicy" />
+            </node>
+            <node concept="2qgKlT" id="7F7y$3JJe6m" role="2OqNvi">
+              <ref role="37wK5l" to="rnx3:1Av7ChmzZ2C" resolve="allHierarchyOptionalRef" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="7F7y$3JJe6n" role="jymVt" />
+    <node concept="2YIFZL" id="7F7y$3JJe6o" role="jymVt">
+      <property role="TrG5h" value="singletonRef" />
+      <node concept="3Tm6S6" id="7F7y$3JJe6p" role="1B3o_S" />
+      <node concept="3cqZAl" id="7F7y$3JJe6q" role="3clF45" />
+      <node concept="37vLTG" id="7F7y$3JJe6r" role="3clF46">
+        <property role="TrG5h" value="defaultPolicy" />
+        <node concept="3Tqbb2" id="7F7y$3JJe6s" role="1tU5fm">
+          <ref role="ehGHo" to="mopj:1EbzjT2R$JP" resolve="UserMergePolicy" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="7F7y$3JJe6t" role="3clF46">
+        <property role="TrG5h" value="defaultAction" />
+        <node concept="3Tqbb2" id="7F7y$3JJe6u" role="1tU5fm">
+          <ref role="ehGHo" to="mopj:3P8JlgmMYnQ" resolve="MergerDefaultAction" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="7F7y$3JJe6v" role="3clF47">
+        <node concept="2Gpval" id="7F7y$3JJe6w" role="3cqZAp">
+          <node concept="2GrKxI" id="7F7y$3JJe6x" role="2Gsz3X">
+            <property role="TrG5h" value="child" />
+          </node>
+          <node concept="3clFbS" id="7F7y$3JJe6y" role="2LFqv$">
+            <node concept="3clFbF" id="7F7y$3JJe6z" role="3cqZAp">
+              <node concept="2OqwBi" id="7F7y$3JJe6$" role="3clFbG">
+                <node concept="2OqwBi" id="7F7y$3JJe6_" role="2Oq$k0">
+                  <node concept="37vLTw" id="7F7y$3JJe6A" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7F7y$3JJe6r" resolve="defaultPolicy" />
+                  </node>
+                  <node concept="3Tsc0h" id="7F7y$3JJe6B" role="2OqNvi">
+                    <ref role="3TtcxE" to="mopj:3PLTv5jwPvF" resolve="referencePolicies" />
+                  </node>
+                </node>
+                <node concept="TSZUe" id="7F7y$3JJe6C" role="2OqNvi">
+                  <node concept="2pJPEk" id="7F7y$3JJe6D" role="25WWJ7">
+                    <node concept="2pJPED" id="7F7y$3JJe6E" role="2pJPEn">
+                      <ref role="2pJxaS" to="mopj:3PLTv5k2w4R" resolve="SingeltonRefPolicy" />
+                      <node concept="2pIpSj" id="7F7y$3JJe6F" role="2pJxcM">
+                        <ref role="2pIpSl" to="mopj:1VmHfRxVF4J" resolve="child" />
+                        <node concept="36biLy" id="7F7y$3JJe6G" role="28nt2d">
+                          <node concept="2GrUjf" id="7F7y$3JJe6H" role="36biLW">
+                            <ref role="2Gs0qQ" node="7F7y$3JJe6x" resolve="child" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="2pIpSj" id="7F7y$3JJe6I" role="2pJxcM">
+                        <ref role="2pIpSl" to="mopj:7jyS5urbTpc" resolve="action" />
+                        <node concept="36biLy" id="7F7y$3JJe6J" role="28nt2d">
+                          <node concept="2OqwBi" id="7F7y$3JJe6K" role="36biLW">
+                            <node concept="3TrEf2" id="7F7y$3JJe6L" role="2OqNvi">
+                              <ref role="3Tt5mk" to="mopj:zgvH9CGX3U" resolve="singleRefAction" />
+                            </node>
+                            <node concept="37vLTw" id="7F7y$3JJe6M" role="2Oq$k0">
+                              <ref role="3cqZAo" node="7F7y$3JJe6t" resolve="defaultAction" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="7F7y$3JJe6N" role="2GsD0m">
+            <node concept="37vLTw" id="7F7y$3JJe6O" role="2Oq$k0">
+              <ref role="3cqZAo" node="7F7y$3JJe6r" resolve="defaultPolicy" />
+            </node>
+            <node concept="2qgKlT" id="7F7y$3JJe6P" role="2OqNvi">
+              <ref role="37wK5l" to="rnx3:1Av7ChmzZ2C" resolve="allHierarchyOptionalRef" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="7F7y$3JJe6Q" role="jymVt" />
+    <node concept="3Tm1VV" id="7F7y$3JJe6R" role="1B3o_S" />
+  </node>
+  <node concept="312cEu" id="7F7y$3Lx5sA">
+    <property role="TrG5h" value="DefaultIdentity" />
+    <node concept="3Tm1VV" id="7F7y$3Lx5sB" role="1B3o_S" />
+    <node concept="3uibUv" id="7F7y$3Lx5Gw" role="EKbjA">
+      <ref role="3uigEE" node="1yAYHyQ2xCj" resolve="Identity" />
+    </node>
+    <node concept="3clFb_" id="7F7y$3Lx5H3" role="jymVt">
+      <property role="TrG5h" value="get" />
+      <node concept="37vLTG" id="7F7y$3Lx5H4" role="3clF46">
+        <property role="TrG5h" value="node" />
+        <node concept="3Tqbb2" id="7F7y$3Lx5H5" role="1tU5fm" />
+      </node>
+      <node concept="3Tm1VV" id="7F7y$3Lx5H7" role="1B3o_S" />
+      <node concept="17QB3L" id="7F7y$3Lx5H8" role="3clF45" />
+      <node concept="3clFbS" id="7F7y$3Lx5H9" role="3clF47">
+        <node concept="Jncv_" id="49zGylVh1kd" role="3cqZAp">
+          <ref role="JncvD" to="tpck:h0TrEE$" resolve="INamedConcept" />
+          <node concept="37vLTw" id="49zGylVhfc3" role="JncvB">
+            <ref role="3cqZAo" node="7F7y$3Lx5H4" resolve="node" />
+          </node>
+          <node concept="3clFbS" id="49zGylVh1kh" role="Jncv$">
+            <node concept="3cpWs6" id="49zGylUhfsS" role="3cqZAp">
+              <node concept="2OqwBi" id="49zGylUhk88" role="3cqZAk">
+                <node concept="Jnkvi" id="49zGylVhlU4" role="2Oq$k0">
+                  <ref role="1M0zk5" node="49zGylVh1kj" resolve="concept" />
+                </node>
+                <node concept="3TrcHB" id="49zGylUhnde" role="2OqNvi">
+                  <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="JncvC" id="49zGylVh1kj" role="JncvA">
+            <property role="TrG5h" value="concept" />
+            <node concept="2jxLKc" id="49zGylVh1kk" role="1tU5fm" />
+          </node>
+        </node>
+        <node concept="3cpWs8" id="5SCs5wc1HSW" role="3cqZAp">
+          <node concept="3cpWsn" id="5SCs5wc1HSX" role="3cpWs9">
+            <property role="TrG5h" value="s" />
+            <node concept="3uibUv" id="5SCs5wc1HSY" role="1tU5fm">
+              <ref role="3uigEE" to="39al:5u_UbmjlGE" resolve="NodeSerializer" />
+            </node>
+            <node concept="2ShNRf" id="5SCs5wc1HSZ" role="33vP2m">
+              <node concept="1pGfFk" id="5SCs5wc1HT0" role="2ShVmc">
+                <ref role="37wK5l" to="39al:3BhIkN6zu7u" resolve="NodeSerializer" />
+                <node concept="37vLTw" id="5SCs5wc1HT1" role="37wK5m">
+                  <ref role="3cqZAo" node="7F7y$3Lx5H4" resolve="node" />
+                </node>
+                <node concept="3clFbT" id="5SCs5wc1HT2" role="37wK5m">
+                  <property role="3clFbU" value="true" />
+                </node>
+                <node concept="Xl_RD" id="5SCs5wc1HT3" role="37wK5m">
+                  <property role="Xl_RC" value="__" />
+                </node>
+                <node concept="3clFbT" id="5SCs5wc1HT4" role="37wK5m">
+                  <property role="3clFbU" value="true" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="5SCs5wc2NNK" role="3cqZAp">
+          <node concept="2OqwBi" id="5SCs5wc2NNL" role="3clFbG">
+            <node concept="37vLTw" id="5SCs5wc2NNM" role="2Oq$k0">
+              <ref role="3cqZAo" node="5SCs5wc1HSX" resolve="s" />
+            </node>
+            <node concept="liA8E" id="5SCs5wc2NNN" role="2OqNvi">
+              <ref role="37wK5l" to="39al:1SOiLeBKwet" resolve="addIgnoredPropertyName" />
+              <node concept="Xl_RD" id="5SCs5wc2NNO" role="37wK5m">
+                <property role="Xl_RC" value="__hash" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7F7y$3M7_fG" role="3cqZAp">
+          <node concept="2OqwBi" id="7F7y$3M7_fH" role="3clFbG">
+            <node concept="37vLTw" id="7F7y$3M7_fI" role="2Oq$k0">
+              <ref role="3cqZAo" node="5SCs5wc1HSX" resolve="s" />
+            </node>
+            <node concept="liA8E" id="7F7y$3M7_fJ" role="2OqNvi">
+              <ref role="37wK5l" to="39al:1SOiLeBKwet" resolve="addIgnoredPropertyName" />
+              <node concept="Xl_RD" id="7F7y$3M7_fK" role="37wK5m">
+                <property role="Xl_RC" value="__nodeID" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7F7y$3Mczqb" role="3cqZAp">
+          <node concept="2OqwBi" id="7F7y$3Mczqc" role="3clFbG">
+            <node concept="37vLTw" id="7F7y$3Mczqd" role="2Oq$k0">
+              <ref role="3cqZAo" node="5SCs5wc1HSX" resolve="s" />
+            </node>
+            <node concept="liA8E" id="7F7y$3Mczqe" role="2OqNvi">
+              <ref role="37wK5l" to="39al:1SOiLeBKwet" resolve="addIgnoredPropertyName" />
+              <node concept="Xl_RD" id="7F7y$3Mczqf" role="37wK5m">
+                <property role="Xl_RC" value="__conceptFQN" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7F7y$3Mc_LG" role="3cqZAp">
+          <node concept="2OqwBi" id="7F7y$3Mc_LH" role="3clFbG">
+            <node concept="37vLTw" id="7F7y$3Mc_LI" role="2Oq$k0">
+              <ref role="3cqZAo" node="5SCs5wc1HSX" resolve="s" />
+            </node>
+            <node concept="liA8E" id="7F7y$3Mc_LJ" role="2OqNvi">
+              <ref role="37wK5l" to="39al:1SOiLeBKwet" resolve="addIgnoredPropertyName" />
+              <node concept="Xl_RD" id="7F7y$3Mc_LK" role="37wK5m">
+                <property role="Xl_RC" value="__conceptID" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7F7y$3LXfyz" role="3cqZAp">
+          <node concept="2OqwBi" id="7F7y$3LXfyw" role="3clFbG">
+            <node concept="10M0yZ" id="7F7y$3LXfyx" role="2Oq$k0">
+              <ref role="1PxDUh" to="wyt6:~System" resolve="System" />
+              <ref role="3cqZAo" to="wyt6:~System.out" resolve="out" />
+            </node>
+            <node concept="liA8E" id="7F7y$3LXfyy" role="2OqNvi">
+              <ref role="37wK5l" to="guwi:~PrintStream.println(java.lang.String)" resolve="println" />
+              <node concept="3cpWs3" id="7F7y$3LXmD9" role="37wK5m">
+                <node concept="2OqwBi" id="7F7y$3LXnCU" role="3uHU7w">
+                  <node concept="37vLTw" id="7F7y$3LXmOs" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7F7y$3Lx5H4" resolve="node" />
+                  </node>
+                  <node concept="2Iv5rx" id="7F7y$3LXoAI" role="2OqNvi" />
+                </node>
+                <node concept="Xl_RD" id="7F7y$3LXjc4" role="3uHU7B">
+                  <property role="Xl_RC" value="-- identity for: " />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7F7y$3M2wIW" role="3cqZAp">
+          <node concept="2OqwBi" id="7F7y$3M2wIX" role="3clFbG">
+            <node concept="10M0yZ" id="7F7y$3M2wIY" role="2Oq$k0">
+              <ref role="1PxDUh" to="wyt6:~System" resolve="System" />
+              <ref role="3cqZAo" to="wyt6:~System.out" resolve="out" />
+            </node>
+            <node concept="liA8E" id="7F7y$3M2wIZ" role="2OqNvi">
+              <ref role="37wK5l" to="guwi:~PrintStream.println(java.lang.String)" resolve="println" />
+              <node concept="3cpWs3" id="7F7y$3M2wJ0" role="37wK5m">
+                <node concept="Xl_RD" id="7F7y$3M2wJ1" role="3uHU7w">
+                  <property role="Xl_RC" value="" />
+                </node>
+                <node concept="2OqwBi" id="7F7y$3M2wJ2" role="3uHU7B">
+                  <node concept="2OqwBi" id="7F7y$3M2wJ3" role="2Oq$k0">
+                    <node concept="37vLTw" id="7F7y$3M2wJ4" role="2Oq$k0">
+                      <ref role="3cqZAo" node="5SCs5wc1HSX" resolve="s" />
+                    </node>
+                    <node concept="liA8E" id="7F7y$3M2wJ5" role="2OqNvi">
+                      <ref role="37wK5l" to="39al:5QEXbzGzMjX" resolve="getXMLAsString" />
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="7F7y$3M2wJ6" role="2OqNvi">
+                    <ref role="37wK5l" to="wyt6:~String.hashCode()" resolve="hashCode" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7F7y$3LXphQ" role="3cqZAp">
+          <node concept="2OqwBi" id="7F7y$3LXphN" role="3clFbG">
+            <node concept="10M0yZ" id="7F7y$3LXphO" role="2Oq$k0">
+              <ref role="1PxDUh" to="wyt6:~System" resolve="System" />
+              <ref role="3cqZAo" to="wyt6:~System.out" resolve="out" />
+            </node>
+            <node concept="liA8E" id="7F7y$3LXphP" role="2OqNvi">
+              <ref role="37wK5l" to="guwi:~PrintStream.println(java.lang.String)" resolve="println" />
+              <node concept="2OqwBi" id="5SCs5wc1HT7" role="37wK5m">
+                <node concept="37vLTw" id="5SCs5wc1HT8" role="2Oq$k0">
+                  <ref role="3cqZAo" node="5SCs5wc1HSX" resolve="s" />
+                </node>
+                <node concept="liA8E" id="5SCs5wc1HT9" role="2OqNvi">
+                  <ref role="37wK5l" to="39al:5QEXbzGzMjX" resolve="getXMLAsString" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7F7y$3LXu2E" role="3cqZAp">
+          <node concept="2OqwBi" id="7F7y$3LXu2B" role="3clFbG">
+            <node concept="10M0yZ" id="7F7y$3LXu2C" role="2Oq$k0">
+              <ref role="1PxDUh" to="wyt6:~System" resolve="System" />
+              <ref role="3cqZAo" to="wyt6:~System.out" resolve="out" />
+            </node>
+            <node concept="liA8E" id="7F7y$3LXu2D" role="2OqNvi">
+              <ref role="37wK5l" to="guwi:~PrintStream.println(java.lang.String)" resolve="println" />
+              <node concept="Xl_RD" id="7F7y$3LXvcs" role="37wK5m">
+                <property role="Xl_RC" value="---" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="7F7y$3LXg7g" role="3cqZAp">
+          <node concept="3cpWs3" id="7F7y$3LXgfC" role="3cqZAk">
+            <node concept="Xl_RD" id="7F7y$3LXgfD" role="3uHU7w">
+              <property role="Xl_RC" value="" />
+            </node>
+            <node concept="2OqwBi" id="7F7y$3LXgfE" role="3uHU7B">
+              <node concept="2OqwBi" id="7F7y$3LXgfF" role="2Oq$k0">
+                <node concept="37vLTw" id="7F7y$3LXgfG" role="2Oq$k0">
+                  <ref role="3cqZAo" node="5SCs5wc1HSX" resolve="s" />
+                </node>
+                <node concept="liA8E" id="7F7y$3LXgfH" role="2OqNvi">
+                  <ref role="37wK5l" to="39al:5QEXbzGzMjX" resolve="getXMLAsString" />
+                </node>
+              </node>
+              <node concept="liA8E" id="7F7y$3LXgfI" role="2OqNvi">
+                <ref role="37wK5l" to="wyt6:~String.hashCode()" resolve="hashCode" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7F7y$3Lx5Ha" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" />
+      </node>
+    </node>
+  </node>
+  <node concept="312cEu" id="49zGylSrV3J">
+    <property role="TrG5h" value="DefaultContentHolderFactory" />
+    <node concept="3clFb_" id="49zGylU4uGD" role="jymVt">
+      <property role="TrG5h" value="propertyMerger" />
+      <node concept="3clFbS" id="49zGylU4uGI" role="3clF47">
+        <node concept="Jncv_" id="49zGylU4uGJ" role="3cqZAp">
+          <ref role="JncvD" to="mopj:6zqIeMU2OVm" resolve="Right" />
+          <node concept="3clFbS" id="49zGylU4uGK" role="Jncv$">
+            <node concept="3cpWs6" id="49zGylU4uGL" role="3cqZAp">
+              <node concept="2ShNRf" id="49zGylU4uGM" role="3cqZAk">
+                <node concept="1pGfFk" id="49zGylU4uGN" role="2ShVmc">
+                  <ref role="37wK5l" node="5lvG0vIU7JA" resolve="BuiltInRight" />
+                  <node concept="2YIFZM" id="49zGylU4uGO" role="37wK5m">
+                    <ref role="37wK5l" to="pjrh:~MetaAdapterByDeclaration.getProperty(org.jetbrains.mps.openapi.model.SNode)" resolve="getProperty" />
+                    <ref role="1Pybhc" to="pjrh:~MetaAdapterByDeclaration" resolve="MetaAdapterByDeclaration" />
+                    <node concept="2OqwBi" id="49zGylU4uGP" role="37wK5m">
+                      <node concept="37vLTw" id="49zGylU4uGQ" role="2Oq$k0">
+                        <ref role="3cqZAo" node="49zGylU4uGG" resolve="propertyPolicy" />
+                      </node>
+                      <node concept="3TrEf2" id="49zGylU4uGR" role="2OqNvi">
+                        <ref role="3Tt5mk" to="mopj:6zqIeMU2u$T" resolve="property" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="JncvC" id="49zGylU4uGS" role="JncvA">
+            <property role="TrG5h" value="action" />
+            <node concept="2jxLKc" id="49zGylU4uGT" role="1tU5fm" />
+          </node>
+          <node concept="2OqwBi" id="49zGylU4uGU" role="JncvB">
+            <node concept="37vLTw" id="49zGylU4uGV" role="2Oq$k0">
+              <ref role="3cqZAo" node="49zGylU4uGG" resolve="propertyPolicy" />
+            </node>
+            <node concept="3TrEf2" id="49zGylU4uGW" role="2OqNvi">
+              <ref role="3Tt5mk" to="mopj:1EbzjT2T4Jd" resolve="action" />
+            </node>
+          </node>
+        </node>
+        <node concept="Jncv_" id="49zGylU4uGX" role="3cqZAp">
+          <ref role="JncvD" to="mopj:1EbzjT2T4Ja" resolve="Left" />
+          <node concept="3clFbS" id="49zGylU4uGY" role="Jncv$">
+            <node concept="3cpWs6" id="49zGylU4uGZ" role="3cqZAp">
+              <node concept="2ShNRf" id="49zGylU4uH0" role="3cqZAk">
+                <node concept="1pGfFk" id="49zGylU4uH1" role="2ShVmc">
+                  <ref role="37wK5l" node="5lvG0vIU78w" resolve="BuiltInLeft" />
+                  <node concept="2YIFZM" id="49zGylU4uH2" role="37wK5m">
+                    <ref role="37wK5l" to="pjrh:~MetaAdapterByDeclaration.getProperty(org.jetbrains.mps.openapi.model.SNode)" resolve="getProperty" />
+                    <ref role="1Pybhc" to="pjrh:~MetaAdapterByDeclaration" resolve="MetaAdapterByDeclaration" />
+                    <node concept="2OqwBi" id="49zGylU4uH3" role="37wK5m">
+                      <node concept="37vLTw" id="49zGylU4uH4" role="2Oq$k0">
+                        <ref role="3cqZAo" node="49zGylU4uGG" resolve="propertyPolicy" />
+                      </node>
+                      <node concept="3TrEf2" id="49zGylU4uH5" role="2OqNvi">
+                        <ref role="3Tt5mk" to="mopj:6zqIeMU2u$T" resolve="property" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="JncvC" id="49zGylU4uH6" role="JncvA">
+            <property role="TrG5h" value="action" />
+            <node concept="2jxLKc" id="49zGylU4uH7" role="1tU5fm" />
+          </node>
+          <node concept="2OqwBi" id="49zGylU4uH8" role="JncvB">
+            <node concept="37vLTw" id="49zGylU4uH9" role="2Oq$k0">
+              <ref role="3cqZAo" node="49zGylU4uGG" resolve="propertyPolicy" />
+            </node>
+            <node concept="3TrEf2" id="49zGylU4uHa" role="2OqNvi">
+              <ref role="3Tt5mk" to="mopj:1EbzjT2T4Jd" resolve="action" />
+            </node>
+          </node>
+        </node>
+        <node concept="Jncv_" id="49zGylU4uHb" role="3cqZAp">
+          <ref role="JncvD" to="mopj:1NgLzfPblhV" resolve="ManualAction" />
+          <node concept="3clFbS" id="49zGylU4uHc" role="Jncv$">
+            <node concept="YS8fn" id="49zGylU4uHd" role="3cqZAp">
+              <node concept="2ShNRf" id="49zGylU4uHe" role="YScLw">
+                <node concept="1pGfFk" id="49zGylU4uHf" role="2ShVmc">
+                  <property role="373rjd" value="true" />
+                  <ref role="37wK5l" to="wyt6:~UnsupportedOperationException.&lt;init&gt;(java.lang.String)" resolve="UnsupportedOperationException" />
+                  <node concept="Xl_RD" id="49zGylU4uHg" role="37wK5m">
+                    <property role="Xl_RC" value="Default action does not support 'ManualAction'" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="JncvC" id="49zGylU4uHh" role="JncvA">
+            <property role="TrG5h" value="action" />
+            <node concept="2jxLKc" id="49zGylU4uHi" role="1tU5fm" />
+          </node>
+          <node concept="2OqwBi" id="49zGylU4uHj" role="JncvB">
+            <node concept="37vLTw" id="49zGylU4uHk" role="2Oq$k0">
+              <ref role="3cqZAo" node="49zGylU4uGG" resolve="propertyPolicy" />
+            </node>
+            <node concept="3TrEf2" id="49zGylU4uHl" role="2OqNvi">
+              <ref role="3Tt5mk" to="mopj:1EbzjT2T4Jd" resolve="action" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="49zGylU4uHm" role="3cqZAp">
+          <node concept="10Nm6u" id="49zGylU4uHn" role="3cqZAk" />
+        </node>
+      </node>
+      <node concept="3uibUv" id="49zGylU4uGF" role="3clF45">
+        <ref role="3uigEE" node="5lvG0vITZsP" resolve="PropertyMerger" />
+      </node>
+      <node concept="37vLTG" id="49zGylU4uGG" role="3clF46">
+        <property role="TrG5h" value="propertyPolicy" />
+        <node concept="3Tqbb2" id="49zGylU4uGH" role="1tU5fm">
+          <ref role="ehGHo" to="mopj:1EbzjT2T4oC" resolve="PropertyPolicy" />
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="49zGylU4uHo" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="49zGylU3t4V" role="jymVt" />
+    <node concept="3clFb_" id="49zGylU9Eyt" role="jymVt">
+      <property role="TrG5h" value="childMerger" />
+      <node concept="3clFbS" id="49zGylU9Eyw" role="3clF47">
+        <node concept="Jncv_" id="49zGylU9N2t" role="3cqZAp">
+          <ref role="JncvD" to="mopj:3PLTv5k2w4J" resolve="SingletonChildPolicy" />
+          <node concept="37vLTw" id="49zGylU9Qh5" role="JncvB">
+            <ref role="3cqZAo" node="49zGylU9FWu" resolve="policy" />
+          </node>
+          <node concept="3clFbS" id="49zGylU9N2v" role="Jncv$">
+            <node concept="3cpWs6" id="49zGylU9ZsX" role="3cqZAp">
+              <node concept="1rXfSq" id="49zGylUa0E1" role="3cqZAk">
+                <ref role="37wK5l" node="49zGylU4vXo" resolve="singeltonChildMerger" />
+                <node concept="Jnkvi" id="49zGylUa25D" role="37wK5m">
+                  <ref role="1M0zk5" node="49zGylU9N2w" resolve="policy" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="JncvC" id="49zGylU9N2w" role="JncvA">
+            <property role="TrG5h" value="policy" />
+            <node concept="2jxLKc" id="49zGylU9N2x" role="1tU5fm" />
+          </node>
+        </node>
+        <node concept="Jncv_" id="49zGylUa50y" role="3cqZAp">
+          <ref role="JncvD" to="mopj:3PLTv5k2w4M" resolve="OptionalChildPolicy" />
+          <node concept="37vLTw" id="49zGylUa5UO" role="JncvB">
+            <ref role="3cqZAo" node="49zGylU9FWu" resolve="childPolicy" />
+          </node>
+          <node concept="3clFbS" id="49zGylUa50A" role="Jncv$">
+            <node concept="3cpWs6" id="49zGylUabwg" role="3cqZAp">
+              <node concept="1rXfSq" id="49zGylUapHE" role="3cqZAk">
+                <ref role="37wK5l" node="49zGylU8pD7" resolve="optionChildMerger" />
+                <node concept="Jnkvi" id="49zGylUarGS" role="37wK5m">
+                  <ref role="1M0zk5" node="49zGylUa50C" resolve="policy" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="JncvC" id="49zGylUa50C" role="JncvA">
+            <property role="TrG5h" value="policy" />
+            <node concept="2jxLKc" id="49zGylUa50D" role="1tU5fm" />
+          </node>
+        </node>
+        <node concept="Jncv_" id="49zGylUau_p" role="3cqZAp">
+          <ref role="JncvD" to="mopj:7jyS5urbTpv" resolve="MultiChildPolicy" />
+          <node concept="37vLTw" id="49zGylUavwb" role="JncvB">
+            <ref role="3cqZAo" node="49zGylU9FWu" resolve="childPolicy" />
+          </node>
+          <node concept="3clFbS" id="49zGylUau_t" role="Jncv$">
+            <node concept="3cpWs6" id="49zGylUaVrD" role="3cqZAp">
+              <node concept="10Nm6u" id="49zGylUaX9X" role="3cqZAk" />
+            </node>
+          </node>
+          <node concept="JncvC" id="49zGylUau_v" role="JncvA">
+            <property role="TrG5h" value="policy" />
+            <node concept="2jxLKc" id="49zGylUau_w" role="1tU5fm" />
+          </node>
+        </node>
+        <node concept="3clFbF" id="49zGylUefch" role="3cqZAp">
+          <node concept="10Nm6u" id="49zGylUefcf" role="3clFbG" />
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="49zGylU9Bvz" role="1B3o_S" />
+      <node concept="3uibUv" id="49zGylU9Cm1" role="3clF45">
+        <ref role="3uigEE" node="5lvG0vIUaC$" resolve="ConceptChildMerger" />
+      </node>
+      <node concept="37vLTG" id="49zGylU9FWu" role="3clF46">
+        <property role="TrG5h" value="childPolicy" />
+        <node concept="3Tqbb2" id="49zGylU9FWt" role="1tU5fm">
+          <ref role="ehGHo" to="mopj:3PLTv5jRo6X" resolve="ChildPolicy" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="49zGylUaS$c" role="jymVt" />
+    <node concept="3clFb_" id="49zGylU4vXo" role="jymVt">
+      <property role="TrG5h" value="singeltonChildMerger" />
+      <node concept="3clFbS" id="49zGylU4vXt" role="3clF47">
+        <node concept="Jncv_" id="49zGylU4vXv" role="3cqZAp">
+          <ref role="JncvD" to="mopj:7jyS5urbByR" resolve="Auto" />
+          <node concept="3clFbS" id="49zGylU4vXw" role="Jncv$">
+            <node concept="3cpWs6" id="49zGylU4vXx" role="3cqZAp">
+              <node concept="2ShNRf" id="49zGylU4vXy" role="3cqZAk">
+                <node concept="1pGfFk" id="49zGylU4vXz" role="2ShVmc">
+                  <ref role="37wK5l" node="3pc485W4OlZ" resolve="AutoChildMerger" />
+                  <node concept="2YIFZM" id="49zGylU4vX$" role="37wK5m">
+                    <ref role="37wK5l" to="pjrh:~MetaAdapterByDeclaration.getContainmentLink(org.jetbrains.mps.openapi.model.SNode)" resolve="getContainmentLink" />
+                    <ref role="1Pybhc" to="pjrh:~MetaAdapterByDeclaration" resolve="MetaAdapterByDeclaration" />
+                    <node concept="2OqwBi" id="49zGylU4vX_" role="37wK5m">
+                      <node concept="37vLTw" id="49zGylU4vXA" role="2Oq$k0">
+                        <ref role="3cqZAo" node="49zGylU4vXr" resolve="childPolicy" />
+                      </node>
+                      <node concept="3TrEf2" id="49zGylU4vXB" role="2OqNvi">
+                        <ref role="3Tt5mk" to="mopj:1VmHfRxVF4J" resolve="child" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="JncvC" id="49zGylU4vXC" role="JncvA">
+            <property role="TrG5h" value="action" />
+            <node concept="2jxLKc" id="49zGylU4vXD" role="1tU5fm" />
+          </node>
+          <node concept="2OqwBi" id="49zGylU4vXE" role="JncvB">
+            <node concept="37vLTw" id="49zGylU4vXF" role="2Oq$k0">
+              <ref role="3cqZAo" node="49zGylU4vXr" resolve="childPolicy" />
+            </node>
+            <node concept="3TrEf2" id="49zGylU4vXG" role="2OqNvi">
+              <ref role="3Tt5mk" to="mopj:7jyS5urbTpc" resolve="action" />
+            </node>
+          </node>
+        </node>
+        <node concept="Jncv_" id="49zGylU4vXV" role="3cqZAp">
+          <ref role="JncvD" to="mopj:1EbzjT2T4Ja" resolve="Left" />
+          <node concept="3clFbS" id="49zGylU4vXW" role="Jncv$">
+            <node concept="3cpWs6" id="49zGylU4vXX" role="3cqZAp">
+              <node concept="2ShNRf" id="49zGylU4vXY" role="3cqZAk">
+                <node concept="1pGfFk" id="49zGylU4vXZ" role="2ShVmc">
+                  <ref role="37wK5l" node="5lvG0vIUfk6" resolve="BuiltInChildLeft" />
+                  <node concept="2YIFZM" id="49zGylU4vY0" role="37wK5m">
+                    <ref role="37wK5l" to="pjrh:~MetaAdapterByDeclaration.getContainmentLink(org.jetbrains.mps.openapi.model.SNode)" resolve="getContainmentLink" />
+                    <ref role="1Pybhc" to="pjrh:~MetaAdapterByDeclaration" resolve="MetaAdapterByDeclaration" />
+                    <node concept="2OqwBi" id="49zGylU4vY1" role="37wK5m">
+                      <node concept="37vLTw" id="49zGylU4vY2" role="2Oq$k0">
+                        <ref role="3cqZAo" node="49zGylU4vXr" resolve="childPolicy" />
+                      </node>
+                      <node concept="3TrEf2" id="49zGylU4vY3" role="2OqNvi">
+                        <ref role="3Tt5mk" to="mopj:1VmHfRxVF4J" resolve="child" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="JncvC" id="49zGylU4vY4" role="JncvA">
+            <property role="TrG5h" value="action" />
+            <node concept="2jxLKc" id="49zGylU4vY5" role="1tU5fm" />
+          </node>
+          <node concept="2OqwBi" id="49zGylU4vY6" role="JncvB">
+            <node concept="37vLTw" id="49zGylU4vY7" role="2Oq$k0">
+              <ref role="3cqZAo" node="49zGylU4vXr" resolve="childPolicy" />
+            </node>
+            <node concept="3TrEf2" id="49zGylU4vY8" role="2OqNvi">
+              <ref role="3Tt5mk" to="mopj:7jyS5urbTpc" resolve="action" />
+            </node>
+          </node>
+        </node>
+        <node concept="Jncv_" id="49zGylU4vY9" role="3cqZAp">
+          <ref role="JncvD" to="mopj:6zqIeMU2OVm" resolve="Right" />
+          <node concept="3clFbS" id="49zGylU4vYa" role="Jncv$">
+            <node concept="3cpWs6" id="49zGylU4vYb" role="3cqZAp">
+              <node concept="2ShNRf" id="49zGylU4vYc" role="3cqZAk">
+                <node concept="1pGfFk" id="49zGylU4vYd" role="2ShVmc">
+                  <ref role="37wK5l" node="5lvG0vIUfwi" resolve="BuiltInChildRight" />
+                  <node concept="2YIFZM" id="49zGylU4vYe" role="37wK5m">
+                    <ref role="37wK5l" to="pjrh:~MetaAdapterByDeclaration.getContainmentLink(org.jetbrains.mps.openapi.model.SNode)" resolve="getContainmentLink" />
+                    <ref role="1Pybhc" to="pjrh:~MetaAdapterByDeclaration" resolve="MetaAdapterByDeclaration" />
+                    <node concept="2OqwBi" id="49zGylU4vYf" role="37wK5m">
+                      <node concept="37vLTw" id="49zGylU4vYg" role="2Oq$k0">
+                        <ref role="3cqZAo" node="49zGylU4vXr" resolve="childPolicy" />
+                      </node>
+                      <node concept="3TrEf2" id="49zGylU4vYh" role="2OqNvi">
+                        <ref role="3Tt5mk" to="mopj:1VmHfRxVF4J" resolve="child" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="JncvC" id="49zGylU4vYi" role="JncvA">
+            <property role="TrG5h" value="action" />
+            <node concept="2jxLKc" id="49zGylU4vYj" role="1tU5fm" />
+          </node>
+          <node concept="2OqwBi" id="49zGylU4vYk" role="JncvB">
+            <node concept="37vLTw" id="49zGylU4vYl" role="2Oq$k0">
+              <ref role="3cqZAo" node="49zGylU4vXr" resolve="childPolicy" />
+            </node>
+            <node concept="3TrEf2" id="49zGylU4vYm" role="2OqNvi">
+              <ref role="3Tt5mk" to="mopj:7jyS5urbTpc" resolve="action" />
+            </node>
+          </node>
+        </node>
+        <node concept="Jncv_" id="49zGylU4vYn" role="3cqZAp">
+          <ref role="JncvD" to="mopj:1NgLzfPblhV" resolve="ManualAction" />
+          <node concept="3clFbS" id="49zGylU4vYo" role="Jncv$">
+            <node concept="YS8fn" id="49zGylU4vYp" role="3cqZAp">
+              <node concept="2ShNRf" id="49zGylU4vYq" role="YScLw">
+                <node concept="1pGfFk" id="49zGylU4vYr" role="2ShVmc">
+                  <property role="373rjd" value="true" />
+                  <ref role="37wK5l" to="wyt6:~UnsupportedOperationException.&lt;init&gt;(java.lang.String)" resolve="UnsupportedOperationException" />
+                  <node concept="Xl_RD" id="49zGylU4vYs" role="37wK5m">
+                    <property role="Xl_RC" value="Default action does not support 'ManualAction'" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="JncvC" id="49zGylU4vYt" role="JncvA">
+            <property role="TrG5h" value="action" />
+            <node concept="2jxLKc" id="49zGylU4vYu" role="1tU5fm" />
+          </node>
+          <node concept="2OqwBi" id="49zGylU4vYv" role="JncvB">
+            <node concept="37vLTw" id="49zGylU4vYw" role="2Oq$k0">
+              <ref role="3cqZAo" node="49zGylU4vXr" resolve="childPolicy" />
+            </node>
+            <node concept="3TrEf2" id="49zGylU4vYx" role="2OqNvi">
+              <ref role="3Tt5mk" to="mopj:7jyS5urbTpc" resolve="action" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="49zGylU4vYy" role="3cqZAp">
+          <node concept="10Nm6u" id="49zGylU4vYz" role="3cqZAk" />
+        </node>
+      </node>
+      <node concept="3uibUv" id="49zGylU4vXq" role="3clF45">
+        <ref role="3uigEE" node="5lvG0vIUaC$" resolve="ConceptChildMerger" />
+      </node>
+      <node concept="37vLTG" id="49zGylU4vXr" role="3clF46">
+        <property role="TrG5h" value="childPolicy" />
+        <node concept="3Tqbb2" id="49zGylU4vXs" role="1tU5fm">
+          <ref role="ehGHo" to="mopj:3PLTv5k2w4J" resolve="SingletonChildPolicy" />
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="49zGylU4vY$" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="49zGylU9zr7" role="jymVt" />
+    <node concept="3clFb_" id="49zGylU8pD7" role="jymVt">
+      <property role="TrG5h" value="optionChildMerger" />
+      <node concept="3clFbS" id="49zGylU8pD8" role="3clF47">
+        <node concept="Jncv_" id="49zGylU8pD9" role="3cqZAp">
+          <ref role="JncvD" to="mopj:7jyS5urbByR" resolve="Auto" />
+          <node concept="3clFbS" id="49zGylU8pDa" role="Jncv$">
+            <node concept="3cpWs6" id="49zGylU8pDb" role="3cqZAp">
+              <node concept="2ShNRf" id="49zGylU8pDc" role="3cqZAk">
+                <node concept="1pGfFk" id="49zGylU8pDd" role="2ShVmc">
+                  <ref role="37wK5l" node="3pc485W4OlZ" resolve="AutoChildMerger" />
+                  <node concept="2YIFZM" id="49zGylU8pDe" role="37wK5m">
+                    <ref role="37wK5l" to="pjrh:~MetaAdapterByDeclaration.getContainmentLink(org.jetbrains.mps.openapi.model.SNode)" resolve="getContainmentLink" />
+                    <ref role="1Pybhc" to="pjrh:~MetaAdapterByDeclaration" resolve="MetaAdapterByDeclaration" />
+                    <node concept="2OqwBi" id="49zGylU8pDf" role="37wK5m">
+                      <node concept="37vLTw" id="49zGylU8pDg" role="2Oq$k0">
+                        <ref role="3cqZAo" node="49zGylU8pEf" resolve="childPolicy" />
+                      </node>
+                      <node concept="3TrEf2" id="49zGylU8pDh" role="2OqNvi">
+                        <ref role="3Tt5mk" to="mopj:1VmHfRxVF4J" resolve="child" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="JncvC" id="49zGylU8pDi" role="JncvA">
+            <property role="TrG5h" value="action" />
+            <node concept="2jxLKc" id="49zGylU8pDj" role="1tU5fm" />
+          </node>
+          <node concept="2OqwBi" id="49zGylU8pDk" role="JncvB">
+            <node concept="37vLTw" id="49zGylU8pDl" role="2Oq$k0">
+              <ref role="3cqZAo" node="49zGylU8pEf" resolve="childPolicy" />
+            </node>
+            <node concept="3TrEf2" id="49zGylU8pDm" role="2OqNvi">
+              <ref role="3Tt5mk" to="mopj:7jyS5urbFnA" resolve="action" />
+            </node>
+          </node>
+        </node>
+        <node concept="Jncv_" id="49zGylU8pDn" role="3cqZAp">
+          <ref role="JncvD" to="mopj:7jyS5urbByQ" resolve="Drop" />
+          <node concept="3clFbS" id="49zGylU8pDo" role="Jncv$">
+            <node concept="3cpWs6" id="49zGylU8pDp" role="3cqZAp">
+              <node concept="2ShNRf" id="49zGylU8pDq" role="3cqZAk">
+                <node concept="1pGfFk" id="49zGylU8pDr" role="2ShVmc">
+                  <ref role="37wK5l" node="57NTRpQ5ILn" resolve="BuiltInChildDrop" />
+                  <node concept="2YIFZM" id="49zGylU8pDs" role="37wK5m">
+                    <ref role="37wK5l" to="pjrh:~MetaAdapterByDeclaration.getContainmentLink(org.jetbrains.mps.openapi.model.SNode)" resolve="getContainmentLink" />
+                    <ref role="1Pybhc" to="pjrh:~MetaAdapterByDeclaration" resolve="MetaAdapterByDeclaration" />
+                    <node concept="2OqwBi" id="49zGylU8pDt" role="37wK5m">
+                      <node concept="37vLTw" id="49zGylU8pDu" role="2Oq$k0">
+                        <ref role="3cqZAo" node="49zGylU8pEf" resolve="childPolicy" />
+                      </node>
+                      <node concept="3TrEf2" id="49zGylU8pDv" role="2OqNvi">
+                        <ref role="3Tt5mk" to="mopj:1VmHfRxVF4J" resolve="child" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="JncvC" id="49zGylU8pDw" role="JncvA">
+            <property role="TrG5h" value="action" />
+            <node concept="2jxLKc" id="49zGylU8pDx" role="1tU5fm" />
+          </node>
+          <node concept="2OqwBi" id="49zGylU8pDy" role="JncvB">
+            <node concept="37vLTw" id="49zGylU8pDz" role="2Oq$k0">
+              <ref role="3cqZAo" node="49zGylU8pEf" resolve="childPolicy" />
+            </node>
+            <node concept="3TrEf2" id="49zGylU8pD$" role="2OqNvi">
+              <ref role="3Tt5mk" to="mopj:7jyS5urbFnA" resolve="action" />
+            </node>
+          </node>
+        </node>
+        <node concept="Jncv_" id="49zGylU8pD_" role="3cqZAp">
+          <ref role="JncvD" to="mopj:1EbzjT2T4Ja" resolve="Left" />
+          <node concept="3clFbS" id="49zGylU8pDA" role="Jncv$">
+            <node concept="3cpWs6" id="49zGylU8pDB" role="3cqZAp">
+              <node concept="2ShNRf" id="49zGylU8pDC" role="3cqZAk">
+                <node concept="1pGfFk" id="49zGylU8pDD" role="2ShVmc">
+                  <ref role="37wK5l" node="5lvG0vIUfk6" resolve="BuiltInChildLeft" />
+                  <node concept="2YIFZM" id="49zGylU8pDE" role="37wK5m">
+                    <ref role="37wK5l" to="pjrh:~MetaAdapterByDeclaration.getContainmentLink(org.jetbrains.mps.openapi.model.SNode)" resolve="getContainmentLink" />
+                    <ref role="1Pybhc" to="pjrh:~MetaAdapterByDeclaration" resolve="MetaAdapterByDeclaration" />
+                    <node concept="2OqwBi" id="49zGylU8pDF" role="37wK5m">
+                      <node concept="37vLTw" id="49zGylU8pDG" role="2Oq$k0">
+                        <ref role="3cqZAo" node="49zGylU8pEf" resolve="childPolicy" />
+                      </node>
+                      <node concept="3TrEf2" id="49zGylU8pDH" role="2OqNvi">
+                        <ref role="3Tt5mk" to="mopj:1VmHfRxVF4J" resolve="child" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="JncvC" id="49zGylU8pDI" role="JncvA">
+            <property role="TrG5h" value="action" />
+            <node concept="2jxLKc" id="49zGylU8pDJ" role="1tU5fm" />
+          </node>
+          <node concept="2OqwBi" id="49zGylU8pDK" role="JncvB">
+            <node concept="37vLTw" id="49zGylU8pDL" role="2Oq$k0">
+              <ref role="3cqZAo" node="49zGylU8pEf" resolve="childPolicy" />
+            </node>
+            <node concept="3TrEf2" id="49zGylU8pDM" role="2OqNvi">
+              <ref role="3Tt5mk" to="mopj:7jyS5urbFnA" resolve="action" />
+            </node>
+          </node>
+        </node>
+        <node concept="Jncv_" id="49zGylU8pDN" role="3cqZAp">
+          <ref role="JncvD" to="mopj:6zqIeMU2OVm" resolve="Right" />
+          <node concept="3clFbS" id="49zGylU8pDO" role="Jncv$">
+            <node concept="3cpWs6" id="49zGylU8pDP" role="3cqZAp">
+              <node concept="2ShNRf" id="49zGylU8pDQ" role="3cqZAk">
+                <node concept="1pGfFk" id="49zGylU8pDR" role="2ShVmc">
+                  <ref role="37wK5l" node="5lvG0vIUfwi" resolve="BuiltInChildRight" />
+                  <node concept="2YIFZM" id="49zGylU8pDS" role="37wK5m">
+                    <ref role="37wK5l" to="pjrh:~MetaAdapterByDeclaration.getContainmentLink(org.jetbrains.mps.openapi.model.SNode)" resolve="getContainmentLink" />
+                    <ref role="1Pybhc" to="pjrh:~MetaAdapterByDeclaration" resolve="MetaAdapterByDeclaration" />
+                    <node concept="2OqwBi" id="49zGylU8pDT" role="37wK5m">
+                      <node concept="37vLTw" id="49zGylU8pDU" role="2Oq$k0">
+                        <ref role="3cqZAo" node="49zGylU8pEf" resolve="childPolicy" />
+                      </node>
+                      <node concept="3TrEf2" id="49zGylU8pDV" role="2OqNvi">
+                        <ref role="3Tt5mk" to="mopj:1VmHfRxVF4J" resolve="child" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="JncvC" id="49zGylU8pDW" role="JncvA">
+            <property role="TrG5h" value="action" />
+            <node concept="2jxLKc" id="49zGylU8pDX" role="1tU5fm" />
+          </node>
+          <node concept="2OqwBi" id="49zGylU8pDY" role="JncvB">
+            <node concept="37vLTw" id="49zGylU8pDZ" role="2Oq$k0">
+              <ref role="3cqZAo" node="49zGylU8pEf" resolve="childPolicy" />
+            </node>
+            <node concept="3TrEf2" id="49zGylU8pE0" role="2OqNvi">
+              <ref role="3Tt5mk" to="mopj:7jyS5urbFnA" resolve="action" />
+            </node>
+          </node>
+        </node>
+        <node concept="Jncv_" id="49zGylU8pE1" role="3cqZAp">
+          <ref role="JncvD" to="mopj:1NgLzfPblhV" resolve="ManualAction" />
+          <node concept="3clFbS" id="49zGylU8pE2" role="Jncv$">
+            <node concept="YS8fn" id="49zGylU8pE3" role="3cqZAp">
+              <node concept="2ShNRf" id="49zGylU8pE4" role="YScLw">
+                <node concept="1pGfFk" id="49zGylU8pE5" role="2ShVmc">
+                  <property role="373rjd" value="true" />
+                  <ref role="37wK5l" to="wyt6:~UnsupportedOperationException.&lt;init&gt;(java.lang.String)" resolve="UnsupportedOperationException" />
+                  <node concept="Xl_RD" id="49zGylU8pE6" role="37wK5m">
+                    <property role="Xl_RC" value="Default action does not support 'ManualAction'" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="JncvC" id="49zGylU8pE7" role="JncvA">
+            <property role="TrG5h" value="action" />
+            <node concept="2jxLKc" id="49zGylU8pE8" role="1tU5fm" />
+          </node>
+          <node concept="2OqwBi" id="49zGylU8pE9" role="JncvB">
+            <node concept="37vLTw" id="49zGylU8pEa" role="2Oq$k0">
+              <ref role="3cqZAo" node="49zGylU8pEf" resolve="childPolicy" />
+            </node>
+            <node concept="3TrEf2" id="49zGylU8pEb" role="2OqNvi">
+              <ref role="3Tt5mk" to="mopj:7jyS5urbFnA" resolve="action" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="49zGylU8pEc" role="3cqZAp">
+          <node concept="10Nm6u" id="49zGylU8pEd" role="3cqZAk" />
+        </node>
+      </node>
+      <node concept="3uibUv" id="49zGylU8pEe" role="3clF45">
+        <ref role="3uigEE" node="5lvG0vIUaC$" resolve="ConceptChildMerger" />
+      </node>
+      <node concept="37vLTG" id="49zGylU8pEf" role="3clF46">
+        <property role="TrG5h" value="childPolicy" />
+        <node concept="3Tqbb2" id="49zGylU8pEg" role="1tU5fm">
+          <ref role="ehGHo" to="mopj:3PLTv5k2w4M" resolve="OptionalChildPolicy" />
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="49zGylU8pEh" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="49zGylUbnMB" role="jymVt" />
+    <node concept="3clFb_" id="49zGylUblK8" role="jymVt">
+      <property role="TrG5h" value="refMerger" />
+      <node concept="3clFbS" id="49zGylUblK9" role="3clF47">
+        <node concept="3cpWs8" id="49zGylUbCmZ" role="3cqZAp">
+          <node concept="3cpWsn" id="49zGylUbCn2" role="3cpWs9">
+            <property role="TrG5h" value="action" />
+            <node concept="3Tqbb2" id="49zGylUbCmX" role="1tU5fm">
+              <ref role="ehGHo" to="mopj:6zqIeMU2OVl" resolve="MergeAction" />
+            </node>
+            <node concept="10Nm6u" id="49zGylUcc3g" role="33vP2m" />
+          </node>
+        </node>
+        <node concept="3cpWs8" id="49zGylUfUup" role="3cqZAp">
+          <node concept="3cpWsn" id="49zGylUfUuq" role="3cpWs9">
+            <property role="TrG5h" value="child" />
+            <node concept="3Tqbb2" id="49zGylUfUur" role="1tU5fm">
+              <ref role="ehGHo" to="tpce:f_TJgxE" resolve="LinkDeclaration" />
+            </node>
+            <node concept="10Nm6u" id="49zGylUfUus" role="33vP2m" />
+          </node>
+        </node>
+        <node concept="Jncv_" id="49zGylUbJjg" role="3cqZAp">
+          <ref role="JncvD" to="mopj:3PLTv5k2w4U" resolve="OptionalRefPolicy" />
+          <node concept="37vLTw" id="49zGylUbO3h" role="JncvB">
+            <ref role="3cqZAo" node="49zGylUblLg" resolve="refPolicy" />
+          </node>
+          <node concept="3clFbS" id="49zGylUbJjk" role="Jncv$">
+            <node concept="3clFbF" id="49zGylUbU55" role="3cqZAp">
+              <node concept="37vLTI" id="49zGylUbYiP" role="3clFbG">
+                <node concept="2OqwBi" id="49zGylUbZQA" role="37vLTx">
+                  <node concept="Jnkvi" id="49zGylUbZi7" role="2Oq$k0">
+                    <ref role="1M0zk5" node="49zGylUbJjm" resolve="policy" />
+                  </node>
+                  <node concept="3TrEf2" id="49zGylUc1uO" role="2OqNvi">
+                    <ref role="3Tt5mk" to="mopj:7jyS5urbFnA" resolve="action" />
+                  </node>
+                </node>
+                <node concept="37vLTw" id="49zGylUbU54" role="37vLTJ">
+                  <ref role="3cqZAo" node="49zGylUbCn2" resolve="action" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="JncvC" id="49zGylUbJjm" role="JncvA">
+            <property role="TrG5h" value="policy" />
+            <node concept="2jxLKc" id="49zGylUbJjn" role="1tU5fm" />
+          </node>
+        </node>
+        <node concept="Jncv_" id="49zGylUcghs" role="3cqZAp">
+          <ref role="JncvD" to="mopj:3PLTv5k2w4R" resolve="SingeltonRefPolicy" />
+          <node concept="37vLTw" id="49zGylUchfn" role="JncvB">
+            <ref role="3cqZAo" node="49zGylUblLg" resolve="refPolicy" />
+          </node>
+          <node concept="3clFbS" id="49zGylUcghw" role="Jncv$">
+            <node concept="3clFbF" id="49zGylUclGT" role="3cqZAp">
+              <node concept="37vLTI" id="49zGylUclGV" role="3clFbG">
+                <node concept="2OqwBi" id="49zGylUclGW" role="37vLTx">
+                  <node concept="Jnkvi" id="49zGylUclGX" role="2Oq$k0">
+                    <ref role="1M0zk5" node="49zGylUcghy" resolve="policy" />
+                  </node>
+                  <node concept="3TrEf2" id="49zGylUclGY" role="2OqNvi">
+                    <ref role="3Tt5mk" to="mopj:7jyS5urbTpc" resolve="action" />
+                  </node>
+                </node>
+                <node concept="37vLTw" id="49zGylUclGZ" role="37vLTJ">
+                  <ref role="3cqZAo" node="49zGylUbCn2" resolve="action" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="JncvC" id="49zGylUcghy" role="JncvA">
+            <property role="TrG5h" value="policy" />
+            <node concept="2jxLKc" id="49zGylUcghz" role="1tU5fm" />
+          </node>
+        </node>
+        <node concept="Jncv_" id="49zGylUfMG1" role="3cqZAp">
+          <ref role="JncvD" to="mopj:1VmHfRxVF4G" resolve="AbstractPolicy" />
+          <node concept="37vLTw" id="49zGylUfOcm" role="JncvB">
+            <ref role="3cqZAo" node="49zGylUblLg" resolve="refPolicy" />
+          </node>
+          <node concept="3clFbS" id="49zGylUfMG5" role="Jncv$">
+            <node concept="3clFbF" id="49zGylUfZXX" role="3cqZAp">
+              <node concept="37vLTI" id="49zGylUg0$0" role="3clFbG">
+                <node concept="2OqwBi" id="49zGylUg3GK" role="37vLTx">
+                  <node concept="Jnkvi" id="49zGylUg3bA" role="2Oq$k0">
+                    <ref role="1M0zk5" node="49zGylUfMG7" resolve="policy" />
+                  </node>
+                  <node concept="3TrEf2" id="49zGylUg5iB" role="2OqNvi">
+                    <ref role="3Tt5mk" to="mopj:1VmHfRxVF4J" resolve="child" />
+                  </node>
+                </node>
+                <node concept="37vLTw" id="49zGylUfZXW" role="37vLTJ">
+                  <ref role="3cqZAo" node="49zGylUfUuq" resolve="child" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="JncvC" id="49zGylUfMG7" role="JncvA">
+            <property role="TrG5h" value="policy" />
+            <node concept="2jxLKc" id="49zGylUfMG8" role="1tU5fm" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="49zGylUc94h" role="3cqZAp" />
+        <node concept="3cpWs8" id="49zGylUfg9a" role="3cqZAp">
+          <node concept="3cpWsn" id="3xLnOvECZkr" role="3cpWs9">
+            <property role="TrG5h" value="conceptRef" />
+            <node concept="3Tqbb2" id="3xLnOvECZks" role="1tU5fm">
+              <ref role="ehGHo" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
+            </node>
+            <node concept="2OqwBi" id="3xLnOvECZkt" role="33vP2m">
+              <node concept="2OqwBi" id="3xLnOvECZku" role="2Oq$k0">
+                <node concept="37vLTw" id="49zGylUf0rK" role="2Oq$k0">
+                  <ref role="3cqZAo" node="49zGylUblLg" resolve="refPolicy" />
+                </node>
+                <node concept="2Xjw5R" id="3xLnOvECZkw" role="2OqNvi">
+                  <node concept="1xMEDy" id="3xLnOvECZkx" role="1xVPHs">
+                    <node concept="chp4Y" id="3xLnOvECZky" role="ri$Ld">
+                      <ref role="cht4Q" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3TrEf2" id="3xLnOvECZkz" role="2OqNvi">
+                <ref role="3Tt5mk" to="mopj:3BP4DuXu_FH" resolve="conceptRef" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="49zGylUfqHa" role="3cqZAp">
+          <node concept="3cpWsn" id="49zGylUfqHd" role="3cpWs9">
+            <property role="TrG5h" value="childLink" />
+            <node concept="3Tqbb2" id="49zGylUfqH8" role="1tU5fm">
+              <ref role="ehGHo" to="tp25:2iMJRNx_nol" resolve="LinkIdRefExpression" />
+            </node>
+            <node concept="2pJPEk" id="49zGylUeKBr" role="33vP2m">
+              <node concept="2pJPED" id="3xLnOvECZkA" role="2pJPEn">
+                <ref role="2pJxaS" to="tp25:2iMJRNx_nol" resolve="LinkIdRefExpression" />
+                <node concept="2pIpSj" id="3xLnOvECZkB" role="2pJxcM">
+                  <ref role="2pIpSl" to="tp25:2iMJRNx_non" resolve="linkDeclaration" />
+                  <node concept="36biLy" id="3xLnOvECZkC" role="28nt2d">
+                    <node concept="37vLTw" id="49zGylUg7W0" role="36biLW">
+                      <ref role="3cqZAo" node="49zGylUfUuq" resolve="child" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2pIpSj" id="3xLnOvECZkE" role="2pJxcM">
+                  <ref role="2pIpSl" to="tp25:2iMJRNx_nom" resolve="conceptDeclaration" />
+                  <node concept="36biLy" id="3xLnOvECZkF" role="28nt2d">
+                    <node concept="37vLTw" id="3xLnOvECZkG" role="36biLW">
+                      <ref role="3cqZAo" node="3xLnOvECZkr" resolve="conceptRef" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="Jncv_" id="49zGylUblKo" role="3cqZAp">
+          <ref role="JncvD" to="mopj:7jyS5urbByQ" resolve="Drop" />
+          <node concept="3clFbS" id="49zGylUblKp" role="Jncv$">
+            <node concept="3cpWs6" id="49zGylUblKq" role="3cqZAp">
+              <node concept="2ShNRf" id="49zGylUblKr" role="3cqZAk">
+                <node concept="1pGfFk" id="49zGylUblKs" role="2ShVmc">
+                  <ref role="37wK5l" node="3xLnOvECWX4" resolve="BuiltInRefDrop" />
+                  <node concept="2YIFZM" id="49zGylUgIGh" role="37wK5m">
+                    <ref role="37wK5l" to="pjrh:~MetaAdapterByDeclaration.getReferenceLink(org.jetbrains.mps.openapi.model.SNode)" resolve="getReferenceLink" />
+                    <ref role="1Pybhc" to="pjrh:~MetaAdapterByDeclaration" resolve="MetaAdapterByDeclaration" />
+                    <node concept="37vLTw" id="49zGylUgIGi" role="37wK5m">
+                      <ref role="3cqZAo" node="49zGylUfqHd" resolve="childLink" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="JncvC" id="49zGylUblKx" role="JncvA">
+            <property role="TrG5h" value="drop" />
+            <node concept="2jxLKc" id="49zGylUblKy" role="1tU5fm" />
+          </node>
+          <node concept="37vLTw" id="49zGylUcdSY" role="JncvB">
+            <ref role="3cqZAo" node="49zGylUbCn2" resolve="action" />
+          </node>
+        </node>
+        <node concept="Jncv_" id="49zGylUblKA" role="3cqZAp">
+          <ref role="JncvD" to="mopj:1EbzjT2T4Ja" resolve="Left" />
+          <node concept="3clFbS" id="49zGylUblKB" role="Jncv$">
+            <node concept="3cpWs6" id="49zGylUblKC" role="3cqZAp">
+              <node concept="2ShNRf" id="49zGylUblKD" role="3cqZAk">
+                <node concept="1pGfFk" id="49zGylUblKE" role="2ShVmc">
+                  <ref role="37wK5l" node="4WBgwWtg2kG" resolve="BuiltInRefLeft" />
+                  <node concept="2YIFZM" id="49zGylUgFG5" role="37wK5m">
+                    <ref role="37wK5l" to="pjrh:~MetaAdapterByDeclaration.getReferenceLink(org.jetbrains.mps.openapi.model.SNode)" resolve="getReferenceLink" />
+                    <ref role="1Pybhc" to="pjrh:~MetaAdapterByDeclaration" resolve="MetaAdapterByDeclaration" />
+                    <node concept="37vLTw" id="49zGylUgFG6" role="37wK5m">
+                      <ref role="3cqZAo" node="49zGylUfqHd" resolve="childLink" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="JncvC" id="49zGylUblKJ" role="JncvA">
+            <property role="TrG5h" value="left" />
+            <node concept="2jxLKc" id="49zGylUblKK" role="1tU5fm" />
+          </node>
+          <node concept="37vLTw" id="49zGylUcqs1" role="JncvB">
+            <ref role="3cqZAo" node="49zGylUbCn2" resolve="action" />
+          </node>
+        </node>
+        <node concept="Jncv_" id="49zGylUblKO" role="3cqZAp">
+          <ref role="JncvD" to="mopj:6zqIeMU2OVm" resolve="Right" />
+          <node concept="3clFbS" id="49zGylUblKP" role="Jncv$">
+            <node concept="3cpWs6" id="49zGylUblKQ" role="3cqZAp">
+              <node concept="2ShNRf" id="49zGylUblKR" role="3cqZAk">
+                <node concept="1pGfFk" id="49zGylUblKS" role="2ShVmc">
+                  <ref role="37wK5l" node="3xLnOvEARIi" resolve="BuiltInRefRight" />
+                  <node concept="2YIFZM" id="49zGylUgLat" role="37wK5m">
+                    <ref role="37wK5l" to="pjrh:~MetaAdapterByDeclaration.getReferenceLink(org.jetbrains.mps.openapi.model.SNode)" resolve="getReferenceLink" />
+                    <ref role="1Pybhc" to="pjrh:~MetaAdapterByDeclaration" resolve="MetaAdapterByDeclaration" />
+                    <node concept="37vLTw" id="49zGylUgLau" role="37wK5m">
+                      <ref role="3cqZAo" node="49zGylUfqHd" resolve="childLink" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="JncvC" id="49zGylUblKX" role="JncvA">
+            <property role="TrG5h" value="right" />
+            <node concept="2jxLKc" id="49zGylUblKY" role="1tU5fm" />
+          </node>
+          <node concept="37vLTw" id="49zGylUcrKV" role="JncvB">
+            <ref role="3cqZAo" node="49zGylUbCn2" resolve="action" />
+          </node>
+        </node>
+        <node concept="Jncv_" id="49zGylUblL2" role="3cqZAp">
+          <ref role="JncvD" to="mopj:1NgLzfPblhV" resolve="ManualAction" />
+          <node concept="3clFbS" id="49zGylUblL3" role="Jncv$">
+            <node concept="YS8fn" id="49zGylUblL4" role="3cqZAp">
+              <node concept="2ShNRf" id="49zGylUblL5" role="YScLw">
+                <node concept="1pGfFk" id="49zGylUblL6" role="2ShVmc">
+                  <property role="373rjd" value="true" />
+                  <ref role="37wK5l" to="wyt6:~UnsupportedOperationException.&lt;init&gt;(java.lang.String)" resolve="UnsupportedOperationException" />
+                  <node concept="Xl_RD" id="49zGylUblL7" role="37wK5m">
+                    <property role="Xl_RC" value="Default action does not support 'ManualAction'" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="JncvC" id="49zGylUblL8" role="JncvA">
+            <property role="TrG5h" value="manual" />
+            <node concept="2jxLKc" id="49zGylUblL9" role="1tU5fm" />
+          </node>
+          <node concept="37vLTw" id="49zGylUcu9w" role="JncvB">
+            <ref role="3cqZAo" node="49zGylUbCn2" resolve="action" />
+          </node>
+        </node>
+        <node concept="3cpWs6" id="49zGylUblLd" role="3cqZAp">
+          <node concept="10Nm6u" id="49zGylUblLe" role="3cqZAk" />
+        </node>
+      </node>
+      <node concept="3uibUv" id="49zGylUblLf" role="3clF45">
+        <ref role="3uigEE" node="4WBgwWtfZU9" resolve="ConceptRefMerger" />
+      </node>
+      <node concept="37vLTG" id="49zGylUblLg" role="3clF46">
+        <property role="TrG5h" value="refPolicy" />
+        <node concept="3Tqbb2" id="49zGylUblLh" role="1tU5fm">
+          <ref role="ehGHo" to="mopj:3PLTv5jwPx8" resolve="ReferencePolicy" />
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="49zGylUblLi" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="49zGylSDZh1" role="jymVt" />
+    <node concept="3clFb_" id="49zGylU1S6L" role="jymVt">
+      <property role="TrG5h" value="propertyMerger" />
+      <node concept="37vLTG" id="49zGylU1S6M" role="3clF46">
+        <property role="TrG5h" value="itemPolicy" />
+        <node concept="3Tqbb2" id="49zGylU1S6N" role="1tU5fm">
+          <ref role="ehGHo" to="mopj:1EbzjT2T4oC" resolve="PropertyPolicy" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="49zGylU1S6O" role="3clF46">
+        <property role="TrG5h" value="inheritedFrom" />
+        <node concept="3uibUv" id="49zGylU1S6P" role="1tU5fm">
+          <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="49zGylU1S6Q" role="1B3o_S" />
+      <node concept="3uibUv" id="49zGylU1S6S" role="3clF45">
+        <ref role="3uigEE" node="3EHNiwzf98t" resolve="ContentHolder" />
+        <node concept="3uibUv" id="49zGylU1S6T" role="11_B2D">
+          <ref role="3uigEE" node="5lvG0vITZsP" resolve="PropertyMerger" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="49zGylU1S6U" role="3clF47">
+        <node concept="3cpWs6" id="49zGylU351A" role="3cqZAp">
+          <node concept="2ShNRf" id="49zGylU351B" role="3cqZAk">
+            <node concept="1pGfFk" id="49zGylU351C" role="2ShVmc">
+              <ref role="37wK5l" node="3EHNiwzfpPs" resolve="SimpleActionContentHolder" />
+              <node concept="3uibUv" id="49zGylU351D" role="1pMfVU">
+                <ref role="3uigEE" node="5lvG0vITZsP" resolve="PropertyMerger" />
+              </node>
+              <node concept="1rXfSq" id="49zGylU3yYo" role="37wK5m">
+                <ref role="37wK5l" node="49zGylU4uGD" resolve="propertyPolicy" />
+                <node concept="37vLTw" id="49zGylU3$VR" role="37wK5m">
+                  <ref role="3cqZAo" node="49zGylU1S6M" resolve="itemPolicy" />
+                </node>
+              </node>
+              <node concept="2OqwBi" id="49zGylU351F" role="37wK5m">
+                <node concept="37vLTw" id="49zGylU351G" role="2Oq$k0">
+                  <ref role="3cqZAo" node="49zGylU1S6M" resolve="itemPolicy" />
+                </node>
+                <node concept="3TrEf2" id="49zGylU351H" role="2OqNvi">
+                  <ref role="3Tt5mk" to="mopj:1EbzjT2T4Jd" resolve="action" />
+                </node>
+              </node>
+              <node concept="37vLTw" id="49zGylU351I" role="37wK5m">
+                <ref role="3cqZAo" node="49zGylU1S6O" resolve="inheritedFrom" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="49zGylU1S6V" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="49zGylU1Rya" role="jymVt" />
+    <node concept="3clFb_" id="49zGylU1S6Y" role="jymVt">
+      <property role="TrG5h" value="childMerger" />
+      <node concept="37vLTG" id="49zGylU1S6Z" role="3clF46">
+        <property role="TrG5h" value="itemPolicy" />
+        <node concept="3Tqbb2" id="49zGylU1S70" role="1tU5fm">
+          <ref role="ehGHo" to="mopj:3PLTv5jRo6X" resolve="ChildPolicy" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="49zGylU1S71" role="3clF46">
+        <property role="TrG5h" value="inheritedFrom" />
+        <node concept="3uibUv" id="49zGylU1S72" role="1tU5fm">
+          <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="49zGylU1S73" role="1B3o_S" />
+      <node concept="3uibUv" id="49zGylU1S75" role="3clF45">
+        <ref role="3uigEE" node="3EHNiwzf98t" resolve="ContentHolder" />
+        <node concept="3uibUv" id="49zGylU1S76" role="11_B2D">
+          <ref role="3uigEE" node="5lvG0vIUaC$" resolve="ConceptChildMerger" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="49zGylU1S77" role="3clF47">
+        <node concept="3cpWs8" id="49zGylUb1Nx" role="3cqZAp">
+          <node concept="3cpWsn" id="49zGylUb1Ny" role="3cpWs9">
+            <property role="TrG5h" value="merger" />
+            <node concept="3uibUv" id="49zGylUb1Nz" role="1tU5fm">
+              <ref role="3uigEE" node="5lvG0vIUaC$" resolve="ConceptChildMerger" />
+            </node>
+            <node concept="1rXfSq" id="49zGylUb4Hx" role="33vP2m">
+              <ref role="37wK5l" node="49zGylU9Eyt" resolve="childMerger" />
+              <node concept="37vLTw" id="49zGylUb5Ec" role="37wK5m">
+                <ref role="3cqZAo" node="49zGylU1S6Z" resolve="itemPolicy" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="49zGylU3l4z" role="3cqZAp">
+          <node concept="2YIFZM" id="49zGylU3l4_" role="3clFbG">
+            <ref role="1Pybhc" node="32ggi2DpDWx" resolve="ContentHolderFactory" />
+            <ref role="37wK5l" node="450aOM1RWmT" resolve="makeContentHolder" />
+            <node concept="37vLTw" id="49zGylUb81j" role="37wK5m">
+              <ref role="3cqZAo" node="49zGylUb1Ny" resolve="merger" />
+            </node>
+            <node concept="37vLTw" id="49zGylU3l4B" role="37wK5m">
+              <ref role="3cqZAo" node="49zGylU1S6Z" resolve="itemPolicy" />
+            </node>
+            <node concept="37vLTw" id="49zGylU3l4C" role="37wK5m">
+              <ref role="3cqZAo" node="49zGylU1S71" resolve="inheritedFrom" />
+            </node>
+            <node concept="3uibUv" id="49zGylU3l4D" role="3PaCim">
+              <ref role="3uigEE" node="5lvG0vIUaC$" resolve="ConceptChildMerger" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="49zGylU1S78" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="49zGylU20OQ" role="jymVt" />
+    <node concept="3clFb_" id="49zGylU1S6$" role="jymVt">
+      <property role="TrG5h" value="refMerger" />
+      <node concept="37vLTG" id="49zGylU1S6_" role="3clF46">
+        <property role="TrG5h" value="itemPolicy" />
+        <node concept="3Tqbb2" id="49zGylU1S6A" role="1tU5fm">
+          <ref role="ehGHo" to="mopj:3PLTv5jwPx8" resolve="ReferencePolicy" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="49zGylU1S6B" role="3clF46">
+        <property role="TrG5h" value="inheritedFrom" />
+        <node concept="3uibUv" id="49zGylU1S6C" role="1tU5fm">
+          <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="49zGylU1S6D" role="1B3o_S" />
+      <node concept="3uibUv" id="49zGylU1S6F" role="3clF45">
+        <ref role="3uigEE" node="3EHNiwzf98t" resolve="ContentHolder" />
+        <node concept="3uibUv" id="49zGylU1S6G" role="11_B2D">
+          <ref role="3uigEE" node="4WBgwWtfZU9" resolve="ConceptRefMerger" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="49zGylU1S6H" role="3clF47">
+        <node concept="3cpWs8" id="49zGylUgTkk" role="3cqZAp">
+          <node concept="3cpWsn" id="49zGylUgTkl" role="3cpWs9">
+            <property role="TrG5h" value="merger" />
+            <node concept="3uibUv" id="49zGylUgTkm" role="1tU5fm">
+              <ref role="3uigEE" node="4WBgwWtfZU9" resolve="ConceptRefMerger" />
+            </node>
+            <node concept="1rXfSq" id="49zGylUgW_M" role="33vP2m">
+              <ref role="37wK5l" node="49zGylUblK8" resolve="refMerger" />
+              <node concept="37vLTw" id="49zGylUgY81" role="37wK5m">
+                <ref role="3cqZAo" node="49zGylU1S6_" resolve="itemPolicy" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="49zGylU1S6K" role="3cqZAp">
+          <node concept="2YIFZM" id="49zGylU38Sg" role="3clFbG">
+            <ref role="1Pybhc" node="32ggi2DpDWx" resolve="ContentHolderFactory" />
+            <ref role="37wK5l" node="450aOM1RWmT" resolve="makeContentHolder" />
+            <node concept="37vLTw" id="49zGylUgZc3" role="37wK5m">
+              <ref role="3cqZAo" node="49zGylUgTkl" resolve="merger" />
+            </node>
+            <node concept="37vLTw" id="49zGylU38Si" role="37wK5m">
+              <ref role="3cqZAo" node="49zGylU1S6_" resolve="itemPolicy" />
+            </node>
+            <node concept="37vLTw" id="49zGylU38Sj" role="37wK5m">
+              <ref role="3cqZAo" node="49zGylU1S6B" resolve="inheritedFrom" />
+            </node>
+            <node concept="3uibUv" id="49zGylU38Sk" role="3PaCim">
+              <ref role="3uigEE" node="4WBgwWtfZU9" resolve="ConceptRefMerger" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="49zGylU1S6I" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="49zGylU21u5" role="jymVt" />
+    <node concept="3clFb_" id="49zGylU1S6o" role="jymVt">
+      <property role="TrG5h" value="idOf" />
+      <node concept="37vLTG" id="49zGylU1S6p" role="3clF46">
+        <property role="TrG5h" value="idFunction" />
+        <node concept="3Tqbb2" id="49zGylU1S6q" role="1tU5fm">
+          <ref role="ehGHo" to="mopj:6celbXx0_R7" resolve="IdFunction" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="49zGylU1S6r" role="3clF46">
+        <property role="TrG5h" value="n" />
+        <node concept="3uibUv" id="49zGylU1S6s" role="1tU5fm">
+          <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
+        </node>
+      </node>
+      <node concept="3uibUv" id="49zGylU1S6t" role="3clF45">
+        <ref role="3uigEE" node="1yAYHyQ2xCj" resolve="Identity" />
+      </node>
+      <node concept="3Tm1VV" id="49zGylU1S6u" role="1B3o_S" />
+      <node concept="3clFbS" id="49zGylU1S6w" role="3clF47">
+        <node concept="3clFbF" id="49zGylU2ck0" role="3cqZAp">
+          <node concept="2ShNRf" id="49zGylU2ck2" role="3clFbG">
+            <node concept="HV5vD" id="49zGylU2ck3" role="2ShVmc">
+              <property role="373rjd" value="true" />
+              <ref role="HV5vE" node="7F7y$3Lx5sA" resolve="DefaultIdentity" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="49zGylU1S6x" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="3Tm1VV" id="49zGylSrV3K" role="1B3o_S" />
+    <node concept="3uibUv" id="49zGylU1ORd" role="EKbjA">
+      <ref role="3uigEE" node="32ggi2DpDWx" resolve="ContentHolderFactory" />
+    </node>
   </node>
 </model>
 

--- a/code/solutions/de.itemis.model.merge.simple.demo/models/de.itemis.model.merge.simple.demo.leftSingltonChild.mps
+++ b/code/solutions/de.itemis.model.merge.simple.demo/models/de.itemis.model.merge.simple.demo.leftSingltonChild.mps
@@ -12,6 +12,11 @@
         <property id="3499368519007574817" name="data" index="2pctC1" />
       </concept>
     </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
     <language id="8688ed72-e0ba-44cb-9688-5c8397cb5bbb" name="de.itemis.model.simple.demo.children">
       <concept id="3912520324585631286" name="de.itemis.model.simple.demo.children.structure.ChildKeeper" flags="ng" index="1d83UR">
         <child id="3912520324598248753" name="optionalChild" index="1aoamK" />
@@ -20,6 +25,7 @@
     </language>
   </registry>
   <node concept="1d83UR" id="3pc485Vw3Jr">
+    <property role="TrG5h" value="ChildKeeperleft" />
     <node concept="2pctC0" id="78fCHIEYtBX" role="1d83UQ">
       <property role="2pctC1" value="lala" />
     </node>

--- a/code/solutions/de.itemis.model.merge.simple.demo/models/de.itemis.model.merge.simple.demo.merge.exec.mps
+++ b/code/solutions/de.itemis.model.merge.simple.demo/models/de.itemis.model.merge.simple.demo.merge.exec.mps
@@ -289,5 +289,33 @@
       </node>
     </node>
   </node>
+  <node concept="poArf" id="7wzAiyq8OUx">
+    <property role="TrG5h" value="ModelMergeWithDefaultActionsExec" />
+    <ref role="pot50" to="2y6h:7wzAiyq8GF4" resolve="ModelMergeWithDefaultActions" />
+    <node concept="1Xw6AR" id="7wzAiyq8OUy" role="ppIIL">
+      <node concept="1dCxOl" id="7wzAiyq8Phd" role="1XwpL7">
+        <property role="1XweGQ" value="r:de7dfd54-d52a-48c3-ad0b-4ff50c9fe414" />
+        <node concept="1j_P7g" id="7wzAiyq8Phe" role="1j$8Uc">
+          <property role="1j_P7h" value="de.itemis.model.merge.simple.demo.leftSingltonChild" />
+        </node>
+      </node>
+    </node>
+    <node concept="1Xw6AR" id="7wzAiyq8OU$" role="ppbcs">
+      <node concept="1dCxOl" id="7wzAiyq8Phi" role="1XwpL7">
+        <property role="1XweGQ" value="r:e0e8921e-c4c0-4e4c-a825-af1f615827e5" />
+        <node concept="1j_P7g" id="7wzAiyq8Phj" role="1j$8Uc">
+          <property role="1j_P7h" value="de.itemis.model.merge.simple.demo.rightSingltonChild" />
+        </node>
+      </node>
+    </node>
+    <node concept="1Xw6AR" id="7wzAiyq8Phn" role="2JagXQ">
+      <node concept="1dCxOl" id="7wzAiyq8Phs" role="1XwpL7">
+        <property role="1XweGQ" value="r:ecd2c27e-0ec1-4753-8900-a6ad3dc40f09" />
+        <node concept="1j_P7g" id="7wzAiyq8Pht" role="1j$8Uc">
+          <property role="1j_P7h" value="de.itemis.model.merge.simple.demo.result" />
+        </node>
+      </node>
+    </node>
+  </node>
 </model>
 

--- a/code/solutions/de.itemis.model.merge.simple.demo/models/de.itemis.model.merge.simple.demo.plugin.mps
+++ b/code/solutions/de.itemis.model.merge.simple.demo/models/de.itemis.model.merge.simple.demo.plugin.mps
@@ -14,6 +14,7 @@
     <import index="9kut" ref="r:c515cf95-0439-4376-8bc5-13a56baa0293(de.itemis.model.simple.demo.children.structure)" />
     <import index="lmxm" ref="r:a3686f62-e70f-468d-94f6-43bd46b56f08(de.itemis.model.simple.demo.collection.structure)" />
     <import index="hsq" ref="r:fc82e0c0-6be8-4ecf-9fa1-3d5bc168484e(de.itemis.model.simple.demo.reference.structure)" />
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
     <import index="z7ot" ref="r:3a3f4bbf-6c2b-49f6-8189-f83260cd20d6(de.itemis.model.simple.demo.collection.keeper.structure)" implicit="true" />
   </imports>
   <registry>
@@ -118,10 +119,22 @@
       <concept id="3471140941804265281" name="de.itemis.model.merge.structure.ActionFunctionAutoParam" flags="ng" index="21Disa" />
       <concept id="7137735640371846599" name="de.itemis.model.merge.structure.IdFunction" flags="ig" index="230_S" />
       <concept id="7137735640371849272" name="de.itemis.model.merge.structure.IdFunctionParam" flags="ng" index="233M7" />
+      <concept id="4415987603494135286" name="de.itemis.model.merge.structure.MergerDefaultAction" flags="ng" index="FwPyy">
+        <child id="635146989628964994" name="existsOnlyOnLeftAction" index="1wbzTg" />
+        <child id="635146989628965002" name="elementOnBothAction" index="1wbzTo" />
+        <child id="635146989623967663" name="propertyAction" index="1woo5X" />
+        <child id="635146989623981637" name="existsOnlyOnRightAction" index="1wo$yn" />
+        <child id="635146989623979230" name="optionalChildAction" index="1wo_8c" />
+        <child id="635146989623975424" name="singleChildAction" index="1woA3i" />
+        <child id="635146989624086778" name="singleRefAction" index="1woUSC" />
+        <child id="635146989624124372" name="optionalRefAction" index="1wp1O6" />
+      </concept>
       <concept id="2120062183195930062" name="de.itemis.model.merge.structure.ActionCollectionFunctionRightParam" flags="ng" index="2Iixis" />
       <concept id="2120062183195394475" name="de.itemis.model.merge.structure.ActionCollectionFunctionLeftParam" flags="ng" index="2IszzT" />
       <concept id="2120062183195260387" name="de.itemis.model.merge.structure.ManualCollectionAction" flags="ig" index="2Iv4ML" />
+      <concept id="7555554651740524246" name="de.itemis.model.merge.structure.Right" flags="ng" index="3iOvoU" />
       <concept id="1912777765298260981" name="de.itemis.model.merge.structure.MergePolicy" flags="ng" index="1olsrb">
+        <property id="6365386016289822930" name="useDefaults" index="vpZK9" />
         <reference id="4176264672384277229" name="conceptRef" index="24zOxU" />
         <child id="7137735640372265540" name="idFunction" index="21DrV" />
         <child id="1912777765298654333" name="propertyPolicies" index="1orW53" />
@@ -130,8 +143,11 @@
       </concept>
       <concept id="1912777765298266446" name="de.itemis.model.merge.structure.EmptyMergeItem" flags="ng" index="1oluLK" />
       <concept id="1912777765298163335" name="de.itemis.model.merge.structure.ModelMerge" flags="ng" index="1olOeT">
+        <property id="3110765452006840876" name="partialPolicy" index="1phRau" />
+        <property id="6743315325753907533" name="useDefaults" index="3P_Oz2" />
         <child id="1912777765298260982" name="items" index="1olsr8" />
         <child id="8218966909317017940" name="additonalLangs" index="3oy5ef" />
+        <child id="364371549494520939" name="defaultAction" index="1wVUQl" />
         <child id="2222162468665533253" name="lang" index="3WPhuS" />
       </concept>
       <concept id="1912777765298654154" name="de.itemis.model.merge.structure.Left" flags="ng" index="1orWrO" />
@@ -228,24 +244,11 @@
     <property role="TrG5h" value="ManualChildMerger" />
     <node concept="1oluLK" id="3pc485VtM0h" role="1olsr8" />
     <node concept="1oluLK" id="3pc485V_gh7" role="1olsr8" />
-    <node concept="1olsrb" id="3pc485VtM0m" role="1olsr8">
+    <node concept="1olsrb" id="7wzAiyppgZs" role="1olsr8">
       <ref role="24zOxU" to="9kut:3pc485Vr2SQ" resolve="ChildKeeper" />
-      <node concept="230_S" id="3pc485VtM7Y" role="21DrV">
-        <node concept="3clFbS" id="3pc485VtM7Z" role="2VODD2">
-          <node concept="3clFbF" id="3pc485VtMcz" role="3cqZAp">
-            <node concept="2OqwBi" id="3pc485VtMBW" role="3clFbG">
-              <node concept="2OqwBi" id="3pc485VtMkN" role="2Oq$k0">
-                <node concept="233M7" id="3pc485VtMcy" role="2Oq$k0" />
-                <node concept="3TrEf2" id="3pc485VtMtl" role="2OqNvi">
-                  <ref role="3Tt5mk" to="9kut:3pc485Vr2SR" resolve="childSingleton" />
-                </node>
-              </node>
-              <node concept="3TrcHB" id="3pc485VtMMe" role="2OqNvi">
-                <ref role="3TsBF5" to="yeyq:32ggi2DCpGx" resolve="data" />
-              </node>
-            </node>
-          </node>
-        </node>
+      <node concept="1orWGm" id="7wzAiyq2T1u" role="1orW53">
+        <ref role="3iOP7l" to="tpck:h0TrG11" resolve="name" />
+        <node concept="3iOvoU" id="7wzAiyq2UKF" role="1orWrN" />
       </node>
       <node concept="1DuYju" id="3pc485VtMT2" role="3JN1Yi">
         <ref role="3Ze0ni" to="9kut:3pc485Vr2SR" resolve="childSingleton" />
@@ -361,8 +364,24 @@
           </node>
         </node>
       </node>
+      <node concept="230_S" id="7wzAiyppitU" role="21DrV">
+        <node concept="3clFbS" id="7wzAiyppitV" role="2VODD2">
+          <node concept="3clFbF" id="7wzAiyppj3g" role="3cqZAp">
+            <node concept="2OqwBi" id="7wzAiyppk_Z" role="3clFbG">
+              <node concept="2OqwBi" id="7wzAiyppjIR" role="2Oq$k0">
+                <node concept="233M7" id="7wzAiyppj3f" role="2Oq$k0" />
+                <node concept="3TrEf2" id="7wzAiyppkqi" role="2OqNvi">
+                  <ref role="3Tt5mk" to="9kut:3pc485Vr2SR" resolve="childSingleton" />
+                </node>
+              </node>
+              <node concept="3TrcHB" id="7wzAiyppmNu" role="2OqNvi">
+                <ref role="3TsBF5" to="yeyq:32ggi2DCpGx" resolve="data" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
     </node>
-    <node concept="1oluLK" id="4Abtb9Kq5$_" role="1olsr8" />
     <node concept="1olsrb" id="4Abtb9Kq5AK" role="1olsr8">
       <ref role="24zOxU" to="yeyq:32ggi2DCpGw" resolve="PropertyDummy" />
       <node concept="230_S" id="4Abtb9Kq5DZ" role="21DrV">
@@ -391,84 +410,104 @@
   </node>
   <node concept="1olOeT" id="3pc485VUmUI">
     <property role="TrG5h" value="ChildMergerAuto" />
-    <node concept="1oluLK" id="3pc485VUmUJ" role="1olsr8" />
-    <node concept="1oluLK" id="3pc485VUmUK" role="1olsr8" />
-    <node concept="1olsrb" id="3pc485VUmUL" role="1olsr8">
+    <property role="1phRau" value="true" />
+    <node concept="1olsrb" id="7wzAiypo3yP" role="1olsr8">
       <ref role="24zOxU" to="9kut:3pc485Vr2SQ" resolve="ChildKeeper" />
-      <node concept="230_S" id="3pc485VUmUM" role="21DrV">
-        <node concept="3clFbS" id="3pc485VUmUN" role="2VODD2">
-          <node concept="3clFbF" id="3pc485VUmUO" role="3cqZAp">
-            <node concept="2OqwBi" id="3pc485VUmUP" role="3clFbG">
-              <node concept="2OqwBi" id="3pc485VUmUQ" role="2Oq$k0">
-                <node concept="233M7" id="3pc485VUmUR" role="2Oq$k0" />
-                <node concept="3TrEf2" id="3pc485VUmUS" role="2OqNvi">
+      <node concept="230_S" id="7wzAiypo4_U" role="21DrV">
+        <node concept="3clFbS" id="7wzAiypo4_V" role="2VODD2">
+          <node concept="3clFbF" id="7wzAiypo5Ci" role="3cqZAp">
+            <node concept="2OqwBi" id="7wzAiypo95H" role="3clFbG">
+              <node concept="2OqwBi" id="7wzAiypo5MW" role="2Oq$k0">
+                <node concept="233M7" id="7wzAiypo5Ch" role="2Oq$k0" />
+                <node concept="3TrEf2" id="7wzAiypo8Sm" role="2OqNvi">
                   <ref role="3Tt5mk" to="9kut:3pc485Vr2SR" resolve="childSingleton" />
                 </node>
               </node>
-              <node concept="3TrcHB" id="3pc485VUmUT" role="2OqNvi">
+              <node concept="3TrcHB" id="7wzAiypoa3i" role="2OqNvi">
                 <ref role="3TsBF5" to="yeyq:32ggi2DCpGx" resolve="data" />
               </node>
             </node>
           </node>
         </node>
       </node>
-      <node concept="1DuYju" id="3pc485VUmUU" role="3JN1Yi">
-        <ref role="3Ze0ni" to="9kut:3pc485Vr2SR" resolve="childSingleton" />
-        <node concept="3JN9zw" id="3pc485VUnhp" role="3JN5mM" />
+      <node concept="1orWGm" id="7wzAiypLlCt" role="1orW53">
+        <ref role="3iOP7l" to="tpck:h0TrG11" resolve="name" />
+        <node concept="3iOvoU" id="7wzAiypZV7M" role="1orWrN" />
       </node>
-      <node concept="1DuYj3" id="3pc485Wbcm0" role="3JN1Yi">
+      <node concept="1DuYju" id="7wzAiypoa_s" role="3JN1Yi">
+        <ref role="3Ze0ni" to="9kut:3pc485Vr2SR" resolve="childSingleton" />
+        <node concept="3JN9zw" id="7wzAiypocaF" role="3JN5mM" />
+      </node>
+      <node concept="1DuYj3" id="7wzAiypob7W" role="3JN1Yi">
         <ref role="3Ze0ni" to="9kut:3pc485WbbkL" resolve="optionalChild" />
-        <node concept="3JN9zw" id="3pc485Wbcp9" role="3JN5mL" />
+        <node concept="3JN9zw" id="7wzAiypobDG" role="3JN5mL" />
       </node>
     </node>
-    <node concept="1oluLK" id="6Ltuup4JpXJ" role="1olsr8" />
+    <node concept="1oluLK" id="7wzAiypocFE" role="1olsr8" />
+    <node concept="1olsrb" id="5xmpdH81V_K" role="1olsr8">
+      <ref role="24zOxU" to="yeyq:32ggi2DCpGw" resolve="PropertyDummy" />
+      <node concept="230_S" id="5xmpdH81V_Y" role="21DrV">
+        <node concept="3clFbS" id="5xmpdH81V_Z" role="2VODD2">
+          <node concept="3clFbF" id="5xmpdH81VA0" role="3cqZAp">
+            <node concept="2OqwBi" id="5xmpdH81VA1" role="3clFbG">
+              <node concept="233M7" id="5xmpdH81VA2" role="2Oq$k0" />
+              <node concept="3TrcHB" id="5xmpdH81VA3" role="2OqNvi">
+                <ref role="3TsBF5" to="yeyq:32ggi2DCpGx" resolve="data" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1orWGm" id="5xmpdH81V_L" role="1orW53">
+        <ref role="3iOP7l" to="yeyq:32ggi2DCpGx" resolve="data" />
+        <node concept="3DZp98" id="5xmpdH81V_M" role="1orWrN">
+          <node concept="3clFbS" id="5xmpdH81V_N" role="2VODD2">
+            <node concept="3clFbF" id="5xmpdH81V_O" role="3cqZAp">
+              <node concept="3cpWs3" id="5xmpdH81V_P" role="3clFbG">
+                <node concept="3cpWs3" id="5xmpdH81V_Q" role="3uHU7B">
+                  <node concept="2OqwBi" id="5xmpdH81V_R" role="3uHU7B">
+                    <node concept="3DZwUI" id="5xmpdH81V_S" role="2Oq$k0" />
+                    <node concept="3TrcHB" id="5xmpdH81V_T" role="2OqNvi">
+                      <ref role="3TsBF5" to="yeyq:32ggi2DCpGx" resolve="data" />
+                    </node>
+                  </node>
+                  <node concept="Xl_RD" id="5xmpdH81V_U" role="3uHU7w">
+                    <property role="Xl_RC" value="&lt;---&gt;" />
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="5xmpdH81V_V" role="3uHU7w">
+                  <node concept="3DScHg" id="5xmpdH81V_W" role="2Oq$k0" />
+                  <node concept="3TrcHB" id="5xmpdH81V_X" role="2OqNvi">
+                    <ref role="3TsBF5" to="yeyq:32ggi2DCpGx" resolve="data" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1oluLK" id="3pc485VUmUK" role="1olsr8" />
     <node concept="pHN19" id="3pc485VUmVr" role="3WPhuS">
       <node concept="2V$Bhx" id="6_mEBr3QEVw" role="2V$M_3">
         <property role="2V$B1T" value="8688ed72-e0ba-44cb-9688-5c8397cb5bbb" />
         <property role="2V$B1Q" value="de.itemis.model.simple.demo.children" />
       </node>
     </node>
-    <node concept="1olsrb" id="3pc485VUmVt" role="1olsr8">
-      <ref role="24zOxU" to="yeyq:32ggi2DCpGw" resolve="PropertyDummy" />
-      <node concept="230_S" id="3pc485VUnjS" role="21DrV">
-        <node concept="3clFbS" id="3pc485VUnjT" role="2VODD2">
-          <node concept="3clFbF" id="3pc485VUnqT" role="3cqZAp">
-            <node concept="2OqwBi" id="3pc485VUn__" role="3clFbG">
-              <node concept="233M7" id="3pc485VUnqS" role="2Oq$k0" />
-              <node concept="3TrcHB" id="3pc485VUnKY" role="2OqNvi">
-                <ref role="3TsBF5" to="yeyq:32ggi2DCpGx" resolve="data" />
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="1orWGm" id="3pc485VUnYn" role="1orW53">
-        <ref role="3iOP7l" to="yeyq:32ggi2DCpGx" resolve="data" />
-        <node concept="3DZp98" id="3pc485VUo3P" role="1orWrN">
-          <node concept="3clFbS" id="3pc485VUo3R" role="2VODD2">
-            <node concept="3clFbF" id="5NUO5YlhsmH" role="3cqZAp">
-              <node concept="3cpWs3" id="5NUO5YlhsmJ" role="3clFbG">
-                <node concept="2OqwBi" id="5NUO5YlhsmK" role="3uHU7w">
-                  <node concept="3DScHg" id="5NUO5YlhsmL" role="2Oq$k0" />
-                  <node concept="3TrcHB" id="5NUO5YlhsmM" role="2OqNvi">
-                    <ref role="3TsBF5" to="yeyq:32ggi2DCpGx" resolve="data" />
-                  </node>
-                </node>
-                <node concept="3cpWs3" id="5NUO5YlhsmN" role="3uHU7B">
-                  <node concept="2OqwBi" id="5NUO5YlhsmO" role="3uHU7B">
-                    <node concept="3DZwUI" id="5NUO5YlhsmP" role="2Oq$k0" />
-                    <node concept="3TrcHB" id="5NUO5YlhsmQ" role="2OqNvi">
-                      <ref role="3TsBF5" to="yeyq:32ggi2DCpGx" resolve="data" />
-                    </node>
-                  </node>
-                  <node concept="Xl_RD" id="5NUO5YlhsmR" role="3uHU7w">
-                    <property role="Xl_RC" value="&lt;---&gt;" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
+    <node concept="FwPyy" id="7F7y$3MBdgM" role="1wVUQl">
+      <node concept="3JN9zw" id="7F7y$3MBdgO" role="1woA3i" />
+      <node concept="3JN9zw" id="7F7y$3MBdgP" role="1wo_8c" />
+      <node concept="3JHzSW" id="7F7y$3MBdgQ" role="1wo$yn" />
+      <node concept="3JN9zx" id="7F7y$3MBdgR" role="1wbzTg" />
+      <node concept="3JN9zw" id="7F7y$3MBdgS" role="1wbzTo" />
+      <node concept="3iOvoU" id="7F7y$3MBdgT" role="1woUSC" />
+      <node concept="3JN9zw" id="7F7y$3MBdgU" role="1wp1O6" />
+      <node concept="3iOvoU" id="7F7y$3MBdgN" role="1woo5X" />
+    </node>
+    <node concept="pHN19" id="7wzAiypZvx6" role="3oy5ef">
+      <node concept="2V$Bhx" id="7wzAiypZw3h" role="2V$M_3">
+        <property role="2V$B1T" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c" />
+        <property role="2V$B1Q" value="jetbrains.mps.lang.core" />
       </node>
     </node>
   </node>
@@ -1005,30 +1044,13 @@
     <property role="TrG5h" value="ChildMergerAutoAndManualAuto" />
     <node concept="1oluLK" id="30FY4ILQVHo" role="1olsr8" />
     <node concept="1oluLK" id="30FY4ILQVHp" role="1olsr8" />
-    <node concept="1olsrb" id="30FY4ILQVHq" role="1olsr8">
+    <node concept="1olsrb" id="7wzAiypp4Mn" role="1olsr8">
       <ref role="24zOxU" to="9kut:3pc485Vr2SQ" resolve="ChildKeeper" />
-      <node concept="230_S" id="30FY4ILQVHr" role="21DrV">
-        <node concept="3clFbS" id="30FY4ILQVHs" role="2VODD2">
-          <node concept="3clFbF" id="30FY4ILQVHt" role="3cqZAp">
-            <node concept="2OqwBi" id="30FY4ILQVHu" role="3clFbG">
-              <node concept="2OqwBi" id="30FY4ILQVHv" role="2Oq$k0">
-                <node concept="233M7" id="30FY4ILQVHw" role="2Oq$k0" />
-                <node concept="3TrEf2" id="30FY4ILQVHx" role="2OqNvi">
-                  <ref role="3Tt5mk" to="9kut:3pc485Vr2SR" resolve="childSingleton" />
-                </node>
-              </node>
-              <node concept="3TrcHB" id="30FY4ILQVHy" role="2OqNvi">
-                <ref role="3TsBF5" to="yeyq:32ggi2DCpGx" resolve="data" />
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="1DuYju" id="30FY4ILQVHz" role="3JN1Yi">
+      <node concept="1DuYju" id="7wzAiypp6NJ" role="3JN1Yi">
         <ref role="3Ze0ni" to="9kut:3pc485Vr2SR" resolve="childSingleton" />
-        <node concept="3JN9zw" id="30FY4ILQVH$" role="3JN5mM" />
+        <node concept="3JN9zw" id="7wzAiypp7nu" role="3JN5mM" />
       </node>
-      <node concept="1DuYj3" id="30FY4ILQVH_" role="3JN1Yi">
+      <node concept="1DuYj3" id="7wzAiypp5Ps" role="3JN1Yi">
         <ref role="3Ze0ni" to="9kut:3pc485WbbkL" resolve="optionalChild" />
         <node concept="3DZp98" id="30FY4ILQW6k" role="3JN5mL">
           <node concept="3clFbS" id="30FY4ILQW6m" role="2VODD2">
@@ -1092,8 +1114,28 @@
           </node>
         </node>
       </node>
+      <node concept="230_S" id="7wzAiypp7St" role="21DrV">
+        <node concept="3clFbS" id="7wzAiypp7Su" role="2VODD2">
+          <node concept="3clFbF" id="7wzAiypp9ux" role="3cqZAp">
+            <node concept="2OqwBi" id="7wzAiyppc5T" role="3clFbG">
+              <node concept="2OqwBi" id="7wzAiyppaa8" role="2Oq$k0">
+                <node concept="233M7" id="7wzAiypp9uw" role="2Oq$k0" />
+                <node concept="3TrEf2" id="7wzAiyppbUz" role="2OqNvi">
+                  <ref role="3Tt5mk" to="9kut:3pc485Vr2SR" resolve="childSingleton" />
+                </node>
+              </node>
+              <node concept="3TrcHB" id="7wzAiyppdej" role="2OqNvi">
+                <ref role="3TsBF5" to="yeyq:32ggi2DCpGx" resolve="data" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1orWGm" id="7wzAiyq3Hfl" role="1orW53">
+        <ref role="3iOP7l" to="tpck:h0TrG11" resolve="name" />
+        <node concept="3iOvoU" id="7wzAiyq3HNT" role="1orWrN" />
+      </node>
     </node>
-    <node concept="1oluLK" id="30FY4ILQVHB" role="1olsr8" />
     <node concept="pHN19" id="30FY4ILQVHC" role="3WPhuS">
       <node concept="2V$Bhx" id="30FY4ILQVHD" role="2V$M_3">
         <property role="2V$B1T" value="8688ed72-e0ba-44cb-9688-5c8397cb5bbb" />
@@ -1597,6 +1639,64 @@
           </node>
         </node>
       </node>
+    </node>
+  </node>
+  <node concept="1olOeT" id="7wzAiyq8GF4">
+    <property role="TrG5h" value="ModelMergeWithDefaultActions" />
+    <property role="3P_Oz2" value="true" />
+    <node concept="1olsrb" id="7wzAiyq8GG0" role="1olsr8">
+      <property role="vpZK9" value="true" />
+      <ref role="24zOxU" to="9kut:3pc485Vr2SQ" resolve="ChildKeeper" />
+      <node concept="230_S" id="7wzAiyq8GG1" role="21DrV">
+        <node concept="3clFbS" id="7wzAiyq8GG2" role="2VODD2">
+          <node concept="3clFbF" id="7wzAiyq8GG3" role="3cqZAp">
+            <node concept="2OqwBi" id="7wzAiyq8GG4" role="3clFbG">
+              <node concept="2OqwBi" id="7wzAiyq8GG5" role="2Oq$k0">
+                <node concept="233M7" id="7wzAiyq8GG6" role="2Oq$k0" />
+                <node concept="3TrEf2" id="7wzAiyq8GG7" role="2OqNvi">
+                  <ref role="3Tt5mk" to="9kut:3pc485Vr2SR" resolve="childSingleton" />
+                </node>
+              </node>
+              <node concept="3TrcHB" id="7wzAiyq8GG8" role="2OqNvi">
+                <ref role="3TsBF5" to="yeyq:32ggi2DCpGx" resolve="data" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1oluLK" id="7wzAiyq8GG9" role="1olsr8" />
+    <node concept="1olsrb" id="7wzAiyq8GGa" role="1olsr8">
+      <property role="vpZK9" value="true" />
+      <ref role="24zOxU" to="yeyq:32ggi2DCpGw" resolve="PropertyDummy" />
+      <node concept="230_S" id="7wzAiyq8GGb" role="21DrV">
+        <node concept="3clFbS" id="7wzAiyq8GGc" role="2VODD2">
+          <node concept="3clFbF" id="7wzAiyq8GGd" role="3cqZAp">
+            <node concept="2OqwBi" id="7wzAiyq8GGe" role="3clFbG">
+              <node concept="233M7" id="7wzAiyq8GGf" role="2Oq$k0" />
+              <node concept="3TrcHB" id="7wzAiyq8GGg" role="2OqNvi">
+                <ref role="3TsBF5" to="yeyq:32ggi2DCpGx" resolve="data" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="pHN19" id="7wzAiyq8GF5" role="3WPhuS">
+      <node concept="2V$Bhx" id="7wzAiyq8GF$" role="2V$M_3">
+        <property role="2V$B1T" value="8688ed72-e0ba-44cb-9688-5c8397cb5bbb" />
+        <property role="2V$B1Q" value="de.itemis.model.simple.demo.children" />
+      </node>
+    </node>
+    <node concept="FwPyy" id="7wzAiyq8GFM" role="1wVUQl">
+      <node concept="3iOvoU" id="7wzAiyq8GFN" role="1woo5X" />
+      <node concept="3JN9zw" id="7wzAiyq8GFO" role="1woA3i" />
+      <node concept="3JN9zw" id="7wzAiyq8GFP" role="1wo_8c" />
+      <node concept="3JHzSW" id="7wzAiyq8GFQ" role="1wo$yn" />
+      <node concept="3JN9zx" id="7wzAiyq8GFR" role="1wbzTg" />
+      <node concept="3JN9zw" id="7wzAiyq8GFS" role="1wbzTo" />
+      <node concept="3iOvoU" id="7wzAiyq8GFT" role="1woUSC" />
+      <node concept="3JN9zw" id="7wzAiyq8GFU" role="1wp1O6" />
     </node>
   </node>
 </model>

--- a/code/solutions/de.itemis.model.merge.simple.demo/models/de.itemis.model.merge.simple.demo.result.mps
+++ b/code/solutions/de.itemis.model.merge.simple.demo/models/de.itemis.model.merge.simple.demo.result.mps
@@ -13,6 +13,11 @@
         <property id="3499368519007574817" name="data" index="2pctC1" />
       </concept>
     </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
     <language id="8688ed72-e0ba-44cb-9688-5c8397cb5bbb" name="de.itemis.model.simple.demo.children">
       <concept id="3912520324585631286" name="de.itemis.model.simple.demo.children.structure.ChildKeeper" flags="ng" index="1d83UR">
         <child id="3912520324598248753" name="optionalChild" index="1aoamK" />
@@ -20,12 +25,13 @@
       </concept>
     </language>
   </registry>
-  <node concept="1d83UR" id="5anw8kxKXpM">
-    <node concept="2pctC0" id="5anw8kxKXpN" role="1d83UQ">
-      <property role="2pctC1" value="lala&lt;---&gt;lala" />
+  <node concept="1d83UR" id="3pc485Vw3Jr">
+    <property role="TrG5h" value="ChildKeeperRight" />
+    <node concept="2pctC0" id="7wzAiyq9tZz" role="1d83UQ">
+      <property role="2pctC1" value="lala" />
     </node>
-    <node concept="2pctC0" id="5anw8kxKXpO" role="1aoamK">
-      <property role="2pctC1" value="haha&lt;---&gt;haha" />
+    <node concept="2pctC0" id="7wzAiyq9tZ_" role="1aoamK">
+      <property role="2pctC1" value="DDDD" />
     </node>
   </node>
 </model>

--- a/code/solutions/de.itemis.model.merge.simple.demo/models/de.itemis.model.merge.simple.demo.rightSingltonChild.mps
+++ b/code/solutions/de.itemis.model.merge.simple.demo/models/de.itemis.model.merge.simple.demo.rightSingltonChild.mps
@@ -12,6 +12,11 @@
         <property id="3499368519007574817" name="data" index="2pctC1" />
       </concept>
     </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
     <language id="8688ed72-e0ba-44cb-9688-5c8397cb5bbb" name="de.itemis.model.simple.demo.children">
       <concept id="3912520324585631286" name="de.itemis.model.simple.demo.children.structure.ChildKeeper" flags="ng" index="1d83UR">
         <child id="3912520324598248753" name="optionalChild" index="1aoamK" />
@@ -20,11 +25,12 @@
     </language>
   </registry>
   <node concept="1d83UR" id="3pc485Vw3Y5">
+    <property role="TrG5h" value="ChildKeeperRight" />
     <node concept="2pctC0" id="78fCHIEYtC1" role="1d83UQ">
       <property role="2pctC1" value="lala" />
     </node>
     <node concept="2pctC0" id="78fCHIEYtC3" role="1aoamK">
-      <property role="2pctC1" value="haha" />
+      <property role="2pctC1" value="DDDD" />
     </node>
   </node>
 </model>

--- a/code/solutions/de.itemis.model.merge.simple.demo/models/de.itemis.model.merge.simple.demo.test@tests.mps
+++ b/code/solutions/de.itemis.model.merge.simple.demo/models/de.itemis.model.merge.simple.demo.test@tests.mps
@@ -2664,7 +2664,7 @@
     <node concept="1qefOq" id="7wzAiyprmaG" role="1SKRRt">
       <node concept="poArf" id="7wzAiyprmaH" role="1qenE9">
         <property role="TrG5h" value="ChildMergeAutoExec" />
-        <ref role="pot50" node="7wzAiyprmaY" />
+        <ref role="pot50" node="7wzAiyprmaY" resolve="ModelMergeWithMissingPolicies" />
         <node concept="1Xw6AR" id="7wzAiyprmaI" role="ppIIL">
           <node concept="1dCxOl" id="7wzAiyprmaJ" role="1XwpL7">
             <property role="1XweGQ" value="r:de7dfd54-d52a-48c3-ad0b-4ff50c9fe414" />
@@ -2769,7 +2769,7 @@
     <node concept="1qefOq" id="7wzAiypP$Us" role="1SKRRt">
       <node concept="poArf" id="7wzAiypP$Ut" role="1qenE9">
         <property role="TrG5h" value="ChildMergeAutoExec" />
-        <ref role="pot50" node="7wzAiypP$UC" />
+        <ref role="pot50" node="7wzAiypP$UC" resolve="ModelMergeWithMissingPolicies" />
         <node concept="1Xw6AR" id="7wzAiypP$Uu" role="ppIIL">
           <node concept="1dCxOl" id="7wzAiypP$Uv" role="1XwpL7">
             <property role="1XweGQ" value="r:de7dfd54-d52a-48c3-ad0b-4ff50c9fe414" />

--- a/code/solutions/de.itemis.model.merge.simple.demo/models/de.itemis.model.merge.simple.demo.test@tests.mps
+++ b/code/solutions/de.itemis.model.merge.simple.demo/models/de.itemis.model.merge.simple.demo.test@tests.mps
@@ -19,7 +19,7 @@
     <import index="yeyq" ref="r:98a265f1-4186-4e32-a289-328d37e5000c(de.itemis.model.simple.demo.property.structure)" />
     <import index="tqvn" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel.tempmodel(MPS.Core/)" />
     <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" />
-    <import index="3o3z" ref="ecfb9949-7433-4db5-85de-0f84d172e4ce/java:com.google.common.collect(de.q60.mps.libs/)" />
+    <import index="3o3z" ref="ecfb9949-7433-4db5-85de-0f84d172e4ce/java:com.google.common.collect(de.q60.mps.collections.libs/)" />
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
     <import index="hsq" ref="r:fc82e0c0-6be8-4ecf-9fa1-3d5bc168484e(de.itemis.model.simple.demo.reference.structure)" />
     <import index="u132" ref="49808fad-9d41-4b96-83fa-9231640f6b2b/java:junit.framework(JUnit/)" />
@@ -29,17 +29,32 @@
     <import index="tp25" ref="r:00000000-0000-4000-0000-011c89590301(jetbrains.mps.lang.smodel.structure)" />
     <import index="xlb7" ref="r:cf42fd0a-68d2-493b-8b77-961658617704(jetbrains.mps.lang.modelapi.behavior)" />
     <import index="gunp" ref="r:a4055897-4d16-4474-96e9-a78cf2abfe5a(de.itemis.model.merge.runtime.runtime)" />
+    <import index="sz2a" ref="r:02b6652e-c87d-4bb2-bfc0-4b5c0d5b9442(de.itemis.model.merge.typesystem)" />
     <import index="lmxm" ref="r:a3686f62-e70f-468d-94f6-43bd46b56f08(de.itemis.model.simple.demo.collection.structure)" implicit="true" />
     <import index="z7ot" ref="r:3a3f4bbf-6c2b-49f6-8189-f83260cd20d6(de.itemis.model.simple.demo.collection.keeper.structure)" implicit="true" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
     <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" implicit="true" />
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
   </imports>
   <registry>
     <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="1215507671101" name="jetbrains.mps.lang.test.structure.NodeErrorCheckOperation" flags="ng" index="1TM$A">
+        <child id="8489045168660938517" name="errorRef" index="3lydEf" />
+      </concept>
+      <concept id="1215603922101" name="jetbrains.mps.lang.test.structure.NodeOperationsContainer" flags="ng" index="7CXmI">
+        <child id="1215604436604" name="nodeOperations" index="7EUXB" />
+      </concept>
+      <concept id="1215607067978" name="jetbrains.mps.lang.test.structure.CheckNodeForErrorMessagesOperation" flags="ng" index="7OXhh">
+        <property id="3743352646565420194" name="includeSelf" index="GvXf4" />
+      </concept>
+      <concept id="7691029917083872157" name="jetbrains.mps.lang.test.structure.IRuleReference" flags="ngI" index="2u4UPC">
+        <reference id="8333855927540250453" name="declaration" index="39XzEq" />
+      </concept>
       <concept id="1211979288880" name="jetbrains.mps.lang.test.structure.AssertMatch" flags="nn" index="JA50E">
         <child id="1211979305365" name="before" index="JA92f" />
         <child id="1211979322383" name="after" index="JAdkl" />
       </concept>
+      <concept id="4531408400484511853" name="jetbrains.mps.lang.test.structure.ReportErrorStatementReference" flags="ng" index="2PYRI3" />
       <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
         <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
       </concept>
@@ -76,6 +91,9 @@
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
       </concept>
+      <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
+        <child id="1137022507850" name="body" index="2VODD2" />
+      </concept>
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
       </concept>
@@ -83,10 +101,6 @@
       <concept id="1081236700938" name="jetbrains.mps.baseLanguage.structure.StaticMethodDeclaration" flags="ig" index="2YIFZL" />
       <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
-      </concept>
-      <concept id="1081256982272" name="jetbrains.mps.baseLanguage.structure.InstanceOfExpression" flags="nn" index="2ZW3vV">
-        <child id="1081256993305" name="classType" index="2ZW6by" />
-        <child id="1081256993304" name="leftExpression" index="2ZW6bz" />
       </concept>
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
       <concept id="1070534934090" name="jetbrains.mps.baseLanguage.structure.CastExpression" flags="nn" index="10QFUN">
@@ -235,6 +249,9 @@
       <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
         <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
       </concept>
+      <concept id="4497478346159780083" name="jetbrains.mps.lang.smodel.structure.LanguageRefExpression" flags="ng" index="pHN19">
+        <child id="3542851458883491298" name="languageId" index="2V$M_3" />
+      </concept>
       <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
       <concept id="4693937538533521280" name="jetbrains.mps.lang.smodel.structure.OfConceptOperation" flags="ng" index="v3k3i">
         <child id="4693937538533538124" name="requestedConcept" index="v3oSu" />
@@ -246,8 +263,18 @@
       <concept id="1171323947159" name="jetbrains.mps.lang.smodel.structure.Model_NodesOperation" flags="nn" index="2SmgA7">
         <child id="1758937410080001570" name="conceptArgument" index="1dBWTz" />
       </concept>
+      <concept id="3542851458883438784" name="jetbrains.mps.lang.smodel.structure.LanguageId" flags="nn" index="2V$Bhx">
+        <property id="3542851458883439831" name="namespace" index="2V$B1Q" />
+        <property id="3542851458883439832" name="languageId" index="2V$B1T" />
+      </concept>
+      <concept id="2644386474300074836" name="jetbrains.mps.lang.smodel.structure.ConceptIdRefExpression" flags="nn" index="35c_gC">
+        <reference id="2644386474300074837" name="conceptDeclaration" index="35c_gD" />
+      </concept>
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
         <reference id="1138405853777" name="concept" index="ehGHo" />
+      </concept>
+      <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
+        <reference id="1138056395725" name="property" index="3TsBF5" />
       </concept>
       <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="nn" index="3TrEf2">
         <reference id="1138056516764" name="link" index="3Tt5mk" />
@@ -258,6 +285,7 @@
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
         <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
       </concept>
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
@@ -271,11 +299,58 @@
       </concept>
     </language>
     <language id="539e8939-08ef-497c-a5fd-25dd10137a55" name="de.itemis.model.merge">
+      <concept id="7137735640371846599" name="de.itemis.model.merge.structure.IdFunction" flags="ig" index="230_S" />
+      <concept id="7137735640371849272" name="de.itemis.model.merge.structure.IdFunctionParam" flags="ng" index="233M7" />
       <concept id="6402745832171993510" name="de.itemis.model.merge.structure.ModelMergeExecution" flags="ng" index="poArf">
         <reference id="6402745832172080681" name="modelMerge" index="pot50" />
         <child id="6402745832172399733" name="right" index="ppbcs" />
         <child id="6402745832172287192" name="left" index="ppIIL" />
         <child id="3370123198533999175" name="result" index="2JagXQ" />
+      </concept>
+      <concept id="4415987603494135286" name="de.itemis.model.merge.structure.MergerDefaultAction" flags="ng" index="FwPyy">
+        <child id="635146989628964994" name="existsOnlyOnLeftAction" index="1wbzTg" />
+        <child id="635146989628965002" name="elementOnBothAction" index="1wbzTo" />
+        <child id="635146989623967663" name="propertyAction" index="1woo5X" />
+        <child id="635146989623981637" name="existsOnlyOnRightAction" index="1wo$yn" />
+        <child id="635146989623979230" name="optionalChildAction" index="1wo_8c" />
+        <child id="635146989623975424" name="singleChildAction" index="1woA3i" />
+        <child id="635146989624086778" name="singleRefAction" index="1woUSC" />
+        <child id="635146989624124372" name="optionalRefAction" index="1wp1O6" />
+      </concept>
+      <concept id="7555554651740524246" name="de.itemis.model.merge.structure.Right" flags="ng" index="3iOvoU" />
+      <concept id="1912777765298260981" name="de.itemis.model.merge.structure.MergePolicy" flags="ng" index="1olsrb">
+        <property id="6365386016289822930" name="useDefaults" index="vpZK9" />
+        <reference id="4176264672384277229" name="conceptRef" index="24zOxU" />
+        <child id="7137735640372265540" name="idFunction" index="21DrV" />
+        <child id="1912777765298654333" name="propertyPolicies" index="1orW53" />
+        <child id="8422540920006574021" name="childPolicies" index="3JN1Yi" />
+      </concept>
+      <concept id="1912777765298266446" name="de.itemis.model.merge.structure.EmptyMergeItem" flags="ng" index="1oluLK" />
+      <concept id="1912777765298163335" name="de.itemis.model.merge.structure.ModelMerge" flags="ng" index="1olOeT">
+        <property id="3110765452006840876" name="partialPolicy" index="1phRau" />
+        <property id="6743315325753907533" name="useDefaults" index="3P_Oz2" />
+        <child id="1912777765298260982" name="items" index="1olsr8" />
+        <child id="8218966909317017940" name="additonalLangs" index="3oy5ef" />
+        <child id="364371549494520939" name="defaultAction" index="1wVUQl" />
+        <child id="2222162468665533253" name="lang" index="3WPhuS" />
+      </concept>
+      <concept id="1912777765298652712" name="de.itemis.model.merge.structure.PropertyPolicy" flags="ng" index="1orWGm">
+        <reference id="7555554651740432697" name="property" index="3iOP7l" />
+        <child id="1912777765298654157" name="action" index="1orWrN" />
+      </concept>
+      <concept id="4427572733341729074" name="de.itemis.model.merge.structure.OptionalChildPolicy" flags="ng" index="1DuYj3" />
+      <concept id="4427572733341729071" name="de.itemis.model.merge.structure.SingletonChildPolicy" flags="ng" index="1DuYju" />
+      <concept id="8422540920009055851" name="de.itemis.model.merge.structure.Add" flags="ng" index="3JHzSW" />
+      <concept id="8422540920006554635" name="de.itemis.model.merge.structure.OptionalPolicy" flags="ng" index="3JN5hs">
+        <child id="8422540920006555110" name="action" index="3JN5mL" />
+      </concept>
+      <concept id="8422540920006539447" name="de.itemis.model.merge.structure.Auto" flags="ng" index="3JN9zw" />
+      <concept id="8422540920006539446" name="de.itemis.model.merge.structure.Drop" flags="ng" index="3JN9zx" />
+      <concept id="8422540920006612555" name="de.itemis.model.merge.structure.SingletonPolicy" flags="ng" index="3JNnos">
+        <child id="8422540920006555110" name="action" index="3JN5mM" />
+      </concept>
+      <concept id="2222162468664160556" name="de.itemis.model.merge.structure.AbstractPolicy" flags="ng" index="3Ze0nh">
+        <reference id="2222162468664160559" name="child" index="3Ze0ni" />
       </concept>
     </language>
     <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
@@ -309,6 +384,7 @@
   <node concept="1lH9Xt" id="6Ltuup4vyIj">
     <property role="TrG5h" value="PropertyMergeExecution" />
     <property role="3DII0k" value="2hh8MJdVwqX/command" />
+    <property role="3GE5qa" value="merging" />
     <node concept="1LZb2c" id="6Ltuup4v_NP" role="1SL9yI">
       <property role="TrG5h" value="testPropertyMerge" />
       <node concept="3cqZAl" id="6Ltuup4v_NQ" role="3clF45" />
@@ -329,13 +405,16 @@
             </node>
           </node>
         </node>
-        <node concept="1gVbGN" id="6Ltuup4wyH9" role="3cqZAp">
-          <node concept="2ZW3vV" id="6Ltuup4wAam" role="1gVkn0">
-            <node concept="3Tqbb2" id="6Ltuup4wAHa" role="2ZW6by">
-              <ref role="ehGHo" to="yeyq:32ggi2DCpGw" resolve="PropertyDummy" />
-            </node>
-            <node concept="37vLTw" id="6Ltuup4wzhn" role="2ZW6bz">
+        <node concept="1gVbGN" id="kewvTA1VeG" role="3cqZAp">
+          <node concept="2OqwBi" id="kewvTA1VeH" role="1gVkn0">
+            <node concept="37vLTw" id="kewvTA1VeI" role="2Oq$k0">
               <ref role="3cqZAo" node="6Ltuup4wtxo" resolve="observedRoot" />
+            </node>
+            <node concept="liA8E" id="kewvTA1VeJ" role="2OqNvi">
+              <ref role="37wK5l" to="mhbf:~SNode.isInstanceOfConcept(org.jetbrains.mps.openapi.language.SAbstractConcept)" resolve="isInstanceOfConcept" />
+              <node concept="35c_gC" id="kewvTA1VeK" role="37wK5m">
+                <ref role="35c_gD" to="yeyq:32ggi2DCpGw" resolve="PropertyDummy" />
+              </node>
             </node>
           </node>
         </node>
@@ -487,6 +566,7 @@
   <node concept="1lH9Xt" id="6Ltuup4wNKw">
     <property role="TrG5h" value="ManualChildMergeExecution" />
     <property role="3DII0k" value="2hh8MJdVwqX/command" />
+    <property role="3GE5qa" value="merging" />
     <node concept="1LZb2c" id="6Ltuup4wNL7" role="1SL9yI">
       <property role="TrG5h" value="manualChildMerging" />
       <node concept="3cqZAl" id="6Ltuup4wNL8" role="3clF45" />
@@ -506,13 +586,16 @@
             </node>
           </node>
         </node>
-        <node concept="1gVbGN" id="6Ltuup4wOSt" role="3cqZAp">
-          <node concept="2ZW3vV" id="6Ltuup4wPv0" role="1gVkn0">
-            <node concept="3Tqbb2" id="6Ltuup4wPLF" role="2ZW6by">
-              <ref role="ehGHo" to="9kut:3pc485Vr2SQ" resolve="ChildKeeper" />
-            </node>
-            <node concept="37vLTw" id="6Ltuup4wPaP" role="2ZW6bz">
+        <node concept="1gVbGN" id="kewvTA1TiR" role="3cqZAp">
+          <node concept="2OqwBi" id="kewvTA1TiS" role="1gVkn0">
+            <node concept="37vLTw" id="kewvTA1TiT" role="2Oq$k0">
               <ref role="3cqZAo" node="6Ltuup4wNZq" resolve="observedRoot" />
+            </node>
+            <node concept="liA8E" id="kewvTA1TiU" role="2OqNvi">
+              <ref role="37wK5l" to="mhbf:~SNode.isInstanceOfConcept(org.jetbrains.mps.openapi.language.SAbstractConcept)" resolve="isInstanceOfConcept" />
+              <node concept="35c_gC" id="kewvTA1TiV" role="37wK5m">
+                <ref role="35c_gD" to="9kut:3pc485Vr2SQ" resolve="ChildKeeper" />
+              </node>
             </node>
           </node>
         </node>
@@ -573,6 +656,7 @@
     </node>
     <node concept="1qefOq" id="6Ltuup4wOLO" role="1SKRRt">
       <node concept="1d83US" id="6Ltuup4wOEW" role="1qenE9">
+        <property role="TrG5h" value="ChildKeeperRight" />
         <node concept="3xLA65" id="6Ltuup4wQrC" role="lGtFl">
           <property role="TrG5h" value="expected" />
         </node>
@@ -588,6 +672,7 @@
   <node concept="1lH9Xt" id="6Ltuup4wYSw">
     <property role="TrG5h" value="AutoChildMergeExecution" />
     <property role="3DII0k" value="2hh8MJdVwqX/command" />
+    <property role="3GE5qa" value="merging" />
     <node concept="1LZb2c" id="6Ltuup4wZbC" role="1SL9yI">
       <property role="TrG5h" value="autoChildMerging" />
       <node concept="3cqZAl" id="6Ltuup4wZbD" role="3clF45" />
@@ -608,12 +693,15 @@
           </node>
         </node>
         <node concept="1gVbGN" id="6Ltuup4wZy6" role="3cqZAp">
-          <node concept="2ZW3vV" id="6Ltuup4wZy7" role="1gVkn0">
-            <node concept="3Tqbb2" id="6Ltuup4wZy8" role="2ZW6by">
-              <ref role="ehGHo" to="9kut:3pc485Vr2SQ" resolve="ChildKeeper" />
-            </node>
-            <node concept="37vLTw" id="6Ltuup4wZy9" role="2ZW6bz">
+          <node concept="2OqwBi" id="kewvTA1IVT" role="1gVkn0">
+            <node concept="37vLTw" id="kewvTA1IbR" role="2Oq$k0">
               <ref role="3cqZAo" node="6Ltuup4wZy0" resolve="observedRoot" />
+            </node>
+            <node concept="liA8E" id="kewvTA1J9T" role="2OqNvi">
+              <ref role="37wK5l" to="mhbf:~SNode.isInstanceOfConcept(org.jetbrains.mps.openapi.language.SAbstractConcept)" resolve="isInstanceOfConcept" />
+              <node concept="35c_gC" id="kewvTA1Kdn" role="37wK5m">
+                <ref role="35c_gD" to="9kut:3pc485Vr2SQ" resolve="ChildKeeper" />
+              </node>
             </node>
           </node>
         </node>
@@ -674,6 +762,7 @@
     </node>
     <node concept="1qefOq" id="6Ltuup4x0dC" role="1SKRRt">
       <node concept="1d83US" id="6Ltuup4wZYd" role="1qenE9">
+        <property role="TrG5h" value="ChildKeeperRight" />
         <node concept="3xLA65" id="6Ltuup4x0kc" role="lGtFl">
           <property role="TrG5h" value="expected" />
         </node>
@@ -681,7 +770,7 @@
           <property role="2pctC1" value="lala&lt;---&gt;lala" />
         </node>
         <node concept="2pctC0" id="1zxgaynEnL6" role="1aoamK">
-          <property role="2pctC1" value="haha&lt;---&gt;haha" />
+          <property role="2pctC1" value="haha&lt;---&gt;DDDD" />
         </node>
       </node>
     </node>
@@ -894,6 +983,7 @@
   <node concept="1lH9Xt" id="77Ot_5af$7e">
     <property role="TrG5h" value="AutoChildCollectionMergeExecution" />
     <property role="3DII0k" value="2hh8MJdVwqX/command" />
+    <property role="3GE5qa" value="merging" />
     <node concept="1LZb2c" id="77Ot_5af$7f" role="1SL9yI">
       <property role="TrG5h" value="autoChildMergingDropLDropR" />
       <node concept="3cqZAl" id="77Ot_5af$7g" role="3clF45" />
@@ -913,13 +1003,16 @@
             </node>
           </node>
         </node>
-        <node concept="1gVbGN" id="77Ot_5af$7$" role="3cqZAp">
-          <node concept="2ZW3vV" id="77Ot_5af$7_" role="1gVkn0">
-            <node concept="3Tqbb2" id="77Ot_5af$7A" role="2ZW6by">
-              <ref role="ehGHo" to="lmxm:6Ltuup4C5JZ" resolve="CollectionKeeper" />
-            </node>
-            <node concept="37vLTw" id="77Ot_5af$7B" role="2ZW6bz">
+        <node concept="1gVbGN" id="kewvTAvpd9" role="3cqZAp">
+          <node concept="2OqwBi" id="kewvTAvpda" role="1gVkn0">
+            <node concept="37vLTw" id="kewvTAvpdb" role="2Oq$k0">
               <ref role="3cqZAo" node="77Ot_5af$7u" resolve="observedRoot" />
+            </node>
+            <node concept="liA8E" id="kewvTAvpdc" role="2OqNvi">
+              <ref role="37wK5l" to="mhbf:~SNode.isInstanceOfConcept(org.jetbrains.mps.openapi.language.SAbstractConcept)" resolve="isInstanceOfConcept" />
+              <node concept="35c_gC" id="kewvTAvpdd" role="37wK5m">
+                <ref role="35c_gD" to="lmxm:6Ltuup4C5JZ" resolve="CollectionKeeper" />
+              </node>
             </node>
           </node>
         </node>
@@ -971,13 +1064,16 @@
             </node>
           </node>
         </node>
-        <node concept="1gVbGN" id="77Ot_5ah_O7" role="3cqZAp">
-          <node concept="2ZW3vV" id="77Ot_5ah_O8" role="1gVkn0">
-            <node concept="3Tqbb2" id="77Ot_5ah_O9" role="2ZW6by">
-              <ref role="ehGHo" to="lmxm:6Ltuup4C5JZ" resolve="CollectionKeeper" />
-            </node>
-            <node concept="37vLTw" id="77Ot_5ah_Oa" role="2ZW6bz">
+        <node concept="1gVbGN" id="kewvTAvpsX" role="3cqZAp">
+          <node concept="2OqwBi" id="kewvTAvpsY" role="1gVkn0">
+            <node concept="37vLTw" id="kewvTAvpsZ" role="2Oq$k0">
               <ref role="3cqZAo" node="77Ot_5ah_O1" resolve="observedRoot" />
+            </node>
+            <node concept="liA8E" id="kewvTAvpt0" role="2OqNvi">
+              <ref role="37wK5l" to="mhbf:~SNode.isInstanceOfConcept(org.jetbrains.mps.openapi.language.SAbstractConcept)" resolve="isInstanceOfConcept" />
+              <node concept="35c_gC" id="kewvTAvpt1" role="37wK5m">
+                <ref role="35c_gD" to="lmxm:6Ltuup4C5JZ" resolve="CollectionKeeper" />
+              </node>
             </node>
           </node>
         </node>
@@ -1029,13 +1125,16 @@
             </node>
           </node>
         </node>
-        <node concept="1gVbGN" id="77Ot_5ap$1T" role="3cqZAp">
-          <node concept="2ZW3vV" id="77Ot_5ap$1U" role="1gVkn0">
-            <node concept="3Tqbb2" id="77Ot_5ap$1V" role="2ZW6by">
-              <ref role="ehGHo" to="lmxm:6Ltuup4C5JZ" resolve="CollectionKeeper" />
-            </node>
-            <node concept="37vLTw" id="77Ot_5ap$1W" role="2ZW6bz">
+        <node concept="1gVbGN" id="kewvTAvpyL" role="3cqZAp">
+          <node concept="2OqwBi" id="kewvTAvpyM" role="1gVkn0">
+            <node concept="37vLTw" id="kewvTAvpyN" role="2Oq$k0">
               <ref role="3cqZAo" node="77Ot_5ap$1N" resolve="observedRoot" />
+            </node>
+            <node concept="liA8E" id="kewvTAvpyO" role="2OqNvi">
+              <ref role="37wK5l" to="mhbf:~SNode.isInstanceOfConcept(org.jetbrains.mps.openapi.language.SAbstractConcept)" resolve="isInstanceOfConcept" />
+              <node concept="35c_gC" id="kewvTAvpyP" role="37wK5m">
+                <ref role="35c_gD" to="lmxm:6Ltuup4C5JZ" resolve="CollectionKeeper" />
+              </node>
             </node>
           </node>
         </node>
@@ -1087,13 +1186,16 @@
             </node>
           </node>
         </node>
-        <node concept="1gVbGN" id="77Ot_5arzVH" role="3cqZAp">
-          <node concept="2ZW3vV" id="77Ot_5arzVI" role="1gVkn0">
-            <node concept="3Tqbb2" id="77Ot_5arzVJ" role="2ZW6by">
-              <ref role="ehGHo" to="lmxm:6Ltuup4C5JZ" resolve="CollectionKeeper" />
-            </node>
-            <node concept="37vLTw" id="77Ot_5arzVK" role="2ZW6bz">
+        <node concept="1gVbGN" id="kewvTAvpBe" role="3cqZAp">
+          <node concept="2OqwBi" id="kewvTAvpBf" role="1gVkn0">
+            <node concept="37vLTw" id="kewvTAvpBg" role="2Oq$k0">
               <ref role="3cqZAo" node="77Ot_5arzVB" resolve="observedRoot" />
+            </node>
+            <node concept="liA8E" id="kewvTAvpBh" role="2OqNvi">
+              <ref role="37wK5l" to="mhbf:~SNode.isInstanceOfConcept(org.jetbrains.mps.openapi.language.SAbstractConcept)" resolve="isInstanceOfConcept" />
+              <node concept="35c_gC" id="kewvTAvpBi" role="37wK5m">
+                <ref role="35c_gD" to="lmxm:6Ltuup4C5JZ" resolve="CollectionKeeper" />
+              </node>
             </node>
           </node>
         </node>
@@ -1145,13 +1247,16 @@
             </node>
           </node>
         </node>
-        <node concept="1gVbGN" id="1IpxBNKeUDp" role="3cqZAp">
-          <node concept="2ZW3vV" id="1IpxBNKeUDq" role="1gVkn0">
-            <node concept="3Tqbb2" id="1IpxBNKeUDr" role="2ZW6by">
-              <ref role="ehGHo" to="z7ot:5CYFCJDOmka" resolve="KeeperOfCollection" />
-            </node>
-            <node concept="37vLTw" id="1IpxBNKeUDs" role="2ZW6bz">
+        <node concept="1gVbGN" id="kewvTAvpFW" role="3cqZAp">
+          <node concept="2OqwBi" id="kewvTAvpFX" role="1gVkn0">
+            <node concept="37vLTw" id="kewvTAvpFY" role="2Oq$k0">
               <ref role="3cqZAo" node="1IpxBNKeUDl" resolve="observedRoot" />
+            </node>
+            <node concept="liA8E" id="kewvTAvpFZ" role="2OqNvi">
+              <ref role="37wK5l" to="mhbf:~SNode.isInstanceOfConcept(org.jetbrains.mps.openapi.language.SAbstractConcept)" resolve="isInstanceOfConcept" />
+              <node concept="35c_gC" id="kewvTAvpG0" role="37wK5m">
+                <ref role="35c_gD" to="z7ot:5CYFCJDOmka" resolve="KeeperOfCollection" />
+              </node>
             </node>
           </node>
         </node>
@@ -1203,13 +1308,16 @@
             </node>
           </node>
         </node>
-        <node concept="1gVbGN" id="30FY4ILVPNw" role="3cqZAp">
-          <node concept="2ZW3vV" id="30FY4ILVPNx" role="1gVkn0">
-            <node concept="3Tqbb2" id="30FY4ILVPNy" role="2ZW6by">
-              <ref role="ehGHo" to="9kut:3pc485Vr2SQ" resolve="ChildKeeper" />
-            </node>
-            <node concept="37vLTw" id="30FY4ILVPNz" role="2ZW6bz">
+        <node concept="1gVbGN" id="kewvTAvpOY" role="3cqZAp">
+          <node concept="2OqwBi" id="kewvTAvpOZ" role="1gVkn0">
+            <node concept="37vLTw" id="kewvTAvpP0" role="2Oq$k0">
               <ref role="3cqZAo" node="30FY4ILVPNs" resolve="observedRoot" />
+            </node>
+            <node concept="liA8E" id="kewvTAvpP1" role="2OqNvi">
+              <ref role="37wK5l" to="mhbf:~SNode.isInstanceOfConcept(org.jetbrains.mps.openapi.language.SAbstractConcept)" resolve="isInstanceOfConcept" />
+              <node concept="35c_gC" id="kewvTAvpP2" role="37wK5m">
+                <ref role="35c_gD" to="9kut:3pc485Vr2SQ" resolve="ChildKeeper" />
+              </node>
             </node>
           </node>
         </node>
@@ -1260,13 +1368,16 @@
             </node>
           </node>
         </node>
-        <node concept="1gVbGN" id="30FY4IMda1y" role="3cqZAp">
-          <node concept="2ZW3vV" id="30FY4IMda1z" role="1gVkn0">
-            <node concept="3Tqbb2" id="30FY4IMda1$" role="2ZW6by">
-              <ref role="ehGHo" to="lmxm:6Ltuup4C5JZ" resolve="CollectionKeeper" />
-            </node>
-            <node concept="37vLTw" id="30FY4IMda1_" role="2ZW6bz">
+        <node concept="1gVbGN" id="kewvTAvqcw" role="3cqZAp">
+          <node concept="2OqwBi" id="kewvTAvqcx" role="1gVkn0">
+            <node concept="37vLTw" id="kewvTAvqcy" role="2Oq$k0">
               <ref role="3cqZAo" node="30FY4IMda1u" resolve="observedRoot" />
+            </node>
+            <node concept="liA8E" id="kewvTAvqcz" role="2OqNvi">
+              <ref role="37wK5l" to="mhbf:~SNode.isInstanceOfConcept(org.jetbrains.mps.openapi.language.SAbstractConcept)" resolve="isInstanceOfConcept" />
+              <node concept="35c_gC" id="kewvTAvqc$" role="37wK5m">
+                <ref role="35c_gD" to="lmxm:6Ltuup4C5JZ" resolve="CollectionKeeper" />
+              </node>
             </node>
           </node>
         </node>
@@ -1521,6 +1632,7 @@
     </node>
     <node concept="1qefOq" id="30FY4ILVPI4" role="1SKRRt">
       <node concept="1d83US" id="30FY4ILVOSw" role="1qenE9">
+        <property role="TrG5h" value="ChildKeeperRight" />
         <node concept="3xLA65" id="30FY4ILVPJq" role="lGtFl">
           <property role="TrG5h" value="expected6" />
         </node>
@@ -1528,7 +1640,7 @@
           <property role="2pctC1" value="lala&lt;---&gt;lala" />
         </node>
         <node concept="2pctC0" id="1zxgaynEnFJ" role="1aoamK">
-          <property role="2pctC1" value="haha&lt;---&gt;haha$$$$" />
+          <property role="2pctC1" value="haha&lt;---&gt;DDDD$$$$" />
         </node>
       </node>
     </node>
@@ -1572,6 +1684,7 @@
   <node concept="1lH9Xt" id="1Tugx$wUtq">
     <property role="TrG5h" value="RefMergeExecutionTest" />
     <property role="3DII0k" value="2hh8MJdVwqX/command" />
+    <property role="3GE5qa" value="merging" />
     <node concept="2XrIbr" id="1Tugx_rSG2" role="1qtyYc">
       <property role="TrG5h" value="assertSequenceContains" />
       <node concept="37vLTG" id="1Tugx_rVIF" role="3clF46">
@@ -2014,6 +2127,7 @@
   <node concept="1lH9Xt" id="4LLXBGbv8iN">
     <property role="TrG5h" value="PropertyMergeExecutionWithEmptyModel" />
     <property role="3DII0k" value="2hh8MJdVwqX/command" />
+    <property role="3GE5qa" value="merging" />
     <node concept="1LZb2c" id="4LLXBGbv8iO" role="1SL9yI">
       <property role="TrG5h" value="testPropertyMergeWithEmptyModel" />
       <node concept="3cqZAl" id="4LLXBGbv8iP" role="3clF45" />
@@ -2034,13 +2148,16 @@
             </node>
           </node>
         </node>
-        <node concept="1gVbGN" id="4LLXBGbv8iX" role="3cqZAp">
-          <node concept="2ZW3vV" id="4LLXBGbv8iY" role="1gVkn0">
-            <node concept="3Tqbb2" id="4LLXBGbv8iZ" role="2ZW6by">
-              <ref role="ehGHo" to="yeyq:32ggi2DCpGw" resolve="PropertyDummy" />
-            </node>
-            <node concept="37vLTw" id="4LLXBGbv8j0" role="2ZW6bz">
+        <node concept="1gVbGN" id="kewvTA200E" role="3cqZAp">
+          <node concept="2OqwBi" id="kewvTA200F" role="1gVkn0">
+            <node concept="37vLTw" id="kewvTA200G" role="2Oq$k0">
               <ref role="3cqZAo" node="4LLXBGbv8iT" resolve="observedRoot" />
+            </node>
+            <node concept="liA8E" id="kewvTA200H" role="2OqNvi">
+              <ref role="37wK5l" to="mhbf:~SNode.isInstanceOfConcept(org.jetbrains.mps.openapi.language.SAbstractConcept)" resolve="isInstanceOfConcept" />
+              <node concept="35c_gC" id="kewvTA200I" role="37wK5m">
+                <ref role="35c_gD" to="yeyq:32ggi2DCpGw" resolve="PropertyDummy" />
+              </node>
             </node>
           </node>
         </node>
@@ -2189,6 +2306,7 @@
   <node concept="1lH9Xt" id="4LLXBGbHXwq">
     <property role="TrG5h" value="AutoChildMergeExecutionWithEmptyModel" />
     <property role="3DII0k" value="2hh8MJdVwqX/command" />
+    <property role="3GE5qa" value="merging" />
     <node concept="1LZb2c" id="4LLXBGbHXwr" role="1SL9yI">
       <property role="TrG5h" value="autoChildMerging" />
       <node concept="3cqZAl" id="4LLXBGbHXws" role="3clF45" />
@@ -2208,13 +2326,16 @@
             </node>
           </node>
         </node>
-        <node concept="1gVbGN" id="4LLXBGbHXwz" role="3cqZAp">
-          <node concept="2ZW3vV" id="4LLXBGbHXw$" role="1gVkn0">
-            <node concept="3Tqbb2" id="4LLXBGbHXw_" role="2ZW6by">
-              <ref role="ehGHo" to="9kut:3pc485Vr2SQ" resolve="ChildKeeper" />
-            </node>
-            <node concept="37vLTw" id="4LLXBGbHXwA" role="2ZW6bz">
+        <node concept="1gVbGN" id="kewvTA1RxX" role="3cqZAp">
+          <node concept="2OqwBi" id="kewvTA1RxY" role="1gVkn0">
+            <node concept="37vLTw" id="kewvTA1RxZ" role="2Oq$k0">
               <ref role="3cqZAo" node="4LLXBGbHXwv" resolve="observedRoot" />
+            </node>
+            <node concept="liA8E" id="kewvTA1Ry0" role="2OqNvi">
+              <ref role="37wK5l" to="mhbf:~SNode.isInstanceOfConcept(org.jetbrains.mps.openapi.language.SAbstractConcept)" resolve="isInstanceOfConcept" />
+              <node concept="35c_gC" id="kewvTA1Ry1" role="37wK5m">
+                <ref role="35c_gD" to="9kut:3pc485Vr2SQ" resolve="ChildKeeper" />
+              </node>
             </node>
           </node>
         </node>
@@ -2431,6 +2552,7 @@
     </node>
     <node concept="1qefOq" id="4LLXBGbHXwW" role="1SKRRt">
       <node concept="1d83US" id="4LLXBGbHXwX" role="1qenE9">
+        <property role="TrG5h" value="ChildKeeperRight" />
         <node concept="3xLA65" id="4LLXBGbHXwY" role="lGtFl">
           <property role="TrG5h" value="expected" />
         </node>
@@ -2438,7 +2560,431 @@
           <property role="2pctC1" value="lala" />
         </node>
         <node concept="2pctC0" id="4LLXBGbHXx0" role="1aoamK">
-          <property role="2pctC1" value="haha" />
+          <property role="2pctC1" value="DDDD" />
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1lH9Xt" id="2GFEb9NzDPl">
+    <property role="3DII0k" value="2hh8MJdVwqX/command" />
+    <property role="TrG5h" value="InputModelsWithUncoveredMergePolicies" />
+    <property role="3GE5qa" value="mergingExecution" />
+    <node concept="1qefOq" id="2GFEb9NzRe8" role="1SKRRt">
+      <node concept="poArf" id="2GFEb9NzRJ7" role="1qenE9">
+        <property role="TrG5h" value="ChildMergeAutoExec" />
+        <ref role="pot50" node="2GFEb9NzZmR" resolve="ModelMergeWithMissingPolicies" />
+        <node concept="1Xw6AR" id="2GFEb9NzRJ8" role="ppIIL">
+          <node concept="1dCxOl" id="2GFEb9NzRJ9" role="1XwpL7">
+            <property role="1XweGQ" value="r:de7dfd54-d52a-48c3-ad0b-4ff50c9fe414" />
+            <node concept="1j_P7g" id="2GFEb9NzRJa" role="1j$8Uc">
+              <property role="1j_P7h" value="de.itemis.model.merge.simple.demo.leftSingltonChild" />
+            </node>
+          </node>
+          <node concept="7CXmI" id="2GFEb9N$ovb" role="lGtFl">
+            <node concept="1TM$A" id="2GFEb9N$ovc" role="7EUXB">
+              <node concept="2PYRI3" id="2GFEb9N$q27" role="3lydEf">
+                <ref role="39XzEq" to="sz2a:2GFEb9Ns1JY" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1Xw6AR" id="2GFEb9NzRJb" role="ppbcs">
+          <node concept="1dCxOl" id="2GFEb9NzRJc" role="1XwpL7">
+            <property role="1XweGQ" value="r:e0e8921e-c4c0-4e4c-a825-af1f615827e5" />
+            <node concept="1j_P7g" id="2GFEb9NzRJd" role="1j$8Uc">
+              <property role="1j_P7h" value="de.itemis.model.merge.simple.demo.rightSingltonChild" />
+            </node>
+          </node>
+          <node concept="7CXmI" id="2GFEb9N$r42" role="lGtFl">
+            <node concept="1TM$A" id="2GFEb9N$r43" role="7EUXB">
+              <node concept="2PYRI3" id="2GFEb9N$r_4" role="3lydEf">
+                <ref role="39XzEq" to="sz2a:2GFEb9NrUQr" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1Xw6AR" id="6qrKgEq_U43" role="2JagXQ">
+          <node concept="1dCxOl" id="6qrKgEq_U4a" role="1XwpL7">
+            <property role="1XweGQ" value="r:ecd2c27e-0ec1-4753-8900-a6ad3dc40f09" />
+            <node concept="1j_P7g" id="6qrKgEq_U4b" role="1j$8Uc">
+              <property role="1j_P7h" value="de.itemis.model.merge.simple.demo.result" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="2GFEb9NzSgk" role="1SKRRt">
+      <node concept="1olOeT" id="2GFEb9NzZmR" role="1qenE9">
+        <property role="TrG5h" value="ModelMergeWithMissingPolicies" />
+        <property role="1phRau" value="true" />
+        <property role="3P_Oz2" value="true" />
+        <node concept="pHN19" id="2GFEb9NzZmS" role="3WPhuS">
+          <node concept="2V$Bhx" id="2GFEb9N$e89" role="2V$M_3">
+            <property role="2V$B1T" value="8688ed72-e0ba-44cb-9688-5c8397cb5bbb" />
+            <property role="2V$B1Q" value="de.itemis.model.simple.demo.children" />
+          </node>
+        </node>
+        <node concept="1olsrb" id="2GFEb9OtuNe" role="1olsr8">
+          <ref role="24zOxU" to="9kut:3pc485Vr2SQ" resolve="ChildKeeper" />
+          <node concept="230_S" id="2GFEb9OtxT6" role="21DrV">
+            <node concept="3clFbS" id="2GFEb9OtxT7" role="2VODD2">
+              <node concept="3clFbF" id="2GFEb9OtyrD" role="3cqZAp">
+                <node concept="2OqwBi" id="2GFEb9Ot$1L" role="3clFbG">
+                  <node concept="2OqwBi" id="2GFEb9OtyAj" role="2Oq$k0">
+                    <node concept="233M7" id="2GFEb9OtyrC" role="2Oq$k0" />
+                    <node concept="3TrEf2" id="2GFEb9Otzlt" role="2OqNvi">
+                      <ref role="3Tt5mk" to="9kut:3pc485Vr2SR" resolve="childSingleton" />
+                    </node>
+                  </node>
+                  <node concept="3TrcHB" id="2GFEb9Ot$iO" role="2OqNvi">
+                    <ref role="3TsBF5" to="yeyq:32ggi2DCpGx" resolve="data" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="FwPyy" id="2GFEb9Otxo0" role="1wVUQl">
+          <node concept="3iOvoU" id="2GFEb9Otxo1" role="1woo5X" />
+          <node concept="3JN9zw" id="2GFEb9Otxo2" role="1woA3i" />
+          <node concept="3JN9zw" id="2GFEb9Otxo3" role="1wo_8c" />
+          <node concept="3JHzSW" id="2GFEb9Otxo4" role="1wo$yn" />
+          <node concept="3JN9zx" id="2GFEb9Otxo5" role="1wbzTg" />
+          <node concept="3JN9zw" id="2GFEb9Otxo6" role="1wbzTo" />
+          <node concept="3iOvoU" id="2GFEb9Otxo7" role="1woUSC" />
+          <node concept="3JN9zw" id="2GFEb9Otxo8" role="1wp1O6" />
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1lH9Xt" id="7wzAiyprlYV">
+    <property role="3DII0k" value="2hh8MJdVwqX/command" />
+    <property role="TrG5h" value="ConceptUsesDefaultActionButNoDefaultActionIsSpecified" />
+    <property role="3GE5qa" value="mergingPolicy" />
+    <node concept="1qefOq" id="7wzAiyprmaG" role="1SKRRt">
+      <node concept="poArf" id="7wzAiyprmaH" role="1qenE9">
+        <property role="TrG5h" value="ChildMergeAutoExec" />
+        <ref role="pot50" node="7wzAiyprmaY" />
+        <node concept="1Xw6AR" id="7wzAiyprmaI" role="ppIIL">
+          <node concept="1dCxOl" id="7wzAiyprmaJ" role="1XwpL7">
+            <property role="1XweGQ" value="r:de7dfd54-d52a-48c3-ad0b-4ff50c9fe414" />
+            <node concept="1j_P7g" id="7wzAiyprmaK" role="1j$8Uc">
+              <property role="1j_P7h" value="de.itemis.model.merge.simple.demo.leftSingltonChild" />
+            </node>
+          </node>
+        </node>
+        <node concept="1Xw6AR" id="7wzAiyprmaO" role="ppbcs">
+          <node concept="1dCxOl" id="7wzAiyprmaP" role="1XwpL7">
+            <property role="1XweGQ" value="r:e0e8921e-c4c0-4e4c-a825-af1f615827e5" />
+            <node concept="1j_P7g" id="7wzAiyprmaQ" role="1j$8Uc">
+              <property role="1j_P7h" value="de.itemis.model.merge.simple.demo.rightSingltonChild" />
+            </node>
+          </node>
+        </node>
+        <node concept="1Xw6AR" id="7wzAiyprmaU" role="2JagXQ">
+          <node concept="1dCxOl" id="7wzAiyprmaV" role="1XwpL7">
+            <property role="1XweGQ" value="r:ecd2c27e-0ec1-4753-8900-a6ad3dc40f09" />
+            <node concept="1j_P7g" id="7wzAiyprmaW" role="1j$8Uc">
+              <property role="1j_P7h" value="de.itemis.model.merge.simple.demo.result" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="7wzAiyprmaX" role="1SKRRt">
+      <node concept="1olOeT" id="7wzAiyprmaY" role="1qenE9">
+        <property role="TrG5h" value="ModelMergeWithMissingPolicies" />
+        <node concept="pHN19" id="7wzAiyprmaZ" role="3WPhuS">
+          <node concept="2V$Bhx" id="7wzAiyprmb0" role="2V$M_3">
+            <property role="2V$B1T" value="8688ed72-e0ba-44cb-9688-5c8397cb5bbb" />
+            <property role="2V$B1Q" value="de.itemis.model.simple.demo.children" />
+          </node>
+        </node>
+        <node concept="1oluLK" id="7wzAiyprnmw" role="1olsr8" />
+        <node concept="1olsrb" id="7wzAiyprmb1" role="1olsr8">
+          <property role="vpZK9" value="true" />
+          <ref role="24zOxU" to="9kut:3pc485Vr2SQ" resolve="ChildKeeper" />
+          <node concept="230_S" id="7wzAiyprmb2" role="21DrV">
+            <node concept="3clFbS" id="7wzAiyprmb3" role="2VODD2">
+              <node concept="3clFbF" id="7wzAiyprmb4" role="3cqZAp">
+                <node concept="2OqwBi" id="7wzAiyprmb5" role="3clFbG">
+                  <node concept="2OqwBi" id="7wzAiyprmb6" role="2Oq$k0">
+                    <node concept="233M7" id="7wzAiyprmb7" role="2Oq$k0" />
+                    <node concept="3TrEf2" id="7wzAiyprmb8" role="2OqNvi">
+                      <ref role="3Tt5mk" to="9kut:3pc485Vr2SR" resolve="childSingleton" />
+                    </node>
+                  </node>
+                  <node concept="3TrcHB" id="7wzAiyprmb9" role="2OqNvi">
+                    <ref role="3TsBF5" to="yeyq:32ggi2DCpGx" resolve="data" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="7CXmI" id="7wzAiypJ0rG" role="lGtFl">
+            <node concept="1TM$A" id="7wzAiypJ0rH" role="7EUXB">
+              <node concept="2PYRI3" id="7wzAiypJ0Fq" role="3lydEf">
+                <ref role="39XzEq" to="sz2a:2GFEb9NASbQ" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1oluLK" id="7wzAiyprnvo" role="1olsr8" />
+        <node concept="1olsrb" id="7wzAiyprnsq" role="1olsr8">
+          <ref role="24zOxU" to="yeyq:32ggi2DCpGw" resolve="PropertyDummy" />
+          <node concept="230_S" id="7wzAiyps_En" role="21DrV">
+            <node concept="3clFbS" id="7wzAiyps_Eo" role="2VODD2">
+              <node concept="3clFbF" id="7wzAiyps_Zi" role="3cqZAp">
+                <node concept="2OqwBi" id="7wzAiypsAac" role="3clFbG">
+                  <node concept="233M7" id="7wzAiyps_Zh" role="2Oq$k0" />
+                  <node concept="3TrcHB" id="7wzAiypsACm" role="2OqNvi">
+                    <ref role="3TsBF5" to="yeyq:32ggi2DCpGx" resolve="data" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1orWGm" id="7wzAiypJ1ix" role="1orW53">
+            <ref role="3iOP7l" to="yeyq:32ggi2DCpGx" resolve="data" />
+            <node concept="3iOvoU" id="7wzAiypJ1pf" role="1orWrN" />
+          </node>
+        </node>
+        <node concept="FwPyy" id="7wzAiyprmba" role="1wVUQl">
+          <node concept="3iOvoU" id="7wzAiyprmbb" role="1woo5X" />
+          <node concept="3JN9zw" id="7wzAiyprmbc" role="1woA3i" />
+          <node concept="3JN9zw" id="7wzAiyprmbd" role="1wo_8c" />
+          <node concept="3JHzSW" id="7wzAiyprmbe" role="1wo$yn" />
+          <node concept="3JN9zx" id="7wzAiyprmbf" role="1wbzTg" />
+          <node concept="3JN9zw" id="7wzAiyprmbg" role="1wbzTo" />
+          <node concept="3iOvoU" id="7wzAiyprmbh" role="1woUSC" />
+          <node concept="3JN9zw" id="7wzAiyprmbi" role="1wp1O6" />
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1lH9Xt" id="7wzAiypPzSx">
+    <property role="3DII0k" value="2hh8MJdVwqX/command" />
+    <property role="3GE5qa" value="mergingPolicy" />
+    <property role="TrG5h" value="IgnoreMissingPoliciesForModelMergeWithPartialPolicy" />
+    <node concept="1qefOq" id="7wzAiypP$Us" role="1SKRRt">
+      <node concept="poArf" id="7wzAiypP$Ut" role="1qenE9">
+        <property role="TrG5h" value="ChildMergeAutoExec" />
+        <ref role="pot50" node="7wzAiypP$UC" />
+        <node concept="1Xw6AR" id="7wzAiypP$Uu" role="ppIIL">
+          <node concept="1dCxOl" id="7wzAiypP$Uv" role="1XwpL7">
+            <property role="1XweGQ" value="r:de7dfd54-d52a-48c3-ad0b-4ff50c9fe414" />
+            <node concept="1j_P7g" id="7wzAiypP$Uw" role="1j$8Uc">
+              <property role="1j_P7h" value="de.itemis.model.merge.simple.demo.leftSingltonChild" />
+            </node>
+          </node>
+        </node>
+        <node concept="1Xw6AR" id="7wzAiypP$Ux" role="ppbcs">
+          <node concept="1dCxOl" id="7wzAiypP$Uy" role="1XwpL7">
+            <property role="1XweGQ" value="r:e0e8921e-c4c0-4e4c-a825-af1f615827e5" />
+            <node concept="1j_P7g" id="7wzAiypP$Uz" role="1j$8Uc">
+              <property role="1j_P7h" value="de.itemis.model.merge.simple.demo.rightSingltonChild" />
+            </node>
+          </node>
+        </node>
+        <node concept="1Xw6AR" id="7wzAiypP$U$" role="2JagXQ">
+          <node concept="1dCxOl" id="7wzAiypP$U_" role="1XwpL7">
+            <property role="1XweGQ" value="r:ecd2c27e-0ec1-4753-8900-a6ad3dc40f09" />
+            <node concept="1j_P7g" id="7wzAiypP$UA" role="1j$8Uc">
+              <property role="1j_P7h" value="de.itemis.model.merge.simple.demo.result" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="7wzAiypP$UB" role="1SKRRt">
+      <node concept="1olOeT" id="7wzAiypP$UC" role="1qenE9">
+        <property role="TrG5h" value="ModelMergeWithMissingPolicies" />
+        <property role="1phRau" value="true" />
+        <node concept="pHN19" id="7wzAiypPS8K" role="3oy5ef">
+          <node concept="2V$Bhx" id="7wzAiypPSDM" role="2V$M_3">
+            <property role="2V$B1T" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c" />
+            <property role="2V$B1Q" value="jetbrains.mps.lang.core" />
+          </node>
+        </node>
+        <node concept="pHN19" id="7wzAiypP$UD" role="3WPhuS">
+          <node concept="2V$Bhx" id="7wzAiypP$UE" role="2V$M_3">
+            <property role="2V$B1T" value="8688ed72-e0ba-44cb-9688-5c8397cb5bbb" />
+            <property role="2V$B1Q" value="de.itemis.model.simple.demo.children" />
+          </node>
+        </node>
+        <node concept="1oluLK" id="7wzAiypP$UF" role="1olsr8" />
+        <node concept="1olsrb" id="7wzAiypP$UG" role="1olsr8">
+          <ref role="24zOxU" to="9kut:3pc485Vr2SQ" resolve="ChildKeeper" />
+          <node concept="230_S" id="7wzAiypP$UH" role="21DrV">
+            <node concept="3clFbS" id="7wzAiypP$UI" role="2VODD2">
+              <node concept="3clFbF" id="7wzAiypP$UJ" role="3cqZAp">
+                <node concept="2OqwBi" id="7wzAiypP$UK" role="3clFbG">
+                  <node concept="2OqwBi" id="7wzAiypP$UL" role="2Oq$k0">
+                    <node concept="233M7" id="7wzAiypP$UM" role="2Oq$k0" />
+                    <node concept="3TrEf2" id="7wzAiypP$UN" role="2OqNvi">
+                      <ref role="3Tt5mk" to="9kut:3pc485Vr2SR" resolve="childSingleton" />
+                    </node>
+                  </node>
+                  <node concept="3TrcHB" id="7wzAiypP$UO" role="2OqNvi">
+                    <ref role="3TsBF5" to="yeyq:32ggi2DCpGx" resolve="data" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1orWGm" id="7wzAiypPBB2" role="1orW53">
+            <ref role="3iOP7l" to="tpck:h0TrG11" resolve="name" />
+            <node concept="3iOvoU" id="7wzAiypPC8L" role="1orWrN" />
+          </node>
+          <node concept="1DuYju" id="7wzAiypPDaH" role="3JN1Yi">
+            <ref role="3Ze0ni" to="9kut:3pc485Vr2SR" resolve="childSingleton" />
+            <node concept="3JN9zw" id="7wzAiypPDGs" role="3JN5mM" />
+          </node>
+          <node concept="1DuYj3" id="7wzAiypPEec" role="3JN1Yi">
+            <ref role="3Ze0ni" to="9kut:3pc485WbbkL" resolve="optionalChild" />
+            <node concept="3JN9zw" id="7wzAiypPEeZ" role="3JN5mL" />
+          </node>
+        </node>
+        <node concept="1oluLK" id="7wzAiypP$US" role="1olsr8" />
+        <node concept="1olsrb" id="7wzAiypP$UT" role="1olsr8">
+          <ref role="24zOxU" to="yeyq:32ggi2DCpGw" resolve="PropertyDummy" />
+          <node concept="230_S" id="7wzAiypP$UU" role="21DrV">
+            <node concept="3clFbS" id="7wzAiypP$UV" role="2VODD2">
+              <node concept="3clFbF" id="7wzAiypP$UW" role="3cqZAp">
+                <node concept="2OqwBi" id="7wzAiypP$UX" role="3clFbG">
+                  <node concept="233M7" id="7wzAiypP$UY" role="2Oq$k0" />
+                  <node concept="3TrcHB" id="7wzAiypP$UZ" role="2OqNvi">
+                    <ref role="3TsBF5" to="yeyq:32ggi2DCpGx" resolve="data" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1orWGm" id="7wzAiypP$V0" role="1orW53">
+            <ref role="3iOP7l" to="yeyq:32ggi2DCpGx" resolve="data" />
+            <node concept="3iOvoU" id="7wzAiypP$V1" role="1orWrN" />
+          </node>
+        </node>
+        <node concept="FwPyy" id="7wzAiypP$V2" role="1wVUQl">
+          <node concept="3iOvoU" id="7wzAiypP$V3" role="1woo5X" />
+          <node concept="3JN9zw" id="7wzAiypP$V4" role="1woA3i" />
+          <node concept="3JN9zw" id="7wzAiypP$V5" role="1wo_8c" />
+          <node concept="3JHzSW" id="7wzAiypP$V6" role="1wo$yn" />
+          <node concept="3JN9zx" id="7wzAiypP$V7" role="1wbzTg" />
+          <node concept="3JN9zw" id="7wzAiypP$V8" role="1wbzTo" />
+          <node concept="3iOvoU" id="7wzAiypP$V9" role="1woUSC" />
+          <node concept="3JN9zw" id="7wzAiypP$Va" role="1wp1O6" />
+        </node>
+        <node concept="7CXmI" id="7wzAiyq0IkH" role="lGtFl">
+          <node concept="7OXhh" id="7wzAiyq0Lqs" role="7EUXB">
+            <property role="GvXf4" value="true" />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1lH9Xt" id="7wzAiyq5t8B">
+    <property role="3DII0k" value="2hh8MJdVwqX/command" />
+    <property role="TrG5h" value="UseDefaultActions" />
+    <property role="3GE5qa" value="merging" />
+    <node concept="1LZb2c" id="7wzAiyq7sWP" role="1SL9yI">
+      <property role="TrG5h" value="mergingWithDefaultActions" />
+      <node concept="3cqZAl" id="7wzAiyq7sWQ" role="3clF45" />
+      <node concept="3clFbS" id="7wzAiyq7sWR" role="3clF47">
+        <node concept="3cpWs8" id="7wzAiyq7sWS" role="3cqZAp">
+          <node concept="3cpWsn" id="7wzAiyq7sWT" role="3cpWs9">
+            <property role="TrG5h" value="observedRoot" />
+            <node concept="3uibUv" id="7wzAiyq7sWU" role="1tU5fm">
+              <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
+            </node>
+            <node concept="2YIFZM" id="7wzAiyq7sWV" role="33vP2m">
+              <ref role="37wK5l" node="77Ot_5atFjz" resolve="rootOf" />
+              <ref role="1Pybhc" node="6Ltuup4xcSI" resolve="TestUtil" />
+              <node concept="3xONca" id="7wzAiyq7sWW" role="37wK5m">
+                <ref role="3xOPvv" node="7wzAiyq5xth" resolve="me" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1gVbGN" id="7wzAiyq7sWX" role="3cqZAp">
+          <node concept="2OqwBi" id="7wzAiyq7sWY" role="1gVkn0">
+            <node concept="37vLTw" id="7wzAiyq7sWZ" role="2Oq$k0">
+              <ref role="3cqZAo" node="7wzAiyq7sWT" resolve="observedRoot" />
+            </node>
+            <node concept="liA8E" id="7wzAiyq7sX0" role="2OqNvi">
+              <ref role="37wK5l" to="mhbf:~SNode.isInstanceOfConcept(org.jetbrains.mps.openapi.language.SAbstractConcept)" resolve="isInstanceOfConcept" />
+              <node concept="35c_gC" id="7wzAiyq7sX1" role="37wK5m">
+                <ref role="35c_gD" to="9kut:3pc485Vr2SQ" resolve="ChildKeeper" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="7wzAiyq7sX2" role="3cqZAp">
+          <node concept="3cpWsn" id="7wzAiyq7sX3" role="3cpWs9">
+            <property role="TrG5h" value="observed" />
+            <node concept="3Tqbb2" id="7wzAiyq7sX4" role="1tU5fm">
+              <ref role="ehGHo" to="9kut:3pc485Vr2SQ" resolve="ChildKeeper" />
+            </node>
+            <node concept="1eOMI4" id="7wzAiyq7sX5" role="33vP2m">
+              <node concept="10QFUN" id="7wzAiyq7sX6" role="1eOMHV">
+                <node concept="3Tqbb2" id="7wzAiyq7sX7" role="10QFUM">
+                  <ref role="ehGHo" to="9kut:3pc485Vr2SQ" resolve="ChildKeeper" />
+                </node>
+                <node concept="37vLTw" id="7wzAiyq7sX8" role="10QFUP">
+                  <ref role="3cqZAo" node="7wzAiyq7sWT" resolve="observedRoot" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7wzAiyq7sX9" role="3cqZAp" />
+        <node concept="3clFbH" id="7wzAiyq7sXa" role="3cqZAp" />
+        <node concept="JA50E" id="7wzAiyq7sXb" role="3cqZAp">
+          <node concept="3xONca" id="7wzAiyq7sXc" role="JA92f">
+            <ref role="3xOPvv" node="7wzAiyq5EF4" resolve="expected" />
+          </node>
+          <node concept="37vLTw" id="7wzAiyq7sXd" role="JAdkl">
+            <ref role="3cqZAo" node="7wzAiyq7sX3" resolve="observed" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="7wzAiyq5xt8" role="1SKRRt">
+      <node concept="poArf" id="7wzAiyq5xta" role="1qenE9">
+        <property role="TrG5h" value="ChildMergeAutoExec" />
+        <ref role="pot50" to="2y6h:7wzAiyq8GF4" resolve="ModelMergeWithDefaultActions" />
+        <node concept="1Xw6AR" id="7wzAiyq5xtb" role="ppIIL">
+          <node concept="1dCxOl" id="7wzAiyq5xtc" role="1XwpL7">
+            <property role="1XweGQ" value="r:de7dfd54-d52a-48c3-ad0b-4ff50c9fe414" />
+            <node concept="1j_P7g" id="7wzAiyq5xtd" role="1j$8Uc">
+              <property role="1j_P7h" value="de.itemis.model.merge.simple.demo.leftSingltonChild" />
+            </node>
+          </node>
+        </node>
+        <node concept="1Xw6AR" id="7wzAiyq5xte" role="ppbcs">
+          <node concept="1dCxOl" id="7wzAiyq5xtf" role="1XwpL7">
+            <property role="1XweGQ" value="r:e0e8921e-c4c0-4e4c-a825-af1f615827e5" />
+            <node concept="1j_P7g" id="7wzAiyq5xtg" role="1j$8Uc">
+              <property role="1j_P7h" value="de.itemis.model.merge.simple.demo.rightSingltonChild" />
+            </node>
+          </node>
+        </node>
+        <node concept="3xLA65" id="7wzAiyq5xth" role="lGtFl">
+          <property role="TrG5h" value="me" />
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="7wzAiyq5EF1" role="1SKRRt">
+      <node concept="1d83US" id="7wzAiyq5EF3" role="1qenE9">
+        <property role="TrG5h" value="ChildKeeperRight" />
+        <node concept="3xLA65" id="7wzAiyq5EF4" role="lGtFl">
+          <property role="TrG5h" value="expected" />
+        </node>
+        <node concept="2pctC0" id="7wzAiyq5EF5" role="1d83UQ">
+          <property role="2pctC1" value="lala" />
+        </node>
+        <node concept="2pctC0" id="7wzAiyq5EF6" role="1aoamK">
+          <property role="2pctC1" value="DDDD" />
         </node>
       </node>
     </node>

--- a/code/solutions/de.itemis.model.merge.test.integration/models/de.itemis.model.merge.test.integration.tests@tests.mps
+++ b/code/solutions/de.itemis.model.merge.test.integration/models/de.itemis.model.merge.test.integration.tests@tests.mps
@@ -59,10 +59,6 @@
       <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
       </concept>
-      <concept id="1081256982272" name="jetbrains.mps.baseLanguage.structure.InstanceOfExpression" flags="nn" index="2ZW3vV">
-        <child id="1081256993305" name="classType" index="2ZW6by" />
-        <child id="1081256993304" name="leftExpression" index="2ZW6bz" />
-      </concept>
       <concept id="1070534934090" name="jetbrains.mps.baseLanguage.structure.CastExpression" flags="nn" index="10QFUN">
         <child id="1070534934091" name="type" index="10QFUM" />
         <child id="1070534934092" name="expression" index="10QFUP" />
@@ -133,6 +129,9 @@
       </concept>
       <concept id="1171323947159" name="jetbrains.mps.lang.smodel.structure.Model_NodesOperation" flags="nn" index="2SmgA7">
         <child id="1758937410080001570" name="conceptArgument" index="1dBWTz" />
+      </concept>
+      <concept id="2644386474300074836" name="jetbrains.mps.lang.smodel.structure.ConceptIdRefExpression" flags="nn" index="35c_gC">
+        <reference id="2644386474300074837" name="conceptDeclaration" index="35c_gD" />
       </concept>
       <concept id="6407023681583036853" name="jetbrains.mps.lang.smodel.structure.NodeAttributeQualifier" flags="ng" index="3CFYIy">
         <reference id="6407023681583036854" name="attributeConcept" index="3CFYIx" />
@@ -208,13 +207,16 @@
             </node>
           </node>
         </node>
-        <node concept="1gVbGN" id="hG_e7_dlJr" role="3cqZAp">
-          <node concept="2ZW3vV" id="hG_e7_dlJs" role="1gVkn0">
-            <node concept="3Tqbb2" id="hG_e7_dlJt" role="2ZW6by">
-              <ref role="ehGHo" to="7e3e:W4mNzjZ9yL" resolve="Annotatable" />
-            </node>
-            <node concept="37vLTw" id="hG_e7_dlJu" role="2ZW6bz">
+        <node concept="1gVbGN" id="6Ltuup4wZy6" role="3cqZAp">
+          <node concept="2OqwBi" id="kewvTA1IVT" role="1gVkn0">
+            <node concept="37vLTw" id="kewvTA1IbR" role="2Oq$k0">
               <ref role="3cqZAo" node="hG_e7_dlJn" resolve="observedRoot" />
+            </node>
+            <node concept="liA8E" id="kewvTA1J9T" role="2OqNvi">
+              <ref role="37wK5l" to="mhbf:~SNode.isInstanceOfConcept(org.jetbrains.mps.openapi.language.SAbstractConcept)" resolve="isInstanceOfConcept" />
+              <node concept="35c_gC" id="kewvTA1Kdn" role="37wK5m">
+                <ref role="35c_gD" to="7e3e:W4mNzjZ9yL" resolve="Annotatable" />
+              </node>
             </node>
           </node>
         </node>
@@ -421,13 +423,16 @@
             </node>
           </node>
         </node>
-        <node concept="1gVbGN" id="4LLXBGbTodM" role="3cqZAp">
-          <node concept="2ZW3vV" id="4LLXBGbTodN" role="1gVkn0">
-            <node concept="3Tqbb2" id="4LLXBGbTodO" role="2ZW6by">
-              <ref role="ehGHo" to="7e3e:W4mNzjZ9yL" resolve="Annotatable" />
-            </node>
-            <node concept="37vLTw" id="4LLXBGbTodP" role="2ZW6bz">
+        <node concept="1gVbGN" id="kewvTAGq$L" role="3cqZAp">
+          <node concept="2OqwBi" id="kewvTAGq$M" role="1gVkn0">
+            <node concept="37vLTw" id="kewvTAGq$N" role="2Oq$k0">
               <ref role="3cqZAo" node="4LLXBGbTodI" resolve="observedRoot" />
+            </node>
+            <node concept="liA8E" id="kewvTAGq$O" role="2OqNvi">
+              <ref role="37wK5l" to="mhbf:~SNode.isInstanceOfConcept(org.jetbrains.mps.openapi.language.SAbstractConcept)" resolve="isInstanceOfConcept" />
+              <node concept="35c_gC" id="kewvTAGq$P" role="37wK5m">
+                <ref role="35c_gD" to="7e3e:W4mNzjZ9yL" resolve="Annotatable" />
+              </node>
             </node>
           </node>
         </node>

--- a/code/solutions/de.itemis.model.merge.test/models/de.itemis.model.merge.test.gen@tests.mps
+++ b/code/solutions/de.itemis.model.merge.test/models/de.itemis.model.merge.test.gen@tests.mps
@@ -4028,7 +4028,7 @@
           </node>
           <node concept="3_1$Yv" id="6QnTwqHg_xo" role="3_9lra">
             <node concept="Xl_RD" id="6QnTwqHgA8L" role="3_1BAH">
-              <property role="Xl_RC" value="Inport A does not occur as first item in merged inport list" />
+              <property role="Xl_RC" value="InPort A does not occur as first item in merged inPort list" />
             </node>
           </node>
         </node>
@@ -4044,7 +4044,7 @@
           </node>
           <node concept="3_1$Yv" id="6QnTwqHgD3F" role="3_9lra">
             <node concept="Xl_RD" id="6QnTwqHgDF4" role="3_1BAH">
-              <property role="Xl_RC" value="Inport B does not occur as second item in merged inport list" />
+              <property role="Xl_RC" value="InPort B does not occur as second item in merged inPort list" />
             </node>
           </node>
         </node>
@@ -4060,7 +4060,7 @@
           </node>
           <node concept="3_1$Yv" id="6QnTwqHlbaW" role="3_9lra">
             <node concept="Xl_RD" id="6QnTwqHlbaX" role="3_1BAH">
-              <property role="Xl_RC" value="Inport C does not occur as third item in merged inport list" />
+              <property role="Xl_RC" value="InPort C does not occur as third item in merged inPort list" />
             </node>
           </node>
         </node>
@@ -4076,7 +4076,7 @@
           </node>
           <node concept="3_1$Yv" id="6QnTwqHgDFl" role="3_9lra">
             <node concept="Xl_RD" id="6QnTwqHgE90" role="3_1BAH">
-              <property role="Xl_RC" value="Inport D does not occur as fourth item in merged inport list" />
+              <property role="Xl_RC" value="InPort D does not occur as fourth item in merged inPort list" />
             </node>
           </node>
         </node>
@@ -4092,7 +4092,7 @@
           </node>
           <node concept="3_1$Yv" id="6QnTwqHlbJs" role="3_9lra">
             <node concept="Xl_RD" id="6QnTwqHlbJt" role="3_1BAH">
-              <property role="Xl_RC" value="Inport E does not occur as fifth item in merged inport list" />
+              <property role="Xl_RC" value="InPort E does not occur as fifth item in merged inPort list" />
             </node>
           </node>
         </node>

--- a/code/solutions/de.itemis.model.merge.test/models/de.itemis.model.merge.test.plugin.mps
+++ b/code/solutions/de.itemis.model.merge.test/models/de.itemis.model.merge.test.plugin.mps
@@ -137,6 +137,7 @@
       </concept>
       <concept id="1912777765298266446" name="de.itemis.model.merge.structure.EmptyMergeItem" flags="ng" index="1oluLK" />
       <concept id="1912777765298163335" name="de.itemis.model.merge.structure.ModelMerge" flags="ng" index="1olOeT">
+        <property id="3110765452006840876" name="partialPolicy" index="1phRau" />
         <child id="1912777765298260982" name="items" index="1olsr8" />
         <child id="2222162468665533253" name="lang" index="3WPhuS" />
       </concept>
@@ -685,6 +686,7 @@
   </node>
   <node concept="1olOeT" id="3xLnOvEDNj_">
     <property role="TrG5h" value="CollectionChildDiamondMerge" />
+    <property role="1phRau" value="true" />
     <node concept="1oluLK" id="3xLnOvEDNjA" role="1olsr8" />
     <node concept="1olsrb" id="3xLnOvEDNjO" role="1olsr8">
       <ref role="24zOxU" to="14sb:1trrptaBskJ" resolve="Data" />

--- a/code/solutions/de.itemis.model.merge.test/models/de.itemis.model.merge.test.test1@tests.mps
+++ b/code/solutions/de.itemis.model.merge.test/models/de.itemis.model.merge.test.test1@tests.mps
@@ -180,6 +180,10 @@
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
+      <concept id="4222318806802425298" name="jetbrains.mps.lang.core.structure.SuppressErrorsAnnotation" flags="ng" index="15s5l7">
+        <property id="8575328350543493365" name="message" index="huDt6" />
+        <property id="2423417345669755629" name="filter" index="1eyWvh" />
+      </concept>
     </language>
     <language id="539e8939-08ef-497c-a5fd-25dd10137a55" name="de.itemis.model.merge">
       <concept id="7137735640371846599" name="de.itemis.model.merge.structure.IdFunction" flags="ig" index="230_S" />
@@ -433,6 +437,14 @@
       </node>
     </node>
     <node concept="1qefOq" id="3EHNiwz2jtW" role="1SKRRt">
+      <node concept="15s5l7" id="kewvTAGoId" role="lGtFl">
+        <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: multi-child policy not completely defined&quot;;FLAVOUR_RULE_ID=&quot;[r:02b6652e-c87d-4bb2-bfc0-4b5c0d5b9442(de.itemis.model.merge.typesystem)/7647305840372727207]&quot;;" />
+        <property role="huDt6" value="Error: multi-child policy not completely defined" />
+      </node>
+      <node concept="15s5l7" id="kewvTAGoHJ" role="lGtFl">
+        <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: merge policy for concept Data does not define ID function&quot;;FLAVOUR_RULE_ID=&quot;[r:02b6652e-c87d-4bb2-bfc0-4b5c0d5b9442(de.itemis.model.merge.typesystem)/7647305840371712554]&quot;;" />
+        <property role="huDt6" value="Error: merge policy for concept Data does not define ID function" />
+      </node>
       <node concept="1olOeT" id="3EHNiwz2jtX" role="1qenE9">
         <property role="TrG5h" value="CheckForMissingMergePolicyForProperty" />
         <node concept="1oluLK" id="3EHNiwz2jtY" role="1olsr8" />
@@ -1629,106 +1641,6 @@
   <node concept="1lH9Xt" id="1trrptaBsHT">
     <property role="TrG5h" value="DiamondChildTest" />
     <property role="3DII0k" value="2hh8MJdVwqX/command" />
-    <node concept="1qefOq" id="1trrptaE8Aa" role="1SKRRt">
-      <node concept="1olOeT" id="1trrptaE8Bd" role="1qenE9">
-        <property role="TrG5h" value="DiamondMerge" />
-        <node concept="1oluLK" id="1trrptaE8Be" role="1olsr8" />
-        <node concept="1oluLK" id="1trrptaE8Bf" role="1olsr8" />
-        <node concept="1olsrb" id="1trrptaE8Bg" role="1olsr8">
-          <ref role="24zOxU" to="14sb:7TOowlgsaNJ" resolve="Interface1" />
-          <node concept="3JNno8" id="1trrptaE8BU" role="3JN1Yi">
-            <ref role="3Ze0ni" to="14sb:1trrptaBsmP" resolve="children" />
-            <node concept="3Z5p37" id="1trrptaE8BW" role="3JNnoR">
-              <property role="3Z5p36" value="1VmHfRxJErw/ExistsOnLeft" />
-              <node concept="3JHL42" id="4S51TVFkvzf" role="3Z4xbE" />
-            </node>
-          </node>
-          <node concept="230_S" id="3PLTv5jEff8" role="21DrV">
-            <node concept="3clFbS" id="3PLTv5jEff9" role="2VODD2">
-              <node concept="3clFbF" id="3PLTv5jEfjD" role="3cqZAp">
-                <node concept="Xl_RD" id="3PLTv5jEfjC" role="3clFbG">
-                  <property role="Xl_RC" value="ç" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1oluLK" id="1trrptaE8Bj" role="1olsr8" />
-        <node concept="1olsrb" id="1trrptaE8Bk" role="1olsr8">
-          <ref role="24zOxU" to="14sb:7TOowlgsaNK" resolve="Interface2" />
-          <node concept="3JNno8" id="1trrptaE8C3" role="3JN1Yi">
-            <ref role="3Ze0ni" to="14sb:1trrptaBsmP" resolve="children" />
-            <node concept="3Z5p37" id="1trrptaFThx" role="3JNnoR">
-              <property role="3Z5p36" value="1VmHfRxJErw/ExistsOnLeft" />
-              <node concept="3JN9zx" id="1trrptaFUWv" role="3Z4xbE" />
-            </node>
-          </node>
-          <node concept="230_S" id="3PLTv5jEfsQ" role="21DrV">
-            <node concept="3clFbS" id="3PLTv5jEfsR" role="2VODD2">
-              <node concept="3clFbF" id="3PLTv5jEfsS" role="3cqZAp">
-                <node concept="Xl_RD" id="3PLTv5jEfsT" role="3clFbG">
-                  <property role="Xl_RC" value="ç" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1oluLK" id="1trrptaE8Bn" role="1olsr8" />
-        <node concept="1oluLK" id="1trrptaE8Bo" role="1olsr8" />
-        <node concept="1olsrb" id="1trrptaE8Bp" role="1olsr8">
-          <ref role="24zOxU" to="14sb:7TOowlgsdak" resolve="Bottom" />
-          <node concept="7CXmI" id="1trrptaE8Bq" role="lGtFl">
-            <node concept="1TM$A" id="1trrptaE8Br" role="7EUXB">
-              <node concept="2PYRI3" id="582YV7z6RWk" role="3lydEf">
-                <ref role="39XzEq" to="sz2a:7TOowlgVJ6e" />
-              </node>
-            </node>
-          </node>
-          <node concept="230_S" id="3PLTv5jEfxz" role="21DrV">
-            <node concept="3clFbS" id="3PLTv5jEfx$" role="2VODD2">
-              <node concept="3clFbF" id="3PLTv5jEfx_" role="3cqZAp">
-                <node concept="Xl_RD" id="3PLTv5jEfxA" role="3clFbG">
-                  <property role="Xl_RC" value="ç" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="pHN19" id="1trrptaE8Bt" role="3WPhuS">
-          <node concept="2V$Bhx" id="1trrptaE8Bu" role="2V$M_3">
-            <property role="2V$B1T" value="0ef84c01-bf36-41ed-9882-d7b70a4a4eba" />
-            <property role="2V$B1Q" value="de.itemis.model.merge.diamond" />
-          </node>
-        </node>
-        <node concept="1olsrb" id="6CwG2k81n_T" role="1olsr8">
-          <ref role="24zOxU" to="14sb:1trrptaBskJ" resolve="Data" />
-        </node>
-        <node concept="1olsrb" id="6CwG2k81n_U" role="1olsr8">
-          <ref role="24zOxU" to="14sb:57$6ALrLfRh" resolve="OtherData" />
-        </node>
-        <node concept="1olsrb" id="6CwG2k81n_V" role="1olsr8">
-          <ref role="24zOxU" to="14sb:jF$CuWiLYJ" resolve="Payload2" />
-        </node>
-        <node concept="1olsrb" id="6CwG2k81n_W" role="1olsr8">
-          <ref role="24zOxU" to="14sb:jF$CuWiLEs" resolve="Payload" />
-        </node>
-        <node concept="1olsrb" id="6CwG2k81n_X" role="1olsr8">
-          <ref role="24zOxU" to="14sb:7Q5WRnfZ$gs" resolve="Statement" />
-        </node>
-        <node concept="1olsrb" id="6CwG2k81n_Y" role="1olsr8">
-          <ref role="24zOxU" to="14sb:7Q5WRnfZJ8c" resolve="EmptyStatement" />
-        </node>
-        <node concept="1olsrb" id="6CwG2k81n_Z" role="1olsr8">
-          <ref role="24zOxU" to="14sb:7Q5WRnfZe3K" resolve="Diamonds" />
-        </node>
-        <node concept="1olsrb" id="6CwG2k81nA0" role="1olsr8">
-          <ref role="24zOxU" to="14sb:jF$CuWiLVm" resolve="Payload1" />
-        </node>
-        <node concept="1olsrb" id="6CwG2k81nA1" role="1olsr8">
-          <ref role="24zOxU" to="14sb:7TOowlgscST" resolve="Top" />
-        </node>
-      </node>
-    </node>
     <node concept="1qefOq" id="1trrptaE6WZ" role="1SKRRt">
       <node concept="1olOeT" id="1trrptaE6XG" role="1qenE9">
         <property role="TrG5h" value="DiamondMerge" />
@@ -2008,6 +1920,14 @@
       </node>
     </node>
     <node concept="1qefOq" id="1trrptaG5Lz" role="1SKRRt">
+      <node concept="15s5l7" id="kewvTAGdjS" role="lGtFl">
+        <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: merge policy for concept Data does not define ID function&quot;;FLAVOUR_RULE_ID=&quot;[r:02b6652e-c87d-4bb2-bfc0-4b5c0d5b9442(de.itemis.model.merge.typesystem)/7647305840371712554]&quot;;" />
+        <property role="huDt6" value="Error: merge policy for concept Data does not define ID function" />
+      </node>
+      <node concept="15s5l7" id="kewvTAGdgA" role="lGtFl">
+        <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: multi-child policy not completely defined&quot;;FLAVOUR_RULE_ID=&quot;[r:02b6652e-c87d-4bb2-bfc0-4b5c0d5b9442(de.itemis.model.merge.typesystem)/7647305840372727207]&quot;;" />
+        <property role="huDt6" value="Error: multi-child policy not completely defined" />
+      </node>
       <node concept="1olOeT" id="1trrptaG5Ng" role="1qenE9">
         <property role="TrG5h" value="IntermediateOverride" />
         <node concept="1oluLK" id="1trrptaG5Nh" role="1olsr8" />

--- a/docs/extensions/utils/model-merger.md
+++ b/docs/extensions/utils/model-merger.md
@@ -9,23 +9,17 @@ Two model merger languages exist. `de.itemis.model.merge` is the new one and is 
 language is deprecated.
 
 This language allows merging models based on merging policies. In the following explanations the term *left* refers to
- one aspect of the first model that should be merged, the term *right* to the same aspect in a second model. Create a new root node of concept [ModelMerge](http://127.0.0.1:63320/node?ref=r%3A58892eeb-9059-4684-af0a-e0f5f7f9800d%28de.itemis.model.merge.structure%29%2F1912777765298163335). The main language 
-has to be defined. If there are additional languages involved, they can be specified as well. Now, merge policies can be defined
-for different concepts. The concepts need to be identifiable by a unique ID, for example, by an ID property. The scope
-of the uniqueness property depends on the context where the model merger is used. Normally, it's the project scope but
-there are cases where the ID needs to be globally unique.
+ one aspect of the first model that should be merged, the term *right* to the same aspect in a second model. 
+ 
+## Model Merge Policies:
 
-The model merge can be executed by creating a [ModelMergeExecution](http://127.0.0.1:63320/node?ref=r%3A58892eeb-9059-4684-af0a-e0f5f7f9800d%28de.itemis.model.merge.structure%29%2F6402745832171993510) node and using the intention `Run Model Merge` or call the `execute` method 
-programmatically.
+Create a new root node of concept [ModelMerge](http://127.0.0.1:63320/node?ref=r%3A58892eeb-9059-4684-af0a-e0f5f7f9800d%28de.itemis.model.merge.structure%29%2F1912777765298163335). The main language used by the models being merged has to be specified. If there are additional languages involved, they can be specified as well. Merge policies shall be defined for all concepts found in the specifie languages. However, during the prototyping of the model merge policies, the flag `using partial policy` can be set `true`. In this case the only policies for concepts found in the models being merged are required, and all other concepts can be ignored. Moreover, the flag `use default actions` can be set `true`, so that merge policies can be empty for the concepts being used. The default action is used for each merge policy defined, if its own flag `use default actions` set to `true`, otherwise `Merge Actions` shall be specified. Independently of how merge actions are defined, each concept being used in the merge must be identifiable by a unique ID, for example, by an ID property. The scope of the uniqueness property depends on the context where the model merger is used. Normally, it's the project scope but there are cases where the ID needs to be globally unique. 
 
-- **Left**: a model pointer to the first model
-- **Right**: a model pointer to the second model
-- **Result**: a model pointer to a model where the results should be saved. When no model is referenced, the left model
- will be overridden.
-- **Merge Policy**: the policy that should be applied to the left and right model
+# Merge Actions:
 
+If a concept is not using default actions, the following actions shall be defined:
 
-## Properties
+### Properties
 
 For properties, three options are possible: 
 
@@ -33,7 +27,7 @@ For properties, three options are possible:
 - **Right**: use the value of the right property, and discard the value of the right property.
 - **Manual**: a custom merger that must return a value of the same type as the property
 
-## Children
+### Children
 
 For child nodes a policy container can be added.
 
@@ -50,10 +44,22 @@ For child nodes a policy container can be added.
     - **Auto**: use the existing merge policies of the children
     - **ManualColl**: a custom merger that must return a node of the same type as the concept
 
-## References
+### References
 
 For references, three options are possible:
 
 - **Left**: use the reference of the left node, and discard the reference of the right node.
 - **Right**: use the reference of the right node and discard the reference of the left node.
 - **Manual**: a custom merger that must return a node of the same type as the referenced node's concept
+
+## Model Merge Execution:
+
+The model merge can be executed by creating a [ModelMergeExecution](http://127.0.0.1:63320/node?ref=r%3A58892eeb-9059-4684-af0a-e0f5f7f9800d%28de.itemis.model.merge.structure%29%2F6402745832171993510) node and using the intention `Run Model Merge` or call the `execute` method 
+programmatically.
+
+- **Left**: a model pointer to the first model
+- **Right**: a model pointer to the second model
+- **Result**: a model pointer to a model where the results should be saved. When no model is referenced, the left model
+ will be overridden.
+- **Merge Policy**: the policy that should be applied to the left and right model
+


### PR DESCRIPTION
For large languages or prototyping it is difficult to define and test merge policies for all concepts at the same time.
For this reason I extended the model merge language to support the modeling of a partial merge policy and the replication of default actions for concepts in without policies.