### PR TITLE
mpsuitl.intentions.runtime: override intentions action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is *loosely* based on [Keep a Changelog](https://keepachangelog.com/e
 
 ### Fixed
 
+- *com.mbeddr.mpsutil.intentions.runtime*: An issue was fixed where the intentions menu was no longer available on read only editor cells
 - *de.itemis.mps.editor.diagram*: An issue was fixed where edges of sub-diagrams where not correctly displayed when the diagram was first opened
 - *de.itemis.mps.editor.diagram*: Diagram boxes not properly support borders.
 - *com.mbeddr.mpsutil.grammarcells*: Cells with multiple transformation texts (mainly optional cells) now match the pattern independent of the order of the elements.

--- a/code/.mps/modules.xml
+++ b/code/.mps/modules.xml
@@ -200,6 +200,7 @@
       <modulePath path="$PROJECT_DIR$/shadowmodels/solutions/test.de.q60.mps.shadowmodels.examples/test.de.q60.mps.shadowmodels.examples.msd" folder="shadowmodels.tests" />
       <modulePath path="$PROJECT_DIR$/shadowmodels/solutions/test.de.q60.mps.shadowmodels.runtime/test.de.q60.mps.shadowmodels.runtime.msd" folder="shadowmodels.tests" />
       <modulePath path="$PROJECT_DIR$/solutions/com.mbeddr.mpsutil.intentions.sandbox/com.mbeddr.mpsutil.intentions.sandbox.msd" folder="intentionsmenu" />
+      <modulePath path="$PROJECT_DIR$/solutions/com.mbeddr.mpsutil.intentions.tests/com.mbeddr.mpsutil.intentions.tests.msd" folder="intentionsmenu" />
       <modulePath path="$PROJECT_DIR$/solutions/de.itemis.model.merge.runtime/de.itemis.model.merge.runtime.msd" folder="modelmerger2" />
       <modulePath path="$PROJECT_DIR$/solutions/de.itemis.model.merge.simple.demo/de.itemis.model.merge.simple.demo.msd" folder="modelmerger2" />
       <modulePath path="$PROJECT_DIR$/solutions/de.itemis.model.merge.test.integration/de.itemis.model.merge.test.integration.msd" folder="modelmerger2" />

--- a/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
+++ b/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
@@ -23735,6 +23735,54 @@
         </node>
       </node>
     </node>
+    <node concept="2G$12M" id="2$4DgwiN5cB" role="3989C9">
+      <property role="TrG5h" value="intentions" />
+      <node concept="1E1JtA" id="2$4DgwiN5eu" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="com.mbeddr.mpsutil.intentions.tests" />
+        <property role="3LESm3" value="73a78daa-4204-43ee-8a0e-1b2b39741908" />
+        <property role="aoJFB" value="eYcmk9QOlj/sources_and_tests" />
+        <node concept="398BVA" id="2$4DgwiN5f7" role="3LF7KH">
+          <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+          <node concept="2Ry0Ak" id="2$4DgwiN5gb" role="iGT6I">
+            <property role="2Ry0Am" value="solutions" />
+            <node concept="2Ry0Ak" id="2$4DgwiN5h7" role="2Ry0An">
+              <property role="2Ry0Am" value="com.mbeddr.mpsutil.intentions.tests" />
+              <node concept="2Ry0Ak" id="2$4DgwiN5i3" role="2Ry0An">
+                <property role="2Ry0Am" value="com.mbeddr.mpsutil.intentions.tests.msd" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2$4DgwiN5F1" role="3bR37C">
+          <node concept="3bR9La" id="2$4DgwiN5F2" role="1SiIV1">
+            <ref role="3bR37D" node="4zIvKyx$cVb" resolve="com.mbeddr.mpsutil.intentions.sandboxlang" />
+          </node>
+        </node>
+        <node concept="1BupzO" id="2$4DgwiN5Fh" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="2$4DgwiN5Fi" role="1HemKq">
+            <node concept="398BVA" id="2$4DgwiN5F3" role="3LXTmr">
+              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="2$4DgwiN5F4" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="2$4DgwiN5F5" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mbeddr.mpsutil.intentions.tests" />
+                  <node concept="2Ry0Ak" id="2$4DgwiN5F6" role="2Ry0An">
+                    <property role="2Ry0Am" value="models" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="2$4DgwiN5Fj" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
     <node concept="2G$12M" id="77YfcvOSSnB" role="3989C9">
       <property role="TrG5h" value="compare" />
       <node concept="1E1JtA" id="77YfcvOTUs4" role="2G$12L">
@@ -24568,6 +24616,9 @@
       </node>
     </node>
     <node concept="1l3spV" id="6$6tsX_CF7v" role="1l3spN">
+      <node concept="L2wRC" id="2$4DgwiPi$G" role="39821P">
+        <ref role="L2wRA" node="4zIvKyx$cVb" resolve="com.mbeddr.mpsutil.intentions.sandboxlang" />
+      </node>
       <node concept="L2wRC" id="F1NWDqwjRk" role="39821P">
         <ref role="L2wRA" node="F1NWDqweoc" resolve="com.mbeddr.mpsutil.grammarcells.sandboxlang" />
       </node>
@@ -24688,6 +24739,9 @@
       <node concept="L2wRC" id="7RNWCAgHJLV" role="39821P">
         <ref role="L2wRA" node="7RNWCAgAFQn" resolve="de.itemis.model.merge.simple.demo.annotated" />
       </node>
+      <node concept="L2wRC" id="2$4DgwiN5K8" role="39821P">
+        <ref role="L2wRA" node="2$4DgwiN5eu" resolve="com.mbeddr.mpsutil.intentions.tests" />
+      </node>
       <node concept="L2wRC" id="7RNWCAgSnf2" role="39821P">
         <ref role="L2wRA" node="5Jy3PcPRnpY" resolve="de.itemis.model.merge.baselang.sandbox" />
       </node>
@@ -24761,6 +24815,9 @@
       </node>
       <node concept="22LTRM" id="2NyZxKpXdyy" role="22LTRK">
         <ref role="22LTRN" node="2NyZxKpXalh" resolve="test.ex.match" />
+      </node>
+      <node concept="22LTRM" id="2$4DgwiOpIY" role="22LTRK">
+        <ref role="22LTRN" node="2$4DgwiN5eu" resolve="com.mbeddr.mpsutil.intentions.tests" />
       </node>
       <node concept="22LTRM" id="2NyZxKpXdDc" role="22LTRK">
         <ref role="22LTRN" node="2NyZxKpX96P" resolve="test.ts.conceptswitch" />

--- a/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
+++ b/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
@@ -23781,6 +23781,22 @@
             </node>
           </node>
         </node>
+        <node concept="3rtmxn" id="LlzPqMOM6f" role="3bR31x">
+          <node concept="3LXTmp" id="LlzPqMOM6g" role="3rtmxm">
+            <node concept="3qWCbU" id="LlzPqMOM6h" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="LlzPqMOM6i" role="3LXTmr">
+              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="LlzPqMOM6j" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="LlzPqMOM6k" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mbeddr.mpsutil.intentions.tests" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
       </node>
     </node>
     <node concept="2G$12M" id="77YfcvOSSnB" role="3989C9">

--- a/code/intentionsmenu/com.mbeddr.mpsutil.intentions.runtime/com.mbeddr.mpsutil.intentions.runtime.msd
+++ b/code/intentionsmenu/com.mbeddr.mpsutil.intentions.runtime/com.mbeddr.mpsutil.intentions.runtime.msd
@@ -31,7 +31,9 @@
     <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="2" />
     <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
     <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
+    <language slang="l:acfc188d-d5d6-4598-b370-6f4a983f05b2:jetbrains.mps.baseLanguage.methodReferences" version="0" />
     <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
+    <language slang="l:63650c59-16c8-498a-99c8-005c7ee9515d:jetbrains.mps.lang.access" version="0" />
     <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
     <language slang="l:18bc6592-03a6-4e29-a83a-7ff23bde13ba:jetbrains.mps.lang.editor" version="14" />
     <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />

--- a/code/intentionsmenu/com.mbeddr.mpsutil.intentions.runtime/models/com/mbeddr/mpsutil/intentions/runtime.mps
+++ b/code/intentionsmenu/com.mbeddr.mpsutil.intentions.runtime/models/com/mbeddr/mpsutil/intentions/runtime.mps
@@ -3185,7 +3185,7 @@
       <node concept="3uibUv" id="4hHbxs9xqLU" role="1tU5fm">
         <ref role="3uigEE" to="i5cy:~AtomicReference" resolve="AtomicReference" />
         <node concept="3uibUv" id="4hHbxs9xqLV" role="11_B2D">
-          <ref role="3uigEE" node="4hHbxs9xqXT" resolve="IntentionsThread" />
+          <ref role="3uigEE" node="4hHbxs9xqXT" resolve="MyIntentionsSupport.MyIntentionsThread" />
         </node>
       </node>
       <node concept="2ShNRf" id="4hHbxs9xqOL" role="33vP2m">
@@ -3784,15 +3784,15 @@
             <property role="3TUv4t" value="true" />
             <property role="TrG5h" value="disposeListener" />
             <node concept="3uibUv" id="3DQAigeNDxE" role="1tU5fm">
-              <ref role="3uigEE" to="exr9:~EditorComponent$EditorDisposeListener" resolve="EditorDisposeListener" />
+              <ref role="3uigEE" to="exr9:~EditorComponent$EditorDisposeListener" resolve="EditorComponent.EditorDisposeListener" />
             </node>
             <node concept="2ShNRf" id="3DQAigeNGCg" role="33vP2m">
               <node concept="YeOm9" id="3DQAigeNPvy" role="2ShVmc">
                 <node concept="1Y3b0j" id="3DQAigeNPv_" role="YeSDq">
                   <property role="2bfB8j" value="true" />
                   <property role="373rjd" value="true" />
-                  <ref role="1Y3XeK" to="exr9:~EditorComponent$EditorDisposeListener" resolve="EditorDisposeListener" />
-                  <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" />
+                  <ref role="1Y3XeK" to="exr9:~EditorComponent$EditorDisposeListener" resolve="EditorComponent.EditorDisposeListener" />
+                  <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
                   <node concept="3Tm1VV" id="3DQAigeNPvA" role="1B3o_S" />
                   <node concept="3clFb_" id="3DQAigeNPvQ" role="jymVt">
                     <property role="TrG5h" value="editorWillBeDisposed" />
@@ -3857,7 +3857,7 @@
                       </node>
                     </node>
                     <node concept="2AHcQZ" id="3DQAigeNPvZ" role="2AJF6D">
-                      <ref role="2AI5Lk" to="wyt6:~Override" />
+                      <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
                     </node>
                   </node>
                 </node>
@@ -4252,7 +4252,7 @@
                               <node concept="22lmx$" id="4hHbxs9xV8B" role="3clFbw">
                                 <node concept="22lmx$" id="4hHbxs9xV8C" role="3uHU7B">
                                   <node concept="1rXfSq" id="3DQAigePpKt" role="3uHU7w">
-                                    <ref role="37wK5l" node="3DQAigePfof" resolve="areIntentionsSupported" />
+                                    <ref role="37wK5l" node="3DQAigePfof" resolve="areIntentionsNotSupported" />
                                   </node>
                                   <node concept="2OqwBi" id="4hHbxs9A2Nj" role="3uHU7B">
                                     <node concept="1rXfSq" id="4hHbxs9A2Nk" role="2Oq$k0">
@@ -4414,14 +4414,14 @@
       <node concept="37vLTG" id="4hHbxs9xM34" role="3clF46">
         <property role="TrG5h" value="thread" />
         <node concept="3uibUv" id="4hHbxs9xM35" role="1tU5fm">
-          <ref role="3uigEE" node="4hHbxs9xqXT" resolve="IntentionsThread" />
+          <ref role="3uigEE" node="4hHbxs9xqXT" resolve="MyIntentionsSupport.MyIntentionsThread" />
         </node>
       </node>
       <node concept="3clFbS" id="4hHbxs9xM36" role="3clF47">
         <node concept="3clFbF" id="4hHbxs9xM37" role="3cqZAp">
           <node concept="2OqwBi" id="4hHbxs9xNMs" role="3clFbG">
             <node concept="37vLTw" id="4hHbxs9xMs4" role="2Oq$k0">
-              <ref role="3cqZAo" node="4hHbxs9xqLS" resolve="myShowIntentionsThread" />
+              <ref role="3cqZAo" node="4hHbxs9xqLS" resolve="myShowIntentionsThreadOverwritten" />
             </node>
             <node concept="liA8E" id="4hHbxs9xNMt" role="2OqNvi">
               <ref role="37wK5l" to="i5cy:~AtomicReference.compareAndSet(java.lang.Object,java.lang.Object)" resolve="compareAndSet" />
@@ -4484,7 +4484,7 @@
               <ref role="37wK5l" to="i5cy:~AtomicReference.set(java.lang.Object)" resolve="set" />
               <node concept="2ShNRf" id="4hHbxs9Aq3K" role="37wK5m">
                 <node concept="1pGfFk" id="4hHbxs9Aq3L" role="2ShVmc">
-                  <ref role="37wK5l" node="4hHbxs9xqY0" resolve="MyIntentionsThread" />
+                  <ref role="37wK5l" node="4hHbxs9xqY0" resolve="MyIntentionsSupport.MyIntentionsThread" />
                 </node>
               </node>
             </node>
@@ -4517,7 +4517,7 @@
           <node concept="3cpWsn" id="3DQAigeOL4H" role="3cpWs9">
             <property role="TrG5h" value="thread" />
             <node concept="3uibUv" id="3DQAigeOL4J" role="1tU5fm">
-              <ref role="3uigEE" node="4hHbxs9xqXT" resolve="IntentionsThread" />
+              <ref role="3uigEE" node="4hHbxs9xqXT" resolve="MyIntentionsSupport.MyIntentionsThread" />
             </node>
             <node concept="2OqwBi" id="3DQAigeOR_N" role="33vP2m">
               <node concept="37vLTw" id="3DQAigeOMnC" role="2Oq$k0">

--- a/code/intentionsmenu/com.mbeddr.mpsutil.intentions.runtime/models/com/mbeddr/mpsutil/intentions/runtime.mps
+++ b/code/intentionsmenu/com.mbeddr.mpsutil.intentions.runtime/models/com/mbeddr/mpsutil/intentions/runtime.mps
@@ -7,6 +7,7 @@
     <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="14" />
     <use id="774bf8a0-62e5-41e1-af63-f4812e60e48b" name="jetbrains.mps.baseLanguage.checkedDots" version="0" />
     <use id="654422bf-e75f-44dc-936d-188890a746ce" name="de.slisson.mps.reflection" version="0" />
+    <use id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures" version="0" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -201,6 +202,7 @@
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
       <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
+      <concept id="1081855346303" name="jetbrains.mps.baseLanguage.structure.BreakStatement" flags="nn" index="3zACq4" />
       <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
@@ -210,6 +212,7 @@
       <concept id="1144230876926" name="jetbrains.mps.baseLanguage.structure.AbstractForStatement" flags="nn" index="1DupvO">
         <child id="1144230900587" name="variable" index="1Duv9x" />
       </concept>
+      <concept id="1082113931046" name="jetbrains.mps.baseLanguage.structure.ContinueStatement" flags="nn" index="3N13vt" />
       <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
         <child id="8356039341262087992" name="line" index="1aUNEU" />
       </concept>
@@ -426,7 +429,6 @@
       <node concept="10P_77" id="5qf1oe_zXOa" role="3clF45" />
     </node>
     <node concept="2tJIrI" id="5qf1oe_zXJT" role="jymVt" />
-    <node concept="2tJIrI" id="5qf1oe_zMRh" role="jymVt" />
     <node concept="2YIFZL" id="5qf1oe_zyw2" role="jymVt">
       <property role="TrG5h" value="isAllowIntentionsInReadOnlyCell" />
       <node concept="37vLTG" id="5qf1oe_zyw3" role="3clF46">
@@ -478,6 +480,14 @@
       </node>
       <node concept="3Tmbuc" id="2jDew64KOaK" role="1B3o_S" />
     </node>
+    <node concept="312cEg" id="26rsnFJK69q" role="jymVt">
+      <property role="TrG5h" value="intentionsSupport" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tmbuc" id="26rsnFJKhfa" role="1B3o_S" />
+      <node concept="3uibUv" id="26rsnFJK69t" role="1tU5fm">
+        <ref role="3uigEE" to="exr9:~IntentionsSupport" resolve="IntentionsSupport" />
+      </node>
+    </node>
     <node concept="2tJIrI" id="2jDew64KOaG" role="jymVt" />
     <node concept="3clFbW" id="2jDew64KaGG" role="jymVt">
       <property role="TrG5h" value="IntentionMenuProducer" />
@@ -509,30 +519,33 @@
             </node>
           </node>
         </node>
-        <node concept="3cpWs8" id="3pwG8PSnrNI" role="3cqZAp">
-          <node concept="3cpWsn" id="3pwG8PSnrNJ" role="3cpWs9">
-            <property role="TrG5h" value="intentionsSupport" />
-            <property role="3TUv4t" value="true" />
-            <node concept="3uibUv" id="3pwG8PSnrNH" role="1tU5fm">
-              <ref role="3uigEE" to="exr9:~IntentionsSupport" resolve="IntentionsSupport" />
+        <node concept="3clFbF" id="26rsnFJKlZT" role="3cqZAp">
+          <node concept="37vLTI" id="26rsnFJKJwA" role="3clFbG">
+            <node concept="2OqwBi" id="26rsnFJKqhq" role="37vLTJ">
+              <node concept="Xjq3P" id="26rsnFJKlZR" role="2Oq$k0" />
+              <node concept="2OwXpG" id="26rsnFJKwDk" role="2OqNvi">
+                <ref role="2Oxat6" node="26rsnFJK69q" resolve="intentionsSupport" />
+              </node>
             </node>
-            <node concept="2OqwBi" id="3pwG8PSnrNK" role="33vP2m">
-              <node concept="37vLTw" id="3pwG8PSnrNL" role="2Oq$k0">
+            <node concept="2OqwBi" id="26rsnFJKNQR" role="37vLTx">
+              <node concept="37vLTw" id="26rsnFJKNQS" role="2Oq$k0">
                 <ref role="3cqZAo" node="2jDew64KaGK" resolve="editor" />
               </node>
-              <node concept="1PnCL0" id="3pwG8PSnrNM" role="2OqNvi">
+              <node concept="1PnCL0" id="26rsnFJKNQT" role="2OqNvi">
                 <ref role="2Oxat5" to="exr9:~EditorComponent.myIntentionsSupport" resolve="myIntentionsSupport" />
               </node>
             </node>
           </node>
         </node>
+        <node concept="3clFbH" id="26rsnFJG04Q" role="3cqZAp" />
+        <node concept="3clFbH" id="26rsnFJMbwq" role="3cqZAp" />
         <node concept="3clFbJ" id="6JxzAvo_Ei0" role="3cqZAp">
           <node concept="3clFbS" id="6JxzAvo_Ei2" role="3clFbx">
             <node concept="3clFbF" id="3pwG8PSkQBc" role="3cqZAp">
               <node concept="37vLTI" id="3pwG8PSkQBd" role="3clFbG">
                 <node concept="2OqwBi" id="3pwG8PSnsVC" role="37vLTJ">
                   <node concept="37vLTw" id="3pwG8PSnsS$" role="2Oq$k0">
-                    <ref role="3cqZAo" node="3pwG8PSnrNJ" resolve="intentionsSupport" />
+                    <ref role="3cqZAo" node="26rsnFJK69q" resolve="intentionsSupport" />
                   </node>
                   <node concept="1PnCL0" id="3pwG8PSntaK" role="2OqNvi">
                     <ref role="2Oxat5" to="exr9:~IntentionsSupport.myLightBulb" resolve="myLightBulb" />
@@ -583,7 +596,7 @@
                                             <node concept="1rXfSq" id="3pwG8PSkQBy" role="3clFbG">
                                               <ref role="37wK5l" node="3pwG8PSkQDq" resolve="checkAndShowMenu" />
                                               <node concept="37vLTw" id="2jDew64YoyU" role="37wK5m">
-                                                <ref role="3cqZAo" node="3pwG8PSnrNJ" resolve="intentionsSupport" />
+                                                <ref role="3cqZAo" node="26rsnFJK69q" resolve="intentionsSupport" />
                                               </node>
                                             </node>
                                           </node>
@@ -610,7 +623,7 @@
               <node concept="37vLTI" id="3pwG8PSkQBT" role="3clFbG">
                 <node concept="2OqwBi" id="3pwG8PSnYh2" role="37vLTJ">
                   <node concept="37vLTw" id="3pwG8PSnYdn" role="2Oq$k0">
-                    <ref role="3cqZAo" node="3pwG8PSnrNJ" resolve="intentionsSupport" />
+                    <ref role="3cqZAo" node="26rsnFJK69q" resolve="intentionsSupport" />
                   </node>
                   <node concept="1PnCL0" id="3pwG8PSnYwH" role="2OqNvi">
                     <ref role="2Oxat5" to="exr9:~IntentionsSupport.myShowIntentionsAction" resolve="myShowIntentionsAction" />
@@ -668,7 +681,7 @@
                                             <node concept="1rXfSq" id="3pwG8PSkQCg" role="3clFbG">
                                               <ref role="37wK5l" node="3pwG8PSkQDq" resolve="checkAndShowMenu" />
                                               <node concept="37vLTw" id="2jDew64YcOp" role="37wK5m">
-                                                <ref role="3cqZAo" node="3pwG8PSnrNJ" resolve="intentionsSupport" />
+                                                <ref role="3cqZAo" node="26rsnFJK69q" resolve="intentionsSupport" />
                                               </node>
                                             </node>
                                           </node>
@@ -691,17 +704,206 @@
                 </node>
               </node>
             </node>
+            <node concept="3clFbF" id="26rsnFK8ZtP" role="3cqZAp">
+              <node concept="1rXfSq" id="26rsnFJG35t" role="3clFbG">
+                <ref role="37wK5l" node="26rsnFJEwJk" resolve="registerAction" />
+              </node>
+            </node>
           </node>
           <node concept="3y3z36" id="6JxzAvo_F3z" role="3clFbw">
             <node concept="10Nm6u" id="6JxzAvo_Fo0" role="3uHU7w" />
             <node concept="37vLTw" id="6JxzAvo_EPz" role="3uHU7B">
-              <ref role="3cqZAo" node="3pwG8PSnrNJ" resolve="intentionsSupport" />
+              <ref role="3cqZAo" node="26rsnFJK69q" resolve="intentionsSupport" />
             </node>
           </node>
         </node>
       </node>
     </node>
     <node concept="2tJIrI" id="2jDew64VROj" role="jymVt" />
+    <node concept="3clFb_" id="26rsnFJEwJk" role="jymVt">
+      <property role="TrG5h" value="overrideShowIntentionAction" />
+      <node concept="3clFbS" id="26rsnFJEwJn" role="3clF47">
+        <node concept="3cpWs8" id="26rsnFJHpbH" role="3cqZAp">
+          <node concept="3cpWsn" id="26rsnFJHpbI" role="3cpWs9">
+            <property role="TrG5h" value="myEditor" />
+            <node concept="3uibUv" id="26rsnFJHluT" role="1tU5fm">
+              <ref role="3uigEE" to="exr9:~EditorComponent" resolve="EditorComponent" />
+            </node>
+            <node concept="2OqwBi" id="26rsnFJHpbJ" role="33vP2m">
+              <node concept="Xjq3P" id="26rsnFJHpbK" role="2Oq$k0" />
+              <node concept="2OwXpG" id="26rsnFJHpbL" role="2OqNvi">
+                <ref role="2Oxat6" node="2jDew64KOaH" resolve="editor" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="26rsnFJTBHW" role="3cqZAp" />
+        <node concept="3cpWs8" id="26rsnFJFlSH" role="3cqZAp">
+          <node concept="3cpWsn" id="26rsnFJFlSG" role="3cpWs9">
+            <property role="3TUv4t" value="true" />
+            <property role="TrG5h" value="ideaActionRegistration" />
+            <node concept="3uibUv" id="26rsnFJFlSI" role="1tU5fm">
+              <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
+            </node>
+            <node concept="2OqwBi" id="26rsnFJFC7b" role="33vP2m">
+              <node concept="2YIFZM" id="26rsnFJFq48" role="2Oq$k0">
+                <ref role="1Pybhc" to="qkt:~ActionManager" resolve="ActionManager" />
+                <ref role="37wK5l" to="qkt:~ActionManager.getInstance()" resolve="getInstance" />
+              </node>
+              <node concept="liA8E" id="26rsnFJFC7c" role="2OqNvi">
+                <ref role="37wK5l" to="qkt:~ActionManager.getActionOrStub(java.lang.String)" resolve="getActionOrStub" />
+                <node concept="10M0yZ" id="26rsnFJGbh7" role="37wK5m">
+                  <ref role="3cqZAo" to="qq03:~MPSActions.EDITOR_SHOW_INTENTIONS_POPUP_ACTION" resolve="EDITOR_SHOW_INTENTIONS_POPUP_ACTION" />
+                  <ref role="1PxDUh" to="qq03:~MPSActions" resolve="MPSActions" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="26rsnFJFlSN" role="3cqZAp">
+          <node concept="3cpWsn" id="26rsnFJFlSM" role="3cpWs9">
+            <property role="TrG5h" value="firstKeyStroke" />
+            <node concept="3uibUv" id="26rsnFJFlSO" role="1tU5fm">
+              <ref role="3uigEE" to="dxuu:~KeyStroke" resolve="KeyStroke" />
+            </node>
+            <node concept="10Nm6u" id="26rsnFJFlSP" role="33vP2m" />
+          </node>
+        </node>
+        <node concept="1DcWWT" id="26rsnFJFlSQ" role="3cqZAp">
+          <node concept="2OqwBi" id="26rsnFJFKe7" role="1DdaDG">
+            <node concept="2OqwBi" id="26rsnFJF$ax" role="2Oq$k0">
+              <node concept="37vLTw" id="26rsnFJFtZH" role="2Oq$k0">
+                <ref role="3cqZAo" node="26rsnFJFlSG" resolve="ideaActionRegistration" />
+              </node>
+              <node concept="liA8E" id="26rsnFJF$ay" role="2OqNvi">
+                <ref role="37wK5l" to="qkt:~AnAction.getShortcutSet()" resolve="getShortcutSet" />
+              </node>
+            </node>
+            <node concept="liA8E" id="26rsnFJFKe8" role="2OqNvi">
+              <ref role="37wK5l" to="qkt:~ShortcutSet.getShortcuts()" resolve="getShortcuts" />
+            </node>
+          </node>
+          <node concept="3cpWsn" id="26rsnFJFlTe" role="1Duv9x">
+            <property role="TrG5h" value="shortcut" />
+            <node concept="3uibUv" id="26rsnFJFlTg" role="1tU5fm">
+              <ref role="3uigEE" to="qkt:~Shortcut" resolve="Shortcut" />
+            </node>
+          </node>
+          <node concept="3clFbS" id="26rsnFJFlSS" role="2LFqv$">
+            <node concept="3clFbJ" id="26rsnFJFlST" role="3cqZAp">
+              <node concept="3fqX7Q" id="26rsnFJFlSU" role="3clFbw">
+                <node concept="2OqwBi" id="26rsnFJFEB$" role="3fr31v">
+                  <node concept="37vLTw" id="26rsnFJFtYQ" role="2Oq$k0">
+                    <ref role="3cqZAo" node="26rsnFJFlTe" resolve="shortcut" />
+                  </node>
+                  <node concept="liA8E" id="26rsnFJFEB_" role="2OqNvi">
+                    <ref role="37wK5l" to="qkt:~Shortcut.isKeyboard()" resolve="isKeyboard" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbS" id="26rsnFJFlSX" role="3clFbx">
+                <node concept="3N13vt" id="26rsnFJFlSY" role="3cqZAp" />
+              </node>
+            </node>
+            <node concept="3clFbJ" id="26rsnFJFlSZ" role="3cqZAp">
+              <node concept="2ZW3vV" id="26rsnFJFlT2" role="3clFbw">
+                <node concept="37vLTw" id="26rsnFJFlT0" role="2ZW6bz">
+                  <ref role="3cqZAo" node="26rsnFJFlTe" resolve="shortcut" />
+                </node>
+                <node concept="3uibUv" id="26rsnFJFlT1" role="2ZW6by">
+                  <ref role="3uigEE" to="qkt:~KeyboardShortcut" resolve="KeyboardShortcut" />
+                </node>
+              </node>
+              <node concept="3clFbS" id="26rsnFJFlT4" role="3clFbx">
+                <node concept="3clFbF" id="26rsnFJFlT5" role="3cqZAp">
+                  <node concept="37vLTI" id="26rsnFJFlT6" role="3clFbG">
+                    <node concept="37vLTw" id="26rsnFJFlT7" role="37vLTJ">
+                      <ref role="3cqZAo" node="26rsnFJFlSM" resolve="firstKeyStroke" />
+                    </node>
+                    <node concept="2OqwBi" id="26rsnFJFtYL" role="37vLTx">
+                      <node concept="1eOMI4" id="26rsnFJFlTc" role="2Oq$k0">
+                        <node concept="10QFUN" id="26rsnFJFlT9" role="1eOMHV">
+                          <node concept="37vLTw" id="26rsnFJFlTa" role="10QFUP">
+                            <ref role="3cqZAo" node="26rsnFJFlTe" resolve="shortcut" />
+                          </node>
+                          <node concept="3uibUv" id="26rsnFJFlTb" role="10QFUM">
+                            <ref role="3uigEE" to="qkt:~KeyboardShortcut" resolve="KeyboardShortcut" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="liA8E" id="26rsnFJFtYM" role="2OqNvi">
+                        <ref role="37wK5l" to="qkt:~KeyboardShortcut.getFirstKeyStroke()" resolve="getFirstKeyStroke" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3zACq4" id="26rsnFJFlTd" role="3cqZAp" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3SKdUt" id="26rsnFJFlTu" role="3cqZAp">
+          <node concept="1PaTwC" id="26rsnFJFlTv" role="1aUNEU">
+            <node concept="3oM_SD" id="26rsnFJFlTw" role="1PaTwD">
+              <property role="3oM_SC" value="fallback" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="26rsnFJFlTj" role="3cqZAp">
+          <node concept="3clFbC" id="26rsnFJFlTk" role="3clFbw">
+            <node concept="37vLTw" id="26rsnFJFlTl" role="3uHU7B">
+              <ref role="3cqZAo" node="26rsnFJFlSM" resolve="firstKeyStroke" />
+            </node>
+            <node concept="10Nm6u" id="26rsnFJFlTm" role="3uHU7w" />
+          </node>
+          <node concept="3clFbS" id="26rsnFJFlTo" role="3clFbx">
+            <node concept="3clFbF" id="26rsnFJFlTp" role="3cqZAp">
+              <node concept="37vLTI" id="26rsnFJFlTq" role="3clFbG">
+                <node concept="37vLTw" id="26rsnFJFlTr" role="37vLTJ">
+                  <ref role="3cqZAo" node="26rsnFJFlSM" resolve="firstKeyStroke" />
+                </node>
+                <node concept="2YIFZM" id="26rsnFJFtYV" role="37vLTx">
+                  <ref role="1Pybhc" to="dxuu:~KeyStroke" resolve="KeyStroke" />
+                  <ref role="37wK5l" to="dxuu:~KeyStroke.getKeyStroke(java.lang.String)" resolve="getKeyStroke" />
+                  <node concept="Xl_RD" id="26rsnFJFtYW" role="37wK5m">
+                    <property role="Xl_RC" value="alt ENTER" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="26rsnFKcTkk" role="3cqZAp" />
+        <node concept="3clFbF" id="26rsnFJHWbn" role="3cqZAp">
+          <node concept="2OqwBi" id="26rsnFJIdxo" role="3clFbG">
+            <node concept="37vLTw" id="26rsnFJI7v6" role="2Oq$k0">
+              <ref role="3cqZAo" node="26rsnFJHpbI" resolve="myEditor" />
+            </node>
+            <node concept="liA8E" id="26rsnFJIdxp" role="2OqNvi">
+              <ref role="37wK5l" to="dxuu:~JComponent.registerKeyboardAction(java.awt.event.ActionListener,javax.swing.KeyStroke,int)" resolve="registerKeyboardAction" />
+              <node concept="2OqwBi" id="26rsnFKcu1C" role="37wK5m">
+                <node concept="37vLTw" id="26rsnFKcu1D" role="2Oq$k0">
+                  <ref role="3cqZAo" node="26rsnFJK69q" resolve="intentionsSupport" />
+                </node>
+                <node concept="1PnCL0" id="26rsnFKcu1E" role="2OqNvi">
+                  <ref role="2Oxat5" to="exr9:~IntentionsSupport.myShowIntentionsAction" resolve="myShowIntentionsAction" />
+                </node>
+              </node>
+              <node concept="37vLTw" id="26rsnFJIdxu" role="37wK5m">
+                <ref role="3cqZAo" node="26rsnFJFlSM" resolve="firstKeyStroke" />
+              </node>
+              <node concept="10M0yZ" id="26rsnFJIdxv" role="37wK5m">
+                <ref role="1PxDUh" to="dxuu:~JComponent" resolve="JComponent" />
+                <ref role="3cqZAo" to="dxuu:~JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT" resolve="WHEN_ANCESTOR_OF_FOCUSED_COMPONENT" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="26rsnFJEnWb" role="1B3o_S" />
+      <node concept="3cqZAl" id="26rsnFJEwyD" role="3clF45" />
+    </node>
+    <node concept="2tJIrI" id="26rsnFJEett" role="jymVt" />
     <node concept="3clFb_" id="3pwG8PSkQDq" role="jymVt">
       <property role="TrG5h" value="checkAndShowMenu" />
       <property role="DiZV1" value="false" />

--- a/code/intentionsmenu/com.mbeddr.mpsutil.intentions.runtime/models/com/mbeddr/mpsutil/intentions/runtime.mps
+++ b/code/intentionsmenu/com.mbeddr.mpsutil.intentions.runtime/models/com/mbeddr/mpsutil/intentions/runtime.mps
@@ -8,6 +8,8 @@
     <use id="774bf8a0-62e5-41e1-af63-f4812e60e48b" name="jetbrains.mps.baseLanguage.checkedDots" version="0" />
     <use id="654422bf-e75f-44dc-936d-188890a746ce" name="de.slisson.mps.reflection" version="0" />
     <use id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures" version="0" />
+    <use id="acfc188d-d5d6-4598-b370-6f4a983f05b2" name="jetbrains.mps.baseLanguage.methodReferences" version="0" />
+    <use id="63650c59-16c8-498a-99c8-005c7ee9515d" name="jetbrains.mps.lang.access" version="0" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -41,6 +43,11 @@
     <import index="uxaq" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.editor.intentions(MPS.Editor/)" />
     <import index="hyam" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt.event(JDK/)" />
     <import index="w1kc" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel(MPS.Core/)" />
+    <import index="i5cy" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util.concurrent.atomic(JDK/)" />
+    <import index="bd8o" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.application(MPS.IDEA/)" />
+    <import index="ev0w" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.typechecking.backend(MPS.Core/)" />
+    <import index="z60i" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt(JDK/)" />
+    <import index="7oz1" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor.configuration(MPS.Editor/)" />
   </imports>
   <registry>
     <language id="654422bf-e75f-44dc-936d-188890a746ce" name="de.slisson.mps.reflection">
@@ -55,6 +62,10 @@
       </concept>
     </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1224071154655" name="jetbrains.mps.baseLanguage.structure.AsExpression" flags="nn" index="0kSF2">
+        <child id="1224071154657" name="classifierType" index="0kSFW" />
+        <child id="1224071154656" name="expression" index="0kSFX" />
+      </concept>
       <concept id="1080223426719" name="jetbrains.mps.baseLanguage.structure.OrExpression" flags="nn" index="22lmx$" />
       <concept id="1082485599095" name="jetbrains.mps.baseLanguage.structure.BlockStatement" flags="nn" index="9aQIb">
         <child id="1082485599096" name="statements" index="9aQI4" />
@@ -65,12 +76,22 @@
       </concept>
       <concept id="1153417849900" name="jetbrains.mps.baseLanguage.structure.GreaterThanOrEqualsExpression" flags="nn" index="2d3UOw" />
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="8118189177080264853" name="jetbrains.mps.baseLanguage.structure.AlternativeType" flags="ig" index="nSUau">
+        <child id="8118189177080264854" name="alternative" index="nSUat" />
+      </concept>
       <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
+      <concept id="1173175405605" name="jetbrains.mps.baseLanguage.structure.ArrayAccessExpression" flags="nn" index="AH0OO">
+        <child id="1173175577737" name="index" index="AHEQo" />
+        <child id="1173175590490" name="array" index="AHHXb" />
+      </concept>
       <concept id="1188207840427" name="jetbrains.mps.baseLanguage.structure.AnnotationInstance" flags="nn" index="2AHcQZ">
         <reference id="1188208074048" name="annotation" index="2AI5Lk" />
       </concept>
       <concept id="1188208481402" name="jetbrains.mps.baseLanguage.structure.HasAnnotation" flags="ngI" index="2AJDlI">
         <child id="1188208488637" name="annotation" index="2AJF6D" />
+      </concept>
+      <concept id="1188220165133" name="jetbrains.mps.baseLanguage.structure.ArrayLiteral" flags="nn" index="2BsdOp">
+        <child id="1188220173759" name="item" index="2BsfMF" />
       </concept>
       <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
         <child id="1154032183016" name="body" index="2LFqv$" />
@@ -82,6 +103,10 @@
       <concept id="1197029447546" name="jetbrains.mps.baseLanguage.structure.FieldReferenceOperation" flags="nn" index="2OwXpG">
         <reference id="1197029500499" name="fieldDeclaration" index="2Oxat6" />
       </concept>
+      <concept id="1083260308424" name="jetbrains.mps.baseLanguage.structure.EnumConstantReference" flags="nn" index="Rm8GO">
+        <reference id="1083260308426" name="enumConstantDeclaration" index="Rm8GQ" />
+        <reference id="1144432896254" name="enumClass" index="1Px2BO" />
+      </concept>
       <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
         <child id="1145553007750" name="creator" index="2ShVmc" />
       </concept>
@@ -91,6 +116,7 @@
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
       </concept>
+      <concept id="4952749571008284462" name="jetbrains.mps.baseLanguage.structure.CatchVariable" flags="ng" index="XOnhg" />
       <concept id="1182160077978" name="jetbrains.mps.baseLanguage.structure.AnonymousClassCreator" flags="nn" index="YeOm9">
         <child id="1182160096073" name="cls" index="YeSDq" />
       </concept>
@@ -108,6 +134,9 @@
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
       <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
       <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
+      <concept id="1070534760951" name="jetbrains.mps.baseLanguage.structure.ArrayType" flags="in" index="10Q1$e">
+        <child id="1070534760952" name="componentType" index="10Q1$1" />
+      </concept>
       <concept id="1070534934090" name="jetbrains.mps.baseLanguage.structure.CastExpression" flags="nn" index="10QFUN">
         <child id="1070534934091" name="type" index="10QFUM" />
         <child id="1070534934092" name="expression" index="10QFUP" />
@@ -124,6 +153,9 @@
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <property id="1176718929932" name="isFinal" index="3TUv4t" />
         <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ngI" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
       </concept>
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
@@ -201,6 +233,13 @@
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
+      <concept id="3093926081414150598" name="jetbrains.mps.baseLanguage.structure.MultipleCatchClause" flags="ng" index="3uVAMA">
+        <child id="8276990574895933173" name="catchBody" index="1zc67A" />
+        <child id="8276990574895933172" name="throwable" index="1zc67B" />
+      </concept>
+      <concept id="8276990574909231788" name="jetbrains.mps.baseLanguage.structure.FinallyClause" flags="ng" index="1wplmZ">
+        <child id="8276990574909234106" name="finallyBody" index="1wplMD" />
+      </concept>
       <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
       <concept id="1081855346303" name="jetbrains.mps.baseLanguage.structure.BreakStatement" flags="nn" index="3zACq4" />
       <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
@@ -212,11 +251,22 @@
       <concept id="1144230876926" name="jetbrains.mps.baseLanguage.structure.AbstractForStatement" flags="nn" index="1DupvO">
         <child id="1144230900587" name="variable" index="1Duv9x" />
       </concept>
+      <concept id="5351203823916750322" name="jetbrains.mps.baseLanguage.structure.TryUniversalStatement" flags="nn" index="3J1_TO">
+        <child id="8276990574886367510" name="catchClause" index="1zxBo5" />
+        <child id="8276990574886367509" name="finallyClause" index="1zxBo6" />
+        <child id="8276990574886367508" name="body" index="1zxBo7" />
+      </concept>
+      <concept id="1163668896201" name="jetbrains.mps.baseLanguage.structure.TernaryOperatorExpression" flags="nn" index="3K4zz7">
+        <child id="1163668914799" name="condition" index="3K4Cdx" />
+        <child id="1163668922816" name="ifTrue" index="3K4E3e" />
+        <child id="1163668934364" name="ifFalse" index="3K4GZi" />
+      </concept>
       <concept id="1082113931046" name="jetbrains.mps.baseLanguage.structure.ContinueStatement" flags="nn" index="3N13vt" />
       <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
         <child id="8356039341262087992" name="line" index="1aUNEU" />
       </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+      <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
       <concept id="1146644641414" name="jetbrains.mps.baseLanguage.structure.ProtectedVisibility" flags="nn" index="3Tmbuc" />
       <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
       <concept id="1170345865475" name="jetbrains.mps.baseLanguage.structure.AnonymousClass" flags="ig" index="1Y3b0j">
@@ -224,14 +274,24 @@
         <child id="1201186121363" name="typeParameter" index="2Ghqu4" />
       </concept>
     </language>
+    <language id="63650c59-16c8-498a-99c8-005c7ee9515d" name="jetbrains.mps.lang.access">
+      <concept id="8974276187400348173" name="jetbrains.mps.lang.access.structure.CommandClosureLiteral" flags="nn" index="1QHqEC" />
+      <concept id="8974276187400348170" name="jetbrains.mps.lang.access.structure.BaseExecuteCommandStatement" flags="nn" index="1QHqEJ">
+        <child id="1423104411234567454" name="repo" index="ukAjM" />
+        <child id="8974276187400348171" name="commandClosureLiteral" index="1QHqEI" />
+      </concept>
+      <concept id="8974276187400348181" name="jetbrains.mps.lang.access.structure.ExecuteLightweightCommandStatement" flags="nn" index="1QHqEK" />
+    </language>
     <language id="774bf8a0-62e5-41e1-af63-f4812e60e48b" name="jetbrains.mps.baseLanguage.checkedDots">
       <concept id="4079382982702596667" name="jetbrains.mps.baseLanguage.checkedDots.structure.CheckedDotExpression" flags="nn" index="2EnYce" />
     </language>
     <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
       <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
         <property id="890797661671409019" name="forceMultiLine" index="3yWfEV" />
+        <child id="1199569906740" name="parameter" index="1bW2Oz" />
         <child id="1199569916463" name="body" index="1bW5cS" />
       </concept>
+      <concept id="8992394414545679616" name="jetbrains.mps.baseLanguage.closures.structure.ClosureVarType" flags="ig" index="3VYd8j" />
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
       <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
@@ -537,451 +597,8 @@
             </node>
           </node>
         </node>
-        <node concept="3clFbH" id="26rsnFJG04Q" role="3cqZAp" />
-        <node concept="3clFbH" id="26rsnFJMbwq" role="3cqZAp" />
-        <node concept="3clFbJ" id="6JxzAvo_Ei0" role="3cqZAp">
-          <node concept="3clFbS" id="6JxzAvo_Ei2" role="3clFbx">
-            <node concept="3clFbF" id="3pwG8PSkQBc" role="3cqZAp">
-              <node concept="37vLTI" id="3pwG8PSkQBd" role="3clFbG">
-                <node concept="2OqwBi" id="3pwG8PSnsVC" role="37vLTJ">
-                  <node concept="37vLTw" id="3pwG8PSnsS$" role="2Oq$k0">
-                    <ref role="3cqZAo" node="26rsnFJK69q" resolve="intentionsSupport" />
-                  </node>
-                  <node concept="1PnCL0" id="3pwG8PSntaK" role="2OqNvi">
-                    <ref role="2Oxat5" to="exr9:~IntentionsSupport.myLightBulb" resolve="myLightBulb" />
-                  </node>
-                </node>
-                <node concept="2ShNRf" id="3pwG8PSkQBf" role="37vLTx">
-                  <node concept="YeOm9" id="3pwG8PSkQBg" role="2ShVmc">
-                    <node concept="1Y3b0j" id="3pwG8PSkQBh" role="YeSDq">
-                      <property role="2bfB8j" value="true" />
-                      <property role="1sVAO0" value="false" />
-                      <property role="1EXbeo" value="false" />
-                      <ref role="1Y3XeK" to="91lp:~LightBulbMenu" resolve="LightBulbMenu" />
-                      <ref role="37wK5l" to="91lp:~LightBulbMenu.&lt;init&gt;()" resolve="LightBulbMenu" />
-                      <node concept="3Tm1VV" id="3pwG8PSkQBi" role="1B3o_S" />
-                      <node concept="3clFb_" id="3pwG8PSkQBj" role="jymVt">
-                        <property role="TrG5h" value="activate" />
-                        <property role="DiZV1" value="false" />
-                        <property role="od$2w" value="false" />
-                        <node concept="2AHcQZ" id="3pwG8PSkQBk" role="2AJF6D">
-                          <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-                        </node>
-                        <node concept="3clFbS" id="3pwG8PSkQBl" role="3clF47">
-                          <node concept="3clFbF" id="3pwG8PSkQBm" role="3cqZAp">
-                            <node concept="2OqwBi" id="3pwG8PSkQBn" role="3clFbG">
-                              <node concept="1rXfSq" id="3pwG8PSkQBo" role="2Oq$k0">
-                                <ref role="37wK5l" node="3pwG8PSkQQM" resolve="getModelAccess" />
-                              </node>
-                              <node concept="liA8E" id="3pwG8PSkQBp" role="2OqNvi">
-                                <ref role="37wK5l" to="lui2:~ModelAccess.runReadAction(java.lang.Runnable)" resolve="runReadAction" />
-                                <node concept="2ShNRf" id="3pwG8PSkQBq" role="37wK5m">
-                                  <node concept="YeOm9" id="3pwG8PSkQBr" role="2ShVmc">
-                                    <node concept="1Y3b0j" id="3pwG8PSkQBs" role="YeSDq">
-                                      <property role="2bfB8j" value="true" />
-                                      <property role="1sVAO0" value="false" />
-                                      <property role="1EXbeo" value="false" />
-                                      <ref role="1Y3XeK" to="wyt6:~Runnable" resolve="Runnable" />
-                                      <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
-                                      <node concept="3Tm1VV" id="3pwG8PSkQBt" role="1B3o_S" />
-                                      <node concept="3clFb_" id="3pwG8PSkQBu" role="jymVt">
-                                        <property role="TrG5h" value="run" />
-                                        <property role="DiZV1" value="false" />
-                                        <property role="od$2w" value="false" />
-                                        <node concept="2AHcQZ" id="3pwG8PSkQBv" role="2AJF6D">
-                                          <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-                                        </node>
-                                        <node concept="3clFbS" id="3pwG8PSkQBw" role="3clF47">
-                                          <node concept="3clFbF" id="3pwG8PSkQBx" role="3cqZAp">
-                                            <node concept="1rXfSq" id="3pwG8PSkQBy" role="3clFbG">
-                                              <ref role="37wK5l" node="3pwG8PSkQDq" resolve="checkAndShowMenu" />
-                                              <node concept="37vLTw" id="2jDew64YoyU" role="37wK5m">
-                                                <ref role="3cqZAo" node="26rsnFJK69q" resolve="intentionsSupport" />
-                                              </node>
-                                            </node>
-                                          </node>
-                                        </node>
-                                        <node concept="3Tm1VV" id="3pwG8PSkQBz" role="1B3o_S" />
-                                        <node concept="3cqZAl" id="3pwG8PSkQB$" role="3clF45" />
-                                      </node>
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="3Tm1VV" id="3pwG8PSkQB_" role="1B3o_S" />
-                        <node concept="3cqZAl" id="3pwG8PSkQBA" role="3clF45" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbF" id="3pwG8PSkQBS" role="3cqZAp">
-              <node concept="37vLTI" id="3pwG8PSkQBT" role="3clFbG">
-                <node concept="2OqwBi" id="3pwG8PSnYh2" role="37vLTJ">
-                  <node concept="37vLTw" id="3pwG8PSnYdn" role="2Oq$k0">
-                    <ref role="3cqZAo" node="26rsnFJK69q" resolve="intentionsSupport" />
-                  </node>
-                  <node concept="1PnCL0" id="3pwG8PSnYwH" role="2OqNvi">
-                    <ref role="2Oxat5" to="exr9:~IntentionsSupport.myShowIntentionsAction" resolve="myShowIntentionsAction" />
-                  </node>
-                </node>
-                <node concept="2ShNRf" id="3pwG8PSkQBV" role="37vLTx">
-                  <node concept="YeOm9" id="3pwG8PSkQBW" role="2ShVmc">
-                    <node concept="1Y3b0j" id="3pwG8PSkQBX" role="YeSDq">
-                      <property role="2bfB8j" value="true" />
-                      <property role="1sVAO0" value="false" />
-                      <property role="1EXbeo" value="false" />
-                      <ref role="1Y3XeK" to="dxuu:~AbstractAction" resolve="AbstractAction" />
-                      <ref role="37wK5l" to="dxuu:~AbstractAction.&lt;init&gt;()" resolve="AbstractAction" />
-                      <node concept="3Tm1VV" id="3pwG8PSkQBY" role="1B3o_S" />
-                      <node concept="3clFb_" id="3pwG8PSkQBZ" role="jymVt">
-                        <property role="TrG5h" value="actionPerformed" />
-                        <property role="DiZV1" value="false" />
-                        <property role="od$2w" value="false" />
-                        <node concept="2AHcQZ" id="3pwG8PSkQC0" role="2AJF6D">
-                          <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-                        </node>
-                        <node concept="37vLTG" id="3pwG8PSkQC1" role="3clF46">
-                          <property role="TrG5h" value="e" />
-                          <property role="3TUv4t" value="false" />
-                          <node concept="3uibUv" id="3pwG8PSkQC2" role="1tU5fm">
-                            <ref role="3uigEE" to="hyam:~ActionEvent" resolve="ActionEvent" />
-                          </node>
-                        </node>
-                        <node concept="3clFbS" id="3pwG8PSkQC3" role="3clF47">
-                          <node concept="3clFbF" id="3pwG8PSkQC4" role="3cqZAp">
-                            <node concept="2OqwBi" id="3pwG8PSkQC5" role="3clFbG">
-                              <node concept="1rXfSq" id="3pwG8PSkQC6" role="2Oq$k0">
-                                <ref role="37wK5l" node="3pwG8PSkQQM" resolve="getModelAccess" />
-                              </node>
-                              <node concept="liA8E" id="3pwG8PSkQC7" role="2OqNvi">
-                                <ref role="37wK5l" to="lui2:~ModelAccess.runReadAction(java.lang.Runnable)" resolve="runReadAction" />
-                                <node concept="2ShNRf" id="3pwG8PSkQC8" role="37wK5m">
-                                  <node concept="YeOm9" id="3pwG8PSkQC9" role="2ShVmc">
-                                    <node concept="1Y3b0j" id="3pwG8PSkQCa" role="YeSDq">
-                                      <property role="2bfB8j" value="true" />
-                                      <property role="1sVAO0" value="false" />
-                                      <property role="1EXbeo" value="false" />
-                                      <ref role="1Y3XeK" to="wyt6:~Runnable" resolve="Runnable" />
-                                      <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
-                                      <node concept="3Tm1VV" id="3pwG8PSkQCb" role="1B3o_S" />
-                                      <node concept="3clFb_" id="3pwG8PSkQCc" role="jymVt">
-                                        <property role="TrG5h" value="run" />
-                                        <property role="DiZV1" value="false" />
-                                        <property role="od$2w" value="false" />
-                                        <node concept="2AHcQZ" id="3pwG8PSkQCd" role="2AJF6D">
-                                          <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-                                        </node>
-                                        <node concept="3clFbS" id="3pwG8PSkQCe" role="3clF47">
-                                          <node concept="3clFbF" id="3pwG8PSkQCf" role="3cqZAp">
-                                            <node concept="1rXfSq" id="3pwG8PSkQCg" role="3clFbG">
-                                              <ref role="37wK5l" node="3pwG8PSkQDq" resolve="checkAndShowMenu" />
-                                              <node concept="37vLTw" id="2jDew64YcOp" role="37wK5m">
-                                                <ref role="3cqZAo" node="26rsnFJK69q" resolve="intentionsSupport" />
-                                              </node>
-                                            </node>
-                                          </node>
-                                        </node>
-                                        <node concept="3Tm1VV" id="3pwG8PSkQCh" role="1B3o_S" />
-                                        <node concept="3cqZAl" id="3pwG8PSkQCi" role="3clF45" />
-                                      </node>
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="3Tm1VV" id="3pwG8PSkQCj" role="1B3o_S" />
-                        <node concept="3cqZAl" id="3pwG8PSkQCk" role="3clF45" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbF" id="26rsnFK8ZtP" role="3cqZAp">
-              <node concept="1rXfSq" id="26rsnFJG35t" role="3clFbG">
-                <ref role="37wK5l" node="26rsnFJEwJk" resolve="registerAction" />
-              </node>
-            </node>
-          </node>
-          <node concept="3y3z36" id="6JxzAvo_F3z" role="3clFbw">
-            <node concept="10Nm6u" id="6JxzAvo_Fo0" role="3uHU7w" />
-            <node concept="37vLTw" id="6JxzAvo_EPz" role="3uHU7B">
-              <ref role="3cqZAo" node="26rsnFJK69q" resolve="intentionsSupport" />
-            </node>
-          </node>
-        </node>
       </node>
     </node>
-    <node concept="2tJIrI" id="2jDew64VROj" role="jymVt" />
-    <node concept="3clFb_" id="26rsnFJEwJk" role="jymVt">
-      <property role="TrG5h" value="overrideShowIntentionAction" />
-      <node concept="3clFbS" id="26rsnFJEwJn" role="3clF47">
-        <node concept="3cpWs8" id="26rsnFJHpbH" role="3cqZAp">
-          <node concept="3cpWsn" id="26rsnFJHpbI" role="3cpWs9">
-            <property role="TrG5h" value="myEditor" />
-            <node concept="3uibUv" id="26rsnFJHluT" role="1tU5fm">
-              <ref role="3uigEE" to="exr9:~EditorComponent" resolve="EditorComponent" />
-            </node>
-            <node concept="2OqwBi" id="26rsnFJHpbJ" role="33vP2m">
-              <node concept="Xjq3P" id="26rsnFJHpbK" role="2Oq$k0" />
-              <node concept="2OwXpG" id="26rsnFJHpbL" role="2OqNvi">
-                <ref role="2Oxat6" node="2jDew64KOaH" resolve="editor" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbH" id="26rsnFJTBHW" role="3cqZAp" />
-        <node concept="3cpWs8" id="26rsnFJFlSH" role="3cqZAp">
-          <node concept="3cpWsn" id="26rsnFJFlSG" role="3cpWs9">
-            <property role="3TUv4t" value="true" />
-            <property role="TrG5h" value="ideaActionRegistration" />
-            <node concept="3uibUv" id="26rsnFJFlSI" role="1tU5fm">
-              <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
-            </node>
-            <node concept="2OqwBi" id="26rsnFJFC7b" role="33vP2m">
-              <node concept="2YIFZM" id="26rsnFJFq48" role="2Oq$k0">
-                <ref role="1Pybhc" to="qkt:~ActionManager" resolve="ActionManager" />
-                <ref role="37wK5l" to="qkt:~ActionManager.getInstance()" resolve="getInstance" />
-              </node>
-              <node concept="liA8E" id="26rsnFJFC7c" role="2OqNvi">
-                <ref role="37wK5l" to="qkt:~ActionManager.getActionOrStub(java.lang.String)" resolve="getActionOrStub" />
-                <node concept="10M0yZ" id="26rsnFJGbh7" role="37wK5m">
-                  <ref role="3cqZAo" to="qq03:~MPSActions.EDITOR_SHOW_INTENTIONS_POPUP_ACTION" resolve="EDITOR_SHOW_INTENTIONS_POPUP_ACTION" />
-                  <ref role="1PxDUh" to="qq03:~MPSActions" resolve="MPSActions" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3cpWs8" id="26rsnFJFlSN" role="3cqZAp">
-          <node concept="3cpWsn" id="26rsnFJFlSM" role="3cpWs9">
-            <property role="TrG5h" value="firstKeyStroke" />
-            <node concept="3uibUv" id="26rsnFJFlSO" role="1tU5fm">
-              <ref role="3uigEE" to="dxuu:~KeyStroke" resolve="KeyStroke" />
-            </node>
-            <node concept="10Nm6u" id="26rsnFJFlSP" role="33vP2m" />
-          </node>
-        </node>
-        <node concept="1DcWWT" id="26rsnFJFlSQ" role="3cqZAp">
-          <node concept="2OqwBi" id="26rsnFJFKe7" role="1DdaDG">
-            <node concept="2OqwBi" id="26rsnFJF$ax" role="2Oq$k0">
-              <node concept="37vLTw" id="26rsnFJFtZH" role="2Oq$k0">
-                <ref role="3cqZAo" node="26rsnFJFlSG" resolve="ideaActionRegistration" />
-              </node>
-              <node concept="liA8E" id="26rsnFJF$ay" role="2OqNvi">
-                <ref role="37wK5l" to="qkt:~AnAction.getShortcutSet()" resolve="getShortcutSet" />
-              </node>
-            </node>
-            <node concept="liA8E" id="26rsnFJFKe8" role="2OqNvi">
-              <ref role="37wK5l" to="qkt:~ShortcutSet.getShortcuts()" resolve="getShortcuts" />
-            </node>
-          </node>
-          <node concept="3cpWsn" id="26rsnFJFlTe" role="1Duv9x">
-            <property role="TrG5h" value="shortcut" />
-            <node concept="3uibUv" id="26rsnFJFlTg" role="1tU5fm">
-              <ref role="3uigEE" to="qkt:~Shortcut" resolve="Shortcut" />
-            </node>
-          </node>
-          <node concept="3clFbS" id="26rsnFJFlSS" role="2LFqv$">
-            <node concept="3clFbJ" id="26rsnFJFlST" role="3cqZAp">
-              <node concept="3fqX7Q" id="26rsnFJFlSU" role="3clFbw">
-                <node concept="2OqwBi" id="26rsnFJFEB$" role="3fr31v">
-                  <node concept="37vLTw" id="26rsnFJFtYQ" role="2Oq$k0">
-                    <ref role="3cqZAo" node="26rsnFJFlTe" resolve="shortcut" />
-                  </node>
-                  <node concept="liA8E" id="26rsnFJFEB_" role="2OqNvi">
-                    <ref role="37wK5l" to="qkt:~Shortcut.isKeyboard()" resolve="isKeyboard" />
-                  </node>
-                </node>
-              </node>
-              <node concept="3clFbS" id="26rsnFJFlSX" role="3clFbx">
-                <node concept="3N13vt" id="26rsnFJFlSY" role="3cqZAp" />
-              </node>
-            </node>
-            <node concept="3clFbJ" id="26rsnFJFlSZ" role="3cqZAp">
-              <node concept="2ZW3vV" id="26rsnFJFlT2" role="3clFbw">
-                <node concept="37vLTw" id="26rsnFJFlT0" role="2ZW6bz">
-                  <ref role="3cqZAo" node="26rsnFJFlTe" resolve="shortcut" />
-                </node>
-                <node concept="3uibUv" id="26rsnFJFlT1" role="2ZW6by">
-                  <ref role="3uigEE" to="qkt:~KeyboardShortcut" resolve="KeyboardShortcut" />
-                </node>
-              </node>
-              <node concept="3clFbS" id="26rsnFJFlT4" role="3clFbx">
-                <node concept="3clFbF" id="26rsnFJFlT5" role="3cqZAp">
-                  <node concept="37vLTI" id="26rsnFJFlT6" role="3clFbG">
-                    <node concept="37vLTw" id="26rsnFJFlT7" role="37vLTJ">
-                      <ref role="3cqZAo" node="26rsnFJFlSM" resolve="firstKeyStroke" />
-                    </node>
-                    <node concept="2OqwBi" id="26rsnFJFtYL" role="37vLTx">
-                      <node concept="1eOMI4" id="26rsnFJFlTc" role="2Oq$k0">
-                        <node concept="10QFUN" id="26rsnFJFlT9" role="1eOMHV">
-                          <node concept="37vLTw" id="26rsnFJFlTa" role="10QFUP">
-                            <ref role="3cqZAo" node="26rsnFJFlTe" resolve="shortcut" />
-                          </node>
-                          <node concept="3uibUv" id="26rsnFJFlTb" role="10QFUM">
-                            <ref role="3uigEE" to="qkt:~KeyboardShortcut" resolve="KeyboardShortcut" />
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="liA8E" id="26rsnFJFtYM" role="2OqNvi">
-                        <ref role="37wK5l" to="qkt:~KeyboardShortcut.getFirstKeyStroke()" resolve="getFirstKeyStroke" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="3zACq4" id="26rsnFJFlTd" role="3cqZAp" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3SKdUt" id="26rsnFJFlTu" role="3cqZAp">
-          <node concept="1PaTwC" id="26rsnFJFlTv" role="1aUNEU">
-            <node concept="3oM_SD" id="26rsnFJFlTw" role="1PaTwD">
-              <property role="3oM_SC" value="fallback" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbJ" id="26rsnFJFlTj" role="3cqZAp">
-          <node concept="3clFbC" id="26rsnFJFlTk" role="3clFbw">
-            <node concept="37vLTw" id="26rsnFJFlTl" role="3uHU7B">
-              <ref role="3cqZAo" node="26rsnFJFlSM" resolve="firstKeyStroke" />
-            </node>
-            <node concept="10Nm6u" id="26rsnFJFlTm" role="3uHU7w" />
-          </node>
-          <node concept="3clFbS" id="26rsnFJFlTo" role="3clFbx">
-            <node concept="3clFbF" id="26rsnFJFlTp" role="3cqZAp">
-              <node concept="37vLTI" id="26rsnFJFlTq" role="3clFbG">
-                <node concept="37vLTw" id="26rsnFJFlTr" role="37vLTJ">
-                  <ref role="3cqZAo" node="26rsnFJFlSM" resolve="firstKeyStroke" />
-                </node>
-                <node concept="2YIFZM" id="26rsnFJFtYV" role="37vLTx">
-                  <ref role="1Pybhc" to="dxuu:~KeyStroke" resolve="KeyStroke" />
-                  <ref role="37wK5l" to="dxuu:~KeyStroke.getKeyStroke(java.lang.String)" resolve="getKeyStroke" />
-                  <node concept="Xl_RD" id="26rsnFJFtYW" role="37wK5m">
-                    <property role="Xl_RC" value="alt ENTER" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbH" id="26rsnFKcTkk" role="3cqZAp" />
-        <node concept="3clFbF" id="26rsnFJHWbn" role="3cqZAp">
-          <node concept="2OqwBi" id="26rsnFJIdxo" role="3clFbG">
-            <node concept="37vLTw" id="26rsnFJI7v6" role="2Oq$k0">
-              <ref role="3cqZAo" node="26rsnFJHpbI" resolve="myEditor" />
-            </node>
-            <node concept="liA8E" id="26rsnFJIdxp" role="2OqNvi">
-              <ref role="37wK5l" to="dxuu:~JComponent.registerKeyboardAction(java.awt.event.ActionListener,javax.swing.KeyStroke,int)" resolve="registerKeyboardAction" />
-              <node concept="2OqwBi" id="26rsnFKcu1C" role="37wK5m">
-                <node concept="37vLTw" id="26rsnFKcu1D" role="2Oq$k0">
-                  <ref role="3cqZAo" node="26rsnFJK69q" resolve="intentionsSupport" />
-                </node>
-                <node concept="1PnCL0" id="26rsnFKcu1E" role="2OqNvi">
-                  <ref role="2Oxat5" to="exr9:~IntentionsSupport.myShowIntentionsAction" resolve="myShowIntentionsAction" />
-                </node>
-              </node>
-              <node concept="37vLTw" id="26rsnFJIdxu" role="37wK5m">
-                <ref role="3cqZAo" node="26rsnFJFlSM" resolve="firstKeyStroke" />
-              </node>
-              <node concept="10M0yZ" id="26rsnFJIdxv" role="37wK5m">
-                <ref role="1PxDUh" to="dxuu:~JComponent" resolve="JComponent" />
-                <ref role="3cqZAo" to="dxuu:~JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT" resolve="WHEN_ANCESTOR_OF_FOCUSED_COMPONENT" />
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="26rsnFJEnWb" role="1B3o_S" />
-      <node concept="3cqZAl" id="26rsnFJEwyD" role="3clF45" />
-    </node>
-    <node concept="2tJIrI" id="26rsnFJEett" role="jymVt" />
-    <node concept="3clFb_" id="3pwG8PSkQDq" role="jymVt">
-      <property role="TrG5h" value="checkAndShowMenu" />
-      <property role="DiZV1" value="false" />
-      <property role="od$2w" value="false" />
-      <node concept="3clFbS" id="3pwG8PSkQDr" role="3clF47">
-        <node concept="3clFbJ" id="3pwG8PSkQDs" role="3cqZAp">
-          <node concept="1rXfSq" id="3pwG8PSkQDt" role="3clFbw">
-            <ref role="37wK5l" node="3pwG8PSkQGh" resolve="isInconsistentEditor" />
-          </node>
-          <node concept="3clFbS" id="3pwG8PSkQDv" role="3clFbx">
-            <node concept="3cpWs6" id="3pwG8PSkQDu" role="3cqZAp" />
-          </node>
-        </node>
-        <node concept="3clFbJ" id="3pwG8PSkQDw" role="3cqZAp">
-          <node concept="1Wc70l" id="5qf1oe_$EA7" role="3clFbw">
-            <node concept="3fqX7Q" id="5qf1oe__0gk" role="3uHU7w">
-              <node concept="2YIFZM" id="5qf1oe__0gm" role="3fr31v">
-                <ref role="37wK5l" node="5qf1oe_zNws" resolve="allowIntentionsInReadOnlySelection" />
-                <ref role="1Pybhc" node="5qf1oe_zyw0" resolve="StyleUtil" />
-                <node concept="37vLTw" id="5qf1oe__0gn" role="37wK5m">
-                  <ref role="3cqZAo" node="2jDew64KOaH" resolve="editor" />
-                </node>
-              </node>
-            </node>
-            <node concept="1eOMI4" id="5qf1oe_$A82" role="3uHU7B">
-              <node concept="22lmx$" id="3pwG8PSkQDx" role="1eOMHV">
-                <node concept="2YIFZM" id="3pwG8PSkTS1" role="3uHU7B">
-                  <ref role="1Pybhc" to="3ahc:~ReadOnlyUtil" resolve="ReadOnlyUtil" />
-                  <ref role="37wK5l" to="3ahc:~ReadOnlyUtil.isSelectionReadOnlyInEditor(jetbrains.mps.openapi.editor.EditorComponent)" resolve="isSelectionReadOnlyInEditor" />
-                  <node concept="37vLTw" id="3pwG8PSkQDz" role="37wK5m">
-                    <ref role="3cqZAo" node="2jDew64KOaH" resolve="editor" />
-                  </node>
-                </node>
-                <node concept="2YIFZM" id="3pwG8PSkTS4" role="3uHU7w">
-                  <ref role="1Pybhc" to="w1kc:~SModelOperations" resolve="SModelOperations" />
-                  <ref role="37wK5l" to="w1kc:~SModelOperations.isReadOnly(org.jetbrains.mps.openapi.model.SModel)" resolve="isReadOnly" />
-                  <node concept="2OqwBi" id="3pwG8PSkQD_" role="37wK5m">
-                    <node concept="2OqwBi" id="3pwG8PSkTS8" role="2Oq$k0">
-                      <node concept="37vLTw" id="3pwG8PSkTS7" role="2Oq$k0">
-                        <ref role="3cqZAo" node="2jDew64KOaH" resolve="editor" />
-                      </node>
-                      <node concept="liA8E" id="3pwG8PSkTS9" role="2OqNvi">
-                        <ref role="37wK5l" to="exr9:~EditorComponent.getSelectedNode()" resolve="getSelectedNode" />
-                      </node>
-                    </node>
-                    <node concept="liA8E" id="3pwG8PSkQDB" role="2OqNvi">
-                      <ref role="37wK5l" to="mhbf:~SNode.getModel()" resolve="getModel" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3clFbS" id="3pwG8PSkQDD" role="3clFbx">
-            <node concept="3cpWs6" id="3pwG8PSkQDC" role="3cqZAp" />
-          </node>
-        </node>
-        <node concept="3clFbF" id="2jDew64XO65" role="3cqZAp">
-          <node concept="2OqwBi" id="2jDew64XSbT" role="3clFbG">
-            <node concept="37vLTw" id="2jDew64XO63" role="2Oq$k0">
-              <ref role="3cqZAo" node="2jDew64XHAU" resolve="intentionsSupport" />
-            </node>
-            <node concept="1PvZjq" id="2jDew64XULy" role="2OqNvi">
-              <ref role="37wK5l" to="exr9:~IntentionsSupport.showIntentionsMenu()" resolve="showIntentionsMenu" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tmbuc" id="3pwG8PSojnf" role="1B3o_S" />
-      <node concept="3cqZAl" id="3pwG8PSkQDH" role="3clF45" />
-      <node concept="37vLTG" id="2jDew64XHAU" role="3clF46">
-        <property role="TrG5h" value="intentionsSupport" />
-        <node concept="3uibUv" id="2jDew64XHAT" role="1tU5fm">
-          <ref role="3uigEE" to="exr9:~IntentionsSupport" resolve="IntentionsSupport" />
-        </node>
-      </node>
-    </node>
-    <node concept="2tJIrI" id="2jDew64VROk" role="jymVt" />
     <node concept="2tJIrI" id="2jDew64KefB" role="jymVt" />
     <node concept="3clFb_" id="2jDew64HgSb" role="jymVt">
       <property role="TrG5h" value="getIntentionsGroup" />
@@ -3558,6 +3175,1487 @@
         </node>
       </node>
     </node>
+  </node>
+  <node concept="312cEu" id="4hHbxs9xqxD">
+    <property role="TrG5h" value="MyIntentionsSupport" />
+    <node concept="2tJIrI" id="4hHbxs9xq_r" role="jymVt" />
+    <node concept="312cEg" id="4hHbxs9xqLS" role="jymVt">
+      <property role="TrG5h" value="myShowIntentionsThreadOverwritten" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3uibUv" id="4hHbxs9xqLU" role="1tU5fm">
+        <ref role="3uigEE" to="i5cy:~AtomicReference" resolve="AtomicReference" />
+        <node concept="3uibUv" id="4hHbxs9xqLV" role="11_B2D">
+          <ref role="3uigEE" node="4hHbxs9xqXT" resolve="IntentionsThread" />
+        </node>
+      </node>
+      <node concept="2ShNRf" id="4hHbxs9xqOL" role="33vP2m">
+        <node concept="1pGfFk" id="4hHbxs9xqON" role="2ShVmc">
+          <property role="373rjd" value="true" />
+          <ref role="37wK5l" to="i5cy:~AtomicReference.&lt;init&gt;()" resolve="AtomicReference" />
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="4hHbxs9xqLX" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="4hHbxs9xq_T" role="jymVt" />
+    <node concept="3Tm1VV" id="4hHbxs9xqxE" role="1B3o_S" />
+    <node concept="3uibUv" id="4hHbxs9xqzS" role="1zkMxy">
+      <ref role="3uigEE" to="exr9:~IntentionsSupport" resolve="IntentionsSupport" />
+    </node>
+    <node concept="3clFbW" id="4hHbxs9xq$1" role="jymVt">
+      <property role="TrG5h" value="IntentionsSupport" />
+      <node concept="3cqZAl" id="4hHbxs9xq$2" role="3clF45" />
+      <node concept="3Tm1VV" id="4hHbxs9xq$3" role="1B3o_S" />
+      <node concept="37vLTG" id="4hHbxs9xq$5" role="3clF46">
+        <property role="TrG5h" value="editor" />
+        <node concept="3uibUv" id="4hHbxs9xq$6" role="1tU5fm">
+          <ref role="3uigEE" to="exr9:~EditorComponent" resolve="EditorComponent" />
+        </node>
+        <node concept="2AHcQZ" id="4hHbxs9xq$7" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="4hHbxs9xq$8" role="3clF47">
+        <node concept="XkiVB" id="4hHbxs9B9zp" role="3cqZAp">
+          <ref role="37wK5l" to="exr9:~IntentionsSupport.&lt;init&gt;(jetbrains.mps.nodeEditor.EditorComponent)" resolve="IntentionsSupport" />
+          <node concept="37vLTw" id="4hHbxs9BciJ" role="37wK5m">
+            <ref role="3cqZAo" node="4hHbxs9xq$5" resolve="editor" />
+          </node>
+        </node>
+        <node concept="3cpWs8" id="4hHbxs9ANMm" role="3cqZAp">
+          <node concept="3cpWsn" id="4hHbxs9ANMl" role="3cpWs9">
+            <property role="3TUv4t" value="true" />
+            <property role="TrG5h" value="ideaActionRegistration" />
+            <node concept="3uibUv" id="4hHbxs9ANMn" role="1tU5fm">
+              <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
+            </node>
+            <node concept="2OqwBi" id="4hHbxs9ASDg" role="33vP2m">
+              <node concept="2YIFZM" id="4hHbxs9AQ$x" role="2Oq$k0">
+                <ref role="1Pybhc" to="qkt:~ActionManager" resolve="ActionManager" />
+                <ref role="37wK5l" to="qkt:~ActionManager.getInstance()" resolve="getInstance" />
+              </node>
+              <node concept="liA8E" id="4hHbxs9ASDh" role="2OqNvi">
+                <ref role="37wK5l" to="qkt:~ActionManager.getActionOrStub(java.lang.String)" resolve="getActionOrStub" />
+                <node concept="10M0yZ" id="4hHbxs9BGLQ" role="37wK5m">
+                  <ref role="3cqZAo" to="qq03:~MPSActions.EDITOR_SHOW_INTENTIONS_POPUP_ACTION" resolve="EDITOR_SHOW_INTENTIONS_POPUP_ACTION" />
+                  <ref role="1PxDUh" to="qq03:~MPSActions" resolve="MPSActions" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="4hHbxs9ANMs" role="3cqZAp">
+          <node concept="3cpWsn" id="4hHbxs9ANMr" role="3cpWs9">
+            <property role="TrG5h" value="firstKeyStroke" />
+            <node concept="3uibUv" id="4hHbxs9ANMt" role="1tU5fm">
+              <ref role="3uigEE" to="dxuu:~KeyStroke" resolve="KeyStroke" />
+            </node>
+            <node concept="10Nm6u" id="4hHbxs9ANMu" role="33vP2m" />
+          </node>
+        </node>
+        <node concept="1DcWWT" id="4hHbxs9ANMv" role="3cqZAp">
+          <node concept="2OqwBi" id="4hHbxs9AVSs" role="1DdaDG">
+            <node concept="2OqwBi" id="4hHbxs9AT8b" role="2Oq$k0">
+              <node concept="37vLTw" id="4hHbxs9AR8g" role="2Oq$k0">
+                <ref role="3cqZAo" node="4hHbxs9ANMl" resolve="ideaActionRegistration" />
+              </node>
+              <node concept="liA8E" id="4hHbxs9AT8c" role="2OqNvi">
+                <ref role="37wK5l" to="qkt:~AnAction.getShortcutSet()" resolve="getShortcutSet" />
+              </node>
+            </node>
+            <node concept="liA8E" id="4hHbxs9AVSt" role="2OqNvi">
+              <ref role="37wK5l" to="qkt:~ShortcutSet.getShortcuts()" resolve="getShortcuts" />
+            </node>
+          </node>
+          <node concept="3cpWsn" id="4hHbxs9ANMR" role="1Duv9x">
+            <property role="TrG5h" value="shortcut" />
+            <node concept="3uibUv" id="4hHbxs9ANMT" role="1tU5fm">
+              <ref role="3uigEE" to="qkt:~Shortcut" resolve="Shortcut" />
+            </node>
+          </node>
+          <node concept="3clFbS" id="4hHbxs9ANMx" role="2LFqv$">
+            <node concept="3clFbJ" id="4hHbxs9ANMy" role="3cqZAp">
+              <node concept="3fqX7Q" id="4hHbxs9ANMz" role="3clFbw">
+                <node concept="2OqwBi" id="4hHbxs9ASxW" role="3fr31v">
+                  <node concept="37vLTw" id="4hHbxs9AQhJ" role="2Oq$k0">
+                    <ref role="3cqZAo" node="4hHbxs9ANMR" resolve="shortcut" />
+                  </node>
+                  <node concept="liA8E" id="4hHbxs9ASxX" role="2OqNvi">
+                    <ref role="37wK5l" to="qkt:~Shortcut.isKeyboard()" resolve="isKeyboard" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbS" id="4hHbxs9ANMA" role="3clFbx">
+                <node concept="3N13vt" id="4hHbxs9ANMB" role="3cqZAp" />
+              </node>
+            </node>
+            <node concept="3clFbJ" id="4hHbxs9ANMC" role="3cqZAp">
+              <node concept="2ZW3vV" id="4hHbxs9ANMF" role="3clFbw">
+                <node concept="37vLTw" id="4hHbxs9ANMD" role="2ZW6bz">
+                  <ref role="3cqZAo" node="4hHbxs9ANMR" resolve="shortcut" />
+                </node>
+                <node concept="3uibUv" id="4hHbxs9ANME" role="2ZW6by">
+                  <ref role="3uigEE" to="qkt:~KeyboardShortcut" resolve="KeyboardShortcut" />
+                </node>
+              </node>
+              <node concept="3clFbS" id="4hHbxs9ANMH" role="3clFbx">
+                <node concept="3clFbF" id="4hHbxs9ANMI" role="3cqZAp">
+                  <node concept="37vLTI" id="4hHbxs9ANMJ" role="3clFbG">
+                    <node concept="37vLTw" id="4hHbxs9ANMK" role="37vLTJ">
+                      <ref role="3cqZAo" node="4hHbxs9ANMr" resolve="firstKeyStroke" />
+                    </node>
+                    <node concept="2OqwBi" id="4hHbxs9AQuZ" role="37vLTx">
+                      <node concept="1eOMI4" id="4hHbxs9ANMP" role="2Oq$k0">
+                        <node concept="10QFUN" id="4hHbxs9ANMM" role="1eOMHV">
+                          <node concept="37vLTw" id="4hHbxs9ANMN" role="10QFUP">
+                            <ref role="3cqZAo" node="4hHbxs9ANMR" resolve="shortcut" />
+                          </node>
+                          <node concept="3uibUv" id="4hHbxs9ANMO" role="10QFUM">
+                            <ref role="3uigEE" to="qkt:~KeyboardShortcut" resolve="KeyboardShortcut" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="liA8E" id="4hHbxs9AQv0" role="2OqNvi">
+                        <ref role="37wK5l" to="qkt:~KeyboardShortcut.getFirstKeyStroke()" resolve="getFirstKeyStroke" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3zACq4" id="4hHbxs9ANMQ" role="3cqZAp" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="4hHbxs9ANMW" role="3cqZAp">
+          <node concept="3clFbC" id="4hHbxs9ANMX" role="3clFbw">
+            <node concept="37vLTw" id="4hHbxs9ANMY" role="3uHU7B">
+              <ref role="3cqZAo" node="4hHbxs9ANMr" resolve="firstKeyStroke" />
+            </node>
+            <node concept="10Nm6u" id="4hHbxs9ANMZ" role="3uHU7w" />
+          </node>
+          <node concept="3clFbS" id="4hHbxs9ANN1" role="3clFbx">
+            <node concept="3SKdUt" id="4hHbxs9ANP9" role="3cqZAp">
+              <node concept="1PaTwC" id="4hHbxs9ANPa" role="1aUNEU">
+                <node concept="3oM_SD" id="4hHbxs9ANPb" role="1PaTwD">
+                  <property role="3oM_SC" value="fallback" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="4hHbxs9ANN2" role="3cqZAp">
+              <node concept="37vLTI" id="4hHbxs9ANN3" role="3clFbG">
+                <node concept="37vLTw" id="4hHbxs9ANN4" role="37vLTJ">
+                  <ref role="3cqZAo" node="4hHbxs9ANMr" resolve="firstKeyStroke" />
+                </node>
+                <node concept="2YIFZM" id="4hHbxs9AQEm" role="37vLTx">
+                  <ref role="1Pybhc" to="dxuu:~KeyStroke" resolve="KeyStroke" />
+                  <ref role="37wK5l" to="dxuu:~KeyStroke.getKeyStroke(java.lang.String)" resolve="getKeyStroke" />
+                  <node concept="Xl_RD" id="4hHbxs9AQEn" role="37wK5m">
+                    <property role="Xl_RC" value="alt ENTER" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4hHbxs9Cz4e" role="3cqZAp">
+          <node concept="37vLTI" id="4hHbxs9CGom" role="3clFbG">
+            <node concept="2OqwBi" id="4hHbxs9C_UY" role="37vLTJ">
+              <node concept="1rXfSq" id="4hHbxs9Cz4c" role="2Oq$k0">
+                <ref role="37wK5l" node="4hHbxs9_oo1" resolve="getIntentionsSupport" />
+              </node>
+              <node concept="1PnCL0" id="4hHbxs9CCWd" role="2OqNvi">
+                <ref role="2Oxat5" to="exr9:~IntentionsSupport.myShowIntentionsAction" resolve="myShowIntentionsAction" />
+              </node>
+            </node>
+            <node concept="2ShNRf" id="4hHbxs9ANNq" role="37vLTx">
+              <node concept="YeOm9" id="4hHbxs9ANNr" role="2ShVmc">
+                <node concept="1Y3b0j" id="4hHbxs9ANNs" role="YeSDq">
+                  <ref role="1Y3XeK" to="dxuu:~AbstractAction" resolve="AbstractAction" />
+                  <ref role="37wK5l" to="dxuu:~AbstractAction.&lt;init&gt;()" resolve="AbstractAction" />
+                  <node concept="3clFb_" id="4hHbxs9ANNt" role="jymVt">
+                    <property role="TrG5h" value="actionPerformed" />
+                    <node concept="2AHcQZ" id="4hHbxs9ANNu" role="2AJF6D">
+                      <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                    </node>
+                    <node concept="37vLTG" id="4hHbxs9ANNv" role="3clF46">
+                      <property role="TrG5h" value="e" />
+                      <node concept="3uibUv" id="4hHbxs9ANNw" role="1tU5fm">
+                        <ref role="3uigEE" to="hyam:~ActionEvent" resolve="ActionEvent" />
+                      </node>
+                    </node>
+                    <node concept="3clFbS" id="4hHbxs9ANNx" role="3clF47">
+                      <node concept="1QHqEK" id="3DQAigeSRJI" role="3cqZAp">
+                        <node concept="1QHqEC" id="3DQAigeSRJK" role="1QHqEI">
+                          <node concept="3clFbS" id="3DQAigeSRJM" role="1bW5cS">
+                            <node concept="3clFbF" id="3DQAigeRu_u" role="3cqZAp">
+                              <node concept="1rXfSq" id="3DQAigeRu_s" role="3clFbG">
+                                <ref role="37wK5l" node="3pwG8PSkQDq" resolve="checkAndShowMenu" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="2OqwBi" id="3DQAigeSVeC" role="ukAjM">
+                          <node concept="1rXfSq" id="3DQAigeST9U" role="2Oq$k0">
+                            <ref role="37wK5l" node="4hHbxs9ygNI" resolve="getEditor" />
+                          </node>
+                          <node concept="1PvZjq" id="3DQAigeSXPj" role="2OqNvi">
+                            <ref role="37wK5l" to="exr9:~EditorComponent.getRepository()" resolve="getRepository" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3Tm1VV" id="4hHbxs9ANN$" role="1B3o_S" />
+                    <node concept="3cqZAl" id="4hHbxs9ANN_" role="3clF45" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3SKdUt" id="4hHbxs9ANPc" role="3cqZAp">
+          <node concept="1PaTwC" id="4hHbxs9ANPd" role="1aUNEU">
+            <node concept="3oM_SD" id="4hHbxs9ANPe" role="1PaTwD">
+              <property role="3oM_SC" value="FIXME" />
+            </node>
+            <node concept="3oM_SD" id="4hHbxs9ANPf" role="1PaTwD">
+              <property role="3oM_SC" value="check" />
+            </node>
+            <node concept="3oM_SD" id="4hHbxs9ANPg" role="1PaTwD">
+              <property role="3oM_SC" value="47d64cfa" />
+            </node>
+            <node concept="3oM_SD" id="4hHbxs9ANPh" role="1PaTwD">
+              <property role="3oM_SC" value="and" />
+            </node>
+            <node concept="3oM_SD" id="4hHbxs9ANPi" role="1PaTwD">
+              <property role="3oM_SC" value="MPS-31891." />
+            </node>
+            <node concept="3oM_SD" id="4hHbxs9ANPj" role="1PaTwD">
+              <property role="3oM_SC" value="Likely" />
+            </node>
+            <node concept="3oM_SD" id="4hHbxs9ANPk" role="1PaTwD">
+              <property role="3oM_SC" value="we" />
+            </node>
+            <node concept="3oM_SD" id="4hHbxs9ANPl" role="1PaTwD">
+              <property role="3oM_SC" value="need" />
+            </node>
+            <node concept="3oM_SD" id="4hHbxs9ANPm" role="1PaTwD">
+              <property role="3oM_SC" value="to" />
+            </node>
+            <node concept="3oM_SD" id="4hHbxs9ANPn" role="1PaTwD">
+              <property role="3oM_SC" value="switch" />
+            </node>
+            <node concept="3oM_SD" id="4hHbxs9ANPo" role="1PaTwD">
+              <property role="3oM_SC" value="to" />
+            </node>
+            <node concept="3oM_SD" id="4hHbxs9ANPp" role="1PaTwD">
+              <property role="3oM_SC" value="use" />
+            </node>
+            <node concept="3oM_SD" id="4hHbxs9ANPq" role="1PaTwD">
+              <property role="3oM_SC" value="idea's" />
+            </node>
+            <node concept="3oM_SD" id="4hHbxs9ANPr" role="1PaTwD">
+              <property role="3oM_SC" value="actions" />
+            </node>
+            <node concept="3oM_SD" id="4hHbxs9ANPs" role="1PaTwD">
+              <property role="3oM_SC" value="not" />
+            </node>
+            <node concept="3oM_SD" id="4hHbxs9ANPt" role="1PaTwD">
+              <property role="3oM_SC" value="only" />
+            </node>
+            <node concept="3oM_SD" id="4hHbxs9ANPu" role="1PaTwD">
+              <property role="3oM_SC" value="to" />
+            </node>
+            <node concept="3oM_SD" id="4hHbxs9ANPv" role="1PaTwD">
+              <property role="3oM_SC" value="keep" />
+            </node>
+            <node concept="3oM_SD" id="4hHbxs9ANPw" role="1PaTwD">
+              <property role="3oM_SC" value="shortcut," />
+            </node>
+          </node>
+        </node>
+        <node concept="3SKdUt" id="4hHbxs9ANPx" role="3cqZAp">
+          <node concept="1PaTwC" id="4hHbxs9ANPy" role="1aUNEU">
+            <node concept="3oM_SD" id="4hHbxs9ANPz" role="1PaTwD">
+              <property role="3oM_SC" value="just" />
+            </node>
+            <node concept="3oM_SD" id="4hHbxs9ANP$" role="1PaTwD">
+              <property role="3oM_SC" value="requires" />
+            </node>
+            <node concept="3oM_SD" id="4hHbxs9ANP_" role="1PaTwD">
+              <property role="3oM_SC" value="some" />
+            </node>
+            <node concept="3oM_SD" id="4hHbxs9ANPA" role="1PaTwD">
+              <property role="3oM_SC" value="deep" />
+            </node>
+            <node concept="3oM_SD" id="4hHbxs9ANPB" role="1PaTwD">
+              <property role="3oM_SC" value="understanding" />
+            </node>
+            <node concept="3oM_SD" id="4hHbxs9ANPC" role="1PaTwD">
+              <property role="3oM_SC" value="of" />
+            </node>
+            <node concept="3oM_SD" id="4hHbxs9ANPD" role="1PaTwD">
+              <property role="3oM_SC" value="DataContext" />
+            </node>
+            <node concept="3oM_SD" id="4hHbxs9ANPE" role="1PaTwD">
+              <property role="3oM_SC" value="to" />
+            </node>
+            <node concept="3oM_SD" id="4hHbxs9ANPF" role="1PaTwD">
+              <property role="3oM_SC" value="integrate" />
+            </node>
+            <node concept="3oM_SD" id="4hHbxs9ANPG" role="1PaTwD">
+              <property role="3oM_SC" value="it" />
+            </node>
+            <node concept="3oM_SD" id="4hHbxs9ANPH" role="1PaTwD">
+              <property role="3oM_SC" value="with" />
+            </node>
+            <node concept="3oM_SD" id="4hHbxs9ANPI" role="1PaTwD">
+              <property role="3oM_SC" value="our" />
+            </node>
+            <node concept="3oM_SD" id="4hHbxs9ANPJ" role="1PaTwD">
+              <property role="3oM_SC" value="thread" />
+            </node>
+            <node concept="3oM_SD" id="4hHbxs9ANPK" role="1PaTwD">
+              <property role="3oM_SC" value="to" />
+            </node>
+            <node concept="3oM_SD" id="4hHbxs9ANPL" role="1PaTwD">
+              <property role="3oM_SC" value="update" />
+            </node>
+            <node concept="3oM_SD" id="4hHbxs9ANPM" role="1PaTwD">
+              <property role="3oM_SC" value="intentions" />
+            </node>
+            <node concept="3oM_SD" id="4hHbxs9ANPN" role="1PaTwD">
+              <property role="3oM_SC" value="menu" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4hHbxs9Dxer" role="3cqZAp">
+          <node concept="2OqwBi" id="4hHbxs9D_Sr" role="3clFbG">
+            <node concept="1rXfSq" id="4hHbxs9Dxep" role="2Oq$k0">
+              <ref role="37wK5l" node="4hHbxs9ygNI" resolve="getEditor" />
+            </node>
+            <node concept="liA8E" id="4hHbxs9DDtI" role="2OqNvi">
+              <ref role="37wK5l" to="dxuu:~JComponent.registerKeyboardAction(java.awt.event.ActionListener,javax.swing.KeyStroke,int)" resolve="registerKeyboardAction" />
+              <node concept="2OqwBi" id="4hHbxs9DHfG" role="37wK5m">
+                <node concept="1rXfSq" id="4hHbxs9DFfU" role="2Oq$k0">
+                  <ref role="37wK5l" node="4hHbxs9_oo1" resolve="getIntentionsSupport" />
+                </node>
+                <node concept="1PnCL0" id="4hHbxs9DJfd" role="2OqNvi">
+                  <ref role="2Oxat5" to="exr9:~IntentionsSupport.myShowIntentionsAction" resolve="myShowIntentionsAction" />
+                </node>
+              </node>
+              <node concept="37vLTw" id="4hHbxs9DNdy" role="37wK5m">
+                <ref role="3cqZAo" node="4hHbxs9ANMr" resolve="firstKeyStroke" />
+              </node>
+              <node concept="10M0yZ" id="4hHbxs9DR1v" role="37wK5m">
+                <ref role="1PxDUh" to="dxuu:~JComponent" resolve="JComponent" />
+                <ref role="3cqZAo" to="dxuu:~JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT" resolve="WHEN_ANCESTOR_OF_FOCUSED_COMPONENT" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="4hHbxs9ANNG" role="3cqZAp">
+          <node concept="3cpWsn" id="4hHbxs9ANNF" role="3cpWs9">
+            <property role="3TUv4t" value="true" />
+            <property role="TrG5h" value="focusListener" />
+            <node concept="3uibUv" id="4hHbxs9ANNH" role="1tU5fm">
+              <ref role="3uigEE" to="hyam:~FocusAdapter" resolve="FocusAdapter" />
+            </node>
+            <node concept="2ShNRf" id="4hHbxs9ANNI" role="33vP2m">
+              <node concept="YeOm9" id="4hHbxs9ANNJ" role="2ShVmc">
+                <node concept="1Y3b0j" id="4hHbxs9ANNK" role="YeSDq">
+                  <ref role="1Y3XeK" to="hyam:~FocusAdapter" resolve="FocusAdapter" />
+                  <ref role="37wK5l" to="hyam:~FocusAdapter.&lt;init&gt;()" resolve="FocusAdapter" />
+                  <node concept="3clFb_" id="4hHbxs9ANNL" role="jymVt">
+                    <property role="TrG5h" value="focusGained" />
+                    <node concept="2AHcQZ" id="4hHbxs9ANNM" role="2AJF6D">
+                      <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                    </node>
+                    <node concept="37vLTG" id="4hHbxs9ANNN" role="3clF46">
+                      <property role="TrG5h" value="e" />
+                      <node concept="3uibUv" id="4hHbxs9ANNO" role="1tU5fm">
+                        <ref role="3uigEE" to="hyam:~FocusEvent" resolve="FocusEvent" />
+                      </node>
+                    </node>
+                    <node concept="3clFbS" id="4hHbxs9ANNP" role="3clF47">
+                      <node concept="3clFbF" id="4hHbxs9ANNQ" role="3cqZAp">
+                        <node concept="1rXfSq" id="4hHbxs9ANNR" role="3clFbG">
+                          <ref role="37wK5l" node="4hHbxs9Ao5A" resolve="updateIntentionsStatus" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3Tm1VV" id="4hHbxs9ANNS" role="1B3o_S" />
+                    <node concept="3cqZAl" id="4hHbxs9ANNT" role="3clF45" />
+                  </node>
+                  <node concept="3clFb_" id="4hHbxs9ANNU" role="jymVt">
+                    <property role="TrG5h" value="focusLost" />
+                    <node concept="2AHcQZ" id="4hHbxs9ANNV" role="2AJF6D">
+                      <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                    </node>
+                    <node concept="37vLTG" id="4hHbxs9ANNW" role="3clF46">
+                      <property role="TrG5h" value="e" />
+                      <node concept="3uibUv" id="4hHbxs9ANNX" role="1tU5fm">
+                        <ref role="3uigEE" to="hyam:~FocusEvent" resolve="FocusEvent" />
+                      </node>
+                    </node>
+                    <node concept="3clFbS" id="4hHbxs9ANNY" role="3clF47">
+                      <node concept="3clFbF" id="7$YkZ3lRNlw" role="3cqZAp">
+                        <node concept="2OqwBi" id="7$YkZ3lRPsR" role="3clFbG">
+                          <node concept="1rXfSq" id="7$YkZ3lRNlu" role="2Oq$k0">
+                            <ref role="37wK5l" node="4hHbxs9_oo1" resolve="getIntentionsSupport" />
+                          </node>
+                          <node concept="1PvZjq" id="7$YkZ3lRRur" role="2OqNvi">
+                            <ref role="37wK5l" to="exr9:~IntentionsSupport.hideLightBulb()" resolve="hideLightBulb" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3SKdUt" id="4hHbxs9ANPO" role="3cqZAp">
+                        <node concept="1PaTwC" id="4hHbxs9ANPP" role="1aUNEU">
+                          <node concept="3oM_SD" id="4hHbxs9ANPQ" role="1PaTwD">
+                            <property role="3oM_SC" value="If" />
+                          </node>
+                          <node concept="3oM_SD" id="4hHbxs9ANPR" role="1PaTwD">
+                            <property role="3oM_SC" value="editor" />
+                          </node>
+                          <node concept="3oM_SD" id="4hHbxs9ANPS" role="1PaTwD">
+                            <property role="3oM_SC" value="lost" />
+                          </node>
+                          <node concept="3oM_SD" id="4hHbxs9ANPT" role="1PaTwD">
+                            <property role="3oM_SC" value="focus," />
+                          </node>
+                          <node concept="3oM_SD" id="4hHbxs9ANPU" role="1PaTwD">
+                            <property role="3oM_SC" value="thread" />
+                          </node>
+                          <node concept="3oM_SD" id="4hHbxs9ANPV" role="1PaTwD">
+                            <property role="3oM_SC" value="can" />
+                          </node>
+                          <node concept="3oM_SD" id="4hHbxs9ANPW" role="1PaTwD">
+                            <property role="3oM_SC" value="be" />
+                          </node>
+                          <node concept="3oM_SD" id="4hHbxs9ANPX" role="1PaTwD">
+                            <property role="3oM_SC" value="stopped" />
+                          </node>
+                          <node concept="3oM_SD" id="4hHbxs9ANPY" role="1PaTwD">
+                            <property role="3oM_SC" value="-" />
+                          </node>
+                          <node concept="3oM_SD" id="4hHbxs9ANPZ" role="1PaTwD">
+                            <property role="3oM_SC" value="it" />
+                          </node>
+                          <node concept="3oM_SD" id="4hHbxs9ANQ0" role="1PaTwD">
+                            <property role="3oM_SC" value="will" />
+                          </node>
+                          <node concept="3oM_SD" id="4hHbxs9ANQ1" role="1PaTwD">
+                            <property role="3oM_SC" value="be" />
+                          </node>
+                          <node concept="3oM_SD" id="4hHbxs9ANQ2" role="1PaTwD">
+                            <property role="3oM_SC" value="any" />
+                          </node>
+                          <node concept="3oM_SD" id="4hHbxs9ANQ3" role="1PaTwD">
+                            <property role="3oM_SC" value="way" />
+                          </node>
+                          <node concept="3oM_SD" id="4hHbxs9ANQ4" role="1PaTwD">
+                            <property role="3oM_SC" value="restarted" />
+                          </node>
+                          <node concept="3oM_SD" id="4hHbxs9ANQ5" role="1PaTwD">
+                            <property role="3oM_SC" value="on" />
+                          </node>
+                          <node concept="3oM_SD" id="4hHbxs9ANQ6" role="1PaTwD">
+                            <property role="3oM_SC" value="focus" />
+                          </node>
+                          <node concept="3oM_SD" id="4hHbxs9ANQ7" role="1PaTwD">
+                            <property role="3oM_SC" value="gain" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="3DQAigeP2_D" role="3cqZAp">
+                        <node concept="1rXfSq" id="3DQAigeP2_B" role="3clFbG">
+                          <ref role="37wK5l" node="3DQAigeOL4F" resolve="stopIntentionThread" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3Tm1VV" id="4hHbxs9ANO3" role="1B3o_S" />
+                    <node concept="3cqZAl" id="4hHbxs9ANO4" role="3clF45" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7$YkZ3lS3z8" role="3cqZAp">
+          <node concept="2OqwBi" id="7$YkZ3lS6GI" role="3clFbG">
+            <node concept="1rXfSq" id="7$YkZ3lS3z6" role="2Oq$k0">
+              <ref role="37wK5l" node="4hHbxs9ygNI" resolve="getEditor" />
+            </node>
+            <node concept="liA8E" id="7$YkZ3lSbc7" role="2OqNvi">
+              <ref role="37wK5l" to="z60i:~Component.addFocusListener(java.awt.event.FocusListener)" resolve="addFocusListener" />
+              <node concept="37vLTw" id="7$YkZ3lScmz" role="37wK5m">
+                <ref role="3cqZAo" node="4hHbxs9ANNF" resolve="focusListener" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="4hHbxs9ANO9" role="3cqZAp">
+          <node concept="3cpWsn" id="4hHbxs9ANO8" role="3cpWs9">
+            <property role="3TUv4t" value="true" />
+            <property role="TrG5h" value="selectionListener" />
+            <node concept="3uibUv" id="4hHbxs9ANOa" role="1tU5fm">
+              <ref role="3uigEE" to="lwvz:~SelectionListener" resolve="SelectionListener" />
+            </node>
+            <node concept="1bVj0M" id="4hHbxs9ANOb" role="33vP2m">
+              <node concept="37vLTG" id="4hHbxs9ANOc" role="1bW2Oz">
+                <property role="TrG5h" value="editorComponent" />
+                <node concept="3VYd8j" id="4hHbxs9ANOd" role="1tU5fm" />
+              </node>
+              <node concept="37vLTG" id="4hHbxs9ANOe" role="1bW2Oz">
+                <property role="TrG5h" value="oldSelection" />
+                <node concept="3VYd8j" id="4hHbxs9ANOf" role="1tU5fm" />
+              </node>
+              <node concept="37vLTG" id="4hHbxs9ANOg" role="1bW2Oz">
+                <property role="TrG5h" value="newSelection" />
+                <node concept="3VYd8j" id="4hHbxs9ANOh" role="1tU5fm" />
+              </node>
+              <node concept="3clFbS" id="4hHbxs9ANOB" role="1bW5cS">
+                <node concept="9aQIb" id="4hHbxs9ANOi" role="3cqZAp">
+                  <node concept="3clFbS" id="4hHbxs9ANOj" role="9aQI4">
+                    <node concept="3clFbJ" id="4hHbxs9ANOk" role="3cqZAp">
+                      <node concept="3clFbC" id="4hHbxs9ANOl" role="3clFbw">
+                        <node concept="37vLTw" id="4hHbxs9ANOm" role="3uHU7B">
+                          <ref role="3cqZAo" node="4hHbxs9ANOe" resolve="oldSelection" />
+                        </node>
+                        <node concept="37vLTw" id="4hHbxs9ANOn" role="3uHU7w">
+                          <ref role="3cqZAo" node="4hHbxs9ANOg" resolve="newSelection" />
+                        </node>
+                      </node>
+                      <node concept="3clFbS" id="4hHbxs9ANOp" role="3clFbx">
+                        <node concept="3cpWs6" id="4hHbxs9ANOq" role="3cqZAp" />
+                      </node>
+                    </node>
+                    <node concept="3clFbJ" id="4hHbxs9ANOr" role="3cqZAp">
+                      <node concept="3fqX7Q" id="4hHbxs9ANOs" role="3clFbw">
+                        <node concept="2OqwBi" id="7$YkZ3lSfBq" role="3fr31v">
+                          <node concept="1eOMI4" id="4hHbxs9ANOx" role="2Oq$k0">
+                            <node concept="10QFUN" id="4hHbxs9ANOu" role="1eOMHV">
+                              <node concept="37vLTw" id="4hHbxs9ANOv" role="10QFUP">
+                                <ref role="3cqZAo" node="4hHbxs9ANOc" resolve="editorComponent" />
+                              </node>
+                              <node concept="3uibUv" id="4hHbxs9ANOw" role="10QFUM">
+                                <ref role="3uigEE" to="exr9:~EditorComponent" resolve="EditorComponent" />
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="liA8E" id="7$YkZ3lSfBr" role="2OqNvi">
+                            <ref role="37wK5l" to="exr9:~EditorComponent.isFocusOwner()" resolve="isFocusOwner" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbS" id="4hHbxs9ANOz" role="3clFbx">
+                        <node concept="3cpWs6" id="4hHbxs9ANO$" role="3cqZAp" />
+                      </node>
+                    </node>
+                    <node concept="3clFbF" id="4hHbxs9ANO_" role="3cqZAp">
+                      <node concept="1rXfSq" id="4hHbxs9ANOA" role="3clFbG">
+                        <ref role="37wK5l" node="4hHbxs9Ao5A" resolve="updateIntentionsStatus" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4hHbxs9ANOC" role="3cqZAp">
+          <node concept="2OqwBi" id="7$YkZ3lSsVB" role="3clFbG">
+            <node concept="2OqwBi" id="7$YkZ3lSlyW" role="2Oq$k0">
+              <node concept="1rXfSq" id="7$YkZ3lSild" role="2Oq$k0">
+                <ref role="37wK5l" node="4hHbxs9ygNI" resolve="getEditor" />
+              </node>
+              <node concept="liA8E" id="7$YkZ3lSotT" role="2OqNvi">
+                <ref role="37wK5l" to="exr9:~EditorComponent.getSelectionManager()" resolve="getSelectionManager" />
+              </node>
+            </node>
+            <node concept="liA8E" id="7$YkZ3lSsVC" role="2OqNvi">
+              <ref role="37wK5l" to="lwvz:~SelectionManager.addSelectionListener(jetbrains.mps.openapi.editor.selection.SelectionListener)" resolve="addSelectionListener" />
+              <node concept="37vLTw" id="7$YkZ3lSsVD" role="37wK5m">
+                <ref role="3cqZAo" node="4hHbxs9ANO8" resolve="selectionListener" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3DQAigeNCsv" role="3cqZAp">
+          <node concept="3cpWsn" id="3DQAigeNCst" role="3cpWs9">
+            <property role="3TUv4t" value="true" />
+            <property role="TrG5h" value="disposeListener" />
+            <node concept="3uibUv" id="3DQAigeNDxE" role="1tU5fm">
+              <ref role="3uigEE" to="exr9:~EditorComponent$EditorDisposeListener" resolve="EditorDisposeListener" />
+            </node>
+            <node concept="2ShNRf" id="3DQAigeNGCg" role="33vP2m">
+              <node concept="YeOm9" id="3DQAigeNPvy" role="2ShVmc">
+                <node concept="1Y3b0j" id="3DQAigeNPv_" role="YeSDq">
+                  <property role="2bfB8j" value="true" />
+                  <property role="373rjd" value="true" />
+                  <ref role="1Y3XeK" to="exr9:~EditorComponent$EditorDisposeListener" resolve="EditorDisposeListener" />
+                  <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" />
+                  <node concept="3Tm1VV" id="3DQAigeNPvA" role="1B3o_S" />
+                  <node concept="3clFb_" id="3DQAigeNPvQ" role="jymVt">
+                    <property role="TrG5h" value="editorWillBeDisposed" />
+                    <node concept="3Tm1VV" id="3DQAigeNPvR" role="1B3o_S" />
+                    <node concept="3cqZAl" id="3DQAigeNPvT" role="3clF45" />
+                    <node concept="37vLTG" id="3DQAigeNPvU" role="3clF46">
+                      <property role="TrG5h" value="component" />
+                      <node concept="3uibUv" id="3DQAigeNPvV" role="1tU5fm">
+                        <ref role="3uigEE" to="exr9:~EditorComponent" resolve="EditorComponent" />
+                      </node>
+                      <node concept="2AHcQZ" id="3DQAigeNPvW" role="2AJF6D">
+                        <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+                      </node>
+                    </node>
+                    <node concept="3clFbS" id="3DQAigeNPvX" role="3clF47">
+                      <node concept="3clFbF" id="3DQAigeOXCM" role="3cqZAp">
+                        <node concept="1rXfSq" id="3DQAigeOXCK" role="3clFbG">
+                          <ref role="37wK5l" node="3DQAigeOL4F" resolve="stopIntentionThread" />
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="3DQAigeO3NP" role="3cqZAp">
+                        <node concept="2OqwBi" id="3DQAigeO73J" role="3clFbG">
+                          <node concept="1rXfSq" id="3DQAigeO3NN" role="2Oq$k0">
+                            <ref role="37wK5l" node="4hHbxs9ygNI" resolve="getEditor" />
+                          </node>
+                          <node concept="liA8E" id="3DQAigeOamj" role="2OqNvi">
+                            <ref role="37wK5l" to="z60i:~Component.removeFocusListener(java.awt.event.FocusListener)" resolve="removeFocusListener" />
+                            <node concept="37vLTw" id="3DQAigeOeoq" role="37wK5m">
+                              <ref role="3cqZAo" node="4hHbxs9ANNF" resolve="focusListener" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="3DQAigeOh2z" role="3cqZAp">
+                        <node concept="2OqwBi" id="3DQAigeOoIm" role="3clFbG">
+                          <node concept="2OqwBi" id="3DQAigeOkfC" role="2Oq$k0">
+                            <node concept="1rXfSq" id="3DQAigeOh2x" role="2Oq$k0">
+                              <ref role="37wK5l" node="4hHbxs9ygNI" resolve="getEditor" />
+                            </node>
+                            <node concept="liA8E" id="3DQAigeOno1" role="2OqNvi">
+                              <ref role="37wK5l" to="exr9:~EditorComponent.getSelectionManager()" resolve="getSelectionManager" />
+                            </node>
+                          </node>
+                          <node concept="liA8E" id="3DQAigeOqo4" role="2OqNvi">
+                            <ref role="37wK5l" to="lwvz:~SelectionManager.removeSelectionListener(jetbrains.mps.openapi.editor.selection.SelectionListener)" resolve="removeSelectionListener" />
+                            <node concept="37vLTw" id="3DQAigeOrNo" role="37wK5m">
+                              <ref role="3cqZAo" node="4hHbxs9ANO8" resolve="selectionListener" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="3DQAigeOuym" role="3cqZAp">
+                        <node concept="2OqwBi" id="3DQAigeOxRi" role="3clFbG">
+                          <node concept="1rXfSq" id="3DQAigeOuyk" role="2Oq$k0">
+                            <ref role="37wK5l" node="4hHbxs9ygNI" resolve="getEditor" />
+                          </node>
+                          <node concept="liA8E" id="3DQAigeO_02" role="2OqNvi">
+                            <ref role="37wK5l" to="exr9:~EditorComponent.removeDisposeListener(jetbrains.mps.nodeEditor.EditorComponent$EditorDisposeListener)" resolve="removeDisposeListener" />
+                            <node concept="Xjq3P" id="3DQAigeOBd8" role="37wK5m" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2AHcQZ" id="3DQAigeNPvZ" role="2AJF6D">
+                      <ref role="2AI5Lk" to="wyt6:~Override" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="3DQAigeNhgs" role="3cqZAp">
+          <node concept="2OqwBi" id="3DQAigeNkoG" role="3clFbG">
+            <node concept="1rXfSq" id="3DQAigeNhgq" role="2Oq$k0">
+              <ref role="37wK5l" node="4hHbxs9ygNI" resolve="getEditor" />
+            </node>
+            <node concept="liA8E" id="3DQAigeNsU8" role="2OqNvi">
+              <ref role="37wK5l" to="exr9:~EditorComponent.addDisposeListener(jetbrains.mps.nodeEditor.EditorComponent$EditorDisposeListener)" resolve="addDisposeListener" />
+              <node concept="37vLTw" id="3DQAigeNu30" role="37wK5m">
+                <ref role="3cqZAo" node="3DQAigeNCst" resolve="disposeListener" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="4hHbxs9_knP" role="jymVt" />
+    <node concept="3clFb_" id="4hHbxs9_oo1" role="jymVt">
+      <property role="TrG5h" value="getIntentionsSupport" />
+      <node concept="3clFbS" id="4hHbxs9_oo4" role="3clF47">
+        <node concept="3clFbF" id="4hHbxs9_smj" role="3cqZAp">
+          <node concept="0kSF2" id="4hHbxs9_uvR" role="3clFbG">
+            <node concept="3uibUv" id="4hHbxs9_uvT" role="0kSFW">
+              <ref role="3uigEE" to="exr9:~IntentionsSupport" resolve="IntentionsSupport" />
+            </node>
+            <node concept="Xjq3P" id="4hHbxs9_smi" role="0kSFX" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="4hHbxs9_le0" role="1B3o_S" />
+      <node concept="3uibUv" id="4hHbxs9_nJ_" role="3clF45">
+        <ref role="3uigEE" to="exr9:~IntentionsSupport" resolve="IntentionsSupport" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="4hHbxs9xqR4" role="jymVt" />
+    <node concept="312cEu" id="4hHbxs9xqXT" role="jymVt">
+      <property role="TrG5h" value="MyIntentionsThread" />
+      <property role="2bfB8j" value="true" />
+      <node concept="3Tm6S6" id="4hHbxs9xqXU" role="1B3o_S" />
+      <node concept="3uibUv" id="4hHbxs9xqXV" role="1zkMxy">
+        <ref role="3uigEE" to="wyt6:~Thread" resolve="Thread" />
+      </node>
+      <node concept="312cEg" id="4hHbxs9xqXW" role="jymVt">
+        <property role="34CwA1" value="true" />
+        <property role="TrG5h" value="myStopRequested" />
+        <node concept="10P_77" id="4hHbxs9xqXY" role="1tU5fm" />
+        <node concept="3Tm6S6" id="4hHbxs9xqXZ" role="1B3o_S" />
+      </node>
+      <node concept="3clFbW" id="4hHbxs9xqY0" role="jymVt">
+        <node concept="3cqZAl" id="4hHbxs9xqY1" role="3clF45" />
+        <node concept="3clFbS" id="4hHbxs9xqY2" role="3clF47">
+          <node concept="XkiVB" id="4hHbxs9xsgf" role="3cqZAp">
+            <ref role="37wK5l" to="wyt6:~Thread.&lt;init&gt;(java.lang.String)" resolve="Thread" />
+            <node concept="Xl_RD" id="4hHbxs9xsgg" role="37wK5m">
+              <property role="Xl_RC" value="Intentions" />
+            </node>
+          </node>
+        </node>
+        <node concept="3Tm1VV" id="4hHbxs9xqY5" role="1B3o_S" />
+      </node>
+      <node concept="3clFb_" id="4hHbxs9xqY6" role="jymVt">
+        <property role="TrG5h" value="requestStop" />
+        <node concept="3clFbS" id="4hHbxs9xqY7" role="3clF47">
+          <node concept="3clFbF" id="4hHbxs9xqY8" role="3cqZAp">
+            <node concept="37vLTI" id="4hHbxs9xqY9" role="3clFbG">
+              <node concept="37vLTw" id="4hHbxs9xqYa" role="37vLTJ">
+                <ref role="3cqZAo" node="4hHbxs9xqXW" resolve="myStopRequested" />
+              </node>
+              <node concept="3clFbT" id="4hHbxs9xqYb" role="37vLTx">
+                <property role="3clFbU" value="true" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cqZAl" id="4hHbxs9xqYc" role="3clF45" />
+      </node>
+      <node concept="2tJIrI" id="3DQAigeODPw" role="jymVt" />
+      <node concept="3clFb_" id="4hHbxs9xqYd" role="jymVt">
+        <property role="TrG5h" value="run" />
+        <node concept="2AHcQZ" id="4hHbxs9xqYe" role="2AJF6D">
+          <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+        </node>
+        <node concept="3clFbS" id="4hHbxs9xqYf" role="3clF47">
+          <node concept="3J1_TO" id="4hHbxs9xr0j" role="3cqZAp">
+            <node concept="3uVAMA" id="4hHbxs9xr0k" role="1zxBo5">
+              <node concept="3clFbS" id="4hHbxs9xr0i" role="1zc67A">
+                <node concept="3SKdUt" id="4hHbxs9xr0u" role="3cqZAp">
+                  <node concept="1PaTwC" id="4hHbxs9xr0v" role="1aUNEU">
+                    <node concept="3oM_SD" id="4hHbxs9xr0w" role="1PaTwD">
+                      <property role="3oM_SC" value="It's" />
+                    </node>
+                    <node concept="3oM_SD" id="4hHbxs9xr0x" role="1PaTwD">
+                      <property role="3oM_SC" value="ok," />
+                    </node>
+                    <node concept="3oM_SD" id="4hHbxs9xr0y" role="1PaTwD">
+                      <property role="3oM_SC" value="we" />
+                    </node>
+                    <node concept="3oM_SD" id="4hHbxs9xr0z" role="1PaTwD">
+                      <property role="3oM_SC" value="don't" />
+                    </node>
+                    <node concept="3oM_SD" id="4hHbxs9xr0$" role="1PaTwD">
+                      <property role="3oM_SC" value="care" />
+                    </node>
+                    <node concept="3oM_SD" id="4hHbxs9xr0_" role="1PaTwD">
+                      <property role="3oM_SC" value="if" />
+                    </node>
+                    <node concept="3oM_SD" id="4hHbxs9xr0A" role="1PaTwD">
+                      <property role="3oM_SC" value="the" />
+                    </node>
+                    <node concept="3oM_SD" id="4hHbxs9xr0B" role="1PaTwD">
+                      <property role="3oM_SC" value="thread" />
+                    </node>
+                    <node concept="3oM_SD" id="4hHbxs9xr0C" role="1PaTwD">
+                      <property role="3oM_SC" value="got" />
+                    </node>
+                    <node concept="3oM_SD" id="4hHbxs9xr0D" role="1PaTwD">
+                      <property role="3oM_SC" value="interrupted" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="XOnhg" id="4hHbxs9xr0e" role="1zc67B">
+                <property role="TrG5h" value="e" />
+                <node concept="nSUau" id="4hHbxs9xr0g" role="1tU5fm">
+                  <node concept="3uibUv" id="4hHbxs9xr0f" role="nSUat">
+                    <ref role="3uigEE" to="wyt6:~InterruptedException" resolve="InterruptedException" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="1wplmZ" id="4hHbxs9xr0l" role="1zxBo6">
+              <node concept="3clFbS" id="4hHbxs9xr0a" role="1wplMD">
+                <node concept="3clFbF" id="4hHbxs9xr0b" role="3cqZAp">
+                  <node concept="1rXfSq" id="4hHbxs9xr0c" role="3clFbG">
+                    <ref role="37wK5l" node="4hHbxs9xM33" resolve="intentionThreadCompleted" />
+                    <node concept="Xjq3P" id="4hHbxs9xr0d" role="37wK5m" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbS" id="4hHbxs9xqYh" role="1zxBo7">
+              <node concept="3clFbF" id="4hHbxs9xqYi" role="3cqZAp">
+                <node concept="2YIFZM" id="4hHbxs9xsgW" role="3clFbG">
+                  <ref role="1Pybhc" to="wyt6:~Thread" resolve="Thread" />
+                  <ref role="37wK5l" to="wyt6:~Thread.sleep(long)" resolve="sleep" />
+                  <node concept="3cmrfG" id="4hHbxs9y9vs" role="37wK5m">
+                    <property role="3cmrfH" value="1000" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbJ" id="4hHbxs9xqYl" role="3cqZAp">
+                <node concept="37vLTw" id="4hHbxs9xqYm" role="3clFbw">
+                  <ref role="3cqZAo" node="4hHbxs9xqXW" resolve="myStopRequested" />
+                </node>
+                <node concept="3clFbS" id="4hHbxs9xqYo" role="3clFbx">
+                  <node concept="3cpWs6" id="4hHbxs9xqYp" role="3cqZAp" />
+                </node>
+              </node>
+              <node concept="3cpWs8" id="4hHbxs9xqYr" role="3cqZAp">
+                <node concept="3cpWsn" id="4hHbxs9xqYq" role="3cpWs9">
+                  <property role="3TUv4t" value="true" />
+                  <property role="TrG5h" value="forceReturn" />
+                  <node concept="10Q1$e" id="4hHbxs9xqYt" role="1tU5fm">
+                    <node concept="10P_77" id="4hHbxs9xqYs" role="10Q1$1" />
+                  </node>
+                  <node concept="2BsdOp" id="4hHbxs9xqYv" role="33vP2m">
+                    <node concept="3clFbT" id="4hHbxs9xqYu" role="2BsfMF" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbF" id="4hHbxs9xqYw" role="3cqZAp">
+                <node concept="2OqwBi" id="4hHbxs9xH_i" role="3clFbG">
+                  <node concept="2YIFZM" id="4hHbxs9xGd9" role="2Oq$k0">
+                    <ref role="1Pybhc" to="bd8o:~ApplicationManager" resolve="ApplicationManager" />
+                    <ref role="37wK5l" to="bd8o:~ApplicationManager.getApplication()" resolve="getApplication" />
+                  </node>
+                  <node concept="liA8E" id="4hHbxs9xH_j" role="2OqNvi">
+                    <ref role="37wK5l" to="bd8o:~Application.invokeAndWait(java.lang.Runnable)" resolve="invokeAndWait" />
+                    <node concept="1bVj0M" id="4hHbxs9xH_k" role="37wK5m">
+                      <node concept="3clFbS" id="4hHbxs9xH_l" role="1bW5cS">
+                        <node concept="3clFbF" id="4hHbxs9xH_m" role="3cqZAp">
+                          <node concept="2OqwBi" id="4hHbxs9z7KJ" role="3clFbG">
+                            <node concept="2OqwBi" id="4hHbxs9z6Q9" role="2Oq$k0">
+                              <node concept="2OqwBi" id="4hHbxs9yZX_" role="2Oq$k0">
+                                <node concept="1rXfSq" id="4hHbxs9yY4v" role="2Oq$k0">
+                                  <ref role="37wK5l" node="4hHbxs9ygNI" resolve="getEditor" />
+                                </node>
+                                <node concept="1PvZjq" id="4hHbxs9z2y0" role="2OqNvi">
+                                  <ref role="37wK5l" to="exr9:~EditorComponent.getRepository()" resolve="getRepository" />
+                                </node>
+                              </node>
+                              <node concept="liA8E" id="4hHbxs9z6Qa" role="2OqNvi">
+                                <ref role="37wK5l" to="lui2:~SRepository.getModelAccess()" resolve="getModelAccess" />
+                              </node>
+                            </node>
+                            <node concept="liA8E" id="4hHbxs9z7KK" role="2OqNvi">
+                              <ref role="37wK5l" to="lui2:~ModelAccess.runReadAction(java.lang.Runnable)" resolve="runReadAction" />
+                              <node concept="1bVj0M" id="4hHbxs9z7KL" role="37wK5m">
+                                <node concept="3clFbS" id="4hHbxs9z7KM" role="1bW5cS">
+                                  <node concept="3clFbF" id="4hHbxs9z7KN" role="3cqZAp">
+                                    <node concept="37vLTI" id="4hHbxs9z7KO" role="3clFbG">
+                                      <node concept="AH0OO" id="4hHbxs9z7KP" role="37vLTJ">
+                                        <node concept="37vLTw" id="4hHbxs9z7KQ" role="AHHXb">
+                                          <ref role="3cqZAo" node="4hHbxs9xqYq" resolve="forceReturn" />
+                                        </node>
+                                        <node concept="3cmrfG" id="4hHbxs9z7KR" role="AHEQo">
+                                          <property role="3cmrfH" value="0" />
+                                        </node>
+                                      </node>
+                                      <node concept="22lmx$" id="4hHbxs9z7KS" role="37vLTx">
+                                        <node concept="1rXfSq" id="3DQAigeTB5J" role="3uHU7w">
+                                          <ref role="37wK5l" node="3DQAigePfof" resolve="areIntentionsNotSupported" />
+                                        </node>
+                                        <node concept="2OqwBi" id="4hHbxs9AagZ" role="3uHU7B">
+                                          <node concept="1rXfSq" id="4hHbxs9Aah0" role="2Oq$k0">
+                                            <ref role="37wK5l" node="4hHbxs9_oo1" resolve="getIntentionsSupport" />
+                                          </node>
+                                          <node concept="1PvZjq" id="4hHbxs9Aah1" role="2OqNvi">
+                                            <ref role="37wK5l" to="exr9:~IntentionsSupport.isInconsistentEditor()" resolve="isInconsistentEditor" />
+                                          </node>
+                                        </node>
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbJ" id="4hHbxs9xqYO" role="3cqZAp">
+                <node concept="AH0OO" id="4hHbxs9xqYP" role="3clFbw">
+                  <node concept="37vLTw" id="4hHbxs9xqYQ" role="AHHXb">
+                    <ref role="3cqZAo" node="4hHbxs9xqYq" resolve="forceReturn" />
+                  </node>
+                  <node concept="3cmrfG" id="4hHbxs9xqYR" role="AHEQo">
+                    <property role="3cmrfH" value="0" />
+                  </node>
+                </node>
+                <node concept="3clFbS" id="4hHbxs9xqYT" role="3clFbx">
+                  <node concept="3cpWs6" id="4hHbxs9xqYU" role="3cqZAp" />
+                </node>
+              </node>
+              <node concept="3cpWs8" id="4hHbxs9xqYW" role="3cqZAp">
+                <node concept="3cpWsn" id="4hHbxs9xqYV" role="3cpWs9">
+                  <property role="3TUv4t" value="true" />
+                  <property role="TrG5h" value="intentionKind" />
+                  <node concept="3uibUv" id="4hHbxs9xqYX" role="1tU5fm">
+                    <ref role="3uigEE" to="nddn:~Kind" resolve="Kind" />
+                  </node>
+                  <node concept="2OqwBi" id="4hHbxs9xVpw" role="33vP2m">
+                    <node concept="liA8E" id="4hHbxs9xVpx" role="2OqNvi">
+                      <ref role="37wK5l" to="lui2:~ModelAccess.computeReadAction(java.util.function.Supplier)" resolve="computeReadAction" />
+                      <node concept="1bVj0M" id="4hHbxs9xVpy" role="37wK5m">
+                        <node concept="3clFbS" id="4hHbxs9xVpz" role="1bW5cS">
+                          <node concept="9aQIb" id="4hHbxs9xVp$" role="3cqZAp">
+                            <node concept="3clFbS" id="4hHbxs9xVp_" role="9aQI4">
+                              <node concept="3SKdUt" id="4hHbxs9xVpA" role="3cqZAp">
+                                <node concept="1PaTwC" id="4hHbxs9xVpB" role="1aUNEU">
+                                  <node concept="3oM_SD" id="4hHbxs9xVpC" role="1PaTwD">
+                                    <property role="3oM_SC" value="TODO" />
+                                  </node>
+                                  <node concept="3oM_SD" id="4hHbxs9xVpD" role="1PaTwD">
+                                    <property role="3oM_SC" value="check" />
+                                  </node>
+                                  <node concept="3oM_SD" id="4hHbxs9xVpE" role="1PaTwD">
+                                    <property role="3oM_SC" value="for" />
+                                  </node>
+                                  <node concept="3oM_SD" id="4hHbxs9xVpF" role="1PaTwD">
+                                    <property role="3oM_SC" value="ActionsAsIntentions" />
+                                  </node>
+                                </node>
+                              </node>
+                              <node concept="3clFbJ" id="4hHbxs9xVpG" role="3cqZAp">
+                                <node concept="3clFbC" id="4hHbxs9xVpH" role="3clFbw">
+                                  <node concept="10Nm6u" id="4hHbxs9xVpJ" role="3uHU7w" />
+                                  <node concept="2OqwBi" id="4hHbxs9zdK8" role="3uHU7B">
+                                    <node concept="1rXfSq" id="4hHbxs9zbmg" role="2Oq$k0">
+                                      <ref role="37wK5l" node="4hHbxs9ygNI" resolve="getEditor" />
+                                    </node>
+                                    <node concept="liA8E" id="4hHbxs9zghf" role="2OqNvi">
+                                      <ref role="37wK5l" to="exr9:~EditorComponent.getTypecheckingSession()" resolve="getTypecheckingSession" />
+                                    </node>
+                                  </node>
+                                </node>
+                                <node concept="3clFbS" id="4hHbxs9xVpK" role="3clFbx">
+                                  <node concept="3cpWs6" id="4hHbxs9xVpL" role="3cqZAp">
+                                    <node concept="10Nm6u" id="4hHbxs9xVpM" role="3cqZAk" />
+                                  </node>
+                                </node>
+                              </node>
+                              <node concept="3cpWs6" id="4hHbxs9xVpN" role="3cqZAp">
+                                <node concept="2OqwBi" id="4hHbxs9xVpO" role="3cqZAk">
+                                  <node concept="2YIFZM" id="4hHbxs9xVpP" role="2Oq$k0">
+                                    <ref role="1Pybhc" to="1ka:~TypecheckingFacade" resolve="TypecheckingFacade" />
+                                    <ref role="37wK5l" to="1ka:~TypecheckingFacade.getFromContext()" resolve="getFromContext" />
+                                  </node>
+                                  <node concept="liA8E" id="4hHbxs9xVpQ" role="2OqNvi">
+                                    <ref role="37wK5l" to="ev0w:~TypecheckingSessionHandler.computeWithSession(jetbrains.mps.typechecking.TypecheckingSession,java.util.function.Function)" resolve="computeWithSession" />
+                                    <node concept="2OqwBi" id="4hHbxs9zjKd" role="37wK5m">
+                                      <node concept="1rXfSq" id="4hHbxs9zjKe" role="2Oq$k0">
+                                        <ref role="37wK5l" node="4hHbxs9ygNI" resolve="getEditor" />
+                                      </node>
+                                      <node concept="liA8E" id="4hHbxs9zjKf" role="2OqNvi">
+                                        <ref role="37wK5l" to="exr9:~EditorComponent.getTypecheckingSession()" resolve="getTypecheckingSession" />
+                                      </node>
+                                    </node>
+                                    <node concept="1bVj0M" id="4hHbxs9xVpS" role="37wK5m">
+                                      <node concept="37vLTG" id="4hHbxs9xVpT" role="1bW2Oz">
+                                        <property role="TrG5h" value="session" />
+                                        <node concept="3VYd8j" id="4hHbxs9xVpU" role="1tU5fm" />
+                                      </node>
+                                      <node concept="3clFbS" id="4hHbxs9xVpV" role="1bW5cS">
+                                        <node concept="3clFbF" id="4hHbxs9xVpW" role="3cqZAp">
+                                          <node concept="2OqwBi" id="4hHbxs9xVpX" role="3clFbG">
+                                            <node concept="2YIFZM" id="4hHbxs9xVpY" role="2Oq$k0">
+                                              <ref role="1Pybhc" to="91lp:~IntentionsManager" resolve="IntentionsManager" />
+                                              <ref role="37wK5l" to="91lp:~IntentionsManager.getInstance()" resolve="getInstance" />
+                                            </node>
+                                            <node concept="liA8E" id="4hHbxs9xVpZ" role="2OqNvi">
+                                              <ref role="37wK5l" to="91lp:~IntentionsManager.getHighestAvailableBaseIntentionType(org.jetbrains.mps.openapi.model.SNode,jetbrains.mps.openapi.editor.EditorContext)" resolve="getHighestAvailableBaseIntentionType" />
+                                              <node concept="2OqwBi" id="4hHbxs9zofJ" role="37wK5m">
+                                                <node concept="1rXfSq" id="4hHbxs9zlIC" role="2Oq$k0">
+                                                  <ref role="37wK5l" node="4hHbxs9ygNI" resolve="getEditor" />
+                                                </node>
+                                                <node concept="liA8E" id="4hHbxs9zqOh" role="2OqNvi">
+                                                  <ref role="37wK5l" to="exr9:~EditorComponent.getSelectedNode()" resolve="getSelectedNode" />
+                                                </node>
+                                              </node>
+                                              <node concept="2OqwBi" id="4hHbxs9zupN" role="37wK5m">
+                                                <node concept="1rXfSq" id="4hHbxs9zupO" role="2Oq$k0">
+                                                  <ref role="37wK5l" node="4hHbxs9ygNI" resolve="getEditor" />
+                                                </node>
+                                                <node concept="liA8E" id="4hHbxs9zupP" role="2OqNvi">
+                                                  <ref role="37wK5l" to="exr9:~EditorComponent.getEditorContext()" resolve="getEditorContext" />
+                                                </node>
+                                              </node>
+                                            </node>
+                                          </node>
+                                        </node>
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="1rXfSq" id="4hHbxs9AjpW" role="2Oq$k0">
+                      <ref role="37wK5l" node="4hHbxs9AeGD" resolve="getModelAccess" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbJ" id="4hHbxs9xqZp" role="3cqZAp">
+                <node concept="22lmx$" id="4hHbxs9xqZq" role="3clFbw">
+                  <node concept="3clFbC" id="4hHbxs9xqZr" role="3uHU7B">
+                    <node concept="37vLTw" id="4hHbxs9xqZs" role="3uHU7B">
+                      <ref role="3cqZAo" node="4hHbxs9xqYV" resolve="intentionKind" />
+                    </node>
+                    <node concept="10Nm6u" id="4hHbxs9xqZt" role="3uHU7w" />
+                  </node>
+                  <node concept="37vLTw" id="4hHbxs9xqZu" role="3uHU7w">
+                    <ref role="3cqZAo" node="4hHbxs9xqXW" resolve="myStopRequested" />
+                  </node>
+                </node>
+                <node concept="3clFbS" id="4hHbxs9xqZw" role="3clFbx">
+                  <node concept="3cpWs6" id="4hHbxs9xqZx" role="3cqZAp" />
+                </node>
+              </node>
+              <node concept="3clFbF" id="4hHbxs9xqZy" role="3cqZAp">
+                <node concept="2OqwBi" id="4hHbxs9xV8w" role="3clFbG">
+                  <node concept="liA8E" id="4hHbxs9xV8x" role="2OqNvi">
+                    <ref role="37wK5l" to="lui2:~ModelAccess.runReadInEDT(java.lang.Runnable)" resolve="runReadInEDT" />
+                    <node concept="1bVj0M" id="4hHbxs9xV8y" role="37wK5m">
+                      <node concept="3clFbS" id="4hHbxs9xV8z" role="1bW5cS">
+                        <node concept="9aQIb" id="4hHbxs9xV8$" role="3cqZAp">
+                          <node concept="3clFbS" id="4hHbxs9xV8_" role="9aQI4">
+                            <node concept="3clFbJ" id="4hHbxs9xV8A" role="3cqZAp">
+                              <node concept="22lmx$" id="4hHbxs9xV8B" role="3clFbw">
+                                <node concept="22lmx$" id="4hHbxs9xV8C" role="3uHU7B">
+                                  <node concept="1rXfSq" id="3DQAigePpKt" role="3uHU7w">
+                                    <ref role="37wK5l" node="3DQAigePfof" resolve="areIntentionsSupported" />
+                                  </node>
+                                  <node concept="2OqwBi" id="4hHbxs9A2Nj" role="3uHU7B">
+                                    <node concept="1rXfSq" id="4hHbxs9A2Nk" role="2Oq$k0">
+                                      <ref role="37wK5l" node="4hHbxs9_oo1" resolve="getIntentionsSupport" />
+                                    </node>
+                                    <node concept="1PvZjq" id="4hHbxs9A5q2" role="2OqNvi">
+                                      <ref role="37wK5l" to="exr9:~IntentionsSupport.isInconsistentEditor()" resolve="isInconsistentEditor" />
+                                    </node>
+                                  </node>
+                                </node>
+                                <node concept="37vLTw" id="4hHbxs9xV8G" role="3uHU7w">
+                                  <ref role="3cqZAo" node="4hHbxs9xqXW" resolve="myStopRequested" />
+                                </node>
+                              </node>
+                              <node concept="3clFbS" id="4hHbxs9xV8H" role="3clFbx">
+                                <node concept="3cpWs6" id="4hHbxs9xV8I" role="3cqZAp" />
+                              </node>
+                            </node>
+                            <node concept="3clFbJ" id="4hHbxs9xV8J" role="3cqZAp">
+                              <node concept="3clFbC" id="4hHbxs9xV8K" role="3clFbw">
+                                <node concept="10Nm6u" id="4hHbxs9xV8M" role="3uHU7w" />
+                                <node concept="2OqwBi" id="4hHbxs9zQQg" role="3uHU7B">
+                                  <node concept="1rXfSq" id="4hHbxs9zOPl" role="2Oq$k0">
+                                    <ref role="37wK5l" node="4hHbxs9ygNI" resolve="getEditor" />
+                                  </node>
+                                  <node concept="liA8E" id="4hHbxs9zTgA" role="2OqNvi">
+                                    <ref role="37wK5l" to="exr9:~EditorComponent.getSelectedCell()" resolve="getSelectedCell" />
+                                  </node>
+                                </node>
+                              </node>
+                              <node concept="9aQIb" id="4hHbxs9xV8N" role="9aQIa">
+                                <node concept="3clFbS" id="4hHbxs9xV8O" role="9aQI4">
+                                  <node concept="3clFbF" id="4hHbxs9_aWB" role="3cqZAp">
+                                    <node concept="2OqwBi" id="4hHbxs9_duG" role="3clFbG">
+                                      <node concept="1PvZjq" id="4hHbxs9_egP" role="2OqNvi">
+                                        <ref role="37wK5l" to="exr9:~IntentionsSupport.adjustLightBulbLocation()" resolve="adjustLightBulbLocation" />
+                                      </node>
+                                      <node concept="1rXfSq" id="4hHbxs9_w$2" role="2Oq$k0">
+                                        <ref role="37wK5l" node="4hHbxs9_oo1" resolve="getIntentionsSupport" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                  <node concept="3clFbF" id="4hHbxs9$YKM" role="3cqZAp">
+                                    <node concept="2OqwBi" id="4hHbxs9_4qP" role="3clFbG">
+                                      <node concept="1PvZjq" id="4hHbxs9_5fs" role="2OqNvi">
+                                        <ref role="37wK5l" to="exr9:~IntentionsSupport.showLightBulbComponent(javax.swing.Icon)" resolve="showLightBulbComponent" />
+                                        <node concept="3K4zz7" id="4hHbxs9xV8T" role="37wK5m">
+                                          <node concept="3clFbC" id="4hHbxs9xV8U" role="3K4Cdx">
+                                            <node concept="37vLTw" id="4hHbxs9xV8V" role="3uHU7B">
+                                              <ref role="3cqZAo" node="4hHbxs9xqYV" resolve="intentionKind" />
+                                            </node>
+                                            <node concept="Rm8GO" id="4hHbxs9xV8W" role="3uHU7w">
+                                              <ref role="1Px2BO" to="nddn:~Kind" resolve="Kind" />
+                                              <ref role="Rm8GQ" to="nddn:~Kind.NORMAL" resolve="NORMAL" />
+                                            </node>
+                                          </node>
+                                          <node concept="10M0yZ" id="4hHbxs9xV8X" role="3K4E3e">
+                                            <ref role="1PxDUh" to="8b49:~Icons" resolve="Icons" />
+                                            <ref role="3cqZAo" to="8b49:~Icons.INTENTION" resolve="INTENTION" />
+                                          </node>
+                                          <node concept="2OqwBi" id="4hHbxs9xV8Y" role="3K4GZi">
+                                            <node concept="2ShNRf" id="4hHbxs9xV8Z" role="2Oq$k0">
+                                              <node concept="1pGfFk" id="4hHbxs9xV90" role="2ShVmc">
+                                                <ref role="37wK5l" to="8b49:~IntentionIconProvider.&lt;init&gt;(jetbrains.mps.openapi.intentions.Kind)" resolve="IntentionIconProvider" />
+                                                <node concept="37vLTw" id="4hHbxs9xV91" role="37wK5m">
+                                                  <ref role="3cqZAo" node="4hHbxs9xqYV" resolve="intentionKind" />
+                                                </node>
+                                              </node>
+                                            </node>
+                                            <node concept="liA8E" id="4hHbxs9xV92" role="2OqNvi">
+                                              <ref role="37wK5l" to="8b49:~IntentionIconProvider.getIcon()" resolve="getIcon" />
+                                            </node>
+                                          </node>
+                                        </node>
+                                      </node>
+                                      <node concept="1rXfSq" id="4hHbxs9_xVs" role="2Oq$k0">
+                                        <ref role="37wK5l" node="4hHbxs9_oo1" resolve="getIntentionsSupport" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                              <node concept="3clFbS" id="4hHbxs9xV93" role="3clFbx">
+                                <node concept="3clFbF" id="4hHbxs9_zWM" role="3cqZAp">
+                                  <node concept="2OqwBi" id="4hHbxs9__Xv" role="3clFbG">
+                                    <node concept="1rXfSq" id="4hHbxs9_zWK" role="2Oq$k0">
+                                      <ref role="37wK5l" node="4hHbxs9_oo1" resolve="getIntentionsSupport" />
+                                    </node>
+                                    <node concept="1PvZjq" id="4hHbxs9_AId" role="2OqNvi">
+                                      <ref role="37wK5l" to="exr9:~IntentionsSupport.hideLightBulb()" resolve="hideLightBulb" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="1rXfSq" id="4hHbxs9AiGC" role="2Oq$k0">
+                    <ref role="37wK5l" node="4hHbxs9AeGD" resolve="getModelAccess" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3Tm1VV" id="4hHbxs9xr0m" role="1B3o_S" />
+        <node concept="3cqZAl" id="4hHbxs9xr0n" role="3clF45" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="4hHbxs9ye5L" role="jymVt" />
+    <node concept="3clFb_" id="4hHbxs9ygNI" role="jymVt">
+      <property role="TrG5h" value="getEditor" />
+      <node concept="3clFbS" id="4hHbxs9ygNL" role="3clF47">
+        <node concept="3clFbF" id="4hHbxs9yhKs" role="3cqZAp">
+          <node concept="2OqwBi" id="4hHbxs9yktJ" role="3clFbG">
+            <node concept="0kSF2" id="4hHbxs9yimh" role="2Oq$k0">
+              <node concept="3uibUv" id="4hHbxs9yimj" role="0kSFW">
+                <ref role="3uigEE" to="exr9:~IntentionsSupport" resolve="IntentionsSupport" />
+              </node>
+              <node concept="Xjq3P" id="4hHbxs9yhKr" role="0kSFX" />
+            </node>
+            <node concept="1PnCL0" id="4hHbxs9yltk" role="2OqNvi">
+              <ref role="2Oxat5" to="exr9:~IntentionsSupport.myEditor" resolve="myEditor" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="4hHbxs9yeZe" role="1B3o_S" />
+      <node concept="3uibUv" id="4hHbxs9yfV3" role="3clF45">
+        <ref role="3uigEE" to="exr9:~EditorComponent" resolve="EditorComponent" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="4hHbxs9Acc2" role="jymVt" />
+    <node concept="3clFb_" id="4hHbxs9AeGD" role="jymVt">
+      <property role="TrG5h" value="getModelAccess" />
+      <node concept="3clFbS" id="4hHbxs9AeGG" role="3clF47">
+        <node concept="3clFbF" id="4hHbxs9Afu5" role="3cqZAp">
+          <node concept="2OqwBi" id="4hHbxs9Afu7" role="3clFbG">
+            <node concept="1rXfSq" id="4hHbxs9Afu8" role="2Oq$k0">
+              <ref role="37wK5l" node="4hHbxs9_oo1" resolve="getIntentionsSupport" />
+            </node>
+            <node concept="1PvZjq" id="4hHbxs9Afu9" role="2OqNvi">
+              <ref role="37wK5l" to="exr9:~IntentionsSupport.getModelAccess()" resolve="getModelAccess" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="4hHbxs9AdVV" role="1B3o_S" />
+      <node concept="3uibUv" id="4hHbxs9Ae$G" role="3clF45">
+        <ref role="3uigEE" to="lui2:~ModelAccess" resolve="ModelAccess" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="4hHbxs9xF7g" role="jymVt" />
+    <node concept="3clFb_" id="4hHbxs9xM33" role="jymVt">
+      <property role="TrG5h" value="intentionThreadCompleted" />
+      <node concept="37vLTG" id="4hHbxs9xM34" role="3clF46">
+        <property role="TrG5h" value="thread" />
+        <node concept="3uibUv" id="4hHbxs9xM35" role="1tU5fm">
+          <ref role="3uigEE" node="4hHbxs9xqXT" resolve="IntentionsThread" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="4hHbxs9xM36" role="3clF47">
+        <node concept="3clFbF" id="4hHbxs9xM37" role="3cqZAp">
+          <node concept="2OqwBi" id="4hHbxs9xNMs" role="3clFbG">
+            <node concept="37vLTw" id="4hHbxs9xMs4" role="2Oq$k0">
+              <ref role="3cqZAo" node="4hHbxs9xqLS" resolve="myShowIntentionsThread" />
+            </node>
+            <node concept="liA8E" id="4hHbxs9xNMt" role="2OqNvi">
+              <ref role="37wK5l" to="i5cy:~AtomicReference.compareAndSet(java.lang.Object,java.lang.Object)" resolve="compareAndSet" />
+              <node concept="37vLTw" id="4hHbxs9xNMu" role="37wK5m">
+                <ref role="3cqZAo" node="4hHbxs9xM34" resolve="thread" />
+              </node>
+              <node concept="10Nm6u" id="4hHbxs9xNMv" role="37wK5m" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="4hHbxs9xM3b" role="1B3o_S" />
+      <node concept="3cqZAl" id="4hHbxs9xM3c" role="3clF45" />
+    </node>
+    <node concept="2tJIrI" id="4hHbxs9AmaE" role="jymVt" />
+    <node concept="3clFb_" id="4hHbxs9Ao5A" role="jymVt">
+      <property role="TrG5h" value="updateIntentionsStatus" />
+      <node concept="3clFbS" id="4hHbxs9Ao5B" role="3clF47">
+        <node concept="3clFbJ" id="4hHbxs9Ao5C" role="3cqZAp">
+          <node concept="3fqX7Q" id="4hHbxs9Ao5D" role="3clFbw">
+            <node concept="2OqwBi" id="4hHbxs9A_rL" role="3fr31v">
+              <node concept="2OqwBi" id="4hHbxs9Axja" role="2Oq$k0">
+                <node concept="1rXfSq" id="4hHbxs9Aslk" role="2Oq$k0">
+                  <ref role="37wK5l" node="4hHbxs9ygNI" resolve="getEditor" />
+                </node>
+                <node concept="1PvZjq" id="4hHbxs9AzDa" role="2OqNvi">
+                  <ref role="37wK5l" to="exr9:~EditorComponent.getEditorConfiguration()" resolve="getEditorConfiguration" />
+                </node>
+              </node>
+              <node concept="2OwXpG" id="4hHbxs9AAeP" role="2OqNvi">
+                <ref role="2Oxat6" to="7oz1:~EditorConfiguration.showLightBulb" resolve="showLightBulb" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbS" id="4hHbxs9Ao5I" role="3clFbx">
+            <node concept="3cpWs6" id="4hHbxs9Ao5J" role="3cqZAp" />
+          </node>
+        </node>
+        <node concept="3clFbF" id="3DQAigeP89T" role="3cqZAp">
+          <node concept="1rXfSq" id="3DQAigeP89R" role="3clFbG">
+            <ref role="37wK5l" node="3DQAigeOL4F" resolve="stopIntentionThread" />
+          </node>
+        </node>
+        <node concept="3clFbF" id="4hHbxs9AJl0" role="3cqZAp">
+          <node concept="2OqwBi" id="4hHbxs9AJRN" role="3clFbG">
+            <node concept="1rXfSq" id="4hHbxs9AJkY" role="2Oq$k0">
+              <ref role="37wK5l" node="4hHbxs9_oo1" resolve="getIntentionsSupport" />
+            </node>
+            <node concept="1PvZjq" id="4hHbxs9ALFE" role="2OqNvi">
+              <ref role="37wK5l" to="exr9:~IntentionsSupport.hideLightBulb()" resolve="hideLightBulb" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4hHbxs9Ao5O" role="3cqZAp">
+          <node concept="2OqwBi" id="4hHbxs9Aq3I" role="3clFbG">
+            <node concept="37vLTw" id="4hHbxs9AoHl" role="2Oq$k0">
+              <ref role="3cqZAo" node="4hHbxs9xqLS" resolve="myShowIntentionsThreadOverwritten" />
+            </node>
+            <node concept="liA8E" id="4hHbxs9Aq3J" role="2OqNvi">
+              <ref role="37wK5l" to="i5cy:~AtomicReference.set(java.lang.Object)" resolve="set" />
+              <node concept="2ShNRf" id="4hHbxs9Aq3K" role="37wK5m">
+                <node concept="1pGfFk" id="4hHbxs9Aq3L" role="2ShVmc">
+                  <ref role="37wK5l" node="4hHbxs9xqY0" resolve="MyIntentionsThread" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4hHbxs9Ao5R" role="3cqZAp">
+          <node concept="2OqwBi" id="4hHbxs9AqHW" role="3clFbG">
+            <node concept="2OqwBi" id="4hHbxs9ApKI" role="2Oq$k0">
+              <node concept="37vLTw" id="4hHbxs9AoHq" role="2Oq$k0">
+                <ref role="3cqZAo" node="4hHbxs9xqLS" resolve="myShowIntentionsThreadOverwritten" />
+              </node>
+              <node concept="liA8E" id="4hHbxs9ApKJ" role="2OqNvi">
+                <ref role="37wK5l" to="i5cy:~AtomicReference.get()" resolve="get" />
+              </node>
+            </node>
+            <node concept="liA8E" id="4hHbxs9AqHX" role="2OqNvi">
+              <ref role="37wK5l" to="wyt6:~Thread.start()" resolve="start" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="4hHbxs9Ao5U" role="1B3o_S" />
+      <node concept="3cqZAl" id="4hHbxs9Ao5V" role="3clF45" />
+    </node>
+    <node concept="2tJIrI" id="3DQAigeOI2S" role="jymVt" />
+    <node concept="3clFb_" id="3DQAigeOL4F" role="jymVt">
+      <property role="TrG5h" value="stopIntentionThread" />
+      <node concept="3clFbS" id="3DQAigeOL4G" role="3clF47">
+        <node concept="3cpWs8" id="3DQAigeOL4I" role="3cqZAp">
+          <node concept="3cpWsn" id="3DQAigeOL4H" role="3cpWs9">
+            <property role="TrG5h" value="thread" />
+            <node concept="3uibUv" id="3DQAigeOL4J" role="1tU5fm">
+              <ref role="3uigEE" node="4hHbxs9xqXT" resolve="IntentionsThread" />
+            </node>
+            <node concept="2OqwBi" id="3DQAigeOR_N" role="33vP2m">
+              <node concept="37vLTw" id="3DQAigeOMnC" role="2Oq$k0">
+                <ref role="3cqZAo" node="4hHbxs9xqLS" resolve="myShowIntentionsThreadOverwritten" />
+              </node>
+              <node concept="liA8E" id="3DQAigeOR_O" role="2OqNvi">
+                <ref role="37wK5l" to="i5cy:~AtomicReference.getAndSet(java.lang.Object)" resolve="getAndSet" />
+                <node concept="10Nm6u" id="3DQAigeOR_P" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="3DQAigeOL4M" role="3cqZAp">
+          <node concept="3y3z36" id="3DQAigeOL4N" role="3clFbw">
+            <node concept="37vLTw" id="3DQAigeOL4O" role="3uHU7B">
+              <ref role="3cqZAo" node="3DQAigeOL4H" resolve="thread" />
+            </node>
+            <node concept="10Nm6u" id="3DQAigeOL4P" role="3uHU7w" />
+          </node>
+          <node concept="3clFbS" id="3DQAigeOL4R" role="3clFbx">
+            <node concept="3clFbF" id="3DQAigeOL4S" role="3cqZAp">
+              <node concept="2OqwBi" id="3DQAigeOOz$" role="3clFbG">
+                <node concept="37vLTw" id="3DQAigeOMn_" role="2Oq$k0">
+                  <ref role="3cqZAo" node="3DQAigeOL4H" resolve="thread" />
+                </node>
+                <node concept="liA8E" id="3DQAigeOOz_" role="2OqNvi">
+                  <ref role="37wK5l" node="4hHbxs9xqY6" resolve="requestStop" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="3DQAigeOL4U" role="1B3o_S" />
+      <node concept="3cqZAl" id="3DQAigeOL4V" role="3clF45" />
+    </node>
+    <node concept="2tJIrI" id="3DQAigeOI2T" role="jymVt" />
+    <node concept="3clFb_" id="3DQAigePfof" role="jymVt">
+      <property role="TrG5h" value="areIntentionsNotSupported" />
+      <node concept="3clFbS" id="3DQAigePfoi" role="3clF47">
+        <node concept="3clFbJ" id="3DQAigeUW3H" role="3cqZAp">
+          <node concept="1Wc70l" id="3DQAigeUW3I" role="3clFbw">
+            <node concept="3fqX7Q" id="3DQAigeUW3J" role="3uHU7w">
+              <node concept="2YIFZM" id="3DQAigeUW3K" role="3fr31v">
+                <ref role="37wK5l" node="5qf1oe_zNws" resolve="allowIntentionsInReadOnlySelection" />
+                <ref role="1Pybhc" node="5qf1oe_zyw0" resolve="StyleUtil" />
+                <node concept="1rXfSq" id="3DQAigeUW3L" role="37wK5m">
+                  <ref role="37wK5l" node="4hHbxs9ygNI" resolve="getEditor" />
+                </node>
+              </node>
+            </node>
+            <node concept="1eOMI4" id="3DQAigeUW3M" role="3uHU7B">
+              <node concept="22lmx$" id="3DQAigeUW3N" role="1eOMHV">
+                <node concept="2YIFZM" id="3DQAigeUW3O" role="3uHU7B">
+                  <ref role="1Pybhc" to="3ahc:~ReadOnlyUtil" resolve="ReadOnlyUtil" />
+                  <ref role="37wK5l" to="3ahc:~ReadOnlyUtil.isSelectionReadOnlyInEditor(jetbrains.mps.openapi.editor.EditorComponent)" resolve="isSelectionReadOnlyInEditor" />
+                  <node concept="1rXfSq" id="3DQAigeUW3P" role="37wK5m">
+                    <ref role="37wK5l" node="4hHbxs9ygNI" resolve="getEditor" />
+                  </node>
+                </node>
+                <node concept="2YIFZM" id="3DQAigeUW3Q" role="3uHU7w">
+                  <ref role="1Pybhc" to="w1kc:~SModelOperations" resolve="SModelOperations" />
+                  <ref role="37wK5l" to="w1kc:~SModelOperations.isReadOnly(org.jetbrains.mps.openapi.model.SModel)" resolve="isReadOnly" />
+                  <node concept="2OqwBi" id="3DQAigeUW3R" role="37wK5m">
+                    <node concept="liA8E" id="3DQAigeUW3S" role="2OqNvi">
+                      <ref role="37wK5l" to="mhbf:~SNode.getModel()" resolve="getModel" />
+                    </node>
+                    <node concept="2OqwBi" id="3DQAigeUW3T" role="2Oq$k0">
+                      <node concept="1rXfSq" id="3DQAigeUW3U" role="2Oq$k0">
+                        <ref role="37wK5l" node="4hHbxs9ygNI" resolve="getEditor" />
+                      </node>
+                      <node concept="liA8E" id="3DQAigeUW3V" role="2OqNvi">
+                        <ref role="37wK5l" to="exr9:~EditorComponent.getSelectedNode()" resolve="getSelectedNode" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbS" id="3DQAigeUW3W" role="3clFbx">
+            <node concept="3cpWs6" id="3DQAigeUW3X" role="3cqZAp">
+              <node concept="3clFbT" id="3DQAigeUYy$" role="3cqZAk">
+                <property role="3clFbU" value="true" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="3DQAigeV55a" role="3cqZAp" />
+        <node concept="3cpWs6" id="3DQAigeV5Kx" role="3cqZAp">
+          <node concept="3clFbT" id="3DQAigeV5KX" role="3cqZAk" />
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="3DQAigePcmT" role="1B3o_S" />
+      <node concept="10P_77" id="3DQAigePe9F" role="3clF45" />
+    </node>
+    <node concept="2tJIrI" id="3DQAigeQ3s0" role="jymVt" />
+    <node concept="3clFb_" id="3pwG8PSkQDq" role="jymVt">
+      <property role="TrG5h" value="checkAndShowMenu" />
+      <property role="DiZV1" value="false" />
+      <property role="od$2w" value="false" />
+      <node concept="3clFbS" id="3pwG8PSkQDr" role="3clF47">
+        <node concept="3clFbJ" id="3pwG8PSkQDs" role="3cqZAp">
+          <node concept="3clFbS" id="3pwG8PSkQDv" role="3clFbx">
+            <node concept="3cpWs6" id="3pwG8PSkQDu" role="3cqZAp" />
+          </node>
+          <node concept="2OqwBi" id="3DQAigeQbFC" role="3clFbw">
+            <node concept="1rXfSq" id="3DQAigeQaMj" role="2Oq$k0">
+              <ref role="37wK5l" node="4hHbxs9_oo1" resolve="getIntentionsSupport" />
+            </node>
+            <node concept="1PvZjq" id="3DQAigeQdGl" role="2OqNvi">
+              <ref role="37wK5l" to="exr9:~IntentionsSupport.isInconsistentEditor()" resolve="isInconsistentEditor" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="3pwG8PSkQDw" role="3cqZAp">
+          <node concept="3clFbS" id="3pwG8PSkQDD" role="3clFbx">
+            <node concept="3cpWs6" id="3pwG8PSkQDC" role="3cqZAp" />
+          </node>
+          <node concept="1rXfSq" id="3DQAigeV2lV" role="3clFbw">
+            <ref role="37wK5l" node="3DQAigePfof" resolve="areIntentionsNotSupported" />
+          </node>
+        </node>
+        <node concept="3clFbF" id="2jDew64XO65" role="3cqZAp">
+          <node concept="2OqwBi" id="2jDew64XSbT" role="3clFbG">
+            <node concept="1rXfSq" id="3DQAigeRzAY" role="2Oq$k0">
+              <ref role="37wK5l" node="4hHbxs9_oo1" resolve="getIntentionsSupport" />
+            </node>
+            <node concept="1PvZjq" id="2jDew64XULy" role="2OqNvi">
+              <ref role="37wK5l" to="exr9:~IntentionsSupport.showIntentionsMenu()" resolve="showIntentionsMenu" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tmbuc" id="3pwG8PSojnf" role="1B3o_S" />
+      <node concept="3cqZAl" id="3pwG8PSkQDH" role="3clF45" />
+    </node>
+    <node concept="2tJIrI" id="3DQAigeQ3s1" role="jymVt" />
   </node>
 </model>
 

--- a/code/intentionsmenu/com.mbeddr.mpsutil.intentions.runtime/models/com/mbeddr/mpsutil/intentions/runtime/plugin.mps
+++ b/code/intentionsmenu/com.mbeddr.mpsutil.intentions.runtime/models/com/mbeddr/mpsutil/intentions/runtime/plugin.mps
@@ -15,6 +15,9 @@
   </imports>
   <registry>
     <language id="654422bf-e75f-44dc-936d-188890a746ce" name="de.slisson.mps.reflection">
+      <concept id="8473566765275063380" name="de.slisson.mps.reflection.structure.ReflectionFieldAccess" flags="ng" index="1PnCL0">
+        <reference id="1197029500499" name="fieldDeclaration" index="2Oxat5" />
+      </concept>
       <concept id="8473566765277240526" name="de.slisson.mps.reflection.structure.ReflectionMethodCall" flags="ng" index="1PvZjq" />
     </language>
     <language id="28f9e497-3b42-4291-aeba-0a1039153ab1" name="jetbrains.mps.lang.plugin">
@@ -152,6 +155,27 @@
                     <node concept="3clFbS" id="3pwG8PSjTLP" role="3clF47">
                       <node concept="3clFbJ" id="6E9H6NYX$7F" role="3cqZAp">
                         <node concept="3clFbS" id="6E9H6NYX$7H" role="3clFbx">
+                          <node concept="3clFbF" id="3DQAigeSu2Z" role="3cqZAp">
+                            <node concept="37vLTI" id="3DQAigeS$d5" role="3clFbG">
+                              <node concept="2ShNRf" id="3DQAigeS$me" role="37vLTx">
+                                <node concept="1pGfFk" id="3DQAigeS$DH" role="2ShVmc">
+                                  <property role="373rjd" value="true" />
+                                  <ref role="37wK5l" to="ih8q:4hHbxs9xq$1" resolve="MyIntentionsSupport" />
+                                  <node concept="37vLTw" id="3DQAigeS$M9" role="37wK5m">
+                                    <ref role="3cqZAo" node="3pwG8PSjTLK" resolve="editorComponent" />
+                                  </node>
+                                </node>
+                              </node>
+                              <node concept="2OqwBi" id="3DQAigeSvJx" role="37vLTJ">
+                                <node concept="37vLTw" id="3DQAigeSu2X" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="3pwG8PSjTLK" resolve="editorComponent" />
+                                </node>
+                                <node concept="1PnCL0" id="3DQAigeSxWl" role="2OqNvi">
+                                  <ref role="2Oxat5" to="exr9:~EditorComponent.myIntentionsSupport" resolve="myIntentionsSupport" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
                           <node concept="3clFbF" id="2jDew64H8Xv" role="3cqZAp">
                             <node concept="2OqwBi" id="2jDew64HaXY" role="3clFbG">
                               <node concept="37vLTw" id="2jDew64H8Xt" role="2Oq$k0">

--- a/code/languages/com.mbeddr.mpsutil.intentions.sandboxlang/models/com.mbeddr.mpsutil.intentions.sandboxlang.intentions.mps
+++ b/code/languages/com.mbeddr.mpsutil.intentions.sandboxlang/models/com.mbeddr.mpsutil.intentions.sandboxlang.intentions.mps
@@ -252,13 +252,13 @@
     </node>
   </node>
   <node concept="2S6QgY" id="frLjuvPz1B">
-    <property role="TrG5h" value="ChildIntentionNotVisible" />
+    <property role="TrG5h" value="ChildIntentionVisibleAltoughReadOnly" />
     <ref role="2ZfgGC" to="iikq:5qf1oe_GcsF" resolve="IChild" />
     <node concept="2S6ZIM" id="frLjuvPz1C" role="2ZfVej">
       <node concept="3clFbS" id="frLjuvPz1D" role="2VODD2">
         <node concept="3clFbF" id="frLjuvPz1E" role="3cqZAp">
           <node concept="Xl_RD" id="frLjuvPz1F" role="3clFbG">
-            <property role="Xl_RC" value="Not Visible In Ready-Only Cell" />
+            <property role="Xl_RC" value="Visible In Ready-Only Cell" />
           </node>
         </node>
       </node>

--- a/code/solutions/com.mbeddr.mpsutil.intentions.tests/com.mbeddr.mpsutil.intentions.tests.msd
+++ b/code/solutions/com.mbeddr.mpsutil.intentions.tests/com.mbeddr.mpsutil.intentions.tests.msd
@@ -9,6 +9,7 @@
     <facet compile="mps" classes="mps" ext="no" type="java">
       <classes generated="true" path="${module}/classes_gen" />
     </facet>
+    <facet type="tests" />
   </facets>
   <dependencies>
     <dependency reexport="false">4972ae94-72e7-499b-8766-0d6acffdb4f2(com.mbeddr.mpsutil.intentions.sandboxlang)</dependency>

--- a/code/solutions/com.mbeddr.mpsutil.intentions.tests/com.mbeddr.mpsutil.intentions.tests.msd
+++ b/code/solutions/com.mbeddr.mpsutil.intentions.tests/com.mbeddr.mpsutil.intentions.tests.msd
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<solution name="com.mbeddr.mpsutil.intentions.tests" uuid="73a78daa-4204-43ee-8a0e-1b2b39741908" moduleVersion="0">
+  <models>
+    <modelRoot type="default" contentPath="${module}">
+      <sourceRoot location="models" />
+    </modelRoot>
+  </models>
+  <facets>
+    <facet compile="mps" classes="mps" ext="no" type="java">
+      <classes generated="true" path="${module}/classes_gen" />
+    </facet>
+  </facets>
+  <dependencies>
+    <dependency reexport="false">4972ae94-72e7-499b-8766-0d6acffdb4f2(com.mbeddr.mpsutil.intentions.sandboxlang)</dependency>
+  </dependencies>
+  <languageVersions>
+    <language slang="l:4972ae94-72e7-499b-8766-0d6acffdb4f2:com.mbeddr.mpsutil.intentions.sandboxlang" version="0" />
+    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
+    <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />
+    <language slang="l:f61473f9-130f-42f6-b98d-6c438812c2f6:jetbrains.mps.baseLanguage.unitTest" version="1" />
+    <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
+    <language slang="l:8585453e-6bfb-4d80-98de-b16074f1d86c:jetbrains.mps.lang.test" version="6" />
+    <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
+  </languageVersions>
+  <dependencyVersions>
+    <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
+    <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
+    <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
+    <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+    <module reference="4972ae94-72e7-499b-8766-0d6acffdb4f2(com.mbeddr.mpsutil.intentions.sandboxlang)" version="0" />
+    <module reference="73a78daa-4204-43ee-8a0e-1b2b39741908(com.mbeddr.mpsutil.intentions.tests)" version="0" />
+    <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
+  </dependencyVersions>
+</solution>
+

--- a/code/solutions/com.mbeddr.mpsutil.intentions.tests/models/com.mbeddr.mpsutil.intentions.tests.tests@tests.mps
+++ b/code/solutions/com.mbeddr.mpsutil.intentions.tests/models/com.mbeddr.mpsutil.intentions.tests.tests@tests.mps
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:40d04b00-2be3-4b3b-909e-f12049589983(com.mbeddr.mpsutil.intentions.tests.tests@tests)">
+  <persistence version="9" />
+  <languages>
+    <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="6" />
+    <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
+    <use id="4972ae94-72e7-499b-8766-0d6acffdb4f2" name="com.mbeddr.mpsutil.intentions.sandboxlang" version="0" />
+  </languages>
+  <imports>
+    <import index="gw4x" ref="r:f1d822a2-1f43-4b14-8097-de7e855e6079(com.mbeddr.mpsutil.intentions.sandboxlang.intentions)" />
+  </imports>
+  <registry>
+    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="1229187653856" name="jetbrains.mps.lang.test.structure.EditorTestCase" flags="lg" index="LiM7Y">
+        <property id="1883175908513350760" name="description" index="3YCmrE" />
+        <child id="3143335925185262946" name="testNodeBefore" index="25YQCW" />
+        <child id="3143335925185262981" name="testNodeResult" index="25YQFr" />
+        <child id="1229187755283" name="code" index="LjaKd" />
+      </concept>
+      <concept id="1229194968594" name="jetbrains.mps.lang.test.structure.AnonymousCellAnnotation" flags="ng" index="LIFWc">
+        <property id="6268941039745498163" name="selectionStart" index="p6zMq" />
+        <property id="6268941039745498165" name="selectionEnd" index="p6zMs" />
+        <property id="1229194968595" name="cellId" index="LIFWd" />
+        <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
+        <property id="1229432188737" name="isLastPosition" index="ZRATv" />
+      </concept>
+      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
+        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
+      </concept>
+      <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
+        <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
+      </concept>
+      <concept id="1225989773458" name="jetbrains.mps.lang.test.structure.InvokeIntentionStatement" flags="nn" index="1MFPAf">
+        <reference id="1225989811227" name="intention" index="1MFYO6" />
+      </concept>
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+    <language id="4972ae94-72e7-499b-8766-0d6acffdb4f2" name="com.mbeddr.mpsutil.intentions.sandboxlang">
+      <concept id="6237210071910106918" name="com.mbeddr.mpsutil.intentions.sandboxlang.structure.Root" flags="ng" index="3NfWa_">
+        <child id="6237210071910106920" name="children" index="3NfWaF" />
+      </concept>
+      <concept id="6237210071910112531" name="com.mbeddr.mpsutil.intentions.sandboxlang.structure.ReadOnlyChildAllowed" flags="ng" index="3NfXyg" />
+    </language>
+  </registry>
+  <node concept="LiM7Y" id="2$4DgwiMmuc">
+    <property role="TrG5h" value="RunIntentionOnReadOnlyCellViaStyleFlag" />
+    <property role="3YCmrE" value="Intensions on readonly cells are only possible via the `com.mbeddr.mpsutil.intentions` language. Such an intention is triggered by this test. The used `cell` annotation is set via console and the correct cell_id is takin from the cell explorer." />
+    <node concept="1qefOq" id="2$4DgwiMmue" role="25YQCW">
+      <node concept="3NfWa_" id="2$4DgwiMmud" role="1qenE9">
+        <property role="TrG5h" value="RootOfReadOnlyAndNonReadOnlyCells" />
+        <node concept="3NfXyg" id="2$4DgwiN1VF" role="3NfWaF">
+          <node concept="LIFWc" id="2$4DgwiN1VI" role="lGtFl">
+            <property role="ZRATv" value="true" />
+            <property role="OXtK3" value="true" />
+            <property role="p6zMq" value="5" />
+            <property role="p6zMs" value="5" />
+            <property role="LIFWd" value="Constant_nfbwof_a" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="2$4DgwiMmug" role="25YQFr">
+      <node concept="3NfWa_" id="2$4DgwiMmui" role="1qenE9">
+        <property role="TrG5h" value="Changed" />
+        <node concept="3NfXyg" id="2$4DgwiN1VJ" role="3NfWaF" />
+      </node>
+    </node>
+    <node concept="3clFbS" id="2$4DgwiMmuo" role="LjaKd">
+      <node concept="1MFPAf" id="2$4DgwiN4By" role="3cqZAp">
+        <ref role="1MFYO6" to="gw4x:frLjuvPz1B" resolve="ChildIntentionVisibleAltoughReadOnly" />
+      </node>
+    </node>
+  </node>
+  <node concept="2XOHcx" id="2$4DgwiMtiM">
+    <property role="2XOHcw" value="${extensions.home}/code" />
+  </node>
+</model>
+

--- a/code/solutions/de.itemis.mps.extensions.changelog/models/de.itemis.mps.extensions.changelog.mps
+++ b/code/solutions/de.itemis.mps.extensions.changelog/models/de.itemis.mps.extensions.changelog.mps
@@ -244,9 +244,9 @@
             <node concept="1PaTwC" id="7Px_cmus87U" role="2hiFM$">
               <node concept="15Ami3" id="7Px_cmus87V" role="1PaTwD">
                 <node concept="37shsh" id="7Px_cmus87W" role="15Aodc">
-                  <node concept="1dCxOk" id="7Px_cmus87X" role="37shsm">
-                    <property role="1XweGW" value="fa13cc63-c476-4d46-9c96-d53670abe7bc" />
-                    <property role="1XxBO9" value="de.itemis.mps.editor.diagram" />
+                  <node concept="1dCxOk" id="2$4DgwiMh92" role="37shsm">
+                    <property role="1XweGW" value="4bff7bbe-ce5f-432e-84bf-60809cb9987c" />
+                    <property role="1XxBO9" value="com.mbeddr.mpsutil.intentions.runtime" />
                   </node>
                 </node>
               </node>
@@ -270,43 +270,111 @@
           <node concept="3oM_SD" id="7Px_cmus887" role="1PaTwD">
             <property role="3oM_SC" value="where" />
           </node>
-          <node concept="3oM_SD" id="7Px_cmus888" role="1PaTwD">
-            <property role="3oM_SC" value="edges" />
-          </node>
-          <node concept="3oM_SD" id="7Px_cmus889" role="1PaTwD">
-            <property role="3oM_SC" value="of" />
-          </node>
-          <node concept="3oM_SD" id="7Px_cmus88a" role="1PaTwD">
-            <property role="3oM_SC" value="sub-diagrams" />
-          </node>
-          <node concept="3oM_SD" id="7Px_cmus88b" role="1PaTwD">
-            <property role="3oM_SC" value="where" />
-          </node>
-          <node concept="3oM_SD" id="7Px_cmus88c" role="1PaTwD">
-            <property role="3oM_SC" value="not" />
-          </node>
-          <node concept="3oM_SD" id="7Px_cmus88d" role="1PaTwD">
-            <property role="3oM_SC" value="correctly" />
-          </node>
-          <node concept="3oM_SD" id="7Px_cmus88e" role="1PaTwD">
-            <property role="3oM_SC" value="displayed" />
-          </node>
-          <node concept="3oM_SD" id="7Px_cmus88f" role="1PaTwD">
-            <property role="3oM_SC" value="when" />
-          </node>
-          <node concept="3oM_SD" id="7Px_cmus88g" role="1PaTwD">
+          <node concept="3oM_SD" id="2$4DgwiMh96" role="1PaTwD">
             <property role="3oM_SC" value="the" />
           </node>
-          <node concept="3oM_SD" id="7Px_cmus88h" role="1PaTwD">
-            <property role="3oM_SC" value="diagram" />
+          <node concept="3oM_SD" id="2$4DgwiMh97" role="1PaTwD">
+            <property role="3oM_SC" value="intentions" />
           </node>
-          <node concept="3oM_SD" id="7Px_cmus88i" role="1PaTwD">
+          <node concept="3oM_SD" id="2$4DgwiMh98" role="1PaTwD">
+            <property role="3oM_SC" value="menu" />
+          </node>
+          <node concept="3oM_SD" id="2$4DgwiMh99" role="1PaTwD">
             <property role="3oM_SC" value="was" />
           </node>
-          <node concept="3oM_SD" id="7Px_cmus88j" role="1PaTwD">
+          <node concept="3oM_SD" id="2$4DgwiMh9a" role="1PaTwD">
+            <property role="3oM_SC" value="no" />
+          </node>
+          <node concept="3oM_SD" id="2$4DgwiMh9b" role="1PaTwD">
+            <property role="3oM_SC" value="longer" />
+          </node>
+          <node concept="3oM_SD" id="2$4DgwiMh9c" role="1PaTwD">
+            <property role="3oM_SC" value="available" />
+          </node>
+          <node concept="3oM_SD" id="2$4DgwiMh9d" role="1PaTwD">
+            <property role="3oM_SC" value="on" />
+          </node>
+          <node concept="3oM_SD" id="2$4DgwiMh9e" role="1PaTwD">
+            <property role="3oM_SC" value="read" />
+          </node>
+          <node concept="3oM_SD" id="2$4DgwiMh9f" role="1PaTwD">
+            <property role="3oM_SC" value="only" />
+          </node>
+          <node concept="3oM_SD" id="2$4DgwiMh9g" role="1PaTwD">
+            <property role="3oM_SC" value="editor" />
+          </node>
+          <node concept="3oM_SD" id="2$4DgwiMh9l" role="1PaTwD">
+            <property role="3oM_SC" value="cells" />
+          </node>
+        </node>
+        <node concept="2DRihI" id="2$4DgwiMh8A" role="15bAlk">
+          <node concept="2hgSXJ" id="2$4DgwiMh8B" role="1PaTwD">
+            <node concept="1PaTwC" id="2$4DgwiMh8C" role="2hiFM$">
+              <node concept="15Ami3" id="2$4DgwiMh8D" role="1PaTwD">
+                <node concept="37shsh" id="2$4DgwiMh8E" role="15Aodc">
+                  <node concept="1dCxOk" id="2$4DgwiMh8F" role="37shsm">
+                    <property role="1XweGW" value="fa13cc63-c476-4d46-9c96-d53670abe7bc" />
+                    <property role="1XxBO9" value="de.itemis.mps.editor.diagram" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3oM_SD" id="2$4DgwiMh8G" role="1PaTwD">
+                <property role="3oM_SC" value=":" />
+              </node>
+            </node>
+          </node>
+          <node concept="3oM_SD" id="2$4DgwiMh8H" role="1PaTwD">
+            <property role="3oM_SC" value="An" />
+          </node>
+          <node concept="3oM_SD" id="2$4DgwiMh8I" role="1PaTwD">
+            <property role="3oM_SC" value="issue" />
+          </node>
+          <node concept="3oM_SD" id="2$4DgwiMh8J" role="1PaTwD">
+            <property role="3oM_SC" value="was" />
+          </node>
+          <node concept="3oM_SD" id="2$4DgwiMh8K" role="1PaTwD">
+            <property role="3oM_SC" value="fixed" />
+          </node>
+          <node concept="3oM_SD" id="2$4DgwiMh8L" role="1PaTwD">
+            <property role="3oM_SC" value="where" />
+          </node>
+          <node concept="3oM_SD" id="2$4DgwiMh8M" role="1PaTwD">
+            <property role="3oM_SC" value="edges" />
+          </node>
+          <node concept="3oM_SD" id="2$4DgwiMh8N" role="1PaTwD">
+            <property role="3oM_SC" value="of" />
+          </node>
+          <node concept="3oM_SD" id="2$4DgwiMh8O" role="1PaTwD">
+            <property role="3oM_SC" value="sub-diagrams" />
+          </node>
+          <node concept="3oM_SD" id="2$4DgwiMh8P" role="1PaTwD">
+            <property role="3oM_SC" value="where" />
+          </node>
+          <node concept="3oM_SD" id="2$4DgwiMh8Q" role="1PaTwD">
+            <property role="3oM_SC" value="not" />
+          </node>
+          <node concept="3oM_SD" id="2$4DgwiMh8R" role="1PaTwD">
+            <property role="3oM_SC" value="correctly" />
+          </node>
+          <node concept="3oM_SD" id="2$4DgwiMh8S" role="1PaTwD">
+            <property role="3oM_SC" value="displayed" />
+          </node>
+          <node concept="3oM_SD" id="2$4DgwiMh8T" role="1PaTwD">
+            <property role="3oM_SC" value="when" />
+          </node>
+          <node concept="3oM_SD" id="2$4DgwiMh8U" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="2$4DgwiMh8V" role="1PaTwD">
+            <property role="3oM_SC" value="diagram" />
+          </node>
+          <node concept="3oM_SD" id="2$4DgwiMh8W" role="1PaTwD">
+            <property role="3oM_SC" value="was" />
+          </node>
+          <node concept="3oM_SD" id="2$4DgwiMh8X" role="1PaTwD">
             <property role="3oM_SC" value="first" />
           </node>
-          <node concept="3oM_SD" id="7Px_cmus88k" role="1PaTwD">
+          <node concept="3oM_SD" id="2$4DgwiMh8Y" role="1PaTwD">
             <property role="3oM_SC" value="opened" />
           </node>
         </node>


### PR DESCRIPTION
Fixes #1233 by registring and overriding a new `alt ENTER` action. 
The bulb is (as before) not visible.