### PR TITLE
Reduce from errors to warnings when finding missing policies.

### DIFF
--- a/code/.mps/modules.xml
+++ b/code/.mps/modules.xml
@@ -80,6 +80,7 @@
       <modulePath path="$PROJECT_DIR$/languages/de.itemis.model.simple.demo.children/de.itemis.model.simple.demo.children.mpl" folder="modelmerger2.test.language" />
       <modulePath path="$PROJECT_DIR$/languages/de.itemis.model.simple.demo.collection.keeper/de.itemis.model.simple.demo.collection.keeper.mpl" folder="modelmerger2.test.language" />
       <modulePath path="$PROJECT_DIR$/languages/de.itemis.model.simple.demo.collection/de.itemis.model.simple.demo.collection.mpl" folder="modelmerger2.test.language" />
+      <modulePath path="$PROJECT_DIR$/languages/de.itemis.model.simple.demo.enums/de.itemis.model.simple.demo.enums.mpl" folder="modelmerger2.test.language" />
       <modulePath path="$PROJECT_DIR$/languages/de.itemis.model.simple.demo.property/de.itemis.model.simple.demo.property.mpl" folder="modelmerger2.test.language" />
       <modulePath path="$PROJECT_DIR$/languages/de.itemis.model.simple.demo.reference/de.itemis.model.simple.demo.reference.mpl" folder="modelmerger2.test.language" />
       <modulePath path="$PROJECT_DIR$/langvis/languages/com.dslfoundry.langvis.demolang/com.dslfoundry.langvis.demolang.mpl" folder="langvis" />

--- a/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
+++ b/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
@@ -18974,6 +18974,11 @@
             </node>
           </node>
         </node>
+        <node concept="1SiIV0" id="75IoIgYoAtf" role="3bR37C">
+          <node concept="3bR9La" id="75IoIgYoAtg" role="1SiIV1">
+            <ref role="3bR37D" node="75IoIgYo$Z9" resolve="de.itemis.model.simple.demo.enums" />
+          </node>
+        </node>
       </node>
       <node concept="1E1JtA" id="5Jy3PcPRnpY" role="2G$12L">
         <property role="BnDLt" value="true" />
@@ -19369,6 +19374,95 @@
             </node>
             <node concept="3qWCbU" id="1RcjJjMqV32" role="3LXTna">
               <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1E1JtD" id="75IoIgYo$Z9" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="de.itemis.model.simple.demo.enums" />
+        <property role="3LESm3" value="bf491fd2-a197-456a-8354-b3b225d4e871" />
+        <node concept="398BVA" id="75IoIgYo$Za" role="3LF7KH">
+          <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+          <node concept="2Ry0Ak" id="75IoIgYo$Zb" role="iGT6I">
+            <property role="2Ry0Am" value="languages" />
+            <node concept="2Ry0Ak" id="75IoIgYo$Zc" role="2Ry0An">
+              <property role="2Ry0Am" value="de.itemis.model.simple.demo.enums" />
+              <node concept="2Ry0Ak" id="75IoIgYo_s6" role="2Ry0An">
+                <property role="2Ry0Am" value="de.itemis.model.simple.demo.enums.mpl" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1BupzO" id="75IoIgYo$Ze" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="75IoIgYo$Zf" role="1HemKq">
+            <node concept="398BVA" id="75IoIgYo$Zg" role="3LXTmr">
+              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="75IoIgYo$Zh" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="75IoIgYo$Zi" role="2Ry0An">
+                  <property role="2Ry0Am" value="de.itemis.model.simple.demo.enums" />
+                  <node concept="2Ry0Ak" id="75IoIgYo$Zj" role="2Ry0An">
+                    <property role="2Ry0Am" value="models" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="75IoIgYo$Zk" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+        <node concept="3rtmxn" id="75IoIgYo$Zl" role="3bR31x">
+          <node concept="3LXTmp" id="75IoIgYo$Zm" role="3rtmxm">
+            <node concept="398BVA" id="75IoIgYo$Zn" role="3LXTmr">
+              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="75IoIgYo$Zo" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="75IoIgYo_Ja" role="2Ry0An">
+                  <property role="2Ry0Am" value="de.itemis.model.simple.demo.enums" />
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="75IoIgYo$Zq" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="75IoIgYo_WM" role="3bR37C">
+          <node concept="3bR9La" id="75IoIgYo_WN" role="1SiIV1">
+            <ref role="3bR37D" node="2UnEDPCh8Ac" resolve="de.itemis.model.simple.demo.property" />
+          </node>
+        </node>
+        <node concept="1yeLz9" id="75IoIgYo_X2" role="1TViLv">
+          <property role="TrG5h" value="de.itemis.model.simple.demo.enums.generator" />
+          <property role="3LESm3" value="7306450b-0779-41f2-97a4-8a2ed3686b8d" />
+          <node concept="1BupzO" id="75IoIgYo_Xk" role="3bR31x">
+            <property role="3ZfqAx" value="generator/templates" />
+            <property role="1Hdu6h" value="true" />
+            <property role="1HemKv" value="true" />
+            <node concept="3LXTmp" id="75IoIgYo_Xl" role="1HemKq">
+              <node concept="398BVA" id="75IoIgYo_X3" role="3LXTmr">
+                <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+                <node concept="2Ry0Ak" id="75IoIgYo_X4" role="iGT6I">
+                  <property role="2Ry0Am" value="languages" />
+                  <node concept="2Ry0Ak" id="75IoIgYo_X5" role="2Ry0An">
+                    <property role="2Ry0Am" value="de.itemis.model.simple.demo.enums" />
+                    <node concept="2Ry0Ak" id="75IoIgYo_X6" role="2Ry0An">
+                      <property role="2Ry0Am" value="generator" />
+                      <node concept="2Ry0Ak" id="75IoIgYo_X7" role="2Ry0An">
+                        <property role="2Ry0Am" value="templates" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3qWCbU" id="75IoIgYo_Xm" role="3LXTna">
+                <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+              </node>
             </node>
           </node>
         </node>
@@ -23376,6 +23470,9 @@
       </node>
       <node concept="L2wRC" id="2UnEDPCihk6" role="39821P">
         <ref role="L2wRA" node="2UnEDPCh8Ac" resolve="de.itemis.model.simple.demo.property" />
+      </node>
+      <node concept="L2wRC" id="75IoIgYo$Ff" role="39821P">
+        <ref role="L2wRA" node="75IoIgYo$Z9" resolve="de.itemis.model.simple.demo.enums" />
       </node>
       <node concept="L2wRC" id="2UnEDPClM$0" role="39821P">
         <ref role="L2wRA" node="2UnEDPClLCV" resolve="de.itemis.model.simple.demo.children" />

--- a/code/languages/de.itemis.model.merge.baselang/generator/templates/de.itemis.model.merge.baselang.generator.templates@generator.mps
+++ b/code/languages/de.itemis.model.merge.baselang/generator/templates/de.itemis.model.merge.baselang.generator.templates@generator.mps
@@ -75,7 +75,7 @@
       <node concept="gft3U" id="5anw8kxNuEs" role="1lVwrX">
         <node concept="2YIFZM" id="2cYlIwYGnFW" role="gfFT$">
           <ref role="37wK5l" to="gunp:2cYlIwYEMiU" resolve="run" />
-          <ref role="1Pybhc" to="gunp:2cYlIwY_fxg" resolve="ModelMergeExecutionRunner" />
+          <ref role="1Pybhc" to="gunp:2cYlIwY_fxg" resolve="ModelMergingRunner" />
           <node concept="10Nm6u" id="2cYlIwYEMMV" role="37wK5m">
             <node concept="29HgVG" id="2cYlIwYKCiG" role="lGtFl">
               <node concept="3NFfHV" id="2cYlIwYKCiH" role="3NFExx">

--- a/code/languages/de.itemis.model.merge.baselang/models/de.itemis.model.merge.baselang.typesystem.mps
+++ b/code/languages/de.itemis.model.merge.baselang/models/de.itemis.model.merge.baselang.typesystem.mps
@@ -100,7 +100,7 @@
               <node concept="2pIpSj" id="5anw8kxL67F" role="2pJxcM">
                 <ref role="2pIpSl" to="tp25:g$ehGDh" resolve="concept" />
                 <node concept="36bGnv" id="2cYlIwYKxU9" role="28nt2d">
-                  <ref role="36bGnp" to="mopj:1EbzjT2RcU7" resolve="ModelMerge" />
+                  <ref role="36bGnp" to="mopj:1EbzjT2RcU7" resolve="ModelMergingPolicy" />
                 </node>
               </node>
             </node>

--- a/code/languages/de.itemis.model.merge.baselang/sandbox/models/de.itemis.model.merge.baselang.sandbox.mps
+++ b/code/languages/de.itemis.model.merge.baselang/sandbox/models/de.itemis.model.merge.baselang.sandbox.mps
@@ -204,7 +204,7 @@
           <node concept="3cpWsn" id="6QQNrZxI98" role="3cpWs9">
             <property role="TrG5h" value="modelMerge" />
             <node concept="3Tqbb2" id="6QQNrZxI99" role="1tU5fm">
-              <ref role="ehGHo" to="mopj:1EbzjT2RcU7" resolve="ModelMerge" />
+              <ref role="ehGHo" to="mopj:1EbzjT2RcU7" resolve="ModelMergingPolicy" />
             </node>
             <node concept="2OqwBi" id="6QQNrZxJJu" role="33vP2m">
               <node concept="2tJFMh" id="6QQNrZxJyQ" role="2Oq$k0">

--- a/code/languages/de.itemis.model.merge.baselang/sandbox/models/de.itemis.model.merge.baselang.sandbox.plugin.mps
+++ b/code/languages/de.itemis.model.merge.baselang/sandbox/models/de.itemis.model.merge.baselang.sandbox.plugin.mps
@@ -53,14 +53,14 @@
     <language id="539e8939-08ef-497c-a5fd-25dd10137a55" name="de.itemis.model.merge">
       <concept id="7137735640371846599" name="de.itemis.model.merge.structure.IdFunction" flags="ig" index="230_S" />
       <concept id="7137735640371849272" name="de.itemis.model.merge.structure.IdFunctionParam" flags="ng" index="233M7" />
-      <concept id="1912777765298260981" name="de.itemis.model.merge.structure.MergePolicy" flags="ng" index="1olsrb">
+      <concept id="1912777765298260981" name="de.itemis.model.merge.structure.ConceptMergingPolicy" flags="ng" index="1olsrb">
         <reference id="4176264672384277229" name="conceptRef" index="24zOxU" />
         <child id="7137735640372265540" name="idFunction" index="21DrV" />
         <child id="1912777765298654333" name="propertyPolicies" index="1orW53" />
       </concept>
-      <concept id="1912777765298266446" name="de.itemis.model.merge.structure.EmptyMergeItem" flags="ng" index="1oluLK" />
-      <concept id="1912777765298163335" name="de.itemis.model.merge.structure.ModelMerge" flags="ng" index="1olOeT">
-        <child id="1912777765298260982" name="items" index="1olsr8" />
+      <concept id="1912777765298266446" name="de.itemis.model.merge.structure.EmptyMergingPolicy" flags="ng" index="1oluLK" />
+      <concept id="1912777765298163335" name="de.itemis.model.merge.structure.ModelMergingPolicy" flags="ng" index="1olOeT">
+        <child id="1912777765298260982" name="policies" index="1olsr8" />
         <child id="2222162468665533253" name="lang" index="3WPhuS" />
       </concept>
       <concept id="1912777765298652712" name="de.itemis.model.merge.structure.PropertyPolicy" flags="ng" index="1orWGm">

--- a/code/languages/de.itemis.model.merge/generator/templates/de.itemis.model.merge.generator.templates@generator.mps
+++ b/code/languages/de.itemis.model.merge/generator/templates/de.itemis.model.merge.generator.templates@generator.mps
@@ -370,33 +370,33 @@
     <property role="TrG5h" value="main" />
     <node concept="2rT7sh" id="5BXbi3$BKCe" role="2rTMjI">
       <property role="TrG5h" value="ModelMergeClazz" />
-      <ref role="2rTdP9" to="mopj:1EbzjT2RcU7" resolve="ModelMerge" />
+      <ref role="2rTdP9" to="mopj:1EbzjT2RcU7" resolve="ModelMergingPolicy" />
       <ref role="2rZz_L" to="tpee:fz12cDA" resolve="ClassConcept" />
     </node>
     <node concept="2rT7sh" id="1U34SqlnOL7" role="2rTMjI">
       <property role="TrG5h" value="ModelMergeExtension" />
-      <ref role="2rTdP9" to="mopj:1EbzjT2RcU7" resolve="ModelMerge" />
+      <ref role="2rTdP9" to="mopj:1EbzjT2RcU7" resolve="ModelMergingPolicy" />
       <ref role="2rZz_L" to="v54s:7335HkeYeM" resolve="Extension" />
     </node>
     <node concept="2rT7sh" id="3Wln5KIFxhH" role="2rTMjI">
       <property role="TrG5h" value="MergePolClazz" />
-      <ref role="2rTdP9" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
+      <ref role="2rTdP9" to="mopj:1EbzjT2R$JP" resolve="ConceptMergingPolicy" />
       <ref role="2rZz_L" to="tpee:fz12cDA" resolve="ClassConcept" />
     </node>
     <node concept="3lhOvk" id="5BXbi3$BI2V" role="3lj3bC">
       <property role="36QftV" value="true" />
       <property role="13Pg2o" value="h94ayQF/true_" />
-      <ref role="30HIoZ" to="mopj:1EbzjT2RcU7" resolve="ModelMerge" />
+      <ref role="30HIoZ" to="mopj:1EbzjT2RcU7" resolve="ModelMergingPolicy" />
       <ref role="3lhOvi" node="5BXbi3$BI9g" resolve="map_ModelMerge_Extension" />
       <ref role="2sgKRv" node="1U34SqlnOL7" resolve="ModelMergeExtension" />
     </node>
     <node concept="3lhOvk" id="5BXbi3$BIgB" role="3lj3bC">
-      <ref role="30HIoZ" to="mopj:1EbzjT2RcU7" resolve="ModelMerge" />
+      <ref role="30HIoZ" to="mopj:1EbzjT2RcU7" resolve="ModelMergingPolicy" />
       <ref role="3lhOvi" node="5BXbi3$BIgE" resolve="map_ModelMerge" />
       <ref role="2sgKRv" node="5BXbi3$BKCe" resolve="ModelMergeClazz" />
     </node>
     <node concept="3lhOvk" id="3Wln5KIGW6N" role="3lj3bC">
-      <ref role="30HIoZ" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
+      <ref role="30HIoZ" to="mopj:1EbzjT2R$JP" resolve="ConceptMergingPolicy" />
       <ref role="3lhOvi" node="3Wln5KIGW6S" resolve="map_MergePolicy" />
       <ref role="2sgKRv" node="3Wln5KIFxhH" resolve="MergePolClazz" />
     </node>
@@ -555,7 +555,7 @@
       </node>
     </node>
     <node concept="n94m4" id="5BXbi3$BI9s" role="lGtFl">
-      <ref role="n9lRv" to="mopj:1EbzjT2RcU7" resolve="ModelMerge" />
+      <ref role="n9lRv" to="mopj:1EbzjT2RcU7" resolve="ModelMergingPolicy" />
     </node>
     <node concept="17Uvod" id="1GS$5Jo7hje" role="lGtFl">
       <property role="2qtEX9" value="name" />
@@ -583,7 +583,7 @@
     <property role="TrG5h" value="map_ModelMerge" />
     <node concept="3Tm1VV" id="5BXbi3$BIgF" role="1B3o_S" />
     <node concept="n94m4" id="5BXbi3$BIgG" role="lGtFl">
-      <ref role="n9lRv" to="mopj:1EbzjT2RcU7" resolve="ModelMerge" />
+      <ref role="n9lRv" to="mopj:1EbzjT2RcU7" resolve="ModelMergingPolicy" />
     </node>
     <node concept="17Uvod" id="5BXbi3$BIh9" role="lGtFl">
       <property role="2qtEX9" value="name" />
@@ -705,7 +705,7 @@
                         </node>
                         <node concept="v3k3i" id="3Wln5KITyZ4" role="2OqNvi">
                           <node concept="chp4Y" id="3Wln5KITzAj" role="v3oSu">
-                            <ref role="cht4Q" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
+                            <ref role="cht4Q" to="mopj:1EbzjT2R$JP" resolve="ConceptMergingPolicy" />
                           </node>
                         </node>
                       </node>
@@ -772,7 +772,7 @@
                                 <node concept="2Xjw5R" id="3Wln5KI_yoF" role="2OqNvi">
                                   <node concept="1xMEDy" id="3Wln5KI_yoG" role="1xVPHs">
                                     <node concept="chp4Y" id="3Wln5KI_yoH" role="ri$Ld">
-                                      <ref role="cht4Q" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
+                                      <ref role="cht4Q" to="mopj:1EbzjT2R$JP" resolve="ConceptMergingPolicy" />
                                     </node>
                                   </node>
                                 </node>
@@ -882,7 +882,7 @@
                                 <node concept="2Xjw5R" id="3Wln5KI_$1c" role="2OqNvi">
                                   <node concept="1xMEDy" id="3Wln5KI_$1d" role="1xVPHs">
                                     <node concept="chp4Y" id="3Wln5KI_$1e" role="ri$Ld">
-                                      <ref role="cht4Q" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
+                                      <ref role="cht4Q" to="mopj:1EbzjT2R$JP" resolve="ConceptMergingPolicy" />
                                     </node>
                                   </node>
                                 </node>
@@ -1004,7 +1004,7 @@
                                         <node concept="2Xjw5R" id="3Dxwj9kIJzz" role="2OqNvi">
                                           <node concept="1xMEDy" id="3Dxwj9kIJz$" role="1xVPHs">
                                             <node concept="chp4Y" id="3Dxwj9kIJz_" role="ri$Ld">
-                                              <ref role="cht4Q" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
+                                              <ref role="cht4Q" to="mopj:1EbzjT2R$JP" resolve="ConceptMergingPolicy" />
                                             </node>
                                           </node>
                                         </node>
@@ -1384,7 +1384,7 @@
     <node concept="2tJIrI" id="3Wln5KIGYea" role="jymVt" />
     <node concept="3Tm1VV" id="3Wln5KIGW6T" role="1B3o_S" />
     <node concept="n94m4" id="3Wln5KIGW6U" role="lGtFl">
-      <ref role="n9lRv" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
+      <ref role="n9lRv" to="mopj:1EbzjT2R$JP" resolve="ConceptMergingPolicy" />
     </node>
     <node concept="17Uvod" id="3Wln5KIGWxJ" role="lGtFl">
       <property role="2qtEX9" value="name" />
@@ -1970,7 +1970,7 @@
                             <node concept="2Xjw5R" id="6IgrZARFI_m" role="2OqNvi">
                               <node concept="1xMEDy" id="6IgrZARFI_n" role="1xVPHs">
                                 <node concept="chp4Y" id="6IgrZARFI_o" role="ri$Ld">
-                                  <ref role="cht4Q" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
+                                  <ref role="cht4Q" to="mopj:1EbzjT2R$JP" resolve="ConceptMergingPolicy" />
                                 </node>
                               </node>
                             </node>
@@ -2070,7 +2070,7 @@
                             <node concept="2Xjw5R" id="3pc485W5wCJ" role="2OqNvi">
                               <node concept="1xMEDy" id="3pc485W5wCK" role="1xVPHs">
                                 <node concept="chp4Y" id="3pc485W5wCL" role="ri$Ld">
-                                  <ref role="cht4Q" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
+                                  <ref role="cht4Q" to="mopj:1EbzjT2R$JP" resolve="ConceptMergingPolicy" />
                                 </node>
                               </node>
                             </node>
@@ -2157,7 +2157,7 @@
                             <node concept="2Xjw5R" id="3pc485W5vK6" role="2OqNvi">
                               <node concept="1xMEDy" id="3pc485W5vK7" role="1xVPHs">
                                 <node concept="chp4Y" id="3pc485W5vK8" role="ri$Ld">
-                                  <ref role="cht4Q" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
+                                  <ref role="cht4Q" to="mopj:1EbzjT2R$JP" resolve="ConceptMergingPolicy" />
                                 </node>
                               </node>
                             </node>
@@ -2250,7 +2250,7 @@
                         <node concept="2Xjw5R" id="368jN$JYfc9" role="2OqNvi">
                           <node concept="1xMEDy" id="368jN$JYfca" role="1xVPHs">
                             <node concept="chp4Y" id="368jN$JYfcb" role="ri$Ld">
-                              <ref role="cht4Q" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
+                              <ref role="cht4Q" to="mopj:1EbzjT2R$JP" resolve="ConceptMergingPolicy" />
                             </node>
                           </node>
                         </node>
@@ -2321,7 +2321,7 @@
                         <node concept="2Xjw5R" id="368jN$K80ZO" role="2OqNvi">
                           <node concept="1xMEDy" id="368jN$K80ZP" role="1xVPHs">
                             <node concept="chp4Y" id="368jN$K80ZQ" role="ri$Ld">
-                              <ref role="cht4Q" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
+                              <ref role="cht4Q" to="mopj:1EbzjT2R$JP" resolve="ConceptMergingPolicy" />
                             </node>
                           </node>
                         </node>
@@ -2410,7 +2410,7 @@
                                 <node concept="2Xjw5R" id="368jN$K9uaT" role="2OqNvi">
                                   <node concept="1xMEDy" id="368jN$K9uaU" role="1xVPHs">
                                     <node concept="chp4Y" id="368jN$K9uaV" role="ri$Ld">
-                                      <ref role="cht4Q" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
+                                      <ref role="cht4Q" to="mopj:1EbzjT2R$JP" resolve="ConceptMergingPolicy" />
                                     </node>
                                   </node>
                                 </node>
@@ -2597,7 +2597,7 @@
                         <node concept="2Xjw5R" id="57NTRpQ5LUL" role="2OqNvi">
                           <node concept="1xMEDy" id="57NTRpQ5LUM" role="1xVPHs">
                             <node concept="chp4Y" id="57NTRpQ5LUN" role="ri$Ld">
-                              <ref role="cht4Q" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
+                              <ref role="cht4Q" to="mopj:1EbzjT2R$JP" resolve="ConceptMergingPolicy" />
                             </node>
                           </node>
                         </node>
@@ -2917,7 +2917,7 @@
                         <node concept="2Xjw5R" id="4WBgwWtgcDj" role="2OqNvi">
                           <node concept="1xMEDy" id="4WBgwWtgcDk" role="1xVPHs">
                             <node concept="chp4Y" id="4WBgwWtgcDl" role="ri$Ld">
-                              <ref role="cht4Q" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
+                              <ref role="cht4Q" to="mopj:1EbzjT2R$JP" resolve="ConceptMergingPolicy" />
                             </node>
                           </node>
                         </node>
@@ -2988,7 +2988,7 @@
                         <node concept="2Xjw5R" id="3xLnOvEATt1" role="2OqNvi">
                           <node concept="1xMEDy" id="3xLnOvEATt2" role="1xVPHs">
                             <node concept="chp4Y" id="3xLnOvEATt3" role="ri$Ld">
-                              <ref role="cht4Q" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
+                              <ref role="cht4Q" to="mopj:1EbzjT2R$JP" resolve="ConceptMergingPolicy" />
                             </node>
                           </node>
                         </node>
@@ -3059,7 +3059,7 @@
                         <node concept="2Xjw5R" id="3xLnOvECZkw" role="2OqNvi">
                           <node concept="1xMEDy" id="3xLnOvECZkx" role="1xVPHs">
                             <node concept="chp4Y" id="3xLnOvECZky" role="ri$Ld">
-                              <ref role="cht4Q" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
+                              <ref role="cht4Q" to="mopj:1EbzjT2R$JP" resolve="ConceptMergingPolicy" />
                             </node>
                           </node>
                         </node>
@@ -3235,7 +3235,7 @@
                                 <node concept="2Xjw5R" id="3xLnOvEDkQY" role="2OqNvi">
                                   <node concept="1xMEDy" id="3xLnOvEDkQZ" role="1xVPHs">
                                     <node concept="chp4Y" id="3xLnOvEDkR0" role="ri$Ld">
-                                      <ref role="cht4Q" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
+                                      <ref role="cht4Q" to="mopj:1EbzjT2R$JP" resolve="ConceptMergingPolicy" />
                                     </node>
                                   </node>
                                 </node>

--- a/code/languages/de.itemis.model.merge/generator/templates/de.itemis.model.merge.generator.templates@generator.mps
+++ b/code/languages/de.itemis.model.merge/generator/templates/de.itemis.model.merge.generator.templates@generator.mps
@@ -700,7 +700,7 @@
                         <node concept="2OqwBi" id="3Wln5KITvoU" role="2Oq$k0">
                           <node concept="30H73N" id="3Wln5KITuNK" role="2Oq$k0" />
                           <node concept="3Tsc0h" id="3Wln5KITvDQ" role="2OqNvi">
-                            <ref role="3TtcxE" to="mopj:1EbzjT2R$JQ" resolve="items" />
+                            <ref role="3TtcxE" to="mopj:1EbzjT2R$JQ" resolve="policies" />
                           </node>
                         </node>
                         <node concept="v3k3i" id="3Wln5KITyZ4" role="2OqNvi">

--- a/code/languages/de.itemis.model.merge/models/de.itemis.model.merge.behavior.mps
+++ b/code/languages/de.itemis.model.merge/models/de.itemis.model.merge.behavior.mps
@@ -20,17 +20,14 @@
     <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" />
     <import index="3o3z" ref="ecfb9949-7433-4db5-85de-0f84d172e4ce/java:com.google.common.collect(de.q60.mps.collections.libs/)" />
-    <import index="1ctc" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util.stream(JDK/)" />
     <import index="1qo3" ref="b0f8641f-bd77-4421-8425-30d9088a82f7/java:org.apache.commons.lang3.tuple(org.apache.commons/)" />
     <import index="tp25" ref="r:00000000-0000-4000-0000-011c89590301(jetbrains.mps.lang.smodel.structure)" />
     <import index="gunp" ref="r:a4055897-4d16-4474-96e9-a78cf2abfe5a(de.itemis.model.merge.runtime.runtime)" />
     <import index="tpeu" ref="r:00000000-0000-4000-0000-011c895902fa(jetbrains.mps.lang.smodel.behavior)" />
     <import index="lui2" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.module(MPS.OpenAPI/)" />
-    <import index="tqvn" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel.tempmodel(MPS.Core/)" />
     <import index="xlb7" ref="r:cf42fd0a-68d2-493b-8b77-961658617704(jetbrains.mps.lang.modelapi.behavior)" />
     <import index="w1kc" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel(MPS.Core/)" />
     <import index="vndm" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel.language(MPS.Core/)" />
-    <import index="80j5" ref="215c4c45-ba99-49f5-9ab7-4b6901a63cfd/java:jetbrains.mps.generator.impl(MPS.Generator/)" />
   </imports>
   <registry>
     <language id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior">
@@ -314,7 +311,7 @@
     </language>
   </registry>
   <node concept="13h7C7" id="1EbzjT2RwgD">
-    <ref role="13h7C2" to="mopj:1EbzjT2RcU7" resolve="ModelMerge" />
+    <ref role="13h7C2" to="mopj:1EbzjT2RcU7" resolve="ModelMergingPolicy" />
     <node concept="13i0hz" id="3xJ_LYXj1c6" role="13h7CS">
       <property role="TrG5h" value="conceptToDefinedMergePolicy" />
       <node concept="3Tm1VV" id="3xJ_LYXj1c7" role="1B3o_S" />
@@ -330,7 +327,7 @@
                   <ref role="ehGHo" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
                 </node>
                 <node concept="3Tqbb2" id="6XtVDsmo_Hc" role="11_B2D">
-                  <ref role="ehGHo" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
+                  <ref role="ehGHo" to="mopj:1EbzjT2R$JP" resolve="ConceptMergingPolicy" />
                 </node>
               </node>
             </node>
@@ -340,12 +337,12 @@
                   <node concept="2OqwBi" id="6XtVDsmoWGv" role="2Oq$k0">
                     <node concept="13iPFW" id="6XtVDsmoWGw" role="2Oq$k0" />
                     <node concept="3Tsc0h" id="6XtVDsmoWGx" role="2OqNvi">
-                      <ref role="3TtcxE" to="mopj:1EbzjT2R$JQ" resolve="items" />
+                      <ref role="3TtcxE" to="mopj:1EbzjT2R$JQ" resolve="policies" />
                     </node>
                   </node>
                   <node concept="v3k3i" id="6XtVDsmoWGy" role="2OqNvi">
                     <node concept="chp4Y" id="6XtVDsmoWGz" role="v3oSu">
-                      <ref role="cht4Q" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
+                      <ref role="cht4Q" to="mopj:1EbzjT2R$JP" resolve="ConceptMergingPolicy" />
                     </node>
                   </node>
                 </node>
@@ -396,7 +393,7 @@
           <ref role="ehGHo" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
         </node>
         <node concept="3Tqbb2" id="3xJ_LYXj8RN" role="3rvSg0">
-          <ref role="ehGHo" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
+          <ref role="ehGHo" to="mopj:1EbzjT2R$JP" resolve="ConceptMergingPolicy" />
         </node>
       </node>
     </node>
@@ -717,7 +714,7 @@
         <node concept="3clFbF" id="2QNuyuiM$PN" role="3cqZAp">
           <node concept="2YIFZM" id="61HvMZcxF4R" role="3clFbG">
             <ref role="37wK5l" to="gunp:7wnapcW0cfS" resolve="run" />
-            <ref role="1Pybhc" to="gunp:18W7Z4VeRuj" resolve="MergeResolverFromModelMerge" />
+            <ref role="1Pybhc" to="gunp:18W7Z4VeRuj" resolve="PolicyMergerResolver" />
             <node concept="13iPFW" id="2QNuyuiM$UG" role="37wK5m" />
           </node>
         </node>
@@ -756,7 +753,7 @@
             <node concept="2OqwBi" id="3Wln5KIUhhy" role="33vP2m">
               <node concept="2YIFZM" id="61HvMZcxF4S" role="2Oq$k0">
                 <ref role="37wK5l" to="gunp:7wnapcW0cfS" resolve="run" />
-                <ref role="1Pybhc" to="gunp:18W7Z4VeRuj" resolve="MergeResolverFromModelMerge" />
+                <ref role="1Pybhc" to="gunp:18W7Z4VeRuj" resolve="PolicyMergerResolver" />
                 <node concept="13iPFW" id="3Wln5KIUhh$" role="37wK5m" />
               </node>
               <node concept="2OwXpG" id="3Wln5KIUhh_" role="2OqNvi">
@@ -1307,8 +1304,8 @@
     </node>
   </node>
   <node concept="13h7C7" id="1VmHfRx_0JJ">
-    <property role="3GE5qa" value="elementpolicies" />
-    <ref role="13h7C2" to="mopj:7jyS5urbJZ2" resolve="ItemPolicy" />
+    <property role="3GE5qa" value="declarationPolicies" />
+    <ref role="13h7C2" to="mopj:7jyS5urbJZ2" resolve="DeclarationPolicy" />
     <node concept="13i0hz" id="1VmHfRx_0K2" role="13h7CS">
       <property role="13i0it" value="true" />
       <property role="TrG5h" value="childLink" />
@@ -1334,7 +1331,7 @@
     </node>
   </node>
   <node concept="13h7C7" id="1VmHfRx_c7E">
-    <property role="3GE5qa" value="elementpolicies" />
+    <property role="3GE5qa" value="declarationPolicies" />
     <ref role="13h7C2" to="mopj:7jyS5urbTpb" resolve="SingletonPolicy" />
     <node concept="13i0hz" id="1Tugx$F11q" role="13h7CS">
       <property role="TrG5h" value="manualAction" />
@@ -1354,7 +1351,7 @@
     </node>
   </node>
   <node concept="13h7C7" id="1VmHfRx_cY5">
-    <property role="3GE5qa" value="elementpolicies" />
+    <property role="3GE5qa" value="declarationPolicies" />
     <ref role="13h7C2" to="mopj:7jyS5urbFgb" resolve="OptionalPolicy" />
     <node concept="13i0hz" id="1Tugx$FTy0" role="13h7CS">
       <property role="TrG5h" value="manualAction" />
@@ -1374,7 +1371,7 @@
     </node>
   </node>
   <node concept="13h7C7" id="1VmHfRx_dNi">
-    <property role="3GE5qa" value="elementpolicies" />
+    <property role="3GE5qa" value="declarationPolicies" />
     <ref role="13h7C2" to="mopj:7jyS5urbTpv" resolve="MultiChildPolicy" />
     <node concept="13i0hz" id="6CwG2k87nXX" role="13h7CS">
       <property role="TrG5h" value="childIdFunction" />
@@ -1396,16 +1393,16 @@
         </node>
         <node concept="3cpWs8" id="1yAYHyQ78$O" role="3cqZAp">
           <node concept="3cpWsn" id="1yAYHyQ78$P" role="3cpWs9">
-            <property role="TrG5h" value="modelmerge" />
+            <property role="TrG5h" value="mergingPolicy" />
             <node concept="3Tqbb2" id="1yAYHyQ78uC" role="1tU5fm">
-              <ref role="ehGHo" to="mopj:1EbzjT2RcU7" resolve="ModelMerge" />
+              <ref role="ehGHo" to="mopj:1EbzjT2RcU7" resolve="ModelMergingPolicy" />
             </node>
             <node concept="2OqwBi" id="1yAYHyQ78$Q" role="33vP2m">
               <node concept="13iPFW" id="6CwG2k87si9" role="2Oq$k0" />
               <node concept="2Xjw5R" id="1yAYHyQ78$S" role="2OqNvi">
                 <node concept="1xMEDy" id="1yAYHyQ78$T" role="1xVPHs">
                   <node concept="chp4Y" id="1yAYHyQ78$U" role="ri$Ld">
-                    <ref role="cht4Q" to="mopj:1EbzjT2RcU7" resolve="ModelMerge" />
+                    <ref role="cht4Q" to="mopj:1EbzjT2RcU7" resolve="ModelMergingPolicy" />
                   </node>
                 </node>
               </node>
@@ -1414,9 +1411,9 @@
         </node>
         <node concept="3cpWs8" id="1yAYHyQ7lxb" role="3cqZAp">
           <node concept="3cpWsn" id="1yAYHyQ7lxc" role="3cpWs9">
-            <property role="TrG5h" value="mergePolicyChild" />
+            <property role="TrG5h" value="childPolicy" />
             <node concept="3Tqbb2" id="1yAYHyQ7lu1" role="1tU5fm">
-              <ref role="ehGHo" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
+              <ref role="ehGHo" to="mopj:1EbzjT2R$JP" resolve="ConceptMergingPolicy" />
             </node>
             <node concept="2OqwBi" id="1yAYHyQ7lxd" role="33vP2m">
               <node concept="2OqwBi" id="1yAYHyQ7lxe" role="2Oq$k0">
@@ -1425,12 +1422,12 @@
                     <ref role="3cqZAo" node="1yAYHyQ78$P" resolve="modelmerge" />
                   </node>
                   <node concept="3Tsc0h" id="1yAYHyQ7lxh" role="2OqNvi">
-                    <ref role="3TtcxE" to="mopj:1EbzjT2R$JQ" resolve="items" />
+                    <ref role="3TtcxE" to="mopj:1EbzjT2R$JQ" resolve="policies" />
                   </node>
                 </node>
                 <node concept="v3k3i" id="1yAYHyQ7lxi" role="2OqNvi">
                   <node concept="chp4Y" id="1yAYHyQ7lxj" role="v3oSu">
-                    <ref role="cht4Q" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
+                    <ref role="cht4Q" to="mopj:1EbzjT2R$JP" resolve="ConceptMergingPolicy" />
                   </node>
                 </node>
               </node>
@@ -1484,7 +1481,7 @@
                 <node concept="37vLTG" id="6CwG2k87w2$" role="1bW2Oz">
                   <property role="TrG5h" value="mp" />
                   <node concept="3Tqbb2" id="6CwG2k87w2_" role="1tU5fm">
-                    <ref role="ehGHo" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
+                    <ref role="ehGHo" to="mopj:1EbzjT2R$JP" resolve="ConceptMergingPolicy" />
                   </node>
                 </node>
                 <node concept="3clFbS" id="6CwG2k87w2A" role="1bW5cS">
@@ -1516,7 +1513,7 @@
     </node>
   </node>
   <node concept="13h7C7" id="1VmHfRxXAgo">
-    <property role="3GE5qa" value="elementpolicies" />
+    <property role="3GE5qa" value="declarationPolicies" />
     <ref role="13h7C2" to="mopj:1VmHfRxVF4G" resolve="AbstractPolicy" />
     <node concept="13i0hz" id="jF$CuWmXO_" role="13h7CS">
       <property role="TrG5h" value="childHasMultipleSubConcepts" />
@@ -1527,14 +1524,14 @@
           <node concept="3cpWsn" id="jF$CuWctI2" role="3cpWs9">
             <property role="TrG5h" value="modelMerge" />
             <node concept="3Tqbb2" id="jF$CuWctEr" role="1tU5fm">
-              <ref role="ehGHo" to="mopj:1EbzjT2RcU7" resolve="ModelMerge" />
+              <ref role="ehGHo" to="mopj:1EbzjT2RcU7" resolve="ModelMergingPolicy" />
             </node>
             <node concept="2OqwBi" id="jF$CuWctI3" role="33vP2m">
               <node concept="13iPFW" id="jF$CuWn2Ng" role="2Oq$k0" />
               <node concept="2Xjw5R" id="jF$CuWctI5" role="2OqNvi">
                 <node concept="1xMEDy" id="jF$CuWctI6" role="1xVPHs">
                   <node concept="chp4Y" id="jF$CuWctI7" role="ri$Ld">
-                    <ref role="cht4Q" to="mopj:1EbzjT2RcU7" resolve="ModelMerge" />
+                    <ref role="cht4Q" to="mopj:1EbzjT2RcU7" resolve="ModelMergingPolicy" />
                   </node>
                 </node>
               </node>
@@ -1705,7 +1702,7 @@
     </node>
   </node>
   <node concept="13h7C7" id="5zr7Q_1V6Sw">
-    <ref role="13h7C2" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
+    <ref role="13h7C2" to="mopj:1EbzjT2R$JP" resolve="ConceptMergingPolicy" />
     <node concept="13i0hz" id="5zr7Q_1V6SF" role="13h7CS">
       <property role="TrG5h" value="allHierarchyProperties" />
       <node concept="3Tm1VV" id="5zr7Q_1V6SG" role="1B3o_S" />
@@ -2374,7 +2371,7 @@
     </node>
   </node>
   <node concept="13h7C7" id="3EHNiwz_w7T">
-    <property role="3GE5qa" value="elementpolicies" />
+    <property role="3GE5qa" value="declarationPolicies" />
     <ref role="13h7C2" to="mopj:1EbzjT2T4oC" resolve="PropertyPolicy" />
     <node concept="13i0hz" id="3EHNiwz_w8A" role="13h7CS">
       <property role="13i0it" value="true" />
@@ -2543,7 +2540,7 @@
     </node>
   </node>
   <node concept="13h7C7" id="6Ltuup4sL$5">
-    <ref role="13h7C2" to="mopj:5zr7Q_1InAA" resolve="ModelMergeExecution" />
+    <ref role="13h7C2" to="mopj:5zr7Q_1InAA" resolve="ModelMergingConfiguration" />
     <node concept="13i0hz" id="6Ltuup4sQ0X" role="13h7CS">
       <property role="TrG5h" value="execute" />
       <node concept="3Tm1VV" id="6Ltuup4sQ0Y" role="1B3o_S" />
@@ -2574,7 +2571,7 @@
           <node concept="3clFbS" id="4LLXBGaeTSe" role="3clFbx">
             <node concept="3clFbF" id="4LLXBGaeX57" role="3cqZAp">
               <node concept="2YIFZM" id="4LLXBGaeXr0" role="3clFbG">
-                <ref role="1Pybhc" to="gunp:2cYlIwY_fxg" resolve="ModelMergeExecutionRunner" />
+                <ref role="1Pybhc" to="gunp:2cYlIwY_fxg" resolve="ModelMergingRunner" />
                 <ref role="37wK5l" to="gunp:4LLXBGafXQt" resolve="runLeftMerge" />
                 <node concept="2OqwBi" id="4LLXBGafUem" role="37wK5m">
                   <node concept="13iPFW" id="4LLXBGafTKq" role="2Oq$k0" />
@@ -2591,7 +2588,7 @@
                 <node concept="2OqwBi" id="4LLXBGafWPZ" role="37wK5m">
                   <node concept="13iPFW" id="4LLXBGafWm1" role="2Oq$k0" />
                   <node concept="3TrEf2" id="4LLXBGafXmw" role="2OqNvi">
-                    <ref role="3Tt5mk" to="mopj:5zr7Q_1IGSD" resolve="modelMerge" />
+                    <ref role="3Tt5mk" to="mopj:5zr7Q_1IGSD" resolve="mergingPolicy" />
                   </node>
                 </node>
               </node>
@@ -2668,7 +2665,7 @@
               </node>
               <node concept="3clFbF" id="4LLXBGagWpb" role="3cqZAp">
                 <node concept="2YIFZM" id="4LLXBGagWpc" role="3clFbG">
-                  <ref role="1Pybhc" to="gunp:2cYlIwY_fxg" resolve="ModelMergeExecutionRunner" />
+                  <ref role="1Pybhc" to="gunp:2cYlIwY_fxg" resolve="ModelMergingRunner" />
                   <ref role="37wK5l" to="gunp:2cYlIwYBdd4" resolve="run" />
                   <node concept="37vLTw" id="4LLXBGagWpd" role="37wK5m">
                     <ref role="3cqZAo" node="4LLXBGagNmw" resolve="resultModel" />
@@ -2676,7 +2673,7 @@
                   <node concept="2OqwBi" id="4LLXBGagWpe" role="37wK5m">
                     <node concept="13iPFW" id="4LLXBGagWpf" role="2Oq$k0" />
                     <node concept="3TrEf2" id="4LLXBGagWpg" role="2OqNvi">
-                      <ref role="3Tt5mk" to="mopj:5zr7Q_1IGSD" resolve="modelMerge" />
+                      <ref role="3Tt5mk" to="mopj:5zr7Q_1IGSD" resolve="mergingPolicy" />
                     </node>
                   </node>
                   <node concept="2OqwBi" id="4LLXBGagWph" role="37wK5m">
@@ -2788,7 +2785,7 @@
     </node>
   </node>
   <node concept="13h7C7" id="1Tugx$FmIs">
-    <property role="3GE5qa" value="elementpolicies" />
+    <property role="3GE5qa" value="declarationPolicies" />
     <ref role="13h7C2" to="mopj:3PLTv5k2w4R" resolve="SingeltonRefPolicy" />
     <node concept="13hLZK" id="1Tugx$FmIt" role="13h7CW">
       <node concept="3clFbS" id="1Tugx$FmIu" role="2VODD2" />
@@ -2826,7 +2823,7 @@
     </node>
   </node>
   <node concept="13h7C7" id="1Tugx$G3aq">
-    <property role="3GE5qa" value="elementpolicies" />
+    <property role="3GE5qa" value="declarationPolicies" />
     <ref role="13h7C2" to="mopj:3PLTv5k2w4U" resolve="OptionalRefPolicy" />
     <node concept="13hLZK" id="1Tugx$G3ar" role="13h7CW">
       <node concept="3clFbS" id="1Tugx$G3as" role="2VODD2" />
@@ -2864,7 +2861,7 @@
     </node>
   </node>
   <node concept="13h7C7" id="1Tugx$Uc$4">
-    <property role="3GE5qa" value="elementpolicies" />
+    <property role="3GE5qa" value="declarationPolicies" />
     <ref role="13h7C2" to="mopj:3PLTv5jwPx8" resolve="ReferencePolicy" />
     <node concept="13i0hz" id="1Tugx$Uc$f" role="13h7CS">
       <property role="13i0iv" value="true" />

--- a/code/languages/de.itemis.model.merge/models/de.itemis.model.merge.behavior.mps
+++ b/code/languages/de.itemis.model.merge/models/de.itemis.model.merge.behavior.mps
@@ -1419,7 +1419,7 @@
               <node concept="2OqwBi" id="1yAYHyQ7lxe" role="2Oq$k0">
                 <node concept="2OqwBi" id="1yAYHyQ7lxf" role="2Oq$k0">
                   <node concept="37vLTw" id="1yAYHyQ7lxg" role="2Oq$k0">
-                    <ref role="3cqZAo" node="1yAYHyQ78$P" resolve="modelmerge" />
+                    <ref role="3cqZAo" node="1yAYHyQ78$P" resolve="mergingPolicy" />
                   </node>
                   <node concept="3Tsc0h" id="1yAYHyQ7lxh" role="2OqNvi">
                     <ref role="3TtcxE" to="mopj:1EbzjT2R$JQ" resolve="policies" />
@@ -1472,7 +1472,7 @@
               <ref role="37wK5l" to="33ny:~Optional.ofNullable(java.lang.Object)" resolve="ofNullable" />
               <ref role="1Pybhc" to="33ny:~Optional" resolve="Optional" />
               <node concept="37vLTw" id="6CwG2k87w2x" role="37wK5m">
-                <ref role="3cqZAo" node="1yAYHyQ7lxc" resolve="mergePolicyChild" />
+                <ref role="3cqZAo" node="1yAYHyQ7lxc" resolve="childPolicy" />
               </node>
             </node>
             <node concept="liA8E" id="6CwG2k87w2y" role="2OqNvi">

--- a/code/languages/de.itemis.model.merge/models/de.itemis.model.merge.constraints.mps
+++ b/code/languages/de.itemis.model.merge/models/de.itemis.model.merge.constraints.mps
@@ -237,7 +237,7 @@
     </language>
   </registry>
   <node concept="1M2fIO" id="1EbzjT2SHHS">
-    <ref role="1M2myG" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
+    <ref role="1M2myG" to="mopj:1EbzjT2R$JP" resolve="ConceptMergingPolicy" />
     <node concept="1N5Pfh" id="3BP4DuXwMl4" role="1Mr941">
       <ref role="1N5Vy1" to="mopj:3BP4DuXu_FH" resolve="conceptRef" />
       <node concept="3dgokm" id="3BP4DuXwMAs" role="1N6uqs">
@@ -246,14 +246,14 @@
             <node concept="3cpWsn" id="3xJ_LYXlqAN" role="3cpWs9">
               <property role="TrG5h" value="modelmerge" />
               <node concept="3Tqbb2" id="3xJ_LYXlnww" role="1tU5fm">
-                <ref role="ehGHo" to="mopj:1EbzjT2RcU7" resolve="ModelMerge" />
+                <ref role="ehGHo" to="mopj:1EbzjT2RcU7" resolve="ModelMergingPolicy" />
               </node>
               <node concept="2OqwBi" id="3xJ_LYXlqAO" role="33vP2m">
                 <node concept="2rP1CM" id="3xJ_LYXlqAP" role="2Oq$k0" />
                 <node concept="2Xjw5R" id="3xJ_LYXlqAQ" role="2OqNvi">
                   <node concept="1xMEDy" id="3xJ_LYXlqAR" role="1xVPHs">
                     <node concept="chp4Y" id="3xJ_LYXlqAS" role="ri$Ld">
-                      <ref role="cht4Q" to="mopj:1EbzjT2RcU7" resolve="ModelMerge" />
+                      <ref role="cht4Q" to="mopj:1EbzjT2RcU7" resolve="ModelMergingPolicy" />
                     </node>
                   </node>
                   <node concept="1xIGOp" id="7TOowlgqSwH" role="1xVPHs" />
@@ -280,7 +280,7 @@
     </node>
   </node>
   <node concept="1M2fIO" id="1NgLzfPd_tj">
-    <property role="3GE5qa" value="elementpolicies" />
+    <property role="3GE5qa" value="declarationPolicies" />
     <ref role="1M2myG" to="mopj:1EbzjT2T4oC" resolve="PropertyPolicy" />
     <node concept="1N5Pfh" id="7jyS5urcz$x" role="1Mr941">
       <ref role="1N5Vy1" to="mopj:6zqIeMU2u$T" resolve="property" />
@@ -290,14 +290,14 @@
             <node concept="3cpWsn" id="7jyS5urdij6" role="3cpWs9">
               <property role="TrG5h" value="mergePol" />
               <node concept="3Tqbb2" id="7jyS5urdhX6" role="1tU5fm">
-                <ref role="ehGHo" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
+                <ref role="ehGHo" to="mopj:1EbzjT2R$JP" resolve="ConceptMergingPolicy" />
               </node>
               <node concept="2OqwBi" id="7jyS5urdij7" role="33vP2m">
                 <node concept="3kakTB" id="7jyS5urdij8" role="2Oq$k0" />
                 <node concept="2Xjw5R" id="7jyS5urdij9" role="2OqNvi">
                   <node concept="1xMEDy" id="7jyS5urdija" role="1xVPHs">
                     <node concept="chp4Y" id="7jyS5urdijb" role="ri$Ld">
-                      <ref role="cht4Q" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
+                      <ref role="cht4Q" to="mopj:1EbzjT2R$JP" resolve="ConceptMergingPolicy" />
                     </node>
                   </node>
                   <node concept="1xIGOp" id="7jyS5urdmIq" role="1xVPHs" />
@@ -313,7 +313,7 @@
                   <node concept="2Xjw5R" id="7jyS5ure98Q" role="2OqNvi">
                     <node concept="1xMEDy" id="7jyS5ure98S" role="1xVPHs">
                       <node concept="chp4Y" id="7jyS5ure9dd" role="ri$Ld">
-                        <ref role="cht4Q" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
+                        <ref role="cht4Q" to="mopj:1EbzjT2R$JP" resolve="ConceptMergingPolicy" />
                       </node>
                     </node>
                     <node concept="1xIGOp" id="7jyS5ure9s1" role="1xVPHs" />
@@ -464,7 +464,7 @@
     </node>
   </node>
   <node concept="1M2fIO" id="7jyS5urktDV">
-    <property role="3GE5qa" value="elementpolicies" />
+    <property role="3GE5qa" value="declarationPolicies" />
     <ref role="1M2myG" to="mopj:7jyS5urbFgb" resolve="OptionalPolicy" />
     <node concept="9SLcT" id="7jyS5urn0tZ" role="9SGkU">
       <node concept="3clFbS" id="7jyS5urn0u0" role="2VODD2">
@@ -588,7 +588,7 @@
     </node>
   </node>
   <node concept="1M2fIO" id="7jyS5urkN7L">
-    <property role="3GE5qa" value="elementpolicies" />
+    <property role="3GE5qa" value="declarationPolicies" />
     <ref role="1M2myG" to="mopj:7jyS5urbTpb" resolve="SingletonPolicy" />
     <node concept="9SLcT" id="7jyS5urmeeO" role="9SGkU">
       <node concept="3clFbS" id="7jyS5urmeeP" role="2VODD2">
@@ -708,7 +708,7 @@
     </node>
   </node>
   <node concept="1M2fIO" id="7jyS5urkOuN">
-    <property role="3GE5qa" value="elementpolicies" />
+    <property role="3GE5qa" value="declarationPolicies" />
     <ref role="1M2myG" to="mopj:7jyS5urbTpv" resolve="MultiChildPolicy" />
     <node concept="1N5Pfh" id="7jyS5urkOuO" role="1Mr941">
       <ref role="1N5Vy1" to="mopj:1VmHfRxVF4J" resolve="child" />
@@ -718,14 +718,14 @@
             <node concept="3cpWsn" id="7jyS5urkO$7" role="3cpWs9">
               <property role="TrG5h" value="mergePol" />
               <node concept="3Tqbb2" id="7jyS5urkO$8" role="1tU5fm">
-                <ref role="ehGHo" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
+                <ref role="ehGHo" to="mopj:1EbzjT2R$JP" resolve="ConceptMergingPolicy" />
               </node>
               <node concept="2OqwBi" id="7jyS5urkO$9" role="33vP2m">
                 <node concept="3kakTB" id="7jyS5urkO$a" role="2Oq$k0" />
                 <node concept="2Xjw5R" id="7jyS5urkO$b" role="2OqNvi">
                   <node concept="1xMEDy" id="7jyS5urkO$c" role="1xVPHs">
                     <node concept="chp4Y" id="7jyS5urkO$d" role="ri$Ld">
-                      <ref role="cht4Q" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
+                      <ref role="cht4Q" to="mopj:1EbzjT2R$JP" resolve="ConceptMergingPolicy" />
                     </node>
                   </node>
                   <node concept="1xIGOp" id="7jyS5urkO$e" role="1xVPHs" />
@@ -741,7 +741,7 @@
                   <node concept="2Xjw5R" id="7jyS5urkO$k" role="2OqNvi">
                     <node concept="1xMEDy" id="7jyS5urkO$l" role="1xVPHs">
                       <node concept="chp4Y" id="7jyS5urkO$m" role="ri$Ld">
-                        <ref role="cht4Q" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
+                        <ref role="cht4Q" to="mopj:1EbzjT2R$JP" resolve="ConceptMergingPolicy" />
                       </node>
                     </node>
                     <node concept="1xIGOp" id="7jyS5urkO$n" role="1xVPHs" />
@@ -781,7 +781,7 @@
     </node>
   </node>
   <node concept="1M2fIO" id="1VmHfRxQ5sl">
-    <property role="3GE5qa" value="elementpolicies.subpolicy" />
+    <property role="3GE5qa" value="declarationPolicies.subpolicy" />
     <ref role="1M2myG" to="mopj:1VmHfRxKMgU" resolve="SubPolicyContainer" />
     <node concept="EnEH3" id="1VmHfRxQ5sm" role="1MhHOB">
       <ref role="EomxK" to="mopj:1VmHfRxKMgV" resolve="subPolicy" />
@@ -978,7 +978,7 @@
     </node>
   </node>
   <node concept="1M2fIO" id="1Av7Chms28S">
-    <property role="3GE5qa" value="elementpolicies" />
+    <property role="3GE5qa" value="declarationPolicies" />
     <ref role="1M2myG" to="mopj:3PLTv5k2w4J" resolve="SingletonChildPolicy" />
     <node concept="1N5Pfh" id="1Av7Chms2eU" role="1Mr941">
       <ref role="1N5Vy1" to="mopj:1VmHfRxVF4J" resolve="child" />
@@ -988,14 +988,14 @@
             <node concept="3cpWsn" id="1Av7Chms2t9" role="3cpWs9">
               <property role="TrG5h" value="mergePol" />
               <node concept="3Tqbb2" id="1Av7Chms2ta" role="1tU5fm">
-                <ref role="ehGHo" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
+                <ref role="ehGHo" to="mopj:1EbzjT2R$JP" resolve="ConceptMergingPolicy" />
               </node>
               <node concept="2OqwBi" id="1Av7Chms2tb" role="33vP2m">
                 <node concept="3kakTB" id="1Av7Chms2tc" role="2Oq$k0" />
                 <node concept="2Xjw5R" id="1Av7Chms2td" role="2OqNvi">
                   <node concept="1xMEDy" id="1Av7Chms2te" role="1xVPHs">
                     <node concept="chp4Y" id="1Av7Chms2tf" role="ri$Ld">
-                      <ref role="cht4Q" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
+                      <ref role="cht4Q" to="mopj:1EbzjT2R$JP" resolve="ConceptMergingPolicy" />
                     </node>
                   </node>
                   <node concept="1xIGOp" id="1Av7Chms2tg" role="1xVPHs" />
@@ -1011,7 +1011,7 @@
                   <node concept="2Xjw5R" id="1Av7Chms2tm" role="2OqNvi">
                     <node concept="1xMEDy" id="1Av7Chms2tn" role="1xVPHs">
                       <node concept="chp4Y" id="1Av7Chms2to" role="ri$Ld">
-                        <ref role="cht4Q" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
+                        <ref role="cht4Q" to="mopj:1EbzjT2R$JP" resolve="ConceptMergingPolicy" />
                       </node>
                     </node>
                     <node concept="1xIGOp" id="1Av7Chms2tp" role="1xVPHs" />
@@ -1051,7 +1051,7 @@
     </node>
   </node>
   <node concept="1M2fIO" id="1Av7Chms2En">
-    <property role="3GE5qa" value="elementpolicies" />
+    <property role="3GE5qa" value="declarationPolicies" />
     <ref role="1M2myG" to="mopj:3PLTv5k2w4R" resolve="SingeltonRefPolicy" />
     <node concept="1N5Pfh" id="1Av7Chms2Eo" role="1Mr941">
       <ref role="1N5Vy1" to="mopj:1VmHfRxVF4J" resolve="child" />
@@ -1061,14 +1061,14 @@
             <node concept="3cpWsn" id="1Av7Chms2LC" role="3cpWs9">
               <property role="TrG5h" value="mergePol" />
               <node concept="3Tqbb2" id="1Av7Chms2LD" role="1tU5fm">
-                <ref role="ehGHo" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
+                <ref role="ehGHo" to="mopj:1EbzjT2R$JP" resolve="ConceptMergingPolicy" />
               </node>
               <node concept="2OqwBi" id="1Av7Chms2LE" role="33vP2m">
                 <node concept="3kakTB" id="1Av7Chms2LF" role="2Oq$k0" />
                 <node concept="2Xjw5R" id="1Av7Chms2LG" role="2OqNvi">
                   <node concept="1xMEDy" id="1Av7Chms2LH" role="1xVPHs">
                     <node concept="chp4Y" id="1Av7Chms2LI" role="ri$Ld">
-                      <ref role="cht4Q" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
+                      <ref role="cht4Q" to="mopj:1EbzjT2R$JP" resolve="ConceptMergingPolicy" />
                     </node>
                   </node>
                   <node concept="1xIGOp" id="1Av7Chms2LJ" role="1xVPHs" />
@@ -1084,7 +1084,7 @@
                   <node concept="2Xjw5R" id="1Av7Chms2LP" role="2OqNvi">
                     <node concept="1xMEDy" id="1Av7Chms2LQ" role="1xVPHs">
                       <node concept="chp4Y" id="1Av7Chms2LR" role="ri$Ld">
-                        <ref role="cht4Q" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
+                        <ref role="cht4Q" to="mopj:1EbzjT2R$JP" resolve="ConceptMergingPolicy" />
                       </node>
                     </node>
                     <node concept="1xIGOp" id="1Av7Chms2LS" role="1xVPHs" />
@@ -1124,7 +1124,7 @@
     </node>
   </node>
   <node concept="1M2fIO" id="1Av7ChmtLFo">
-    <property role="3GE5qa" value="elementpolicies" />
+    <property role="3GE5qa" value="declarationPolicies" />
     <ref role="1M2myG" to="mopj:3PLTv5k2w4M" resolve="OptionalChildPolicy" />
     <node concept="1N5Pfh" id="1Av7ChmtLFp" role="1Mr941">
       <ref role="1N5Vy1" to="mopj:1VmHfRxVF4J" resolve="child" />
@@ -1134,14 +1134,14 @@
             <node concept="3cpWsn" id="1Av7ChmtPnr" role="3cpWs9">
               <property role="TrG5h" value="mergePol" />
               <node concept="3Tqbb2" id="1Av7ChmtPns" role="1tU5fm">
-                <ref role="ehGHo" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
+                <ref role="ehGHo" to="mopj:1EbzjT2R$JP" resolve="ConceptMergingPolicy" />
               </node>
               <node concept="2OqwBi" id="1Av7ChmtPnt" role="33vP2m">
                 <node concept="3kakTB" id="1Av7ChmtPnu" role="2Oq$k0" />
                 <node concept="2Xjw5R" id="1Av7ChmtPnv" role="2OqNvi">
                   <node concept="1xMEDy" id="1Av7ChmtPnw" role="1xVPHs">
                     <node concept="chp4Y" id="1Av7ChmtPnx" role="ri$Ld">
-                      <ref role="cht4Q" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
+                      <ref role="cht4Q" to="mopj:1EbzjT2R$JP" resolve="ConceptMergingPolicy" />
                     </node>
                   </node>
                   <node concept="1xIGOp" id="1Av7ChmtPny" role="1xVPHs" />
@@ -1157,7 +1157,7 @@
                   <node concept="2Xjw5R" id="1Av7ChmtPnC" role="2OqNvi">
                     <node concept="1xMEDy" id="1Av7ChmtPnD" role="1xVPHs">
                       <node concept="chp4Y" id="1Av7ChmtPnE" role="ri$Ld">
-                        <ref role="cht4Q" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
+                        <ref role="cht4Q" to="mopj:1EbzjT2R$JP" resolve="ConceptMergingPolicy" />
                       </node>
                     </node>
                     <node concept="1xIGOp" id="1Av7ChmtPnF" role="1xVPHs" />
@@ -1197,7 +1197,7 @@
     </node>
   </node>
   <node concept="1M2fIO" id="1Av7ChmtPBG">
-    <property role="3GE5qa" value="elementpolicies" />
+    <property role="3GE5qa" value="declarationPolicies" />
     <ref role="1M2myG" to="mopj:3PLTv5k2w4U" resolve="OptionalRefPolicy" />
     <node concept="1N5Pfh" id="1Av7ChmtPBH" role="1Mr941">
       <ref role="1N5Vy1" to="mopj:1VmHfRxVF4J" resolve="child" />
@@ -1207,14 +1207,14 @@
             <node concept="3cpWsn" id="1Av7ChmtPGB" role="3cpWs9">
               <property role="TrG5h" value="mergePol" />
               <node concept="3Tqbb2" id="1Av7ChmtPGC" role="1tU5fm">
-                <ref role="ehGHo" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
+                <ref role="ehGHo" to="mopj:1EbzjT2R$JP" resolve="ConceptMergingPolicy" />
               </node>
               <node concept="2OqwBi" id="1Av7ChmtPGD" role="33vP2m">
                 <node concept="3kakTB" id="1Av7ChmtPGE" role="2Oq$k0" />
                 <node concept="2Xjw5R" id="1Av7ChmtPGF" role="2OqNvi">
                   <node concept="1xMEDy" id="1Av7ChmtPGG" role="1xVPHs">
                     <node concept="chp4Y" id="1Av7ChmtPGH" role="ri$Ld">
-                      <ref role="cht4Q" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
+                      <ref role="cht4Q" to="mopj:1EbzjT2R$JP" resolve="ConceptMergingPolicy" />
                     </node>
                   </node>
                   <node concept="1xIGOp" id="1Av7ChmtPGI" role="1xVPHs" />
@@ -1230,7 +1230,7 @@
                   <node concept="2Xjw5R" id="1Av7ChmtPGO" role="2OqNvi">
                     <node concept="1xMEDy" id="1Av7ChmtPGP" role="1xVPHs">
                       <node concept="chp4Y" id="1Av7ChmtPGQ" role="ri$Ld">
-                        <ref role="cht4Q" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
+                        <ref role="cht4Q" to="mopj:1EbzjT2R$JP" resolve="ConceptMergingPolicy" />
                       </node>
                     </node>
                     <node concept="1xIGOp" id="1Av7ChmtPGR" role="1xVPHs" />

--- a/code/languages/de.itemis.model.merge/models/de.itemis.model.merge.editor.mps
+++ b/code/languages/de.itemis.model.merge/models/de.itemis.model.merge.editor.mps
@@ -1554,20 +1554,6 @@
     <node concept="3Tm1VV" id="39IQCXdoK20" role="1B3o_S" />
     <node concept="3lBaaS" id="39IQCXdoK22" role="3l$a4r">
       <node concept="3clFbS" id="39IQCXdoK23" role="2VODD2">
-        <node concept="3clFbF" id="6XR_ZZHr1MW" role="3cqZAp">
-          <node concept="2OqwBi" id="6XR_ZZHr1MT" role="3clFbG">
-            <node concept="10M0yZ" id="6XR_ZZHr1MU" role="2Oq$k0">
-              <ref role="1PxDUh" to="wyt6:~System" resolve="System" />
-              <ref role="3cqZAo" to="wyt6:~System.out" resolve="out" />
-            </node>
-            <node concept="liA8E" id="6XR_ZZHr1MV" role="2OqNvi">
-              <ref role="37wK5l" to="guwi:~PrintStream.println(java.lang.String)" resolve="println" />
-              <node concept="Xl_RD" id="6XR_ZZHr1Sc" role="37wK5m">
-                <property role="Xl_RC" value="---&gt; CP" />
-              </node>
-            </node>
-          </node>
-        </node>
         <node concept="3cpWs8" id="1VmHfRx$Os9" role="3cqZAp">
           <node concept="3cpWsn" id="1VmHfRx$Osa" role="3cpWs9">
             <property role="TrG5h" value="mergePol" />

--- a/code/languages/de.itemis.model.merge/models/de.itemis.model.merge.editor.mps
+++ b/code/languages/de.itemis.model.merge/models/de.itemis.model.merge.editor.mps
@@ -3,7 +3,6 @@
   <persistence version="9" />
   <languages>
     <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="14" />
-    <use id="aee9cad2-acd4-4608-aef2-0004f6a1cdbd" name="jetbrains.mps.lang.actions" version="4" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -12,7 +11,6 @@
     <import index="tpce" ref="r:00000000-0000-4000-0000-011c89590292(jetbrains.mps.lang.structure.structure)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" />
     <import index="fulz" ref="r:6f792c44-2a5d-40e8-9f05-33f7d4ae26ec(jetbrains.mps.editor.runtime.completion)" />
-    <import index="z60i" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt(JDK/)" />
     <import index="av1m" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.menus.style(MPS.Editor/)" />
     <import index="rnx3" ref="r:424d540e-f1fc-49a5-b16d-3f9264b84dee(de.itemis.model.merge.behavior)" />
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
@@ -330,7 +328,7 @@
     </language>
   </registry>
   <node concept="24kQdi" id="1EbzjT2RA54">
-    <ref role="1XX52x" to="mopj:1EbzjT2RcU7" resolve="ModelMerge" />
+    <ref role="1XX52x" to="mopj:1EbzjT2RcU7" resolve="ModelMergingPolicy" />
     <node concept="3EZMnI" id="1EbzjT2RJn_" role="2wV5jI">
       <node concept="2iRkQZ" id="1EbzjT2RJnA" role="2iSdaV" />
       <node concept="3EZMnI" id="1EbzjT2RJrI" role="3EZMnx">
@@ -364,15 +362,25 @@
           <node concept="2iRkQZ" id="78fCHIExZbM" role="2czzBx" />
         </node>
       </node>
+      <node concept="3EZMnI" id="5HyGTP182kd" role="3EZMnx">
+        <node concept="VPM3Z" id="5HyGTP182kf" role="3F10Kt" />
+        <node concept="3F0ifn" id="5HyGTP182yV" role="3EZMnx">
+          <property role="3F0ifm" value="Partial policy: " />
+        </node>
+        <node concept="3F0A7n" id="5HyGTP182Ag" role="3EZMnx">
+          <ref role="1NtTu8" to="mopj:5HbTgGuQTJM" resolve="partialPolicy" />
+        </node>
+        <node concept="2iRfu4" id="5HyGTP182ki" role="2iSdaV" />
+      </node>
       <node concept="3F2HdR" id="1EbzjT2RA56" role="3EZMnx">
-        <ref role="1NtTu8" to="mopj:1EbzjT2R$JQ" resolve="items" />
+        <ref role="1NtTu8" to="mopj:1EbzjT2R$JQ" resolve="policies" />
         <node concept="2iRkQZ" id="1EbzjT2RA58" role="2czzBx" />
         <node concept="4$FPG" id="1EbzjT2RGFW" role="4_6I_">
           <node concept="3clFbS" id="1EbzjT2RGFX" role="2VODD2">
             <node concept="3clFbF" id="1EbzjT2RGHV" role="3cqZAp">
               <node concept="2pJPEk" id="1EbzjT2RGHT" role="3clFbG">
                 <node concept="2pJPED" id="1EbzjT2RGLJ" role="2pJPEn">
-                  <ref role="2pJxaS" to="mopj:1EbzjT2RA5e" resolve="EmptyMergeItem" />
+                  <ref role="2pJxaS" to="mopj:1EbzjT2RA5e" resolve="EmptyMergingPolicy" />
                 </node>
               </node>
             </node>
@@ -382,11 +390,11 @@
     </node>
   </node>
   <node concept="24kQdi" id="1EbzjT2RA67">
-    <ref role="1XX52x" to="mopj:1EbzjT2RA5e" resolve="EmptyMergeItem" />
+    <ref role="1XX52x" to="mopj:1EbzjT2RA5e" resolve="EmptyMergingPolicy" />
     <node concept="3F0ifn" id="1EbzjT2RA69" role="2wV5jI" />
   </node>
   <node concept="24kQdi" id="1EbzjT2RI8k">
-    <ref role="1XX52x" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
+    <ref role="1XX52x" to="mopj:1EbzjT2R$JP" resolve="ConceptMergingPolicy" />
     <node concept="3EZMnI" id="1EbzjT2RQ93" role="2wV5jI">
       <node concept="3EZMnI" id="1EbzjT2RQ9a" role="3EZMnx">
         <node concept="VPM3Z" id="1EbzjT2RQ9c" role="3F10Kt" />
@@ -584,7 +592,7 @@
     </node>
   </node>
   <node concept="24kQdi" id="1EbzjT2T4JE">
-    <property role="3GE5qa" value="elementpolicies" />
+    <property role="3GE5qa" value="declarationPolicies" />
     <ref role="1XX52x" to="mopj:1EbzjT2T4oC" resolve="PropertyPolicy" />
     <node concept="3EZMnI" id="1NgLzfPc8aR" role="2wV5jI">
       <node concept="1iCGBv" id="6zqIeMU2DGI" role="3EZMnx">
@@ -629,7 +637,7 @@
     <node concept="B$lHz" id="1NgLzfPdgrh" role="6VMZX" />
   </node>
   <node concept="24kQdi" id="7jyS5urbFov">
-    <property role="3GE5qa" value="elementpolicies" />
+    <property role="3GE5qa" value="declarationPolicies" />
     <ref role="1XX52x" to="mopj:7jyS5urbFgb" resolve="OptionalPolicy" />
     <node concept="3EZMnI" id="7jyS5urbFox" role="2wV5jI">
       <node concept="1iCGBv" id="7jyS5urbFoC" role="3EZMnx">
@@ -651,7 +659,7 @@
     </node>
   </node>
   <node concept="24kQdi" id="7jyS5urbTpW">
-    <property role="3GE5qa" value="elementpolicies" />
+    <property role="3GE5qa" value="declarationPolicies" />
     <ref role="1XX52x" to="mopj:7jyS5urbTpv" resolve="MultiChildPolicy" />
     <node concept="3EZMnI" id="7jyS5urbTpY" role="2wV5jI">
       <node concept="1iCGBv" id="7jyS5urbTqm" role="3EZMnx">
@@ -675,7 +683,7 @@
     </node>
   </node>
   <node concept="24kQdi" id="7jyS5urceI2">
-    <property role="3GE5qa" value="elementpolicies" />
+    <property role="3GE5qa" value="declarationPolicies" />
     <ref role="1XX52x" to="mopj:7jyS5urbTpb" resolve="SingletonPolicy" />
     <node concept="3EZMnI" id="7jyS5urceI4" role="2wV5jI">
       <node concept="1iCGBv" id="7jyS5urceIb" role="3EZMnx">
@@ -706,14 +714,14 @@
           <node concept="3cpWsn" id="5nY1J0YNoiS" role="3cpWs9">
             <property role="TrG5h" value="mergePol" />
             <node concept="3Tqbb2" id="5nY1J0YNogK" role="1tU5fm">
-              <ref role="ehGHo" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
+              <ref role="ehGHo" to="mopj:1EbzjT2R$JP" resolve="ConceptMergingPolicy" />
             </node>
             <node concept="2OqwBi" id="5nY1J0YNoiT" role="33vP2m">
               <node concept="3lBN6O" id="5nY1J0YNoiU" role="2Oq$k0" />
               <node concept="2Xjw5R" id="5nY1J0YNoiV" role="2OqNvi">
                 <node concept="1xMEDy" id="5nY1J0YNoiW" role="1xVPHs">
                   <node concept="chp4Y" id="5nY1J0YNoiX" role="ri$Ld">
-                    <ref role="cht4Q" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
+                    <ref role="cht4Q" to="mopj:1EbzjT2R$JP" resolve="ConceptMergingPolicy" />
                   </node>
                 </node>
                 <node concept="1xIGOp" id="5nY1J0YNoiY" role="1xVPHs" />
@@ -936,7 +944,7 @@
                         <node concept="2Xjw5R" id="1VmHfRxCZa4" role="2OqNvi">
                           <node concept="1xMEDy" id="1VmHfRxCZa5" role="1xVPHs">
                             <node concept="chp4Y" id="1VmHfRxCZa6" role="ri$Ld">
-                              <ref role="cht4Q" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
+                              <ref role="cht4Q" to="mopj:1EbzjT2R$JP" resolve="ConceptMergingPolicy" />
                             </node>
                           </node>
                           <node concept="1xIGOp" id="1VmHfRxCZa7" role="1xVPHs" />
@@ -1022,7 +1030,7 @@
       <node concept="37vLTG" id="1VmHfRxCZ9Q" role="3clF46">
         <property role="TrG5h" value="childPolicy" />
         <node concept="3Tqbb2" id="1VmHfRxCZ9R" role="1tU5fm">
-          <ref role="ehGHo" to="mopj:7jyS5urbJZ2" resolve="ItemPolicy" />
+          <ref role="ehGHo" to="mopj:7jyS5urbJZ2" resolve="DeclarationPolicy" />
         </node>
       </node>
       <node concept="3Tm1VV" id="1VmHfRxCZax" role="1B3o_S" />
@@ -1165,7 +1173,7 @@
         <property role="TrG5h" value="itemPolicies" />
         <node concept="3vKaQO" id="5v01ES7uQ9Z" role="1tU5fm">
           <node concept="3Tqbb2" id="5v01ES7uQa0" role="3O5elw">
-            <ref role="ehGHo" to="mopj:7jyS5urbJZ2" resolve="ItemPolicy" />
+            <ref role="ehGHo" to="mopj:7jyS5urbJZ2" resolve="DeclarationPolicy" />
           </node>
         </node>
       </node>
@@ -1308,7 +1316,7 @@
         <property role="TrG5h" value="itemPolicies" />
         <node concept="3vKaQO" id="5v01ES7Bdrw" role="1tU5fm">
           <node concept="3Tqbb2" id="5v01ES7Bdrx" role="3O5elw">
-            <ref role="ehGHo" to="mopj:7jyS5urbJZ2" resolve="ItemPolicy" />
+            <ref role="ehGHo" to="mopj:7jyS5urbJZ2" resolve="DeclarationPolicy" />
           </node>
         </node>
       </node>
@@ -1564,14 +1572,14 @@
           <node concept="3cpWsn" id="1VmHfRx$Osa" role="3cpWs9">
             <property role="TrG5h" value="mergePol" />
             <node concept="3Tqbb2" id="1VmHfRx$Osb" role="1tU5fm">
-              <ref role="ehGHo" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
+              <ref role="ehGHo" to="mopj:1EbzjT2R$JP" resolve="ConceptMergingPolicy" />
             </node>
             <node concept="2OqwBi" id="1VmHfRx$Osc" role="33vP2m">
               <node concept="3lBMY0" id="1VmHfRxBQnt" role="2Oq$k0" />
               <node concept="2Xjw5R" id="1VmHfRx$Ose" role="2OqNvi">
                 <node concept="1xMEDy" id="1VmHfRx$Osf" role="1xVPHs">
                   <node concept="chp4Y" id="1VmHfRx$Osg" role="ri$Ld">
-                    <ref role="cht4Q" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
+                    <ref role="cht4Q" to="mopj:1EbzjT2R$JP" resolve="ConceptMergingPolicy" />
                   </node>
                 </node>
                 <node concept="1xIGOp" id="1VmHfRx$Osh" role="1xVPHs" />
@@ -1583,7 +1591,7 @@
           <node concept="3cpWsn" id="5v01ES7ECEi" role="3cpWs9">
             <property role="TrG5h" value="itemPolicies" />
             <node concept="2I9FWS" id="5v01ES7EBg5" role="1tU5fm">
-              <ref role="2I9WkF" to="mopj:7jyS5urbJZ2" resolve="ItemPolicy" />
+              <ref role="2I9WkF" to="mopj:7jyS5urbJZ2" resolve="DeclarationPolicy" />
             </node>
             <node concept="2OqwBi" id="5v01ES7ECEj" role="33vP2m">
               <node concept="37vLTw" id="5v01ES7ECEk" role="2Oq$k0">
@@ -1613,7 +1621,7 @@
     </node>
   </node>
   <node concept="24kQdi" id="1VmHfRxKMhn">
-    <property role="3GE5qa" value="elementpolicies.subpolicy" />
+    <property role="3GE5qa" value="declarationPolicies.subpolicy" />
     <ref role="1XX52x" to="mopj:1VmHfRxKMgU" resolve="SubPolicyContainer" />
     <node concept="3EZMnI" id="1VmHfRxLaor" role="2wV5jI">
       <node concept="3F0A7n" id="2dyrZ3FkWkm" role="3EZMnx">
@@ -1629,7 +1637,7 @@
     </node>
   </node>
   <node concept="24kQdi" id="1VmHfRxXVC8">
-    <property role="3GE5qa" value="elementpolicies" />
+    <property role="3GE5qa" value="declarationPolicies" />
     <ref role="1XX52x" to="mopj:1VmHfRxVF4G" resolve="AbstractPolicy" />
     <node concept="B$lHz" id="1VmHfRxXVCa" role="2wV5jI" />
   </node>
@@ -1656,18 +1664,18 @@
                       <node concept="2Xjw5R" id="2dyrZ3FeKQW" role="2OqNvi">
                         <node concept="1xMEDy" id="2dyrZ3FeKQX" role="1xVPHs">
                           <node concept="chp4Y" id="2dyrZ3FeKQY" role="ri$Ld">
-                            <ref role="cht4Q" to="mopj:1EbzjT2RcU7" resolve="ModelMerge" />
+                            <ref role="cht4Q" to="mopj:1EbzjT2RcU7" resolve="ModelMergingPolicy" />
                           </node>
                         </node>
                       </node>
                     </node>
                     <node concept="3Tsc0h" id="2dyrZ3FeKQZ" role="2OqNvi">
-                      <ref role="3TtcxE" to="mopj:1EbzjT2R$JQ" resolve="items" />
+                      <ref role="3TtcxE" to="mopj:1EbzjT2R$JQ" resolve="policies" />
                     </node>
                   </node>
                   <node concept="v3k3i" id="2dyrZ3FeKR0" role="2OqNvi">
                     <node concept="chp4Y" id="2dyrZ3FeKR1" role="v3oSu">
-                      <ref role="cht4Q" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
+                      <ref role="cht4Q" to="mopj:1EbzjT2R$JP" resolve="ConceptMergingPolicy" />
                     </node>
                   </node>
                 </node>
@@ -1738,7 +1746,7 @@
       </node>
     </node>
     <node concept="KNhPl" id="2dyrZ3Fdtis" role="KNiz3">
-      <ref role="2RIln$" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
+      <ref role="2RIln$" to="mopj:1EbzjT2R$JP" resolve="ConceptMergingPolicy" />
       <node concept="3koIoq" id="2dyrZ3FdtjT" role="3koIrf">
         <ref role="3koIov" to="mopj:3BP4DuXu_FH" resolve="conceptRef" />
       </node>
@@ -1749,7 +1757,7 @@
     <property role="TrG5h" value="ModelMergeItemCS" />
     <node concept="3Tm1VV" id="2dyrZ3FfSai" role="1B3o_S" />
     <node concept="KNhPm" id="2dyrZ3FfSbi" role="KNiz3">
-      <ref role="2RIln$" to="mopj:1EbzjT2R$JU" resolve="ModelMergeItem" />
+      <ref role="2RIln$" to="mopj:1EbzjT2R$JU" resolve="MergingPolicy" />
     </node>
     <node concept="3lBaaS" id="2dyrZ3FfSak" role="3l$a4r">
       <node concept="3clFbS" id="2dyrZ3FfSal" role="2VODD2">
@@ -1770,19 +1778,19 @@
                       <node concept="2Xjw5R" id="2dyrZ3FgDue" role="2OqNvi">
                         <node concept="1xMEDy" id="2dyrZ3FgDuf" role="1xVPHs">
                           <node concept="chp4Y" id="2dyrZ3FgDug" role="ri$Ld">
-                            <ref role="cht4Q" to="mopj:1EbzjT2RcU7" resolve="ModelMerge" />
+                            <ref role="cht4Q" to="mopj:1EbzjT2RcU7" resolve="ModelMergingPolicy" />
                           </node>
                         </node>
                         <node concept="1xIGOp" id="2dyrZ3FgE4N" role="1xVPHs" />
                       </node>
                     </node>
                     <node concept="3Tsc0h" id="2dyrZ3FgDuh" role="2OqNvi">
-                      <ref role="3TtcxE" to="mopj:1EbzjT2R$JQ" resolve="items" />
+                      <ref role="3TtcxE" to="mopj:1EbzjT2R$JQ" resolve="policies" />
                     </node>
                   </node>
                   <node concept="v3k3i" id="2dyrZ3FgDui" role="2OqNvi">
                     <node concept="chp4Y" id="2dyrZ3FgDuj" role="v3oSu">
-                      <ref role="cht4Q" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
+                      <ref role="cht4Q" to="mopj:1EbzjT2R$JP" resolve="ConceptMergingPolicy" />
                     </node>
                   </node>
                 </node>
@@ -2107,7 +2115,7 @@
     </node>
   </node>
   <node concept="24kQdi" id="5zr7Q_1InPb">
-    <ref role="1XX52x" to="mopj:5zr7Q_1InAA" resolve="ModelMergeExecution" />
+    <ref role="1XX52x" to="mopj:5zr7Q_1InAA" resolve="ModelMergingConfiguration" />
     <node concept="3EZMnI" id="5zr7Q_1InPd" role="2wV5jI">
       <node concept="3EZMnI" id="5zr7Q_1J32S" role="3EZMnx">
         <node concept="VPM3Z" id="5zr7Q_1J32U" role="3F10Kt" />
@@ -2171,7 +2179,7 @@
           <property role="3F0ifm" value="Merge Policy:" />
         </node>
         <node concept="1iCGBv" id="6qrKgEqpHzl" role="3EZMnx">
-          <ref role="1NtTu8" to="mopj:5zr7Q_1IGSD" resolve="modelMerge" />
+          <ref role="1NtTu8" to="mopj:5zr7Q_1IGSD" resolve="mergingPolicy" />
           <node concept="1sVBvm" id="6qrKgEqpHzm" role="1sWHZn">
             <node concept="3F0A7n" id="6qrKgEqpHzn" role="2wV5jI">
               <property role="1Intyy" value="true" />
@@ -2194,14 +2202,14 @@
           <node concept="3cpWsn" id="5v01ES7t9sV" role="3cpWs9">
             <property role="TrG5h" value="mergePol" />
             <node concept="3Tqbb2" id="5v01ES7t9sW" role="1tU5fm">
-              <ref role="ehGHo" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
+              <ref role="ehGHo" to="mopj:1EbzjT2R$JP" resolve="ConceptMergingPolicy" />
             </node>
             <node concept="2OqwBi" id="5v01ES7t9sX" role="33vP2m">
               <node concept="3lBMY0" id="5v01ES7t9sY" role="2Oq$k0" />
               <node concept="2Xjw5R" id="5v01ES7t9sZ" role="2OqNvi">
                 <node concept="1xMEDy" id="5v01ES7t9t0" role="1xVPHs">
                   <node concept="chp4Y" id="5v01ES7t9t1" role="ri$Ld">
-                    <ref role="cht4Q" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
+                    <ref role="cht4Q" to="mopj:1EbzjT2R$JP" resolve="ConceptMergingPolicy" />
                   </node>
                 </node>
                 <node concept="1xIGOp" id="5v01ES7t9t2" role="1xVPHs" />
@@ -2213,7 +2221,7 @@
           <node concept="3cpWsn" id="5v01ES7uJG4" role="3cpWs9">
             <property role="TrG5h" value="itemPolicies" />
             <node concept="2I9FWS" id="5v01ES7uzB$" role="1tU5fm">
-              <ref role="2I9WkF" to="mopj:7jyS5urbJZ2" resolve="ItemPolicy" />
+              <ref role="2I9WkF" to="mopj:7jyS5urbJZ2" resolve="DeclarationPolicy" />
             </node>
             <node concept="2OqwBi" id="5v01ES7uJG5" role="33vP2m">
               <node concept="37vLTw" id="5v01ES7uJG6" role="2Oq$k0">

--- a/code/languages/de.itemis.model.merge/models/de.itemis.model.merge.intentions.mps
+++ b/code/languages/de.itemis.model.merge/models/de.itemis.model.merge.intentions.mps
@@ -55,7 +55,7 @@
   </registry>
   <node concept="2S6QgY" id="5zr7Q_1L8CO">
     <property role="TrG5h" value="RunMerge" />
-    <ref role="2ZfgGC" to="mopj:5zr7Q_1InAA" resolve="ModelMergeExecution" />
+    <ref role="2ZfgGC" to="mopj:5zr7Q_1InAA" resolve="ModelMergingConfiguration" />
     <node concept="2S6ZIM" id="5zr7Q_1L8CP" role="2ZfVej">
       <node concept="3clFbS" id="5zr7Q_1L8CQ" role="2VODD2">
         <node concept="3clFbF" id="5zr7Q_1L8O5" role="3cqZAp">

--- a/code/languages/de.itemis.model.merge/models/de.itemis.model.merge.plugin.mps
+++ b/code/languages/de.itemis.model.merge/models/de.itemis.model.merge.plugin.mps
@@ -121,7 +121,7 @@
                 <node concept="2Xjw5R" id="6celbXx1A0L" role="2OqNvi">
                   <node concept="1xMEDy" id="6celbXx1A0M" role="1xVPHs">
                     <node concept="chp4Y" id="6celbXx1A0N" role="ri$Ld">
-                      <ref role="cht4Q" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
+                      <ref role="cht4Q" to="mopj:1EbzjT2R$JP" resolve="ConceptMergingPolicy" />
                     </node>
                   </node>
                 </node>

--- a/code/languages/de.itemis.model.merge/models/de.itemis.model.merge.structure.mps
+++ b/code/languages/de.itemis.model.merge/models/de.itemis.model.merge.structure.mps
@@ -64,14 +64,14 @@
   </registry>
   <node concept="1TIwiD" id="1EbzjT2RcU7">
     <property role="EcuMT" value="1912777765298163335" />
-    <property role="TrG5h" value="ModelMerge" />
+    <property role="TrG5h" value="ModelMergingPolicy" />
     <property role="19KtqR" value="true" />
     <node concept="1TJgyj" id="1EbzjT2R$JQ" role="1TKVEi">
       <property role="IQ2ns" value="1912777765298260982" />
       <property role="20lmBu" value="fLJjDmT/aggregation" />
-      <property role="20kJfa" value="items" />
+      <property role="20kJfa" value="policies" />
       <property role="20lbJX" value="fLJekj5/_0__n" />
-      <ref role="20lvS9" node="1EbzjT2R$JU" resolve="ModelMergeItem" />
+      <ref role="20lvS9" node="1EbzjT2R$JU" resolve="MergingPolicy" />
     </node>
     <node concept="1TJgyj" id="1VmHfRy0Ud5" role="1TKVEi">
       <property role="IQ2ns" value="2222162468665533253" />
@@ -90,10 +90,15 @@
     <node concept="PrWs8" id="4mbxYkJdXnB" role="PzmwI">
       <ref role="PrY4T" to="tpck:h0TrEE$" resolve="INamedConcept" />
     </node>
+    <node concept="1TJgyi" id="5HbTgGuQTJM" role="1TKVEl">
+      <property role="IQ2nx" value="6578603516629851122" />
+      <property role="TrG5h" value="partialPolicy" />
+      <ref role="AX2Wp" to="tpck:fKAQMTB" resolve="boolean" />
+    </node>
   </node>
   <node concept="1TIwiD" id="1EbzjT2R$JP">
     <property role="EcuMT" value="1912777765298260981" />
-    <property role="TrG5h" value="MergePolicy" />
+    <property role="TrG5h" value="ConceptMergingPolicy" />
     <node concept="1TJgyj" id="3BP4DuXu_FH" role="1TKVEi">
       <property role="IQ2ns" value="4176264672384277229" />
       <property role="20kJfa" value="conceptRef" />
@@ -128,25 +133,25 @@
       <ref role="20lvS9" node="3PLTv5jwPx8" resolve="ReferencePolicy" />
     </node>
     <node concept="PrWs8" id="1EbzjT2R$JV" role="PzmwI">
-      <ref role="PrY4T" node="1EbzjT2R$JU" resolve="ModelMergeItem" />
+      <ref role="PrY4T" node="1EbzjT2R$JU" resolve="MergingPolicy" />
     </node>
   </node>
   <node concept="PlHQZ" id="1EbzjT2R$JU">
     <property role="EcuMT" value="1912777765298260986" />
-    <property role="TrG5h" value="ModelMergeItem" />
+    <property role="TrG5h" value="MergingPolicy" />
   </node>
   <node concept="1TIwiD" id="1EbzjT2RA5e">
     <property role="EcuMT" value="1912777765298266446" />
-    <property role="TrG5h" value="EmptyMergeItem" />
+    <property role="TrG5h" value="EmptyMergingPolicy" />
     <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
     <node concept="PrWs8" id="1EbzjT2RA5f" role="PzmwI">
-      <ref role="PrY4T" node="1EbzjT2R$JU" resolve="ModelMergeItem" />
+      <ref role="PrY4T" node="1EbzjT2R$JU" resolve="MergingPolicy" />
     </node>
   </node>
   <node concept="1TIwiD" id="1EbzjT2T4oC">
     <property role="EcuMT" value="1912777765298652712" />
     <property role="TrG5h" value="PropertyPolicy" />
-    <property role="3GE5qa" value="elementpolicies" />
+    <property role="3GE5qa" value="declarationPolicies" />
     <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
     <node concept="1TJgyj" id="1EbzjT2T4Jd" role="1TKVEi">
       <property role="IQ2ns" value="1912777765298654157" />
@@ -237,7 +242,7 @@
   </node>
   <node concept="1TIwiD" id="7jyS5urbFgb">
     <property role="EcuMT" value="8422540920006554635" />
-    <property role="3GE5qa" value="elementpolicies" />
+    <property role="3GE5qa" value="declarationPolicies" />
     <property role="TrG5h" value="OptionalPolicy" />
     <ref role="1TJDcQ" node="1VmHfRxVF4G" resolve="AbstractPolicy" />
     <node concept="1TJgyj" id="7jyS5urbFnA" role="1TKVEi">
@@ -250,12 +255,12 @@
   </node>
   <node concept="PlHQZ" id="7jyS5urbJZ2">
     <property role="EcuMT" value="8422540920006574018" />
-    <property role="3GE5qa" value="elementpolicies" />
-    <property role="TrG5h" value="ItemPolicy" />
+    <property role="3GE5qa" value="declarationPolicies" />
+    <property role="TrG5h" value="DeclarationPolicy" />
   </node>
   <node concept="1TIwiD" id="7jyS5urbTpb">
     <property role="EcuMT" value="8422540920006612555" />
-    <property role="3GE5qa" value="elementpolicies" />
+    <property role="3GE5qa" value="declarationPolicies" />
     <property role="TrG5h" value="SingletonPolicy" />
     <ref role="1TJDcQ" node="1VmHfRxVF4G" resolve="AbstractPolicy" />
     <node concept="1TJgyj" id="7jyS5urbTpc" role="1TKVEi">
@@ -268,7 +273,7 @@
   </node>
   <node concept="1TIwiD" id="7jyS5urbTpv">
     <property role="EcuMT" value="8422540920006612575" />
-    <property role="3GE5qa" value="elementpolicies" />
+    <property role="3GE5qa" value="declarationPolicies" />
     <property role="TrG5h" value="MultiChildPolicy" />
     <ref role="1TJDcQ" node="1VmHfRxVF4G" resolve="AbstractPolicy" />
     <node concept="1TJgyj" id="7jyS5urbTpw" role="1TKVEi">
@@ -300,7 +305,7 @@
   </node>
   <node concept="25R3W" id="1VmHfRxJEru">
     <property role="3F6X1D" value="2222162468661012190" />
-    <property role="3GE5qa" value="elementpolicies.subpolicy" />
+    <property role="3GE5qa" value="declarationPolicies.subpolicy" />
     <property role="TrG5h" value="SubPolicy" />
     <node concept="25R33" id="1VmHfRxJErv" role="25R1y">
       <property role="3tVfz5" value="2222162468661012191" />
@@ -320,7 +325,7 @@
   </node>
   <node concept="1TIwiD" id="1VmHfRxKMgU">
     <property role="EcuMT" value="2222162468661306426" />
-    <property role="3GE5qa" value="elementpolicies.subpolicy" />
+    <property role="3GE5qa" value="declarationPolicies.subpolicy" />
     <property role="TrG5h" value="SubPolicyContainer" />
     <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
     <node concept="1TJgyj" id="1VmHfRxLaon" role="1TKVEi">
@@ -338,7 +343,7 @@
   </node>
   <node concept="1TIwiD" id="1VmHfRxVF4G">
     <property role="EcuMT" value="2222162468664160556" />
-    <property role="3GE5qa" value="elementpolicies" />
+    <property role="3GE5qa" value="declarationPolicies" />
     <property role="TrG5h" value="AbstractPolicy" />
     <property role="R5$K7" value="true" />
     <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
@@ -349,12 +354,12 @@
       <ref role="20lvS9" to="tpce:f_TJgxE" resolve="LinkDeclaration" />
     </node>
     <node concept="PrWs8" id="3PLTv5jMJTa" role="PzmwI">
-      <ref role="PrY4T" node="7jyS5urbJZ2" resolve="ItemPolicy" />
+      <ref role="PrY4T" node="7jyS5urbJZ2" resolve="DeclarationPolicy" />
     </node>
   </node>
   <node concept="1TIwiD" id="5zr7Q_1InAA">
     <property role="EcuMT" value="6402745832171993510" />
-    <property role="TrG5h" value="ModelMergeExecution" />
+    <property role="TrG5h" value="ModelMergingConfiguration" />
     <property role="19KtqR" value="true" />
     <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
     <node concept="1TJgyj" id="5zr7Q_1Jvjo" role="1TKVEi">
@@ -379,9 +384,9 @@
     </node>
     <node concept="1TJgyj" id="5zr7Q_1IGSD" role="1TKVEi">
       <property role="IQ2ns" value="6402745832172080681" />
-      <property role="20kJfa" value="modelMerge" />
+      <property role="20kJfa" value="mergingPolicy" />
       <property role="20lbJX" value="fLJekj4/_1" />
-      <ref role="20lvS9" node="1EbzjT2RcU7" resolve="ModelMerge" />
+      <ref role="20lvS9" node="1EbzjT2RcU7" resolve="ModelMergingPolicy" />
     </node>
     <node concept="PrWs8" id="5zr7Q_1J31C" role="PzmwI">
       <ref role="PrY4T" to="tpck:h0TrEE$" resolve="INamedConcept" />
@@ -402,24 +407,24 @@
   </node>
   <node concept="PlHQZ" id="3PLTv5jwPx8">
     <property role="EcuMT" value="4427572733332904008" />
-    <property role="3GE5qa" value="elementpolicies" />
+    <property role="3GE5qa" value="declarationPolicies" />
     <property role="TrG5h" value="ReferencePolicy" />
     <node concept="PrWs8" id="3PLTv5jRo70" role="PrDN$">
-      <ref role="PrY4T" node="7jyS5urbJZ2" resolve="ItemPolicy" />
+      <ref role="PrY4T" node="7jyS5urbJZ2" resolve="DeclarationPolicy" />
     </node>
   </node>
   <node concept="PlHQZ" id="3PLTv5jRo6X">
     <property role="EcuMT" value="4427572733338812861" />
-    <property role="3GE5qa" value="elementpolicies" />
+    <property role="3GE5qa" value="declarationPolicies" />
     <property role="TrG5h" value="ChildPolicy" />
     <node concept="PrWs8" id="3PLTv5jRo6Y" role="PrDN$">
-      <ref role="PrY4T" node="7jyS5urbJZ2" resolve="ItemPolicy" />
+      <ref role="PrY4T" node="7jyS5urbJZ2" resolve="DeclarationPolicy" />
     </node>
   </node>
   <node concept="1TIwiD" id="3PLTv5k2w4J">
     <property role="EcuMT" value="4427572733341729071" />
     <property role="TrG5h" value="SingletonChildPolicy" />
-    <property role="3GE5qa" value="elementpolicies" />
+    <property role="3GE5qa" value="declarationPolicies" />
     <ref role="1TJDcQ" node="7jyS5urbTpb" resolve="SingletonPolicy" />
     <node concept="PrWs8" id="3PLTv5k2w4K" role="PzmwI">
       <ref role="PrY4T" node="3PLTv5jRo6X" resolve="ChildPolicy" />
@@ -427,7 +432,7 @@
   </node>
   <node concept="1TIwiD" id="3PLTv5k2w4M">
     <property role="EcuMT" value="4427572733341729074" />
-    <property role="3GE5qa" value="elementpolicies" />
+    <property role="3GE5qa" value="declarationPolicies" />
     <property role="TrG5h" value="OptionalChildPolicy" />
     <ref role="1TJDcQ" node="7jyS5urbFgb" resolve="OptionalPolicy" />
     <node concept="PrWs8" id="3PLTv5k2w4N" role="PzmwI">
@@ -436,7 +441,7 @@
   </node>
   <node concept="1TIwiD" id="3PLTv5k2w4R">
     <property role="EcuMT" value="4427572733341729079" />
-    <property role="3GE5qa" value="elementpolicies" />
+    <property role="3GE5qa" value="declarationPolicies" />
     <property role="TrG5h" value="SingeltonRefPolicy" />
     <ref role="1TJDcQ" node="7jyS5urbTpb" resolve="SingletonPolicy" />
     <node concept="PrWs8" id="3PLTv5k2w4S" role="PzmwI">
@@ -445,7 +450,7 @@
   </node>
   <node concept="1TIwiD" id="3PLTv5k2w4U">
     <property role="EcuMT" value="4427572733341729082" />
-    <property role="3GE5qa" value="elementpolicies" />
+    <property role="3GE5qa" value="declarationPolicies" />
     <property role="TrG5h" value="OptionalRefPolicy" />
     <ref role="1TJDcQ" node="7jyS5urbFgb" resolve="OptionalPolicy" />
     <node concept="PrWs8" id="3PLTv5k2w4V" role="PzmwI">

--- a/code/languages/de.itemis.model.merge/models/de.itemis.model.merge.typesystem.mps
+++ b/code/languages/de.itemis.model.merge/models/de.itemis.model.merge.typesystem.mps
@@ -2279,7 +2279,7 @@
             <property role="TrG5h" value="mmp" />
             <node concept="nSUau" id="6CwG2k7Ofrg" role="1tU5fm">
               <node concept="3uibUv" id="6CwG2k7OgYo" role="nSUat">
-                <ref role="3uigEE" to="gunp:6CwG2k7NbpD" resolve="MissingMergePolicies" />
+                <ref role="3uigEE" to="gunp:6CwG2k7NbpD" resolve="MissingMergingPolicies" />
               </node>
             </node>
           </node>
@@ -2380,7 +2380,7 @@
               <property role="TrG5h" value="mp" />
               <node concept="nSUau" id="6CwG2k7RWQK" role="1tU5fm">
                 <node concept="3uibUv" id="6CwG2k7RZyj" role="nSUat">
-                  <ref role="3uigEE" to="gunp:6CwG2k7NbpD" resolve="MissingMergePolicies" />
+                  <ref role="3uigEE" to="gunp:6CwG2k7NbpD" resolve="MissingMergingPolicies" />
                 </node>
               </node>
             </node>

--- a/code/languages/de.itemis.model.merge/models/de.itemis.model.merge.typesystem.mps
+++ b/code/languages/de.itemis.model.merge/models/de.itemis.model.merge.typesystem.mps
@@ -618,12 +618,12 @@
     </node>
     <node concept="1YaCAy" id="1VmHfRxDtD6" role="1YuTPh">
       <property role="TrG5h" value="mergePolicy" />
-      <ref role="1YaFvo" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
+      <ref role="1YaFvo" to="mopj:1EbzjT2R$JP" resolve="ConceptMergingPolicy" />
     </node>
   </node>
   <node concept="18kY7G" id="1VmHfRxTFH9">
     <property role="TrG5h" value="check_MultiChildPolicy" />
-    <property role="3GE5qa" value="elementpolicies" />
+    <property role="3GE5qa" value="declarationPolicies" />
     <node concept="3clFbS" id="1VmHfRxTFHa" role="18ibNy">
       <node concept="3clFbJ" id="6CwG2k882Pd" role="3cqZAp">
         <node concept="3clFbS" id="6CwG2k882Pf" role="3clFbx">
@@ -648,42 +648,42 @@
               </node>
             </node>
           </node>
-          <node concept="2MkqsV" id="6CwG2k8848E" role="3cqZAp">
-            <node concept="3cpWs3" id="6CwG2k887OQ" role="2MkJ7o">
-              <node concept="Xl_RD" id="6CwG2k887OT" role="3uHU7w">
+          <node concept="a7r0C" id="5HyGTP1_hlC" role="3cqZAp">
+            <node concept="3cpWs3" id="5HyGTP1_hlE" role="a7wSD">
+              <node concept="Xl_RD" id="5HyGTP1_hlF" role="3uHU7w">
                 <property role="Xl_RC" value=" does not define ID function" />
               </node>
-              <node concept="3cpWs3" id="6CwG2k8854B" role="3uHU7B">
-                <node concept="Xl_RD" id="6CwG2k88492" role="3uHU7B">
+              <node concept="3cpWs3" id="5HyGTP1_hlG" role="3uHU7B">
+                <node concept="Xl_RD" id="5HyGTP1_hlH" role="3uHU7B">
                   <property role="Xl_RC" value="merge policy for concept " />
                 </node>
-                <node concept="2OqwBi" id="2xeWAXXQ5u9" role="3uHU7w">
-                  <node concept="37vLTw" id="2xeWAXXQxPF" role="2Oq$k0">
+                <node concept="2OqwBi" id="5HyGTP1_hlI" role="3uHU7w">
+                  <node concept="37vLTw" id="5HyGTP1_hlJ" role="2Oq$k0">
                     <ref role="3cqZAo" node="2xeWAXXQxP_" resolve="target" />
                   </node>
-                  <node concept="2qgKlT" id="2xeWAXXQ616" role="2OqNvi">
+                  <node concept="2qgKlT" id="5HyGTP1_hlK" role="2OqNvi">
                     <ref role="37wK5l" to="tpcn:280s3ZNTXNS" resolve="getPresentation" />
                   </node>
                 </node>
               </node>
             </node>
-            <node concept="1YBJjd" id="6CwG2k8849d" role="1urrMF">
+            <node concept="1YBJjd" id="5HyGTP1_hlL" role="1urrMF">
               <ref role="1YBMHb" node="1VmHfRxTFHc" resolve="multiChildPolicy" />
             </node>
-            <node concept="3Cnw8n" id="2xeWAXXRosw" role="1urrFz">
+            <node concept="3Cnw8n" id="5HyGTP1_hlM" role="1urrFz">
               <ref role="QpYPw" node="2xeWAXXPaU3" resolve="fixMissingIdFunction" />
-              <node concept="3CnSsL" id="2xeWAXXRoHy" role="3Coj4f">
+              <node concept="3CnSsL" id="5HyGTP1_hlN" role="3Coj4f">
                 <ref role="QkamJ" node="2xeWAXXQybw" resolve="conc" />
-                <node concept="2OqwBi" id="2xeWAXXRqbp" role="3CoRuB">
-                  <node concept="2OqwBi" id="2xeWAXXRpc8" role="2Oq$k0">
-                    <node concept="1YBJjd" id="2xeWAXXRoZr" role="2Oq$k0">
+                <node concept="2OqwBi" id="5HyGTP1_hlO" role="3CoRuB">
+                  <node concept="2OqwBi" id="5HyGTP1_hlP" role="2Oq$k0">
+                    <node concept="1YBJjd" id="5HyGTP1_hlQ" role="2Oq$k0">
                       <ref role="1YBMHb" node="1VmHfRxTFHc" resolve="multiChildPolicy" />
                     </node>
-                    <node concept="3TrEf2" id="2xeWAXXRpRb" role="2OqNvi">
+                    <node concept="3TrEf2" id="5HyGTP1_hlR" role="2OqNvi">
                       <ref role="3Tt5mk" to="mopj:1VmHfRxVF4J" resolve="child" />
                     </node>
                   </node>
-                  <node concept="3TrEf2" id="2xeWAXXRqV7" role="2OqNvi">
+                  <node concept="3TrEf2" id="5HyGTP1_hlS" role="2OqNvi">
                     <ref role="3Tt5mk" to="tpce:fA0lvVK" resolve="target" />
                   </node>
                 </node>
@@ -750,11 +750,11 @@
               </node>
             </node>
             <node concept="3clFbS" id="1VmHfRxTMZj" role="3clFbx">
-              <node concept="2MkqsV" id="1VmHfRxTNQd" role="3cqZAp">
-                <node concept="Xl_RD" id="1VmHfRxTNQp" role="2MkJ7o">
+              <node concept="2MkqsV" id="5HyGTP1_hIK" role="3cqZAp">
+                <node concept="Xl_RD" id="5HyGTP1_hIM" role="2MkJ7o">
                   <property role="Xl_RC" value="duplicate subpolicy" />
                 </node>
-                <node concept="2GrUjf" id="1VmHfRxTNQ$" role="1urrMF">
+                <node concept="2GrUjf" id="5HyGTP1_hIN" role="1urrMF">
                   <ref role="2Gs0qQ" node="1VmHfRxTL_u" resolve="subPolicycontainer" />
                 </node>
               </node>
@@ -830,7 +830,7 @@
   </node>
   <node concept="18kY7G" id="2dyrZ3FogZg">
     <property role="TrG5h" value="check_SubPolicyContainer" />
-    <property role="3GE5qa" value="elementpolicies.subpolicy" />
+    <property role="3GE5qa" value="declarationPolicies.subpolicy" />
     <node concept="3clFbS" id="2dyrZ3FogZh" role="18ibNy">
       <node concept="3clFbH" id="2dyrZ3FohjL" role="3cqZAp" />
       <node concept="3cpWs8" id="2dyrZ3Fomd5" role="3cqZAp">
@@ -1021,7 +1021,7 @@
     </node>
     <node concept="1YaCAy" id="5zr7Q_1Kho0" role="1YuTPh">
       <property role="TrG5h" value="mergeModelExecution" />
-      <ref role="1YaFvo" to="mopj:5zr7Q_1InAA" resolve="ModelMergeExecution" />
+      <ref role="1YaFvo" to="mopj:5zr7Q_1InAA" resolve="ModelMergingConfiguration" />
     </node>
   </node>
   <node concept="18kY7G" id="7TOowlgBzBR">
@@ -1037,7 +1037,7 @@
               </node>
               <node concept="2YIFZM" id="61HvMZcxF4P" role="33vP2m">
                 <ref role="37wK5l" to="gunp:7wnapcW0cfS" resolve="run" />
-                <ref role="1Pybhc" to="gunp:18W7Z4VeRuj" resolve="MergeResolverFromModelMerge" />
+                <ref role="1Pybhc" to="gunp:18W7Z4VeRuj" resolve="PolicyMergerResolver" />
                 <node concept="1YBJjd" id="3EHNiwz7rFu" role="37wK5m">
                   <ref role="1YBMHb" node="7TOowlgBzBU" resolve="modelMerge" />
                 </node>
@@ -1075,812 +1075,823 @@
           </node>
           <node concept="3clFbH" id="ZzVzivroYU" role="3cqZAp" />
           <node concept="3clFbH" id="60iGZSKk8Po" role="3cqZAp" />
-          <node concept="3clFbH" id="60iGZSKk8Ui" role="3cqZAp" />
-          <node concept="3SKdUt" id="60iGZSKkaa7" role="3cqZAp">
-            <node concept="1PaTwC" id="60iGZSKkaa8" role="1aUNEU">
-              <node concept="3oM_SD" id="60iGZSKkaa9" role="1PaTwD">
-                <property role="3oM_SC" value="--Missing" />
-              </node>
-              <node concept="3oM_SD" id="60iGZSKkb1o" role="1PaTwD">
-                <property role="3oM_SC" value="Property" />
-              </node>
-              <node concept="3oM_SD" id="60iGZSKkdrG" role="1PaTwD">
-                <property role="3oM_SC" value="Policy" />
-              </node>
-            </node>
-          </node>
-          <node concept="3cpWs8" id="582YV7z0eIx" role="3cqZAp">
-            <node concept="3cpWsn" id="582YV7z0eIy" role="3cpWs9">
-              <property role="TrG5h" value="conceptToRelevantProperties" />
-              <node concept="1ajhzC" id="582YV7z0eIt" role="1tU5fm">
-                <node concept="3Tqbb2" id="582YV7z0eIu" role="1ajw0F">
-                  <ref role="ehGHo" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
-                </node>
-                <node concept="3uibUv" id="582YV7z0eIv" role="1ajl9A">
-                  <ref role="3uigEE" to="33ny:~HashSet" resolve="HashSet" />
-                  <node concept="3Tqbb2" id="582YV7z0eIw" role="11_B2D">
-                    <ref role="ehGHo" to="tpce:f_TJgxF" resolve="PropertyDeclaration" />
+          <node concept="3clFbJ" id="5HyGTP18aDh" role="3cqZAp">
+            <node concept="3clFbS" id="5HyGTP18aDj" role="3clFbx">
+              <node concept="3SKdUt" id="60iGZSKkaa7" role="3cqZAp">
+                <node concept="1PaTwC" id="60iGZSKkaa8" role="1aUNEU">
+                  <node concept="3oM_SD" id="60iGZSKkaa9" role="1PaTwD">
+                    <property role="3oM_SC" value="--Missing" />
+                  </node>
+                  <node concept="3oM_SD" id="60iGZSKkb1o" role="1PaTwD">
+                    <property role="3oM_SC" value="Property" />
+                  </node>
+                  <node concept="3oM_SD" id="60iGZSKkdrG" role="1PaTwD">
+                    <property role="3oM_SC" value="Policy" />
                   </node>
                 </node>
               </node>
-              <node concept="1bVj0M" id="582YV7z0eIz" role="33vP2m">
-                <node concept="3clFbS" id="582YV7z0eI$" role="1bW5cS">
-                  <node concept="3cpWs8" id="582YV7z0eI_" role="3cqZAp">
-                    <node concept="3cpWsn" id="582YV7z0eIA" role="3cpWs9">
-                      <property role="TrG5h" value="forbiddenProperties" />
-                      <node concept="2OqwBi" id="582YV7z0eIB" role="33vP2m">
-                        <node concept="35c_gC" id="582YV7z0eIC" role="2Oq$k0">
-                          <ref role="35c_gD" to="tpck:gw2VY9q" resolve="BaseConcept" />
-                        </node>
-                        <node concept="liA8E" id="582YV7z0eID" role="2OqNvi">
-                          <ref role="37wK5l" to="c17a:~SAbstractConcept.getProperties()" resolve="getProperties" />
-                        </node>
-                      </node>
-                      <node concept="3vKaQO" id="582YV7z0eIE" role="1tU5fm">
-                        <node concept="3uibUv" id="582YV7z0eIF" role="3O5elw">
-                          <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
-                        </node>
+              <node concept="3cpWs8" id="582YV7z0eIx" role="3cqZAp">
+                <node concept="3cpWsn" id="582YV7z0eIy" role="3cpWs9">
+                  <property role="TrG5h" value="conceptToRelevantProperties" />
+                  <node concept="1ajhzC" id="582YV7z0eIt" role="1tU5fm">
+                    <node concept="3Tqbb2" id="582YV7z0eIu" role="1ajw0F">
+                      <ref role="ehGHo" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
+                    </node>
+                    <node concept="3uibUv" id="582YV7z0eIv" role="1ajl9A">
+                      <ref role="3uigEE" to="33ny:~HashSet" resolve="HashSet" />
+                      <node concept="3Tqbb2" id="582YV7z0eIw" role="11_B2D">
+                        <ref role="ehGHo" to="tpce:f_TJgxF" resolve="PropertyDeclaration" />
                       </node>
                     </node>
                   </node>
-                  <node concept="3clFbF" id="4ZputZW5ecH" role="3cqZAp">
-                    <node concept="2ShNRf" id="4ZputZW5ecD" role="3clFbG">
-                      <node concept="1pGfFk" id="4ZputZW5vO$" role="2ShVmc">
-                        <ref role="37wK5l" to="33ny:~HashSet.&lt;init&gt;(java.util.Collection)" resolve="HashSet" />
-                        <node concept="2OqwBi" id="4ZputZW5QrT" role="37wK5m">
-                          <node concept="2OqwBi" id="4ZputZW5QrU" role="2Oq$k0">
-                            <node concept="2OqwBi" id="4ZputZW5QrV" role="2Oq$k0">
-                              <node concept="37vLTw" id="4ZputZW5QrW" role="2Oq$k0">
-                                <ref role="3cqZAo" node="582YV7z0eJ5" resolve="acd" />
-                              </node>
-                              <node concept="2qgKlT" id="4ZputZW5QrX" role="2OqNvi">
-                                <ref role="37wK5l" to="tpcn:hEwILLM" resolve="getPropertyDeclarations" />
-                              </node>
+                  <node concept="1bVj0M" id="582YV7z0eIz" role="33vP2m">
+                    <node concept="3clFbS" id="582YV7z0eI$" role="1bW5cS">
+                      <node concept="3cpWs8" id="582YV7z0eI_" role="3cqZAp">
+                        <node concept="3cpWsn" id="582YV7z0eIA" role="3cpWs9">
+                          <property role="TrG5h" value="forbiddenProperties" />
+                          <node concept="2OqwBi" id="582YV7z0eIB" role="33vP2m">
+                            <node concept="35c_gC" id="582YV7z0eIC" role="2Oq$k0">
+                              <ref role="35c_gD" to="tpck:gw2VY9q" resolve="BaseConcept" />
                             </node>
-                            <node concept="3zZkjj" id="4ZputZW5QrY" role="2OqNvi">
-                              <node concept="1bVj0M" id="4ZputZW5QrZ" role="23t8la">
-                                <node concept="3clFbS" id="4ZputZW5Qs0" role="1bW5cS">
-                                  <node concept="3clFbF" id="4ZputZW5Qs1" role="3cqZAp">
-                                    <node concept="3fqX7Q" id="4ZputZW5Qs2" role="3clFbG">
-                                      <node concept="2OqwBi" id="4ZputZW5Qs3" role="3fr31v">
-                                        <node concept="37vLTw" id="4ZputZW5Qs4" role="2Oq$k0">
-                                          <ref role="3cqZAo" node="582YV7z0eIA" resolve="forbiddenProperties" />
-                                        </node>
-                                        <node concept="2HwmR7" id="4ZputZW5Qs5" role="2OqNvi">
-                                          <node concept="1bVj0M" id="4ZputZW5Qs6" role="23t8la">
-                                            <node concept="3clFbS" id="4ZputZW5Qs7" role="1bW5cS">
-                                              <node concept="3clFbF" id="4ZputZW5Qs8" role="3cqZAp">
-                                                <node concept="2OqwBi" id="4ZputZW5Qs9" role="3clFbG">
-                                                  <node concept="37vLTw" id="4ZputZW5Qsa" role="2Oq$k0">
-                                                    <ref role="3cqZAo" node="7Z$RfkF7IGb" resolve="it" />
-                                                  </node>
-                                                  <node concept="2qgKlT" id="4ZputZW5Qsb" role="2OqNvi">
-                                                    <ref role="37wK5l" to="tpcn:4MKjpUYnih4" resolve="is" />
-                                                    <node concept="37vLTw" id="4ZputZW5Qsc" role="37wK5m">
-                                                      <ref role="3cqZAo" node="7Z$RfkF7IG9" resolve="prop" />
+                            <node concept="liA8E" id="582YV7z0eID" role="2OqNvi">
+                              <ref role="37wK5l" to="c17a:~SAbstractConcept.getProperties()" resolve="getProperties" />
+                            </node>
+                          </node>
+                          <node concept="3vKaQO" id="582YV7z0eIE" role="1tU5fm">
+                            <node concept="3uibUv" id="582YV7z0eIF" role="3O5elw">
+                              <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="4ZputZW5ecH" role="3cqZAp">
+                        <node concept="2ShNRf" id="4ZputZW5ecD" role="3clFbG">
+                          <node concept="1pGfFk" id="4ZputZW5vO$" role="2ShVmc">
+                            <ref role="37wK5l" to="33ny:~HashSet.&lt;init&gt;(java.util.Collection)" resolve="HashSet" />
+                            <node concept="2OqwBi" id="4ZputZW5QrT" role="37wK5m">
+                              <node concept="2OqwBi" id="4ZputZW5QrU" role="2Oq$k0">
+                                <node concept="2OqwBi" id="4ZputZW5QrV" role="2Oq$k0">
+                                  <node concept="37vLTw" id="4ZputZW5QrW" role="2Oq$k0">
+                                    <ref role="3cqZAo" node="582YV7z0eJ5" resolve="acd" />
+                                  </node>
+                                  <node concept="2qgKlT" id="4ZputZW5QrX" role="2OqNvi">
+                                    <ref role="37wK5l" to="tpcn:hEwILLM" resolve="getPropertyDeclarations" />
+                                  </node>
+                                </node>
+                                <node concept="3zZkjj" id="4ZputZW5QrY" role="2OqNvi">
+                                  <node concept="1bVj0M" id="4ZputZW5QrZ" role="23t8la">
+                                    <node concept="3clFbS" id="4ZputZW5Qs0" role="1bW5cS">
+                                      <node concept="3clFbF" id="4ZputZW5Qs1" role="3cqZAp">
+                                        <node concept="3fqX7Q" id="4ZputZW5Qs2" role="3clFbG">
+                                          <node concept="2OqwBi" id="4ZputZW5Qs3" role="3fr31v">
+                                            <node concept="37vLTw" id="4ZputZW5Qs4" role="2Oq$k0">
+                                              <ref role="3cqZAo" node="582YV7z0eIA" resolve="forbiddenProperties" />
+                                            </node>
+                                            <node concept="2HwmR7" id="4ZputZW5Qs5" role="2OqNvi">
+                                              <node concept="1bVj0M" id="4ZputZW5Qs6" role="23t8la">
+                                                <node concept="3clFbS" id="4ZputZW5Qs7" role="1bW5cS">
+                                                  <node concept="3clFbF" id="4ZputZW5Qs8" role="3cqZAp">
+                                                    <node concept="2OqwBi" id="4ZputZW5Qs9" role="3clFbG">
+                                                      <node concept="37vLTw" id="4ZputZW5Qsa" role="2Oq$k0">
+                                                        <ref role="3cqZAo" node="7Z$RfkF7IGb" resolve="it" />
+                                                      </node>
+                                                      <node concept="2qgKlT" id="4ZputZW5Qsb" role="2OqNvi">
+                                                        <ref role="37wK5l" to="tpcn:4MKjpUYnih4" resolve="is" />
+                                                        <node concept="37vLTw" id="4ZputZW5Qsc" role="37wK5m">
+                                                          <ref role="3cqZAo" node="7Z$RfkF7IG9" resolve="prop" />
+                                                        </node>
+                                                      </node>
                                                     </node>
                                                   </node>
                                                 </node>
+                                                <node concept="gl6BB" id="7Z$RfkF7IG9" role="1bW2Oz">
+                                                  <property role="TrG5h" value="prop" />
+                                                  <node concept="2jxLKc" id="7Z$RfkF7IGa" role="1tU5fm" />
+                                                </node>
                                               </node>
-                                            </node>
-                                            <node concept="gl6BB" id="7Z$RfkF7IG9" role="1bW2Oz">
-                                              <property role="TrG5h" value="prop" />
-                                              <node concept="2jxLKc" id="7Z$RfkF7IGa" role="1tU5fm" />
                                             </node>
                                           </node>
                                         </node>
                                       </node>
                                     </node>
+                                    <node concept="gl6BB" id="7Z$RfkF7IGb" role="1bW2Oz">
+                                      <property role="TrG5h" value="it" />
+                                      <node concept="2jxLKc" id="7Z$RfkF7IGc" role="1tU5fm" />
+                                    </node>
                                   </node>
                                 </node>
-                                <node concept="gl6BB" id="7Z$RfkF7IGb" role="1bW2Oz">
-                                  <property role="TrG5h" value="it" />
-                                  <node concept="2jxLKc" id="7Z$RfkF7IGc" role="1tU5fm" />
-                                </node>
                               </node>
+                              <node concept="ANE8D" id="4ZputZW5Qsh" role="2OqNvi" />
+                            </node>
+                            <node concept="3Tqbb2" id="4ZputZW5Dbu" role="1pMfVU">
+                              <ref role="ehGHo" to="tpce:f_TJgxF" resolve="PropertyDeclaration" />
                             </node>
                           </node>
-                          <node concept="ANE8D" id="4ZputZW5Qsh" role="2OqNvi" />
                         </node>
-                        <node concept="3Tqbb2" id="4ZputZW5Dbu" role="1pMfVU">
-                          <ref role="ehGHo" to="tpce:f_TJgxF" resolve="PropertyDeclaration" />
-                        </node>
+                      </node>
+                    </node>
+                    <node concept="37vLTG" id="582YV7z0eJ5" role="1bW2Oz">
+                      <property role="TrG5h" value="acd" />
+                      <node concept="3Tqbb2" id="582YV7z0eJ6" role="1tU5fm">
+                        <ref role="ehGHo" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
                       </node>
                     </node>
                   </node>
                 </node>
-                <node concept="37vLTG" id="582YV7z0eJ5" role="1bW2Oz">
-                  <property role="TrG5h" value="acd" />
-                  <node concept="3Tqbb2" id="582YV7z0eJ6" role="1tU5fm">
-                    <ref role="ehGHo" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
+              </node>
+              <node concept="3SKdUt" id="1FQTM0rQebS" role="3cqZAp">
+                <node concept="1PaTwC" id="1FQTM0rQebT" role="1aUNEU">
+                  <node concept="3oM_SD" id="1FQTM0rQebU" role="1PaTwD">
+                    <property role="3oM_SC" value="This" />
+                  </node>
+                  <node concept="3oM_SD" id="1FQTM0rQfI4" role="1PaTwD">
+                    <property role="3oM_SC" value="warning" />
+                  </node>
+                  <node concept="3oM_SD" id="1FQTM0rQfIB" role="1PaTwD">
+                    <property role="3oM_SC" value="ensures" />
+                  </node>
+                  <node concept="3oM_SD" id="1FQTM0rQfKl" role="1PaTwD">
+                    <property role="3oM_SC" value="that" />
+                  </node>
+                  <node concept="3oM_SD" id="1FQTM0rQfMB" role="1PaTwD">
+                    <property role="3oM_SC" value="is" />
+                  </node>
+                  <node concept="3oM_SD" id="1FQTM0rQfNR" role="1PaTwD">
+                    <property role="3oM_SC" value="not" />
+                  </node>
+                  <node concept="3oM_SD" id="1FQTM0rQfNY" role="1PaTwD">
+                    <property role="3oM_SC" value="possible" />
+                  </node>
+                  <node concept="3oM_SD" id="1FQTM0rQfPA" role="1PaTwD">
+                    <property role="3oM_SC" value="that" />
+                  </node>
+                  <node concept="3oM_SD" id="1FQTM0rQfQT" role="1PaTwD">
+                    <property role="3oM_SC" value="a" />
+                  </node>
+                  <node concept="3oM_SD" id="1FQTM0rQfRz" role="1PaTwD">
+                    <property role="3oM_SC" value="Auto-Merge-Policy" />
+                  </node>
+                  <node concept="3oM_SD" id="1FQTM0rQfWS" role="1PaTwD">
+                    <property role="3oM_SC" value="is" />
+                  </node>
+                  <node concept="3oM_SD" id="1FQTM0rQfYe" role="1PaTwD">
+                    <property role="3oM_SC" value="propagated" />
+                  </node>
+                  <node concept="3oM_SD" id="1FQTM0rQfZr" role="1PaTwD">
+                    <property role="3oM_SC" value="down" />
+                  </node>
+                  <node concept="3oM_SD" id="1FQTM0rQg1j" role="1PaTwD">
+                    <property role="3oM_SC" value="to" />
                   </node>
                 </node>
               </node>
-            </node>
-          </node>
-          <node concept="3SKdUt" id="1FQTM0rQebS" role="3cqZAp">
-            <node concept="1PaTwC" id="1FQTM0rQebT" role="1aUNEU">
-              <node concept="3oM_SD" id="1FQTM0rQebU" role="1PaTwD">
-                <property role="3oM_SC" value="This" />
-              </node>
-              <node concept="3oM_SD" id="1FQTM0rQfI4" role="1PaTwD">
-                <property role="3oM_SC" value="warning" />
-              </node>
-              <node concept="3oM_SD" id="1FQTM0rQfIB" role="1PaTwD">
-                <property role="3oM_SC" value="ensures" />
-              </node>
-              <node concept="3oM_SD" id="1FQTM0rQfKl" role="1PaTwD">
-                <property role="3oM_SC" value="that" />
-              </node>
-              <node concept="3oM_SD" id="1FQTM0rQfMB" role="1PaTwD">
-                <property role="3oM_SC" value="is" />
-              </node>
-              <node concept="3oM_SD" id="1FQTM0rQfNR" role="1PaTwD">
-                <property role="3oM_SC" value="not" />
-              </node>
-              <node concept="3oM_SD" id="1FQTM0rQfNY" role="1PaTwD">
-                <property role="3oM_SC" value="possible" />
-              </node>
-              <node concept="3oM_SD" id="1FQTM0rQfPA" role="1PaTwD">
-                <property role="3oM_SC" value="that" />
-              </node>
-              <node concept="3oM_SD" id="1FQTM0rQfQT" role="1PaTwD">
-                <property role="3oM_SC" value="a" />
-              </node>
-              <node concept="3oM_SD" id="1FQTM0rQfRz" role="1PaTwD">
-                <property role="3oM_SC" value="Auto-Merge-Policy" />
-              </node>
-              <node concept="3oM_SD" id="1FQTM0rQfWS" role="1PaTwD">
-                <property role="3oM_SC" value="is" />
-              </node>
-              <node concept="3oM_SD" id="1FQTM0rQfYe" role="1PaTwD">
-                <property role="3oM_SC" value="propagated" />
-              </node>
-              <node concept="3oM_SD" id="1FQTM0rQfZr" role="1PaTwD">
-                <property role="3oM_SC" value="down" />
-              </node>
-              <node concept="3oM_SD" id="1FQTM0rQg1j" role="1PaTwD">
-                <property role="3oM_SC" value="to" />
-              </node>
-            </node>
-          </node>
-          <node concept="3SKdUt" id="1FQTM0rQh0q" role="3cqZAp">
-            <node concept="1PaTwC" id="1FQTM0rQh0r" role="1aUNEU">
-              <node concept="3oM_SD" id="1FQTM0rQh0s" role="1PaTwD">
-                <property role="3oM_SC" value="some" />
-              </node>
-              <node concept="3oM_SD" id="1FQTM0rQh$T" role="1PaTwD">
-                <property role="3oM_SC" value="leaf-Concepts." />
-              </node>
-              <node concept="3oM_SD" id="1FQTM0rQhC6" role="1PaTwD">
-                <property role="3oM_SC" value="Even" />
-              </node>
-              <node concept="3oM_SD" id="1FQTM0rQhDk" role="1PaTwD">
-                <property role="3oM_SC" value="if" />
-              </node>
-              <node concept="3oM_SD" id="1FQTM0rQhDT" role="1PaTwD">
-                <property role="3oM_SC" value="all" />
-              </node>
-              <node concept="3oM_SD" id="1FQTM0rQhGD" role="1PaTwD">
-                <property role="3oM_SC" value="children" />
-              </node>
-              <node concept="3oM_SD" id="1FQTM0rQhKx" role="1PaTwD">
-                <property role="3oM_SC" value="in" />
-              </node>
-              <node concept="3oM_SD" id="1FQTM0rQhLN" role="1PaTwD">
-                <property role="3oM_SC" value="all" />
-              </node>
-              <node concept="3oM_SD" id="1FQTM0rQhMs" role="1PaTwD">
-                <property role="3oM_SC" value="Concepts" />
-              </node>
-              <node concept="3oM_SD" id="1FQTM0rQhN6" role="1PaTwD">
-                <property role="3oM_SC" value="would" />
-              </node>
-              <node concept="3oM_SD" id="1FQTM0rQhNL" role="1PaTwD">
-                <property role="3oM_SC" value="be" />
-              </node>
-              <node concept="3oM_SD" id="1FQTM0rQhP7" role="1PaTwD">
-                <property role="3oM_SC" value="handled" />
-              </node>
-              <node concept="3oM_SD" id="1FQTM0rQhRk" role="1PaTwD">
-                <property role="3oM_SC" value="by" />
-              </node>
-              <node concept="3oM_SD" id="1FQTM0rQhSG" role="1PaTwD">
-                <property role="3oM_SC" value="Auto," />
-              </node>
-              <node concept="3oM_SD" id="1FQTM0rQhVr" role="1PaTwD">
-                <property role="3oM_SC" value="then" />
-              </node>
-              <node concept="3oM_SD" id="1FQTM0rQhYS" role="1PaTwD">
-                <property role="3oM_SC" value="it" />
-              </node>
-              <node concept="3oM_SD" id="1FQTM0rQhZD" role="1PaTwD">
-                <property role="3oM_SC" value="is" />
-              </node>
-              <node concept="3oM_SD" id="1FQTM0rQi15" role="1PaTwD">
-                <property role="3oM_SC" value="assured" />
-              </node>
-            </node>
-          </node>
-          <node concept="3SKdUt" id="1FQTM0rQj14" role="3cqZAp">
-            <node concept="1PaTwC" id="1FQTM0rQj15" role="1aUNEU">
-              <node concept="3oM_SD" id="1FQTM0rQj16" role="1PaTwD">
-                <property role="3oM_SC" value="that" />
-              </node>
-              <node concept="3oM_SD" id="1FQTM0rQjR2" role="1PaTwD">
-                <property role="3oM_SC" value="the" />
-              </node>
-              <node concept="3oM_SD" id="1FQTM0rQjTf" role="1PaTwD">
-                <property role="3oM_SC" value="defined" />
-              </node>
-              <node concept="3oM_SD" id="1FQTM0rQjXh" role="1PaTwD">
-                <property role="3oM_SC" value="Merge-Policies" />
-              </node>
-              <node concept="3oM_SD" id="1FQTM0rQk0d" role="1PaTwD">
-                <property role="3oM_SC" value="for" />
-              </node>
-              <node concept="3oM_SD" id="1FQTM0rQk3Q" role="1PaTwD">
-                <property role="3oM_SC" value="properties" />
-              </node>
-              <node concept="3oM_SD" id="1FQTM0rQk4X" role="1PaTwD">
-                <property role="3oM_SC" value="makes" />
-              </node>
-              <node concept="3oM_SD" id="1FQTM0rQk6J" role="1PaTwD">
-                <property role="3oM_SC" value="the" />
-              </node>
-              <node concept="3oM_SD" id="1FQTM0rQk7o" role="1PaTwD">
-                <property role="3oM_SC" value="ModelMerge" />
-              </node>
-              <node concept="3oM_SD" id="1FQTM0rQkac" role="1PaTwD">
-                <property role="3oM_SC" value="well" />
-              </node>
-              <node concept="3oM_SD" id="1FQTM0rQkc1" role="1PaTwD">
-                <property role="3oM_SC" value="defined." />
-              </node>
-            </node>
-          </node>
-          <node concept="3clFbF" id="ZzVzivTlPG" role="3cqZAp">
-            <node concept="2YIFZM" id="6MgS2un_soA" role="3clFbG">
-              <ref role="37wK5l" node="ZzVzivR$xp" resolve="warn" />
-              <ref role="1Pybhc" node="1trrptaK_0z" resolve="CheckinRuleUtil" />
-              <node concept="2OqwBi" id="6MgS2un_soB" role="37wK5m">
-                <node concept="1YBJjd" id="6MgS2un_soC" role="2Oq$k0">
-                  <ref role="1YBMHb" node="7TOowlgBzBU" resolve="modelMerge" />
-                </node>
-                <node concept="2qgKlT" id="6MgS2un_soD" role="2OqNvi">
-                  <ref role="37wK5l" to="rnx3:3xJ_LYXlmVz" resolve="languageConcepts" />
-                </node>
-              </node>
-              <node concept="37vLTw" id="6MgS2un_soE" role="37wK5m">
-                <ref role="3cqZAo" node="ZzVzivMLGl" resolve="repository" />
-              </node>
-              <node concept="2OqwBi" id="6MgS2unBOb7" role="37wK5m">
-                <node concept="37vLTw" id="6MgS2unBNk$" role="2Oq$k0">
-                  <ref role="3cqZAo" node="3EHNiwz7rFs" resolve="mergerResolver" />
-                </node>
-                <node concept="liA8E" id="6MgS2unBPjZ" role="2OqNvi">
-                  <ref role="37wK5l" to="gunp:6MgS2unA2UL" resolve="conceptToProperty" />
-                </node>
-              </node>
-              <node concept="37vLTw" id="6MgS2un_soJ" role="37wK5m">
-                <ref role="3cqZAo" node="582YV7z0eIy" resolve="conceptToRelevantProperties" />
-              </node>
-              <node concept="1bVj0M" id="6MgS2un_soK" role="37wK5m">
-                <node concept="37vLTG" id="6MgS2un_soL" role="1bW2Oz">
-                  <property role="TrG5h" value="sac" />
-                  <node concept="3uibUv" id="6MgS2un_soM" role="1tU5fm">
-                    <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
+              <node concept="3SKdUt" id="1FQTM0rQh0q" role="3cqZAp">
+                <node concept="1PaTwC" id="1FQTM0rQh0r" role="1aUNEU">
+                  <node concept="3oM_SD" id="1FQTM0rQh0s" role="1PaTwD">
+                    <property role="3oM_SC" value="some" />
+                  </node>
+                  <node concept="3oM_SD" id="1FQTM0rQh$T" role="1PaTwD">
+                    <property role="3oM_SC" value="leaf-Concepts." />
+                  </node>
+                  <node concept="3oM_SD" id="1FQTM0rQhC6" role="1PaTwD">
+                    <property role="3oM_SC" value="Even" />
+                  </node>
+                  <node concept="3oM_SD" id="1FQTM0rQhDk" role="1PaTwD">
+                    <property role="3oM_SC" value="if" />
+                  </node>
+                  <node concept="3oM_SD" id="1FQTM0rQhDT" role="1PaTwD">
+                    <property role="3oM_SC" value="all" />
+                  </node>
+                  <node concept="3oM_SD" id="1FQTM0rQhGD" role="1PaTwD">
+                    <property role="3oM_SC" value="children" />
+                  </node>
+                  <node concept="3oM_SD" id="1FQTM0rQhKx" role="1PaTwD">
+                    <property role="3oM_SC" value="in" />
+                  </node>
+                  <node concept="3oM_SD" id="1FQTM0rQhLN" role="1PaTwD">
+                    <property role="3oM_SC" value="all" />
+                  </node>
+                  <node concept="3oM_SD" id="1FQTM0rQhMs" role="1PaTwD">
+                    <property role="3oM_SC" value="Concepts" />
+                  </node>
+                  <node concept="3oM_SD" id="1FQTM0rQhN6" role="1PaTwD">
+                    <property role="3oM_SC" value="would" />
+                  </node>
+                  <node concept="3oM_SD" id="1FQTM0rQhNL" role="1PaTwD">
+                    <property role="3oM_SC" value="be" />
+                  </node>
+                  <node concept="3oM_SD" id="1FQTM0rQhP7" role="1PaTwD">
+                    <property role="3oM_SC" value="handled" />
+                  </node>
+                  <node concept="3oM_SD" id="1FQTM0rQhRk" role="1PaTwD">
+                    <property role="3oM_SC" value="by" />
+                  </node>
+                  <node concept="3oM_SD" id="1FQTM0rQhSG" role="1PaTwD">
+                    <property role="3oM_SC" value="Auto," />
+                  </node>
+                  <node concept="3oM_SD" id="1FQTM0rQhVr" role="1PaTwD">
+                    <property role="3oM_SC" value="then" />
+                  </node>
+                  <node concept="3oM_SD" id="1FQTM0rQhYS" role="1PaTwD">
+                    <property role="3oM_SC" value="it" />
+                  </node>
+                  <node concept="3oM_SD" id="1FQTM0rQhZD" role="1PaTwD">
+                    <property role="3oM_SC" value="is" />
+                  </node>
+                  <node concept="3oM_SD" id="1FQTM0rQi15" role="1PaTwD">
+                    <property role="3oM_SC" value="assured" />
                   </node>
                 </node>
-                <node concept="37vLTG" id="6MgS2un_soN" role="1bW2Oz">
-                  <property role="TrG5h" value="pd" />
-                  <node concept="3Tqbb2" id="6MgS2un_soO" role="1tU5fm">
-                    <ref role="ehGHo" to="tpce:f_TJgxF" resolve="PropertyDeclaration" />
+              </node>
+              <node concept="3SKdUt" id="1FQTM0rQj14" role="3cqZAp">
+                <node concept="1PaTwC" id="1FQTM0rQj15" role="1aUNEU">
+                  <node concept="3oM_SD" id="1FQTM0rQj16" role="1PaTwD">
+                    <property role="3oM_SC" value="that" />
+                  </node>
+                  <node concept="3oM_SD" id="1FQTM0rQjR2" role="1PaTwD">
+                    <property role="3oM_SC" value="the" />
+                  </node>
+                  <node concept="3oM_SD" id="1FQTM0rQjTf" role="1PaTwD">
+                    <property role="3oM_SC" value="defined" />
+                  </node>
+                  <node concept="3oM_SD" id="1FQTM0rQjXh" role="1PaTwD">
+                    <property role="3oM_SC" value="Merge-Policies" />
+                  </node>
+                  <node concept="3oM_SD" id="1FQTM0rQk0d" role="1PaTwD">
+                    <property role="3oM_SC" value="for" />
+                  </node>
+                  <node concept="3oM_SD" id="1FQTM0rQk3Q" role="1PaTwD">
+                    <property role="3oM_SC" value="properties" />
+                  </node>
+                  <node concept="3oM_SD" id="1FQTM0rQk4X" role="1PaTwD">
+                    <property role="3oM_SC" value="makes" />
+                  </node>
+                  <node concept="3oM_SD" id="1FQTM0rQk6J" role="1PaTwD">
+                    <property role="3oM_SC" value="the" />
+                  </node>
+                  <node concept="3oM_SD" id="1FQTM0rQk7o" role="1PaTwD">
+                    <property role="3oM_SC" value="ModelMerge" />
+                  </node>
+                  <node concept="3oM_SD" id="1FQTM0rQkac" role="1PaTwD">
+                    <property role="3oM_SC" value="well" />
+                  </node>
+                  <node concept="3oM_SD" id="1FQTM0rQkc1" role="1PaTwD">
+                    <property role="3oM_SC" value="defined." />
                   </node>
                 </node>
-                <node concept="3clFbS" id="6MgS2un_soP" role="1bW5cS">
-                  <node concept="a7r0C" id="6MgS2un_soQ" role="3cqZAp">
-                    <node concept="3cpWs3" id="6MgS2un_soR" role="a7wSD">
-                      <node concept="37vLTw" id="6MgS2un_soS" role="3uHU7w">
-                        <ref role="3cqZAo" node="6MgS2un_soN" resolve="pd" />
+              </node>
+              <node concept="3clFbF" id="ZzVzivTlPG" role="3cqZAp">
+                <node concept="2YIFZM" id="6MgS2un_soA" role="3clFbG">
+                  <ref role="37wK5l" node="ZzVzivR$xp" resolve="warn" />
+                  <ref role="1Pybhc" node="1trrptaK_0z" resolve="CheckinRuleUtil" />
+                  <node concept="2OqwBi" id="6MgS2un_soB" role="37wK5m">
+                    <node concept="1YBJjd" id="6MgS2un_soC" role="2Oq$k0">
+                      <ref role="1YBMHb" node="7TOowlgBzBU" resolve="modelMerge" />
+                    </node>
+                    <node concept="2qgKlT" id="6MgS2un_soD" role="2OqNvi">
+                      <ref role="37wK5l" to="rnx3:3xJ_LYXlmVz" resolve="languageConcepts" />
+                    </node>
+                  </node>
+                  <node concept="37vLTw" id="6MgS2un_soE" role="37wK5m">
+                    <ref role="3cqZAo" node="ZzVzivMLGl" resolve="repository" />
+                  </node>
+                  <node concept="2OqwBi" id="6MgS2unBOb7" role="37wK5m">
+                    <node concept="37vLTw" id="6MgS2unBNk$" role="2Oq$k0">
+                      <ref role="3cqZAo" node="3EHNiwz7rFs" resolve="mergerResolver" />
+                    </node>
+                    <node concept="liA8E" id="6MgS2unBPjZ" role="2OqNvi">
+                      <ref role="37wK5l" to="gunp:6MgS2unA2UL" resolve="conceptToProperty" />
+                    </node>
+                  </node>
+                  <node concept="37vLTw" id="6MgS2un_soJ" role="37wK5m">
+                    <ref role="3cqZAo" node="582YV7z0eIy" resolve="conceptToRelevantProperties" />
+                  </node>
+                  <node concept="1bVj0M" id="6MgS2un_soK" role="37wK5m">
+                    <node concept="37vLTG" id="6MgS2un_soL" role="1bW2Oz">
+                      <property role="TrG5h" value="sac" />
+                      <node concept="3uibUv" id="6MgS2un_soM" role="1tU5fm">
+                        <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
                       </node>
-                      <node concept="3cpWs3" id="6MgS2un_soT" role="3uHU7B">
-                        <node concept="3cpWs3" id="6MgS2un_soU" role="3uHU7B">
-                          <node concept="Xl_RD" id="6MgS2un_soV" role="3uHU7B">
-                            <property role="Xl_RC" value="concept " />
+                    </node>
+                    <node concept="37vLTG" id="6MgS2un_soN" role="1bW2Oz">
+                      <property role="TrG5h" value="pd" />
+                      <node concept="3Tqbb2" id="6MgS2un_soO" role="1tU5fm">
+                        <ref role="ehGHo" to="tpce:f_TJgxF" resolve="PropertyDeclaration" />
+                      </node>
+                    </node>
+                    <node concept="3clFbS" id="6MgS2un_soP" role="1bW5cS">
+                      <node concept="a7r0C" id="6MgS2un_soQ" role="3cqZAp">
+                        <node concept="3cpWs3" id="6MgS2un_soR" role="a7wSD">
+                          <node concept="37vLTw" id="6MgS2un_soS" role="3uHU7w">
+                            <ref role="3cqZAo" node="6MgS2un_soN" resolve="pd" />
                           </node>
-                          <node concept="37vLTw" id="6MgS2un_soW" role="3uHU7w">
+                          <node concept="3cpWs3" id="6MgS2un_soT" role="3uHU7B">
+                            <node concept="3cpWs3" id="6MgS2un_soU" role="3uHU7B">
+                              <node concept="Xl_RD" id="6MgS2un_soV" role="3uHU7B">
+                                <property role="Xl_RC" value="concept " />
+                              </node>
+                              <node concept="37vLTw" id="6MgS2un_soW" role="3uHU7w">
+                                <ref role="3cqZAo" node="6MgS2un_soL" resolve="sac" />
+                              </node>
+                            </node>
+                            <node concept="Xl_RD" id="6MgS2un_soX" role="3uHU7w">
+                              <property role="Xl_RC" value=" is missing merge policy for property " />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="2YIFZM" id="6MgS2un_soY" role="1urrMF">
+                          <ref role="37wK5l" node="582YV7yWtlM" resolve="warningNode" />
+                          <ref role="1Pybhc" node="1trrptaK_0z" resolve="CheckinRuleUtil" />
+                          <node concept="1YBJjd" id="6MgS2un_soZ" role="37wK5m">
+                            <ref role="1YBMHb" node="7TOowlgBzBU" resolve="modelMerge" />
+                          </node>
+                          <node concept="37vLTw" id="6MgS2un_sp0" role="37wK5m">
                             <ref role="3cqZAo" node="6MgS2un_soL" resolve="sac" />
                           </node>
                         </node>
-                        <node concept="Xl_RD" id="6MgS2un_soX" role="3uHU7w">
-                          <property role="Xl_RC" value=" is missing merge policy for property " />
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="2YIFZM" id="6MgS2un_soY" role="1urrMF">
-                      <ref role="37wK5l" node="582YV7yWtlM" resolve="warningNode" />
-                      <ref role="1Pybhc" node="1trrptaK_0z" resolve="CheckinRuleUtil" />
-                      <node concept="1YBJjd" id="6MgS2un_soZ" role="37wK5m">
-                        <ref role="1YBMHb" node="7TOowlgBzBU" resolve="modelMerge" />
-                      </node>
-                      <node concept="37vLTw" id="6MgS2un_sp0" role="37wK5m">
-                        <ref role="3cqZAo" node="6MgS2un_soL" resolve="sac" />
                       </node>
                     </node>
                   </node>
                 </node>
               </node>
-            </node>
-          </node>
-          <node concept="3clFbH" id="ZzVzivUfmo" role="3cqZAp" />
-          <node concept="3SKdUt" id="60iGZSKkceL" role="3cqZAp">
-            <node concept="1PaTwC" id="60iGZSKkceM" role="1aUNEU">
-              <node concept="3oM_SD" id="60iGZSKkdqu" role="1PaTwD">
-                <property role="3oM_SC" value="--Missing" />
-              </node>
-              <node concept="3oM_SD" id="60iGZSKkdtA" role="1PaTwD">
-                <property role="3oM_SC" value="Child" />
-              </node>
-              <node concept="3oM_SD" id="60iGZSKkduP" role="1PaTwD">
-                <property role="3oM_SC" value="Policy" />
-              </node>
-            </node>
-          </node>
-          <node concept="3cpWs8" id="582YV7z0meD" role="3cqZAp">
-            <node concept="3cpWsn" id="582YV7z0meE" role="3cpWs9">
-              <property role="TrG5h" value="conceptToRelevantChildren" />
-              <node concept="1ajhzC" id="582YV7z0me_" role="1tU5fm">
-                <node concept="3Tqbb2" id="582YV7z0meA" role="1ajw0F">
-                  <ref role="ehGHo" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
-                </node>
-                <node concept="3uibUv" id="582YV7z0meB" role="1ajl9A">
-                  <ref role="3uigEE" to="33ny:~HashSet" resolve="HashSet" />
-                  <node concept="3Tqbb2" id="582YV7z0meC" role="11_B2D">
-                    <ref role="ehGHo" to="tpce:f_TJgxE" resolve="LinkDeclaration" />
+              <node concept="3clFbH" id="ZzVzivUfmo" role="3cqZAp" />
+              <node concept="3SKdUt" id="60iGZSKkceL" role="3cqZAp">
+                <node concept="1PaTwC" id="60iGZSKkceM" role="1aUNEU">
+                  <node concept="3oM_SD" id="60iGZSKkdqu" role="1PaTwD">
+                    <property role="3oM_SC" value="--Missing" />
+                  </node>
+                  <node concept="3oM_SD" id="60iGZSKkdtA" role="1PaTwD">
+                    <property role="3oM_SC" value="Child" />
+                  </node>
+                  <node concept="3oM_SD" id="60iGZSKkduP" role="1PaTwD">
+                    <property role="3oM_SC" value="Policy" />
                   </node>
                 </node>
               </node>
-              <node concept="1bVj0M" id="582YV7z0meF" role="33vP2m">
-                <node concept="3clFbS" id="582YV7z0meG" role="1bW5cS">
-                  <node concept="3cpWs8" id="582YV7z0meH" role="3cqZAp">
-                    <node concept="3cpWsn" id="582YV7z0meI" role="3cpWs9">
-                      <property role="TrG5h" value="forbiddenChildren" />
-                      <node concept="3vKaQO" id="582YV7z0meJ" role="1tU5fm">
-                        <node concept="3uibUv" id="582YV7z0meK" role="3O5elw">
-                          <ref role="3uigEE" to="c17a:~SContainmentLink" resolve="SContainmentLink" />
-                        </node>
-                      </node>
-                      <node concept="2OqwBi" id="582YV7z0meL" role="33vP2m">
-                        <node concept="35c_gC" id="582YV7z0meM" role="2Oq$k0">
-                          <ref role="35c_gD" to="tpck:gw2VY9q" resolve="BaseConcept" />
-                        </node>
-                        <node concept="liA8E" id="582YV7z0meN" role="2OqNvi">
-                          <ref role="37wK5l" to="c17a:~SAbstractConcept.getContainmentLinks()" resolve="getContainmentLinks" />
-                        </node>
+              <node concept="3cpWs8" id="582YV7z0meD" role="3cqZAp">
+                <node concept="3cpWsn" id="582YV7z0meE" role="3cpWs9">
+                  <property role="TrG5h" value="conceptToRelevantChildren" />
+                  <node concept="1ajhzC" id="582YV7z0me_" role="1tU5fm">
+                    <node concept="3Tqbb2" id="582YV7z0meA" role="1ajw0F">
+                      <ref role="ehGHo" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
+                    </node>
+                    <node concept="3uibUv" id="582YV7z0meB" role="1ajl9A">
+                      <ref role="3uigEE" to="33ny:~HashSet" resolve="HashSet" />
+                      <node concept="3Tqbb2" id="582YV7z0meC" role="11_B2D">
+                        <ref role="ehGHo" to="tpce:f_TJgxE" resolve="LinkDeclaration" />
                       </node>
                     </node>
                   </node>
-                  <node concept="3clFbF" id="4ZputZW5ZW6" role="3cqZAp">
-                    <node concept="2ShNRf" id="4ZputZW5ZW2" role="3clFbG">
-                      <node concept="1pGfFk" id="4ZputZW61kK" role="2ShVmc">
-                        <ref role="37wK5l" to="33ny:~HashSet.&lt;init&gt;(java.util.Collection)" resolve="HashSet" />
-                        <node concept="2OqwBi" id="4ZputZW6g9S" role="37wK5m">
-                          <node concept="2OqwBi" id="4ZputZW6g9T" role="2Oq$k0">
-                            <node concept="2OqwBi" id="4ZputZW6g9U" role="2Oq$k0">
-                              <node concept="2OqwBi" id="4ZputZW6g9V" role="2Oq$k0">
-                                <node concept="37vLTw" id="4ZputZW6g9W" role="2Oq$k0">
-                                  <ref role="3cqZAo" node="582YV7z0mfd" resolve="acd" />
-                                </node>
-                                <node concept="2qgKlT" id="4ZputZW6g9X" role="2OqNvi">
-                                  <ref role="37wK5l" to="tpcn:hEwILKK" resolve="getLinkDeclarations" />
-                                </node>
-                              </node>
-                              <node concept="3zZkjj" id="4ZputZW6g9Y" role="2OqNvi">
-                                <node concept="1bVj0M" id="4ZputZW6g9Z" role="23t8la">
-                                  <node concept="3clFbS" id="4ZputZW6ga0" role="1bW5cS">
-                                    <node concept="3clFbF" id="4ZputZW6ga1" role="3cqZAp">
-                                      <node concept="3fqX7Q" id="4ZputZW6ga2" role="3clFbG">
-                                        <node concept="2OqwBi" id="4ZputZW6ga3" role="3fr31v">
-                                          <node concept="2OqwBi" id="4ZputZW6ga4" role="2Oq$k0">
-                                            <node concept="37vLTw" id="4ZputZW6ga5" role="2Oq$k0">
-                                              <ref role="3cqZAo" node="7Z$RfkF7IGd" resolve="it" />
-                                            </node>
-                                            <node concept="3TrcHB" id="4ZputZW6ga6" role="2OqNvi">
-                                              <ref role="3TsBF5" to="tpce:3Ftr4R6BH8$" resolve="metaClass" />
-                                            </node>
-                                          </node>
-                                          <node concept="21noJN" id="4ZputZW6ga7" role="2OqNvi">
-                                            <node concept="21nZrQ" id="4ZputZW6ga8" role="21noJM">
-                                              <ref role="21nZrZ" to="tpce:3Ftr4R6BFyn" resolve="reference" />
-                                            </node>
-                                          </node>
-                                        </node>
-                                      </node>
+                  <node concept="1bVj0M" id="582YV7z0meF" role="33vP2m">
+                    <node concept="3clFbS" id="582YV7z0meG" role="1bW5cS">
+                      <node concept="3cpWs8" id="582YV7z0meH" role="3cqZAp">
+                        <node concept="3cpWsn" id="582YV7z0meI" role="3cpWs9">
+                          <property role="TrG5h" value="forbiddenChildren" />
+                          <node concept="3vKaQO" id="582YV7z0meJ" role="1tU5fm">
+                            <node concept="3uibUv" id="582YV7z0meK" role="3O5elw">
+                              <ref role="3uigEE" to="c17a:~SContainmentLink" resolve="SContainmentLink" />
+                            </node>
+                          </node>
+                          <node concept="2OqwBi" id="582YV7z0meL" role="33vP2m">
+                            <node concept="35c_gC" id="582YV7z0meM" role="2Oq$k0">
+                              <ref role="35c_gD" to="tpck:gw2VY9q" resolve="BaseConcept" />
+                            </node>
+                            <node concept="liA8E" id="582YV7z0meN" role="2OqNvi">
+                              <ref role="37wK5l" to="c17a:~SAbstractConcept.getContainmentLinks()" resolve="getContainmentLinks" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="4ZputZW5ZW6" role="3cqZAp">
+                        <node concept="2ShNRf" id="4ZputZW5ZW2" role="3clFbG">
+                          <node concept="1pGfFk" id="4ZputZW61kK" role="2ShVmc">
+                            <ref role="37wK5l" to="33ny:~HashSet.&lt;init&gt;(java.util.Collection)" resolve="HashSet" />
+                            <node concept="2OqwBi" id="4ZputZW6g9S" role="37wK5m">
+                              <node concept="2OqwBi" id="4ZputZW6g9T" role="2Oq$k0">
+                                <node concept="2OqwBi" id="4ZputZW6g9U" role="2Oq$k0">
+                                  <node concept="2OqwBi" id="4ZputZW6g9V" role="2Oq$k0">
+                                    <node concept="37vLTw" id="4ZputZW6g9W" role="2Oq$k0">
+                                      <ref role="3cqZAo" node="582YV7z0mfd" resolve="acd" />
+                                    </node>
+                                    <node concept="2qgKlT" id="4ZputZW6g9X" role="2OqNvi">
+                                      <ref role="37wK5l" to="tpcn:hEwILKK" resolve="getLinkDeclarations" />
                                     </node>
                                   </node>
-                                  <node concept="gl6BB" id="7Z$RfkF7IGd" role="1bW2Oz">
-                                    <property role="TrG5h" value="it" />
-                                    <node concept="2jxLKc" id="7Z$RfkF7IGe" role="1tU5fm" />
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                            <node concept="3zZkjj" id="4ZputZW6gab" role="2OqNvi">
-                              <node concept="1bVj0M" id="4ZputZW6gac" role="23t8la">
-                                <node concept="3clFbS" id="4ZputZW6gad" role="1bW5cS">
-                                  <node concept="3clFbF" id="4ZputZW6gae" role="3cqZAp">
-                                    <node concept="3fqX7Q" id="4ZputZW6gaf" role="3clFbG">
-                                      <node concept="2OqwBi" id="4ZputZW6gag" role="3fr31v">
-                                        <node concept="37vLTw" id="4ZputZW6gah" role="2Oq$k0">
-                                          <ref role="3cqZAo" node="582YV7z0meI" resolve="forbiddenChildren" />
-                                        </node>
-                                        <node concept="2HwmR7" id="4ZputZW6gai" role="2OqNvi">
-                                          <node concept="1bVj0M" id="4ZputZW6gaj" role="23t8la">
-                                            <node concept="3clFbS" id="4ZputZW6gak" role="1bW5cS">
-                                              <node concept="3clFbF" id="4ZputZW6gal" role="3cqZAp">
-                                                <node concept="2OqwBi" id="4ZputZW6gam" role="3clFbG">
-                                                  <node concept="37vLTw" id="4ZputZW6gan" role="2Oq$k0">
-                                                    <ref role="3cqZAo" node="7Z$RfkF7IGh" resolve="it" />
-                                                  </node>
-                                                  <node concept="2qgKlT" id="4ZputZW6gao" role="2OqNvi">
-                                                    <ref role="37wK5l" to="tpcn:4MKjpUYniHA" resolve="is" />
-                                                    <node concept="37vLTw" id="4ZputZW6gap" role="37wK5m">
-                                                      <ref role="3cqZAo" node="7Z$RfkF7IGf" resolve="child" />
-                                                    </node>
-                                                  </node>
+                                  <node concept="3zZkjj" id="4ZputZW6g9Y" role="2OqNvi">
+                                    <node concept="1bVj0M" id="4ZputZW6g9Z" role="23t8la">
+                                      <node concept="3clFbS" id="4ZputZW6ga0" role="1bW5cS">
+                                        <node concept="3clFbF" id="4ZputZW6ga1" role="3cqZAp">
+                                          <node concept="3fqX7Q" id="4ZputZW6ga2" role="3clFbG">
+                                            <node concept="2OqwBi" id="4ZputZW6ga3" role="3fr31v">
+                                              <node concept="2OqwBi" id="4ZputZW6ga4" role="2Oq$k0">
+                                                <node concept="37vLTw" id="4ZputZW6ga5" role="2Oq$k0">
+                                                  <ref role="3cqZAo" node="7Z$RfkF7IGd" resolve="it" />
+                                                </node>
+                                                <node concept="3TrcHB" id="4ZputZW6ga6" role="2OqNvi">
+                                                  <ref role="3TsBF5" to="tpce:3Ftr4R6BH8$" resolve="metaClass" />
+                                                </node>
+                                              </node>
+                                              <node concept="21noJN" id="4ZputZW6ga7" role="2OqNvi">
+                                                <node concept="21nZrQ" id="4ZputZW6ga8" role="21noJM">
+                                                  <ref role="21nZrZ" to="tpce:3Ftr4R6BFyn" resolve="reference" />
                                                 </node>
                                               </node>
                                             </node>
-                                            <node concept="gl6BB" id="7Z$RfkF7IGf" role="1bW2Oz">
-                                              <property role="TrG5h" value="child" />
-                                              <node concept="2jxLKc" id="7Z$RfkF7IGg" role="1tU5fm" />
+                                          </node>
+                                        </node>
+                                      </node>
+                                      <node concept="gl6BB" id="7Z$RfkF7IGd" role="1bW2Oz">
+                                        <property role="TrG5h" value="it" />
+                                        <node concept="2jxLKc" id="7Z$RfkF7IGe" role="1tU5fm" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                                <node concept="3zZkjj" id="4ZputZW6gab" role="2OqNvi">
+                                  <node concept="1bVj0M" id="4ZputZW6gac" role="23t8la">
+                                    <node concept="3clFbS" id="4ZputZW6gad" role="1bW5cS">
+                                      <node concept="3clFbF" id="4ZputZW6gae" role="3cqZAp">
+                                        <node concept="3fqX7Q" id="4ZputZW6gaf" role="3clFbG">
+                                          <node concept="2OqwBi" id="4ZputZW6gag" role="3fr31v">
+                                            <node concept="37vLTw" id="4ZputZW6gah" role="2Oq$k0">
+                                              <ref role="3cqZAo" node="582YV7z0meI" resolve="forbiddenChildren" />
+                                            </node>
+                                            <node concept="2HwmR7" id="4ZputZW6gai" role="2OqNvi">
+                                              <node concept="1bVj0M" id="4ZputZW6gaj" role="23t8la">
+                                                <node concept="3clFbS" id="4ZputZW6gak" role="1bW5cS">
+                                                  <node concept="3clFbF" id="4ZputZW6gal" role="3cqZAp">
+                                                    <node concept="2OqwBi" id="4ZputZW6gam" role="3clFbG">
+                                                      <node concept="37vLTw" id="4ZputZW6gan" role="2Oq$k0">
+                                                        <ref role="3cqZAo" node="7Z$RfkF7IGh" resolve="it" />
+                                                      </node>
+                                                      <node concept="2qgKlT" id="4ZputZW6gao" role="2OqNvi">
+                                                        <ref role="37wK5l" to="tpcn:4MKjpUYniHA" resolve="is" />
+                                                        <node concept="37vLTw" id="4ZputZW6gap" role="37wK5m">
+                                                          <ref role="3cqZAo" node="7Z$RfkF7IGf" resolve="child" />
+                                                        </node>
+                                                      </node>
+                                                    </node>
+                                                  </node>
+                                                </node>
+                                                <node concept="gl6BB" id="7Z$RfkF7IGf" role="1bW2Oz">
+                                                  <property role="TrG5h" value="child" />
+                                                  <node concept="2jxLKc" id="7Z$RfkF7IGg" role="1tU5fm" />
+                                                </node>
+                                              </node>
                                             </node>
                                           </node>
                                         </node>
                                       </node>
                                     </node>
+                                    <node concept="gl6BB" id="7Z$RfkF7IGh" role="1bW2Oz">
+                                      <property role="TrG5h" value="it" />
+                                      <node concept="2jxLKc" id="7Z$RfkF7IGi" role="1tU5fm" />
+                                    </node>
                                   </node>
                                 </node>
-                                <node concept="gl6BB" id="7Z$RfkF7IGh" role="1bW2Oz">
-                                  <property role="TrG5h" value="it" />
-                                  <node concept="2jxLKc" id="7Z$RfkF7IGi" role="1tU5fm" />
-                                </node>
                               </node>
+                              <node concept="ANE8D" id="4ZputZW6gau" role="2OqNvi" />
+                            </node>
+                            <node concept="3Tqbb2" id="4ZputZW67YO" role="1pMfVU">
+                              <ref role="ehGHo" to="tpce:f_TJgxE" resolve="LinkDeclaration" />
                             </node>
                           </node>
-                          <node concept="ANE8D" id="4ZputZW6gau" role="2OqNvi" />
                         </node>
-                        <node concept="3Tqbb2" id="4ZputZW67YO" role="1pMfVU">
-                          <ref role="ehGHo" to="tpce:f_TJgxE" resolve="LinkDeclaration" />
-                        </node>
+                      </node>
+                    </node>
+                    <node concept="37vLTG" id="582YV7z0mfd" role="1bW2Oz">
+                      <property role="TrG5h" value="acd" />
+                      <node concept="3Tqbb2" id="582YV7z0mfe" role="1tU5fm">
+                        <ref role="ehGHo" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
                       </node>
                     </node>
                   </node>
                 </node>
-                <node concept="37vLTG" id="582YV7z0mfd" role="1bW2Oz">
-                  <property role="TrG5h" value="acd" />
-                  <node concept="3Tqbb2" id="582YV7z0mfe" role="1tU5fm">
-                    <ref role="ehGHo" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
+              </node>
+              <node concept="3clFbF" id="ZzVzivVFWG" role="3cqZAp">
+                <node concept="2YIFZM" id="6MgS2un_o5h" role="3clFbG">
+                  <ref role="37wK5l" node="ZzVzivR$xp" resolve="warn" />
+                  <ref role="1Pybhc" node="1trrptaK_0z" resolve="CheckinRuleUtil" />
+                  <node concept="2OqwBi" id="6MgS2un_o5i" role="37wK5m">
+                    <node concept="1YBJjd" id="6MgS2un_o5j" role="2Oq$k0">
+                      <ref role="1YBMHb" node="7TOowlgBzBU" resolve="modelMerge" />
+                    </node>
+                    <node concept="2qgKlT" id="6MgS2un_o5k" role="2OqNvi">
+                      <ref role="37wK5l" to="rnx3:3xJ_LYXlmVz" resolve="languageConcepts" />
+                    </node>
                   </node>
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3clFbF" id="ZzVzivVFWG" role="3cqZAp">
-            <node concept="2YIFZM" id="6MgS2un_o5h" role="3clFbG">
-              <ref role="37wK5l" node="ZzVzivR$xp" resolve="warn" />
-              <ref role="1Pybhc" node="1trrptaK_0z" resolve="CheckinRuleUtil" />
-              <node concept="2OqwBi" id="6MgS2un_o5i" role="37wK5m">
-                <node concept="1YBJjd" id="6MgS2un_o5j" role="2Oq$k0">
-                  <ref role="1YBMHb" node="7TOowlgBzBU" resolve="modelMerge" />
-                </node>
-                <node concept="2qgKlT" id="6MgS2un_o5k" role="2OqNvi">
-                  <ref role="37wK5l" to="rnx3:3xJ_LYXlmVz" resolve="languageConcepts" />
-                </node>
-              </node>
-              <node concept="37vLTw" id="6MgS2un_o5l" role="37wK5m">
-                <ref role="3cqZAo" node="ZzVzivMLGl" resolve="repository" />
-              </node>
-              <node concept="2OqwBi" id="6MgS2unBQcH" role="37wK5m">
-                <node concept="37vLTw" id="6MgS2unBQcI" role="2Oq$k0">
-                  <ref role="3cqZAo" node="3EHNiwz7rFs" resolve="mergerResolver" />
-                </node>
-                <node concept="liA8E" id="6MgS2unBRIA" role="2OqNvi">
-                  <ref role="37wK5l" to="gunp:6MgS2unAdH$" resolve="conceptToChildLink" />
-                </node>
-              </node>
-              <node concept="37vLTw" id="6MgS2un_o5q" role="37wK5m">
-                <ref role="3cqZAo" node="582YV7z0meE" resolve="conceptToRelevantChildren" />
-              </node>
-              <node concept="1bVj0M" id="6MgS2un_o5r" role="37wK5m">
-                <node concept="37vLTG" id="6MgS2un_o5s" role="1bW2Oz">
-                  <property role="TrG5h" value="sac" />
-                  <node concept="3uibUv" id="6MgS2un_o5t" role="1tU5fm">
-                    <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
+                  <node concept="37vLTw" id="6MgS2un_o5l" role="37wK5m">
+                    <ref role="3cqZAo" node="ZzVzivMLGl" resolve="repository" />
                   </node>
-                </node>
-                <node concept="37vLTG" id="6MgS2un_o5u" role="1bW2Oz">
-                  <property role="TrG5h" value="ld" />
-                  <node concept="3Tqbb2" id="6MgS2un_o5v" role="1tU5fm">
-                    <ref role="ehGHo" to="tpce:f_TJgxE" resolve="LinkDeclaration" />
+                  <node concept="2OqwBi" id="6MgS2unBQcH" role="37wK5m">
+                    <node concept="37vLTw" id="6MgS2unBQcI" role="2Oq$k0">
+                      <ref role="3cqZAo" node="3EHNiwz7rFs" resolve="mergerResolver" />
+                    </node>
+                    <node concept="liA8E" id="6MgS2unBRIA" role="2OqNvi">
+                      <ref role="37wK5l" to="gunp:6MgS2unAdH$" resolve="conceptToChildLink" />
+                    </node>
                   </node>
-                </node>
-                <node concept="3clFbS" id="6MgS2un_o5w" role="1bW5cS">
-                  <node concept="a7r0C" id="6MgS2un_o5x" role="3cqZAp">
-                    <node concept="3cpWs3" id="6MgS2un_o5y" role="a7wSD">
-                      <node concept="2OqwBi" id="6MgS2un_o5z" role="3uHU7w">
-                        <node concept="37vLTw" id="6MgS2un_o5$" role="2Oq$k0">
-                          <ref role="3cqZAo" node="6MgS2un_o5u" resolve="ld" />
-                        </node>
-                        <node concept="2qgKlT" id="6MgS2un_o5_" role="2OqNvi">
-                          <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
-                        </node>
+                  <node concept="37vLTw" id="6MgS2un_o5q" role="37wK5m">
+                    <ref role="3cqZAo" node="582YV7z0meE" resolve="conceptToRelevantChildren" />
+                  </node>
+                  <node concept="1bVj0M" id="6MgS2un_o5r" role="37wK5m">
+                    <node concept="37vLTG" id="6MgS2un_o5s" role="1bW2Oz">
+                      <property role="TrG5h" value="sac" />
+                      <node concept="3uibUv" id="6MgS2un_o5t" role="1tU5fm">
+                        <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
                       </node>
-                      <node concept="3cpWs3" id="6MgS2un_o5A" role="3uHU7B">
-                        <node concept="3cpWs3" id="6MgS2un_o5B" role="3uHU7B">
-                          <node concept="Xl_RD" id="6MgS2un_o5C" role="3uHU7B">
-                            <property role="Xl_RC" value="concept" />
+                    </node>
+                    <node concept="37vLTG" id="6MgS2un_o5u" role="1bW2Oz">
+                      <property role="TrG5h" value="ld" />
+                      <node concept="3Tqbb2" id="6MgS2un_o5v" role="1tU5fm">
+                        <ref role="ehGHo" to="tpce:f_TJgxE" resolve="LinkDeclaration" />
+                      </node>
+                    </node>
+                    <node concept="3clFbS" id="6MgS2un_o5w" role="1bW5cS">
+                      <node concept="a7r0C" id="6MgS2un_o5x" role="3cqZAp">
+                        <node concept="3cpWs3" id="6MgS2un_o5y" role="a7wSD">
+                          <node concept="2OqwBi" id="6MgS2un_o5z" role="3uHU7w">
+                            <node concept="37vLTw" id="6MgS2un_o5$" role="2Oq$k0">
+                              <ref role="3cqZAo" node="6MgS2un_o5u" resolve="ld" />
+                            </node>
+                            <node concept="2qgKlT" id="6MgS2un_o5_" role="2OqNvi">
+                              <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                            </node>
                           </node>
-                          <node concept="37vLTw" id="6MgS2un_o5D" role="3uHU7w">
+                          <node concept="3cpWs3" id="6MgS2un_o5A" role="3uHU7B">
+                            <node concept="3cpWs3" id="6MgS2un_o5B" role="3uHU7B">
+                              <node concept="Xl_RD" id="6MgS2un_o5C" role="3uHU7B">
+                                <property role="Xl_RC" value="concept" />
+                              </node>
+                              <node concept="37vLTw" id="6MgS2un_o5D" role="3uHU7w">
+                                <ref role="3cqZAo" node="6MgS2un_o5s" resolve="sac" />
+                              </node>
+                            </node>
+                            <node concept="Xl_RD" id="6MgS2un_o5E" role="3uHU7w">
+                              <property role="Xl_RC" value=" is missing merge policy for child " />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="2YIFZM" id="6MgS2un_o5F" role="1urrMF">
+                          <ref role="1Pybhc" node="1trrptaK_0z" resolve="CheckinRuleUtil" />
+                          <ref role="37wK5l" node="582YV7yWtlM" resolve="warningNode" />
+                          <node concept="1YBJjd" id="6MgS2un_o5G" role="37wK5m">
+                            <ref role="1YBMHb" node="7TOowlgBzBU" resolve="modelMerge" />
+                          </node>
+                          <node concept="37vLTw" id="6MgS2un_o5H" role="37wK5m">
                             <ref role="3cqZAo" node="6MgS2un_o5s" resolve="sac" />
                           </node>
                         </node>
-                        <node concept="Xl_RD" id="6MgS2un_o5E" role="3uHU7w">
-                          <property role="Xl_RC" value=" is missing merge policy for child " />
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="2YIFZM" id="6MgS2un_o5F" role="1urrMF">
-                      <ref role="1Pybhc" node="1trrptaK_0z" resolve="CheckinRuleUtil" />
-                      <ref role="37wK5l" node="582YV7yWtlM" resolve="warningNode" />
-                      <node concept="1YBJjd" id="6MgS2un_o5G" role="37wK5m">
-                        <ref role="1YBMHb" node="7TOowlgBzBU" resolve="modelMerge" />
-                      </node>
-                      <node concept="37vLTw" id="6MgS2un_o5H" role="37wK5m">
-                        <ref role="3cqZAo" node="6MgS2un_o5s" resolve="sac" />
                       </node>
                     </node>
                   </node>
                 </node>
               </node>
-            </node>
-          </node>
-          <node concept="3clFbH" id="1trrptaJ3Pf" role="3cqZAp" />
-          <node concept="3SKdUt" id="60iGZSKkdxR" role="3cqZAp">
-            <node concept="1PaTwC" id="60iGZSKkdxS" role="1aUNEU">
-              <node concept="3oM_SD" id="60iGZSKkdxT" role="1PaTwD">
-                <property role="3oM_SC" value="--Missing" />
-              </node>
-              <node concept="3oM_SD" id="60iGZSKkeH0" role="1PaTwD">
-                <property role="3oM_SC" value="Reference" />
-              </node>
-              <node concept="3oM_SD" id="60iGZSKkeJv" role="1PaTwD">
-                <property role="3oM_SC" value="Policy" />
-              </node>
-            </node>
-          </node>
-          <node concept="3cpWs8" id="3PLTv5jZpdb" role="3cqZAp">
-            <node concept="3cpWsn" id="3PLTv5jZpdc" role="3cpWs9">
-              <property role="TrG5h" value="conceptToRelevantReferences" />
-              <node concept="1ajhzC" id="3PLTv5jZpdd" role="1tU5fm">
-                <node concept="3Tqbb2" id="3PLTv5jZpde" role="1ajw0F">
-                  <ref role="ehGHo" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
-                </node>
-                <node concept="3uibUv" id="3PLTv5jZpdf" role="1ajl9A">
-                  <ref role="3uigEE" to="33ny:~HashSet" resolve="HashSet" />
-                  <node concept="3Tqbb2" id="3PLTv5jZpdg" role="11_B2D">
-                    <ref role="ehGHo" to="tpce:f_TJgxE" resolve="LinkDeclaration" />
+              <node concept="3clFbH" id="1trrptaJ3Pf" role="3cqZAp" />
+              <node concept="3SKdUt" id="60iGZSKkdxR" role="3cqZAp">
+                <node concept="1PaTwC" id="60iGZSKkdxS" role="1aUNEU">
+                  <node concept="3oM_SD" id="60iGZSKkdxT" role="1PaTwD">
+                    <property role="3oM_SC" value="--Missing" />
+                  </node>
+                  <node concept="3oM_SD" id="60iGZSKkeH0" role="1PaTwD">
+                    <property role="3oM_SC" value="Reference" />
+                  </node>
+                  <node concept="3oM_SD" id="60iGZSKkeJv" role="1PaTwD">
+                    <property role="3oM_SC" value="Policy" />
                   </node>
                 </node>
               </node>
-              <node concept="1bVj0M" id="3PLTv5jZpdh" role="33vP2m">
-                <node concept="3clFbS" id="3PLTv5jZpdi" role="1bW5cS">
-                  <node concept="3cpWs8" id="3PLTv5jZpdj" role="3cqZAp">
-                    <node concept="3cpWsn" id="3PLTv5jZpdk" role="3cpWs9">
-                      <property role="TrG5h" value="forbiddenChildren" />
-                      <node concept="3vKaQO" id="3PLTv5jZpdl" role="1tU5fm">
-                        <node concept="3uibUv" id="3PLTv5jZpdm" role="3O5elw">
-                          <ref role="3uigEE" to="c17a:~SContainmentLink" resolve="SContainmentLink" />
-                        </node>
-                      </node>
-                      <node concept="2OqwBi" id="3PLTv5jZpdn" role="33vP2m">
-                        <node concept="35c_gC" id="3PLTv5jZpdo" role="2Oq$k0">
-                          <ref role="35c_gD" to="tpck:gw2VY9q" resolve="BaseConcept" />
-                        </node>
-                        <node concept="liA8E" id="3PLTv5jZpdp" role="2OqNvi">
-                          <ref role="37wK5l" to="c17a:~SAbstractConcept.getContainmentLinks()" resolve="getContainmentLinks" />
-                        </node>
+              <node concept="3cpWs8" id="3PLTv5jZpdb" role="3cqZAp">
+                <node concept="3cpWsn" id="3PLTv5jZpdc" role="3cpWs9">
+                  <property role="TrG5h" value="conceptToRelevantReferences" />
+                  <node concept="1ajhzC" id="3PLTv5jZpdd" role="1tU5fm">
+                    <node concept="3Tqbb2" id="3PLTv5jZpde" role="1ajw0F">
+                      <ref role="ehGHo" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
+                    </node>
+                    <node concept="3uibUv" id="3PLTv5jZpdf" role="1ajl9A">
+                      <ref role="3uigEE" to="33ny:~HashSet" resolve="HashSet" />
+                      <node concept="3Tqbb2" id="3PLTv5jZpdg" role="11_B2D">
+                        <ref role="ehGHo" to="tpce:f_TJgxE" resolve="LinkDeclaration" />
                       </node>
                     </node>
                   </node>
-                  <node concept="3clFbF" id="4ZputZW6pvI" role="3cqZAp">
-                    <node concept="2ShNRf" id="4ZputZW6pvE" role="3clFbG">
-                      <node concept="1pGfFk" id="4ZputZW6rC3" role="2ShVmc">
-                        <ref role="37wK5l" to="33ny:~HashSet.&lt;init&gt;(java.util.Collection)" resolve="HashSet" />
-                        <node concept="2OqwBi" id="4ZputZW6BL4" role="37wK5m">
-                          <node concept="2OqwBi" id="4ZputZW6BL5" role="2Oq$k0">
-                            <node concept="2OqwBi" id="4ZputZW6BL6" role="2Oq$k0">
-                              <node concept="2OqwBi" id="4ZputZW6BL7" role="2Oq$k0">
-                                <node concept="37vLTw" id="4ZputZW6BL8" role="2Oq$k0">
-                                  <ref role="3cqZAo" node="3PLTv5jZpe1" resolve="acd" />
-                                </node>
-                                <node concept="2qgKlT" id="4ZputZW6BL9" role="2OqNvi">
-                                  <ref role="37wK5l" to="tpcn:hEwILKK" resolve="getLinkDeclarations" />
-                                </node>
-                              </node>
-                              <node concept="3zZkjj" id="4ZputZW6BLa" role="2OqNvi">
-                                <node concept="1bVj0M" id="4ZputZW6BLb" role="23t8la">
-                                  <node concept="3clFbS" id="4ZputZW6BLc" role="1bW5cS">
-                                    <node concept="3clFbF" id="4ZputZW6BLd" role="3cqZAp">
-                                      <node concept="2OqwBi" id="4ZputZW6BLe" role="3clFbG">
-                                        <node concept="2OqwBi" id="4ZputZW6BLf" role="2Oq$k0">
-                                          <node concept="37vLTw" id="4ZputZW6BLg" role="2Oq$k0">
-                                            <ref role="3cqZAo" node="7Z$RfkF7IGj" resolve="it" />
-                                          </node>
-                                          <node concept="3TrcHB" id="4ZputZW6BLh" role="2OqNvi">
-                                            <ref role="3TsBF5" to="tpce:3Ftr4R6BH8$" resolve="metaClass" />
-                                          </node>
-                                        </node>
-                                        <node concept="21noJN" id="4ZputZW6BLi" role="2OqNvi">
-                                          <node concept="21nZrQ" id="4ZputZW6BLj" role="21noJM">
-                                            <ref role="21nZrZ" to="tpce:3Ftr4R6BFyn" resolve="reference" />
+                  <node concept="1bVj0M" id="3PLTv5jZpdh" role="33vP2m">
+                    <node concept="3clFbS" id="3PLTv5jZpdi" role="1bW5cS">
+                      <node concept="3cpWs8" id="3PLTv5jZpdj" role="3cqZAp">
+                        <node concept="3cpWsn" id="3PLTv5jZpdk" role="3cpWs9">
+                          <property role="TrG5h" value="forbiddenChildren" />
+                          <node concept="3vKaQO" id="3PLTv5jZpdl" role="1tU5fm">
+                            <node concept="3uibUv" id="3PLTv5jZpdm" role="3O5elw">
+                              <ref role="3uigEE" to="c17a:~SContainmentLink" resolve="SContainmentLink" />
+                            </node>
+                          </node>
+                          <node concept="2OqwBi" id="3PLTv5jZpdn" role="33vP2m">
+                            <node concept="35c_gC" id="3PLTv5jZpdo" role="2Oq$k0">
+                              <ref role="35c_gD" to="tpck:gw2VY9q" resolve="BaseConcept" />
+                            </node>
+                            <node concept="liA8E" id="3PLTv5jZpdp" role="2OqNvi">
+                              <ref role="37wK5l" to="c17a:~SAbstractConcept.getContainmentLinks()" resolve="getContainmentLinks" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="4ZputZW6pvI" role="3cqZAp">
+                        <node concept="2ShNRf" id="4ZputZW6pvE" role="3clFbG">
+                          <node concept="1pGfFk" id="4ZputZW6rC3" role="2ShVmc">
+                            <ref role="37wK5l" to="33ny:~HashSet.&lt;init&gt;(java.util.Collection)" resolve="HashSet" />
+                            <node concept="2OqwBi" id="4ZputZW6BL4" role="37wK5m">
+                              <node concept="2OqwBi" id="4ZputZW6BL5" role="2Oq$k0">
+                                <node concept="2OqwBi" id="4ZputZW6BL6" role="2Oq$k0">
+                                  <node concept="2OqwBi" id="4ZputZW6BL7" role="2Oq$k0">
+                                    <node concept="37vLTw" id="4ZputZW6BL8" role="2Oq$k0">
+                                      <ref role="3cqZAo" node="3PLTv5jZpe1" resolve="acd" />
+                                    </node>
+                                    <node concept="2qgKlT" id="4ZputZW6BL9" role="2OqNvi">
+                                      <ref role="37wK5l" to="tpcn:hEwILKK" resolve="getLinkDeclarations" />
+                                    </node>
+                                  </node>
+                                  <node concept="3zZkjj" id="4ZputZW6BLa" role="2OqNvi">
+                                    <node concept="1bVj0M" id="4ZputZW6BLb" role="23t8la">
+                                      <node concept="3clFbS" id="4ZputZW6BLc" role="1bW5cS">
+                                        <node concept="3clFbF" id="4ZputZW6BLd" role="3cqZAp">
+                                          <node concept="2OqwBi" id="4ZputZW6BLe" role="3clFbG">
+                                            <node concept="2OqwBi" id="4ZputZW6BLf" role="2Oq$k0">
+                                              <node concept="37vLTw" id="4ZputZW6BLg" role="2Oq$k0">
+                                                <ref role="3cqZAo" node="7Z$RfkF7IGj" resolve="it" />
+                                              </node>
+                                              <node concept="3TrcHB" id="4ZputZW6BLh" role="2OqNvi">
+                                                <ref role="3TsBF5" to="tpce:3Ftr4R6BH8$" resolve="metaClass" />
+                                              </node>
+                                            </node>
+                                            <node concept="21noJN" id="4ZputZW6BLi" role="2OqNvi">
+                                              <node concept="21nZrQ" id="4ZputZW6BLj" role="21noJM">
+                                                <ref role="21nZrZ" to="tpce:3Ftr4R6BFyn" resolve="reference" />
+                                              </node>
+                                            </node>
                                           </node>
                                         </node>
                                       </node>
+                                      <node concept="gl6BB" id="7Z$RfkF7IGj" role="1bW2Oz">
+                                        <property role="TrG5h" value="it" />
+                                        <node concept="2jxLKc" id="7Z$RfkF7IGk" role="1tU5fm" />
+                                      </node>
                                     </node>
                                   </node>
-                                  <node concept="gl6BB" id="7Z$RfkF7IGj" role="1bW2Oz">
-                                    <property role="TrG5h" value="it" />
-                                    <node concept="2jxLKc" id="7Z$RfkF7IGk" role="1tU5fm" />
-                                  </node>
                                 </node>
-                              </node>
-                            </node>
-                            <node concept="3zZkjj" id="4ZputZW6BLm" role="2OqNvi">
-                              <node concept="1bVj0M" id="4ZputZW6BLn" role="23t8la">
-                                <node concept="3clFbS" id="4ZputZW6BLo" role="1bW5cS">
-                                  <node concept="3clFbF" id="4ZputZW6BLp" role="3cqZAp">
-                                    <node concept="3fqX7Q" id="4ZputZW6BLq" role="3clFbG">
-                                      <node concept="2OqwBi" id="4ZputZW6BLr" role="3fr31v">
-                                        <node concept="37vLTw" id="4ZputZW6BLs" role="2Oq$k0">
-                                          <ref role="3cqZAo" node="3PLTv5jZpdk" resolve="forbiddenChildren" />
-                                        </node>
-                                        <node concept="2HwmR7" id="4ZputZW6BLt" role="2OqNvi">
-                                          <node concept="1bVj0M" id="4ZputZW6BLu" role="23t8la">
-                                            <node concept="3clFbS" id="4ZputZW6BLv" role="1bW5cS">
-                                              <node concept="3clFbF" id="4ZputZW6BLw" role="3cqZAp">
-                                                <node concept="2OqwBi" id="4ZputZW6BLx" role="3clFbG">
-                                                  <node concept="37vLTw" id="4ZputZW6BLy" role="2Oq$k0">
-                                                    <ref role="3cqZAo" node="7Z$RfkF7IGn" resolve="it" />
-                                                  </node>
-                                                  <node concept="2qgKlT" id="4ZputZW6BLz" role="2OqNvi">
-                                                    <ref role="37wK5l" to="tpcn:4MKjpUYniHA" resolve="is" />
-                                                    <node concept="37vLTw" id="4ZputZW6BL$" role="37wK5m">
-                                                      <ref role="3cqZAo" node="7Z$RfkF7IGl" resolve="child" />
+                                <node concept="3zZkjj" id="4ZputZW6BLm" role="2OqNvi">
+                                  <node concept="1bVj0M" id="4ZputZW6BLn" role="23t8la">
+                                    <node concept="3clFbS" id="4ZputZW6BLo" role="1bW5cS">
+                                      <node concept="3clFbF" id="4ZputZW6BLp" role="3cqZAp">
+                                        <node concept="3fqX7Q" id="4ZputZW6BLq" role="3clFbG">
+                                          <node concept="2OqwBi" id="4ZputZW6BLr" role="3fr31v">
+                                            <node concept="37vLTw" id="4ZputZW6BLs" role="2Oq$k0">
+                                              <ref role="3cqZAo" node="3PLTv5jZpdk" resolve="forbiddenChildren" />
+                                            </node>
+                                            <node concept="2HwmR7" id="4ZputZW6BLt" role="2OqNvi">
+                                              <node concept="1bVj0M" id="4ZputZW6BLu" role="23t8la">
+                                                <node concept="3clFbS" id="4ZputZW6BLv" role="1bW5cS">
+                                                  <node concept="3clFbF" id="4ZputZW6BLw" role="3cqZAp">
+                                                    <node concept="2OqwBi" id="4ZputZW6BLx" role="3clFbG">
+                                                      <node concept="37vLTw" id="4ZputZW6BLy" role="2Oq$k0">
+                                                        <ref role="3cqZAo" node="7Z$RfkF7IGn" resolve="it" />
+                                                      </node>
+                                                      <node concept="2qgKlT" id="4ZputZW6BLz" role="2OqNvi">
+                                                        <ref role="37wK5l" to="tpcn:4MKjpUYniHA" resolve="is" />
+                                                        <node concept="37vLTw" id="4ZputZW6BL$" role="37wK5m">
+                                                          <ref role="3cqZAo" node="7Z$RfkF7IGl" resolve="child" />
+                                                        </node>
+                                                      </node>
                                                     </node>
                                                   </node>
                                                 </node>
+                                                <node concept="gl6BB" id="7Z$RfkF7IGl" role="1bW2Oz">
+                                                  <property role="TrG5h" value="child" />
+                                                  <node concept="2jxLKc" id="7Z$RfkF7IGm" role="1tU5fm" />
+                                                </node>
                                               </node>
-                                            </node>
-                                            <node concept="gl6BB" id="7Z$RfkF7IGl" role="1bW2Oz">
-                                              <property role="TrG5h" value="child" />
-                                              <node concept="2jxLKc" id="7Z$RfkF7IGm" role="1tU5fm" />
                                             </node>
                                           </node>
                                         </node>
                                       </node>
                                     </node>
+                                    <node concept="gl6BB" id="7Z$RfkF7IGn" role="1bW2Oz">
+                                      <property role="TrG5h" value="it" />
+                                      <node concept="2jxLKc" id="7Z$RfkF7IGo" role="1tU5fm" />
+                                    </node>
                                   </node>
                                 </node>
-                                <node concept="gl6BB" id="7Z$RfkF7IGn" role="1bW2Oz">
-                                  <property role="TrG5h" value="it" />
-                                  <node concept="2jxLKc" id="7Z$RfkF7IGo" role="1tU5fm" />
-                                </node>
                               </node>
+                              <node concept="ANE8D" id="4ZputZW6BLD" role="2OqNvi" />
+                            </node>
+                            <node concept="3Tqbb2" id="4ZputZW6yTV" role="1pMfVU">
+                              <ref role="ehGHo" to="tpce:f_TJgxE" resolve="LinkDeclaration" />
                             </node>
                           </node>
-                          <node concept="ANE8D" id="4ZputZW6BLD" role="2OqNvi" />
                         </node>
-                        <node concept="3Tqbb2" id="4ZputZW6yTV" role="1pMfVU">
-                          <ref role="ehGHo" to="tpce:f_TJgxE" resolve="LinkDeclaration" />
-                        </node>
+                      </node>
+                    </node>
+                    <node concept="37vLTG" id="3PLTv5jZpe1" role="1bW2Oz">
+                      <property role="TrG5h" value="acd" />
+                      <node concept="3Tqbb2" id="3PLTv5jZpe2" role="1tU5fm">
+                        <ref role="ehGHo" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
                       </node>
                     </node>
                   </node>
                 </node>
-                <node concept="37vLTG" id="3PLTv5jZpe1" role="1bW2Oz">
-                  <property role="TrG5h" value="acd" />
-                  <node concept="3Tqbb2" id="3PLTv5jZpe2" role="1tU5fm">
-                    <ref role="ehGHo" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
+              </node>
+              <node concept="3clFbH" id="3PLTv5jZnYP" role="3cqZAp" />
+              <node concept="3clFbF" id="3PLTv5jWJhA" role="3cqZAp">
+                <node concept="2YIFZM" id="6MgS2unBUCj" role="3clFbG">
+                  <ref role="37wK5l" node="ZzVzivR$xp" resolve="warn" />
+                  <ref role="1Pybhc" node="1trrptaK_0z" resolve="CheckinRuleUtil" />
+                  <node concept="2OqwBi" id="6MgS2unBUCk" role="37wK5m">
+                    <node concept="1YBJjd" id="6MgS2unBUCl" role="2Oq$k0">
+                      <ref role="1YBMHb" node="7TOowlgBzBU" resolve="modelMerge" />
+                    </node>
+                    <node concept="2qgKlT" id="6MgS2unBUCm" role="2OqNvi">
+                      <ref role="37wK5l" to="rnx3:3xJ_LYXlmVz" resolve="languageConcepts" />
+                    </node>
+                  </node>
+                  <node concept="37vLTw" id="6MgS2unBUCn" role="37wK5m">
+                    <ref role="3cqZAo" node="ZzVzivMLGl" resolve="repository" />
+                  </node>
+                  <node concept="2OqwBi" id="6MgS2unBUCo" role="37wK5m">
+                    <node concept="37vLTw" id="6MgS2unBUCp" role="2Oq$k0">
+                      <ref role="3cqZAo" node="3EHNiwz7rFs" resolve="mergerResolver" />
+                    </node>
+                    <node concept="liA8E" id="6MgS2unBUCq" role="2OqNvi">
+                      <ref role="37wK5l" to="gunp:6MgS2unAqjX" resolve="conceptToReferenceLink" />
+                    </node>
+                  </node>
+                  <node concept="37vLTw" id="6MgS2unBUCr" role="37wK5m">
+                    <ref role="3cqZAo" node="3PLTv5jZpdc" resolve="conceptToRelevantReferences" />
+                  </node>
+                  <node concept="1bVj0M" id="6MgS2unBUCs" role="37wK5m">
+                    <node concept="37vLTG" id="6MgS2unBUCt" role="1bW2Oz">
+                      <property role="TrG5h" value="sac" />
+                      <node concept="3uibUv" id="6MgS2unBUCu" role="1tU5fm">
+                        <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
+                      </node>
+                    </node>
+                    <node concept="37vLTG" id="6MgS2unBUCv" role="1bW2Oz">
+                      <property role="TrG5h" value="ld" />
+                      <node concept="3Tqbb2" id="6MgS2unBUCw" role="1tU5fm">
+                        <ref role="ehGHo" to="tpce:f_TJgxE" resolve="LinkDeclaration" />
+                      </node>
+                    </node>
+                    <node concept="3clFbS" id="6MgS2unBUCx" role="1bW5cS">
+                      <node concept="a7r0C" id="6MgS2unBUCy" role="3cqZAp">
+                        <node concept="3cpWs3" id="6MgS2unBUCz" role="a7wSD">
+                          <node concept="2OqwBi" id="6MgS2unBUC$" role="3uHU7w">
+                            <node concept="37vLTw" id="6MgS2unBUC_" role="2Oq$k0">
+                              <ref role="3cqZAo" node="6MgS2unBUCv" resolve="ld" />
+                            </node>
+                            <node concept="2qgKlT" id="6MgS2unBUCA" role="2OqNvi">
+                              <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                            </node>
+                          </node>
+                          <node concept="3cpWs3" id="6MgS2unBUCB" role="3uHU7B">
+                            <node concept="3cpWs3" id="6MgS2unBUCC" role="3uHU7B">
+                              <node concept="Xl_RD" id="6MgS2unBUCD" role="3uHU7B">
+                                <property role="Xl_RC" value="concept" />
+                              </node>
+                              <node concept="37vLTw" id="6MgS2unBUCE" role="3uHU7w">
+                                <ref role="3cqZAo" node="6MgS2unBUCt" resolve="sac" />
+                              </node>
+                            </node>
+                            <node concept="Xl_RD" id="6MgS2unBUCF" role="3uHU7w">
+                              <property role="Xl_RC" value=" is missing merge policy for reference " />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="2YIFZM" id="6MgS2unBUCG" role="1urrMF">
+                          <ref role="37wK5l" node="582YV7yWtlM" resolve="warningNode" />
+                          <ref role="1Pybhc" node="1trrptaK_0z" resolve="CheckinRuleUtil" />
+                          <node concept="1YBJjd" id="6MgS2unBUCH" role="37wK5m">
+                            <ref role="1YBMHb" node="7TOowlgBzBU" resolve="modelMerge" />
+                          </node>
+                          <node concept="37vLTw" id="6MgS2unBUCI" role="37wK5m">
+                            <ref role="3cqZAo" node="6MgS2unBUCt" resolve="sac" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
                   </node>
                 </node>
               </node>
             </node>
-          </node>
-          <node concept="3clFbH" id="3PLTv5jZnYP" role="3cqZAp" />
-          <node concept="3clFbF" id="3PLTv5jWJhA" role="3cqZAp">
-            <node concept="2YIFZM" id="6MgS2unBUCj" role="3clFbG">
-              <ref role="37wK5l" node="ZzVzivR$xp" resolve="warn" />
-              <ref role="1Pybhc" node="1trrptaK_0z" resolve="CheckinRuleUtil" />
-              <node concept="2OqwBi" id="6MgS2unBUCk" role="37wK5m">
-                <node concept="1YBJjd" id="6MgS2unBUCl" role="2Oq$k0">
+            <node concept="3fqX7Q" id="5HyGTP18ewM" role="3clFbw">
+              <node concept="2OqwBi" id="5HyGTP18flK" role="3fr31v">
+                <node concept="1YBJjd" id="5HyGTP18eRe" role="2Oq$k0">
                   <ref role="1YBMHb" node="7TOowlgBzBU" resolve="modelMerge" />
                 </node>
-                <node concept="2qgKlT" id="6MgS2unBUCm" role="2OqNvi">
-                  <ref role="37wK5l" to="rnx3:3xJ_LYXlmVz" resolve="languageConcepts" />
-                </node>
-              </node>
-              <node concept="37vLTw" id="6MgS2unBUCn" role="37wK5m">
-                <ref role="3cqZAo" node="ZzVzivMLGl" resolve="repository" />
-              </node>
-              <node concept="2OqwBi" id="6MgS2unBUCo" role="37wK5m">
-                <node concept="37vLTw" id="6MgS2unBUCp" role="2Oq$k0">
-                  <ref role="3cqZAo" node="3EHNiwz7rFs" resolve="mergerResolver" />
-                </node>
-                <node concept="liA8E" id="6MgS2unBUCq" role="2OqNvi">
-                  <ref role="37wK5l" to="gunp:6MgS2unAqjX" resolve="conceptToReferenceLink" />
-                </node>
-              </node>
-              <node concept="37vLTw" id="6MgS2unBUCr" role="37wK5m">
-                <ref role="3cqZAo" node="3PLTv5jZpdc" resolve="conceptToRelevantReferences" />
-              </node>
-              <node concept="1bVj0M" id="6MgS2unBUCs" role="37wK5m">
-                <node concept="37vLTG" id="6MgS2unBUCt" role="1bW2Oz">
-                  <property role="TrG5h" value="sac" />
-                  <node concept="3uibUv" id="6MgS2unBUCu" role="1tU5fm">
-                    <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
-                  </node>
-                </node>
-                <node concept="37vLTG" id="6MgS2unBUCv" role="1bW2Oz">
-                  <property role="TrG5h" value="ld" />
-                  <node concept="3Tqbb2" id="6MgS2unBUCw" role="1tU5fm">
-                    <ref role="ehGHo" to="tpce:f_TJgxE" resolve="LinkDeclaration" />
-                  </node>
-                </node>
-                <node concept="3clFbS" id="6MgS2unBUCx" role="1bW5cS">
-                  <node concept="a7r0C" id="6MgS2unBUCy" role="3cqZAp">
-                    <node concept="3cpWs3" id="6MgS2unBUCz" role="a7wSD">
-                      <node concept="2OqwBi" id="6MgS2unBUC$" role="3uHU7w">
-                        <node concept="37vLTw" id="6MgS2unBUC_" role="2Oq$k0">
-                          <ref role="3cqZAo" node="6MgS2unBUCv" resolve="ld" />
-                        </node>
-                        <node concept="2qgKlT" id="6MgS2unBUCA" role="2OqNvi">
-                          <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
-                        </node>
-                      </node>
-                      <node concept="3cpWs3" id="6MgS2unBUCB" role="3uHU7B">
-                        <node concept="3cpWs3" id="6MgS2unBUCC" role="3uHU7B">
-                          <node concept="Xl_RD" id="6MgS2unBUCD" role="3uHU7B">
-                            <property role="Xl_RC" value="concept" />
-                          </node>
-                          <node concept="37vLTw" id="6MgS2unBUCE" role="3uHU7w">
-                            <ref role="3cqZAo" node="6MgS2unBUCt" resolve="sac" />
-                          </node>
-                        </node>
-                        <node concept="Xl_RD" id="6MgS2unBUCF" role="3uHU7w">
-                          <property role="Xl_RC" value=" is missing merge policy for reference " />
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="2YIFZM" id="6MgS2unBUCG" role="1urrMF">
-                      <ref role="37wK5l" node="582YV7yWtlM" resolve="warningNode" />
-                      <ref role="1Pybhc" node="1trrptaK_0z" resolve="CheckinRuleUtil" />
-                      <node concept="1YBJjd" id="6MgS2unBUCH" role="37wK5m">
-                        <ref role="1YBMHb" node="7TOowlgBzBU" resolve="modelMerge" />
-                      </node>
-                      <node concept="37vLTw" id="6MgS2unBUCI" role="37wK5m">
-                        <ref role="3cqZAo" node="6MgS2unBUCt" resolve="sac" />
-                      </node>
-                    </node>
-                  </node>
+                <node concept="3TrcHB" id="5HyGTP18i3D" role="2OqNvi">
+                  <ref role="3TsBF5" to="mopj:5HbTgGuQTJM" resolve="partialPolicy" />
                 </node>
               </node>
             </node>
           </node>
           <node concept="3clFbH" id="3PLTv5jWI4$" role="3cqZAp" />
-          <node concept="3clFbH" id="60iGZSKpnRn" role="3cqZAp" />
-          <node concept="3clFbH" id="60iGZSKpnWL" role="3cqZAp" />
           <node concept="3SKdUt" id="60iGZSKpphR" role="3cqZAp">
             <node concept="1PaTwC" id="60iGZSKpphS" role="1aUNEU">
               <node concept="3oM_SD" id="60iGZSKpphT" role="1PaTwD">
@@ -2111,7 +2122,7 @@
             <property role="TrG5h" value="e" />
             <node concept="nSUau" id="7TOowlgVHwY" role="1tU5fm">
               <node concept="3uibUv" id="7TOowlgVHDe" role="nSUat">
-                <ref role="3uigEE" to="gunp:7TOowlgU0QJ" resolve="MergePolicyConflict" />
+                <ref role="3uigEE" to="gunp:7TOowlgU0QJ" resolve="MergingPolicyConflict" />
               </node>
             </node>
           </node>
@@ -2342,7 +2353,7 @@
     </node>
     <node concept="1YaCAy" id="7TOowlgBzBU" role="1YuTPh">
       <property role="TrG5h" value="modelMerge" />
-      <ref role="1YaFvo" to="mopj:1EbzjT2RcU7" resolve="ModelMerge" />
+      <ref role="1YaFvo" to="mopj:1EbzjT2RcU7" resolve="ModelMergingPolicy" />
     </node>
   </node>
   <node concept="312cEu" id="1trrptaK_0z">
@@ -2356,7 +2367,7 @@
           <node concept="3clFbS" id="6CwG2k7RWQH" role="1zxBo7">
             <node concept="3clFbF" id="6CwG2k7SgN_" role="3cqZAp">
               <node concept="2YIFZM" id="6CwG2k7SkfI" role="3clFbG">
-                <ref role="1Pybhc" to="gunp:18W7Z4VeRuj" resolve="MergeResolverFromModelMerge" />
+                <ref role="1Pybhc" to="gunp:18W7Z4VeRuj" resolve="PolicyMergerResolver" />
                 <ref role="37wK5l" to="gunp:7wnapcW0cfS" resolve="run" />
                 <node concept="37vLTw" id="6CwG2k7SkfJ" role="37wK5m">
                   <ref role="3cqZAo" node="1trrptaRHnA" resolve="modelMerge" />
@@ -2409,7 +2420,7 @@
       <node concept="37vLTG" id="1trrptaRHnA" role="3clF46">
         <property role="TrG5h" value="modelMerge" />
         <node concept="3Tqbb2" id="1trrptaRHnB" role="1tU5fm">
-          <ref role="ehGHo" to="mopj:1EbzjT2RcU7" resolve="ModelMerge" />
+          <ref role="ehGHo" to="mopj:1EbzjT2RcU7" resolve="ModelMergingPolicy" />
         </node>
       </node>
       <node concept="3Tm1VV" id="1trrptaRHoz" role="1B3o_S" />
@@ -2723,7 +2734,7 @@
           <node concept="3cpWsn" id="582YV7yWtm8" role="3cpWs9">
             <property role="TrG5h" value="warningNode" />
             <node concept="3Tqbb2" id="582YV7yWtm9" role="1tU5fm">
-              <ref role="ehGHo" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
+              <ref role="ehGHo" to="mopj:1EbzjT2R$JP" resolve="ConceptMergingPolicy" />
             </node>
             <node concept="2OqwBi" id="582YV7yWtma" role="33vP2m">
               <node concept="2OqwBi" id="582YV7yWtmb" role="2Oq$k0">
@@ -2732,12 +2743,12 @@
                     <ref role="3cqZAo" node="582YV7yWtm_" resolve="modelMerge" />
                   </node>
                   <node concept="3Tsc0h" id="582YV7yWtme" role="2OqNvi">
-                    <ref role="3TtcxE" to="mopj:1EbzjT2R$JQ" resolve="items" />
+                    <ref role="3TtcxE" to="mopj:1EbzjT2R$JQ" resolve="policies" />
                   </node>
                 </node>
                 <node concept="v3k3i" id="582YV7yWtmf" role="2OqNvi">
                   <node concept="chp4Y" id="582YV7yWtmg" role="v3oSu">
-                    <ref role="cht4Q" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
+                    <ref role="cht4Q" to="mopj:1EbzjT2R$JP" resolve="ConceptMergingPolicy" />
                   </node>
                 </node>
               </node>
@@ -2793,7 +2804,7 @@
       <node concept="37vLTG" id="582YV7yWtm_" role="3clF46">
         <property role="TrG5h" value="modelMerge" />
         <node concept="3Tqbb2" id="582YV7yWtmA" role="1tU5fm">
-          <ref role="ehGHo" to="mopj:1EbzjT2RcU7" resolve="ModelMerge" />
+          <ref role="ehGHo" to="mopj:1EbzjT2RcU7" resolve="ModelMergingPolicy" />
         </node>
       </node>
       <node concept="37vLTG" id="582YV7yWtmB" role="3clF46">
@@ -3175,7 +3186,7 @@
     <node concept="Q6JDH" id="6CwG2k7XCNT" role="Q6Id_">
       <property role="TrG5h" value="modelmerge" />
       <node concept="3Tqbb2" id="6CwG2k7XCO1" role="Q6QK4">
-        <ref role="ehGHo" to="mopj:1EbzjT2RcU7" resolve="ModelMerge" />
+        <ref role="ehGHo" to="mopj:1EbzjT2RcU7" resolve="ModelMergingPolicy" />
       </node>
     </node>
     <node concept="Q5ZZ6" id="6CwG2k7XBSQ" role="Q6x$H">
@@ -3218,12 +3229,12 @@
                         <ref role="QwW4h" node="6CwG2k7XCNT" resolve="modelmerge" />
                       </node>
                       <node concept="3Tsc0h" id="4ZputZW4pDf" role="2OqNvi">
-                        <ref role="3TtcxE" to="mopj:1EbzjT2R$JQ" resolve="items" />
+                        <ref role="3TtcxE" to="mopj:1EbzjT2R$JQ" resolve="policies" />
                       </node>
                     </node>
                     <node concept="v3k3i" id="4ZputZW4pDg" role="2OqNvi">
                       <node concept="chp4Y" id="4ZputZW4pDh" role="v3oSu">
-                        <ref role="cht4Q" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
+                        <ref role="cht4Q" to="mopj:1EbzjT2R$JP" resolve="ConceptMergingPolicy" />
                       </node>
                     </node>
                   </node>
@@ -3265,13 +3276,13 @@
                     <ref role="QwW4h" node="6CwG2k7XCNT" resolve="modelmerge" />
                   </node>
                   <node concept="3Tsc0h" id="1trrptaOm_w" role="2OqNvi">
-                    <ref role="3TtcxE" to="mopj:1EbzjT2R$JQ" resolve="items" />
+                    <ref role="3TtcxE" to="mopj:1EbzjT2R$JQ" resolve="policies" />
                   </node>
                 </node>
                 <node concept="TSZUe" id="1trrptaOpbZ" role="2OqNvi">
                   <node concept="2pJPEk" id="1trrptaOpmV" role="25WWJ7">
                     <node concept="2pJPED" id="1trrptaOp_z" role="2pJPEn">
-                      <ref role="2pJxaS" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
+                      <ref role="2pJxaS" to="mopj:1EbzjT2R$JP" resolve="ConceptMergingPolicy" />
                       <node concept="2pIpSj" id="6HsBp$TfUMl" role="2pJxcM">
                         <ref role="2pIpSl" to="mopj:6celbXx2c94" resolve="idFunction" />
                         <node concept="36biLy" id="6HsBp$TfUWt" role="28nt2d">
@@ -3319,7 +3330,7 @@
     </node>
   </node>
   <node concept="Q5z_Y" id="2xeWAXXL1C3">
-    <property role="3GE5qa" value="elementpolicies" />
+    <property role="3GE5qa" value="declarationPolicies" />
     <property role="TrG5h" value="fixMIssingSubPolicy" />
     <node concept="Q6JDH" id="2xeWAXXL1I6" role="Q6Id_">
       <property role="TrG5h" value="mcp" />
@@ -3476,14 +3487,14 @@
           <node concept="3cpWsn" id="2xeWAXXQz1f" role="3cpWs9">
             <property role="TrG5h" value="modelMerge" />
             <node concept="3Tqbb2" id="2xeWAXXQz0W" role="1tU5fm">
-              <ref role="ehGHo" to="mopj:1EbzjT2RcU7" resolve="ModelMerge" />
+              <ref role="ehGHo" to="mopj:1EbzjT2RcU7" resolve="ModelMergingPolicy" />
             </node>
             <node concept="2OqwBi" id="2xeWAXXQz1g" role="33vP2m">
               <node concept="Q6c8r" id="2xeWAXXQz1h" role="2Oq$k0" />
               <node concept="2Xjw5R" id="2xeWAXXQz1i" role="2OqNvi">
                 <node concept="1xMEDy" id="2xeWAXXQz1j" role="1xVPHs">
                   <node concept="chp4Y" id="2xeWAXXQz1k" role="ri$Ld">
-                    <ref role="cht4Q" to="mopj:1EbzjT2RcU7" resolve="ModelMerge" />
+                    <ref role="cht4Q" to="mopj:1EbzjT2RcU7" resolve="ModelMergingPolicy" />
                   </node>
                 </node>
               </node>
@@ -3494,7 +3505,7 @@
           <node concept="3cpWsn" id="2xeWAXXQEDJ" role="3cpWs9">
             <property role="TrG5h" value="mp" />
             <node concept="3Tqbb2" id="2xeWAXXQEAL" role="1tU5fm">
-              <ref role="ehGHo" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
+              <ref role="ehGHo" to="mopj:1EbzjT2R$JP" resolve="ConceptMergingPolicy" />
             </node>
             <node concept="2OqwBi" id="2xeWAXXQEDK" role="33vP2m">
               <node concept="2OqwBi" id="2xeWAXXQEDL" role="2Oq$k0">
@@ -3504,7 +3515,7 @@
                 <node concept="2Rf3mk" id="2xeWAXXQEDN" role="2OqNvi">
                   <node concept="1xMEDy" id="2xeWAXXQEDO" role="1xVPHs">
                     <node concept="chp4Y" id="2xeWAXXQEDP" role="ri$Ld">
-                      <ref role="cht4Q" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
+                      <ref role="cht4Q" to="mopj:1EbzjT2R$JP" resolve="ConceptMergingPolicy" />
                     </node>
                   </node>
                 </node>
@@ -3543,7 +3554,7 @@
               <node concept="37vLTI" id="2xeWAXXRTxa" role="3clFbG">
                 <node concept="2pJPEk" id="2xeWAXXRT_X" role="37vLTx">
                   <node concept="2pJPED" id="2xeWAXXRT_Y" role="2pJPEn">
-                    <ref role="2pJxaS" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
+                    <ref role="2pJxaS" to="mopj:1EbzjT2R$JP" resolve="ConceptMergingPolicy" />
                     <node concept="2pIpSj" id="2xeWAXXRT_Z" role="2pJxcM">
                       <ref role="2pIpSl" to="mopj:3BP4DuXu_FH" resolve="conceptRef" />
                       <node concept="36biLy" id="2xeWAXXRTA0" role="28nt2d">
@@ -3566,7 +3577,7 @@
                     <ref role="3cqZAo" node="2xeWAXXQz1f" resolve="modelMerge" />
                   </node>
                   <node concept="3Tsc0h" id="2xeWAXXRU7L" role="2OqNvi">
-                    <ref role="3TtcxE" to="mopj:1EbzjT2R$JQ" resolve="items" />
+                    <ref role="3TtcxE" to="mopj:1EbzjT2R$JQ" resolve="policies" />
                   </node>
                 </node>
                 <node concept="TSZUe" id="2xeWAXXRWWW" role="2OqNvi">

--- a/code/languages/de.itemis.model.simple.demo.enums/de.itemis.model.simple.demo.enums.mpl
+++ b/code/languages/de.itemis.model.simple.demo.enums/de.itemis.model.simple.demo.enums.mpl
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<language namespace="de.itemis.model.simple.demo.enums" uuid="bf491fd2-a197-456a-8354-b3b225d4e871" languageVersion="0" moduleVersion="0">
+  <models>
+    <modelRoot type="default" contentPath="${module}">
+      <sourceRoot location="models" />
+    </modelRoot>
+  </models>
+  <facets>
+    <facet compile="mps" classes="mps" ext="yes" type="java">
+      <classes generated="true" path="${module}/classes_gen" />
+    </facet>
+  </facets>
+  <accessoryModels />
+  <generators>
+    <generator alias="main" namespace="de.itemis.model.simple.demo.enums.generator" uuid="7306450b-0779-41f2-97a4-8a2ed3686b8d">
+      <models>
+        <modelRoot type="default" contentPath="${module}/generator">
+          <sourceRoot location="templates" />
+        </modelRoot>
+      </models>
+      <facets>
+        <facet compile="mps" classes="mps" ext="no" type="java">
+          <classes generated="true" path="${module}/generator/classes_gen" />
+        </facet>
+      </facets>
+      <external-templates />
+      <languageVersions>
+        <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
+        <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
+        <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="2" />
+        <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
+        <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
+        <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
+        <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
+        <language slang="l:b401a680-8325-4110-8fd3-84331ff25bef:jetbrains.mps.lang.generator" version="4" />
+        <language slang="l:d7706f63-9be2-479c-a3da-ae92af1e64d5:jetbrains.mps.lang.generator.generationContext" version="2" />
+        <language slang="l:289fcc83-6543-41e8-a5ca-768235715ce4:jetbrains.mps.lang.generator.generationParameters" version="0" />
+        <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
+        <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
+        <language slang="l:13744753-c81f-424a-9c1b-cf8943bf4e86:jetbrains.mps.lang.sharedConcepts" version="0" />
+        <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
+        <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
+        <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
+      </languageVersions>
+      <dependencyVersions>
+        <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
+        <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
+        <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
+        <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+        <module reference="bf491fd2-a197-456a-8354-b3b225d4e871(de.itemis.model.simple.demo.enums)" version="0" />
+        <module reference="7306450b-0779-41f2-97a4-8a2ed3686b8d(de.itemis.model.simple.demo.enums.generator)" version="0" />
+        <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
+      </dependencyVersions>
+      <mapping-priorities />
+    </generator>
+  </generators>
+  <dependencies>
+    <dependency reexport="false">e50b0500-6fd7-4c7f-a730-9d841358ca2b(de.itemis.model.simple.demo.property)</dependency>
+  </dependencies>
+  <languageVersions>
+    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
+    <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />
+    <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
+    <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="2" />
+    <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
+    <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
+    <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
+    <language slang="l:aee9cad2-acd4-4608-aef2-0004f6a1cdbd:jetbrains.mps.lang.actions" version="4" />
+    <language slang="l:af65afd8-f0dd-4942-87d9-63a55f2a9db1:jetbrains.mps.lang.behavior" version="2" />
+    <language slang="l:3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1:jetbrains.mps.lang.constraints" version="6" />
+    <language slang="l:e51810c5-7308-4642-bcb6-469e61b5dd18:jetbrains.mps.lang.constraints.msg.specification" version="0" />
+    <language slang="l:47257bf3-78d3-470b-89d9-8c3261a61d15:jetbrains.mps.lang.constraints.rules" version="0" />
+    <language slang="l:5dae8159-ab99-46bb-a40d-0cee30ee7018:jetbrains.mps.lang.constraints.rules.kinds" version="0" />
+    <language slang="l:134c38d4-e3af-4d9e-b069-1c7df0a4005d:jetbrains.mps.lang.constraints.rules.skeleton" version="0" />
+    <language slang="l:3ad5badc-1d9c-461c-b7b1-fa2fcd0a0ae7:jetbrains.mps.lang.context" version="0" />
+    <language slang="l:ea3159bf-f48e-4720-bde2-86dba75f0d34:jetbrains.mps.lang.context.defs" version="0" />
+    <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
+    <language slang="l:f4ad079d-bc71-4ffb-9600-9328705cf998:jetbrains.mps.lang.descriptor" version="0" />
+    <language slang="l:18bc6592-03a6-4e29-a83a-7ff23bde13ba:jetbrains.mps.lang.editor" version="14" />
+    <language slang="l:ad93155d-79b2-4759-b10c-55123e763903:jetbrains.mps.lang.messages" version="0" />
+    <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
+    <language slang="l:d4615e3b-d671-4ba9-af01-2b78369b0ba7:jetbrains.mps.lang.pattern" version="2" />
+    <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
+    <language slang="l:982eb8df-2c96-4bd7-9963-11712ea622e5:jetbrains.mps.lang.resources" version="2" />
+    <language slang="l:b3551702-269c-4f05-ba61-58060cef4292:jetbrains.mps.lang.rulesAndMessages" version="0" />
+    <language slang="l:d8f591ec-4d86-4af2-9f92-a9e93c803ffa:jetbrains.mps.lang.scopes" version="0" />
+    <language slang="l:13744753-c81f-424a-9c1b-cf8943bf4e86:jetbrains.mps.lang.sharedConcepts" version="0" />
+    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
+    <language slang="l:c72da2b9-7cce-4447-8389-f407dc1158b7:jetbrains.mps.lang.structure" version="9" />
+    <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
+    <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
+    <language slang="l:7a5dda62-9140-4668-ab76-d5ed1746f2b2:jetbrains.mps.lang.typesystem" version="5" />
+  </languageVersions>
+  <dependencyVersions>
+    <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
+    <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
+    <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
+    <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+    <module reference="bf491fd2-a197-456a-8354-b3b225d4e871(de.itemis.model.simple.demo.enums)" version="0" />
+    <module reference="e50b0500-6fd7-4c7f-a730-9d841358ca2b(de.itemis.model.simple.demo.property)" version="0" />
+    <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
+    <module reference="a9e4c532-c5f5-4bb7-99ef-42abb73bbb70(jetbrains.mps.lang.descriptor.aspects)" version="0" />
+  </dependencyVersions>
+  <extendedLanguages />
+</language>
+

--- a/code/languages/de.itemis.model.simple.demo.enums/generator/templates/de.itemis.model.simple.demo.enums.generator.templates@generator.mps
+++ b/code/languages/de.itemis.model.simple.demo.enums/generator/templates/de.itemis.model.simple.demo.enums.generator.templates@generator.mps
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:9640dad7-13c6-4c8c-8d08-7f88a65d650b(de.itemis.model.simple.demo.enums.generator.templates@generator)">
+  <persistence version="9" />
+  <languages>
+    <devkit ref="a2eb3a43-fcc2-4200-80dc-c60110c4862d(jetbrains.mps.devkit.templates)" />
+  </languages>
+  <imports>
+    <import index="7y8w" ref="r:5e14b5a3-3989-4ab3-a15a-50ea008667da(de.itemis.model.simple.demo.enums.structure)" />
+  </imports>
+  <registry>
+    <language id="b401a680-8325-4110-8fd3-84331ff25bef" name="jetbrains.mps.lang.generator">
+      <concept id="1095416546421" name="jetbrains.mps.lang.generator.structure.MappingConfiguration" flags="ig" index="bUwia" />
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="bUwia" id="38FdiWsmfmN">
+    <property role="TrG5h" value="main" />
+  </node>
+</model>
+

--- a/code/languages/de.itemis.model.simple.demo.enums/models/de.itemis.model.simple.demo.enums.behavior.mps
+++ b/code/languages/de.itemis.model.simple.demo.enums/models/de.itemis.model.simple.demo.enums.behavior.mps
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:78b66a3f-0bcf-46f6-a8f9-f79d6fdf70ed(de.itemis.model.simple.demo.enums.behavior)">
+  <persistence version="9" />
+  <languages>
+    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
+    <use id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior" version="2" />
+    <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
+  </languages>
+  <imports />
+  <registry />
+</model>
+

--- a/code/languages/de.itemis.model.simple.demo.enums/models/de.itemis.model.simple.demo.enums.constraints.mps
+++ b/code/languages/de.itemis.model.simple.demo.enums/models/de.itemis.model.simple.demo.enums.constraints.mps
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:22883d81-de71-42d8-abe7-b2dd1660b600(de.itemis.model.simple.demo.enums.constraints)">
+  <persistence version="9" />
+  <languages>
+    <use id="5dae8159-ab99-46bb-a40d-0cee30ee7018" name="jetbrains.mps.lang.constraints.rules.kinds" version="0" />
+    <use id="ea3159bf-f48e-4720-bde2-86dba75f0d34" name="jetbrains.mps.lang.context.defs" version="0" />
+    <use id="e51810c5-7308-4642-bcb6-469e61b5dd18" name="jetbrains.mps.lang.constraints.msg.specification" version="0" />
+    <use id="134c38d4-e3af-4d9e-b069-1c7df0a4005d" name="jetbrains.mps.lang.constraints.rules.skeleton" version="0" />
+    <use id="b3551702-269c-4f05-ba61-58060cef4292" name="jetbrains.mps.lang.rulesAndMessages" version="0" />
+    <use id="3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1" name="jetbrains.mps.lang.constraints" version="6" />
+    <use id="13744753-c81f-424a-9c1b-cf8943bf4e86" name="jetbrains.mps.lang.sharedConcepts" version="0" />
+    <use id="3ad5badc-1d9c-461c-b7b1-fa2fcd0a0ae7" name="jetbrains.mps.lang.context" version="0" />
+    <use id="ad93155d-79b2-4759-b10c-55123e763903" name="jetbrains.mps.lang.messages" version="0" />
+    <devkit ref="00000000-0000-4000-0000-5604ebd4f22c(jetbrains.mps.devkit.aspect.constraints)" />
+  </languages>
+  <imports />
+  <registry />
+</model>
+

--- a/code/languages/de.itemis.model.simple.demo.enums/models/de.itemis.model.simple.demo.enums.editor.mps
+++ b/code/languages/de.itemis.model.simple.demo.enums/models/de.itemis.model.simple.demo.enums.editor.mps
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:69589d50-d03c-4a42-b47d-b8b9e68884ba(de.itemis.model.simple.demo.enums.editor)">
+  <persistence version="9" />
+  <languages>
+    <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="14" />
+    <use id="aee9cad2-acd4-4608-aef2-0004f6a1cdbd" name="jetbrains.mps.lang.actions" version="4" />
+    <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
+  </languages>
+  <imports />
+  <registry />
+</model>
+

--- a/code/languages/de.itemis.model.simple.demo.enums/models/de.itemis.model.simple.demo.enums.structure.mps
+++ b/code/languages/de.itemis.model.simple.demo.enums/models/de.itemis.model.simple.demo.enums.structure.mps
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:5e14b5a3-3989-4ab3-a15a-50ea008667da(de.itemis.model.simple.demo.enums.structure)">
+  <persistence version="9" />
+  <languages>
+    <devkit ref="78434eb8-b0e5-444b-850d-e7c4ad2da9ab(jetbrains.mps.devkit.aspect.structure)" />
+  </languages>
+  <imports>
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
+    <import index="yeyq" ref="r:98a265f1-4186-4e32-a289-328d37e5000c(de.itemis.model.simple.demo.property.structure)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="c72da2b9-7cce-4447-8389-f407dc1158b7" name="jetbrains.mps.lang.structure">
+      <concept id="3348158742936976480" name="jetbrains.mps.lang.structure.structure.EnumerationMemberDeclaration" flags="ng" index="25R33">
+        <property id="1421157252384165432" name="memberId" index="3tVfz5" />
+      </concept>
+      <concept id="3348158742936976479" name="jetbrains.mps.lang.structure.structure.EnumerationDeclaration" flags="ng" index="25R3W">
+        <reference id="1075010451642646892" name="defaultMember" index="1H5jkz" />
+        <child id="3348158742936976577" name="members" index="25R1y" />
+      </concept>
+      <concept id="1082978164218" name="jetbrains.mps.lang.structure.structure.DataTypeDeclaration" flags="ng" index="AxPO6">
+        <property id="7791109065626895363" name="datatypeId" index="3F6X1D" />
+      </concept>
+      <concept id="1169125787135" name="jetbrains.mps.lang.structure.structure.AbstractConceptDeclaration" flags="ig" index="PkWjJ">
+        <property id="6714410169261853888" name="conceptId" index="EcuMT" />
+        <child id="1071489727083" name="linkDeclaration" index="1TKVEi" />
+        <child id="1071489727084" name="propertyDeclaration" index="1TKVEl" />
+      </concept>
+      <concept id="1071489090640" name="jetbrains.mps.lang.structure.structure.ConceptDeclaration" flags="ig" index="1TIwiD">
+        <property id="1096454100552" name="rootable" index="19KtqR" />
+        <reference id="1071489389519" name="extends" index="1TJDcQ" />
+      </concept>
+      <concept id="1071489288299" name="jetbrains.mps.lang.structure.structure.PropertyDeclaration" flags="ig" index="1TJgyi">
+        <property id="241647608299431129" name="propertyId" index="IQ2nx" />
+        <reference id="1082985295845" name="dataType" index="AX2Wp" />
+      </concept>
+      <concept id="1071489288298" name="jetbrains.mps.lang.structure.structure.LinkDeclaration" flags="ig" index="1TJgyj">
+        <property id="1071599776563" name="role" index="20kJfa" />
+        <property id="1071599937831" name="metaClass" index="20lmBu" />
+        <property id="241647608299431140" name="linkId" index="IQ2ns" />
+        <reference id="1071599976176" name="target" index="20lvS9" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="25R3W" id="38FdiWsmfOB">
+    <property role="3F6X1D" value="3615041602350284071" />
+    <property role="TrG5h" value="SomeEnumeration" />
+    <ref role="1H5jkz" node="38FdiWsmfOC" resolve="default" />
+    <node concept="25R33" id="38FdiWsmfOC" role="25R1y">
+      <property role="3tVfz5" value="3615041602350284072" />
+      <property role="TrG5h" value="default" />
+    </node>
+    <node concept="25R33" id="38FdiWsmggi" role="25R1y">
+      <property role="3tVfz5" value="3615041602350285842" />
+      <property role="TrG5h" value="firstMember" />
+    </node>
+    <node concept="25R33" id="38FdiWsmgq3" role="25R1y">
+      <property role="3tVfz5" value="3615041602350286467" />
+      <property role="TrG5h" value="secondMember" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="38FdiWsmguW">
+    <property role="EcuMT" value="3615041602350286780" />
+    <property role="TrG5h" value="ConceptWithEnum" />
+    <property role="19KtqR" value="true" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" />
+    <node concept="1TJgyi" id="38FdiWsmgEl" role="1TKVEl">
+      <property role="IQ2nx" value="3615041602350287509" />
+      <property role="TrG5h" value="data" />
+      <ref role="AX2Wp" node="38FdiWsmfOB" resolve="SomeEnumeration" />
+    </node>
+    <node concept="1TJgyj" id="38FdiWsmi$e" role="1TKVEi">
+      <property role="IQ2ns" value="3615041602350295310" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="idProperty" />
+      <ref role="20lvS9" to="yeyq:32ggi2DCpGw" resolve="PropertyDummy" />
+    </node>
+  </node>
+</model>
+

--- a/code/languages/de.itemis.model.simple.demo.enums/models/de.itemis.model.simple.demo.enums.structure.mps
+++ b/code/languages/de.itemis.model.simple.demo.enums/models/de.itemis.model.simple.demo.enums.structure.mps
@@ -67,7 +67,7 @@
     <property role="EcuMT" value="3615041602350286780" />
     <property role="TrG5h" value="ConceptWithEnum" />
     <property role="19KtqR" value="true" />
-    <ref role="1TJDcQ" to="tpck:gw2VY9q" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
     <node concept="1TJgyi" id="38FdiWsmgEl" role="1TKVEl">
       <property role="IQ2nx" value="3615041602350287509" />
       <property role="TrG5h" value="data" />

--- a/code/languages/de.itemis.model.simple.demo.enums/models/de.itemis.model.simple.demo.enums.typesystem.mps
+++ b/code/languages/de.itemis.model.simple.demo.enums/models/de.itemis.model.simple.demo.enums.typesystem.mps
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:cad49041-3650-4fc3-88ef-4f58681dbbbb(de.itemis.model.simple.demo.enums.typesystem)">
+  <persistence version="9" />
+  <languages>
+    <use id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem" version="5" />
+    <devkit ref="00000000-0000-4000-0000-1de82b3a4936(jetbrains.mps.devkit.aspect.typesystem)" />
+  </languages>
+  <imports />
+  <registry />
+</model>
+

--- a/code/solutions/de.itemis.model.merge.runtime/de.itemis.model.merge.runtime.msd
+++ b/code/solutions/de.itemis.model.merge.runtime/de.itemis.model.merge.runtime.msd
@@ -28,8 +28,6 @@
     <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
     <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="2" />
     <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
-    <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
-    <language slang="l:515552c7-fcc0-4ab4-9789-2f3c49344e85:jetbrains.mps.baseLanguage.varVariable" version="0" />
     <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
     <language slang="l:c0080a47-7e37-4558-bee9-9ae18e690549:jetbrains.mps.lang.extension" version="2" />
     <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />

--- a/code/solutions/de.itemis.model.merge.runtime/models/de.itemis.model.merge.runtime.runtime.mps
+++ b/code/solutions/de.itemis.model.merge.runtime/models/de.itemis.model.merge.runtime.runtime.mps
@@ -3844,7 +3844,7 @@
                         <node concept="1eOMI4" id="6MgS2unbc1L" role="3uHU7w">
                           <node concept="2OqwBi" id="6MgS2unbc1M" role="1eOMHV">
                             <node concept="37vLTw" id="32ggi2Dqja8" role="2Oq$k0">
-                              <ref role="3cqZAo" node="32ggi2DqhHN" resolve="modelMerge" />
+                              <ref role="3cqZAo" node="32ggi2DqhHN" resolve="mergingPolicy" />
                             </node>
                             <node concept="2qgKlT" id="6MgS2unbc1Q" role="2OqNvi">
                               <ref role="37wK5l" to="rnx3:28CFLxJaWOS" resolve="globalId" />
@@ -4756,13 +4756,13 @@
               <ref role="1Pybhc" node="18W7Z4VeRuj" resolve="PolicyMergerResolver" />
               <ref role="37wK5l" node="2QNuyuiLuqz" resolve="run" />
               <node concept="37vLTw" id="3a5mjFh18u2" role="37wK5m">
-                <ref role="3cqZAo" node="3a5mjFh18tT" resolve="modelMerge" />
+                <ref role="3cqZAo" node="3a5mjFh18tT" resolve="mergingPolicy" />
               </node>
               <node concept="2ShNRf" id="3a5mjFh18u3" role="37wK5m">
                 <node concept="1pGfFk" id="3a5mjFh18u4" role="2ShVmc">
                   <ref role="37wK5l" node="32ggi2DqhCi" resolve="ContentHolderFactoryExtension" />
                   <node concept="37vLTw" id="3a5mjFh18u5" role="37wK5m">
-                    <ref role="3cqZAo" node="3a5mjFh18tT" resolve="modelMerge" />
+                    <ref role="3cqZAo" node="3a5mjFh18tT" resolve="mergingPolicy" />
                   </node>
                 </node>
               </node>
@@ -4772,7 +4772,7 @@
         <node concept="3clFbF" id="3a5mjFh18u6" role="3cqZAp">
           <node concept="2ShNRf" id="3a5mjFh18u7" role="3clFbG">
             <node concept="1pGfFk" id="3a5mjFh18u8" role="2ShVmc">
-              <ref role="37wK5l" node="3a5mjFgYr6e" resolve="ModelMergerRunner" />
+              <ref role="37wK5l" node="3a5mjFgYr6e" resolve="ModelMerger" />
               <node concept="37vLTw" id="3a5mjFh18u9" role="37wK5m">
                 <ref role="3cqZAo" node="3a5mjFh18tZ" resolve="modelMergeResult" />
               </node>
@@ -9109,7 +9109,7 @@
             </node>
             <node concept="2ShNRf" id="7wnapcW0H9g" role="37wK5m">
               <node concept="HV5vD" id="7wnapcW0H9h" role="2ShVmc">
-                <ref role="HV5vE" node="450aOM1SYvz" resolve="Impl" />
+                <ref role="HV5vE" node="450aOM1SYvz" resolve="ContentHolderFactory.Impl" />
               </node>
             </node>
           </node>
@@ -9145,7 +9145,7 @@
               <ref role="1Pybhc" node="2rVXF9$L4no" resolve="ConceptGraphBuilder" />
               <node concept="2OqwBi" id="1trrptaAwvS" role="37wK5m">
                 <node concept="37vLTw" id="1trrptaAwvT" role="2Oq$k0">
-                  <ref role="3cqZAo" node="2QNuyuiLuq_" resolve="modelMerge" />
+                  <ref role="3cqZAo" node="2QNuyuiLuq_" resolve="mergingPolicy" />
                 </node>
                 <node concept="2qgKlT" id="1trrptaAwvU" role="2OqNvi">
                   <ref role="37wK5l" to="rnx3:3xJ_LYXlmVz" resolve="languageConcepts" />
@@ -9167,7 +9167,7 @@
             </node>
             <node concept="2OqwBi" id="1trrptaAyao" role="33vP2m">
               <node concept="37vLTw" id="1trrptaAyap" role="2Oq$k0">
-                <ref role="3cqZAo" node="2QNuyuiLuq_" resolve="modelMerge" />
+                <ref role="3cqZAo" node="2QNuyuiLuq_" resolve="mergingPolicy" />
               </node>
               <node concept="2qgKlT" id="1trrptaAyaq" role="2OqNvi">
                 <ref role="37wK5l" to="rnx3:3xJ_LYXj1c6" resolve="conceptToDefinedMergePolicy" />
@@ -9195,7 +9195,7 @@
                 </node>
               </node>
               <node concept="37vLTw" id="6B0NpqHsVXX" role="37wK5m">
-                <ref role="3cqZAo" node="2QNuyuiLuq_" resolve="modelMerge" />
+                <ref role="3cqZAo" node="2QNuyuiLuq_" resolve="mergingPolicy" />
               </node>
               <node concept="2OqwBi" id="6B0NpqHtN1Q" role="37wK5m">
                 <node concept="37vLTw" id="6B0NpqHtN1R" role="2Oq$k0">
@@ -9224,7 +9224,7 @@
             <node concept="3fqX7Q" id="5HyGTP1aLVp" role="3uHU7B">
               <node concept="2OqwBi" id="5HyGTP1aLVr" role="3fr31v">
                 <node concept="37vLTw" id="5HyGTP1aLVs" role="2Oq$k0">
-                  <ref role="3cqZAo" node="2QNuyuiLuq_" resolve="modelMerge" />
+                  <ref role="3cqZAo" node="2QNuyuiLuq_" resolve="mergingPolicy" />
                 </node>
                 <node concept="3TrcHB" id="5HyGTP1aLVt" role="2OqNvi">
                   <ref role="3TsBF5" to="mopj:5HbTgGuQTJM" resolve="partialPolicy" />
@@ -9368,7 +9368,7 @@
         <node concept="TUZQ0" id="6B0NpqHvdyn" role="3nqlJM">
           <property role="TUZQ4" value="modelMerge defined by user" />
           <node concept="zr_55" id="6B0NpqHvdyp" role="zr_5Q">
-            <ref role="zr_51" node="2QNuyuiLuq_" resolve="modelMerge" />
+            <ref role="zr_51" node="2QNuyuiLuq_" resolve="mergingPolicy" />
           </node>
         </node>
         <node concept="TUZQ0" id="6B0NpqHvdyq" role="3nqlJM">
@@ -10166,7 +10166,7 @@
                 <node concept="37vLTI" id="1FQTM0rQ0xl" role="3clFbG">
                   <node concept="Rm8GO" id="1FQTM0rQ0xm" role="37vLTx">
                     <ref role="Rm8GQ" node="1trrptaBMq3" resolve="property" />
-                    <ref role="1Px2BO" node="1trrptaBMbp" resolve="MergePolicyConflict.Type" />
+                    <ref role="1Px2BO" node="1trrptaBMbp" resolve="MergingPolicyConflict.Type" />
                   </node>
                   <node concept="2OqwBi" id="1FQTM0rQ0xn" role="37vLTJ">
                     <node concept="37vLTw" id="1FQTM0rQ0xo" role="2Oq$k0">
@@ -10314,7 +10314,7 @@
                 <node concept="37vLTI" id="1FQTM0rQ0xN" role="3clFbG">
                   <node concept="Rm8GO" id="1FQTM0rQ0xO" role="37vLTx">
                     <ref role="Rm8GQ" node="1trrptaBO1u" resolve="child" />
-                    <ref role="1Px2BO" node="1trrptaBMbp" resolve="MergePolicyConflict.Type" />
+                    <ref role="1Px2BO" node="1trrptaBMbp" resolve="MergingPolicyConflict.Type" />
                   </node>
                   <node concept="2OqwBi" id="1FQTM0rQ0xP" role="37vLTJ">
                     <node concept="37vLTw" id="1FQTM0rQ0xQ" role="2Oq$k0">
@@ -10427,7 +10427,7 @@
                 <node concept="37vLTI" id="3PLTv5jM0X7" role="3clFbG">
                   <node concept="Rm8GO" id="60iGZSK0ZIv" role="37vLTx">
                     <ref role="Rm8GQ" node="60iGZSK0Rew" resolve="reference" />
-                    <ref role="1Px2BO" node="1trrptaBMbp" resolve="MergePolicyConflict.Type" />
+                    <ref role="1Px2BO" node="1trrptaBMbp" resolve="MergingPolicyConflict.Type" />
                   </node>
                   <node concept="2OqwBi" id="3PLTv5jM0X9" role="37vLTJ">
                     <node concept="37vLTw" id="3PLTv5jM0Xa" role="2Oq$k0">
@@ -10469,7 +10469,7 @@
                 <node concept="37vLTI" id="60iGZSK0PBe" role="3clFbG">
                   <node concept="Rm8GO" id="60iGZSK10B8" role="37vLTx">
                     <ref role="Rm8GQ" node="60iGZSK0Qq0" resolve="idFunction" />
-                    <ref role="1Px2BO" node="1trrptaBMbp" resolve="MergePolicyConflict.Type" />
+                    <ref role="1Px2BO" node="1trrptaBMbp" resolve="MergingPolicyConflict.Type" />
                   </node>
                   <node concept="2OqwBi" id="60iGZSK0PBg" role="37vLTJ">
                     <node concept="37vLTw" id="60iGZSK0PBh" role="2Oq$k0">
@@ -11878,7 +11878,7 @@
                 <node concept="YS8fn" id="3EHNiwzxL05" role="3cqZAp">
                   <node concept="2ShNRf" id="3EHNiwzxL06" role="YScLw">
                     <node concept="1pGfFk" id="3EHNiwzxL07" role="2ShVmc">
-                      <ref role="37wK5l" node="7TOowlgU2mX" resolve="MergePolicyConflict" />
+                      <ref role="37wK5l" node="7TOowlgU2mX" resolve="MergingPolicyConflict" />
                       <node concept="37vLTw" id="1trrptaCV5I" role="37wK5m">
                         <ref role="3cqZAo" node="3EHNiwzsGL7" resolve="key" />
                       </node>
@@ -13377,11 +13377,11 @@
       <property role="TrG5h" value="type" />
       <node concept="3Tm1VV" id="1trrptaBTh4" role="1B3o_S" />
       <node concept="3uibUv" id="1trrptaBUT4" role="1tU5fm">
-        <ref role="3uigEE" node="1trrptaBMbp" resolve="MergePolicyConflict.Type" />
+        <ref role="3uigEE" node="1trrptaBMbp" resolve="MergingPolicyConflict.Type" />
       </node>
       <node concept="Rm8GO" id="1trrptaBWR3" role="33vP2m">
         <ref role="Rm8GQ" node="1trrptaBPE5" resolve="unkown" />
-        <ref role="1Px2BO" node="1trrptaBMbp" resolve="MergePolicyConflict.Type" />
+        <ref role="1Px2BO" node="1trrptaBMbp" resolve="MergingPolicyConflict.Type" />
       </node>
     </node>
     <node concept="2tJIrI" id="7TOowlgU2m3" role="jymVt" />

--- a/code/solutions/de.itemis.model.merge.runtime/models/de.itemis.model.merge.runtime.runtime.mps
+++ b/code/solutions/de.itemis.model.merge.runtime/models/de.itemis.model.merge.runtime.runtime.mps
@@ -10,8 +10,6 @@
     <use id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc" version="2" />
     <use id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text" version="0" />
     <use id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core" version="2" />
-    <use id="760a0a8c-eabb-4521-8bfd-65db761a9ba3" name="jetbrains.mps.baseLanguage.logging" version="0" />
-    <use id="515552c7-fcc0-4ab4-9789-2f3c49344e85" name="jetbrains.mps.baseLanguage.varVariable" version="0" />
   </languages>
   <imports>
     <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" />
@@ -450,7 +448,7 @@
   </registry>
   <node concept="3HP615" id="5lvG0vITZsP">
     <property role="TrG5h" value="PropertyMerger" />
-    <property role="3GE5qa" value="property" />
+    <property role="3GE5qa" value="mergers.property" />
     <node concept="3clFb_" id="5lvG0vITZEM" role="jymVt">
       <property role="TrG5h" value="property" />
       <node concept="3clFbS" id="5lvG0vITZEP" role="3clF47" />
@@ -704,7 +702,7 @@
   </node>
   <node concept="312cEu" id="5lvG0vIU6rH">
     <property role="TrG5h" value="BuiltInLeft" />
-    <property role="3GE5qa" value="property" />
+    <property role="3GE5qa" value="mergers.property" />
     <node concept="3Tm1VV" id="5lvG0vIU6rI" role="1B3o_S" />
     <node concept="3uibUv" id="5lvG0vIU6Ru" role="1zkMxy">
       <ref role="3uigEE" node="5lvG0vIU6vj" resolve="BuiltInPropertyMerger" />
@@ -764,7 +762,7 @@
   <node concept="312cEu" id="5lvG0vIU6vj">
     <property role="TrG5h" value="BuiltInPropertyMerger" />
     <property role="1sVAO0" value="true" />
-    <property role="3GE5qa" value="property" />
+    <property role="3GE5qa" value="mergers.property" />
     <node concept="2tJIrI" id="5lvG0vIU6y3" role="jymVt" />
     <node concept="312cEg" id="5lvG0vIU6I5" role="jymVt">
       <property role="TrG5h" value="myProperty" />
@@ -819,7 +817,7 @@
     </node>
   </node>
   <node concept="312cEu" id="5lvG0vIU7oP">
-    <property role="3GE5qa" value="property" />
+    <property role="3GE5qa" value="mergers.property" />
     <property role="TrG5h" value="BuiltInRight" />
     <node concept="3Tm1VV" id="5lvG0vIU7oQ" role="1B3o_S" />
     <node concept="3uibUv" id="5lvG0vIU7qt" role="1zkMxy">
@@ -879,7 +877,7 @@
   </node>
   <node concept="3HP615" id="5lvG0vIUaC$">
     <property role="TrG5h" value="ConceptChildMerger" />
-    <property role="3GE5qa" value="child" />
+    <property role="3GE5qa" value="mergers.child" />
     <node concept="3clFb_" id="5lvG0vIUaXG" role="jymVt">
       <property role="TrG5h" value="link" />
       <node concept="3clFbS" id="5lvG0vIUaXJ" role="3clF47" />
@@ -984,7 +982,7 @@
   <node concept="312cEu" id="5lvG0vIUb3x">
     <property role="TrG5h" value="BuiltInChildMerger" />
     <property role="1sVAO0" value="true" />
-    <property role="3GE5qa" value="child" />
+    <property role="3GE5qa" value="mergers.child" />
     <node concept="312cEg" id="5lvG0vIUbdg" role="jymVt">
       <property role="TrG5h" value="myLink" />
       <property role="3TUv4t" value="true" />
@@ -1038,7 +1036,7 @@
     </node>
   </node>
   <node concept="312cEu" id="5lvG0vIUbyR">
-    <property role="3GE5qa" value="child" />
+    <property role="3GE5qa" value="mergers.child" />
     <property role="TrG5h" value="BuiltInChildLeft" />
     <node concept="3Tm1VV" id="5lvG0vIUbyS" role="1B3o_S" />
     <node concept="3uibUv" id="5lvG0vIUb$f" role="1zkMxy">
@@ -1117,7 +1115,7 @@
     </node>
   </node>
   <node concept="312cEu" id="5lvG0vIUfwf">
-    <property role="3GE5qa" value="child" />
+    <property role="3GE5qa" value="mergers.child" />
     <property role="TrG5h" value="BuiltInChildRight" />
     <node concept="3Tm1VV" id="5lvG0vIUfwg" role="1B3o_S" />
     <node concept="3uibUv" id="5lvG0vIUfwh" role="1zkMxy">
@@ -1308,7 +1306,7 @@
     <node concept="3Tm1VV" id="3Wln5KIV2Yi" role="1B3o_S" />
   </node>
   <node concept="312cEu" id="57NTRpQ5ILk">
-    <property role="3GE5qa" value="child" />
+    <property role="3GE5qa" value="mergers.child" />
     <property role="TrG5h" value="BuiltInChildDrop" />
     <node concept="3Tm1VV" id="3pc485W4NSP" role="1B3o_S" />
     <node concept="3uibUv" id="57NTRpQ5ILm" role="1zkMxy">
@@ -1369,7 +1367,7 @@
   </node>
   <node concept="3HP615" id="4WBgwWtfZU9">
     <property role="TrG5h" value="ConceptRefMerger" />
-    <property role="3GE5qa" value="reference" />
+    <property role="3GE5qa" value="mergers.reference" />
     <node concept="3clFb_" id="4WBgwWtfZUa" role="jymVt">
       <property role="TrG5h" value="reference" />
       <node concept="3clFbS" id="4WBgwWtfZUb" role="3clF47" />
@@ -1395,7 +1393,7 @@
     <node concept="3Tm1VV" id="4WBgwWtfZUn" role="1B3o_S" />
   </node>
   <node concept="312cEu" id="4WBgwWtg02Q">
-    <property role="3GE5qa" value="reference" />
+    <property role="3GE5qa" value="mergers.reference" />
     <property role="TrG5h" value="BuiltInRefMerger" />
     <property role="1sVAO0" value="true" />
     <node concept="312cEg" id="4WBgwWtg0to" role="jymVt">
@@ -1459,7 +1457,7 @@
     </node>
   </node>
   <node concept="312cEu" id="4WBgwWtg1Z6">
-    <property role="3GE5qa" value="reference" />
+    <property role="3GE5qa" value="mergers.reference" />
     <property role="TrG5h" value="BuiltInRefLeft" />
     <node concept="3Tm1VV" id="4WBgwWtg1Z7" role="1B3o_S" />
     <node concept="3clFbW" id="4WBgwWtg2kG" role="jymVt">
@@ -1508,7 +1506,7 @@
     </node>
   </node>
   <node concept="312cEu" id="3xLnOvEARIg">
-    <property role="3GE5qa" value="reference" />
+    <property role="3GE5qa" value="mergers.reference" />
     <property role="TrG5h" value="BuiltInRefRight" />
     <node concept="3Tm1VV" id="3xLnOvEARIh" role="1B3o_S" />
     <node concept="3clFbW" id="3xLnOvEARIi" role="jymVt">
@@ -1557,7 +1555,7 @@
     </node>
   </node>
   <node concept="312cEu" id="3xLnOvECWX2">
-    <property role="3GE5qa" value="reference" />
+    <property role="3GE5qa" value="mergers.reference" />
     <property role="TrG5h" value="BuiltInRefDrop" />
     <node concept="3Tm1VV" id="3xLnOvECWX3" role="1B3o_S" />
     <node concept="3clFbW" id="3xLnOvECWX4" role="jymVt">
@@ -1605,7 +1603,7 @@
   </node>
   <node concept="3HP615" id="2siB1jiqYnr">
     <property role="TrG5h" value="CollectionElementMerger" />
-    <property role="3GE5qa" value="collection" />
+    <property role="3GE5qa" value="mergers.collection" />
     <node concept="2tJIrI" id="2siB1jiqYq4" role="jymVt" />
     <node concept="3clFb_" id="2siB1jiqYnw" role="jymVt">
       <property role="TrG5h" value="merge" />
@@ -1653,7 +1651,7 @@
   </node>
   <node concept="312cEu" id="2siB1jir4HM">
     <property role="TrG5h" value="LeftCollectionMerger" />
-    <property role="3GE5qa" value="collection" />
+    <property role="3GE5qa" value="mergers.collection" />
     <node concept="3Tm1VV" id="2siB1jir4HN" role="1B3o_S" />
     <node concept="3uibUv" id="2siB1jir4IU" role="EKbjA">
       <ref role="3uigEE" node="2siB1jiqYnr" resolve="CollectionElementMerger" />
@@ -1719,7 +1717,7 @@
   </node>
   <node concept="312cEu" id="2siB1jir5Qw">
     <property role="TrG5h" value="RightCollectionMerger" />
-    <property role="3GE5qa" value="collection" />
+    <property role="3GE5qa" value="mergers.collection" />
     <node concept="3Tm1VV" id="2siB1jir5Qx" role="1B3o_S" />
     <node concept="3uibUv" id="2siB1jir5Qy" role="EKbjA">
       <ref role="3uigEE" node="2siB1jiqYnr" resolve="CollectionElementMerger" />
@@ -1785,7 +1783,7 @@
   </node>
   <node concept="312cEu" id="2siB1jir6k5">
     <property role="TrG5h" value="DropCollectionMerger" />
-    <property role="3GE5qa" value="collection" />
+    <property role="3GE5qa" value="mergers.collection" />
     <node concept="3Tm1VV" id="2siB1jir6k6" role="1B3o_S" />
     <node concept="3uibUv" id="2siB1jir6k7" role="EKbjA">
       <ref role="3uigEE" node="2siB1jiqYnr" resolve="CollectionElementMerger" />
@@ -1837,7 +1835,7 @@
     </node>
   </node>
   <node concept="312cEu" id="6IgrZARCsAs">
-    <property role="3GE5qa" value="collection" />
+    <property role="3GE5qa" value="mergers.collection" />
     <property role="TrG5h" value="MetaCollectionMerger" />
     <node concept="312cEg" id="6IgrZARCu85" role="jymVt">
       <property role="TrG5h" value="myLink" />
@@ -3276,7 +3274,7 @@
     <node concept="3Tm1VV" id="1yAYHyQ2xCk" role="1B3o_S" />
   </node>
   <node concept="3HP615" id="32ggi2DpDWx">
-    <property role="3GE5qa" value="mergetraversal.content" />
+    <property role="3GE5qa" value="traversing.content" />
     <property role="TrG5h" value="ContentHolderFactory" />
     <node concept="2tJIrI" id="32ggi2DpDXz" role="jymVt" />
     <node concept="3clFb_" id="32ggi2DpDYO" role="jymVt">
@@ -3284,7 +3282,7 @@
       <node concept="37vLTG" id="32ggi2DpE1Y" role="3clF46">
         <property role="TrG5h" value="itemPolicy" />
         <node concept="3Tqbb2" id="32ggi2DpE2D" role="1tU5fm">
-          <ref role="ehGHo" to="mopj:7jyS5urbJZ2" resolve="ItemPolicy" />
+          <ref role="ehGHo" to="mopj:7jyS5urbJZ2" resolve="DeclarationPolicy" />
         </node>
       </node>
       <node concept="37vLTG" id="32ggi2DpE3F" role="3clF46">
@@ -3380,7 +3378,7 @@
         <node concept="37vLTG" id="450aOM1SZog" role="3clF46">
           <property role="TrG5h" value="itemPolicy" />
           <node concept="3Tqbb2" id="450aOM1SZoh" role="1tU5fm">
-            <ref role="ehGHo" to="mopj:7jyS5urbJZ2" resolve="ItemPolicy" />
+            <ref role="ehGHo" to="mopj:7jyS5urbJZ2" resolve="DeclarationPolicy" />
           </node>
         </node>
         <node concept="37vLTG" id="450aOM1SZoi" role="3clF46">
@@ -3590,7 +3588,7 @@
       <node concept="37vLTG" id="450aOM1RWmW" role="3clF46">
         <property role="TrG5h" value="ip" />
         <node concept="3Tqbb2" id="450aOM1RWmX" role="1tU5fm">
-          <ref role="ehGHo" to="mopj:7jyS5urbJZ2" resolve="ItemPolicy" />
+          <ref role="ehGHo" to="mopj:7jyS5urbJZ2" resolve="DeclarationPolicy" />
         </node>
       </node>
       <node concept="37vLTG" id="450aOM1RWmY" role="3clF46">
@@ -3762,7 +3760,7 @@
     <node concept="3Tm1VV" id="32ggi2DpDWy" role="1B3o_S" />
   </node>
   <node concept="312cEu" id="32ggi2DqedF">
-    <property role="3GE5qa" value="mergetraversal.content" />
+    <property role="3GE5qa" value="traversing.content" />
     <property role="TrG5h" value="ContentHolderFactoryExtension" />
     <node concept="2tJIrI" id="32ggi2Dqewg" role="jymVt" />
     <node concept="312cEg" id="32ggi2DqoUH" role="jymVt">
@@ -4095,9 +4093,9 @@
       </node>
       <node concept="3Tm1VV" id="32ggi2DqhCm" role="1B3o_S" />
       <node concept="37vLTG" id="32ggi2DqhHN" role="3clF46">
-        <property role="TrG5h" value="modelMerge" />
+        <property role="TrG5h" value="mergingPolicy" />
         <node concept="3Tqbb2" id="32ggi2DqhHM" role="1tU5fm">
-          <ref role="ehGHo" to="mopj:1EbzjT2RcU7" resolve="ModelMerge" />
+          <ref role="ehGHo" to="mopj:1EbzjT2RcU7" resolve="ModelMergingPolicy" />
         </node>
       </node>
     </node>
@@ -4110,7 +4108,7 @@
       <node concept="37vLTG" id="32ggi2DqeiX" role="3clF46">
         <property role="TrG5h" value="itemPolicy" />
         <node concept="3Tqbb2" id="32ggi2DqeiY" role="1tU5fm">
-          <ref role="ehGHo" to="mopj:7jyS5urbJZ2" resolve="ItemPolicy" />
+          <ref role="ehGHo" to="mopj:7jyS5urbJZ2" resolve="DeclarationPolicy" />
         </node>
       </node>
       <node concept="37vLTG" id="32ggi2DqeiZ" role="3clF46">
@@ -4544,8 +4542,8 @@
     </node>
   </node>
   <node concept="312cEu" id="2V55j61W8Fq">
-    <property role="TrG5h" value="ModelMergerRunner" />
-    <property role="3GE5qa" value="mergetraversal" />
+    <property role="TrG5h" value="ModelMerger" />
+    <property role="3GE5qa" value="traversing" />
     <node concept="2tJIrI" id="60iGZSJKTqX" role="jymVt" />
     <node concept="312cEg" id="3a5mjFgXyW2" role="jymVt">
       <property role="TrG5h" value="modelMergeResult" />
@@ -4755,7 +4753,7 @@
               <ref role="3uigEE" node="2QNuyuiL5OR" resolve="MergerResolverImpl" />
             </node>
             <node concept="2YIFZM" id="3a5mjFh18u1" role="33vP2m">
-              <ref role="1Pybhc" node="18W7Z4VeRuj" resolve="MergeResolverFromModelMerge" />
+              <ref role="1Pybhc" node="18W7Z4VeRuj" resolve="PolicyMergerResolver" />
               <ref role="37wK5l" node="2QNuyuiLuqz" resolve="run" />
               <node concept="37vLTw" id="3a5mjFh18u2" role="37wK5m">
                 <ref role="3cqZAo" node="3a5mjFh18tT" resolve="modelMerge" />
@@ -4783,12 +4781,12 @@
         </node>
       </node>
       <node concept="3uibUv" id="3a5mjFh18tV" role="3clF45">
-        <ref role="3uigEE" node="2V55j61W8Fq" resolve="ModelMergerRunner" />
+        <ref role="3uigEE" node="2V55j61W8Fq" resolve="ModelMerger" />
       </node>
       <node concept="37vLTG" id="3a5mjFh18tT" role="3clF46">
-        <property role="TrG5h" value="modelMerge" />
+        <property role="TrG5h" value="mergingPolicy" />
         <node concept="3Tqbb2" id="3a5mjFh18tU" role="1tU5fm">
-          <ref role="ehGHo" to="mopj:1EbzjT2RcU7" resolve="ModelMerge" />
+          <ref role="ehGHo" to="mopj:1EbzjT2RcU7" resolve="ModelMergingPolicy" />
         </node>
       </node>
       <node concept="3Tm1VV" id="3a5mjFh18tW" role="1B3o_S" />
@@ -8056,7 +8054,7 @@
     </node>
   </node>
   <node concept="312cEu" id="3pc485W4NhM">
-    <property role="3GE5qa" value="child" />
+    <property role="3GE5qa" value="mergers.child" />
     <property role="TrG5h" value="AutoChildMerger" />
     <node concept="3Tm1VV" id="3pc485W4NhN" role="1B3o_S" />
     <node concept="3uibUv" id="3pc485W4No8" role="EKbjA">
@@ -8232,7 +8230,7 @@
     </node>
   </node>
   <node concept="312cEu" id="6Ltuup4QbkK">
-    <property role="3GE5qa" value="collection" />
+    <property role="3GE5qa" value="mergers.collection" />
     <property role="TrG5h" value="AutoCollectionMerger" />
     <node concept="3Tm1VV" id="6Ltuup4QbkL" role="1B3o_S" />
     <node concept="3uibUv" id="6Ltuup4Qbnz" role="EKbjA">
@@ -8320,7 +8318,7 @@
   </node>
   <node concept="312cEu" id="5ahhjncnrmv">
     <property role="TrG5h" value="MergedNode" />
-    <property role="3GE5qa" value="mergetraversal" />
+    <property role="3GE5qa" value="traversing" />
     <node concept="312cEg" id="5ahhjncnEd$" role="jymVt">
       <property role="TrG5h" value="link" />
       <property role="3TUv4t" value="true" />
@@ -8426,7 +8424,7 @@
   </node>
   <node concept="312cEu" id="2rVXF9$L4no">
     <property role="TrG5h" value="ConceptGraphBuilder" />
-    <property role="3GE5qa" value="mergetraversal" />
+    <property role="3GE5qa" value="traversing" />
     <node concept="2tJIrI" id="2rVXF9$M2VX" role="jymVt" />
     <node concept="2YIFZL" id="7TOowlgojIp" role="jymVt">
       <property role="TrG5h" value="directSubConcepts" />
@@ -9097,156 +9095,38 @@
     <node concept="3Tm1VV" id="2rVXF9$L4np" role="1B3o_S" />
   </node>
   <node concept="312cEu" id="18W7Z4VeRuj">
-    <property role="TrG5h" value="MergeResolverFromModelMerge" />
-    <property role="3GE5qa" value="mergetraversal" />
+    <property role="TrG5h" value="PolicyMergerResolver" />
+    <property role="3GE5qa" value="traversing" />
     <node concept="2tJIrI" id="18W7Z4VeRx7" role="jymVt" />
-    <node concept="2YIFZL" id="18W7Z4Vmw0z" role="jymVt">
-      <property role="TrG5h" value="traverse" />
-      <node concept="3clFbS" id="18W7Z4Vmw0G" role="3clF47">
-        <node concept="3cpWs8" id="3PLTv5jCaZ7" role="3cqZAp">
-          <node concept="3cpWsn" id="3PLTv5jCaZ8" role="3cpWs9">
-            <property role="TrG5h" value="resultBuilder" />
-            <node concept="3uibUv" id="3PLTv5jCazx" role="1tU5fm">
-              <ref role="3uigEE" node="3PLTv5jAE8Y" resolve="MergerResolverBuilder" />
+    <node concept="2YIFZL" id="7wnapcW0cfS" role="jymVt">
+      <property role="TrG5h" value="run" />
+      <node concept="3clFbS" id="7wnapcW0cfT" role="3clF47">
+        <node concept="3clFbF" id="7wnapcW0GAh" role="3cqZAp">
+          <node concept="1rXfSq" id="7wnapcW0GAf" role="3clFbG">
+            <ref role="37wK5l" node="2QNuyuiLuqz" resolve="run" />
+            <node concept="37vLTw" id="7wnapcW0GQv" role="37wK5m">
+              <ref role="3cqZAo" node="7wnapcW0cgE" resolve="modelMerge" />
             </node>
-            <node concept="2ShNRf" id="3PLTv5jCaZ9" role="33vP2m">
-              <node concept="HV5vD" id="3PLTv5jCaZa" role="2ShVmc">
-                <ref role="HV5vE" node="3PLTv5jAE8Y" resolve="MergerResolverBuilder" />
+            <node concept="2ShNRf" id="7wnapcW0H9g" role="37wK5m">
+              <node concept="HV5vD" id="7wnapcW0H9h" role="2ShVmc">
+                <ref role="HV5vE" node="450aOM1SYvz" resolve="Impl" />
               </node>
             </node>
           </node>
         </node>
-        <node concept="2Gpval" id="18W7Z4Vmw1Y" role="3cqZAp">
-          <node concept="2GrKxI" id="18W7Z4Vmw1Z" role="2Gsz3X">
-            <property role="TrG5h" value="r" />
-          </node>
-          <node concept="3clFbS" id="18W7Z4Vmw21" role="2LFqv$">
-            <node concept="3clFbF" id="2rVXF9_4mHP" role="3cqZAp">
-              <node concept="1rXfSq" id="2rVXF9_4mHQ" role="3clFbG">
-                <ref role="37wK5l" node="7YSeTY81ace" resolve="traverse" />
-                <node concept="37vLTw" id="2rVXF9_4mI4" role="37wK5m">
-                  <ref role="3cqZAo" node="18W7Z4Vmw0_" resolve="graph" />
-                </node>
-                <node concept="2GrUjf" id="2rVXF9_4qKc" role="37wK5m">
-                  <ref role="2Gs0qQ" node="18W7Z4Vmw1Z" resolve="r" />
-                </node>
-                <node concept="37vLTw" id="1trrptaACa7" role="37wK5m">
-                  <ref role="3cqZAo" node="18W7Z4Vmw0C" resolve="sconceptToMergePolicy" />
-                </node>
-                <node concept="2ShNRf" id="2rVXF9_4mHU" role="37wK5m">
-                  <node concept="HV5vD" id="2rVXF9_4mHV" role="2ShVmc">
-                    <ref role="HV5vE" node="7YSeTY7XhnK" resolve="TraversalState" />
-                  </node>
-                </node>
-                <node concept="37vLTw" id="3PLTv5jCgwG" role="37wK5m">
-                  <ref role="3cqZAo" node="3PLTv5jCaZ8" resolve="resultBuilder" />
-                </node>
-                <node concept="37vLTw" id="32ggi2Dzc9d" role="37wK5m">
-                  <ref role="3cqZAo" node="32ggi2DzbrS" resolve="contentHolderFactory" />
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="37vLTw" id="hG_e7A2RzH" role="2GsD0m">
-            <ref role="3cqZAo" node="hG_e7A2WUQ" resolve="roots" />
-          </node>
-        </node>
-        <node concept="3clFbH" id="1trrptaALwV" role="3cqZAp" />
-        <node concept="3clFbF" id="3PLTv5jCRTo" role="3cqZAp">
-          <node concept="2OqwBi" id="3PLTv5jCS8b" role="3clFbG">
-            <node concept="37vLTw" id="3PLTv5jCRTm" role="2Oq$k0">
-              <ref role="3cqZAo" node="3PLTv5jCaZ8" resolve="resultBuilder" />
-            </node>
-            <node concept="liA8E" id="3PLTv5jCSjY" role="2OqNvi">
-              <ref role="37wK5l" node="3PLTv5jAQ29" resolve="build" />
-            </node>
-          </node>
-        </node>
       </node>
-      <node concept="37vLTG" id="hG_e7A2WUQ" role="3clF46">
-        <property role="TrG5h" value="roots" />
-        <node concept="A3Dl8" id="hG_e7A2Z1D" role="1tU5fm">
-          <node concept="3uibUv" id="hG_e7A2Z1E" role="A3Ik2">
-            <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
-          </node>
-        </node>
-      </node>
-      <node concept="37vLTG" id="18W7Z4Vmw0_" role="3clF46">
-        <property role="TrG5h" value="graph" />
-        <node concept="3uibUv" id="18W7Z4Vmw0A" role="1tU5fm">
-          <ref role="3uigEE" to="agc3:~Graph" resolve="Graph" />
-          <node concept="3uibUv" id="18W7Z4Vmw0B" role="11_B2D">
-            <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
-          </node>
-        </node>
-      </node>
-      <node concept="37vLTG" id="18W7Z4Vmw0C" role="3clF46">
-        <property role="TrG5h" value="sconceptToMergePolicy" />
-        <node concept="3uibUv" id="1trrptaAA8D" role="1tU5fm">
-          <ref role="3uigEE" to="33ny:~Map" resolve="Map" />
-          <node concept="3uibUv" id="1trrptaAA8E" role="11_B2D">
-            <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
-          </node>
-          <node concept="3Tqbb2" id="1trrptaAA8F" role="11_B2D">
-            <ref role="ehGHo" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
-          </node>
-        </node>
-      </node>
-      <node concept="37vLTG" id="32ggi2DzbrS" role="3clF46">
-        <property role="TrG5h" value="contentHolderFactory" />
-        <node concept="3uibUv" id="32ggi2DzbCp" role="1tU5fm">
-          <ref role="3uigEE" node="32ggi2DpDWx" resolve="ContentHolderFactory" />
-        </node>
-      </node>
-      <node concept="3Tm6S6" id="1trrptaxNwV" role="1B3o_S" />
-      <node concept="3uibUv" id="1trrptaAeaT" role="3clF45">
+      <node concept="3uibUv" id="7wnapcW0cgD" role="3clF45">
         <ref role="3uigEE" node="2QNuyuiL5OR" resolve="MergerResolverImpl" />
       </node>
-      <node concept="P$JXv" id="6B0NpqHznCk" role="lGtFl">
-        <node concept="TZ5HA" id="6B0NpqHznCl" role="TZ5H$">
-          <node concept="1dT_AC" id="6B0NpqHznCm" role="1dT_Ay">
-            <property role="1dT_AB" value="Traverses the graph from a root to the leaf (for all roots ony by one)." />
-          </node>
-        </node>
-        <node concept="TZ5HA" id="6B0NpqHzoz9" role="TZ5H$">
-          <node concept="1dT_AC" id="6B0NpqHzoza" role="1dT_Ay">
-            <property role="1dT_AB" value="During this traversal for each concept of 'graph' it is determined what kind of merger-objects are " />
-          </node>
-        </node>
-        <node concept="TZ5HA" id="6B0NpqHzAss" role="TZ5H$">
-          <node concept="1dT_AC" id="6B0NpqHzAst" role="1dT_Ay">
-            <property role="1dT_AB" value="valid for its properties, children and references. During the traversal merger-objects of parent-concepts are" />
-          </node>
-        </node>
-        <node concept="TZ5HA" id="6B0NpqHzAvD" role="TZ5H$">
-          <node concept="1dT_AC" id="6B0NpqHzAvE" role="1dT_Ay">
-            <property role="1dT_AB" value="propagated to their descendants. This way an inheritance hierarchy is implemented." />
-          </node>
-        </node>
-        <node concept="TUZQ0" id="6B0NpqHznCn" role="3nqlJM">
-          <property role="TUZQ4" value="graph of concept hierarchy" />
-          <node concept="zr_55" id="6B0NpqHznCp" role="zr_5Q">
-            <ref role="zr_51" node="18W7Z4Vmw0_" resolve="graph" />
-          </node>
-        </node>
-        <node concept="TUZQ0" id="6B0NpqHznCq" role="3nqlJM">
-          <property role="TUZQ4" value="concepts mapped to MergePolicies " />
-          <node concept="zr_55" id="6B0NpqHznCs" role="zr_5Q">
-            <ref role="zr_51" node="18W7Z4Vmw0C" resolve="sconceptToMergePolicy" />
-          </node>
-        </node>
-        <node concept="TUZQ0" id="6B0NpqHznCt" role="3nqlJM">
-          <property role="TUZQ4" value=" " />
-          <node concept="zr_55" id="6B0NpqHznCv" role="zr_5Q">
-            <ref role="zr_51" node="32ggi2DzbrS" resolve="contentHolderFactory" />
-          </node>
-        </node>
-        <node concept="x79VA" id="6B0NpqHznCw" role="3nqlJM">
-          <property role="x79VB" value=" " />
+      <node concept="37vLTG" id="7wnapcW0cgE" role="3clF46">
+        <property role="TrG5h" value="modelMerge" />
+        <node concept="3Tqbb2" id="7wnapcW0cgF" role="1tU5fm">
+          <ref role="ehGHo" to="mopj:1EbzjT2RcU7" resolve="ModelMergingPolicy" />
         </node>
       </node>
+      <node concept="3Tm1VV" id="7wnapcW0cgG" role="1B3o_S" />
     </node>
-    <node concept="2tJIrI" id="2rVXF9$IT92" role="jymVt" />
+    <node concept="2tJIrI" id="5HbTgGuEp3M" role="jymVt" />
     <node concept="2YIFZL" id="2QNuyuiLuqz" role="jymVt">
       <property role="TrG5h" value="run" />
       <node concept="3clFbS" id="2QNuyuiLuqB" role="3clF47">
@@ -9282,7 +9162,7 @@
                 <ref role="ehGHo" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
               </node>
               <node concept="3Tqbb2" id="1trrptaAxHC" role="3rvSg0">
-                <ref role="ehGHo" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
+                <ref role="ehGHo" to="mopj:1EbzjT2R$JP" resolve="ConceptMergingPolicy" />
               </node>
             </node>
             <node concept="2OqwBi" id="1trrptaAyao" role="33vP2m">
@@ -9304,8 +9184,7 @@
                 <ref role="ehGHo" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
               </node>
             </node>
-            <node concept="2YIFZM" id="6B0NpqHsVXZ" role="33vP2m">
-              <ref role="1Pybhc" node="18W7Z4VeRuj" resolve="MergeResolverFromModelMerge" />
+            <node concept="1rXfSq" id="5HbTgGuF0dU" role="33vP2m">
               <ref role="37wK5l" node="6B0NpqHsVXS" resolve="missingConcepts" />
               <node concept="2OqwBi" id="6B0NpqHut3g" role="37wK5m">
                 <node concept="37vLTw" id="6B0NpqHut3h" role="2Oq$k0">
@@ -9333,7 +9212,7 @@
             <node concept="YS8fn" id="6XtVDsmyYg8" role="3cqZAp">
               <node concept="2ShNRf" id="6XtVDsmyYi5" role="YScLw">
                 <node concept="1pGfFk" id="6CwG2k7O7Aw" role="2ShVmc">
-                  <ref role="37wK5l" node="6CwG2k7Nbuo" resolve="MissingMergePolicies" />
+                  <ref role="37wK5l" node="6CwG2k7Nbuo" resolve="MissingMergingPolicies" />
                   <node concept="37vLTw" id="6CwG2k7O7F3" role="37wK5m">
                     <ref role="3cqZAo" node="6XtVDsmy$sD" resolve="missingConcepts" />
                   </node>
@@ -9341,15 +9220,27 @@
               </node>
             </node>
           </node>
-          <node concept="3eOSWO" id="6XtVDsmyWDk" role="3clFbw">
-            <node concept="3cmrfG" id="6XtVDsmyWEW" role="3uHU7w">
-              <property role="3cmrfH" value="0" />
-            </node>
-            <node concept="2OqwBi" id="6XtVDsmySJ2" role="3uHU7B">
-              <node concept="37vLTw" id="6XtVDsmyR3I" role="2Oq$k0">
-                <ref role="3cqZAo" node="6XtVDsmy$sD" resolve="missingConcepts" />
+          <node concept="1Wc70l" id="5HyGTP1aDxe" role="3clFbw">
+            <node concept="3fqX7Q" id="5HyGTP1aLVp" role="3uHU7B">
+              <node concept="2OqwBi" id="5HyGTP1aLVr" role="3fr31v">
+                <node concept="37vLTw" id="5HyGTP1aLVs" role="2Oq$k0">
+                  <ref role="3cqZAo" node="2QNuyuiLuq_" resolve="modelMerge" />
+                </node>
+                <node concept="3TrcHB" id="5HyGTP1aLVt" role="2OqNvi">
+                  <ref role="3TsBF5" to="mopj:5HbTgGuQTJM" resolve="partialPolicy" />
+                </node>
               </node>
-              <node concept="34oBXx" id="6XtVDsmz1yR" role="2OqNvi" />
+            </node>
+            <node concept="3eOSWO" id="6XtVDsmyWDk" role="3uHU7w">
+              <node concept="3cmrfG" id="6XtVDsmyWEW" role="3uHU7w">
+                <property role="3cmrfH" value="0" />
+              </node>
+              <node concept="2OqwBi" id="6XtVDsmySJ2" role="3uHU7B">
+                <node concept="37vLTw" id="6XtVDsmyR3I" role="2Oq$k0">
+                  <ref role="3cqZAo" node="6XtVDsmy$sD" resolve="missingConcepts" />
+                </node>
+                <node concept="34oBXx" id="6XtVDsmz1yR" role="2OqNvi" />
+              </node>
             </node>
           </node>
         </node>
@@ -9363,7 +9254,7 @@
                 <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
               </node>
               <node concept="3Tqbb2" id="1trrptaAyt5" role="11_B2D">
-                <ref role="ehGHo" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
+                <ref role="ehGHo" to="mopj:1EbzjT2R$JP" resolve="ConceptMergingPolicy" />
               </node>
             </node>
             <node concept="1rXfSq" id="1trrptaAyt6" role="33vP2m">
@@ -9452,9 +9343,9 @@
         <ref role="3uigEE" node="2QNuyuiL5OR" resolve="MergerResolverImpl" />
       </node>
       <node concept="37vLTG" id="2QNuyuiLuq_" role="3clF46">
-        <property role="TrG5h" value="modelMerge" />
+        <property role="TrG5h" value="mergingPolicy" />
         <node concept="3Tqbb2" id="2QNuyuiLuqA" role="1tU5fm">
-          <ref role="ehGHo" to="mopj:1EbzjT2RcU7" resolve="ModelMerge" />
+          <ref role="ehGHo" to="mopj:1EbzjT2RcU7" resolve="ModelMergingPolicy" />
         </node>
       </node>
       <node concept="37vLTG" id="7wnapcW0odE" role="3clF46">
@@ -9466,12 +9357,12 @@
       <node concept="P$JXv" id="6B0NpqHvdyk" role="lGtFl">
         <node concept="TZ5HA" id="6B0NpqHvdyl" role="TZ5H$">
           <node concept="1dT_AC" id="6B0NpqHvdym" role="1dT_Ay">
-            <property role="1dT_AB" value="Based on the user defined 'ModelMerge' we get an object which given 'SAbstractConcept' and 'SABstractLink'" />
+            <property role="1dT_AB" value="Based on the user defined 'ModelMergingPolicy' we get an object which given 'SAbstractConcept' and 'SAbstractLink'" />
           </node>
         </node>
         <node concept="TZ5HA" id="6B0NpqHv$pQ" role="TZ5H$">
           <node concept="1dT_AC" id="6B0NpqHv$pR" role="1dT_Ay">
-            <property role="1dT_AB" value="returns approriate Merger-Objects for properties, children and references." />
+            <property role="1dT_AB" value="returns appropriate Merger-Objects for properties, children and references." />
           </node>
         </node>
         <node concept="TUZQ0" id="6B0NpqHvdyn" role="3nqlJM">
@@ -9491,6 +9382,154 @@
         </node>
       </node>
     </node>
+    <node concept="2tJIrI" id="5HbTgGuDJD_" role="jymVt" />
+    <node concept="2YIFZL" id="18W7Z4Vmw0z" role="jymVt">
+      <property role="TrG5h" value="traverse" />
+      <node concept="3clFbS" id="18W7Z4Vmw0G" role="3clF47">
+        <node concept="3cpWs8" id="3PLTv5jCaZ7" role="3cqZAp">
+          <node concept="3cpWsn" id="3PLTv5jCaZ8" role="3cpWs9">
+            <property role="TrG5h" value="resultBuilder" />
+            <node concept="3uibUv" id="3PLTv5jCazx" role="1tU5fm">
+              <ref role="3uigEE" node="3PLTv5jAE8Y" resolve="MergerResolverBuilder" />
+            </node>
+            <node concept="2ShNRf" id="3PLTv5jCaZ9" role="33vP2m">
+              <node concept="HV5vD" id="3PLTv5jCaZa" role="2ShVmc">
+                <ref role="HV5vE" node="3PLTv5jAE8Y" resolve="MergerResolverBuilder" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2Gpval" id="18W7Z4Vmw1Y" role="3cqZAp">
+          <node concept="2GrKxI" id="18W7Z4Vmw1Z" role="2Gsz3X">
+            <property role="TrG5h" value="r" />
+          </node>
+          <node concept="3clFbS" id="18W7Z4Vmw21" role="2LFqv$">
+            <node concept="3clFbF" id="2rVXF9_4mHP" role="3cqZAp">
+              <node concept="1rXfSq" id="2rVXF9_4mHQ" role="3clFbG">
+                <ref role="37wK5l" node="7YSeTY81ace" resolve="traverse" />
+                <node concept="37vLTw" id="2rVXF9_4mI4" role="37wK5m">
+                  <ref role="3cqZAo" node="18W7Z4Vmw0_" resolve="graph" />
+                </node>
+                <node concept="2GrUjf" id="2rVXF9_4qKc" role="37wK5m">
+                  <ref role="2Gs0qQ" node="18W7Z4Vmw1Z" resolve="r" />
+                </node>
+                <node concept="37vLTw" id="1trrptaACa7" role="37wK5m">
+                  <ref role="3cqZAo" node="18W7Z4Vmw0C" resolve="sconceptToMergePolicy" />
+                </node>
+                <node concept="2ShNRf" id="2rVXF9_4mHU" role="37wK5m">
+                  <node concept="HV5vD" id="2rVXF9_4mHV" role="2ShVmc">
+                    <ref role="HV5vE" node="7YSeTY7XhnK" resolve="TraversalState" />
+                  </node>
+                </node>
+                <node concept="37vLTw" id="3PLTv5jCgwG" role="37wK5m">
+                  <ref role="3cqZAo" node="3PLTv5jCaZ8" resolve="resultBuilder" />
+                </node>
+                <node concept="37vLTw" id="32ggi2Dzc9d" role="37wK5m">
+                  <ref role="3cqZAo" node="32ggi2DzbrS" resolve="contentHolderFactory" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="37vLTw" id="hG_e7A2RzH" role="2GsD0m">
+            <ref role="3cqZAo" node="hG_e7A2WUQ" resolve="roots" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="1trrptaALwV" role="3cqZAp" />
+        <node concept="3clFbF" id="3PLTv5jCRTo" role="3cqZAp">
+          <node concept="2OqwBi" id="3PLTv5jCS8b" role="3clFbG">
+            <node concept="37vLTw" id="3PLTv5jCRTm" role="2Oq$k0">
+              <ref role="3cqZAo" node="3PLTv5jCaZ8" resolve="resultBuilder" />
+            </node>
+            <node concept="liA8E" id="3PLTv5jCSjY" role="2OqNvi">
+              <ref role="37wK5l" node="3PLTv5jAQ29" resolve="build" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="hG_e7A2WUQ" role="3clF46">
+        <property role="TrG5h" value="roots" />
+        <node concept="A3Dl8" id="hG_e7A2Z1D" role="1tU5fm">
+          <node concept="3uibUv" id="hG_e7A2Z1E" role="A3Ik2">
+            <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="18W7Z4Vmw0_" role="3clF46">
+        <property role="TrG5h" value="graph" />
+        <node concept="3uibUv" id="18W7Z4Vmw0A" role="1tU5fm">
+          <ref role="3uigEE" to="agc3:~Graph" resolve="Graph" />
+          <node concept="3uibUv" id="18W7Z4Vmw0B" role="11_B2D">
+            <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="18W7Z4Vmw0C" role="3clF46">
+        <property role="TrG5h" value="sconceptToMergePolicy" />
+        <node concept="3uibUv" id="1trrptaAA8D" role="1tU5fm">
+          <ref role="3uigEE" to="33ny:~Map" resolve="Map" />
+          <node concept="3uibUv" id="1trrptaAA8E" role="11_B2D">
+            <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
+          </node>
+          <node concept="3Tqbb2" id="1trrptaAA8F" role="11_B2D">
+            <ref role="ehGHo" to="mopj:1EbzjT2R$JP" resolve="ConceptMergingPolicy" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="32ggi2DzbrS" role="3clF46">
+        <property role="TrG5h" value="contentHolderFactory" />
+        <node concept="3uibUv" id="32ggi2DzbCp" role="1tU5fm">
+          <ref role="3uigEE" node="32ggi2DpDWx" resolve="ContentHolderFactory" />
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="1trrptaxNwV" role="1B3o_S" />
+      <node concept="3uibUv" id="1trrptaAeaT" role="3clF45">
+        <ref role="3uigEE" node="2QNuyuiL5OR" resolve="MergerResolverImpl" />
+      </node>
+      <node concept="P$JXv" id="6B0NpqHznCk" role="lGtFl">
+        <node concept="TZ5HA" id="6B0NpqHznCl" role="TZ5H$">
+          <node concept="1dT_AC" id="6B0NpqHznCm" role="1dT_Ay">
+            <property role="1dT_AB" value="Traverses the graph from a root to the leaf (for all roots ony by one)." />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="6B0NpqHzoz9" role="TZ5H$">
+          <node concept="1dT_AC" id="6B0NpqHzoza" role="1dT_Ay">
+            <property role="1dT_AB" value="During this traversal for each concept of 'graph' it is determined what kind of merger-objects are " />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="6B0NpqHzAss" role="TZ5H$">
+          <node concept="1dT_AC" id="6B0NpqHzAst" role="1dT_Ay">
+            <property role="1dT_AB" value="valid for its properties, children and references. During the traversal merger-objects of parent-concepts are" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="6B0NpqHzAvD" role="TZ5H$">
+          <node concept="1dT_AC" id="6B0NpqHzAvE" role="1dT_Ay">
+            <property role="1dT_AB" value="propagated to their descendants. This way an inheritance hierarchy is implemented." />
+          </node>
+        </node>
+        <node concept="TUZQ0" id="6B0NpqHznCn" role="3nqlJM">
+          <property role="TUZQ4" value="graph of concept hierarchy" />
+          <node concept="zr_55" id="6B0NpqHznCp" role="zr_5Q">
+            <ref role="zr_51" node="18W7Z4Vmw0_" resolve="graph" />
+          </node>
+        </node>
+        <node concept="TUZQ0" id="6B0NpqHznCq" role="3nqlJM">
+          <property role="TUZQ4" value="concepts mapped to MergePolicies " />
+          <node concept="zr_55" id="6B0NpqHznCs" role="zr_5Q">
+            <ref role="zr_51" node="18W7Z4Vmw0C" resolve="sconceptToMergePolicy" />
+          </node>
+        </node>
+        <node concept="TUZQ0" id="6B0NpqHznCt" role="3nqlJM">
+          <property role="TUZQ4" value=" " />
+          <node concept="zr_55" id="6B0NpqHznCv" role="zr_5Q">
+            <ref role="zr_51" node="32ggi2DzbrS" resolve="contentHolderFactory" />
+          </node>
+        </node>
+        <node concept="x79VA" id="6B0NpqHznCw" role="3nqlJM">
+          <property role="x79VB" value=" " />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="2rVXF9$IT92" role="jymVt" />
     <node concept="2tJIrI" id="6B0NpqHsYYR" role="jymVt" />
     <node concept="2YIFZL" id="6B0NpqHsVXS" role="jymVt">
       <property role="TrG5h" value="missingConcepts" />
@@ -9511,7 +9550,7 @@
       <node concept="37vLTG" id="6B0NpqHsVXF" role="3clF46">
         <property role="TrG5h" value="modelMerge" />
         <node concept="3Tqbb2" id="6B0NpqHsVXG" role="1tU5fm">
-          <ref role="ehGHo" to="mopj:1EbzjT2RcU7" resolve="ModelMerge" />
+          <ref role="ehGHo" to="mopj:1EbzjT2RcU7" resolve="ModelMergingPolicy" />
         </node>
       </node>
       <node concept="37vLTG" id="6B0NpqHsVXH" role="3clF46">
@@ -9581,34 +9620,6 @@
       </node>
     </node>
     <node concept="2tJIrI" id="7wnapcW0q48" role="jymVt" />
-    <node concept="2YIFZL" id="7wnapcW0cfS" role="jymVt">
-      <property role="TrG5h" value="run" />
-      <node concept="3clFbS" id="7wnapcW0cfT" role="3clF47">
-        <node concept="3clFbF" id="7wnapcW0GAh" role="3cqZAp">
-          <node concept="1rXfSq" id="7wnapcW0GAf" role="3clFbG">
-            <ref role="37wK5l" node="2QNuyuiLuqz" resolve="run" />
-            <node concept="37vLTw" id="7wnapcW0GQv" role="37wK5m">
-              <ref role="3cqZAo" node="7wnapcW0cgE" resolve="modelMerge" />
-            </node>
-            <node concept="2ShNRf" id="7wnapcW0H9g" role="37wK5m">
-              <node concept="HV5vD" id="7wnapcW0H9h" role="2ShVmc">
-                <ref role="HV5vE" node="450aOM1SYvz" resolve="ContentHolderFactory.Impl" />
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3uibUv" id="7wnapcW0cgD" role="3clF45">
-        <ref role="3uigEE" node="2QNuyuiL5OR" resolve="MergerResolverImpl" />
-      </node>
-      <node concept="37vLTG" id="7wnapcW0cgE" role="3clF46">
-        <property role="TrG5h" value="modelMerge" />
-        <node concept="3Tqbb2" id="7wnapcW0cgF" role="1tU5fm">
-          <ref role="ehGHo" to="mopj:1EbzjT2RcU7" resolve="ModelMerge" />
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="7wnapcW0cgG" role="1B3o_S" />
-    </node>
     <node concept="2tJIrI" id="2QNuyuiM5am" role="jymVt" />
     <node concept="2YIFZL" id="7TOowlhaG9v" role="jymVt">
       <property role="TrG5h" value="rootsConcepts" />
@@ -9705,7 +9716,7 @@
           <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
         </node>
         <node concept="3Tqbb2" id="7YSeTY8ifr$" role="11_B2D">
-          <ref role="ehGHo" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
+          <ref role="ehGHo" to="mopj:1EbzjT2R$JP" resolve="ConceptMergingPolicy" />
         </node>
       </node>
       <node concept="37vLTG" id="7YSeTY8ifrh" role="3clF46">
@@ -9725,7 +9736,7 @@
             <ref role="ehGHo" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
           </node>
           <node concept="3Tqbb2" id="7YSeTY8ifrn" role="11_B2D">
-            <ref role="ehGHo" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
+            <ref role="ehGHo" to="mopj:1EbzjT2R$JP" resolve="ConceptMergingPolicy" />
           </node>
         </node>
       </node>
@@ -9739,7 +9750,7 @@
                 <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
               </node>
               <node concept="3Tqbb2" id="7YSeTY8ifqC" role="11_B2D">
-                <ref role="ehGHo" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
+                <ref role="ehGHo" to="mopj:1EbzjT2R$JP" resolve="ConceptMergingPolicy" />
               </node>
             </node>
             <node concept="2ShNRf" id="7YSeTY8ifqD" role="33vP2m">
@@ -9749,7 +9760,7 @@
                   <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
                 </node>
                 <node concept="3Tqbb2" id="7YSeTY8ifqG" role="1pMfVU">
-                  <ref role="ehGHo" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
+                  <ref role="ehGHo" to="mopj:1EbzjT2R$JP" resolve="ConceptMergingPolicy" />
                 </node>
               </node>
             </node>
@@ -9859,7 +9870,7 @@
           <node concept="3cpWsn" id="7YSeTY81uqE" role="3cpWs9">
             <property role="TrG5h" value="mergePolicy" />
             <node concept="3Tqbb2" id="7YSeTY81ufE" role="1tU5fm">
-              <ref role="ehGHo" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
+              <ref role="ehGHo" to="mopj:1EbzjT2R$JP" resolve="ConceptMergingPolicy" />
             </node>
             <node concept="2OqwBi" id="7YSeTY81uqF" role="33vP2m">
               <node concept="37vLTw" id="7YSeTY81uqG" role="2Oq$k0">
@@ -9986,7 +9997,7 @@
             <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
           </node>
           <node concept="3Tqbb2" id="7YSeTY81adE" role="11_B2D">
-            <ref role="ehGHo" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
+            <ref role="ehGHo" to="mopj:1EbzjT2R$JP" resolve="ConceptMergingPolicy" />
           </node>
         </node>
       </node>
@@ -10085,7 +10096,7 @@
                 </node>
                 <node concept="2YIFZM" id="7wnapcVWaZM" role="33vP2m">
                   <ref role="37wK5l" node="3EHNiwzzsrZ" resolve="mergeWithPrevious" />
-                  <ref role="1Pybhc" node="18W7Z4VeRuj" resolve="MergeResolverFromModelMerge" />
+                  <ref role="1Pybhc" node="18W7Z4VeRuj" resolve="PolicyMergerResolver" />
                   <node concept="2OqwBi" id="7wnapcVWaZN" role="37wK5m">
                     <node concept="37vLTw" id="7wnapcVWaZO" role="2Oq$k0">
                       <ref role="3cqZAo" node="3PLTv5jCBTi" resolve="propMap" />
@@ -10146,7 +10157,7 @@
               <property role="TrG5h" value="mpc" />
               <node concept="nSUau" id="1FQTM0rQ0xh" role="1tU5fm">
                 <node concept="3uibUv" id="1FQTM0rQ0xi" role="nSUat">
-                  <ref role="3uigEE" node="7TOowlgU0QJ" resolve="MergePolicyConflict" />
+                  <ref role="3uigEE" node="7TOowlgU0QJ" resolve="MergingPolicyConflict" />
                 </node>
               </node>
             </node>
@@ -10232,7 +10243,7 @@
                 </node>
                 <node concept="2YIFZM" id="hG_e7_WLSp" role="33vP2m">
                   <ref role="37wK5l" node="3EHNiwzzsrZ" resolve="mergeWithPrevious" />
-                  <ref role="1Pybhc" node="18W7Z4VeRuj" resolve="MergeResolverFromModelMerge" />
+                  <ref role="1Pybhc" node="18W7Z4VeRuj" resolve="PolicyMergerResolver" />
                   <node concept="2OqwBi" id="hG_e7_WLSq" role="37wK5m">
                     <node concept="liA8E" id="hG_e7_WLSr" role="2OqNvi">
                       <ref role="37wK5l" to="33ny:~Map.get(java.lang.Object)" resolve="get" />
@@ -10294,7 +10305,7 @@
               <property role="TrG5h" value="mpc" />
               <node concept="nSUau" id="1FQTM0rQ0xJ" role="1tU5fm">
                 <node concept="3uibUv" id="1FQTM0rQ0xK" role="nSUat">
-                  <ref role="3uigEE" node="7TOowlgU0QJ" resolve="MergePolicyConflict" />
+                  <ref role="3uigEE" node="7TOowlgU0QJ" resolve="MergingPolicyConflict" />
                 </node>
               </node>
             </node>
@@ -10407,7 +10418,7 @@
               <property role="TrG5h" value="mpc" />
               <node concept="nSUau" id="3PLTv5jM0X3" role="1tU5fm">
                 <node concept="3uibUv" id="3PLTv5jM0X4" role="nSUat">
-                  <ref role="3uigEE" node="7TOowlgU0QJ" resolve="MergePolicyConflict" />
+                  <ref role="3uigEE" node="7TOowlgU0QJ" resolve="MergingPolicyConflict" />
                 </node>
               </node>
             </node>
@@ -10449,7 +10460,7 @@
               <property role="TrG5h" value="mpc" />
               <node concept="nSUau" id="60iGZSK0Ouv" role="1tU5fm">
                 <node concept="3uibUv" id="60iGZSK0Pq4" role="nSUat">
-                  <ref role="3uigEE" node="7TOowlgU0QJ" resolve="MergePolicyConflict" />
+                  <ref role="3uigEE" node="7TOowlgU0QJ" resolve="MergingPolicyConflict" />
                 </node>
               </node>
             </node>
@@ -10709,10 +10720,10 @@
         <node concept="3clFbH" id="3PLTv5jM0nG" role="3cqZAp" />
       </node>
       <node concept="3uibUv" id="1FQTM0rQ0z7" role="Sfmx6">
-        <ref role="3uigEE" node="7TOowlgU0QJ" resolve="MergePolicyConflict" />
+        <ref role="3uigEE" node="7TOowlgU0QJ" resolve="MergingPolicyConflict" />
       </node>
       <node concept="3uibUv" id="1FQTM0rQ0z8" role="Sfmx6">
-        <ref role="3uigEE" node="7TOowlgU0QJ" resolve="MergePolicyConflict" />
+        <ref role="3uigEE" node="7TOowlgU0QJ" resolve="MergingPolicyConflict" />
       </node>
       <node concept="37vLTG" id="3PLTv5jChmG" role="3clF46">
         <property role="TrG5h" value="resultBuilder" />
@@ -10729,7 +10740,7 @@
       <node concept="37vLTG" id="1FQTM0rPUjw" role="3clF46">
         <property role="TrG5h" value="mergePolicy" />
         <node concept="3Tqbb2" id="1FQTM0rPUjx" role="1tU5fm">
-          <ref role="ehGHo" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
+          <ref role="ehGHo" to="mopj:1EbzjT2R$JP" resolve="ConceptMergingPolicy" />
         </node>
       </node>
       <node concept="37vLTG" id="1FQTM0rPUjy" role="3clF46">
@@ -11012,7 +11023,7 @@
       <node concept="37vLTG" id="1FQTM0rPQwA" role="3clF46">
         <property role="TrG5h" value="mergePolicy" />
         <node concept="3Tqbb2" id="1FQTM0rPQwB" role="1tU5fm">
-          <ref role="ehGHo" to="mopj:1EbzjT2R$JP" resolve="MergePolicy" />
+          <ref role="ehGHo" to="mopj:1EbzjT2R$JP" resolve="ConceptMergingPolicy" />
         </node>
       </node>
       <node concept="37vLTG" id="1FQTM0rPQwC" role="3clF46">
@@ -12169,13 +12180,11 @@
         <property role="TrG5h" value="C" />
       </node>
     </node>
-    <node concept="2tJIrI" id="3EHNiwzsy2i" role="jymVt" />
     <node concept="3Tm1VV" id="18W7Z4VeRuk" role="1B3o_S" />
-    <node concept="2tJIrI" id="3PLTv5jA_Pa" role="jymVt" />
   </node>
   <node concept="312cEu" id="7YSeTY7XhnK">
     <property role="TrG5h" value="TraversalState" />
-    <property role="3GE5qa" value="mergetraversal" />
+    <property role="3GE5qa" value="traversing" />
     <node concept="2tJIrI" id="7YSeTY7XjhN" role="jymVt" />
     <node concept="312cEg" id="7YSeTY7Xkfw" role="jymVt">
       <property role="TrG5h" value="propertyCollector" />
@@ -13348,7 +13357,8 @@
     </node>
   </node>
   <node concept="312cEu" id="7TOowlgU0QJ">
-    <property role="TrG5h" value="MergePolicyConflict" />
+    <property role="TrG5h" value="MergingPolicyConflict" />
+    <property role="3GE5qa" value="exceptions" />
     <node concept="312cEg" id="7TOowlgU0V6" role="jymVt">
       <property role="TrG5h" value="violationFor" />
       <node concept="3Tm1VV" id="7TOowlgU0TF" role="1B3o_S" />
@@ -13494,7 +13504,7 @@
   </node>
   <node concept="312cEu" id="2rVXF9$Ou7E">
     <property role="TrG5h" value="MapWrapper" />
-    <property role="3GE5qa" value="mergetraversal" />
+    <property role="3GE5qa" value="traversing" />
     <node concept="312cEg" id="2rVXF9$OFBw" role="jymVt">
       <property role="TrG5h" value="propToAction" />
       <node concept="3Tm6S6" id="2rVXF9$OFAM" role="1B3o_S" />
@@ -13984,7 +13994,7 @@
   </node>
   <node concept="312cEu" id="2QNuyuiL5OR">
     <property role="TrG5h" value="MergerResolverImpl" />
-    <property role="3GE5qa" value="mergetraversal" />
+    <property role="3GE5qa" value="traversing" />
     <node concept="312cEg" id="2QNuyuiL71i" role="jymVt">
       <property role="TrG5h" value="propertyMergePolicy" />
       <node concept="3Tm1VV" id="2QNuyuiL7de" role="1B3o_S" />
@@ -14932,7 +14942,7 @@
   </node>
   <node concept="312cEu" id="3PLTv5jAE8Y">
     <property role="TrG5h" value="MergerResolverBuilder" />
-    <property role="3GE5qa" value="mergetraversal" />
+    <property role="3GE5qa" value="traversing" />
     <node concept="312cEg" id="3PLTv5jAOJL" role="jymVt">
       <property role="TrG5h" value="porpertyMergePolicy" />
       <node concept="3Tm1VV" id="3PLTv5jAFJt" role="1B3o_S" />
@@ -15142,7 +15152,7 @@
   <node concept="3HP615" id="61HvMZcnXGe">
     <property role="2bfB8j" value="true" />
     <property role="TrG5h" value="MergerResolver" />
-    <property role="3GE5qa" value="mergetraversal" />
+    <property role="3GE5qa" value="traversing" />
     <node concept="3clFb_" id="61HvMZco8bl" role="jymVt">
       <property role="TrG5h" value="childMergerFor" />
       <node concept="3uibUv" id="61HvMZcosjY" role="3clF45">
@@ -15206,7 +15216,7 @@
     <node concept="3Tm1VV" id="61HvMZcnXGf" role="1B3o_S" />
   </node>
   <node concept="312cEu" id="3EHNiwzfoWk">
-    <property role="3GE5qa" value="mergetraversal.content" />
+    <property role="3GE5qa" value="traversing.content" />
     <property role="TrG5h" value="SimpleActionContentHolder" />
     <node concept="2tJIrI" id="3EHNiwzfpEf" role="jymVt" />
     <node concept="312cEg" id="3EHNiwzfpM0" role="jymVt">
@@ -15472,7 +15482,7 @@
   </node>
   <node concept="3HP615" id="3EHNiwzf98t">
     <property role="TrG5h" value="ContentHolder" />
-    <property role="3GE5qa" value="mergetraversal.content" />
+    <property role="3GE5qa" value="traversing.content" />
     <node concept="2tJIrI" id="3EHNiwzf99n" role="jymVt" />
     <node concept="3clFb_" id="3EHNiwzf9b7" role="jymVt">
       <property role="TrG5h" value="isSame" />
@@ -15480,6 +15490,9 @@
         <property role="TrG5h" value="otherStuff" />
         <node concept="3uibUv" id="3EHNiwzfp9a" role="1tU5fm">
           <ref role="3uigEE" node="3EHNiwzf98t" resolve="ContentHolder" />
+          <node concept="16syzq" id="5HbTgGu$1RP" role="11_B2D">
+            <ref role="16sUi3" node="6gT8sje5Mei" resolve="C" />
+          </node>
         </node>
       </node>
       <node concept="3clFbS" id="3EHNiwzf9ba" role="3clF47" />
@@ -15529,7 +15542,7 @@
     </node>
   </node>
   <node concept="312cEu" id="3EHNiwzhbvm">
-    <property role="3GE5qa" value="mergetraversal.content" />
+    <property role="3GE5qa" value="traversing.content" />
     <property role="TrG5h" value="SubPolicyContainerContentHolder" />
     <node concept="2tJIrI" id="3EHNiwzhbHw" role="jymVt" />
     <node concept="312cEg" id="3EHNiwzhbR4" role="jymVt">
@@ -15943,7 +15956,8 @@
     </node>
   </node>
   <node concept="312cEu" id="6CwG2k7NbpD">
-    <property role="TrG5h" value="MissingMergePolicies" />
+    <property role="TrG5h" value="MissingMergingPolicies" />
+    <property role="3GE5qa" value="exceptions" />
     <node concept="2tJIrI" id="6CwG2k7Nbrv" role="jymVt" />
     <node concept="312cEg" id="6CwG2k7Nbt5" role="jymVt">
       <property role="TrG5h" value="missingPoliciesFor" />
@@ -16012,7 +16026,7 @@
     </node>
   </node>
   <node concept="312cEu" id="2cYlIwY_fxg">
-    <property role="TrG5h" value="ModelMergeExecutionRunner" />
+    <property role="TrG5h" value="ModelMergingRunner" />
     <node concept="2tJIrI" id="2cYlIwY_$$I" role="jymVt" />
     <node concept="2YIFZL" id="2cYlIwYBdd4" role="jymVt">
       <property role="TrG5h" value="run" />
@@ -16054,7 +16068,7 @@
         <node concept="3clFbH" id="2cYlIwYL_lO" role="3cqZAp" />
         <node concept="3clFbF" id="2cYlIwYLAED" role="3cqZAp">
           <node concept="2YIFZM" id="2cYlIwYLAEC" role="3clFbG">
-            <ref role="1Pybhc" node="2cYlIwY_fxg" resolve="ModelMergeExecutionRunner" />
+            <ref role="1Pybhc" node="2cYlIwY_fxg" resolve="ModelMergingRunner" />
             <ref role="37wK5l" node="2cYlIwYLAEx" resolve="run" />
             <node concept="37vLTw" id="2cYlIwYLAE$" role="37wK5m">
               <ref role="3cqZAo" node="2cYlIwYLzXO" resolve="smodelL" />
@@ -16079,7 +16093,7 @@
       <node concept="37vLTG" id="2cYlIwYBdd8" role="3clF46">
         <property role="TrG5h" value="modelMerge" />
         <node concept="3Tqbb2" id="2cYlIwYBdd9" role="1tU5fm">
-          <ref role="ehGHo" to="mopj:1EbzjT2RcU7" resolve="ModelMerge" />
+          <ref role="ehGHo" to="mopj:1EbzjT2RcU7" resolve="ModelMergingPolicy" />
         </node>
       </node>
       <node concept="37vLTG" id="2cYlIwYBdda" role="3clF46">
@@ -16137,7 +16151,7 @@
       <node concept="37vLTG" id="4LLXBGaeZ2s" role="3clF46">
         <property role="TrG5h" value="modelMerge" />
         <node concept="3Tqbb2" id="4LLXBGaeZ2t" role="1tU5fm">
-          <ref role="ehGHo" to="mopj:1EbzjT2RcU7" resolve="ModelMerge" />
+          <ref role="ehGHo" to="mopj:1EbzjT2RcU7" resolve="ModelMergingPolicy" />
         </node>
       </node>
       <node concept="37vLTG" id="4LLXBGaeZ2u" role="3clF46">
@@ -16203,7 +16217,7 @@
       <node concept="3clFbS" id="4LLXBGafXQB" role="3clF47">
         <node concept="3clFbF" id="4LLXBGafXQC" role="3cqZAp">
           <node concept="2YIFZM" id="4LLXBGafZ0W" role="3clFbG">
-            <ref role="1Pybhc" node="2cYlIwY_fxg" resolve="ModelMergeExecutionRunner" />
+            <ref role="1Pybhc" node="2cYlIwY_fxg" resolve="ModelMergingRunner" />
             <ref role="37wK5l" node="4LLXBGaeWni" resolve="runLeftMerge" />
             <node concept="1rXfSq" id="4LLXBGafXQG" role="37wK5m">
               <ref role="37wK5l" node="4LLXBGaeZ2$" resolve="resolveModel" />
@@ -16245,7 +16259,7 @@
       <node concept="37vLTG" id="4LLXBGafXQz" role="3clF46">
         <property role="TrG5h" value="modelMerge" />
         <node concept="3Tqbb2" id="4LLXBGafXQ$" role="1tU5fm">
-          <ref role="ehGHo" to="mopj:1EbzjT2RcU7" resolve="ModelMerge" />
+          <ref role="ehGHo" to="mopj:1EbzjT2RcU7" resolve="ModelMergingPolicy" />
         </node>
       </node>
       <node concept="3Tm1VV" id="4LLXBGafXQA" role="1B3o_S" />
@@ -16259,7 +16273,7 @@
             <property role="TrG5h" value="mergedModel" />
             <node concept="H_c77" id="4LLXBGaLH2y" role="1tU5fm" />
             <node concept="2YIFZM" id="4LLXBGaeWRu" role="33vP2m">
-              <ref role="1Pybhc" node="2cYlIwY_fxg" resolve="ModelMergeExecutionRunner" />
+              <ref role="1Pybhc" node="2cYlIwY_fxg" resolve="ModelMergingRunner" />
               <ref role="37wK5l" node="2cYlIwYEMiU" resolve="run" />
               <node concept="37vLTw" id="4LLXBGaeWnz" role="37wK5m">
                 <ref role="3cqZAo" node="4LLXBGaeWno" resolve="modelMerge" />
@@ -16325,7 +16339,7 @@
       <node concept="37vLTG" id="4LLXBGaeWno" role="3clF46">
         <property role="TrG5h" value="modelMerge" />
         <node concept="3Tqbb2" id="4LLXBGaeWnp" role="1tU5fm">
-          <ref role="ehGHo" to="mopj:1EbzjT2RcU7" resolve="ModelMerge" />
+          <ref role="ehGHo" to="mopj:1EbzjT2RcU7" resolve="ModelMergingPolicy" />
         </node>
       </node>
       <node concept="3Tm1VV" id="4LLXBGaeWnr" role="1B3o_S" />
@@ -16350,7 +16364,7 @@
       <node concept="37vLTG" id="2cYlIwYLAEn" role="3clF46">
         <property role="TrG5h" value="modelMerge" />
         <node concept="3Tqbb2" id="2cYlIwYLAEo" role="1tU5fm">
-          <ref role="ehGHo" to="mopj:1EbzjT2RcU7" resolve="ModelMerge" />
+          <ref role="ehGHo" to="mopj:1EbzjT2RcU7" resolve="ModelMergingPolicy" />
         </node>
       </node>
       <node concept="37vLTG" id="2cYlIwYLAEp" role="3clF46">
@@ -16416,7 +16430,7 @@
                 <node concept="2OqwBi" id="2cYlIwYLADW" role="1eOMHV">
                   <node concept="2OqwBi" id="2cYlIwYLADX" role="2Oq$k0">
                     <node concept="2YIFZM" id="6B0NpqH$0UD" role="2Oq$k0">
-                      <ref role="1Pybhc" node="2V55j61W8Fq" resolve="ModelMergerRunner" />
+                      <ref role="1Pybhc" node="2V55j61W8Fq" resolve="ModelMerger" />
                       <ref role="37wK5l" node="3a5mjFh18tR" resolve="create" />
                       <node concept="37vLTw" id="6B0NpqH$0UE" role="37wK5m">
                         <ref role="3cqZAo" node="2cYlIwYLAEn" resolve="modelMerge" />
@@ -16527,7 +16541,7 @@
       <node concept="37vLTG" id="2cYlIwYEMiW" role="3clF46">
         <property role="TrG5h" value="modelMerge" />
         <node concept="3Tqbb2" id="2cYlIwYEMiX" role="1tU5fm">
-          <ref role="ehGHo" to="mopj:1EbzjT2RcU7" resolve="ModelMerge" />
+          <ref role="ehGHo" to="mopj:1EbzjT2RcU7" resolve="ModelMergingPolicy" />
         </node>
       </node>
       <node concept="37vLTG" id="2cYlIwYEMiY" role="3clF46">

--- a/code/solutions/de.itemis.model.merge.simple.demo/de.itemis.model.merge.simple.demo.msd
+++ b/code/solutions/de.itemis.model.merge.simple.demo/de.itemis.model.merge.simple.demo.msd
@@ -25,12 +25,14 @@
     <dependency reexport="false">6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)</dependency>
     <dependency reexport="false">7866978e-a0f0-4cc7-81bc-4d213d9375e1(jetbrains.mps.lang.smodel)</dependency>
     <dependency reexport="false">446c26eb-2b7b-4bf0-9b35-f83fa582753e(jetbrains.mps.lang.modelapi)</dependency>
+    <dependency reexport="false">bf491fd2-a197-456a-8354-b3b225d4e871(de.itemis.model.simple.demo.enums)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:539e8939-08ef-497c-a5fd-25dd10137a55:de.itemis.model.merge" version="0" />
     <language slang="l:8688ed72-e0ba-44cb-9688-5c8397cb5bbb:de.itemis.model.simple.demo.children" version="0" />
     <language slang="l:e50b0500-6fd7-4c7f-a730-9d841358ce8b:de.itemis.model.simple.demo.collection" version="0" />
     <language slang="l:36ead753-43ea-471e-bcb9-d4fb1e637bbc:de.itemis.model.simple.demo.collection.keeper" version="0" />
+    <language slang="l:bf491fd2-a197-456a-8354-b3b225d4e871:de.itemis.model.simple.demo.enums" version="0" />
     <language slang="l:81362899-970b-421b-9fe3-2b64b343f769:de.itemis.model.simple.demo.property" version="0" />
     <language slang="l:e50b0500-6fd7-4c7f-a730-9d841358ca2b:de.itemis.model.simple.demo.property" version="0" />
     <language slang="l:6001215c-aa6e-4f9f-bfc2-f22e3c7250b2:de.itemis.model.simple.demo.reference" version="0" />
@@ -59,6 +61,7 @@
     <module reference="8688ed72-e0ba-44cb-9688-5c8397cb5bbb(de.itemis.model.simple.demo.children)" version="0" />
     <module reference="e50b0500-6fd7-4c7f-a730-9d841358ce8b(de.itemis.model.simple.demo.collection)" version="0" />
     <module reference="36ead753-43ea-471e-bcb9-d4fb1e637bbc(de.itemis.model.simple.demo.collection.keeper)" version="0" />
+    <module reference="bf491fd2-a197-456a-8354-b3b225d4e871(de.itemis.model.simple.demo.enums)" version="0" />
     <module reference="81362899-970b-421b-9fe3-2b64b343f769(de.itemis.model.simple.demo.property)" version="0" />
     <module reference="e50b0500-6fd7-4c7f-a730-9d841358ca2b(de.itemis.model.simple.demo.property)" version="0" />
     <module reference="6001215c-aa6e-4f9f-bfc2-f22e3c7250b2(de.itemis.model.simple.demo.reference)" version="0" />

--- a/code/solutions/de.itemis.model.merge.simple.demo/models/de.itemis.model.merge.simple.demo.enumLeft.mps
+++ b/code/solutions/de.itemis.model.merge.simple.demo/models/de.itemis.model.merge.simple.demo.enumLeft.mps
@@ -8,7 +8,7 @@
   <registry>
     <language id="bf491fd2-a197-456a-8354-b3b225d4e871" name="de.itemis.model.simple.demo.enums">
       <concept id="3615041602350286780" name="de.itemis.model.simple.demo.enums.structure.ConceptWithEnum" flags="ng" index="Iszaj">
-        <child id="3615041602350295310" name="id" index="IsxKx" />
+        <child id="3615041602350295310" name="idProperty" index="IsxKx" />
       </concept>
     </language>
     <language id="e50b0500-6fd7-4c7f-a730-9d841358ca2b" name="de.itemis.model.simple.demo.property">

--- a/code/solutions/de.itemis.model.merge.simple.demo/models/de.itemis.model.merge.simple.demo.enumLeft.mps
+++ b/code/solutions/de.itemis.model.merge.simple.demo/models/de.itemis.model.merge.simple.demo.enumLeft.mps
@@ -1,17 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<model ref="r:ecd2c27e-0ec1-4753-8900-a6ad3dc40f09(de.itemis.model.merge.simple.demo.result)">
+<model ref="r:91ea9791-daad-455e-bc56-6603fc63e28c(de.itemis.model.merge.simple.demo.enumLeft)">
   <persistence version="9" />
   <languages>
-    <use id="e50b0500-6fd7-4c7f-a730-9d841358ca2b" name="de.itemis.model.simple.demo.property" version="0" />
-    <use id="6001215c-aa6e-4f9f-bfc2-f22e3c7250b2" name="de.itemis.model.simple.demo.reference" version="0" />
-    <use id="8688ed72-e0ba-44cb-9688-5c8397cb5bbb" name="de.itemis.model.simple.demo.children" version="0" />
     <use id="bf491fd2-a197-456a-8354-b3b225d4e871" name="de.itemis.model.simple.demo.enums" version="0" />
   </languages>
   <imports />
   <registry>
     <language id="bf491fd2-a197-456a-8354-b3b225d4e871" name="de.itemis.model.simple.demo.enums">
       <concept id="3615041602350286780" name="de.itemis.model.simple.demo.enums.structure.ConceptWithEnum" flags="ng" index="Iszaj">
-        <child id="3615041602350295310" name="idProperty" index="IsxKx" />
+        <child id="3615041602350295310" name="id" index="IsxKx" />
       </concept>
     </language>
     <language id="e50b0500-6fd7-4c7f-a730-9d841358ca2b" name="de.itemis.model.simple.demo.property">
@@ -21,7 +18,7 @@
     </language>
   </registry>
   <node concept="Iszaj" id="38FdiWsm$dV">
-    <node concept="2pctC0" id="75IoIgYnRHd" role="IsxKx">
+    <node concept="2pctC0" id="38FdiWsm$dW" role="IsxKx">
       <property role="2pctC1" value="SomeData" />
     </node>
   </node>

--- a/code/solutions/de.itemis.model.merge.simple.demo/models/de.itemis.model.merge.simple.demo.enumRight.mps
+++ b/code/solutions/de.itemis.model.merge.simple.demo/models/de.itemis.model.merge.simple.demo.enumRight.mps
@@ -10,7 +10,7 @@
     <language id="bf491fd2-a197-456a-8354-b3b225d4e871" name="de.itemis.model.simple.demo.enums">
       <concept id="3615041602350286780" name="de.itemis.model.simple.demo.enums.structure.ConceptWithEnum" flags="ng" index="Iszaj">
         <property id="3615041602350287509" name="data" index="IszYU" />
-        <child id="3615041602350295310" name="id" index="IsxKx" />
+        <child id="3615041602350295310" name="idProperty" index="IsxKx" />
       </concept>
     </language>
     <language id="e50b0500-6fd7-4c7f-a730-9d841358ca2b" name="de.itemis.model.simple.demo.property">

--- a/code/solutions/de.itemis.model.merge.simple.demo/models/de.itemis.model.merge.simple.demo.enumRight.mps
+++ b/code/solutions/de.itemis.model.merge.simple.demo/models/de.itemis.model.merge.simple.demo.enumRight.mps
@@ -1,17 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<model ref="r:ecd2c27e-0ec1-4753-8900-a6ad3dc40f09(de.itemis.model.merge.simple.demo.result)">
+<model ref="r:d6171117-57e2-4a57-90db-2aab60257cc0(de.itemis.model.merge.simple.demo.enumRight)">
   <persistence version="9" />
   <languages>
-    <use id="e50b0500-6fd7-4c7f-a730-9d841358ca2b" name="de.itemis.model.simple.demo.property" version="0" />
-    <use id="6001215c-aa6e-4f9f-bfc2-f22e3c7250b2" name="de.itemis.model.simple.demo.reference" version="0" />
-    <use id="8688ed72-e0ba-44cb-9688-5c8397cb5bbb" name="de.itemis.model.simple.demo.children" version="0" />
     <use id="bf491fd2-a197-456a-8354-b3b225d4e871" name="de.itemis.model.simple.demo.enums" version="0" />
+    <use id="e50b0500-6fd7-4c7f-a730-9d841358ca2b" name="de.itemis.model.simple.demo.property" version="0" />
   </languages>
   <imports />
   <registry>
     <language id="bf491fd2-a197-456a-8354-b3b225d4e871" name="de.itemis.model.simple.demo.enums">
       <concept id="3615041602350286780" name="de.itemis.model.simple.demo.enums.structure.ConceptWithEnum" flags="ng" index="Iszaj">
-        <child id="3615041602350295310" name="idProperty" index="IsxKx" />
+        <property id="3615041602350287509" name="data" index="IszYU" />
+        <child id="3615041602350295310" name="id" index="IsxKx" />
       </concept>
     </language>
     <language id="e50b0500-6fd7-4c7f-a730-9d841358ca2b" name="de.itemis.model.simple.demo.property">
@@ -21,7 +20,8 @@
     </language>
   </registry>
   <node concept="Iszaj" id="38FdiWsm$dV">
-    <node concept="2pctC0" id="75IoIgYnRHd" role="IsxKx">
+    <property role="IszYU" value="38FdiWsmggi/firstMember" />
+    <node concept="2pctC0" id="38FdiWsm$dW" role="IsxKx">
       <property role="2pctC1" value="SomeData" />
     </node>
   </node>

--- a/code/solutions/de.itemis.model.merge.simple.demo/models/de.itemis.model.merge.simple.demo.merge.exec.mps
+++ b/code/solutions/de.itemis.model.merge.simple.demo/models/de.itemis.model.merge.simple.demo.merge.exec.mps
@@ -291,7 +291,7 @@
   </node>
   <node concept="poArf" id="38FdiWsmxTE">
     <property role="TrG5h" value="ConceptWithEnumExec" />
-    <ref role="pot50" to="2y6h:38FdiWsmiLf" resolve="ConceptWithEnum" />
+    <ref role="pot50" to="2y6h:38FdiWsmiLf" resolve="MergeConceptWithEnum" />
     <node concept="1Xw6AR" id="38FdiWsmxTF" role="ppIIL">
       <node concept="1dCxOl" id="38FdiWsmylu" role="1XwpL7">
         <property role="1XweGQ" value="r:91ea9791-daad-455e-bc56-6603fc63e28c" />

--- a/code/solutions/de.itemis.model.merge.simple.demo/models/de.itemis.model.merge.simple.demo.merge.exec.mps
+++ b/code/solutions/de.itemis.model.merge.simple.demo/models/de.itemis.model.merge.simple.demo.merge.exec.mps
@@ -29,8 +29,8 @@
       </concept>
     </language>
     <language id="539e8939-08ef-497c-a5fd-25dd10137a55" name="de.itemis.model.merge">
-      <concept id="6402745832171993510" name="de.itemis.model.merge.structure.ModelMergeExecution" flags="ng" index="poArf">
-        <reference id="6402745832172080681" name="modelMerge" index="pot50" />
+      <concept id="6402745832171993510" name="de.itemis.model.merge.structure.ModelMergingConfiguration" flags="ng" index="poArf">
+        <reference id="6402745832172080681" name="mergingPolicy" index="pot50" />
         <child id="6402745832172399733" name="right" index="ppbcs" />
         <child id="6402745832172287192" name="left" index="ppIIL" />
         <child id="3370123198533999175" name="result" index="2JagXQ" />
@@ -284,6 +284,34 @@
       <node concept="1dCxOl" id="1Tugx_8FCL" role="1XwpL7">
         <property role="1XweGQ" value="r:ecd2c27e-0ec1-4753-8900-a6ad3dc40f09" />
         <node concept="1j_P7g" id="1Tugx_8FCM" role="1j$8Uc">
+          <property role="1j_P7h" value="de.itemis.model.merge.simple.demo.result" />
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="poArf" id="38FdiWsmxTE">
+    <property role="TrG5h" value="ConceptWithEnumExec" />
+    <ref role="pot50" to="2y6h:38FdiWsmiLf" resolve="ConceptWithEnum" />
+    <node concept="1Xw6AR" id="38FdiWsmxTF" role="ppIIL">
+      <node concept="1dCxOl" id="38FdiWsmylu" role="1XwpL7">
+        <property role="1XweGQ" value="r:91ea9791-daad-455e-bc56-6603fc63e28c" />
+        <node concept="1j_P7g" id="38FdiWsmylv" role="1j$8Uc">
+          <property role="1j_P7h" value="de.itemis.model.merge.simple.demo.enumLeft" />
+        </node>
+      </node>
+    </node>
+    <node concept="1Xw6AR" id="38FdiWsmxTH" role="ppbcs">
+      <node concept="1dCxOl" id="38FdiWsmyqr" role="1XwpL7">
+        <property role="1XweGQ" value="r:d6171117-57e2-4a57-90db-2aab60257cc0" />
+        <node concept="1j_P7g" id="38FdiWsmyqs" role="1j$8Uc">
+          <property role="1j_P7h" value="de.itemis.model.merge.simple.demo.enumRight" />
+        </node>
+      </node>
+    </node>
+    <node concept="1Xw6AR" id="38FdiWsmyx0" role="2JagXQ">
+      <node concept="1dCxOl" id="38FdiWsmy_X" role="1XwpL7">
+        <property role="1XweGQ" value="r:ecd2c27e-0ec1-4753-8900-a6ad3dc40f09" />
+        <node concept="1j_P7g" id="38FdiWsmy_Y" role="1j$8Uc">
           <property role="1j_P7h" value="de.itemis.model.merge.simple.demo.result" />
         </node>
       </node>

--- a/code/solutions/de.itemis.model.merge.simple.demo/models/de.itemis.model.merge.simple.demo.plugin.mps
+++ b/code/solutions/de.itemis.model.merge.simple.demo/models/de.itemis.model.merge.simple.demo.plugin.mps
@@ -1620,7 +1620,7 @@
               <node concept="2OqwBi" id="38FdiWsmurk" role="2Oq$k0">
                 <node concept="233M7" id="38FdiWsmugD" role="2Oq$k0" />
                 <node concept="3TrEf2" id="38FdiWsmuJI" role="2OqNvi">
-                  <ref role="3Tt5mk" to="7y8w:38FdiWsmi$e" resolve="id" />
+                  <ref role="3Tt5mk" to="7y8w:38FdiWsmi$e" resolve="idProperty" />
                 </node>
               </node>
               <node concept="3TrcHB" id="38FdiWsmvDg" role="2OqNvi">

--- a/code/solutions/de.itemis.model.merge.simple.demo/models/de.itemis.model.merge.simple.demo.plugin.mps
+++ b/code/solutions/de.itemis.model.merge.simple.demo/models/de.itemis.model.merge.simple.demo.plugin.mps
@@ -14,6 +14,7 @@
     <import index="9kut" ref="r:c515cf95-0439-4376-8bc5-13a56baa0293(de.itemis.model.simple.demo.children.structure)" />
     <import index="lmxm" ref="r:a3686f62-e70f-468d-94f6-43bd46b56f08(de.itemis.model.simple.demo.collection.structure)" />
     <import index="hsq" ref="r:fc82e0c0-6be8-4ecf-9fa1-3d5bc168484e(de.itemis.model.simple.demo.reference.structure)" />
+    <import index="7y8w" ref="r:5e14b5a3-3989-4ab3-a15a-50ea008667da(de.itemis.model.simple.demo.enums.structure)" />
     <import index="z7ot" ref="r:3a3f4bbf-6c2b-49f6-8189-f83260cd20d6(de.itemis.model.simple.demo.collection.keeper.structure)" implicit="true" />
   </imports>
   <registry>
@@ -121,16 +122,18 @@
       <concept id="2120062183195930062" name="de.itemis.model.merge.structure.ActionCollectionFunctionRightParam" flags="ng" index="2Iixis" />
       <concept id="2120062183195394475" name="de.itemis.model.merge.structure.ActionCollectionFunctionLeftParam" flags="ng" index="2IszzT" />
       <concept id="2120062183195260387" name="de.itemis.model.merge.structure.ManualCollectionAction" flags="ig" index="2Iv4ML" />
-      <concept id="1912777765298260981" name="de.itemis.model.merge.structure.MergePolicy" flags="ng" index="1olsrb">
+      <concept id="7555554651740524246" name="de.itemis.model.merge.structure.Right" flags="ng" index="3iOvoU" />
+      <concept id="1912777765298260981" name="de.itemis.model.merge.structure.ConceptMergingPolicy" flags="ng" index="1olsrb">
         <reference id="4176264672384277229" name="conceptRef" index="24zOxU" />
         <child id="7137735640372265540" name="idFunction" index="21DrV" />
         <child id="1912777765298654333" name="propertyPolicies" index="1orW53" />
         <child id="4427572733332903915" name="referencePolicies" index="1IWF8q" />
         <child id="8422540920006574021" name="childPolicies" index="3JN1Yi" />
       </concept>
-      <concept id="1912777765298266446" name="de.itemis.model.merge.structure.EmptyMergeItem" flags="ng" index="1oluLK" />
-      <concept id="1912777765298163335" name="de.itemis.model.merge.structure.ModelMerge" flags="ng" index="1olOeT">
-        <child id="1912777765298260982" name="items" index="1olsr8" />
+      <concept id="1912777765298266446" name="de.itemis.model.merge.structure.EmptyMergingPolicy" flags="ng" index="1oluLK" />
+      <concept id="1912777765298163335" name="de.itemis.model.merge.structure.ModelMergingPolicy" flags="ng" index="1olOeT">
+        <property id="6578603516629851122" name="partialPolicy" index="15$7VT" />
+        <child id="1912777765298260982" name="policies" index="1olsr8" />
         <child id="8218966909317017940" name="additonalLangs" index="3oy5ef" />
         <child id="2222162468665533253" name="lang" index="3WPhuS" />
       </concept>
@@ -422,12 +425,6 @@
       </node>
     </node>
     <node concept="1oluLK" id="6Ltuup4JpXJ" role="1olsr8" />
-    <node concept="pHN19" id="3pc485VUmVr" role="3WPhuS">
-      <node concept="2V$Bhx" id="6_mEBr3QEVw" role="2V$M_3">
-        <property role="2V$B1T" value="8688ed72-e0ba-44cb-9688-5c8397cb5bbb" />
-        <property role="2V$B1Q" value="de.itemis.model.simple.demo.children" />
-      </node>
-    </node>
     <node concept="1olsrb" id="3pc485VUmVt" role="1olsr8">
       <ref role="24zOxU" to="yeyq:32ggi2DCpGw" resolve="PropertyDummy" />
       <node concept="230_S" id="3pc485VUnjS" role="21DrV">
@@ -469,6 +466,12 @@
             </node>
           </node>
         </node>
+      </node>
+    </node>
+    <node concept="pHN19" id="3pc485VUmVr" role="3WPhuS">
+      <node concept="2V$Bhx" id="6_mEBr3QEVw" role="2V$M_3">
+        <property role="2V$B1T" value="8688ed72-e0ba-44cb-9688-5c8397cb5bbb" />
+        <property role="2V$B1Q" value="de.itemis.model.simple.demo.children" />
       </node>
     </node>
   </node>
@@ -1596,6 +1599,65 @@
             </node>
           </node>
         </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1olOeT" id="38FdiWsmiLf">
+    <property role="TrG5h" value="MergeConceptWithEnum" />
+    <property role="15$7VT" value="true" />
+    <node concept="1oluLK" id="38FdiWsmAvT" role="1olsr8" />
+    <node concept="1oluLK" id="38FdiWsmAxz" role="1olsr8" />
+    <node concept="1olsrb" id="38FdiWsmtV_" role="1olsr8">
+      <ref role="24zOxU" to="7y8w:38FdiWsmguW" resolve="ConceptWithEnum" />
+      <node concept="1DuYj3" id="75IoIgYnIYP" role="3JN1Yi">
+        <ref role="3Ze0ni" to="7y8w:38FdiWsmi$e" resolve="idProperty" />
+        <node concept="3JN9zw" id="75IoIgYnJ4w" role="3JN5mL" />
+      </node>
+      <node concept="230_S" id="38FdiWsmtYR" role="21DrV">
+        <node concept="3clFbS" id="38FdiWsmtYS" role="2VODD2">
+          <node concept="3clFbF" id="38FdiWsmugE" role="3cqZAp">
+            <node concept="2OqwBi" id="38FdiWsmv1_" role="3clFbG">
+              <node concept="2OqwBi" id="38FdiWsmurk" role="2Oq$k0">
+                <node concept="233M7" id="38FdiWsmugD" role="2Oq$k0" />
+                <node concept="3TrEf2" id="38FdiWsmuJI" role="2OqNvi">
+                  <ref role="3Tt5mk" to="7y8w:38FdiWsmi$e" resolve="id" />
+                </node>
+              </node>
+              <node concept="3TrcHB" id="38FdiWsmvDg" role="2OqNvi">
+                <ref role="3TsBF5" to="yeyq:32ggi2DCpGx" resolve="data" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1orWGm" id="38FdiWsmvHJ" role="1orW53">
+        <ref role="3iOP7l" to="7y8w:38FdiWsmgEl" resolve="data" />
+        <node concept="3iOvoU" id="38FdiWsmw0l" role="1orWrN" />
+      </node>
+    </node>
+    <node concept="1olsrb" id="38FdiWsmwRF" role="1olsr8">
+      <ref role="24zOxU" to="yeyq:32ggi2DCpGw" resolve="PropertyDummy" />
+      <node concept="230_S" id="38FdiWsmwW_" role="21DrV">
+        <node concept="3clFbS" id="38FdiWsmwWA" role="2VODD2">
+          <node concept="3clFbF" id="38FdiWsmxeo" role="3cqZAp">
+            <node concept="2OqwBi" id="38FdiWsmxp2" role="3clFbG">
+              <node concept="233M7" id="38FdiWsmxen" role="2Oq$k0" />
+              <node concept="3TrcHB" id="38FdiWsmxI1" role="2OqNvi">
+                <ref role="3TsBF5" to="yeyq:32ggi2DCpGx" resolve="data" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1orWGm" id="38FdiWsmxPF" role="1orW53">
+        <ref role="3iOP7l" to="yeyq:32ggi2DCpGx" resolve="data" />
+        <node concept="3iOvoU" id="38FdiWsmxQo" role="1orWrN" />
+      </node>
+    </node>
+    <node concept="pHN19" id="38FdiWsmiLg" role="3WPhuS">
+      <node concept="2V$Bhx" id="38FdiWsmsd3" role="2V$M_3">
+        <property role="2V$B1T" value="bf491fd2-a197-456a-8354-b3b225d4e871" />
+        <property role="2V$B1Q" value="de.itemis.model.simple.demo.enums" />
       </node>
     </node>
   </node>

--- a/code/solutions/de.itemis.model.merge.simple.demo/models/de.itemis.model.merge.simple.demo.test@tests.mps
+++ b/code/solutions/de.itemis.model.merge.simple.demo/models/de.itemis.model.merge.simple.demo.test@tests.mps
@@ -270,8 +270,8 @@
       </concept>
     </language>
     <language id="539e8939-08ef-497c-a5fd-25dd10137a55" name="de.itemis.model.merge">
-      <concept id="6402745832171993510" name="de.itemis.model.merge.structure.ModelMergeExecution" flags="ng" index="poArf">
-        <reference id="6402745832172080681" name="modelMerge" index="pot50" />
+      <concept id="6402745832171993510" name="de.itemis.model.merge.structure.ModelMergingConfiguration" flags="ng" index="poArf">
+        <reference id="6402745832172080681" name="mergingPolicy" index="pot50" />
         <child id="6402745832172399733" name="right" index="ppbcs" />
         <child id="6402745832172287192" name="left" index="ppIIL" />
         <child id="3370123198533999175" name="result" index="2JagXQ" />
@@ -734,7 +734,7 @@
                 <ref role="3cqZAo" node="6Ltuup4xdCG" resolve="me" />
               </node>
               <node concept="3TrEf2" id="4LLXBGanQ1G" role="2OqNvi">
-                <ref role="3Tt5mk" to="mopj:5zr7Q_1IGSD" resolve="modelMerge" />
+                <ref role="3Tt5mk" to="mopj:5zr7Q_1IGSD" resolve="mergingPolicy" />
               </node>
             </node>
             <node concept="2OqwBi" id="4LLXBGanSyd" role="37wK5m">

--- a/code/solutions/de.itemis.model.merge.simple.demo/models/de.itemis.model.merge.simple.demo.test@tests.mps
+++ b/code/solutions/de.itemis.model.merge.simple.demo/models/de.itemis.model.merge.simple.demo.test@tests.mps
@@ -19,7 +19,7 @@
     <import index="yeyq" ref="r:98a265f1-4186-4e32-a289-328d37e5000c(de.itemis.model.simple.demo.property.structure)" />
     <import index="tqvn" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel.tempmodel(MPS.Core/)" />
     <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" />
-    <import index="3o3z" ref="ecfb9949-7433-4db5-85de-0f84d172e4ce/java:com.google.common.collect(de.q60.mps.libs/)" />
+    <import index="3o3z" ref="ecfb9949-7433-4db5-85de-0f84d172e4ce/java:com.google.common.collect(de.q60.mps.collections.libs/)" />
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
     <import index="hsq" ref="r:fc82e0c0-6be8-4ecf-9fa1-3d5bc168484e(de.itemis.model.simple.demo.reference.structure)" />
     <import index="u132" ref="49808fad-9d41-4b96-83fa-9231640f6b2b/java:junit.framework(JUnit/)" />
@@ -83,10 +83,6 @@
       <concept id="1081236700938" name="jetbrains.mps.baseLanguage.structure.StaticMethodDeclaration" flags="ig" index="2YIFZL" />
       <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
-      </concept>
-      <concept id="1081256982272" name="jetbrains.mps.baseLanguage.structure.InstanceOfExpression" flags="nn" index="2ZW3vV">
-        <child id="1081256993305" name="classType" index="2ZW6by" />
-        <child id="1081256993304" name="leftExpression" index="2ZW6bz" />
       </concept>
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
       <concept id="1070534934090" name="jetbrains.mps.baseLanguage.structure.CastExpression" flags="nn" index="10QFUN">
@@ -246,6 +242,9 @@
       <concept id="1171323947159" name="jetbrains.mps.lang.smodel.structure.Model_NodesOperation" flags="nn" index="2SmgA7">
         <child id="1758937410080001570" name="conceptArgument" index="1dBWTz" />
       </concept>
+      <concept id="2644386474300074836" name="jetbrains.mps.lang.smodel.structure.ConceptIdRefExpression" flags="nn" index="35c_gC">
+        <reference id="2644386474300074837" name="conceptDeclaration" index="35c_gD" />
+      </concept>
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
         <reference id="1138405853777" name="concept" index="ehGHo" />
       </concept>
@@ -329,13 +328,16 @@
             </node>
           </node>
         </node>
-        <node concept="1gVbGN" id="6Ltuup4wyH9" role="3cqZAp">
-          <node concept="2ZW3vV" id="6Ltuup4wAam" role="1gVkn0">
-            <node concept="3Tqbb2" id="6Ltuup4wAHa" role="2ZW6by">
-              <ref role="ehGHo" to="yeyq:32ggi2DCpGw" resolve="PropertyDummy" />
-            </node>
-            <node concept="37vLTw" id="6Ltuup4wzhn" role="2ZW6bz">
+        <node concept="1gVbGN" id="kewvTA1VeG" role="3cqZAp">
+          <node concept="2OqwBi" id="kewvTA1VeH" role="1gVkn0">
+            <node concept="37vLTw" id="kewvTA1VeI" role="2Oq$k0">
               <ref role="3cqZAo" node="6Ltuup4wtxo" resolve="observedRoot" />
+            </node>
+            <node concept="liA8E" id="kewvTA1VeJ" role="2OqNvi">
+              <ref role="37wK5l" to="mhbf:~SNode.isInstanceOfConcept(org.jetbrains.mps.openapi.language.SAbstractConcept)" resolve="isInstanceOfConcept" />
+              <node concept="35c_gC" id="kewvTA1VeK" role="37wK5m">
+                <ref role="35c_gD" to="yeyq:32ggi2DCpGw" resolve="PropertyDummy" />
+              </node>
             </node>
           </node>
         </node>
@@ -506,13 +508,16 @@
             </node>
           </node>
         </node>
-        <node concept="1gVbGN" id="6Ltuup4wOSt" role="3cqZAp">
-          <node concept="2ZW3vV" id="6Ltuup4wPv0" role="1gVkn0">
-            <node concept="3Tqbb2" id="6Ltuup4wPLF" role="2ZW6by">
-              <ref role="ehGHo" to="9kut:3pc485Vr2SQ" resolve="ChildKeeper" />
-            </node>
-            <node concept="37vLTw" id="6Ltuup4wPaP" role="2ZW6bz">
+        <node concept="1gVbGN" id="kewvTA1TiR" role="3cqZAp">
+          <node concept="2OqwBi" id="kewvTA1TiS" role="1gVkn0">
+            <node concept="37vLTw" id="kewvTA1TiT" role="2Oq$k0">
               <ref role="3cqZAo" node="6Ltuup4wNZq" resolve="observedRoot" />
+            </node>
+            <node concept="liA8E" id="kewvTA1TiU" role="2OqNvi">
+              <ref role="37wK5l" to="mhbf:~SNode.isInstanceOfConcept(org.jetbrains.mps.openapi.language.SAbstractConcept)" resolve="isInstanceOfConcept" />
+              <node concept="35c_gC" id="kewvTA1TiV" role="37wK5m">
+                <ref role="35c_gD" to="9kut:3pc485Vr2SQ" resolve="ChildKeeper" />
+              </node>
             </node>
           </node>
         </node>
@@ -608,12 +613,15 @@
           </node>
         </node>
         <node concept="1gVbGN" id="6Ltuup4wZy6" role="3cqZAp">
-          <node concept="2ZW3vV" id="6Ltuup4wZy7" role="1gVkn0">
-            <node concept="3Tqbb2" id="6Ltuup4wZy8" role="2ZW6by">
-              <ref role="ehGHo" to="9kut:3pc485Vr2SQ" resolve="ChildKeeper" />
-            </node>
-            <node concept="37vLTw" id="6Ltuup4wZy9" role="2ZW6bz">
+          <node concept="2OqwBi" id="kewvTA1IVT" role="1gVkn0">
+            <node concept="37vLTw" id="kewvTA1IbR" role="2Oq$k0">
               <ref role="3cqZAo" node="6Ltuup4wZy0" resolve="observedRoot" />
+            </node>
+            <node concept="liA8E" id="kewvTA1J9T" role="2OqNvi">
+              <ref role="37wK5l" to="mhbf:~SNode.isInstanceOfConcept(org.jetbrains.mps.openapi.language.SAbstractConcept)" resolve="isInstanceOfConcept" />
+              <node concept="35c_gC" id="kewvTA1Kdn" role="37wK5m">
+                <ref role="35c_gD" to="9kut:3pc485Vr2SQ" resolve="ChildKeeper" />
+              </node>
             </node>
           </node>
         </node>
@@ -716,7 +724,7 @@
         </node>
         <node concept="3clFbF" id="4LLXBGanLhs" role="3cqZAp">
           <node concept="2YIFZM" id="4LLXBGanMc$" role="3clFbG">
-            <ref role="1Pybhc" to="gunp:2cYlIwY_fxg" resolve="ModelMergeExecutionRunner" />
+            <ref role="1Pybhc" to="gunp:2cYlIwY_fxg" resolve="ModelMergingRunner" />
             <ref role="37wK5l" to="gunp:2cYlIwYBdd4" resolve="run" />
             <node concept="37vLTw" id="4LLXBGanNVd" role="37wK5m">
               <ref role="3cqZAo" node="6Ltuup4xdCM" resolve="model" />
@@ -759,7 +767,7 @@
       <node concept="37vLTG" id="6Ltuup4xdCG" role="3clF46">
         <property role="TrG5h" value="me" />
         <node concept="3Tqbb2" id="6Ltuup4xdCH" role="1tU5fm">
-          <ref role="ehGHo" to="mopj:5zr7Q_1InAA" resolve="ModelMergeExecution" />
+          <ref role="ehGHo" to="mopj:5zr7Q_1InAA" resolve="ModelMergingConfiguration" />
         </node>
       </node>
       <node concept="3Tm1VV" id="6Ltuup4xdCJ" role="1B3o_S" />
@@ -795,7 +803,7 @@
       <node concept="37vLTG" id="6Ltuup4xhzI" role="3clF46">
         <property role="TrG5h" value="me" />
         <node concept="3Tqbb2" id="6Ltuup4xhzJ" role="1tU5fm">
-          <ref role="ehGHo" to="mopj:5zr7Q_1InAA" resolve="ModelMergeExecution" />
+          <ref role="ehGHo" to="mopj:5zr7Q_1InAA" resolve="ModelMergingConfiguration" />
         </node>
       </node>
       <node concept="3Tm1VV" id="6Ltuup4xhzM" role="1B3o_S" />
@@ -883,7 +891,7 @@
       <node concept="37vLTG" id="77Ot_5atFj_" role="3clF46">
         <property role="TrG5h" value="me" />
         <node concept="3Tqbb2" id="77Ot_5atFjA" role="1tU5fm">
-          <ref role="ehGHo" to="mopj:5zr7Q_1InAA" resolve="ModelMergeExecution" />
+          <ref role="ehGHo" to="mopj:5zr7Q_1InAA" resolve="ModelMergingConfiguration" />
         </node>
       </node>
       <node concept="3Tm1VV" id="77Ot_5atFjT" role="1B3o_S" />
@@ -913,13 +921,16 @@
             </node>
           </node>
         </node>
-        <node concept="1gVbGN" id="77Ot_5af$7$" role="3cqZAp">
-          <node concept="2ZW3vV" id="77Ot_5af$7_" role="1gVkn0">
-            <node concept="3Tqbb2" id="77Ot_5af$7A" role="2ZW6by">
-              <ref role="ehGHo" to="lmxm:6Ltuup4C5JZ" resolve="CollectionKeeper" />
-            </node>
-            <node concept="37vLTw" id="77Ot_5af$7B" role="2ZW6bz">
+        <node concept="1gVbGN" id="kewvTAvpd9" role="3cqZAp">
+          <node concept="2OqwBi" id="kewvTAvpda" role="1gVkn0">
+            <node concept="37vLTw" id="kewvTAvpdb" role="2Oq$k0">
               <ref role="3cqZAo" node="77Ot_5af$7u" resolve="observedRoot" />
+            </node>
+            <node concept="liA8E" id="kewvTAvpdc" role="2OqNvi">
+              <ref role="37wK5l" to="mhbf:~SNode.isInstanceOfConcept(org.jetbrains.mps.openapi.language.SAbstractConcept)" resolve="isInstanceOfConcept" />
+              <node concept="35c_gC" id="kewvTAvpdd" role="37wK5m">
+                <ref role="35c_gD" to="lmxm:6Ltuup4C5JZ" resolve="CollectionKeeper" />
+              </node>
             </node>
           </node>
         </node>
@@ -971,13 +982,16 @@
             </node>
           </node>
         </node>
-        <node concept="1gVbGN" id="77Ot_5ah_O7" role="3cqZAp">
-          <node concept="2ZW3vV" id="77Ot_5ah_O8" role="1gVkn0">
-            <node concept="3Tqbb2" id="77Ot_5ah_O9" role="2ZW6by">
-              <ref role="ehGHo" to="lmxm:6Ltuup4C5JZ" resolve="CollectionKeeper" />
-            </node>
-            <node concept="37vLTw" id="77Ot_5ah_Oa" role="2ZW6bz">
+        <node concept="1gVbGN" id="kewvTAvpsX" role="3cqZAp">
+          <node concept="2OqwBi" id="kewvTAvpsY" role="1gVkn0">
+            <node concept="37vLTw" id="kewvTAvpsZ" role="2Oq$k0">
               <ref role="3cqZAo" node="77Ot_5ah_O1" resolve="observedRoot" />
+            </node>
+            <node concept="liA8E" id="kewvTAvpt0" role="2OqNvi">
+              <ref role="37wK5l" to="mhbf:~SNode.isInstanceOfConcept(org.jetbrains.mps.openapi.language.SAbstractConcept)" resolve="isInstanceOfConcept" />
+              <node concept="35c_gC" id="kewvTAvpt1" role="37wK5m">
+                <ref role="35c_gD" to="lmxm:6Ltuup4C5JZ" resolve="CollectionKeeper" />
+              </node>
             </node>
           </node>
         </node>
@@ -1029,13 +1043,16 @@
             </node>
           </node>
         </node>
-        <node concept="1gVbGN" id="77Ot_5ap$1T" role="3cqZAp">
-          <node concept="2ZW3vV" id="77Ot_5ap$1U" role="1gVkn0">
-            <node concept="3Tqbb2" id="77Ot_5ap$1V" role="2ZW6by">
-              <ref role="ehGHo" to="lmxm:6Ltuup4C5JZ" resolve="CollectionKeeper" />
-            </node>
-            <node concept="37vLTw" id="77Ot_5ap$1W" role="2ZW6bz">
+        <node concept="1gVbGN" id="kewvTAvpyL" role="3cqZAp">
+          <node concept="2OqwBi" id="kewvTAvpyM" role="1gVkn0">
+            <node concept="37vLTw" id="kewvTAvpyN" role="2Oq$k0">
               <ref role="3cqZAo" node="77Ot_5ap$1N" resolve="observedRoot" />
+            </node>
+            <node concept="liA8E" id="kewvTAvpyO" role="2OqNvi">
+              <ref role="37wK5l" to="mhbf:~SNode.isInstanceOfConcept(org.jetbrains.mps.openapi.language.SAbstractConcept)" resolve="isInstanceOfConcept" />
+              <node concept="35c_gC" id="kewvTAvpyP" role="37wK5m">
+                <ref role="35c_gD" to="lmxm:6Ltuup4C5JZ" resolve="CollectionKeeper" />
+              </node>
             </node>
           </node>
         </node>
@@ -1087,13 +1104,16 @@
             </node>
           </node>
         </node>
-        <node concept="1gVbGN" id="77Ot_5arzVH" role="3cqZAp">
-          <node concept="2ZW3vV" id="77Ot_5arzVI" role="1gVkn0">
-            <node concept="3Tqbb2" id="77Ot_5arzVJ" role="2ZW6by">
-              <ref role="ehGHo" to="lmxm:6Ltuup4C5JZ" resolve="CollectionKeeper" />
-            </node>
-            <node concept="37vLTw" id="77Ot_5arzVK" role="2ZW6bz">
+        <node concept="1gVbGN" id="kewvTAvpBe" role="3cqZAp">
+          <node concept="2OqwBi" id="kewvTAvpBf" role="1gVkn0">
+            <node concept="37vLTw" id="kewvTAvpBg" role="2Oq$k0">
               <ref role="3cqZAo" node="77Ot_5arzVB" resolve="observedRoot" />
+            </node>
+            <node concept="liA8E" id="kewvTAvpBh" role="2OqNvi">
+              <ref role="37wK5l" to="mhbf:~SNode.isInstanceOfConcept(org.jetbrains.mps.openapi.language.SAbstractConcept)" resolve="isInstanceOfConcept" />
+              <node concept="35c_gC" id="kewvTAvpBi" role="37wK5m">
+                <ref role="35c_gD" to="lmxm:6Ltuup4C5JZ" resolve="CollectionKeeper" />
+              </node>
             </node>
           </node>
         </node>
@@ -1145,13 +1165,16 @@
             </node>
           </node>
         </node>
-        <node concept="1gVbGN" id="1IpxBNKeUDp" role="3cqZAp">
-          <node concept="2ZW3vV" id="1IpxBNKeUDq" role="1gVkn0">
-            <node concept="3Tqbb2" id="1IpxBNKeUDr" role="2ZW6by">
-              <ref role="ehGHo" to="z7ot:5CYFCJDOmka" resolve="KeeperOfCollection" />
-            </node>
-            <node concept="37vLTw" id="1IpxBNKeUDs" role="2ZW6bz">
+        <node concept="1gVbGN" id="kewvTAvpFW" role="3cqZAp">
+          <node concept="2OqwBi" id="kewvTAvpFX" role="1gVkn0">
+            <node concept="37vLTw" id="kewvTAvpFY" role="2Oq$k0">
               <ref role="3cqZAo" node="1IpxBNKeUDl" resolve="observedRoot" />
+            </node>
+            <node concept="liA8E" id="kewvTAvpFZ" role="2OqNvi">
+              <ref role="37wK5l" to="mhbf:~SNode.isInstanceOfConcept(org.jetbrains.mps.openapi.language.SAbstractConcept)" resolve="isInstanceOfConcept" />
+              <node concept="35c_gC" id="kewvTAvpG0" role="37wK5m">
+                <ref role="35c_gD" to="z7ot:5CYFCJDOmka" resolve="KeeperOfCollection" />
+              </node>
             </node>
           </node>
         </node>
@@ -1203,13 +1226,16 @@
             </node>
           </node>
         </node>
-        <node concept="1gVbGN" id="30FY4ILVPNw" role="3cqZAp">
-          <node concept="2ZW3vV" id="30FY4ILVPNx" role="1gVkn0">
-            <node concept="3Tqbb2" id="30FY4ILVPNy" role="2ZW6by">
-              <ref role="ehGHo" to="9kut:3pc485Vr2SQ" resolve="ChildKeeper" />
-            </node>
-            <node concept="37vLTw" id="30FY4ILVPNz" role="2ZW6bz">
+        <node concept="1gVbGN" id="kewvTAvpOY" role="3cqZAp">
+          <node concept="2OqwBi" id="kewvTAvpOZ" role="1gVkn0">
+            <node concept="37vLTw" id="kewvTAvpP0" role="2Oq$k0">
               <ref role="3cqZAo" node="30FY4ILVPNs" resolve="observedRoot" />
+            </node>
+            <node concept="liA8E" id="kewvTAvpP1" role="2OqNvi">
+              <ref role="37wK5l" to="mhbf:~SNode.isInstanceOfConcept(org.jetbrains.mps.openapi.language.SAbstractConcept)" resolve="isInstanceOfConcept" />
+              <node concept="35c_gC" id="kewvTAvpP2" role="37wK5m">
+                <ref role="35c_gD" to="9kut:3pc485Vr2SQ" resolve="ChildKeeper" />
+              </node>
             </node>
           </node>
         </node>
@@ -1260,13 +1286,16 @@
             </node>
           </node>
         </node>
-        <node concept="1gVbGN" id="30FY4IMda1y" role="3cqZAp">
-          <node concept="2ZW3vV" id="30FY4IMda1z" role="1gVkn0">
-            <node concept="3Tqbb2" id="30FY4IMda1$" role="2ZW6by">
-              <ref role="ehGHo" to="lmxm:6Ltuup4C5JZ" resolve="CollectionKeeper" />
-            </node>
-            <node concept="37vLTw" id="30FY4IMda1_" role="2ZW6bz">
+        <node concept="1gVbGN" id="kewvTAvqcw" role="3cqZAp">
+          <node concept="2OqwBi" id="kewvTAvqcx" role="1gVkn0">
+            <node concept="37vLTw" id="kewvTAvqcy" role="2Oq$k0">
               <ref role="3cqZAo" node="30FY4IMda1u" resolve="observedRoot" />
+            </node>
+            <node concept="liA8E" id="kewvTAvqcz" role="2OqNvi">
+              <ref role="37wK5l" to="mhbf:~SNode.isInstanceOfConcept(org.jetbrains.mps.openapi.language.SAbstractConcept)" resolve="isInstanceOfConcept" />
+              <node concept="35c_gC" id="kewvTAvqc$" role="37wK5m">
+                <ref role="35c_gD" to="lmxm:6Ltuup4C5JZ" resolve="CollectionKeeper" />
+              </node>
             </node>
           </node>
         </node>
@@ -2034,13 +2063,16 @@
             </node>
           </node>
         </node>
-        <node concept="1gVbGN" id="4LLXBGbv8iX" role="3cqZAp">
-          <node concept="2ZW3vV" id="4LLXBGbv8iY" role="1gVkn0">
-            <node concept="3Tqbb2" id="4LLXBGbv8iZ" role="2ZW6by">
-              <ref role="ehGHo" to="yeyq:32ggi2DCpGw" resolve="PropertyDummy" />
-            </node>
-            <node concept="37vLTw" id="4LLXBGbv8j0" role="2ZW6bz">
+        <node concept="1gVbGN" id="kewvTA200E" role="3cqZAp">
+          <node concept="2OqwBi" id="kewvTA200F" role="1gVkn0">
+            <node concept="37vLTw" id="kewvTA200G" role="2Oq$k0">
               <ref role="3cqZAo" node="4LLXBGbv8iT" resolve="observedRoot" />
+            </node>
+            <node concept="liA8E" id="kewvTA200H" role="2OqNvi">
+              <ref role="37wK5l" to="mhbf:~SNode.isInstanceOfConcept(org.jetbrains.mps.openapi.language.SAbstractConcept)" resolve="isInstanceOfConcept" />
+              <node concept="35c_gC" id="kewvTA200I" role="37wK5m">
+                <ref role="35c_gD" to="yeyq:32ggi2DCpGw" resolve="PropertyDummy" />
+              </node>
             </node>
           </node>
         </node>
@@ -2208,13 +2240,16 @@
             </node>
           </node>
         </node>
-        <node concept="1gVbGN" id="4LLXBGbHXwz" role="3cqZAp">
-          <node concept="2ZW3vV" id="4LLXBGbHXw$" role="1gVkn0">
-            <node concept="3Tqbb2" id="4LLXBGbHXw_" role="2ZW6by">
-              <ref role="ehGHo" to="9kut:3pc485Vr2SQ" resolve="ChildKeeper" />
-            </node>
-            <node concept="37vLTw" id="4LLXBGbHXwA" role="2ZW6bz">
+        <node concept="1gVbGN" id="kewvTA1RxX" role="3cqZAp">
+          <node concept="2OqwBi" id="kewvTA1RxY" role="1gVkn0">
+            <node concept="37vLTw" id="kewvTA1RxZ" role="2Oq$k0">
               <ref role="3cqZAo" node="4LLXBGbHXwv" resolve="observedRoot" />
+            </node>
+            <node concept="liA8E" id="kewvTA1Ry0" role="2OqNvi">
+              <ref role="37wK5l" to="mhbf:~SNode.isInstanceOfConcept(org.jetbrains.mps.openapi.language.SAbstractConcept)" resolve="isInstanceOfConcept" />
+              <node concept="35c_gC" id="kewvTA1Ry1" role="37wK5m">
+                <ref role="35c_gD" to="9kut:3pc485Vr2SQ" resolve="ChildKeeper" />
+              </node>
             </node>
           </node>
         </node>

--- a/code/solutions/de.itemis.model.merge.test.integration/models/de.itemis.model.merge.test.integration.plugin.mps
+++ b/code/solutions/de.itemis.model.merge.test.integration/models/de.itemis.model.merge.test.integration.plugin.mps
@@ -53,14 +53,14 @@
     <language id="539e8939-08ef-497c-a5fd-25dd10137a55" name="de.itemis.model.merge">
       <concept id="7137735640371846599" name="de.itemis.model.merge.structure.IdFunction" flags="ig" index="230_S" />
       <concept id="7137735640371849272" name="de.itemis.model.merge.structure.IdFunctionParam" flags="ng" index="233M7" />
-      <concept id="1912777765298260981" name="de.itemis.model.merge.structure.MergePolicy" flags="ng" index="1olsrb">
+      <concept id="1912777765298260981" name="de.itemis.model.merge.structure.ConceptMergingPolicy" flags="ng" index="1olsrb">
         <reference id="4176264672384277229" name="conceptRef" index="24zOxU" />
         <child id="7137735640372265540" name="idFunction" index="21DrV" />
         <child id="1912777765298654333" name="propertyPolicies" index="1orW53" />
       </concept>
-      <concept id="1912777765298266446" name="de.itemis.model.merge.structure.EmptyMergeItem" flags="ng" index="1oluLK" />
-      <concept id="1912777765298163335" name="de.itemis.model.merge.structure.ModelMerge" flags="ng" index="1olOeT">
-        <child id="1912777765298260982" name="items" index="1olsr8" />
+      <concept id="1912777765298266446" name="de.itemis.model.merge.structure.EmptyMergingPolicy" flags="ng" index="1oluLK" />
+      <concept id="1912777765298163335" name="de.itemis.model.merge.structure.ModelMergingPolicy" flags="ng" index="1olOeT">
+        <child id="1912777765298260982" name="policies" index="1olsr8" />
         <child id="2222162468665533253" name="lang" index="3WPhuS" />
       </concept>
       <concept id="1912777765298654154" name="de.itemis.model.merge.structure.Left" flags="ng" index="1orWrO" />

--- a/code/solutions/de.itemis.model.merge.test.integration/models/de.itemis.model.merge.test.integration.tests@tests.mps
+++ b/code/solutions/de.itemis.model.merge.test.integration/models/de.itemis.model.merge.test.integration.tests@tests.mps
@@ -19,7 +19,6 @@
     <import index="tp25" ref="r:00000000-0000-4000-0000-011c89590301(jetbrains.mps.lang.smodel.structure)" />
     <import index="xlb7" ref="r:cf42fd0a-68d2-493b-8b77-961658617704(jetbrains.mps.lang.modelapi.behavior)" />
     <import index="z1c3" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.project(MPS.Core/)" />
-    <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" />
     <import index="1xlh" ref="r:83d91843-991e-414a-ada7-28ed0de69bb1(de.itemis.model.test.integration.plugin)" />
   </imports>
@@ -58,10 +57,6 @@
       </concept>
       <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
-      </concept>
-      <concept id="1081256982272" name="jetbrains.mps.baseLanguage.structure.InstanceOfExpression" flags="nn" index="2ZW3vV">
-        <child id="1081256993305" name="classType" index="2ZW6by" />
-        <child id="1081256993304" name="leftExpression" index="2ZW6bz" />
       </concept>
       <concept id="1070534934090" name="jetbrains.mps.baseLanguage.structure.CastExpression" flags="nn" index="10QFUN">
         <child id="1070534934091" name="type" index="10QFUM" />
@@ -134,6 +129,9 @@
       <concept id="1171323947159" name="jetbrains.mps.lang.smodel.structure.Model_NodesOperation" flags="nn" index="2SmgA7">
         <child id="1758937410080001570" name="conceptArgument" index="1dBWTz" />
       </concept>
+      <concept id="2644386474300074836" name="jetbrains.mps.lang.smodel.structure.ConceptIdRefExpression" flags="nn" index="35c_gC">
+        <reference id="2644386474300074837" name="conceptDeclaration" index="35c_gD" />
+      </concept>
       <concept id="6407023681583036853" name="jetbrains.mps.lang.smodel.structure.NodeAttributeQualifier" flags="ng" index="3CFYIy">
         <reference id="6407023681583036854" name="attributeConcept" index="3CFYIx" />
       </concept>
@@ -174,8 +172,8 @@
       </concept>
     </language>
     <language id="539e8939-08ef-497c-a5fd-25dd10137a55" name="de.itemis.model.merge">
-      <concept id="6402745832171993510" name="de.itemis.model.merge.structure.ModelMergeExecution" flags="ng" index="poArf">
-        <reference id="6402745832172080681" name="modelMerge" index="pot50" />
+      <concept id="6402745832171993510" name="de.itemis.model.merge.structure.ModelMergingConfiguration" flags="ng" index="poArf">
+        <reference id="6402745832172080681" name="mergingPolicy" index="pot50" />
         <child id="6402745832172399733" name="right" index="ppbcs" />
         <child id="6402745832172287192" name="left" index="ppIIL" />
       </concept>
@@ -208,13 +206,16 @@
             </node>
           </node>
         </node>
-        <node concept="1gVbGN" id="hG_e7_dlJr" role="3cqZAp">
-          <node concept="2ZW3vV" id="hG_e7_dlJs" role="1gVkn0">
-            <node concept="3Tqbb2" id="hG_e7_dlJt" role="2ZW6by">
-              <ref role="ehGHo" to="7e3e:W4mNzjZ9yL" resolve="Annotatable" />
-            </node>
-            <node concept="37vLTw" id="hG_e7_dlJu" role="2ZW6bz">
+        <node concept="1gVbGN" id="6Ltuup4wZy6" role="3cqZAp">
+          <node concept="2OqwBi" id="kewvTA1IVT" role="1gVkn0">
+            <node concept="37vLTw" id="kewvTA1IbR" role="2Oq$k0">
               <ref role="3cqZAo" node="hG_e7_dlJn" resolve="observedRoot" />
+            </node>
+            <node concept="liA8E" id="kewvTA1J9T" role="2OqNvi">
+              <ref role="37wK5l" to="mhbf:~SNode.isInstanceOfConcept(org.jetbrains.mps.openapi.language.SAbstractConcept)" resolve="isInstanceOfConcept" />
+              <node concept="35c_gC" id="kewvTA1Kdn" role="37wK5m">
+                <ref role="35c_gD" to="7e3e:W4mNzjZ9yL" resolve="Annotatable" />
+              </node>
             </node>
           </node>
         </node>
@@ -421,13 +422,16 @@
             </node>
           </node>
         </node>
-        <node concept="1gVbGN" id="4LLXBGbTodM" role="3cqZAp">
-          <node concept="2ZW3vV" id="4LLXBGbTodN" role="1gVkn0">
-            <node concept="3Tqbb2" id="4LLXBGbTodO" role="2ZW6by">
-              <ref role="ehGHo" to="7e3e:W4mNzjZ9yL" resolve="Annotatable" />
-            </node>
-            <node concept="37vLTw" id="4LLXBGbTodP" role="2ZW6bz">
+        <node concept="1gVbGN" id="kewvTAGq$L" role="3cqZAp">
+          <node concept="2OqwBi" id="kewvTAGq$M" role="1gVkn0">
+            <node concept="37vLTw" id="kewvTAGq$N" role="2Oq$k0">
               <ref role="3cqZAo" node="4LLXBGbTodI" resolve="observedRoot" />
+            </node>
+            <node concept="liA8E" id="kewvTAGq$O" role="2OqNvi">
+              <ref role="37wK5l" to="mhbf:~SNode.isInstanceOfConcept(org.jetbrains.mps.openapi.language.SAbstractConcept)" resolve="isInstanceOfConcept" />
+              <node concept="35c_gC" id="kewvTAGq$P" role="37wK5m">
+                <ref role="35c_gD" to="7e3e:W4mNzjZ9yL" resolve="Annotatable" />
+              </node>
             </node>
           </node>
         </node>

--- a/code/solutions/de.itemis.model.merge.test/de.itemis.model.merge.test.msd
+++ b/code/solutions/de.itemis.model.merge.test/de.itemis.model.merge.test.msd
@@ -30,7 +30,6 @@
     <language slang="l:9343567c-db05-48c8-bba6-fdc3f5c1b3c0:de.itemis.model.merge.baselang" version="0" />
     <language slang="l:0ef84c01-bf36-41ed-9882-d7b70a4a4eba:de.itemis.model.merge.diamond" version="0" />
     <language slang="l:81362899-970b-421b-9fe3-2b64b343f769:de.itemis.model.simple.demo.property" version="0" />
-    <language slang="l:e50b0500-6fd7-4c7f-a730-9d841358ca2b:de.itemis.model.simple.demo.property" version="0" />
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
     <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />
     <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />

--- a/code/solutions/de.itemis.model.merge.test/models/de.itemis.model.merge.test.gen@tests.mps
+++ b/code/solutions/de.itemis.model.merge.test/models/de.itemis.model.merge.test.gen@tests.mps
@@ -27,7 +27,6 @@
     <import index="lui2" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.module(MPS.OpenAPI/)" />
     <import index="mopj" ref="r:58892eeb-9059-4684-af0a-e0f5f7f9800d(de.itemis.model.merge.structure)" />
     <import index="k6li" ref="r:7c40b043-67ab-4fff-a68c-bb3e633629e4(test.de.itemis.mps.modelmerger.testlanguage.structure)" />
-    <import index="da0s" ref="r:c5ef02fd-fc0b-460a-bea5-97c4d7c6c4cf(de.itemis.model.merge.baselang.sandbox)" />
   </imports>
   <registry>
     <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
@@ -4325,7 +4324,7 @@
           <node concept="3cpWsn" id="5hEfjVobgxW" role="3cpWs9">
             <property role="TrG5h" value="modelMerge" />
             <node concept="3Tqbb2" id="5hEfjVobgxX" role="1tU5fm">
-              <ref role="ehGHo" to="mopj:1EbzjT2RcU7" resolve="ModelMerge" />
+              <ref role="ehGHo" to="mopj:1EbzjT2RcU7" resolve="ModelMergingPolicy" />
             </node>
             <node concept="2OqwBi" id="5hEfjVobgxY" role="33vP2m">
               <node concept="37vLTw" id="5hEfjVobgxZ" role="2Oq$k0">
@@ -4351,12 +4350,12 @@
         </node>
       </node>
       <node concept="3Tqbb2" id="5hEfjVobgxE" role="3clF45">
-        <ref role="ehGHo" to="mopj:1EbzjT2RcU7" resolve="ModelMerge" />
+        <ref role="ehGHo" to="mopj:1EbzjT2RcU7" resolve="ModelMergingPolicy" />
       </node>
       <node concept="37vLTG" id="5hEfjVobgxC" role="3clF46">
         <property role="TrG5h" value="nodePtr" />
         <node concept="2sp9CU" id="5hEfjVobgxD" role="1tU5fm">
-          <ref role="2sp9C9" to="mopj:1EbzjT2RcU7" resolve="ModelMerge" />
+          <ref role="2sp9C9" to="mopj:1EbzjT2RcU7" resolve="ModelMergingPolicy" />
         </node>
       </node>
       <node concept="3Tm1VV" id="5hEfjVobgy6" role="1B3o_S" />

--- a/code/solutions/de.itemis.model.merge.test/models/de.itemis.model.merge.test.plugin.mps
+++ b/code/solutions/de.itemis.model.merge.test/models/de.itemis.model.merge.test.plugin.mps
@@ -128,16 +128,16 @@
       <concept id="2120062183195394475" name="de.itemis.model.merge.structure.ActionCollectionFunctionLeftParam" flags="ng" index="2IszzT" />
       <concept id="2120062183195260387" name="de.itemis.model.merge.structure.ManualCollectionAction" flags="ig" index="2Iv4ML" />
       <concept id="7555554651740524246" name="de.itemis.model.merge.structure.Right" flags="ng" index="3iOvoU" />
-      <concept id="1912777765298260981" name="de.itemis.model.merge.structure.MergePolicy" flags="ng" index="1olsrb">
+      <concept id="1912777765298260981" name="de.itemis.model.merge.structure.ConceptMergingPolicy" flags="ng" index="1olsrb">
         <reference id="4176264672384277229" name="conceptRef" index="24zOxU" />
         <child id="7137735640372265540" name="idFunction" index="21DrV" />
         <child id="1912777765298654333" name="propertyPolicies" index="1orW53" />
         <child id="4427572733332903915" name="referencePolicies" index="1IWF8q" />
         <child id="8422540920006574021" name="childPolicies" index="3JN1Yi" />
       </concept>
-      <concept id="1912777765298266446" name="de.itemis.model.merge.structure.EmptyMergeItem" flags="ng" index="1oluLK" />
-      <concept id="1912777765298163335" name="de.itemis.model.merge.structure.ModelMerge" flags="ng" index="1olOeT">
-        <child id="1912777765298260982" name="items" index="1olsr8" />
+      <concept id="1912777765298266446" name="de.itemis.model.merge.structure.EmptyMergingPolicy" flags="ng" index="1oluLK" />
+      <concept id="1912777765298163335" name="de.itemis.model.merge.structure.ModelMergingPolicy" flags="ng" index="1olOeT">
+        <child id="1912777765298260982" name="policies" index="1olsr8" />
         <child id="2222162468665533253" name="lang" index="3WPhuS" />
       </concept>
       <concept id="1912777765298654154" name="de.itemis.model.merge.structure.Left" flags="ng" index="1orWrO" />

--- a/code/solutions/de.itemis.model.merge.test/models/de.itemis.model.merge.test.plugin2.mps
+++ b/code/solutions/de.itemis.model.merge.test/models/de.itemis.model.merge.test.plugin2.mps
@@ -33,8 +33,8 @@
       </concept>
     </language>
     <language id="539e8939-08ef-497c-a5fd-25dd10137a55" name="de.itemis.model.merge">
-      <concept id="6402745832171993510" name="de.itemis.model.merge.structure.ModelMergeExecution" flags="ng" index="poArf">
-        <reference id="6402745832172080681" name="modelMerge" index="pot50" />
+      <concept id="6402745832171993510" name="de.itemis.model.merge.structure.ModelMergingConfiguration" flags="ng" index="poArf">
+        <reference id="6402745832172080681" name="mergingPolicy" index="pot50" />
         <child id="6402745832172399733" name="right" index="ppbcs" />
         <child id="6402745832172287192" name="left" index="ppIIL" />
       </concept>

--- a/code/solutions/de.itemis.model.merge.test/models/de.itemis.model.merge.test.test1@tests.mps
+++ b/code/solutions/de.itemis.model.merge.test/models/de.itemis.model.merge.test.test1@tests.mps
@@ -6,7 +6,6 @@
     <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
     <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
     <use id="539e8939-08ef-497c-a5fd-25dd10137a55" name="de.itemis.model.merge" version="0" />
-    <use id="e50b0500-6fd7-4c7f-a730-9d841358ca2b" name="de.itemis.model.simple.demo.property" version="0" />
   </languages>
   <imports>
     <import index="mopj" ref="r:58892eeb-9059-4684-af0a-e0f5f7f9800d(de.itemis.model.merge.structure)" />
@@ -180,20 +179,24 @@
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
+      <concept id="4222318806802425298" name="jetbrains.mps.lang.core.structure.SuppressErrorsAnnotation" flags="ng" index="15s5l7">
+        <property id="8575328350543493365" name="message" index="huDt6" />
+        <property id="2423417345669755629" name="filter" index="1eyWvh" />
+      </concept>
     </language>
     <language id="539e8939-08ef-497c-a5fd-25dd10137a55" name="de.itemis.model.merge">
       <concept id="7137735640371846599" name="de.itemis.model.merge.structure.IdFunction" flags="ig" index="230_S" />
       <concept id="7137735640371849272" name="de.itemis.model.merge.structure.IdFunctionParam" flags="ng" index="233M7" />
       <concept id="7555554651740524246" name="de.itemis.model.merge.structure.Right" flags="ng" index="3iOvoU" />
-      <concept id="1912777765298260981" name="de.itemis.model.merge.structure.MergePolicy" flags="ng" index="1olsrb">
+      <concept id="1912777765298260981" name="de.itemis.model.merge.structure.ConceptMergingPolicy" flags="ng" index="1olsrb">
         <reference id="4176264672384277229" name="conceptRef" index="24zOxU" />
         <child id="7137735640372265540" name="idFunction" index="21DrV" />
         <child id="1912777765298654333" name="propertyPolicies" index="1orW53" />
         <child id="8422540920006574021" name="childPolicies" index="3JN1Yi" />
       </concept>
-      <concept id="1912777765298266446" name="de.itemis.model.merge.structure.EmptyMergeItem" flags="ng" index="1oluLK" />
-      <concept id="1912777765298163335" name="de.itemis.model.merge.structure.ModelMerge" flags="ng" index="1olOeT">
-        <child id="1912777765298260982" name="items" index="1olsr8" />
+      <concept id="1912777765298266446" name="de.itemis.model.merge.structure.EmptyMergingPolicy" flags="ng" index="1oluLK" />
+      <concept id="1912777765298163335" name="de.itemis.model.merge.structure.ModelMergingPolicy" flags="ng" index="1olOeT">
+        <child id="1912777765298260982" name="policies" index="1olsr8" />
         <child id="2222162468665533253" name="lang" index="3WPhuS" />
       </concept>
       <concept id="1912777765298654154" name="de.itemis.model.merge.structure.Left" flags="ng" index="1orWrO" />
@@ -433,6 +436,14 @@
       </node>
     </node>
     <node concept="1qefOq" id="3EHNiwz2jtW" role="1SKRRt">
+      <node concept="15s5l7" id="kewvTAGoId" role="lGtFl">
+        <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: multi-child policy not completely defined&quot;;FLAVOUR_RULE_ID=&quot;[r:02b6652e-c87d-4bb2-bfc0-4b5c0d5b9442(de.itemis.model.merge.typesystem)/7647305840372727207]&quot;;" />
+        <property role="huDt6" value="Error: multi-child policy not completely defined" />
+      </node>
+      <node concept="15s5l7" id="kewvTAGoHJ" role="lGtFl">
+        <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: merge policy for concept Data does not define ID function&quot;;FLAVOUR_RULE_ID=&quot;[r:02b6652e-c87d-4bb2-bfc0-4b5c0d5b9442(de.itemis.model.merge.typesystem)/7647305840371712554]&quot;;" />
+        <property role="huDt6" value="Error: merge policy for concept Data does not define ID function" />
+      </node>
       <node concept="1olOeT" id="3EHNiwz2jtX" role="1qenE9">
         <property role="TrG5h" value="CheckForMissingMergePolicyForProperty" />
         <node concept="1oluLK" id="3EHNiwz2jtY" role="1olsr8" />
@@ -1630,6 +1641,14 @@
     <property role="TrG5h" value="DiamondChildTest" />
     <property role="3DII0k" value="2hh8MJdVwqX/command" />
     <node concept="1qefOq" id="1trrptaE8Aa" role="1SKRRt">
+      <node concept="15s5l7" id="kewvTAGds5" role="lGtFl">
+        <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: multi-child policy not completely defined&quot;;FLAVOUR_RULE_ID=&quot;[r:02b6652e-c87d-4bb2-bfc0-4b5c0d5b9442(de.itemis.model.merge.typesystem)/7647305840372727207]&quot;;" />
+        <property role="huDt6" value="Error: multi-child policy not completely defined" />
+      </node>
+      <node concept="15s5l7" id="kewvTAGdqr" role="lGtFl">
+        <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: merge policy for concept Data does not define ID function&quot;;FLAVOUR_RULE_ID=&quot;[r:02b6652e-c87d-4bb2-bfc0-4b5c0d5b9442(de.itemis.model.merge.typesystem)/7647305840371712554]&quot;;" />
+        <property role="huDt6" value="Error: merge policy for concept Data does not define ID function" />
+      </node>
       <node concept="1olOeT" id="1trrptaE8Bd" role="1qenE9">
         <property role="TrG5h" value="DiamondMerge" />
         <node concept="1oluLK" id="1trrptaE8Be" role="1olsr8" />
@@ -2008,6 +2027,14 @@
       </node>
     </node>
     <node concept="1qefOq" id="1trrptaG5Lz" role="1SKRRt">
+      <node concept="15s5l7" id="kewvTAGdjS" role="lGtFl">
+        <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: merge policy for concept Data does not define ID function&quot;;FLAVOUR_RULE_ID=&quot;[r:02b6652e-c87d-4bb2-bfc0-4b5c0d5b9442(de.itemis.model.merge.typesystem)/7647305840371712554]&quot;;" />
+        <property role="huDt6" value="Error: merge policy for concept Data does not define ID function" />
+      </node>
+      <node concept="15s5l7" id="kewvTAGdgA" role="lGtFl">
+        <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: multi-child policy not completely defined&quot;;FLAVOUR_RULE_ID=&quot;[r:02b6652e-c87d-4bb2-bfc0-4b5c0d5b9442(de.itemis.model.merge.typesystem)/7647305840372727207]&quot;;" />
+        <property role="huDt6" value="Error: multi-child policy not completely defined" />
+      </node>
       <node concept="1olOeT" id="1trrptaG5Ng" role="1qenE9">
         <property role="TrG5h" value="IntermediateOverride" />
         <node concept="1oluLK" id="1trrptaG5Nh" role="1olsr8" />

--- a/code/solutions/de.itemis.model.merge.test/models/de.itemis.model.merge.test.util.mps
+++ b/code/solutions/de.itemis.model.merge.test/models/de.itemis.model.merge.test.util.mps
@@ -150,15 +150,15 @@
     </language>
     <language id="539e8939-08ef-497c-a5fd-25dd10137a55" name="de.itemis.model.merge">
       <concept id="7137735640371846599" name="de.itemis.model.merge.structure.IdFunction" flags="ig" index="230_S" />
-      <concept id="1912777765298260981" name="de.itemis.model.merge.structure.MergePolicy" flags="ng" index="1olsrb">
+      <concept id="1912777765298260981" name="de.itemis.model.merge.structure.ConceptMergingPolicy" flags="ng" index="1olsrb">
         <reference id="4176264672384277229" name="conceptRef" index="24zOxU" />
         <child id="7137735640372265540" name="idFunction" index="21DrV" />
         <child id="1912777765298654333" name="propertyPolicies" index="1orW53" />
         <child id="8422540920006574021" name="childPolicies" index="3JN1Yi" />
       </concept>
-      <concept id="1912777765298266446" name="de.itemis.model.merge.structure.EmptyMergeItem" flags="ng" index="1oluLK" />
-      <concept id="1912777765298163335" name="de.itemis.model.merge.structure.ModelMerge" flags="ng" index="1olOeT">
-        <child id="1912777765298260982" name="items" index="1olsr8" />
+      <concept id="1912777765298266446" name="de.itemis.model.merge.structure.EmptyMergingPolicy" flags="ng" index="1oluLK" />
+      <concept id="1912777765298163335" name="de.itemis.model.merge.structure.ModelMergingPolicy" flags="ng" index="1olOeT">
+        <child id="1912777765298260982" name="policies" index="1olsr8" />
         <child id="2222162468665533253" name="lang" index="3WPhuS" />
       </concept>
       <concept id="1912777765298654154" name="de.itemis.model.merge.structure.Left" flags="ng" index="1orWrO" />

--- a/code/solutions/de.itemis.mps.extensions.changelog/models/de.itemis.mps.extensions.changelog.mps
+++ b/code/solutions/de.itemis.mps.extensions.changelog/models/de.itemis.mps.extensions.changelog.mps
@@ -81,6 +81,9 @@
       </concept>
     </language>
     <language id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text">
+      <concept id="3133179214568824809" name="jetbrains.mps.lang.text.structure.NodeWrapperElement" flags="nn" index="tu5oc">
+        <child id="3133179214568824810" name="node" index="tu5of" />
+      </concept>
       <concept id="1094247804558289146" name="jetbrains.mps.lang.text.structure.BulletLine" flags="ng" index="2DRihI" />
       <concept id="5106752179536586436" name="jetbrains.mps.lang.text.structure.IndentedPoint" flags="ngI" index="2RT3b8">
         <property id="5106752179536586491" name="indentation" index="2RT3bR" />
@@ -102,6 +105,157 @@
     <property role="TrG5h" value="Changelog" />
     <property role="15SkSo" value="Po4Z58IlRA/monthYear" />
     <property role="2hl1$G" value="md" />
+    <node concept="15bmVD" id="75IoIgYnSqu" role="15bmVC">
+      <node concept="15ShDW" id="75IoIgYnSqr" role="15bq2Y">
+        <property role="15ShDY" value="Po4Z58IgBx/December" />
+        <property role="15ShDw" value="2024" />
+      </node>
+      <node concept="15bAme" id="75IoIgYnSD9" role="15bAlL">
+        <property role="15bAli" value="Po4Z58tnOF/changed" />
+        <node concept="2DRihI" id="75IoIgYnSDa" role="15bAlk">
+          <node concept="tu5oc" id="75IoIgYnTeD" role="1PaTwD">
+            <node concept="2hgSXJ" id="75IoIgYnTeE" role="tu5of">
+              <node concept="1PaTwC" id="75IoIgYnTeF" role="2hiFM$">
+                <node concept="15Ami3" id="75IoIgYnTeG" role="1PaTwD">
+                  <node concept="37shsh" id="75IoIgYnTeH" role="15Aodc">
+                    <node concept="1dCxOk" id="75IoIgYnTq8" role="37shsm">
+                      <property role="1XweGW" value="539e8939-08ef-497c-a5fd-25dd10137a55" />
+                      <property role="1XxBO9" value="de.itemis.model.merge" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3oM_SD" id="75IoIgYnTeJ" role="1PaTwD">
+                  <property role="3oM_SC" value=":" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3oM_SD" id="75IoIgYnTeC" role="1PaTwD">
+            <property role="3oM_SC" value="" />
+          </node>
+          <node concept="3oM_SD" id="75IoIgYnTcZ" role="1PaTwD">
+            <property role="3oM_SC" value="Reduced" />
+          </node>
+          <node concept="3oM_SD" id="75IoIgYnSWG" role="1PaTwD">
+            <property role="3oM_SC" value="from" />
+          </node>
+          <node concept="3oM_SD" id="75IoIgYnTv1" role="1PaTwD">
+            <property role="3oM_SC" value="Errors" />
+          </node>
+          <node concept="3oM_SD" id="75IoIgYnT1_" role="1PaTwD">
+            <property role="3oM_SC" value="to" />
+          </node>
+          <node concept="3oM_SD" id="75IoIgYnT1A" role="1PaTwD">
+            <property role="3oM_SC" value="Warning" />
+          </node>
+          <node concept="3oM_SD" id="75IoIgYnTyi" role="1PaTwD">
+            <property role="3oM_SC" value="checks" />
+          </node>
+          <node concept="3oM_SD" id="75IoIgYnTzV" role="1PaTwD">
+            <property role="3oM_SC" value="that" />
+          </node>
+          <node concept="3oM_SD" id="75IoIgYnT_$" role="1PaTwD">
+            <property role="3oM_SC" value="force" />
+          </node>
+          <node concept="3oM_SD" id="75IoIgYnTCR" role="1PaTwD">
+            <property role="3oM_SC" value="policies" />
+          </node>
+          <node concept="3oM_SD" id="75IoIgYnTEw" role="1PaTwD">
+            <property role="3oM_SC" value="for" />
+          </node>
+          <node concept="3oM_SD" id="75IoIgYnTG9" role="1PaTwD">
+            <property role="3oM_SC" value="all" />
+          </node>
+          <node concept="3oM_SD" id="75IoIgYnTGa" role="1PaTwD">
+            <property role="3oM_SC" value="concepts" />
+          </node>
+          <node concept="3oM_SD" id="75IoIgYnTJr" role="1PaTwD">
+            <property role="3oM_SC" value="in" />
+          </node>
+          <node concept="3oM_SD" id="75IoIgYnTL6" role="1PaTwD">
+            <property role="3oM_SC" value="a" />
+          </node>
+          <node concept="3oM_SD" id="75IoIgYnTMJ" role="1PaTwD">
+            <property role="3oM_SC" value="language." />
+          </node>
+          <node concept="3oM_SD" id="75IoIgYnTMK" role="1PaTwD">
+            <property role="3oM_SC" value="In" />
+          </node>
+          <node concept="3oM_SD" id="75IoIgYnTOp" role="1PaTwD">
+            <property role="3oM_SC" value="this" />
+          </node>
+          <node concept="3oM_SD" id="75IoIgYnTQ2" role="1PaTwD">
+            <property role="3oM_SC" value="way" />
+          </node>
+          <node concept="3oM_SD" id="75IoIgYnTTl" role="1PaTwD">
+            <property role="3oM_SC" value="one" />
+          </node>
+          <node concept="3oM_SD" id="75IoIgYnTUY" role="1PaTwD">
+            <property role="3oM_SC" value="can" />
+          </node>
+          <node concept="3oM_SD" id="75IoIgYnTUZ" role="1PaTwD">
+            <property role="3oM_SC" value="prototype" />
+          </node>
+          <node concept="3oM_SD" id="75IoIgYnTYg" role="1PaTwD">
+            <property role="3oM_SC" value="with" />
+          </node>
+          <node concept="3oM_SD" id="75IoIgYnTYh" role="1PaTwD">
+            <property role="3oM_SC" value="small" />
+          </node>
+          <node concept="3oM_SD" id="75IoIgYnTZU" role="1PaTwD">
+            <property role="3oM_SC" value="set" />
+          </node>
+          <node concept="3oM_SD" id="75IoIgYnU1z" role="1PaTwD">
+            <property role="3oM_SC" value="of" />
+          </node>
+          <node concept="3oM_SD" id="75IoIgYnU3c" role="1PaTwD">
+            <property role="3oM_SC" value="merge" />
+          </node>
+          <node concept="3oM_SD" id="75IoIgYnU3d" role="1PaTwD">
+            <property role="3oM_SC" value="policies." />
+          </node>
+          <node concept="3oM_SD" id="75IoIgYnUmI" role="1PaTwD">
+            <property role="3oM_SC" value="Use" />
+          </node>
+          <node concept="3oM_SD" id="75IoIgYnUon" role="1PaTwD">
+            <property role="3oM_SC" value="Partial" />
+          </node>
+          <node concept="3oM_SD" id="75IoIgYnUtg" role="1PaTwD">
+            <property role="3oM_SC" value="police" />
+          </node>
+          <node concept="3oM_SD" id="75IoIgYnUuT" role="1PaTwD">
+            <property role="3oM_SC" value="flag" />
+          </node>
+          <node concept="3oM_SD" id="75IoIgYnUwy" role="1PaTwD">
+            <property role="3oM_SC" value="in" />
+          </node>
+          <node concept="3oM_SD" id="75IoIgYnUyb" role="1PaTwD">
+            <property role="3oM_SC" value="your" />
+          </node>
+          <node concept="3oM_SD" id="75IoIgYnUCH" role="1PaTwD">
+            <property role="3oM_SC" value="MergingPolicy" />
+          </node>
+          <node concept="3oM_SD" id="75IoIgYnUFY" role="1PaTwD">
+            <property role="3oM_SC" value="to" />
+          </node>
+          <node concept="3oM_SD" id="75IoIgYnUHB" role="1PaTwD">
+            <property role="3oM_SC" value="deactivate" />
+          </node>
+          <node concept="3oM_SD" id="75IoIgYnUKU" role="1PaTwD">
+            <property role="3oM_SC" value="runtime" />
+          </node>
+          <node concept="3oM_SD" id="75IoIgYnUOb" role="1PaTwD">
+            <property role="3oM_SC" value="checks" />
+          </node>
+          <node concept="3oM_SD" id="75IoIgYnUPO" role="1PaTwD">
+            <property role="3oM_SC" value="as" />
+          </node>
+          <node concept="3oM_SD" id="75IoIgYnUXY" role="1PaTwD">
+            <property role="3oM_SC" value="well." />
+          </node>
+        </node>
+      </node>
+    </node>
     <node concept="1Pa9Pv" id="43oF0KsR_JA" role="15bnHq">
       <node concept="1PaTwC" id="43oF0KsR_JB" role="1PaQFQ">
         <node concept="3oM_SD" id="43oF0KsR_JC" role="1PaTwD">


### PR DESCRIPTION
For large languages or prototyping it is difficult to define and test merge policies for all concepts at the same time.
After some experiments trying to create default policies, we saw that we could not avoid the definition of merge policy at least for elements found the model, because the identity function must be defined.

As workaround I just reduce errors to warnings when finding missing policies. Additionally I added a flag to indicate an user is interesting to use a partial merge policy, so that some assertions and checks during the merge could be ignored.