### PR TITLE
tables: extract gridmodel tests to a separate solution

### DIFF
--- a/code/.mps/modules.xml
+++ b/code/.mps/modules.xml
@@ -216,6 +216,7 @@
       <modulePath path="$PROJECT_DIR$/tables/languages/de.slisson.mps.tables/de.slisson.mps.tables.mpl" folder="tables" />
       <modulePath path="$PROJECT_DIR$/tables/languages/de.slisson.mps.tables/runtime/de.slisson.mps.tables.runtime.msd" folder="tables" />
       <modulePath path="$PROJECT_DIR$/tables/languages/de.slisson.mps.tables/sandbox/de.slisson.mps.tables.sandbox.msd" folder="tables" />
+      <modulePath path="$PROJECT_DIR$/tables/solutions/test.de.slisson.mps.tables.runtime/test.de.slisson.mps.tables.runtime.msd" folder="tables" />
       <modulePath path="$PROJECT_DIR$/tables/solutions/test.de.slisson.mps.tables/test.de.slisson.mps.tables.msd" folder="tables" />
       <modulePath path="$PROJECT_DIR$/third-party/solutions/MPS.ThirdParty/MPS.ThirdParty.msd" folder="3rd-party" />
       <modulePath path="$PROJECT_DIR$/third-party/solutions/third.party.usage.test/third.party.usage.test.msd" folder="3rd-party" />

--- a/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
+++ b/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
@@ -18208,6 +18208,72 @@
           </node>
         </node>
       </node>
+      <node concept="1E1JtA" id="2f7xPXzHwm6" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="test.de.slisson.mps.tables.runtime" />
+        <property role="3LESm3" value="49592127-72ac-4bd8-85ec-afb542cd18d5" />
+        <property role="aoJFB" value="eYcmk9QOlj/sources_and_tests" />
+        <node concept="398BVA" id="2f7xPXzHwm7" role="3LF7KH">
+          <ref role="398BVh" node="5mH$9t6e_IG" resolve="tables.home" />
+          <node concept="2Ry0Ak" id="2f7xPXzHwm8" role="iGT6I">
+            <property role="2Ry0Am" value="solutions" />
+            <node concept="2Ry0Ak" id="2f7xPXzHwm9" role="2Ry0An">
+              <property role="2Ry0Am" value="test.de.slisson.mps.tables.runtime" />
+              <node concept="2Ry0Ak" id="2f7xPXzHwnH" role="2Ry0An">
+                <property role="2Ry0Am" value="test.de.slisson.mps.tables.runtime.msd" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3rtmxn" id="2f7xPXzHwmd" role="3bR31x">
+          <node concept="3LXTmp" id="2f7xPXzHwme" role="3rtmxm">
+            <node concept="3qWCbU" id="2f7xPXzHwmf" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="2f7xPXzHwmg" role="3LXTmr">
+              <ref role="398BVh" node="5mH$9t6e_IG" resolve="tables.home" />
+              <node concept="2Ry0Ak" id="2f7xPXzHwmh" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="2f7xPXzHwQ1" role="2Ry0An">
+                  <property role="2Ry0Am" value="test.de.slisson.mps.tables.runtime" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2f7xPXzHwmj" role="3bR37C">
+          <node concept="3bR9La" id="2f7xPXzHwmk" role="1SiIV1">
+            <ref role="3bR37D" node="29so9Vb$6T5" resolve="de.slisson.mps.tables.runtime" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2f7xPXzHwmp" role="3bR37C">
+          <node concept="3bR9La" id="2f7xPXzHwmq" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
+          </node>
+        </node>
+        <node concept="1BupzO" id="2f7xPXzHwmr" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="2f7xPXzHwr5" role="1HemKq">
+            <node concept="398BVA" id="2f7xPXzHwqK" role="3LXTmr">
+              <ref role="398BVh" node="5mH$9t6e_IG" resolve="tables.home" />
+              <node concept="2Ry0Ak" id="2f7xPXzHwqL" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="2f7xPXzHwqM" role="2Ry0An">
+                  <property role="2Ry0Am" value="test.de.slisson.mps.tables.runtime" />
+                  <node concept="2Ry0Ak" id="2f7xPXzHwqN" role="2Ry0An">
+                    <property role="2Ry0Am" value="models" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="2f7xPXzHwr6" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+      </node>
       <node concept="1E1JtD" id="5mH$9t6eA1O" role="2G$12L">
         <property role="BnDLt" value="true" />
         <property role="TrG5h" value="de.slisson.mps.tables.demolang" />
