### PR TITLE
EditableSModel: few methods to become history

### DIFF
--- a/code/shadowmodels/solutions/de.q60.mps.shadowmodels.runtime/models/smodel.mps
+++ b/code/shadowmodels/solutions/de.q60.mps.shadowmodels.runtime/models/smodel.mps
@@ -12589,10 +12589,21 @@
       <property role="TrG5h" value="updateTimestamp" />
       <property role="DiZV1" value="false" />
       <property role="od$2w" value="false" />
-      <node concept="2AHcQZ" id="4QZGLsLEOen" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      <node concept="3clFbS" id="4QZGLsLEOeo" role="3clF47">
+        <node concept="3SKdUt" id="7ayziuV7G6V" role="3cqZAp">
+          <node concept="1PaTwC" id="7ayziuV7G6W" role="1aUNEU">
+            <node concept="3oM_SD" id="7ayziuV7GXq" role="1PaTwD">
+              <property role="3oM_SC" value="to" />
+            </node>
+            <node concept="3oM_SD" id="7ayziuV7GXF" role="1PaTwD">
+              <property role="3oM_SC" value="be" />
+            </node>
+            <node concept="3oM_SD" id="7ayziuV7GXH" role="1PaTwD">
+              <property role="3oM_SC" value="removed" />
+            </node>
+          </node>
+        </node>
       </node>
-      <node concept="3clFbS" id="4QZGLsLEOeo" role="3clF47" />
       <node concept="3Tm1VV" id="4QZGLsLEOep" role="1B3o_S" />
       <node concept="3cqZAl" id="4QZGLsLEOeq" role="3clF45" />
     </node>
@@ -12600,10 +12611,20 @@
       <property role="TrG5h" value="needsReloading" />
       <property role="DiZV1" value="false" />
       <property role="od$2w" value="false" />
-      <node concept="2AHcQZ" id="4QZGLsLEOes" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-      </node>
       <node concept="3clFbS" id="4QZGLsLEOet" role="3clF47">
+        <node concept="3SKdUt" id="7ayziuV7GYf" role="3cqZAp">
+          <node concept="1PaTwC" id="7ayziuV7GYg" role="1aUNEU">
+            <node concept="3oM_SD" id="7ayziuV7GYh" role="1PaTwD">
+              <property role="3oM_SC" value="to" />
+            </node>
+            <node concept="3oM_SD" id="7ayziuV7GYi" role="1PaTwD">
+              <property role="3oM_SC" value="be" />
+            </node>
+            <node concept="3oM_SD" id="7ayziuV7GYj" role="1PaTwD">
+              <property role="3oM_SC" value="removed" />
+            </node>
+          </node>
+        </node>
         <node concept="3cpWs6" id="4QZGLsLEOeu" role="3cqZAp">
           <node concept="3clFbT" id="4QZGLsLEOev" role="3cqZAk">
             <property role="3clFbU" value="false" />
@@ -12738,9 +12759,6 @@
       <property role="TrG5h" value="rename" />
       <property role="DiZV1" value="false" />
       <property role="od$2w" value="false" />
-      <node concept="2AHcQZ" id="4QZGLsLEOfh" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-      </node>
       <node concept="37vLTG" id="4QZGLsLEOfi" role="3clF46">
         <property role="TrG5h" value="newModelName" />
         <property role="3TUv4t" value="false" />
@@ -12752,6 +12770,19 @@
         <node concept="10P_77" id="4QZGLsLEOfl" role="1tU5fm" />
       </node>
       <node concept="3clFbS" id="4QZGLsLEOfm" role="3clF47">
+        <node concept="3SKdUt" id="7ayziuV7IL0" role="3cqZAp">
+          <node concept="1PaTwC" id="7ayziuV7IL1" role="1aUNEU">
+            <node concept="3oM_SD" id="7ayziuV7IL2" role="1PaTwD">
+              <property role="3oM_SC" value="to" />
+            </node>
+            <node concept="3oM_SD" id="7ayziuV7IL3" role="1PaTwD">
+              <property role="3oM_SC" value="be" />
+            </node>
+            <node concept="3oM_SD" id="7ayziuV7IL4" role="1PaTwD">
+              <property role="3oM_SC" value="removed" />
+            </node>
+          </node>
+        </node>
         <node concept="YS8fn" id="4QZGLsLEOfo" role="3cqZAp">
           <node concept="2ShNRf" id="4QZGLsLEPTG" role="YScLw">
             <node concept="1pGfFk" id="4QZGLsLEPTI" role="2ShVmc">
@@ -12784,10 +12815,20 @@
       <property role="TrG5h" value="reloadFromSource" />
       <property role="DiZV1" value="false" />
       <property role="od$2w" value="false" />
-      <node concept="2AHcQZ" id="4QZGLsLEOfz" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-      </node>
       <node concept="3clFbS" id="4QZGLsLEOf$" role="3clF47">
+        <node concept="3SKdUt" id="7ayziuV7Mmp" role="3cqZAp">
+          <node concept="1PaTwC" id="7ayziuV7Mmq" role="1aUNEU">
+            <node concept="3oM_SD" id="7ayziuV7Mmr" role="1PaTwD">
+              <property role="3oM_SC" value="to" />
+            </node>
+            <node concept="3oM_SD" id="7ayziuV7Mms" role="1PaTwD">
+              <property role="3oM_SC" value="be" />
+            </node>
+            <node concept="3oM_SD" id="7ayziuV7Mmt" role="1PaTwD">
+              <property role="3oM_SC" value="removed" />
+            </node>
+          </node>
+        </node>
         <node concept="YS8fn" id="4QZGLsLEOfA" role="3cqZAp">
           <node concept="2ShNRf" id="4QZGLsLEPTP" role="YScLw">
             <node concept="1pGfFk" id="4QZGLsLEPTR" role="2ShVmc">


### PR DESCRIPTION
Remove Override annotation to get ready for upcoming changes in MPS, where these methods cease to exist

I'm about to push changes into MPS master where these methods are either deleted, moved to another base class or there's a default implementation in EditableModelDescriptor. No annotation helps to have both versions compiled. Once my changes are in master, these methods could get removed from SM_ShadowModel as well