### PR TITLE
xmodelgen: use enhanced transform in mapping configurations step

### DIFF
--- a/code/hacks/languages/de.itemis.mps.hacks.xmodelgen/de.itemis.mps.hacks.xmodelgen.mpl
+++ b/code/hacks/languages/de.itemis.mps.hacks.xmodelgen/de.itemis.mps.hacks.xmodelgen.mpl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<language namespace="de.itemis.mps.hacks.xmodelgen" uuid="c5eeb6dc-2f3d-45ae-a7be-929daeb6bda1" languageVersion="0" moduleVersion="0">
+<language namespace="de.itemis.mps.hacks.xmodelgen" uuid="c5eeb6dc-2f3d-45ae-a7be-929daeb6bda1" languageVersion="1" moduleVersion="0">
   <models>
     <modelRoot contentPath="${module}" type="default">
       <sourceRoot location="models" />
@@ -45,8 +45,10 @@
     <language slang="l:b401a680-8325-4110-8fd3-84331ff25bef:jetbrains.mps.lang.generator" version="4" />
     <language slang="l:d7706f63-9be2-479c-a3da-ae92af1e64d5:jetbrains.mps.lang.generator.generationContext" version="2" />
     <language slang="l:d7a92d38-f7db-40d0-8431-763b0c3c9f20:jetbrains.mps.lang.intentions" version="1" />
+    <language slang="l:90746344-04fd-4286-97d5-b46ae6a81709:jetbrains.mps.lang.migration" version="2" />
     <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
     <language slang="l:d4615e3b-d671-4ba9-af01-2b78369b0ba7:jetbrains.mps.lang.pattern" version="2" />
+    <language slang="l:28f9e497-3b42-4291-aeba-0a1039153ab1:jetbrains.mps.lang.plugin" version="6" />
     <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
     <language slang="l:3ecd7c84-cde3-45de-886c-135ecc69b742:jetbrains.mps.lang.refactoring" version="0" />
     <language slang="l:982eb8df-2c96-4bd7-9963-11712ea622e5:jetbrains.mps.lang.resources" version="2" />
@@ -55,6 +57,7 @@
     <language slang="l:0eddeefa-c2d6-4437-bc2c-de50fd4ce470:jetbrains.mps.lang.script" version="1" />
     <language slang="l:13744753-c81f-424a-9c1b-cf8943bf4e86:jetbrains.mps.lang.sharedConcepts" version="0" />
     <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
+    <language slang="l:1a8554c4-eb84-43ba-8c34-6f0d90c6e75a:jetbrains.mps.lang.smodel.query" version="3" />
     <language slang="l:c72da2b9-7cce-4447-8389-f407dc1158b7:jetbrains.mps.lang.structure" version="9" />
     <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
     <language slang="l:b83431fe-5c8f-40bc-8a36-65e25f4dd253:jetbrains.mps.lang.textGen" version="1" />
@@ -78,6 +81,7 @@
     <module reference="a9e4c532-c5f5-4bb7-99ef-42abb73bbb70(jetbrains.mps.lang.descriptor.aspects)" version="0" />
     <module reference="b401a680-8325-4110-8fd3-84331ff25bef(jetbrains.mps.lang.generator)" version="0" />
     <module reference="7ab1a6fa-0a11-4b95-9e48-75f363d6cb00(jetbrains.mps.lang.generator.plan)" version="0" />
+    <module reference="528ff3b9-5fc4-40dd-931f-c6ce3650640e(jetbrains.mps.lang.migration.runtime)" version="0" />
     <module reference="446c26eb-2b7b-4bf0-9b35-f83fa582753e(jetbrains.mps.lang.modelapi)" version="0" />
     <module reference="d7eb0a2a-bd50-4576-beae-e4a89db35f20(jetbrains.mps.lang.scopes.runtime)" version="0" />
     <module reference="7866978e-a0f0-4cc7-81bc-4d213d9375e1(jetbrains.mps.lang.smodel)" version="1" />

--- a/code/hacks/languages/de.itemis.mps.hacks.xmodelgen/models/behavior.mps
+++ b/code/hacks/languages/de.itemis.mps.hacks.xmodelgen/models/behavior.mps
@@ -27,7 +27,7 @@
     <import index="28nf" ref="215c4c45-ba99-49f5-9ab7-4b6901a63cfd/java:jetbrains.mps.generator.impl.query(MPS.Generator/)" />
     <import index="r99j" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.generator.runtime(MPS.Core/)" />
     <import index="r99k" ref="215c4c45-ba99-49f5-9ab7-4b6901a63cfd/java:jetbrains.mps.generator.runtime(MPS.Generator/)" />
-    <import index="gxwz" ref="r:d1800018-44fb-4b2e-b3ae-2afea554d27b(de.itemis.mps.hacks.xmodelgen.structure)" implicit="true" />
+    <import index="gxwz" ref="r:d1800018-44fb-4b2e-b3ae-2afea554d27b(de.itemis.mps.hacks.xmodelgen.structure)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
     <import index="tpf8" ref="r:00000000-0000-4000-0000-011c895902e8(jetbrains.mps.lang.generator.structure)" implicit="true" />
     <import index="bjdw" ref="r:4a23ef0d-9c2f-48a6-8597-fbdd5b11f792(jetbrains.mps.lang.generator.plan.structure)" implicit="true" />
