### PR TITLE
Make intentions executable even if they have children, just like in MPS IntentionMenuProducer.

### DIFF
--- a/code/intentionsmenu/com.mbeddr.mpsutil.intentions.runtime/models/com/mbeddr/mpsutil/intentions/runtime.mps
+++ b/code/intentionsmenu/com.mbeddr.mpsutil.intentions.runtime/models/com/mbeddr/mpsutil/intentions/runtime.mps
@@ -2134,6 +2134,24 @@
                   </node>
                 </node>
               </node>
+              <node concept="3clFbF" id="WznLMVAI9e" role="3cqZAp">
+                <node concept="2OqwBi" id="WznLMVB0IN" role="3clFbG">
+                  <node concept="2OqwBi" id="WznLMVAMUi" role="2Oq$k0">
+                    <node concept="37vLTw" id="WznLMVAI9c" role="2Oq$k0">
+                      <ref role="3cqZAo" node="3pwG8PSkQKs" resolve="intentionActionGroup" />
+                    </node>
+                    <node concept="liA8E" id="WznLMVAWzG" role="2OqNvi">
+                      <ref role="37wK5l" to="qkt:~AnAction.getTemplatePresentation()" resolve="getTemplatePresentation" />
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="WznLMVB5do" role="2OqNvi">
+                    <ref role="37wK5l" to="qkt:~Presentation.setPerformGroup(boolean)" resolve="setPerformGroup" />
+                    <node concept="3clFbT" id="WznLMVB7UB" role="37wK5m">
+                      <property role="3clFbU" value="true" />
+                    </node>
+                  </node>
+                </node>
+              </node>
               <node concept="3clFbF" id="3pwG8PSkQKT" role="3cqZAp">
                 <node concept="2OqwBi" id="3pwG8PSkU2T" role="3clFbG">
                   <node concept="37vLTw" id="3pwG8PSkU2S" role="2Oq$k0">


### PR DESCRIPTION
Based on this line: https://github.com/JetBrains/MPS/blob/master/editor/intentions-runtime/source/jetbrains/mps/editor/intentions/IntentionMenuProducer.java#L152

Otherwise an action that is a popup group is not "performable" in the ordinary sense.

Only affects versions for MPS 2023.2 and higher which have the MyIntentionMenuProducer implementation.