### PR TITLE
include a GitHub workflow for vulnerability scanning

### DIFF
--- a/.github/workflows/vulnerability-scanning.yml
+++ b/.github/workflows/vulnerability-scanning.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
       - name: Call setup
-        run: ./gradlew build_allScripts
+        run: ./gradlew dependencies
       - name: Depcheck
         uses: dependency-check/Dependency-Check_Action@main
         env:

--- a/.github/workflows/vulnerability-scanning.yml
+++ b/.github/workflows/vulnerability-scanning.yml
@@ -1,0 +1,33 @@
+on: [workflow_dispatch]
+
+jobs:
+  depchecktest:
+    runs-on: ubuntu-latest
+    name: depecheck_test
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+      - name: Call setup
+        run: ./gradlew build_allScripts
+      - name: Depcheck
+        uses: dependency-check/Dependency-Check_Action@main
+        env:
+          # actions/setup-java changes JAVA_HOME, so it needs to be reset to match the depcheck image
+          JAVA_HOME: /opt/jdk
+        id: Depcheck
+        with:
+          project: 'MPS-extensions'
+          format: 'HTML'
+          out: 'reports'
+      - name: Upload Test results
+        uses: actions/upload-artifact@master
+        with:
+           name: Depcheck report
+           path: ${{github.workspace}}/reports

--- a/.github/workflows/vulnerability-scanning.yml
+++ b/.github/workflows/vulnerability-scanning.yml
@@ -26,6 +26,8 @@ jobs:
           project: 'MPS-extensions'
           format: 'HTML'
           out: 'reports'
+          args: >
+            --exclude github/workspace/build/mps/**
       - name: Upload Test results
         uses: actions/upload-artifact@master
         with:

--- a/.github/workflows/vulnerability-scanning.yml
+++ b/.github/workflows/vulnerability-scanning.yml
@@ -27,7 +27,7 @@ jobs:
           format: 'HTML'
           out: 'reports'
           args: >
-            --exclude github/workspace/build/mps/**
+            --exclude ${{github.workspace}}/build/mps/**
       - name: Upload Test results
         uses: actions/upload-artifact@master
         with:

--- a/.github/workflows/vulnerability-scanning.yml
+++ b/.github/workflows/vulnerability-scanning.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Call setup
         run: ./gradlew dependencies
       - name: Depcheck
-        uses: dependency-check/Dependency-Check_Action@main
+        uses: dependency-check/Dependency-Check_Action@3102a65fd5f36d0000297576acc56a475b0de98d
         env:
           # actions/setup-java changes JAVA_HOME, so it needs to be reset to match the depcheck image
           JAVA_HOME: /opt/jdk
@@ -29,7 +29,7 @@ jobs:
           args: >
             --exclude ${{github.workspace}}/build/mps/**
       - name: Upload Test results
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v4
         with:
            name: Depcheck report
            path: ${{github.workspace}}/reports

--- a/.github/workflows/vulnerability-scanning.yml
+++ b/.github/workflows/vulnerability-scanning.yml
@@ -1,4 +1,4 @@
-on: [workflow_dispatch]
+on: [pull_request]
 
 jobs:
   depchecktest:


### PR DESCRIPTION
Currently, the build won't fail.  We would have to add an argument like --failOnCVSS 7 to fail the build for issues with high severity. For example, for jgraphx we would have to add it as a false positive since we can't update the library.
You can find the output for a run on the actions page: https://github.com/JetBrains/MPS-extensions/actions/runs/12163684040?pr=1075. There is an artifact [Depcheck report](https://github.com/JetBrains/MPS-extensions/actions/runs/12163684040/artifacts/2274387072).
Alternativelly, we could only add it for the `workflow_dispatch` event. Then you would have to call it manually.