### PR TITLE
richtext: fixed RichTextUtil for Text creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project are documented in this file.
 
 The format is *loosely* based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) .The project does *not* follow Semantic Versioning and the changes are documented in reverse chronological order, grouped by calendar month.
 
+## May 2025
+
+### Fixed
+
+- *de.slisson.mps.richtext* RichTextUtil.createTextFromSingleString() creates `Text` instance without unexpected prepended space.
+
 ## April 2025
 
 ### Fixed

--- a/code/richtext/languages/richtext/languageModels/behavior.mps
+++ b/code/richtext/languages/richtext/languageModels/behavior.mps
@@ -209,6 +209,25 @@
         <property id="8970989240999019144" name="text" index="1dT_AB" />
       </concept>
     </language>
+    <language id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation">
+      <concept id="5455284157994012186" name="jetbrains.mps.lang.quotation.structure.NodeBuilderInitLink" flags="ng" index="2pIpSj">
+        <reference id="5455284157994012188" name="link" index="2pIpSl" />
+        <child id="1595412875168045827" name="initValue" index="28nt2d" />
+      </concept>
+      <concept id="5455284157993863837" name="jetbrains.mps.lang.quotation.structure.NodeBuilder" flags="nn" index="2pJPEk">
+        <child id="5455284157993863838" name="quotedNode" index="2pJPEn" />
+      </concept>
+      <concept id="5455284157993863840" name="jetbrains.mps.lang.quotation.structure.NodeBuilderNode" flags="nn" index="2pJPED">
+        <reference id="5455284157993910961" name="concept" index="2pJxaS" />
+        <child id="5455284157993911099" name="values" index="2pJxcM" />
+      </concept>
+      <concept id="8182547171709738802" name="jetbrains.mps.lang.quotation.structure.NodeBuilderList" flags="nn" index="36be1Y">
+        <child id="8182547171709738803" name="nodes" index="36be1Z" />
+      </concept>
+      <concept id="8182547171709752110" name="jetbrains.mps.lang.quotation.structure.NodeBuilderExpression" flags="nn" index="36biLy">
+        <child id="8182547171709752112" name="expression" index="36biLW" />
+      </concept>
+    </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
       <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
         <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
@@ -2527,54 +2546,70 @@
       </node>
       <node concept="3Tm1VV" id="5mf_X_La5K6" role="1B3o_S" />
       <node concept="3clFbS" id="5mf_X_La5K7" role="3clF47">
-        <node concept="3cpWs8" id="5mf_X_La5Kn" role="3cqZAp">
-          <node concept="3cpWsn" id="5mf_X_La5Ko" role="3cpWs9">
-            <property role="TrG5h" value="t" />
-            <node concept="3Tqbb2" id="5mf_X_La5Kp" role="1tU5fm">
-              <ref role="ehGHo" to="87nw:2dWzqxEB$Tx" resolve="Text" />
+        <node concept="3SKdUt" id="1LvhRAPD0cd" role="3cqZAp">
+          <node concept="1PaTwC" id="1LvhRAPD0ce" role="1aUNEU">
+            <node concept="3oM_SD" id="1LvhRAPD0cf" role="1PaTwD">
+              <property role="3oM_SC" value="use" />
             </node>