@@ -24361,6 +24427,9 @@
       <node concept="L2wRC" id="5mH$9t6eCBc" role="39821P">
         <ref role="L2wRA" node="5mH$9t6e_Fl" resolve="test.de.slisson.mps.tables" />
       </node>
+      <node concept="L2wRC" id="2f7xPXzHwTX" role="39821P">
+        <ref role="L2wRA" node="2f7xPXzHwm6" resolve="test.de.slisson.mps.tables.runtime" />
+      </node>
       <node concept="L2wRC" id="5mH$9t6eE6L" role="39821P">
         <ref role="L2wRA" node="5mH$9t6eA1O" resolve="de.slisson.mps.tables.demolang" />
       </node>
@@ -24509,9 +24578,6 @@
       </node>
       <node concept="22LTRM" id="7qi8mU1OzVQ" role="22LTRK">
         <ref role="22LTRN" node="6$6tsX_CJdr" resolve="test.de.itemis.mps.editor.diagram.solution" />
-      </node>
-      <node concept="22LTRM" id="5mH$9t6eAr5" role="22LTRK">
-        <ref role="22LTRN" node="5mH$9t6e_Fl" resolve="test.de.slisson.mps.tables" />
       </node>
       <node concept="22LTRM" id="7i5Cc6Lw3P$" role="22LTRK">
         <ref role="22LTRN" node="5mH$9t6eAsB" resolve="test.de.itemis.mps.editor.celllayout" />

--- a/code/tables/languages/de.slisson.mps.tables/runtime/de.slisson.mps.tables.runtime.msd
+++ b/code/tables/languages/de.slisson.mps.tables/runtime/de.slisson.mps.tables.runtime.msd
@@ -38,7 +38,6 @@
     <language slang="l:c7d5b9dd-a05f-4be2-bc73-f2e16994cc67:jetbrains.mps.baseLanguage.lightweightdsl" version="1" />
     <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
     <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
-    <language slang="l:f61473f9-130f-42f6-b98d-6c438812c2f6:jetbrains.mps.baseLanguage.unitTest" version="1" />
     <language slang="l:63650c59-16c8-498a-99c8-005c7ee9515d:jetbrains.mps.lang.access" version="0" />
     <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
     <language slang="l:18bc6592-03a6-4e29-a83a-7ff23bde13ba:jetbrains.mps.lang.editor" version="14" />

--- a/code/tables/languages/de.slisson.mps.tables/runtime/models/de/slisson/mps/tables/runtime/gridmodel.mps
+++ b/code/tables/languages/de.slisson.mps.tables/runtime/models/de/slisson/mps/tables/runtime/gridmodel.mps
@@ -12165,7 +12165,7 @@
       <property role="1EzhhJ" value="false" />
       <property role="TrG5h" value="clone" />
       <property role="DiZV1" value="false" />
-      <node concept="3Tmbuc" id="3jHPIDnjwjE" role="1B3o_S" />
+      <node concept="3Tm1VV" id="2f7xPXzC$W2" role="1B3o_S" />
       <node concept="3uibUv" id="3jHPIDnjwqH" role="3clF45">
         <ref role="3uigEE" node="7C0FR5AJvc6" resolve="HeaderReference" />
       </node>
@@ -20139,7 +20139,7 @@
       <property role="1EzhhJ" value="false" />
       <property role="TrG5h" value="clone" />
       <property role="DiZV1" value="false" />
