### PR TITLE
querylist: inline editor expressions improvements

### DIFF
--- a/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
+++ b/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
@@ -23628,6 +23628,11 @@
             </node>
           </node>
         </node>
+        <node concept="1SiIV0" id="4EGFz66TUtk" role="3bR37C">
+          <node concept="3bR9La" id="4EGFz66TUtl" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
+          </node>
+        </node>
       </node>
       <node concept="1E1JtD" id="4zIvKyxCri3" role="2G$12L">
         <property role="BnDLt" value="true" />

--- a/code/querylist/com.mbeddr.mpsutil.editor.querylist.demolang/com.mbeddr.mpsutil.editor.querylist.demolang.mpl
+++ b/code/querylist/com.mbeddr.mpsutil.editor.querylist.demolang/com.mbeddr.mpsutil.editor.querylist.demolang.mpl
@@ -17,6 +17,7 @@
     <dependency reexport="false">f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)</dependency>
     <dependency reexport="false">8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)</dependency>
     <dependency reexport="false">c72da2b9-7cce-4447-8389-f407dc1158b7(jetbrains.mps.lang.structure)</dependency>
+    <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:120e1c9d-4e27-4478-b2af-b2c3bd3850b0:com.mbeddr.mpsutil.editor.querylist" version="0" />

--- a/code/querylist/com.mbeddr.mpsutil.editor.querylist.demolang/languageModels/editor.mps
+++ b/code/querylist/com.mbeddr.mpsutil.editor.querylist.demolang/languageModels/editor.mps
@@ -37,12 +37,15 @@
         <child id="1080736633877" name="cellModel" index="2wV5jI" />
       </concept>
       <concept id="795210086017940429" name="jetbrains.mps.lang.editor.structure.ReadOnlyStyleClassItem" flags="lg" index="xShMh" />
+      <concept id="1239814640496" name="jetbrains.mps.lang.editor.structure.CellLayout_VerticalGrid" flags="nn" index="2EHx9g" />
       <concept id="1186403751766" name="jetbrains.mps.lang.editor.structure.FontStyleStyleClassItem" flags="ln" index="Vb9p2" />
       <concept id="1186414536763" name="jetbrains.mps.lang.editor.structure.BooleanStyleSheetItem" flags="ln" index="VOi$J">
         <property id="1186414551515" name="flag" index="VOm3f" />
       </concept>
       <concept id="1186414860679" name="jetbrains.mps.lang.editor.structure.EditableStyleClassItem" flags="ln" index="VPxyj" />
       <concept id="1186414928363" name="jetbrains.mps.lang.editor.structure.SelectableStyleSheetItem" flags="ln" index="VPM3Z" />
+      <concept id="1233758997495" name="jetbrains.mps.lang.editor.structure.PunctuationLeftStyleClassItem" flags="ln" index="11L4FC" />
+      <concept id="1233759184865" name="jetbrains.mps.lang.editor.structure.PunctuationRightStyleClassItem" flags="ln" index="11LMrY" />
       <concept id="1139848536355" name="jetbrains.mps.lang.editor.structure.CellModel_WithRole" flags="ng" index="1$h60E">
         <reference id="1140103550593" name="relationDeclaration" index="1NtTu8" />
       </concept>
@@ -246,7 +249,7 @@
       <concept id="5820306262933734929" name="com.mbeddr.mpsutil.editor.querylist.structure.Parameter_AnchorNode" flags="ng" index="AS6u$" />
       <concept id="5820306262933951366" name="com.mbeddr.mpsutil.editor.querylist.structure.Paramter_insertBefore" flags="ng" index="AVj8N" />
       <concept id="5820306262934114343" name="com.mbeddr.mpsutil.editor.querylist.structure.Function_DeleteElement" flags="ig" index="AVF6i" />
-      <concept id="2239254897981410197" name="com.mbeddr.mpsutil.editor.querylist.structure.QueryListNodeExpression" flags="ng" index="GFMny" />
+      <concept id="2239254897981410197" name="com.mbeddr.mpsutil.editor.querylist.structure.QueryListInputExpression" flags="ng" index="GFMny" />
       <concept id="7238779735251712681" name="com.mbeddr.mpsutil.editor.querylist.structure.QueryListInlineEditorComponent" flags="ig" index="1yz3lS" />
     </language>
     <language id="aee9cad2-acd4-4608-aef2-0004f6a1cdbd" name="jetbrains.mps.lang.actions">
@@ -260,6 +263,9 @@
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1204834851141" name="jetbrains.mps.lang.smodel.structure.PoundExpression" flags="ng" index="25Kdxt">
+        <child id="1204834868751" name="expression" index="25KhWn" />
+      </concept>
       <concept id="1179168000618" name="jetbrains.mps.lang.smodel.structure.Node_GetIndexInParentOperation" flags="nn" index="2bSWHS" />
       <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
         <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
@@ -268,6 +274,7 @@
         <child id="1144104376918" name="parameter" index="1xVPHs" />
       </concept>
       <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
+      <concept id="7453996997717780434" name="jetbrains.mps.lang.smodel.structure.Node_GetSConceptOperation" flags="nn" index="2yIwOk" />
       <concept id="2396822768958367367" name="jetbrains.mps.lang.smodel.structure.AbstractTypeCastExpression" flags="nn" index="$5XWr">
         <child id="6733348108486823193" name="leftExpression" index="1m5AlR" />
         <child id="3906496115198199033" name="conceptArgument" index="3oSUPX" />
@@ -614,37 +621,46 @@
                 <node concept="1HfYo3" id="6QZo_pQb4Bb" role="1HlULh">
                   <node concept="3TQlhw" id="6QZo_pQb4Bc" role="1Hhtcw">
                     <node concept="3clFbS" id="6QZo_pQb4Bd" role="2VODD2">
+                      <node concept="3clFbH" id="3$DkTBDaaDm" role="3cqZAp" />
                       <node concept="3clFbF" id="6QZo_pQb76V" role="3cqZAp">
                         <node concept="3cpWs3" id="6QZo_pQgYhV" role="3clFbG">
                           <node concept="Xl_RD" id="6QZo_pQgYi0" role="3uHU7w">
                             <property role="Xl_RC" value=": " />
                           </node>
-                          <node concept="3cpWs3" id="6QZo_pQb7sr" role="3uHU7B">
-                            <node concept="3cpWs3" id="1WjrBsNIVX7" role="3uHU7B">
-                              <node concept="2OqwBi" id="1WjrBsNIZqG" role="3uHU7B">
-                                <node concept="2JrnkZ" id="1WjrBsNIZmj" role="2Oq$k0">
-                                  <node concept="GFMny" id="1WjrBsNJotP" role="2JrQYb" />
-                                </node>
-                                <node concept="liA8E" id="1WjrBsNIZwA" role="2OqNvi">
-                                  <ref role="37wK5l" to="mhbf:~SNode.getNodeId()" resolve="getNodeId" />
-                                </node>
+                          <node concept="3cpWs3" id="4EGFz66WtYw" role="3uHU7B">
+                            <node concept="2tpSsP" id="4EGFz66WuF3" role="3uHU7w" />
+                            <node concept="3cpWs3" id="4EGFz66WsAh" role="3uHU7B">
+                              <node concept="Xl_RD" id="4EGFz66WtiE" role="3uHU7w">
+                                <property role="Xl_RC" value=" / " />
                               </node>
-                              <node concept="Xl_RD" id="6QZo_pQb76U" role="3uHU7w">
-                                <property role="Xl_RC" value=" # " />
-                              </node>
-                            </node>
-                            <node concept="2OqwBi" id="6QZo_pQbiOh" role="3uHU7w">
-                              <node concept="2OqwBi" id="6QZo_pQb7Hz" role="2Oq$k0">
-                                <node concept="pncrf" id="6QZo_pQb7B9" role="2Oq$k0" />
-                                <node concept="2Xjw5R" id="6QZo_pQbiki" role="2OqNvi">
-                                  <node concept="1xMEDy" id="6QZo_pQbikk" role="1xVPHs">
-                                    <node concept="chp4Y" id="6QZo_pQbivE" role="ri$Ld">
-                                      <ref role="cht4Q" to="tpee:fzclF8l" resolve="Statement" />
+                              <node concept="3cpWs3" id="6QZo_pQb7sr" role="3uHU7B">
+                                <node concept="3cpWs3" id="1WjrBsNIVX7" role="3uHU7B">
+                                  <node concept="2OqwBi" id="1WjrBsNIZqG" role="3uHU7B">
+                                    <node concept="2JrnkZ" id="1WjrBsNIZmj" role="2Oq$k0">
+                                      <node concept="GFMny" id="1WjrBsNJotP" role="2JrQYb" />
+                                    </node>
+                                    <node concept="liA8E" id="1WjrBsNIZwA" role="2OqNvi">
+                                      <ref role="37wK5l" to="mhbf:~SNode.getNodeId()" resolve="getNodeId" />
                                     </node>
                                   </node>
+                                  <node concept="Xl_RD" id="6QZo_pQb76U" role="3uHU7w">
+                                    <property role="Xl_RC" value=" # " />
+                                  </node>
+                                </node>
+                                <node concept="2OqwBi" id="6QZo_pQbiOh" role="3uHU7w">
+                                  <node concept="2OqwBi" id="6QZo_pQb7Hz" role="2Oq$k0">
+                                    <node concept="pncrf" id="6QZo_pQb7B9" role="2Oq$k0" />
+                                    <node concept="2Xjw5R" id="6QZo_pQbiki" role="2OqNvi">
+                                      <node concept="1xMEDy" id="6QZo_pQbikk" role="1xVPHs">
+                                        <node concept="chp4Y" id="6QZo_pQbivE" role="ri$Ld">
+                                          <ref role="cht4Q" to="tpee:fzclF8l" resolve="Statement" />
+                                        </node>
+                                      </node>
+                                    </node>
+                                  </node>
+                                  <node concept="2bSWHS" id="6QZo_pQbj8R" role="2OqNvi" />
                                 </node>
                               </node>
-                              <node concept="2bSWHS" id="6QZo_pQbj8R" role="2OqNvi" />
                             </node>
                           </node>
                         </node>
@@ -654,16 +670,63 @@
                 </node>
               </node>
               <node concept="r$x8Z" id="6QZo_pQeCRI" role="3EZMnx" />
-              <node concept="l2Vlx" id="6QZo_pQgDIs" role="2iSdaV" />
+              <node concept="2iRfu4" id="4EGFz66XWB$" role="2iSdaV" />
               <node concept="VPM3Z" id="6QZo_pQbms0" role="3F10Kt">
                 <property role="VOm3f" value="false" />
+              </node>
+              <node concept="3F0ifn" id="1ji15Rhgnku" role="3EZMnx">
+                <property role="3F0ifm" value="(" />
+                <node concept="11LMrY" id="1ji15RhgnkW" role="3F10Kt">
+                  <property role="VOm3f" value="true" />
+                </node>
+              </node>
+              <node concept="3F0ifn" id="1ji15Rhgnkx" role="3EZMnx">
+                <property role="3F0ifm" value="other expressions of the same concept:" />
+              </node>
+              <node concept="s8t4o" id="1ji15RhfF4E" role="3EZMnx">
+                <property role="28Zw97" value="true" />
+                <ref role="28F8cf" to="tpee:f$Xl_Og" resolve="StringLiteral" />
+                <node concept="xShMh" id="1ji15RhfF4G" role="3F10Kt">
+                  <property role="VOm3f" value="true" />
+                </node>
+                <node concept="s8sZD" id="1ji15RhfF4H" role="sbcd9">
+                  <node concept="3clFbS" id="1ji15RhfF4I" role="2VODD2">
+                    <node concept="3clFbF" id="4EGFz66H_5K" role="3cqZAp">
+                      <node concept="2OqwBi" id="4EGFz66Kqkt" role="3clFbG">
+                        <node concept="2OqwBi" id="4EGFz66K2RZ" role="2Oq$k0">
+                          <node concept="GFMny" id="4EGFz66H_5I" role="2Oq$k0" />
+                          <node concept="3TrEf2" id="4EGFz66Ko9U" role="2OqNvi">
+                            <ref role="3Tt5mk" to="gei:5oklODae9FX" resolve="statementList" />
+                          </node>
+                        </node>
+                        <node concept="2Rf3mk" id="4EGFz66KsKP" role="2OqNvi">
+                          <node concept="1xMEDy" id="4EGFz66KsKR" role="1xVPHs">
+                            <node concept="25Kdxt" id="4EGFz66Ldjx" role="ri$Ld">
+                              <node concept="2OqwBi" id="4EGFz66Lgf1" role="25KhWn">
+                                <node concept="pncrf" id="4EGFz66LfdH" role="2Oq$k0" />
+                                <node concept="2yIwOk" id="4EGFz66Liwx" role="2OqNvi" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="2iRkQZ" id="4EGFz66M2S9" role="2czzBy" />
+              </node>
+              <node concept="3F0ifn" id="1ji15RhgnkL" role="3EZMnx">
+                <property role="3F0ifm" value=")" />
+                <node concept="11L4FC" id="1ji15RhgnkX" role="3F10Kt">
+                  <property role="VOm3f" value="true" />
+                </node>
               </node>
             </node>
           </node>
           <node concept="3F0ifn" id="57wonSLX3DT" role="3EmGlc">
             <property role="3F0ifm" value="folded" />
           </node>
-          <node concept="2iRkQZ" id="535SrlQ5QBg" role="2czzBy" />
+          <node concept="2EHx9g" id="4EGFz66XVP6" role="2czzBy" />
         </node>
         <node concept="l2Vlx" id="535SrlQ5QBh" role="2iSdaV" />
         <node concept="VPM3Z" id="535SrlQ5QBi" role="3F10Kt">

--- a/code/querylist/com.mbeddr.mpsutil.editor.querylist.runtime/models/com/mbeddr/mpsutil/editor/querylist/runtime.mps
+++ b/code/querylist/com.mbeddr.mpsutil.editor.querylist.runtime/models/com/mbeddr/mpsutil/editor/querylist/runtime.mps
@@ -271,6 +271,7 @@
         <child id="1199542457201" name="resultType" index="1ajl9A" />
       </concept>
       <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
+        <property id="890797661671409019" name="forceMultiLine" index="3yWfEV" />
         <child id="1199569906740" name="parameter" index="1bW2Oz" />
         <child id="1199569916463" name="body" index="1bW5cS" />
       </concept>
@@ -365,10 +366,10 @@
         <child id="1237721435807" name="elementType" index="HW$YZ" />
       </concept>
       <concept id="1227022179634" name="jetbrains.mps.baseLanguage.collections.structure.AddLastElementOperation" flags="nn" index="2Ke9KJ" />
+      <concept id="1227026094155" name="jetbrains.mps.baseLanguage.collections.structure.RemoveLastElementOperation" flags="nn" index="2Kt5_m" />
       <concept id="1160600644654" name="jetbrains.mps.baseLanguage.collections.structure.ListCreatorWithInit" flags="nn" index="Tc6Ow" />
       <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
       <concept id="1171391069720" name="jetbrains.mps.baseLanguage.collections.structure.GetIndexOfOperation" flags="nn" index="2WmjW8" />
-      <concept id="1162934736510" name="jetbrains.mps.baseLanguage.collections.structure.GetElementOperation" flags="nn" index="34jXtK" />
       <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
       <concept id="1225711141656" name="jetbrains.mps.baseLanguage.collections.structure.ListElementAccessExpression" flags="nn" index="1y4W85">
         <child id="1225711182005" name="list" index="1y566C" />
@@ -1455,9 +1456,28 @@
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="4DLCSzVGTmO" role="3cqZAp">
-          <node concept="1rXfSq" id="4DLCSzVGTmP" role="3clFbG">
-            <ref role="37wK5l" to="emqf:~AbstractCellListHandler.createInnerCells()" resolve="createInnerCells" />
+        <node concept="3clFbF" id="4EGFz66Zeh9" role="3cqZAp">
+          <node concept="2YIFZM" id="4EGFz66Zj8U" role="3clFbG">
+            <ref role="37wK5l" node="1WjrBsNI2hk" resolve="runWithContext" />
+            <ref role="1Pybhc" node="1WjrBsNHO$4" resolve="QueryListContext" />
+            <node concept="2ShNRf" id="4EGFz66Zj8V" role="37wK5m">
+              <node concept="1pGfFk" id="4EGFz66Zj8W" role="2ShVmc">
+                <ref role="37wK5l" node="1WjrBsNI9Ji" resolve="QueryListContext" />
+                <node concept="37vLTw" id="4EGFz66ZCR1" role="37wK5m">
+                  <ref role="3cqZAo" node="1SwultAiTIH" resolve="myOwner" />
+                </node>
+              </node>
+            </node>
+            <node concept="1bVj0M" id="4EGFz66Zj8Y" role="37wK5m">
+              <property role="3yWfEV" value="true" />
+              <node concept="3clFbS" id="4EGFz66Zj8Z" role="1bW5cS">
+                <node concept="3clFbF" id="4DLCSzVGTmO" role="3cqZAp">
+                  <node concept="1rXfSq" id="4DLCSzVGTmP" role="3clFbG">
+                    <ref role="37wK5l" to="emqf:~AbstractCellListHandler.createInnerCells()" resolve="createInnerCells" />
+                  </node>
+                </node>
+              </node>
+            </node>
           </node>
         </node>
         <node concept="3clFbH" id="4DLCSzVGTmQ" role="3cqZAp" />
@@ -3718,19 +3738,7 @@
             <node concept="37vLTw" id="1WjrBsNHZaI" role="2Oq$k0">
               <ref role="3cqZAo" node="1WjrBsNI1Jv" resolve="ourContextStack" />
             </node>
-            <node concept="34jXtK" id="1WjrBsNHZAl" role="2OqNvi">
-              <node concept="3cpWsd" id="1WjrBsNI0xG" role="25WWJ7">
-                <node concept="3cmrfG" id="1WjrBsNI0xX" role="3uHU7w">
-                  <property role="3cmrfH" value="1" />
-                </node>
-                <node concept="2OqwBi" id="1WjrBsNHZOf" role="3uHU7B">
-                  <node concept="37vLTw" id="1WjrBsNHZDE" role="2Oq$k0">
-                    <ref role="3cqZAo" node="1WjrBsNI1Jv" resolve="ourContextStack" />
-                  </node>
-                  <node concept="34oBXx" id="1WjrBsNI091" role="2OqNvi" />
-                </node>
-              </node>
-            </node>
+            <node concept="2Kt5_m" id="4EGFz669eCA" role="2OqNvi" />
           </node>
         </node>
       </node>

--- a/code/querylist/com.mbeddr.mpsutil.editor.querylist/generator/template/main@generator.mps
+++ b/code/querylist/com.mbeddr.mpsutil.editor.querylist/generator/template/main@generator.mps
@@ -132,6 +132,7 @@
       <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
       <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
       <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
+      <concept id="1225271283259" name="jetbrains.mps.baseLanguage.structure.NPEEqualsExpression" flags="nn" index="17R0WA" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
@@ -300,13 +301,20 @@
       </concept>
     </language>
     <language id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc">
+      <concept id="6832197706140896242" name="jetbrains.mps.baseLanguage.javadoc.structure.FieldDocComment" flags="ng" index="z59LJ" />
       <concept id="5349172909345501395" name="jetbrains.mps.baseLanguage.javadoc.structure.BaseDocComment" flags="ng" index="P$AiS">
+        <child id="8465538089690331502" name="body" index="TZ5H$" />
         <child id="5383422241790532083" name="tags" index="3nqlJM" />
       </concept>
       <concept id="5349172909345532724" name="jetbrains.mps.baseLanguage.javadoc.structure.MethodDocComment" flags="ng" index="P$JXv" />
-      <concept id="8465538089690331500" name="jetbrains.mps.baseLanguage.javadoc.structure.CommentLine" flags="ng" index="TZ5HA" />
+      <concept id="8465538089690331500" name="jetbrains.mps.baseLanguage.javadoc.structure.CommentLine" flags="ng" index="TZ5HA">
+        <child id="8970989240999019149" name="part" index="1dT_Ay" />
+      </concept>
       <concept id="8465538089690331492" name="jetbrains.mps.baseLanguage.javadoc.structure.DeprecatedBlockDocTag" flags="ng" index="TZ5HI">
         <child id="2667874559098216723" name="text" index="3HnX3l" />
+      </concept>
+      <concept id="8970989240999019143" name="jetbrains.mps.baseLanguage.javadoc.structure.TextCommentLinePart" flags="ng" index="1dT_AC">
+        <property id="8970989240999019144" name="text" index="1dT_AB" />
       </concept>
     </language>
     <language id="d7706f63-9be2-479c-a3da-ae92af1e64d5" name="jetbrains.mps.lang.generator.generationContext">
@@ -340,6 +348,9 @@
       <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
         <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
       </concept>
+      <concept id="1138411891628" name="jetbrains.mps.lang.smodel.structure.SNodeOperation" flags="nn" index="eCIE_">
+        <child id="1144104376918" name="parameter" index="1xVPHs" />
+      </concept>
       <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
       <concept id="7453996997717780434" name="jetbrains.mps.lang.smodel.structure.Node_GetSConceptOperation" flags="nn" index="2yIwOk" />
       <concept id="2396822768958367367" name="jetbrains.mps.lang.smodel.structure.AbstractTypeCastExpression" flags="nn" index="$5XWr">
@@ -352,6 +363,7 @@
         <child id="1145404616321" name="leftExpression" index="2JrQYb" />
       </concept>
       <concept id="1171310072040" name="jetbrains.mps.lang.smodel.structure.Node_GetContainingRootOperation" flags="nn" index="2Rxl7S" />
+      <concept id="1171407110247" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorOperation" flags="nn" index="2Xjw5R" />
       <concept id="2644386474300074836" name="jetbrains.mps.lang.smodel.structure.ConceptIdRefExpression" flags="nn" index="35c_gC">
         <reference id="2644386474300074837" name="conceptDeclaration" index="35c_gD" />
       </concept>
@@ -360,6 +372,9 @@
       </concept>
       <concept id="1171999116870" name="jetbrains.mps.lang.smodel.structure.Node_IsNullOperation" flags="nn" index="3w_OXm" />
       <concept id="1172008320231" name="jetbrains.mps.lang.smodel.structure.Node_IsNotNullOperation" flags="nn" index="3x8VRR" />
+      <concept id="1144101972840" name="jetbrains.mps.lang.smodel.structure.OperationParm_Concept" flags="ng" index="1xMEDy">
+        <child id="1207343664468" name="conceptArgument" index="ri$Ld" />
+      </concept>
       <concept id="1140137987495" name="jetbrains.mps.lang.smodel.structure.SNodeTypeCastExpression" flags="nn" index="1PxgMI" />
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
         <reference id="1138405853777" name="concept" index="ehGHo" />
@@ -733,13 +748,16 @@
       </node>
     </node>
     <node concept="3aamgX" id="1WjrBsNJ6XR" role="3acgRq">
-      <ref role="30HIoZ" to="bbp5:1WjrBsNJ4Il" resolve="QueryListNodeExpression" />
+      <ref role="30HIoZ" to="bbp5:1WjrBsNJ4Il" resolve="QueryListInputExpression" />
       <node concept="gft3U" id="1WjrBsNJ708" role="1lVwrX">
         <node concept="1PxgMI" id="1WjrBsNJ75s" role="gfFT$">
           <node concept="2OqwBi" id="1WjrBsNJ70Z" role="1m5AlR">
             <node concept="2YIFZM" id="1WjrBsNJ70u" role="2Oq$k0">
               <ref role="37wK5l" to="d2zl:1WjrBsNI5cO" resolve="getCurrentContext" />
               <ref role="1Pybhc" to="d2zl:1WjrBsNHO$4" resolve="QueryListContext" />
+              <node concept="5jKBG" id="4EGFz671CDh" role="lGtFl">
+                <ref role="v9R2y" node="4EGFz671olF" resolve="getOwningQueryListContext" />
+              </node>
             </node>
             <node concept="liA8E" id="1WjrBsNJ73y" role="2OqNvi">
               <ref role="37wK5l" to="d2zl:1WjrBsNIalZ" resolve="getSNode" />
@@ -777,6 +795,9 @@
           <node concept="2YIFZM" id="3YRpSuyPEcz" role="2Oq$k0">
             <ref role="37wK5l" to="d2zl:1WjrBsNI5cO" resolve="getCurrentContext" />
             <ref role="1Pybhc" to="d2zl:1WjrBsNHO$4" resolve="QueryListContext" />
+            <node concept="5jKBG" id="4EGFz671Cqi" role="lGtFl">
+              <ref role="v9R2y" node="4EGFz671olF" resolve="getOwningQueryListContext" />
+            </node>
           </node>
           <node concept="liA8E" id="3YRpSuyPEtr" role="2OqNvi">
             <ref role="37wK5l" to="d2zl:3YRpSuyOFjn" resolve="getIndex" />
@@ -812,566 +833,533 @@
         </node>
         <node concept="3clFbS" id="fYh_FPI" role="3clF47">
           <node concept="3clFbH" id="1WjrBsNIfyg" role="3cqZAp" />
-          <node concept="3clFbF" id="1WjrBsNIhWC" role="3cqZAp">
-            <node concept="2YIFZM" id="1WjrBsNI_nd" role="3clFbG">
-              <ref role="37wK5l" to="d2zl:1WjrBsNIs6Y" resolve="computeWithContext" />
-              <ref role="1Pybhc" to="d2zl:1WjrBsNHO$4" resolve="QueryListContext" />
-              <node concept="2ShNRf" id="1WjrBsNI_ne" role="37wK5m">
-                <node concept="1pGfFk" id="1WjrBsNI_nf" role="2ShVmc">
-                  <ref role="37wK5l" to="d2zl:1WjrBsNI9Ji" resolve="QueryListContext" />
-                  <node concept="37vLTw" id="1WjrBsNI_ng" role="37wK5m">
+          <node concept="3cpWs8" id="1WjrBsNI_nj" role="3cqZAp">
+            <node concept="3cpWsn" id="1WjrBsNI_nk" role="3cpWs9">
+              <property role="TrG5h" value="handler" />
+              <node concept="3uibUv" id="1WjrBsNI_nl" role="1tU5fm">
+                <ref role="3uigEE" to="d2zl:1BXECvJT402" resolve="QueryListHandler" />
+              </node>
+              <node concept="2ShNRf" id="1WjrBsNI_nm" role="33vP2m">
+                <node concept="1pGfFk" id="1WjrBsNI_nn" role="2ShVmc">
+                  <ref role="37wK5l" node="1BXECvJWl_s" resolve="_context_class_.GeneratedQueryListHandler" />
+                  <node concept="37vLTw" id="1WjrBsNI_no" role="37wK5m">
+                    <ref role="3cqZAo" node="fYh_FQ2" resolve="editorContext" />
+                  </node>
+                  <node concept="37vLTw" id="1WjrBsNI_np" role="37wK5m">
                     <ref role="3cqZAo" node="fYh_FQ7" resolve="node" />
+                  </node>
+                  <node concept="1ZhdrF" id="1WjrBsNI_nq" role="lGtFl">
+                    <property role="2qtEX8" value="baseMethodDeclaration" />
+                    <property role="P3scX" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1204053956946/1068499141037" />
+                    <node concept="3$xsQk" id="1WjrBsNI_nr" role="3$ytzL">
+                      <node concept="3clFbS" id="1WjrBsNI_ns" role="2VODD2">
+                        <node concept="3clFbF" id="13m3hIRlJ$" role="3cqZAp">
+                          <node concept="2OqwBi" id="13m3hIRlJA" role="3clFbG">
+                            <node concept="1iwH7S" id="13m3hIRlJB" role="2Oq$k0" />
+                            <node concept="1iwH70" id="13m3hIRlJC" role="2OqNvi">
+                              <ref role="1iwH77" to="tpc3:5QbehOJMFlo" resolve="generated.constructor" />
+                              <node concept="30H73N" id="13m3hIRlJD" role="1iwH7V" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
                   </node>
                 </node>
               </node>