-            <node concept="2ShNRf" id="5mf_X_La5Kr" role="33vP2m">
-              <node concept="3zrR0B" id="5mf_X_La5Ks" role="2ShVmc">
-                <node concept="3Tqbb2" id="5mf_X_La5Kt" role="3zrR0E">
-                  <ref role="ehGHo" to="87nw:2dWzqxEB$Tx" resolve="Text" />
+            <node concept="3oM_SD" id="1LvhRAPD0i5" role="1PaTwD">
+              <property role="3oM_SC" value="quotation" />
+            </node>
+            <node concept="3oM_SD" id="1LvhRAPD0iB" role="1PaTwD">
+              <property role="3oM_SC" value="to" />
+            </node>
+            <node concept="3oM_SD" id="1LvhRAPD0iC" role="1PaTwD">
+              <property role="3oM_SC" value="avoid" />
+            </node>
+            <node concept="3oM_SD" id="1LvhRAPD0iT" role="1PaTwD">
+              <property role="3oM_SC" value="Text" />
+            </node>
+            <node concept="3oM_SD" id="1LvhRAPD0jq" role="1PaTwD">
+              <property role="3oM_SC" value="constructor" />
+            </node>
+            <node concept="3oM_SD" id="1LvhRAPDi5W" role="1PaTwD">
+              <property role="3oM_SC" value="call" />
+            </node>
+            <node concept="3oM_SD" id="1LvhRAPD0kr" role="1PaTwD">
+              <property role="3oM_SC" value="with" />
+            </node>
+            <node concept="3oM_SD" id="1LvhRAPD0kG" role="1PaTwD">
+              <property role="3oM_SC" value="a" />
+            </node>
+            <node concept="3oM_SD" id="1LvhRAPD9vW" role="1PaTwD">
+              <property role="3oM_SC" value="spacer" />
+            </node>
+            <node concept="3oM_SD" id="1LvhRAPD0kH" role="1PaTwD">
+              <property role="3oM_SC" value="word" />
+            </node>
+            <node concept="3oM_SD" id="1LvhRAPD9wZ" role="1PaTwD">
+              <property role="3oM_SC" value="('" />
+            </node>
+            <node concept="3oM_SD" id="1LvhRAPD9xg" role="1PaTwD">
+              <property role="3oM_SC" value="')" />
+            </node>
+            <node concept="3oM_SD" id="1LvhRAPD0kY" role="1PaTwD">
+              <property role="3oM_SC" value="initialisation" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="1LvhRAPD9kE" role="3cqZAp">
+          <node concept="2pJPEk" id="1LvhRAPCQwK" role="3clFbG">
+            <node concept="2pJPED" id="1LvhRAPCQwO" role="2pJPEn">
+              <ref role="2pJxaS" to="87nw:2dWzqxEB$Tx" resolve="Text" />
+              <node concept="2pIpSj" id="1LvhRAPCQFI" role="2pJxcM">
+                <ref role="2pIpSl" to="87nw:2dWzqxEBBFI" resolve="words" />
+                <node concept="36be1Y" id="1LvhRAPCQW9" role="28nt2d">
+                  <node concept="36biLy" id="1LvhRAPCQXq" role="36be1Z">
+                    <node concept="1rXfSq" id="7YwMzcjUikz" role="36biLW">
+                      <ref role="37wK5l" node="5mf_X_L9Y2C" resolve="createSingleWordFromText" />
+                      <node concept="37vLTw" id="7YwMzcjUivP" role="37wK5m">
+                        <ref role="3cqZAo" node="5mf_X_La5Kl" resolve="text" />
+                      </node>
+                    </node>
+                  </node>
                 </node>
               </node>
             </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="5mf_X_La5Kw" role="3cqZAp">
-          <node concept="2OqwBi" id="5mf_X_La5Li" role="3clFbG">
-            <node concept="2OqwBi" id="5mf_X_La5KQ" role="2Oq$k0">
-              <node concept="37vLTw" id="5mf_X_La5Kx" role="2Oq$k0">
-                <ref role="3cqZAo" node="5mf_X_La5Ko" resolve="t" />
-              </node>
-              <node concept="3Tsc0h" id="5mf_X_La5KW" role="2OqNvi">
-                <ref role="3TtcxE" to="87nw:2dWzqxEBBFI" resolve="words" />
-              </node>
-            </node>
-            <node concept="TSZUe" id="5mf_X_La5Lo" role="2OqNvi">
-              <node concept="1rXfSq" id="7YwMzcjUikz" role="25WWJ7">
-                <ref role="37wK5l" node="5mf_X_L9Y2C" resolve="createSingleWordFromText" />
-                <node concept="37vLTw" id="7YwMzcjUivP" role="37wK5m">
-                  <ref role="3cqZAo" node="5mf_X_La5Kl" resolve="text" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="7YwMzcjU8wq" role="3cqZAp">
-          <node concept="2OqwBi" id="7YwMzcjU8Kc" role="3clFbG">
-            <node concept="37vLTw" id="7YwMzcjU8wo" role="2Oq$k0">
-              <ref role="3cqZAo" node="5mf_X_La5Ko" resolve="t" />
-            </node>
-            <node concept="2qgKlT" id="7YwMzcjU98_" role="2OqNvi">
-              <ref role="37wK5l" node="3mI$71cQ6Aw" resolve="ensureNormalized" />
-            </node>
-          </node>
-        </node>
-        <node concept="3cpWs6" id="5mf_X_La5Lt" role="3cqZAp">
-          <node concept="37vLTw" id="5mf_X_La5Lv" role="3cqZAk">
-            <ref role="3cqZAo" node="5mf_X_La5Ko" resolve="t" />
           </node>
         </node>
       </node>