@@ -208,26 +208,48 @@
         <child id="1199569916463" name="body" index="1bW5cS" />
       </concept>
     </language>
+    <language id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation">
+      <concept id="5455284157994012186" name="jetbrains.mps.lang.quotation.structure.NodeBuilderInitLink" flags="ng" index="2pIpSj">
+        <reference id="5455284157994012188" name="link" index="2pIpSl" />
+        <child id="1595412875168045827" name="initValue" index="28nt2d" />
+      </concept>
+      <concept id="5455284157993911077" name="jetbrains.mps.lang.quotation.structure.NodeBuilderInitProperty" flags="ng" index="2pJxcG">
+        <reference id="5455284157993911078" name="property" index="2pJxcJ" />
+        <child id="1595412875168045201" name="initValue" index="28ntcv" />
+      </concept>
+      <concept id="5455284157993863837" name="jetbrains.mps.lang.quotation.structure.NodeBuilder" flags="nn" index="2pJPEk">
+        <child id="5455284157993863838" name="quotedNode" index="2pJPEn" />
+      </concept>
+      <concept id="5455284157993863840" name="jetbrains.mps.lang.quotation.structure.NodeBuilderNode" flags="nn" index="2pJPED">
+        <reference id="5455284157993910961" name="concept" index="2pJxaS" />
+        <child id="5455284157993911099" name="values" index="2pJxcM" />
+      </concept>
+      <concept id="6985522012210254362" name="jetbrains.mps.lang.quotation.structure.NodeBuilderPropertyExpression" flags="nn" index="WxPPo">
+        <child id="6985522012210254363" name="expression" index="WxPPp" />
+      </concept>
+    </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
       <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
         <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
       </concept>
-      <concept id="2396822768958367367" name="jetbrains.mps.lang.smodel.structure.AbstractTypeCastExpression" flags="nn" index="$5XWr">
-        <child id="6733348108486823193" name="leftExpression" index="1m5AlR" />
-        <child id="3906496115198199033" name="conceptArgument" index="3oSUPX" />
+      <concept id="1138411891628" name="jetbrains.mps.lang.smodel.structure.SNodeOperation" flags="nn" index="eCIE_">
+        <child id="1144104376918" name="parameter" index="1xVPHs" />
       </concept>
       <concept id="1143234257716" name="jetbrains.mps.lang.smodel.structure.Node_GetModelOperation" flags="nn" index="I4A8Y" />
       <concept id="1145404486709" name="jetbrains.mps.lang.smodel.structure.SemanticDowncastExpression" flags="nn" index="2JrnkZ">
         <child id="1145404616321" name="leftExpression" index="2JrQYb" />
       </concept>
+      <concept id="1966870290088668512" name="jetbrains.mps.lang.smodel.structure.Enum_MemberLiteral" flags="ng" index="2ViDtV">
+        <reference id="1966870290088668516" name="memberDeclaration" index="2ViDtZ" />
+      </concept>
+      <concept id="1171407110247" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorOperation" flags="nn" index="2Xjw5R" />
       <concept id="3562215692195599741" name="jetbrains.mps.lang.smodel.structure.SLinkImplicitSelect" flags="nn" index="13MTOL">
         <reference id="3562215692195600259" name="link" index="13MTZf" />
       </concept>
-      <concept id="1139613262185" name="jetbrains.mps.lang.smodel.structure.Node_GetParentOperation" flags="nn" index="1mfA1w" />
-      <concept id="1180636770613" name="jetbrains.mps.lang.smodel.structure.SNodeCreator" flags="nn" index="3zrR0B">
-        <child id="1180636770616" name="createdType" index="3zrR0E" />
+      <concept id="1144100932627" name="jetbrains.mps.lang.smodel.structure.OperationParm_Inclusion" flags="ng" index="1xIGOp" />
+      <concept id="1144101972840" name="jetbrains.mps.lang.smodel.structure.OperationParm_Concept" flags="ng" index="1xMEDy">
+        <child id="1207343664468" name="conceptArgument" index="ri$Ld" />
       </concept>
-      <concept id="1140137987495" name="jetbrains.mps.lang.smodel.structure.SNodeTypeCastExpression" flags="nn" index="1PxgMI" />
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
         <reference id="1138405853777" name="concept" index="ehGHo" />
       </concept>
@@ -236,6 +258,9 @@
       </concept>
       <concept id="1138056282393" name="jetbrains.mps.lang.smodel.structure.SLinkListAccess" flags="nn" index="3Tsc0h">
         <reference id="1138056546658" name="link" index="3TtcxE" />
+      </concept>
+      <concept id="5779574625830813396" name="jetbrains.mps.lang.smodel.structure.EnumerationIdRefExpression" flags="ng" index="1XH99k">
+        <reference id="5779574625830813397" name="enumDeclaration" index="1XH99l" />
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
@@ -365,13 +390,15 @@
           </node>
           <node concept="2OqwBi" id="6KgrWUnjiO2" role="2GsD0m">
             <node concept="2OqwBi" id="6KgrWUnhZf$" role="2Oq$k0">