-              <node concept="1bVj0M" id="1WjrBsNI_nh" role="37wK5m">
-                <node concept="3clFbS" id="1WjrBsNI_ni" role="1bW5cS">
-                  <node concept="3cpWs8" id="1WjrBsNI_nj" role="3cqZAp">
-                    <node concept="3cpWsn" id="1WjrBsNI_nk" role="3cpWs9">
-                      <property role="TrG5h" value="handler" />
-                      <node concept="3uibUv" id="1WjrBsNI_nl" role="1tU5fm">
-                        <ref role="3uigEE" to="d2zl:1BXECvJT402" resolve="QueryListHandler" />
-                      </node>
-                      <node concept="2ShNRf" id="1WjrBsNI_nm" role="33vP2m">
-                        <node concept="1pGfFk" id="1WjrBsNI_nn" role="2ShVmc">
-                          <ref role="37wK5l" node="1BXECvJWl_s" resolve="_context_class_.GeneratedQueryListHandler" />
-                          <node concept="37vLTw" id="1WjrBsNI_no" role="37wK5m">
-                            <ref role="3cqZAo" node="fYh_FQ2" resolve="editorContext" />
-                          </node>
-                          <node concept="37vLTw" id="1WjrBsNI_np" role="37wK5m">
-                            <ref role="3cqZAo" node="fYh_FQ7" resolve="node" />
-                          </node>
-                          <node concept="1ZhdrF" id="1WjrBsNI_nq" role="lGtFl">
-                            <property role="2qtEX8" value="baseMethodDeclaration" />
-                            <property role="P3scX" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1204053956946/1068499141037" />
-                            <node concept="3$xsQk" id="1WjrBsNI_nr" role="3$ytzL">
-                              <node concept="3clFbS" id="1WjrBsNI_ns" role="2VODD2">
-                                <node concept="3clFbF" id="13m3hIRlJ$" role="3cqZAp">
-                                  <node concept="2OqwBi" id="13m3hIRlJA" role="3clFbG">
-                                    <node concept="1iwH7S" id="13m3hIRlJB" role="2Oq$k0" />
-                                    <node concept="1iwH70" id="13m3hIRlJC" role="2OqNvi">
-                                      <ref role="1iwH77" to="tpc3:5QbehOJMFlo" resolve="generated.constructor" />
-                                      <node concept="30H73N" id="13m3hIRlJD" role="1iwH7V" />
-                                    </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="1WjrBsNI_nF" role="3cqZAp">
+            <node concept="3cpWsn" id="1WjrBsNI_nG" role="3cpWs9">
+              <property role="TrG5h" value="editorCell" />
+              <node concept="3uibUv" id="1WjrBsNI_nH" role="1tU5fm">
+                <ref role="3uigEE" to="d2zl:5oklODahdyQ" resolve="EditorCell_QueryList" />
+              </node>
+              <node concept="2OqwBi" id="1WjrBsNI_nI" role="33vP2m">
+                <node concept="37vLTw" id="1WjrBsNI_nJ" role="2Oq$k0">
+                  <ref role="3cqZAo" node="1WjrBsNI_nk" resolve="handler" />
+                </node>
+                <node concept="liA8E" id="1WjrBsNI_nK" role="2OqNvi">
+                  <ref role="37wK5l" to="d2zl:4DLCSzVGTmw" resolve="createCells" />
+                  <node concept="2ShNRf" id="1WjrBsNI_nM" role="37wK5m">
+                    <node concept="1pGfFk" id="1WjrBsNI_nN" role="2ShVmc">
+                      <ref role="37wK5l" to="kcid:~CellLayout_Horizontal.&lt;init&gt;()" resolve="CellLayout_Horizontal" />
+                      <node concept="1ZhdrF" id="1WjrBsNI_nO" role="lGtFl">
+                        <property role="2qtEX8" value="baseMethodDeclaration" />
+                        <property role="P3scX" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1204053956946/1068499141037" />
+                        <node concept="3$xsQk" id="1WjrBsNI_nP" role="3$ytzL">
+                          <node concept="3clFbS" id="1WjrBsNI_nQ" role="2VODD2">
+                            <node concept="3cpWs8" id="1WjrBsNI_nR" role="3cqZAp">
+                              <node concept="3cpWsn" id="1WjrBsNI_nS" role="3cpWs9">
+                                <property role="TrG5h" value="cellLayout" />
+                                <node concept="2OqwBi" id="1WjrBsNI_nT" role="33vP2m">
+                                  <node concept="30H73N" id="1WjrBsNI_nU" role="2Oq$k0" />
+                                  <node concept="3TrEf2" id="1WjrBsNI_nV" role="2OqNvi">
+                                    <ref role="3Tt5mk" to="bbp5:gAczzzC" resolve="cellLayout" />
                                   </node>
+                                </node>
+                                <node concept="3Tqbb2" id="1WjrBsNI_nW" role="1tU5fm">
+                                  <ref role="ehGHo" to="tpc2:g6iR17a" resolve="CellLayout" />
                                 </node>
                               </node>
                             </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3cpWs8" id="1WjrBsNI_nF" role="3cqZAp">
-                    <node concept="3cpWsn" id="1WjrBsNI_nG" role="3cpWs9">
-                      <property role="TrG5h" value="editorCell" />
-                      <node concept="3uibUv" id="1WjrBsNI_nH" role="1tU5fm">
-                        <ref role="3uigEE" to="d2zl:5oklODahdyQ" resolve="EditorCell_QueryList" />
-                      </node>
-                      <node concept="2OqwBi" id="1WjrBsNI_nI" role="33vP2m">
-                        <node concept="37vLTw" id="1WjrBsNI_nJ" role="2Oq$k0">
-                          <ref role="3cqZAo" node="1WjrBsNI_nk" resolve="handler" />
-                        </node>
-                        <node concept="liA8E" id="1WjrBsNI_nK" role="2OqNvi">
-                          <ref role="37wK5l" to="d2zl:4DLCSzVGTmw" resolve="createCells" />
-                          <node concept="2ShNRf" id="1WjrBsNI_nM" role="37wK5m">
-                            <node concept="1pGfFk" id="1WjrBsNI_nN" role="2ShVmc">
-                              <ref role="37wK5l" to="kcid:~CellLayout_Horizontal.&lt;init&gt;()" resolve="CellLayout_Horizontal" />
-                              <node concept="1ZhdrF" id="1WjrBsNI_nO" role="lGtFl">
-                                <property role="2qtEX8" value="baseMethodDeclaration" />
-                                <property role="P3scX" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1204053956946/1068499141037" />
-                                <node concept="3$xsQk" id="1WjrBsNI_nP" role="3$ytzL">
-                                  <node concept="3clFbS" id="1WjrBsNI_nQ" role="2VODD2">
-                                    <node concept="3cpWs8" id="1WjrBsNI_nR" role="3cqZAp">
-                                      <node concept="3cpWsn" id="1WjrBsNI_nS" role="3cpWs9">
-                                        <property role="TrG5h" value="cellLayout" />
-                                        <node concept="2OqwBi" id="1WjrBsNI_nT" role="33vP2m">
-                                          <node concept="30H73N" id="1WjrBsNI_nU" role="2Oq$k0" />
-                                          <node concept="3TrEf2" id="1WjrBsNI_nV" role="2OqNvi">
-                                            <ref role="3Tt5mk" to="bbp5:gAczzzC" resolve="cellLayout" />
-                                          </node>
-                                        </node>
-                                        <node concept="3Tqbb2" id="1WjrBsNI_nW" role="1tU5fm">
-                                          <ref role="ehGHo" to="tpc2:g6iR17a" resolve="CellLayout" />
-                                        </node>
-                                      </node>
-                                    </node>
-                                    <node concept="3SKdUt" id="1WjrBsNI_nX" role="3cqZAp">
-                                      <node concept="1PaTwC" id="17qUVvSZkNn" role="1aUNEU">
-                                        <node concept="3oM_SD" id="17qUVvSZkNo" role="1PaTwD">
-                                          <property role="3oM_SC" value="no" />
-                                        </node>
-                                        <node concept="3oM_SD" id="17qUVvSZkNp" role="1PaTwD">
-                                          <property role="3oM_SC" value="cell" />
-                                        </node>
-                                        <node concept="3oM_SD" id="17qUVvSZkNq" role="1PaTwD">
-                                          <property role="3oM_SC" value="layout" />
-                                        </node>
-                                        <node concept="3oM_SD" id="17qUVvSZkNr" role="1PaTwD">
-                                          <property role="3oM_SC" value="defined" />
-                                        </node>
-                                        <node concept="3oM_SD" id="17qUVvSZkNs" role="1PaTwD">
-                                          <property role="3oM_SC" value="(obsolete)" />
-                                        </node>
-                                      </node>
-                                    </node>
-                                    <node concept="3clFbJ" id="1WjrBsNI_nZ" role="3cqZAp">
-                                      <node concept="3clFbC" id="1WjrBsNI_o0" role="3clFbw">
-                                        <node concept="10Nm6u" id="1WjrBsNI_o1" role="3uHU7w" />
-                                        <node concept="37vLTw" id="1WjrBsNI_o2" role="3uHU7B">
-                                          <ref role="3cqZAo" node="1WjrBsNI_nS" resolve="cellLayout" />
-                                        </node>
-                                      </node>
-                                      <node concept="3clFbS" id="1WjrBsNI_o3" role="3clFbx">
-                                        <node concept="3clFbJ" id="1WjrBsNI_o4" role="3cqZAp">
-                                          <node concept="3clFbS" id="1WjrBsNI_o5" role="3clFbx">
-                                            <node concept="3cpWs6" id="1WjrBsNI_o6" role="3cqZAp">
-                                              <node concept="2OqwBi" id="1WjrBsNI_o7" role="3cqZAk">
-                                                <node concept="3TrEf2" id="1WjrBsNI_o8" role="2OqNvi">
-                                                  <ref role="3Tt5mk" to="tpee:hDpISCB" resolve="constructorDeclaration" />
-                                                </node>
-                                                <node concept="1PxgMI" id="1WjrBsNI_o9" role="2Oq$k0">
-                                                  <node concept="2OqwBi" id="1WjrBsNI_oa" role="1m5AlR">
-                                                    <node concept="2c44tf" id="1WjrBsNI_ob" role="2Oq$k0">
-                                                      <node concept="2ShNRf" id="1WjrBsNI_oc" role="2c44tc">
-                                                        <node concept="1pGfFk" id="1WjrBsNI_od" role="2ShVmc">
-                                                          <ref role="37wK5l" to="kcid:~CellLayout_Vertical.&lt;init&gt;()" resolve="CellLayout_Vertical" />
-                                                        </node>
-                                                      </node>
-                                                    </node>
-                                                    <node concept="3TrEf2" id="1WjrBsNI_oe" role="2OqNvi">
-                                                      <ref role="3Tt5mk" to="tpee:gEShVi6" resolve="creator" />
-                                                    </node>
-                                                  </node>
-                                                  <node concept="chp4Y" id="1SbcsM_IMW1" role="3oSUPX">
-                                                    <ref role="cht4Q" to="tpee:hDpGfJe" resolve="ClassCreator" />
-                                                  </node>
-                                                </node>
-                                              </node>
-                                            </node>
-                                          </node>
-                                          <node concept="2OqwBi" id="1WjrBsNI_of" role="3clFbw">
-                                            <node concept="2qgKlT" id="1WjrBsNI_og" role="2OqNvi">
-                                              <ref role="37wK5l" to="1hk2:i2IdWzG" resolve="isVertical" />
-                                            </node>
-                                            <node concept="30H73N" id="1WjrBsNI_oh" role="2Oq$k0" />
-                                          </node>
-                                        </node>
-                                        <node concept="3cpWs6" id="1WjrBsNI_oi" role="3cqZAp">
-                                          <node concept="2OqwBi" id="1WjrBsNI_oj" role="3cqZAk">
-                                            <node concept="3TrEf2" id="1WjrBsNI_ok" role="2OqNvi">
-                                              <ref role="3Tt5mk" to="tpee:hDpISCB" resolve="constructorDeclaration" />
-                                            </node>
-                                            <node concept="1PxgMI" id="1WjrBsNI_ol" role="2Oq$k0">
-                                              <node concept="2OqwBi" id="1WjrBsNI_om" role="1m5AlR">
-                                                <node concept="2c44tf" id="1WjrBsNI_on" role="2Oq$k0">
-                                                  <node concept="2ShNRf" id="1WjrBsNI_oo" role="2c44tc">
-                                                    <node concept="1pGfFk" id="1WjrBsNI_op" role="2ShVmc">
-                                                      <ref role="37wK5l" to="kcid:~CellLayout_Horizontal.&lt;init&gt;()" resolve="CellLayout_Horizontal" />
-                                                    </node>
-                                                  </node>
-                                                </node>
-                                                <node concept="3TrEf2" id="1WjrBsNI_oq" role="2OqNvi">
-                                                  <ref role="3Tt5mk" to="tpee:gEShVi6" resolve="creator" />
-                                                </node>
-                                              </node>
-                                              <node concept="chp4Y" id="1SbcsM_IMVS" role="3oSUPX">
-                                                <ref role="cht4Q" to="tpee:hDpGfJe" resolve="ClassCreator" />
-                                              </node>
-                                            </node>
-                                          </node>
-                                        </node>
-                                      </node>
-                                    </node>
-                                    <node concept="3SKdUt" id="1WjrBsNI_or" role="3cqZAp">
-                                      <node concept="1PaTwC" id="17qUVvSZkNt" role="1aUNEU">
-                                        <node concept="3oM_SD" id="17qUVvSZkNu" role="1PaTwD">
-                                          <property role="3oM_SC" value="choose" />
-                                        </node>
-                                        <node concept="3oM_SD" id="17qUVvSZkNv" role="1PaTwD">
-                                          <property role="3oM_SC" value="cell" />
-                                        </node>
-                                        <node concept="3oM_SD" id="17qUVvSZkNw" role="1PaTwD">
-                                          <property role="3oM_SC" value="layout" />
-                                        </node>
-                                      </node>
-                                    </node>
-                                    <node concept="3clFbJ" id="1WjrBsNI_ot" role="3cqZAp">
-                                      <node concept="2OqwBi" id="1WjrBsNI_ou" role="3clFbw">
-                                        <node concept="37vLTw" id="1WjrBsNI_ov" role="2Oq$k0">
-                                          <ref role="3cqZAo" node="1WjrBsNI_nS" resolve="cellLayout" />
-                                        </node>
-                                        <node concept="1mIQ4w" id="1WjrBsNI_ow" role="2OqNvi">
-                                          <node concept="chp4Y" id="1WjrBsNI_ox" role="cj9EA">
-                                            <ref role="cht4Q" to="tpc2:g6iRkMY" resolve="CellLayout_Vertical" />
-                                          </node>
-                                        </node>
-                                      </node>
-                                      <node concept="3clFbS" id="1WjrBsNI_oy" role="3clFbx">
-                                        <node concept="3cpWs6" id="1WjrBsNI_oz" role="3cqZAp">
-                                          <node concept="2OqwBi" id="1WjrBsNI_o$" role="3cqZAk">
-                                            <node concept="1PxgMI" id="1WjrBsNI_o_" role="2Oq$k0">
-                                              <node concept="2OqwBi" id="1WjrBsNI_oA" role="1m5AlR">
-                                                <node concept="3TrEf2" id="1WjrBsNI_oB" role="2OqNvi">
-                                                  <ref role="3Tt5mk" to="tpee:gEShVi6" resolve="creator" />
-                                                </node>
-                                                <node concept="2c44tf" id="1WjrBsNI_oC" role="2Oq$k0">
-                                                  <node concept="2ShNRf" id="1WjrBsNI_oD" role="2c44tc">
-                                                    <node concept="1pGfFk" id="1WjrBsNI_oE" role="2ShVmc">
-                                                      <ref role="37wK5l" to="kcid:~CellLayout_Vertical.&lt;init&gt;()" resolve="CellLayout_Vertical" />
-                                                    </node>
-                                                  </node>
-                                                </node>
-                                              </node>
-                                              <node concept="chp4Y" id="1SbcsM_IMW6" role="3oSUPX">
-                                                <ref role="cht4Q" to="tpee:hDpGfJe" resolve="ClassCreator" />
-                                              </node>
-                                            </node>
-                                            <node concept="3TrEf2" id="1WjrBsNI_oF" role="2OqNvi">
-                                              <ref role="3Tt5mk" to="tpee:hDpISCB" resolve="constructorDeclaration" />
-                                            </node>
-                                          </node>
-                                        </node>
-                                      </node>
-                                    </node>
-                                    <node concept="3clFbJ" id="1WjrBsNI_oG" role="3cqZAp">
-                                      <node concept="3clFbS" id="1WjrBsNI_oH" role="3clFbx">
-                                        <node concept="3cpWs6" id="1WjrBsNI_oI" role="3cqZAp">
-                                          <node concept="2OqwBi" id="1WjrBsNI_oJ" role="3cqZAk">
-                                            <node concept="1PxgMI" id="1WjrBsNI_oK" role="2Oq$k0">
-                                              <node concept="2OqwBi" id="1WjrBsNI_oL" role="1m5AlR">
-                                                <node concept="3TrEf2" id="1WjrBsNI_oM" role="2OqNvi">
-                                                  <ref role="3Tt5mk" to="tpee:gEShVi6" resolve="creator" />
-                                                </node>
-                                                <node concept="2c44tf" id="1WjrBsNI_oN" role="2Oq$k0">
-                                                  <node concept="2ShNRf" id="1WjrBsNI_oO" role="2c44tc">
-                                                    <node concept="1pGfFk" id="1WjrBsNI_oP" role="2ShVmc">
-                                                      <ref role="37wK5l" to="kcid:~CellLayout_Horizontal.&lt;init&gt;()" resolve="CellLayout_Horizontal" />
-                                                    </node>
-                                                  </node>
-                                                </node>
-                                              </node>
-                                              <node concept="chp4Y" id="1SbcsM_IMW7" role="3oSUPX">
-                                                <ref role="cht4Q" to="tpee:hDpGfJe" resolve="ClassCreator" />
-                                              </node>
-                                            </node>
-                                            <node concept="3TrEf2" id="1WjrBsNI_oQ" role="2OqNvi">
-                                              <ref role="3Tt5mk" to="tpee:hDpISCB" resolve="constructorDeclaration" />
-                                            </node>
-                                          </node>
-                                        </node>
-                                      </node>
-                                      <node concept="2OqwBi" id="1WjrBsNI_oR" role="3clFbw">
-                                        <node concept="37vLTw" id="1WjrBsNI_oS" role="2Oq$k0">
-                                          <ref role="3cqZAo" node="1WjrBsNI_nS" resolve="cellLayout" />
-                                        </node>
-                                        <node concept="1mIQ4w" id="1WjrBsNI_oT" role="2OqNvi">
-                                          <node concept="chp4Y" id="1WjrBsNI_oU" role="cj9EA">
-                                            <ref role="cht4Q" to="tpc2:g6iRfq5" resolve="CellLayout_Horizontal" />
-                                          </node>
-                                        </node>
-                                      </node>
-                                    </node>
-                                    <node concept="3clFbJ" id="1WjrBsNI_oV" role="3cqZAp">
-                                      <node concept="3clFbS" id="1WjrBsNI_oW" role="3clFbx">
-                                        <node concept="3cpWs6" id="1WjrBsNI_oX" role="3cqZAp">
-                                          <node concept="2OqwBi" id="1WjrBsNI_oY" role="3cqZAk">
-                                            <node concept="3TrEf2" id="1WjrBsNI_oZ" role="2OqNvi">
-                                              <ref role="3Tt5mk" to="tpee:hDpISCB" resolve="constructorDeclaration" />
-                                            </node>
-                                            <node concept="1PxgMI" id="1WjrBsNI_p0" role="2Oq$k0">
-                                              <node concept="2OqwBi" id="1WjrBsNI_p1" role="1m5AlR">
-                                                <node concept="2c44tf" id="1WjrBsNI_p2" role="2Oq$k0">
-                                                  <node concept="2ShNRf" id="1WjrBsNI_p3" role="2c44tc">
-                                                    <node concept="1pGfFk" id="1WjrBsNI_p4" role="2ShVmc">
-                                                      <ref role="37wK5l" to="kcid:~CellLayout_Flow.&lt;init&gt;()" resolve="CellLayout_Flow" />
-                                                    </node>
-                                                  </node>
-                                                </node>
-                                                <node concept="3TrEf2" id="1WjrBsNI_p5" role="2OqNvi">
-                                                  <ref role="3Tt5mk" to="tpee:gEShVi6" resolve="creator" />
-                                                </node>
-                                              </node>
-                                              <node concept="chp4Y" id="1SbcsM_IMW0" role="3oSUPX">
-                                                <ref role="cht4Q" to="tpee:hDpGfJe" resolve="ClassCreator" />
-                                              </node>
-                                            </node>
-                                          </node>
-                                        </node>
-                                      </node>
-                                      <node concept="2OqwBi" id="1WjrBsNI_p6" role="3clFbw">
-                                        <node concept="1mIQ4w" id="1WjrBsNI_p7" role="2OqNvi">
-                                          <node concept="chp4Y" id="1WjrBsNI_p8" role="cj9EA">
-                                            <ref role="cht4Q" to="tpc2:g6iR$Wm" resolve="CellLayout_Flow" />
-                                          </node>
-                                        </node>
-                                        <node concept="37vLTw" id="1WjrBsNI_p9" role="2Oq$k0">
-                                          <ref role="3cqZAo" node="1WjrBsNI_nS" resolve="cellLayout" />
-                                        </node>
-                                      </node>
-                                    </node>
-                                    <node concept="3clFbJ" id="1WjrBsNI_pa" role="3cqZAp">
-                                      <node concept="3clFbS" id="1WjrBsNI_pb" role="3clFbx">
-                                        <node concept="3cpWs6" id="1WjrBsNI_pc" role="3cqZAp">
-                                          <node concept="2OqwBi" id="1WjrBsNI_pd" role="3cqZAk">
-                                            <node concept="1PxgMI" id="1WjrBsNI_pe" role="2Oq$k0">
-                                              <node concept="2OqwBi" id="1WjrBsNI_pf" role="1m5AlR">
-                                                <node concept="2c44tf" id="1WjrBsNI_pg" role="2Oq$k0">
-                                                  <node concept="2ShNRf" id="1WjrBsNI_ph" role="2c44tc">
-                                                    <node concept="1pGfFk" id="1WjrBsNI_pi" role="2ShVmc">
-                                                      <ref role="37wK5l" to="kcid:~CellLayout_Indent.&lt;init&gt;()" resolve="CellLayout_Indent" />
-                                                    </node>
-                                                  </node>
-                                                </node>
-                                                <node concept="3TrEf2" id="1WjrBsNI_pj" role="2OqNvi">
-                                                  <ref role="3Tt5mk" to="tpee:gEShVi6" resolve="creator" />
-                                                </node>
-                                              </node>
-                                              <node concept="chp4Y" id="1SbcsM_IMVV" role="3oSUPX">
-                                                <ref role="cht4Q" to="tpee:hDpGfJe" resolve="ClassCreator" />
-                                              </node>
-                                            </node>
-                                            <node concept="3TrEf2" id="1WjrBsNI_pk" role="2OqNvi">
-                                              <ref role="3Tt5mk" to="tpee:hDpISCB" resolve="constructorDeclaration" />
-                                            </node>
-                                          </node>
-                                        </node>
-                                      </node>
-                                      <node concept="2OqwBi" id="1WjrBsNI_pl" role="3clFbw">
-                                        <node concept="37vLTw" id="1WjrBsNI_pm" role="2Oq$k0">
-                                          <ref role="3cqZAo" node="1WjrBsNI_nS" resolve="cellLayout" />
-                                        </node>
-                                        <node concept="1mIQ4w" id="1WjrBsNI_pn" role="2OqNvi">
-                                          <node concept="chp4Y" id="1WjrBsNI_po" role="cj9EA">
-                                            <ref role="cht4Q" to="tpc2:i0l2Vh1" resolve="CellLayout_Indent" />
-                                          </node>
-                                        </node>
-                                      </node>
-                                    </node>
-                                    <node concept="3clFbJ" id="1WjrBsNI_pp" role="3cqZAp">
-                                      <node concept="3clFbS" id="1WjrBsNI_pq" role="3clFbx">
-                                        <node concept="3cpWs6" id="1WjrBsNI_pr" role="3cqZAp">
-                                          <node concept="2OqwBi" id="1WjrBsNI_ps" role="3cqZAk">
-                                            <node concept="3TrEf2" id="1WjrBsNI_pt" role="2OqNvi">
-                                              <ref role="3Tt5mk" to="tpee:hDpISCB" resolve="constructorDeclaration" />
-                                            </node>
-                                            <node concept="1PxgMI" id="1WjrBsNI_pu" role="2Oq$k0">
-                                              <node concept="2OqwBi" id="1WjrBsNI_pv" role="1m5AlR">
-                                                <node concept="2c44tf" id="1WjrBsNI_pw" role="2Oq$k0">
-                                                  <node concept="2ShNRf" id="1WjrBsNI_px" role="2c44tc">
-                                                    <node concept="1pGfFk" id="1WjrBsNI_py" role="2ShVmc">
-                                                      <ref role="37wK5l" to="kcid:~CellLayout_Superscript.&lt;init&gt;()" resolve="CellLayout_Superscript" />
-                                                    </node>
-                                                  </node>
-                                                </node>
-                                                <node concept="3TrEf2" id="1WjrBsNI_pz" role="2OqNvi">
-                                                  <ref role="3Tt5mk" to="tpee:gEShVi6" resolve="creator" />
-                                                </node>
-                                              </node>
-                                              <node concept="chp4Y" id="1SbcsM_IMW3" role="3oSUPX">
-                                                <ref role="cht4Q" to="tpee:hDpGfJe" resolve="ClassCreator" />
-                                              </node>
-                                            </node>
-                                          </node>
-                                        </node>
-                                      </node>
-                                      <node concept="2OqwBi" id="1WjrBsNI_p$" role="3clFbw">
-                                        <node concept="1mIQ4w" id="1WjrBsNI_p_" role="2OqNvi">
-                                          <node concept="chp4Y" id="1WjrBsNI_pA" role="cj9EA">
-                                            <ref role="cht4Q" to="tpc2:1CJP367e8q1" resolve="CellLayout_Superscript" />
-                                          </node>
-                                        </node>
-                                        <node concept="37vLTw" id="1WjrBsNI_pB" role="2Oq$k0">
-                                          <ref role="3cqZAo" node="1WjrBsNI_nS" resolve="cellLayout" />
-                                        </node>
-                                      </node>
-                                    </node>
-                                    <node concept="3clFbJ" id="1WjrBsNI_pC" role="3cqZAp">
-                                      <node concept="2OqwBi" id="1WjrBsNI_pD" role="3clFbw">
-                                        <node concept="1mIQ4w" id="1WjrBsNI_pE" role="2OqNvi">
-                                          <node concept="chp4Y" id="1WjrBsNI_pF" role="cj9EA">
-                                            <ref role="cht4Q" to="tpc2:5ahn_dtVdm1" resolve="CellLayout_Table" />
-                                          </node>
-                                        </node>
-                                        <node concept="37vLTw" id="1WjrBsNI_pG" role="2Oq$k0">
-                                          <ref role="3cqZAo" node="1WjrBsNI_nS" resolve="cellLayout" />
-                                        </node>
-                                      </node>
-                                      <node concept="3clFbS" id="1WjrBsNI_pH" role="3clFbx">
-                                        <node concept="3cpWs6" id="1WjrBsNI_pI" role="3cqZAp">
-                                          <node concept="2OqwBi" id="1WjrBsNI_pJ" role="3cqZAk">
-                                            <node concept="3TrEf2" id="1WjrBsNI_pK" role="2OqNvi">
-                                              <ref role="3Tt5mk" to="tpee:hDpISCB" resolve="constructorDeclaration" />
-                                            </node>
-                                            <node concept="1PxgMI" id="1WjrBsNI_pL" role="2Oq$k0">
-                                              <node concept="2OqwBi" id="1WjrBsNI_pM" role="1m5AlR">
-                                                <node concept="3TrEf2" id="1WjrBsNI_pN" role="2OqNvi">
-                                                  <ref role="3Tt5mk" to="tpee:gEShVi6" resolve="creator" />
-                                                </node>
-                                                <node concept="2c44tf" id="1WjrBsNI_pO" role="2Oq$k0">
-                                                  <node concept="2ShNRf" id="1WjrBsNI_pP" role="2c44tc">
-                                                    <node concept="1pGfFk" id="1WjrBsNI_pQ" role="2ShVmc">
-                                                      <ref role="37wK5l" to="kcid:~CellLayout_Table.&lt;init&gt;()" resolve="CellLayout_Table" />
-                                                    </node>
-                                                  </node>
-                                                </node>
-                                              </node>
-                                              <node concept="chp4Y" id="1SbcsM_IMVT" role="3oSUPX">
-                                                <ref role="cht4Q" to="tpee:hDpGfJe" resolve="ClassCreator" />
-                                              </node>
-                                            </node>
-                                          </node>
-                                        </node>
-                                      </node>
-                                    </node>
-                                    <node concept="3SKdUt" id="1WjrBsNI_pR" role="3cqZAp">
-                                      <node concept="1PaTwC" id="17qUVvSZkNx" role="1aUNEU">
-                                        <node concept="3oM_SD" id="17qUVvSZkNy" role="1PaTwD">
-                                          <property role="3oM_SC" value="error" />
-                                        </node>
-                                      </node>
-                                    </node>
-                                    <node concept="3cpWs6" id="1WjrBsNI_pT" role="3cqZAp">
-                                      <node concept="10Nm6u" id="1WjrBsNI_pU" role="3cqZAk" />
-                                    </node>
-                                  </node>
+                            <node concept="3SKdUt" id="1WjrBsNI_nX" role="3cqZAp">
+                              <node concept="1PaTwC" id="17qUVvSZkNn" role="1aUNEU">
+                                <node concept="3oM_SD" id="17qUVvSZkNo" role="1PaTwD">
+                                  <property role="3oM_SC" value="no" />
+                                </node>
+                                <node concept="3oM_SD" id="17qUVvSZkNp" role="1PaTwD">
+                                  <property role="3oM_SC" value="cell" />
+                                </node>
+                                <node concept="3oM_SD" id="17qUVvSZkNq" role="1PaTwD">
+                                  <property role="3oM_SC" value="layout" />
+                                </node>
+                                <node concept="3oM_SD" id="17qUVvSZkNr" role="1PaTwD">
+                                  <property role="3oM_SC" value="defined" />
+                                </node>
+                                <node concept="3oM_SD" id="17qUVvSZkNs" role="1PaTwD">
+                                  <property role="3oM_SC" value="(obsolete)" />
                                 </node>
                               </node>
                             </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3clFbF" id="7vDkgomVfmM" role="3cqZAp">