--- a/code/richtext/solutions/test.de.slisson.mps.richtext/models/test.de.slisson.mps.richtext@tests.mps
+++ b/code/richtext/solutions/test.de.slisson.mps.richtext/models/test.de.slisson.mps.richtext@tests.mps
@@ -7,6 +7,7 @@
     <use id="92d2ea16-5a42-4fdf-a676-c7604efe3504" name="de.slisson.mps.richtext" version="0" />
     <use id="72aaeb1c-fe8a-4e47-87d1-ddb7621d2773" name="de.slisson.mps.richtext.test" version="0" />
     <use id="0f2ccb7a-482c-4ebf-bf26-faa5b895afe4" name="de.slisson.mps.editor.multiline.test" version="0" />
+    <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
     <import index="ekwn" ref="r:9832fb5f-2578-4b58-8014-a5de79da988e(jetbrains.mps.ide.editor.actions)" />
@@ -15,6 +16,8 @@
     <import index="93vl" ref="r:ea46d830-b6c1-459f-bca3-d44c20d00c02(de.slisson.mps.editor.multiline.cells)" />
     <import index="b8lf" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor.selection(MPS.Editor/)" />
     <import index="r7s8" ref="r:bef7c8c4-a9ab-4327-9bdc-f32ca505c6e7(de.slisson.mps.richtext.plugin)" />
+    <import index="tbr6" ref="r:6a005c26-87c0-43c4-8cf3-49ffba1099df(de.slisson.mps.richtext.behavior)" />
+    <import index="87nw" ref="r:ca2ab6bb-f6e7-4c0f-a88c-b78b9b31fff3(de.slisson.mps.richtext.structure)" />
     <import index="exr9" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor(MPS.Editor/)" implicit="true" />
     <import index="lwvz" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.selection(MPS.Editor/)" implicit="true" />
     <import index="nv7s" ref="r:5c159ab7-3233-4e69-b050-e9bc91f86aaa(de.slisson.mps.editor.multiline.test)" implicit="true" />
@@ -46,19 +49,31 @@
       <concept id="4239542196496927193" name="jetbrains.mps.lang.test.structure.MPSActionReference" flags="ng" index="1iFQzN">
         <reference id="4239542196496929559" name="action" index="1iFR8X" />
       </concept>
+      <concept id="1216913645126" name="jetbrains.mps.lang.test.structure.NodesTestCase" flags="lg" index="1lH9Xt">
+        <property id="2616911529524314943" name="accessMode" index="3DII0k" />
+        <child id="1217501895093" name="testMethods" index="1SL9yI" />
+      </concept>
       <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
         <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
       </concept>
+      <concept id="1225978065297" name="jetbrains.mps.lang.test.structure.SimpleNodeTest" flags="ng" index="1LZb2c" />
     </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
       <concept id="1224071154655" name="jetbrains.mps.baseLanguage.structure.AsExpression" flags="nn" index="0kSF2">
         <child id="1224071154657" name="classifierType" index="0kSFW" />
         <child id="1224071154656" name="expression" index="0kSFX" />
       </concept>
+      <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
       </concept>
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <child id="1068431790190" name="initializer" index="33vP2m" />
@@ -66,8 +81,16 @@
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
+      <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123135" name="body" index="3clF47" />
+      </concept>
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
       <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
@@ -80,8 +103,10 @@
         <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
       </concept>
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
@@ -93,6 +118,13 @@
       </concept>
       <concept id="2557074442922438156" name="de.slisson.mps.richtext.structure.Word" flags="ng" index="19SUe$">
         <property id="2557074442922438158" name="escapedValue" index="19SUeA" />
