### PR TITLE
diagrams: make borders work in diagram boxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is *loosely* based on [Keep a Changelog](https://keepachangelog.com/e
 ### Fixed
 
 - *de.itemis.mps.editor.diagram*: An issue was fixed where edges of sub-diagrams where not correctly displayed when the diagram was first opened
+- *de.itemis.mps.editor.diagram*: Diagram boxes not properly support borders.
 
 ## January 2025
 

--- a/code/celllayout/languages/de.itemis.mps.celllayout/models/styles/editor.mps
+++ b/code/celllayout/languages/de.itemis.mps.celllayout/models/styles/editor.mps
@@ -173,6 +173,11 @@
         <ref role="3cqZAo" to="lzb2:~JBColor.LIGHT_GRAY" resolve="LIGHT_GRAY" />
       </node>
     </node>
+    <node concept="3t5Usi" id="1LTeG_mKfof" role="V601i">
+      <property role="TrG5h" value="-custom-border-painting" />
+      <node concept="10P_77" id="1LTeG_mKfoT" role="3t5Oan" />
+      <node concept="3clFbT" id="1LTeG_mKfpg" role="3t49C2" />
+    </node>
     <node concept="3t5Usi" id="2FAXvauFoRY" role="V601i">
       <property role="iBDjm" value="7zL4upErSle/simple" />
       <property role="TrG5h" value="_border-left-color" />

--- a/code/celllayout/solutions/de.slisson.mps.editor.celllayout.runtime/models/de/itemis/mps/editor/celllayout/runtime.mps
+++ b/code/celllayout/solutions/de.slisson.mps.editor.celllayout.runtime/models/de/itemis/mps/editor/celllayout/runtime.mps
@@ -15549,8 +15549,54 @@
         </node>
       </node>
       <node concept="3cqZAl" id="6SVXTgIadmj" role="3clF45" />
-      <node concept="3Tmbuc" id="6p1TdwlSH1F" role="1B3o_S" />
+      <node concept="3Tm1VV" id="1LTeG_lJTdn" role="1B3o_S" />
       <node concept="3clFbS" id="6SVXTgIadml" role="3clF47">
+        <node concept="3clFbF" id="j5ilhpVNAh" role="3cqZAp">
+          <node concept="1rXfSq" id="j5ilhpVNAg" role="3clFbG">
+            <ref role="37wK5l" node="j5ilhpVo42" resolve="paintBorders" />
+            <node concept="37vLTw" id="j5ilhpVOUu" role="37wK5m">
+              <ref role="3cqZAo" node="6SVXTgIanX8" resolve="g" />
+            </node>
+            <node concept="37vLTw" id="j5ilhpVTeV" role="37wK5m">
+              <ref role="3cqZAo" node="6SVXTgIad$c" resolve="cell" />
+            </node>
+            <node concept="3clFbT" id="j5ilhpVXzx" role="37wK5m" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="j5ilhpVffi" role="jymVt" />
+    <node concept="3clFb_" id="j5ilhpVo42" role="jymVt">
+      <property role="TrG5h" value="paintBorders" />
+      <node concept="3clFbS" id="j5ilhpVo45" role="3clF47">
+        <node concept="3clFbJ" id="1LTeG_mKjWA" role="3cqZAp">
+          <node concept="3clFbS" id="1LTeG_mKjWC" role="3clFbx">
+            <node concept="3cpWs6" id="1LTeG_mKAvC" role="3cqZAp" />
+          </node>
+          <node concept="1Wc70l" id="j5ilhpVEZK" role="3clFbw">
+            <node concept="3fqX7Q" id="j5ilhpVGHC" role="3uHU7w">
+              <node concept="37vLTw" id="j5ilhpVHYZ" role="3fr31v">
+                <ref role="3cqZAo" node="j5ilhpVxhM" resolve="isCustomPainting" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="1LTeG_mKtgc" role="3uHU7B">
+              <node concept="2OqwBi" id="1LTeG_mKqBv" role="2Oq$k0">
+                <node concept="37vLTw" id="1LTeG_mKnIQ" role="2Oq$k0">
+                  <ref role="3cqZAo" node="j5ilhpVqRe" resolve="cell" />
+                </node>
+                <node concept="liA8E" id="1LTeG_mKsjU" role="2OqNvi">
+                  <ref role="37wK5l" to="f4zo:~EditorCell.getStyle()" resolve="getStyle" />
+                </node>
+              </node>
+              <node concept="liA8E" id="1LTeG_mKy$d" role="2OqNvi">
+                <ref role="37wK5l" to="hox0:~Style.get(jetbrains.mps.openapi.editor.style.StyleAttribute)" resolve="get" />
+                <node concept="1Z6Ecs" id="1LTeG_mKzz9" role="37wK5m">
+                  <ref role="1Z6EpT" to="z0fb:1LTeG_mKfof" resolve="-custom-border-painting" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
         <node concept="3cpWs8" id="4dksFc0xtf4" role="3cqZAp">
           <node concept="3cpWsn" id="4dksFc0xtf5" role="3cpWs9">
             <property role="TrG5h" value="boxModel" />
@@ -15561,7 +15607,7 @@
               <ref role="37wK5l" to="rtot:JPngvNtXqk" resolve="getInstance" />
               <ref role="1Pybhc" to="rtot:3Osd_yxeiP0" resolve="EditorCellBoxModel" />
               <node concept="37vLTw" id="4dksFc0xtf7" role="37wK5m">
-                <ref role="3cqZAo" node="6SVXTgIad$c" resolve="cell" />
+                <ref role="3cqZAo" node="j5ilhpVqRe" resolve="cell" />
               </node>
             </node>
           </node>
@@ -15599,10 +15645,10 @@
               <node concept="1rXfSq" id="6SVXTgIaedT" role="3clFbG">
                 <ref role="37wK5l" node="6SVXTgIadNz" resolve="paintBorder" />
                 <node concept="37vLTw" id="6SVXTgIaoxS" role="37wK5m">
-                  <ref role="3cqZAo" node="6SVXTgIanX8" resolve="g" />
+                  <ref role="3cqZAo" node="j5ilhpVpDg" resolve="g" />
                 </node>
                 <node concept="37vLTw" id="6SVXTgIaejF" role="37wK5m">
-                  <ref role="3cqZAo" node="6SVXTgIad$c" resolve="cell" />
+                  <ref role="3cqZAo" node="j5ilhpVqRe" resolve="cell" />
                 </node>
               </node>
             </node>
@@ -15615,12 +15661,15 @@
                   <node concept="3clFbS" id="6SVXTgIae$B" role="2LFqv$">
                     <node concept="3clFbF" id="6SVXTgIaeIz" role="3cqZAp">
                       <node concept="1rXfSq" id="6SVXTgIaeIy" role="3clFbG">
-                        <ref role="37wK5l" node="6SVXTgIadmh" resolve="paintBorders" />
+                        <ref role="37wK5l" node="j5ilhpVo42" resolve="paintBorders" />
                         <node concept="37vLTw" id="6SVXTgIaoc0" role="37wK5m">
-                          <ref role="3cqZAo" node="6SVXTgIanX8" resolve="g" />
+                          <ref role="3cqZAo" node="j5ilhpVpDg" resolve="g" />
                         </node>
                         <node concept="2GrUjf" id="6SVXTgIaeNY" role="37wK5m">
                           <ref role="2Gs0qQ" node="6SVXTgIae$_" resolve="child" />
+                        </node>
+                        <node concept="37vLTw" id="j5ilhq09lF" role="37wK5m">
+                          <ref role="3cqZAo" node="j5ilhpVxhM" resolve="isCustomPainting" />
                         </node>
                       </node>
                     </node>
@@ -15631,7 +15680,7 @@
                         <ref role="3uigEE" to="f4zo:~EditorCell_Collection" resolve="EditorCell_Collection" />
                       </node>
                       <node concept="37vLTw" id="6SVXTgIaeCv" role="10QFUP">
-                        <ref role="3cqZAo" node="6SVXTgIad$c" resolve="cell" />
+                        <ref role="3cqZAo" node="j5ilhpVqRe" resolve="cell" />
                       </node>
                     </node>
                   </node>
@@ -15642,14 +15691,14 @@
                   <ref role="3uigEE" to="f4zo:~EditorCell_Collection" resolve="EditorCell_Collection" />
                 </node>
                 <node concept="37vLTw" id="6SVXTgIaepv" role="2ZW6bz">
-                  <ref role="3cqZAo" node="6SVXTgIad$c" resolve="cell" />
+                  <ref role="3cqZAo" node="j5ilhpVqRe" resolve="cell" />
                 </node>
               </node>
             </node>
           </node>
           <node concept="2OqwBi" id="4dksFc0xt2J" role="3clFbw">
             <node concept="37vLTw" id="4dksFc0xt0J" role="2Oq$k0">
-              <ref role="3cqZAo" node="6SVXTgIanX8" resolve="g" />
+              <ref role="3cqZAo" node="j5ilhpVpDg" resolve="g" />
             </node>
             <node concept="liA8E" id="4dksFc0xt7g" role="2OqNvi">
               <ref role="37wK5l" to="z60i:~Graphics.hitClip(int,int,int,int)" resolve="hitClip" />
@@ -15709,6 +15758,24 @@
           </node>
         </node>
       </node>
+      <node concept="3Tm1VV" id="j5ilhpVi20" role="1B3o_S" />
+      <node concept="3cqZAl" id="j5ilhpVnPt" role="3clF45" />
+      <node concept="37vLTG" id="j5ilhpVpDg" role="3clF46">
+        <property role="TrG5h" value="g" />
+        <node concept="3uibUv" id="j5ilhpVpDf" role="1tU5fm">
+          <ref role="3uigEE" to="z60i:~Graphics2D" resolve="Graphics2D" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="j5ilhpVqRe" role="3clF46">
+        <property role="TrG5h" value="cell" />
+        <node concept="3uibUv" id="j5ilhpVsip" role="1tU5fm">
+          <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="j5ilhpVxhM" role="3clF46">
+        <property role="TrG5h" value="isCustomPainting" />
+        <node concept="10P_77" id="j5ilhpVAMc" role="1tU5fm" />
+      </node>
     </node>
     <node concept="2tJIrI" id="1Vvv4A7Htil" role="jymVt" />
     <node concept="3clFb_" id="6SVXTgIadNz" role="jymVt">
@@ -15726,7 +15793,6 @@
         </node>
       </node>
       <node concept="3cqZAl" id="6SVXTgIadN_" role="3clF45" />
-      <node concept="3Tmbuc" id="6p1TdwlSH$N" role="1B3o_S" />
       <node concept="3clFbS" id="6SVXTgIadNB" role="3clF47">
         <node concept="3cpWs8" id="2FAXvauFLSQ" role="3cqZAp">
           <node concept="3cpWsn" id="2FAXvauFLSR" role="3cpWs9">
@@ -16602,6 +16668,7 @@
           </node>
         </node>
       </node>
+      <node concept="3Tmbuc" id="6p1TdwlSH$N" role="1B3o_S" />
     </node>
     <node concept="2tJIrI" id="6SVXTgIahlK" role="jymVt" />
     <node concept="3clFb_" id="6SVXTgIahvW" role="jymVt">
@@ -16708,7 +16775,7 @@
         </node>
       </node>
       <node concept="3cqZAl" id="6p1TdwlSfRw" role="3clF45" />
-      <node concept="3Tmbuc" id="6p1TdwlSINY" role="1B3o_S" />
+      <node concept="3Tm1VV" id="1LTeG_lBB94" role="1B3o_S" />
       <node concept="3clFbS" id="6p1TdwlSfRy" role="3clF47">
         <node concept="2Gpval" id="6p1TdwlSlwS" role="3cqZAp">
           <node concept="2GrKxI" id="6p1TdwlSlwU" role="2Gsz3X">

--- a/code/diagram/languages/de.itemis.mps.editor.diagram.demoentities/languageModels/editor.mps
+++ b/code/diagram/languages/de.itemis.mps.editor.diagram.demoentities/languageModels/editor.mps
@@ -15,6 +15,7 @@
     <import index="wo6c" ref="r:de91083f-90a8-4dd4-83b1-8a92d65ab81d(de.itemis.mps.editor.diagram.shapes)" />
     <import index="vgho" ref="1144260c-e9a5-49a2-9add-39a1a1a7077e/java:org.eclipse.elk.core.math(de.itemis.mps.editor.diagram.runtime/)" />
     <import index="z60i" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt(JDK/)" />
+    <import index="z0fb" ref="r:0b928dd6-dd7e-45a8-b309-a2e315b7877a(de.itemis.mps.editor.celllayout.styles.editor)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
     <import index="88j9" ref="r:20c4aa5c-ab36-4815-af32-01895ee9c2f5(de.itemis.mps.editor.diagram.editor)" implicit="true" />
     <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" implicit="true" />
@@ -504,7 +505,57 @@
       <node concept="ahg9e" id="30bR1EZsvUl" role="aCds2">
         <node concept="238au4" id="30bR1EZsvUn" role="23bJyd">
           <node concept="3EZMnI" id="30bR1EZs_2z" role="2wV5jI">
+            <node concept="3tD6jV" id="1LTeG_moNqA" role="3F10Kt">
+              <ref role="3tD7wE" to="z0fb:6SVXTgI9FWQ" resolve="_border-color" />
+              <node concept="3sjG9q" id="1LTeG_moNqB" role="3tD6jU">
+                <node concept="3clFbS" id="1LTeG_moNqC" role="2VODD2">
+                  <node concept="3clFbF" id="1LTeG_moNAB" role="3cqZAp">
+                    <node concept="10M0yZ" id="1LTeG_mC4NQ" role="3clFbG">
+                      <ref role="3cqZAo" to="z60i:~Color.LIGHT_GRAY" resolve="LIGHT_GRAY" />
+                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3tD6jV" id="1LTeG_moNBQ" role="3F10Kt">
+              <ref role="3tD7wE" to="z0fb:6SVXTgI9G1E" resolve="_border-size" />
+              <node concept="3sjG9q" id="1LTeG_moNBS" role="3tD6jU">
+                <node concept="3clFbS" id="1LTeG_moNBU" role="2VODD2">
+                  <node concept="3clFbF" id="1LTeG_moO0r" role="3cqZAp">
+                    <node concept="3cmrfG" id="1LTeG_moO0q" role="3clFbG">
+                      <property role="3cmrfH" value="2" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
             <node concept="3EZMnI" id="6OfpnAgb2CF" role="3EZMnx">
+              <node concept="3tD6jV" id="1LTeG_mBv1u" role="3F10Kt">
+                <ref role="3tD7wE" to="z0fb:2FAXvauFp1a" resolve="_border-bottom-color" />
+                <node concept="3sjG9q" id="1LTeG_mBv1v" role="3tD6jU">
+                  <node concept="3clFbS" id="1LTeG_mBv1w" role="2VODD2">
+                    <node concept="3clFbF" id="1LTeG_mBv1x" role="3cqZAp">
+                      <node concept="10M0yZ" id="1LTeG_mC3VT" role="3clFbG">
+                        <ref role="3cqZAo" to="z60i:~Color.BLACK" resolve="BLACK" />
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3tD6jV" id="1LTeG_mBv1z" role="3F10Kt">
+                <ref role="3tD7wE" to="z0fb:2FAXvauFpbi" resolve="_border-bottom-size" />
+                <node concept="3sjG9q" id="1LTeG_mBv1$" role="3tD6jU">
+                  <node concept="3clFbS" id="1LTeG_mBv1_" role="2VODD2">
+                    <node concept="3clFbF" id="1LTeG_mBv1A" role="3cqZAp">
+                      <node concept="3cmrfG" id="1LTeG_mBv1B" role="3clFbG">
+                        <property role="3cmrfH" value="1" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
               <node concept="2iRfu4" id="6OfpnAgb2CG" role="2iSdaV" />
               <node concept="3F0ifn" id="30bR1EZs_2E" role="3EZMnx">
                 <property role="3F0ifm" value="entity" />
@@ -935,9 +986,7 @@
       <node concept="pkWqt" id="6nZQGuG5umb" role="3wlkzV">
         <node concept="3clFbS" id="6nZQGuG5umc" role="2VODD2">
           <node concept="3clFbF" id="6nZQGuG5uzJ" role="3cqZAp">
-            <node concept="3clFbT" id="6nZQGuG5uzI" role="3clFbG">
-              <property role="3clFbU" value="true" />
-            </node>
+            <node concept="3clFbT" id="6nZQGuG5uzI" role="3clFbG" />
           </node>
         </node>
       </node>

--- a/code/solutions/de.itemis.mps.extensions.changelog/models/de.itemis.mps.extensions.changelog.mps
+++ b/code/solutions/de.itemis.mps.extensions.changelog/models/de.itemis.mps.extensions.changelog.mps
@@ -182,6 +182,42 @@
             <property role="3oM_SC" value="opened" />
           </node>
         </node>
+        <node concept="2DRihI" id="j5ilhq0L2l" role="15bAlk">
+          <property role="2RT3bR" value="0" />
+          <node concept="2hgSXJ" id="j5ilhq0L3m" role="1PaTwD">
+            <node concept="1PaTwC" id="j5ilhq0L3n" role="2hiFM$">
+              <node concept="15Ami3" id="j5ilhq0L3o" role="1PaTwD">
+                <node concept="37shsh" id="j5ilhq0L3p" role="15Aodc">
+                  <node concept="1dCxOk" id="j5ilhq0L3q" role="37shsm">
+                    <property role="1XweGW" value="fa13cc63-c476-4d46-9c96-d53670abe7bc" />
+                    <property role="1XxBO9" value="de.itemis.mps.editor.diagram" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3oM_SD" id="j5ilhq0L3r" role="1PaTwD">
+                <property role="3oM_SC" value=":" />
+              </node>
+            </node>
+          </node>
+          <node concept="3oM_SD" id="j5ilhq0L3w" role="1PaTwD">
+            <property role="3oM_SC" value="Diagram" />
+          </node>
+          <node concept="3oM_SD" id="j5ilhq0L3x" role="1PaTwD">
+            <property role="3oM_SC" value="boxes" />
+          </node>
+          <node concept="3oM_SD" id="j5ilhq0L3y" role="1PaTwD">
+            <property role="3oM_SC" value="not" />
+          </node>
+          <node concept="3oM_SD" id="j5ilhq0L3z" role="1PaTwD">
+            <property role="3oM_SC" value="properly" />
+          </node>
+          <node concept="3oM_SD" id="j5ilhq0L3$" role="1PaTwD">
+            <property role="3oM_SC" value="support" />
+          </node>
+          <node concept="3oM_SD" id="j5ilhq0L3_" role="1PaTwD">
+            <property role="3oM_SC" value="borders." />
+          </node>
+        </node>
       </node>
     </node>
     <node concept="15bmVD" id="1HjGWYxfrII" role="15bmVC">


### PR DESCRIPTION
<img width="359" alt="Screenshot 2025-03-05 at 10 58 50" src="https://github.com/user-attachments/assets/81899c23-532e-45cf-82db-bb579ef73244" />

There is now also a new style attribute `-custom-border-painting` to circumvent the border painter of the celllayout language. To draw the border manually, call `Borderpainter#paintBorders` with isCustomPainting set to true.

This PR should also fix https://github.com/JetBrains/MPS-extensions/issues/81 but I could only reproduce half of the issue.