-                    <node concept="2OqwBi" id="7vDkgomViaV" role="3clFbG">
-                      <node concept="37vLTw" id="7vDkgomVfmK" role="2Oq$k0">
-                        <ref role="3cqZAo" node="1WjrBsNI_nG" resolve="editorCell" />
-                      </node>
-                      <node concept="liA8E" id="7vDkgomVqJ1" role="2OqNvi">
-                        <ref role="37wK5l" to="d2zl:7vDkgomUY9j" resolve="setTargeConcept" />
-                        <node concept="35c_gC" id="7vDkgomWFe8" role="37wK5m">
-                          <ref role="35c_gD" to="tpck:gw2VY9q" resolve="BaseConcept" />
-                          <node concept="1ZhdrF" id="7vDkgomWJov" role="lGtFl">
-                            <property role="2qtEX8" value="conceptDeclaration" />
-                            <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/2644386474300074836/2644386474300074837" />
-                            <node concept="3$xsQk" id="7vDkgomWJow" role="3$ytzL">
-                              <node concept="3clFbS" id="7vDkgomWJox" role="2VODD2">
-                                <node concept="3clFbF" id="7vDkgomWLHP" role="3cqZAp">
-                                  <node concept="2OqwBi" id="7vDkgomWNq2" role="3clFbG">
-                                    <node concept="30H73N" id="7vDkgomWLHO" role="2Oq$k0" />
-                                    <node concept="3TrEf2" id="7vDkgomWOZ7" role="2OqNvi">
-                                      <ref role="3Tt5mk" to="bbp5:C$q8A2yeI6" resolve="elementsConcept" />
-                                    </node>
-                                  </node>
+                            <node concept="3clFbJ" id="1WjrBsNI_nZ" role="3cqZAp">
+                              <node concept="3clFbC" id="1WjrBsNI_o0" role="3clFbw">
+                                <node concept="10Nm6u" id="1WjrBsNI_o1" role="3uHU7w" />
+                                <node concept="37vLTw" id="1WjrBsNI_o2" role="3uHU7B">
+                                  <ref role="3cqZAo" node="1WjrBsNI_nS" resolve="cellLayout" />
                                 </node>
                               </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3clFbF" id="7vDkgomYQCT" role="3cqZAp">
-                    <node concept="2OqwBi" id="7vDkgomYQCU" role="3clFbG">
-                      <node concept="37vLTw" id="7vDkgomYQCV" role="2Oq$k0">
-                        <ref role="3cqZAo" node="1WjrBsNI_nG" resolve="editorCell" />
-                      </node>
-                      <node concept="liA8E" id="7vDkgomYQCW" role="2OqNvi">
-                        <ref role="37wK5l" to="d2zl:7vDkgomYIqr" resolve="setOwner" />
-                        <node concept="2OqwBi" id="7vDkgomYZkC" role="37wK5m">
-                          <node concept="37vLTw" id="7vDkgomYXNx" role="2Oq$k0">
-                            <ref role="3cqZAo" node="fYh_FQ7" resolve="node" />
-                          </node>
-                          <node concept="2yIwOk" id="7vDkgomZ1OU" role="2OqNvi" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3cpWs8" id="1WjrBsNI_pV" role="3cqZAp">
-                    <node concept="5jKBG" id="76N1O$KguuA" role="lGtFl">
-                      <ref role="v9R2y" to="tpc3:4v1iCryNDHi" resolve="template_cellSetupBlock" />
-                    </node>
-                    <node concept="3cpWsn" id="1WjrBsNI_pX" role="3cpWs9">
-                      <property role="TrG5h" value="i" />
-                      <node concept="10Oyi0" id="1WjrBsNI_pY" role="1tU5fm" />
-                    </node>
-                  </node>
-                  <node concept="3clFbF" id="1WjrBsNI_pZ" role="3cqZAp">
-                    <node concept="2OqwBi" id="1WjrBsNI_q0" role="3clFbG">
-                      <node concept="37vLTw" id="1WjrBsNI_q1" role="2Oq$k0">
-                        <ref role="3cqZAo" node="1WjrBsNI_nG" resolve="editorCell" />
-                      </node>
-                      <node concept="liA8E" id="1WjrBsNI_q2" role="2OqNvi">
-                        <ref role="37wK5l" to="g51k:~EditorCell_Collection.setGridLayout(boolean)" resolve="setGridLayout" />
-                        <node concept="3clFbT" id="1WjrBsNI_q3" role="37wK5m">
-                          <property role="3clFbU" value="true" />
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="1W57fq" id="1WjrBsNI_q4" role="lGtFl">
-                      <node concept="3IZrLx" id="1WjrBsNI_q5" role="3IZSJc">
-                        <node concept="3clFbS" id="1WjrBsNI_q6" role="2VODD2">
-                          <node concept="3clFbF" id="1WjrBsNI_q7" role="3cqZAp">
-                            <node concept="2OqwBi" id="1WjrBsNI_q8" role="3clFbG">
-                              <node concept="30H73N" id="1WjrBsNI_q9" role="2Oq$k0" />
-                              <node concept="2qgKlT" id="1WjrBsNI_qa" role="2OqNvi">
-                                <ref role="37wK5l" to="1hk2:i2IfsZ1" resolve="isVerticalGrid" />
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3clFbF" id="3DPg8zpyaE0" role="3cqZAp">
-                    <node concept="2OqwBi" id="3DPg8zpyaE2" role="3clFbG">
-                      <node concept="37vLTw" id="3GM_nagTAwe" role="2Oq$k0">
-                        <ref role="3cqZAo" node="1WjrBsNI_nG" resolve="editorCell" />
-                      </node>
-                      <node concept="liA8E" id="3DPg8zpyaFB" role="2OqNvi">
-                        <ref role="37wK5l" to="g51k:~EditorCell_Collection.setFoldable(boolean)" resolve="setFoldable" />
-                        <node concept="3clFbT" id="3DPg8zpyaFC" role="37wK5m">
-                          <property role="3clFbU" value="true" />
-                          <node concept="1W57fq" id="3DPg8zpygQy" role="lGtFl">
-                            <node concept="gft3U" id="5_YqJ2SmGlx" role="UU_$l">
-                              <node concept="1rXfSq" id="5_YqJ2SmGBP" role="gfFT$">
-                                <ref role="37wK5l" to="tpc3:5_YqJ2SmBvw" resolve="_condition_" />
-                                <node concept="1ZhdrF" id="5_YqJ2SmGOS" role="lGtFl">
-                                  <property role="P3scX" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1204053956946/1068499141037" />
-                                  <property role="2qtEX8" value="baseMethodDeclaration" />
-                                  <node concept="3$xsQk" id="5_YqJ2SmGOT" role="3$ytzL">
-                                    <node concept="3clFbS" id="5_YqJ2SmGOU" role="2VODD2">
-                                      <node concept="3clFbF" id="3DPg8zpygRj" role="3cqZAp">
-                                        <node concept="2OqwBi" id="3DPg8zpygRl" role="3clFbG">
-                                          <node concept="1iwH7S" id="3DPg8zpygRk" role="2Oq$k0" />
-                                          <node concept="1iwH70" id="3DPg8zpygRp" role="2OqNvi">
-                                            <ref role="1iwH77" to="tpc3:hG092go" resolve="query_method" />
-                                            <node concept="2OqwBi" id="3DPg8zpygRs" role="1iwH7V">
-                                              <node concept="30H73N" id="3DPg8zpygRr" role="2Oq$k0" />
-                                              <node concept="3TrEf2" id="3DPg8zpygRw" role="2OqNvi">
-                                                <ref role="3Tt5mk" to="bbp5:3ZqNA5Aj2vB" resolve="usesFoldingCondition" />
+                              <node concept="3clFbS" id="1WjrBsNI_o3" role="3clFbx">
+                                <node concept="3clFbJ" id="1WjrBsNI_o4" role="3cqZAp">
+                                  <node concept="3clFbS" id="1WjrBsNI_o5" role="3clFbx">
+                                    <node concept="3cpWs6" id="1WjrBsNI_o6" role="3cqZAp">
+                                      <node concept="2OqwBi" id="1WjrBsNI_o7" role="3cqZAk">
+                                        <node concept="3TrEf2" id="1WjrBsNI_o8" role="2OqNvi">
+                                          <ref role="3Tt5mk" to="tpee:hDpISCB" resolve="constructorDeclaration" />
+                                        </node>
+                                        <node concept="1PxgMI" id="1WjrBsNI_o9" role="2Oq$k0">
+                                          <node concept="2OqwBi" id="1WjrBsNI_oa" role="1m5AlR">
+                                            <node concept="2c44tf" id="1WjrBsNI_ob" role="2Oq$k0">
+                                              <node concept="2ShNRf" id="1WjrBsNI_oc" role="2c44tc">
+                                                <node concept="1pGfFk" id="1WjrBsNI_od" role="2ShVmc">
+                                                  <ref role="37wK5l" to="kcid:~CellLayout_Vertical.&lt;init&gt;()" resolve="CellLayout_Vertical" />
+                                                </node>
                                               </node>
+                                            </node>
+                                            <node concept="3TrEf2" id="1WjrBsNI_oe" role="2OqNvi">
+                                              <ref role="3Tt5mk" to="tpee:gEShVi6" resolve="creator" />
+                                            </node>
+                                          </node>
+                                          <node concept="chp4Y" id="1SbcsM_IMW1" role="3oSUPX">
+                                            <ref role="cht4Q" to="tpee:hDpGfJe" resolve="ClassCreator" />
+                                          </node>
+                                        </node>
+                                      </node>
+                                    </node>
+                                  </node>
+                                  <node concept="2OqwBi" id="1WjrBsNI_of" role="3clFbw">
+                                    <node concept="2qgKlT" id="1WjrBsNI_og" role="2OqNvi">
+                                      <ref role="37wK5l" to="1hk2:i2IdWzG" resolve="isVertical" />
+                                    </node>
+                                    <node concept="30H73N" id="1WjrBsNI_oh" role="2Oq$k0" />
+                                  </node>
+                                </node>
+                                <node concept="3cpWs6" id="1WjrBsNI_oi" role="3cqZAp">
+                                  <node concept="2OqwBi" id="1WjrBsNI_oj" role="3cqZAk">
+                                    <node concept="3TrEf2" id="1WjrBsNI_ok" role="2OqNvi">
+                                      <ref role="3Tt5mk" to="tpee:hDpISCB" resolve="constructorDeclaration" />
+                                    </node>
+                                    <node concept="1PxgMI" id="1WjrBsNI_ol" role="2Oq$k0">
+                                      <node concept="2OqwBi" id="1WjrBsNI_om" role="1m5AlR">
+                                        <node concept="2c44tf" id="1WjrBsNI_on" role="2Oq$k0">
+                                          <node concept="2ShNRf" id="1WjrBsNI_oo" role="2c44tc">
+                                            <node concept="1pGfFk" id="1WjrBsNI_op" role="2ShVmc">
+                                              <ref role="37wK5l" to="kcid:~CellLayout_Horizontal.&lt;init&gt;()" resolve="CellLayout_Horizontal" />
                                             </node>
                                           </node>
                                         </node>
+                                        <node concept="3TrEf2" id="1WjrBsNI_oq" role="2OqNvi">
+                                          <ref role="3Tt5mk" to="tpee:gEShVi6" resolve="creator" />
+                                        </node>
+                                      </node>
+                                      <node concept="chp4Y" id="1SbcsM_IMVS" role="3oSUPX">
+                                        <ref role="cht4Q" to="tpee:hDpGfJe" resolve="ClassCreator" />
                                       </node>
                                     </node>
                                   </node>
                                 </node>
                               </node>
                             </node>
-                            <node concept="3IZrLx" id="3DPg8zpygQz" role="3IZSJc">
-                              <node concept="3clFbS" id="3DPg8zpygQ$" role="2VODD2">
-                                <node concept="3clFbF" id="3DPg8zpygQ_" role="3cqZAp">
-                                  <node concept="2OqwBi" id="3DPg8zpygQG" role="3clFbG">
-                                    <node concept="2OqwBi" id="3DPg8zpygQB" role="2Oq$k0">
-                                      <node concept="30H73N" id="3DPg8zpygQA" role="2Oq$k0" />
-                                      <node concept="3TrEf2" id="3DPg8zpygQF" role="2OqNvi">
+                            <node concept="3SKdUt" id="1WjrBsNI_or" role="3cqZAp">
+                              <node concept="1PaTwC" id="17qUVvSZkNt" role="1aUNEU">
+                                <node concept="3oM_SD" id="17qUVvSZkNu" role="1PaTwD">
+                                  <property role="3oM_SC" value="choose" />
+                                </node>
+                                <node concept="3oM_SD" id="17qUVvSZkNv" role="1PaTwD">
+                                  <property role="3oM_SC" value="cell" />
+                                </node>
+                                <node concept="3oM_SD" id="17qUVvSZkNw" role="1PaTwD">
+                                  <property role="3oM_SC" value="layout" />
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="3clFbJ" id="1WjrBsNI_ot" role="3cqZAp">
+                              <node concept="2OqwBi" id="1WjrBsNI_ou" role="3clFbw">
+                                <node concept="37vLTw" id="1WjrBsNI_ov" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="1WjrBsNI_nS" resolve="cellLayout" />
+                                </node>
+                                <node concept="1mIQ4w" id="1WjrBsNI_ow" role="2OqNvi">
+                                  <node concept="chp4Y" id="1WjrBsNI_ox" role="cj9EA">
+                                    <ref role="cht4Q" to="tpc2:g6iRkMY" resolve="CellLayout_Vertical" />
+                                  </node>
+                                </node>
+                              </node>
+                              <node concept="3clFbS" id="1WjrBsNI_oy" role="3clFbx">
+                                <node concept="3cpWs6" id="1WjrBsNI_oz" role="3cqZAp">
+                                  <node concept="2OqwBi" id="1WjrBsNI_o$" role="3cqZAk">
+                                    <node concept="1PxgMI" id="1WjrBsNI_o_" role="2Oq$k0">
+                                      <node concept="2OqwBi" id="1WjrBsNI_oA" role="1m5AlR">
+                                        <node concept="3TrEf2" id="1WjrBsNI_oB" role="2OqNvi">
+                                          <ref role="3Tt5mk" to="tpee:gEShVi6" resolve="creator" />
+                                        </node>
+                                        <node concept="2c44tf" id="1WjrBsNI_oC" role="2Oq$k0">
+                                          <node concept="2ShNRf" id="1WjrBsNI_oD" role="2c44tc">
+                                            <node concept="1pGfFk" id="1WjrBsNI_oE" role="2ShVmc">
+                                              <ref role="37wK5l" to="kcid:~CellLayout_Vertical.&lt;init&gt;()" resolve="CellLayout_Vertical" />
+                                            </node>
+                                          </node>
+                                        </node>
+                                      </node>
+                                      <node concept="chp4Y" id="1SbcsM_IMW6" role="3oSUPX">
+                                        <ref role="cht4Q" to="tpee:hDpGfJe" resolve="ClassCreator" />
+                                      </node>
+                                    </node>
+                                    <node concept="3TrEf2" id="1WjrBsNI_oF" role="2OqNvi">
+                                      <ref role="3Tt5mk" to="tpee:hDpISCB" resolve="constructorDeclaration" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="3clFbJ" id="1WjrBsNI_oG" role="3cqZAp">
+                              <node concept="3clFbS" id="1WjrBsNI_oH" role="3clFbx">
+                                <node concept="3cpWs6" id="1WjrBsNI_oI" role="3cqZAp">
+                                  <node concept="2OqwBi" id="1WjrBsNI_oJ" role="3cqZAk">
+                                    <node concept="1PxgMI" id="1WjrBsNI_oK" role="2Oq$k0">
+                                      <node concept="2OqwBi" id="1WjrBsNI_oL" role="1m5AlR">
+                                        <node concept="3TrEf2" id="1WjrBsNI_oM" role="2OqNvi">
+                                          <ref role="3Tt5mk" to="tpee:gEShVi6" resolve="creator" />
+                                        </node>
+                                        <node concept="2c44tf" id="1WjrBsNI_oN" role="2Oq$k0">
+                                          <node concept="2ShNRf" id="1WjrBsNI_oO" role="2c44tc">
+                                            <node concept="1pGfFk" id="1WjrBsNI_oP" role="2ShVmc">
+                                              <ref role="37wK5l" to="kcid:~CellLayout_Horizontal.&lt;init&gt;()" resolve="CellLayout_Horizontal" />
+                                            </node>
+                                          </node>
+                                        </node>
+                                      </node>
+                                      <node concept="chp4Y" id="1SbcsM_IMW7" role="3oSUPX">
+                                        <ref role="cht4Q" to="tpee:hDpGfJe" resolve="ClassCreator" />
+                                      </node>
+                                    </node>
+                                    <node concept="3TrEf2" id="1WjrBsNI_oQ" role="2OqNvi">
+                                      <ref role="3Tt5mk" to="tpee:hDpISCB" resolve="constructorDeclaration" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                              <node concept="2OqwBi" id="1WjrBsNI_oR" role="3clFbw">
+                                <node concept="37vLTw" id="1WjrBsNI_oS" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="1WjrBsNI_nS" resolve="cellLayout" />
+                                </node>
+                                <node concept="1mIQ4w" id="1WjrBsNI_oT" role="2OqNvi">
+                                  <node concept="chp4Y" id="1WjrBsNI_oU" role="cj9EA">
+                                    <ref role="cht4Q" to="tpc2:g6iRfq5" resolve="CellLayout_Horizontal" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="3clFbJ" id="1WjrBsNI_oV" role="3cqZAp">
+                              <node concept="3clFbS" id="1WjrBsNI_oW" role="3clFbx">
+                                <node concept="3cpWs6" id="1WjrBsNI_oX" role="3cqZAp">
+                                  <node concept="2OqwBi" id="1WjrBsNI_oY" role="3cqZAk">
+                                    <node concept="3TrEf2" id="1WjrBsNI_oZ" role="2OqNvi">
+                                      <ref role="3Tt5mk" to="tpee:hDpISCB" resolve="constructorDeclaration" />
+                                    </node>
+                                    <node concept="1PxgMI" id="1WjrBsNI_p0" role="2Oq$k0">
+                                      <node concept="2OqwBi" id="1WjrBsNI_p1" role="1m5AlR">
+                                        <node concept="2c44tf" id="1WjrBsNI_p2" role="2Oq$k0">
+                                          <node concept="2ShNRf" id="1WjrBsNI_p3" role="2c44tc">
+                                            <node concept="1pGfFk" id="1WjrBsNI_p4" role="2ShVmc">
+                                              <ref role="37wK5l" to="kcid:~CellLayout_Flow.&lt;init&gt;()" resolve="CellLayout_Flow" />
+                                            </node>
+                                          </node>
+                                        </node>
+                                        <node concept="3TrEf2" id="1WjrBsNI_p5" role="2OqNvi">
+                                          <ref role="3Tt5mk" to="tpee:gEShVi6" resolve="creator" />
+                                        </node>
+                                      </node>
+                                      <node concept="chp4Y" id="1SbcsM_IMW0" role="3oSUPX">
+                                        <ref role="cht4Q" to="tpee:hDpGfJe" resolve="ClassCreator" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                              <node concept="2OqwBi" id="1WjrBsNI_p6" role="3clFbw">
+                                <node concept="1mIQ4w" id="1WjrBsNI_p7" role="2OqNvi">
+                                  <node concept="chp4Y" id="1WjrBsNI_p8" role="cj9EA">
+                                    <ref role="cht4Q" to="tpc2:g6iR$Wm" resolve="CellLayout_Flow" />
+                                  </node>
+                                </node>
+                                <node concept="37vLTw" id="1WjrBsNI_p9" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="1WjrBsNI_nS" resolve="cellLayout" />
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="3clFbJ" id="1WjrBsNI_pa" role="3cqZAp">
+                              <node concept="3clFbS" id="1WjrBsNI_pb" role="3clFbx">
+                                <node concept="3cpWs6" id="1WjrBsNI_pc" role="3cqZAp">
+                                  <node concept="2OqwBi" id="1WjrBsNI_pd" role="3cqZAk">
+                                    <node concept="1PxgMI" id="1WjrBsNI_pe" role="2Oq$k0">
+                                      <node concept="2OqwBi" id="1WjrBsNI_pf" role="1m5AlR">
+                                        <node concept="2c44tf" id="1WjrBsNI_pg" role="2Oq$k0">
+                                          <node concept="2ShNRf" id="1WjrBsNI_ph" role="2c44tc">
+                                            <node concept="1pGfFk" id="1WjrBsNI_pi" role="2ShVmc">
+                                              <ref role="37wK5l" to="kcid:~CellLayout_Indent.&lt;init&gt;()" resolve="CellLayout_Indent" />
+                                            </node>
+                                          </node>
+                                        </node>
+                                        <node concept="3TrEf2" id="1WjrBsNI_pj" role="2OqNvi">
+                                          <ref role="3Tt5mk" to="tpee:gEShVi6" resolve="creator" />
+                                        </node>
+                                      </node>
+                                      <node concept="chp4Y" id="1SbcsM_IMVV" role="3oSUPX">
+                                        <ref role="cht4Q" to="tpee:hDpGfJe" resolve="ClassCreator" />
+                                      </node>
+                                    </node>
+                                    <node concept="3TrEf2" id="1WjrBsNI_pk" role="2OqNvi">
+                                      <ref role="3Tt5mk" to="tpee:hDpISCB" resolve="constructorDeclaration" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                              <node concept="2OqwBi" id="1WjrBsNI_pl" role="3clFbw">
+                                <node concept="37vLTw" id="1WjrBsNI_pm" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="1WjrBsNI_nS" resolve="cellLayout" />
+                                </node>
+                                <node concept="1mIQ4w" id="1WjrBsNI_pn" role="2OqNvi">
+                                  <node concept="chp4Y" id="1WjrBsNI_po" role="cj9EA">
+                                    <ref role="cht4Q" to="tpc2:i0l2Vh1" resolve="CellLayout_Indent" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="3clFbJ" id="1WjrBsNI_pp" role="3cqZAp">
+                              <node concept="3clFbS" id="1WjrBsNI_pq" role="3clFbx">
+                                <node concept="3cpWs6" id="1WjrBsNI_pr" role="3cqZAp">
+                                  <node concept="2OqwBi" id="1WjrBsNI_ps" role="3cqZAk">
+                                    <node concept="3TrEf2" id="1WjrBsNI_pt" role="2OqNvi">
+                                      <ref role="3Tt5mk" to="tpee:hDpISCB" resolve="constructorDeclaration" />
+                                    </node>
+                                    <node concept="1PxgMI" id="1WjrBsNI_pu" role="2Oq$k0">
+                                      <node concept="2OqwBi" id="1WjrBsNI_pv" role="1m5AlR">
+                                        <node concept="2c44tf" id="1WjrBsNI_pw" role="2Oq$k0">
+                                          <node concept="2ShNRf" id="1WjrBsNI_px" role="2c44tc">
+                                            <node concept="1pGfFk" id="1WjrBsNI_py" role="2ShVmc">
+                                              <ref role="37wK5l" to="kcid:~CellLayout_Superscript.&lt;init&gt;()" resolve="CellLayout_Superscript" />
+                                            </node>
+                                          </node>
+                                        </node>
+                                        <node concept="3TrEf2" id="1WjrBsNI_pz" role="2OqNvi">
+                                          <ref role="3Tt5mk" to="tpee:gEShVi6" resolve="creator" />
+                                        </node>
+                                      </node>
+                                      <node concept="chp4Y" id="1SbcsM_IMW3" role="3oSUPX">
+                                        <ref role="cht4Q" to="tpee:hDpGfJe" resolve="ClassCreator" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                              <node concept="2OqwBi" id="1WjrBsNI_p$" role="3clFbw">
+                                <node concept="1mIQ4w" id="1WjrBsNI_p_" role="2OqNvi">
+                                  <node concept="chp4Y" id="1WjrBsNI_pA" role="cj9EA">
+                                    <ref role="cht4Q" to="tpc2:1CJP367e8q1" resolve="CellLayout_Superscript" />
+                                  </node>
+                                </node>
+                                <node concept="37vLTw" id="1WjrBsNI_pB" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="1WjrBsNI_nS" resolve="cellLayout" />
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="3clFbJ" id="1WjrBsNI_pC" role="3cqZAp">
+                              <node concept="2OqwBi" id="1WjrBsNI_pD" role="3clFbw">
+                                <node concept="1mIQ4w" id="1WjrBsNI_pE" role="2OqNvi">
+                                  <node concept="chp4Y" id="1WjrBsNI_pF" role="cj9EA">
+                                    <ref role="cht4Q" to="tpc2:5ahn_dtVdm1" resolve="CellLayout_Table" />
+                                  </node>
+                                </node>
+                                <node concept="37vLTw" id="1WjrBsNI_pG" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="1WjrBsNI_nS" resolve="cellLayout" />
+                                </node>
+                              </node>
+                              <node concept="3clFbS" id="1WjrBsNI_pH" role="3clFbx">
+                                <node concept="3cpWs6" id="1WjrBsNI_pI" role="3cqZAp">
+                                  <node concept="2OqwBi" id="1WjrBsNI_pJ" role="3cqZAk">
+                                    <node concept="3TrEf2" id="1WjrBsNI_pK" role="2OqNvi">
+                                      <ref role="3Tt5mk" to="tpee:hDpISCB" resolve="constructorDeclaration" />
+                                    </node>
+                                    <node concept="1PxgMI" id="1WjrBsNI_pL" role="2Oq$k0">
+                                      <node concept="2OqwBi" id="1WjrBsNI_pM" role="1m5AlR">
+                                        <node concept="3TrEf2" id="1WjrBsNI_pN" role="2OqNvi">
+                                          <ref role="3Tt5mk" to="tpee:gEShVi6" resolve="creator" />
+                                        </node>
+                                        <node concept="2c44tf" id="1WjrBsNI_pO" role="2Oq$k0">
+                                          <node concept="2ShNRf" id="1WjrBsNI_pP" role="2c44tc">
+                                            <node concept="1pGfFk" id="1WjrBsNI_pQ" role="2ShVmc">
+                                              <ref role="37wK5l" to="kcid:~CellLayout_Table.&lt;init&gt;()" resolve="CellLayout_Table" />
+                                            </node>
+                                          </node>
+                                        </node>
+                                      </node>
+                                      <node concept="chp4Y" id="1SbcsM_IMVT" role="3oSUPX">
+                                        <ref role="cht4Q" to="tpee:hDpGfJe" resolve="ClassCreator" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="3SKdUt" id="1WjrBsNI_pR" role="3cqZAp">
+                              <node concept="1PaTwC" id="17qUVvSZkNx" role="1aUNEU">
+                                <node concept="3oM_SD" id="17qUVvSZkNy" role="1PaTwD">
+                                  <property role="3oM_SC" value="error" />
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="3cpWs6" id="1WjrBsNI_pT" role="3cqZAp">
+                              <node concept="10Nm6u" id="1WjrBsNI_pU" role="3cqZAk" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="7vDkgomVfmM" role="3cqZAp">
+            <node concept="2OqwBi" id="7vDkgomViaV" role="3clFbG">
+              <node concept="37vLTw" id="7vDkgomVfmK" role="2Oq$k0">
+                <ref role="3cqZAo" node="1WjrBsNI_nG" resolve="editorCell" />
+              </node>
+              <node concept="liA8E" id="7vDkgomVqJ1" role="2OqNvi">
+                <ref role="37wK5l" to="d2zl:7vDkgomUY9j" resolve="setTargeConcept" />
+                <node concept="35c_gC" id="7vDkgomWFe8" role="37wK5m">
+                  <ref role="35c_gD" to="tpck:gw2VY9q" resolve="BaseConcept" />
+                  <node concept="1ZhdrF" id="7vDkgomWJov" role="lGtFl">
+                    <property role="2qtEX8" value="conceptDeclaration" />
+                    <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/2644386474300074836/2644386474300074837" />
+                    <node concept="3$xsQk" id="7vDkgomWJow" role="3$ytzL">
+                      <node concept="3clFbS" id="7vDkgomWJox" role="2VODD2">
+                        <node concept="3clFbF" id="7vDkgomWLHP" role="3cqZAp">
+                          <node concept="2OqwBi" id="7vDkgomWNq2" role="3clFbG">
+                            <node concept="30H73N" id="7vDkgomWLHO" role="2Oq$k0" />
+                            <node concept="3TrEf2" id="7vDkgomWOZ7" role="2OqNvi">
+                              <ref role="3Tt5mk" to="bbp5:C$q8A2yeI6" resolve="elementsConcept" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="7vDkgomYQCT" role="3cqZAp">
+            <node concept="2OqwBi" id="7vDkgomYQCU" role="3clFbG">
+              <node concept="37vLTw" id="7vDkgomYQCV" role="2Oq$k0">
+                <ref role="3cqZAo" node="1WjrBsNI_nG" resolve="editorCell" />
+              </node>
+              <node concept="liA8E" id="7vDkgomYQCW" role="2OqNvi">
+                <ref role="37wK5l" to="d2zl:7vDkgomYIqr" resolve="setOwner" />
+                <node concept="2OqwBi" id="7vDkgomYZkC" role="37wK5m">
+                  <node concept="37vLTw" id="7vDkgomYXNx" role="2Oq$k0">
+                    <ref role="3cqZAo" node="fYh_FQ7" resolve="node" />
+                  </node>
+                  <node concept="2yIwOk" id="7vDkgomZ1OU" role="2OqNvi" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="1WjrBsNI_pV" role="3cqZAp">
+            <node concept="5jKBG" id="76N1O$KguuA" role="lGtFl">
+              <ref role="v9R2y" to="tpc3:4v1iCryNDHi" resolve="template_cellSetupBlock" />
+            </node>
+            <node concept="3cpWsn" id="1WjrBsNI_pX" role="3cpWs9">
+              <property role="TrG5h" value="i" />
+              <node concept="10Oyi0" id="1WjrBsNI_pY" role="1tU5fm" />
+            </node>
+          </node>
+          <node concept="3clFbF" id="1WjrBsNI_pZ" role="3cqZAp">
+            <node concept="2OqwBi" id="1WjrBsNI_q0" role="3clFbG">
+              <node concept="37vLTw" id="1WjrBsNI_q1" role="2Oq$k0">
+                <ref role="3cqZAo" node="1WjrBsNI_nG" resolve="editorCell" />
+              </node>
+              <node concept="liA8E" id="1WjrBsNI_q2" role="2OqNvi">
+                <ref role="37wK5l" to="g51k:~EditorCell_Collection.setGridLayout(boolean)" resolve="setGridLayout" />
+                <node concept="3clFbT" id="1WjrBsNI_q3" role="37wK5m">
+                  <property role="3clFbU" value="true" />
+                </node>
+              </node>
+            </node>
+            <node concept="1W57fq" id="1WjrBsNI_q4" role="lGtFl">
+              <node concept="3IZrLx" id="1WjrBsNI_q5" role="3IZSJc">
+                <node concept="3clFbS" id="1WjrBsNI_q6" role="2VODD2">
+                  <node concept="3clFbF" id="1WjrBsNI_q7" role="3cqZAp">
+                    <node concept="2OqwBi" id="1WjrBsNI_q8" role="3clFbG">
+                      <node concept="30H73N" id="1WjrBsNI_q9" role="2Oq$k0" />
+                      <node concept="2qgKlT" id="1WjrBsNI_qa" role="2OqNvi">
+                        <ref role="37wK5l" to="1hk2:i2IfsZ1" resolve="isVerticalGrid" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="3DPg8zpyaE0" role="3cqZAp">
+            <node concept="2OqwBi" id="3DPg8zpyaE2" role="3clFbG">
+              <node concept="37vLTw" id="3GM_nagTAwe" role="2Oq$k0">
+                <ref role="3cqZAo" node="1WjrBsNI_nG" resolve="editorCell" />
+              </node>
+              <node concept="liA8E" id="3DPg8zpyaFB" role="2OqNvi">
+                <ref role="37wK5l" to="g51k:~EditorCell_Collection.setFoldable(boolean)" resolve="setFoldable" />
+                <node concept="3clFbT" id="3DPg8zpyaFC" role="37wK5m">
+                  <property role="3clFbU" value="true" />
+                  <node concept="1W57fq" id="3DPg8zpygQy" role="lGtFl">
+                    <node concept="gft3U" id="5_YqJ2SmGlx" role="UU_$l">
+                      <node concept="1rXfSq" id="5_YqJ2SmGBP" role="gfFT$">
+                        <ref role="37wK5l" to="tpc3:5_YqJ2SmBvw" resolve="_condition_" />
+                        <node concept="1ZhdrF" id="5_YqJ2SmGOS" role="lGtFl">
+                          <property role="P3scX" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1204053956946/1068499141037" />
+                          <property role="2qtEX8" value="baseMethodDeclaration" />
+                          <node concept="3$xsQk" id="5_YqJ2SmGOT" role="3$ytzL">
+                            <node concept="3clFbS" id="5_YqJ2SmGOU" role="2VODD2">
+                              <node concept="3clFbF" id="3DPg8zpygRj" role="3cqZAp">
+                                <node concept="2OqwBi" id="3DPg8zpygRl" role="3clFbG">
+                                  <node concept="1iwH7S" id="3DPg8zpygRk" role="2Oq$k0" />
+                                  <node concept="1iwH70" id="3DPg8zpygRp" role="2OqNvi">
+                                    <ref role="1iwH77" to="tpc3:hG092go" resolve="query_method" />
+                                    <node concept="2OqwBi" id="3DPg8zpygRs" role="1iwH7V">
+                                      <node concept="30H73N" id="3DPg8zpygRr" role="2Oq$k0" />
+                                      <node concept="3TrEf2" id="3DPg8zpygRw" role="2OqNvi">
                                         <ref role="3Tt5mk" to="bbp5:3ZqNA5Aj2vB" resolve="usesFoldingCondition" />
                                       </node>
                                     </node>