+      </concept>
+    </language>
+    <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
+      <concept id="2524418899405758586" name="jetbrains.mps.baseLanguage.closures.structure.InferredClosureParameterDeclaration" flags="ig" index="gl6BB" />
+      <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
+        <child id="1199569906740" name="parameter" index="1bW2Oz" />
+        <child id="1199569916463" name="body" index="1bW5cS" />
       </concept>
     </language>
     <language id="0f2ccb7a-482c-4ebf-bf26-faa5b895afe4" name="de.slisson.mps.editor.multiline.test">
@@ -115,6 +147,15 @@
       </concept>
       <concept id="1171978097730" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertEquals" flags="nn" index="3vlDli" />
     </language>
+    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
+      <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
+        <reference id="1138405853777" name="concept" index="ehGHo" />
+      </concept>
+      <concept id="1138056282393" name="jetbrains.mps.lang.smodel.structure.SLinkListAccess" flags="nn" index="3Tsc0h">
+        <reference id="1138056546658" name="link" index="3TtcxE" />
+      </concept>
+    </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
         <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
@@ -133,6 +174,13 @@
       <concept id="6193633844718719637" name="de.slisson.mps.richtext.test.structure.RichtextCellReference" flags="ng" index="3aJYv0">
         <reference id="6193633844718720470" name="annotation" index="3aJY3X" />
       </concept>
+    </language>
+    <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
+        <child id="1204796294226" name="closure" index="23t8la" />
+      </concept>
+      <concept id="1240687580870" name="jetbrains.mps.baseLanguage.collections.structure.JoinOperation" flags="nn" index="3uJxvA" />
+      <concept id="1202128969694" name="jetbrains.mps.baseLanguage.collections.structure.SelectOperation" flags="nn" index="3$u5V9" />
     </language>
   </registry>
   <node concept="LiM7Y" id="5nOdiEvCwwp">
@@ -2557,6 +2605,121 @@
             <property role="p6zMv" value="0" />
             <property role="LIFWc" value="159" />
             <property role="TrG5h" value="richtext" />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1lH9Xt" id="3mJlZfNAT7M">
