### PR TITLE
Revert "build: use MPS 2025.1-RC1"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,11 +43,11 @@ logger.info 'Repository username: {}', project.nexusUsername
 // Dependency versions
 
 // major version, e.g. '2021.1', '2021.2'
-ext.mpsMajor = '2025.1'
+ext.mpsMajor = '9999.9'
 // optional minor/bugfix number (not added to the final build version)
 ext.mpsMinor = ''
 // e.g. Beta, EAP, RC
-ext.mpsReleaseType = 'RC1'
+ext.mpsReleaseType = ''
 
 def appendOpt = { str,pre -> !str.isEmpty() ? "${pre}${str}" : "" }
 ext.mpsVersion =  "$mpsMajor" + appendOpt(mpsMinor, '.') + appendOpt(mpsReleaseType, '-')
@@ -95,7 +95,9 @@ configurations {
 }
 
 dependencies {
-    mps "com.jetbrains:mps:$mpsVersion"
+    // For published releases adjust ext.mpsMajor and ext.mpsMinor above and use this dependency:
+    // mps "com.jetbrains:mps:$mpsVersion"
+    mps "com.jetbrains.mps:mps-prerelease:251.23774.234"
 }
 
 repositories {
@@ -186,7 +188,7 @@ configurations {
 
     collections {
         transitive = false
-        attributes.attribute(TargetJvmEnvironment.TARGET_JVM_ENVIRONMENT_ATTRIBUTE, objects.named(TargetJvmEnvironment.class, TargetJvmEnvironment.STANDARD_JVM))
+        attributes.attribute(TargetJvmEnvironment.TARGET_JVM_ENVIRONMENT_ATTRIBUTE, objects.named(TargetJvmEnvironment.class, TargetJvmEnvironment.STANDARD_JVM)) 
     }
 }
 


### PR DESCRIPTION
This reverts commit 6fe5d9c972810df70baa7d0bb898519246292718. Cascading merges shouldn't touch MPS versions.