-                                    <node concept="3w_OXm" id="3DPg8zpygQK" role="2OqNvi" />
                                   </node>
                                 </node>
                               </node>
@@ -1380,303 +1368,318 @@
                         </node>
                       </node>
                     </node>
-                    <node concept="1W57fq" id="3DPg8zpyaFE" role="lGtFl">
-                      <node concept="3IZrLx" id="3DPg8zpyaFF" role="3IZSJc">
-                        <node concept="3clFbS" id="3DPg8zpyaFG" role="2VODD2">
-                          <node concept="3clFbF" id="3DPg8zpygQq" role="3cqZAp">
-                            <node concept="2OqwBi" id="3DPg8zpygQs" role="3clFbG">
-                              <node concept="30H73N" id="3DPg8zpygQr" role="2Oq$k0" />
-                              <node concept="2qgKlT" id="3DPg8zpygQw" role="2OqNvi">
-                                <ref role="37wK5l" to="1hk2:3ZqNA5Aj2vG" resolve="isFoldingEnabled" />
+                    <node concept="3IZrLx" id="3DPg8zpygQz" role="3IZSJc">
+                      <node concept="3clFbS" id="3DPg8zpygQ$" role="2VODD2">
+                        <node concept="3clFbF" id="3DPg8zpygQ_" role="3cqZAp">
+                          <node concept="2OqwBi" id="3DPg8zpygQG" role="3clFbG">
+                            <node concept="2OqwBi" id="3DPg8zpygQB" role="2Oq$k0">
+                              <node concept="30H73N" id="3DPg8zpygQA" role="2Oq$k0" />
+                              <node concept="3TrEf2" id="3DPg8zpygQF" role="2OqNvi">
+                                <ref role="3Tt5mk" to="bbp5:3ZqNA5Aj2vB" resolve="usesFoldingCondition" />
                               </node>
+                            </node>
+                            <node concept="3w_OXm" id="3DPg8zpygQK" role="2OqNvi" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="1W57fq" id="3DPg8zpyaFE" role="lGtFl">
+              <node concept="3IZrLx" id="3DPg8zpyaFF" role="3IZSJc">
+                <node concept="3clFbS" id="3DPg8zpyaFG" role="2VODD2">
+                  <node concept="3clFbF" id="3DPg8zpygQq" role="3cqZAp">
+                    <node concept="2OqwBi" id="3DPg8zpygQs" role="3clFbG">
+                      <node concept="30H73N" id="3DPg8zpygQr" role="2Oq$k0" />
+                      <node concept="2qgKlT" id="3DPg8zpygQw" role="2OqNvi">
+                        <ref role="37wK5l" to="1hk2:3ZqNA5Aj2vG" resolve="isFoldingEnabled" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="1WjrBsNI_qU" role="3cqZAp">
+            <node concept="2OqwBi" id="1WjrBsNI_qV" role="3clFbG">
+              <node concept="37vLTw" id="1WjrBsNI_qW" role="2Oq$k0">
+                <ref role="3cqZAo" node="1WjrBsNI_nG" resolve="editorCell" />
+              </node>
+              <node concept="liA8E" id="1WjrBsNI_qX" role="2OqNvi">
+                <ref role="37wK5l" to="g51k:~EditorCell_Collection.setFoldedCell(jetbrains.mps.openapi.editor.cells.EditorCell)" resolve="setFoldedCell" />
+                <node concept="10Nm6u" id="1WjrBsNI_qY" role="37wK5m">
+                  <node concept="5jKBG" id="76N1O$KguuB" role="lGtFl">
+                    <ref role="v9R2y" to="tpc3:gXIFsmA" resolve="template_CreateCellExpression" />
+                    <node concept="3NFfHV" id="1WjrBsNI_r0" role="5jGum">
+                      <node concept="3clFbS" id="1WjrBsNI_r1" role="2VODD2">
+                        <node concept="3clFbF" id="1WjrBsNI_r2" role="3cqZAp">
+                          <node concept="2OqwBi" id="1WjrBsNI_r3" role="3clFbG">
+                            <node concept="30H73N" id="1WjrBsNI_r4" role="2Oq$k0" />
+                            <node concept="3TrEf2" id="1WjrBsNI_r5" role="2OqNvi">
+                              <ref role="3Tt5mk" to="bbp5:5fDszETGVtQ" resolve="foldedCellModel" />
                             </node>
                           </node>
                         </node>
                       </node>
                     </node>
                   </node>
-                  <node concept="3clFbF" id="1WjrBsNI_qU" role="3cqZAp">
-                    <node concept="2OqwBi" id="1WjrBsNI_qV" role="3clFbG">
-                      <node concept="37vLTw" id="1WjrBsNI_qW" role="2Oq$k0">
-                        <ref role="3cqZAo" node="1WjrBsNI_nG" resolve="editorCell" />
+                </node>
+              </node>
+            </node>
+            <node concept="1W57fq" id="1WjrBsNI_r6" role="lGtFl">
+              <node concept="3IZrLx" id="1WjrBsNI_r7" role="3IZSJc">
+                <node concept="3clFbS" id="1WjrBsNI_r8" role="2VODD2">
+                  <node concept="3clFbF" id="1WjrBsNI_r9" role="3cqZAp">
+                    <node concept="1Wc70l" id="1WjrBsNI_ra" role="3clFbG">
+                      <node concept="3y3z36" id="1WjrBsNI_rb" role="3uHU7w">
+                        <node concept="2OqwBi" id="1WjrBsNI_rc" role="3uHU7B">
+                          <node concept="30H73N" id="1WjrBsNI_rd" role="2Oq$k0" />
+                          <node concept="3TrEf2" id="1WjrBsNI_re" role="2OqNvi">
+                            <ref role="3Tt5mk" to="bbp5:5fDszETGVtQ" resolve="foldedCellModel" />
+                          </node>
+                        </node>
+                        <node concept="10Nm6u" id="1WjrBsNI_rf" role="3uHU7w" />
                       </node>
-                      <node concept="liA8E" id="1WjrBsNI_qX" role="2OqNvi">
-                        <ref role="37wK5l" to="g51k:~EditorCell_Collection.setFoldedCell(jetbrains.mps.openapi.editor.cells.EditorCell)" resolve="setFoldedCell" />
-                        <node concept="10Nm6u" id="1WjrBsNI_qY" role="37wK5m">
-                          <node concept="5jKBG" id="76N1O$KguuB" role="lGtFl">
-                            <ref role="v9R2y" to="tpc3:gXIFsmA" resolve="template_CreateCellExpression" />
-                            <node concept="3NFfHV" id="1WjrBsNI_r0" role="5jGum">
-                              <node concept="3clFbS" id="1WjrBsNI_r1" role="2VODD2">
-                                <node concept="3clFbF" id="1WjrBsNI_r2" role="3cqZAp">
-                                  <node concept="2OqwBi" id="1WjrBsNI_r3" role="3clFbG">
-                                    <node concept="30H73N" id="1WjrBsNI_r4" role="2Oq$k0" />
-                                    <node concept="3TrEf2" id="1WjrBsNI_r5" role="2OqNvi">
-                                      <ref role="3Tt5mk" to="bbp5:5fDszETGVtQ" resolve="foldedCellModel" />
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
+                      <node concept="2OqwBi" id="1WjrBsNI_rg" role="3uHU7B">
+                        <node concept="2qgKlT" id="1WjrBsNI_rh" role="2OqNvi">
+                          <ref role="37wK5l" to="1hk2:3ZqNA5Aj2vG" resolve="isFoldingEnabled" />
+                        </node>
+                        <node concept="30H73N" id="1WjrBsNI_ri" role="2Oq$k0" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="1WjrBsNI_qb" role="3cqZAp">
+            <node concept="2OqwBi" id="1WjrBsNI_qc" role="3clFbG">
+              <node concept="37vLTw" id="1WjrBsNI_qd" role="2Oq$k0">
+                <ref role="3cqZAo" node="1WjrBsNI_nG" resolve="editorCell" />
+              </node>
+              <node concept="liA8E" id="1WjrBsNI_qe" role="2OqNvi">
+                <ref role="37wK5l" to="g51k:~EditorCell_Collection.setUsesBraces(boolean)" resolve="setUsesBraces" />
+                <node concept="3clFbT" id="1WjrBsNI_qf" role="37wK5m">
+                  <property role="3clFbU" value="true" />
+                </node>
+              </node>
+            </node>
+            <node concept="1W57fq" id="1WjrBsNI_qg" role="lGtFl">
+              <node concept="3IZrLx" id="1WjrBsNI_qh" role="3IZSJc">
+                <node concept="3clFbS" id="1WjrBsNI_qi" role="2VODD2">
+                  <node concept="3clFbF" id="1WjrBsNI_qj" role="3cqZAp">
+                    <node concept="2OqwBi" id="1WjrBsNI_qk" role="3clFbG">
+                      <node concept="30H73N" id="1WjrBsNI_ql" role="2Oq$k0" />
+                      <node concept="3TrcHB" id="1WjrBsNI_qm" role="2OqNvi">
+                        <ref role="3TsBF5" to="bbp5:gAczwbW" resolve="usesBraces" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="5qrsiYWt4ZB" role="3cqZAp">
+            <node concept="2OqwBi" id="5qrsiYWtihk" role="3clFbG">
+              <node concept="37vLTw" id="5qrsiYWt4Z_" role="2Oq$k0">
+                <ref role="3cqZAo" node="1WjrBsNI_nG" resolve="editorCell" />
+              </node>
+              <node concept="liA8E" id="5qrsiYWtj_2" role="2OqNvi">
+                <ref role="37wK5l" to="g51k:~EditorCell_Collection.setInitiallyCollapsed(boolean)" resolve="setInitiallyCollapsed" />
+                <node concept="3clFbT" id="5qrsiYWtjEn" role="37wK5m">
+                  <property role="3clFbU" value="true" />
+                </node>
+              </node>
+            </node>
+            <node concept="1W57fq" id="5qrsiYWtjXF" role="lGtFl">
+              <node concept="3IZrLx" id="5qrsiYWtjXH" role="3IZSJc">
+                <node concept="3clFbS" id="5qrsiYWtjXJ" role="2VODD2">
+                  <node concept="3clFbF" id="5qrsiYWtqmz" role="3cqZAp">
+                    <node concept="1Wc70l" id="5qrsiYWtrta" role="3clFbG">
+                      <node concept="2OqwBi" id="5qrsiYWtrJH" role="3uHU7w">
+                        <node concept="30H73N" id="5qrsiYWtrBP" role="2Oq$k0" />
+                        <node concept="3TrcHB" id="rlw0PZTB$b" role="2OqNvi">
+                          <ref role="3TsBF5" to="bbp5:5qrsiYWrGSx" resolve="collapseByDefault" />
+                        </node>
+                      </node>
+                      <node concept="1Wc70l" id="3fRhD4HpLBl" role="3uHU7B">
+                        <node concept="2OqwBi" id="3fRhD4HpLOi" role="3uHU7B">
+                          <node concept="30H73N" id="3fRhD4HpLI9" role="2Oq$k0" />
+                          <node concept="2qgKlT" id="rlw0PZT_ix" role="2OqNvi">
+                            <ref role="37wK5l" to="1hk2:3ZqNA5Aj2vG" resolve="isFoldingEnabled" />
+                          </node>
+                        </node>
+                        <node concept="3clFbC" id="5qrsiYWtr2V" role="3uHU7w">
+                          <node concept="2OqwBi" id="5qrsiYWtqu5" role="3uHU7B">
+                            <node concept="30H73N" id="5qrsiYWtqmy" role="2Oq$k0" />
+                            <node concept="3TrEf2" id="rlw0PZTAul" role="2OqNvi">
+                              <ref role="3Tt5mk" to="bbp5:5qrsiYWrGSD" resolve="collapseByDefaultCondition" />
                             </node>
                           </node>
+                          <node concept="10Nm6u" id="5qrsiYWtrdi" role="3uHU7w" />
                         </node>
                       </node>
                     </node>
-                    <node concept="1W57fq" id="1WjrBsNI_r6" role="lGtFl">
-                      <node concept="3IZrLx" id="1WjrBsNI_r7" role="3IZSJc">
-                        <node concept="3clFbS" id="1WjrBsNI_r8" role="2VODD2">
-                          <node concept="3clFbF" id="1WjrBsNI_r9" role="3cqZAp">
-                            <node concept="1Wc70l" id="1WjrBsNI_ra" role="3clFbG">
-                              <node concept="3y3z36" id="1WjrBsNI_rb" role="3uHU7w">
-                                <node concept="2OqwBi" id="1WjrBsNI_rc" role="3uHU7B">
-                                  <node concept="30H73N" id="1WjrBsNI_rd" role="2Oq$k0" />
-                                  <node concept="3TrEf2" id="1WjrBsNI_re" role="2OqNvi">
-                                    <ref role="3Tt5mk" to="bbp5:5fDszETGVtQ" resolve="foldedCellModel" />
-                                  </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="4AgRrBJoXoH" role="3cqZAp">
+            <node concept="2OqwBi" id="4AgRrBJoY4C" role="3clFbG">
+              <node concept="37vLTw" id="4AgRrBJoXoF" role="2Oq$k0">
+                <ref role="3cqZAo" node="1WjrBsNI_nG" resolve="editorCell" />
+              </node>
+              <node concept="liA8E" id="4AgRrBJoY_G" role="2OqNvi">
+                <ref role="37wK5l" to="g51k:~EditorCell_Collection.setInitiallyCollapsed(boolean)" resolve="setInitiallyCollapsed" />
+                <node concept="1rXfSq" id="T_6DrmT4F7" role="37wK5m">
+                  <ref role="37wK5l" node="4m$$SBGc$_p" resolve="collapseByDefault" />
+                  <node concept="1ZhdrF" id="T_6DrmUf0B" role="lGtFl">
+                    <property role="2qtEX8" value="baseMethodDeclaration" />
+                    <property role="P3scX" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1204053956946/1068499141037" />
+                    <node concept="3$xsQk" id="T_6DrmUf0C" role="3$ytzL">
+                      <node concept="3clFbS" id="T_6DrmUf0D" role="2VODD2">
+                        <node concept="3clFbF" id="4m$$SBGd3Yv" role="3cqZAp">
+                          <node concept="2OqwBi" id="4m$$SBGd3Yw" role="3clFbG">
+                            <node concept="1iwH70" id="4m$$SBGd3Yx" role="2OqNvi">
+                              <ref role="1iwH77" to="tpc3:hG092go" resolve="query_method" />
+                              <node concept="2OqwBi" id="4m$$SBGd4Gu" role="1iwH7V">
+                                <node concept="30H73N" id="4m$$SBGd3Yz" role="2Oq$k0" />
+                                <node concept="3TrEf2" id="4m$$SBGd52H" role="2OqNvi">
+                                  <ref role="3Tt5mk" to="bbp5:5qrsiYWrGSD" resolve="collapseByDefaultCondition" />
                                 </node>
-                                <node concept="10Nm6u" id="1WjrBsNI_rf" role="3uHU7w" />
-                              </node>
-                              <node concept="2OqwBi" id="1WjrBsNI_rg" role="3uHU7B">
-                                <node concept="2qgKlT" id="1WjrBsNI_rh" role="2OqNvi">
-                                  <ref role="37wK5l" to="1hk2:3ZqNA5Aj2vG" resolve="isFoldingEnabled" />
-                                </node>
-                                <node concept="30H73N" id="1WjrBsNI_ri" role="2Oq$k0" />
                               </node>
                             </node>
+                            <node concept="1iwH7S" id="4m$$SBGd3Y_" role="2Oq$k0" />
                           </node>
                         </node>
                       </node>
                     </node>
                   </node>
-                  <node concept="3clFbF" id="1WjrBsNI_qb" role="3cqZAp">
-                    <node concept="2OqwBi" id="1WjrBsNI_qc" role="3clFbG">
-                      <node concept="37vLTw" id="1WjrBsNI_qd" role="2Oq$k0">
-                        <ref role="3cqZAo" node="1WjrBsNI_nG" resolve="editorCell" />
-                      </node>
-                      <node concept="liA8E" id="1WjrBsNI_qe" role="2OqNvi">
-                        <ref role="37wK5l" to="g51k:~EditorCell_Collection.setUsesBraces(boolean)" resolve="setUsesBraces" />
-                        <node concept="3clFbT" id="1WjrBsNI_qf" role="37wK5m">
-                          <property role="3clFbU" value="true" />
+                </node>
+              </node>
+            </node>
+            <node concept="1W57fq" id="4AgRrBJp$hu" role="lGtFl">
+              <node concept="3IZrLx" id="4AgRrBJp$hw" role="3IZSJc">
+                <node concept="3clFbS" id="4AgRrBJp$hy" role="2VODD2">
+                  <node concept="3clFbF" id="4AgRrBJp_2A" role="3cqZAp">
+                    <node concept="1Wc70l" id="3fRhD4HpMcb" role="3clFbG">
+                      <node concept="2OqwBi" id="3fRhD4HpMpG" role="3uHU7B">
+                        <node concept="30H73N" id="3fRhD4HpMjL" role="2Oq$k0" />
+                        <node concept="2qgKlT" id="rlw0PZTDJ4" role="2OqNvi">
+                          <ref role="37wK5l" to="1hk2:3ZqNA5Aj2vG" resolve="isFoldingEnabled" />
                         </node>
                       </node>
-                    </node>
-                    <node concept="1W57fq" id="1WjrBsNI_qg" role="lGtFl">
-                      <node concept="3IZrLx" id="1WjrBsNI_qh" role="3IZSJc">
-                        <node concept="3clFbS" id="1WjrBsNI_qi" role="2VODD2">
-                          <node concept="3clFbF" id="1WjrBsNI_qj" role="3cqZAp">
-                            <node concept="2OqwBi" id="1WjrBsNI_qk" role="3clFbG">
-                              <node concept="30H73N" id="1WjrBsNI_ql" role="2Oq$k0" />
-                              <node concept="3TrcHB" id="1WjrBsNI_qm" role="2OqNvi">
-                                <ref role="3TsBF5" to="bbp5:gAczwbW" resolve="usesBraces" />
-                              </node>
-                            </node>
+                      <node concept="3y3z36" id="4AgRrBJp_jN" role="3uHU7w">
+                        <node concept="10Nm6u" id="4AgRrBJp_oB" role="3uHU7w" />
+                        <node concept="2OqwBi" id="4AgRrBJp_2C" role="3uHU7B">
+                          <node concept="30H73N" id="4AgRrBJp_2D" role="2Oq$k0" />
+                          <node concept="3TrEf2" id="rlw0PZTCDD" role="2OqNvi">
+                            <ref role="3Tt5mk" to="bbp5:5qrsiYWrGSD" resolve="collapseByDefaultCondition" />
                           </node>
                         </node>
                       </node>
                     </node>
                   </node>
-                  <node concept="3clFbF" id="5qrsiYWt4ZB" role="3cqZAp">
-                    <node concept="2OqwBi" id="5qrsiYWtihk" role="3clFbG">
-                      <node concept="37vLTw" id="5qrsiYWt4Z_" role="2Oq$k0">
-                        <ref role="3cqZAo" node="1WjrBsNI_nG" resolve="editorCell" />
-                      </node>
-                      <node concept="liA8E" id="5qrsiYWtj_2" role="2OqNvi">
-                        <ref role="37wK5l" to="g51k:~EditorCell_Collection.setInitiallyCollapsed(boolean)" resolve="setInitiallyCollapsed" />
-                        <node concept="3clFbT" id="5qrsiYWtjEn" role="37wK5m">
-                          <property role="3clFbU" value="true" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="T_6DrmDlWn" role="3cqZAp">
+            <node concept="2OqwBi" id="T_6DrmDlWo" role="3clFbG">
+              <node concept="37vLTw" id="T_6DrmDlWp" role="2Oq$k0">
+                <ref role="3cqZAo" node="1WjrBsNI_nG" resolve="editorCell" />
+              </node>
+              <node concept="liA8E" id="T_6DrmDlWq" role="2OqNvi">
+                <ref role="37wK5l" to="d2zl:T_6DrmDarn" resolve="toggleDisableModelChecking" />
+                <node concept="3clFbT" id="T_6DrmDlWr" role="37wK5m">
+                  <property role="3clFbU" value="true" />
+                </node>
+              </node>
+            </node>
+            <node concept="1W57fq" id="T_6DrmDlWs" role="lGtFl">
+              <node concept="3IZrLx" id="T_6DrmDlWt" role="3IZSJc">
+                <node concept="3clFbS" id="T_6DrmDlWu" role="2VODD2">
+                  <node concept="3clFbF" id="T_6DrmDlWv" role="3cqZAp">
+                    <node concept="1Wc70l" id="T_6DrmDlWw" role="3clFbG">
+                      <node concept="2OqwBi" id="T_6DrmDlWx" role="3uHU7w">
+                        <node concept="30H73N" id="T_6DrmDlWy" role="2Oq$k0" />
+                        <node concept="3TrcHB" id="T_6DrmDlWz" role="2OqNvi">
+                          <ref role="3TsBF5" to="bbp5:T_6DrmCUS2" resolve="disableModelChecking" />
                         </node>
                       </node>