+    <property role="3DII0k" value="2hh8MJdVwqX/command" />
+    <property role="TrG5h" value="RichtextUtil" />
+    <node concept="1LZb2c" id="3mJlZfNAT7Q" role="1SL9yI">
+      <property role="TrG5h" value="testCreateSingleWordFromText" />
+      <node concept="3cqZAl" id="3mJlZfNAT7R" role="3clF45" />
+      <node concept="3clFbS" id="3mJlZfNAT7V" role="3clF47">
+        <node concept="3cpWs8" id="3mJlZfNATs7" role="3cqZAp">
+          <node concept="3cpWsn" id="3mJlZfNATs8" role="3cpWs9">
+            <property role="TrG5h" value="wordText" />
+            <node concept="17QB3L" id="3mJlZfNATlW" role="1tU5fm" />
+            <node concept="Xl_RD" id="3mJlZfNATs9" role="33vP2m">
+              <property role="Xl_RC" value="A word" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3mJlZfNATtB" role="3cqZAp">
+          <node concept="3cpWsn" id="3mJlZfNATtC" role="3cpWs9">
+            <property role="TrG5h" value="word" />
+            <node concept="3Tqbb2" id="3mJlZfNATty" role="1tU5fm">
+              <ref role="ehGHo" to="87nw:2dWzqxEBMSc" resolve="Word" />
+            </node>
+            <node concept="2YIFZM" id="3mJlZfNATtD" role="33vP2m">
+              <ref role="37wK5l" to="tbr6:5mf_X_L9Y2C" resolve="createSingleWordFromText" />
+              <ref role="1Pybhc" to="tbr6:5mf_X_L9Y2A" resolve="RichTextUtil" />
+              <node concept="37vLTw" id="3mJlZfNATtE" role="37wK5m">
+                <ref role="3cqZAo" node="3mJlZfNATs8" resolve="wordText" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="3mJlZfNAUFt" role="3cqZAp">
+          <node concept="37vLTw" id="3mJlZfNAUNU" role="3tpDZB">
+            <ref role="3cqZAo" node="3mJlZfNATs8" resolve="wordText" />
+          </node>
+          <node concept="2OqwBi" id="3mJlZfNAU5y" role="3tpDZA">
+            <node concept="37vLTw" id="3mJlZfNATZ0" role="2Oq$k0">
+              <ref role="3cqZAo" node="3mJlZfNATtC" resolve="word" />
+            </node>
+            <node concept="2qgKlT" id="3mJlZfNAUub" role="2OqNvi">
+              <ref role="37wK5l" to="tbr6:ehGfXvI_DB" resolve="getText" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="3mJlZfNAUP5" role="1SL9yI">
+      <property role="TrG5h" value="testCreateTextFromSingleString" />
+      <node concept="3cqZAl" id="3mJlZfNAUP6" role="3clF45" />
+      <node concept="3clFbS" id="3mJlZfNAUPa" role="3clF47">
+        <node concept="3cpWs8" id="3mJlZfNAVnt" role="3cqZAp">
+          <node concept="3cpWsn" id="3mJlZfNAVnw" role="3cpWs9">
+            <property role="TrG5h" value="textContent" />
+            <node concept="17QB3L" id="3mJlZfNAVns" role="1tU5fm" />
+            <node concept="Xl_RD" id="3mJlZfNAVot" role="33vP2m">
+              <property role="Xl_RC" value="Some text with words..." />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3mJlZfNAVEb" role="3cqZAp">
+          <node concept="3cpWsn" id="3mJlZfNAVEc" role="3cpWs9">
+            <property role="TrG5h" value="text" />
+            <node concept="3Tqbb2" id="3mJlZfNAVDM" role="1tU5fm">
+              <ref role="ehGHo" to="87nw:2dWzqxEB$Tx" resolve="Text" />
+            </node>
+            <node concept="2YIFZM" id="3mJlZfNAVEd" role="33vP2m">
+              <ref role="37wK5l" to="tbr6:5mf_X_La5K4" resolve="createTextFromSingleString" />
+              <ref role="1Pybhc" to="tbr6:5mf_X_L9Y2A" resolve="RichTextUtil" />
+              <node concept="37vLTw" id="3mJlZfNAVEe" role="37wK5m">
+                <ref role="3cqZAo" node="3mJlZfNAVnw" resolve="textContent" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="3mJlZfNAVSy" role="3cqZAp">
+          <node concept="37vLTw" id="3mJlZfNAWkz" role="3tpDZB">
+            <ref role="3cqZAo" node="3mJlZfNAVnw" resolve="textContent" />
+          </node>
+          <node concept="2OqwBi" id="1LvhRAPANKz" role="3tpDZA">
+            <node concept="2OqwBi" id="1LvhRAPAXcR" role="2Oq$k0">
+              <node concept="2OqwBi" id="3mJlZfNAW1C" role="2Oq$k0">
+                <node concept="37vLTw" id="3mJlZfNAVTi" role="2Oq$k0">
+                  <ref role="3cqZAo" node="3mJlZfNAVEc" resolve="text" />
+                </node>
+                <node concept="3Tsc0h" id="1LvhRAPAQ8s" role="2OqNvi">
+                  <ref role="3TtcxE" to="87nw:2dWzqxEBBFI" resolve="words" />
+                </node>
+              </node>
+              <node concept="3$u5V9" id="1LvhRAPAXBf" role="2OqNvi">
+                <node concept="1bVj0M" id="1LvhRAPAXBh" role="23t8la">
+                  <node concept="3clFbS" id="1LvhRAPAXBi" role="1bW5cS">
+                    <node concept="3clFbF" id="1LvhRAPAYXi" role="3cqZAp">
+                      <node concept="2OqwBi" id="1LvhRAPAZhu" role="3clFbG">
+                        <node concept="37vLTw" id="1LvhRAPAYXh" role="2Oq$k0">
+                          <ref role="3cqZAo" node="1LvhRAPAXBj" resolve="it" />
+                        </node>
+                        <node concept="2qgKlT" id="1LvhRAPAZH8" role="2OqNvi">
+                          <ref role="37wK5l" to="tbr6:3Q5enzfMT4t" resolve="toTextString" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="gl6BB" id="1LvhRAPAXBj" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="1LvhRAPAXBk" role="1tU5fm" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3uJxvA" id="1LvhRAPAQ3N" role="2OqNvi" />
           </node>
         </node>
       </node>