-              <node concept="1PxgMI" id="6KgrWUnhZf_" role="2Oq$k0">
-                <node concept="2OqwBi" id="6KgrWUnhZfA" role="1m5AlR">
-                  <node concept="13iPFW" id="6KgrWUnhZfB" role="2Oq$k0" />
-                  <node concept="1mfA1w" id="6KgrWUnhZfC" role="2OqNvi" />
-                </node>
-                <node concept="chp4Y" id="1k1VwvtPsKu" role="3oSUPX">
-                  <ref role="cht4Q" to="gxwz:Pogn2S65r1" resolve="MappingConfigStep" />
+              <node concept="2OqwBi" id="6KgrWUnhZfA" role="2Oq$k0">
+                <node concept="13iPFW" id="6KgrWUnhZfB" role="2Oq$k0" />
+                <node concept="2Xjw5R" id="77EUucAjbxL" role="2OqNvi">
+                  <node concept="1xMEDy" id="77EUucAjbxN" role="1xVPHs">
+                    <node concept="chp4Y" id="77EUucAjbHV" role="ri$Ld">
+                      <ref role="cht4Q" to="gxwz:Pogn2S65r1" resolve="MappingConfigStep" />
+                    </node>
+                  </node>
+                  <node concept="1xIGOp" id="77EUucAjbMp" role="1xVPHs" />
                 </node>
               </node>
               <node concept="3Tsc0h" id="6KgrWUnhZfD" role="2OqNvi">
@@ -428,6 +455,27 @@
         </node>
       </node>
       <node concept="3cqZAl" id="Pogn2S69Gw" role="3clF45" />
+    </node>
+    <node concept="13i0hz" id="77EUucAgxfQ" role="13h7CS">
+      <property role="TrG5h" value="setLanguage" />
+      <ref role="13i0hy" to="tpeu:5e7X3XCKW4J" resolve="setLanguage" />
+      <node concept="3Tm1VV" id="77EUucAgxfR" role="1B3o_S" />
+      <node concept="3clFbS" id="77EUucAgxfW" role="3clF47">
+        <node concept="YS8fn" id="77EUucAgyZ2" role="3cqZAp">
+          <node concept="2ShNRf" id="77EUucAgyZ3" role="YScLw">
+            <node concept="1pGfFk" id="77EUucAgyZ4" role="2ShVmc">
+              <ref role="37wK5l" to="wyt6:~UnsupportedOperationException.&lt;init&gt;()" resolve="UnsupportedOperationException" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="77EUucAgxfX" role="3clF46">
+        <property role="TrG5h" value="language" />
+        <node concept="3uibUv" id="77EUucAgxfY" role="1tU5fm">
+          <ref role="3uigEE" to="w1kc:~Language" resolve="Language" />
+        </node>
+      </node>
+      <node concept="3cqZAl" id="77EUucAgxfZ" role="3clF45" />
     </node>
     <node concept="13i0hz" id="6KgrWUnjw4o" role="13h7CS">
       <property role="TrG5h" value="getMCRuntime" />
@@ -626,52 +674,41 @@
             </node>
           </node>
         </node>
-        <node concept="3cpWs8" id="6KgrWUnjwHI" role="3cqZAp">
-          <node concept="3cpWsn" id="6KgrWUnjwHJ" role="3cpWs9">
-            <property role="TrG5h" value="mcRuntime" />
-            <node concept="3uibUv" id="6KgrWUnjwHK" role="1tU5fm">
-              <ref role="3uigEE" to="r99k:~TemplateMappingConfiguration" resolve="TemplateMappingConfiguration" />
+        <node concept="3clFbF" id="6KgrWUnjP5m" role="3cqZAp">
+          <node concept="2OqwBi" id="77EUucAje46" role="3clFbG">
+            <node concept="37vLTw" id="77EUucAje47" role="2Oq$k0">
+              <ref role="3cqZAo" node="6KgrWUnjwHC" resolve="mcRuntimes" />
             </node>
-            <node concept="2OqwBi" id="6KgrWUnjwHL" role="33vP2m">
-              <node concept="37vLTw" id="6KgrWUnjwHM" role="2Oq$k0">
-                <ref role="3cqZAo" node="6KgrWUnjwHC" resolve="mcRuntimes" />
-              </node>
-              <node concept="1z4cxt" id="6KgrWUnjwHN" role="2OqNvi">
-                <node concept="1bVj0M" id="6KgrWUnjwHO" role="23t8la">
-                  <node concept="3clFbS" id="6KgrWUnjwHP" role="1bW5cS">
-                    <node concept="3clFbF" id="6KgrWUnjwHQ" role="3cqZAp">
-                      <node concept="17R0WA" id="6KgrWUnjwHR" role="3clFbG">
-                        <node concept="2OqwBi" id="6KgrWUnjwHS" role="3uHU7w">
-                          <node concept="3TrcHB" id="6KgrWUnjwHU" role="2OqNvi">
-                            <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
-                          </node>
-                          <node concept="37vLTw" id="4L1Le7tlfpL" role="2Oq$k0">
-                            <ref role="3cqZAo" node="6KgrWUnjwFZ" resolve="mc" />
-                          </node>
+            <node concept="1z4cxt" id="77EUucAje48" role="2OqNvi">
+              <node concept="1bVj0M" id="77EUucAje49" role="23t8la">
+                <node concept="3clFbS" id="77EUucAje4a" role="1bW5cS">
+                  <node concept="3clFbF" id="77EUucAje4b" role="3cqZAp">
+                    <node concept="17R0WA" id="77EUucAje4c" role="3clFbG">
+                      <node concept="2OqwBi" id="77EUucAje4d" role="3uHU7w">
+                        <node concept="3TrcHB" id="77EUucAje4e" role="2OqNvi">
+                          <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
                         </node>
