### PR TITLE
Use actual StyleRegistry of an editor instead of singleton

### DIFF
--- a/code/diagram/solutions/de.itemis.mps.editor.diagram.runtime/models/de/itemis/mps/editor/diagram/runtime/plugin.mps
+++ b/code/diagram/solutions/de.itemis.mps.editor.diagram.runtime/models/de/itemis/mps/editor/diagram/runtime/plugin.mps
@@ -4465,12 +4465,21 @@
               <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
             </node>
             <node concept="2OqwBi" id="5CBfeKkID_D" role="33vP2m">
-              <node concept="2YIFZM" id="5CBfeKkICS5" role="2Oq$k0">
-                <ref role="37wK5l" to="hox0:~StyleRegistry.getInstance()" resolve="getInstance" />
-                <ref role="1Pybhc" to="hox0:~StyleRegistry" resolve="StyleRegistry" />
-              </node>
               <node concept="liA8E" id="5CBfeKkIEHk" role="2OqNvi">
                 <ref role="37wK5l" to="hox0:~StyleRegistry.getEditorBackground()" resolve="getEditorBackground" />
+              </node>
+              <node concept="2OqwBi" id="6SqTcxhYYFX" role="2Oq$k0">
+                <node concept="2OqwBi" id="6SqTcxhYTbv" role="2Oq$k0">
+                  <node concept="37vLTw" id="6SqTcxhYRnd" role="2Oq$k0">
+                    <ref role="3cqZAo" node="5CBfeKl7WTx" resolve="cell" />
+                  </node>
+                  <node concept="liA8E" id="6SqTcxhYX2n" role="2OqNvi">
+                    <ref role="37wK5l" to="f4zo:~EditorCell.getEditorComponent()" resolve="getEditorComponent" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="6SqTcxhZ2Bs" role="2OqNvi">
+                  <ref role="37wK5l" to="cj4x:~EditorComponent.getStyleRegistry()" resolve="getStyleRegistry" />
+                </node>
               </node>
             </node>
           </node>

--- a/code/pagination/solutions/de.itemis.mps.editor.pagination.runtime/models/de.itemis.mps.editor.pagination.runtime.ui.mps
+++ b/code/pagination/solutions/de.itemis.mps.editor.pagination.runtime/models/de.itemis.mps.editor.pagination.runtime.ui.mps
@@ -1445,12 +1445,21 @@
                             <ref role="37wK5l" to="lzb2:~ColorUtil.mix(java.awt.Color,java.awt.Color,double)" resolve="mix" />
                             <ref role="1Pybhc" to="lzb2:~ColorUtil" resolve="ColorUtil" />
                             <node concept="2OqwBi" id="2mFBf1FJbuC" role="37wK5m">
-                              <node concept="2YIFZM" id="2mFBf1FJall" role="2Oq$k0">
-                                <ref role="37wK5l" to="hox0:~StyleRegistry.getInstance()" resolve="getInstance" />
-                                <ref role="1Pybhc" to="hox0:~StyleRegistry" resolve="StyleRegistry" />
-                              </node>
                               <node concept="liA8E" id="2mFBf1FJcDr" role="2OqNvi">
                                 <ref role="37wK5l" to="hox0:~StyleRegistry.getEditorBackground()" resolve="getEditorBackground" />
+                              </node>
+                              <node concept="2OqwBi" id="6SqTcxhZAkL" role="2Oq$k0">
+                                <node concept="2OqwBi" id="6SqTcxhZzBF" role="2Oq$k0">
+                                  <node concept="37vLTw" id="6SqTcxhZy$d" role="2Oq$k0">
+                                    <ref role="3cqZAo" node="1wtMaD$hD8" resolve="myContext" />
+                                  </node>
+                                  <node concept="liA8E" id="6SqTcxhZ_zC" role="2OqNvi">
+                                    <ref role="37wK5l" to="cj4x:~EditorContext.getEditorComponent()" resolve="getEditorComponent" />
+                                  </node>
+                                </node>
+                                <node concept="liA8E" id="6SqTcxhZBHZ" role="2OqNvi">
+                                  <ref role="37wK5l" to="cj4x:~EditorComponent.getStyleRegistry()" resolve="getStyleRegistry" />
+                                </node>
                               </node>
                             </node>
                             <node concept="10M0yZ" id="2mFBf1FJgg2" role="37wK5m">

--- a/code/tables/languages/de.slisson.mps.tables/runtime/models/de/slisson/mps/tables/runtime/cells.mps
+++ b/code/tables/languages/de.slisson.mps.tables/runtime/models/de/slisson/mps/tables/runtime/cells.mps
@@ -9378,12 +9378,16 @@
                         <node concept="liA8E" id="1oWwpQE9jla" role="2OqNvi">
                           <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
                           <node concept="2OqwBi" id="2fUANpqbWX0" role="37wK5m">
-                            <node concept="2YIFZM" id="2fUANpqbUXE" role="2Oq$k0">
-                              <ref role="37wK5l" to="hox0:~StyleRegistry.getInstance()" resolve="getInstance" />
-                              <ref role="1Pybhc" to="hox0:~StyleRegistry" resolve="StyleRegistry" />
-                            </node>
                             <node concept="liA8E" id="2fUANpqc2Yr" role="2OqNvi">
                               <ref role="37wK5l" to="hox0:~StyleRegistry.getEditorBackground()" resolve="getEditorBackground" />
+                            </node>
+                            <node concept="2OqwBi" id="6SqTcxhWFkj" role="2Oq$k0">
+                              <node concept="37vLTw" id="6SqTcxhWtkz" role="2Oq$k0">
+                                <ref role="3cqZAo" node="5prQSJ52grS" resolve="comp" />
+                              </node>
+                              <node concept="liA8E" id="6SqTcxhWMkP" role="2OqNvi">
+                                <ref role="37wK5l" to="exr9:~EditorComponent.getStyleRegistry()" resolve="getStyleRegistry" />
+                              </node>
                             </node>
                           </node>
                         </node>


### PR DESCRIPTION
Patch against  maintenance/mps20243 so that we can remove deprecated code in 2025.1