-                    </node>
-                    <node concept="1W57fq" id="5qrsiYWtjXF" role="lGtFl">
-                      <node concept="3IZrLx" id="5qrsiYWtjXH" role="3IZSJc">
-                        <node concept="3clFbS" id="5qrsiYWtjXJ" role="2VODD2">
-                          <node concept="3clFbF" id="5qrsiYWtqmz" role="3cqZAp">
-                            <node concept="1Wc70l" id="5qrsiYWtrta" role="3clFbG">
-                              <node concept="2OqwBi" id="5qrsiYWtrJH" role="3uHU7w">
-                                <node concept="30H73N" id="5qrsiYWtrBP" role="2Oq$k0" />
-                                <node concept="3TrcHB" id="rlw0PZTB$b" role="2OqNvi">
-                                  <ref role="3TsBF5" to="bbp5:5qrsiYWrGSx" resolve="collapseByDefault" />
-                                </node>
-                              </node>
-                              <node concept="1Wc70l" id="3fRhD4HpLBl" role="3uHU7B">
-                                <node concept="2OqwBi" id="3fRhD4HpLOi" role="3uHU7B">
-                                  <node concept="30H73N" id="3fRhD4HpLI9" role="2Oq$k0" />
-                                  <node concept="2qgKlT" id="rlw0PZT_ix" role="2OqNvi">
-                                    <ref role="37wK5l" to="1hk2:3ZqNA5Aj2vG" resolve="isFoldingEnabled" />
-                                  </node>
-                                </node>
-                                <node concept="3clFbC" id="5qrsiYWtr2V" role="3uHU7w">
-                                  <node concept="2OqwBi" id="5qrsiYWtqu5" role="3uHU7B">
-                                    <node concept="30H73N" id="5qrsiYWtqmy" role="2Oq$k0" />
-                                    <node concept="3TrEf2" id="rlw0PZTAul" role="2OqNvi">
-                                      <ref role="3Tt5mk" to="bbp5:5qrsiYWrGSD" resolve="collapseByDefaultCondition" />
-                                    </node>
-                                  </node>
-                                  <node concept="10Nm6u" id="5qrsiYWtrdi" role="3uHU7w" />
-                                </node>
-                              </node>
-                            </node>
+                      <node concept="3clFbC" id="T_6DrmDlWC" role="3uHU7B">
+                        <node concept="2OqwBi" id="T_6DrmDlWD" role="3uHU7B">
+                          <node concept="30H73N" id="T_6DrmDlWE" role="2Oq$k0" />
+                          <node concept="3TrEf2" id="T_6DrmDlWF" role="2OqNvi">
+                            <ref role="3Tt5mk" to="bbp5:T_6DrmCTj$" resolve="disableModelCheckingCondition" />
                           </node>
                         </node>
+                        <node concept="10Nm6u" id="T_6DrmDlWG" role="3uHU7w" />
                       </node>
                     </node>
                   </node>
-                  <node concept="3clFbF" id="4AgRrBJoXoH" role="3cqZAp">
-                    <node concept="2OqwBi" id="4AgRrBJoY4C" role="3clFbG">
-                      <node concept="37vLTw" id="4AgRrBJoXoF" role="2Oq$k0">
-                        <ref role="3cqZAo" node="1WjrBsNI_nG" resolve="editorCell" />
-                      </node>
-                      <node concept="liA8E" id="4AgRrBJoY_G" role="2OqNvi">
-                        <ref role="37wK5l" to="g51k:~EditorCell_Collection.setInitiallyCollapsed(boolean)" resolve="setInitiallyCollapsed" />
-                        <node concept="1rXfSq" id="T_6DrmT4F7" role="37wK5m">
-                          <ref role="37wK5l" node="4m$$SBGc$_p" resolve="collapseByDefault" />
-                          <node concept="1ZhdrF" id="T_6DrmUf0B" role="lGtFl">
-                            <property role="2qtEX8" value="baseMethodDeclaration" />
-                            <property role="P3scX" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1204053956946/1068499141037" />
-                            <node concept="3$xsQk" id="T_6DrmUf0C" role="3$ytzL">
-                              <node concept="3clFbS" id="T_6DrmUf0D" role="2VODD2">
-                                <node concept="3clFbF" id="4m$$SBGd3Yv" role="3cqZAp">
-                                  <node concept="2OqwBi" id="4m$$SBGd3Yw" role="3clFbG">
-                                    <node concept="1iwH70" id="4m$$SBGd3Yx" role="2OqNvi">
-                                      <ref role="1iwH77" to="tpc3:hG092go" resolve="query_method" />
-                                      <node concept="2OqwBi" id="4m$$SBGd4Gu" role="1iwH7V">
-                                        <node concept="30H73N" id="4m$$SBGd3Yz" role="2Oq$k0" />
-                                        <node concept="3TrEf2" id="4m$$SBGd52H" role="2OqNvi">
-                                          <ref role="3Tt5mk" to="bbp5:5qrsiYWrGSD" resolve="collapseByDefaultCondition" />
-                                        </node>
-                                      </node>
-                                    </node>
-                                    <node concept="1iwH7S" id="4m$$SBGd3Y_" role="2Oq$k0" />
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="1W57fq" id="4AgRrBJp$hu" role="lGtFl">
-                      <node concept="3IZrLx" id="4AgRrBJp$hw" role="3IZSJc">
-                        <node concept="3clFbS" id="4AgRrBJp$hy" role="2VODD2">
-                          <node concept="3clFbF" id="4AgRrBJp_2A" role="3cqZAp">
-                            <node concept="1Wc70l" id="3fRhD4HpMcb" role="3clFbG">
-                              <node concept="2OqwBi" id="3fRhD4HpMpG" role="3uHU7B">
-                                <node concept="30H73N" id="3fRhD4HpMjL" role="2Oq$k0" />
-                                <node concept="2qgKlT" id="rlw0PZTDJ4" role="2OqNvi">
-                                  <ref role="37wK5l" to="1hk2:3ZqNA5Aj2vG" resolve="isFoldingEnabled" />
-                                </node>
-                              </node>
-                              <node concept="3y3z36" id="4AgRrBJp_jN" role="3uHU7w">
-                                <node concept="10Nm6u" id="4AgRrBJp_oB" role="3uHU7w" />
-                                <node concept="2OqwBi" id="4AgRrBJp_2C" role="3uHU7B">
-                                  <node concept="30H73N" id="4AgRrBJp_2D" role="2Oq$k0" />
-                                  <node concept="3TrEf2" id="rlw0PZTCDD" role="2OqNvi">
-                                    <ref role="3Tt5mk" to="bbp5:5qrsiYWrGSD" resolve="collapseByDefaultCondition" />
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3clFbF" id="T_6DrmDlWn" role="3cqZAp">
-                    <node concept="2OqwBi" id="T_6DrmDlWo" role="3clFbG">
-                      <node concept="37vLTw" id="T_6DrmDlWp" role="2Oq$k0">
-                        <ref role="3cqZAo" node="1WjrBsNI_nG" resolve="editorCell" />
-                      </node>
-                      <node concept="liA8E" id="T_6DrmDlWq" role="2OqNvi">
-                        <ref role="37wK5l" to="d2zl:T_6DrmDarn" resolve="toggleDisableModelChecking" />
-                        <node concept="3clFbT" id="T_6DrmDlWr" role="37wK5m">
-                          <property role="3clFbU" value="true" />
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="1W57fq" id="T_6DrmDlWs" role="lGtFl">
-                      <node concept="3IZrLx" id="T_6DrmDlWt" role="3IZSJc">
-                        <node concept="3clFbS" id="T_6DrmDlWu" role="2VODD2">
-                          <node concept="3clFbF" id="T_6DrmDlWv" role="3cqZAp">
-                            <node concept="1Wc70l" id="T_6DrmDlWw" role="3clFbG">
-                              <node concept="2OqwBi" id="T_6DrmDlWx" role="3uHU7w">
-                                <node concept="30H73N" id="T_6DrmDlWy" role="2Oq$k0" />
-                                <node concept="3TrcHB" id="T_6DrmDlWz" role="2OqNvi">
-                                  <ref role="3TsBF5" to="bbp5:T_6DrmCUS2" resolve="disableModelChecking" />
-                                </node>
-                              </node>
-                              <node concept="3clFbC" id="T_6DrmDlWC" role="3uHU7B">
-                                <node concept="2OqwBi" id="T_6DrmDlWD" role="3uHU7B">
-                                  <node concept="30H73N" id="T_6DrmDlWE" role="2Oq$k0" />
-                                  <node concept="3TrEf2" id="T_6DrmDlWF" role="2OqNvi">
-                                    <ref role="3Tt5mk" to="bbp5:T_6DrmCTj$" resolve="disableModelCheckingCondition" />
-                                  </node>
-                                </node>
-                                <node concept="10Nm6u" id="T_6DrmDlWG" role="3uHU7w" />
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3clFbF" id="T_6DrmDlWH" role="3cqZAp">
-                    <node concept="2OqwBi" id="T_6DrmDlWI" role="3clFbG">
-                      <node concept="37vLTw" id="T_6DrmDlWJ" role="2Oq$k0">
-                        <ref role="3cqZAo" node="1WjrBsNI_nG" resolve="editorCell" />
-                      </node>
-                      <node concept="liA8E" id="T_6DrmDlWK" role="2OqNvi">
-                        <ref role="37wK5l" to="d2zl:T_6DrmDarn" resolve="toggleDisableModelChecking" />
-                        <node concept="1rXfSq" id="T_6DrmT844" role="37wK5m">
-                          <ref role="37wK5l" node="T_6DrmSRWQ" resolve="disableModelChecking" />
-                          <node concept="1ZhdrF" id="T_6DrmUk$R" role="lGtFl">
-                            <property role="2qtEX8" value="baseMethodDeclaration" />
-                            <property role="P3scX" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1204053956946/1068499141037" />
-                            <node concept="3$xsQk" id="T_6DrmUk$S" role="3$ytzL">
-                              <node concept="3clFbS" id="T_6DrmUk$T" role="2VODD2">
-                                <node concept="3clFbF" id="T_6DrmUlzD" role="3cqZAp">
-                                  <node concept="2OqwBi" id="T_6DrmUlzE" role="3clFbG">
-                                    <node concept="1iwH70" id="T_6DrmUlzF" role="2OqNvi">
-                                      <ref role="1iwH77" to="tpc3:hG092go" resolve="query_method" />
-                                      <node concept="2OqwBi" id="T_6DrmUlzG" role="1iwH7V">
-                                        <node concept="30H73N" id="T_6DrmUlzH" role="2Oq$k0" />
-                                        <node concept="3TrEf2" id="T_6DrmUlzI" role="2OqNvi">
-                                          <ref role="3Tt5mk" to="bbp5:T_6DrmCTj$" resolve="disableModelCheckingCondition" />
-                                        </node>
-                                      </node>
-                                    </node>
-                                    <node concept="1iwH7S" id="T_6DrmUlzJ" role="2Oq$k0" />
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="1W57fq" id="T_6DrmDlWY" role="lGtFl">
-                      <node concept="3IZrLx" id="T_6DrmDlWZ" role="3IZSJc">
-                        <node concept="3clFbS" id="T_6DrmDlX0" role="2VODD2">
-                          <node concept="3clFbF" id="T_6DrmDlX1" role="3cqZAp">
-                            <node concept="3y3z36" id="T_6DrmDlX6" role="3clFbG">
-                              <node concept="10Nm6u" id="T_6DrmDlX7" role="3uHU7w" />
-                              <node concept="2OqwBi" id="T_6DrmDlX8" role="3uHU7B">
-                                <node concept="30H73N" id="T_6DrmDlX9" role="2Oq$k0" />
-                                <node concept="3TrEf2" id="T_6DrmDBhx" role="2OqNvi">
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="T_6DrmDlWH" role="3cqZAp">
+            <node concept="2OqwBi" id="T_6DrmDlWI" role="3clFbG">
+              <node concept="37vLTw" id="T_6DrmDlWJ" role="2Oq$k0">
+                <ref role="3cqZAo" node="1WjrBsNI_nG" resolve="editorCell" />
+              </node>
+              <node concept="liA8E" id="T_6DrmDlWK" role="2OqNvi">
+                <ref role="37wK5l" to="d2zl:T_6DrmDarn" resolve="toggleDisableModelChecking" />
+                <node concept="1rXfSq" id="T_6DrmT844" role="37wK5m">
+                  <ref role="37wK5l" node="T_6DrmSRWQ" resolve="disableModelChecking" />
+                  <node concept="1ZhdrF" id="T_6DrmUk$R" role="lGtFl">
+                    <property role="2qtEX8" value="baseMethodDeclaration" />
+                    <property role="P3scX" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1204053956946/1068499141037" />
+                    <node concept="3$xsQk" id="T_6DrmUk$S" role="3$ytzL">
+                      <node concept="3clFbS" id="T_6DrmUk$T" role="2VODD2">
+                        <node concept="3clFbF" id="T_6DrmUlzD" role="3cqZAp">
+                          <node concept="2OqwBi" id="T_6DrmUlzE" role="3clFbG">
+                            <node concept="1iwH70" id="T_6DrmUlzF" role="2OqNvi">
+                              <ref role="1iwH77" to="tpc3:hG092go" resolve="query_method" />
+                              <node concept="2OqwBi" id="T_6DrmUlzG" role="1iwH7V">
+                                <node concept="30H73N" id="T_6DrmUlzH" role="2Oq$k0" />
+                                <node concept="3TrEf2" id="T_6DrmUlzI" role="2OqNvi">
                                   <ref role="3Tt5mk" to="bbp5:T_6DrmCTj$" resolve="disableModelCheckingCondition" />
                                 </node>
                               </node>
                             </node>
+                            <node concept="1iwH7S" id="T_6DrmUlzJ" role="2Oq$k0" />
                           </node>
                         </node>
                       </node>
                     </node>
                   </node>
-                  <node concept="3cpWs6" id="1WjrBsNI_rj" role="3cqZAp">
-                    <node concept="37vLTw" id="1WjrBsNI_rk" role="3cqZAk">
-                      <ref role="3cqZAo" node="1WjrBsNI_nG" resolve="editorCell" />
+                </node>
+              </node>
+            </node>
+            <node concept="1W57fq" id="T_6DrmDlWY" role="lGtFl">
+              <node concept="3IZrLx" id="T_6DrmDlWZ" role="3IZSJc">
+                <node concept="3clFbS" id="T_6DrmDlX0" role="2VODD2">
+                  <node concept="3clFbF" id="T_6DrmDlX1" role="3cqZAp">
+                    <node concept="3y3z36" id="T_6DrmDlX6" role="3clFbG">
+                      <node concept="10Nm6u" id="T_6DrmDlX7" role="3uHU7w" />
+                      <node concept="2OqwBi" id="T_6DrmDlX8" role="3uHU7B">
+                        <node concept="30H73N" id="T_6DrmDlX9" role="2Oq$k0" />
+                        <node concept="3TrEf2" id="T_6DrmDBhx" role="2OqNvi">
+                          <ref role="3Tt5mk" to="bbp5:T_6DrmCTj$" resolve="disableModelCheckingCondition" />
+                        </node>
+                      </node>
                     </node>
                   </node>
                 </node>
               </node>
+            </node>
+          </node>
+          <node concept="3cpWs6" id="1WjrBsNI_rj" role="3cqZAp">
+            <node concept="37vLTw" id="1WjrBsNI_rk" role="3cqZAk">
+              <ref role="3cqZAo" node="1WjrBsNI_nG" resolve="editorCell" />
             </node>
           </node>
           <node concept="3clFbH" id="1WjrBsNIgqg" role="3cqZAp" />
@@ -2002,14 +2005,6 @@
       <property role="TrG5h" value="_context_" />
       <node concept="312cEu" id="heOoiGW" role="jymVt">
         <property role="TrG5h" value="class_CellModel_RefNodeList_ListHandler" />
-        <node concept="312cEg" id="1AuRJ4GJjYK" role="jymVt">
-          <property role="34CwA1" value="false" />
-          <property role="eg7rD" value="false" />
-          <property role="TrG5h" value="myNode" />
-          <property role="3TUv4t" value="false" />
-          <node concept="3Tm6S6" id="1AuRJ4GJhfx" role="1B3o_S" />
-          <node concept="3Tqbb2" id="1AuRJ4GJmI7" role="1tU5fm" />
-        </node>
         <node concept="3Tm6S6" id="1y7DiaVv336" role="1B3o_S" />
         <node concept="17Uvod" id="heOoiMo" role="lGtFl">
           <property role="2qtEX9" value="name" />
@@ -2031,6 +2026,21 @@
           </node>
         </node>
         <node concept="raruj" id="heOooWn" role="lGtFl" />
+        <node concept="312cEg" id="1AuRJ4GJjYK" role="jymVt">
+          <property role="34CwA1" value="false" />
+          <property role="eg7rD" value="false" />
+          <property role="TrG5h" value="myNode" />
+          <property role="3TUv4t" value="false" />
+          <node concept="3Tm6S6" id="1AuRJ4GJhfx" role="1B3o_S" />
+          <node concept="3Tqbb2" id="1AuRJ4GJmI7" role="1tU5fm" />
+          <node concept="z59LJ" id="4EGFz66mZ1m" role="lGtFl">
+            <node concept="TZ5HA" id="4EGFz66mZ1n" role="TZ5H$">
+              <node concept="1dT_AC" id="4EGFz66mZ1o" role="1dT_Ay">
+                <property role="1dT_AB" value="allows node access in the query with ConceptFunctionParameter_node" />
+              </node>
+            </node>
+          </node>
+        </node>
         <node concept="3clFbW" id="heOoiM2" role="jymVt">
           <node concept="3Tm1VV" id="heOoiMn" role="1B3o_S" />
           <node concept="37vLTG" id="heOoiMl" role="3clF46">
@@ -8155,6 +8165,209 @@
         <node concept="3Tm6S6" id="4Hw51cn4eQI" role="1B3o_S" />
       </node>
       <node concept="3Tm1VV" id="3IFXLmitRn2" role="1B3o_S" />
+    </node>
+  </node>
+  <node concept="13MO4I" id="4EGFz671olF">
+    <property role="TrG5h" value="getOwningQueryListContext" />
+    <ref role="3gUMe" to="bbp5:4EGFz66rZ5j" resolve="AbstractQueryListInlineEditorExpression" />
+    <node concept="2YIFZM" id="4EGFz671$ld" role="13RCb5">
+      <ref role="37wK5l" to="d2zl:1WjrBsNI5cO" resolve="getCurrentContext" />
+      <ref role="1Pybhc" to="d2zl:1WjrBsNHO$4" resolve="QueryListContext" />
+      <node concept="raruj" id="4EGFz671$lB" role="lGtFl" />
+      <node concept="1W57fq" id="4EGFz671$m2" role="lGtFl">
+        <node concept="3IZrLx" id="4EGFz671$m3" role="3IZSJc">
+          <node concept="3clFbS" id="4EGFz671$m4" role="2VODD2">
+            <node concept="3clFbF" id="4EGFz671oTF" role="3cqZAp">
+              <node concept="17R0WA" id="4EGFz671_rx" role="3clFbG">
+                <node concept="2OqwBi" id="4EGFz671AyR" role="3uHU7w">
+                  <node concept="30H73N" id="4EGFz671_UE" role="2Oq$k0" />
+                  <node concept="2Xjw5R" id="4EGFz671BiI" role="2OqNvi">
+                    <node concept="1xMEDy" id="4EGFz671BiK" role="1xVPHs">
+                      <node concept="chp4Y" id="4EGFz671B_n" role="ri$Ld">
+                        <ref role="cht4Q" to="bbp5:5oklODadopi" resolve="CellModel_QueryList" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="4EGFz671pk2" role="3uHU7B">
+                  <node concept="30H73N" id="4EGFz671oTE" role="2Oq$k0" />
+                  <node concept="2qgKlT" id="4EGFz671xMp" role="2OqNvi">
+                    <ref role="37wK5l" to="1hk2:4EGFz671r3O" resolve="getOwningQueryList" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3SKdUt" id="4EGFz672ZIx" role="3cqZAp">
+              <node concept="1PaTwC" id="4EGFz672ZIy" role="1aUNEU">
+                <node concept="3oM_SD" id="4EGFz672ZIz" role="1PaTwD">
+                  <property role="3oM_SC" value="else:" />
+                </node>
+                <node concept="3oM_SD" id="4EGFz672ZIZ" role="1PaTwD">
+                  <property role="3oM_SC" value="if" />
+                </node>
+                <node concept="3oM_SD" id="4EGFz672ZID" role="1PaTwD">
+                  <property role="3oM_SC" value="expressions" />
+                </node>
+                <node concept="3oM_SD" id="4EGFz672ZJ2" role="1PaTwD">
+                  <property role="3oM_SC" value="are" />
+                </node>
+                <node concept="3oM_SD" id="4EGFz672ZJ7" role="1PaTwD">
+                  <property role="3oM_SC" value="used" />
+                </node>
+                <node concept="3oM_SD" id="4EGFz672ZJd" role="1PaTwD">
+                  <property role="3oM_SC" value="in" />
+                </node>
+                <node concept="3oM_SD" id="4EGFz672ZJh" role="1PaTwD">
+                  <property role="3oM_SC" value="a" />
+                </node>
+                <node concept="3oM_SD" id="4EGFz672ZP3" role="1PaTwD">
+                  <property role="3oM_SC" value="query" />
+                </node>
+                <node concept="3oM_SD" id="4EGFz672ZJo" role="1PaTwD">
+                  <property role="3oM_SC" value="list," />
+                </node>
+                <node concept="3oM_SD" id="4EGFz672ZJv" role="1PaTwD">
+                  <property role="3oM_SC" value="but" />
+                </node>
+                <node concept="3oM_SD" id="4EGFz672ZJ$" role="1PaTwD">
+                  <property role="3oM_SC" value="not" />
+                </node>
+                <node concept="3oM_SD" id="4EGFz672ZJD" role="1PaTwD">
+                  <property role="3oM_SC" value="in" />
+                </node>
+                <node concept="3oM_SD" id="4EGFz672ZJU" role="1PaTwD">
+                  <property role="3oM_SC" value="its" />
+                </node>
+                <node concept="3oM_SD" id="4EGFz672ZJZ" role="1PaTwD">
+                  <property role="3oM_SC" value="inline" />
+                </node>
+                <node concept="3oM_SD" id="4EGFz672ZKh" role="1PaTwD">
+                  <property role="3oM_SC" value="editor," />
+                </node>
+                <node concept="3oM_SD" id="4EGFz672ZKr" role="1PaTwD">
+                  <property role="3oM_SC" value="" />
+                </node>
+              </node>
+            </node>
+            <node concept="3SKdUt" id="4EGFz672ZLr" role="3cqZAp">
+              <node concept="1PaTwC" id="4EGFz672ZL4" role="1aUNEU">
+                <node concept="3oM_SD" id="4EGFz672ZL3" role="1PaTwD">
+                  <property role="3oM_SC" value="we" />
+                </node>
+                <node concept="3oM_SD" id="4EGFz672ZKv" role="1PaTwD">
+                  <property role="3oM_SC" value="have" />
+                </node>
+                <node concept="3oM_SD" id="4EGFz672ZKH" role="1PaTwD">
+                  <property role="3oM_SC" value="nested" />
+                </node>
+                <node concept="3oM_SD" id="4EGFz672ZKP" role="1PaTwD">
+                  <property role="3oM_SC" value="query" />
+                </node>
+                <node concept="3oM_SD" id="4EGFz672ZKW" role="1PaTwD">
+                  <property role="3oM_SC" value="lists" />
+                </node>
+                <node concept="3oM_SD" id="4EGFz672ZLH" role="1PaTwD">
+                  <property role="3oM_SC" value="and" />
+                </node>
+                <node concept="3oM_SD" id="4EGFz672ZLU" role="1PaTwD">
+                  <property role="3oM_SC" value="the" />
+                </node>
+                <node concept="3oM_SD" id="4EGFz672ZM3" role="1PaTwD">
+                  <property role="3oM_SC" value="right" />
+                </node>
+                <node concept="3oM_SD" id="4EGFz672ZMa" role="1PaTwD">
+                  <property role="3oM_SC" value="context" />
+                </node>
+                <node concept="3oM_SD" id="4EGFz672ZMj" role="1PaTwD">
+                  <property role="3oM_SC" value="is" />
+                </node>
+                <node concept="3oM_SD" id="4EGFz672ZMn" role="1PaTwD">
+                  <property role="3oM_SC" value="the" />
+                </node>
+                <node concept="3oM_SD" id="4EGFz672ZN6" role="1PaTwD">
+                  <property role="3oM_SC" value="parent" />
+                </node>
+                <node concept="3oM_SD" id="4EGFz672ZMv" role="1PaTwD">
+                  <property role="3oM_SC" value="of" />
+                </node>
+                <node concept="3oM_SD" id="4EGFz672ZMz" role="1PaTwD">
+                  <property role="3oM_SC" value="the" />
+                </node>
+                <node concept="3oM_SD" id="4EGFz672ZMC" role="1PaTwD">
+                  <property role="3oM_SC" value="current" />
+                </node>
+                <node concept="3oM_SD" id="4EGFz672ZML" role="1PaTwD">
+                  <property role="3oM_SC" value="one" />
+                </node>
+                <node concept="3oM_SD" id="4EGFz672ZMQ" role="1PaTwD">
+                  <property role="3oM_SC" value="" />
+                </node>
+              </node>
+            </node>
+            <node concept="3SKdUt" id="4EGFz672ZNv" role="3cqZAp">
+              <node concept="1PaTwC" id="4EGFz672ZN9" role="1aUNEU">
+                <node concept="3oM_SD" id="4EGFz672ZN8" role="1PaTwD">
+                  <property role="3oM_SC" value="(current" />
+                </node>
+                <node concept="3oM_SD" id="4EGFz672ZP6" role="1PaTwD">
+                  <property role="3oM_SC" value="is" />
+                </node>
+                <node concept="3oM_SD" id="4EGFz672ZNV" role="1PaTwD">
+                  <property role="3oM_SC" value="created" />
+                </node>
+                <node concept="3oM_SD" id="4EGFz672ZP8" role="1PaTwD">
+                  <property role="3oM_SC" value="for" />
+                </node>
+                <node concept="3oM_SD" id="4EGFz672ZPd" role="1PaTwD">
+                  <property role="3oM_SC" value="the" />
+                </node>
+                <node concept="3oM_SD" id="4EGFz672ZPi" role="1PaTwD">
+                  <property role="3oM_SC" value="nested" />
+                </node>
+                <node concept="3oM_SD" id="4EGFz672ZPq" role="1PaTwD">
+                  <property role="3oM_SC" value="querylist," />
+                </node>
+                <node concept="3oM_SD" id="4EGFz672ZO7" role="1PaTwD">
+                  <property role="3oM_SC" value="but" />
+                </node>
+                <node concept="3oM_SD" id="4EGFz672ZOc" role="1PaTwD">
+                  <property role="3oM_SC" value="we" />
+                </node>
+                <node concept="3oM_SD" id="4EGFz672ZPB" role="1PaTwD">
+                  <property role="3oM_SC" value="are" />
+                </node>
+                <node concept="3oM_SD" id="4EGFz672ZPG" role="1PaTwD">
+                  <property role="3oM_SC" value="still" />
+                </node>
+                <node concept="3oM_SD" id="4EGFz672ZPN" role="1PaTwD">
+                  <property role="3oM_SC" value="outside" />
+                </node>
+                <node concept="3oM_SD" id="4EGFz672ZPW" role="1PaTwD">
+                  <property role="3oM_SC" value="of" />
+                </node>
+                <node concept="3oM_SD" id="4EGFz672ZQC" role="1PaTwD">
+                  <property role="3oM_SC" value="it)" />
+                </node>
+                <node concept="3oM_SD" id="4EGFz672ZK7" role="1PaTwD" />
+                <node concept="3oM_SD" id="4EGFz672ZIR" role="1PaTwD">
+                  <property role="3oM_SC" value="" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="gft3U" id="4EGFz671BSA" role="UU_$l">
+          <node concept="2OqwBi" id="4EGFz671CaZ" role="gfFT$">
+            <node concept="2YIFZM" id="4EGFz671Cci" role="2Oq$k0">
+              <ref role="37wK5l" to="d2zl:1WjrBsNI5cO" resolve="getCurrentContext" />
+              <ref role="1Pybhc" to="d2zl:1WjrBsNHO$4" resolve="QueryListContext" />
+            </node>
+            <node concept="liA8E" id="4EGFz671Cle" role="2OqNvi">
+              <ref role="37wK5l" to="d2zl:1WjrBsNI3Qi" resolve="getParentContext" />
+            </node>
+          </node>
+        </node>
+      </node>
     </node>
   </node>
 </model>