-                        <node concept="2OqwBi" id="6KgrWUnjwHV" role="3uHU7B">
-                          <node concept="37vLTw" id="6KgrWUnjwHW" role="2Oq$k0">
-                            <ref role="3cqZAo" node="7Z$RfkF7IEp" resolve="it" />
-                          </node>
-                          <node concept="liA8E" id="6KgrWUnjwHX" role="2OqNvi">
-                            <ref role="37wK5l" to="r99k:~TemplateMappingConfiguration.getName()" resolve="getName" />
-                          </node>
+                        <node concept="37vLTw" id="77EUucAje4f" role="2Oq$k0">
+                          <ref role="3cqZAo" node="6KgrWUnjwFZ" resolve="mc" />
+                        </node>
+                      </node>
+                      <node concept="2OqwBi" id="77EUucAje4g" role="3uHU7B">
+                        <node concept="37vLTw" id="77EUucAje4h" role="2Oq$k0">
+                          <ref role="3cqZAo" node="77EUucAje4j" resolve="it" />
+                        </node>
+                        <node concept="liA8E" id="77EUucAje4i" role="2OqNvi">
+                          <ref role="37wK5l" to="r99k:~TemplateMappingConfiguration.getName()" resolve="getName" />
                         </node>
                       </node>
                     </node>
                   </node>
-                  <node concept="gl6BB" id="7Z$RfkF7IEp" role="1bW2Oz">
-                    <property role="TrG5h" value="it" />
-                    <node concept="2jxLKc" id="7Z$RfkF7IEq" role="1tU5fm" />
-                  </node>
+                </node>
+                <node concept="gl6BB" id="77EUucAje4j" role="1bW2Oz">
+                  <property role="TrG5h" value="it" />
+                  <node concept="2jxLKc" id="77EUucAje4k" role="1tU5fm" />
                 </node>
               </node>
             </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="6KgrWUnjP5m" role="3cqZAp">
-          <node concept="37vLTw" id="6KgrWUnjP5k" role="3clFbG">
-            <ref role="3cqZAo" node="6KgrWUnjwHJ" resolve="mcRuntime" />
           </node>
         </node>
       </node>
@@ -686,7 +723,7 @@
             <node concept="2OqwBi" id="Pogn2S6dNG" role="2Oq$k0">
               <node concept="13iPFW" id="Pogn2S6dFn" role="2Oq$k0" />
               <node concept="3Tsc0h" id="Pogn2S6e0c" role="2OqNvi">
-                <ref role="3TtcxE" to="bjdw:2ztrlDPivEd" resolve="languages" />
+                <ref role="3TtcxE" to="bjdw:1009c2Af5ZQ" resolve="entries" />
               </node>
             </node>
             <node concept="2Kehj3" id="Pogn2S6l3r" role="2OqNvi" />
@@ -697,14 +734,31 @@
             <node concept="2OqwBi" id="Pogn2S6qmL" role="2Oq$k0">
               <node concept="13iPFW" id="Pogn2S6oym" role="2Oq$k0" />
               <node concept="3Tsc0h" id="Pogn2S6qNC" role="2OqNvi">
-                <ref role="3TtcxE" to="bjdw:2ztrlDPivEd" resolve="languages" />
+                <ref role="3TtcxE" to="bjdw:1009c2Af5ZQ" resolve="entries" />
               </node>
             </node>
             <node concept="TSZUe" id="Pogn2S6uXe" role="2OqNvi">
-              <node concept="2ShNRf" id="Pogn2S6v6x" role="25WWJ7">
-                <node concept="3zrR0B" id="Pogn2S6vp$" role="2ShVmc">
-                  <node concept="3Tqbb2" id="Pogn2S6vpA" role="3zrR0E">
-                    <ref role="ehGHo" to="gxwz:Pogn2S693Y" resolve="MCListLanguageIdentity" />
+              <node concept="2pJPEk" id="77EUucAgj5s" role="25WWJ7">
+                <node concept="2pJPED" id="77EUucAgj5w" role="2pJPEn">
+                  <ref role="2pJxaS" to="bjdw:1009c2Af4wf" resolve="LanguageEntry" />
+                  <node concept="2pJxcG" id="77EUucAjIb_" role="2pJxcM">
+                    <ref role="2pJxcJ" to="bjdw:1009c2Af5ZI" resolve="kind" />
+                    <node concept="WxPPo" id="77EUucAjIjZ" role="28ntcv">
+                      <node concept="2OqwBi" id="77EUucAjJ4_" role="WxPPp">
+                        <node concept="1XH99k" id="77EUucAjIjX" role="2Oq$k0">
+                          <ref role="1XH99l" to="bjdw:1009c2Af4wi" resolve="TransformKind" />
+                        </node>
+                        <node concept="2ViDtV" id="77EUucAjJHu" role="2OqNvi">
+                          <ref role="2ViDtZ" to="bjdw:1009c2Af4wj" resolve="Transform" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2pIpSj" id="77EUucAgjpV" role="2pJxcM">
+                    <ref role="2pIpSl" to="bjdw:1009c2Af4wg" resolve="language" />
+                    <node concept="2pJPED" id="77EUucAgjtF" role="28nt2d">
+                      <ref role="2pJxaS" to="gxwz:Pogn2S693Y" resolve="MCListLanguageIdentity" />
+                    </node>
                   </node>
                 </node>
               </node>