-      <node concept="3Tmbuc" id="3jHPIDnjyH8" role="1B3o_S" />
+      <node concept="3Tm1VV" id="2f7xPXzCAxk" role="1B3o_S" />
       <node concept="3uibUv" id="3jHPIDnj$hN" role="3clF45">
         <ref role="3uigEE" node="3jHPIDnje7S" resolve="StringHeaderReference" />
       </node>

--- a/code/tables/solutions/test.de.slisson.mps.tables.runtime/models/test.de.slisson.mps.tables.runtime.gridmodel@tests.mps
+++ b/code/tables/solutions/test.de.slisson.mps.tables.runtime/models/test.de.slisson.mps.tables.runtime.gridmodel@tests.mps
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<model ref="r:d1f5452a-df80-42c6-b4f0-3cb45f5ef6f9(de.slisson.mps.tables.runtime.gridmodel@tests)">
+<model ref="r:329d5b7a-6a7b-4471-8c81-ab2fbbd6baf9(test.de.slisson.mps.tables.runtime.gridmodel@tests)">
   <persistence version="9" />
   <attribute name="concise" value="true" />
   <languages>
+    <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="6" />
     <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
     <use id="774bf8a0-62e5-41e1-af63-f4812e60e48b" name="jetbrains.mps.baseLanguage.checkedDots" version="0" />
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />

--- a/code/tables/solutions/test.de.slisson.mps.tables.runtime/test.de.slisson.mps.tables.runtime.msd
+++ b/code/tables/solutions/test.de.slisson.mps.tables.runtime/test.de.slisson.mps.tables.runtime.msd
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<solution name="test.de.slisson.mps.tables.runtime" uuid="49592127-72ac-4bd8-85ec-afb542cd18d5" moduleVersion="0">
+  <models>
+    <modelRoot contentPath="${module}" type="default">
+      <sourceRoot path="${module}/models" />
+    </modelRoot>
+  </models>
+  <facets>
+    <facet type="java" compile="mps" classes="mps" ext="no">
+      <classes generated="true" path="${module}/classes_gen" />
+    </facet>
+    <facet type="tests" />
+  </facets>
+  <dependencies>
+    <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
+    <dependency reexport="false">da21218f-a674-474d-8b4e-d59e33007003(de.slisson.mps.tables.runtime)</dependency>
+  </dependencies>
+  <languageVersions>
+    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
+    <language slang="l:774bf8a0-62e5-41e1-af63-f4812e60e48b:jetbrains.mps.baseLanguage.checkedDots" version="0" />
+    <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />
+    <language slang="l:f61473f9-130f-42f6-b98d-6c438812c2f6:jetbrains.mps.baseLanguage.unitTest" version="1" />
+    <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
+    <language slang="l:8585453e-6bfb-4d80-98de-b16074f1d86c:jetbrains.mps.lang.test" version="6" />
+    <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
+  </languageVersions>
+  <dependencyVersions>
+    <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
+    <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
+    <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
+    <module reference="1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)" version="0" />
+    <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
+    <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+    <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
+    <module reference="848ef45d-e560-4e35-853c-f35a64cc135c(de.itemis.mps.editor.celllayout.runtime)" version="0" />
+    <module reference="24c96a96-b7a1-4f30-82da-0f8e279a2661(de.itemis.mps.editor.celllayout.styles)" version="0" />
+    <module reference="cce85e64-7b37-4ad5-b0e6-9d18324cdfb3(de.itemis.mps.selection.runtime)" version="0" />
+    <module reference="da21218f-a674-474d-8b4e-d59e33007003(de.slisson.mps.tables.runtime)" version="0" />
+    <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
+    <module reference="49592127-72ac-4bd8-85ec-afb542cd18d5(test.de.slisson.mps.tables.runtime)" version="0" />
+  </dependencyVersions>
+</solution>
+


### PR DESCRIPTION
This eliminates indirect dependency of tables.runtime on testing infrastructure.