--- a/code/querylist/com.mbeddr.mpsutil.editor.querylist/generator/template/main@generator.mps
+++ b/code/querylist/com.mbeddr.mpsutil.editor.querylist/generator/template/main@generator.mps
@@ -223,7 +223,6 @@
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
       <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
       <concept id="1146644641414" name="jetbrains.mps.baseLanguage.structure.ProtectedVisibility" flags="nn" index="3Tmbuc" />
-      <concept id="1178893518978" name="jetbrains.mps.baseLanguage.structure.ThisConstructorInvocation" flags="nn" index="1VxSAg" />
       <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
       <concept id="1170345865475" name="jetbrains.mps.baseLanguage.structure.AnonymousClass" flags="ig" index="1Y3b0j">
         <reference id="1170346070688" name="classifier" index="1Y3XeK" />
@@ -304,14 +303,9 @@
       <concept id="6832197706140896242" name="jetbrains.mps.baseLanguage.javadoc.structure.FieldDocComment" flags="ng" index="z59LJ" />
       <concept id="5349172909345501395" name="jetbrains.mps.baseLanguage.javadoc.structure.BaseDocComment" flags="ng" index="P$AiS">
         <child id="8465538089690331502" name="body" index="TZ5H$" />
-        <child id="5383422241790532083" name="tags" index="3nqlJM" />
       </concept>
-      <concept id="5349172909345532724" name="jetbrains.mps.baseLanguage.javadoc.structure.MethodDocComment" flags="ng" index="P$JXv" />
       <concept id="8465538089690331500" name="jetbrains.mps.baseLanguage.javadoc.structure.CommentLine" flags="ng" index="TZ5HA">
         <child id="8970989240999019149" name="part" index="1dT_Ay" />
-      </concept>
-      <concept id="8465538089690331492" name="jetbrains.mps.baseLanguage.javadoc.structure.DeprecatedBlockDocTag" flags="ng" index="TZ5HI">
-        <child id="2667874559098216723" name="text" index="3HnX3l" />
       </concept>
       <concept id="8970989240999019143" name="jetbrains.mps.baseLanguage.javadoc.structure.TextCommentLinePart" flags="ng" index="1dT_AC">
         <property id="8970989240999019144" name="text" index="1dT_AB" />
@@ -841,7 +835,7 @@
               </node>
               <node concept="2ShNRf" id="1WjrBsNI_nm" role="33vP2m">
                 <node concept="1pGfFk" id="1WjrBsNI_nn" role="2ShVmc">
-                  <ref role="37wK5l" node="1BXECvJWl_s" resolve="_context_class_.GeneratedQueryListHandler" />
+                  <ref role="37wK5l" node="5vc9XxaAaFz" resolve="_context_class_.GeneratedQueryListHandler" />
                   <node concept="37vLTw" id="1WjrBsNI_no" role="37wK5m">
                     <ref role="3cqZAo" node="fYh_FQ2" resolve="editorContext" />
                   </node>
@@ -859,6 +853,28 @@
                             <node concept="1iwH70" id="13m3hIRlJC" role="2OqNvi">
                               <ref role="1iwH77" to="tpc3:5QbehOJMFlo" resolve="generated.constructor" />
                               <node concept="30H73N" id="13m3hIRlJD" role="1iwH7V" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbT" id="4EGFz66RMbQ" role="37wK5m">
+                    <node concept="17Uvod" id="4EGFz66RN86" role="lGtFl">
+                      <property role="2qtEX9" value="value" />
+                      <property role="P4ACc" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123137/1068580123138" />
+                      <node concept="3zFVjK" id="4EGFz66RN87" role="3zH0cK">
+                        <node concept="3clFbS" id="4EGFz66RN88" role="2VODD2">
+                          <node concept="3clFbF" id="4EGFz66RPlQ" role="3cqZAp">
+                            <node concept="2OqwBi" id="4EGFz66RPlR" role="3clFbG">
+                              <node concept="30H73N" id="4EGFz66RPlS" role="2Oq$k0" />
+                              <node concept="2qgKlT" id="4EGFz66RPlT" role="2OqNvi">
+                                <ref role="37wK5l" to="tpcb:i0pNf1r" resolve="getBooleanStyleValue" />
+                                <node concept="35c_gC" id="4EGFz66RPlU" role="37wK5m">
+                                  <ref role="35c_gD" to="tpc2:G99PKEU3Jd" resolve="ReadOnlyStyleClassItem" />
+                                </node>
+                                <node concept="3clFbT" id="4EGFz66RPlV" role="37wK5m" />
+                              </node>
                             </node>
                           </node>
                         </node>
@@ -1801,40 +1817,6 @@
         <property role="2bfB8j" value="false" />
         <property role="TrG5h" value="GeneratedQueryListHandler" />
         <property role="1sVAO0" value="true" />
-        <node concept="3clFbW" id="1BXECvJWl_s" role="jymVt">
-          <node concept="3cqZAl" id="1BXECvJWl_u" role="3clF45" />
-          <node concept="3Tm1VV" id="1BXECvJWl_v" role="1B3o_S" />
-          <node concept="3clFbS" id="1BXECvJWl_w" role="3clF47">
-            <node concept="1VxSAg" id="5vc9XxaAf85" role="3cqZAp">
-              <ref role="37wK5l" node="5vc9XxaAaFz" resolve="_context_class_.GeneratedQueryListHandler" />
-              <node concept="37vLTw" id="5vc9XxaAgTr" role="37wK5m">
-                <ref role="3cqZAo" node="1BXECvJWlHy" resolve="context" />
-              </node>
-              <node concept="37vLTw" id="5vc9XxaAkll" role="37wK5m">
-                <ref role="3cqZAo" node="1BXECvJWlKM" resolve="node" />
-              </node>
-              <node concept="3clFbT" id="5vc9XxaAmmg" role="37wK5m" />
-            </node>
-          </node>
-          <node concept="37vLTG" id="1BXECvJWlHy" role="3clF46">
-            <property role="TrG5h" value="context" />
-            <node concept="3uibUv" id="1BXECvJWlHx" role="1tU5fm">
-              <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
-            </node>
-          </node>
-          <node concept="37vLTG" id="1BXECvJWlKM" role="3clF46">
-            <property role="TrG5h" value="node" />
-            <node concept="3Tqbb2" id="1BXECvJWlNW" role="1tU5fm" />
-          </node>
-          <node concept="P$JXv" id="5vc9XxaATPf" role="lGtFl">
-            <node concept="TZ5HI" id="5vc9XxaATPg" role="3nqlJM">
-              <node concept="TZ5HA" id="5vc9XxaATPh" role="3HnX3l" />
-            </node>
-          </node>
-          <node concept="2AHcQZ" id="5vc9XxaATPi" role="2AJF6D">
-            <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-          </node>
-        </node>
         <node concept="2tJIrI" id="5vc9XxaAfFg" role="jymVt" />
         <node concept="3clFbW" id="5vc9XxaAaFz" role="jymVt">
           <node concept="3cqZAl" id="5vc9XxaAaF$" role="3clF45" />
@@ -1902,7 +1884,6 @@
             </node>
           </node>
         </node>
-        <node concept="3Tm1VV" id="1BXECvJW3Iu" role="1B3o_S" />
         <node concept="3uibUv" id="1BXECvJW4ZU" role="1zkMxy">
           <ref role="3uigEE" to="d2zl:1BXECvJT402" resolve="QueryListHandler" />
         </node>
@@ -1994,6 +1975,7 @@
             </node>
           </node>
         </node>
+        <node concept="3Tm6S6" id="4EGFz66RwQJ" role="1B3o_S" />
       </node>
       <node concept="3Tm1VV" id="h9B3LlU" role="1B3o_S" />
     </node>
@@ -2004,7 +1986,7 @@
     <node concept="312cEu" id="heOoi6W" role="13RCb5">
       <property role="TrG5h" value="_context_" />
       <node concept="312cEu" id="heOoiGW" role="jymVt">
-        <property role="TrG5h" value="class_CellModel_RefNodeList_ListHandler" />
+        <property role="TrG5h" value="class_CellModel_QueryList_QueryListHandler" />
         <node concept="3Tm6S6" id="1y7DiaVv336" role="1B3o_S" />
         <node concept="17Uvod" id="heOoiMo" role="lGtFl">
           <property role="2qtEX9" value="name" />
@@ -2062,27 +2044,8 @@
               <node concept="37vLTw" id="2BHiRxgmFoX" role="37wK5m">
                 <ref role="3cqZAo" node="heOoiMh" resolve="ownerNode" />
               </node>
-              <node concept="3clFbT" id="5vc9XxaBkeU" role="37wK5m">
-                <node concept="17Uvod" id="5vc9XxaBkTN" role="lGtFl">
-                  <property role="2qtEX9" value="value" />
-                  <property role="P4ACc" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123137/1068580123138" />
-                  <node concept="3zFVjK" id="5vc9XxaBkTO" role="3zH0cK">
-                    <node concept="3clFbS" id="5vc9XxaBkTP" role="2VODD2">
-                      <node concept="3clFbF" id="5vc9XxaBlwe" role="3cqZAp">
-                        <node concept="2OqwBi" id="5vc9XxaBlwf" role="3clFbG">
-                          <node concept="30H73N" id="5vc9XxaBlwg" role="2Oq$k0" />
-                          <node concept="2qgKlT" id="5vc9XxaBlwh" role="2OqNvi">
-                            <ref role="37wK5l" to="tpcb:i0pNf1r" resolve="getBooleanStyleValue" />
-                            <node concept="35c_gC" id="5vc9XxaBlwi" role="37wK5m">
-                              <ref role="35c_gD" to="tpc2:G99PKEU3Jd" resolve="ReadOnlyStyleClassItem" />
-                            </node>
-                            <node concept="3clFbT" id="5vc9XxaBlwj" role="37wK5m" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
+              <node concept="37vLTw" id="4EGFz66S1At" role="37wK5m">
+                <ref role="3cqZAo" node="4EGFz66RZ3u" resolve="readOnly" />
               </node>
             </node>
             <node concept="3clFbF" id="1AuRJ4GJnll" role="3cqZAp">
@@ -2100,6 +2063,10 @@
             <ref role="2rW$FS" to="tpc3:5QbehOJMFlo" resolve="generated.constructor" />
           </node>
           <node concept="3cqZAl" id="30xB0zHnCu_" role="3clF45" />
+          <node concept="37vLTG" id="4EGFz66RZ3u" role="3clF46">
+            <property role="TrG5h" value="readOnly" />
+            <node concept="10P_77" id="4EGFz66S0rz" role="1tU5fm" />
+          </node>
         </node>
         <node concept="3clFb_" id="13m3hISN3d" role="jymVt">
           <property role="1EzhhJ" value="false" />
@@ -2911,7 +2878,7 @@
                               </node>
                             </node>
                             <node concept="Xjq3P" id="6CvwwnunY$9" role="2Oq$k0">
-                              <ref role="1HBi2w" node="heOoiGW" resolve="_context_.class_CellModel_RefNodeList_ListHandler" />
+                              <ref role="1HBi2w" node="heOoiGW" resolve="_context_.class_CellModel_QueryList_QueryListHandler" />
                             </node>
                           </node>
                         </node>

--- a/code/querylist/com.mbeddr.mpsutil.editor.querylist/languageModels/behavior.mps
+++ b/code/querylist/com.mbeddr.mpsutil.editor.querylist/languageModels/behavior.mps
@@ -1503,7 +1503,8 @@
     </node>
   </node>
   <node concept="13h7C7" id="1WjrBsNJ6aV">
-    <ref role="13h7C2" to="bbp5:1WjrBsNJ4Il" resolve="QueryListNodeExpression" />
+    <property role="3GE5qa" value="expressions" />
+    <ref role="13h7C2" to="bbp5:1WjrBsNJ4Il" resolve="QueryListInputExpression" />
     <node concept="13hLZK" id="1WjrBsNJ6aW" role="13h7CW">
       <node concept="3clFbS" id="1WjrBsNJ6aX" role="2VODD2" />
     </node>
@@ -1518,12 +1519,8 @@
               <node concept="2OqwBi" id="1WjrBsNJ5tz" role="2Oq$k0">
                 <node concept="2OqwBi" id="1WjrBsNJ5t$" role="2Oq$k0">
                   <node concept="13iPFW" id="1WjrBsNJ6dK" role="2Oq$k0" />
-                  <node concept="2Xjw5R" id="1WjrBsNJ5tA" role="2OqNvi">
-                    <node concept="1xMEDy" id="1WjrBsNJ5tB" role="1xVPHs">
-                      <node concept="chp4Y" id="1WjrBsNJ5tC" role="ri$Ld">
-                        <ref role="cht4Q" to="bbp5:5oklODadopi" resolve="CellModel_QueryList" />
-                      </node>
-                    </node>
+                  <node concept="2qgKlT" id="4EGFz671u8k" role="2OqNvi">
+                    <ref role="37wK5l" node="4EGFz671r3O" resolve="getOwningQueryList" />
                   </node>
                 </node>
                 <node concept="2Xjw5R" id="1WjrBsNJ5tD" role="2OqNvi">
@@ -1565,6 +1562,42 @@
     </node>
     <node concept="13hLZK" id="3YRpSuyxXtQ" role="13h7CW">
       <node concept="3clFbS" id="3YRpSuyxXtR" role="2VODD2" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="4EGFz671r3x">
+    <property role="3GE5qa" value="expressions" />
+    <ref role="13h7C2" to="bbp5:4EGFz66rZ5j" resolve="AbstractQueryListInlineEditorExpression" />
+    <node concept="13i0hz" id="4EGFz671r3O" role="13h7CS">
+      <property role="TrG5h" value="getOwningQueryList" />
+      <node concept="3Tm1VV" id="4EGFz671r3P" role="1B3o_S" />
+      <node concept="3Tqbb2" id="4EGFz671r48" role="3clF45">
+        <ref role="ehGHo" to="bbp5:5oklODadopi" resolve="CellModel_QueryList" />
+      </node>
+      <node concept="3clFbS" id="4EGFz671r3R" role="3clF47">
+        <node concept="3clFbF" id="4EGFz671r6b" role="3cqZAp">
+          <node concept="1PxgMI" id="4EGFz671tjV" role="3clFbG">
+            <node concept="chp4Y" id="4EGFz671tm4" role="3oSUPX">
+              <ref role="cht4Q" to="bbp5:5oklODadopi" resolve="CellModel_QueryList" />
+            </node>
+            <node concept="2OqwBi" id="4EGFz671s99" role="1m5AlR">
+              <node concept="2OqwBi" id="4EGFz671rjk" role="2Oq$k0">
+                <node concept="13iPFW" id="4EGFz671r6a" role="2Oq$k0" />
+                <node concept="2Xjw5R" id="4EGFz671rMJ" role="2OqNvi">
+                  <node concept="1xMEDy" id="4EGFz671rML" role="1xVPHs">
+                    <node concept="chp4Y" id="4EGFz671rQ1" role="ri$Ld">
+                      <ref role="cht4Q" to="bbp5:6hPjX46YnED" resolve="QueryListInlineEditorComponent" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="1mfA1w" id="4EGFz671t2z" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="13hLZK" id="4EGFz671r3y" role="13h7CW">
+      <node concept="3clFbS" id="4EGFz671r3z" role="2VODD2" />
     </node>
   </node>
 </model>

--- a/code/querylist/com.mbeddr.mpsutil.editor.querylist/languageModels/constraints.mps
+++ b/code/querylist/com.mbeddr.mpsutil.editor.querylist/languageModels/constraints.mps
@@ -216,7 +216,7 @@
                       </node>
                       <node concept="359W_D" id="1ji15RhfQ9v" role="3uHU7w">
                         <ref role="359W_E" to="bbp5:5oklODadopi" resolve="CellModel_QueryList" />
-                        <ref role="359W_F" to="bbp5:6hPjX46YZPG" />
+                        <ref role="359W_F" to="bbp5:6hPjX46YZPG" resolve="editorComponent" />
                       </node>
                     </node>
                   </node>

--- a/code/querylist/com.mbeddr.mpsutil.editor.querylist/languageModels/constraints.mps
+++ b/code/querylist/com.mbeddr.mpsutil.editor.querylist/languageModels/constraints.mps
@@ -2,13 +2,16 @@
 <model ref="120e1c9d-4e27-4478-b2af-b2c3bd3850b0/r:e367e031-8513-4312-bec5-9d0e07b637ea(com.mbeddr.mpsutil.editor.querylist/com.mbeddr.mpsutil.editor.querylist.constraints)">
   <persistence version="9" />
   <languages>
+    <use id="3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1" name="jetbrains.mps.lang.constraints" version="6" />
     <devkit ref="00000000-0000-4000-0000-5604ebd4f22c(jetbrains.mps.devkit.aspect.constraints)" />
   </languages>
   <imports>
-    <import index="bbp5" ref="120e1c9d-4e27-4478-b2af-b2c3bd3850b0/r:ea4f2df6-5e5c-49de-8679-6112ec7dd9c3(com.mbeddr.mpsutil.editor.querylist/com.mbeddr.mpsutil.editor.querylist.structure)" implicit="true" />
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" />
+    <import index="bbp5" ref="120e1c9d-4e27-4478-b2af-b2c3bd3850b0/r:ea4f2df6-5e5c-49de-8679-6112ec7dd9c3(com.mbeddr.mpsutil.editor.querylist/com.mbeddr.mpsutil.editor.querylist.structure)" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
@@ -16,11 +19,25 @@
       <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
         <child id="1137022507850" name="body" index="2VODD2" />
       </concept>
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="1225271283259" name="jetbrains.mps.baseLanguage.structure.NPEEqualsExpression" flags="nn" index="17R0WA" />
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
+        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
+        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
+      </concept>
+      <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
+        <child id="8356039341262087992" name="line" index="1aUNEU" />
       </concept>
     </language>
     <language id="3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1" name="jetbrains.mps.lang.constraints">
@@ -31,6 +48,14 @@
         <child id="6702802731807737306" name="canBeChild" index="9Vyp8" />
       </concept>
     </language>
+    <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
+      <concept id="2524418899405758586" name="jetbrains.mps.baseLanguage.closures.structure.InferredClosureParameterDeclaration" flags="ig" index="gl6BB" />
+      <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
+        <property id="890797661671409019" name="forceMultiLine" index="3yWfEV" />
+        <child id="1199569906740" name="parameter" index="1bW2Oz" />
+        <child id="1199569916463" name="body" index="1bW5cS" />
+      </concept>
+    </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
       <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
         <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
@@ -38,12 +63,40 @@
       <concept id="1138411891628" name="jetbrains.mps.lang.smodel.structure.SNodeOperation" flags="nn" index="eCIE_">
         <child id="1144104376918" name="parameter" index="1xVPHs" />
       </concept>
+      <concept id="1173122760281" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorsOperation" flags="nn" index="z$bX8" />
+      <concept id="7504436213544206332" name="jetbrains.mps.lang.smodel.structure.Node_ContainingLinkOperation" flags="nn" index="2NL2c5" />
       <concept id="1171407110247" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorOperation" flags="nn" index="2Xjw5R" />
+      <concept id="2644386474301421077" name="jetbrains.mps.lang.smodel.structure.LinkIdRefExpression" flags="nn" index="359W_D">
+        <reference id="2644386474301421078" name="conceptDeclaration" index="359W_E" />
+        <reference id="2644386474301421079" name="linkDeclaration" index="359W_F" />
+      </concept>
       <concept id="1172008320231" name="jetbrains.mps.lang.smodel.structure.Node_IsNotNullOperation" flags="nn" index="3x8VRR" />
       <concept id="1144100932627" name="jetbrains.mps.lang.smodel.structure.OperationParm_Inclusion" flags="ng" index="1xIGOp" />
       <concept id="1144101972840" name="jetbrains.mps.lang.smodel.structure.OperationParm_Concept" flags="ng" index="1xMEDy">
         <child id="1207343664468" name="conceptArgument" index="ri$Ld" />
       </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+    <language id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text">
+      <concept id="155656958578482948" name="jetbrains.mps.lang.text.structure.Word" flags="nn" index="3oM_SD">
+        <property id="155656958578482949" name="value" index="3oM_SC" />
+      </concept>
+      <concept id="2535923850359271782" name="jetbrains.mps.lang.text.structure.Line" flags="nn" index="1PaTwC">
+        <child id="2535923850359271783" name="elements" index="1PaTwD" />
+      </concept>
+    </language>
+    <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
+        <child id="1204796294226" name="closure" index="23t8la" />
+      </concept>
+      <concept id="1235566554328" name="jetbrains.mps.baseLanguage.collections.structure.AnyOperation" flags="nn" index="2HwmR7" />
     </language>
   </registry>
   <node concept="1M2fIO" id="6QZo_pQhgJt">
@@ -69,47 +122,111 @@
       </node>
     </node>
   </node>
-  <node concept="1M2fIO" id="1WjrBsNJoAC">
-    <ref role="1M2myG" to="bbp5:1WjrBsNJ4Il" resolve="QueryListNodeExpression" />
+  <node concept="1M2fIO" id="4EGFz66rZ_1">
+    <property role="3GE5qa" value="expressions" />
+    <ref role="1M2myG" to="bbp5:4EGFz66rZ5j" resolve="AbstractQueryListInlineEditorExpression" />
     <node concept="9S07l" id="5RIakkDIUFs" role="9Vyp8">
       <node concept="3clFbS" id="5RIakkDIUFt" role="2VODD2">
-        <node concept="3clFbF" id="5RIakkDIUFu" role="3cqZAp">
-          <node concept="2OqwBi" id="5RIakkDIUFv" role="3clFbG">
-            <node concept="2OqwBi" id="5RIakkDIUFw" role="2Oq$k0">
-              <node concept="nLn13" id="5RIakkDIUFx" role="2Oq$k0" />
-              <node concept="2Xjw5R" id="5RIakkDIUFy" role="2OqNvi">
-                <node concept="1xMEDy" id="5RIakkDIUFz" role="1xVPHs">
-                  <node concept="chp4Y" id="5RIakkDIUF$" role="ri$Ld">
-                    <ref role="cht4Q" to="bbp5:5oklODadopi" resolve="CellModel_QueryList" />
-                  </node>
-                </node>
-                <node concept="1xIGOp" id="5RIakkDIUF_" role="1xVPHs" />
-              </node>
+        <node concept="3SKdUt" id="1ji15RhgldT" role="3cqZAp">
+          <node concept="1PaTwC" id="1ji15RhgldU" role="1aUNEU">
+            <node concept="3oM_SD" id="4EGFz66rZS1" role="1PaTwD">
+              <property role="3oM_SC" value="queryListInlineEditorExpression" />
             </node>
-            <node concept="3x8VRR" id="5RIakkDIUFA" role="2OqNvi" />
+            <node concept="3oM_SD" id="1ji15Rhglen" role="1PaTwD">
+              <property role="3oM_SC" value="only" />
+            </node>
+            <node concept="3oM_SD" id="1ji15Rhglet" role="1PaTwD">
+              <property role="3oM_SC" value="makes" />
+            </node>
+            <node concept="3oM_SD" id="1ji15Rhgle$" role="1PaTwD">
+              <property role="3oM_SC" value="sense" />
+            </node>
+            <node concept="3oM_SD" id="1ji15RhgleF" role="1PaTwD">
+              <property role="3oM_SC" value="inside" />
+            </node>
+            <node concept="3oM_SD" id="1ji15RhgleN" role="1PaTwD">
+              <property role="3oM_SC" value="of" />
+            </node>
+            <node concept="3oM_SD" id="1ji15RhgleR" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="1ji15Rhglg5" role="1PaTwD">
+              <property role="3oM_SC" value="queryList" />
+            </node>
+            <node concept="3oM_SD" id="1ji15Rhglf9" role="1PaTwD">
+              <property role="3oM_SC" value="inline" />
+            </node>
+            <node concept="3oM_SD" id="1ji15Rhglf$" role="1PaTwD">
+              <property role="3oM_SC" value="editor" />
+            </node>
+            <node concept="3oM_SD" id="1ji15RhglYp" role="1PaTwD">
+              <property role="3oM_SC" value="component," />
+            </node>
+            <node concept="3oM_SD" id="1ji15RhglfB" role="1PaTwD">
+              <property role="3oM_SC" value="but" />
+            </node>
+            <node concept="3oM_SD" id="1ji15RhglfG" role="1PaTwD">
+              <property role="3oM_SC" value="not" />
+            </node>
+            <node concept="3oM_SD" id="1ji15RhglfL" role="1PaTwD">
+              <property role="3oM_SC" value="in" />
+            </node>
+            <node concept="3oM_SD" id="1ji15RhglfP" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="1ji15RhglfU" role="1PaTwD">
+              <property role="3oM_SC" value="other" />
+            </node>
+            <node concept="3oM_SD" id="1ji15RhgmRh" role="1PaTwD">
+              <property role="3oM_SC" value="parts" />
+            </node>
+            <node concept="3oM_SD" id="1ji15RhglYK" role="1PaTwD">
+              <property role="3oM_SC" value="of" />
+            </node>
+            <node concept="3oM_SD" id="1ji15RhglYO" role="1PaTwD">
+              <property role="3oM_SC" value="queryList" />
+            </node>
+            <node concept="3oM_SD" id="1ji15Rhglgn" role="1PaTwD">
+              <property role="3oM_SC" value="definition" />
+            </node>
+            <node concept="3oM_SD" id="1ji15Rhglec" role="1PaTwD">
+              <property role="3oM_SC" value="" />
+            </node>
           </node>
         </node>
-      </node>
-    </node>
-  </node>
-  <node concept="1M2fIO" id="3YRpSuyOedA">
-    <ref role="1M2myG" to="bbp5:3YRpSuyOe2M" resolve="QueryListIndexExpression" />
-    <node concept="9S07l" id="3YRpSuyOedB" role="9Vyp8">
-      <node concept="3clFbS" id="3YRpSuyOedC" role="2VODD2">
-        <node concept="3clFbF" id="3YRpSuyOeis" role="3cqZAp">
-          <node concept="2OqwBi" id="3YRpSuyOeit" role="3clFbG">
-            <node concept="2OqwBi" id="3YRpSuyOeiu" role="2Oq$k0">
-              <node concept="nLn13" id="3YRpSuyOeiv" role="2Oq$k0" />
-              <node concept="2Xjw5R" id="3YRpSuyOeiw" role="2OqNvi">
-                <node concept="1xMEDy" id="3YRpSuyOeix" role="1xVPHs">
-                  <node concept="chp4Y" id="3YRpSuyOeiy" role="ri$Ld">
-                    <ref role="cht4Q" to="bbp5:5oklODadopi" resolve="CellModel_QueryList" />
-                  </node>
-                </node>
-                <node concept="1xIGOp" id="3YRpSuyOeiz" role="1xVPHs" />
+        <node concept="3clFbF" id="1ji15RhfR0j" role="3cqZAp">
+          <node concept="2OqwBi" id="5LNx5xzbvep" role="3clFbG">
+            <node concept="2OqwBi" id="5LNx5xzbveq" role="2Oq$k0">
+              <node concept="nLn13" id="5LNx5xzbver" role="2Oq$k0" />
+              <node concept="z$bX8" id="5LNx5xzbves" role="2OqNvi">
+                <node concept="1xIGOp" id="5LNx5xzbvet" role="1xVPHs" />
               </node>
             </node>