--- a/code/hacks/languages/de.itemis.mps.hacks.xmodelgen/models/de.itemis.mps.hacks.xmodelgen.migration.mps
+++ b/code/hacks/languages/de.itemis.mps.hacks.xmodelgen/models/de.itemis.mps.hacks.xmodelgen.migration.mps
@@ -1,0 +1,332 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:eb69ab04-47be-41a9-935b-41a242a1c60e(de.itemis.mps.hacks.xmodelgen.migration)">
+  <persistence version="9" />
+  <languages>
+    <use id="90746344-04fd-4286-97d5-b46ae6a81709" name="jetbrains.mps.lang.migration" version="2" />
+    <use id="c7d5b9dd-a05f-4be2-bc73-f2e16994cc67" name="jetbrains.mps.baseLanguage.lightweightdsl" version="1" />
+    <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
+    <use id="28f9e497-3b42-4291-aeba-0a1039153ab1" name="jetbrains.mps.lang.plugin" version="6" />
+    <use id="d4615e3b-d671-4ba9-af01-2b78369b0ba7" name="jetbrains.mps.lang.pattern" version="2" />
+    <devkit ref="2787ae0c-1f54-4fbf-b0b7-caf2b5beecbc(jetbrains.mps.devkit.aspect.migration)" />
+  </languages>
+  <imports>
+    <import index="lui2" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.module(MPS.OpenAPI/)" />
+    <import index="slm6" ref="90746344-04fd-4286-97d5-b46ae6a81709/r:52a3d974-bd4f-4651-ba6e-a2de5e336d95(jetbrains.mps.lang.migration/jetbrains.mps.lang.migration.methods)" />
+    <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" />
+    <import index="gxwz" ref="r:d1800018-44fb-4b2e-b3ae-2afea554d27b(de.itemis.mps.hacks.xmodelgen.structure)" />
+    <import index="bjdw" ref="r:4a23ef0d-9c2f-48a6-8597-fbdd5b11f792(jetbrains.mps.lang.generator.plan.structure)" />
+  </imports>
+  <registry>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
+      <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
+      <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu">
+        <child id="1165602531693" name="superclass" index="1zkMxy" />
+      </concept>
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123134" name="parameter" index="3clF46" />
+        <child id="1068580123135" name="body" index="3clF47" />
+      </concept>
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
+        <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
+      </concept>
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+        <reference id="1107535924139" name="classifier" index="3uigEE" />
+      </concept>
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
+        <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+    </language>
+    <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
+      <concept id="2524418899405758586" name="jetbrains.mps.baseLanguage.closures.structure.InferredClosureParameterDeclaration" flags="ig" index="gl6BB" />
+      <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
+        <child id="1199569906740" name="parameter" index="1bW2Oz" />
+        <child id="1199569916463" name="body" index="1bW5cS" />
+      </concept>
+    </language>
+    <language id="c7d5b9dd-a05f-4be2-bc73-f2e16994cc67" name="jetbrains.mps.baseLanguage.lightweightdsl">
+      <concept id="8880393040217246788" name="jetbrains.mps.baseLanguage.lightweightdsl.structure.MethodParameterInstance" flags="ig" index="ffn8J">
+        <reference id="8880393040217294897" name="decl" index="ffrpq" />
+      </concept>
+      <concept id="3751132065236767083" name="jetbrains.mps.baseLanguage.lightweightdsl.structure.DependentTypeInstance" flags="ig" index="q3mfm">
+        <reference id="3751132065236767084" name="decl" index="q3mfh" />
+        <reference id="9097849371505568270" name="point" index="1QQUv3" />
+      </concept>
+      <concept id="3751132065236767060" name="jetbrains.mps.baseLanguage.lightweightdsl.structure.MethodInstance" flags="ig" index="q3mfD">
+        <reference id="19209059688387895" name="decl" index="2VtyIY" />
+      </concept>
+      <concept id="6478870542308708689" name="jetbrains.mps.baseLanguage.lightweightdsl.structure.PropertyInstance" flags="ig" index="3tT0cZ">
+        <reference id="8585153554445465961" name="decl" index="25KYV2" />
+      </concept>
+      <concept id="6478870542308703666" name="jetbrains.mps.baseLanguage.lightweightdsl.structure.MemberPlaceholder" flags="ng" index="3tTeZs">
+        <property id="6478870542308703667" name="caption" index="3tTeZt" />
+        <reference id="6478870542308703669" name="decl" index="3tTeZr" />
+      </concept>
+      <concept id="6478870542308871875" name="jetbrains.mps.baseLanguage.lightweightdsl.structure.BooleanPropertyInstance" flags="ig" index="3tYpMH">
+        <property id="6478870542308871876" name="value" index="3tYpME" />
+      </concept>
+      <concept id="6478870542308871428" name="jetbrains.mps.baseLanguage.lightweightdsl.structure.StringPropertyInstance" flags="ig" index="3tYpXE">
+        <property id="6478870542308871429" name="value" index="3tYpXF" />
+      </concept>
+    </language>
+    <language id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation">
+      <concept id="5455284157994012186" name="jetbrains.mps.lang.quotation.structure.NodeBuilderInitLink" flags="ng" index="2pIpSj">
+        <reference id="5455284157994012188" name="link" index="2pIpSl" />
+        <child id="1595412875168045827" name="initValue" index="28nt2d" />
+      </concept>
+      <concept id="5455284157993911077" name="jetbrains.mps.lang.quotation.structure.NodeBuilderInitProperty" flags="ng" index="2pJxcG">
+        <reference id="5455284157993911078" name="property" index="2pJxcJ" />
+        <child id="1595412875168045201" name="initValue" index="28ntcv" />
+      </concept>
+      <concept id="5455284157993863837" name="jetbrains.mps.lang.quotation.structure.NodeBuilder" flags="nn" index="2pJPEk">
+        <child id="5455284157993863838" name="quotedNode" index="2pJPEn" />
+      </concept>
+      <concept id="5455284157993863840" name="jetbrains.mps.lang.quotation.structure.NodeBuilderNode" flags="nn" index="2pJPED">
+        <reference id="5455284157993910961" name="concept" index="2pJxaS" />
+        <child id="5455284157993911099" name="values" index="2pJxcM" />
+      </concept>
+      <concept id="6985522012210254362" name="jetbrains.mps.lang.quotation.structure.NodeBuilderPropertyExpression" flags="nn" index="WxPPo">
+        <child id="6985522012210254363" name="expression" index="WxPPp" />
+      </concept>
+    </language>
+    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
+        <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
+      </concept>
+      <concept id="1966870290088668512" name="jetbrains.mps.lang.smodel.structure.Enum_MemberLiteral" flags="ng" index="2ViDtV">
+        <reference id="1966870290088668516" name="memberDeclaration" index="2ViDtZ" />
+      </concept>
+      <concept id="1138056282393" name="jetbrains.mps.lang.smodel.structure.SLinkListAccess" flags="nn" index="3Tsc0h">
+        <reference id="1138056546658" name="link" index="3TtcxE" />
+      </concept>
+      <concept id="5779574625830813396" name="jetbrains.mps.lang.smodel.structure.EnumerationIdRefExpression" flags="ng" index="1XH99k">
+        <reference id="5779574625830813397" name="enumDeclaration" index="1XH99l" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+    <language id="90746344-04fd-4286-97d5-b46ae6a81709" name="jetbrains.mps.lang.migration">
+      <concept id="8352104482584315555" name="jetbrains.mps.lang.migration.structure.MigrationScript" flags="ig" index="3SyAh_">
+        <property id="5820409521797704727" name="fromVersion" index="qMTe8" />
+      </concept>
+    </language>
+    <language id="1a8554c4-eb84-43ba-8c34-6f0d90c6e75a" name="jetbrains.mps.lang.smodel.query">
+      <concept id="7738379549910147341" name="jetbrains.mps.lang.smodel.query.structure.InstancesExpression" flags="ng" index="qVDSY">
+        <child id="7738379549910147342" name="conceptArg" index="qVDSX" />
+      </concept>
+      <concept id="4234138103881610891" name="jetbrains.mps.lang.smodel.query.structure.WithStatement" flags="ng" index="L3pyB">
+        <child id="4234138103881610935" name="scope" index="L3pyr" />
+        <child id="4234138103881610892" name="stmts" index="L3pyw" />
+      </concept>
+    </language>
+    <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
+        <child id="1204796294226" name="closure" index="23t8la" />
+      </concept>
+      <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="nn" index="25WWJ4">
+        <child id="540871147943773366" name="argument" index="25WWJ7" />
+      </concept>
+      <concept id="1204980550705" name="jetbrains.mps.baseLanguage.collections.structure.VisitAllOperation" flags="nn" index="2es0OD" />
+      <concept id="1227022210526" name="jetbrains.mps.baseLanguage.collections.structure.ClearAllElementsOperation" flags="nn" index="2Kehj3" />
+      <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
+      <concept id="1202120902084" name="jetbrains.mps.baseLanguage.collections.structure.WhereOperation" flags="nn" index="3zZkjj" />
+      <concept id="1176501494711" name="jetbrains.mps.baseLanguage.collections.structure.IsNotEmptyOperation" flags="nn" index="3GX2aA" />
+    </language>
+  </registry>
+  <node concept="3SyAh_" id="77EUucAjrRa">
+    <property role="qMTe8" value="0" />
+    <property role="TrG5h" value="UseEnhancedTransformStep" />
+    <node concept="3Tm1VV" id="77EUucAjrRb" role="1B3o_S" />
+    <node concept="3tTeZs" id="77EUucAjrRc" role="jymVt">
+      <property role="3tTeZt" value="&lt;no execute after&gt;" />
+      <ref role="3tTeZr" to="slm6:7ay_HjIMt1a" resolve="execute after" />
+    </node>
+    <node concept="3tTeZs" id="77EUucAjrRd" role="jymVt">
+      <property role="3tTeZt" value="&lt;no required data&gt;" />
+      <ref role="3tTeZr" to="slm6:5TUCQr2FPTh" resolve="requires annotation data" />
+    </node>
+    <node concept="3tTeZs" id="77EUucAjrRe" role="jymVt">
+      <property role="3tTeZt" value="&lt;no produced data&gt;" />
+      <ref role="3tTeZr" to="slm6:5TUCQr2C271" resolve="produces annotation data" />
+    </node>
+    <node concept="2tJIrI" id="77EUucAjrRf" role="jymVt" />
+    <node concept="3tYpMH" id="77EUucAjrRg" role="jymVt">
+      <property role="TrG5h" value="isRerunnable" />
+      <property role="3tYpME" value="true" />
+      <ref role="25KYV2" to="slm6:1JWcQ2VeWIs" resolve="isRerunnable" />
+      <node concept="3Tm1VV" id="77EUucAjrRh" role="1B3o_S" />
+      <node concept="10P_77" id="77EUucAjrRi" role="1tU5fm" />
+    </node>
+    <node concept="3tYpXE" id="77EUucAjuu1" role="jymVt">
+      <property role="TrG5h" value="description" />
+      <property role="3tYpXF" value="Use enhanced transform in mapping configurations step" />
+      <ref role="25KYV2" to="slm6:1_lSsE3RFpE" resolve="description" />
+      <node concept="3Tm1VV" id="77EUucAjuu3" role="1B3o_S" />
+      <node concept="17QB3L" id="77EUucAjuu4" role="1tU5fm" />
+    </node>
+    <node concept="q3mfD" id="77EUucAjrRk" role="jymVt">
+      <property role="TrG5h" value="execute" />
+      <ref role="2VtyIY" to="slm6:4ubqdNOF9cA" resolve="execute" />
+      <node concept="3Tm1VV" id="77EUucAjrRm" role="1B3o_S" />
+      <node concept="3clFbS" id="77EUucAjrRo" role="3clF47">
+        <node concept="L3pyB" id="77EUucAjuRj" role="3cqZAp">
+          <node concept="3clFbS" id="77EUucAjuRk" role="L3pyw">
+            <node concept="3clFbF" id="77EUucAjuZt" role="3cqZAp">
+              <node concept="2OqwBi" id="77EUucAjCYj" role="3clFbG">
+                <node concept="2OqwBi" id="77EUucAjw5Z" role="2Oq$k0">
+                  <node concept="qVDSY" id="77EUucAjuZr" role="2Oq$k0">
+                    <node concept="chp4Y" id="77EUucAjv1F" role="qVDSX">
+                      <ref role="cht4Q" to="gxwz:Pogn2S65r1" resolve="MappingConfigStep" />
+                    </node>
+                  </node>
+                  <node concept="3zZkjj" id="77EUucAjy36" role="2OqNvi">
+                    <node concept="1bVj0M" id="77EUucAjy38" role="23t8la">
+                      <node concept="3clFbS" id="77EUucAjy39" role="1bW5cS">
+                        <node concept="3clFbF" id="77EUucAjyfH" role="3cqZAp">
+                          <node concept="2OqwBi" id="77EUucAj__w" role="3clFbG">
+                            <node concept="2OqwBi" id="77EUucAjywg" role="2Oq$k0">
+                              <node concept="37vLTw" id="77EUucAjyfG" role="2Oq$k0">
+                                <ref role="3cqZAo" node="77EUucAjy3a" resolve="it" />
+                              </node>
+                              <node concept="3Tsc0h" id="77EUucAjyT_" role="2OqNvi">
+                                <ref role="3TtcxE" to="bjdw:2ztrlDPivEd" resolve="languages" />
+                              </node>
+                            </node>
+                            <node concept="3GX2aA" id="77EUucAjCow" role="2OqNvi" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="gl6BB" id="77EUucAjy3a" role="1bW2Oz">
+                        <property role="TrG5h" value="it" />
+                        <node concept="2jxLKc" id="77EUucAjy3b" role="1tU5fm" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="2es0OD" id="77EUucAjEIf" role="2OqNvi">
+                  <node concept="1bVj0M" id="77EUucAjEIh" role="23t8la">
+                    <node concept="3clFbS" id="77EUucAjEIi" role="1bW5cS">
+                      <node concept="3clFbF" id="77EUucAkgIQ" role="3cqZAp">
+                        <node concept="2OqwBi" id="77EUucAkiRK" role="3clFbG">
+                          <node concept="2OqwBi" id="77EUucAkgSt" role="2Oq$k0">
+                            <node concept="37vLTw" id="77EUucAkgIO" role="2Oq$k0">
+                              <ref role="3cqZAo" node="77EUucAjEIj" resolve="it" />
+                            </node>
+                            <node concept="3Tsc0h" id="77EUucAki01" role="2OqNvi">
+                              <ref role="3TtcxE" to="bjdw:1009c2Af5ZQ" resolve="entries" />
+                            </node>
+                          </node>
+                          <node concept="2Kehj3" id="77EUucAkpMZ" role="2OqNvi" />
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="77EUucAjJZZ" role="3cqZAp">
+                        <node concept="2OqwBi" id="77EUucAke54" role="3clFbG">
+                          <node concept="2OqwBi" id="77EUucAjKg0" role="2Oq$k0">
+                            <node concept="37vLTw" id="77EUucAjJZY" role="2Oq$k0">
+                              <ref role="3cqZAo" node="77EUucAjEIj" resolve="it" />
+                            </node>
+                            <node concept="3Tsc0h" id="77EUucAjKMA" role="2OqNvi">
+                              <ref role="3TtcxE" to="bjdw:1009c2Af5ZQ" resolve="entries" />
+                            </node>
+                          </node>
+                          <node concept="TSZUe" id="77EUucAktBI" role="2OqNvi">
+                            <node concept="2pJPEk" id="77EUucAgj5s" role="25WWJ7">
+                              <node concept="2pJPED" id="77EUucAgj5w" role="2pJPEn">
+                                <ref role="2pJxaS" to="bjdw:1009c2Af4wf" resolve="LanguageEntry" />
+                                <node concept="2pJxcG" id="77EUucAjIb_" role="2pJxcM">
+                                  <ref role="2pJxcJ" to="bjdw:1009c2Af5ZI" resolve="kind" />
+                                  <node concept="WxPPo" id="77EUucAjIjZ" role="28ntcv">
+                                    <node concept="2OqwBi" id="77EUucAjJ4_" role="WxPPp">
+                                      <node concept="1XH99k" id="77EUucAjIjX" role="2Oq$k0">
+                                        <ref role="1XH99l" to="bjdw:1009c2Af4wi" resolve="TransformKind" />
+                                      </node>
+                                      <node concept="2ViDtV" id="77EUucAjJHu" role="2OqNvi">
+                                        <ref role="2ViDtZ" to="bjdw:1009c2Af4wj" resolve="Transform" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                                <node concept="2pIpSj" id="77EUucAgjpV" role="2pJxcM">
+                                  <ref role="2pIpSl" to="bjdw:1009c2Af4wg" resolve="language" />
+                                  <node concept="2pJPED" id="77EUucAgjtF" role="28nt2d">
+                                    <ref role="2pJxaS" to="gxwz:Pogn2S693Y" resolve="MCListLanguageIdentity" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="77EUucAjZR2" role="3cqZAp">
+                        <node concept="2OqwBi" id="77EUucAk4ec" role="3clFbG">
+                          <node concept="2OqwBi" id="77EUucAk0i3" role="2Oq$k0">
+                            <node concept="37vLTw" id="77EUucAjZR0" role="2Oq$k0">
+                              <ref role="3cqZAo" node="77EUucAjEIj" resolve="it" />
+                            </node>
+                            <node concept="3Tsc0h" id="77EUucAk1KU" role="2OqNvi">
+                              <ref role="3TtcxE" to="bjdw:2ztrlDPivEd" resolve="languages" />
+                            </node>
+                          </node>
+                          <node concept="2Kehj3" id="77EUucAk8N$" role="2OqNvi" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="gl6BB" id="77EUucAjEIj" role="1bW2Oz">
+                      <property role="TrG5h" value="it" />
+                      <node concept="2jxLKc" id="77EUucAjEIk" role="1tU5fm" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="37vLTw" id="77EUucAjuSg" role="L3pyr">
+            <ref role="3cqZAo" node="77EUucAjrRq" resolve="m" />
+          </node>
+        </node>
+      </node>
+      <node concept="ffn8J" id="77EUucAjrRq" role="3clF46">
+        <property role="TrG5h" value="m" />
+        <ref role="ffrpq" to="slm6:7fCCGqboj9J" resolve="m" />
+        <node concept="3uibUv" id="77EUucAjrRp" role="1tU5fm">
+          <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
+        </node>
+      </node>
+      <node concept="q3mfm" id="77EUucAjrRr" role="3clF45">
+        <ref role="q3mfh" to="slm6:4F5w8gPXEEe" />
+        <ref role="1QQUv3" node="77EUucAjrRk" resolve="execute" />
+      </node>
+    </node>
+    <node concept="3tTeZs" id="77EUucAjrRs" role="jymVt">
+      <property role="3tTeZt" value="&lt;no result checking&gt;" />
+      <ref role="3tTeZr" to="slm6:1JWcQ2VeXpD" resolve="check" />
+    </node>
+    <node concept="3uibUv" id="77EUucAjrRv" role="1zkMxy">
+      <ref role="3uigEE" to="slm6:5TUCQr2ybBO" resolve="HasMigrationScriptReference" />
+    </node>
+  </node>
+</model>
+

