### PR TITLE
stubs: use external compilation in stubs solutions to enable MPS module classloading

### DIFF
--- a/code/.mps/vcs.xml
+++ b/code/.mps/vcs.xml
@@ -1,5 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="IssueNavigationConfiguration">
+    <option name="links">
+      <list>
+        <IssueNavigationLink>
+          <option name="issueRegexp" value="#(\d+)" />
+          <option name="linkRegexp" value="https://github.com/JetBrains/MPS-extensions/pull/$1" />
+        </IssueNavigationLink>
+      </list>
+    </option>
+  </component>
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$/.." vcs="Git" />
   </component>

--- a/code/batik/solutions/de.itemis.stubs.batik.msd
+++ b/code/batik/solutions/de.itemis.stubs.batik.msd
@@ -7,7 +7,7 @@
     </modelRoot>
   </models>
   <facets>
-    <facet type="java" compile="off" classes="mps" ext="yes">
+    <facet type="java" compile="ext" classes="mps" ext="no">
       <classes generated="true" />
       <library location="${module}/lib/xmlgraphics-commons.jar" />
       <library location="${module}/lib/batik-all.jar" />

--- a/code/xml/solutions/de.itemis.stubs.xml.msd
+++ b/code/xml/solutions/de.itemis.stubs.xml.msd
@@ -7,7 +7,7 @@
     </modelRoot>
   </models>
   <facets>
-    <facet type="java" compile="off" classes="mps" ext="yes">
+    <facet type="java" compile="ext" classes="mps" ext="no">
       <classes generated="true" />
       <library location="${module}/lib/xercesImpl.jar" />
       <library location="${module}/lib/xml-apis-ext.jar" />


### PR DESCRIPTION
Enable external compilation for `de.itemis.stubs.batik` and `de.itemis.stubs.xml` stubs solutions to fix classloading issues with deployed modules.

- Stubs solutions that contain classes not compiled by MPS should be explicitly configured to be compiled externally according to the [Migration Guide](https://www.jetbrains.com/help/mps/migration-guide.html#mps20241_migration). Otherwise, such solutions don't use MPS module classloader during runtime and specifically don't consider module dependencies for classloading. This gets particularly configured by the generated build script that contains the generated module descriptor for a stubs solution. If external compilation is specified for the module, its module dependencies are also added to the generated descriptor and can be used in runtime classloading:

  ![image](https://github.com/user-attachments/assets/c09d8d75-bfc3-4aee-ae4d-2687fd317085)
   
- The PR also disables extension contribution for both stubs solutions, since neither of them provides any extensions to MPS (such as plugins or extension points).

- Additionally, issue navigator config for the Github project has been added to simplify navigation to PRs and issues. 