### PR TITLE
avoid CCE when not AbstractModule

### DIFF
--- a/code/hacks/solutions/de.slisson.mps.hacks.editor/models/de/slisson/mps/hacks/editor.mps
+++ b/code/hacks/solutions/de.slisson.mps.hacks.editor/models/de/slisson/mps/hacks/editor.mps
@@ -6154,9 +6154,6 @@
           </node>
         </node>
       </node>
-      <node concept="2AHcQZ" id="5nA3diwsmQn" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-      </node>
     </node>
     <node concept="3clFb_" id="5nA3diwsmQq" role="jymVt">
       <property role="TrG5h" value="isMultiple" />
@@ -6173,9 +6170,6 @@
             </node>
           </node>
         </node>
-      </node>
-      <node concept="2AHcQZ" id="5nA3diwsmQz" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
     <node concept="3clFb_" id="5nA3diwsmQA" role="jymVt">
@@ -6198,9 +6192,6 @@
             </node>
           </node>
         </node>
-      </node>
-      <node concept="2AHcQZ" id="5nA3diwsmQN" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
     <node concept="3clFb_" id="5nA3diwsmQQ" role="jymVt">

--- a/code/model-api/org.modelix.model.mpsadapters/models/org.modelix.model.mpsadapters.mps.mps
+++ b/code/model-api/org.modelix.model.mpsadapters/models/org.modelix.model.mpsadapters.mps.mps
@@ -14738,31 +14738,31 @@
               <node concept="17QB3L" id="4bf8ZXPce8D" role="3clF45" />
               <node concept="3Tm1VV" id="4bf8ZXPce8E" role="1B3o_S" />
               <node concept="3clFbS" id="4bf8ZXPce8F" role="3clF47">
-                <node concept="3cpWs8" id="1oPURZ49NDe" role="3cqZAp">
-                  <node concept="3cpWsn" id="1oPURZ49NDf" role="3cpWs9">
-                    <property role="TrG5h" value="moduleDescriptor" />
-                    <node concept="3uibUv" id="1oPURZ491yE" role="1tU5fm">
-                      <ref role="3uigEE" to="w0gx:~ModuleDescriptor" resolve="ModuleDescriptor" />
-                    </node>
-                    <node concept="2OqwBi" id="1oPURZ49NDg" role="33vP2m">
-                      <node concept="1eOMI4" id="1oPURZ49NDh" role="2Oq$k0">
-                        <node concept="10QFUN" id="1oPURZ49NDi" role="1eOMHV">
-                          <node concept="3uibUv" id="1oPURZ49NDj" role="10QFUM">
-                            <ref role="3uigEE" to="z1c4:~AbstractModule" resolve="AbstractModule" />
+                <node concept="3clFbJ" id="25OQfQHA6Ua" role="3cqZAp">
+                  <node concept="3clFbS" id="25OQfQHA6Uc" role="3clFbx">
+                    <node concept="3cpWs8" id="1oPURZ49NDe" role="3cqZAp">
+                      <node concept="3cpWsn" id="1oPURZ49NDf" role="3cpWs9">
+                        <property role="TrG5h" value="moduleDescriptor" />
+                        <node concept="3uibUv" id="1oPURZ491yE" role="1tU5fm">
+                          <ref role="3uigEE" to="w0gx:~ModuleDescriptor" resolve="ModuleDescriptor" />
+                        </node>
+                        <node concept="2OqwBi" id="1oPURZ49NDg" role="33vP2m">
+                          <node concept="1eOMI4" id="1oPURZ49NDh" role="2Oq$k0">
+                            <node concept="10QFUN" id="1oPURZ49NDi" role="1eOMHV">
+                              <node concept="3uibUv" id="1oPURZ49NDj" role="10QFUM">
+                                <ref role="3uigEE" to="z1c4:~AbstractModule" resolve="AbstractModule" />
+                              </node>
+                              <node concept="37vLTw" id="1oPURZ49NDk" role="10QFUP">
+                                <ref role="3cqZAo" node="4bf8ZXPce8B" resolve="element" />
+                              </node>
+                            </node>
                           </node>
-                          <node concept="37vLTw" id="1oPURZ49NDk" role="10QFUP">
-                            <ref role="3cqZAo" node="4bf8ZXPce8B" resolve="element" />
+                          <node concept="liA8E" id="1oPURZ49NDl" role="2OqNvi">
+                            <ref role="37wK5l" to="z1c4:~AbstractModule.getModuleDescriptor()" resolve="getModuleDescriptor" />
                           </node>
                         </node>
                       </node>
-                      <node concept="liA8E" id="1oPURZ49NDl" role="2OqNvi">
-                        <ref role="37wK5l" to="z1c4:~AbstractModule.getModuleDescriptor()" resolve="getModuleDescriptor" />
-                      </node>
                     </node>
-                  </node>
-                </node>
-                <node concept="3clFbJ" id="25OQfQHA6Ua" role="3cqZAp">
-                  <node concept="3clFbS" id="25OQfQHA6Uc" role="3clFbx">
                     <node concept="3cpWs6" id="25OQfQHADhq" role="3cqZAp">
                       <node concept="2YIFZM" id="25OQfQHALED" role="3cqZAk">
                         <ref role="37wK5l" to="wyt6:~Integer.toString(int)" resolve="toString" />


### PR DESCRIPTION
Not all SModule instances are AbstractModule.
And to remove some legacy API methods, we'd need their overrides not to demand their presence.