-            <node concept="3x8VRR" id="3YRpSuyOei$" role="2OqNvi" />
+            <node concept="2HwmR7" id="1ji15RhfQ9l" role="2OqNvi">
+              <node concept="1bVj0M" id="1ji15RhfQ9n" role="23t8la">
+                <property role="3yWfEV" value="true" />
+                <node concept="3clFbS" id="1ji15RhfQ9o" role="1bW5cS">
+                  <node concept="3clFbF" id="1ji15RhfQ9p" role="3cqZAp">
+                    <node concept="17R0WA" id="1ji15RhfQ9r" role="3clFbG">
+                      <node concept="2OqwBi" id="1ji15RhfQ9s" role="3uHU7B">
+                        <node concept="37vLTw" id="1ji15RhfQ9t" role="2Oq$k0">
+                          <ref role="3cqZAo" node="1ji15RhfQ9A" resolve="it" />
+                        </node>
+                        <node concept="2NL2c5" id="1ji15RhfQ9u" role="2OqNvi" />
+                      </node>
+                      <node concept="359W_D" id="1ji15RhfQ9v" role="3uHU7w">
+                        <ref role="359W_E" to="bbp5:5oklODadopi" resolve="CellModel_QueryList" />
+                        <ref role="359W_F" to="bbp5:6hPjX46YZPG" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="gl6BB" id="1ji15RhfQ9A" role="1bW2Oz">
+                  <property role="TrG5h" value="it" />
+                  <node concept="2jxLKc" id="1ji15RhfQ9B" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
           </node>
         </node>
       </node>

--- a/code/querylist/com.mbeddr.mpsutil.editor.querylist/languageModels/editor.mps
+++ b/code/querylist/com.mbeddr.mpsutil.editor.querylist/languageModels/editor.mps
@@ -3382,13 +3382,13 @@
                             <ref role="3cqZAo" node="4EGFz66CW2L" resolve="icon" />
                           </node>
                           <node concept="liA8E" id="4EGFz66AcSf" role="2OqNvi">
-                            <ref role="37wK5l" to="dxuu:~Icon.getIconWidth()" resolve="getIconWidth" />
+                            <ref role="37wK5l" to="dxuu:~Icon.getIconHeight()" resolve="getIconHeight" />
                           </node>
                         </node>
                         <node concept="2OqwBi" id="4EGFz66AcSg" role="37vLTJ">
                           <node concept="Xjq3P" id="4EGFz66AcSh" role="2Oq$k0" />
                           <node concept="2OwXpG" id="4EGFz66AcSi" role="2OqNvi">
-                            <ref role="2Oxat5" to="g51k:~EditorCell_Basic.myWidth" resolve="myWidth" />
+                            <ref role="2Oxat5" to="g51k:~EditorCell_Basic.myHeight" resolve="myHeight" />
                           </node>
                         </node>
                       </node>

--- a/code/querylist/com.mbeddr.mpsutil.editor.querylist/languageModels/editor.mps
+++ b/code/querylist/com.mbeddr.mpsutil.editor.querylist/languageModels/editor.mps
@@ -399,11 +399,11 @@
                   <node concept="2ShNRf" id="4EGFz66E2Gc" role="3clFbG">
                     <node concept="1pGfFk" id="4EGFz66E2Gd" role="2ShVmc">
                       <property role="373rjd" value="true" />
-                      <ref role="37wK5l" node="4EGFz66CYq0" />
+                      <ref role="37wK5l" node="4EGFz66CYq0" resolve="IconCell" />
                       <node concept="pncrf" id="4EGFz66E2Ge" role="37wK5m" />
                       <node concept="10M0yZ" id="4EGFz66uAoo" role="37wK5m">
                         <ref role="3cqZAo" to="z2i8:~AllIcons$General.ContextHelp" resolve="ContextHelp" />
-                        <ref role="1PxDUh" to="z2i8:~AllIcons$General" resolve="General" />
+                        <ref role="1PxDUh" to="z2i8:~AllIcons$General" resolve="AllIcons.General" />
                       </node>
                       <node concept="3cmrfG" id="4EGFz66E2Gg" role="37wK5m">
                         <property role="3cmrfH" value="5" />

--- a/code/querylist/com.mbeddr.mpsutil.editor.querylist/languageModels/editor.mps
+++ b/code/querylist/com.mbeddr.mpsutil.editor.querylist/languageModels/editor.mps
@@ -13,16 +13,22 @@
     <import index="iwwu" ref="r:2c4d9270-b6d6-44af-aecd-e01a223680db(jetbrains.mps.kernel.model)" />
     <import index="pjrh" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel.adapter(MPS.Core/)" />
     <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" />
+    <import index="av1m" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.menus.style(MPS.Editor/)" />
+    <import index="tpco" ref="r:00000000-0000-4000-0000-011c89590284(jetbrains.mps.lang.core.editor)" />
+    <import index="tpen" ref="r:00000000-0000-4000-0000-011c895902c3(jetbrains.mps.baseLanguage.editor)" />
+    <import index="exr9" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor(MPS.Editor/)" />
+    <import index="cj4x" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor(MPS.Editor/)" />
+    <import index="f4zo" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.cells(MPS.Editor/)" />
+    <import index="g51k" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor.cells(MPS.Editor/)" />
+    <import index="z60i" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt(JDK/)" />
+    <import index="z2i8" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.icons(MPS.IDEA/)" />
+    <import index="dxuu" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:javax.swing(JDK/)" />
+    <import index="jan3" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt.image(JDK/)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
     <import index="1hk2" ref="120e1c9d-4e27-4478-b2af-b2c3bd3850b0/r:81daaeb5-5b7a-4c8c-9e3c-0003a366fd18(com.mbeddr.mpsutil.editor.querylist/com.mbeddr.mpsutil.editor.querylist.behavior)" implicit="true" />
     <import index="tpce" ref="r:00000000-0000-4000-0000-011c89590292(jetbrains.mps.lang.structure.structure)" implicit="true" />
     <import index="tpcn" ref="r:00000000-0000-4000-0000-011c8959028b(jetbrains.mps.lang.structure.behavior)" implicit="true" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
-    <import index="tpco" ref="r:00000000-0000-4000-0000-011c89590284(jetbrains.mps.lang.core.editor)" implicit="true" />
-    <import index="tpen" ref="r:00000000-0000-4000-0000-011c895902c3(jetbrains.mps.baseLanguage.editor)" implicit="true" />
-    <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" implicit="true" />
-    <import index="fulz" ref="r:6f792c44-2a5d-40e8-9f05-33f7d4ae26ec(jetbrains.mps.editor.runtime.completion)" implicit="true" />
-    <import index="av1m" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.menus.style(MPS.Editor/)" implicit="true" />
   </imports>
   <registry>
     <language id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor">
@@ -31,8 +37,12 @@
       </concept>
       <concept id="1164052439493" name="jetbrains.mps.lang.editor.structure.CellMenuPart_AbstractGroup_MatchingText" flags="in" index="6VE3a" />
       <concept id="1164052588708" name="jetbrains.mps.lang.editor.structure.CellMenuPart_AbstractGroup_DescriptionText" flags="in" index="6WeAF" />
+      <concept id="1078308402140" name="jetbrains.mps.lang.editor.structure.CellModel_Custom" flags="sg" stub="8104358048506730068" index="gc7cB">
+        <child id="1176795024817" name="cellProvider" index="3YsKMw" />
+      </concept>
       <concept id="1106270549637" name="jetbrains.mps.lang.editor.structure.CellLayout_Horizontal" flags="nn" index="2iRfu4" />
       <concept id="1106270571710" name="jetbrains.mps.lang.editor.structure.CellLayout_Vertical" flags="nn" index="2iRkQZ" />
+      <concept id="1106270637846" name="jetbrains.mps.lang.editor.structure.CellLayout_Flow" flags="nn" index="2iR$Sn" />
       <concept id="1237303669825" name="jetbrains.mps.lang.editor.structure.CellLayout_Indent" flags="nn" index="l2Vlx" />
       <concept id="1237308012275" name="jetbrains.mps.lang.editor.structure.IndentLayoutNewLineStyleClassItem" flags="ln" index="ljvvj" />
       <concept id="1142886221719" name="jetbrains.mps.lang.editor.structure.QueryFunction_NodeCondition" flags="in" index="pkWqt" />
@@ -91,7 +101,7 @@
         <reference id="1381004262292426837" name="parentStyleClass" index="1k5W1q" />
       </concept>
       <concept id="772883491827578824" name="jetbrains.mps.lang.editor.structure.CompletionCustomization_CustomizeFunction" flags="ig" index="3lBaaS" />
-      <concept id="772883491827671409" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameterCustomize_CompletionItemInformation" flags="ng" index="3lBNg1" />
+      <concept id="772883491827672261" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameterCustomize_ParentNode" flags="ng" index="3lBN6P" />
       <concept id="772883491827671446" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameterCustomize_Style" flags="ng" index="3lBNjA" />
       <concept id="1223387125302" name="jetbrains.mps.lang.editor.structure.QueryFunction_Boolean" flags="in" index="3nzxsE" />
       <concept id="1165420413719" name="jetbrains.mps.lang.editor.structure.CellMenuPart_Generic_Group" flags="ng" index="1ou48o">
@@ -105,6 +115,11 @@
       </concept>
       <concept id="1165424657443" name="jetbrains.mps.lang.editor.structure.CellMenuPart_Generic_Item_Handler" flags="in" index="1oIgkG" />
       <concept id="1088185857835" name="jetbrains.mps.lang.editor.structure.InlineEditorComponent" flags="ig" index="1sVBvm" />
+      <concept id="1215007762405" name="jetbrains.mps.lang.editor.structure.FloatStyleClassItem" flags="ln" index="3$6MrZ">
+        <property id="1215007802031" name="value" index="3$6WeP" />
+      </concept>
+      <concept id="1215007883204" name="jetbrains.mps.lang.editor.structure.PaddingLeftStyleClassItem" flags="ln" index="3$7fVu" />
+      <concept id="1215007897487" name="jetbrains.mps.lang.editor.structure.PaddingRightStyleClassItem" flags="ln" index="3$7jql" />
       <concept id="1139848536355" name="jetbrains.mps.lang.editor.structure.CellModel_WithRole" flags="ng" index="1$h60E">
         <property id="1214560368769" name="emptyNoTargetText" index="39s7Ar" />
         <property id="1139852716018" name="noTargetText" index="1$x2rV" />
@@ -141,19 +156,26 @@
         <child id="1088612958265" name="ifTrueCellModel" index="1QoS34" />
         <child id="1088612973955" name="ifFalseCellModel" index="1QoVPY" />
       </concept>
+      <concept id="1176749715029" name="jetbrains.mps.lang.editor.structure.QueryFunction_CellProvider" flags="in" index="3VJUX4" />
       <concept id="1166049232041" name="jetbrains.mps.lang.editor.structure.AbstractComponent" flags="ng" index="1XWOmA">
         <reference id="1166049300910" name="conceptDeclaration" index="1XX52x" />
       </concept>
       <concept id="1176809959526" name="jetbrains.mps.lang.editor.structure.QueryFunction_Color" flags="in" index="3ZlJ5R" />
     </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
-      <concept id="1080223426719" name="jetbrains.mps.baseLanguage.structure.OrExpression" flags="nn" index="22lmx$" />
       <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
         <child id="1068498886297" name="rValue" index="37vLTx" />
         <child id="1068498886295" name="lValue" index="37vLTJ" />
       </concept>
+      <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
       <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
+      <concept id="1188207840427" name="jetbrains.mps.baseLanguage.structure.AnnotationInstance" flags="nn" index="2AHcQZ">
+        <reference id="1188208074048" name="annotation" index="2AI5Lk" />
+      </concept>
+      <concept id="1188208481402" name="jetbrains.mps.baseLanguage.structure.HasAnnotation" flags="ngI" index="2AJDlI">
+        <child id="1188208488637" name="annotation" index="2AJF6D" />
+      </concept>
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
@@ -168,22 +190,35 @@
         <child id="1137022507850" name="body" index="2VODD2" />
       </concept>
       <concept id="1070475354124" name="jetbrains.mps.baseLanguage.structure.ThisExpression" flags="nn" index="Xjq3P" />
+      <concept id="1070475587102" name="jetbrains.mps.baseLanguage.structure.SuperConstructorInvocation" flags="nn" index="XkiVB" />
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="1182160077978" name="jetbrains.mps.baseLanguage.structure.AnonymousClassCreator" flags="nn" index="YeOm9">
+        <child id="1182160096073" name="cls" index="YeSDq" />
       </concept>
       <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
       </concept>
+      <concept id="1070533707846" name="jetbrains.mps.baseLanguage.structure.StaticFieldReference" flags="nn" index="10M0yZ">
+        <reference id="1144433057691" name="classifier" index="1PxDUh" />
+      </concept>
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
+      <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
       <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
       <concept id="1068390468200" name="jetbrains.mps.baseLanguage.structure.FieldDeclaration" flags="ig" index="312cEg">
         <property id="8606350594693632173" name="isTransient" index="eg7rD" />
         <property id="1240249534625" name="isVolatile" index="34CwA1" />
       </concept>
-      <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu" />
+      <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu">
+        <child id="1165602531693" name="superclass" index="1zkMxy" />
+      </concept>
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <property id="1176718929932" name="isFinal" index="3TUv4t" />
         <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ngI" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
       </concept>
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
@@ -216,9 +251,11 @@
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
+      <concept id="1068580123140" name="jetbrains.mps.baseLanguage.structure.ConstructorDeclaration" flags="ig" index="3clFbW" />
       <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
         <property id="1068580320021" name="value" index="3cmrfH" />
       </concept>
+      <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
       <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
         <child id="1068581517676" name="expression" index="3cqZAk" />
       </concept>
@@ -235,7 +272,9 @@
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
+      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
       <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
+        <property id="521412098689998745" name="nonStatic" index="2bfB8j" />
         <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
       </concept>
       <concept id="7812454656619025412" name="jetbrains.mps.baseLanguage.structure.LocalMethodCall" flags="nn" index="1rXfSq" />
@@ -252,7 +291,19 @@
       </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
       <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
+      <concept id="1146644641414" name="jetbrains.mps.baseLanguage.structure.ProtectedVisibility" flags="nn" index="3Tmbuc" />
       <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
+      <concept id="1170345865475" name="jetbrains.mps.baseLanguage.structure.AnonymousClass" flags="ig" index="1Y3b0j">
+        <reference id="1170346070688" name="classifier" index="1Y3XeK" />
+      </concept>
+    </language>
+    <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
+      <concept id="2524418899405758586" name="jetbrains.mps.baseLanguage.closures.structure.InferredClosureParameterDeclaration" flags="ig" index="gl6BB" />
+      <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
+        <property id="890797661671409019" name="forceMultiLine" index="3yWfEV" />
+        <child id="1199569906740" name="parameter" index="1bW2Oz" />
+        <child id="1199569916463" name="body" index="1bW5cS" />
+      </concept>
     </language>
     <language id="aee9cad2-acd4-4608-aef2-0004f6a1cdbd" name="jetbrains.mps.lang.actions">
       <concept id="5979988948250981289" name="jetbrains.mps.lang.actions.structure.SNodeCreatorAndInitializer" flags="nn" index="2fJWfE" />
@@ -265,14 +316,21 @@
       <concept id="4705942098322467729" name="jetbrains.mps.lang.smodel.structure.EnumMemberReference" flags="ng" index="21nZrQ">
         <reference id="4705942098322467736" name="decl" index="21nZrZ" />
       </concept>
+      <concept id="1138411891628" name="jetbrains.mps.lang.smodel.structure.SNodeOperation" flags="nn" index="eCIE_">
+        <child id="1144104376918" name="parameter" index="1xVPHs" />
+      </concept>
       <concept id="1140725362528" name="jetbrains.mps.lang.smodel.structure.Link_SetTargetOperation" flags="nn" index="2oxUTD">
         <child id="1140725362529" name="linkTarget" index="2oxUTC" />
       </concept>
       <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
-      <concept id="2644386474300074836" name="jetbrains.mps.lang.smodel.structure.ConceptIdRefExpression" flags="nn" index="35c_gC">
-        <reference id="2644386474300074837" name="conceptDeclaration" index="35c_gD" />
+      <concept id="1173122760281" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorsOperation" flags="nn" index="z$bX8" />
+      <concept id="7504436213544206332" name="jetbrains.mps.lang.smodel.structure.Node_ContainingLinkOperation" flags="nn" index="2NL2c5" />
+      <concept id="2644386474301421077" name="jetbrains.mps.lang.smodel.structure.LinkIdRefExpression" flags="nn" index="359W_D">
+        <reference id="2644386474301421078" name="conceptDeclaration" index="359W_E" />
+        <reference id="2644386474301421079" name="linkDeclaration" index="359W_F" />
       </concept>
       <concept id="1171999116870" name="jetbrains.mps.lang.smodel.structure.Node_IsNullOperation" flags="nn" index="3w_OXm" />
+      <concept id="1144100932627" name="jetbrains.mps.lang.smodel.structure.OperationParm_Inclusion" flags="ng" index="1xIGOp" />
       <concept id="1180636770613" name="jetbrains.mps.lang.smodel.structure.SNodeCreator" flags="nn" index="3zrR0B">
         <child id="1180636770616" name="createdType" index="3zrR0E" />
       </concept>
@@ -296,12 +354,16 @@
       </concept>
     </language>
     <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
+        <child id="1204796294226" name="closure" index="23t8la" />
+      </concept>
       <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="nn" index="25WWJ4">
         <child id="540871147943773366" name="argument" index="25WWJ7" />
       </concept>
       <concept id="1151688443754" name="jetbrains.mps.baseLanguage.collections.structure.ListType" flags="in" index="_YKpA">
         <child id="1151688676805" name="elementType" index="_ZDj9" />
       </concept>
+      <concept id="1235566554328" name="jetbrains.mps.baseLanguage.collections.structure.AnyOperation" flags="nn" index="2HwmR7" />
       <concept id="1237721394592" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerCreator" flags="nn" index="HWqM0">
         <child id="1237721435808" name="initValue" index="HW$Y0" />
         <child id="1237721435807" name="elementType" index="HW$YZ" />
@@ -324,17 +386,130 @@
         <ref role="1k5W1q" to="tpc5:hF4yUZ8" resolve="header" />
       </node>
       <node concept="3F0ifn" id="T_6DrmKnTy" role="3EZMnx" />
-      <node concept="3F0ifn" id="T_6DrmK2WO" role="3EZMnx">
-        <property role="3F0ifm" value="Note: Model checking is not available for dynamically generated nodes." />
-        <node concept="Vb9p2" id="T_6DrmLbZe" role="3F10Kt" />
-        <node concept="VPXOz" id="hEUNSPq" role="3F10Kt">
-          <property role="VOm3f" value="true" />
+      <node concept="3EZMnI" id="3$DkTBDdOWn" role="3EZMnx">
+        <node concept="VPM3Z" id="3$DkTBDdOWp" role="3F10Kt" />
+        <node concept="Vb9p2" id="3$DkTBDdPNN" role="3F10Kt" />
+        <node concept="2iRkQZ" id="3$DkTBDhrih" role="2iSdaV" />
+        <node concept="3EZMnI" id="4EGFz66wLg3" role="3EZMnx">
+          <node concept="2iRfu4" id="4EGFz66wLg4" role="2iSdaV" />
+          <node concept="gc7cB" id="4EGFz66t_Hq" role="3EZMnx">
+            <node concept="3VJUX4" id="4EGFz66t_Hs" role="3YsKMw">
+              <node concept="3clFbS" id="4EGFz66t_Hu" role="2VODD2">
+                <node concept="3clFbF" id="4EGFz66E2Gb" role="3cqZAp">
+                  <node concept="2ShNRf" id="4EGFz66E2Gc" role="3clFbG">
+                    <node concept="1pGfFk" id="4EGFz66E2Gd" role="2ShVmc">
+                      <property role="373rjd" value="true" />
+                      <ref role="37wK5l" node="4EGFz66CYq0" />
+                      <node concept="pncrf" id="4EGFz66E2Ge" role="37wK5m" />
+                      <node concept="10M0yZ" id="4EGFz66uAoo" role="37wK5m">
+                        <ref role="3cqZAo" to="z2i8:~AllIcons$General.ContextHelp" resolve="ContextHelp" />
+                        <ref role="1PxDUh" to="z2i8:~AllIcons$General" resolve="General" />
+                      </node>
+                      <node concept="3cmrfG" id="4EGFz66E2Gg" role="37wK5m">
+                        <property role="3cmrfH" value="5" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3F0ifn" id="3$DkTBDdKL_" role="3EZMnx">
+            <property role="3F0ifm" value="Expressions available in the query list inline editor definition:" />
+            <node concept="Vb9p2" id="3$DkTBDeu02" role="3F10Kt" />
+            <node concept="VPM3Z" id="4EGFz66x_Yv" role="3F10Kt" />
+          </node>
         </node>
-        <node concept="30gYXW" id="hF0kJTp" role="3F10Kt">
-          <property role="Vb096" value="fLwANPq/yellow" />
+        <node concept="3EZMnI" id="3$DkTBDeuiN" role="3EZMnx">
+          <node concept="2iR$Sn" id="3$DkTBDeuiO" role="2iSdaV" />
+          <node concept="3F0ifn" id="3$DkTBDeuiP" role="3EZMnx">
+            <property role="3F0ifm" value="*" />
+            <node concept="Vb9p2" id="3$DkTBDeuiQ" role="3F10Kt" />
+            <node concept="3$7fVu" id="3$DkTBDeuiR" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="3$DkTBDeuiS" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="3$DkTBDeuiT" role="3EZMnx">
+            <property role="3F0ifm" value="queryListInput:" />
+            <node concept="3$7fVu" id="3$DkTBDeuiV" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="3$DkTBDeuiW" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="3$DkTBDeuiY" role="3EZMnx">
+            <property role="3F0ifm" value="input node of the query list" />
+            <node concept="Vb9p2" id="3$DkTBDeuiU" role="3F10Kt" />
+          </node>
         </node>
-        <node concept="30h1P$" id="hF0kJVV" role="3F10Kt">
-          <property role="Vb096" value="fLwANPt/cyan" />
+        <node concept="3EZMnI" id="3$DkTBDf4xi" role="3EZMnx">
+          <node concept="2iR$Sn" id="3$DkTBDf4xj" role="2iSdaV" />
+          <node concept="3F0ifn" id="3$DkTBDf4xk" role="3EZMnx">
+            <property role="3F0ifm" value="*" />
+            <node concept="Vb9p2" id="3$DkTBDf4xl" role="3F10Kt" />
+            <node concept="3$7fVu" id="3$DkTBDf4xm" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="3$DkTBDf4xn" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="3$DkTBDf4xo" role="3EZMnx">
+            <property role="3F0ifm" value="queryListIndex:" />
+            <node concept="3$7fVu" id="3$DkTBDf4xq" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+            <node concept="3$7jql" id="3$DkTBDf4xr" role="3F10Kt">
+              <property role="3$6WeP" value="0.5" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="3$DkTBDf4xt" role="3EZMnx">
+            <property role="3F0ifm" value="index of the current node in the query list" />
+            <node concept="Vb9p2" id="3$DkTBDf4xv" role="3F10Kt" />
+          </node>
+        </node>
+      </node>
+      <node concept="3F0ifn" id="3$DkTBDdLvL" role="3EZMnx" />
+      <node concept="3EZMnI" id="4EGFz66B62h" role="3EZMnx">
+        <node concept="2iRfu4" id="4EGFz66B62i" role="2iSdaV" />
+        <node concept="gc7cB" id="4EGFz66AcQN" role="3EZMnx">
+          <node concept="3VJUX4" id="4EGFz66AcQO" role="3YsKMw">
+            <node concept="3clFbS" id="4EGFz66AcQP" role="2VODD2">
+              <node concept="3clFbF" id="4EGFz66DiW2" role="3cqZAp">
+                <node concept="2ShNRf" id="4EGFz66DiVY" role="3clFbG">
+                  <node concept="1pGfFk" id="4EGFz66DkaF" role="2ShVmc">
+                    <property role="373rjd" value="true" />
+                    <ref role="37wK5l" node="4EGFz66CYq0" resolve="IconCell" />
+                    <node concept="pncrf" id="4EGFz66Dkc4" role="37wK5m" />
+                    <node concept="10M0yZ" id="4EGFz66DkkN" role="37wK5m">
+                      <ref role="3cqZAo" to="z2i8:~AllIcons$General.Note" resolve="Note" />
+                      <ref role="1PxDUh" to="z2i8:~AllIcons$General" resolve="AllIcons.General" />
+                    </node>
+                    <node concept="3cmrfG" id="4EGFz66DkjH" role="37wK5m">
+                      <property role="3cmrfH" value="5" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3F0ifn" id="T_6DrmK2WO" role="3EZMnx">
+          <property role="3F0ifm" value="Model checking is not available for dynamically generated nodes." />
+          <node concept="Vb9p2" id="T_6DrmLbZe" role="3F10Kt" />
+          <node concept="VPXOz" id="hEUNSPq" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+          <node concept="30gYXW" id="hF0kJTp" role="3F10Kt">
+            <property role="Vb096" value="fLwANPq/yellow" />
+          </node>
+          <node concept="30h1P$" id="hF0kJVV" role="3F10Kt">
+            <property role="Vb096" value="fLwANPt/cyan" />
+          </node>
         </node>
       </node>
       <node concept="3F0ifn" id="T_6DrmKowI" role="3EZMnx" />
@@ -2873,66 +3048,58 @@
       <node concept="2iRfu4" id="57wonSLZwSt" role="2iSdaV" />
     </node>
   </node>
-  <node concept="24kQdi" id="3YRpSuyTT6n">
-    <ref role="1XX52x" to="bbp5:1WjrBsNJ4Il" resolve="QueryListNodeExpression" />
-    <node concept="PMmxH" id="3YRpSuyTTeP" role="2wV5jI">
-      <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
-      <ref role="1k5W1q" to="tpen:hgVS8CF" resolve="KeyWord" />
-      <node concept="Vb9p2" id="2wdLO7KhY7b" role="3F10Kt">
-        <property role="Vbekb" value="g1_kEg4/ITALIC" />
-      </node>
-      <node concept="VPRnO" id="6FVg9o8F4Fd" role="3F10Kt">
-        <property role="VOm3f" value="true" />
-      </node>
-    </node>
-  </node>
-  <node concept="24kQdi" id="3YRpSuyTSH0">
-    <ref role="1XX52x" to="bbp5:3YRpSuyOe2M" resolve="QueryListIndexExpression" />
-    <node concept="PMmxH" id="3YRpSuyTSPu" role="2wV5jI">
-      <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
-      <ref role="1k5W1q" to="tpen:hgVS8CF" resolve="KeyWord" />
-      <node concept="Vb9p2" id="3YRpSuyUoTk" role="3F10Kt">
-        <property role="Vbekb" value="g1_kEg4/ITALIC" />
-      </node>
-      <node concept="VPRnO" id="3YRpSuyUoTl" role="3F10Kt">
-        <property role="VOm3f" value="true" />
-      </node>
-    </node>
-  </node>
   <node concept="3dRTYf" id="3YRpSuyTTvI">
     <property role="TrG5h" value="QueryListExpression" />
     <node concept="3Tm1VV" id="3YRpSuyTTvJ" role="1B3o_S" />
     <node concept="KNhPm" id="3YRpSuyTU2t" role="KNiz3">
-      <ref role="2RIln$" to="tpee:fz3vP1J" resolve="Expression" />
+      <ref role="2RIln$" to="bbp5:4EGFz66rZ5j" resolve="AbstractQueryListInlineEditorExpression" />
     </node>
     <node concept="3lBaaS" id="3YRpSuyTTvL" role="3l$a4r">
       <node concept="3clFbS" id="3YRpSuyTTvM" role="2VODD2">
