### PR TITLE
Revert "make pip install work on MacOS"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -472,7 +472,7 @@ publishing {
 
 task pipInstall(type: Exec) {
     inputs.file("requirements.txt")
-    commandLine "python3", "-m", "pip", "install", "--break-system-packages", "-r", "requirements.txt"
+    commandLine "python3", "-m", "pip", "install", "-r", "requirements.txt"
 }
 
 task previewDocs(type: Exec, dependsOn: pipInstall) {


### PR DESCRIPTION
This reverts commit c8754d903ec1c4a222212a0d530ebb0de8cd2ef3.