### PR TITLE
slisson.mps.tables: try to apply more styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is *loosely* based on [Keep a Changelog](https://keepachangelog.com/e
 ### Fixed
 
 - *com.mbeddr.mpsutil.treenotation*: Tree cells now don't show insert/delete buttons when they are read-only.
+- *de.slisson.mps.tables*: Styles on tables, vertical, horizontal, vertical%, partial table and query should not also be applied. A known issue is that the most specified style is not always applied.
 
 ### Changed
 

--- a/code/solutions/de.itemis.mps.extensions.changelog/models/de.itemis.mps.extensions.changelog.mps
+++ b/code/solutions/de.itemis.mps.extensions.changelog/models/de.itemis.mps.extensions.changelog.mps
@@ -289,6 +289,108 @@
             <property role="3oM_SC" value="read-only." />
           </node>
         </node>
+        <node concept="2DRihI" id="S1tcgyYKDl" role="15bAlk">
+          <property role="2RT3bR" value="0" />
+          <node concept="2hgSXJ" id="S1tcgyYKE8" role="1PaTwD">
+            <node concept="1PaTwC" id="S1tcgyYKE9" role="2hiFM$">
+              <node concept="15Ami3" id="S1tcgyYKEa" role="1PaTwD">
+                <node concept="37shsh" id="S1tcgyYKEb" role="15Aodc">
+                  <node concept="1dCxOk" id="S1tcgyYKEc" role="37shsm">
+                    <property role="1XweGW" value="7e450f4e-1ac3-41ef-a851-4598161bdb94" />
+                    <property role="1XxBO9" value="de.slisson.mps.tables" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3oM_SD" id="S1tcgyYKEd" role="1PaTwD">
+                <property role="3oM_SC" value=":" />
+              </node>
+            </node>
+          </node>
+          <node concept="3oM_SD" id="S1tcgyYKEi" role="1PaTwD">
+            <property role="3oM_SC" value="Styles" />
+          </node>
+          <node concept="3oM_SD" id="S1tcgyYKEj" role="1PaTwD">
+            <property role="3oM_SC" value="on" />
+          </node>
+          <node concept="3oM_SD" id="S1tcgyYKEk" role="1PaTwD">
+            <property role="3oM_SC" value="tables," />
+          </node>
+          <node concept="3oM_SD" id="S1tcgyYLoB" role="1PaTwD">
+            <property role="3oM_SC" value="vertical," />
+          </node>
+          <node concept="3oM_SD" id="S1tcgyYLoC" role="1PaTwD">
+            <property role="3oM_SC" value="horizontal," />
+          </node>
+          <node concept="3oM_SD" id="S1tcgyYLoE" role="1PaTwD">
+            <property role="3oM_SC" value="vertical%," />
+          </node>
+          <node concept="3oM_SD" id="S1tcgyYLrU" role="1PaTwD">
+            <property role="3oM_SC" value="partial" />
+          </node>
+          <node concept="3oM_SD" id="S1tcgyYLrV" role="1PaTwD">
+            <property role="3oM_SC" value="table" />
+          </node>
+          <node concept="3oM_SD" id="S1tcgyZ1nA" role="1PaTwD">
+            <property role="3oM_SC" value="and" />
+          </node>
+          <node concept="3oM_SD" id="S1tcgyZ1nB" role="1PaTwD">
+            <property role="3oM_SC" value="query" />
+          </node>
+          <node concept="3oM_SD" id="S1tcgyZ1nC" role="1PaTwD">
+            <property role="3oM_SC" value="should" />
+          </node>
+          <node concept="3oM_SD" id="S1tcgyZ1nD" role="1PaTwD">
+            <property role="3oM_SC" value="not" />
+          </node>
+          <node concept="3oM_SD" id="S1tcgyZ1nE" role="1PaTwD">
+            <property role="3oM_SC" value="also" />
+          </node>
+          <node concept="3oM_SD" id="S1tcgyZ1nF" role="1PaTwD">
+            <property role="3oM_SC" value="be" />
+          </node>
+          <node concept="3oM_SD" id="S1tcgyZ1nG" role="1PaTwD">
+            <property role="3oM_SC" value="applied." />
+          </node>
+          <node concept="3oM_SD" id="S1tcgyZ1nJ" role="1PaTwD">
+            <property role="3oM_SC" value="A" />
+          </node>
+          <node concept="3oM_SD" id="S1tcgyZ1nK" role="1PaTwD">
+            <property role="3oM_SC" value="known" />
+          </node>
+          <node concept="3oM_SD" id="S1tcgyZ1nL" role="1PaTwD">
+            <property role="3oM_SC" value="issue" />
+          </node>
+          <node concept="3oM_SD" id="S1tcgyZ1nM" role="1PaTwD">
+            <property role="3oM_SC" value="is" />
+          </node>
+          <node concept="3oM_SD" id="S1tcgyZ1nN" role="1PaTwD">
+            <property role="3oM_SC" value="that" />
+          </node>
+          <node concept="3oM_SD" id="S1tcgyZ1nO" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="S1tcgyZ1nP" role="1PaTwD">
+            <property role="3oM_SC" value="most" />
+          </node>
+          <node concept="3oM_SD" id="S1tcgyZ1nQ" role="1PaTwD">
+            <property role="3oM_SC" value="specified" />
+          </node>
+          <node concept="3oM_SD" id="S1tcgyZ1nR" role="1PaTwD">
+            <property role="3oM_SC" value="style" />
+          </node>
+          <node concept="3oM_SD" id="S1tcgyZ1nS" role="1PaTwD">
+            <property role="3oM_SC" value="is" />
+          </node>
+          <node concept="3oM_SD" id="S1tcgyZ1nT" role="1PaTwD">
+            <property role="3oM_SC" value="not" />
+          </node>
+          <node concept="3oM_SD" id="S1tcgyZ1nU" role="1PaTwD">
+            <property role="3oM_SC" value="always" />
+          </node>
+          <node concept="3oM_SD" id="S1tcgyZ1nV" role="1PaTwD">
+            <property role="3oM_SC" value="applied." />
+          </node>
+        </node>
       </node>
       <node concept="15bAme" id="7qYSchhSpfs" role="15bAlL">
         <property role="15bAli" value="Po4Z58tnOF/changed" />

--- a/code/tables/languages/de.slisson.mps.tables.demolang/languageModels/editor.mps
+++ b/code/tables/languages/de.slisson.mps.tables.demolang/languageModels/editor.mps
@@ -16,8 +16,8 @@
     <import index="reoo" ref="r:1e59a084-7ebe-4e95-89ab-c58a7e396583(de.slisson.mps.tables.editor)" />
     <import index="z60i" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt(JDK/)" />
     <import index="dr5r" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util.logging(JDK/)" />
-    <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
     <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" implicit="true" />
+    <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
   </imports>
   <registry>
     <language id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor">
@@ -168,15 +168,10 @@
       </concept>
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
       <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
-      <concept id="1070534934090" name="jetbrains.mps.baseLanguage.structure.CastExpression" flags="nn" index="10QFUN">
-        <child id="1070534934091" name="type" index="10QFUM" />
-        <child id="1070534934092" name="expression" index="10QFUP" />
-      </concept>
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <property id="1176718929932" name="isFinal" index="3TUv4t" />
         <child id="1068431790190" name="initializer" index="33vP2m" />
       </concept>
-      <concept id="1092119917967" name="jetbrains.mps.baseLanguage.structure.MulExpression" flags="nn" index="17qRlL" />
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
@@ -224,9 +219,6 @@
       <concept id="1206060495898" name="jetbrains.mps.baseLanguage.structure.ElsifClause" flags="ng" index="3eNFk2">
         <child id="1206060619838" name="condition" index="3eO9$A" />
         <child id="1206060644605" name="statementList" index="3eOfB_" />
-      </concept>
-      <concept id="1079359253375" name="jetbrains.mps.baseLanguage.structure.ParenthesizedExpression" flags="nn" index="1eOMI4">
-        <child id="1079359253376" name="expression" index="1eOMHV" />
       </concept>
       <concept id="1081506773034" name="jetbrains.mps.baseLanguage.structure.LessThanExpression" flags="nn" index="3eOVzh" />
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
@@ -353,10 +345,8 @@
       <concept id="3785936898437629002" name="de.slisson.mps.tables.structure.BorderLeftWidthStyleItem" flags="lg" index="3hShR6" />
       <concept id="3785936898437629743" name="de.slisson.mps.tables.structure.BorderTopWidthStyleItem" flags="lg" index="3hShUz" />
       <concept id="3785936898437629812" name="de.slisson.mps.tables.structure.BorderBottomWidthStyleItem" flags="lg" index="3hShVS" />
-      <concept id="3785936898437444905" name="de.slisson.mps.tables.structure.IntegerTableStyleItemQuery" flags="ig" index="3hSyM_" />
       <concept id="3785936898437423425" name="de.slisson.mps.tables.structure.IntegerTableStyleItem" flags="lg" index="3hSBzd">
         <property id="3785936898437424562" name="value" index="3hSBKY" />
-        <child id="1221064706952" name="query" index="1d8cEk" />
       </concept>
       <concept id="3785936898438628050" name="de.slisson.mps.tables.structure.BorderBottomColorItem" flags="lg" index="3hWdHu" />
       <concept id="3785936898438628594" name="de.slisson.mps.tables.structure.BorderLeftColorItem" flags="lg" index="3hWdPY" />
@@ -1149,90 +1139,14 @@
         <node concept="2reCLy" id="1dAqnm8qrEc" role="2reCL6">
           <node concept="2rfbtV" id="2c3czgp39Zg" role="2recC9">
             <property role="2rfbtB" value="ID" />
-            <node concept="1g0IQG" id="3GKqtdpwAf6" role="1geGt4">
-              <node concept="3hShVS" id="3GKqtdpwAf8" role="3F10Kt">
-                <property role="3hSBKY" value="2" />
-              </node>
-              <node concept="3hWdHu" id="3GKqtdpwAfd" role="3F10Kt">
-                <property role="Vb097" value="fLwANPu/blue" />
-              </node>
-              <node concept="3tD6jV" id="3IadBSL68Dl" role="3F10Kt">
-                <ref role="3tD7wE" to="reoo:7$DZq89TvVX" resolve="horizontal-sticky-cell" />
-                <node concept="3sjG9q" id="3IadBSL68Dn" role="3tD6jU">
-                  <node concept="3clFbS" id="3IadBSL68Dp" role="2VODD2">
-                    <node concept="3clFbF" id="3IadBSL68Iy" role="3cqZAp">
-                      <node concept="3clFbT" id="3IadBSL68Ix" role="3clFbG">
-                        <property role="3clFbU" value="true" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3tD6jV" id="3IadBSL3_$4" role="3F10Kt">
-                <ref role="3tD7wE" to="reoo:2fUANpqfeyN" resolve="vertical-sticky-cell" />
-                <node concept="3sjG9q" id="3IadBSL3_$6" role="3tD6jU">
-                  <node concept="3clFbS" id="3IadBSL3_$8" role="2VODD2">
-                    <node concept="3clFbF" id="3IadBSL3_D0" role="3cqZAp">
-                      <node concept="3clFbT" id="3IadBSL3_CZ" role="3clFbG">
-                        <property role="3clFbU" value="true" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
+            <node concept="1g0IQG" id="3GKqtdpwAf6" role="1geGt4" />
           </node>
           <node concept="3F0A7n" id="1dAqnm8qrEi" role="2reSmM">
             <ref role="1NtTu8" to="nnej:1dAqnm8oBxw" resolve="name" />
           </node>
           <node concept="1g0IQG" id="4UkcdCuOpNJ" role="1geGt4">
-            <node concept="3hWdHu" id="3GKqtdpxOBj" role="3F10Kt">
-              <property role="Vb097" value="fLwANPu/blue" />
-            </node>
-            <node concept="3hShR6" id="3GKqtdpxOBo" role="3F10Kt">
-              <property role="3hSBKY" value="20" />
-              <node concept="3hSyM_" id="2FAXvauIHCo" role="1d8cEk">
-                <node concept="3clFbS" id="2FAXvauIHCp" role="2VODD2">
-                  <node concept="3clFbF" id="2FAXvauIHF4" role="3cqZAp">
-                    <node concept="1eOMI4" id="2FAXvauIIPR" role="3clFbG">
-                      <node concept="10QFUN" id="2FAXvauIIPS" role="1eOMHV">
-                        <node concept="2YIFZM" id="2FAXvauIIPN" role="10QFUP">
-                          <ref role="37wK5l" to="wyt6:~Math.round(double)" resolve="round" />
-                          <ref role="1Pybhc" to="wyt6:~Math" resolve="Math" />
-                          <node concept="17qRlL" id="2FAXvauIIPO" role="37wK5m">
-                            <node concept="3cmrfG" id="2FAXvauIIPP" role="3uHU7w">
-                              <property role="3cmrfH" value="30" />
-                            </node>
-                            <node concept="2YIFZM" id="2FAXvauIIPQ" role="3uHU7B">
-                              <ref role="1Pybhc" to="wyt6:~Math" resolve="Math" />
-                              <ref role="37wK5l" to="wyt6:~Math.random()" resolve="random" />
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="10Oyi0" id="2FAXvauIJ0q" role="10QFUM" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3hWdPY" id="3GKqtdpxOBw" role="3F10Kt">
-              <property role="Vb097" value="fLwANPr/green" />
-            </node>
-            <node concept="3hWdWw" id="3GKqtdpxOBE" role="3F10Kt">
-              <property role="Vb097" value="g1_qRwE/darkGreen" />
-            </node>
-            <node concept="3tD6jV" id="3IadBSL5iLD" role="3F10Kt">
-              <ref role="3tD7wE" to="reoo:7$DZq89TvVX" resolve="horizontal-sticky-cell" />
-              <node concept="3sjG9q" id="3IadBSL5iLF" role="3tD6jU">
-                <node concept="3clFbS" id="3IadBSL5iLH" role="2VODD2">
-                  <node concept="3clFbF" id="3IadBSL5iMg" role="3cqZAp">
-                    <node concept="3clFbT" id="3IadBSL5iMf" role="3clFbG">
-                      <property role="3clFbU" value="true" />
-                    </node>
-                  </node>
-                </node>
-              </node>
+            <node concept="3hWdWw" id="S1tcgybP2l" role="3F10Kt">
+              <property role="Vb097" value="hGRnIZc/lightBlue" />
             </node>
           </node>
         </node>
@@ -1281,15 +1195,16 @@
             </node>
           </node>
         </node>
-      </node>
-      <node concept="1g0IQG" id="5ryePYcTIW0" role="1geGt4">
-        <node concept="3hWdHu" id="3iamoN_P6wv" role="3hTmz4">
-          <property role="Vb097" value="fLwANPq/yellow" />
+        <node concept="1g0IQG" id="S1tcgy6onB" role="1geGt4">
+          <node concept="3hWdWw" id="S1tcgy6onC" role="3F10Kt">
+            <property role="Vb097" value="fLwANPn/red" />
+            <node concept="3hZEK$" id="S1tcgynWLD" role="3hZOwg">
+              <property role="3hZETZ" value="00aa0050" />
+            </node>
+          </node>
         </node>
-        <node concept="3hShVS" id="3iamoN_P8nJ" role="3hTmz4">
-          <property role="3hSBKY" value="3" />
-        </node>
       </node>
+      <node concept="1g0IQG" id="5ryePYcTIW0" role="1geGt4" />
     </node>
     <node concept="3EZMnI" id="2bN5SDonx$m" role="6VMZX">
       <node concept="l2Vlx" id="2bN5SDonx$n" role="2iSdaV" />
@@ -4206,6 +4121,11 @@
                 <ref role="3opR$y" to="nnej:40oIQyHYmE7" resolve="result" />
               </node>
             </node>
+            <node concept="1g0IQG" id="S1tcgyZ66u" role="1geGt4">
+              <node concept="3hWdWw" id="S1tcgyZ6D_" role="3F10Kt">
+                <property role="Vb097" value="fLwANPt/cyan" />
+              </node>
+            </node>
           </node>
           <node concept="2r3VGE" id="40oIQyHYXeD" role="170dB$">
             <property role="TrG5h" value="yExpressions" />
@@ -4322,6 +4242,9 @@
                     </node>
                   </node>
                 </node>
+              </node>
+              <node concept="3hWdWw" id="S1tcgz0jBf" role="3F10Kt">
+                <property role="Vb097" value="hGRnIZc/lightBlue" />
               </node>
             </node>
           </node>
@@ -4441,6 +4364,9 @@
                   </node>
                 </node>
               </node>
+            </node>
+            <node concept="3hWdWw" id="S1tcgz1rAa" role="3F10Kt">
+              <property role="Vb097" value="hGRnIZc/lightBlue" />
             </node>
           </node>
         </node>

--- a/code/tables/languages/de.slisson.mps.tables/generator/template/main@generator.mps
+++ b/code/tables/languages/de.slisson.mps.tables/generator/template/main@generator.mps
@@ -1422,7 +1422,7 @@
                     <ref role="3cqZAo" node="1rJc_ytgKUx" resolve="grid" />
                   </node>
                   <node concept="liA8E" id="3olMEllxiCS" role="2OqNvi">
-                    <ref role="37wK5l" to="6dpw:3olMEllwclW" resolve="setStyle" />
+                    <ref role="37wK5l" to="6dpw:S1tcgxMc9D" resolve="setOrAddStyle" />
                     <node concept="37vLTw" id="3olMEllxiH2" role="37wK5m">
                       <ref role="3cqZAo" node="5ryePYd8Jfp" resolve="style" />
                     </node>
@@ -2219,6 +2219,51 @@
                                 </node>
                                 <node concept="5jKBG" id="6hpM9fmFEbe" role="lGtFl">
                                   <ref role="v9R2y" to="tpc3:4v1iCryNDHi" resolve="template_cellSetupBlock" />
+                                </node>
+                              </node>
+                              <node concept="3cpWs8" id="25DLT7wc7XP" role="3cqZAp">
+                                <node concept="3cpWsn" id="25DLT7wc7XQ" role="3cpWs9">
+                                  <property role="TrG5h" value="factory" />
+                                  <node concept="3uibUv" id="25DLT7wc7XR" role="1tU5fm">
+                                    <ref role="3uigEE" to="oghc:7AHcygoqpzC" resolve="ITableStyleFactory" />
+                                  </node>
+                                  <node concept="2ShNRf" id="25DLT7wkdrW" role="33vP2m">
+                                    <node concept="HV5vD" id="25DLT7wkdrX" role="2ShVmc">
+                                      <ref role="HV5vE" to="oghc:7AHcygoswPK" resolve="TableStyleFactoryDummy" />
+                                    </node>
+                                    <node concept="5jKBG" id="25DLT7wkdrY" role="lGtFl">
+                                      <ref role="v9R2y" node="4UkcdCuFKlk" resolve="reduce_IStylable" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                              <node concept="3clFbF" id="25DLT7w7RLT" role="3cqZAp">
+                                <node concept="2OqwBi" id="25DLT7w81xA" role="3clFbG">
+                                  <node concept="2OqwBi" id="25DLT7w7Vlz" role="2Oq$k0">
+                                    <node concept="37vLTw" id="25DLT7w7RLR" role="2Oq$k0">
+                                      <ref role="3cqZAo" node="1dAqnm8$DVo" resolve="editorCell" />
+                                    </node>
+                                    <node concept="liA8E" id="25DLT7w7ZqS" role="2OqNvi">
+                                      <ref role="37wK5l" to="g51k:~EditorCell_Basic.getStyle()" resolve="getStyle" />
+                                    </node>
+                                  </node>
+                                  <node concept="liA8E" id="25DLT7w857t" role="2OqNvi">
+                                    <ref role="37wK5l" to="hox0:~Style.putAll(jetbrains.mps.openapi.editor.style.Style)" resolve="putAll" />
+                                    <node concept="2OqwBi" id="25DLT7wcmGC" role="37wK5m">
+                                      <node concept="37vLTw" id="25DLT7wclD8" role="2Oq$k0">
+                                        <ref role="3cqZAo" node="25DLT7wc7XQ" resolve="factory" />
+                                      </node>
+                                      <node concept="liA8E" id="25DLT7wcnSu" role="2OqNvi">
+                                        <ref role="37wK5l" to="oghc:7AHcygoqpVD" resolve="createStyle" />
+                                        <node concept="3cmrfG" id="25DLT7wcoMk" role="37wK5m">
+                                          <property role="3cmrfH" value="0" />
+                                        </node>
+                                        <node concept="3cmrfG" id="25DLT7wctfu" role="37wK5m">
+                                          <property role="3cmrfH" value="0" />
+                                        </node>
+                                      </node>
+                                    </node>
+                                  </node>
                                 </node>
                               </node>
                               <node concept="3clFbF" id="1dAqnm8tX5_" role="3cqZAp">
@@ -7868,7 +7913,7 @@
                         <ref role="3cqZAo" node="1U60oYvtFg2" resolve="gridElement" />
                       </node>
                       <node concept="liA8E" id="7CiSlGyl0Ea" role="2OqNvi">
-                        <ref role="37wK5l" to="6dpw:3olMEllwadv" resolve="setStyle" />
+                        <ref role="37wK5l" to="6dpw:S1tcgxN1bb" resolve="setOrAddStyle" />
                         <node concept="2OqwBi" id="7CiSlGyl1jc" role="37wK5m">
                           <node concept="2ShNRf" id="7CiSlGyl1jd" role="2Oq$k0">
                             <node concept="HV5vD" id="7CiSlGyl1je" role="2ShVmc">
@@ -9079,7 +9124,7 @@
                 <ref role="3cqZAo" node="3olMEllzLUq" resolve="grid" />
               </node>
               <node concept="liA8E" id="3olMEll$n$q" role="2OqNvi">
-                <ref role="37wK5l" to="6dpw:3olMEllwclW" resolve="setStyle" />
+                <ref role="37wK5l" to="6dpw:S1tcgxMc9D" resolve="setOrAddStyle" />
                 <node concept="37vLTw" id="3olMEll$nAt" role="37wK5m">
                   <ref role="3cqZAo" node="5ryePYcSAnC" resolve="style" />
                 </node>
@@ -9623,7 +9668,7 @@
                 <ref role="3cqZAo" node="3olMEll$wgs" resolve="grid" />
               </node>
               <node concept="liA8E" id="3olMEll$wi6" role="2OqNvi">
-                <ref role="37wK5l" to="6dpw:3olMEllwclW" resolve="setStyle" />
+                <ref role="37wK5l" to="6dpw:S1tcgxMc9D" resolve="setOrAddStyle" />
                 <node concept="37vLTw" id="3olMEll$wi7" role="37wK5m">
                   <ref role="3cqZAo" node="3olMEll$whU" resolve="style" />
                 </node>

--- a/code/tables/languages/de.slisson.mps.tables/runtime/models/de/slisson/mps/tables/runtime/cells.mps
+++ b/code/tables/languages/de.slisson.mps.tables/runtime/models/de/slisson/mps/tables/runtime/cells.mps
@@ -11409,6 +11409,120 @@
             </node>
           </node>
         </node>
+        <node concept="3clFbH" id="25DLT7wrbIb" role="3cqZAp" />
+        <node concept="3clFbJ" id="25DLT7wrgC4" role="3cqZAp">
+          <node concept="3clFbS" id="25DLT7wrgC6" role="3clFbx">
+            <node concept="3cpWs6" id="25DLT7ws3qa" role="3cqZAp">
+              <node concept="2OqwBi" id="25DLT7wsoPR" role="3cqZAk">
+                <node concept="2OqwBi" id="25DLT7wsgSg" role="2Oq$k0">
+                  <node concept="1rXfSq" id="25DLT7wsaOO" role="2Oq$k0">
+                    <ref role="37wK5l" node="4gCFRNzc0za" resolve="getTable" />
+                  </node>
+                  <node concept="liA8E" id="25DLT7wsmcG" role="2OqNvi">
+                    <ref role="37wK5l" to="g51k:~EditorCell_Basic.getStyle()" resolve="getStyle" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="25DLT7wsCxU" role="2OqNvi">
+                  <ref role="37wK5l" to="hox0:~Style.get(jetbrains.mps.openapi.editor.style.StyleAttribute)" resolve="get" />
+                  <node concept="37vLTw" id="25DLT7wsIdQ" role="37wK5m">
+                    <ref role="3cqZAo" node="2FAXvauHUvM" resolve="attribute" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="25DLT7wrBTz" role="3clFbw">
+            <node concept="2OqwBi" id="25DLT7wrtwc" role="2Oq$k0">
+              <node concept="1rXfSq" id="25DLT7wrnwW" role="2Oq$k0">
+                <ref role="37wK5l" node="4gCFRNzc0za" resolve="getTable" />
+              </node>
+              <node concept="liA8E" id="25DLT7wr_7l" role="2OqNvi">
+                <ref role="37wK5l" to="g51k:~EditorCell_Basic.getStyle()" resolve="getStyle" />
+              </node>
+            </node>
+            <node concept="liA8E" id="25DLT7wrFWZ" role="2OqNvi">
+              <ref role="37wK5l" to="hox0:~Style.isSpecified(jetbrains.mps.openapi.editor.style.StyleAttribute)" resolve="isSpecified" />
+              <node concept="37vLTw" id="25DLT7wrSqt" role="37wK5m">
+                <ref role="3cqZAo" node="2FAXvauHUvM" resolve="attribute" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="25DLT7x29gg" role="3cqZAp" />
+        <node concept="3clFbJ" id="25DLT7wNtzT" role="3cqZAp">
+          <node concept="3clFbS" id="25DLT7wNtzU" role="3clFbx">
+            <node concept="3cpWs6" id="25DLT7wNtzV" role="3cqZAp">
+              <node concept="2OqwBi" id="25DLT7wNtzW" role="3cqZAk">
+                <node concept="2OqwBi" id="25DLT7wNtzX" role="2Oq$k0">
+                  <node concept="2OqwBi" id="25DLT7wNtzY" role="2Oq$k0">
+                    <node concept="2OqwBi" id="25DLT7wNtzZ" role="2Oq$k0">
+                      <node concept="1rXfSq" id="25DLT7wNt$0" role="2Oq$k0">
+                        <ref role="37wK5l" node="4gCFRNzc0za" resolve="getTable" />
+                      </node>
+                      <node concept="liA8E" id="25DLT7wNt$1" role="2OqNvi">
+                        <ref role="37wK5l" node="7Nzu1McBs8f" resolve="getGrid" />
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="25DLT7wNt$2" role="2OqNvi">
+                      <ref role="37wK5l" to="6dpw:20OswHEb5oT" resolve="getElement" />
+                      <node concept="1rXfSq" id="25DLT7wNt$3" role="37wK5m">
+                        <ref role="37wK5l" node="4gCFRNz3a7W" resolve="getGridPosition" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="25DLT7wNt$4" role="2OqNvi">
+                    <ref role="37wK5l" to="6dpw:3olMEllwaBa" resolve="getStyle" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="25DLT7wNt$5" role="2OqNvi">
+                  <ref role="37wK5l" to="hox0:~Style.get(jetbrains.mps.openapi.editor.style.StyleAttribute)" resolve="get" />
+                  <node concept="37vLTw" id="25DLT7wNt$6" role="37wK5m">
+                    <ref role="3cqZAo" node="2FAXvauHUvM" resolve="attribute" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="25DLT7wNt$7" role="3clFbw">
+            <node concept="2OqwBi" id="25DLT7wNt$8" role="2Oq$k0">
+              <node concept="2OqwBi" id="25DLT7wNt$9" role="2Oq$k0">
+                <node concept="2OqwBi" id="25DLT7wNt$a" role="2Oq$k0">
+                  <node concept="1rXfSq" id="25DLT7wNt$b" role="2Oq$k0">
+                    <ref role="37wK5l" node="4gCFRNzc0za" resolve="getTable" />
+                  </node>
+                  <node concept="liA8E" id="25DLT7wNt$c" role="2OqNvi">
+                    <ref role="37wK5l" node="7Nzu1McBs8f" resolve="getGrid" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="25DLT7wNt$d" role="2OqNvi">
+                  <ref role="37wK5l" to="6dpw:20OswHEb5oT" resolve="getElement" />
+                  <node concept="2ShNRf" id="25DLT7wNMx7" role="37wK5m">
+                    <node concept="1pGfFk" id="25DLT7wOhOD" role="2ShVmc">
+                      <property role="373rjd" value="true" />
+                      <ref role="37wK5l" to="sse1:20OswHE0h6W" resolve="GridPosition" />
+                      <node concept="3cmrfG" id="25DLT7wOrxr" role="37wK5m">
+                        <property role="3cmrfH" value="0" />
+                      </node>
+                      <node concept="3cmrfG" id="25DLT7wO$Er" role="37wK5m">
+                        <property role="3cmrfH" value="0" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="25DLT7wNt$f" role="2OqNvi">
+                <ref role="37wK5l" to="6dpw:3olMEllwaBa" resolve="getStyle" />
+              </node>
+            </node>
+            <node concept="liA8E" id="25DLT7wNt$g" role="2OqNvi">
+              <ref role="37wK5l" to="hox0:~Style.isSpecified(jetbrains.mps.openapi.editor.style.StyleAttribute)" resolve="isSpecified" />
+              <node concept="37vLTw" id="25DLT7wNt$h" role="37wK5m">
+                <ref role="3cqZAo" node="2FAXvauHUvM" resolve="attribute" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="25DLT7x29gh" role="3cqZAp" />
         <node concept="3cpWs6" id="2FAXvauHUwS" role="3cqZAp">
           <node concept="10Nm6u" id="2FAXvauI4zO" role="3cqZAk" />
         </node>

--- a/code/tables/languages/de.slisson.mps.tables/runtime/models/de/slisson/mps/tables/runtime/gridmodel.mps
+++ b/code/tables/languages/de.slisson.mps.tables/runtime/models/de/slisson/mps/tables/runtime/gridmodel.mps
@@ -949,6 +949,18 @@
         </node>
       </node>
     </node>
+    <node concept="3clFb_" id="S1tcgxN1bb" role="jymVt">
+      <property role="TrG5h" value="setOrAddStyle" />
+      <node concept="3cqZAl" id="S1tcgxN1bc" role="3clF45" />
+      <node concept="3Tm1VV" id="S1tcgxN1bd" role="1B3o_S" />
+      <node concept="3clFbS" id="S1tcgxN1be" role="3clF47" />
+      <node concept="37vLTG" id="S1tcgxN1bf" role="3clF46">
+        <property role="TrG5h" value="style" />
+        <node concept="3uibUv" id="S1tcgxN1bg" role="1tU5fm">
+          <ref role="3uigEE" to="hox0:~Style" resolve="Style" />
+        </node>
+      </node>
+    </node>
     <node concept="3clFb_" id="3olMEllwaBa" role="jymVt">
       <property role="TrG5h" value="getStyle" />
       <node concept="3uibUv" id="3olMEllwaHC" role="3clF45">
@@ -9703,6 +9715,7 @@
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
+    <node concept="2tJIrI" id="S1tcgxN6m$" role="jymVt" />
     <node concept="3clFb_" id="3olMEllwclP" role="jymVt">
       <property role="1EzhhJ" value="false" />
       <property role="TrG5h" value="getStyle" />
@@ -9764,6 +9777,56 @@
         </node>
       </node>
     </node>
+    <node concept="2tJIrI" id="S1tcgxN4jd" role="jymVt" />
+    <node concept="3clFb_" id="S1tcgxMc9D" role="jymVt">
+      <property role="TrG5h" value="setOrAddStyle" />
+      <node concept="3clFbS" id="S1tcgxMc9G" role="3clF47">
+        <node concept="3clFbJ" id="S1tcgxMEeE" role="3cqZAp">
+          <node concept="3clFbS" id="S1tcgxMEeG" role="3clFbx">
+            <node concept="3clFbF" id="S1tcgxMNgg" role="3cqZAp">
+              <node concept="1rXfSq" id="S1tcgxMNge" role="3clFbG">
+                <ref role="37wK5l" node="3olMEllwclW" resolve="setStyle" />
+                <node concept="37vLTw" id="S1tcgxMQzR" role="37wK5m">
+                  <ref role="3cqZAo" node="S1tcgxMeqI" resolve="style" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbC" id="S1tcgxMIgV" role="3clFbw">
+            <node concept="37vLTw" id="S1tcgxMGci" role="3uHU7B">
+              <ref role="3cqZAo" node="3olMElluqFz" resolve="myStyle" />
+            </node>
+            <node concept="10Nm6u" id="S1tcgxML1I" role="3uHU7w" />
+          </node>
+          <node concept="9aQIb" id="S1tcgxMTuO" role="9aQIa">
+            <node concept="3clFbS" id="S1tcgxMTuP" role="9aQI4">
+              <node concept="3clFbF" id="S1tcgxMjtL" role="3cqZAp">
+                <node concept="2OqwBi" id="S1tcgxMlfk" role="3clFbG">
+                  <node concept="37vLTw" id="S1tcgxMjtK" role="2Oq$k0">
+                    <ref role="3cqZAo" node="3olMElluqFz" resolve="myStyle" />
+                  </node>
+                  <node concept="liA8E" id="S1tcgxMndQ" role="2OqNvi">
+                    <ref role="37wK5l" to="hox0:~Style.putAll(jetbrains.mps.openapi.editor.style.Style)" resolve="putAll" />
+                    <node concept="37vLTw" id="S1tcgxMqit" role="37wK5m">
+                      <ref role="3cqZAo" node="S1tcgxMeqI" resolve="style" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="S1tcgxMa2U" role="1B3o_S" />
+      <node concept="3cqZAl" id="S1tcgxMa8X" role="3clF45" />
+      <node concept="37vLTG" id="S1tcgxMeqI" role="3clF46">
+        <property role="TrG5h" value="style" />
+        <node concept="3uibUv" id="S1tcgxMeqH" role="1tU5fm">
+          <ref role="3uigEE" to="hox0:~Style" resolve="Style" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="S1tcgxN8pV" role="jymVt" />
     <node concept="3clFb_" id="7C0FR5AKAR3" role="jymVt">
       <property role="1EzhhJ" value="false" />
       <property role="TrG5h" value="getSpanY" />
@@ -9780,6 +9843,7 @@
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
+    <node concept="2tJIrI" id="S1tcgxNbs_" role="jymVt" />
     <node concept="3clFb_" id="7C0FR5AKAR8" role="jymVt">
       <property role="1EzhhJ" value="false" />
       <property role="TrG5h" value="setSpanX" />
@@ -9832,6 +9896,7 @@
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
+    <node concept="2tJIrI" id="S1tcgxNdvW" role="jymVt" />
     <node concept="3clFb_" id="2c3czgnejF6" role="jymVt">
       <property role="1EzhhJ" value="false" />
       <property role="TrG5h" value="incrementSpanningX" />
@@ -9867,6 +9932,7 @@
         </node>
       </node>
     </node>
+    <node concept="2tJIrI" id="S1tcgxNfzj" role="jymVt" />
     <node concept="3clFb_" id="2c3czgnejFb" role="jymVt">
       <property role="1EzhhJ" value="false" />
       <property role="TrG5h" value="incrementSpanningY" />
@@ -9902,6 +9968,7 @@
         </node>
       </node>
     </node>
+    <node concept="2tJIrI" id="S1tcgxNhAE" role="jymVt" />
     <node concept="3clFb_" id="7C0FR5AKARf" role="jymVt">
       <property role="1EzhhJ" value="false" />
       <property role="TrG5h" value="setSpanY" />
@@ -10041,6 +10108,7 @@
         </node>
       </node>
     </node>
+    <node concept="2tJIrI" id="S1tcgxNjE1" role="jymVt" />
     <node concept="3clFb_" id="5TY7OGKEFQG" role="jymVt">
       <property role="1EzhhJ" value="false" />
       <property role="TrG5h" value="setSubstituteInfo" />
@@ -10066,6 +10134,7 @@
         </node>
       </node>
     </node>
+    <node concept="2tJIrI" id="S1tcgxNlHo" role="jymVt" />
     <node concept="3clFb_" id="5TY7OGKEFQN" role="jymVt">
       <property role="1EzhhJ" value="false" />
       <property role="TrG5h" value="setSubstituteInfo" />
@@ -10503,6 +10572,7 @@
         </node>
       </node>
     </node>
+    <node concept="2tJIrI" id="S1tcgxNnKJ" role="jymVt" />
     <node concept="3clFb_" id="7C0FR5Benin" role="jymVt">
       <property role="1EzhhJ" value="false" />
       <property role="TrG5h" value="setRightRowCreateHandler" />
@@ -11422,6 +11492,7 @@
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
+    <node concept="2tJIrI" id="S1tcgxNpO6" role="jymVt" />
     <node concept="3Tm1VV" id="7C0FR5ApyNn" role="1B3o_S" />
     <node concept="3uibUv" id="7C0FR5ApDfp" role="EKbjA">
       <ref role="3uigEE" node="7C0FR5Aonyd" resolve="IGridElement" />
@@ -11468,6 +11539,7 @@
         </node>
       </node>
     </node>
+    <node concept="2tJIrI" id="S1tcgxNsQK" role="jymVt" />
     <node concept="3clFb_" id="1U60oYwdH9_" role="jymVt">
       <property role="1EzhhJ" value="false" />
       <property role="TrG5h" value="getWidth" />
@@ -11481,6 +11553,7 @@
         </node>
       </node>
     </node>
+    <node concept="2tJIrI" id="S1tcgxNuU7" role="jymVt" />
     <node concept="3clFb_" id="1U60oYwdH9E" role="jymVt">
       <property role="1EzhhJ" value="false" />
       <property role="TrG5h" value="setHeight" />
@@ -11503,6 +11576,7 @@
         </node>
       </node>
     </node>
+    <node concept="2tJIrI" id="S1tcgxNwXu" role="jymVt" />
     <node concept="3clFb_" id="1U60oYwdH9L" role="jymVt">
       <property role="1EzhhJ" value="false" />
       <property role="TrG5h" value="setWidth" />
@@ -11525,6 +11599,7 @@
         </node>
       </node>
     </node>
+    <node concept="2tJIrI" id="S1tcgxNz0P" role="jymVt" />
     <node concept="3clFb_" id="1U60oYwtJMu" role="jymVt">
       <property role="1EzhhJ" value="false" />
       <property role="TrG5h" value="getMinHeight" />
@@ -11538,6 +11613,7 @@
         </node>
       </node>
     </node>
+    <node concept="2tJIrI" id="S1tcgxN_4c" role="jymVt" />
     <node concept="3clFb_" id="1U60oYwtJMz" role="jymVt">
       <property role="1EzhhJ" value="false" />
       <property role="TrG5h" value="getMinWidth" />
@@ -27417,7 +27493,7 @@
                   <ref role="3cqZAo" node="RywcYwuy6H" resolve="element" />
                 </node>
                 <node concept="liA8E" id="3GKqtdp$fEV" role="2OqNvi">
-                  <ref role="37wK5l" node="3olMEllwclW" resolve="setStyle" />
+                  <ref role="37wK5l" node="S1tcgxMc9D" resolve="setOrAddStyle" />
                   <node concept="2OqwBi" id="3GKqtdp$fKE" role="37wK5m">
                     <node concept="37vLTw" id="3GKqtdp$fI6" role="2Oq$k0">
                       <ref role="3cqZAo" node="RywcYwuy6M" resolve="header" />


### PR DESCRIPTION
If there is no style, the style from the grid element 0x0 will be used. The application order is at the moment still sometimes incorrect. The most specific style is not used.

 - fixes https://github.com/JetBrains/MPS-extensions/issues/553