-        <node concept="3clFbJ" id="3YRpSuyTUkL" role="3cqZAp">
-          <node concept="22lmx$" id="3YRpSuyU0pg" role="3clFbw">
-            <node concept="17R0WA" id="3YRpSuyTZAd" role="3uHU7B">
-              <node concept="2OqwBi" id="3YRpSuyTULd" role="3uHU7B">
-                <node concept="3lBNg1" id="3YRpSuyTUtI" role="2Oq$k0" />
-                <node concept="liA8E" id="3YRpSuyTV5D" role="2OqNvi">
-                  <ref role="37wK5l" to="fulz:6MqJAGngeyC" resolve="getOutputConcept" />
+        <node concept="3cpWs8" id="3$DkTBDd2Kw" role="3cqZAp">
+          <node concept="3cpWsn" id="3$DkTBDd2Kx" role="3cpWs9">
+            <property role="TrG5h" value="isInsideOfQueryListEditor" />
+            <node concept="10P_77" id="3$DkTBDd2Jh" role="1tU5fm" />
+            <node concept="2OqwBi" id="3$DkTBDd2Ky" role="33vP2m">
+              <node concept="2OqwBi" id="3$DkTBDd2Kz" role="2Oq$k0">
+                <node concept="3lBN6P" id="3$DkTBDd2K$" role="2Oq$k0" />
+                <node concept="z$bX8" id="3$DkTBDd2K_" role="2OqNvi">
+                  <node concept="1xIGOp" id="3$DkTBDd2KA" role="1xVPHs" />
                 </node>
               </node>
-              <node concept="35c_gC" id="3YRpSuyTZJF" role="3uHU7w">
-                <ref role="35c_gD" to="bbp5:3YRpSuyOe2M" resolve="QueryListIndexExpression" />
-              </node>
-            </node>
-            <node concept="17R0WA" id="3YRpSuyU0zl" role="3uHU7w">
-              <node concept="2OqwBi" id="3YRpSuyU0zm" role="3uHU7B">
-                <node concept="3lBNg1" id="3YRpSuyU0zn" role="2Oq$k0" />
-                <node concept="liA8E" id="3YRpSuyU0zo" role="2OqNvi">
-                  <ref role="37wK5l" to="fulz:6MqJAGngeyC" resolve="getOutputConcept" />
+              <node concept="2HwmR7" id="3$DkTBDd2KB" role="2OqNvi">
+                <node concept="1bVj0M" id="3$DkTBDd2KC" role="23t8la">
+                  <property role="3yWfEV" value="true" />
+                  <node concept="3clFbS" id="3$DkTBDd2KD" role="1bW5cS">
+                    <node concept="3clFbF" id="3$DkTBDd2KE" role="3cqZAp">
+                      <node concept="17R0WA" id="3$DkTBDd2KF" role="3clFbG">
+                        <node concept="2OqwBi" id="3$DkTBDd2KG" role="3uHU7B">
+                          <node concept="37vLTw" id="3$DkTBDd2KH" role="2Oq$k0">
+                            <ref role="3cqZAo" node="3$DkTBDd2KK" resolve="it" />
+                          </node>
+                          <node concept="2NL2c5" id="3$DkTBDd2KI" role="2OqNvi" />
+                        </node>
+                        <node concept="359W_D" id="3$DkTBDd2KJ" role="3uHU7w">
+                          <ref role="359W_E" to="bbp5:5oklODadopi" resolve="CellModel_QueryList" />
+                          <ref role="359W_F" to="bbp5:6hPjX46YZPG" resolve="editorComponent" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="gl6BB" id="3$DkTBDd2KK" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="3$DkTBDd2KL" role="1tU5fm" />
+                  </node>
                 </node>
-              </node>
-              <node concept="35c_gC" id="3YRpSuyU0zp" role="3uHU7w">
-                <ref role="35c_gD" to="bbp5:1WjrBsNJ4Il" resolve="QueryListNodeExpression" />
               </node>
             </node>
           </node>
-          <node concept="3clFbS" id="3YRpSuyTUkN" role="3clFbx">
+        </node>
+        <node concept="3clFbJ" id="3$DkTBDd2yw" role="3cqZAp">
+          <node concept="37vLTw" id="3$DkTBDd3u9" role="3clFbw">
+            <ref role="3cqZAo" node="3$DkTBDd2Kx" resolve="isInsideOfQueryListEditor" />
+          </node>
+          <node concept="3clFbS" id="3$DkTBDd2yy" role="3clFbx">
             <node concept="3clFbF" id="3YRpSuyU1ft" role="3cqZAp">
               <node concept="2OqwBi" id="3YRpSuyU1v9" role="3clFbG">
                 <node concept="3lBNjA" id="3YRpSuyU1fs" role="2Oq$k0" />
@@ -2947,6 +3114,310 @@
           </node>
         </node>
       </node>
+    </node>
+  </node>
+  <node concept="24kQdi" id="4EGFz66rZ5k">
+    <property role="3GE5qa" value="expressions" />
+    <ref role="1XX52x" to="bbp5:4EGFz66rZ5j" resolve="AbstractQueryListInlineEditorExpression" />
+    <node concept="PMmxH" id="3YRpSuyTSPu" role="2wV5jI">
+      <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
+      <ref role="1k5W1q" to="tpen:hgVS8CF" resolve="KeyWord" />
+      <node concept="Vb9p2" id="3YRpSuyUoTk" role="3F10Kt">
+        <property role="Vbekb" value="g1_kEg4/ITALIC" />
+      </node>
+      <node concept="VPRnO" id="3YRpSuyUoTl" role="3F10Kt">
+        <property role="VOm3f" value="true" />
+      </node>
+    </node>
+  </node>
+  <node concept="312cEu" id="4EGFz66CKB4">
+    <property role="TrG5h" value="IconCell" />
+    <node concept="2tJIrI" id="4EGFz66CSH7" role="jymVt" />
+    <node concept="312cEg" id="4EGFz66CW2L" role="jymVt">
+      <property role="TrG5h" value="icon" />
+      <node concept="3Tm6S6" id="4EGFz66CV8O" role="1B3o_S" />
+      <node concept="3uibUv" id="4EGFz66CW1h" role="1tU5fm">
+        <ref role="3uigEE" to="dxuu:~Icon" resolve="Icon" />
+      </node>
+    </node>
+    <node concept="312cEg" id="4EGFz66D8Xh" role="jymVt">
+      <property role="TrG5h" value="voffset" />
+      <node concept="3Tm6S6" id="4EGFz66D8bN" role="1B3o_S" />
+      <node concept="10Oyi0" id="4EGFz66D8VG" role="1tU5fm" />
+    </node>
+    <node concept="2tJIrI" id="4EGFz66CT56" role="jymVt" />
+    <node concept="3clFbW" id="4EGFz66CYq0" role="jymVt">
+      <node concept="3cqZAl" id="4EGFz66CYq1" role="3clF45" />
+      <node concept="3clFbS" id="4EGFz66CYq3" role="3clF47">
+        <node concept="XkiVB" id="4EGFz66D2ZG" role="3cqZAp">
+          <ref role="37wK5l" to="exr9:~AbstractCellProvider.&lt;init&gt;(org.jetbrains.mps.openapi.model.SNode)" resolve="AbstractCellProvider" />
+          <node concept="37vLTw" id="4EGFz66D3xT" role="37wK5m">
+            <ref role="3cqZAo" node="4EGFz66D32R" resolve="node" />
+          </node>
+        </node>
+        <node concept="3clFbF" id="4EGFz66CZFa" role="3cqZAp">
+          <node concept="37vLTI" id="4EGFz66D11P" role="3clFbG">
+            <node concept="37vLTw" id="4EGFz66D14Z" role="37vLTx">
+              <ref role="3cqZAo" node="4EGFz66CZdn" resolve="icon" />
+            </node>
+            <node concept="2OqwBi" id="4EGFz66D05N" role="37vLTJ">
+              <node concept="Xjq3P" id="4EGFz66CZF9" role="2Oq$k0" />
+              <node concept="2OwXpG" id="4EGFz66D0QS" role="2OqNvi">
+                <ref role="2Oxat5" node="4EGFz66CW2L" resolve="icon" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4EGFz66Da$u" role="3cqZAp">
+          <node concept="37vLTI" id="4EGFz66DedZ" role="3clFbG">
+            <node concept="37vLTw" id="4EGFz66Demw" role="37vLTx">
+              <ref role="3cqZAo" node="4EGFz66D65V" resolve="voffset" />
+            </node>
+            <node concept="2OqwBi" id="4EGFz66Db0$" role="37vLTJ">
+              <node concept="Xjq3P" id="4EGFz66Da$s" role="2Oq$k0" />
+              <node concept="2OwXpG" id="4EGFz66DbNQ" role="2OqNvi">
+                <ref role="2Oxat5" node="4EGFz66D8Xh" resolve="voffset" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="4EGFz66CYq4" role="1B3o_S" />
+      <node concept="37vLTG" id="4EGFz66D32R" role="3clF46">
+        <property role="TrG5h" value="node" />
+        <node concept="3Tqbb2" id="4EGFz66D3wD" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="4EGFz66CZdn" role="3clF46">
+        <property role="TrG5h" value="icon" />
+        <node concept="3uibUv" id="4EGFz66CZdm" role="1tU5fm">
+          <ref role="3uigEE" to="dxuu:~Icon" resolve="Icon" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="4EGFz66D65V" role="3clF46">
+        <property role="TrG5h" value="voffset" />
+        <node concept="10Oyi0" id="4EGFz66D6oY" role="1tU5fm" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="4EGFz66CT58" role="jymVt" />
+    <node concept="3clFb_" id="4EGFz66AcR0" role="jymVt">
+      <property role="TrG5h" value="createEditorCell" />
+      <node concept="3Tm1VV" id="4EGFz66AcR1" role="1B3o_S" />
+      <node concept="3uibUv" id="4EGFz66AcR2" role="3clF45">
+        <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+      </node>
+      <node concept="37vLTG" id="4EGFz66AcR3" role="3clF46">
+        <property role="TrG5h" value="context" />
+        <node concept="3uibUv" id="4EGFz66AcR4" role="1tU5fm">
+          <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="4EGFz66AcR5" role="3clF47">
+        <node concept="3clFbF" id="4EGFz66AcR6" role="3cqZAp">
+          <node concept="2ShNRf" id="4EGFz66AcR7" role="3clFbG">
+            <node concept="YeOm9" id="4EGFz66AcR8" role="2ShVmc">
+              <node concept="1Y3b0j" id="4EGFz66AcR9" role="YeSDq">
+                <property role="2bfB8j" value="true" />
+                <property role="373rjd" value="true" />
+                <ref role="1Y3XeK" to="g51k:~EditorCell_Basic" resolve="EditorCell_Basic" />
+                <ref role="37wK5l" to="g51k:~EditorCell_Basic.&lt;init&gt;(jetbrains.mps.openapi.editor.EditorContext,org.jetbrains.mps.openapi.model.SNode)" resolve="EditorCell_Basic" />
+                <node concept="3Tm1VV" id="4EGFz66AcRa" role="1B3o_S" />
+                <node concept="3clFb_" id="4EGFz66AcRb" role="jymVt">
+                  <property role="TrG5h" value="paintContent" />
+                  <node concept="3Tmbuc" id="4EGFz66AcRc" role="1B3o_S" />
+                  <node concept="3cqZAl" id="4EGFz66AcRd" role="3clF45" />
+                  <node concept="37vLTG" id="4EGFz66AcRe" role="3clF46">
+                    <property role="TrG5h" value="g" />
+                    <node concept="3uibUv" id="4EGFz66AcRf" role="1tU5fm">
+                      <ref role="3uigEE" to="z60i:~Graphics" resolve="Graphics" />
+                    </node>
+                  </node>
+                  <node concept="37vLTG" id="4EGFz66AcRg" role="3clF46">
+                    <property role="TrG5h" value="parentSettings" />
+                    <node concept="3uibUv" id="4EGFz66AcRh" role="1tU5fm">
+                      <ref role="3uigEE" to="g51k:~ParentSettings" resolve="ParentSettings" />
+                    </node>
+                  </node>
+                  <node concept="3clFbS" id="4EGFz66AcRi" role="3clF47">
+                    <node concept="3cpWs8" id="4EGFz66AcRj" role="3cqZAp">
+                      <node concept="3cpWsn" id="4EGFz66AcRk" role="3cpWs9">
+                        <property role="TrG5h" value="iconImage" />
+                        <node concept="3uibUv" id="4EGFz66AcRl" role="1tU5fm">
+                          <ref role="3uigEE" to="jan3:~BufferedImage" resolve="BufferedImage" />
+                        </node>
+                        <node concept="2ShNRf" id="4EGFz66AcRm" role="33vP2m">
+                          <node concept="1pGfFk" id="4EGFz66AcRn" role="2ShVmc">
+                            <property role="373rjd" value="true" />
+                            <ref role="37wK5l" to="jan3:~BufferedImage.&lt;init&gt;(int,int,int)" resolve="BufferedImage" />
+                            <node concept="2OqwBi" id="4EGFz66AcRo" role="37wK5m">
+                              <node concept="37vLTw" id="4EGFz66AcRp" role="2Oq$k0">
+                                <ref role="3cqZAo" node="4EGFz66CW2L" resolve="icon" />
+                              </node>
+                              <node concept="liA8E" id="4EGFz66AcRq" role="2OqNvi">
+                                <ref role="37wK5l" to="dxuu:~Icon.getIconWidth()" resolve="getIconWidth" />
+                              </node>
+                            </node>
+                            <node concept="2OqwBi" id="4EGFz66AcRr" role="37wK5m">
+                              <node concept="37vLTw" id="4EGFz66AcRs" role="2Oq$k0">
+                                <ref role="3cqZAo" node="4EGFz66CW2L" resolve="icon" />
+                              </node>
+                              <node concept="liA8E" id="4EGFz66AcRt" role="2OqNvi">
+                                <ref role="37wK5l" to="dxuu:~Icon.getIconHeight()" resolve="getIconHeight" />
+                              </node>
+                            </node>
+                            <node concept="10M0yZ" id="4EGFz66AcRu" role="37wK5m">
+                              <ref role="3cqZAo" to="jan3:~BufferedImage.TYPE_INT_ARGB" resolve="TYPE_INT_ARGB" />
+                              <ref role="1PxDUh" to="jan3:~BufferedImage" resolve="BufferedImage" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbF" id="4EGFz66AcRv" role="3cqZAp">
+                      <node concept="2OqwBi" id="4EGFz66AcRw" role="3clFbG">
+                        <node concept="37vLTw" id="4EGFz66AcRx" role="2Oq$k0">
+                          <ref role="3cqZAo" node="4EGFz66CW2L" resolve="icon" />
+                        </node>
+                        <node concept="liA8E" id="4EGFz66AcRy" role="2OqNvi">
+                          <ref role="37wK5l" to="dxuu:~Icon.paintIcon(java.awt.Component,java.awt.Graphics,int,int)" resolve="paintIcon" />
+                          <node concept="10Nm6u" id="4EGFz66AcRz" role="37wK5m" />
+                          <node concept="2OqwBi" id="4EGFz66AcR$" role="37wK5m">
+                            <node concept="37vLTw" id="4EGFz66AcR_" role="2Oq$k0">
+                              <ref role="3cqZAo" node="4EGFz66AcRk" resolve="iconImage" />
+                            </node>
+                            <node concept="liA8E" id="4EGFz66AcRA" role="2OqNvi">
+                              <ref role="37wK5l" to="jan3:~BufferedImage.getGraphics()" resolve="getGraphics" />
+                            </node>
+                          </node>
+                          <node concept="3cmrfG" id="4EGFz66AcRB" role="37wK5m">
+                            <property role="3cmrfH" value="0" />
+                          </node>
+                          <node concept="3cmrfG" id="4EGFz66AcRC" role="37wK5m">
+                            <property role="3cmrfH" value="0" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3cpWs8" id="4EGFz66AcRD" role="3cqZAp">
+                      <node concept="3cpWsn" id="4EGFz66AcRE" role="3cpWs9">
+                        <property role="TrG5h" value="parent" />
+                        <node concept="3uibUv" id="4EGFz66AcRF" role="1tU5fm">
+                          <ref role="3uigEE" to="g51k:~EditorCell_Collection" resolve="EditorCell_Collection" />
+                        </node>
+                        <node concept="2OqwBi" id="4EGFz66AcRG" role="33vP2m">
+                          <node concept="Xjq3P" id="4EGFz66AcRH" role="2Oq$k0" />
+                          <node concept="liA8E" id="4EGFz66AcRI" role="2OqNvi">
+                            <ref role="37wK5l" to="g51k:~EditorCell_Basic.getParent()" resolve="getParent" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbF" id="4EGFz66AcRJ" role="3cqZAp">
+                      <node concept="2OqwBi" id="4EGFz66AcRK" role="3clFbG">
+                        <node concept="37vLTw" id="4EGFz66AcRL" role="2Oq$k0">
+                          <ref role="3cqZAo" node="4EGFz66AcRe" resolve="g" />
+                        </node>
+                        <node concept="liA8E" id="4EGFz66AcRM" role="2OqNvi">
+                          <ref role="37wK5l" to="z60i:~Graphics.drawImage(java.awt.Image,int,int,java.awt.image.ImageObserver)" resolve="drawImage" />
+                          <node concept="37vLTw" id="4EGFz66AcRN" role="37wK5m">
+                            <ref role="3cqZAo" node="4EGFz66AcRk" resolve="iconImage" />
+                          </node>
+                          <node concept="2OqwBi" id="4EGFz66AcRO" role="37wK5m">
+                            <node concept="37vLTw" id="4EGFz66AcRP" role="2Oq$k0">
+                              <ref role="3cqZAo" node="4EGFz66AcRE" resolve="parent" />
+                            </node>
+                            <node concept="liA8E" id="4EGFz66AcRQ" role="2OqNvi">
+                              <ref role="37wK5l" to="g51k:~EditorCell_Basic.getX()" resolve="getX" />
+                            </node>
+                          </node>
+                          <node concept="3cpWs3" id="4EGFz66AcRR" role="37wK5m">
+                            <node concept="2OqwBi" id="4EGFz66AcRS" role="3uHU7B">
+                              <node concept="37vLTw" id="4EGFz66AcRT" role="2Oq$k0">
+                                <ref role="3cqZAo" node="4EGFz66AcRE" resolve="parent" />
+                              </node>
+                              <node concept="liA8E" id="4EGFz66AcRU" role="2OqNvi">
+                                <ref role="37wK5l" to="g51k:~EditorCell_Basic.getY()" resolve="getY" />
+                              </node>
+                            </node>
+                            <node concept="37vLTw" id="4EGFz66DgT5" role="3uHU7w">
+                              <ref role="3cqZAo" node="4EGFz66D8Xh" resolve="voffset" />
+                            </node>
+                          </node>
+                          <node concept="10Nm6u" id="4EGFz66AcRW" role="37wK5m" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2AHcQZ" id="4EGFz66AcRX" role="2AJF6D">
+                    <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                  </node>
+                </node>
+                <node concept="2tJIrI" id="4EGFz66AcRY" role="jymVt" />
+                <node concept="3clFb_" id="4EGFz66AcRZ" role="jymVt">
+                  <property role="TrG5h" value="relayoutImpl" />
+                  <node concept="3Tmbuc" id="4EGFz66AcS0" role="1B3o_S" />
+                  <node concept="3cqZAl" id="4EGFz66AcS1" role="3clF45" />
+                  <node concept="3clFbS" id="4EGFz66AcS2" role="3clF47">
+                    <node concept="3clFbF" id="4EGFz66AcS3" role="3cqZAp">
+                      <node concept="37vLTI" id="4EGFz66AcS4" role="3clFbG">
+                        <node concept="2OqwBi" id="4EGFz66AcS5" role="37vLTx">
+                          <node concept="37vLTw" id="4EGFz66AcS6" role="2Oq$k0">
+                            <ref role="3cqZAo" node="4EGFz66CW2L" resolve="icon" />
+                          </node>
+                          <node concept="liA8E" id="4EGFz66AcS7" role="2OqNvi">
+                            <ref role="37wK5l" to="dxuu:~Icon.getIconWidth()" resolve="getIconWidth" />
+                          </node>
+                        </node>
+                        <node concept="2OqwBi" id="4EGFz66AcS8" role="37vLTJ">
+                          <node concept="Xjq3P" id="4EGFz66AcS9" role="2Oq$k0" />
+                          <node concept="2OwXpG" id="4EGFz66AcSa" role="2OqNvi">
+                            <ref role="2Oxat5" to="g51k:~EditorCell_Basic.myWidth" resolve="myWidth" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbF" id="4EGFz66AcSb" role="3cqZAp">
+                      <node concept="37vLTI" id="4EGFz66AcSc" role="3clFbG">
+                        <node concept="2OqwBi" id="4EGFz66AcSd" role="37vLTx">
+                          <node concept="37vLTw" id="4EGFz66AcSe" role="2Oq$k0">
+                            <ref role="3cqZAo" node="4EGFz66CW2L" resolve="icon" />
+                          </node>
+                          <node concept="liA8E" id="4EGFz66AcSf" role="2OqNvi">
+                            <ref role="37wK5l" to="dxuu:~Icon.getIconWidth()" resolve="getIconWidth" />
+                          </node>
+                        </node>
+                        <node concept="2OqwBi" id="4EGFz66AcSg" role="37vLTJ">
+                          <node concept="Xjq3P" id="4EGFz66AcSh" role="2Oq$k0" />
+                          <node concept="2OwXpG" id="4EGFz66AcSi" role="2OqNvi">
+                            <ref role="2Oxat5" to="g51k:~EditorCell_Basic.myWidth" resolve="myWidth" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2AHcQZ" id="4EGFz66AcSj" role="2AJF6D">
+                    <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                  </node>
+                </node>
+                <node concept="37vLTw" id="4EGFz66AcSk" role="37wK5m">
+                  <ref role="3cqZAo" node="4EGFz66AcR3" resolve="context" />
+                </node>
+                <node concept="1rXfSq" id="4EGFz66AcSl" role="37wK5m">
+                  <ref role="37wK5l" to="exr9:~AbstractCellProvider.getSNode()" resolve="getSNode" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="4EGFz66AcSm" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="4EGFz66CKBx" role="jymVt" />
+    <node concept="2tJIrI" id="4EGFz66CKBy" role="jymVt" />
+    <node concept="3Tm1VV" id="4EGFz66CKB5" role="1B3o_S" />
+    <node concept="3uibUv" id="4EGFz66COnO" role="1zkMxy">
+      <ref role="3uigEE" to="exr9:~AbstractCellProvider" resolve="AbstractCellProvider" />
     </node>
   </node>
 </model>

--- a/code/querylist/com.mbeddr.mpsutil.editor.querylist/languageModels/structure.mps
+++ b/code/querylist/com.mbeddr.mpsutil.editor.querylist/languageModels/structure.mps
@@ -22,6 +22,7 @@
       <concept id="1169125787135" name="jetbrains.mps.lang.structure.structure.AbstractConceptDeclaration" flags="ig" index="PkWjJ">
         <property id="6714410169261853888" name="conceptId" index="EcuMT" />
         <property id="4628067390765907488" name="conceptShortDescription" index="R4oN_" />
+        <property id="4628067390765956802" name="abstract" index="R5$K7" />
         <property id="5092175715804935370" name="conceptAlias" index="34LRSv" />
         <child id="1071489727083" name="linkDeclaration" index="1TKVEi" />
         <child id="1071489727084" name="propertyDeclaration" index="1TKVEl" />
@@ -509,11 +510,12 @@
     <ref role="1TJDcQ" to="tpee:g76ryKb" resolve="ConceptFunctionParameter" />
   </node>
   <node concept="1TIwiD" id="1WjrBsNJ4Il">
-    <property role="TrG5h" value="QueryListNodeExpression" />
-    <property role="34LRSv" value="node" />
+    <property role="TrG5h" value="QueryListInputExpression" />
+    <property role="34LRSv" value="queryListInput" />
     <property role="EcuMT" value="2239254897981410197" />
-    <property role="R4oN_" value="the current queried node" />
-    <ref role="1TJDcQ" to="tpee:fz3vP1J" resolve="Expression" />
+    <property role="R4oN_" value="input node of the query list" />
+    <property role="3GE5qa" value="expressions" />
+    <ref role="1TJDcQ" node="4EGFz66rZ5j" resolve="AbstractQueryListInlineEditorExpression" />
   </node>
   <node concept="1TIwiD" id="57wonSM3yKg">
     <property role="EcuMT" value="5899822706488912912" />
@@ -534,8 +536,16 @@
   <node concept="1TIwiD" id="3YRpSuyOe2M">
     <property role="TrG5h" value="QueryListIndexExpression" />
     <property role="EcuMT" value="4591252177377353906" />
-    <property role="R4oN_" value="the index of the current queried node" />
-    <property role="34LRSv" value="index" />
+    <property role="R4oN_" value="index of the current node in the query list" />
+    <property role="34LRSv" value="queryListIndex" />
+    <property role="3GE5qa" value="expressions" />
+    <ref role="1TJDcQ" node="4EGFz66rZ5j" resolve="AbstractQueryListInlineEditorExpression" />
+  </node>
+  <node concept="1TIwiD" id="4EGFz66rZ5j">
+    <property role="EcuMT" value="5380867182533013843" />
+    <property role="TrG5h" value="AbstractQueryListInlineEditorExpression" />
+    <property role="R5$K7" value="true" />
+    <property role="3GE5qa" value="expressions" />
     <ref role="1TJDcQ" to="tpee:fz3vP1J" resolve="Expression" />
   </node>
 </model>

--- a/code/querylist/com.mbeddr.mpsutil.editor.querylist/languageModels/typesystem.mps
+++ b/code/querylist/com.mbeddr.mpsutil.editor.querylist/languageModels/typesystem.mps
@@ -151,6 +151,7 @@
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
         <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
       </concept>
       <concept id="3364660638048049745" name="jetbrains.mps.lang.core.structure.LinkAttribute" flags="ng" index="A9Btn">
@@ -322,6 +323,7 @@
   </node>
   <node concept="1YbPZF" id="1WjrBsNJ4Is">
     <property role="TrG5h" value="typeof_QueryListNodeExpression" />
+    <property role="3GE5qa" value="expressions" />
     <node concept="3clFbS" id="1WjrBsNJ4It" role="18ibNy">
       <node concept="1Z5TYs" id="1WjrBsNJ4Kr" role="3cqZAp">
         <node concept="mw_s8" id="1WjrBsNJ4KH" role="1ZfhKB">
@@ -356,11 +358,12 @@
     </node>
     <node concept="1YaCAy" id="1WjrBsNJ4Iv" role="1YuTPh">
       <property role="TrG5h" value="node" />
-      <ref role="1YaFvo" to="bbp5:1WjrBsNJ4Il" resolve="QueryListNodeExpression" />
+      <ref role="1YaFvo" to="bbp5:1WjrBsNJ4Il" resolve="QueryListInputExpression" />
     </node>
   </node>
   <node concept="1YbPZF" id="3YRpSuyOeJn">
     <property role="TrG5h" value="typeof_QueryListIndexExpression" />
+    <property role="3GE5qa" value="expressions" />
     <node concept="3clFbS" id="3YRpSuyOeJo" role="18ibNy">
       <node concept="1Z5TYs" id="3YRpSuyOfbt" role="3cqZAp">
         <node concept="mw_s8" id="3YRpSuyOfbD" role="1ZfhKB">


### PR DESCRIPTION
`QueryListNodeExpression` provides access to the input node of the query, but due to its ambiguous alias (`node`) conflicts with the `ConceptFunctionParameter_node` parameter of the query function, which makes it easy to pick up the wrong expression without directly noticing this. Also the code using both expressions at the same time becomes confusing.

Furthermore, `QueryListNodeExpression` and `QueryListIndexExpression` are currently allowed to be used outside of the querylist inline editor component, i.e. when there is no loop through the query list yet and no need for accessing index and querylist input node. Also, using the expressions in the nested querylist resulted in a wrong node and index to be returned: if used in the nested querylist query, the values were incorrectly returned for the nested querylist, but not for its owning parent querylist.

This PR provides the following changes to address the above issues:

- use unique, consolidated aliases for both expressions: `queryListInput` and `queryListIndex` 
- display short information about these available expressions in the querylist editor inspector to hint the user at this feature
- restrict usage of both expressions only inside of the querylist inline editor
- process the location of the expression (in the querylist editor or other parts of the querylist) and return the values from the correct querylist context