--- a/code/richtext/solutions/test.de.slisson.mps.richtext/test.de.slisson.mps.richtext.msd
+++ b/code/richtext/solutions/test.de.slisson.mps.richtext/test.de.slisson.mps.richtext.msd
@@ -23,9 +23,18 @@
     <language slang="l:72aaeb1c-fe8a-4e47-87d1-ddb7621d2773:de.slisson.mps.richtext.test" version="0" />
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
     <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />
+    <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
+    <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="2" />
+    <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
+    <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
+    <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
     <language slang="l:f61473f9-130f-42f6-b98d-6c438812c2f6:jetbrains.mps.baseLanguage.unitTest" version="1" />
     <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
+    <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
+    <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
+    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
     <language slang="l:8585453e-6bfb-4d80-98de-b16074f1d86c:jetbrains.mps.lang.test" version="6" />
+    <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
   </languageVersions>
   <dependencyVersions>

--- a/code/solutions/de.itemis.mps.extensions.changelog/models/de.itemis.mps.extensions.changelog.mps
+++ b/code/solutions/de.itemis.mps.extensions.changelog/models/de.itemis.mps.extensions.changelog.mps
@@ -233,6 +233,48 @@
         </node>
       </node>
     </node>
+    <node concept="15bmVD" id="5i$JLes82u9" role="15bmVC">
+      <node concept="15ShDW" id="5i$JLes82u6" role="15bq2Y">
+        <property role="15ShDY" value="Po4Z58IgAy/May" />
+        <property role="15ShDw" value="2025" />
+      </node>
+      <node concept="15bAme" id="5i$JLes82u7" role="15bAlL">
+        <node concept="2DRihI" id="5i$JLes82u8" role="15bAlk">
+          <node concept="15Ami3" id="5i$JLes82ue" role="1PaTwD">
+            <node concept="37shsh" id="5i$JLes82uf" role="15Aodc">
+              <node concept="1dCxOk" id="5i$JLes82xG" role="37shsm">
+                <property role="1XweGW" value="92d2ea16-5a42-4fdf-a676-c7604efe3504" />
+                <property role="1XxBO9" value="de.slisson.mps.richtext" />
+              </node>
+            </node>
+          </node>
+          <node concept="3oM_SD" id="5i$JLes82Dc" role="1PaTwD">
+            <property role="3oM_SC" value="RichTextUtil.createTextFromSingleString()" />
+          </node>
+          <node concept="3oM_SD" id="5i$JLes82D5" role="1PaTwD">
+            <property role="3oM_SC" value="creates" />
+          </node>
+          <node concept="3oM_SD" id="5i$JLes82D6" role="1PaTwD">
+            <property role="3oM_SC" value="`Text`" />
+          </node>
+          <node concept="3oM_SD" id="5i$JLes82D7" role="1PaTwD">
+            <property role="3oM_SC" value="instance" />
+          </node>
+          <node concept="3oM_SD" id="5i$JLes82D8" role="1PaTwD">
+            <property role="3oM_SC" value="without" />
+          </node>
+          <node concept="3oM_SD" id="5i$JLes82D9" role="1PaTwD">
+            <property role="3oM_SC" value="unexpected" />
+          </node>
+          <node concept="3oM_SD" id="5i$JLes82Da" role="1PaTwD">
+            <property role="3oM_SC" value="prepended" />
+          </node>
+          <node concept="3oM_SD" id="5i$JLes82Db" role="1PaTwD">
+            <property role="3oM_SC" value="space." />
+          </node>
+        </node>
+      </node>
+    </node>
     <node concept="15bmVD" id="7qYSchhSpfu" role="15bmVC">
       <node concept="15ShDW" id="7qYSchhSpfr" role="15bq2Y">
         <property role="15ShDY" value="Po4Z58IgAt/April" />


### PR DESCRIPTION
Fixed utility class for creating instances of `Text` to avoid space ` ` before the actual string content. This might be helpful when requiring exact `Text` content, for example in nodes compare scenarios.

_Note_: fixed method  `RichTextUtil.createTextFromSingleString()` is only available as utility for the external usage, but not used in the richtext language itself. Therefore the change has no impact on the language behavior. 