--- a/code/hacks/languages/de.itemis.mps.hacks.xmodelgen/models/structure.mps
+++ b/code/hacks/languages/de.itemis.mps.hacks.xmodelgen/models/structure.mps
@@ -42,6 +42,7 @@
   <node concept="1TIwiD" id="Pogn2S65r1">
     <property role="EcuMT" value="961590472824346305" />
     <property role="TrG5h" value="MappingConfigStep" />
+    <property role="34LRSv" value="mapping configurations" />
     <ref role="1TJDcQ" to="bjdw:1_4co2y1Lw2" resolve="Transform" />
     <node concept="1TJgyj" id="6KgrWUnhWLD" role="1TKVEi">
       <property role="IQ2ns" value="7786846688815598697" />


### PR DESCRIPTION
Transform.[languages](http://127.0.0.1:63320/node?ref=r%3A4a23ef0d-9c2f-48a6-8597-fbdd5b11f792%28jetbrains.mps.lang.generator.plan.structure%29%2F2944629966652439181) has been deprecated since 2023.1 (see [EnhancedTransformStep](http://127.0.0.1:63320/node?ref=r%3A18ce53c3-75ab-44c5-9292-2f157dd0081e%28jetbrains.mps.lang.generator.plan.migration%29%2F5914941733269717090)). [MappingConfigStep](http://127.0.0.1:63320/node?ref=r%3Ad1800018-44fb-4b2e-b3ae-2afea554d27b%28de.itemis.mps.hacks.xmodelgen.structure%29%2F961590472824346305) should be updated and existing instances migrated to use the new, enhanced version of the Transform. 