### PR TITLE
mpsutil.intentions: Add support for grouping intention actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is *loosely* based on [Keep a Changelog](https://keepachangelog.com/e
 ### Added
 
 - *com.mbeddr.mpsutil.compare* The language has a new assert statement *assert generated model* to generate models or single nodes and compare them in tests. TextGen is also supported. Referenced nodes must be instances of richtext Words when the latter option is used. More option can be set in the inspector.
+- *com.mbeddr.mpsutil.intentions* Group annotations can now be also added to action declarations and are active when the actions are added to the *ActionsAsIntentions* group.
 
 ## April 2025
 

--- a/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
+++ b/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
@@ -24085,29 +24085,19 @@
             <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
           </node>
         </node>
-        <node concept="1SiIV0" id="24lzbKW1X7S" role="3bR37C">
-          <node concept="3bR9La" id="24lzbKW1X7T" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
-          </node>
-        </node>
         <node concept="1SiIV0" id="24lzbKW1X7U" role="3bR37C">
           <node concept="3bR9La" id="24lzbKW1X7V" role="1SiIV1">
             <ref role="3bR37D" to="ffeo:3MI1gu0QouH" resolve="jetbrains.mps.editor.runtime" />
           </node>
         </node>
-        <node concept="1SiIV0" id="38Yx6hD5qf_" role="3bR37C">
-          <node concept="3bR9La" id="38Yx6hD5qfA" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:7Kfy9QB6L8K" resolve="jetbrains.mps.lang.plugin" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="38Yx6hD5qfB" role="3bR37C">
-          <node concept="3bR9La" id="38Yx6hD5qfC" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:7Kfy9QB6L7y" resolve="jetbrains.mps.lang.intentions" />
-          </node>
-        </node>
         <node concept="1SiIV0" id="38Yx6hD5qfD" role="3bR37C">
           <node concept="3bR9La" id="38Yx6hD5qfE" role="1SiIV1">
             <ref role="3bR37D" node="54z9_KDR0Ol" resolve="com.mbeddr.mpsutil.intentions" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="5gDLJkL8X6j" role="3bR37C">
+          <node concept="3bR9La" id="5gDLJkL8X6k" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1TaHNgiIbIQ" resolve="MPS.Core" />
           </node>
         </node>
       </node>
@@ -24696,6 +24686,11 @@
             <node concept="3qWCbU" id="4zIvKyx$dr9" role="3LXTna">
               <property role="3qWCbO" value="icons/**, resources/**" />
             </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="5gDLJkL8X8O" role="3bR37C">
+          <node concept="3bR9La" id="5gDLJkL8X8P" role="1SiIV1">
+            <ref role="3bR37D" node="1sO539bGQvB" resolve="de.slisson.mps.richtext" />
           </node>
         </node>
       </node>

--- a/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
+++ b/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
@@ -14606,6 +14606,11 @@
               </node>
             </node>
           </node>
+          <node concept="1SiIV0" id="6EyoeN03yyC" role="3bR37C">
+            <node concept="3bR9La" id="6EyoeN03yyD" role="1SiIV1">
+              <ref role="3bR37D" to="ffeo:7Kfy9QB6L8K" resolve="jetbrains.mps.lang.plugin" />
+            </node>
+          </node>
         </node>
         <node concept="1BupzO" id="4PRpvcZJNy7" role="3bR31x">
           <property role="3ZfqAx" value="languageModels" />
@@ -14632,6 +14637,31 @@
         <node concept="1SiIV0" id="2oNsb9219Ke" role="3bR37C">
           <node concept="Rbm2T" id="2oNsb9219Kf" role="1SiIV1">
             <ref role="1E1Vl2" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="6EyoeN03yyl" role="3bR37C">
+          <node concept="3bR9La" id="6EyoeN03yym" role="1SiIV1">
+            <ref role="3bR37D" node="3NH93cznmT7" resolve="com.mbeddr.mpsutil.intentions.runtime" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="6EyoeN03yyn" role="3bR37C">
+          <node concept="3bR9La" id="6EyoeN03yyo" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1ia2VB5guYy" resolve="MPS.IDEA" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="6EyoeN03yyp" role="3bR37C">
+          <node concept="3bR9La" id="6EyoeN03yyq" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:7Kfy9QB6L8K" resolve="jetbrains.mps.lang.plugin" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="6EyoeN03yyr" role="3bR37C">
+          <node concept="3bR9La" id="6EyoeN03yys" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1TaHNgiIbIZ" resolve="MPS.Editor" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="6EyoeN03yyt" role="3bR37C">
+          <node concept="3bR9La" id="6EyoeN03yyu" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1TaHNgiIbJb" resolve="MPS.Platform" />
           </node>
         </node>
       </node>
@@ -24023,6 +24053,46 @@
                 </node>
               </node>
             </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="6EyoeN03M86" role="3bR37C">
+          <node concept="3bR9La" id="6EyoeN03M87" role="1SiIV1">
+            <ref role="3bR37D" node="3NH93cznmT7" resolve="com.mbeddr.mpsutil.intentions.runtime" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="6EyoeN03M88" role="3bR37C">
+          <node concept="3bR9La" id="6EyoeN03M89" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1ia2VB5guYy" resolve="MPS.IDEA" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="6EyoeN03M8a" role="3bR37C">
+          <node concept="3bR9La" id="6EyoeN03M8b" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1TaHNgiIbJ$" resolve="jetbrains.mps.ide.editor" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="3yn97gb3Rq4" role="3bR37C">
+          <node concept="3bR9La" id="3yn97gb3Rq5" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1TaHNgiIbJb" resolve="MPS.Platform" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="24lzbKW1X7O" role="3bR37C">
+          <node concept="3bR9La" id="24lzbKW1X7P" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:44LXwdzyvTi" resolve="Annotations" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="24lzbKW1X7Q" role="3bR37C">
+          <node concept="3bR9La" id="24lzbKW1X7R" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="24lzbKW1X7S" role="3bR37C">
+          <node concept="3bR9La" id="24lzbKW1X7T" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="24lzbKW1X7U" role="3bR37C">
+          <node concept="3bR9La" id="24lzbKW1X7V" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:3MI1gu0QouH" resolve="jetbrains.mps.editor.runtime" />
           </node>
         </node>
       </node>

--- a/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
+++ b/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
@@ -24095,6 +24095,21 @@
             <ref role="3bR37D" to="ffeo:3MI1gu0QouH" resolve="jetbrains.mps.editor.runtime" />
           </node>
         </node>
+        <node concept="1SiIV0" id="38Yx6hD5qf_" role="3bR37C">
+          <node concept="3bR9La" id="38Yx6hD5qfA" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:7Kfy9QB6L8K" resolve="jetbrains.mps.lang.plugin" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="38Yx6hD5qfB" role="3bR37C">
+          <node concept="3bR9La" id="38Yx6hD5qfC" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:7Kfy9QB6L7y" resolve="jetbrains.mps.lang.intentions" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="38Yx6hD5qfD" role="3bR37C">
+          <node concept="3bR9La" id="38Yx6hD5qfE" role="1SiIV1">
+            <ref role="3bR37D" node="54z9_KDR0Ol" resolve="com.mbeddr.mpsutil.intentions" />
+          </node>
+        </node>
       </node>
     </node>
     <node concept="2G$12M" id="77YfcvOSSnB" role="3989C9">

--- a/code/compare/languages/com.mbeddr.mpsutil.compare/generator/template/main@generator.mps
+++ b/code/compare/languages/com.mbeddr.mpsutil.compare/generator/template/main@generator.mps
@@ -1157,9 +1157,9 @@
                     <node concept="3uibUv" id="3iWn33TWTK" role="1tU5fm">
                       <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
                     </node>
-                    <node concept="2YIFZM" id="t0OlD0QFm8" role="33vP2m">
-                      <ref role="37wK5l" to="qjvf:t0OlD0QDMt" resolve="getRepository" />
-                      <ref role="1Pybhc" to="qjvf:t0OlD0QCBC" resolve="RepositoryHelper" />
+                    <node concept="2YIFZM" id="7un1ewSBEed" role="33vP2m">
+                      <ref role="37wK5l" to="mqum:t0OlD0QDMt" resolve="getRepository" />
+                      <ref role="1Pybhc" to="mqum:t0OlD0QCBC" resolve="RepositoryHelper" />
                     </node>
                   </node>
                 </node>
@@ -1522,9 +1522,9 @@
                         </node>
                         <node concept="liA8E" id="6Od11GYalxm" role="2OqNvi">
                           <ref role="37wK5l" to="mhbf:~SNodeReference.resolve(org.jetbrains.mps.openapi.module.SRepository)" resolve="resolve" />
-                          <node concept="2YIFZM" id="t0OlD0SbfP" role="37wK5m">
-                            <ref role="37wK5l" to="qjvf:t0OlD0QDMt" resolve="getRepository" />
-                            <ref role="1Pybhc" to="qjvf:t0OlD0QCBC" resolve="RepositoryHelper" />
+                          <node concept="2YIFZM" id="7un1ewSBEee" role="37wK5m">
+                            <ref role="37wK5l" to="mqum:t0OlD0QDMt" resolve="getRepository" />
+                            <ref role="1Pybhc" to="mqum:t0OlD0QCBC" resolve="RepositoryHelper" />
                           </node>
                         </node>
                       </node>
@@ -1611,9 +1611,9 @@
                     <node concept="37vLTw" id="5oR1gCFTGbq" role="37wK5m">
                       <ref role="3cqZAo" node="6Od11GYalx4" resolve="input" />
                     </node>
-                    <node concept="2YIFZM" id="t0OlD0SbmE" role="37wK5m">
-                      <ref role="37wK5l" to="qjvf:t0OlD0QDMt" resolve="getRepository" />
-                      <ref role="1Pybhc" to="qjvf:t0OlD0QCBC" resolve="RepositoryHelper" />
+                    <node concept="2YIFZM" id="7un1ewSBEef" role="37wK5m">
+                      <ref role="37wK5l" to="mqum:t0OlD0QDMt" resolve="getRepository" />
+                      <ref role="1Pybhc" to="mqum:t0OlD0QCBC" resolve="RepositoryHelper" />
                     </node>
                   </node>
                 </node>
@@ -1719,9 +1719,9 @@
                       </node>
                       <node concept="liA8E" id="t0OlD0QMMU" role="2OqNvi">
                         <ref role="37wK5l" to="mhbf:~SNodeReference.resolve(org.jetbrains.mps.openapi.module.SRepository)" resolve="resolve" />
-                        <node concept="2YIFZM" id="t0OlD0SaOZ" role="37wK5m">
-                          <ref role="37wK5l" to="qjvf:t0OlD0QDMt" resolve="getRepository" />
-                          <ref role="1Pybhc" to="qjvf:t0OlD0QCBC" resolve="RepositoryHelper" />
+                        <node concept="2YIFZM" id="7un1ewSBEeg" role="37wK5m">
+                          <ref role="37wK5l" to="mqum:t0OlD0QDMt" resolve="getRepository" />
+                          <ref role="1Pybhc" to="mqum:t0OlD0QCBC" resolve="RepositoryHelper" />
                         </node>
                       </node>
                     </node>
@@ -1786,9 +1786,9 @@
                         </node>
                         <node concept="liA8E" id="t0OlD0QMNo" role="2OqNvi">
                           <ref role="37wK5l" to="mhbf:~SNodeReference.resolve(org.jetbrains.mps.openapi.module.SRepository)" resolve="resolve" />
-                          <node concept="2YIFZM" id="t0OlD0SauQ" role="37wK5m">
-                            <ref role="37wK5l" to="qjvf:t0OlD0QDMt" resolve="getRepository" />
-                            <ref role="1Pybhc" to="qjvf:t0OlD0QCBC" resolve="RepositoryHelper" />
+                          <node concept="2YIFZM" id="7un1ewSBEeh" role="37wK5m">
+                            <ref role="37wK5l" to="mqum:t0OlD0QDMt" resolve="getRepository" />
+                            <ref role="1Pybhc" to="mqum:t0OlD0QCBC" resolve="RepositoryHelper" />
                           </node>
                         </node>
                       </node>
@@ -1847,9 +1847,9 @@
                     <node concept="37vLTw" id="t0OlD0QMNR" role="37wK5m">
                       <ref role="3cqZAo" node="t0OlD0QMN5" resolve="input" />
                     </node>
-                    <node concept="2YIFZM" id="t0OlD0SaWP" role="37wK5m">
-                      <ref role="37wK5l" to="qjvf:t0OlD0QDMt" resolve="getRepository" />
-                      <ref role="1Pybhc" to="qjvf:t0OlD0QCBC" resolve="RepositoryHelper" />
+                    <node concept="2YIFZM" id="7un1ewSBEei" role="37wK5m">
+                      <ref role="37wK5l" to="mqum:t0OlD0QDMt" resolve="getRepository" />
+                      <ref role="1Pybhc" to="mqum:t0OlD0QCBC" resolve="RepositoryHelper" />
                     </node>
                   </node>
                 </node>
@@ -2000,9 +2000,9 @@
                         </node>
                         <node concept="liA8E" id="t0OlD0QMP0" role="2OqNvi">
                           <ref role="37wK5l" to="mhbf:~SNodeReference.resolve(org.jetbrains.mps.openapi.module.SRepository)" resolve="resolve" />
-                          <node concept="2YIFZM" id="t0OlD0QMOF" role="37wK5m">
-                            <ref role="37wK5l" to="qjvf:t0OlD0QDMt" resolve="getRepository" />
-                            <ref role="1Pybhc" to="qjvf:t0OlD0QCBC" resolve="RepositoryHelper" />
+                          <node concept="2YIFZM" id="7un1ewSBEej" role="37wK5m">
+                            <ref role="37wK5l" to="mqum:t0OlD0QDMt" resolve="getRepository" />
+                            <ref role="1Pybhc" to="mqum:t0OlD0QCBC" resolve="RepositoryHelper" />
                           </node>
                         </node>
                       </node>
@@ -2061,9 +2061,9 @@
                     <node concept="37vLTw" id="t0OlD0QMPA" role="37wK5m">
                       <ref role="3cqZAo" node="t0OlD0QMOH" resolve="input" />
                     </node>
-                    <node concept="2YIFZM" id="t0OlD0SaoI" role="37wK5m">
-                      <ref role="37wK5l" to="qjvf:t0OlD0QDMt" resolve="getRepository" />
-                      <ref role="1Pybhc" to="qjvf:t0OlD0QCBC" resolve="RepositoryHelper" />
+                    <node concept="2YIFZM" id="7un1ewSBEek" role="37wK5m">
+                      <ref role="37wK5l" to="mqum:t0OlD0QDMt" resolve="getRepository" />
+                      <ref role="1Pybhc" to="mqum:t0OlD0QCBC" resolve="RepositoryHelper" />
                     </node>
                   </node>
                 </node>

--- a/code/compare/languages/com.mbeddr.mpsutil.compare/languageModels/behavior.mps
+++ b/code/compare/languages/com.mbeddr.mpsutil.compare/languageModels/behavior.mps
@@ -53,13 +53,11 @@
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
       </concept>
-      <concept id="1081236700938" name="jetbrains.mps.baseLanguage.structure.StaticMethodDeclaration" flags="ig" index="2YIFZL" />
       <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
       </concept>
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
       <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
-      <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu" />
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <child id="1068431790190" name="initializer" index="33vP2m" />
       </concept>
@@ -98,9 +96,6 @@
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
-      <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
-        <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
-      </concept>
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
       </concept>
@@ -117,9 +112,6 @@
         <child id="1163668934364" name="ifFalse" index="3K4GZi" />
       </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
-      <concept id="1116615150612" name="jetbrains.mps.baseLanguage.structure.ClassifierClassExpression" flags="nn" index="3VsKOn">
-        <reference id="1116615189566" name="classifier" index="3VsUkX" />
-      </concept>
       <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
     </language>
     <language id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation">
@@ -170,38 +162,6 @@
     <node concept="13hLZK" id="6Od11GY7saB" role="13h7CW">
       <node concept="3clFbS" id="6Od11GY7saC" role="2VODD2" />
     </node>
-  </node>
-  <node concept="312cEu" id="t0OlD0QCBC">
-    <property role="TrG5h" value="RepositoryHelper" />
-    <node concept="2YIFZL" id="t0OlD0QDMt" role="jymVt">
-      <property role="TrG5h" value="getRepository" />
-      <node concept="3clFbS" id="t0OlD0QDMv" role="3clF47">
-        <node concept="3clFbF" id="t0OlD0QDMW" role="3cqZAp">
-          <node concept="2OqwBi" id="t0OlD0QDMY" role="3clFbG">
-            <node concept="2OqwBi" id="t0OlD0QDMZ" role="2Oq$k0">
-              <node concept="2YIFZM" id="t0OlD0QDN0" role="2Oq$k0">
-                <ref role="37wK5l" to="3a50:~MPSCoreComponents.getInstance()" resolve="getInstance" />
-                <ref role="1Pybhc" to="3a50:~MPSCoreComponents" resolve="MPSCoreComponents" />
-              </node>
-              <node concept="liA8E" id="t0OlD0QDN1" role="2OqNvi">
-                <ref role="37wK5l" to="3a50:~MPSCoreComponents.getPlatform()" resolve="getPlatform" />
-              </node>
-            </node>
-            <node concept="liA8E" id="t0OlD0QDN2" role="2OqNvi">
-              <ref role="37wK5l" to="wyuk:~ComponentHost.findComponent(java.lang.Class)" resolve="findComponent" />
-              <node concept="3VsKOn" id="t0OlD0QDN3" role="37wK5m">
-                <ref role="3VsUkX" to="w1kc:~MPSModuleRepository" resolve="MPSModuleRepository" />
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3uibUv" id="t0OlD0QDMw" role="3clF45">
-        <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
-      </node>
-      <node concept="3Tm1VV" id="t0OlD0QDMx" role="1B3o_S" />
-    </node>
-    <node concept="3Tm1VV" id="t0OlD0QCBD" role="1B3o_S" />
   </node>
   <node concept="13h7C7" id="t0OlD0UlBC">
     <ref role="13h7C2" to="8do3:t0OlD0Ulrx" resolve="IDiffable" />

--- a/code/compare/solutions/com.mbeddr.mpsutil.comparator/models/.model
+++ b/code/compare/solutions/com.mbeddr.mpsutil.comparator/models/.model
@@ -43,6 +43,9 @@
     <import index="1m72" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.components(MPS.IDEA/)" />
     <import index="mk8z" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.progress(MPS.Core/)" />
     <import index="yyf4" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.util(MPS.OpenAPI/)" />
+    <import index="3a50" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.ide(MPS.Platform/)" />
+    <import index="wyuk" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.components(MPS.Core/)" />
+    <import index="w1kc" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel(MPS.Core/)" />
     <import index="qjvf" ref="r:82cadfba-0fcc-402e-8eaa-37395d383fb6(com.mbeddr.mpsutil.compare.behavior)" implicit="true" />
     <import index="guwi" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.io(JDK/)" implicit="true" />
   </imports>

--- a/code/compare/solutions/com.mbeddr.mpsutil.comparator/models/RepositoryHelper.mpsr
+++ b/code/compare/solutions/com.mbeddr.mpsutil.comparator/models/RepositoryHelper.mpsr
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:ec874b45-e888-42e6-995a-a298cefdff55(com.mbeddr.mpsutil.comparator.code)" content="root">
+  <persistence version="9" />
+  <imports>
+    <import index="3a50" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.ide(MPS.Platform/)" implicit="true" />
+    <import index="wyuk" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.components(MPS.Core/)" implicit="true" />
+    <import index="w1kc" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel(MPS.Core/)" implicit="true" />
+    <import index="lui2" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.module(MPS.OpenAPI/)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1081236700938" name="jetbrains.mps.baseLanguage.structure.StaticMethodDeclaration" flags="ig" index="2YIFZL" />
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
+      </concept>
+      <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu" />
+      <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123135" name="body" index="3clF47" />
+      </concept>
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+      <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
+        <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
+      </concept>
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+        <reference id="1107535924139" name="classifier" index="3uigEE" />
+      </concept>
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
+        <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+      <concept id="1116615150612" name="jetbrains.mps.baseLanguage.structure.ClassifierClassExpression" flags="nn" index="3VsKOn">
+        <reference id="1116615189566" name="classifier" index="3VsUkX" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="312cEu" id="t0OlD0QCBC">
+    <property role="TrG5h" value="RepositoryHelper" />
+    <node concept="2YIFZL" id="t0OlD0QDMt" role="jymVt">
+      <property role="TrG5h" value="getRepository" />
+      <node concept="3clFbS" id="t0OlD0QDMv" role="3clF47">
+        <node concept="3clFbF" id="t0OlD0QDMW" role="3cqZAp">
+          <node concept="2OqwBi" id="t0OlD0QDMY" role="3clFbG">
+            <node concept="2OqwBi" id="t0OlD0QDMZ" role="2Oq$k0">
+              <node concept="2YIFZM" id="t0OlD0QDN0" role="2Oq$k0">
+                <ref role="37wK5l" to="3a50:~MPSCoreComponents.getInstance()" resolve="getInstance" />
+                <ref role="1Pybhc" to="3a50:~MPSCoreComponents" resolve="MPSCoreComponents" />
+              </node>
+              <node concept="liA8E" id="t0OlD0QDN1" role="2OqNvi">
+                <ref role="37wK5l" to="3a50:~MPSCoreComponents.getPlatform()" resolve="getPlatform" />
+              </node>
+            </node>
+            <node concept="liA8E" id="t0OlD0QDN2" role="2OqNvi">
+              <ref role="37wK5l" to="wyuk:~ComponentHost.findComponent(java.lang.Class)" resolve="findComponent" />
+              <node concept="3VsKOn" id="t0OlD0QDN3" role="37wK5m">
+                <ref role="3VsUkX" to="w1kc:~MPSModuleRepository" resolve="MPSModuleRepository" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3uibUv" id="t0OlD0QDMw" role="3clF45">
+        <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
+      </node>
+      <node concept="3Tm1VV" id="t0OlD0QDMx" role="1B3o_S" />
+    </node>
+    <node concept="3Tm1VV" id="t0OlD0QCBD" role="1B3o_S" />
+  </node>
+</model>
+

--- a/code/intentionsmenu/com.mbeddr.mpsutil.intentions.runtime/com.mbeddr.mpsutil.intentions.runtime.msd
+++ b/code/intentionsmenu/com.mbeddr.mpsutil.intentions.runtime/com.mbeddr.mpsutil.intentions.runtime.msd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <solution name="com.mbeddr.mpsutil.intentions.runtime" uuid="4bff7bbe-ce5f-432e-84bf-60809cb9987c" moduleVersion="0">
   <models>
-    <modelRoot contentPath="${module}" type="default">
+    <modelRoot type="default" contentPath="${module}">
       <sourceRoot location="models" />
     </modelRoot>
   </models>

--- a/code/intentionsmenu/com.mbeddr.mpsutil.intentions.runtime/com.mbeddr.mpsutil.intentions.runtime.msd
+++ b/code/intentionsmenu/com.mbeddr.mpsutil.intentions.runtime/com.mbeddr.mpsutil.intentions.runtime.msd
@@ -31,7 +31,6 @@
     <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="2" />
     <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
     <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
-    <language slang="l:acfc188d-d5d6-4598-b370-6f4a983f05b2:jetbrains.mps.baseLanguage.methodReferences" version="0" />
     <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
     <language slang="l:63650c59-16c8-498a-99c8-005c7ee9515d:jetbrains.mps.lang.access" version="0" />
     <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />

--- a/code/intentionsmenu/com.mbeddr.mpsutil.intentions.runtime/models/com/mbeddr/mpsutil/intentions/runtime.mps
+++ b/code/intentionsmenu/com.mbeddr.mpsutil.intentions.runtime/models/com/mbeddr/mpsutil/intentions/runtime.mps
@@ -3,13 +3,12 @@
   <persistence version="9" />
   <languages>
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
-    <use id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core" version="2" />
     <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="14" />
     <use id="774bf8a0-62e5-41e1-af63-f4812e60e48b" name="jetbrains.mps.baseLanguage.checkedDots" version="0" />
     <use id="654422bf-e75f-44dc-936d-188890a746ce" name="de.slisson.mps.reflection" version="0" />
     <use id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures" version="0" />
-    <use id="acfc188d-d5d6-4598-b370-6f4a983f05b2" name="jetbrains.mps.baseLanguage.methodReferences" version="0" />
     <use id="63650c59-16c8-498a-99c8-005c7ee9515d" name="jetbrains.mps.lang.access" version="0" />
+    <use id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc" version="2" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -48,6 +47,8 @@
     <import index="ev0w" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.typechecking.backend(MPS.Core/)" />
     <import index="z60i" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt(JDK/)" />
     <import index="7oz1" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor.configuration(MPS.Editor/)" />
+    <import index="8rsk" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.actionSystem.ex(MPS.IDEA/)" />
+    <import index="zn9m" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.util(MPS.IDEA/)" />
   </imports>
   <registry>
     <language id="654422bf-e75f-44dc-936d-188890a746ce" name="de.slisson.mps.reflection">
@@ -75,6 +76,7 @@
         <child id="1068498886295" name="lValue" index="37vLTJ" />
       </concept>
       <concept id="1153417849900" name="jetbrains.mps.baseLanguage.structure.GreaterThanOrEqualsExpression" flags="nn" index="2d3UOw" />
+      <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
       <concept id="8118189177080264853" name="jetbrains.mps.baseLanguage.structure.AlternativeType" flags="ig" index="nSUau">
         <child id="8118189177080264854" name="alternative" index="nSUat" />
@@ -148,6 +150,7 @@
       <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu">
         <property id="1075300953594" name="abstractClass" index="1sVAO0" />
         <property id="1221565133444" name="isFinal" index="1EXbeo" />
+        <child id="1095933932569" name="implementedInterface" index="EKbjA" />
         <child id="1165602531693" name="superclass" index="1zkMxy" />
       </concept>
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
@@ -271,7 +274,6 @@
       <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
       <concept id="1170345865475" name="jetbrains.mps.baseLanguage.structure.AnonymousClass" flags="ig" index="1Y3b0j">
         <reference id="1170346070688" name="classifier" index="1Y3XeK" />
-        <child id="1201186121363" name="typeParameter" index="2Ghqu4" />
       </concept>
     </language>
     <language id="63650c59-16c8-498a-99c8-005c7ee9515d" name="jetbrains.mps.lang.access">
@@ -286,12 +288,25 @@
       <concept id="4079382982702596667" name="jetbrains.mps.baseLanguage.checkedDots.structure.CheckedDotExpression" flags="nn" index="2EnYce" />
     </language>
     <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
+      <concept id="2524418899405758586" name="jetbrains.mps.baseLanguage.closures.structure.InferredClosureParameterDeclaration" flags="ig" index="gl6BB" />
       <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
         <property id="890797661671409019" name="forceMultiLine" index="3yWfEV" />
         <child id="1199569906740" name="parameter" index="1bW2Oz" />
         <child id="1199569916463" name="body" index="1bW5cS" />
       </concept>
       <concept id="8992394414545679616" name="jetbrains.mps.baseLanguage.closures.structure.ClosureVarType" flags="ig" index="3VYd8j" />
+    </language>
+    <language id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc">
+      <concept id="5349172909345501395" name="jetbrains.mps.baseLanguage.javadoc.structure.BaseDocComment" flags="ng" index="P$AiS">
+        <child id="8465538089690331502" name="body" index="TZ5H$" />
+      </concept>
+      <concept id="5349172909345532724" name="jetbrains.mps.baseLanguage.javadoc.structure.MethodDocComment" flags="ng" index="P$JXv" />
+      <concept id="8465538089690331500" name="jetbrains.mps.baseLanguage.javadoc.structure.CommentLine" flags="ng" index="TZ5HA">
+        <child id="8970989240999019149" name="part" index="1dT_Ay" />
+      </concept>
+      <concept id="8970989240999019143" name="jetbrains.mps.baseLanguage.javadoc.structure.TextCommentLinePart" flags="ng" index="1dT_AC">
+        <property id="8970989240999019144" name="text" index="1dT_AB" />
+      </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
       <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
@@ -318,6 +333,9 @@
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
@@ -331,12 +349,19 @@
       </concept>
     </language>
     <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
+        <child id="1204796294226" name="closure" index="23t8la" />
+      </concept>
       <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="nn" index="25WWJ4">
         <child id="540871147943773366" name="argument" index="25WWJ7" />
       </concept>
       <concept id="1226511727824" name="jetbrains.mps.baseLanguage.collections.structure.SetType" flags="in" index="2hMVRd">
         <child id="1226511765987" name="elementType" index="2hN53Y" />
       </concept>
+      <concept id="1151688443754" name="jetbrains.mps.baseLanguage.collections.structure.ListType" flags="in" index="_YKpA">
+        <child id="1151688676805" name="elementType" index="_ZDj9" />
+      </concept>
+      <concept id="1151702311717" name="jetbrains.mps.baseLanguage.collections.structure.ToListOperation" flags="nn" index="ANE8D" />
       <concept id="1153943597977" name="jetbrains.mps.baseLanguage.collections.structure.ForEachStatement" flags="nn" index="2Gpval">
         <child id="1153944400369" name="variable" index="2Gsz3X" />
         <child id="1153944424730" name="inputSequence" index="2GsD0m" />
@@ -345,7 +370,42 @@
       <concept id="1153944233411" name="jetbrains.mps.baseLanguage.collections.structure.ForEachVariableReference" flags="nn" index="2GrUjf">
         <reference id="1153944258490" name="variable" index="2Gs0qQ" />
       </concept>
+      <concept id="1237721394592" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerCreator" flags="nn" index="HWqM0">
+        <child id="1237721435807" name="elementType" index="HW$YZ" />
+      </concept>
+      <concept id="1227008614712" name="jetbrains.mps.baseLanguage.collections.structure.LinkedListCreator" flags="nn" index="2Jqq0_" />
+      <concept id="1201306600024" name="jetbrains.mps.baseLanguage.collections.structure.ContainsKeyOperation" flags="nn" index="2Nt0df">
+        <child id="1201654602639" name="key" index="38cxEo" />
+      </concept>
+      <concept id="1160600644654" name="jetbrains.mps.baseLanguage.collections.structure.ListCreatorWithInit" flags="nn" index="Tc6Ow" />
       <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
+      <concept id="4611582986551314327" name="jetbrains.mps.baseLanguage.collections.structure.OfTypeOperation" flags="nn" index="UnYns">
+        <child id="4611582986551314344" name="requestedType" index="UnYnz" />
+      </concept>
+      <concept id="1160666733551" name="jetbrains.mps.baseLanguage.collections.structure.AddAllElementsOperation" flags="nn" index="X8dFx" />
+      <concept id="1240217271293" name="jetbrains.mps.baseLanguage.collections.structure.LinkedHashSetCreator" flags="nn" index="32HrFt" />
+      <concept id="1240325842691" name="jetbrains.mps.baseLanguage.collections.structure.AsSequenceOperation" flags="nn" index="39bAoz" />
+      <concept id="1240424373525" name="jetbrains.mps.baseLanguage.collections.structure.MappingType" flags="in" index="3f3tKP">
+        <child id="1240424397093" name="keyType" index="3f3zw5" />
+        <child id="1240424402756" name="valueType" index="3f3$T$" />
+      </concept>
+      <concept id="1197683403723" name="jetbrains.mps.baseLanguage.collections.structure.MapType" flags="in" index="3rvAFt">
+        <child id="1197683466920" name="keyType" index="3rvQeY" />
+        <child id="1197683475734" name="valueType" index="3rvSg0" />
+      </concept>
+      <concept id="1197686869805" name="jetbrains.mps.baseLanguage.collections.structure.HashMapCreator" flags="nn" index="3rGOSV">
+        <child id="1197687026896" name="keyType" index="3rHrn6" />
+        <child id="1197687035757" name="valueType" index="3rHtpV" />
+      </concept>
+      <concept id="1165530316231" name="jetbrains.mps.baseLanguage.collections.structure.IsEmptyOperation" flags="nn" index="1v1jN8" />
+      <concept id="1225727723840" name="jetbrains.mps.baseLanguage.collections.structure.FindFirstOperation" flags="nn" index="1z4cxt" />
+      <concept id="1240824834947" name="jetbrains.mps.baseLanguage.collections.structure.ValueAccessOperation" flags="nn" index="3AV6Ez" />
+      <concept id="1240825616499" name="jetbrains.mps.baseLanguage.collections.structure.KeyAccessOperation" flags="nn" index="3AY5_j" />
+      <concept id="1197932370469" name="jetbrains.mps.baseLanguage.collections.structure.MapElement" flags="nn" index="3EllGN">
+        <child id="1197932505799" name="map" index="3ElQJh" />
+        <child id="1197932525128" name="key" index="3ElVtu" />
+      </concept>
+      <concept id="1172254888721" name="jetbrains.mps.baseLanguage.collections.structure.ContainsOperation" flags="nn" index="3JPx81" />
     </language>
   </registry>
   <node concept="312cEu" id="5qf1oe_zyw0">
@@ -527,6 +587,46 @@
   <node concept="312cEu" id="2jDew64JcPx">
     <property role="TrG5h" value="MyIntentionMenuProducer" />
     <node concept="2tJIrI" id="2jDew64KOaE" role="jymVt" />
+    <node concept="Wx3nA" id="6Kw22eW7L03" role="jymVt">
+      <property role="TrG5h" value="GROUPNAME_KEY" />
+      <node concept="3Tm1VV" id="6Kw22eW7pcO" role="1B3o_S" />
+      <node concept="3uibUv" id="6Kw22eW7wxo" role="1tU5fm">
+        <ref role="3uigEE" to="zn9m:~Key" resolve="Key" />
+        <node concept="17QB3L" id="6Kw22eW7DmF" role="11_B2D" />
+      </node>
+      <node concept="2ShNRf" id="6Kw22eW7TUy" role="33vP2m">
+        <node concept="1pGfFk" id="6Kw22eW7Wvi" role="2ShVmc">
+          <property role="373rjd" value="true" />
+          <ref role="37wK5l" to="zn9m:~Key.&lt;init&gt;(java.lang.String)" resolve="Key" />
+          <node concept="Xl_RD" id="6Kw22eW7X6Q" role="37wK5m">
+            <property role="Xl_RC" value="groupName" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="Wx3nA" id="5Rdndlpp80A" role="jymVt">
+      <property role="TrG5h" value="groupedActionsCache" />
+      <node concept="3Tm1VV" id="5RdndlpoVwT" role="1B3o_S" />
+      <node concept="2ShNRf" id="5RdndlpphrM" role="33vP2m">
+        <node concept="3rGOSV" id="ZxI3JAdAP9" role="2ShVmc">
+          <node concept="17QB3L" id="ZxI3JAdL52" role="3rHrn6" />
+          <node concept="2hMVRd" id="2Ef_vJ5WSfd" role="3rHtpV">
+            <node concept="3uibUv" id="2Ef_vJ5WYol" role="2hN53Y">
+              <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3rvAFt" id="ZxI3JAcvMm" role="1tU5fm">
+        <node concept="17QB3L" id="ZxI3JAcBtn" role="3rvQeY" />
+        <node concept="2hMVRd" id="2Ef_vJ5X4yv" role="3rvSg0">
+          <node concept="3uibUv" id="2Ef_vJ5X4yw" role="2hN53Y">
+            <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6Kw22eW7iqb" role="jymVt" />
     <node concept="312cEg" id="2jDew64KOaH" role="jymVt">
       <property role="34CwA1" value="false" />
       <property role="eg7rD" value="false" />
@@ -548,7 +648,7 @@
         <ref role="3uigEE" to="exr9:~IntentionsSupport" resolve="IntentionsSupport" />
       </node>
     </node>
-    <node concept="2tJIrI" id="2jDew64KOaG" role="jymVt" />
+    <node concept="2tJIrI" id="1eqBxP9l39a" role="jymVt" />
     <node concept="3clFbW" id="2jDew64KaGG" role="jymVt">
       <property role="TrG5h" value="IntentionMenuProducer" />
       <node concept="3cqZAl" id="2jDew64KaGH" role="3clF45" />
@@ -599,7 +699,7 @@
         </node>
       </node>
     </node>
-    <node concept="2tJIrI" id="2jDew64KefB" role="jymVt" />
+    <node concept="2tJIrI" id="7YiW3LCny9o" role="jymVt" />
     <node concept="3clFb_" id="2jDew64HgSb" role="jymVt">
       <property role="TrG5h" value="getIntentionsGroup" />
       <node concept="3Tm1VV" id="2jDew64HgSc" role="1B3o_S" />
@@ -630,29 +730,23 @@
           <node concept="3cpWsn" id="3pwG8PSkQL9" role="3cpWs9">
             <property role="3TUv4t" value="false" />
             <property role="TrG5h" value="groupItems" />
-            <node concept="3uibUv" id="3pwG8PSkQLb" role="1tU5fm">
-              <ref role="3uigEE" to="33ny:~List" resolve="List" />
-              <node concept="3uibUv" id="3pwG8PSkQLc" role="11_B2D">
+            <node concept="_YKpA" id="3iqDEt5g2rj" role="1tU5fm">
+              <node concept="3uibUv" id="3pwG8PSkQLc" role="_ZDj9">
                 <ref role="3uigEE" to="18ew:~Pair" resolve="Pair" />
                 <node concept="3uibUv" id="7me2y0SLnF1" role="11_B2D">
                   <ref role="3uigEE" to="nddn:~IntentionExecutable" resolve="IntentionExecutable" />
                 </node>
-                <node concept="3uibUv" id="3pwG8PSkQLe" role="11_B2D">
-                  <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
-                </node>
+                <node concept="3Tqbb2" id="7b8v2ssfgUj" role="11_B2D" />
               </node>
             </node>
-            <node concept="2ShNRf" id="3pwG8PSkU30" role="33vP2m">
-              <node concept="1pGfFk" id="3pwG8PSkU31" role="2ShVmc">
-                <ref role="37wK5l" to="33ny:~ArrayList.&lt;init&gt;()" resolve="ArrayList" />
-                <node concept="3uibUv" id="3pwG8PSkQLg" role="1pMfVU">
+            <node concept="2ShNRf" id="7b8v2ssf42a" role="33vP2m">
+              <node concept="Tc6Ow" id="7b8v2ssf42b" role="2ShVmc">
+                <node concept="3uibUv" id="7b8v2ssf42c" role="HW$YZ">
                   <ref role="3uigEE" to="18ew:~Pair" resolve="Pair" />
-                  <node concept="3uibUv" id="7me2y0SLqbn" role="11_B2D">
+                  <node concept="3uibUv" id="7b8v2ssf42d" role="11_B2D">
                     <ref role="3uigEE" to="nddn:~IntentionExecutable" resolve="IntentionExecutable" />
                   </node>
-                  <node concept="3uibUv" id="3pwG8PSkQLi" role="11_B2D">
-                    <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
-                  </node>
+                  <node concept="3Tqbb2" id="7b8v2ssf42e" role="11_B2D" />
                 </node>
               </node>
             </node>
@@ -663,9 +757,8 @@
             <node concept="37vLTw" id="3pwG8PSkU34" role="2Oq$k0">
               <ref role="3cqZAo" node="3pwG8PSkQL9" resolve="groupItems" />
             </node>
-            <node concept="liA8E" id="3pwG8PSkU36" role="2OqNvi">
-              <ref role="37wK5l" to="33ny:~List.addAll(java.util.Collection)" resolve="addAll" />
-              <node concept="1rXfSq" id="3pwG8PSkQLl" role="37wK5m">
+            <node concept="X8dFx" id="3iqDEt5gost" role="2OqNvi">
+              <node concept="1rXfSq" id="3pwG8PSkQLl" role="25WWJ7">
                 <ref role="37wK5l" node="2jDew64HgSp" resolve="getEnabledIntentions" />
               </node>
             </node>
@@ -681,26 +774,6 @@
             </node>
             <node concept="3oM_SD" id="17qUVvSZltd" role="1PaTwD">
               <property role="3oM_SC" value="intentions" />
-            </node>
-          </node>
-        </node>
-        <node concept="3cpWs8" id="3pwG8PSkQLn" role="3cqZAp">
-          <node concept="3cpWsn" id="3pwG8PSkQLm" role="3cpWs9">
-            <property role="3TUv4t" value="false" />
-            <property role="TrG5h" value="actions" />
-            <node concept="3uibUv" id="3pwG8PSkQLo" role="1tU5fm">
-              <ref role="3uigEE" to="33ny:~List" resolve="List" />
-              <node concept="3uibUv" id="3pwG8PSkQLp" role="11_B2D">
-                <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
-              </node>
-            </node>
-            <node concept="2ShNRf" id="3pwG8PSkU37" role="33vP2m">
-              <node concept="1pGfFk" id="3pwG8PSkU38" role="2ShVmc">
-                <ref role="37wK5l" to="33ny:~ArrayList.&lt;init&gt;()" resolve="ArrayList" />
-                <node concept="3uibUv" id="3pwG8PSkQLr" role="1pMfVU">
-                  <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
-                </node>
-              </node>
             </node>
           </node>
         </node>
@@ -720,8 +793,8 @@
                 </node>
               </node>
             </node>
-            <node concept="37vLTw" id="3pwG8PSkQLy" role="37wK5m">
-              <ref role="3cqZAo" node="3pwG8PSkQLm" resolve="actions" />
+            <node concept="37vLTw" id="3iqDEt5iMcf" role="37wK5m">
+              <ref role="3cqZAo" node="3pwG8PSkQL9" resolve="groupItems" />
             </node>
             <node concept="37vLTw" id="3pwG8PSkQLz" role="37wK5m">
               <ref role="3cqZAo" node="2jDew64HgSg" resolve="dataContext" />
@@ -729,49 +802,15 @@
           </node>
         </node>
         <node concept="3clFbJ" id="3pwG8PSkQL$" role="3cqZAp">
-          <node concept="1Wc70l" id="3pwG8PSkQL_" role="3clFbw">
-            <node concept="2OqwBi" id="3pwG8PSkU6E" role="3uHU7B">
-              <node concept="37vLTw" id="3pwG8PSkU6D" role="2Oq$k0">
-                <ref role="3cqZAo" node="3pwG8PSkQL9" resolve="groupItems" />
-              </node>
-              <node concept="liA8E" id="3pwG8PSkU6F" role="2OqNvi">
-                <ref role="37wK5l" to="33ny:~List.isEmpty()" resolve="isEmpty" />
-              </node>
+          <node concept="2OqwBi" id="3pwG8PSkU6E" role="3clFbw">
+            <node concept="37vLTw" id="3pwG8PSkU6D" role="2Oq$k0">
+              <ref role="3cqZAo" node="3pwG8PSkQL9" resolve="groupItems" />
             </node>
-            <node concept="2OqwBi" id="3pwG8PSkU6J" role="3uHU7w">
-              <node concept="37vLTw" id="3pwG8PSkU6I" role="2Oq$k0">
-                <ref role="3cqZAo" node="3pwG8PSkQLm" resolve="actions" />
-              </node>
-              <node concept="liA8E" id="3pwG8PSkU6K" role="2OqNvi">
-                <ref role="37wK5l" to="33ny:~List.isEmpty()" resolve="isEmpty" />
-              </node>
-            </node>
+            <node concept="1v1jN8" id="3iqDEt5gzmW" role="2OqNvi" />
           </node>
           <node concept="3clFbS" id="3pwG8PSkQLD" role="3clFbx">
             <node concept="3cpWs6" id="3pwG8PSkQLE" role="3cqZAp">
               <node concept="10Nm6u" id="3pwG8PSkQLF" role="3cqZAk" />
-            </node>
-          </node>
-        </node>
-        <node concept="3SKdUt" id="3pwG8PSkQS1" role="3cqZAp">
-          <node concept="1PaTwC" id="17qUVvSZlte" role="1aUNEU">
-            <node concept="3oM_SD" id="17qUVvSZltf" role="1PaTwD">
-              <property role="3oM_SC" value="TODO" />
-            </node>
-            <node concept="3oM_SD" id="17qUVvSZltg" role="1PaTwD">
-              <property role="3oM_SC" value="sort" />
-            </node>
-            <node concept="3oM_SD" id="17qUVvSZlth" role="1PaTwD">
-              <property role="3oM_SC" value="actions" />
-            </node>
-            <node concept="3oM_SD" id="17qUVvSZlti" role="1PaTwD">
-              <property role="3oM_SC" value="&amp;" />
-            </node>
-            <node concept="3oM_SD" id="17qUVvSZltj" role="1PaTwD">
-              <property role="3oM_SC" value="intentions" />
-            </node>
-            <node concept="3oM_SD" id="17qUVvSZltk" role="1PaTwD">
-              <property role="3oM_SC" value="together" />
             </node>
           </node>
         </node>
@@ -782,182 +821,12 @@
             <node concept="37vLTw" id="3pwG8PSkQLI" role="37wK5m">
               <ref role="3cqZAo" node="3pwG8PSkQL9" resolve="groupItems" />
             </node>
-            <node concept="2ShNRf" id="3pwG8PSkQLJ" role="37wK5m">
-              <node concept="YeOm9" id="3pwG8PSkQLK" role="2ShVmc">
-                <node concept="1Y3b0j" id="3pwG8PSkQLL" role="YeSDq">
-                  <property role="2bfB8j" value="true" />
-                  <property role="1sVAO0" value="false" />
-                  <property role="1EXbeo" value="false" />
-                  <ref role="1Y3XeK" to="33ny:~Comparator" resolve="Comparator" />
-                  <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
-                  <node concept="3Tm1VV" id="3pwG8PSkQLM" role="1B3o_S" />
-                  <node concept="3clFb_" id="3pwG8PSkQLN" role="jymVt">
-                    <property role="TrG5h" value="compare" />
-                    <property role="DiZV1" value="false" />
-                    <property role="od$2w" value="false" />
-                    <node concept="2AHcQZ" id="3pwG8PSkQLO" role="2AJF6D">
-                      <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-                    </node>
-                    <node concept="37vLTG" id="3pwG8PSkQLP" role="3clF46">
-                      <property role="TrG5h" value="o1" />
-                      <property role="3TUv4t" value="false" />
-                      <node concept="3uibUv" id="3pwG8PSkQLQ" role="1tU5fm">
-                        <ref role="3uigEE" to="18ew:~Pair" resolve="Pair" />
-                        <node concept="3uibUv" id="7me2y0SLtv0" role="11_B2D">
-                          <ref role="3uigEE" to="nddn:~IntentionExecutable" resolve="IntentionExecutable" />
-                        </node>
-                        <node concept="3uibUv" id="3pwG8PSkQLS" role="11_B2D">
-                          <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="37vLTG" id="3pwG8PSkQLT" role="3clF46">
-                      <property role="TrG5h" value="o2" />
-                      <property role="3TUv4t" value="false" />
-                      <node concept="3uibUv" id="3pwG8PSkQLU" role="1tU5fm">
-                        <ref role="3uigEE" to="18ew:~Pair" resolve="Pair" />
-                        <node concept="3uibUv" id="7me2y0SLu4M" role="11_B2D">
-                          <ref role="3uigEE" to="nddn:~IntentionExecutable" resolve="IntentionExecutable" />
-                        </node>
-                        <node concept="3uibUv" id="3pwG8PSkQLW" role="11_B2D">
-                          <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="3clFbS" id="3pwG8PSkQLX" role="3clF47">
-                      <node concept="3cpWs8" id="3pwG8PSkQLZ" role="3cqZAp">
-                        <node concept="3cpWsn" id="3pwG8PSkQLY" role="3cpWs9">
-                          <property role="3TUv4t" value="false" />
-                          <property role="TrG5h" value="intention1" />
-                          <node concept="3uibUv" id="7me2y0SLuta" role="1tU5fm">
-                            <ref role="3uigEE" to="nddn:~IntentionExecutable" resolve="IntentionExecutable" />
-                          </node>
-                          <node concept="2OqwBi" id="3pwG8PSkU6Y" role="33vP2m">
-                            <node concept="37vLTw" id="3pwG8PSkU6X" role="2Oq$k0">
-                              <ref role="3cqZAo" node="3pwG8PSkQLP" resolve="o1" />
-                            </node>
-                            <node concept="2OwXpG" id="3pwG8PSkU6Z" role="2OqNvi">
-                              <ref role="2Oxat6" to="18ew:~Pair.o1" resolve="o1" />
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="3cpWs8" id="3pwG8PSkQM3" role="3cqZAp">
-                        <node concept="3cpWsn" id="3pwG8PSkQM2" role="3cpWs9">
-                          <property role="3TUv4t" value="false" />
-                          <property role="TrG5h" value="intention2" />
-                          <node concept="3uibUv" id="7me2y0SLuYi" role="1tU5fm">
-                            <ref role="3uigEE" to="nddn:~IntentionExecutable" resolve="IntentionExecutable" />
-                          </node>
-                          <node concept="2OqwBi" id="3pwG8PSkU7a" role="33vP2m">
-                            <node concept="37vLTw" id="3pwG8PSkU79" role="2Oq$k0">
-                              <ref role="3cqZAo" node="3pwG8PSkQLT" resolve="o2" />
-                            </node>
-                            <node concept="2OwXpG" id="3pwG8PSkU7b" role="2OqNvi">
-                              <ref role="2Oxat6" to="18ew:~Pair.o1" resolve="o1" />
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="3cpWs8" id="3pwG8PSkQM7" role="3cqZAp">
-                        <node concept="3cpWsn" id="3pwG8PSkQM6" role="3cpWs9">
-                          <property role="3TUv4t" value="false" />
-                          <property role="TrG5h" value="node1" />
-                          <node concept="3uibUv" id="3pwG8PSkQM8" role="1tU5fm">
-                            <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
-                          </node>
-                          <node concept="2OqwBi" id="3pwG8PSkU7m" role="33vP2m">
-                            <node concept="37vLTw" id="3pwG8PSkU7l" role="2Oq$k0">
-                              <ref role="3cqZAo" node="3pwG8PSkQLP" resolve="o1" />
-                            </node>
-                            <node concept="2OwXpG" id="3pwG8PSkU7n" role="2OqNvi">
-                              <ref role="2Oxat6" to="18ew:~Pair.o2" resolve="o2" />
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="3cpWs8" id="3pwG8PSkQMb" role="3cqZAp">
-                        <node concept="3cpWsn" id="3pwG8PSkQMa" role="3cpWs9">
-                          <property role="3TUv4t" value="false" />
-                          <property role="TrG5h" value="node2" />
-                          <node concept="3uibUv" id="3pwG8PSkQMc" role="1tU5fm">
-                            <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
-                          </node>
-                          <node concept="2OqwBi" id="3pwG8PSkU7y" role="33vP2m">
-                            <node concept="37vLTw" id="3pwG8PSkU7x" role="2Oq$k0">
-                              <ref role="3cqZAo" node="3pwG8PSkQLT" resolve="o2" />
-                            </node>
-                            <node concept="2OwXpG" id="3pwG8PSkU7z" role="2OqNvi">
-                              <ref role="2Oxat6" to="18ew:~Pair.o2" resolve="o2" />
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="3cpWs8" id="3pwG8PSkQMf" role="3cqZAp">
-                        <node concept="3cpWsn" id="3pwG8PSkQMe" role="3cpWs9">
-                          <property role="3TUv4t" value="false" />
-                          <property role="TrG5h" value="context" />
-                          <node concept="3uibUv" id="3pwG8PSkQMg" role="1tU5fm">
-                            <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
-                          </node>
-                          <node concept="2OqwBi" id="3pwG8PSkU7I" role="33vP2m">
-                            <node concept="37vLTw" id="3pwG8PSkU7H" role="2Oq$k0">
-                              <ref role="3cqZAo" node="2jDew64KOaH" resolve="editor" />
-                            </node>
-                            <node concept="liA8E" id="3pwG8PSkU7J" role="2OqNvi">
-                              <ref role="37wK5l" to="exr9:~EditorComponent.getEditorContext()" resolve="getEditorContext" />
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="3cpWs6" id="3pwG8PSkQMi" role="3cqZAp">
-                        <node concept="2OqwBi" id="3pwG8PSkQMj" role="3cqZAk">
-                          <node concept="2OqwBi" id="3pwG8PSkU7U" role="2Oq$k0">
-                            <node concept="37vLTw" id="3pwG8PSkU7T" role="2Oq$k0">
-                              <ref role="3cqZAo" node="3pwG8PSkQLY" resolve="intention1" />
-                            </node>
-                            <node concept="liA8E" id="3pwG8PSkU7V" role="2OqNvi">
-                              <ref role="37wK5l" to="nddn:~IntentionExecutable.getDescription(org.jetbrains.mps.openapi.model.SNode,jetbrains.mps.openapi.editor.EditorContext)" resolve="getDescription" />
-                              <node concept="37vLTw" id="3pwG8PSkQMl" role="37wK5m">
-                                <ref role="3cqZAo" node="3pwG8PSkQM6" resolve="node1" />
-                              </node>
-                              <node concept="37vLTw" id="3pwG8PSkQMm" role="37wK5m">
-                                <ref role="3cqZAo" node="3pwG8PSkQMe" resolve="context" />
-                              </node>
-                            </node>
-                          </node>
-                          <node concept="liA8E" id="3pwG8PSkQMn" role="2OqNvi">
-                            <ref role="37wK5l" to="wyt6:~String.compareTo(java.lang.String)" resolve="compareTo" />
-                            <node concept="2OqwBi" id="3pwG8PSkU86" role="37wK5m">
-                              <node concept="37vLTw" id="3pwG8PSkU85" role="2Oq$k0">
-                                <ref role="3cqZAo" node="3pwG8PSkQM2" resolve="intention2" />
-                              </node>
-                              <node concept="liA8E" id="3pwG8PSkU87" role="2OqNvi">
-                                <ref role="37wK5l" to="nddn:~IntentionExecutable.getDescription(org.jetbrains.mps.openapi.model.SNode,jetbrains.mps.openapi.editor.EditorContext)" resolve="getDescription" />
-                                <node concept="37vLTw" id="3pwG8PSkQMp" role="37wK5m">
-                                  <ref role="3cqZAo" node="3pwG8PSkQMa" resolve="node2" />
-                                </node>
-                                <node concept="37vLTw" id="3pwG8PSkQMq" role="37wK5m">
-                                  <ref role="3cqZAo" node="3pwG8PSkQMe" resolve="context" />
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="3Tm1VV" id="3pwG8PSkQMr" role="1B3o_S" />
-                    <node concept="10Oyi0" id="3pwG8PSkQMs" role="3clF45" />
-                  </node>
-                  <node concept="3uibUv" id="3pwG8PSkQMt" role="2Ghqu4">
-                    <ref role="3uigEE" to="18ew:~Pair" resolve="Pair" />
-                    <node concept="3uibUv" id="7me2y0SLsOW" role="11_B2D">
-                      <ref role="3uigEE" to="nddn:~IntentionExecutable" resolve="IntentionExecutable" />
-                    </node>
-                    <node concept="3uibUv" id="3pwG8PSkQMv" role="11_B2D">
-                      <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
-                    </node>
-                  </node>
+            <node concept="2ShNRf" id="7b8v2ssaH18" role="37wK5m">
+              <node concept="1pGfFk" id="7b8v2ssaQuH" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" node="7b8v2ssaiBZ" resolve="IntentionsComparator" />
+                <node concept="37vLTw" id="7b8v2ssb0jJ" role="37wK5m">
+                  <ref role="3cqZAo" node="2jDew64KOaH" resolve="editor" />
                 </node>
               </node>
             </node>
@@ -975,9 +844,6 @@
               <node concept="37vLTw" id="3pwG8PSp_fb" role="37wK5m">
                 <ref role="3cqZAo" node="3pwG8PSkQL9" resolve="groupItems" />
               </node>
-              <node concept="37vLTw" id="3pwG8PSp_fc" role="37wK5m">
-                <ref role="3cqZAo" node="3pwG8PSkQLm" resolve="actions" />
-              </node>
             </node>
           </node>
         </node>
@@ -991,7 +857,465 @@
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
-    <node concept="2tJIrI" id="2jDew64MtYG" role="jymVt" />
+    <node concept="2tJIrI" id="2A8KNgIqwh6" role="jymVt" />
+    <node concept="3clFb_" id="2A8KNgIs$a3" role="jymVt">
+      <property role="TrG5h" value="processActionGroup" />
+      <node concept="3clFbS" id="2A8KNgIs$a6" role="3clF47">
+        <node concept="3cpWs8" id="2A8KNgItV64" role="3cqZAp">
+          <node concept="3cpWsn" id="2A8KNgItV65" role="3cpWs9">
+            <property role="TrG5h" value="groups" />
+            <node concept="3uibUv" id="2A8KNgItV66" role="1tU5fm">
+              <ref role="3uigEE" to="33ny:~TreeMap" resolve="TreeMap" />
+              <node concept="17QB3L" id="2A8KNgItV67" role="11_B2D" />
+              <node concept="_YKpA" id="7b8v2ssg0ol" role="11_B2D">
+                <node concept="3uibUv" id="7b8v2ssg0om" role="_ZDj9">
+                  <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
+                </node>
+              </node>
+            </node>
+            <node concept="2ShNRf" id="2A8KNgItV6a" role="33vP2m">
+              <node concept="1pGfFk" id="2A8KNgItV6b" role="2ShVmc">
+                <ref role="37wK5l" to="33ny:~TreeMap.&lt;init&gt;()" resolve="TreeMap" />
+                <node concept="17QB3L" id="2A8KNgItV6c" role="1pMfVU" />
+                <node concept="_YKpA" id="7b8v2ssfLRv" role="1pMfVU">
+                  <node concept="3uibUv" id="7b8v2ssfTTQ" role="_ZDj9">
+                    <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7skMbp07y7o" role="3cqZAp" />
+        <node concept="2Gpval" id="2A8KNgIv5U5" role="3cqZAp">
+          <node concept="2GrKxI" id="2A8KNgIv5U7" role="2Gsz3X">
+            <property role="TrG5h" value="action" />
+          </node>
+          <node concept="37vLTw" id="2A8KNgIvB1J" role="2GsD0m">
+            <ref role="3cqZAo" node="2A8KNgItzj$" resolve="actions" />
+          </node>
+          <node concept="3clFbS" id="2A8KNgIv5Ub" role="2LFqv$">
+            <node concept="3cpWs8" id="2A8KNgIu5dq" role="3cqZAp">
+              <node concept="3cpWsn" id="2A8KNgIu5dr" role="3cpWs9">
+                <property role="TrG5h" value="groupName" />
+                <node concept="17QB3L" id="2A8KNgIu5ds" role="1tU5fm" />
+                <node concept="1rXfSq" id="2A8KNgIu5dt" role="33vP2m">
+                  <ref role="37wK5l" node="3pwG8PSpGSr" resolve="getGroupName" />
+                  <node concept="2GrUjf" id="2A8KNgIwcwK" role="37wK5m">
+                    <ref role="2Gs0qQ" node="2A8KNgIv5U7" resolve="action" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="2fCwEDfHkrh" role="3cqZAp">
+              <node concept="1rXfSq" id="2fCwEDfHkrf" role="3clFbG">
+                <ref role="37wK5l" node="3pZvzolpwf_" resolve="trimGroupNameFromActionTextAndUpdate" />
+                <node concept="2GrUjf" id="2fCwEDfHqg4" role="37wK5m">
+                  <ref role="2Gs0qQ" node="2A8KNgIv5U7" resolve="action" />
+                </node>
+                <node concept="37vLTw" id="2fCwEDfHB2N" role="37wK5m">
+                  <ref role="3cqZAo" node="2A8KNgIu5dr" resolve="groupName" />
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs8" id="2A8KNgIu5e0" role="3cqZAp">
+              <node concept="3cpWsn" id="2A8KNgIu5e1" role="3cpWs9">
+                <property role="TrG5h" value="c" />
+                <node concept="3uibUv" id="2A8KNgIu5e2" role="1tU5fm">
+                  <ref role="3uigEE" to="33ny:~List" resolve="List" />
+                  <node concept="3uibUv" id="2A8KNgIu5e3" role="11_B2D">
+                    <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="2A8KNgIu5e4" role="33vP2m">
+                  <node concept="37vLTw" id="2A8KNgIu5e5" role="2Oq$k0">
+                    <ref role="3cqZAo" node="2A8KNgItV65" resolve="groups" />
+                  </node>
+                  <node concept="liA8E" id="2A8KNgIu5e6" role="2OqNvi">
+                    <ref role="37wK5l" to="33ny:~TreeMap.get(java.lang.Object)" resolve="get" />
+                    <node concept="37vLTw" id="2A8KNgIu5e7" role="37wK5m">
+                      <ref role="3cqZAo" node="2A8KNgIu5dr" resolve="groupName" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbJ" id="2A8KNgIu5e8" role="3cqZAp">
+              <node concept="3clFbS" id="2A8KNgIu5e9" role="3clFbx">
+                <node concept="3clFbF" id="2A8KNgIu5ea" role="3cqZAp">
+                  <node concept="37vLTI" id="2A8KNgIu5eb" role="3clFbG">
+                    <node concept="37vLTw" id="2A8KNgIu5ec" role="37vLTJ">
+                      <ref role="3cqZAo" node="2A8KNgIu5e1" resolve="c" />
+                    </node>
+                    <node concept="2ShNRf" id="2A8KNgIu5ed" role="37vLTx">
+                      <node concept="1pGfFk" id="2A8KNgIu5ee" role="2ShVmc">
+                        <ref role="37wK5l" to="33ny:~ArrayList.&lt;init&gt;(int)" resolve="ArrayList" />
+                        <node concept="3uibUv" id="2A8KNgIu5ef" role="1pMfVU">
+                          <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
+                        </node>
+                        <node concept="3cmrfG" id="2A8KNgIu5eg" role="37wK5m">
+                          <property role="3cmrfH" value="4" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbF" id="2A8KNgIu5eh" role="3cqZAp">
+                  <node concept="2OqwBi" id="2A8KNgIu5ei" role="3clFbG">
+                    <node concept="37vLTw" id="2A8KNgIu5ej" role="2Oq$k0">
+                      <ref role="3cqZAo" node="2A8KNgItV65" resolve="groups" />
+                    </node>
+                    <node concept="liA8E" id="2A8KNgIu5ek" role="2OqNvi">
+                      <ref role="37wK5l" to="33ny:~TreeMap.put(java.lang.Object,java.lang.Object)" resolve="put" />
+                      <node concept="37vLTw" id="2A8KNgIu5el" role="37wK5m">
+                        <ref role="3cqZAo" node="2A8KNgIu5dr" resolve="groupName" />
+                      </node>
+                      <node concept="37vLTw" id="2A8KNgIu5em" role="37wK5m">
+                        <ref role="3cqZAo" node="2A8KNgIu5e1" resolve="c" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbC" id="2A8KNgIu5en" role="3clFbw">
+                <node concept="10Nm6u" id="2A8KNgIu5eo" role="3uHU7w" />
+                <node concept="37vLTw" id="2A8KNgIu5ep" role="3uHU7B">
+                  <ref role="3cqZAo" node="2A8KNgIu5e1" resolve="c" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="2A8KNgIu5eI" role="3cqZAp">
+              <node concept="2OqwBi" id="2A8KNgIu5eJ" role="3clFbG">
+                <node concept="37vLTw" id="2A8KNgIu5eK" role="2Oq$k0">
+                  <ref role="3cqZAo" node="2A8KNgIu5e1" resolve="c" />
+                </node>
+                <node concept="liA8E" id="2A8KNgIu5eL" role="2OqNvi">
+                  <ref role="37wK5l" to="33ny:~List.add(java.lang.Object)" resolve="add" />
+                  <node concept="2GrUjf" id="6Kw22eW4553" role="37wK5m">
+                    <ref role="2Gs0qQ" node="2A8KNgIv5U7" resolve="action" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="3DeU_KsjPOX" role="3cqZAp" />
+        <node concept="3clFbJ" id="4XO$XQbTXni" role="3cqZAp">
+          <node concept="3clFbS" id="4XO$XQbTXnk" role="3clFbx">
+            <node concept="2Gpval" id="3DeU_KsjZS8" role="3cqZAp">
+              <node concept="2GrKxI" id="3DeU_KsjZSa" role="2Gsz3X">
+                <property role="TrG5h" value="entry" />
+              </node>
+              <node concept="37vLTw" id="4XO$XQbUqH7" role="2GsD0m">
+                <ref role="3cqZAo" node="5Rdndlpp80A" resolve="groupedActionsCache" />
+              </node>
+              <node concept="3clFbS" id="3DeU_KsjZSe" role="2LFqv$">
+                <node concept="3cpWs8" id="3DeU_KsltHr" role="3cqZAp">
+                  <node concept="3cpWsn" id="3DeU_KsltHs" role="3cpWs9">
+                    <property role="TrG5h" value="groupname" />
+                    <node concept="17QB3L" id="3DeU_Kslo6I" role="1tU5fm" />
+                    <node concept="2OqwBi" id="3DeU_KsltHt" role="33vP2m">
+                      <node concept="2GrUjf" id="3DeU_KsltHu" role="2Oq$k0">
+                        <ref role="2Gs0qQ" node="3DeU_KsjZSa" resolve="entry" />
+                      </node>
+                      <node concept="3AY5_j" id="3DeU_KsltHv" role="2OqNvi" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3cpWs8" id="3DeU_KskO9$" role="3cqZAp">
+                  <node concept="3cpWsn" id="3DeU_KskO9_" role="3cpWs9">
+                    <property role="TrG5h" value="c" />
+                    <node concept="3uibUv" id="3DeU_KskO9A" role="1tU5fm">
+                      <ref role="3uigEE" to="33ny:~List" resolve="List" />
+                      <node concept="3uibUv" id="3DeU_KskO9B" role="11_B2D">
+                        <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
+                      </node>
+                    </node>
+                    <node concept="2OqwBi" id="3DeU_KskO9C" role="33vP2m">
+                      <node concept="37vLTw" id="3DeU_KskO9D" role="2Oq$k0">
+                        <ref role="3cqZAo" node="2A8KNgItV65" resolve="groups" />
+                      </node>
+                      <node concept="liA8E" id="3DeU_KskO9E" role="2OqNvi">
+                        <ref role="37wK5l" to="33ny:~TreeMap.get(java.lang.Object)" resolve="get" />
+                        <node concept="37vLTw" id="3DeU_KsltHw" role="37wK5m">
+                          <ref role="3cqZAo" node="3DeU_KsltHs" resolve="groupname" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbJ" id="3DeU_KskO9G" role="3cqZAp">
+                  <node concept="3clFbS" id="3DeU_KskO9H" role="3clFbx">
+                    <node concept="3clFbF" id="3DeU_KskO9I" role="3cqZAp">
+                      <node concept="37vLTI" id="3DeU_KskO9J" role="3clFbG">
+                        <node concept="37vLTw" id="3DeU_KskO9K" role="37vLTJ">
+                          <ref role="3cqZAo" node="3DeU_KskO9_" resolve="c" />
+                        </node>
+                        <node concept="2ShNRf" id="3DeU_KskO9L" role="37vLTx">
+                          <node concept="1pGfFk" id="3DeU_KskO9M" role="2ShVmc">
+                            <ref role="37wK5l" to="33ny:~ArrayList.&lt;init&gt;(int)" resolve="ArrayList" />
+                            <node concept="3uibUv" id="3DeU_KskO9N" role="1pMfVU">
+                              <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
+                            </node>
+                            <node concept="3cmrfG" id="3DeU_KskO9O" role="37wK5m">
+                              <property role="3cmrfH" value="4" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbF" id="3DeU_KskO9P" role="3cqZAp">
+                      <node concept="2OqwBi" id="3DeU_KskO9Q" role="3clFbG">
+                        <node concept="37vLTw" id="3DeU_KskO9R" role="2Oq$k0">
+                          <ref role="3cqZAo" node="2A8KNgItV65" resolve="groups" />
+                        </node>
+                        <node concept="liA8E" id="3DeU_KskO9S" role="2OqNvi">
+                          <ref role="37wK5l" to="33ny:~TreeMap.put(java.lang.Object,java.lang.Object)" resolve="put" />
+                          <node concept="37vLTw" id="3DeU_KskO9T" role="37wK5m">
+                            <ref role="3cqZAo" node="3DeU_KsltHs" resolve="groupname" />
+                          </node>
+                          <node concept="37vLTw" id="3DeU_KskO9U" role="37wK5m">
+                            <ref role="3cqZAo" node="3DeU_KskO9_" resolve="c" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbC" id="3DeU_KskO9V" role="3clFbw">
+                    <node concept="10Nm6u" id="3DeU_KskO9W" role="3uHU7w" />
+                    <node concept="37vLTw" id="3DeU_KskO9X" role="3uHU7B">
+                      <ref role="3cqZAo" node="3DeU_KskO9_" resolve="c" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbF" id="3DeU_KskO9Y" role="3cqZAp">
+                  <node concept="2OqwBi" id="3DeU_KskO9Z" role="3clFbG">
+                    <node concept="37vLTw" id="3DeU_KskOa0" role="2Oq$k0">
+                      <ref role="3cqZAo" node="3DeU_KskO9_" resolve="c" />
+                    </node>
+                    <node concept="liA8E" id="3DeU_KskOa1" role="2OqNvi">
+                      <ref role="37wK5l" to="33ny:~List.addAll(java.util.Collection)" resolve="addAll" />
+                      <node concept="2OqwBi" id="3DeU_Ksm6CG" role="37wK5m">
+                        <node concept="2GrUjf" id="3DeU_Ksm1vI" role="2Oq$k0">
+                          <ref role="2Gs0qQ" node="3DeU_KsjZSa" resolve="entry" />
+                        </node>
+                        <node concept="3AV6Ez" id="3DeU_KsmfbO" role="2OqNvi" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="37vLTw" id="4XO$XQbU2l3" role="3clFbw">
+            <ref role="3cqZAo" node="4XO$XQbSz9M" resolve="checkCache" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="2A8KNgIuWkb" role="3cqZAp" />
+        <node concept="3cpWs6" id="4yZHsKxMjoP" role="3cqZAp">
+          <node concept="37vLTw" id="4yZHsKxMsHr" role="3cqZAk">
+            <ref role="3cqZAo" node="2A8KNgItV65" resolve="groups" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="2A8KNgIsmZj" role="1B3o_S" />
+      <node concept="37vLTG" id="2A8KNgIsGiw" role="3clF46">
+        <property role="TrG5h" value="mainGroup" />
+        <node concept="3uibUv" id="2A8KNgIsGiv" role="1tU5fm">
+          <ref role="3uigEE" to="qkt:~DefaultActionGroup" resolve="DefaultActionGroup" />
+        </node>
+        <node concept="2AHcQZ" id="7b8v2ss23Vy" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="7irjju2YwZU" role="3clF46">
+        <property role="TrG5h" value="currentGroup" />
+        <node concept="3uibUv" id="7irjju2YEnf" role="1tU5fm">
+          <ref role="3uigEE" to="qkt:~DefaultActionGroup" resolve="DefaultActionGroup" />
+        </node>
+        <node concept="2AHcQZ" id="7b8v2ss1ONQ" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="2A8KNgItzj$" role="3clF46">
+        <property role="TrG5h" value="actions" />
+        <node concept="_YKpA" id="2A8KNgItEGB" role="1tU5fm">
+          <node concept="3uibUv" id="2A8KNgItFgd" role="_ZDj9">
+            <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
+          </node>
+        </node>
+        <node concept="2AHcQZ" id="7b8v2ss2grN" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="4XO$XQbSz9M" role="3clF46">
+        <property role="TrG5h" value="checkCache" />
+        <node concept="10P_77" id="4XO$XQbS_tQ" role="1tU5fm" />
+      </node>
+      <node concept="3uibUv" id="4yZHsKxM47G" role="3clF45">
+        <ref role="3uigEE" to="33ny:~TreeMap" resolve="TreeMap" />
+        <node concept="17QB3L" id="4yZHsKxM47H" role="11_B2D" />
+        <node concept="_YKpA" id="7b8v2ssg72U" role="11_B2D">
+          <node concept="3uibUv" id="7b8v2ssg72V" role="_ZDj9">
+            <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="4yZHsKxN69V" role="jymVt" />
+    <node concept="3clFb_" id="4yZHsKxNkJT" role="jymVt">
+      <property role="TrG5h" value="populateMainMenu" />
+      <node concept="37vLTG" id="4yZHsKxO40S" role="3clF46">
+        <property role="TrG5h" value="mainGroup" />
+        <node concept="3uibUv" id="4yZHsKxO40T" role="1tU5fm">
+          <ref role="3uigEE" to="qkt:~DefaultActionGroup" resolve="DefaultActionGroup" />
+        </node>
+        <node concept="2AHcQZ" id="7b8v2ss2sV3" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="4yZHsKxNOS$" role="3clF46">
+        <property role="TrG5h" value="groups" />
+        <node concept="3uibUv" id="4yZHsKxNX6I" role="1tU5fm">
+          <ref role="3uigEE" to="33ny:~TreeMap" resolve="TreeMap" />
+          <node concept="17QB3L" id="4yZHsKxNX6J" role="11_B2D" />
+          <node concept="_YKpA" id="7b8v2ssb_dT" role="11_B2D">
+            <node concept="3uibUv" id="7b8v2ssbFSJ" role="_ZDj9">
+              <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
+            </node>
+          </node>
+        </node>
+        <node concept="2AHcQZ" id="7b8v2ss2H8e" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="4yZHsKxNkJW" role="3clF47">
+        <node concept="2Gpval" id="2A8KNgIu5eO" role="3cqZAp">
+          <node concept="2GrKxI" id="2A8KNgIu5eP" role="2Gsz3X">
+            <property role="TrG5h" value="entry" />
+          </node>
+          <node concept="3clFbS" id="2A8KNgIu5eQ" role="2LFqv$">
+            <node concept="3cpWs8" id="2A8KNgIu5eR" role="3cqZAp">
+              <node concept="3cpWsn" id="2A8KNgIu5eS" role="3cpWs9">
+                <property role="TrG5h" value="groupName" />
+                <node concept="17QB3L" id="2A8KNgIu5eT" role="1tU5fm" />
+                <node concept="2OqwBi" id="2A8KNgIu5eU" role="33vP2m">
+                  <node concept="2GrUjf" id="2A8KNgIu5eV" role="2Oq$k0">
+                    <ref role="2Gs0qQ" node="2A8KNgIu5eP" resolve="entry" />
+                  </node>
+                  <node concept="liA8E" id="2A8KNgIu5eW" role="2OqNvi">
+                    <ref role="37wK5l" to="33ny:~Map$Entry.getKey()" resolve="getKey" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbJ" id="2A8KNgIu5eX" role="3cqZAp">
+              <node concept="3clFbS" id="2A8KNgIu5eY" role="3clFbx">
+                <node concept="3clFbF" id="2A8KNgIu5eZ" role="3cqZAp">
+                  <node concept="2OqwBi" id="2A8KNgIu5f0" role="3clFbG">
+                    <node concept="37vLTw" id="2A8KNgIu5f1" role="2Oq$k0">
+                      <ref role="3cqZAo" node="4yZHsKxO40S" resolve="mainGroup" />
+                    </node>
+                    <node concept="liA8E" id="2A8KNgIu5f2" role="2OqNvi">
+                      <ref role="37wK5l" to="qkt:~DefaultActionGroup.addSeparator()" resolve="addSeparator" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbC" id="2A8KNgIu5f3" role="3clFbw">
+                <node concept="10Nm6u" id="2A8KNgIu5f4" role="3uHU7w" />
+                <node concept="37vLTw" id="2A8KNgIu5f5" role="3uHU7B">
+                  <ref role="3cqZAo" node="2A8KNgIu5eS" resolve="groupName" />
+                </node>
+              </node>
+              <node concept="9aQIb" id="2A8KNgIu5f6" role="9aQIa">
+                <node concept="3clFbS" id="2A8KNgIu5f7" role="9aQI4">
+                  <node concept="3clFbF" id="2A8KNgIu5f8" role="3cqZAp">
+                    <node concept="2OqwBi" id="2A8KNgIu5f9" role="3clFbG">
+                      <node concept="37vLTw" id="2A8KNgIu5fa" role="2Oq$k0">
+                        <ref role="3cqZAo" node="4yZHsKxO40S" resolve="mainGroup" />
+                      </node>
+                      <node concept="liA8E" id="2A8KNgIu5fb" role="2OqNvi">
+                        <ref role="37wK5l" to="qkt:~DefaultActionGroup.addSeparator(java.lang.String)" resolve="addSeparator" />
+                        <node concept="37vLTw" id="2A8KNgIu5fc" role="37wK5m">
+                          <ref role="3cqZAo" node="2A8KNgIu5eS" resolve="groupName" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs8" id="2A8KNgIu5fd" role="3cqZAp">
+              <node concept="3cpWsn" id="2A8KNgIu5fe" role="3cpWs9">
+                <property role="TrG5h" value="toSortCopy" />
+                <node concept="2ShNRf" id="2A8KNgIu5fh" role="33vP2m">
+                  <node concept="1pGfFk" id="2A8KNgIu5fi" role="2ShVmc">
+                    <ref role="37wK5l" to="33ny:~ArrayList.&lt;init&gt;(java.util.Collection)" resolve="ArrayList" />
+                    <node concept="2OqwBi" id="2A8KNgIu5fj" role="37wK5m">
+                      <node concept="2GrUjf" id="2A8KNgIu5fk" role="2Oq$k0">
+                        <ref role="2Gs0qQ" node="2A8KNgIu5eP" resolve="entry" />
+                      </node>
+                      <node concept="liA8E" id="2A8KNgIu5fl" role="2OqNvi">
+                        <ref role="37wK5l" to="33ny:~Map$Entry.getValue()" resolve="getValue" />
+                      </node>
+                    </node>
+                    <node concept="3uibUv" id="2A8KNgIu5fm" role="1pMfVU">
+                      <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3uibUv" id="2A8KNgIu5ff" role="1tU5fm">
+                  <ref role="3uigEE" to="33ny:~ArrayList" resolve="ArrayList" />
+                  <node concept="3uibUv" id="2A8KNgIu5fg" role="11_B2D">
+                    <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="2A8KNgIu5fn" role="3cqZAp">
+              <node concept="2OqwBi" id="2A8KNgIu5fo" role="3clFbG">
+                <node concept="37vLTw" id="2A8KNgIu5fp" role="2Oq$k0">
+                  <ref role="3cqZAo" node="2A8KNgIu5fe" resolve="toSortCopy" />
+                </node>
+                <node concept="liA8E" id="2A8KNgIu5fq" role="2OqNvi">
+                  <ref role="37wK5l" to="33ny:~ArrayList.sort(java.util.Comparator)" resolve="sort" />
+                  <node concept="2ShNRf" id="2A8KNgIu5fr" role="37wK5m">
+                    <node concept="1pGfFk" id="2A8KNgIu5fs" role="2ShVmc">
+                      <ref role="37wK5l" to="18ew:~ToStringComparator.&lt;init&gt;()" resolve="ToStringComparator" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="2A8KNgIu5ft" role="3cqZAp">
+              <node concept="2OqwBi" id="2A8KNgIu5fu" role="3clFbG">
+                <node concept="37vLTw" id="2A8KNgIu5fv" role="2Oq$k0">
+                  <ref role="3cqZAo" node="4yZHsKxO40S" resolve="mainGroup" />
+                </node>
+                <node concept="liA8E" id="2A8KNgIu5fw" role="2OqNvi">
+                  <ref role="37wK5l" to="qkt:~DefaultActionGroup.addAll(java.util.Collection)" resolve="addAll" />
+                  <node concept="37vLTw" id="2A8KNgIu5fx" role="37wK5m">
+                    <ref role="3cqZAo" node="2A8KNgIu5fe" resolve="toSortCopy" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="2A8KNgIu5fy" role="2GsD0m">
+            <node concept="liA8E" id="2A8KNgIu5fz" role="2OqNvi">
+              <ref role="37wK5l" to="33ny:~TreeMap.entrySet()" resolve="entrySet" />
+            </node>
+            <node concept="37vLTw" id="2A8KNgIu5f$" role="2Oq$k0">
+              <ref role="3cqZAo" node="4yZHsKxNOS$" resolve="groups" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="4yZHsKxNeMy" role="1B3o_S" />
+      <node concept="3cqZAl" id="4yZHsKxNeM_" role="3clF45" />
+    </node>
+    <node concept="2tJIrI" id="2A8KNgIsgsF" role="jymVt" />
     <node concept="3clFb_" id="3pwG8PSp_f8" role="jymVt">
       <property role="TrG5h" value="getIntentionsGroup" />
       <node concept="3Tmbuc" id="3pwG8PSp_f9" role="1B3o_S" />
@@ -1000,9 +1324,8 @@
       </node>
       <node concept="37vLTG" id="3pwG8PSp_eW" role="3clF46">
         <property role="TrG5h" value="groupItems" />
-        <node concept="3uibUv" id="3pwG8PSp_eX" role="1tU5fm">
-          <ref role="3uigEE" to="33ny:~List" resolve="List" />
-          <node concept="3uibUv" id="3pwG8PSp_eY" role="11_B2D">
+        <node concept="_YKpA" id="7b8v2sscA6x" role="1tU5fm">
+          <node concept="3uibUv" id="3pwG8PSp_eY" role="_ZDj9">
             <ref role="3uigEE" to="18ew:~Pair" resolve="Pair" />
             <node concept="3uibUv" id="7me2y0SLBrW" role="11_B2D">
               <ref role="3uigEE" to="nddn:~IntentionExecutable" resolve="IntentionExecutable" />
@@ -1010,15 +1333,6 @@
             <node concept="3uibUv" id="3pwG8PSp_f0" role="11_B2D">
               <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
             </node>
-          </node>
-        </node>
-      </node>
-      <node concept="37vLTG" id="3pwG8PSp_f1" role="3clF46">
-        <property role="TrG5h" value="actions" />
-        <node concept="3uibUv" id="3pwG8PSp_f2" role="1tU5fm">
-          <ref role="3uigEE" to="33ny:~List" resolve="List" />
-          <node concept="3uibUv" id="3pwG8PSp_f3" role="11_B2D">
-            <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
           </node>
         </node>
       </node>
@@ -1038,27 +1352,44 @@
             </node>
           </node>
         </node>
-        <node concept="3clFbH" id="3pwG8PSpKgb" role="3cqZAp" />
-        <node concept="3cpWs8" id="3pwG8PSpQVZ" role="3cqZAp">
-          <node concept="3cpWsn" id="3pwG8PSpQW0" role="3cpWs9">
-            <property role="TrG5h" value="groups" />
-            <node concept="3uibUv" id="3pwG8PSueRi" role="1tU5fm">
-              <ref role="3uigEE" to="33ny:~TreeMap" resolve="TreeMap" />
-              <node concept="17QB3L" id="3pwG8PSuibW" role="11_B2D" />
-              <node concept="3uibUv" id="6d0zIQxcMCE" role="11_B2D">
-                <ref role="3uigEE" to="33ny:~List" resolve="List" />
-                <node concept="3uibUv" id="6d0zIQxcOR$" role="11_B2D">
+        <node concept="3cpWs8" id="2A8KNgIxO_C" role="3cqZAp">
+          <node concept="3cpWsn" id="2A8KNgIxO_F" role="3cpWs9">
+            <property role="TrG5h" value="actions" />
+            <node concept="_YKpA" id="2A8KNgIxO_$" role="1tU5fm">
+              <node concept="3uibUv" id="2A8KNgIxY$P" role="_ZDj9">
+                <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
+              </node>
+            </node>
+            <node concept="2ShNRf" id="2A8KNgIyjGu" role="33vP2m">
+              <node concept="2Jqq0_" id="2A8KNgIyMzD" role="2ShVmc">
+                <node concept="3uibUv" id="2A8KNgIyV2U" role="HW$YZ">
                   <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
                 </node>
               </node>
             </node>
-            <node concept="2ShNRf" id="6d0zIQxcRgB" role="33vP2m">
-              <node concept="1pGfFk" id="6d0zIQxd7Zw" role="2ShVmc">
+          </node>
+        </node>
+        <node concept="3clFbH" id="4lECbAxge4I" role="3cqZAp" />
+        <node concept="3cpWs8" id="4yZHsKxPnS$" role="3cqZAp">
+          <node concept="3cpWsn" id="4yZHsKxPnSB" role="3cpWs9">
+            <property role="TrG5h" value="groups" />
+            <node concept="3uibUv" id="4yZHsKxPnSC" role="1tU5fm">
+              <ref role="3uigEE" to="33ny:~TreeMap" resolve="TreeMap" />
+              <node concept="17QB3L" id="4yZHsKxPnSD" role="11_B2D" />
+              <node concept="3uibUv" id="4yZHsKxPnSE" role="11_B2D">
+                <ref role="3uigEE" to="33ny:~List" resolve="List" />
+                <node concept="3uibUv" id="4yZHsKxPnSF" role="11_B2D">
+                  <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
+                </node>
+              </node>
+            </node>
+            <node concept="2ShNRf" id="4yZHsKxPnSG" role="33vP2m">
+              <node concept="1pGfFk" id="4yZHsKxPnSH" role="2ShVmc">
                 <ref role="37wK5l" to="33ny:~TreeMap.&lt;init&gt;()" resolve="TreeMap" />
-                <node concept="17QB3L" id="6d0zIQxd9rp" role="1pMfVU" />
-                <node concept="3uibUv" id="6d0zIQxdaha" role="1pMfVU">
+                <node concept="17QB3L" id="4yZHsKxPnSI" role="1pMfVU" />
+                <node concept="3uibUv" id="4yZHsKxPnSJ" role="1pMfVU">
                   <ref role="3uigEE" to="33ny:~List" resolve="List" />
-                  <node concept="3uibUv" id="6d0zIQxdbU3" role="11_B2D">
+                  <node concept="3uibUv" id="4yZHsKxPnSK" role="11_B2D">
                     <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
                   </node>
                 </node>
@@ -1066,6 +1397,7 @@
             </node>
           </node>
         </node>
+        <node concept="3clFbH" id="4yZHsKxP7YD" role="3cqZAp" />
         <node concept="1DcWWT" id="3pwG8PSpFWd" role="3cqZAp">
           <node concept="37vLTw" id="3pwG8PSpFWe" role="1DdaDG">
             <ref role="3cqZAo" node="3pwG8PSp_eW" resolve="groupItems" />
@@ -1084,375 +1416,277 @@
             </node>
           </node>
           <node concept="3clFbS" id="3pwG8PSpFWj" role="2LFqv$">
-            <node concept="3cpWs8" id="3pwG8PSq660" role="3cqZAp">
-              <node concept="3cpWsn" id="3pwG8PSq661" role="3cpWs9">
-                <property role="TrG5h" value="intentionEntry" />
-                <node concept="3uibUv" id="3pwG8PSq65Z" role="1tU5fm">
-                  <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
-                </node>
-                <node concept="1rXfSq" id="3pwG8PSq662" role="33vP2m">
-                  <ref role="37wK5l" node="3pwG8PSkQJj" resolve="getIntentionGroup" />
-                  <node concept="2OqwBi" id="3pwG8PSq663" role="37wK5m">
-                    <node concept="37vLTw" id="3pwG8PSq664" role="2Oq$k0">
-                      <ref role="3cqZAo" node="3pwG8PSpFWf" resolve="pair" />
-                    </node>
-                    <node concept="2OwXpG" id="3pwG8PSq665" role="2OqNvi">
-                      <ref role="2Oxat6" to="18ew:~Pair.o1" resolve="o1" />
-                    </node>
-                  </node>
-                  <node concept="2OqwBi" id="3pwG8PSq666" role="37wK5m">
-                    <node concept="37vLTw" id="3pwG8PSq667" role="2Oq$k0">
-                      <ref role="3cqZAo" node="3pwG8PSpFWf" resolve="pair" />
-                    </node>
-                    <node concept="2OwXpG" id="3pwG8PSq668" role="2OqNvi">
-                      <ref role="2Oxat6" to="18ew:~Pair.o2" resolve="o2" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3cpWs8" id="3pwG8PSq6Q2" role="3cqZAp">
-              <node concept="3cpWsn" id="3pwG8PSq6Q3" role="3cpWs9">
-                <property role="TrG5h" value="groupName" />
-                <node concept="17QB3L" id="3pwG8PSq6PK" role="1tU5fm" />
-                <node concept="1rXfSq" id="3pwG8PSq6Q4" role="33vP2m">
-                  <ref role="37wK5l" node="3pwG8PSpGSr" resolve="getGroupName" />
-                  <node concept="37vLTw" id="3pwG8PSq6Q5" role="37wK5m">
-                    <ref role="3cqZAo" node="3pwG8PSq661" resolve="intentionEntry" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3SKdUt" id="3pZvzolt2Zu" role="3cqZAp">
-              <node concept="1PaTwC" id="3pZvzolt2Zv" role="1aUNEU">
-                <node concept="3oM_SD" id="3pZvzolt7BI" role="1PaTwD">
-                  <property role="3oM_SC" value="cut" />
-                </node>
-                <node concept="3oM_SD" id="3pZvzolt7BK" role="1PaTwD">
-                  <property role="3oM_SC" value="off" />
-                </node>
-                <node concept="3oM_SD" id="3pZvzolt7BN" role="1PaTwD">
-                  <property role="3oM_SC" value="the" />
-                </node>
-                <node concept="3oM_SD" id="3pZvzolt7BR" role="1PaTwD">
-                  <property role="3oM_SC" value="groupName" />
-                </node>
-                <node concept="3oM_SD" id="3pZvzolt7BW" role="1PaTwD">
-                  <property role="3oM_SC" value="from" />
-                </node>
-                <node concept="3oM_SD" id="3pZvzolt7C2" role="1PaTwD">
-                  <property role="3oM_SC" value="the" />
-                </node>
-                <node concept="3oM_SD" id="3pZvzolt7C9" role="1PaTwD">
-                  <property role="3oM_SC" value="action," />
-                </node>
-                <node concept="3oM_SD" id="3pZvzolt7Ch" role="1PaTwD">
-                  <property role="3oM_SC" value="if" />
-                </node>
-                <node concept="3oM_SD" id="3pZvzolt7Cq" role="1PaTwD">
-                  <property role="3oM_SC" value="action" />
-                </node>
-                <node concept="3oM_SD" id="3pZvzolt7C$" role="1PaTwD">
-                  <property role="3oM_SC" value="is" />
-                </node>
-                <node concept="3oM_SD" id="3pZvzolt7CJ" role="1PaTwD">
-                  <property role="3oM_SC" value="not" />
-                </node>
-                <node concept="3oM_SD" id="3pZvzolt7CV" role="1PaTwD">
-                  <property role="3oM_SC" value="a" />
-                </node>
-                <node concept="3oM_SD" id="3pZvzolt7D8" role="1PaTwD">
-                  <property role="3oM_SC" value="group," />
-                </node>
-                <node concept="3oM_SD" id="3pZvzolt7Dm" role="1PaTwD">
-                  <property role="3oM_SC" value="i.e." />
-                </node>
-                <node concept="3oM_SD" id="3pZvzolt7D_" role="1PaTwD">
-                  <property role="3oM_SC" value="has" />
-                </node>
-                <node concept="3oM_SD" id="3pZvzolt7DP" role="1PaTwD">
-                  <property role="3oM_SC" value="no" />
-                </node>
-                <node concept="3oM_SD" id="3pZvzolt7E6" role="1PaTwD">
-                  <property role="3oM_SC" value="submenu," />
-                </node>
-                <node concept="3oM_SD" id="3pZvzolt8Rv" role="1PaTwD">
-                  <property role="3oM_SC" value="" />
-                </node>
-              </node>
-            </node>
-            <node concept="3SKdUt" id="3pZvzoltfB5" role="3cqZAp">
-              <node concept="1PaTwC" id="3pZvzoltfAI" role="1aUNEU">
-                <node concept="3oM_SD" id="3pZvzoltfAH" role="1PaTwD">
-                  <property role="3oM_SC" value="and" />
-                </node>
-                <node concept="3oM_SD" id="3pZvzolt8RM" role="1PaTwD">
-                  <property role="3oM_SC" value="the" />
-                </node>
-                <node concept="3oM_SD" id="3pZvzolt8S6" role="1PaTwD">
-                  <property role="3oM_SC" value="intention" />
-                </node>
-                <node concept="3oM_SD" id="3pZvzolt8Sr" role="1PaTwD">
-                  <property role="3oM_SC" value="annotation" />
-                </node>
-                <node concept="3oM_SD" id="3pZvzoltipc" role="1PaTwD">
-                  <property role="3oM_SC" value="was" />
-                </node>
-                <node concept="3oM_SD" id="3pZvzoltipq" role="1PaTwD">
-                  <property role="3oM_SC" value="not" />
-                </node>
-                <node concept="3oM_SD" id="3pZvzoltipx" role="1PaTwD">
-                  <property role="3oM_SC" value="used." />
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbF" id="3pZvzols0Bn" role="3cqZAp">
-              <node concept="1rXfSq" id="3pZvzols0Bl" role="3clFbG">
-                <ref role="37wK5l" node="3pZvzolpwf_" resolve="trimGroupNameFromActionText" />
-                <node concept="37vLTw" id="3pZvzols489" role="37wK5m">
-                  <ref role="3cqZAo" node="3pwG8PSq661" resolve="intentionEntry" />
-                </node>
-                <node concept="37vLTw" id="3pZvzolsaBu" role="37wK5m">
-                  <ref role="3cqZAo" node="3pwG8PSq6Q3" resolve="groupName" />
-                </node>
-              </node>
-            </node>
-            <node concept="3cpWs8" id="6d0zIQxdhDi" role="3cqZAp">
-              <node concept="3cpWsn" id="6d0zIQxdhDj" role="3cpWs9">
-                <property role="TrG5h" value="c" />
-                <node concept="3uibUv" id="6d0zIQxdhkN" role="1tU5fm">
-                  <ref role="3uigEE" to="33ny:~List" resolve="List" />
-                  <node concept="3uibUv" id="6d0zIQxdhkQ" role="11_B2D">
-                    <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
-                  </node>
-                </node>
-                <node concept="2OqwBi" id="6d0zIQxdhDk" role="33vP2m">
-                  <node concept="37vLTw" id="6d0zIQxdhDl" role="2Oq$k0">
-                    <ref role="3cqZAo" node="3pwG8PSpQW0" resolve="groups" />
-                  </node>
-                  <node concept="liA8E" id="6d0zIQxdhDm" role="2OqNvi">
-                    <ref role="37wK5l" to="33ny:~TreeMap.get(java.lang.Object)" resolve="get" />
-                    <node concept="37vLTw" id="6d0zIQxdhDn" role="37wK5m">
-                      <ref role="3cqZAo" node="3pwG8PSq6Q3" resolve="groupName" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbJ" id="6d0zIQxdjdR" role="3cqZAp">
-              <node concept="3clFbS" id="6d0zIQxdjdT" role="3clFbx">
-                <node concept="3clFbF" id="6d0zIQxdGGv" role="3cqZAp">
-                  <node concept="37vLTI" id="6d0zIQxdHHc" role="3clFbG">
-                    <node concept="37vLTw" id="6d0zIQxdGGt" role="37vLTJ">
-                      <ref role="3cqZAo" node="6d0zIQxdhDj" resolve="c" />
-                    </node>
-                    <node concept="2ShNRf" id="6d0zIQxdp7Z" role="37vLTx">
-                      <node concept="1pGfFk" id="6d0zIQxdqy8" role="2ShVmc">
-                        <ref role="37wK5l" to="33ny:~ArrayList.&lt;init&gt;(int)" resolve="ArrayList" />
-                        <node concept="3uibUv" id="6d0zIQxdr8q" role="1pMfVU">
-                          <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
-                        </node>
-                        <node concept="3cmrfG" id="6d0zIQxdrYn" role="37wK5m">
-                          <property role="3cmrfH" value="4" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="3clFbF" id="3pwG8PSq77f" role="3cqZAp">
-                  <node concept="2OqwBi" id="3pwG8PSq7d5" role="3clFbG">
-                    <node concept="37vLTw" id="3pwG8PSq77d" role="2Oq$k0">
-                      <ref role="3cqZAo" node="3pwG8PSpQW0" resolve="groups" />
-                    </node>
-                    <node concept="liA8E" id="3pwG8PSq8w0" role="2OqNvi">
-                      <ref role="37wK5l" to="33ny:~TreeMap.put(java.lang.Object,java.lang.Object)" resolve="put" />
-                      <node concept="37vLTw" id="3pwG8PSq8zq" role="37wK5m">
-                        <ref role="3cqZAo" node="3pwG8PSq6Q3" resolve="groupName" />
-                      </node>
-                      <node concept="37vLTw" id="6d0zIQxdJRj" role="37wK5m">
-                        <ref role="3cqZAo" node="6d0zIQxdhDj" resolve="c" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3clFbC" id="6d0zIQxdk8o" role="3clFbw">
-                <node concept="10Nm6u" id="6d0zIQxdkel" role="3uHU7w" />
-                <node concept="37vLTw" id="6d0zIQxdjoW" role="3uHU7B">
-                  <ref role="3cqZAo" node="6d0zIQxdhDj" resolve="c" />
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbF" id="6d0zIQxdlsG" role="3cqZAp">
-              <node concept="2OqwBi" id="6d0zIQxdmm7" role="3clFbG">
-                <node concept="37vLTw" id="6d0zIQxdlsE" role="2Oq$k0">
-                  <ref role="3cqZAo" node="6d0zIQxdhDj" resolve="c" />
-                </node>
-                <node concept="liA8E" id="6d0zIQxdnn7" role="2OqNvi">
-                  <ref role="37wK5l" to="33ny:~List.add(java.lang.Object)" resolve="add" />
-                  <node concept="37vLTw" id="6d0zIQxdnDK" role="37wK5m">
-                    <ref role="3cqZAo" node="3pwG8PSq661" resolve="intentionEntry" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="2Gpval" id="3pwG8PSq979" role="3cqZAp">
-          <node concept="2GrKxI" id="3pwG8PSq97b" role="2Gsz3X">
-            <property role="TrG5h" value="entry" />
-          </node>
-          <node concept="3clFbS" id="3pwG8PSq97d" role="2LFqv$">
-            <node concept="3cpWs8" id="3pwG8PSsP9T" role="3cqZAp">
-              <node concept="3cpWsn" id="3pwG8PSsP9U" role="3cpWs9">
-                <property role="TrG5h" value="groupName" />
-                <node concept="17QB3L" id="3pwG8PSsP89" role="1tU5fm" />
-                <node concept="2OqwBi" id="3pwG8PSsP9V" role="33vP2m">
-                  <node concept="2GrUjf" id="3pwG8PSsP9W" role="2Oq$k0">
-                    <ref role="2Gs0qQ" node="3pwG8PSq97b" resolve="entry" />
-                  </node>
-                  <node concept="liA8E" id="3pwG8PSsP9X" role="2OqNvi">
-                    <ref role="37wK5l" to="33ny:~Map$Entry.getKey()" resolve="getKey" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbJ" id="3pwG8PSsQSU" role="3cqZAp">
-              <node concept="3clFbS" id="3pwG8PSsQSW" role="3clFbx">
-                <node concept="3clFbF" id="3pwG8PSsRk6" role="3cqZAp">
-                  <node concept="2OqwBi" id="3pwG8PSsRso" role="3clFbG">
-                    <node concept="37vLTw" id="3pwG8PSsRk4" role="2Oq$k0">
-                      <ref role="3cqZAo" node="3pwG8PSpFW8" resolve="mainGroup" />
-                    </node>
-                    <node concept="liA8E" id="3pwG8PSsS$s" role="2OqNvi">
-                      <ref role="37wK5l" to="qkt:~DefaultActionGroup.addSeparator()" resolve="addSeparator" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3clFbC" id="3pwG8PSsRi_" role="3clFbw">
-                <node concept="10Nm6u" id="3pwG8PSsRjm" role="3uHU7w" />
-                <node concept="37vLTw" id="3pwG8PSsRag" role="3uHU7B">
-                  <ref role="3cqZAo" node="3pwG8PSsP9U" resolve="groupName" />
-                </node>
-              </node>
-              <node concept="9aQIb" id="3pwG8PSsSOD" role="9aQIa">
-                <node concept="3clFbS" id="3pwG8PSsSOE" role="9aQI4">
-                  <node concept="3clFbF" id="3pwG8PSrWaY" role="3cqZAp">
-                    <node concept="2OqwBi" id="3pwG8PSrW$C" role="3clFbG">
-                      <node concept="37vLTw" id="3pwG8PSrWaW" role="2Oq$k0">
-                        <ref role="3cqZAo" node="3pwG8PSpFW8" resolve="mainGroup" />
-                      </node>
-                      <node concept="liA8E" id="3pwG8PSrYWm" role="2OqNvi">
-                        <ref role="37wK5l" to="qkt:~DefaultActionGroup.addSeparator(java.lang.String)" resolve="addSeparator" />
-                        <node concept="37vLTw" id="3pwG8PSsP9Y" role="37wK5m">
-                          <ref role="3cqZAo" node="3pwG8PSsP9U" resolve="groupName" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3cpWs8" id="6d0zIQxdw_7" role="3cqZAp">
-              <node concept="3cpWsn" id="6d0zIQxdw_d" role="3cpWs9">
-                <property role="TrG5h" value="toSortCopy" />
-                <node concept="3uibUv" id="6d0zIQxdw_f" role="1tU5fm">
-                  <ref role="3uigEE" to="33ny:~ArrayList" resolve="ArrayList" />
-                  <node concept="3uibUv" id="6d0zIQxdwSN" role="11_B2D">
-                    <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
-                  </node>
-                </node>
-                <node concept="2ShNRf" id="6d0zIQxdxzC" role="33vP2m">
-                  <node concept="1pGfFk" id="6d0zIQxdyLJ" role="2ShVmc">
-                    <ref role="37wK5l" to="33ny:~ArrayList.&lt;init&gt;(java.util.Collection)" resolve="ArrayList" />
-                    <node concept="2OqwBi" id="3pwG8PSsUXK" role="37wK5m">
-                      <node concept="2GrUjf" id="3pwG8PSsUO1" role="2Oq$k0">
-                        <ref role="2Gs0qQ" node="3pwG8PSq97b" resolve="entry" />
-                      </node>
-                      <node concept="liA8E" id="3pwG8PSsZrb" role="2OqNvi">
-                        <ref role="37wK5l" to="33ny:~Map$Entry.getValue()" resolve="getValue" />
-                      </node>
-                    </node>
-                    <node concept="3uibUv" id="6d0zIQxdyZ8" role="1pMfVU">
+            <node concept="3clFbJ" id="2A8KNgIzBzz" role="3cqZAp">
+              <node concept="3clFbS" id="2A8KNgIzBz_" role="3clFbx">
+                <node concept="3cpWs8" id="1eCiahnMozy" role="3cqZAp">
+                  <node concept="3cpWsn" id="1eCiahnMozz" role="3cpWs9">
+                    <property role="TrG5h" value="action" />
+                    <node concept="3uibUv" id="1eCiahnMgoZ" role="1tU5fm">
                       <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
                     </node>
+                    <node concept="2OqwBi" id="1eCiahnMoz$" role="33vP2m">
+                      <node concept="0kSF2" id="1eCiahnMoz_" role="2Oq$k0">
+                        <node concept="3uibUv" id="1eCiahnMozA" role="0kSFW">
+                          <ref role="3uigEE" node="3iqDEt5ltY_" resolve="ActionsAsIntentionsExecutable" />
+                        </node>
+                        <node concept="2OqwBi" id="1eCiahnMozB" role="0kSFX">
+                          <node concept="37vLTw" id="1eCiahnMozC" role="2Oq$k0">
+                            <ref role="3cqZAo" node="3pwG8PSpFWf" resolve="pair" />
+                          </node>
+                          <node concept="2OwXpG" id="1eCiahnMozD" role="2OqNvi">
+                            <ref role="2Oxat6" to="18ew:~Pair.o1" resolve="o1" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="liA8E" id="1eCiahnMozE" role="2OqNvi">
+                        <ref role="37wK5l" node="3_qLs3ubao0" resolve="getAction" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbJ" id="1eCiahnMA4k" role="3cqZAp">
+                  <node concept="3clFbS" id="1eCiahnMA4m" role="3clFbx">
+                    <node concept="3cpWs8" id="2A8KNgIIBIr" role="3cqZAp">
+                      <node concept="3cpWsn" id="2A8KNgIIBIs" role="3cpWs9">
+                        <property role="TrG5h" value="group" />
+                        <node concept="3uibUv" id="2A8KNgIIzYd" role="1tU5fm">
+                          <ref role="3uigEE" to="qkt:~DefaultActionGroup" resolve="DefaultActionGroup" />
+                        </node>
+                        <node concept="1eOMI4" id="2A8KNgIK_TN" role="33vP2m">
+                          <node concept="10QFUN" id="2A8KNgIK_TK" role="1eOMHV">
+                            <node concept="3uibUv" id="2A8KNgIK_TP" role="10QFUM">
+                              <ref role="3uigEE" to="qkt:~DefaultActionGroup" resolve="DefaultActionGroup" />
+                            </node>
+                            <node concept="37vLTw" id="1eCiahnMozF" role="10QFUP">
+                              <ref role="3cqZAo" node="1eCiahnMozz" resolve="action" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbF" id="4yZHsKxPKRh" role="3cqZAp">
+                      <node concept="2OqwBi" id="4yZHsKxPSF3" role="3clFbG">
+                        <node concept="37vLTw" id="4yZHsKxPKRf" role="2Oq$k0">
+                          <ref role="3cqZAo" node="4yZHsKxPnSB" resolve="groups" />
+                        </node>
+                        <node concept="liA8E" id="4yZHsKxQ5zU" role="2OqNvi">
+                          <ref role="37wK5l" to="33ny:~TreeMap.putAll(java.util.Map)" resolve="putAll" />
+                          <node concept="1rXfSq" id="2A8KNgIJ8T7" role="37wK5m">
+                            <ref role="37wK5l" node="2A8KNgIs$a3" resolve="processActionGroup" />
+                            <node concept="37vLTw" id="2A8KNgIJgG$" role="37wK5m">
+                              <ref role="3cqZAo" node="3pwG8PSpFW8" resolve="mainGroup" />
+                            </node>
+                            <node concept="37vLTw" id="7irjju30iLi" role="37wK5m">
+                              <ref role="3cqZAo" node="2A8KNgIIBIs" resolve="group" />
+                            </node>
+                            <node concept="2OqwBi" id="2A8KNgIJXF1" role="37wK5m">
+                              <node concept="2OqwBi" id="2A8KNgIJKog" role="2Oq$k0">
+                                <node concept="2OqwBi" id="FWwRLn6D$f" role="2Oq$k0">
+                                  <node concept="liA8E" id="FWwRLn6D$j" role="2OqNvi">
+                                    <ref role="37wK5l" to="qkt:~DefaultActionGroup.getChildren(com.intellij.openapi.actionSystem.AnActionEvent)" resolve="getChildren" />
+                                    <node concept="10Nm6u" id="FWwRLn6D$h" role="37wK5m" />
+                                  </node>
+                                  <node concept="37vLTw" id="2A8KNgIJqDO" role="2Oq$k0">
+                                    <ref role="3cqZAo" node="2A8KNgIIBIs" resolve="group" />
+                                  </node>
+                                </node>
+                                <node concept="39bAoz" id="2A8KNgIJOQM" role="2OqNvi" />
+                              </node>
+                              <node concept="ANE8D" id="2A8KNgIK4np" role="2OqNvi" />
+                            </node>
+                            <node concept="3clFbT" id="4XO$XQbTlYz" role="37wK5m" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbF" id="2A8KNgIzQ$Y" role="3cqZAp">
+                      <node concept="2OqwBi" id="2A8KNgIzWpL" role="3clFbG">
+                        <node concept="37vLTw" id="2A8KNgIzQ$W" role="2Oq$k0">
+                          <ref role="3cqZAo" node="2A8KNgIxO_F" resolve="actions" />
+                        </node>
+                        <node concept="TSZUe" id="7irjju2TZV1" role="2OqNvi">
+                          <node concept="37vLTw" id="5TeFNpcMDZy" role="25WWJ7">
+                            <ref role="3cqZAo" node="2A8KNgIIBIs" resolve="group" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2ZW3vV" id="1eCiahnMNFA" role="3clFbw">
+                    <node concept="3uibUv" id="1eCiahnMUiZ" role="2ZW6by">
+                      <ref role="3uigEE" to="qkt:~DefaultActionGroup" resolve="DefaultActionGroup" />
+                    </node>
+                    <node concept="37vLTw" id="1eCiahnMH5m" role="2ZW6bz">
+                      <ref role="3cqZAo" node="1eCiahnMozz" resolve="action" />
+                    </node>
                   </node>
                 </node>
               </node>
-            </node>
-            <node concept="3clFbF" id="6d0zIQxdB5n" role="3cqZAp">
-              <node concept="2OqwBi" id="6d0zIQxdCWf" role="3clFbG">
-                <node concept="37vLTw" id="6d0zIQxdB5l" role="2Oq$k0">
-                  <ref role="3cqZAo" node="6d0zIQxdw_d" resolve="toSortCopy" />
+              <node concept="2ZW3vV" id="2A8KNgIzHBv" role="3clFbw">
+                <node concept="3uibUv" id="2A8KNgIzHBw" role="2ZW6by">
+                  <ref role="3uigEE" node="3iqDEt5ltY_" resolve="ActionsAsIntentionsExecutable" />
                 </node>
-                <node concept="liA8E" id="6d0zIQxdEwl" role="2OqNvi">
-                  <ref role="37wK5l" to="33ny:~ArrayList.sort(java.util.Comparator)" resolve="sort" />
-                  <node concept="2ShNRf" id="6d0zIQxdERJ" role="37wK5m">
-                    <node concept="1pGfFk" id="6d0zIQxdGfd" role="2ShVmc">
-                      <ref role="37wK5l" to="18ew:~ToStringComparator.&lt;init&gt;()" resolve="ToStringComparator" />
+                <node concept="2OqwBi" id="2A8KNgIzHBx" role="2ZW6bz">
+                  <node concept="37vLTw" id="2A8KNgIzHBy" role="2Oq$k0">
+                    <ref role="3cqZAo" node="3pwG8PSpFWf" resolve="pair" />
+                  </node>
+                  <node concept="2OwXpG" id="2A8KNgIzHBz" role="2OqNvi">
+                    <ref role="2Oxat6" to="18ew:~Pair.o1" resolve="o1" />
+                  </node>
+                </node>
+              </node>
+              <node concept="9aQIb" id="2A8KNgI$gF5" role="9aQIa">
+                <node concept="3clFbS" id="2A8KNgI$gF6" role="9aQI4">
+                  <node concept="3clFbF" id="2A8KNgI$pIj" role="3cqZAp">
+                    <node concept="2OqwBi" id="2A8KNgI$wBW" role="3clFbG">
+                      <node concept="37vLTw" id="2A8KNgI$pIi" role="2Oq$k0">
+                        <ref role="3cqZAo" node="2A8KNgIxO_F" resolve="actions" />
+                      </node>
+                      <node concept="TSZUe" id="2A8KNgI$_m3" role="2OqNvi">
+                        <node concept="1rXfSq" id="2A8KNgI$GeI" role="25WWJ7">
+                          <ref role="37wK5l" node="3pwG8PSkQJj" resolve="getIntentionGroup" />
+                          <node concept="2OqwBi" id="2A8KNgI$GeJ" role="37wK5m">
+                            <node concept="37vLTw" id="2A8KNgI$GeK" role="2Oq$k0">
+                              <ref role="3cqZAo" node="3pwG8PSpFWf" resolve="pair" />
+                            </node>
+                            <node concept="2OwXpG" id="2A8KNgI$GeL" role="2OqNvi">
+                              <ref role="2Oxat6" to="18ew:~Pair.o1" resolve="o1" />
+                            </node>
+                          </node>
+                          <node concept="2OqwBi" id="2A8KNgI$GeM" role="37wK5m">
+                            <node concept="37vLTw" id="2A8KNgI$GeN" role="2Oq$k0">
+                              <ref role="3cqZAo" node="3pwG8PSpFWf" resolve="pair" />
+                            </node>
+                            <node concept="2OwXpG" id="2A8KNgI$GeO" role="2OqNvi">
+                              <ref role="2Oxat6" to="18ew:~Pair.o2" resolve="o2" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
                     </node>
                   </node>
                 </node>
               </node>
             </node>
-            <node concept="3clFbF" id="3pwG8PSsT8s" role="3cqZAp">
-              <node concept="2OqwBi" id="3pwG8PSsTyo" role="3clFbG">
-                <node concept="37vLTw" id="3pwG8PSsT8q" role="2Oq$k0">
+          </node>
+        </node>
+        <node concept="3clFbF" id="4yZHsKxQ$FF" role="3cqZAp">
+          <node concept="2OqwBi" id="4yZHsKxQHUi" role="3clFbG">
+            <node concept="37vLTw" id="4yZHsKxQ$FD" role="2Oq$k0">
+              <ref role="3cqZAo" node="4yZHsKxPnSB" resolve="groups" />
+            </node>
+            <node concept="liA8E" id="4yZHsKxQQHf" role="2OqNvi">
+              <ref role="37wK5l" to="33ny:~TreeMap.putAll(java.util.Map)" resolve="putAll" />
+              <node concept="1rXfSq" id="2A8KNgIxjc9" role="37wK5m">
+                <ref role="37wK5l" node="2A8KNgIs$a3" resolve="processActionGroup" />
+                <node concept="37vLTw" id="2A8KNgIxreA" role="37wK5m">
                   <ref role="3cqZAo" node="3pwG8PSpFW8" resolve="mainGroup" />
                 </node>
-                <node concept="liA8E" id="3pwG8PSsUEs" role="2OqNvi">
-                  <ref role="37wK5l" to="qkt:~DefaultActionGroup.addAll(java.util.Collection)" resolve="addAll" />
-                  <node concept="37vLTw" id="6d0zIQxd$x4" role="37wK5m">
-                    <ref role="3cqZAo" node="6d0zIQxdw_d" resolve="toSortCopy" />
-                  </node>
+                <node concept="10Nm6u" id="7irjju309q0" role="37wK5m" />
+                <node concept="37vLTw" id="2A8KNgIzocz" role="37wK5m">
+                  <ref role="3cqZAo" node="2A8KNgIxO_F" resolve="actions" />
+                </node>
+                <node concept="3clFbT" id="4XO$XQbTIHk" role="37wK5m">
+                  <property role="3clFbU" value="true" />
                 </node>
               </node>
-            </node>
-          </node>
-          <node concept="2OqwBi" id="3pwG8PSvpFb" role="2GsD0m">
-            <node concept="liA8E" id="3pwG8PSvsrw" role="2OqNvi">
-              <ref role="37wK5l" to="33ny:~TreeMap.entrySet()" resolve="entrySet" />
-            </node>
-            <node concept="37vLTw" id="3pwG8PSq9Cg" role="2Oq$k0">
-              <ref role="3cqZAo" node="3pwG8PSpQW0" resolve="groups" />
             </node>
           </node>
         </node>
-        <node concept="3clFbH" id="3pwG8PSq9nF" role="3cqZAp" />
-        <node concept="3clFbJ" id="3pwG8PSte48" role="3cqZAp">
-          <node concept="3clFbS" id="3pwG8PSte4a" role="3clFbx">
-            <node concept="3clFbF" id="3pwG8PSthDL" role="3cqZAp">
-              <node concept="2OqwBi" id="3pwG8PSthO2" role="3clFbG">
-                <node concept="37vLTw" id="3pwG8PSthDJ" role="2Oq$k0">
-                  <ref role="3cqZAo" node="3pwG8PSpFW8" resolve="mainGroup" />
+        <node concept="3clFbH" id="4yZHsKxLO2X" role="3cqZAp" />
+        <node concept="3clFbF" id="4yZHsKxRiqm" role="3cqZAp">
+          <node concept="1rXfSq" id="4yZHsKxRiqk" role="3clFbG">
+            <ref role="37wK5l" node="4yZHsKxNkJT" resolve="populateMainMenu" />
+            <node concept="37vLTw" id="4yZHsKxRtUE" role="37wK5m">
+              <ref role="3cqZAo" node="3pwG8PSpFW8" resolve="mainGroup" />
+            </node>
+            <node concept="37vLTw" id="4yZHsKxRAfC" role="37wK5m">
+              <ref role="3cqZAo" node="4yZHsKxPnSB" resolve="groups" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="4yZHsKxRaPF" role="3cqZAp" />
+        <node concept="3cpWs8" id="7$D8CBwecGN" role="3cqZAp">
+          <node concept="3cpWsn" id="7$D8CBwecGO" role="3cpWs9">
+            <property role="TrG5h" value="mainActionsItems" />
+            <node concept="2OqwBi" id="7$D8CBweZs4" role="33vP2m">
+              <node concept="2OqwBi" id="7$D8CBweOWR" role="2Oq$k0">
+                <node concept="2OqwBi" id="7$D8CBwecGP" role="2Oq$k0">
+                  <node concept="37vLTw" id="7$D8CBwecGQ" role="2Oq$k0">
+                    <ref role="3cqZAo" node="3pwG8PSpFW8" resolve="mainGroup" />
+                  </node>
+                  <node concept="liA8E" id="7$D8CBwecGR" role="2OqNvi">
+                    <ref role="37wK5l" to="qkt:~DefaultActionGroup.getChildActionsOrStubs()" resolve="getChildActionsOrStubs" />
+                  </node>
                 </node>
-                <node concept="liA8E" id="3pwG8PStiW6" role="2OqNvi">
-                  <ref role="37wK5l" to="qkt:~DefaultActionGroup.addSeparator()" resolve="addSeparator" />
-                </node>
+                <node concept="39bAoz" id="7$D8CBweUdA" role="2OqNvi" />
+              </node>
+              <node concept="ANE8D" id="7$D8CBwf803" role="2OqNvi" />
+            </node>
+            <node concept="_YKpA" id="7$D8CBwfodL" role="1tU5fm">
+              <node concept="3uibUv" id="7$D8CBwfxy2" role="_ZDj9">
+                <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
               </node>
             </node>
-            <node concept="3clFbF" id="3pwG8PSpFWv" role="3cqZAp">
-              <node concept="2OqwBi" id="3pwG8PSpFWw" role="3clFbG">
-                <node concept="37vLTw" id="3pwG8PSpFWx" role="2Oq$k0">
-                  <ref role="3cqZAo" node="3pwG8PSpFW8" resolve="mainGroup" />
-                </node>
-                <node concept="liA8E" id="3pwG8PSpFWy" role="2OqNvi">
-                  <ref role="37wK5l" to="qkt:~DefaultActionGroup.addAll(java.util.Collection)" resolve="addAll" />
-                  <node concept="37vLTw" id="3pwG8PSpFWz" role="37wK5m">
-                    <ref role="3cqZAo" node="3pwG8PSp_f1" resolve="actions" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="7MgvKqkoMsh" role="3cqZAp" />
+        <node concept="2Gpval" id="34IQvDnCjLF" role="3cqZAp">
+          <node concept="2GrKxI" id="34IQvDnCjLH" role="2Gsz3X">
+            <property role="TrG5h" value="childAction" />
+          </node>
+          <node concept="37vLTw" id="7$D8CBwecGS" role="2GsD0m">
+            <ref role="3cqZAo" node="7$D8CBwecGO" resolve="mainActionsItems" />
+          </node>
+          <node concept="3clFbS" id="34IQvDnCjLL" role="2LFqv$">
+            <node concept="3cpWs8" id="lMPJvi7im9" role="3cqZAp">
+              <node concept="3cpWsn" id="lMPJvi7ima" role="3cpWs9">
+                <property role="TrG5h" value="groupName" />
+                <node concept="17QB3L" id="lMPJvi79q6" role="1tU5fm" />
+                <node concept="1rXfSq" id="lMPJvi7imb" role="33vP2m">
+                  <ref role="37wK5l" node="3pwG8PSpGSr" resolve="getGroupName" />
+                  <node concept="2GrUjf" id="lMPJvi7imc" role="37wK5m">
+                    <ref role="2Gs0qQ" node="34IQvDnCjLH" resolve="childAction" />
                   </node>
                 </node>
               </node>
             </node>
-          </node>
-          <node concept="3fqX7Q" id="3pwG8PStgRO" role="3clFbw">
-            <node concept="2OqwBi" id="3pwG8PStgRQ" role="3fr31v">
-              <node concept="37vLTw" id="3pwG8PStgRR" role="2Oq$k0">
-                <ref role="3cqZAo" node="3pwG8PSp_f1" resolve="actions" />
+            <node concept="3clFbJ" id="7rKJ8ltNEtx" role="3cqZAp">
+              <node concept="3clFbS" id="7rKJ8ltNEtz" role="3clFbx">
+                <node concept="3clFbF" id="4uJx3VrGW1m" role="3cqZAp">
+                  <node concept="1rXfSq" id="4uJx3VrGW1k" role="3clFbG">
+                    <ref role="37wK5l" node="lMPJvi802g" resolve="substituteAction" />
+                    <node concept="37vLTw" id="4uJx3VrH70m" role="37wK5m">
+                      <ref role="3cqZAo" node="3pwG8PSpFW8" resolve="mainGroup" />
+                    </node>
+                    <node concept="2GrUjf" id="4uJx3VrHoLI" role="37wK5m">
+                      <ref role="2Gs0qQ" node="34IQvDnCjLH" resolve="childAction" />
+                    </node>
+                    <node concept="37vLTw" id="4uJx3VrHXrd" role="37wK5m">
+                      <ref role="3cqZAo" node="lMPJvi7ima" resolve="groupName" />
+                    </node>
+                  </node>
+                </node>
               </node>
-              <node concept="liA8E" id="3pwG8PStgRS" role="2OqNvi">
-                <ref role="37wK5l" to="33ny:~List.isEmpty()" resolve="isEmpty" />
+              <node concept="1Wc70l" id="7rKJ8ltP4xl" role="3clFbw">
+                <node concept="3fqX7Q" id="7rKJ8ltPT9A" role="3uHU7w">
+                  <node concept="1eOMI4" id="7rKJ8ltPT9C" role="3fr31v">
+                    <node concept="2ZW3vV" id="7rKJ8ltPT9D" role="1eOMHV">
+                      <node concept="3uibUv" id="7rKJ8ltPT9E" role="2ZW6by">
+                        <ref role="3uigEE" node="2jDew64QLb0" resolve="IntentionActionGroup" />
+                      </node>
+                      <node concept="2GrUjf" id="7rKJ8ltPT9F" role="2ZW6bz">
+                        <ref role="2Gs0qQ" node="34IQvDnCjLH" resolve="childAction" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="7rKJ8ltOMyb" role="3uHU7B">
+                  <node concept="37vLTw" id="lMPJvi7imd" role="2Oq$k0">
+                    <ref role="3cqZAo" node="lMPJvi7ima" resolve="groupName" />
+                  </node>
+                  <node concept="17RvpY" id="7rKJ8ltOV3T" role="2OqNvi" />
+                </node>
               </node>
             </node>
           </node>
@@ -1463,150 +1697,417 @@
           </node>
         </node>
       </node>
+      <node concept="2AHcQZ" id="7b8v2ss2TCu" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+      </node>
     </node>
-    <node concept="2tJIrI" id="2jDew64Qmgc" role="jymVt" />
-    <node concept="3clFb_" id="3pZvzolpwf_" role="jymVt">
-      <property role="TrG5h" value="trimGroupNameFromActionText" />
-      <node concept="3clFbS" id="3pZvzolpwfC" role="3clF47">
-        <node concept="3clFbJ" id="3pZvzolpEqJ" role="3cqZAp">
-          <node concept="3fqX7Q" id="3pZvzolpP1r" role="3clFbw">
-            <node concept="2ZW3vV" id="3pZvzolpP1t" role="3fr31v">
-              <node concept="3uibUv" id="3pZvzolpP1u" role="2ZW6by">
-                <ref role="3uigEE" node="2jDew64QLb0" resolve="IntentionActionGroup" />
+    <node concept="2tJIrI" id="lMPJvi7zUt" role="jymVt" />
+    <node concept="3clFb_" id="lMPJvi802g" role="jymVt">
+      <property role="TrG5h" value="substituteAction" />
+      <node concept="3clFbS" id="lMPJvi802j" role="3clF47">
+        <node concept="3cpWs8" id="lMPJvibh0b" role="3cqZAp">
+          <node concept="3cpWsn" id="lMPJvibh0c" role="3cpWs9">
+            <property role="TrG5h" value="mainActionsItems" />
+            <node concept="2OqwBi" id="lMPJvibh0d" role="33vP2m">
+              <node concept="2OqwBi" id="lMPJvibh0e" role="2Oq$k0">
+                <node concept="2OqwBi" id="lMPJvibh0f" role="2Oq$k0">
+                  <node concept="37vLTw" id="lMPJvibh0g" role="2Oq$k0">
+                    <ref role="3cqZAo" node="lMPJvi9cDl" resolve="mainGroup" />
+                  </node>
+                  <node concept="liA8E" id="lMPJvibh0h" role="2OqNvi">
+                    <ref role="37wK5l" to="qkt:~DefaultActionGroup.getChildActionsOrStubs()" resolve="getChildActionsOrStubs" />
+                  </node>
+                </node>
+                <node concept="39bAoz" id="lMPJvibh0i" role="2OqNvi" />
               </node>
-              <node concept="37vLTw" id="3pZvzolpP1v" role="2ZW6bz">
-                <ref role="3cqZAo" node="3pZvzolpzLz" resolve="action" />
+              <node concept="ANE8D" id="lMPJvibh0j" role="2OqNvi" />
+            </node>
+            <node concept="_YKpA" id="lMPJvibh0k" role="1tU5fm">
+              <node concept="3uibUv" id="lMPJvibh0l" role="_ZDj9">
+                <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
               </node>
             </node>
           </node>
-          <node concept="3clFbS" id="3pZvzolpEqL" role="3clFbx">
+        </node>
+        <node concept="3clFbH" id="lMPJvibh0a" role="3cqZAp" />
+        <node concept="3cpWs8" id="1H8cikHKZYs" role="3cqZAp">
+          <node concept="3cpWsn" id="1H8cikHKZYt" role="3cpWs9">
+            <property role="TrG5h" value="oldTemplatePresentation" />
+            <node concept="3uibUv" id="1H8cikHKZYu" role="1tU5fm">
+              <ref role="3uigEE" to="qkt:~Presentation" resolve="Presentation" />
+            </node>
+            <node concept="2OqwBi" id="4lECbAx9NDO" role="33vP2m">
+              <node concept="2OqwBi" id="1H8cikHKZYv" role="2Oq$k0">
+                <node concept="37vLTw" id="lMPJvib8bL" role="2Oq$k0">
+                  <ref role="3cqZAo" node="lMPJvi8JyR" resolve="oldAction" />
+                </node>
+                <node concept="liA8E" id="1H8cikHKZYx" role="2OqNvi">
+                  <ref role="37wK5l" to="qkt:~AnAction.getTemplatePresentation()" resolve="getTemplatePresentation" />
+                </node>
+              </node>
+              <node concept="liA8E" id="4lECbAx9TNQ" role="2OqNvi">
+                <ref role="37wK5l" to="qkt:~Presentation.clone()" resolve="clone" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="lMPJvi9JBH" role="3cqZAp" />
+        <node concept="3cpWs8" id="1H8cikHJemP" role="3cqZAp">
+          <node concept="3cpWsn" id="1H8cikHJemQ" role="3cpWs9">
+            <property role="TrG5h" value="newAction" />
+            <node concept="3uibUv" id="1H8cikHJemO" role="1tU5fm">
+              <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
+            </node>
+            <node concept="2ShNRf" id="1H8cikHJemR" role="33vP2m">
+              <node concept="YeOm9" id="1H8cikHJemS" role="2ShVmc">
+                <node concept="1Y3b0j" id="1H8cikHJemT" role="YeSDq">
+                  <property role="2bfB8j" value="true" />
+                  <property role="373rjd" value="true" />
+                  <ref role="37wK5l" to="qkt:~AnAction.&lt;init&gt;()" resolve="AnAction" />
+                  <ref role="1Y3XeK" to="qkt:~AnAction" resolve="AnAction" />
+                  <node concept="3Tm1VV" id="1H8cikHJemU" role="1B3o_S" />
+                  <node concept="3clFb_" id="1H8cikHJemV" role="jymVt">
+                    <property role="TrG5h" value="actionPerformed" />
+                    <node concept="3Tm1VV" id="1H8cikHJemW" role="1B3o_S" />
+                    <node concept="3cqZAl" id="1H8cikHJemX" role="3clF45" />
+                    <node concept="37vLTG" id="1H8cikHJemY" role="3clF46">
+                      <property role="TrG5h" value="event" />
+                      <node concept="3uibUv" id="1H8cikHJemZ" role="1tU5fm">
+                        <ref role="3uigEE" to="qkt:~AnActionEvent" resolve="AnActionEvent" />
+                      </node>
+                      <node concept="2AHcQZ" id="1H8cikHJen0" role="2AJF6D">
+                        <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+                      </node>
+                    </node>
+                    <node concept="3clFbS" id="1H8cikHJen1" role="3clF47">
+                      <node concept="3clFbF" id="1H8cikHN0op" role="3cqZAp">
+                        <node concept="2OqwBi" id="1H8cikHN5tP" role="3clFbG">
+                          <node concept="37vLTw" id="lMPJvic9LV" role="2Oq$k0">
+                            <ref role="3cqZAo" node="lMPJvi8JyR" resolve="oldAction" />
+                          </node>
+                          <node concept="liA8E" id="1H8cikHNd5d" role="2OqNvi">
+                            <ref role="37wK5l" to="qkt:~AnAction.actionPerformed(com.intellij.openapi.actionSystem.AnActionEvent)" resolve="actionPerformed" />
+                            <node concept="37vLTw" id="1H8cikHNlGd" role="37wK5m">
+                              <ref role="3cqZAo" node="1H8cikHJemY" resolve="event" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2AHcQZ" id="1H8cikHJen2" role="2AJF6D">
+                      <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="1H8cikHKeRg" role="3cqZAp">
+          <node concept="3cpWsn" id="1H8cikHKeRh" role="3cpWs9">
+            <property role="TrG5h" value="newTemplatePresentation" />
+            <node concept="3uibUv" id="1H8cikHKcvt" role="1tU5fm">
+              <ref role="3uigEE" to="qkt:~Presentation" resolve="Presentation" />
+            </node>
+            <node concept="2OqwBi" id="1H8cikHKeRi" role="33vP2m">
+              <node concept="37vLTw" id="1H8cikHO64r" role="2Oq$k0">
+                <ref role="3cqZAo" node="1H8cikHJemQ" resolve="newAction" />
+              </node>
+              <node concept="liA8E" id="1H8cikHKeRk" role="2OqNvi">
+                <ref role="37wK5l" to="qkt:~AnAction.getTemplatePresentation()" resolve="getTemplatePresentation" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="1H8cikHJXxQ" role="3cqZAp">
+          <node concept="2OqwBi" id="1H8cikHK9Sh" role="3clFbG">
+            <node concept="37vLTw" id="1H8cikHKeRl" role="2Oq$k0">
+              <ref role="3cqZAo" node="1H8cikHKeRh" resolve="newTemplatePresentation" />
+            </node>
+            <node concept="liA8E" id="1H8cikHKnI1" role="2OqNvi">
+              <ref role="37wK5l" to="qkt:~Presentation.setText(java.lang.String)" resolve="setText" />
+              <node concept="2OqwBi" id="1H8cikHLPqV" role="37wK5m">
+                <node concept="37vLTw" id="1H8cikHLKDU" role="2Oq$k0">
+                  <ref role="3cqZAo" node="1H8cikHKZYt" resolve="oldTemplatePresentation" />
+                </node>
+                <node concept="liA8E" id="1H8cikHLVCL" role="2OqNvi">
+                  <ref role="37wK5l" to="qkt:~Presentation.getText()" resolve="getText" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="1H8cikHM0bR" role="3cqZAp">
+          <node concept="2OqwBi" id="1H8cikHM0bS" role="3clFbG">
+            <node concept="37vLTw" id="1H8cikHM0bT" role="2Oq$k0">
+              <ref role="3cqZAo" node="1H8cikHKeRh" resolve="newTemplatePresentation" />
+            </node>
+            <node concept="liA8E" id="1H8cikHM0bU" role="2OqNvi">
+              <ref role="37wK5l" to="qkt:~Presentation.setDescription(java.lang.String)" resolve="setDescription" />
+              <node concept="2OqwBi" id="1H8cikHM0bV" role="37wK5m">
+                <node concept="37vLTw" id="1H8cikHM0bW" role="2Oq$k0">
+                  <ref role="3cqZAo" node="1H8cikHKZYt" resolve="oldTemplatePresentation" />
+                </node>
+                <node concept="liA8E" id="1H8cikHM0bX" role="2OqNvi">
+                  <ref role="37wK5l" to="qkt:~Presentation.getDescription()" resolve="getDescription" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="1H8cikHM7e$" role="3cqZAp">
+          <node concept="2OqwBi" id="1H8cikHM7e_" role="3clFbG">
+            <node concept="37vLTw" id="1H8cikHM7eA" role="2Oq$k0">
+              <ref role="3cqZAo" node="1H8cikHKeRh" resolve="newTemplatePresentation" />
+            </node>
+            <node concept="liA8E" id="1H8cikHM7eB" role="2OqNvi">
+              <ref role="37wK5l" to="qkt:~Presentation.setIcon(javax.swing.Icon)" resolve="setIcon" />
+              <node concept="2OqwBi" id="1H8cikHM7eC" role="37wK5m">
+                <node concept="37vLTw" id="1H8cikHM7eD" role="2Oq$k0">
+                  <ref role="3cqZAo" node="1H8cikHKZYt" resolve="oldTemplatePresentation" />
+                </node>
+                <node concept="liA8E" id="1H8cikHM7eE" role="2OqNvi">
+                  <ref role="37wK5l" to="qkt:~Presentation.getIcon()" resolve="getIcon" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="lMPJviaHaO" role="3cqZAp" />
+        <node concept="3clFbF" id="3huof8oTrcY" role="3cqZAp">
+          <node concept="2OqwBi" id="3huof8oTw3M" role="3clFbG">
+            <node concept="37vLTw" id="3huof8oTrcX" role="2Oq$k0">
+              <ref role="3cqZAo" node="lMPJvi9cDl" resolve="mainGroup" />
+            </node>
+            <node concept="liA8E" id="3huof8oTDrd" role="2OqNvi">
+              <ref role="37wK5l" to="qkt:~DefaultActionGroup.replaceAction(com.intellij.openapi.actionSystem.AnAction,com.intellij.openapi.actionSystem.AnAction)" resolve="replaceAction" />
+              <node concept="37vLTw" id="lMPJvicjTT" role="37wK5m">
+                <ref role="3cqZAo" node="lMPJvi8JyR" resolve="oldAction" />
+              </node>
+              <node concept="37vLTw" id="1H8cikHJen8" role="37wK5m">
+                <ref role="3cqZAo" node="1H8cikHJemQ" resolve="newAction" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="7$D8CBwheR9" role="3cqZAp">
+          <node concept="3cpWsn" id="7$D8CBwheRa" role="3cpWs9">
+            <property role="TrG5h" value="oldGroup" />
+            <node concept="3uibUv" id="7$D8CBwhcyv" role="1tU5fm">
+              <ref role="3uigEE" to="7bx7:~BaseGroup" resolve="BaseGroup" />
+            </node>
+            <node concept="2OqwBi" id="7$D8CBwheRb" role="33vP2m">
+              <node concept="2OqwBi" id="7$D8CBwheRc" role="2Oq$k0">
+                <node concept="37vLTw" id="7$D8CBwheRd" role="2Oq$k0">
+                  <ref role="3cqZAo" node="lMPJvibh0c" resolve="mainActionsItems" />
+                </node>
+                <node concept="UnYns" id="7$D8CBwheRe" role="2OqNvi">
+                  <node concept="3uibUv" id="7$D8CBwheRf" role="UnYnz">
+                    <ref role="3uigEE" to="7bx7:~BaseGroup" resolve="BaseGroup" />
+                  </node>
+                </node>
+              </node>
+              <node concept="1z4cxt" id="7$D8CBwheRg" role="2OqNvi">
+                <node concept="1bVj0M" id="7$D8CBwheRh" role="23t8la">
+                  <node concept="3clFbS" id="7$D8CBwheRi" role="1bW5cS">
+                    <node concept="3clFbF" id="7$D8CBwheRj" role="3cqZAp">
+                      <node concept="2OqwBi" id="7$D8CBwheRk" role="3clFbG">
+                        <node concept="37vLTw" id="7$D8CBwheRl" role="2Oq$k0">
+                          <ref role="3cqZAo" node="7$D8CBwheRo" resolve="it" />
+                        </node>
+                        <node concept="liA8E" id="7$D8CBwheRm" role="2OqNvi">
+                          <ref role="37wK5l" to="qkt:~DefaultActionGroup.containsAction(com.intellij.openapi.actionSystem.AnAction)" resolve="containsAction" />
+                          <node concept="37vLTw" id="lMPJvibANc" role="37wK5m">
+                            <ref role="3cqZAo" node="lMPJvi8JyR" resolve="oldAction" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="gl6BB" id="7$D8CBwheRo" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="7$D8CBwheRp" role="1tU5fm" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="2YDlKV42s9Y" role="3cqZAp">
+          <node concept="3clFbS" id="2YDlKV42sa0" role="3clFbx">
+            <node concept="3clFbF" id="69lhSVqGSJd" role="3cqZAp">
+              <node concept="2OqwBi" id="69lhSVqGYff" role="3clFbG">
+                <node concept="37vLTw" id="69lhSVqGSJb" role="2Oq$k0">
+                  <ref role="3cqZAo" node="7$D8CBwheRa" resolve="oldGroup" />
+                </node>
+                <node concept="liA8E" id="69lhSVqH75K" role="2OqNvi">
+                  <ref role="37wK5l" to="qkt:~DefaultActionGroup.remove(com.intellij.openapi.actionSystem.AnAction)" resolve="remove" />
+                  <node concept="37vLTw" id="lMPJvibsFq" role="37wK5m">
+                    <ref role="3cqZAo" node="lMPJvi8JyR" resolve="oldAction" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3y3z36" id="2YDlKV42IGx" role="3clFbw">
+            <node concept="10Nm6u" id="2YDlKV42ORK" role="3uHU7w" />
+            <node concept="37vLTw" id="2YDlKV42$vr" role="3uHU7B">
+              <ref role="3cqZAo" node="7$D8CBwheRa" resolve="oldGroup" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="lMPJvibRGm" role="3cqZAp" />
+        <node concept="3clFbJ" id="1eqBxP9lFhT" role="3cqZAp">
+          <node concept="3clFbS" id="1eqBxP9lFhN" role="3clFbx">
+            <node concept="3clFbF" id="2Ef_vJ5TrUj" role="3cqZAp">
+              <node concept="37vLTI" id="2Ef_vJ5Uf3A" role="3clFbG">
+                <node concept="3EllGN" id="2Ef_vJ5TAZ3" role="37vLTJ">
+                  <node concept="37vLTw" id="lMPJvidi7Y" role="3ElVtu">
+                    <ref role="3cqZAo" node="lMPJviaN1m" resolve="groupName" />
+                  </node>
+                  <node concept="37vLTw" id="lMPJvi8dK4" role="3ElQJh">
+                    <ref role="3cqZAo" node="5Rdndlpp80A" resolve="groupedActionsCache" />
+                  </node>
+                </node>
+                <node concept="2ShNRf" id="2Ef_vJ5Xqw6" role="37vLTx">
+                  <node concept="32HrFt" id="2Ef_vJ5Xqrg" role="2ShVmc">
+                    <node concept="3uibUv" id="2Ef_vJ5Xqrh" role="HW$YZ">
+                      <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3fqX7Q" id="1eqBxP9lFhV" role="3clFbw">
+            <node concept="2OqwBi" id="1eqBxP9lFhP" role="3fr31v">
+              <node concept="37vLTw" id="lMPJvi8dK_" role="2Oq$k0">
+                <ref role="3cqZAo" node="5Rdndlpp80A" resolve="groupedActionsCache" />
+              </node>
+              <node concept="2Nt0df" id="1eqBxP9lFhR" role="2OqNvi">
+                <node concept="37vLTw" id="1eqBxP9lFhX" role="38cxEo">
+                  <ref role="3cqZAo" node="lMPJviaN1m" resolve="groupName" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7MgvKqknvqX" role="3cqZAp">
+          <node concept="2OqwBi" id="2Ef_vJ5VG$q" role="3clFbG">
+            <node concept="3EllGN" id="2Ef_vJ5RAL8" role="2Oq$k0">
+              <node concept="37vLTw" id="lMPJvidq_z" role="3ElVtu">
+                <ref role="3cqZAo" node="lMPJviaN1m" resolve="groupName" />
+              </node>
+              <node concept="37vLTw" id="lMPJvi8dL6" role="3ElQJh">
+                <ref role="3cqZAo" node="5Rdndlpp80A" resolve="groupedActionsCache" />
+              </node>
+            </node>
+            <node concept="TSZUe" id="2Ef_vJ5XF4x" role="2OqNvi">
+              <node concept="37vLTw" id="lMPJvid8A$" role="25WWJ7">
+                <ref role="3cqZAo" node="lMPJvi8JyR" resolve="oldAction" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="2Ef_vJ5Vswn" role="3cqZAp" />
+      </node>
+      <node concept="3Tm1VV" id="lMPJvi7SXa" role="1B3o_S" />
+      <node concept="3cqZAl" id="lMPJvi7Ziq" role="3clF45" />
+      <node concept="37vLTG" id="lMPJvi9cDl" role="3clF46">
+        <property role="TrG5h" value="mainGroup" />
+        <node concept="3uibUv" id="lMPJvi9ix4" role="1tU5fm">
+          <ref role="3uigEE" to="7bx7:~BaseGroup" resolve="BaseGroup" />
+        </node>
+        <node concept="2AHcQZ" id="7b8v2ss36sn" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="lMPJvi8JyR" role="3clF46">
+        <property role="TrG5h" value="oldAction" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3uibUv" id="lMPJvi8JyQ" role="1tU5fm">
+          <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
+        </node>
+        <node concept="2AHcQZ" id="7b8v2ss3iW0" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="lMPJviaN1m" role="3clF46">
+        <property role="TrG5h" value="groupName" />
+        <node concept="17QB3L" id="lMPJviaN1C" role="1tU5fm" />
+        <node concept="2AHcQZ" id="7b8v2ss3H7l" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="2jDew64Qmgc" role="jymVt" />
+    <node concept="3clFb_" id="3pZvzolpwf_" role="jymVt">
+      <property role="TrG5h" value="trimGroupNameFromActionTextAndUpdate" />
+      <node concept="3clFbS" id="3pZvzolpwfC" role="3clF47">
+        <node concept="3clFbJ" id="5qkmDQk7tlt" role="3cqZAp">
+          <node concept="3clFbS" id="5qkmDQk7tlv" role="3clFbx">
             <node concept="3cpWs8" id="3pZvzolqck1" role="3cqZAp">
               <node concept="3cpWsn" id="3pZvzolqck2" role="3cpWs9">
                 <property role="TrG5h" value="text" />
                 <node concept="17QB3L" id="3pZvzolqck3" role="1tU5fm" />
-                <node concept="2OqwBi" id="3pZvzolqck4" role="33vP2m">
-                  <node concept="2OqwBi" id="3pZvzolqck5" role="2Oq$k0">
-                    <node concept="37vLTw" id="3pZvzolqck6" role="2Oq$k0">
-                      <ref role="3cqZAo" node="3pZvzolpzLz" resolve="action" />
-                    </node>
-                    <node concept="liA8E" id="3pZvzolqck7" role="2OqNvi">
-                      <ref role="37wK5l" to="qkt:~AnAction.getTemplatePresentation()" resolve="getTemplatePresentation" />
-                    </node>
+                <node concept="1rXfSq" id="7b8v2ssIYyv" role="33vP2m">
+                  <ref role="37wK5l" node="7b8v2ssFpTf" resolve="trimGroupNameFromActionText" />
+                  <node concept="37vLTw" id="7b8v2ssJprQ" role="37wK5m">
+                    <ref role="3cqZAo" node="3pZvzolpzLz" resolve="action" />
                   </node>
-                  <node concept="liA8E" id="3pZvzolqck8" role="2OqNvi">
-                    <ref role="37wK5l" to="qkt:~Presentation.getText()" resolve="getText" />
+                  <node concept="37vLTw" id="7b8v2ssJECE" role="37wK5m">
+                    <ref role="3cqZAo" node="3pZvzolpBeb" resolve="groupName" />
                   </node>
                 </node>
               </node>
             </node>
-            <node concept="3clFbJ" id="3pZvzolq8Yp" role="3cqZAp">
-              <node concept="3clFbS" id="3pZvzolq8Yr" role="3clFbx">
-                <node concept="3SKdUt" id="3pZvzolsS9j" role="3cqZAp">
-                  <node concept="1PaTwC" id="3pZvzolsS9k" role="1aUNEU">
-                    <node concept="3oM_SD" id="3pZvzolsV8k" role="1PaTwD">
-                      <property role="3oM_SC" value="add" />
-                    </node>
-                    <node concept="3oM_SD" id="3pZvzolsV8m" role="1PaTwD">
-                      <property role="3oM_SC" value="+1" />
-                    </node>
-                    <node concept="3oM_SD" id="3pZvzolsV8p" role="1PaTwD">
-                      <property role="3oM_SC" value="in" />
-                    </node>
-                    <node concept="3oM_SD" id="3pZvzolsV8C" role="1PaTwD">
-                      <property role="3oM_SC" value="substring" />
-                    </node>
-                    <node concept="3oM_SD" id="3pZvzolsV8H" role="1PaTwD">
-                      <property role="3oM_SC" value="to" />
-                    </node>
-                    <node concept="3oM_SD" id="3pZvzolsV8N" role="1PaTwD">
-                      <property role="3oM_SC" value="cut" />
-                    </node>
-                    <node concept="3oM_SD" id="3pZvzolsV8U" role="1PaTwD">
-                      <property role="3oM_SC" value="off" />
-                    </node>
-                    <node concept="3oM_SD" id="3pZvzolsV92" role="1PaTwD">
-                      <property role="3oM_SC" value="the" />
-                    </node>
-                    <node concept="3oM_SD" id="3pZvzolsV9b" role="1PaTwD">
-                      <property role="3oM_SC" value="colon" />
-                    </node>
-                    <node concept="3oM_SD" id="3pZvzolsV9l" role="1PaTwD">
-                      <property role="3oM_SC" value="after" />
-                    </node>
-                    <node concept="3oM_SD" id="3pZvzolsV9w" role="1PaTwD">
-                      <property role="3oM_SC" value="the" />
-                    </node>
-                    <node concept="3oM_SD" id="3pZvzolsV9G" role="1PaTwD">
-                      <property role="3oM_SC" value="groupName" />
-                    </node>
+            <node concept="3clFbF" id="3pZvzolm1oQ" role="3cqZAp">
+              <node concept="2OqwBi" id="3pZvzolmb07" role="3clFbG">
+                <node concept="2OqwBi" id="3pZvzolm59K" role="2Oq$k0">
+                  <node concept="37vLTw" id="3pZvzolm1oO" role="2Oq$k0">
+                    <ref role="3cqZAo" node="3pZvzolpzLz" resolve="action" />
+                  </node>
+                  <node concept="liA8E" id="3pZvzolm8FW" role="2OqNvi">
+                    <ref role="37wK5l" to="qkt:~AnAction.getTemplatePresentation()" resolve="getTemplatePresentation" />
                   </node>
                 </node>
-                <node concept="3clFbF" id="3pZvzolm1oQ" role="3cqZAp">
-                  <node concept="2OqwBi" id="3pZvzolmb07" role="3clFbG">
-                    <node concept="2OqwBi" id="3pZvzolm59K" role="2Oq$k0">
-                      <node concept="37vLTw" id="3pZvzolm1oO" role="2Oq$k0">
-                        <ref role="3cqZAo" node="3pZvzolpzLz" resolve="action" />
-                      </node>
-                      <node concept="liA8E" id="3pZvzolm8FW" role="2OqNvi">
-                        <ref role="37wK5l" to="qkt:~AnAction.getTemplatePresentation()" resolve="getTemplatePresentation" />
-                      </node>
-                    </node>
-                    <node concept="liA8E" id="3pZvzolmeOD" role="2OqNvi">
-                      <ref role="37wK5l" to="qkt:~Presentation.setText(java.lang.String)" resolve="setText" />
-                      <node concept="2OqwBi" id="3pZvzolmzk3" role="37wK5m">
-                        <node concept="2OqwBi" id="3pZvzolmjWV" role="2Oq$k0">
-                          <node concept="37vLTw" id="3pZvzolmhSV" role="2Oq$k0">
-                            <ref role="3cqZAo" node="3pZvzolqck2" resolve="text" />
-                          </node>
-                          <node concept="liA8E" id="3pZvzolmnyg" role="2OqNvi">
-                            <ref role="37wK5l" to="wyt6:~String.substring(int)" resolve="substring" />
-                            <node concept="3cpWs3" id="3pZvzolsEDU" role="37wK5m">
-                              <node concept="3cmrfG" id="3pZvzolsEJo" role="3uHU7w">
-                                <property role="3cmrfH" value="1" />
-                              </node>
-                              <node concept="2OqwBi" id="3pZvzolreqn" role="3uHU7B">
-                                <node concept="37vLTw" id="3pZvzolraE$" role="2Oq$k0">
-                                  <ref role="3cqZAo" node="3pZvzolpBeb" resolve="groupName" />
-                                </node>
-                                <node concept="liA8E" id="3pZvzolrhFo" role="2OqNvi">
-                                  <ref role="37wK5l" to="wyt6:~String.length()" resolve="length" />
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="17S1cR" id="3pZvzolmHIg" role="2OqNvi" />
-                      </node>
-                    </node>
+                <node concept="liA8E" id="3pZvzolmeOD" role="2OqNvi">
+                  <ref role="37wK5l" to="qkt:~Presentation.setText(java.lang.String)" resolve="setText" />
+                  <node concept="37vLTw" id="7b8v2ssKy7v" role="37wK5m">
+                    <ref role="3cqZAo" node="3pZvzolqck2" resolve="text" />
                   </node>
                 </node>
               </node>
-              <node concept="1Wc70l" id="3pZvzolqK4g" role="3clFbw">
-                <node concept="2OqwBi" id="3pZvzolqQ0G" role="3uHU7w">
-                  <node concept="37vLTw" id="3pZvzolqMhi" role="2Oq$k0">
-                    <ref role="3cqZAo" node="3pZvzolqck2" resolve="text" />
+            </node>
+            <node concept="3clFbF" id="1NzaUygG$Jl" role="3cqZAp">
+              <node concept="2OqwBi" id="1NzaUygG$Jm" role="3clFbG">
+                <node concept="2OqwBi" id="1NzaUygG$Jn" role="2Oq$k0">
+                  <node concept="37vLTw" id="1NzaUygG$Jo" role="2Oq$k0">
+                    <ref role="3cqZAo" node="3pZvzolpzLz" resolve="action" />
                   </node>
-                  <node concept="liA8E" id="3pZvzolqSjV" role="2OqNvi">
-                    <ref role="37wK5l" to="wyt6:~String.startsWith(java.lang.String)" resolve="startsWith" />
-                    <node concept="37vLTw" id="3pZvzolqVNv" role="37wK5m">
-                      <ref role="3cqZAo" node="3pZvzolpBeb" resolve="groupName" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="1Wc70l" id="3pZvzolqyGY" role="3uHU7B">
-                  <node concept="3y3z36" id="3pZvzolqs4n" role="3uHU7B">
-                    <node concept="37vLTw" id="3pZvzolqidM" role="3uHU7B">
-                      <ref role="3cqZAo" node="3pZvzolqck2" resolve="text" />
-                    </node>
-                    <node concept="10Nm6u" id="3pZvzolqvEd" role="3uHU7w" />
-                  </node>
-                  <node concept="2OqwBi" id="5KWvuz1uFuy" role="3uHU7w">
-                    <node concept="37vLTw" id="3pZvzolq_lp" role="2Oq$k0">
-                      <ref role="3cqZAo" node="3pZvzolpBeb" resolve="groupName" />
-                    </node>
-                    <node concept="17RvpY" id="5KWvuz1w10D" role="2OqNvi" />
+                  <node concept="liA8E" id="1NzaUygG$Jp" role="2OqNvi">
+                    <ref role="37wK5l" to="qkt:~AnAction.getTemplatePresentation()" resolve="getTemplatePresentation" />
                   </node>
                 </node>
+                <node concept="liA8E" id="1NzaUygG$Jq" role="2OqNvi">
+                  <ref role="37wK5l" to="qkt:~Presentation.putClientProperty(com.intellij.openapi.util.Key,java.lang.Object)" resolve="putClientProperty" />
+                  <node concept="37vLTw" id="1NzaUygG$JW" role="37wK5m">
+                    <ref role="3cqZAo" node="6Kw22eW7L03" resolve="GROUPNAME_KEY" />
+                  </node>
+                  <node concept="37vLTw" id="1NzaUygG$Jr" role="37wK5m">
+                    <ref role="3cqZAo" node="3pZvzolpBeb" resolve="groupName" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3fqX7Q" id="5qkmDQk7yGd" role="3clFbw">
+            <node concept="2ZW3vV" id="5qkmDQk7K2a" role="3fr31v">
+              <node concept="3uibUv" id="5qkmDQk7PFt" role="2ZW6by">
+                <ref role="3uigEE" node="2jDew64QLb0" resolve="IntentionActionGroup" />
+              </node>
+              <node concept="37vLTw" id="5qkmDQk7EJ5" role="2ZW6bz">
+                <ref role="3cqZAo" node="3pZvzolpzLz" resolve="action" />
               </node>
             </node>
           </node>
@@ -1618,13 +2119,201 @@
         <node concept="3uibUv" id="3pZvzolpzLy" role="1tU5fm">
           <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
         </node>
+        <node concept="2AHcQZ" id="7b8v2ss3THC" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
       </node>
       <node concept="37vLTG" id="3pZvzolpBeb" role="3clF46">
         <property role="TrG5h" value="groupName" />
         <node concept="17QB3L" id="3pZvzolpE5e" role="1tU5fm" />
+        <node concept="2AHcQZ" id="7b8v2ss49UX" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+        </node>
       </node>
       <node concept="3cqZAl" id="3pZvzolpUMR" role="3clF45" />
+      <node concept="P$JXv" id="7b8v2ssggme" role="lGtFl">
+        <node concept="TZ5HA" id="7b8v2ssggmf" role="TZ5H$">
+          <node concept="1dT_AC" id="7b8v2ssggmg" role="1dT_Ay">
+            <property role="1dT_AB" value="" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="7b8v2ssguR5" role="TZ5H$">
+          <node concept="1dT_AC" id="7b8v2ssguR6" role="1dT_Ay">
+            <property role="1dT_AB" value="cut off the groupName from the action, if action is not a group, i.e. has no submenu and the intention annotation was not used. " />
+          </node>
+        </node>
+      </node>
     </node>
+    <node concept="2tJIrI" id="7b8v2ssEwpv" role="jymVt" />
+    <node concept="3clFb_" id="7b8v2ssFpTf" role="jymVt">
+      <property role="TrG5h" value="trimGroupNameFromActionText" />
+      <node concept="37vLTG" id="7b8v2ssFF26" role="3clF46">
+        <property role="TrG5h" value="action" />
+        <node concept="3uibUv" id="7b8v2ssFF27" role="1tU5fm">
+          <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
+        </node>
+        <node concept="2AHcQZ" id="7b8v2ssFF28" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="7b8v2ssFT5B" role="3clF46">
+        <property role="TrG5h" value="groupName" />
+        <node concept="17QB3L" id="7b8v2ssFT5C" role="1tU5fm" />
+        <node concept="2AHcQZ" id="7b8v2ssFT5D" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="7b8v2ssFpTi" role="3clF47">
+        <node concept="3clFbF" id="7b8v2ssRVQX" role="3cqZAp">
+          <node concept="1rXfSq" id="7b8v2ssRVQV" role="3clFbG">
+            <ref role="37wK5l" node="7b8v2ssPXom" resolve="trimGroupNameFromActionText" />
+            <node concept="2OqwBi" id="7b8v2ssS4LS" role="37wK5m">
+              <node concept="2OqwBi" id="7b8v2ssS4LT" role="2Oq$k0">
+                <node concept="37vLTw" id="7b8v2ssS4LU" role="2Oq$k0">
+                  <ref role="3cqZAo" node="7b8v2ssFF26" resolve="action" />
+                </node>
+                <node concept="liA8E" id="7b8v2ssS4LV" role="2OqNvi">
+                  <ref role="37wK5l" to="qkt:~AnAction.getTemplatePresentation()" resolve="getTemplatePresentation" />
+                </node>
+              </node>
+              <node concept="liA8E" id="7b8v2ssS4LW" role="2OqNvi">
+                <ref role="37wK5l" to="qkt:~Presentation.getText()" resolve="getText" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="7b8v2ssShVr" role="37wK5m">
+              <ref role="3cqZAo" node="7b8v2ssFT5B" resolve="groupName" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="7b8v2ssEN4o" role="1B3o_S" />
+      <node concept="17QB3L" id="7b8v2ssEWNj" role="3clF45" />
+    </node>
+    <node concept="2tJIrI" id="7b8v2ssPSeP" role="jymVt" />
+    <node concept="3clFb_" id="7b8v2ssPXom" role="jymVt">
+      <property role="TrG5h" value="trimGroupNameFromActionText" />
+      <node concept="37vLTG" id="7b8v2ssTkkT" role="3clF46">
+        <property role="TrG5h" value="text" />
+        <node concept="17QB3L" id="7b8v2ssTkkU" role="1tU5fm" />
+        <node concept="2AHcQZ" id="7b8v2ssTkkV" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="7b8v2ssPXoq" role="3clF46">
+        <property role="TrG5h" value="groupName" />
+        <node concept="17QB3L" id="7b8v2ssPXor" role="1tU5fm" />
+        <node concept="2AHcQZ" id="7b8v2ssPXos" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="7b8v2ssPXot" role="3clF47">
+        <node concept="3clFbJ" id="7b8v2ssPXoA" role="3cqZAp">
+          <node concept="3clFbS" id="7b8v2ssPXoB" role="3clFbx">
+            <node concept="3SKdUt" id="7b8v2ssPXoC" role="3cqZAp">
+              <node concept="1PaTwC" id="7b8v2ssPXoD" role="1aUNEU">
+                <node concept="3oM_SD" id="7b8v2ssPXoE" role="1PaTwD">
+                  <property role="3oM_SC" value="add" />
+                </node>
+                <node concept="3oM_SD" id="7b8v2ssPXoF" role="1PaTwD">
+                  <property role="3oM_SC" value="+1" />
+                </node>
+                <node concept="3oM_SD" id="7b8v2ssPXoG" role="1PaTwD">
+                  <property role="3oM_SC" value="in" />
+                </node>
+                <node concept="3oM_SD" id="7b8v2ssPXoH" role="1PaTwD">
+                  <property role="3oM_SC" value="substring" />
+                </node>
+                <node concept="3oM_SD" id="7b8v2ssPXoI" role="1PaTwD">
+                  <property role="3oM_SC" value="to" />
+                </node>
+                <node concept="3oM_SD" id="7b8v2ssPXoJ" role="1PaTwD">
+                  <property role="3oM_SC" value="cut" />
+                </node>
+                <node concept="3oM_SD" id="7b8v2ssPXoK" role="1PaTwD">
+                  <property role="3oM_SC" value="off" />
+                </node>
+                <node concept="3oM_SD" id="7b8v2ssPXoL" role="1PaTwD">
+                  <property role="3oM_SC" value="the" />
+                </node>
+                <node concept="3oM_SD" id="7b8v2ssPXoM" role="1PaTwD">
+                  <property role="3oM_SC" value="colon" />
+                </node>
+                <node concept="3oM_SD" id="7b8v2ssPXoN" role="1PaTwD">
+                  <property role="3oM_SC" value="after" />
+                </node>
+                <node concept="3oM_SD" id="7b8v2ssPXoO" role="1PaTwD">
+                  <property role="3oM_SC" value="the" />
+                </node>
+                <node concept="3oM_SD" id="7b8v2ssPXoP" role="1PaTwD">
+                  <property role="3oM_SC" value="groupName" />
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs6" id="7b8v2ssPXoQ" role="3cqZAp">
+              <node concept="2OqwBi" id="7b8v2ssPXoR" role="3cqZAk">
+                <node concept="2OqwBi" id="7b8v2ssPXoS" role="2Oq$k0">
+                  <node concept="37vLTw" id="7b8v2ssPXoT" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7b8v2ssTkkT" resolve="text" />
+                  </node>
+                  <node concept="liA8E" id="7b8v2ssPXoU" role="2OqNvi">
+                    <ref role="37wK5l" to="wyt6:~String.substring(int)" resolve="substring" />
+                    <node concept="3cpWs3" id="7b8v2ssPXoV" role="37wK5m">
+                      <node concept="3cmrfG" id="7b8v2ssPXoW" role="3uHU7w">
+                        <property role="3cmrfH" value="1" />
+                      </node>
+                      <node concept="2OqwBi" id="7b8v2ssPXoX" role="3uHU7B">
+                        <node concept="37vLTw" id="7b8v2ssPXoY" role="2Oq$k0">
+                          <ref role="3cqZAo" node="7b8v2ssPXoq" resolve="groupName" />
+                        </node>
+                        <node concept="liA8E" id="7b8v2ssPXoZ" role="2OqNvi">
+                          <ref role="37wK5l" to="wyt6:~String.length()" resolve="length" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="17S1cR" id="7b8v2ssPXp0" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
+          <node concept="1Wc70l" id="7b8v2ssPXp1" role="3clFbw">
+            <node concept="2OqwBi" id="7b8v2ssPXp2" role="3uHU7w">
+              <node concept="37vLTw" id="7b8v2ssPXp3" role="2Oq$k0">
+                <ref role="3cqZAo" node="7b8v2ssTkkT" resolve="text" />
+              </node>
+              <node concept="liA8E" id="7b8v2ssPXp4" role="2OqNvi">
+                <ref role="37wK5l" to="wyt6:~String.startsWith(java.lang.String)" resolve="startsWith" />
+                <node concept="37vLTw" id="7b8v2ssPXp5" role="37wK5m">
+                  <ref role="3cqZAo" node="7b8v2ssPXoq" resolve="groupName" />
+                </node>
+              </node>
+            </node>
+            <node concept="1Wc70l" id="7b8v2ssPXp6" role="3uHU7B">
+              <node concept="3y3z36" id="7b8v2ssPXp7" role="3uHU7B">
+                <node concept="37vLTw" id="7b8v2ssPXp8" role="3uHU7B">
+                  <ref role="3cqZAo" node="7b8v2ssTkkT" resolve="text" />
+                </node>
+                <node concept="10Nm6u" id="7b8v2ssPXp9" role="3uHU7w" />
+              </node>
+              <node concept="2OqwBi" id="4fJ7VbKm9d$" role="3uHU7w">
+                <node concept="37vLTw" id="4fJ7VbK8fSt" role="2Oq$k0">
+                  <ref role="3cqZAo" node="7b8v2ssPXoq" resolve="groupName" />
+                </node>
+                <node concept="17RvpY" id="4fJ7VbKmhGd" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="7b8v2ssPXpd" role="3cqZAp">
+          <node concept="37vLTw" id="7b8v2ssPXpe" role="3cqZAk">
+            <ref role="3cqZAo" node="7b8v2ssTkkT" resolve="text" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="7b8v2ssPXpf" role="1B3o_S" />
+      <node concept="17QB3L" id="7b8v2ssPXpg" role="3clF45" />
+    </node>
+    <node concept="2tJIrI" id="7b8v2ssPXol" role="jymVt" />
     <node concept="2tJIrI" id="2jDew64Pxne" role="jymVt" />
     <node concept="3clFb_" id="3pwG8PSpGSr" role="jymVt">
       <property role="TrG5h" value="getGroupName" />
@@ -1633,10 +2322,112 @@
         <node concept="3uibUv" id="3pwG8PSpHTA" role="1tU5fm">
           <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
         </node>
+        <node concept="2AHcQZ" id="7b8v2ss4ms5" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
       </node>
       <node concept="17QB3L" id="3pwG8PSpHC0" role="3clF45" />
-      <node concept="3Tmbuc" id="3pwG8PSqo2G" role="1B3o_S" />
       <node concept="3clFbS" id="3pwG8PSpGSv" role="3clF47">
+        <node concept="3cpWs8" id="3pwG8PSsz1H" role="3cqZAp">
+          <node concept="3cpWsn" id="3pwG8PSsz1K" role="3cpWs9">
+            <property role="TrG5h" value="groupName" />
+            <node concept="17QB3L" id="3pwG8PSsz1F" role="1tU5fm" />
+            <node concept="2OqwBi" id="6Kw22eWaqPv" role="33vP2m">
+              <node concept="2OqwBi" id="6Kw22eWadXy" role="2Oq$k0">
+                <node concept="37vLTw" id="6Kw22eWa98k" role="2Oq$k0">
+                  <ref role="3cqZAo" node="3pwG8PSpHHh" resolve="action" />
+                </node>
+                <node concept="liA8E" id="6Kw22eWamfe" role="2OqNvi">
+                  <ref role="37wK5l" to="qkt:~AnAction.getTemplatePresentation()" resolve="getTemplatePresentation" />
+                </node>
+              </node>
+              <node concept="liA8E" id="6Kw22eWavqG" role="2OqNvi">
+                <ref role="37wK5l" to="qkt:~Presentation.getClientProperty(com.intellij.openapi.util.Key)" resolve="getClientProperty" />
+                <node concept="37vLTw" id="2VOpD3139MX" role="37wK5m">
+                  <ref role="3cqZAo" node="6Kw22eW7L03" resolve="GROUPNAME_KEY" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="2VOpD313Esp" role="3cqZAp">
+          <node concept="3clFbS" id="2VOpD313Esr" role="3clFbx">
+            <node concept="3cpWs6" id="2VOpD3146s2" role="3cqZAp">
+              <node concept="37vLTw" id="2VOpD314eLY" role="3cqZAk">
+                <ref role="3cqZAo" node="3pwG8PSsz1K" resolve="groupName" />
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="2VOpD313TPJ" role="3clFbw">
+            <node concept="37vLTw" id="2VOpD313J2H" role="2Oq$k0">
+              <ref role="3cqZAo" node="3pwG8PSsz1K" resolve="groupName" />
+            </node>
+            <node concept="17RvpY" id="2VOpD3141HS" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="2tnlAX7XkA" role="3cqZAp" />
+        <node concept="3cpWs8" id="1x595U4mUSB" role="3cqZAp">
+          <node concept="3cpWsn" id="1x595U4mUSC" role="3cpWs9">
+            <property role="TrG5h" value="entry" />
+            <node concept="3f3tKP" id="1x595U4mRaR" role="1tU5fm">
+              <node concept="17QB3L" id="1x595U4mRb0" role="3f3zw5" />
+              <node concept="2hMVRd" id="1x595U4mRb1" role="3f3$T$">
+                <node concept="3uibUv" id="1x595U4mRb2" role="2hN53Y">
+                  <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
+                </node>
+              </node>
+            </node>
+            <node concept="2OqwBi" id="1x595U4mUSD" role="33vP2m">
+              <node concept="37vLTw" id="1x595U4nAVf" role="2Oq$k0">
+                <ref role="3cqZAo" node="5Rdndlpp80A" resolve="groupedActionsCache" />
+              </node>
+              <node concept="1z4cxt" id="1x595U4mUSF" role="2OqNvi">
+                <node concept="1bVj0M" id="1x595U4mUSG" role="23t8la">
+                  <node concept="3clFbS" id="1x595U4mUSH" role="1bW5cS">
+                    <node concept="3clFbF" id="1x595U4mUSI" role="3cqZAp">
+                      <node concept="2OqwBi" id="1x595U4mUSJ" role="3clFbG">
+                        <node concept="2OqwBi" id="1x595U4mUSK" role="2Oq$k0">
+                          <node concept="37vLTw" id="1x595U4mUSL" role="2Oq$k0">
+                            <ref role="3cqZAo" node="1x595U4mUSP" resolve="it" />
+                          </node>
+                          <node concept="3AV6Ez" id="1x595U4mUSM" role="2OqNvi" />
+                        </node>
+                        <node concept="3JPx81" id="1x595U4mUSN" role="2OqNvi">
+                          <node concept="37vLTw" id="1x595U4mUSO" role="25WWJ7">
+                            <ref role="3cqZAo" node="3pwG8PSpHHh" resolve="action" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="gl6BB" id="1x595U4mUSP" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="1x595U4mUSQ" role="1tU5fm" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="1x595U4nHge" role="3cqZAp">
+          <node concept="3clFbS" id="1x595U4nHgg" role="3clFbx">
+            <node concept="3cpWs6" id="1x595U4ofeh" role="3cqZAp">
+              <node concept="2OqwBi" id="1x595U4opVq" role="3cqZAk">
+                <node concept="37vLTw" id="1x595U4oflY" role="2Oq$k0">
+                  <ref role="3cqZAo" node="1x595U4mUSC" resolve="entry" />
+                </node>
+                <node concept="3AY5_j" id="1x595U4owov" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
+          <node concept="3y3z36" id="1x595U4o4Qa" role="3clFbw">
+            <node concept="10Nm6u" id="1x595U4o8R5" role="3uHU7w" />
+            <node concept="37vLTw" id="1x595U4nHnS" role="3uHU7B">
+              <ref role="3cqZAo" node="1x595U4mUSC" resolve="entry" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="1x595U4nwOr" role="3cqZAp" />
         <node concept="3clFbJ" id="2xgTENkV5Ei" role="3cqZAp">
           <node concept="3clFbS" id="2xgTENkV5Ek" role="3clFbx">
             <node concept="3cpWs6" id="2xgTENkV7jA" role="3cqZAp">
@@ -1666,7 +2457,6 @@
             </node>
           </node>
         </node>
-        <node concept="3clFbH" id="2xgTENkV5at" role="3cqZAp" />
         <node concept="3cpWs8" id="3pwG8PSsoLy" role="3cqZAp">
           <node concept="3cpWsn" id="3pwG8PSsoLz" role="3cpWs9">
             <property role="TrG5h" value="text" />
@@ -1735,11 +2525,9 @@
           </node>
         </node>
         <node concept="3clFbH" id="3pwG8PSsw8P" role="3cqZAp" />
-        <node concept="3cpWs8" id="3pwG8PSsz1H" role="3cqZAp">
-          <node concept="3cpWsn" id="3pwG8PSsz1K" role="3cpWs9">
-            <property role="TrG5h" value="groupName" />
-            <node concept="17QB3L" id="3pwG8PSsz1F" role="1tU5fm" />
-            <node concept="2OqwBi" id="3pwG8PSszBn" role="33vP2m">
+        <node concept="3clFbF" id="2VOpD312DcT" role="3cqZAp">
+          <node concept="37vLTI" id="2VOpD312DcV" role="3clFbG">
+            <node concept="2OqwBi" id="3pwG8PSszBn" role="37vLTx">
               <node concept="37vLTw" id="3pwG8PSszxq" role="2Oq$k0">
                 <ref role="3cqZAo" node="3pwG8PSsoLz" resolve="text" />
               </node>
@@ -1753,8 +2541,12 @@
                 </node>
               </node>
             </node>
+            <node concept="37vLTw" id="2VOpD312DcZ" role="37vLTJ">
+              <ref role="3cqZAo" node="3pwG8PSsz1K" resolve="groupName" />
+            </node>
           </node>
         </node>
+        <node concept="3clFbH" id="6Kw22eW9sg7" role="3cqZAp" />
         <node concept="3cpWs6" id="3pwG8PSs_F8" role="3cqZAp">
           <node concept="37vLTw" id="3pwG8PSsAzu" role="3cqZAk">
             <ref role="3cqZAo" node="3pwG8PSsz1K" resolve="groupName" />
@@ -1764,10 +2556,9 @@
       <node concept="2AHcQZ" id="3pwG8PSsKNl" role="2AJF6D">
         <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
       </node>
+      <node concept="3Tm1VV" id="7c2$qLP_HH8" role="1B3o_S" />
     </node>
     <node concept="2tJIrI" id="2jDew64Pxng" role="jymVt" />
-    <node concept="2tJIrI" id="2jDew64PJHF" role="jymVt" />
-    <node concept="2tJIrI" id="2jDew64MtYH" role="jymVt" />
     <node concept="3clFb_" id="3pwG8PSkQJj" role="jymVt">
       <property role="TrG5h" value="getIntentionGroup" />
       <property role="DiZV1" value="false" />
@@ -1778,12 +2569,18 @@
         <node concept="3uibUv" id="7me2y0SLESH" role="1tU5fm">
           <ref role="3uigEE" to="nddn:~IntentionExecutable" resolve="IntentionExecutable" />
         </node>
+        <node concept="2AHcQZ" id="7b8v2ss4O5i" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
       </node>
       <node concept="37vLTG" id="3pwG8PSkQJm" role="3clF46">
         <property role="TrG5h" value="node" />
         <property role="3TUv4t" value="true" />
         <node concept="3uibUv" id="3pwG8PSkQJn" role="1tU5fm">
           <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
+        </node>
+        <node concept="2AHcQZ" id="7b8v2ss52lz" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
         </node>
       </node>
       <node concept="3clFbS" id="3pwG8PSkQJo" role="3clF47">
@@ -2093,6 +2890,9 @@
         <node concept="3uibUv" id="2xgTENkWs0k" role="1tU5fm">
           <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
         </node>
+        <node concept="2AHcQZ" id="7b8v2ss5oSE" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
       </node>
       <node concept="37vLTG" id="2xgTENkWs0l" role="3clF46">
         <property role="TrG5h" value="intention" />
@@ -2100,10 +2900,16 @@
         <node concept="3uibUv" id="7me2y0SMO4G" role="1tU5fm">
           <ref role="3uigEE" to="nddn:~IntentionExecutable" resolve="IntentionExecutable" />
         </node>
+        <node concept="2AHcQZ" id="7b8v2ss5_p4" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
       </node>
       <node concept="37vLTG" id="2xgTENkWs0n" role="3clF46">
         <property role="TrG5h" value="text" />
         <node concept="17QB3L" id="2xgTENkWzuN" role="1tU5fm" />
+        <node concept="2AHcQZ" id="7b8v2ss5ZSu" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
       </node>
       <node concept="3clFbS" id="2xgTENkWrX_" role="3clF47">
         <node concept="3cpWs8" id="2xgTENkX278" role="3cqZAp">
@@ -2232,58 +3038,6 @@
     <node concept="3clFb_" id="2jDew64RVuQ" role="jymVt">
       <property role="TrG5h" value="executeIntention" />
       <node concept="3clFbS" id="2jDew64RVuS" role="3clF47">
-        <node concept="3cpWs8" id="2jDew64RVuT" role="3cqZAp">
-          <node concept="3cpWsn" id="2jDew64RVuU" role="3cpWs9">
-            <property role="TrG5h" value="dataContext" />
-            <node concept="3uibUv" id="2jDew64RVuV" role="1tU5fm">
-              <ref role="3uigEE" to="qkt:~DataContext" resolve="DataContext" />
-            </node>
-            <node concept="2OqwBi" id="2jDew64RVuW" role="33vP2m">
-              <node concept="2YIFZM" id="2jDew64RVuX" role="2Oq$k0">
-                <ref role="37wK5l" to="ddhc:~DataManager.getInstance()" resolve="getInstance" />
-                <ref role="1Pybhc" to="ddhc:~DataManager" resolve="DataManager" />
-              </node>
-              <node concept="liA8E" id="2jDew64RVuY" role="2OqNvi">
-                <ref role="37wK5l" to="ddhc:~DataManager.getDataContext(java.awt.Component)" resolve="getDataContext" />
-                <node concept="37vLTw" id="2jDew64RVuZ" role="37wK5m">
-                  <ref role="3cqZAo" node="2jDew64KOaH" resolve="editor" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3cpWs8" id="2jDew64RVv0" role="3cqZAp">
-          <node concept="3cpWsn" id="2jDew64RVv1" role="3cpWs9">
-            <property role="3TUv4t" value="false" />
-            <property role="TrG5h" value="project" />
-            <node concept="2OqwBi" id="2jDew64RVv2" role="33vP2m">
-              <node concept="10M0yZ" id="2jDew64RVv3" role="2Oq$k0">
-                <ref role="1PxDUh" to="qq03:~MPSCommonDataKeys" resolve="MPSCommonDataKeys" />
-                <ref role="3cqZAo" to="qq03:~MPSCommonDataKeys.MPS_PROJECT" resolve="MPS_PROJECT" />
-              </node>
-              <node concept="liA8E" id="2jDew64RVv4" role="2OqNvi">
-                <ref role="37wK5l" to="qkt:~DataKey.getData(com.intellij.openapi.actionSystem.DataContext)" resolve="getData" />
-                <node concept="37vLTw" id="2jDew64RVv5" role="37wK5m">
-                  <ref role="3cqZAo" node="2jDew64RVuU" resolve="dataContext" />
-                </node>
-              </node>
-            </node>
-            <node concept="3uibUv" id="2jDew64RVv6" role="1tU5fm">
-              <ref role="3uigEE" to="z1c3:~Project" resolve="Project" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbJ" id="2jDew64RVv7" role="3cqZAp">
-          <node concept="3clFbC" id="2jDew64RVv8" role="3clFbw">
-            <node concept="37vLTw" id="2jDew64RVv9" role="3uHU7B">
-              <ref role="3cqZAo" node="2jDew64RVv1" resolve="project" />
-            </node>
-            <node concept="10Nm6u" id="2jDew64RVva" role="3uHU7w" />
-          </node>
-          <node concept="3clFbS" id="2jDew64RVvb" role="3clFbx">
-            <node concept="3cpWs6" id="2jDew64RVvc" role="3cqZAp" />
-          </node>
-        </node>
         <node concept="3clFbF" id="2jDew64RVvd" role="3cqZAp">
           <node concept="2OqwBi" id="2jDew64RVve" role="3clFbG">
             <node concept="1rXfSq" id="2jDew64RVvf" role="2Oq$k0">
@@ -2659,11 +3413,17 @@
         <node concept="3uibUv" id="2jDew64HgSE" role="1tU5fm">
           <ref role="3uigEE" to="nddn:~IntentionExecutable" resolve="IntentionExecutable" />
         </node>
+        <node concept="2AHcQZ" id="7b8v2ss6KCM" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
       </node>
       <node concept="37vLTG" id="2jDew64HgSF" role="3clF46">
         <property role="TrG5h" value="node" />
         <node concept="3uibUv" id="2jDew64HgSG" role="1tU5fm">
           <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
+        </node>
+        <node concept="2AHcQZ" id="7b8v2ss6Xff" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
         </node>
       </node>
       <node concept="3clFbS" id="2jDew64HgSI" role="3clF47">
@@ -2739,15 +3499,25 @@
         <node concept="3uibUv" id="3pwG8PSkQMW" role="1tU5fm">
           <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
         </node>
+        <node concept="2AHcQZ" id="7b8v2ss79K_" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
       </node>
-      <node concept="37vLTG" id="3pwG8PSkQMX" role="3clF46">
-        <property role="TrG5h" value="actions" />
-        <property role="3TUv4t" value="false" />
-        <node concept="3uibUv" id="3pwG8PSkQMY" role="1tU5fm">
-          <ref role="3uigEE" to="33ny:~List" resolve="List" />
-          <node concept="3uibUv" id="3pwG8PSkQMZ" role="11_B2D">
-            <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
+      <node concept="37vLTG" id="3iqDEt5iQjZ" role="3clF46">
+        <property role="TrG5h" value="groupItems" />
+        <node concept="_YKpA" id="3iqDEt5iUFy" role="1tU5fm">
+          <node concept="3uibUv" id="3iqDEt5iUFz" role="_ZDj9">
+            <ref role="3uigEE" to="18ew:~Pair" resolve="Pair" />
+            <node concept="3uibUv" id="3iqDEt5iUF$" role="11_B2D">
+              <ref role="3uigEE" to="nddn:~IntentionExecutable" resolve="IntentionExecutable" />
+            </node>
+            <node concept="3uibUv" id="3iqDEt5iUF_" role="11_B2D">
+              <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
+            </node>
           </node>
+        </node>
+        <node concept="2AHcQZ" id="7b8v2ss7miM" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
         </node>
       </node>
       <node concept="37vLTG" id="3pwG8PSkQN0" role="3clF46">
@@ -2755,6 +3525,9 @@
         <property role="3TUv4t" value="false" />
         <node concept="3uibUv" id="3pwG8PSkQN1" role="1tU5fm">
           <ref role="3uigEE" to="qkt:~DataContext" resolve="DataContext" />
+        </node>
+        <node concept="2AHcQZ" id="7b8v2ss7yOS" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
         </node>
       </node>
       <node concept="3clFbS" id="3pwG8PSkQN2" role="3clF47">
@@ -2853,19 +3626,31 @@
                     <ref role="3cqZAo" node="3pwG8PSkQNx" resolve="presentation" />
                   </node>
                   <node concept="liA8E" id="3pwG8PSkUan" role="2OqNvi">
-                    <ref role="37wK5l" to="qkt:~Presentation.isVisible()" resolve="isVisible" />
+                    <ref role="37wK5l" to="qkt:~Presentation.isEnabledAndVisible()" resolve="isEnabledAndVisible" />
                   </node>
                 </node>
                 <node concept="3clFbS" id="3pwG8PSkQNT" role="3clFbx">
-                  <node concept="3clFbF" id="3pwG8PSkQNU" role="3cqZAp">
-                    <node concept="2OqwBi" id="3pwG8PSkUar" role="3clFbG">
-                      <node concept="37vLTw" id="3pwG8PSkUaq" role="2Oq$k0">
-                        <ref role="3cqZAo" node="3pwG8PSkQMX" resolve="actions" />
+                  <node concept="3clFbF" id="3iqDEt5ovVC" role="3cqZAp">
+                    <node concept="2OqwBi" id="3iqDEt5ovVD" role="3clFbG">
+                      <node concept="37vLTw" id="3iqDEt5ovVE" role="2Oq$k0">
+                        <ref role="3cqZAo" node="3iqDEt5iQjZ" resolve="groupItems" />
                       </node>
-                      <node concept="liA8E" id="3pwG8PSkUas" role="2OqNvi">
-                        <ref role="37wK5l" to="33ny:~List.add(java.lang.Object)" resolve="add" />
-                        <node concept="37vLTw" id="3pwG8PSkQNW" role="37wK5m">
-                          <ref role="3cqZAo" node="3pwG8PSkQMV" resolve="action" />
+                      <node concept="TSZUe" id="3iqDEt5ovVF" role="2OqNvi">
+                        <node concept="2ShNRf" id="3iqDEt5ovVG" role="25WWJ7">
+                          <node concept="1pGfFk" id="3iqDEt5ovVH" role="2ShVmc">
+                            <property role="373rjd" value="true" />
+                            <ref role="37wK5l" to="18ew:~Pair.&lt;init&gt;(java.lang.Object,java.lang.Object)" resolve="Pair" />
+                            <node concept="2ShNRf" id="3iqDEt5ovVI" role="37wK5m">
+                              <node concept="1pGfFk" id="3iqDEt5ovVJ" role="2ShVmc">
+                                <property role="373rjd" value="true" />
+                                <ref role="37wK5l" node="3iqDEt5lUki" resolve="ActionsAsIntentionsExecutable" />
+                                <node concept="37vLTw" id="3iqDEt5ovVK" role="37wK5m">
+                                  <ref role="3cqZAo" node="3pwG8PSkQMV" resolve="action" />
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="10Nm6u" id="3iqDEt5oWVp" role="37wK5m" />
+                          </node>
                         </node>
                       </node>
                     </node>
@@ -2900,16 +3685,69 @@
                 </node>
               </node>
               <node concept="3clFbS" id="3pwG8PSkQNb" role="2LFqv$">
-                <node concept="3clFbF" id="29wDeGI8z3F" role="3cqZAp">
-                  <node concept="2OqwBi" id="29wDeGI8AU1" role="3clFbG">
-                    <node concept="37vLTw" id="29wDeGI8z3D" role="2Oq$k0">
-                      <ref role="3cqZAo" node="3pwG8PSkQMX" resolve="actions" />
+                <node concept="3clFbF" id="3K6HeJZ0Ngl" role="3cqZAp">
+                  <node concept="2OqwBi" id="3K6HeJZ0Ngm" role="3clFbG">
+                    <node concept="liA8E" id="3K6HeJZ0Ngo" role="2OqNvi">
+                      <ref role="37wK5l" to="qkt:~AnAction.update(com.intellij.openapi.actionSystem.AnActionEvent)" resolve="update" />
+                      <node concept="2YIFZM" id="3K6HeJZ0Ngp" role="37wK5m">
+                        <ref role="37wK5l" to="qkt:~AnActionEvent.createFromAnAction(com.intellij.openapi.actionSystem.AnAction,java.awt.event.InputEvent,java.lang.String,com.intellij.openapi.actionSystem.DataContext)" resolve="createFromAnAction" />
+                        <ref role="1Pybhc" to="qkt:~AnActionEvent" resolve="AnActionEvent" />
+                        <node concept="37vLTw" id="3K6HeJZ0Ngq" role="37wK5m">
+                          <ref role="3cqZAo" node="3pwG8PSkQNh" resolve="child" />
+                        </node>
+                        <node concept="10Nm6u" id="3K6HeJZ0Ngr" role="37wK5m" />
+                        <node concept="Xl_RD" id="3K6HeJZ0Ngs" role="37wK5m">
+                          <property role="Xl_RC" value="" />
+                        </node>
+                        <node concept="37vLTw" id="3K6HeJZ0Ngt" role="37wK5m">
+                          <ref role="3cqZAo" node="3pwG8PSkQN0" resolve="dataContext" />
+                        </node>
+                      </node>
                     </node>
-                    <node concept="liA8E" id="29wDeGI8EAn" role="2OqNvi">
-                      <ref role="37wK5l" to="33ny:~List.add(java.lang.Object)" resolve="add" />
-                      <node concept="37vLTw" id="29wDeGI8J3U" role="37wK5m">
+                    <node concept="37vLTw" id="3K6HeJZ14jj" role="2Oq$k0">
+                      <ref role="3cqZAo" node="3pwG8PSkQNh" resolve="child" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbJ" id="24yqMXFXV8V" role="3cqZAp">
+                  <node concept="3clFbS" id="24yqMXFXV8X" role="3clFbx">
+                    <node concept="3clFbF" id="3iqDEt5ksml" role="3cqZAp">
+                      <node concept="2OqwBi" id="3iqDEt5kxFa" role="3clFbG">
+                        <node concept="37vLTw" id="3iqDEt5ksmj" role="2Oq$k0">
+                          <ref role="3cqZAo" node="3iqDEt5iQjZ" resolve="groupItems" />
+                        </node>
+                        <node concept="TSZUe" id="3iqDEt5kB6D" role="2OqNvi">
+                          <node concept="2ShNRf" id="3iqDEt5kFaQ" role="25WWJ7">
+                            <node concept="1pGfFk" id="3iqDEt5lFhb" role="2ShVmc">
+                              <property role="373rjd" value="true" />
+                              <ref role="37wK5l" to="18ew:~Pair.&lt;init&gt;(java.lang.Object,java.lang.Object)" resolve="Pair" />
+                              <node concept="2ShNRf" id="3iqDEt5lLiO" role="37wK5m">
+                                <node concept="1pGfFk" id="3iqDEt5nu__" role="2ShVmc">
+                                  <property role="373rjd" value="true" />
+                                  <ref role="37wK5l" node="3iqDEt5lUki" resolve="ActionsAsIntentionsExecutable" />
+                                  <node concept="37vLTw" id="69lhSVqEntQ" role="37wK5m">
+                                    <ref role="3cqZAo" node="3pwG8PSkQNh" resolve="child" />
+                                  </node>
+                                </node>
+                              </node>
+                              <node concept="10Nm6u" id="3iqDEt5o05r" role="37wK5m" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="24yqMXFZ9Qy" role="3clFbw">
+                    <node concept="2OqwBi" id="24yqMXFYWIE" role="2Oq$k0">
+                      <node concept="37vLTw" id="24yqMXFYMd4" role="2Oq$k0">
                         <ref role="3cqZAo" node="3pwG8PSkQNh" resolve="child" />
                       </node>
+                      <node concept="liA8E" id="24yqMXFZ3pM" role="2OqNvi">
+                        <ref role="37wK5l" to="qkt:~AnAction.getTemplatePresentation()" resolve="getTemplatePresentation" />
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="24yqMXFZgj7" role="2OqNvi">
+                      <ref role="37wK5l" to="qkt:~Presentation.isEnabledAndVisible()" resolve="isEnabledAndVisible" />
                     </node>
                   </node>
                 </node>
@@ -4656,6 +5494,460 @@
       <node concept="3cqZAl" id="3pwG8PSkQDH" role="3clF45" />
     </node>
     <node concept="2tJIrI" id="3DQAigeQ3s1" role="jymVt" />
+  </node>
+  <node concept="312cEu" id="3iqDEt5ltY_">
+    <property role="TrG5h" value="ActionsAsIntentionsExecutable" />
+    <node concept="312cEg" id="3iqDEt5lVwn" role="jymVt">
+      <property role="TrG5h" value="action" />
+      <node concept="3Tm6S6" id="3iqDEt5lUUO" role="1B3o_S" />
+      <node concept="3uibUv" id="3iqDEt5lVtz" role="1tU5fm">
+        <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="3iqDEt5lUvz" role="jymVt" />
+    <node concept="3clFbW" id="3iqDEt5lUki" role="jymVt">
+      <node concept="3cqZAl" id="3iqDEt5lUkj" role="3clF45" />
+      <node concept="3clFbS" id="3iqDEt5lUkl" role="3clF47">
+        <node concept="3clFbF" id="3iqDEt5lWBW" role="3cqZAp">
+          <node concept="37vLTI" id="3iqDEt5lXBC" role="3clFbG">
+            <node concept="37vLTw" id="3iqDEt5lXSF" role="37vLTx">
+              <ref role="3cqZAo" node="3iqDEt5lUrP" resolve="action" />
+            </node>
+            <node concept="2OqwBi" id="3iqDEt5lWMX" role="37vLTJ">
+              <node concept="Xjq3P" id="3iqDEt5lWBV" role="2Oq$k0" />
+              <node concept="2OwXpG" id="3iqDEt5lX1h" role="2OqNvi">
+                <ref role="2Oxat6" node="3iqDEt5lVwn" resolve="action" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="3iqDEt5lUkm" role="1B3o_S" />
+      <node concept="37vLTG" id="3iqDEt5lUrP" role="3clF46">
+        <property role="TrG5h" value="action" />
+        <node concept="3uibUv" id="3iqDEt5lUrO" role="1tU5fm">
+          <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="3_qLs3ub92X" role="jymVt" />
+    <node concept="3clFb_" id="3_qLs3ubao0" role="jymVt">
+      <property role="TrG5h" value="getAction" />
+      <node concept="3clFbS" id="3_qLs3ubao3" role="3clF47">
+        <node concept="3clFbF" id="3_qLs3ubbw4" role="3cqZAp">
+          <node concept="37vLTw" id="3_qLs3ubbw3" role="3clFbG">
+            <ref role="3cqZAo" node="3iqDEt5lVwn" resolve="action" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="3_qLs3ub9Xr" role="1B3o_S" />
+      <node concept="3uibUv" id="3_qLs3ubakK" role="3clF45">
+        <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="3iqDEt5lUd3" role="jymVt" />
+    <node concept="3Tm1VV" id="3iqDEt5ltYA" role="1B3o_S" />
+    <node concept="3uibUv" id="3iqDEt5lu0p" role="EKbjA">
+      <ref role="3uigEE" to="nddn:~IntentionExecutable" resolve="IntentionExecutable" />
+    </node>
+    <node concept="3clFb_" id="3iqDEt5lu0L" role="jymVt">
+      <property role="TrG5h" value="getDescription" />
+      <node concept="3Tm1VV" id="3iqDEt5lu0M" role="1B3o_S" />
+      <node concept="3uibUv" id="3iqDEt5lu0O" role="3clF45">
+        <ref role="3uigEE" to="wyt6:~String" resolve="String" />
+      </node>
+      <node concept="37vLTG" id="3iqDEt5lu0P" role="3clF46">
+        <property role="TrG5h" value="node" />
+        <node concept="3uibUv" id="3iqDEt5lu0Q" role="1tU5fm">
+          <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="3iqDEt5lu0R" role="3clF46">
+        <property role="TrG5h" value="context" />
+        <node concept="3uibUv" id="3iqDEt5lu0S" role="1tU5fm">
+          <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="3iqDEt5lu0T" role="3clF47">
+        <node concept="3clFbF" id="3iqDEt5pbCG" role="3cqZAp">
+          <node concept="2OqwBi" id="3iqDEt5pdPb" role="3clFbG">
+            <node concept="2OqwBi" id="3iqDEt5pdnw" role="2Oq$k0">
+              <node concept="2OqwBi" id="3iqDEt5pctn" role="2Oq$k0">
+                <node concept="37vLTw" id="3iqDEt5pbCF" role="2Oq$k0">
+                  <ref role="3cqZAo" node="3iqDEt5lVwn" resolve="action" />
+                </node>
+                <node concept="liA8E" id="3iqDEt5pd1o" role="2OqNvi">
+                  <ref role="37wK5l" to="qkt:~AnAction.getTemplatePresentation()" resolve="getTemplatePresentation" />
+                </node>
+              </node>
+              <node concept="liA8E" id="3iqDEt5pdHu" role="2OqNvi">
+                <ref role="37wK5l" to="qkt:~Presentation.clone()" resolve="clone" />
+              </node>
+            </node>
+            <node concept="liA8E" id="3iqDEt5pdYS" role="2OqNvi">
+              <ref role="37wK5l" to="qkt:~Presentation.toString()" resolve="toString" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="3iqDEt5lu0U" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="3iqDEt5ludO" role="jymVt" />
+    <node concept="3clFb_" id="3iqDEt5lu0X" role="jymVt">
+      <property role="TrG5h" value="execute" />
+      <node concept="3Tm1VV" id="3iqDEt5lu0Y" role="1B3o_S" />
+      <node concept="3cqZAl" id="3iqDEt5lu10" role="3clF45" />
+      <node concept="37vLTG" id="3iqDEt5lu11" role="3clF46">
+        <property role="TrG5h" value="node" />
+        <node concept="3uibUv" id="3iqDEt5lu12" role="1tU5fm">
+          <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="3iqDEt5lu13" role="3clF46">
+        <property role="TrG5h" value="context" />
+        <node concept="3uibUv" id="3iqDEt5lu14" role="1tU5fm">
+          <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="3iqDEt5lu15" role="3clF47" />
+      <node concept="2AHcQZ" id="3iqDEt5lu16" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="3iqDEt5lu9V" role="jymVt" />
+    <node concept="3clFb_" id="3iqDEt5lu17" role="jymVt">
+      <property role="TrG5h" value="getDescriptor" />
+      <node concept="3Tm1VV" id="3iqDEt5lu18" role="1B3o_S" />
+      <node concept="3uibUv" id="3iqDEt5lu1a" role="3clF45">
+        <ref role="3uigEE" to="nddn:~IntentionDescriptor" resolve="IntentionDescriptor" />
+      </node>
+      <node concept="3clFbS" id="3iqDEt5lu1b" role="3clF47">
+        <node concept="3clFbF" id="3iqDEt5prq3" role="3cqZAp">
+          <node concept="2ShNRf" id="3iqDEt5prq1" role="3clFbG">
+            <node concept="YeOm9" id="3iqDEt5pw4t" role="2ShVmc">
+              <node concept="1Y3b0j" id="3iqDEt5pw4w" role="YeSDq">
+                <property role="2bfB8j" value="true" />
+                <property role="373rjd" value="true" />
+                <ref role="1Y3XeK" to="nddn:~IntentionDescriptor" resolve="IntentionDescriptor" />
+                <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
+                <node concept="3Tm1VV" id="3iqDEt5pw4x" role="1B3o_S" />
+                <node concept="3clFb_" id="3iqDEt5pw4J" role="jymVt">
+                  <property role="TrG5h" value="getPresentation" />
+                  <node concept="3Tm1VV" id="3iqDEt5pw4K" role="1B3o_S" />
+                  <node concept="17QB3L" id="3iqDEt5pOcg" role="3clF45" />
+                  <node concept="3clFbS" id="3iqDEt5pw4N" role="3clF47">
+                    <node concept="3clFbF" id="3iqDEt5pz6R" role="3cqZAp">
+                      <node concept="2OqwBi" id="3iqDEt5pA8u" role="3clFbG">
+                        <node concept="2OqwBi" id="3iqDEt5p_qA" role="2Oq$k0">
+                          <node concept="2OqwBi" id="3iqDEt5p$gy" role="2Oq$k0">
+                            <node concept="37vLTw" id="3iqDEt5pz6Q" role="2Oq$k0">
+                              <ref role="3cqZAo" node="3iqDEt5lVwn" resolve="action" />
+                            </node>
+                            <node concept="liA8E" id="3iqDEt5p$WC" role="2OqNvi">
+                              <ref role="37wK5l" to="qkt:~AnAction.getTemplatePresentation()" resolve="getTemplatePresentation" />
+                            </node>
+                          </node>
+                          <node concept="liA8E" id="3iqDEt5p_SM" role="2OqNvi">
+                            <ref role="37wK5l" to="qkt:~Presentation.clone()" resolve="clone" />
+                          </node>
+                        </node>
+                        <node concept="liA8E" id="3iqDEt5pAqy" role="2OqNvi">
+                          <ref role="37wK5l" to="qkt:~Presentation.toString()" resolve="toString" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2AHcQZ" id="3iqDEt5pw4P" role="2AJF6D">
+                    <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                  </node>
+                </node>
+                <node concept="2tJIrI" id="3iqDEt5pw4Q" role="jymVt" />
+                <node concept="3clFb_" id="3iqDEt5pw4R" role="jymVt">
+                  <property role="TrG5h" value="getPersistentStateKey" />
+                  <node concept="3Tm1VV" id="3iqDEt5pw4S" role="1B3o_S" />
+                  <node concept="17QB3L" id="3iqDEt5pPrR" role="3clF45" />
+                  <node concept="3clFbS" id="3iqDEt5pw4V" role="3clF47">
+                    <node concept="3clFbF" id="3iqDEt5pCmT" role="3cqZAp">
+                      <node concept="10Nm6u" id="3iqDEt5pCmS" role="3clFbG" />
+                    </node>
+                  </node>
+                  <node concept="2AHcQZ" id="3iqDEt5pw4X" role="2AJF6D">
+                    <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                  </node>
+                </node>
+                <node concept="2tJIrI" id="3iqDEt5pw4Y" role="jymVt" />
+                <node concept="3clFb_" id="3iqDEt5pw4Z" role="jymVt">
+                  <property role="TrG5h" value="getKind" />
+                  <node concept="3Tm1VV" id="3iqDEt5pw50" role="1B3o_S" />
+                  <node concept="3uibUv" id="3iqDEt5pw52" role="3clF45">
+                    <ref role="3uigEE" to="nddn:~Kind" resolve="Kind" />
+                  </node>
+                  <node concept="3clFbS" id="3iqDEt5pw53" role="3clF47">
+                    <node concept="3clFbF" id="3iqDEt5pEGU" role="3cqZAp">
+                      <node concept="Rm8GO" id="3iqDEt5pEWt" role="3clFbG">
+                        <ref role="Rm8GQ" to="nddn:~Kind.NORMAL" resolve="NORMAL" />
+                        <ref role="1Px2BO" to="nddn:~Kind" resolve="Kind" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2AHcQZ" id="3iqDEt5pw55" role="2AJF6D">
+                    <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                  </node>
+                </node>
+                <node concept="2tJIrI" id="3iqDEt5pw56" role="jymVt" />
+                <node concept="3clFb_" id="3iqDEt5pw57" role="jymVt">
+                  <property role="TrG5h" value="isAvailableInChildNodes" />
+                  <node concept="3Tm1VV" id="3iqDEt5pw58" role="1B3o_S" />
+                  <node concept="10P_77" id="3iqDEt5pw5a" role="3clF45" />
+                  <node concept="3clFbS" id="3iqDEt5pw5b" role="3clF47">
+                    <node concept="3clFbF" id="3iqDEt5pKMf" role="3cqZAp">
+                      <node concept="3clFbT" id="3iqDEt5pKMe" role="3clFbG" />
+                    </node>
+                  </node>
+                  <node concept="2AHcQZ" id="3iqDEt5pw5d" role="2AJF6D">
+                    <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                  </node>
+                </node>
+                <node concept="2tJIrI" id="3iqDEt5pw5e" role="jymVt" />
+                <node concept="3clFb_" id="3iqDEt5pw5f" role="jymVt">
+                  <property role="TrG5h" value="getIntentionNodeReference" />
+                  <node concept="3Tm1VV" id="3iqDEt5pw5g" role="1B3o_S" />
+                  <node concept="2AHcQZ" id="3iqDEt5pw5i" role="2AJF6D">
+                    <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+                  </node>
+                  <node concept="3uibUv" id="3iqDEt5pw5j" role="3clF45">
+                    <ref role="3uigEE" to="mhbf:~SNodeReference" resolve="SNodeReference" />
+                  </node>
+                  <node concept="3clFbS" id="3iqDEt5pw5k" role="3clF47">
+                    <node concept="3clFbF" id="3iqDEt5pNkI" role="3cqZAp">
+                      <node concept="10Nm6u" id="3iqDEt5pNkH" role="3clFbG" />
+                    </node>
+                  </node>
+                  <node concept="2AHcQZ" id="3iqDEt5pw5m" role="2AJF6D">
+                    <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="3iqDEt5lu1c" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+  </node>
+  <node concept="312cEu" id="7b8v2ss9Juw">
+    <property role="TrG5h" value="IntentionsComparator" />
+    <node concept="2tJIrI" id="7b8v2ssahyY" role="jymVt" />
+    <node concept="312cEg" id="7b8v2ssajJx" role="jymVt">
+      <property role="TrG5h" value="component" />
+      <node concept="3uibUv" id="7b8v2ssajgL" role="1tU5fm">
+        <ref role="3uigEE" to="exr9:~EditorComponent" resolve="EditorComponent" />
+      </node>
+      <node concept="3Tm6S6" id="7b8v2ssak5m" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="7b8v2ssajdo" role="jymVt" />
+    <node concept="3clFbW" id="7b8v2ssaiBZ" role="jymVt">
+      <node concept="3cqZAl" id="7b8v2ssaiC0" role="3clF45" />
+      <node concept="3clFbS" id="7b8v2ssaiC2" role="3clF47">
+        <node concept="3clFbF" id="7b8v2ssaliL" role="3cqZAp">
+          <node concept="37vLTI" id="7b8v2ssapsG" role="3clFbG">
+            <node concept="37vLTw" id="7b8v2ssapWR" role="37vLTx">
+              <ref role="3cqZAo" node="7b8v2ssaj1u" resolve="component" />
+            </node>
+            <node concept="2OqwBi" id="7b8v2ssalXd" role="37vLTJ">
+              <node concept="Xjq3P" id="7b8v2ssaliK" role="2Oq$k0" />
+              <node concept="2OwXpG" id="7b8v2ssanuW" role="2OqNvi">
+                <ref role="2Oxat6" node="7b8v2ssajJx" resolve="component" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="7b8v2ssaiC3" role="1B3o_S" />
+      <node concept="37vLTG" id="7b8v2ssaj1u" role="3clF46">
+        <property role="TrG5h" value="component" />
+        <node concept="3uibUv" id="7b8v2ssaj1t" role="1tU5fm">
+          <ref role="3uigEE" to="exr9:~EditorComponent" resolve="EditorComponent" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="7b8v2ssahSZ" role="jymVt" />
+    <node concept="3clFb_" id="7b8v2ssa1Qn" role="jymVt">
+      <property role="TrG5h" value="compare" />
+      <property role="DiZV1" value="false" />
+      <property role="od$2w" value="false" />
+      <node concept="2AHcQZ" id="7b8v2ssa1Qo" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+      <node concept="37vLTG" id="7b8v2ssa1Qp" role="3clF46">
+        <property role="TrG5h" value="o1" />
+        <property role="3TUv4t" value="false" />
+        <node concept="3uibUv" id="7b8v2ssa1Qq" role="1tU5fm">
+          <ref role="3uigEE" to="18ew:~Pair" resolve="Pair" />
+          <node concept="3uibUv" id="7b8v2ssa1Qr" role="11_B2D">
+            <ref role="3uigEE" to="nddn:~IntentionExecutable" resolve="IntentionExecutable" />
+          </node>
+          <node concept="3uibUv" id="7b8v2ssa1Qs" role="11_B2D">
+            <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="7b8v2ssa1Qt" role="3clF46">
+        <property role="TrG5h" value="o2" />
+        <property role="3TUv4t" value="false" />
+        <node concept="3uibUv" id="7b8v2ssa1Qu" role="1tU5fm">
+          <ref role="3uigEE" to="18ew:~Pair" resolve="Pair" />
+          <node concept="3uibUv" id="7b8v2ssa1Qv" role="11_B2D">
+            <ref role="3uigEE" to="nddn:~IntentionExecutable" resolve="IntentionExecutable" />
+          </node>
+          <node concept="3uibUv" id="7b8v2ssa1Qw" role="11_B2D">
+            <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbS" id="7b8v2ssa1Qx" role="3clF47">
+        <node concept="3cpWs8" id="7b8v2ssa1Qy" role="3cqZAp">
+          <node concept="3cpWsn" id="7b8v2ssa1Qz" role="3cpWs9">
+            <property role="3TUv4t" value="false" />
+            <property role="TrG5h" value="intention1" />
+            <node concept="3uibUv" id="7b8v2ssa1Q$" role="1tU5fm">
+              <ref role="3uigEE" to="nddn:~IntentionExecutable" resolve="IntentionExecutable" />
+            </node>
+            <node concept="2OqwBi" id="7b8v2ssa1Q_" role="33vP2m">
+              <node concept="37vLTw" id="7b8v2ssa1QA" role="2Oq$k0">
+                <ref role="3cqZAo" node="7b8v2ssa1Qp" resolve="o1" />
+              </node>
+              <node concept="2OwXpG" id="7b8v2ssa1QB" role="2OqNvi">
+                <ref role="2Oxat6" to="18ew:~Pair.o1" resolve="o1" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="7b8v2ssa1QC" role="3cqZAp">
+          <node concept="3cpWsn" id="7b8v2ssa1QD" role="3cpWs9">
+            <property role="3TUv4t" value="false" />
+            <property role="TrG5h" value="intention2" />
+            <node concept="3uibUv" id="7b8v2ssa1QE" role="1tU5fm">
+              <ref role="3uigEE" to="nddn:~IntentionExecutable" resolve="IntentionExecutable" />
+            </node>
+            <node concept="2OqwBi" id="7b8v2ssa1QF" role="33vP2m">
+              <node concept="37vLTw" id="7b8v2ssa1QG" role="2Oq$k0">
+                <ref role="3cqZAo" node="7b8v2ssa1Qt" resolve="o2" />
+              </node>
+              <node concept="2OwXpG" id="7b8v2ssa1QH" role="2OqNvi">
+                <ref role="2Oxat6" to="18ew:~Pair.o1" resolve="o1" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="7b8v2ssa1QI" role="3cqZAp">
+          <node concept="3cpWsn" id="7b8v2ssa1QJ" role="3cpWs9">
+            <property role="3TUv4t" value="false" />
+            <property role="TrG5h" value="node1" />
+            <node concept="3uibUv" id="7b8v2ssa1QK" role="1tU5fm">
+              <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
+            </node>
+            <node concept="2OqwBi" id="7b8v2ssa1QL" role="33vP2m">
+              <node concept="37vLTw" id="7b8v2ssa1QM" role="2Oq$k0">
+                <ref role="3cqZAo" node="7b8v2ssa1Qp" resolve="o1" />
+              </node>
+              <node concept="2OwXpG" id="7b8v2ssa1QN" role="2OqNvi">
+                <ref role="2Oxat6" to="18ew:~Pair.o2" resolve="o2" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="7b8v2ssa1QO" role="3cqZAp">
+          <node concept="3cpWsn" id="7b8v2ssa1QP" role="3cpWs9">
+            <property role="3TUv4t" value="false" />
+            <property role="TrG5h" value="node2" />
+            <node concept="3uibUv" id="7b8v2ssa1QQ" role="1tU5fm">
+              <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
+            </node>
+            <node concept="2OqwBi" id="7b8v2ssa1QR" role="33vP2m">
+              <node concept="37vLTw" id="7b8v2ssa1QS" role="2Oq$k0">
+                <ref role="3cqZAo" node="7b8v2ssa1Qt" resolve="o2" />
+              </node>
+              <node concept="2OwXpG" id="7b8v2ssa1QT" role="2OqNvi">
+                <ref role="2Oxat6" to="18ew:~Pair.o2" resolve="o2" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="7b8v2ssa1QU" role="3cqZAp">
+          <node concept="3cpWsn" id="7b8v2ssa1QV" role="3cpWs9">
+            <property role="3TUv4t" value="false" />
+            <property role="TrG5h" value="context" />
+            <node concept="3uibUv" id="7b8v2ssa1QW" role="1tU5fm">
+              <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+            </node>
+            <node concept="2OqwBi" id="7b8v2ssa1QX" role="33vP2m">
+              <node concept="37vLTw" id="7b8v2ssa1QY" role="2Oq$k0">
+                <ref role="3cqZAo" node="7b8v2ssajJx" resolve="component" />
+              </node>
+              <node concept="liA8E" id="7b8v2ssa1QZ" role="2OqNvi">
+                <ref role="37wK5l" to="exr9:~EditorComponent.getEditorContext()" resolve="getEditorContext" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="7b8v2ssa1R0" role="3cqZAp">
+          <node concept="2OqwBi" id="7b8v2ssa1R1" role="3cqZAk">
+            <node concept="2OqwBi" id="7b8v2ssa1R2" role="2Oq$k0">
+              <node concept="37vLTw" id="7b8v2ssa1R3" role="2Oq$k0">
+                <ref role="3cqZAo" node="7b8v2ssa1Qz" resolve="intention1" />
+              </node>
+              <node concept="liA8E" id="7b8v2ssa1R4" role="2OqNvi">
+                <ref role="37wK5l" to="nddn:~IntentionExecutable.getDescription(org.jetbrains.mps.openapi.model.SNode,jetbrains.mps.openapi.editor.EditorContext)" resolve="getDescription" />
+                <node concept="37vLTw" id="7b8v2ssa1R5" role="37wK5m">
+                  <ref role="3cqZAo" node="7b8v2ssa1QJ" resolve="node1" />
+                </node>
+                <node concept="37vLTw" id="7b8v2ssa1R6" role="37wK5m">
+                  <ref role="3cqZAo" node="7b8v2ssa1QV" resolve="context" />
+                </node>
+              </node>
+            </node>
+            <node concept="liA8E" id="7b8v2ssa1R7" role="2OqNvi">
+              <ref role="37wK5l" to="wyt6:~String.compareTo(java.lang.String)" resolve="compareTo" />
+              <node concept="2OqwBi" id="7b8v2ssa1R8" role="37wK5m">
+                <node concept="37vLTw" id="7b8v2ssa1R9" role="2Oq$k0">
+                  <ref role="3cqZAo" node="7b8v2ssa1QD" resolve="intention2" />
+                </node>
+                <node concept="liA8E" id="7b8v2ssa1Ra" role="2OqNvi">
+                  <ref role="37wK5l" to="nddn:~IntentionExecutable.getDescription(org.jetbrains.mps.openapi.model.SNode,jetbrains.mps.openapi.editor.EditorContext)" resolve="getDescription" />
+                  <node concept="37vLTw" id="7b8v2ssa1Rb" role="37wK5m">
+                    <ref role="3cqZAo" node="7b8v2ssa1QP" resolve="node2" />
+                  </node>
+                  <node concept="37vLTw" id="7b8v2ssa1Rc" role="37wK5m">
+                    <ref role="3cqZAo" node="7b8v2ssa1QV" resolve="context" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="7b8v2ssa1Rd" role="1B3o_S" />
+      <node concept="10Oyi0" id="7b8v2ssa1Re" role="3clF45" />
+    </node>
+    <node concept="2tJIrI" id="7b8v2ssa1Oj" role="jymVt" />
+    <node concept="3Tm1VV" id="7b8v2ss9Jux" role="1B3o_S" />
+    <node concept="3uibUv" id="7b8v2ss9JKw" role="EKbjA">
+      <ref role="3uigEE" to="33ny:~Comparator" resolve="Comparator" />
+      <node concept="3uibUv" id="7b8v2ss9NmS" role="11_B2D">
+        <ref role="3uigEE" to="18ew:~Pair" resolve="Pair" />
+        <node concept="3uibUv" id="7b8v2ss9NmT" role="11_B2D">
+          <ref role="3uigEE" to="nddn:~IntentionExecutable" resolve="IntentionExecutable" />
+        </node>
+        <node concept="3uibUv" id="7b8v2ss9NmU" role="11_B2D">
+          <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
+        </node>
+      </node>
+    </node>
   </node>
 </model>
 

--- a/code/intentionsmenu/com.mbeddr.mpsutil.intentions.runtime/models/com/mbeddr/mpsutil/intentions/runtime.mps
+++ b/code/intentionsmenu/com.mbeddr.mpsutil.intentions.runtime/models/com/mbeddr/mpsutil/intentions/runtime.mps
@@ -23,12 +23,10 @@
     <import index="qkt" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.actionSystem(MPS.IDEA/)" />
     <import index="qq03" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.ide.actions(MPS.Platform/)" />
     <import index="7bx7" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.workbench.action(MPS.Platform/)" />
-    <import index="ddhc" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ide(MPS.IDEA/)" />
     <import index="18ew" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.util(MPS.Core/)" />
     <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" />
     <import index="f4zo" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.cells(MPS.Editor/)" />
     <import index="lui2" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.module(MPS.OpenAPI/)" />
-    <import index="z1c3" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.project(MPS.Core/)" />
     <import index="mhfm" ref="3f233e7f-b8a6-46d2-a57f-795d56775243/java:org.jetbrains.annotations(Annotations/)" />
     <import index="nlpl" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.editor.runtime.commands(MPS.Editor/)" />
     <import index="nddn" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.intentions(MPS.Editor/)" />
@@ -47,8 +45,8 @@
     <import index="ev0w" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.typechecking.backend(MPS.Core/)" />
     <import index="z60i" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt(JDK/)" />
     <import index="7oz1" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor.configuration(MPS.Editor/)" />
-    <import index="8rsk" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.actionSystem.ex(MPS.IDEA/)" />
     <import index="zn9m" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.util(MPS.IDEA/)" />
+    <import index="3o3z" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.google.common.collect(MPS.IDEA/)" />
   </imports>
   <registry>
     <language id="654422bf-e75f-44dc-936d-188890a746ce" name="de.slisson.mps.reflection">
@@ -94,6 +92,9 @@
       </concept>
       <concept id="1188220165133" name="jetbrains.mps.baseLanguage.structure.ArrayLiteral" flags="nn" index="2BsdOp">
         <child id="1188220173759" name="item" index="2BsfMF" />
+      </concept>
+      <concept id="2820489544401957797" name="jetbrains.mps.baseLanguage.structure.DefaultClassCreator" flags="nn" index="HV5vD">
+        <reference id="2820489544401957798" name="classifier" index="HV5vE" />
       </concept>
       <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
         <child id="1154032183016" name="body" index="2LFqv$" />
@@ -374,38 +375,17 @@
         <child id="1237721435807" name="elementType" index="HW$YZ" />
       </concept>
       <concept id="1227008614712" name="jetbrains.mps.baseLanguage.collections.structure.LinkedListCreator" flags="nn" index="2Jqq0_" />
-      <concept id="1201306600024" name="jetbrains.mps.baseLanguage.collections.structure.ContainsKeyOperation" flags="nn" index="2Nt0df">
-        <child id="1201654602639" name="key" index="38cxEo" />
-      </concept>
       <concept id="1160600644654" name="jetbrains.mps.baseLanguage.collections.structure.ListCreatorWithInit" flags="nn" index="Tc6Ow" />
       <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
       <concept id="4611582986551314327" name="jetbrains.mps.baseLanguage.collections.structure.OfTypeOperation" flags="nn" index="UnYns">
         <child id="4611582986551314344" name="requestedType" index="UnYnz" />
       </concept>
       <concept id="1160666733551" name="jetbrains.mps.baseLanguage.collections.structure.AddAllElementsOperation" flags="nn" index="X8dFx" />
-      <concept id="1240217271293" name="jetbrains.mps.baseLanguage.collections.structure.LinkedHashSetCreator" flags="nn" index="32HrFt" />
       <concept id="1240325842691" name="jetbrains.mps.baseLanguage.collections.structure.AsSequenceOperation" flags="nn" index="39bAoz" />
-      <concept id="1240424373525" name="jetbrains.mps.baseLanguage.collections.structure.MappingType" flags="in" index="3f3tKP">
-        <child id="1240424397093" name="keyType" index="3f3zw5" />
-        <child id="1240424402756" name="valueType" index="3f3$T$" />
-      </concept>
-      <concept id="1197683403723" name="jetbrains.mps.baseLanguage.collections.structure.MapType" flags="in" index="3rvAFt">
-        <child id="1197683466920" name="keyType" index="3rvQeY" />
-        <child id="1197683475734" name="valueType" index="3rvSg0" />
-      </concept>
-      <concept id="1197686869805" name="jetbrains.mps.baseLanguage.collections.structure.HashMapCreator" flags="nn" index="3rGOSV">
-        <child id="1197687026896" name="keyType" index="3rHrn6" />
-        <child id="1197687035757" name="valueType" index="3rHtpV" />
-      </concept>
       <concept id="1165530316231" name="jetbrains.mps.baseLanguage.collections.structure.IsEmptyOperation" flags="nn" index="1v1jN8" />
       <concept id="1225727723840" name="jetbrains.mps.baseLanguage.collections.structure.FindFirstOperation" flags="nn" index="1z4cxt" />
       <concept id="1240824834947" name="jetbrains.mps.baseLanguage.collections.structure.ValueAccessOperation" flags="nn" index="3AV6Ez" />
       <concept id="1240825616499" name="jetbrains.mps.baseLanguage.collections.structure.KeyAccessOperation" flags="nn" index="3AY5_j" />
-      <concept id="1197932370469" name="jetbrains.mps.baseLanguage.collections.structure.MapElement" flags="nn" index="3EllGN">
-        <child id="1197932505799" name="map" index="3ElQJh" />
-        <child id="1197932525128" name="key" index="3ElVtu" />
-      </concept>
-      <concept id="1172254888721" name="jetbrains.mps.baseLanguage.collections.structure.ContainsOperation" flags="nn" index="3JPx81" />
     </language>
   </registry>
   <node concept="312cEu" id="5qf1oe_zyw0">
@@ -585,10 +565,11 @@
     </node>
   </node>
   <node concept="312cEu" id="2jDew64JcPx">
-    <property role="TrG5h" value="MyIntentionMenuProducer" />
+    <property role="TrG5h" value="ActionIntentionMenuProducer" />
     <node concept="2tJIrI" id="2jDew64KOaE" role="jymVt" />
     <node concept="Wx3nA" id="6Kw22eW7L03" role="jymVt">
       <property role="TrG5h" value="GROUPNAME_KEY" />
+      <property role="3TUv4t" value="true" />
       <node concept="3Tm1VV" id="6Kw22eW7pcO" role="1B3o_S" />
       <node concept="3uibUv" id="6Kw22eW7wxo" role="1tU5fm">
         <ref role="3uigEE" to="zn9m:~Key" resolve="Key" />
@@ -606,24 +587,17 @@
     </node>
     <node concept="Wx3nA" id="5Rdndlpp80A" role="jymVt">
       <property role="TrG5h" value="groupedActionsCache" />
-      <node concept="3Tm1VV" id="5RdndlpoVwT" role="1B3o_S" />
-      <node concept="2ShNRf" id="5RdndlpphrM" role="33vP2m">
-        <node concept="3rGOSV" id="ZxI3JAdAP9" role="2ShVmc">
-          <node concept="17QB3L" id="ZxI3JAdL52" role="3rHrn6" />
-          <node concept="2hMVRd" id="2Ef_vJ5WSfd" role="3rHtpV">
-            <node concept="3uibUv" id="2Ef_vJ5WYol" role="2hN53Y">
-              <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
-            </node>
-          </node>
+      <node concept="3Tm6S6" id="6ob0HsMKAMj" role="1B3o_S" />
+      <node concept="3uibUv" id="4rzEAhzpOGu" role="1tU5fm">
+        <ref role="3uigEE" to="3o3z:~SetMultimap" resolve="SetMultimap" />
+        <node concept="17QB3L" id="4rzEAhzq8VJ" role="11_B2D" />
+        <node concept="3uibUv" id="4rzEAhzqcrj" role="11_B2D">
+          <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
         </node>
       </node>
-      <node concept="3rvAFt" id="ZxI3JAcvMm" role="1tU5fm">
-        <node concept="17QB3L" id="ZxI3JAcBtn" role="3rvQeY" />
-        <node concept="2hMVRd" id="2Ef_vJ5X4yv" role="3rvSg0">
-          <node concept="3uibUv" id="2Ef_vJ5X4yw" role="2hN53Y">
-            <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
-          </node>
-        </node>
+      <node concept="2YIFZM" id="4rzEAhztDk9" role="33vP2m">
+        <ref role="37wK5l" to="3o3z:~HashMultimap.create()" resolve="create" />
+        <ref role="1Pybhc" to="3o3z:~HashMultimap" resolve="HashMultimap" />
       </node>
     </node>
     <node concept="2tJIrI" id="6Kw22eW7iqb" role="jymVt" />
@@ -687,12 +661,11 @@
                 <ref role="2Oxat6" node="26rsnFJK69q" resolve="intentionsSupport" />
               </node>
             </node>
-            <node concept="2OqwBi" id="26rsnFJKNQR" role="37vLTx">
-              <node concept="37vLTw" id="26rsnFJKNQS" role="2Oq$k0">
+            <node concept="2YIFZM" id="38Yx6hD7WAp" role="37vLTx">
+              <ref role="37wK5l" node="38Yx6hD6a9o" resolve="getIntentionsSupport" />
+              <ref role="1Pybhc" node="4hHbxs9xqxD" resolve="MyIntentionsSupport" />
+              <node concept="37vLTw" id="38Yx6hD7WAq" role="37wK5m">
                 <ref role="3cqZAo" node="2jDew64KaGK" resolve="editor" />
-              </node>
-              <node concept="1PnCL0" id="26rsnFJKNQT" role="2OqNvi">
-                <ref role="2Oxat5" to="exr9:~EditorComponent.myIntentionsSupport" resolve="myIntentionsSupport" />
               </node>
             </node>
           </node>
@@ -865,24 +838,15 @@
           <node concept="3cpWsn" id="2A8KNgItV65" role="3cpWs9">
             <property role="TrG5h" value="groups" />
             <node concept="3uibUv" id="2A8KNgItV66" role="1tU5fm">
-              <ref role="3uigEE" to="33ny:~TreeMap" resolve="TreeMap" />
+              <ref role="3uigEE" to="3o3z:~ListMultimap" resolve="ListMultimap" />
               <node concept="17QB3L" id="2A8KNgItV67" role="11_B2D" />
-              <node concept="_YKpA" id="7b8v2ssg0ol" role="11_B2D">
-                <node concept="3uibUv" id="7b8v2ssg0om" role="_ZDj9">
-                  <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
-                </node>
+              <node concept="3uibUv" id="2H0U9ns7ZQR" role="11_B2D">
+                <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
               </node>
             </node>
-            <node concept="2ShNRf" id="2A8KNgItV6a" role="33vP2m">
-              <node concept="1pGfFk" id="2A8KNgItV6b" role="2ShVmc">
-                <ref role="37wK5l" to="33ny:~TreeMap.&lt;init&gt;()" resolve="TreeMap" />
-                <node concept="17QB3L" id="2A8KNgItV6c" role="1pMfVU" />
-                <node concept="_YKpA" id="7b8v2ssfLRv" role="1pMfVU">
-                  <node concept="3uibUv" id="7b8v2ssfTTQ" role="_ZDj9">
-                    <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
-                  </node>
-                </node>
-              </node>
+            <node concept="2YIFZM" id="2H0U9ns6Iin" role="33vP2m">
+              <ref role="37wK5l" to="3o3z:~ArrayListMultimap.create()" resolve="create" />
+              <ref role="1Pybhc" to="3o3z:~ArrayListMultimap" resolve="ArrayListMultimap" />
             </node>
           </node>
         </node>
@@ -918,80 +882,17 @@
                 </node>
               </node>
             </node>
-            <node concept="3cpWs8" id="2A8KNgIu5e0" role="3cqZAp">
-              <node concept="3cpWsn" id="2A8KNgIu5e1" role="3cpWs9">
-                <property role="TrG5h" value="c" />
-                <node concept="3uibUv" id="2A8KNgIu5e2" role="1tU5fm">
-                  <ref role="3uigEE" to="33ny:~List" resolve="List" />
-                  <node concept="3uibUv" id="2A8KNgIu5e3" role="11_B2D">
-                    <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
+            <node concept="3clFbF" id="2H0U9ns6Yxz" role="3cqZAp">
+              <node concept="2OqwBi" id="2H0U9ns76$o" role="3clFbG">
+                <node concept="37vLTw" id="2H0U9ns6Yxx" role="2Oq$k0">
+                  <ref role="3cqZAo" node="2A8KNgItV65" resolve="groups" />
+                </node>
+                <node concept="liA8E" id="2H0U9ns7drW" role="2OqNvi">
+                  <ref role="37wK5l" to="3o3z:~Multimap.put(java.lang.Object,java.lang.Object)" resolve="put" />
+                  <node concept="37vLTw" id="2H0U9ns7jC1" role="37wK5m">
+                    <ref role="3cqZAo" node="2A8KNgIu5dr" resolve="groupName" />
                   </node>
-                </node>
-                <node concept="2OqwBi" id="2A8KNgIu5e4" role="33vP2m">
-                  <node concept="37vLTw" id="2A8KNgIu5e5" role="2Oq$k0">
-                    <ref role="3cqZAo" node="2A8KNgItV65" resolve="groups" />
-                  </node>
-                  <node concept="liA8E" id="2A8KNgIu5e6" role="2OqNvi">
-                    <ref role="37wK5l" to="33ny:~TreeMap.get(java.lang.Object)" resolve="get" />
-                    <node concept="37vLTw" id="2A8KNgIu5e7" role="37wK5m">
-                      <ref role="3cqZAo" node="2A8KNgIu5dr" resolve="groupName" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbJ" id="2A8KNgIu5e8" role="3cqZAp">
-              <node concept="3clFbS" id="2A8KNgIu5e9" role="3clFbx">
-                <node concept="3clFbF" id="2A8KNgIu5ea" role="3cqZAp">
-                  <node concept="37vLTI" id="2A8KNgIu5eb" role="3clFbG">
-                    <node concept="37vLTw" id="2A8KNgIu5ec" role="37vLTJ">
-                      <ref role="3cqZAo" node="2A8KNgIu5e1" resolve="c" />
-                    </node>
-                    <node concept="2ShNRf" id="2A8KNgIu5ed" role="37vLTx">
-                      <node concept="1pGfFk" id="2A8KNgIu5ee" role="2ShVmc">
-                        <ref role="37wK5l" to="33ny:~ArrayList.&lt;init&gt;(int)" resolve="ArrayList" />
-                        <node concept="3uibUv" id="2A8KNgIu5ef" role="1pMfVU">
-                          <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
-                        </node>
-                        <node concept="3cmrfG" id="2A8KNgIu5eg" role="37wK5m">
-                          <property role="3cmrfH" value="4" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="3clFbF" id="2A8KNgIu5eh" role="3cqZAp">
-                  <node concept="2OqwBi" id="2A8KNgIu5ei" role="3clFbG">
-                    <node concept="37vLTw" id="2A8KNgIu5ej" role="2Oq$k0">
-                      <ref role="3cqZAo" node="2A8KNgItV65" resolve="groups" />
-                    </node>
-                    <node concept="liA8E" id="2A8KNgIu5ek" role="2OqNvi">
-                      <ref role="37wK5l" to="33ny:~TreeMap.put(java.lang.Object,java.lang.Object)" resolve="put" />
-                      <node concept="37vLTw" id="2A8KNgIu5el" role="37wK5m">
-                        <ref role="3cqZAo" node="2A8KNgIu5dr" resolve="groupName" />
-                      </node>
-                      <node concept="37vLTw" id="2A8KNgIu5em" role="37wK5m">
-                        <ref role="3cqZAo" node="2A8KNgIu5e1" resolve="c" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3clFbC" id="2A8KNgIu5en" role="3clFbw">
-                <node concept="10Nm6u" id="2A8KNgIu5eo" role="3uHU7w" />
-                <node concept="37vLTw" id="2A8KNgIu5ep" role="3uHU7B">
-                  <ref role="3cqZAo" node="2A8KNgIu5e1" resolve="c" />
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbF" id="2A8KNgIu5eI" role="3cqZAp">
-              <node concept="2OqwBi" id="2A8KNgIu5eJ" role="3clFbG">
-                <node concept="37vLTw" id="2A8KNgIu5eK" role="2Oq$k0">
-                  <ref role="3cqZAo" node="2A8KNgIu5e1" resolve="c" />
-                </node>
-                <node concept="liA8E" id="2A8KNgIu5eL" role="2OqNvi">
-                  <ref role="37wK5l" to="33ny:~List.add(java.lang.Object)" resolve="add" />
-                  <node concept="2GrUjf" id="6Kw22eW4553" role="37wK5m">
+                  <node concept="2GrUjf" id="2H0U9ns7GWF" role="37wK5m">
                     <ref role="2Gs0qQ" node="2A8KNgIv5U7" resolve="action" />
                   </node>
                 </node>
@@ -1006,100 +907,42 @@
               <node concept="2GrKxI" id="3DeU_KsjZSa" role="2Gsz3X">
                 <property role="TrG5h" value="entry" />
               </node>
-              <node concept="37vLTw" id="4XO$XQbUqH7" role="2GsD0m">
-                <ref role="3cqZAo" node="5Rdndlpp80A" resolve="groupedActionsCache" />
+              <node concept="2OqwBi" id="2H0U9nsf0JK" role="2GsD0m">
+                <node concept="1rXfSq" id="6ob0HsMLWUZ" role="2Oq$k0">
+                  <ref role="37wK5l" node="6ob0HsML7OT" resolve="getCache" />
+                </node>
+                <node concept="liA8E" id="2H0U9nsf6yg" role="2OqNvi">
+                  <ref role="37wK5l" to="3o3z:~SetMultimap.asMap()" resolve="asMap" />
+                </node>
               </node>
               <node concept="3clFbS" id="3DeU_KsjZSe" role="2LFqv$">
                 <node concept="3cpWs8" id="3DeU_KsltHr" role="3cqZAp">
                   <node concept="3cpWsn" id="3DeU_KsltHs" role="3cpWs9">
-                    <property role="TrG5h" value="groupname" />
+                    <property role="TrG5h" value="groupName" />
                     <node concept="17QB3L" id="3DeU_Kslo6I" role="1tU5fm" />
                     <node concept="2OqwBi" id="3DeU_KsltHt" role="33vP2m">
                       <node concept="2GrUjf" id="3DeU_KsltHu" role="2Oq$k0">
                         <ref role="2Gs0qQ" node="3DeU_KsjZSa" resolve="entry" />
                       </node>
-                      <node concept="3AY5_j" id="3DeU_KsltHv" role="2OqNvi" />
+                      <node concept="3AY5_j" id="2H0U9nsfE4F" role="2OqNvi" />
                     </node>
                   </node>
                 </node>
-                <node concept="3cpWs8" id="3DeU_KskO9$" role="3cqZAp">
-                  <node concept="3cpWsn" id="3DeU_KskO9_" role="3cpWs9">
-                    <property role="TrG5h" value="c" />
-                    <node concept="3uibUv" id="3DeU_KskO9A" role="1tU5fm">
-                      <ref role="3uigEE" to="33ny:~List" resolve="List" />
-                      <node concept="3uibUv" id="3DeU_KskO9B" role="11_B2D">
-                        <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
+                <node concept="3clFbF" id="6ob0HsMZXw$" role="3cqZAp">
+                  <node concept="2OqwBi" id="6ob0HsMZZPl" role="3clFbG">
+                    <node concept="37vLTw" id="6ob0HsN0udr" role="2Oq$k0">
+                      <ref role="3cqZAo" node="2A8KNgItV65" resolve="groups" />
+                    </node>
+                    <node concept="liA8E" id="6ob0HsN069c" role="2OqNvi">
+                      <ref role="37wK5l" to="3o3z:~Multimap.putAll(java.lang.Object,java.lang.Iterable)" resolve="putAll" />
+                      <node concept="37vLTw" id="6ob0HsN0Stv" role="37wK5m">
+                        <ref role="3cqZAo" node="3DeU_KsltHs" resolve="groupName" />
                       </node>
-                    </node>
-                    <node concept="2OqwBi" id="3DeU_KskO9C" role="33vP2m">
-                      <node concept="37vLTw" id="3DeU_KskO9D" role="2Oq$k0">
-                        <ref role="3cqZAo" node="2A8KNgItV65" resolve="groups" />
-                      </node>
-                      <node concept="liA8E" id="3DeU_KskO9E" role="2OqNvi">
-                        <ref role="37wK5l" to="33ny:~TreeMap.get(java.lang.Object)" resolve="get" />
-                        <node concept="37vLTw" id="3DeU_KsltHw" role="37wK5m">
-                          <ref role="3cqZAo" node="3DeU_KsltHs" resolve="groupname" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="3clFbJ" id="3DeU_KskO9G" role="3cqZAp">
-                  <node concept="3clFbS" id="3DeU_KskO9H" role="3clFbx">
-                    <node concept="3clFbF" id="3DeU_KskO9I" role="3cqZAp">
-                      <node concept="37vLTI" id="3DeU_KskO9J" role="3clFbG">
-                        <node concept="37vLTw" id="3DeU_KskO9K" role="37vLTJ">
-                          <ref role="3cqZAo" node="3DeU_KskO9_" resolve="c" />
-                        </node>
-                        <node concept="2ShNRf" id="3DeU_KskO9L" role="37vLTx">
-                          <node concept="1pGfFk" id="3DeU_KskO9M" role="2ShVmc">
-                            <ref role="37wK5l" to="33ny:~ArrayList.&lt;init&gt;(int)" resolve="ArrayList" />
-                            <node concept="3uibUv" id="3DeU_KskO9N" role="1pMfVU">
-                              <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
-                            </node>
-                            <node concept="3cmrfG" id="3DeU_KskO9O" role="37wK5m">
-                              <property role="3cmrfH" value="4" />
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="3clFbF" id="3DeU_KskO9P" role="3cqZAp">
-                      <node concept="2OqwBi" id="3DeU_KskO9Q" role="3clFbG">
-                        <node concept="37vLTw" id="3DeU_KskO9R" role="2Oq$k0">
-                          <ref role="3cqZAo" node="2A8KNgItV65" resolve="groups" />
-                        </node>
-                        <node concept="liA8E" id="3DeU_KskO9S" role="2OqNvi">
-                          <ref role="37wK5l" to="33ny:~TreeMap.put(java.lang.Object,java.lang.Object)" resolve="put" />
-                          <node concept="37vLTw" id="3DeU_KskO9T" role="37wK5m">
-                            <ref role="3cqZAo" node="3DeU_KsltHs" resolve="groupname" />
-                          </node>
-                          <node concept="37vLTw" id="3DeU_KskO9U" role="37wK5m">
-                            <ref role="3cqZAo" node="3DeU_KskO9_" resolve="c" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3clFbC" id="3DeU_KskO9V" role="3clFbw">
-                    <node concept="10Nm6u" id="3DeU_KskO9W" role="3uHU7w" />
-                    <node concept="37vLTw" id="3DeU_KskO9X" role="3uHU7B">
-                      <ref role="3cqZAo" node="3DeU_KskO9_" resolve="c" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="3clFbF" id="3DeU_KskO9Y" role="3cqZAp">
-                  <node concept="2OqwBi" id="3DeU_KskO9Z" role="3clFbG">
-                    <node concept="37vLTw" id="3DeU_KskOa0" role="2Oq$k0">
-                      <ref role="3cqZAo" node="3DeU_KskO9_" resolve="c" />
-                    </node>
-                    <node concept="liA8E" id="3DeU_KskOa1" role="2OqNvi">
-                      <ref role="37wK5l" to="33ny:~List.addAll(java.util.Collection)" resolve="addAll" />
-                      <node concept="2OqwBi" id="3DeU_Ksm6CG" role="37wK5m">
-                        <node concept="2GrUjf" id="3DeU_Ksm1vI" role="2Oq$k0">
+                      <node concept="2OqwBi" id="6ob0HsN0c5E" role="37wK5m">
+                        <node concept="2GrUjf" id="6ob0HsN09YN" role="2Oq$k0">
                           <ref role="2Gs0qQ" node="3DeU_KsjZSa" resolve="entry" />
                         </node>
-                        <node concept="3AV6Ez" id="3DeU_KsmfbO" role="2OqNvi" />
+                        <node concept="3AV6Ez" id="2H0U9nsfOGL" role="2OqNvi" />
                       </node>
                     </node>
                   </node>
@@ -1153,16 +996,401 @@
         <node concept="10P_77" id="4XO$XQbS_tQ" role="1tU5fm" />
       </node>
       <node concept="3uibUv" id="4yZHsKxM47G" role="3clF45">
-        <ref role="3uigEE" to="33ny:~TreeMap" resolve="TreeMap" />
+        <ref role="3uigEE" to="3o3z:~ListMultimap" resolve="ListMultimap" />
         <node concept="17QB3L" id="4yZHsKxM47H" role="11_B2D" />
-        <node concept="_YKpA" id="7b8v2ssg72U" role="11_B2D">
-          <node concept="3uibUv" id="7b8v2ssg72V" role="_ZDj9">
-            <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
-          </node>
+        <node concept="3uibUv" id="2H0U9ns9Nz0" role="11_B2D">
+          <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
         </node>
       </node>
     </node>
-    <node concept="2tJIrI" id="4yZHsKxN69V" role="jymVt" />
+    <node concept="2tJIrI" id="2H0U9nsgtGV" role="jymVt" />
+    <node concept="3clFb_" id="2H0U9nsj9du" role="jymVt">
+      <property role="TrG5h" value="findGroupNameForActionInCache" />
+      <node concept="3clFbS" id="2H0U9nsj9d$" role="3clF47">
+        <node concept="1DcWWT" id="2H0U9nsj9d_" role="3cqZAp">
+          <node concept="2OqwBi" id="2H0U9nsj9dA" role="1DdaDG">
+            <node concept="2OqwBi" id="2H0U9nsj9dB" role="2Oq$k0">
+              <node concept="1rXfSq" id="2H0U9nsjlpg" role="2Oq$k0">
+                <ref role="37wK5l" node="6ob0HsML7OT" resolve="getCache" />
+              </node>
+              <node concept="liA8E" id="2H0U9nsj9dD" role="2OqNvi">
+                <ref role="37wK5l" to="3o3z:~SetMultimap.asMap()" resolve="asMap" />
+              </node>
+            </node>
+            <node concept="liA8E" id="2H0U9nsj9dE" role="2OqNvi">
+              <ref role="37wK5l" to="33ny:~Map.entrySet()" resolve="entrySet" />
+            </node>
+          </node>
+          <node concept="3cpWsn" id="2H0U9nsj9dF" role="1Duv9x">
+            <property role="TrG5h" value="entry" />
+            <node concept="3uibUv" id="2H0U9nsj9dG" role="1tU5fm">
+              <ref role="3uigEE" to="33ny:~Map$Entry" resolve="Map.Entry" />
+              <node concept="17QB3L" id="2H0U9nsjxyv" role="11_B2D" />
+              <node concept="3uibUv" id="2H0U9nsj9dI" role="11_B2D">
+                <ref role="3uigEE" to="33ny:~Collection" resolve="Collection" />
+                <node concept="3uibUv" id="2H0U9nsjBso" role="11_B2D">
+                  <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbS" id="2H0U9nsj9dK" role="2LFqv$">
+            <node concept="3clFbJ" id="2H0U9nsj9dL" role="3cqZAp">
+              <node concept="2OqwBi" id="2H0U9nsj9dM" role="3clFbw">
+                <node concept="2OqwBi" id="2H0U9nsj9dN" role="2Oq$k0">
+                  <node concept="37vLTw" id="2H0U9nsj9dO" role="2Oq$k0">
+                    <ref role="3cqZAo" node="2H0U9nsj9dF" resolve="entry" />
+                  </node>
+                  <node concept="liA8E" id="2H0U9nsj9dP" role="2OqNvi">
+                    <ref role="37wK5l" to="33ny:~Map$Entry.getValue()" resolve="getValue" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="2H0U9nsj9dQ" role="2OqNvi">
+                  <ref role="37wK5l" to="33ny:~Collection.contains(java.lang.Object)" resolve="contains" />
+                  <node concept="37vLTw" id="2H0U9nsj9dR" role="37wK5m">
+                    <ref role="3cqZAo" node="2H0U9nsj9dy" resolve="action" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbS" id="2H0U9nsj9dS" role="3clFbx">
+                <node concept="3cpWs6" id="2H0U9nsj9dT" role="3cqZAp">
+                  <node concept="2OqwBi" id="2H0U9nsj9dU" role="3cqZAk">
+                    <node concept="37vLTw" id="2H0U9nsj9dV" role="2Oq$k0">
+                      <ref role="3cqZAo" node="2H0U9nsj9dF" resolve="entry" />
+                    </node>
+                    <node concept="liA8E" id="2H0U9nsj9dW" role="2OqNvi">
+                      <ref role="37wK5l" to="33ny:~Map$Entry.getKey()" resolve="getKey" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="2H0U9nsj9dX" role="3cqZAp">
+          <node concept="10Nm6u" id="2H0U9nsj9dY" role="3cqZAk" />
+        </node>
+      </node>
+      <node concept="17QB3L" id="2H0U9nsjHmc" role="3clF45" />
+      <node concept="37vLTG" id="2H0U9nsj9dy" role="3clF46">
+        <property role="TrG5h" value="action" />
+        <node concept="3uibUv" id="2H0U9nsj9dz" role="1tU5fm">
+          <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="2H0U9nsj9dZ" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="2H0U9nsgtGW" role="jymVt" />
+    <node concept="2tJIrI" id="2H0U9ns2urk" role="jymVt" />
+    <node concept="3clFb_" id="3pwG8PSpGSr" role="jymVt">
+      <property role="TrG5h" value="getGroupName" />
+      <node concept="37vLTG" id="3pwG8PSpHHh" role="3clF46">
+        <property role="TrG5h" value="action" />
+        <node concept="3uibUv" id="3pwG8PSpHTA" role="1tU5fm">
+          <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
+        </node>
+        <node concept="2AHcQZ" id="7b8v2ss4ms5" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="17QB3L" id="3pwG8PSpHC0" role="3clF45" />
+      <node concept="3clFbS" id="3pwG8PSpGSv" role="3clF47">
+        <node concept="3cpWs8" id="3pwG8PSsz1H" role="3cqZAp">
+          <node concept="3cpWsn" id="3pwG8PSsz1K" role="3cpWs9">
+            <property role="TrG5h" value="groupName" />
+            <node concept="17QB3L" id="3pwG8PSsz1F" role="1tU5fm" />
+            <node concept="2OqwBi" id="6Kw22eWaqPv" role="33vP2m">
+              <node concept="2OqwBi" id="6Kw22eWadXy" role="2Oq$k0">
+                <node concept="37vLTw" id="6Kw22eWa98k" role="2Oq$k0">
+                  <ref role="3cqZAo" node="3pwG8PSpHHh" resolve="action" />
+                </node>
+                <node concept="liA8E" id="6Kw22eWamfe" role="2OqNvi">
+                  <ref role="37wK5l" to="qkt:~AnAction.getTemplatePresentation()" resolve="getTemplatePresentation" />
+                </node>
+              </node>
+              <node concept="liA8E" id="6Kw22eWavqG" role="2OqNvi">
+                <ref role="37wK5l" to="qkt:~Presentation.getClientProperty(com.intellij.openapi.util.Key)" resolve="getClientProperty" />
+                <node concept="37vLTw" id="2VOpD3139MX" role="37wK5m">
+                  <ref role="3cqZAo" node="6Kw22eW7L03" resolve="GROUPNAME_KEY" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="2VOpD313Esp" role="3cqZAp">
+          <node concept="3clFbS" id="2VOpD313Esr" role="3clFbx">
+            <node concept="3cpWs6" id="2VOpD3146s2" role="3cqZAp">
+              <node concept="37vLTw" id="2VOpD314eLY" role="3cqZAk">
+                <ref role="3cqZAo" node="3pwG8PSsz1K" resolve="groupName" />
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="2VOpD313TPJ" role="3clFbw">
+            <node concept="37vLTw" id="2VOpD313J2H" role="2Oq$k0">
+              <ref role="3cqZAo" node="3pwG8PSsz1K" resolve="groupName" />
+            </node>
+            <node concept="17RvpY" id="2VOpD3141HS" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="2tnlAX7XkA" role="3cqZAp" />
+        <node concept="3cpWs8" id="1x595U4mUSB" role="3cqZAp">
+          <node concept="3cpWsn" id="1x595U4mUSC" role="3cpWs9">
+            <property role="TrG5h" value="key" />
+            <node concept="17QB3L" id="2H0U9nshUh$" role="1tU5fm" />
+            <node concept="1rXfSq" id="2H0U9nsgWiO" role="33vP2m">
+              <ref role="37wK5l" node="2H0U9nsj9du" resolve="findGroupNameForActionInCache" />
+              <node concept="37vLTw" id="2H0U9nshe_z" role="37wK5m">
+                <ref role="3cqZAo" node="3pwG8PSpHHh" resolve="action" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="1x595U4nHge" role="3cqZAp">
+          <node concept="3clFbS" id="1x595U4nHgg" role="3clFbx">
+            <node concept="3cpWs6" id="1x595U4ofeh" role="3cqZAp">
+              <node concept="37vLTw" id="1x595U4oflY" role="3cqZAk">
+                <ref role="3cqZAo" node="1x595U4mUSC" resolve="key" />
+              </node>
+            </node>
+          </node>
+          <node concept="3y3z36" id="1x595U4o4Qa" role="3clFbw">
+            <node concept="10Nm6u" id="1x595U4o8R5" role="3uHU7w" />
+            <node concept="37vLTw" id="1x595U4nHnS" role="3uHU7B">
+              <ref role="3cqZAo" node="1x595U4mUSC" resolve="key" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="1x595U4nwOr" role="3cqZAp" />
+        <node concept="3clFbJ" id="2xgTENkV5Ei" role="3cqZAp">
+          <node concept="3clFbS" id="2xgTENkV5Ek" role="3clFbx">
+            <node concept="3cpWs6" id="2xgTENkV7jA" role="3cqZAp">
+              <node concept="2OqwBi" id="2xgTENkV8gI" role="3cqZAk">
+                <node concept="1eOMI4" id="2xgTENkV7DH" role="2Oq$k0">
+                  <node concept="10QFUN" id="2xgTENkV7DE" role="1eOMHV">
+                    <node concept="3uibUv" id="2xgTENkV7DJ" role="10QFUM">
+                      <ref role="3uigEE" node="2jDew64QLb0" resolve="IntentionActionGroup" />
+                    </node>
+                    <node concept="37vLTw" id="2xgTENkV7DK" role="10QFUP">
+                      <ref role="3cqZAo" node="3pwG8PSpHHh" resolve="action" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="liA8E" id="2xgTENkV9CR" role="2OqNvi">
+                  <ref role="37wK5l" node="2jDew64QLcf" resolve="getGroupName" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2ZW3vV" id="2xgTENkV6Ko" role="3clFbw">
+            <node concept="3uibUv" id="2xgTENkV7fT" role="2ZW6by">
+              <ref role="3uigEE" node="2jDew64QLb0" resolve="IntentionActionGroup" />
+            </node>
+            <node concept="37vLTw" id="2xgTENkV6ay" role="2ZW6bz">
+              <ref role="3cqZAo" node="3pwG8PSpHHh" resolve="action" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3pwG8PSsoLy" role="3cqZAp">
+          <node concept="3cpWsn" id="3pwG8PSsoLz" role="3cpWs9">
+            <property role="TrG5h" value="text" />
+            <node concept="17QB3L" id="3pwG8PSspYn" role="1tU5fm" />
+            <node concept="2OqwBi" id="3pwG8PSsoL$" role="33vP2m">
+              <node concept="2OqwBi" id="3pwG8PSsoL_" role="2Oq$k0">
+                <node concept="37vLTw" id="3pwG8PSsoLA" role="2Oq$k0">
+                  <ref role="3cqZAo" node="3pwG8PSpHHh" resolve="action" />
+                </node>
+                <node concept="liA8E" id="3pwG8PSsoLB" role="2OqNvi">
+                  <ref role="37wK5l" to="qkt:~AnAction.getTemplatePresentation()" resolve="getTemplatePresentation" />
+                </node>
+              </node>
+              <node concept="liA8E" id="3pwG8PSsoLC" role="2OqNvi">
+                <ref role="37wK5l" to="qkt:~Presentation.getText()" resolve="getText" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="3pwG8PSsrmI" role="3cqZAp">
+          <node concept="3clFbS" id="3pwG8PSsrmK" role="3clFbx">
+            <node concept="3cpWs6" id="3pwG8PSsrWM" role="3cqZAp">
+              <node concept="Xl_RD" id="3pwG8PSssf3" role="3cqZAk">
+                <property role="Xl_RC" value="" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbC" id="3pwG8PSsrTY" role="3clFbw">
+            <node concept="10Nm6u" id="3pwG8PSsrWc" role="3uHU7w" />
+            <node concept="37vLTw" id="3pwG8PSsrGf" role="3uHU7B">
+              <ref role="3cqZAo" node="3pwG8PSsoLz" resolve="text" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="3pwG8PSsqXD" role="3cqZAp" />
+        <node concept="3cpWs8" id="3pwG8PSsv5W" role="3cqZAp">
+          <node concept="3cpWsn" id="3pwG8PSsv5X" role="3cpWs9">
+            <property role="TrG5h" value="separatorPosition" />
+            <node concept="10Oyi0" id="3pwG8PSsv5O" role="1tU5fm" />
+            <node concept="2OqwBi" id="3pwG8PSsv5Y" role="33vP2m">
+              <node concept="37vLTw" id="3pwG8PSsv5Z" role="2Oq$k0">
+                <ref role="3cqZAo" node="3pwG8PSsoLz" resolve="text" />
+              </node>
+              <node concept="liA8E" id="3pwG8PSsv60" role="2OqNvi">
+                <ref role="37wK5l" to="wyt6:~String.indexOf(java.lang.String)" resolve="indexOf" />
+                <node concept="Xl_RD" id="3pwG8PSsv61" role="37wK5m">
+                  <property role="Xl_RC" value=":" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="3pwG8PSsw$H" role="3cqZAp">
+          <node concept="3clFbS" id="3pwG8PSsw$J" role="3clFbx">
+            <node concept="3cpWs6" id="3pwG8PSsxQ$" role="3cqZAp">
+              <node concept="Xl_RD" id="3pwG8PSsybc" role="3cqZAk" />
+            </node>
+          </node>
+          <node concept="3eOVzh" id="3pwG8PSsxLI" role="3clFbw">
+            <node concept="3cmrfG" id="3pwG8PSsxLV" role="3uHU7w">
+              <property role="3cmrfH" value="0" />
+            </node>
+            <node concept="37vLTw" id="3pwG8PSsx1b" role="3uHU7B">
+              <ref role="3cqZAo" node="3pwG8PSsv5X" resolve="separatorPosition" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="3pwG8PSsw8P" role="3cqZAp" />
+        <node concept="3clFbF" id="2VOpD312DcT" role="3cqZAp">
+          <node concept="37vLTI" id="2VOpD312DcV" role="3clFbG">
+            <node concept="2OqwBi" id="3pwG8PSszBn" role="37vLTx">
+              <node concept="37vLTw" id="3pwG8PSszxq" role="2Oq$k0">
+                <ref role="3cqZAo" node="3pwG8PSsoLz" resolve="text" />
+              </node>
+              <node concept="liA8E" id="3pwG8PSs$mC" role="2OqNvi">
+                <ref role="37wK5l" to="wyt6:~String.substring(int,int)" resolve="substring" />
+                <node concept="3cmrfG" id="3pwG8PSs$nV" role="37wK5m">
+                  <property role="3cmrfH" value="0" />
+                </node>
+                <node concept="37vLTw" id="3pwG8PSs$Ep" role="37wK5m">
+                  <ref role="3cqZAo" node="3pwG8PSsv5X" resolve="separatorPosition" />
+                </node>
+              </node>
+            </node>
+            <node concept="37vLTw" id="2VOpD312DcZ" role="37vLTJ">
+              <ref role="3cqZAo" node="3pwG8PSsz1K" resolve="groupName" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6Kw22eW9sg7" role="3cqZAp" />
+        <node concept="3cpWs6" id="3pwG8PSs_F8" role="3cqZAp">
+          <node concept="37vLTw" id="3pwG8PSsAzu" role="3cqZAk">
+            <ref role="3cqZAo" node="3pwG8PSsz1K" resolve="groupName" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="3pwG8PSsKNl" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+      </node>
+      <node concept="3Tm1VV" id="6ob0HsMOPZX" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="6ob0HsMQoQq" role="jymVt" />
+    <node concept="3clFb_" id="6ob0HsML7OT" role="jymVt">
+      <property role="TrG5h" value="getCache" />
+      <node concept="3clFbS" id="6ob0HsML7OW" role="3clF47">
+        <node concept="3clFbF" id="6ob0HsMLHeC" role="3cqZAp">
+          <node concept="37vLTw" id="6ob0HsMLHeB" role="3clFbG">
+            <ref role="3cqZAo" node="5Rdndlpp80A" resolve="groupedActionsCache" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="6ob0HsMLhPo" role="1B3o_S" />
+      <node concept="3uibUv" id="4rzEAhzrkch" role="3clF45">
+        <ref role="3uigEE" to="3o3z:~SetMultimap" resolve="SetMultimap" />
+        <node concept="17QB3L" id="4rzEAhzrkci" role="11_B2D" />
+        <node concept="3uibUv" id="4rzEAhzrkcj" role="11_B2D">
+          <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6ob0HsMPj78" role="jymVt" />
+    <node concept="3clFb_" id="2jDew64RVuQ" role="jymVt">
+      <property role="TrG5h" value="executeIntention" />
+      <node concept="3clFbS" id="2jDew64RVuS" role="3clF47">
+        <node concept="3clFbF" id="2jDew64RVvd" role="3cqZAp">
+          <node concept="2OqwBi" id="2jDew64RVve" role="3clFbG">
+            <node concept="1rXfSq" id="2jDew64RVvf" role="2Oq$k0">
+              <ref role="37wK5l" node="3pwG8PSkQQM" resolve="getModelAccess" />
+            </node>
+            <node concept="liA8E" id="2jDew64RVvg" role="2OqNvi">
+              <ref role="37wK5l" to="lui2:~ModelAccess.executeCommandInEDT(java.lang.Runnable)" resolve="executeCommandInEDT" />
+              <node concept="2ShNRf" id="2jDew64RVvh" role="37wK5m">
+                <node concept="YeOm9" id="2jDew64RVvi" role="2ShVmc">
+                  <node concept="1Y3b0j" id="2jDew64RVvj" role="YeSDq">
+                    <property role="2bfB8j" value="true" />
+                    <property role="1sVAO0" value="false" />
+                    <property role="1EXbeo" value="false" />
+                    <ref role="1Y3XeK" to="nlpl:~EditorCommand" resolve="EditorCommand" />
+                    <ref role="37wK5l" to="nlpl:~EditorCommand.&lt;init&gt;(jetbrains.mps.openapi.editor.EditorComponent)" resolve="EditorCommand" />
+                    <node concept="3Tm1VV" id="2jDew64RVvk" role="1B3o_S" />
+                    <node concept="3clFb_" id="2jDew64RVvl" role="jymVt">
+                      <property role="TrG5h" value="doExecute" />
+                      <property role="DiZV1" value="false" />
+                      <property role="od$2w" value="false" />
+                      <node concept="2AHcQZ" id="2jDew64RVvm" role="2AJF6D">
+                        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                      </node>
+                      <node concept="3clFbS" id="2jDew64RVvn" role="3clF47">
+                        <node concept="3clFbF" id="2jDew64RVvo" role="3cqZAp">
+                          <node concept="2OqwBi" id="2jDew64RVvp" role="3clFbG">
+                            <node concept="37vLTw" id="2jDew64RVvq" role="2Oq$k0">
+                              <ref role="3cqZAo" node="2jDew64RVv$" resolve="intention" />
+                            </node>
+                            <node concept="liA8E" id="2jDew64RVvr" role="2OqNvi">
+                              <ref role="37wK5l" to="nddn:~IntentionExecutable.execute(org.jetbrains.mps.openapi.model.SNode,jetbrains.mps.openapi.editor.EditorContext)" resolve="execute" />
+                              <node concept="37vLTw" id="2jDew64RVvs" role="37wK5m">
+                                <ref role="3cqZAo" node="2jDew64RVvA" resolve="node" />
+                              </node>
+                              <node concept="2OqwBi" id="2jDew64RVvt" role="37wK5m">
+                                <node concept="37vLTw" id="2jDew64RVvu" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="2jDew64KOaH" resolve="editor" />
+                                </node>
+                                <node concept="liA8E" id="2jDew64RVvv" role="2OqNvi">
+                                  <ref role="37wK5l" to="exr9:~EditorComponent.getEditorContext()" resolve="getEditorContext" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3Tm1VV" id="2jDew64RVvw" role="1B3o_S" />
+                      <node concept="3cqZAl" id="2jDew64RVvx" role="3clF45" />
+                    </node>
+                    <node concept="37vLTw" id="2jDew64RVvy" role="37wK5m">
+                      <ref role="3cqZAo" node="2jDew64KOaH" resolve="editor" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3cqZAl" id="2jDew64RVvz" role="3clF45" />
+      <node concept="37vLTG" id="2jDew64RVv$" role="3clF46">
+        <property role="TrG5h" value="intention" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3uibUv" id="2jDew64RVv_" role="1tU5fm">
+          <ref role="3uigEE" to="nddn:~IntentionExecutable" resolve="IntentionExecutable" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="2jDew64RVvA" role="3clF46">
+        <property role="TrG5h" value="node" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3uibUv" id="2jDew64RVvB" role="1tU5fm">
+          <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="2jDew64RVvC" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="6ob0HsMRL5h" role="jymVt" />
     <node concept="3clFb_" id="4yZHsKxNkJT" role="jymVt">
       <property role="TrG5h" value="populateMainMenu" />
       <node concept="37vLTG" id="4yZHsKxO40S" role="3clF46">
@@ -1177,12 +1405,10 @@
       <node concept="37vLTG" id="4yZHsKxNOS$" role="3clF46">
         <property role="TrG5h" value="groups" />
         <node concept="3uibUv" id="4yZHsKxNX6I" role="1tU5fm">
-          <ref role="3uigEE" to="33ny:~TreeMap" resolve="TreeMap" />
+          <ref role="3uigEE" to="3o3z:~Multimap" resolve="Multimap" />
           <node concept="17QB3L" id="4yZHsKxNX6J" role="11_B2D" />
-          <node concept="_YKpA" id="7b8v2ssb_dT" role="11_B2D">
-            <node concept="3uibUv" id="7b8v2ssbFSJ" role="_ZDj9">
-              <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
-            </node>
+          <node concept="3uibUv" id="2H0U9nsbPo4" role="11_B2D">
+            <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
           </node>
         </node>
         <node concept="2AHcQZ" id="7b8v2ss2H8e" role="2AJF6D">
@@ -1203,9 +1429,7 @@
                   <node concept="2GrUjf" id="2A8KNgIu5eV" role="2Oq$k0">
                     <ref role="2Gs0qQ" node="2A8KNgIu5eP" resolve="entry" />
                   </node>
-                  <node concept="liA8E" id="2A8KNgIu5eW" role="2OqNvi">
-                    <ref role="37wK5l" to="33ny:~Map$Entry.getKey()" resolve="getKey" />
-                  </node>
+                  <node concept="3AY5_j" id="2H0U9nskNcq" role="2OqNvi" />
                 </node>
               </node>
             </node>
@@ -1256,9 +1480,7 @@
                       <node concept="2GrUjf" id="2A8KNgIu5fk" role="2Oq$k0">
                         <ref role="2Gs0qQ" node="2A8KNgIu5eP" resolve="entry" />
                       </node>
-                      <node concept="liA8E" id="2A8KNgIu5fl" role="2OqNvi">
-                        <ref role="37wK5l" to="33ny:~Map$Entry.getValue()" resolve="getValue" />
-                      </node>
+                      <node concept="3AV6Ez" id="2H0U9nskTx3" role="2OqNvi" />
                     </node>
                     <node concept="3uibUv" id="2A8KNgIu5fm" role="1pMfVU">
                       <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
@@ -1303,16 +1525,16 @@
             </node>
           </node>
           <node concept="2OqwBi" id="2A8KNgIu5fy" role="2GsD0m">
-            <node concept="liA8E" id="2A8KNgIu5fz" role="2OqNvi">
-              <ref role="37wK5l" to="33ny:~TreeMap.entrySet()" resolve="entrySet" />
-            </node>
             <node concept="37vLTw" id="2A8KNgIu5f$" role="2Oq$k0">
               <ref role="3cqZAo" node="4yZHsKxNOS$" resolve="groups" />
+            </node>
+            <node concept="liA8E" id="2H0U9nskGCX" role="2OqNvi">
+              <ref role="37wK5l" to="3o3z:~Multimap.asMap()" resolve="asMap" />
             </node>
           </node>
         </node>
       </node>
-      <node concept="3Tm1VV" id="4yZHsKxNeMy" role="1B3o_S" />
+      <node concept="3Tmbuc" id="6ob0HsMO9tW" role="1B3o_S" />
       <node concept="3cqZAl" id="4yZHsKxNeM_" role="3clF45" />
     </node>
     <node concept="2tJIrI" id="2A8KNgIsgsF" role="jymVt" />
@@ -1374,26 +1596,15 @@
           <node concept="3cpWsn" id="4yZHsKxPnSB" role="3cpWs9">
             <property role="TrG5h" value="groups" />
             <node concept="3uibUv" id="4yZHsKxPnSC" role="1tU5fm">
-              <ref role="3uigEE" to="33ny:~TreeMap" resolve="TreeMap" />
+              <ref role="3uigEE" to="3o3z:~Multimap" resolve="Multimap" />
               <node concept="17QB3L" id="4yZHsKxPnSD" role="11_B2D" />
-              <node concept="3uibUv" id="4yZHsKxPnSE" role="11_B2D">
-                <ref role="3uigEE" to="33ny:~List" resolve="List" />
-                <node concept="3uibUv" id="4yZHsKxPnSF" role="11_B2D">
-                  <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
-                </node>
+              <node concept="3uibUv" id="2H0U9nsaQF$" role="11_B2D">
+                <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
               </node>
             </node>
-            <node concept="2ShNRf" id="4yZHsKxPnSG" role="33vP2m">
-              <node concept="1pGfFk" id="4yZHsKxPnSH" role="2ShVmc">
-                <ref role="37wK5l" to="33ny:~TreeMap.&lt;init&gt;()" resolve="TreeMap" />
-                <node concept="17QB3L" id="4yZHsKxPnSI" role="1pMfVU" />
-                <node concept="3uibUv" id="4yZHsKxPnSJ" role="1pMfVU">
-                  <ref role="3uigEE" to="33ny:~List" resolve="List" />
-                  <node concept="3uibUv" id="4yZHsKxPnSK" role="11_B2D">
-                    <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
-                  </node>
-                </node>
-              </node>
+            <node concept="2YIFZM" id="2H0U9nsbsae" role="33vP2m">
+              <ref role="37wK5l" to="3o3z:~HashMultimap.create()" resolve="create" />
+              <ref role="1Pybhc" to="3o3z:~HashMultimap" resolve="HashMultimap" />
             </node>
           </node>
         </node>
@@ -1470,7 +1681,7 @@
                           <ref role="3cqZAo" node="4yZHsKxPnSB" resolve="groups" />
                         </node>
                         <node concept="liA8E" id="4yZHsKxQ5zU" role="2OqNvi">
-                          <ref role="37wK5l" to="33ny:~TreeMap.putAll(java.util.Map)" resolve="putAll" />
+                          <ref role="37wK5l" to="3o3z:~Multimap.putAll(com.google.common.collect.Multimap)" resolve="putAll" />
                           <node concept="1rXfSq" id="2A8KNgIJ8T7" role="37wK5m">
                             <ref role="37wK5l" node="2A8KNgIs$a3" resolve="processActionGroup" />
                             <node concept="37vLTw" id="2A8KNgIJgG$" role="37wK5m">
@@ -1576,7 +1787,7 @@
               <ref role="3cqZAo" node="4yZHsKxPnSB" resolve="groups" />
             </node>
             <node concept="liA8E" id="4yZHsKxQQHf" role="2OqNvi">
-              <ref role="37wK5l" to="33ny:~TreeMap.putAll(java.util.Map)" resolve="putAll" />
+              <ref role="37wK5l" to="3o3z:~Multimap.putAll(com.google.common.collect.Multimap)" resolve="putAll" />
               <node concept="1rXfSq" id="2A8KNgIxjc9" role="37wK5m">
                 <ref role="37wK5l" node="2A8KNgIs$a3" resolve="processActionGroup" />
                 <node concept="37vLTw" id="2A8KNgIxreA" role="37wK5m">
@@ -1956,54 +2167,18 @@
             </node>
           </node>
         </node>
-        <node concept="3clFbH" id="lMPJvibRGm" role="3cqZAp" />
-        <node concept="3clFbJ" id="1eqBxP9lFhT" role="3cqZAp">
-          <node concept="3clFbS" id="1eqBxP9lFhN" role="3clFbx">
-            <node concept="3clFbF" id="2Ef_vJ5TrUj" role="3cqZAp">
-              <node concept="37vLTI" id="2Ef_vJ5Uf3A" role="3clFbG">
-                <node concept="3EllGN" id="2Ef_vJ5TAZ3" role="37vLTJ">
-                  <node concept="37vLTw" id="lMPJvidi7Y" role="3ElVtu">
-                    <ref role="3cqZAo" node="lMPJviaN1m" resolve="groupName" />
-                  </node>
-                  <node concept="37vLTw" id="lMPJvi8dK4" role="3ElQJh">
-                    <ref role="3cqZAo" node="5Rdndlpp80A" resolve="groupedActionsCache" />
-                  </node>
-                </node>
-                <node concept="2ShNRf" id="2Ef_vJ5Xqw6" role="37vLTx">
-                  <node concept="32HrFt" id="2Ef_vJ5Xqrg" role="2ShVmc">
-                    <node concept="3uibUv" id="2Ef_vJ5Xqrh" role="HW$YZ">
-                      <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
-                    </node>
-                  </node>
-                </node>
-              </node>
+        <node concept="3clFbH" id="2H0U9ns1deQ" role="3cqZAp" />
+        <node concept="3clFbF" id="2H0U9nrVSDe" role="3cqZAp">
+          <node concept="2OqwBi" id="2H0U9nrW9Mp" role="3clFbG">
+            <node concept="1rXfSq" id="2H0U9nrVSDi" role="2Oq$k0">
+              <ref role="37wK5l" node="6ob0HsML7OT" resolve="getCache" />
             </node>
-          </node>
-          <node concept="3fqX7Q" id="1eqBxP9lFhV" role="3clFbw">
-            <node concept="2OqwBi" id="1eqBxP9lFhP" role="3fr31v">
-              <node concept="37vLTw" id="lMPJvi8dK_" role="2Oq$k0">
-                <ref role="3cqZAo" node="5Rdndlpp80A" resolve="groupedActionsCache" />
-              </node>
-              <node concept="2Nt0df" id="1eqBxP9lFhR" role="2OqNvi">
-                <node concept="37vLTw" id="1eqBxP9lFhX" role="38cxEo">
-                  <ref role="3cqZAo" node="lMPJviaN1m" resolve="groupName" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="7MgvKqknvqX" role="3cqZAp">
-          <node concept="2OqwBi" id="2Ef_vJ5VG$q" role="3clFbG">
-            <node concept="3EllGN" id="2Ef_vJ5RAL8" role="2Oq$k0">
-              <node concept="37vLTw" id="lMPJvidq_z" role="3ElVtu">
+            <node concept="liA8E" id="2H0U9nrWe4M" role="2OqNvi">
+              <ref role="37wK5l" to="3o3z:~Multimap.put(java.lang.Object,java.lang.Object)" resolve="put" />
+              <node concept="37vLTw" id="2H0U9nrWCn5" role="37wK5m">
                 <ref role="3cqZAo" node="lMPJviaN1m" resolve="groupName" />
               </node>
-              <node concept="37vLTw" id="lMPJvi8dL6" role="3ElQJh">
-                <ref role="3cqZAo" node="5Rdndlpp80A" resolve="groupedActionsCache" />
-              </node>
-            </node>
-            <node concept="TSZUe" id="2Ef_vJ5XF4x" role="2OqNvi">
-              <node concept="37vLTw" id="lMPJvid8A$" role="25WWJ7">
+              <node concept="37vLTw" id="2H0U9nrWJmC" role="37wK5m">
                 <ref role="3cqZAo" node="lMPJvi8JyR" resolve="oldAction" />
               </node>
             </node>
@@ -2011,7 +2186,7 @@
         </node>
         <node concept="3clFbH" id="2Ef_vJ5Vswn" role="3cqZAp" />
       </node>
-      <node concept="3Tm1VV" id="lMPJvi7SXa" role="1B3o_S" />
+      <node concept="3Tmbuc" id="6ob0HsMOj3L" role="1B3o_S" />
       <node concept="3cqZAl" id="lMPJvi7Ziq" role="3clF45" />
       <node concept="37vLTG" id="lMPJvi9cDl" role="3clF46">
         <property role="TrG5h" value="mainGroup" />
@@ -2186,7 +2361,7 @@
           </node>
         </node>
       </node>
-      <node concept="3Tm1VV" id="7b8v2ssEN4o" role="1B3o_S" />
+      <node concept="3Tmbuc" id="6ob0HsMOuMX" role="1B3o_S" />
       <node concept="17QB3L" id="7b8v2ssEWNj" role="3clF45" />
     </node>
     <node concept="2tJIrI" id="7b8v2ssPSeP" role="jymVt" />
@@ -2310,255 +2485,11 @@
           </node>
         </node>
       </node>
-      <node concept="3Tm1VV" id="7b8v2ssPXpf" role="1B3o_S" />
+      <node concept="3Tmbuc" id="6ob0HsMO_Dk" role="1B3o_S" />
       <node concept="17QB3L" id="7b8v2ssPXpg" role="3clF45" />
     </node>
     <node concept="2tJIrI" id="7b8v2ssPXol" role="jymVt" />
     <node concept="2tJIrI" id="2jDew64Pxne" role="jymVt" />
-    <node concept="3clFb_" id="3pwG8PSpGSr" role="jymVt">
-      <property role="TrG5h" value="getGroupName" />
-      <node concept="37vLTG" id="3pwG8PSpHHh" role="3clF46">
-        <property role="TrG5h" value="action" />
-        <node concept="3uibUv" id="3pwG8PSpHTA" role="1tU5fm">
-          <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
-        </node>
-        <node concept="2AHcQZ" id="7b8v2ss4ms5" role="2AJF6D">
-          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
-        </node>
-      </node>
-      <node concept="17QB3L" id="3pwG8PSpHC0" role="3clF45" />
-      <node concept="3clFbS" id="3pwG8PSpGSv" role="3clF47">
-        <node concept="3cpWs8" id="3pwG8PSsz1H" role="3cqZAp">
-          <node concept="3cpWsn" id="3pwG8PSsz1K" role="3cpWs9">
-            <property role="TrG5h" value="groupName" />
-            <node concept="17QB3L" id="3pwG8PSsz1F" role="1tU5fm" />
-            <node concept="2OqwBi" id="6Kw22eWaqPv" role="33vP2m">
-              <node concept="2OqwBi" id="6Kw22eWadXy" role="2Oq$k0">
-                <node concept="37vLTw" id="6Kw22eWa98k" role="2Oq$k0">
-                  <ref role="3cqZAo" node="3pwG8PSpHHh" resolve="action" />
-                </node>
-                <node concept="liA8E" id="6Kw22eWamfe" role="2OqNvi">
-                  <ref role="37wK5l" to="qkt:~AnAction.getTemplatePresentation()" resolve="getTemplatePresentation" />
-                </node>
-              </node>
-              <node concept="liA8E" id="6Kw22eWavqG" role="2OqNvi">
-                <ref role="37wK5l" to="qkt:~Presentation.getClientProperty(com.intellij.openapi.util.Key)" resolve="getClientProperty" />
-                <node concept="37vLTw" id="2VOpD3139MX" role="37wK5m">
-                  <ref role="3cqZAo" node="6Kw22eW7L03" resolve="GROUPNAME_KEY" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbJ" id="2VOpD313Esp" role="3cqZAp">
-          <node concept="3clFbS" id="2VOpD313Esr" role="3clFbx">
-            <node concept="3cpWs6" id="2VOpD3146s2" role="3cqZAp">
-              <node concept="37vLTw" id="2VOpD314eLY" role="3cqZAk">
-                <ref role="3cqZAo" node="3pwG8PSsz1K" resolve="groupName" />
-              </node>
-            </node>
-          </node>
-          <node concept="2OqwBi" id="2VOpD313TPJ" role="3clFbw">
-            <node concept="37vLTw" id="2VOpD313J2H" role="2Oq$k0">
-              <ref role="3cqZAo" node="3pwG8PSsz1K" resolve="groupName" />
-            </node>
-            <node concept="17RvpY" id="2VOpD3141HS" role="2OqNvi" />
-          </node>
-        </node>
-        <node concept="3clFbH" id="2tnlAX7XkA" role="3cqZAp" />
-        <node concept="3cpWs8" id="1x595U4mUSB" role="3cqZAp">
-          <node concept="3cpWsn" id="1x595U4mUSC" role="3cpWs9">
-            <property role="TrG5h" value="entry" />
-            <node concept="3f3tKP" id="1x595U4mRaR" role="1tU5fm">
-              <node concept="17QB3L" id="1x595U4mRb0" role="3f3zw5" />
-              <node concept="2hMVRd" id="1x595U4mRb1" role="3f3$T$">
-                <node concept="3uibUv" id="1x595U4mRb2" role="2hN53Y">
-                  <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
-                </node>
-              </node>
-            </node>
-            <node concept="2OqwBi" id="1x595U4mUSD" role="33vP2m">
-              <node concept="37vLTw" id="1x595U4nAVf" role="2Oq$k0">
-                <ref role="3cqZAo" node="5Rdndlpp80A" resolve="groupedActionsCache" />
-              </node>
-              <node concept="1z4cxt" id="1x595U4mUSF" role="2OqNvi">
-                <node concept="1bVj0M" id="1x595U4mUSG" role="23t8la">
-                  <node concept="3clFbS" id="1x595U4mUSH" role="1bW5cS">
-                    <node concept="3clFbF" id="1x595U4mUSI" role="3cqZAp">
-                      <node concept="2OqwBi" id="1x595U4mUSJ" role="3clFbG">
-                        <node concept="2OqwBi" id="1x595U4mUSK" role="2Oq$k0">
-                          <node concept="37vLTw" id="1x595U4mUSL" role="2Oq$k0">
-                            <ref role="3cqZAo" node="1x595U4mUSP" resolve="it" />
-                          </node>
-                          <node concept="3AV6Ez" id="1x595U4mUSM" role="2OqNvi" />
-                        </node>
-                        <node concept="3JPx81" id="1x595U4mUSN" role="2OqNvi">
-                          <node concept="37vLTw" id="1x595U4mUSO" role="25WWJ7">
-                            <ref role="3cqZAo" node="3pwG8PSpHHh" resolve="action" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="gl6BB" id="1x595U4mUSP" role="1bW2Oz">
-                    <property role="TrG5h" value="it" />
-                    <node concept="2jxLKc" id="1x595U4mUSQ" role="1tU5fm" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbJ" id="1x595U4nHge" role="3cqZAp">
-          <node concept="3clFbS" id="1x595U4nHgg" role="3clFbx">
-            <node concept="3cpWs6" id="1x595U4ofeh" role="3cqZAp">
-              <node concept="2OqwBi" id="1x595U4opVq" role="3cqZAk">
-                <node concept="37vLTw" id="1x595U4oflY" role="2Oq$k0">
-                  <ref role="3cqZAo" node="1x595U4mUSC" resolve="entry" />
-                </node>
-                <node concept="3AY5_j" id="1x595U4owov" role="2OqNvi" />
-              </node>
-            </node>
-          </node>
-          <node concept="3y3z36" id="1x595U4o4Qa" role="3clFbw">
-            <node concept="10Nm6u" id="1x595U4o8R5" role="3uHU7w" />
-            <node concept="37vLTw" id="1x595U4nHnS" role="3uHU7B">
-              <ref role="3cqZAo" node="1x595U4mUSC" resolve="entry" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbH" id="1x595U4nwOr" role="3cqZAp" />
-        <node concept="3clFbJ" id="2xgTENkV5Ei" role="3cqZAp">
-          <node concept="3clFbS" id="2xgTENkV5Ek" role="3clFbx">
-            <node concept="3cpWs6" id="2xgTENkV7jA" role="3cqZAp">
-              <node concept="2OqwBi" id="2xgTENkV8gI" role="3cqZAk">
-                <node concept="1eOMI4" id="2xgTENkV7DH" role="2Oq$k0">
-                  <node concept="10QFUN" id="2xgTENkV7DE" role="1eOMHV">
-                    <node concept="3uibUv" id="2xgTENkV7DJ" role="10QFUM">
-                      <ref role="3uigEE" node="2jDew64QLb0" resolve="IntentionActionGroup" />
-                    </node>
-                    <node concept="37vLTw" id="2xgTENkV7DK" role="10QFUP">
-                      <ref role="3cqZAo" node="3pwG8PSpHHh" resolve="action" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="liA8E" id="2xgTENkV9CR" role="2OqNvi">
-                  <ref role="37wK5l" node="2jDew64QLcf" resolve="getGroupName" />
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="2ZW3vV" id="2xgTENkV6Ko" role="3clFbw">
-            <node concept="3uibUv" id="2xgTENkV7fT" role="2ZW6by">
-              <ref role="3uigEE" node="2jDew64QLb0" resolve="IntentionActionGroup" />
-            </node>
-            <node concept="37vLTw" id="2xgTENkV6ay" role="2ZW6bz">
-              <ref role="3cqZAo" node="3pwG8PSpHHh" resolve="action" />
-            </node>
-          </node>
-        </node>
-        <node concept="3cpWs8" id="3pwG8PSsoLy" role="3cqZAp">
-          <node concept="3cpWsn" id="3pwG8PSsoLz" role="3cpWs9">
-            <property role="TrG5h" value="text" />
-            <node concept="17QB3L" id="3pwG8PSspYn" role="1tU5fm" />
-            <node concept="2OqwBi" id="3pwG8PSsoL$" role="33vP2m">
-              <node concept="2OqwBi" id="3pwG8PSsoL_" role="2Oq$k0">
-                <node concept="37vLTw" id="3pwG8PSsoLA" role="2Oq$k0">
-                  <ref role="3cqZAo" node="3pwG8PSpHHh" resolve="action" />
-                </node>
-                <node concept="liA8E" id="3pwG8PSsoLB" role="2OqNvi">
-                  <ref role="37wK5l" to="qkt:~AnAction.getTemplatePresentation()" resolve="getTemplatePresentation" />
-                </node>
-              </node>
-              <node concept="liA8E" id="3pwG8PSsoLC" role="2OqNvi">
-                <ref role="37wK5l" to="qkt:~Presentation.getText()" resolve="getText" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbJ" id="3pwG8PSsrmI" role="3cqZAp">
-          <node concept="3clFbS" id="3pwG8PSsrmK" role="3clFbx">
-            <node concept="3cpWs6" id="3pwG8PSsrWM" role="3cqZAp">
-              <node concept="Xl_RD" id="3pwG8PSssf3" role="3cqZAk">
-                <property role="Xl_RC" value="" />
-              </node>
-            </node>
-          </node>
-          <node concept="3clFbC" id="3pwG8PSsrTY" role="3clFbw">
-            <node concept="10Nm6u" id="3pwG8PSsrWc" role="3uHU7w" />
-            <node concept="37vLTw" id="3pwG8PSsrGf" role="3uHU7B">
-              <ref role="3cqZAo" node="3pwG8PSsoLz" resolve="text" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbH" id="3pwG8PSsqXD" role="3cqZAp" />
-        <node concept="3cpWs8" id="3pwG8PSsv5W" role="3cqZAp">
-          <node concept="3cpWsn" id="3pwG8PSsv5X" role="3cpWs9">
-            <property role="TrG5h" value="separatorPosition" />
-            <node concept="10Oyi0" id="3pwG8PSsv5O" role="1tU5fm" />
-            <node concept="2OqwBi" id="3pwG8PSsv5Y" role="33vP2m">
-              <node concept="37vLTw" id="3pwG8PSsv5Z" role="2Oq$k0">
-                <ref role="3cqZAo" node="3pwG8PSsoLz" resolve="text" />
-              </node>
-              <node concept="liA8E" id="3pwG8PSsv60" role="2OqNvi">
-                <ref role="37wK5l" to="wyt6:~String.indexOf(java.lang.String)" resolve="indexOf" />
-                <node concept="Xl_RD" id="3pwG8PSsv61" role="37wK5m">
-                  <property role="Xl_RC" value=":" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbJ" id="3pwG8PSsw$H" role="3cqZAp">
-          <node concept="3clFbS" id="3pwG8PSsw$J" role="3clFbx">
-            <node concept="3cpWs6" id="3pwG8PSsxQ$" role="3cqZAp">
-              <node concept="Xl_RD" id="3pwG8PSsybc" role="3cqZAk" />
-            </node>
-          </node>
-          <node concept="3eOVzh" id="3pwG8PSsxLI" role="3clFbw">
-            <node concept="3cmrfG" id="3pwG8PSsxLV" role="3uHU7w">
-              <property role="3cmrfH" value="0" />
-            </node>
-            <node concept="37vLTw" id="3pwG8PSsx1b" role="3uHU7B">
-              <ref role="3cqZAo" node="3pwG8PSsv5X" resolve="separatorPosition" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbH" id="3pwG8PSsw8P" role="3cqZAp" />
-        <node concept="3clFbF" id="2VOpD312DcT" role="3cqZAp">
-          <node concept="37vLTI" id="2VOpD312DcV" role="3clFbG">
-            <node concept="2OqwBi" id="3pwG8PSszBn" role="37vLTx">
-              <node concept="37vLTw" id="3pwG8PSszxq" role="2Oq$k0">
-                <ref role="3cqZAo" node="3pwG8PSsoLz" resolve="text" />
-              </node>
-              <node concept="liA8E" id="3pwG8PSs$mC" role="2OqNvi">
-                <ref role="37wK5l" to="wyt6:~String.substring(int,int)" resolve="substring" />
-                <node concept="3cmrfG" id="3pwG8PSs$nV" role="37wK5m">
-                  <property role="3cmrfH" value="0" />
-                </node>
-                <node concept="37vLTw" id="3pwG8PSs$Ep" role="37wK5m">
-                  <ref role="3cqZAo" node="3pwG8PSsv5X" resolve="separatorPosition" />
-                </node>
-              </node>
-            </node>
-            <node concept="37vLTw" id="2VOpD312DcZ" role="37vLTJ">
-              <ref role="3cqZAo" node="3pwG8PSsz1K" resolve="groupName" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbH" id="6Kw22eW9sg7" role="3cqZAp" />
-        <node concept="3cpWs6" id="3pwG8PSs_F8" role="3cqZAp">
-          <node concept="37vLTw" id="3pwG8PSsAzu" role="3cqZAk">
-            <ref role="3cqZAo" node="3pwG8PSsz1K" resolve="groupName" />
-          </node>
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="3pwG8PSsKNl" role="2AJF6D">
-        <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
-      </node>
-      <node concept="3Tm1VV" id="7c2$qLP_HH8" role="1B3o_S" />
-    </node>
-    <node concept="2tJIrI" id="2jDew64Pxng" role="jymVt" />
     <node concept="3clFb_" id="3pwG8PSkQJj" role="jymVt">
       <property role="TrG5h" value="getIntentionGroup" />
       <property role="DiZV1" value="false" />
@@ -3035,87 +2966,6 @@
       </node>
     </node>
     <node concept="2tJIrI" id="2jDew64MFfM" role="jymVt" />
-    <node concept="3clFb_" id="2jDew64RVuQ" role="jymVt">
-      <property role="TrG5h" value="executeIntention" />
-      <node concept="3clFbS" id="2jDew64RVuS" role="3clF47">
-        <node concept="3clFbF" id="2jDew64RVvd" role="3cqZAp">
-          <node concept="2OqwBi" id="2jDew64RVve" role="3clFbG">
-            <node concept="1rXfSq" id="2jDew64RVvf" role="2Oq$k0">
-              <ref role="37wK5l" node="3pwG8PSkQQM" resolve="getModelAccess" />
-            </node>
-            <node concept="liA8E" id="2jDew64RVvg" role="2OqNvi">
-              <ref role="37wK5l" to="lui2:~ModelAccess.executeCommandInEDT(java.lang.Runnable)" resolve="executeCommandInEDT" />
-              <node concept="2ShNRf" id="2jDew64RVvh" role="37wK5m">
-                <node concept="YeOm9" id="2jDew64RVvi" role="2ShVmc">
-                  <node concept="1Y3b0j" id="2jDew64RVvj" role="YeSDq">
-                    <property role="2bfB8j" value="true" />
-                    <property role="1sVAO0" value="false" />
-                    <property role="1EXbeo" value="false" />
-                    <ref role="1Y3XeK" to="nlpl:~EditorCommand" resolve="EditorCommand" />
-                    <ref role="37wK5l" to="nlpl:~EditorCommand.&lt;init&gt;(jetbrains.mps.openapi.editor.EditorComponent)" resolve="EditorCommand" />
-                    <node concept="3Tm1VV" id="2jDew64RVvk" role="1B3o_S" />
-                    <node concept="3clFb_" id="2jDew64RVvl" role="jymVt">
-                      <property role="TrG5h" value="doExecute" />
-                      <property role="DiZV1" value="false" />
-                      <property role="od$2w" value="false" />
-                      <node concept="2AHcQZ" id="2jDew64RVvm" role="2AJF6D">
-                        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-                      </node>
-                      <node concept="3clFbS" id="2jDew64RVvn" role="3clF47">
-                        <node concept="3clFbF" id="2jDew64RVvo" role="3cqZAp">
-                          <node concept="2OqwBi" id="2jDew64RVvp" role="3clFbG">
-                            <node concept="37vLTw" id="2jDew64RVvq" role="2Oq$k0">
-                              <ref role="3cqZAo" node="2jDew64RVv$" resolve="intention" />
-                            </node>
-                            <node concept="liA8E" id="2jDew64RVvr" role="2OqNvi">
-                              <ref role="37wK5l" to="nddn:~IntentionExecutable.execute(org.jetbrains.mps.openapi.model.SNode,jetbrains.mps.openapi.editor.EditorContext)" resolve="execute" />
-                              <node concept="37vLTw" id="2jDew64RVvs" role="37wK5m">
-                                <ref role="3cqZAo" node="2jDew64RVvA" resolve="node" />
-                              </node>
-                              <node concept="2OqwBi" id="2jDew64RVvt" role="37wK5m">
-                                <node concept="37vLTw" id="2jDew64RVvu" role="2Oq$k0">
-                                  <ref role="3cqZAo" node="2jDew64KOaH" resolve="editor" />
-                                </node>
-                                <node concept="liA8E" id="2jDew64RVvv" role="2OqNvi">
-                                  <ref role="37wK5l" to="exr9:~EditorComponent.getEditorContext()" resolve="getEditorContext" />
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="3Tm1VV" id="2jDew64RVvw" role="1B3o_S" />
-                      <node concept="3cqZAl" id="2jDew64RVvx" role="3clF45" />
-                    </node>
-                    <node concept="37vLTw" id="2jDew64RVvy" role="37wK5m">
-                      <ref role="3cqZAo" node="2jDew64KOaH" resolve="editor" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3cqZAl" id="2jDew64RVvz" role="3clF45" />
-      <node concept="37vLTG" id="2jDew64RVv$" role="3clF46">
-        <property role="TrG5h" value="intention" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3uibUv" id="2jDew64RVv_" role="1tU5fm">
-          <ref role="3uigEE" to="nddn:~IntentionExecutable" resolve="IntentionExecutable" />
-        </node>
-      </node>
-      <node concept="37vLTG" id="2jDew64RVvA" role="3clF46">
-        <property role="TrG5h" value="node" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3uibUv" id="2jDew64RVvB" role="1tU5fm">
-          <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="2jDew64RVvC" role="1B3o_S" />
-    </node>
-    <node concept="2tJIrI" id="2jDew64JPLD" role="jymVt" />
-    <node concept="2tJIrI" id="2jDew64MVr6" role="jymVt" />
     <node concept="3clFb_" id="2jDew64HgSp" role="jymVt">
       <property role="TrG5h" value="getEnabledIntentions" />
       <node concept="3Tmbuc" id="2jDew64HgSq" role="1B3o_S" />
@@ -3803,7 +3653,7 @@
       <property role="TrG5h" value="myProducer" />
       <node concept="3Tmbuc" id="2jDew64S3eZ" role="1B3o_S" />
       <node concept="3uibUv" id="2jDew64S3rJ" role="1tU5fm">
-        <ref role="3uigEE" node="2jDew64JcPx" resolve="MyIntentionMenuProducer" />
+        <ref role="3uigEE" node="2jDew64JcPx" resolve="ActionIntentionMenuProducer" />
       </node>
     </node>
     <node concept="312cEg" id="2jDew64QLb1" role="jymVt">
@@ -3885,7 +3735,7 @@
       <node concept="37vLTG" id="2jDew64S3FW" role="3clF46">
         <property role="TrG5h" value="produer" />
         <node concept="3uibUv" id="2jDew64S3Ii" role="1tU5fm">
-          <ref role="3uigEE" node="2jDew64JcPx" resolve="MyIntentionMenuProducer" />
+          <ref role="3uigEE" node="2jDew64JcPx" resolve="ActionIntentionMenuProducer" />
         </node>
       </node>
       <node concept="37vLTG" id="2jDew64QLbw" role="3clF46">
@@ -4716,6 +4566,67 @@
             </node>
           </node>
         </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="38Yx6hD6ioO" role="jymVt" />
+    <node concept="2YIFZL" id="38Yx6hD6a9o" role="jymVt">
+      <property role="TrG5h" value="getIntentionsSupport" />
+      <node concept="37vLTG" id="38Yx6hD6d3S" role="3clF46">
+        <property role="TrG5h" value="editor" />
+        <node concept="3uibUv" id="38Yx6hD6d3T" role="1tU5fm">
+          <ref role="3uigEE" to="exr9:~EditorComponent" resolve="EditorComponent" />
+        </node>
+        <node concept="2AHcQZ" id="38Yx6hD6d3U" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="38Yx6hD6a9r" role="3clF47">
+        <node concept="3clFbF" id="38Yx6hD6odJ" role="3cqZAp">
+          <node concept="2OqwBi" id="38Yx6hD6qLQ" role="3clFbG">
+            <node concept="37vLTw" id="38Yx6hD6odI" role="2Oq$k0">
+              <ref role="3cqZAo" node="38Yx6hD6d3S" resolve="editor" />
+            </node>
+            <node concept="1PnCL0" id="38Yx6hD6ua2" role="2OqNvi">
+              <ref role="2Oxat5" to="exr9:~EditorComponent.myIntentionsSupport" resolve="myIntentionsSupport" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="38Yx6hD5OQw" role="1B3o_S" />
+      <node concept="3uibUv" id="38Yx6hD69Np" role="3clF45">
+        <ref role="3uigEE" to="exr9:~IntentionsSupport" resolve="IntentionsSupport" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="38Yx6hD6ym1" role="jymVt" />
+    <node concept="2YIFZL" id="38Yx6hD6zfT" role="jymVt">
+      <property role="TrG5h" value="getIntentionMenuProducer" />
+      <node concept="37vLTG" id="38Yx6hD6zfU" role="3clF46">
+        <property role="TrG5h" value="editor" />
+        <node concept="3uibUv" id="38Yx6hD6zfV" role="1tU5fm">
+          <ref role="3uigEE" to="exr9:~EditorComponent" resolve="EditorComponent" />
+        </node>
+        <node concept="2AHcQZ" id="38Yx6hD6zfW" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="38Yx6hD6zfX" role="3clF47">
+        <node concept="3clFbF" id="38Yx6hD6BcX" role="3cqZAp">
+          <node concept="2OqwBi" id="38Yx6hD6B$r" role="3clFbG">
+            <node concept="1rXfSq" id="38Yx6hD6BcW" role="2Oq$k0">
+              <ref role="37wK5l" node="38Yx6hD6a9o" resolve="getIntentionsSupport" />
+              <node concept="37vLTw" id="38Yx6hD6Bpe" role="37wK5m">
+                <ref role="3cqZAo" node="38Yx6hD6zfU" resolve="editor" />
+              </node>
+            </node>
+            <node concept="1PnCL0" id="38Yx6hD6BKq" role="2OqNvi">
+              <ref role="2Oxat5" to="exr9:~IntentionsSupport.myMenuProducer" resolve="myMenuProducer" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="38Yx6hD6zg2" role="1B3o_S" />
+      <node concept="3uibUv" id="38Yx6hD6zg3" role="3clF45">
+        <ref role="3uigEE" to="uxaq:~IntentionMenuProducer" resolve="IntentionMenuProducer" />
       </node>
     </node>
     <node concept="2tJIrI" id="4hHbxs9_knP" role="jymVt" />
@@ -5611,12 +5522,155 @@
           <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
         </node>
       </node>
-      <node concept="3clFbS" id="3iqDEt5lu15" role="3clF47" />
+      <node concept="3clFbS" id="3iqDEt5lu15" role="3clF47">
+        <node concept="3SKdUt" id="6ob0HsMJ_ww" role="3cqZAp">
+          <node concept="1PaTwC" id="6ob0HsMJ_wx" role="1aUNEU">
+            <node concept="3oM_SD" id="6ob0HsMJ_Kl" role="1PaTwD">
+              <property role="3oM_SC" value="This" />
+            </node>
+            <node concept="3oM_SD" id="6ob0HsMJ_Km" role="1PaTwD">
+              <property role="3oM_SC" value="method" />
+            </node>
+            <node concept="3oM_SD" id="6ob0HsMJ_Kn" role="1PaTwD">
+              <property role="3oM_SC" value="is" />
+            </node>
+            <node concept="3oM_SD" id="6ob0HsMJ_Ko" role="1PaTwD">
+              <property role="3oM_SC" value="never" />
+            </node>
+            <node concept="3oM_SD" id="6ob0HsMJ_Kp" role="1PaTwD">
+              <property role="3oM_SC" value="executed," />
+            </node>
+            <node concept="3oM_SD" id="6ob0HsMK9RQ" role="1PaTwD">
+              <property role="3oM_SC" value="we" />
+            </node>
+            <node concept="3oM_SD" id="6ob0HsMK9S7" role="1PaTwD">
+              <property role="3oM_SC" value="only" />
+            </node>
+            <node concept="3oM_SD" id="6ob0HsMK9So" role="1PaTwD">
+              <property role="3oM_SC" value="need" />
+            </node>
+            <node concept="3oM_SD" id="6ob0HsMK9ST" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="6ob0HsMK9SU" role="1PaTwD">
+              <property role="3oM_SC" value="getDescription" />
+            </node>
+            <node concept="3oM_SD" id="6ob0HsMK9Tb" role="1PaTwD">
+              <property role="3oM_SC" value="method" />
+            </node>
+          </node>
+        </node>
+      </node>
       <node concept="2AHcQZ" id="3iqDEt5lu16" role="2AJF6D">
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
     <node concept="2tJIrI" id="3iqDEt5lu9V" role="jymVt" />
+    <node concept="312cEu" id="38Yx6hD8$94" role="jymVt">
+      <property role="2bfB8j" value="true" />
+      <property role="TrG5h" value="ActionsDescriptor" />
+      <node concept="3clFb_" id="3iqDEt5pw4J" role="jymVt">
+        <property role="TrG5h" value="getPresentation" />
+        <node concept="3Tm1VV" id="3iqDEt5pw4K" role="1B3o_S" />
+        <node concept="17QB3L" id="3iqDEt5pOcg" role="3clF45" />
+        <node concept="3clFbS" id="3iqDEt5pw4N" role="3clF47">
+          <node concept="3clFbF" id="3iqDEt5pz6R" role="3cqZAp">
+            <node concept="2OqwBi" id="3iqDEt5pA8u" role="3clFbG">
+              <node concept="2OqwBi" id="3iqDEt5p_qA" role="2Oq$k0">
+                <node concept="2OqwBi" id="3iqDEt5p$gy" role="2Oq$k0">
+                  <node concept="37vLTw" id="3iqDEt5pz6Q" role="2Oq$k0">
+                    <ref role="3cqZAo" node="3iqDEt5lVwn" resolve="action" />
+                  </node>
+                  <node concept="liA8E" id="3iqDEt5p$WC" role="2OqNvi">
+                    <ref role="37wK5l" to="qkt:~AnAction.getTemplatePresentation()" resolve="getTemplatePresentation" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="3iqDEt5p_SM" role="2OqNvi">
+                  <ref role="37wK5l" to="qkt:~Presentation.clone()" resolve="clone" />
+                </node>
+              </node>
+              <node concept="liA8E" id="3iqDEt5pAqy" role="2OqNvi">
+                <ref role="37wK5l" to="qkt:~Presentation.toString()" resolve="toString" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2AHcQZ" id="3iqDEt5pw4P" role="2AJF6D">
+          <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+        </node>
+      </node>
+      <node concept="2tJIrI" id="3iqDEt5pw4Q" role="jymVt" />
+      <node concept="3clFb_" id="3iqDEt5pw4R" role="jymVt">
+        <property role="TrG5h" value="getPersistentStateKey" />
+        <node concept="3Tm1VV" id="3iqDEt5pw4S" role="1B3o_S" />
+        <node concept="17QB3L" id="3iqDEt5pPrR" role="3clF45" />
+        <node concept="3clFbS" id="3iqDEt5pw4V" role="3clF47">
+          <node concept="3clFbF" id="3iqDEt5pCmT" role="3cqZAp">
+            <node concept="10Nm6u" id="3iqDEt5pCmS" role="3clFbG" />
+          </node>
+        </node>
+        <node concept="2AHcQZ" id="3iqDEt5pw4X" role="2AJF6D">
+          <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+        </node>
+      </node>
+      <node concept="2tJIrI" id="3iqDEt5pw4Y" role="jymVt" />
+      <node concept="3clFb_" id="3iqDEt5pw4Z" role="jymVt">
+        <property role="TrG5h" value="getKind" />
+        <node concept="3Tm1VV" id="3iqDEt5pw50" role="1B3o_S" />
+        <node concept="3uibUv" id="3iqDEt5pw52" role="3clF45">
+          <ref role="3uigEE" to="nddn:~Kind" resolve="Kind" />
+        </node>
+        <node concept="3clFbS" id="3iqDEt5pw53" role="3clF47">
+          <node concept="3clFbF" id="3iqDEt5pEGU" role="3cqZAp">
+            <node concept="Rm8GO" id="3iqDEt5pEWt" role="3clFbG">
+              <ref role="Rm8GQ" to="nddn:~Kind.NORMAL" resolve="NORMAL" />
+              <ref role="1Px2BO" to="nddn:~Kind" resolve="Kind" />
+            </node>
+          </node>
+        </node>
+        <node concept="2AHcQZ" id="3iqDEt5pw55" role="2AJF6D">
+          <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+        </node>
+      </node>
+      <node concept="2tJIrI" id="3iqDEt5pw56" role="jymVt" />
+      <node concept="3clFb_" id="3iqDEt5pw57" role="jymVt">
+        <property role="TrG5h" value="isAvailableInChildNodes" />
+        <node concept="3Tm1VV" id="3iqDEt5pw58" role="1B3o_S" />
+        <node concept="10P_77" id="3iqDEt5pw5a" role="3clF45" />
+        <node concept="3clFbS" id="3iqDEt5pw5b" role="3clF47">
+          <node concept="3clFbF" id="3iqDEt5pKMf" role="3cqZAp">
+            <node concept="3clFbT" id="3iqDEt5pKMe" role="3clFbG" />
+          </node>
+        </node>
+        <node concept="2AHcQZ" id="3iqDEt5pw5d" role="2AJF6D">
+          <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+        </node>
+      </node>
+      <node concept="2tJIrI" id="3iqDEt5pw5e" role="jymVt" />
+      <node concept="3clFb_" id="3iqDEt5pw5f" role="jymVt">
+        <property role="TrG5h" value="getIntentionNodeReference" />
+        <node concept="3Tm1VV" id="3iqDEt5pw5g" role="1B3o_S" />
+        <node concept="2AHcQZ" id="3iqDEt5pw5i" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+        </node>
+        <node concept="3uibUv" id="3iqDEt5pw5j" role="3clF45">
+          <ref role="3uigEE" to="mhbf:~SNodeReference" resolve="SNodeReference" />
+        </node>
+        <node concept="3clFbS" id="3iqDEt5pw5k" role="3clF47">
+          <node concept="3clFbF" id="3iqDEt5pNkI" role="3cqZAp">
+            <node concept="10Nm6u" id="3iqDEt5pNkH" role="3clFbG" />
+          </node>
+        </node>
+        <node concept="2AHcQZ" id="3iqDEt5pw5m" role="2AJF6D">
+          <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="38Yx6hD8$95" role="1B3o_S" />
+      <node concept="3uibUv" id="38Yx6hD8$$X" role="EKbjA">
+        <ref role="3uigEE" to="nddn:~IntentionDescriptor" resolve="IntentionDescriptor" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="38Yx6hD8zua" role="jymVt" />
     <node concept="3clFb_" id="3iqDEt5lu17" role="jymVt">
       <property role="TrG5h" value="getDescriptor" />
       <node concept="3Tm1VV" id="3iqDEt5lu18" role="1B3o_S" />
@@ -5626,110 +5680,9 @@
       <node concept="3clFbS" id="3iqDEt5lu1b" role="3clF47">
         <node concept="3clFbF" id="3iqDEt5prq3" role="3cqZAp">
           <node concept="2ShNRf" id="3iqDEt5prq1" role="3clFbG">
-            <node concept="YeOm9" id="3iqDEt5pw4t" role="2ShVmc">
-              <node concept="1Y3b0j" id="3iqDEt5pw4w" role="YeSDq">
-                <property role="2bfB8j" value="true" />
-                <property role="373rjd" value="true" />
-                <ref role="1Y3XeK" to="nddn:~IntentionDescriptor" resolve="IntentionDescriptor" />
-                <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
-                <node concept="3Tm1VV" id="3iqDEt5pw4x" role="1B3o_S" />
-                <node concept="3clFb_" id="3iqDEt5pw4J" role="jymVt">
-                  <property role="TrG5h" value="getPresentation" />
-                  <node concept="3Tm1VV" id="3iqDEt5pw4K" role="1B3o_S" />
-                  <node concept="17QB3L" id="3iqDEt5pOcg" role="3clF45" />
-                  <node concept="3clFbS" id="3iqDEt5pw4N" role="3clF47">
-                    <node concept="3clFbF" id="3iqDEt5pz6R" role="3cqZAp">
-                      <node concept="2OqwBi" id="3iqDEt5pA8u" role="3clFbG">
-                        <node concept="2OqwBi" id="3iqDEt5p_qA" role="2Oq$k0">
-                          <node concept="2OqwBi" id="3iqDEt5p$gy" role="2Oq$k0">
-                            <node concept="37vLTw" id="3iqDEt5pz6Q" role="2Oq$k0">
-                              <ref role="3cqZAo" node="3iqDEt5lVwn" resolve="action" />
-                            </node>
-                            <node concept="liA8E" id="3iqDEt5p$WC" role="2OqNvi">
-                              <ref role="37wK5l" to="qkt:~AnAction.getTemplatePresentation()" resolve="getTemplatePresentation" />
-                            </node>
-                          </node>
-                          <node concept="liA8E" id="3iqDEt5p_SM" role="2OqNvi">
-                            <ref role="37wK5l" to="qkt:~Presentation.clone()" resolve="clone" />
-                          </node>
-                        </node>
-                        <node concept="liA8E" id="3iqDEt5pAqy" role="2OqNvi">
-                          <ref role="37wK5l" to="qkt:~Presentation.toString()" resolve="toString" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="2AHcQZ" id="3iqDEt5pw4P" role="2AJF6D">
-                    <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-                  </node>
-                </node>
-                <node concept="2tJIrI" id="3iqDEt5pw4Q" role="jymVt" />
-                <node concept="3clFb_" id="3iqDEt5pw4R" role="jymVt">
-                  <property role="TrG5h" value="getPersistentStateKey" />
-                  <node concept="3Tm1VV" id="3iqDEt5pw4S" role="1B3o_S" />
-                  <node concept="17QB3L" id="3iqDEt5pPrR" role="3clF45" />
-                  <node concept="3clFbS" id="3iqDEt5pw4V" role="3clF47">
-                    <node concept="3clFbF" id="3iqDEt5pCmT" role="3cqZAp">
-                      <node concept="10Nm6u" id="3iqDEt5pCmS" role="3clFbG" />
-                    </node>
-                  </node>
-                  <node concept="2AHcQZ" id="3iqDEt5pw4X" role="2AJF6D">
-                    <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-                  </node>
-                </node>
-                <node concept="2tJIrI" id="3iqDEt5pw4Y" role="jymVt" />
-                <node concept="3clFb_" id="3iqDEt5pw4Z" role="jymVt">
-                  <property role="TrG5h" value="getKind" />
-                  <node concept="3Tm1VV" id="3iqDEt5pw50" role="1B3o_S" />
-                  <node concept="3uibUv" id="3iqDEt5pw52" role="3clF45">
-                    <ref role="3uigEE" to="nddn:~Kind" resolve="Kind" />
-                  </node>
-                  <node concept="3clFbS" id="3iqDEt5pw53" role="3clF47">
-                    <node concept="3clFbF" id="3iqDEt5pEGU" role="3cqZAp">
-                      <node concept="Rm8GO" id="3iqDEt5pEWt" role="3clFbG">
-                        <ref role="Rm8GQ" to="nddn:~Kind.NORMAL" resolve="NORMAL" />
-                        <ref role="1Px2BO" to="nddn:~Kind" resolve="Kind" />
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="2AHcQZ" id="3iqDEt5pw55" role="2AJF6D">
-                    <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-                  </node>
-                </node>
-                <node concept="2tJIrI" id="3iqDEt5pw56" role="jymVt" />
-                <node concept="3clFb_" id="3iqDEt5pw57" role="jymVt">
-                  <property role="TrG5h" value="isAvailableInChildNodes" />
-                  <node concept="3Tm1VV" id="3iqDEt5pw58" role="1B3o_S" />
-                  <node concept="10P_77" id="3iqDEt5pw5a" role="3clF45" />
-                  <node concept="3clFbS" id="3iqDEt5pw5b" role="3clF47">
-                    <node concept="3clFbF" id="3iqDEt5pKMf" role="3cqZAp">
-                      <node concept="3clFbT" id="3iqDEt5pKMe" role="3clFbG" />
-                    </node>
-                  </node>
-                  <node concept="2AHcQZ" id="3iqDEt5pw5d" role="2AJF6D">
-                    <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-                  </node>
-                </node>
-                <node concept="2tJIrI" id="3iqDEt5pw5e" role="jymVt" />
-                <node concept="3clFb_" id="3iqDEt5pw5f" role="jymVt">
-                  <property role="TrG5h" value="getIntentionNodeReference" />
-                  <node concept="3Tm1VV" id="3iqDEt5pw5g" role="1B3o_S" />
-                  <node concept="2AHcQZ" id="3iqDEt5pw5i" role="2AJF6D">
-                    <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
-                  </node>
-                  <node concept="3uibUv" id="3iqDEt5pw5j" role="3clF45">
-                    <ref role="3uigEE" to="mhbf:~SNodeReference" resolve="SNodeReference" />
-                  </node>
-                  <node concept="3clFbS" id="3iqDEt5pw5k" role="3clF47">
-                    <node concept="3clFbF" id="3iqDEt5pNkI" role="3cqZAp">
-                      <node concept="10Nm6u" id="3iqDEt5pNkH" role="3clFbG" />
-                    </node>
-                  </node>
-                  <node concept="2AHcQZ" id="3iqDEt5pw5m" role="2AJF6D">
-                    <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-                  </node>
-                </node>
-              </node>
+            <node concept="HV5vD" id="38Yx6hD8Bk$" role="2ShVmc">
+              <property role="373rjd" value="true" />
+              <ref role="HV5vE" node="38Yx6hD8$94" resolve="ActionsAsIntentionsExecutable.ActionsDescriptor" />
             </node>
           </node>
         </node>
@@ -5784,7 +5737,7 @@
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
       <node concept="37vLTG" id="7b8v2ssa1Qp" role="3clF46">
-        <property role="TrG5h" value="o1" />
+        <property role="TrG5h" value="left" />
         <property role="3TUv4t" value="false" />
         <node concept="3uibUv" id="7b8v2ssa1Qq" role="1tU5fm">
           <ref role="3uigEE" to="18ew:~Pair" resolve="Pair" />
@@ -5797,7 +5750,7 @@
         </node>
       </node>
       <node concept="37vLTG" id="7b8v2ssa1Qt" role="3clF46">
-        <property role="TrG5h" value="o2" />
+        <property role="TrG5h" value="right" />
         <property role="3TUv4t" value="false" />
         <node concept="3uibUv" id="7b8v2ssa1Qu" role="1tU5fm">
           <ref role="3uigEE" to="18ew:~Pair" resolve="Pair" />
@@ -5819,7 +5772,7 @@
             </node>
             <node concept="2OqwBi" id="7b8v2ssa1Q_" role="33vP2m">
               <node concept="37vLTw" id="7b8v2ssa1QA" role="2Oq$k0">
-                <ref role="3cqZAo" node="7b8v2ssa1Qp" resolve="o1" />
+                <ref role="3cqZAo" node="7b8v2ssa1Qp" resolve="left" />
               </node>
               <node concept="2OwXpG" id="7b8v2ssa1QB" role="2OqNvi">
                 <ref role="2Oxat6" to="18ew:~Pair.o1" resolve="o1" />
@@ -5836,7 +5789,7 @@
             </node>
             <node concept="2OqwBi" id="7b8v2ssa1QF" role="33vP2m">
               <node concept="37vLTw" id="7b8v2ssa1QG" role="2Oq$k0">
-                <ref role="3cqZAo" node="7b8v2ssa1Qt" resolve="o2" />
+                <ref role="3cqZAo" node="7b8v2ssa1Qt" resolve="right" />
               </node>
               <node concept="2OwXpG" id="7b8v2ssa1QH" role="2OqNvi">
                 <ref role="2Oxat6" to="18ew:~Pair.o1" resolve="o1" />
@@ -5853,7 +5806,7 @@
             </node>
             <node concept="2OqwBi" id="7b8v2ssa1QL" role="33vP2m">
               <node concept="37vLTw" id="7b8v2ssa1QM" role="2Oq$k0">
-                <ref role="3cqZAo" node="7b8v2ssa1Qp" resolve="o1" />
+                <ref role="3cqZAo" node="7b8v2ssa1Qp" resolve="left" />
               </node>
               <node concept="2OwXpG" id="7b8v2ssa1QN" role="2OqNvi">
                 <ref role="2Oxat6" to="18ew:~Pair.o2" resolve="o2" />
@@ -5870,7 +5823,7 @@
             </node>
             <node concept="2OqwBi" id="7b8v2ssa1QR" role="33vP2m">
               <node concept="37vLTw" id="7b8v2ssa1QS" role="2Oq$k0">
-                <ref role="3cqZAo" node="7b8v2ssa1Qt" resolve="o2" />
+                <ref role="3cqZAo" node="7b8v2ssa1Qt" resolve="right" />
               </node>
               <node concept="2OwXpG" id="7b8v2ssa1QT" role="2OqNvi">
                 <ref role="2Oxat6" to="18ew:~Pair.o2" resolve="o2" />

--- a/code/intentionsmenu/com.mbeddr.mpsutil.intentions.runtime/models/com/mbeddr/mpsutil/intentions/runtime.mps
+++ b/code/intentionsmenu/com.mbeddr.mpsutil.intentions.runtime/models/com/mbeddr/mpsutil/intentions/runtime.mps
@@ -47,6 +47,7 @@
     <import index="7oz1" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor.configuration(MPS.Editor/)" />
     <import index="zn9m" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.util(MPS.IDEA/)" />
     <import index="3o3z" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.google.common.collect(MPS.IDEA/)" />
+    <import index="9j2l" ref="r:acd2b506-390d-4e84-8c47-cd8fb8c9e0c0(com.mbeddr.mpsutil.intentions.behavior)" implicit="true" />
   </imports>
   <registry>
     <language id="654422bf-e75f-44dc-936d-188890a746ce" name="de.slisson.mps.reflection">
@@ -313,9 +314,13 @@
       <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
         <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
       </concept>
+      <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
       <concept id="2396822768958367367" name="jetbrains.mps.lang.smodel.structure.AbstractTypeCastExpression" flags="nn" index="$5XWr">
         <child id="6733348108486823193" name="leftExpression" index="1m5AlR" />
         <child id="3906496115198199033" name="conceptArgument" index="3oSUPX" />
+      </concept>
+      <concept id="2644386474300074836" name="jetbrains.mps.lang.smodel.structure.ConceptIdRefExpression" flags="nn" index="35c_gC">
+        <reference id="2644386474300074837" name="conceptDeclaration" index="35c_gD" />
       </concept>
       <concept id="6407023681583036853" name="jetbrains.mps.lang.smodel.structure.NodeAttributeQualifier" flags="ng" index="3CFYIy">
         <reference id="6407023681583036854" name="attributeConcept" index="3CFYIx" />
@@ -1235,8 +1240,13 @@
               </node>
               <node concept="liA8E" id="3pwG8PSsv60" role="2OqNvi">
                 <ref role="37wK5l" to="wyt6:~String.indexOf(java.lang.String)" resolve="indexOf" />
-                <node concept="Xl_RD" id="3pwG8PSsv61" role="37wK5m">
-                  <property role="Xl_RC" value=":" />
+                <node concept="2OqwBi" id="5gDLJkKSTFi" role="37wK5m">
+                  <node concept="35c_gC" id="5gDLJkKSFtZ" role="2Oq$k0">
+                    <ref role="35c_gD" to="tegv:54z9_KDO4Av" resolve="GroupAnnotation" />
+                  </node>
+                  <node concept="2qgKlT" id="5gDLJkKT0XL" role="2OqNvi">
+                    <ref role="37wK5l" to="9j2l:24lzbKWhznQ" resolve="getSeparator" />
+                  </node>
                 </node>
               </node>
             </node>
@@ -2862,8 +2872,13 @@
               </node>
               <node concept="liA8E" id="2xgTENkX27h" role="2OqNvi">
                 <ref role="37wK5l" to="wyt6:~String.indexOf(java.lang.String)" resolve="indexOf" />
-                <node concept="Xl_RD" id="2xgTENkX27i" role="37wK5m">
-                  <property role="Xl_RC" value=":" />
+                <node concept="2OqwBi" id="5gDLJkL8uyJ" role="37wK5m">
+                  <node concept="35c_gC" id="5gDLJkL8gJ7" role="2Oq$k0">
+                    <ref role="35c_gD" to="tegv:54z9_KDO4Av" resolve="GroupAnnotation" />
+                  </node>
+                  <node concept="2qgKlT" id="5gDLJkL8$VF" role="2OqNvi">
+                    <ref role="37wK5l" to="9j2l:24lzbKWhznQ" resolve="getSeparator" />
+                  </node>
                 </node>
               </node>
             </node>
@@ -3941,8 +3956,8 @@
           </node>
         </node>
         <node concept="1DcWWT" id="4hHbxs9ANMv" role="3cqZAp">
-          <node concept="2OqwBi" id="4hHbxs9AVSs" role="1DdaDG">
-            <node concept="2OqwBi" id="4hHbxs9AT8b" role="2Oq$k0">
+          <node concept="2EnYce" id="5gDLJkKOQJU" role="1DdaDG">
+            <node concept="2EnYce" id="5gDLJkKOPK9" role="2Oq$k0">
               <node concept="37vLTw" id="4hHbxs9AR8g" role="2Oq$k0">
                 <ref role="3cqZAo" node="4hHbxs9ANMl" resolve="ideaActionRegistration" />
               </node>
@@ -5307,6 +5322,42 @@
     <node concept="3clFb_" id="3DQAigePfof" role="jymVt">
       <property role="TrG5h" value="areIntentionsNotSupported" />
       <node concept="3clFbS" id="3DQAigePfoi" role="3clF47">
+        <node concept="3cpWs8" id="5gDLJkKOSrS" role="3cqZAp">
+          <node concept="3cpWsn" id="5gDLJkKOSrT" role="3cpWs9">
+            <property role="TrG5h" value="model" />
+            <node concept="3uibUv" id="5gDLJkKOKHf" role="1tU5fm">
+              <ref role="3uigEE" to="mhbf:~SModel" resolve="SModel" />
+            </node>
+            <node concept="2OqwBi" id="5gDLJkKOSrU" role="33vP2m">
+              <node concept="liA8E" id="5gDLJkKOSrV" role="2OqNvi">
+                <ref role="37wK5l" to="mhbf:~SNode.getModel()" resolve="getModel" />
+              </node>
+              <node concept="2OqwBi" id="5gDLJkKOSrW" role="2Oq$k0">
+                <node concept="1rXfSq" id="5gDLJkKOSrX" role="2Oq$k0">
+                  <ref role="37wK5l" node="4hHbxs9ygNI" resolve="getEditor" />
+                </node>
+                <node concept="liA8E" id="5gDLJkKOSrY" role="2OqNvi">
+                  <ref role="37wK5l" to="exr9:~EditorComponent.getSelectedNode()" resolve="getSelectedNode" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="5gDLJkKOXuS" role="3cqZAp">
+          <node concept="3clFbS" id="5gDLJkKOXuU" role="3clFbx">
+            <node concept="3cpWs6" id="5gDLJkKP6F6" role="3cqZAp">
+              <node concept="3clFbT" id="5gDLJkKP7Yu" role="3cqZAk">
+                <property role="3clFbU" value="true" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbC" id="5gDLJkKP2Cn" role="3clFbw">
+            <node concept="10Nm6u" id="5gDLJkKP41n" role="3uHU7w" />
+            <node concept="37vLTw" id="5gDLJkKOZRI" role="3uHU7B">
+              <ref role="3cqZAo" node="5gDLJkKOSrT" resolve="model" />
+            </node>
+          </node>
+        </node>
         <node concept="3clFbJ" id="3DQAigeUW3H" role="3cqZAp">
           <node concept="1Wc70l" id="3DQAigeUW3I" role="3clFbw">
             <node concept="3fqX7Q" id="3DQAigeUW3J" role="3uHU7w">
@@ -5330,18 +5381,8 @@
                 <node concept="2YIFZM" id="3DQAigeUW3Q" role="3uHU7w">
                   <ref role="1Pybhc" to="w1kc:~SModelOperations" resolve="SModelOperations" />
                   <ref role="37wK5l" to="w1kc:~SModelOperations.isReadOnly(org.jetbrains.mps.openapi.model.SModel)" resolve="isReadOnly" />
-                  <node concept="2OqwBi" id="3DQAigeUW3R" role="37wK5m">
-                    <node concept="liA8E" id="3DQAigeUW3S" role="2OqNvi">
-                      <ref role="37wK5l" to="mhbf:~SNode.getModel()" resolve="getModel" />
-                    </node>
-                    <node concept="2OqwBi" id="3DQAigeUW3T" role="2Oq$k0">
-                      <node concept="1rXfSq" id="3DQAigeUW3U" role="2Oq$k0">
-                        <ref role="37wK5l" node="4hHbxs9ygNI" resolve="getEditor" />
-                      </node>
-                      <node concept="liA8E" id="3DQAigeUW3V" role="2OqNvi">
-                        <ref role="37wK5l" to="exr9:~EditorComponent.getSelectedNode()" resolve="getSelectedNode" />
-                      </node>
-                    </node>
+                  <node concept="37vLTw" id="5gDLJkKOSrZ" role="37wK5m">
+                    <ref role="3cqZAo" node="5gDLJkKOSrT" resolve="model" />
                   </node>
                 </node>
               </node>

--- a/code/intentionsmenu/com.mbeddr.mpsutil.intentions.runtime/models/com/mbeddr/mpsutil/intentions/runtime/plugin.mps
+++ b/code/intentionsmenu/com.mbeddr.mpsutil.intentions.runtime/models/com/mbeddr/mpsutil/intentions/runtime/plugin.mps
@@ -12,6 +12,7 @@
     <import index="kvq8" ref="r:2e938759-cfd0-47cd-9046-896d85204f59(de.slisson.mps.hacks.editor)" />
     <import index="exr9" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor(MPS.Editor/)" />
     <import index="ih8q" ref="r:990d360b-3ac3-45fa-8ed3-0bbf017bba84(com.mbeddr.mpsutil.intentions.runtime)" />
+    <import index="3o3z" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.google.common.collect(MPS.IDEA/)" implicit="true" />
   </imports>
   <registry>
     <language id="654422bf-e75f-44dc-936d-188890a746ce" name="de.slisson.mps.reflection">
@@ -109,7 +110,9 @@
     <language id="443f4c36-fcf5-4eb6-9500-8d06ed259e3e" name="jetbrains.mps.baseLanguage.classifiers">
       <concept id="1213999088275" name="jetbrains.mps.baseLanguage.classifiers.structure.DefaultClassifierFieldDeclaration" flags="ig" index="2BZ0e9" />
       <concept id="1213999117680" name="jetbrains.mps.baseLanguage.classifiers.structure.DefaultClassifierFieldAccessOperation" flags="nn" index="2BZ7hE" />
-      <concept id="1205752633985" name="jetbrains.mps.baseLanguage.classifiers.structure.ThisClassifierExpression" flags="nn" index="2WthIp" />
+      <concept id="1205752633985" name="jetbrains.mps.baseLanguage.classifiers.structure.ThisClassifierExpression" flags="nn" index="2WthIp">
+        <reference id="1218736638915" name="classifier" index="32nkFo" />
+      </concept>
       <concept id="1205756064662" name="jetbrains.mps.baseLanguage.classifiers.structure.IMemberOperation" flags="ngI" index="2WEnae">
         <reference id="1205756909548" name="member" index="2WH_rO" />
       </concept>
@@ -128,6 +131,13 @@
       <node concept="3Tm6S6" id="3pwG8PSiG3l" role="1B3o_S" />
       <node concept="3uibUv" id="3pwG8PSjPUz" role="1tU5fm">
         <ref role="3uigEE" to="kvq8:2WlJ6VKPQcy" resolve="EditorComponentCreationListener" />
+      </node>
+    </node>
+    <node concept="2BZ0e9" id="3$Ib8kTSdKs" role="2uRRBA">
+      <property role="TrG5h" value="producer" />
+      <node concept="3Tm6S6" id="3$Ib8kTSdKt" role="1B3o_S" />
+      <node concept="3uibUv" id="3$Ib8kTSekI" role="1tU5fm">
+        <ref role="3uigEE" to="ih8q:2jDew64JcPx" resolve="ActionIntentionMenuProducer" />
       </node>
     </node>
     <node concept="2uRRBT" id="3pwG8PSjRMg" role="2uRRB$">
@@ -176,6 +186,27 @@
                               </node>
                             </node>
                           </node>
+                          <node concept="3clFbF" id="3$Ib8kTSf64" role="3cqZAp">
+                            <node concept="37vLTI" id="3$Ib8kTSfH0" role="3clFbG">
+                              <node concept="2OqwBi" id="3$Ib8kTSf5Y" role="37vLTJ">
+                                <node concept="2WthIp" id="3$Ib8kTSf61" role="2Oq$k0">
+                                  <ref role="32nkFo" node="3pwG8PSiG1M" resolve="IntentionsProjectPlugin" />
+                                </node>
+                                <node concept="2BZ7hE" id="3$Ib8kTSf63" role="2OqNvi">
+                                  <ref role="2WH_rO" node="3$Ib8kTSdKs" resolve="producer" />
+                                </node>
+                              </node>
+                              <node concept="2ShNRf" id="3$Ib8kTSd$L" role="37vLTx">
+                                <node concept="1pGfFk" id="3$Ib8kTSd$M" role="2ShVmc">
+                                  <property role="373rjd" value="true" />
+                                  <ref role="37wK5l" to="ih8q:2jDew64KaGG" resolve="ActionIntentionMenuProducer" />
+                                  <node concept="37vLTw" id="3$Ib8kTSd$N" role="37wK5m">
+                                    <ref role="3cqZAo" node="3pwG8PSjTLK" resolve="editorComponent" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
                           <node concept="3clFbF" id="2jDew64H8Xv" role="3cqZAp">
                             <node concept="2OqwBi" id="2jDew64HaXY" role="3clFbG">
                               <node concept="37vLTw" id="2jDew64H8Xt" role="2Oq$k0">
@@ -183,13 +214,12 @@
                               </node>
                               <node concept="liA8E" id="2jDew64Hd5G" role="2OqNvi">
                                 <ref role="37wK5l" to="exr9:~EditorComponent.setIntentionMenuProducer(jetbrains.mps.editor.intentions.IntentionMenuProducer)" resolve="setIntentionMenuProducer" />
-                                <node concept="2ShNRf" id="2jDew64L6Ki" role="37wK5m">
-                                  <node concept="1pGfFk" id="2jDew64L7EE" role="2ShVmc">
-                                    <property role="373rjd" value="true" />
-                                    <ref role="37wK5l" to="ih8q:2jDew64KaGG" resolve="MyIntentionMenuProducer" />
-                                    <node concept="37vLTw" id="2jDew64OYEu" role="37wK5m">
-                                      <ref role="3cqZAo" node="3pwG8PSjTLK" resolve="editorComponent" />
-                                    </node>
+                                <node concept="2OqwBi" id="3$Ib8kTSglQ" role="37wK5m">
+                                  <node concept="2WthIp" id="3$Ib8kTSglT" role="2Oq$k0">
+                                    <ref role="32nkFo" node="3pwG8PSiG1M" resolve="IntentionsProjectPlugin" />
+                                  </node>
+                                  <node concept="2BZ7hE" id="3$Ib8kTSglV" role="2OqNvi">
+                                    <ref role="2WH_rO" node="3$Ib8kTSdKs" resolve="producer" />
                                   </node>
                                 </node>
                               </node>
@@ -218,7 +248,28 @@
                     </node>
                     <node concept="3cqZAl" id="3pwG8PSjTLU" role="3clF45" />
                     <node concept="3Tm1VV" id="3pwG8PSjTLV" role="1B3o_S" />
-                    <node concept="3clFbS" id="3pwG8PSjTLX" role="3clF47" />
+                    <node concept="3clFbS" id="3pwG8PSjTLX" role="3clF47">
+                      <node concept="3clFbF" id="3$Ib8kTSg_I" role="3cqZAp">
+                        <node concept="2OqwBi" id="3$Ib8kTShuh" role="3clFbG">
+                          <node concept="2OqwBi" id="3$Ib8kTSgH8" role="2Oq$k0">
+                            <node concept="2OqwBi" id="3$Ib8kTSg_C" role="2Oq$k0">
+                              <node concept="2WthIp" id="3$Ib8kTSg_F" role="2Oq$k0">
+                                <ref role="32nkFo" node="3pwG8PSiG1M" resolve="IntentionsProjectPlugin" />
+                              </node>
+                              <node concept="2BZ7hE" id="3$Ib8kTSg_H" role="2OqNvi">
+                                <ref role="2WH_rO" node="3$Ib8kTSdKs" resolve="producer" />
+                              </node>
+                            </node>
+                            <node concept="liA8E" id="3$Ib8kTSh8t" role="2OqNvi">
+                              <ref role="37wK5l" to="ih8q:6ob0HsML7OT" resolve="getCache" />
+                            </node>
+                          </node>
+                          <node concept="liA8E" id="3$Ib8kTSjND" role="2OqNvi">
+                            <ref role="37wK5l" to="3o3z:~Multimap.clear()" resolve="clear" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
                   </node>
                   <node concept="1KvdUw" id="3pwG8PSkN7p" role="37wK5m" />
                 </node>

--- a/code/intentionsmenu/com.mbeddr.mpsutil.intentions/com.mbeddr.mpsutil.intentions.mpl
+++ b/code/intentionsmenu/com.mbeddr.mpsutil.intentions/com.mbeddr.mpsutil.intentions.mpl
@@ -27,6 +27,7 @@
       <dependencies>
         <dependency reexport="false">d7a92d38-f7db-40d0-8431-763b0c3c9f20(jetbrains.mps.lang.intentions)</dependency>
         <dependency reexport="false">79a2d464-32b0-48d2-96f9-b40717277a07(jetbrains.mps.lang.intentions#1192798684353)</dependency>
+        <dependency reexport="false">28f9e497-3b42-4291-aeba-0a1039153ab1(jetbrains.mps.lang.plugin)</dependency>
       </dependencies>
       <languageVersions>
         <language slang="l:b92f861d-0184-446d-b88b-6dcf0e070241:com.mbeddr.mpsutil.intentions" version="0" />
@@ -58,6 +59,7 @@
         <module reference="d8b925c6-05d7-4247-8905-0d6d8767608f(com.mbeddr.mpsutil.intentions#4354378109086982941)" version="0" />
         <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
         <module reference="443f4c36-fcf5-4eb6-9500-8d06ed259e3e(jetbrains.mps.baseLanguage.classifiers)" version="0" />
+        <module reference="fd392034-7849-419d-9071-12563d152375(jetbrains.mps.baseLanguage.closures)" version="0" />
         <module reference="c7d5b9dd-a05f-4be2-bc73-f2e16994cc67(jetbrains.mps.baseLanguage.lightweightdsl)" version="0" />
         <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
         <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
@@ -65,6 +67,7 @@
         <module reference="3ac18869-0828-4401-abad-822a47bf83f1(jetbrains.mps.lang.descriptor#9020561928507175817)" version="0" />
         <module reference="d7a92d38-f7db-40d0-8431-763b0c3c9f20(jetbrains.mps.lang.intentions)" version="0" />
         <module reference="79a2d464-32b0-48d2-96f9-b40717277a07(jetbrains.mps.lang.intentions#1192798684353)" version="0" />
+        <module reference="28f9e497-3b42-4291-aeba-0a1039153ab1(jetbrains.mps.lang.plugin)" version="0" />
         <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
       </dependencyVersions>
       <mapping-priorities>
@@ -88,8 +91,15 @@
   <dependencies>
     <dependency reexport="false">d7a92d38-f7db-40d0-8431-763b0c3c9f20(jetbrains.mps.lang.intentions)</dependency>
     <dependency reexport="false" scope="generate-into">f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)</dependency>
+    <dependency reexport="false">28f9e497-3b42-4291-aeba-0a1039153ab1(jetbrains.mps.lang.plugin)</dependency>
+    <dependency reexport="false">1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)</dependency>
+    <dependency reexport="false">4bff7bbe-ce5f-432e-84bf-60809cb9987c(com.mbeddr.mpsutil.intentions.runtime)</dependency>
+    <dependency reexport="false">498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)</dependency>
+    <dependency reexport="false">742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)</dependency>
   </dependencies>
   <languageVersions>
+    <language slang="l:309e0004-4976-4416-b947-ec02ae4ecef2:com.mbeddr.mpsutil.modellisteners" version="0" />
+    <language slang="l:654422bf-e75f-44dc-936d-188890a746ce:de.slisson.mps.reflection" version="0" />
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
     <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />
     <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
@@ -117,6 +127,7 @@
     <language slang="l:982eb8df-2c96-4bd7-9963-11712ea622e5:jetbrains.mps.lang.resources" version="2" />
     <language slang="l:b3551702-269c-4f05-ba61-58060cef4292:jetbrains.mps.lang.rulesAndMessages" version="0" />
     <language slang="l:d8f591ec-4d86-4af2-9f92-a9e93c803ffa:jetbrains.mps.lang.scopes" version="0" />
+    <language slang="l:13744753-c81f-424a-9c1b-cf8943bf4e86:jetbrains.mps.lang.sharedConcepts" version="0" />
     <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
     <language slang="l:c72da2b9-7cce-4447-8389-f407dc1158b7:jetbrains.mps.lang.structure" version="9" />
     <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
@@ -127,16 +138,22 @@
     <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
     <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
     <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
+    <module reference="1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)" version="0" />
+    <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+    <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
     <module reference="b92f861d-0184-446d-b88b-6dcf0e070241(com.mbeddr.mpsutil.intentions)" version="0" />
+    <module reference="4bff7bbe-ce5f-432e-84bf-60809cb9987c(com.mbeddr.mpsutil.intentions.runtime)" version="0" />
     <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
     <module reference="443f4c36-fcf5-4eb6-9500-8d06ed259e3e(jetbrains.mps.baseLanguage.classifiers)" version="0" />
+    <module reference="fd392034-7849-419d-9071-12563d152375(jetbrains.mps.baseLanguage.closures)" version="0" />
     <module reference="c7d5b9dd-a05f-4be2-bc73-f2e16994cc67(jetbrains.mps.baseLanguage.lightweightdsl)" version="0" />
     <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
     <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
     <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
     <module reference="a9e4c532-c5f5-4bb7-99ef-42abb73bbb70(jetbrains.mps.lang.descriptor.aspects)" version="0" />
     <module reference="d7a92d38-f7db-40d0-8431-763b0c3c9f20(jetbrains.mps.lang.intentions)" version="0" />
+    <module reference="28f9e497-3b42-4291-aeba-0a1039153ab1(jetbrains.mps.lang.plugin)" version="0" />
     <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
   </dependencyVersions>
   <extendedLanguages />

--- a/code/intentionsmenu/com.mbeddr.mpsutil.intentions/com.mbeddr.mpsutil.intentions.mpl
+++ b/code/intentionsmenu/com.mbeddr.mpsutil.intentions/com.mbeddr.mpsutil.intentions.mpl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <language namespace="com.mbeddr.mpsutil.intentions" uuid="b92f861d-0184-446d-b88b-6dcf0e070241" languageVersion="0" moduleVersion="0">
   <models>
-    <modelRoot contentPath="${module}" type="default">
+    <modelRoot type="default" contentPath="${module}">
       <sourceRoot location="languageModels" />
     </modelRoot>
   </models>

--- a/code/intentionsmenu/com.mbeddr.mpsutil.intentions/generator/template/main@generator.mps
+++ b/code/intentionsmenu/com.mbeddr.mpsutil.intentions/generator/template/main@generator.mps
@@ -14,12 +14,17 @@
     <import index="tegv" ref="r:b91d2412-f094-4e55-8db6-3c782d7edc40(com.mbeddr.mpsutil.intentions.structure)" />
     <import index="tp3j" ref="r:00000000-0000-4000-0000-011c89590353(jetbrains.mps.lang.intentions.structure)" />
     <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" />
+    <import index="tp4k" ref="r:00000000-0000-4000-0000-011c89590368(jetbrains.mps.lang.plugin.structure)" />
   </imports>
   <registry>
     <language id="13744753-c81f-424a-9c1b-cf8943bf4e86" name="jetbrains.mps.lang.sharedConcepts">
       <concept id="1161622665029" name="jetbrains.mps.lang.sharedConcepts.structure.ConceptFunctionParameter_model" flags="nn" index="1Q6Npb" />
     </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
+        <child id="1068498886297" name="rValue" index="37vLTx" />
+        <child id="1068498886295" name="lValue" index="37vLTJ" />
+      </concept>
       <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
         <child id="1154032183016" name="body" index="2LFqv$" />
@@ -40,6 +45,7 @@
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
+      <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
       <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
@@ -181,11 +187,14 @@
   <node concept="bUwia" id="54z9_KDNYf0">
     <property role="TrG5h" value="main" />
     <node concept="1puMqW" id="54z9_KDQsXH" role="1puA0r">
-      <ref role="1puQsG" node="54z9_KDOLKh" resolve="updateDescription" />
+      <ref role="1puQsG" node="54z9_KDOLKh" resolve="updateIntentionDescription" />
+    </node>
+    <node concept="1puMqW" id="2oNrKyBcZT$" role="1puA0r">
+      <ref role="1puQsG" node="2oNrKyBcHqN" resolve="updateActionDescription" />
     </node>
   </node>
   <node concept="1pmfR0" id="54z9_KDOLKh">
-    <property role="TrG5h" value="updateDescription" />
+    <property role="TrG5h" value="updateIntentionDescription" />
     <property role="1v3f2W" value="hpv1Zf2/pre_processing" />
     <property role="1v3jST" value="true" />
     <node concept="1pplIY" id="54z9_KDOLKi" role="1pqMTA">
@@ -218,7 +227,7 @@
                           </node>
                           <node concept="3CFZ6_" id="54z9_KDOSXr" role="2OqNvi">
                             <node concept="3CFYIy" id="54z9_KDOSXs" role="3CFYIz">
-                              <ref role="3CFYIx" to="tegv:54z9_KDO4Av" resolve="IntentionGroupAnnotation" />
+                              <ref role="3CFYIx" to="tegv:54z9_KDO4Av" resolve="GroupAnnotation" />
                             </node>
                           </node>
                         </node>
@@ -295,7 +304,7 @@
                       </node>
                       <node concept="3CFZ6_" id="54z9_KDQPDa" role="2OqNvi">
                         <node concept="3CFYIy" id="54z9_KDQPDb" role="3CFYIz">
-                          <ref role="3CFYIx" to="tegv:54z9_KDO4Av" resolve="IntentionGroupAnnotation" />
+                          <ref role="3CFYIx" to="tegv:54z9_KDO4Av" resolve="GroupAnnotation" />
                         </node>
                       </node>
                     </node>
@@ -473,7 +482,7 @@
                   </node>
                   <node concept="3CFZ6_" id="54z9_KDPaQq" role="2OqNvi">
                     <node concept="3CFYIy" id="54z9_KDPaTW" role="3CFYIz">
-                      <ref role="3CFYIx" to="tegv:54z9_KDO4Av" resolve="IntentionGroupAnnotation" />
+                      <ref role="3CFYIx" to="tegv:54z9_KDO4Av" resolve="GroupAnnotation" />
                     </node>
                   </node>
                 </node>
@@ -483,6 +492,145 @@
           </node>
           <node concept="37vLTw" id="54z9_KDOT8o" role="2GsD0m">
             <ref role="3cqZAo" node="54z9_KDOSXf" resolve="all" />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1pmfR0" id="2oNrKyBcHqN">
+    <property role="TrG5h" value="updateActionDescription" />
+    <property role="1v3f2W" value="hpv1Zf2/pre_processing" />
+    <property role="1v3jST" value="true" />
+    <node concept="1pplIY" id="2oNrKyBcHqO" role="1pqMTA">
+      <node concept="3clFbS" id="2oNrKyBcHqP" role="2VODD2">
+        <node concept="3cpWs8" id="2oNrKyBcHqQ" role="3cqZAp">
+          <node concept="3cpWsn" id="2oNrKyBcHqR" role="3cpWs9">
+            <property role="TrG5h" value="all" />
+            <node concept="A3Dl8" id="2oNrKyBcHqS" role="1tU5fm">
+              <node concept="3Tqbb2" id="2oNrKyBcHqT" role="A3Ik2">
+                <ref role="ehGHo" to="tp4k:hwsE7KS" resolve="ActionDeclaration" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="2oNrKyBcHqU" role="33vP2m">
+              <node concept="2OqwBi" id="2oNrKyBcHqV" role="2Oq$k0">
+                <node concept="1Q6Npb" id="2oNrKyBcHqW" role="2Oq$k0" />
+                <node concept="2RRcyG" id="2oNrKyBcHqX" role="2OqNvi">
+                  <node concept="chp4Y" id="2oNrKyBcHqY" role="3MHsoP">
+                    <ref role="cht4Q" to="tp4k:hwsE7KS" resolve="ActionDeclaration" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3zZkjj" id="2oNrKyBcHqZ" role="2OqNvi">
+                <node concept="1bVj0M" id="2oNrKyBcHr0" role="23t8la">
+                  <node concept="3clFbS" id="2oNrKyBcHr1" role="1bW5cS">
+                    <node concept="3clFbF" id="2oNrKyBcHr2" role="3cqZAp">
+                      <node concept="2OqwBi" id="2oNrKyBcHr3" role="3clFbG">
+                        <node concept="2OqwBi" id="2oNrKyBcHr4" role="2Oq$k0">
+                          <node concept="37vLTw" id="2oNrKyBcHr5" role="2Oq$k0">
+                            <ref role="3cqZAo" node="2oNrKyBcHr9" resolve="it" />
+                          </node>
+                          <node concept="3CFZ6_" id="2oNrKyBcHr6" role="2OqNvi">
+                            <node concept="3CFYIy" id="2oNrKyBcHr7" role="3CFYIz">
+                              <ref role="3CFYIx" to="tegv:54z9_KDO4Av" resolve="GroupAnnotation" />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3x8VRR" id="2oNrKyBcHr8" role="2OqNvi" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="gl6BB" id="2oNrKyBcHr9" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="2oNrKyBcHra" role="1tU5fm" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2Gpval" id="2oNrKyBcHrb" role="3cqZAp">
+          <node concept="2GrKxI" id="2oNrKyBcHrc" role="2Gsz3X">
+            <property role="TrG5h" value="actionDeclaration" />
+          </node>
+          <node concept="3clFbS" id="2oNrKyBcHrd" role="2LFqv$">
+            <node concept="3cpWs8" id="2oNrKyBcLIw" role="3cqZAp">
+              <node concept="3cpWsn" id="2oNrKyBcLIz" role="3cpWs9">
+                <property role="TrG5h" value="caption" />
+                <node concept="17QB3L" id="2oNrKyBcLIu" role="1tU5fm" />
+                <node concept="2OqwBi" id="2oNrKyBcN8I" role="33vP2m">
+                  <node concept="2GrUjf" id="2oNrKyBcMSE" role="2Oq$k0">
+                    <ref role="2Gs0qQ" node="2oNrKyBcHrc" resolve="actionDeclaration" />
+                  </node>
+                  <node concept="3TrcHB" id="2oNrKyBcPph" role="2OqNvi">
+                    <ref role="3TsBF5" to="tp4k:hyuzpDp" resolve="caption" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs8" id="2oNrKyBcHru" role="3cqZAp">
+              <node concept="3cpWsn" id="2oNrKyBcHrv" role="3cpWs9">
+                <property role="TrG5h" value="newCaption" />
+                <node concept="17QB3L" id="2oNrKyBcHrw" role="1tU5fm" />
+                <node concept="3cpWs3" id="2oNrKyBcYqf" role="33vP2m">
+                  <node concept="37vLTw" id="2oNrKyBcYLf" role="3uHU7w">
+                    <ref role="3cqZAo" node="2oNrKyBcLIz" resolve="caption" />
+                  </node>
+                  <node concept="3cpWs3" id="2oNrKyBcHrx" role="3uHU7B">
+                    <node concept="2OqwBi" id="2oNrKyBcHrz" role="3uHU7B">
+                      <node concept="2OqwBi" id="2oNrKyBcHr$" role="2Oq$k0">
+                        <node concept="2GrUjf" id="2oNrKyBcHr_" role="2Oq$k0">
+                          <ref role="2Gs0qQ" node="2oNrKyBcHrc" resolve="actionDeclaration" />
+                        </node>
+                        <node concept="3CFZ6_" id="2oNrKyBcHrA" role="2OqNvi">
+                          <node concept="3CFYIy" id="2oNrKyBcZU5" role="3CFYIz">
+                            <ref role="3CFYIx" to="tegv:54z9_KDO4Av" resolve="GroupAnnotation" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3TrcHB" id="2oNrKyBcHrC" role="2OqNvi">
+                        <ref role="3TsBF5" to="tegv:54z9_KDO50a" resolve="label" />
+                      </node>
+                    </node>
+                    <node concept="Xl_RD" id="2oNrKyBcHry" role="3uHU7w">
+                      <property role="Xl_RC" value=": " />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="2oNrKyBcSDq" role="3cqZAp">
+              <node concept="37vLTI" id="2oNrKyBcW7G" role="3clFbG">
+                <node concept="37vLTw" id="2oNrKyBcW9G" role="37vLTx">
+                  <ref role="3cqZAo" node="2oNrKyBcHrv" resolve="newCaption" />
+                </node>
+                <node concept="2OqwBi" id="2oNrKyBcSTH" role="37vLTJ">
+                  <node concept="2GrUjf" id="2oNrKyBcSDo" role="2Oq$k0">
+                    <ref role="2Gs0qQ" node="2oNrKyBcHrc" resolve="actionDeclaration" />
+                  </node>
+                  <node concept="3TrcHB" id="2oNrKyBcTK_" role="2OqNvi">
+                    <ref role="3TsBF5" to="tp4k:hyuzpDp" resolve="caption" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="2oNrKyBcHsB" role="3cqZAp">
+              <node concept="2OqwBi" id="2oNrKyBcHsC" role="3clFbG">
+                <node concept="2OqwBi" id="2oNrKyBcHsD" role="2Oq$k0">
+                  <node concept="2GrUjf" id="2oNrKyBcHsE" role="2Oq$k0">
+                    <ref role="2Gs0qQ" node="2oNrKyBcHrc" resolve="actionDeclaration" />
+                  </node>
+                  <node concept="3CFZ6_" id="2oNrKyBcHsF" role="2OqNvi">
+                    <node concept="3CFYIy" id="2oNrKyBcHsG" role="3CFYIz">
+                      <ref role="3CFYIx" to="tegv:54z9_KDO4Av" resolve="GroupAnnotation" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3YRAZt" id="2oNrKyBcHsH" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
+          <node concept="37vLTw" id="2oNrKyBcHsI" role="2GsD0m">
+            <ref role="3cqZAo" node="2oNrKyBcHqR" resolve="all" />
           </node>
         </node>
       </node>

--- a/code/intentionsmenu/com.mbeddr.mpsutil.intentions/generator/template/main@generator.mps
+++ b/code/intentionsmenu/com.mbeddr.mpsutil.intentions/generator/template/main@generator.mps
@@ -15,16 +15,13 @@
     <import index="tp3j" ref="r:00000000-0000-4000-0000-011c89590353(jetbrains.mps.lang.intentions.structure)" />
     <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" />
     <import index="tp4k" ref="r:00000000-0000-4000-0000-011c89590368(jetbrains.mps.lang.plugin.structure)" />
+    <import index="9j2l" ref="r:acd2b506-390d-4e84-8c47-cd8fb8c9e0c0(com.mbeddr.mpsutil.intentions.behavior)" />
   </imports>
   <registry>
     <language id="13744753-c81f-424a-9c1b-cf8943bf4e86" name="jetbrains.mps.lang.sharedConcepts">
       <concept id="1161622665029" name="jetbrains.mps.lang.sharedConcepts.structure.ConceptFunctionParameter_model" flags="nn" index="1Q6Npb" />
     </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
-      <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
-        <child id="1068498886297" name="rValue" index="37vLTx" />
-        <child id="1068498886295" name="lValue" index="37vLTJ" />
-      </concept>
       <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
         <child id="1154032183016" name="body" index="2LFqv$" />
@@ -36,8 +33,8 @@
       <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
         <child id="1137022507850" name="body" index="2VODD2" />
       </concept>
-      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
-        <property id="1070475926801" name="value" index="Xl_RC" />
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
       </concept>
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <child id="1068431790190" name="initializer" index="33vP2m" />
@@ -45,29 +42,22 @@
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
-      <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
-      <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
-      <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
-        <child id="1068580123160" name="condition" index="3clFbw" />
-        <child id="1068580123161" name="ifTrue" index="3clFbx" />
-      </concept>
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
-      <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
       <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
         <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
       </concept>
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
-      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
-        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
-        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
     </language>
     <language id="b401a680-8325-4110-8fd3-84331ff25bef" name="jetbrains.mps.lang.generator">
@@ -91,74 +81,23 @@
         <child id="1199569916463" name="body" index="1bW5cS" />
       </concept>
     </language>
-    <language id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation">
-      <concept id="5455284157994012186" name="jetbrains.mps.lang.quotation.structure.NodeBuilderInitLink" flags="ng" index="2pIpSj">
-        <reference id="5455284157994012188" name="link" index="2pIpSl" />
-        <child id="1595412875168045827" name="initValue" index="28nt2d" />
-      </concept>
-      <concept id="5455284157993911077" name="jetbrains.mps.lang.quotation.structure.NodeBuilderInitProperty" flags="ng" index="2pJxcG">
-        <reference id="5455284157993911078" name="property" index="2pJxcJ" />
-        <child id="1595412875168045201" name="initValue" index="28ntcv" />
-      </concept>
-      <concept id="5455284157993863837" name="jetbrains.mps.lang.quotation.structure.NodeBuilder" flags="nn" index="2pJPEk">
-        <child id="5455284157993863838" name="quotedNode" index="2pJPEn" />
-      </concept>
-      <concept id="5455284157993863840" name="jetbrains.mps.lang.quotation.structure.NodeBuilderNode" flags="nn" index="2pJPED">
-        <reference id="5455284157993910961" name="concept" index="2pJxaS" />
-        <child id="5455284157993911099" name="values" index="2pJxcM" />
-      </concept>
-      <concept id="6985522012210254362" name="jetbrains.mps.lang.quotation.structure.NodeBuilderPropertyExpression" flags="nn" index="WxPPo">
-        <child id="6985522012210254363" name="expression" index="WxPPp" />
-      </concept>
-      <concept id="8182547171709752110" name="jetbrains.mps.lang.quotation.structure.NodeBuilderExpression" flags="nn" index="36biLy">
-        <child id="8182547171709752112" name="expression" index="36biLW" />
-      </concept>
-    </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
       <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
         <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
       </concept>
-      <concept id="1138411891628" name="jetbrains.mps.lang.smodel.structure.SNodeOperation" flags="nn" index="eCIE_">
-        <child id="1144104376918" name="parameter" index="1xVPHs" />
-      </concept>
-      <concept id="2396822768958367367" name="jetbrains.mps.lang.smodel.structure.AbstractTypeCastExpression" flags="nn" index="$5XWr">
-        <child id="6733348108486823193" name="leftExpression" index="1m5AlR" />
-        <child id="3906496115198199033" name="conceptArgument" index="3oSUPX" />
-      </concept>
-      <concept id="1171305280644" name="jetbrains.mps.lang.smodel.structure.Node_GetDescendantsOperation" flags="nn" index="2Rf3mk" />
       <concept id="1171315804604" name="jetbrains.mps.lang.smodel.structure.Model_RootsOperation" flags="nn" index="2RRcyG">
         <child id="6750920497477046361" name="conceptArgument" index="3MHsoP" />
       </concept>
-      <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
-        <child id="1177027386292" name="conceptArgument" index="cj9EA" />
-      </concept>
       <concept id="1172008320231" name="jetbrains.mps.lang.smodel.structure.Node_IsNotNullOperation" flags="nn" index="3x8VRR" />
-      <concept id="1144101972840" name="jetbrains.mps.lang.smodel.structure.OperationParm_Concept" flags="ng" index="1xMEDy">
-        <child id="1207343664468" name="conceptArgument" index="ri$Ld" />
-      </concept>
       <concept id="6407023681583036853" name="jetbrains.mps.lang.smodel.structure.NodeAttributeQualifier" flags="ng" index="3CFYIy">
         <reference id="6407023681583036854" name="attributeConcept" index="3CFYIx" />
       </concept>
       <concept id="6407023681583031218" name="jetbrains.mps.lang.smodel.structure.AttributeAccess" flags="nn" index="3CFZ6_">
         <child id="6407023681583036852" name="qualifier" index="3CFYIz" />
       </concept>
-      <concept id="1140131837776" name="jetbrains.mps.lang.smodel.structure.Node_ReplaceWithAnotherOperation" flags="nn" index="1P9Npp">
-        <child id="1140131861877" name="replacementNode" index="1P9ThW" />
-      </concept>
-      <concept id="1140137987495" name="jetbrains.mps.lang.smodel.structure.SNodeTypeCastExpression" flags="nn" index="1PxgMI" />
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
         <reference id="1138405853777" name="concept" index="ehGHo" />
       </concept>
-      <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
-        <reference id="1138056395725" name="property" index="3TsBF5" />
-      </concept>
-      <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="nn" index="3TrEf2">
-        <reference id="1138056516764" name="link" index="3Tt5mk" />
-      </concept>
-      <concept id="1138056282393" name="jetbrains.mps.lang.smodel.structure.SLinkListAccess" flags="nn" index="3Tsc0h">
-        <reference id="1138056546658" name="link" index="3TtcxE" />
-      </concept>
-      <concept id="1228341669568" name="jetbrains.mps.lang.smodel.structure.Node_DetachOperation" flags="nn" index="3YRAZt" />
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
@@ -180,7 +119,6 @@
       <concept id="1153944233411" name="jetbrains.mps.baseLanguage.collections.structure.ForEachVariableReference" flags="nn" index="2GrUjf">
         <reference id="1153944258490" name="variable" index="2Gs0qQ" />
       </concept>
-      <concept id="1165595910856" name="jetbrains.mps.baseLanguage.collections.structure.GetLastOperation" flags="nn" index="1yVyf7" />
       <concept id="1202120902084" name="jetbrains.mps.baseLanguage.collections.structure.WhereOperation" flags="nn" index="3zZkjj" />
     </language>
   </registry>
@@ -249,244 +187,13 @@
             <property role="TrG5h" value="i" />
           </node>
           <node concept="3clFbS" id="54z9_KDOT6J" role="2LFqv$">
-            <node concept="3cpWs8" id="54z9_KDOTFn" role="3cqZAp">
-              <node concept="3cpWsn" id="54z9_KDOTFo" role="3cpWs9">
-                <property role="TrG5h" value="f" />
-                <node concept="3Tqbb2" id="54z9_KDOTFl" role="1tU5fm">
-                  <ref role="ehGHo" to="tp3j:hmS6ZEB" resolve="DescriptionBlock" />
+            <node concept="3clFbF" id="24lzbKWi0JJ" role="3cqZAp">
+              <node concept="2YIFZM" id="24lzbKWi0Lp" role="3clFbG">
+                <ref role="37wK5l" to="9j2l:24lzbKWhSQ3" resolve="updateIntention" />
+                <ref role="1Pybhc" to="9j2l:24lzbKWhRGV" resolve="DescriptionUpdater" />
+                <node concept="2GrUjf" id="24lzbKWi0LP" role="37wK5m">
+                  <ref role="2Gs0qQ" node="54z9_KDOT6H" resolve="i" />
                 </node>
-                <node concept="2OqwBi" id="54z9_KDOTFp" role="33vP2m">
-                  <node concept="2GrUjf" id="54z9_KDOTFq" role="2Oq$k0">
-                    <ref role="2Gs0qQ" node="54z9_KDOT6H" resolve="i" />
-                  </node>
-                  <node concept="3TrEf2" id="54z9_KDOTFr" role="2OqNvi">
-                    <ref role="3Tt5mk" to="tp3j:2c3oNEsfd2D" resolve="descriptionFunction" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3cpWs8" id="54z9_KDP1VH" role="3cqZAp">
-              <node concept="3cpWsn" id="54z9_KDP1VI" role="3cpWs9">
-                <property role="TrG5h" value="l" />
-                <node concept="3Tqbb2" id="54z9_KDP1VG" role="1tU5fm">
-                  <ref role="ehGHo" to="tpee:fzclF8l" resolve="Statement" />
-                </node>
-                <node concept="2OqwBi" id="54z9_KDP1VJ" role="33vP2m">
-                  <node concept="2OqwBi" id="54z9_KDP1VK" role="2Oq$k0">
-                    <node concept="2OqwBi" id="54z9_KDP1VL" role="2Oq$k0">
-                      <node concept="37vLTw" id="54z9_KDP1VM" role="2Oq$k0">
-                        <ref role="3cqZAo" node="54z9_KDOTFo" resolve="f" />
-                      </node>
-                      <node concept="3TrEf2" id="54z9_KDP1VN" role="2OqNvi">
-                        <ref role="3Tt5mk" to="tpee:gyVODHa" resolve="body" />
-                      </node>
-                    </node>
-                    <node concept="3Tsc0h" id="54z9_KDP1VO" role="2OqNvi">
-                      <ref role="3TtcxE" to="tpee:fzcqZ_x" resolve="statement" />
-                    </node>
-                  </node>
-                  <node concept="1yVyf7" id="54z9_KDP1VP" role="2OqNvi" />
-                </node>
-              </node>
-            </node>
-            <node concept="3cpWs8" id="54z9_KDQPD5" role="3cqZAp">
-              <node concept="3cpWsn" id="54z9_KDQPD6" role="3cpWs9">
-                <property role="TrG5h" value="s" />
-                <node concept="17QB3L" id="54z9_KDQPCk" role="1tU5fm" />
-                <node concept="3cpWs3" id="54z9_KDQQ5p" role="33vP2m">
-                  <node concept="Xl_RD" id="54z9_KDQQ5s" role="3uHU7w">
-                    <property role="Xl_RC" value=": " />
-                  </node>
-                  <node concept="2OqwBi" id="54z9_KDQPD7" role="3uHU7B">
-                    <node concept="2OqwBi" id="54z9_KDQPD8" role="2Oq$k0">
-                      <node concept="2GrUjf" id="54z9_KDQPD9" role="2Oq$k0">
-                        <ref role="2Gs0qQ" node="54z9_KDOT6H" resolve="i" />
-                      </node>
-                      <node concept="3CFZ6_" id="54z9_KDQPDa" role="2OqNvi">
-                        <node concept="3CFYIy" id="54z9_KDQPDb" role="3CFYIz">
-                          <ref role="3CFYIx" to="tegv:54z9_KDO4Av" resolve="GroupAnnotation" />
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="3TrcHB" id="54z9_KDQPDc" role="2OqNvi">
-                      <ref role="3TsBF5" to="tegv:54z9_KDO50a" resolve="label" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbJ" id="54z9_KDOTId" role="3cqZAp">
-              <node concept="3clFbS" id="54z9_KDOTIf" role="3clFbx">
-                <node concept="3clFbF" id="54z9_KDP22K" role="3cqZAp">
-                  <node concept="2OqwBi" id="54z9_KDP24Q" role="3clFbG">
-                    <node concept="37vLTw" id="54z9_KDP22I" role="2Oq$k0">
-                      <ref role="3cqZAo" node="54z9_KDP1VI" resolve="l" />
-                    </node>
-                    <node concept="1P9Npp" id="54z9_KDP2h8" role="2OqNvi">
-                      <node concept="2pJPEk" id="54z9_KDP2hz" role="1P9ThW">
-                        <node concept="2pJPED" id="54z9_KDP2ia" role="2pJPEn">
-                          <ref role="2pJxaS" to="tpee:fzclF8j" resolve="ExpressionStatement" />
-                          <node concept="2pIpSj" id="54z9_KDP2jl" role="2pJxcM">
-                            <ref role="2pIpSl" to="tpee:fzclF8k" resolve="expression" />
-                            <node concept="2pJPED" id="54z9_KDP2k2" role="28nt2d">
-                              <ref role="2pJxaS" to="tpee:fzcpWvV" resolve="PlusExpression" />
-                              <node concept="2pIpSj" id="54z9_KDP2kf" role="2pJxcM">
-                                <ref role="2pIpSl" to="tpee:fJuHU4s" resolve="leftExpression" />
-                                <node concept="2pJPED" id="54z9_KDP2kt" role="28nt2d">
-                                  <ref role="2pJxaS" to="tpee:f$Xl_Og" resolve="StringLiteral" />
-                                  <node concept="2pJxcG" id="54z9_KDP2kE" role="2pJxcM">
-                                    <ref role="2pJxcJ" to="tpee:f$Xl_Oh" resolve="value" />
-                                    <node concept="WxPPo" id="27yO7ubqcMO" role="28ntcv">
-                                      <node concept="37vLTw" id="54z9_KDQPDd" role="WxPPp">
-                                        <ref role="3cqZAo" node="54z9_KDQPD6" resolve="s" />
-                                      </node>
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                              <node concept="2pIpSj" id="54z9_KDP3h6" role="2pJxcM">
-                                <ref role="2pIpSl" to="tpee:fJuHU4r" resolve="rightExpression" />
-                                <node concept="2pJPED" id="54z9_KDP3o5" role="28nt2d">
-                                  <ref role="2pJxaS" to="tpee:fHeOMHZ" resolve="ParenthesizedExpression" />
-                                  <node concept="2pIpSj" id="54z9_KDP3oi" role="2pJxcM">
-                                    <ref role="2pIpSl" to="tpee:fHeOMI0" resolve="expression" />
-                                    <node concept="36biLy" id="54z9_KDP3ow" role="28nt2d">
-                                      <node concept="2OqwBi" id="54z9_KDP3N6" role="36biLW">
-                                        <node concept="1PxgMI" id="54z9_KDP3HE" role="2Oq$k0">
-                                          <node concept="37vLTw" id="54z9_KDP3oF" role="1m5AlR">
-                                            <ref role="3cqZAo" node="54z9_KDP1VI" resolve="l" />
-                                          </node>
-                                          <node concept="chp4Y" id="1RGhARQgVdR" role="3oSUPX">
-                                            <ref role="cht4Q" to="tpee:fzclF8j" resolve="ExpressionStatement" />
-                                          </node>
-                                        </node>
-                                        <node concept="3TrEf2" id="54z9_KDP46G" role="2OqNvi">
-                                          <ref role="3Tt5mk" to="tpee:fzclF8k" resolve="expression" />
-                                        </node>
-                                      </node>
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="2OqwBi" id="54z9_KDP1l$" role="3clFbw">
-                <node concept="37vLTw" id="54z9_KDP1VQ" role="2Oq$k0">
-                  <ref role="3cqZAo" node="54z9_KDP1VI" resolve="l" />
-                </node>
-                <node concept="1mIQ4w" id="54z9_KDP1OF" role="2OqNvi">
-                  <node concept="chp4Y" id="54z9_KDP1PE" role="cj9EA">
-                    <ref role="cht4Q" to="tpee:fzclF8j" resolve="ExpressionStatement" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="2Gpval" id="54z9_KDP4GC" role="3cqZAp">
-              <node concept="2GrKxI" id="54z9_KDP4GH" role="2Gsz3X">
-                <property role="TrG5h" value="r" />
-              </node>
-              <node concept="3clFbS" id="54z9_KDP4GM" role="2LFqv$">
-                <node concept="3cpWs8" id="54z9_KDP765" role="3cqZAp">
-                  <node concept="3cpWsn" id="54z9_KDP766" role="3cpWs9">
-                    <property role="TrG5h" value="ex" />
-                    <node concept="3Tqbb2" id="54z9_KDP75p" role="1tU5fm">
-                      <ref role="ehGHo" to="tpee:fz3vP1J" resolve="Expression" />
-                    </node>
-                    <node concept="2OqwBi" id="54z9_KDP767" role="33vP2m">
-                      <node concept="2GrUjf" id="54z9_KDP768" role="2Oq$k0">
-                        <ref role="2Gs0qQ" node="54z9_KDP4GH" resolve="r" />
-                      </node>
-                      <node concept="3TrEf2" id="54z9_KDP769" role="2OqNvi">
-                        <ref role="3Tt5mk" to="tpee:fzcqZ_G" resolve="expression" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="3clFbF" id="54z9_KDP61x" role="3cqZAp">
-                  <node concept="2OqwBi" id="54z9_KDP78z" role="3clFbG">
-                    <node concept="37vLTw" id="54z9_KDP76a" role="2Oq$k0">
-                      <ref role="3cqZAo" node="54z9_KDP766" resolve="ex" />
-                    </node>
-                    <node concept="1P9Npp" id="54z9_KDP7hz" role="2OqNvi">
-                      <node concept="2pJPEk" id="54z9_KDP9AS" role="1P9ThW">
-                        <node concept="2pJPED" id="54z9_KDP95A" role="2pJPEn">
-                          <ref role="2pJxaS" to="tpee:fzcpWvV" resolve="PlusExpression" />
-                          <node concept="2pIpSj" id="54z9_KDP95B" role="2pJxcM">
-                            <ref role="2pIpSl" to="tpee:fJuHU4s" resolve="leftExpression" />
-                            <node concept="2pJPED" id="54z9_KDP95C" role="28nt2d">
-                              <ref role="2pJxaS" to="tpee:f$Xl_Og" resolve="StringLiteral" />
-                              <node concept="2pJxcG" id="54z9_KDP95D" role="2pJxcM">
-                                <ref role="2pJxcJ" to="tpee:f$Xl_Oh" resolve="value" />
-                                <node concept="WxPPo" id="27yO7ubqcMP" role="28ntcv">
-                                  <node concept="37vLTw" id="54z9_KDQPDe" role="WxPPp">
-                                    <ref role="3cqZAo" node="54z9_KDQPD6" resolve="s" />
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                          <node concept="2pIpSj" id="54z9_KDP95K" role="2pJxcM">
-                            <ref role="2pIpSl" to="tpee:fJuHU4r" resolve="rightExpression" />
-                            <node concept="2pJPED" id="54z9_KDP95L" role="28nt2d">
-                              <ref role="2pJxaS" to="tpee:fHeOMHZ" resolve="ParenthesizedExpression" />
-                              <node concept="2pIpSj" id="54z9_KDP95M" role="2pJxcM">
-                                <ref role="2pIpSl" to="tpee:fHeOMI0" resolve="expression" />
-                                <node concept="36biLy" id="54z9_KDP95N" role="28nt2d">
-                                  <node concept="2OqwBi" id="54z9_KDP9N3" role="36biLW">
-                                    <node concept="2GrUjf" id="54z9_KDP9Jx" role="2Oq$k0">
-                                      <ref role="2Gs0qQ" node="54z9_KDP4GH" resolve="r" />
-                                    </node>
-                                    <node concept="3TrEf2" id="54z9_KDPa89" role="2OqNvi">
-                                      <ref role="3Tt5mk" to="tpee:fzcqZ_G" resolve="expression" />
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="2OqwBi" id="54z9_KDP5Di" role="2GsD0m">
-                <node concept="2OqwBi" id="54z9_KDP4Y_" role="2Oq$k0">
-                  <node concept="37vLTw" id="54z9_KDP4U3" role="2Oq$k0">
-                    <ref role="3cqZAo" node="54z9_KDOTFo" resolve="f" />
-                  </node>
-                  <node concept="3TrEf2" id="54z9_KDP5hN" role="2OqNvi">
-                    <ref role="3Tt5mk" to="tpee:gyVODHa" resolve="body" />
-                  </node>
-                </node>
-                <node concept="2Rf3mk" id="54z9_KDP5Yo" role="2OqNvi">
-                  <node concept="1xMEDy" id="54z9_KDP5Yq" role="1xVPHs">
-                    <node concept="chp4Y" id="54z9_KDP5Zb" role="ri$Ld">
-                      <ref role="cht4Q" to="tpee:fzcpWvY" resolve="ReturnStatement" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbF" id="54z9_KDPahS" role="3cqZAp">
-              <node concept="2OqwBi" id="54z9_KDPaZc" role="3clFbG">
-                <node concept="2OqwBi" id="54z9_KDPaoj" role="2Oq$k0">
-                  <node concept="2GrUjf" id="54z9_KDPahQ" role="2Oq$k0">
-                    <ref role="2Gs0qQ" node="54z9_KDOT6H" resolve="i" />
-                  </node>
-                  <node concept="3CFZ6_" id="54z9_KDPaQq" role="2OqNvi">
-                    <node concept="3CFYIy" id="54z9_KDPaTW" role="3CFYIz">
-                      <ref role="3CFYIx" to="tegv:54z9_KDO4Av" resolve="GroupAnnotation" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="3YRAZt" id="1RGhARQgV$M" role="2OqNvi" />
               </node>
             </node>
           </node>
@@ -550,82 +257,16 @@
         </node>
         <node concept="2Gpval" id="2oNrKyBcHrb" role="3cqZAp">
           <node concept="2GrKxI" id="2oNrKyBcHrc" role="2Gsz3X">
-            <property role="TrG5h" value="actionDeclaration" />
+            <property role="TrG5h" value="declaration" />
           </node>
           <node concept="3clFbS" id="2oNrKyBcHrd" role="2LFqv$">
-            <node concept="3cpWs8" id="2oNrKyBcLIw" role="3cqZAp">
-              <node concept="3cpWsn" id="2oNrKyBcLIz" role="3cpWs9">
-                <property role="TrG5h" value="caption" />
-                <node concept="17QB3L" id="2oNrKyBcLIu" role="1tU5fm" />
-                <node concept="2OqwBi" id="2oNrKyBcN8I" role="33vP2m">
-                  <node concept="2GrUjf" id="2oNrKyBcMSE" role="2Oq$k0">
-                    <ref role="2Gs0qQ" node="2oNrKyBcHrc" resolve="actionDeclaration" />
-                  </node>
-                  <node concept="3TrcHB" id="2oNrKyBcPph" role="2OqNvi">
-                    <ref role="3TsBF5" to="tp4k:hyuzpDp" resolve="caption" />
-                  </node>
+            <node concept="3clFbF" id="24lzbKWkdBA" role="3cqZAp">
+              <node concept="2YIFZM" id="24lzbKWke2D" role="3clFbG">
+                <ref role="37wK5l" to="9j2l:24lzbKWk9jN" resolve="updateAction" />
+                <ref role="1Pybhc" to="9j2l:24lzbKWhRGV" resolve="DescriptionUpdater" />
+                <node concept="2GrUjf" id="24lzbKWke2E" role="37wK5m">
+                  <ref role="2Gs0qQ" node="2oNrKyBcHrc" resolve="declaration" />
                 </node>
-              </node>
-            </node>
-            <node concept="3cpWs8" id="2oNrKyBcHru" role="3cqZAp">
-              <node concept="3cpWsn" id="2oNrKyBcHrv" role="3cpWs9">
-                <property role="TrG5h" value="newCaption" />
-                <node concept="17QB3L" id="2oNrKyBcHrw" role="1tU5fm" />
-                <node concept="3cpWs3" id="2oNrKyBcYqf" role="33vP2m">
-                  <node concept="37vLTw" id="2oNrKyBcYLf" role="3uHU7w">
-                    <ref role="3cqZAo" node="2oNrKyBcLIz" resolve="caption" />
-                  </node>
-                  <node concept="3cpWs3" id="2oNrKyBcHrx" role="3uHU7B">
-                    <node concept="2OqwBi" id="2oNrKyBcHrz" role="3uHU7B">
-                      <node concept="2OqwBi" id="2oNrKyBcHr$" role="2Oq$k0">
-                        <node concept="2GrUjf" id="2oNrKyBcHr_" role="2Oq$k0">
-                          <ref role="2Gs0qQ" node="2oNrKyBcHrc" resolve="actionDeclaration" />
-                        </node>
-                        <node concept="3CFZ6_" id="2oNrKyBcHrA" role="2OqNvi">
-                          <node concept="3CFYIy" id="2oNrKyBcZU5" role="3CFYIz">
-                            <ref role="3CFYIx" to="tegv:54z9_KDO4Av" resolve="GroupAnnotation" />
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="3TrcHB" id="2oNrKyBcHrC" role="2OqNvi">
-                        <ref role="3TsBF5" to="tegv:54z9_KDO50a" resolve="label" />
-                      </node>
-                    </node>
-                    <node concept="Xl_RD" id="2oNrKyBcHry" role="3uHU7w">
-                      <property role="Xl_RC" value=": " />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbF" id="2oNrKyBcSDq" role="3cqZAp">
-              <node concept="37vLTI" id="2oNrKyBcW7G" role="3clFbG">
-                <node concept="37vLTw" id="2oNrKyBcW9G" role="37vLTx">
-                  <ref role="3cqZAo" node="2oNrKyBcHrv" resolve="newCaption" />
-                </node>
-                <node concept="2OqwBi" id="2oNrKyBcSTH" role="37vLTJ">
-                  <node concept="2GrUjf" id="2oNrKyBcSDo" role="2Oq$k0">
-                    <ref role="2Gs0qQ" node="2oNrKyBcHrc" resolve="actionDeclaration" />
-                  </node>
-                  <node concept="3TrcHB" id="2oNrKyBcTK_" role="2OqNvi">
-                    <ref role="3TsBF5" to="tp4k:hyuzpDp" resolve="caption" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbF" id="2oNrKyBcHsB" role="3cqZAp">
-              <node concept="2OqwBi" id="2oNrKyBcHsC" role="3clFbG">
-                <node concept="2OqwBi" id="2oNrKyBcHsD" role="2Oq$k0">
-                  <node concept="2GrUjf" id="2oNrKyBcHsE" role="2Oq$k0">
-                    <ref role="2Gs0qQ" node="2oNrKyBcHrc" resolve="actionDeclaration" />
-                  </node>
-                  <node concept="3CFZ6_" id="2oNrKyBcHsF" role="2OqNvi">
-                    <node concept="3CFYIy" id="2oNrKyBcHsG" role="3CFYIz">
-                      <ref role="3CFYIx" to="tegv:54z9_KDO4Av" resolve="GroupAnnotation" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="3YRAZt" id="2oNrKyBcHsH" role="2OqNvi" />
               </node>
             </node>
           </node>

--- a/code/intentionsmenu/com.mbeddr.mpsutil.intentions/languageModels/behavior.mps
+++ b/code/intentionsmenu/com.mbeddr.mpsutil.intentions/languageModels/behavior.mps
@@ -3,8 +3,6 @@
   <persistence version="9" />
   <languages>
     <use id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior" version="2" />
-    <use id="654422bf-e75f-44dc-936d-188890a746ce" name="de.slisson.mps.reflection" version="0" />
-    <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="14" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -15,14 +13,12 @@
     <import index="7bx7" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.workbench.action(MPS.Platform/)" />
     <import index="ih8q" ref="r:990d360b-3ac3-45fa-8ed3-0bbf017bba84(com.mbeddr.mpsutil.intentions.runtime)" />
     <import index="tp4k" ref="r:00000000-0000-4000-0000-011c89590368(jetbrains.mps.lang.plugin.structure)" />
-    <import index="tegv" ref="r:b91d2412-f094-4e55-8db6-3c782d7edc40(com.mbeddr.mpsutil.intentions.structure)" implicit="true" />
+    <import index="tp3j" ref="r:00000000-0000-4000-0000-011c89590353(jetbrains.mps.lang.intentions.structure)" />
+    <import index="tegv" ref="r:b91d2412-f094-4e55-8db6-3c782d7edc40(com.mbeddr.mpsutil.intentions.structure)" />
+    <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" />
+    <import index="3o3z" ref="39983771-4e9b-401b-a1a9-1da6c777c843/java:com.google.common.collect(MPS.ThirdParty/)" implicit="true" />
   </imports>
   <registry>
-    <language id="654422bf-e75f-44dc-936d-188890a746ce" name="de.slisson.mps.reflection">
-      <concept id="8473566765275063380" name="de.slisson.mps.reflection.structure.ReflectionFieldAccess" flags="ng" index="1PnCL0">
-        <reference id="1197029500499" name="fieldDeclaration" index="2Oxat5" />
-      </concept>
-    </language>
     <language id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior">
       <concept id="1225194240794" name="jetbrains.mps.lang.behavior.structure.ConceptBehavior" flags="ng" index="13h7C7">
         <reference id="1225194240799" name="concept" index="13h7C2" />
@@ -30,7 +26,9 @@
         <child id="1225194240801" name="constructor" index="13h7CW" />
       </concept>
       <concept id="1225194413805" name="jetbrains.mps.lang.behavior.structure.ConceptConstructorDeclaration" flags="in" index="13hLZK" />
-      <concept id="1225194472830" name="jetbrains.mps.lang.behavior.structure.ConceptMethodDeclaration" flags="ng" index="13i0hz" />
+      <concept id="1225194472830" name="jetbrains.mps.lang.behavior.structure.ConceptMethodDeclaration" flags="ng" index="13i0hz">
+        <property id="5864038008284099149" name="isStatic" index="2Ki8OM" />
+      </concept>
       <concept id="1225194691553" name="jetbrains.mps.lang.behavior.structure.ThisNodeExpression" flags="nn" index="13iPFW" />
     </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
@@ -43,6 +41,7 @@
         <child id="1068498886295" name="lValue" index="37vLTJ" />
       </concept>
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
       <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
         <child id="1154032183016" name="body" index="2LFqv$" />
       </concept>
@@ -50,14 +49,21 @@
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
       </concept>
-      <concept id="3870108946630849399" name="jetbrains.mps.baseLanguage.structure.StaticFieldReferenceOperation" flags="ng" index="SiP3y" />
       <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
         <child id="1137022507850" name="body" index="2VODD2" />
+      </concept>
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="1081236700938" name="jetbrains.mps.baseLanguage.structure.StaticMethodDeclaration" flags="ig" index="2YIFZL" />
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
       </concept>
       <concept id="1070534934090" name="jetbrains.mps.baseLanguage.structure.CastExpression" flags="nn" index="10QFUN">
         <child id="1070534934091" name="type" index="10QFUM" />
         <child id="1070534934092" name="expression" index="10QFUP" />
       </concept>
+      <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu" />
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <child id="1068431790190" name="initializer" index="33vP2m" />
       </concept>
@@ -89,6 +95,7 @@
       <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
         <property id="1068580123138" name="value" index="3clFbU" />
       </concept>
+      <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
       <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6" />
       <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
         <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
@@ -97,6 +104,10 @@
       <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+      <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
+        <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
       </concept>
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
@@ -110,17 +121,59 @@
       </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
     </language>
+    <language id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation">
+      <concept id="5455284157994012186" name="jetbrains.mps.lang.quotation.structure.NodeBuilderInitLink" flags="ng" index="2pIpSj">
+        <reference id="5455284157994012188" name="link" index="2pIpSl" />
+        <child id="1595412875168045827" name="initValue" index="28nt2d" />
+      </concept>
+      <concept id="5455284157993911077" name="jetbrains.mps.lang.quotation.structure.NodeBuilderInitProperty" flags="ng" index="2pJxcG">
+        <reference id="5455284157993911078" name="property" index="2pJxcJ" />
+        <child id="1595412875168045201" name="initValue" index="28ntcv" />
+      </concept>
+      <concept id="5455284157993863837" name="jetbrains.mps.lang.quotation.structure.NodeBuilder" flags="nn" index="2pJPEk">
+        <child id="5455284157993863838" name="quotedNode" index="2pJPEn" />
+      </concept>
+      <concept id="5455284157993863840" name="jetbrains.mps.lang.quotation.structure.NodeBuilderNode" flags="nn" index="2pJPED">
+        <reference id="5455284157993910961" name="concept" index="2pJxaS" />
+        <child id="5455284157993911099" name="values" index="2pJxcM" />
+      </concept>
+      <concept id="6985522012210254362" name="jetbrains.mps.lang.quotation.structure.NodeBuilderPropertyExpression" flags="nn" index="WxPPo">
+        <child id="6985522012210254363" name="expression" index="WxPPp" />
+      </concept>
+      <concept id="8182547171709752110" name="jetbrains.mps.lang.quotation.structure.NodeBuilderExpression" flags="nn" index="36biLy">
+        <child id="8182547171709752112" name="expression" index="36biLW" />
+      </concept>
+    </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
       <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
         <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
+      </concept>
+      <concept id="1138411891628" name="jetbrains.mps.lang.smodel.structure.SNodeOperation" flags="nn" index="eCIE_">
+        <child id="1144104376918" name="parameter" index="1xVPHs" />
       </concept>
       <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
       <concept id="2396822768958367367" name="jetbrains.mps.lang.smodel.structure.AbstractTypeCastExpression" flags="nn" index="$5XWr">
         <child id="6733348108486823193" name="leftExpression" index="1m5AlR" />
         <child id="3906496115198199033" name="conceptArgument" index="3oSUPX" />
       </concept>
+      <concept id="1171305280644" name="jetbrains.mps.lang.smodel.structure.Node_GetDescendantsOperation" flags="nn" index="2Rf3mk" />
       <concept id="1139613262185" name="jetbrains.mps.lang.smodel.structure.Node_GetParentOperation" flags="nn" index="1mfA1w" />
+      <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
+        <child id="1177027386292" name="conceptArgument" index="cj9EA" />
+      </concept>
       <concept id="1171999116870" name="jetbrains.mps.lang.smodel.structure.Node_IsNullOperation" flags="nn" index="3w_OXm" />
+      <concept id="1144101972840" name="jetbrains.mps.lang.smodel.structure.OperationParm_Concept" flags="ng" index="1xMEDy">
+        <child id="1207343664468" name="conceptArgument" index="ri$Ld" />
+      </concept>
+      <concept id="6407023681583036853" name="jetbrains.mps.lang.smodel.structure.NodeAttributeQualifier" flags="ng" index="3CFYIy">
+        <reference id="6407023681583036854" name="attributeConcept" index="3CFYIx" />
+      </concept>
+      <concept id="6407023681583031218" name="jetbrains.mps.lang.smodel.structure.AttributeAccess" flags="nn" index="3CFZ6_">
+        <child id="6407023681583036852" name="qualifier" index="3CFYIz" />
+      </concept>
+      <concept id="1140131837776" name="jetbrains.mps.lang.smodel.structure.Node_ReplaceWithAnotherOperation" flags="nn" index="1P9Npp">
+        <child id="1140131861877" name="replacementNode" index="1P9ThW" />
+      </concept>
       <concept id="1140137987495" name="jetbrains.mps.lang.smodel.structure.SNodeTypeCastExpression" flags="nn" index="1PxgMI">
         <property id="1238684351431" name="asCast" index="1BlNFB" />
       </concept>
@@ -130,6 +183,13 @@
       <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
         <reference id="1138056395725" name="property" index="3TsBF5" />
       </concept>
+      <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="nn" index="3TrEf2">
+        <reference id="1138056516764" name="link" index="3Tt5mk" />
+      </concept>
+      <concept id="1138056282393" name="jetbrains.mps.lang.smodel.structure.SLinkListAccess" flags="nn" index="3Tsc0h">
+        <reference id="1138056546658" name="link" index="3TtcxE" />
+      </concept>
+      <concept id="1228341669568" name="jetbrains.mps.lang.smodel.structure.Node_DetachOperation" flags="nn" index="3YRAZt" />
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
@@ -152,10 +212,7 @@
         <reference id="1153944258490" name="variable" index="2Gs0qQ" />
       </concept>
       <concept id="1167380149909" name="jetbrains.mps.baseLanguage.collections.structure.RemoveElementOperation" flags="nn" index="3dhRuq" />
-      <concept id="1197932370469" name="jetbrains.mps.baseLanguage.collections.structure.MapElement" flags="nn" index="3EllGN">
-        <child id="1197932505799" name="map" index="3ElQJh" />
-        <child id="1197932525128" name="key" index="3ElVtu" />
-      </concept>
+      <concept id="1165595910856" name="jetbrains.mps.baseLanguage.collections.structure.GetLastOperation" flags="nn" index="1yVyf7" />
     </language>
   </registry>
   <node concept="13h7C7" id="54O0Dxcsiiz">
@@ -252,23 +309,17 @@
           <node concept="3cpWsn" id="7Sc8bwtQ_oO" role="3cpWs9">
             <property role="TrG5h" value="producer" />
             <node concept="3uibUv" id="7Sc8bwtQ$Wy" role="1tU5fm">
-              <ref role="3uigEE" to="ih8q:2jDew64JcPx" resolve="MyIntentionMenuProducer" />
+              <ref role="3uigEE" to="ih8q:2jDew64JcPx" resolve="ActionIntentionMenuProducer" />
             </node>
             <node concept="0kSF2" id="7Sc8bwtQ_oP" role="33vP2m">
               <node concept="3uibUv" id="7Sc8bwtQ_oQ" role="0kSFW">
-                <ref role="3uigEE" to="ih8q:2jDew64JcPx" resolve="MyIntentionMenuProducer" />
+                <ref role="3uigEE" to="ih8q:2jDew64JcPx" resolve="ActionIntentionMenuProducer" />
               </node>
-              <node concept="2OqwBi" id="7Sc8bwtQ_oR" role="0kSFX">
-                <node concept="2OqwBi" id="7Sc8bwtQ_oS" role="2Oq$k0">
-                  <node concept="37vLTw" id="7Sc8bwtQ_oT" role="2Oq$k0">
-                    <ref role="3cqZAo" node="7Sc8bwtP$z6" resolve="editorComponent" />
-                  </node>
-                  <node concept="1PnCL0" id="7Sc8bwtQ_oU" role="2OqNvi">
-                    <ref role="2Oxat5" to="exr9:~EditorComponent.myIntentionsSupport" resolve="myIntentionsSupport" />
-                  </node>
-                </node>
-                <node concept="1PnCL0" id="7Sc8bwtQ_oV" role="2OqNvi">
-                  <ref role="2Oxat5" to="exr9:~IntentionsSupport.myMenuProducer" resolve="myMenuProducer" />
+              <node concept="2YIFZM" id="38Yx6hD7qU0" role="0kSFX">
+                <ref role="37wK5l" to="ih8q:38Yx6hD6zfT" resolve="getIntentionMenuProducer" />
+                <ref role="1Pybhc" to="ih8q:4hHbxs9xqxD" resolve="MyIntentionsSupport" />
+                <node concept="37vLTw" id="38Yx6hD7qWt" role="37wK5m">
+                  <ref role="3cqZAo" node="7Sc8bwtP$z6" resolve="editorComponent" />
                 </node>
               </node>
             </node>
@@ -282,16 +333,19 @@
                 <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
               </node>
             </node>
-            <node concept="3EllGN" id="7Sc8bwtQBCF" role="33vP2m">
-              <node concept="37vLTw" id="$kD7tOMSUJ" role="3ElVtu">
-                <ref role="3cqZAo" node="$kD7tOMSHu" resolve="oldValue" />
-              </node>
-              <node concept="2OqwBi" id="7Sc8bwtQBCH" role="3ElQJh">
+            <node concept="2OqwBi" id="4rzEAhzof0l" role="33vP2m">
+              <node concept="2OqwBi" id="7Sc8bwtQBCH" role="2Oq$k0">
                 <node concept="37vLTw" id="7Sc8bwtQBCI" role="2Oq$k0">
                   <ref role="3cqZAo" node="7Sc8bwtQ_oO" resolve="producer" />
                 </node>
-                <node concept="SiP3y" id="7Sc8bwtQBCJ" role="2OqNvi">
-                  <ref role="3cqZAo" to="ih8q:5Rdndlpp80A" resolve="groupedActionsCache" />
+                <node concept="liA8E" id="6ob0HsMLRkc" role="2OqNvi">
+                  <ref role="37wK5l" to="ih8q:6ob0HsML7OT" resolve="getCache" />
+                </node>
+              </node>
+              <node concept="liA8E" id="4rzEAhzohen" role="2OqNvi">
+                <ref role="37wK5l" to="3o3z:~SetMultimap.get(java.lang.Object)" resolve="get" />
+                <node concept="37vLTw" id="4rzEAhzohAz" role="37wK5m">
+                  <ref role="3cqZAo" node="$kD7tOMSHu" resolve="oldValue" />
                 </node>
               </node>
             </node>
@@ -363,9 +417,402 @@
         <node concept="17QB3L" id="$kD7tOMWSI" role="1tU5fm" />
       </node>
     </node>
+    <node concept="13i0hz" id="24lzbKWhznQ" role="13h7CS">
+      <property role="TrG5h" value="getSeparator" />
+      <property role="2Ki8OM" value="true" />
+      <node concept="3Tm1VV" id="24lzbKWhznR" role="1B3o_S" />
+      <node concept="17QB3L" id="24lzbKWhzrV" role="3clF45" />
+      <node concept="3clFbS" id="24lzbKWhznT" role="3clF47">
+        <node concept="3clFbF" id="24lzbKWhzte" role="3cqZAp">
+          <node concept="Xl_RD" id="24lzbKWhztd" role="3clFbG">
+            <property role="Xl_RC" value=":" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="13i0hz" id="24lzbKWiSKe" role="13h7CS">
+      <property role="TrG5h" value="generateGroupedCaption" />
+      <node concept="3Tm1VV" id="24lzbKWiSKf" role="1B3o_S" />
+      <node concept="17QB3L" id="24lzbKWiSOj" role="3clF45" />
+      <node concept="3clFbS" id="24lzbKWiSKh" role="3clF47">
+        <node concept="3clFbF" id="24lzbKWiUo$" role="3cqZAp">
+          <node concept="3cpWs3" id="38Yx6hD3$ON" role="3clFbG">
+            <node concept="37vLTw" id="38Yx6hD3$P_" role="3uHU7w">
+              <ref role="3cqZAo" node="24lzbKWiXKS" resolve="caption" />
+            </node>
+            <node concept="3cpWs3" id="24lzbKWiW4n" role="3uHU7B">
+              <node concept="2OqwBi" id="24lzbKWiU_c" role="3uHU7B">
+                <node concept="13iPFW" id="24lzbKWiUoy" role="2Oq$k0" />
+                <node concept="3TrcHB" id="24lzbKWiUNo" role="2OqNvi">
+                  <ref role="3TsBF5" to="tegv:54z9_KDO50a" resolve="label" />
+                </node>
+              </node>
+              <node concept="Xl_RD" id="24lzbKWiW4q" role="3uHU7w">
+                <property role="Xl_RC" value=": " />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="24lzbKWiXKS" role="3clF46">
+        <property role="TrG5h" value="caption" />
+        <node concept="17QB3L" id="24lzbKWiXKR" role="1tU5fm" />
+      </node>
+    </node>
     <node concept="13hLZK" id="$kD7tOMQMy" role="13h7CW">
       <node concept="3clFbS" id="$kD7tOMQMz" role="2VODD2" />
     </node>
+  </node>
+  <node concept="312cEu" id="24lzbKWhRGV">
+    <property role="TrG5h" value="DescriptionUpdater" />
+    <node concept="2YIFZL" id="24lzbKWhSQ3" role="jymVt">
+      <property role="TrG5h" value="updateIntention" />
+      <node concept="3clFbS" id="24lzbKWhSQ6" role="3clF47">
+        <node concept="3cpWs8" id="24lzbKWhSRY" role="3cqZAp">
+          <node concept="3cpWsn" id="24lzbKWhSRZ" role="3cpWs9">
+            <property role="TrG5h" value="f" />
+            <node concept="3Tqbb2" id="24lzbKWhSS0" role="1tU5fm">
+              <ref role="ehGHo" to="tp3j:hmS6ZEB" resolve="DescriptionBlock" />
+            </node>
+            <node concept="2OqwBi" id="24lzbKWhSS1" role="33vP2m">
+              <node concept="37vLTw" id="24lzbKWhUzH" role="2Oq$k0">
+                <ref role="3cqZAo" node="24lzbKWhSQx" resolve="declaration" />
+              </node>
+              <node concept="3TrEf2" id="24lzbKWhSS3" role="2OqNvi">
+                <ref role="3Tt5mk" to="tp3j:2c3oNEsfd2D" resolve="descriptionFunction" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="24lzbKWhSS4" role="3cqZAp">
+          <node concept="3cpWsn" id="24lzbKWhSS5" role="3cpWs9">
+            <property role="TrG5h" value="l" />
+            <node concept="3Tqbb2" id="24lzbKWhSS6" role="1tU5fm">
+              <ref role="ehGHo" to="tpee:fzclF8l" resolve="Statement" />
+            </node>
+            <node concept="2OqwBi" id="24lzbKWhSS7" role="33vP2m">
+              <node concept="2OqwBi" id="24lzbKWhSS8" role="2Oq$k0">
+                <node concept="2OqwBi" id="24lzbKWhSS9" role="2Oq$k0">
+                  <node concept="37vLTw" id="24lzbKWhSSa" role="2Oq$k0">
+                    <ref role="3cqZAo" node="24lzbKWhSRZ" resolve="f" />
+                  </node>
+                  <node concept="3TrEf2" id="24lzbKWhSSb" role="2OqNvi">
+                    <ref role="3Tt5mk" to="tpee:gyVODHa" resolve="body" />
+                  </node>
+                </node>
+                <node concept="3Tsc0h" id="24lzbKWhSSc" role="2OqNvi">
+                  <ref role="3TtcxE" to="tpee:fzcqZ_x" resolve="statement" />
+                </node>
+              </node>
+              <node concept="1yVyf7" id="24lzbKWhSSd" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="24lzbKWhSSe" role="3cqZAp">
+          <node concept="3cpWsn" id="24lzbKWhSSf" role="3cpWs9">
+            <property role="TrG5h" value="s" />
+            <node concept="17QB3L" id="24lzbKWhSSg" role="1tU5fm" />
+            <node concept="2OqwBi" id="24lzbKWj3ws" role="33vP2m">
+              <node concept="2OqwBi" id="24lzbKWj2$s" role="2Oq$k0">
+                <node concept="37vLTw" id="24lzbKWj1Q9" role="2Oq$k0">
+                  <ref role="3cqZAo" node="24lzbKWhSQx" resolve="declaration" />
+                </node>
+                <node concept="3CFZ6_" id="24lzbKWj2XP" role="2OqNvi">
+                  <node concept="3CFYIy" id="24lzbKWj3iP" role="3CFYIz">
+                    <ref role="3CFYIx" to="tegv:54z9_KDO4Av" resolve="GroupAnnotation" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2qgKlT" id="24lzbKWj3La" role="2OqNvi">
+                <ref role="37wK5l" node="24lzbKWiSKe" resolve="generateGroupedCaption" />
+                <node concept="Xl_RD" id="24lzbKWj3QE" role="37wK5m">
+                  <property role="Xl_RC" value="" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="24lzbKWhSSt" role="3cqZAp">
+          <node concept="3clFbS" id="24lzbKWhSSu" role="3clFbx">
+            <node concept="3clFbF" id="24lzbKWhSSv" role="3cqZAp">
+              <node concept="2OqwBi" id="24lzbKWhSSw" role="3clFbG">
+                <node concept="37vLTw" id="24lzbKWhSSx" role="2Oq$k0">
+                  <ref role="3cqZAo" node="24lzbKWhSS5" resolve="l" />
+                </node>
+                <node concept="1P9Npp" id="24lzbKWhSSy" role="2OqNvi">
+                  <node concept="2pJPEk" id="24lzbKWhSSz" role="1P9ThW">
+                    <node concept="2pJPED" id="24lzbKWhSS$" role="2pJPEn">
+                      <ref role="2pJxaS" to="tpee:fzclF8j" resolve="ExpressionStatement" />
+                      <node concept="2pIpSj" id="24lzbKWhSS_" role="2pJxcM">
+                        <ref role="2pIpSl" to="tpee:fzclF8k" resolve="expression" />
+                        <node concept="2pJPED" id="24lzbKWhSSA" role="28nt2d">
+                          <ref role="2pJxaS" to="tpee:fzcpWvV" resolve="PlusExpression" />
+                          <node concept="2pIpSj" id="24lzbKWhSSB" role="2pJxcM">
+                            <ref role="2pIpSl" to="tpee:fJuHU4s" resolve="leftExpression" />
+                            <node concept="2pJPED" id="24lzbKWhSSC" role="28nt2d">
+                              <ref role="2pJxaS" to="tpee:f$Xl_Og" resolve="StringLiteral" />
+                              <node concept="2pJxcG" id="24lzbKWhSSD" role="2pJxcM">
+                                <ref role="2pJxcJ" to="tpee:f$Xl_Oh" resolve="value" />
+                                <node concept="WxPPo" id="24lzbKWhSSE" role="28ntcv">
+                                  <node concept="37vLTw" id="24lzbKWhSSF" role="WxPPp">
+                                    <ref role="3cqZAo" node="24lzbKWhSSf" resolve="s" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="2pIpSj" id="24lzbKWhSSG" role="2pJxcM">
+                            <ref role="2pIpSl" to="tpee:fJuHU4r" resolve="rightExpression" />
+                            <node concept="2pJPED" id="24lzbKWhSSH" role="28nt2d">
+                              <ref role="2pJxaS" to="tpee:fHeOMHZ" resolve="ParenthesizedExpression" />
+                              <node concept="2pIpSj" id="24lzbKWhSSI" role="2pJxcM">
+                                <ref role="2pIpSl" to="tpee:fHeOMI0" resolve="expression" />
+                                <node concept="36biLy" id="24lzbKWhSSJ" role="28nt2d">
+                                  <node concept="2OqwBi" id="24lzbKWhSSK" role="36biLW">
+                                    <node concept="1PxgMI" id="24lzbKWhSSL" role="2Oq$k0">
+                                      <node concept="37vLTw" id="24lzbKWhSSM" role="1m5AlR">
+                                        <ref role="3cqZAo" node="24lzbKWhSS5" resolve="l" />
+                                      </node>
+                                      <node concept="chp4Y" id="24lzbKWhSSN" role="3oSUPX">
+                                        <ref role="cht4Q" to="tpee:fzclF8j" resolve="ExpressionStatement" />
+                                      </node>
+                                    </node>
+                                    <node concept="3TrEf2" id="24lzbKWhSSO" role="2OqNvi">
+                                      <ref role="3Tt5mk" to="tpee:fzclF8k" resolve="expression" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="24lzbKWhSSP" role="3clFbw">
+            <node concept="37vLTw" id="24lzbKWhSSQ" role="2Oq$k0">
+              <ref role="3cqZAo" node="24lzbKWhSS5" resolve="l" />
+            </node>
+            <node concept="1mIQ4w" id="24lzbKWhSSR" role="2OqNvi">
+              <node concept="chp4Y" id="24lzbKWhSSS" role="cj9EA">
+                <ref role="cht4Q" to="tpee:fzclF8j" resolve="ExpressionStatement" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2Gpval" id="24lzbKWhSST" role="3cqZAp">
+          <node concept="2GrKxI" id="24lzbKWhSSU" role="2Gsz3X">
+            <property role="TrG5h" value="r" />
+          </node>
+          <node concept="3clFbS" id="24lzbKWhSSV" role="2LFqv$">
+            <node concept="3cpWs8" id="24lzbKWhSSW" role="3cqZAp">
+              <node concept="3cpWsn" id="24lzbKWhSSX" role="3cpWs9">
+                <property role="TrG5h" value="ex" />
+                <node concept="3Tqbb2" id="24lzbKWhSSY" role="1tU5fm">
+                  <ref role="ehGHo" to="tpee:fz3vP1J" resolve="Expression" />
+                </node>
+                <node concept="2OqwBi" id="24lzbKWhSSZ" role="33vP2m">
+                  <node concept="2GrUjf" id="24lzbKWhST0" role="2Oq$k0">
+                    <ref role="2Gs0qQ" node="24lzbKWhSSU" resolve="r" />
+                  </node>
+                  <node concept="3TrEf2" id="24lzbKWhST1" role="2OqNvi">
+                    <ref role="3Tt5mk" to="tpee:fzcqZ_G" resolve="expression" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="24lzbKWhST2" role="3cqZAp">
+              <node concept="2OqwBi" id="24lzbKWhST3" role="3clFbG">
+                <node concept="37vLTw" id="24lzbKWhST4" role="2Oq$k0">
+                  <ref role="3cqZAo" node="24lzbKWhSSX" resolve="ex" />
+                </node>
+                <node concept="1P9Npp" id="24lzbKWhST5" role="2OqNvi">
+                  <node concept="2pJPEk" id="24lzbKWhST6" role="1P9ThW">
+                    <node concept="2pJPED" id="24lzbKWhST7" role="2pJPEn">
+                      <ref role="2pJxaS" to="tpee:fzcpWvV" resolve="PlusExpression" />
+                      <node concept="2pIpSj" id="24lzbKWhST8" role="2pJxcM">
+                        <ref role="2pIpSl" to="tpee:fJuHU4s" resolve="leftExpression" />
+                        <node concept="2pJPED" id="24lzbKWhST9" role="28nt2d">
+                          <ref role="2pJxaS" to="tpee:f$Xl_Og" resolve="StringLiteral" />
+                          <node concept="2pJxcG" id="24lzbKWhSTa" role="2pJxcM">
+                            <ref role="2pJxcJ" to="tpee:f$Xl_Oh" resolve="value" />
+                            <node concept="WxPPo" id="24lzbKWhSTb" role="28ntcv">
+                              <node concept="37vLTw" id="24lzbKWhSTc" role="WxPPp">
+                                <ref role="3cqZAo" node="24lzbKWhSSf" resolve="s" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="2pIpSj" id="24lzbKWhSTd" role="2pJxcM">
+                        <ref role="2pIpSl" to="tpee:fJuHU4r" resolve="rightExpression" />
+                        <node concept="2pJPED" id="24lzbKWhSTe" role="28nt2d">
+                          <ref role="2pJxaS" to="tpee:fHeOMHZ" resolve="ParenthesizedExpression" />
+                          <node concept="2pIpSj" id="24lzbKWhSTf" role="2pJxcM">
+                            <ref role="2pIpSl" to="tpee:fHeOMI0" resolve="expression" />
+                            <node concept="36biLy" id="24lzbKWhSTg" role="28nt2d">
+                              <node concept="2OqwBi" id="24lzbKWhSTh" role="36biLW">
+                                <node concept="2GrUjf" id="24lzbKWhSTi" role="2Oq$k0">
+                                  <ref role="2Gs0qQ" node="24lzbKWhSSU" resolve="r" />
+                                </node>
+                                <node concept="3TrEf2" id="24lzbKWhSTj" role="2OqNvi">
+                                  <ref role="3Tt5mk" to="tpee:fzcqZ_G" resolve="expression" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="24lzbKWhSTk" role="2GsD0m">
+            <node concept="2OqwBi" id="24lzbKWhSTl" role="2Oq$k0">
+              <node concept="37vLTw" id="24lzbKWhSTm" role="2Oq$k0">
+                <ref role="3cqZAo" node="24lzbKWhSRZ" resolve="f" />
+              </node>
+              <node concept="3TrEf2" id="24lzbKWhSTn" role="2OqNvi">
+                <ref role="3Tt5mk" to="tpee:gyVODHa" resolve="body" />
+              </node>
+            </node>
+            <node concept="2Rf3mk" id="24lzbKWhSTo" role="2OqNvi">
+              <node concept="1xMEDy" id="24lzbKWhSTp" role="1xVPHs">
+                <node concept="chp4Y" id="24lzbKWhSTq" role="ri$Ld">
+                  <ref role="cht4Q" to="tpee:fzcpWvY" resolve="ReturnStatement" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="24lzbKWhSTr" role="3cqZAp">
+          <node concept="2OqwBi" id="24lzbKWhSTs" role="3clFbG">
+            <node concept="2OqwBi" id="24lzbKWhSTt" role="2Oq$k0">
+              <node concept="37vLTw" id="24lzbKWhUWp" role="2Oq$k0">
+                <ref role="3cqZAo" node="24lzbKWhSQx" resolve="declaration" />
+              </node>
+              <node concept="3CFZ6_" id="24lzbKWhSTv" role="2OqNvi">
+                <node concept="3CFYIy" id="24lzbKWhSTw" role="3CFYIz">
+                  <ref role="3CFYIx" to="tegv:54z9_KDO4Av" resolve="GroupAnnotation" />
+                </node>
+              </node>
+            </node>
+            <node concept="3YRAZt" id="24lzbKWhSTx" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="3clFbF" id="24lzbKWkOi1" role="3cqZAp">
+          <node concept="37vLTw" id="24lzbKWkOhZ" role="3clFbG">
+            <ref role="3cqZAo" node="24lzbKWhSQx" resolve="declaration" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="24lzbKWhSPH" role="1B3o_S" />
+      <node concept="37vLTG" id="24lzbKWhSQx" role="3clF46">
+        <property role="TrG5h" value="declaration" />
+        <node concept="3Tqbb2" id="24lzbKWhSQw" role="1tU5fm">
+          <ref role="ehGHo" to="tp3j:2c3oNEsfcpP" resolve="BaseIntentionDeclaration" />
+        </node>
+      </node>
+      <node concept="3Tqbb2" id="24lzbKWkNy0" role="3clF45">
+        <ref role="ehGHo" to="tp3j:2c3oNEsfcpP" resolve="BaseIntentionDeclaration" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="24lzbKWk9iF" role="jymVt" />
+    <node concept="2YIFZL" id="24lzbKWk9jN" role="jymVt">
+      <property role="TrG5h" value="updateAction" />
+      <node concept="3clFbS" id="24lzbKWk9jQ" role="3clF47">
+        <node concept="3cpWs8" id="2oNrKyBcLIw" role="3cqZAp">
+          <node concept="3cpWsn" id="2oNrKyBcLIz" role="3cpWs9">
+            <property role="TrG5h" value="caption" />
+            <node concept="17QB3L" id="2oNrKyBcLIu" role="1tU5fm" />
+            <node concept="2OqwBi" id="2oNrKyBcN8I" role="33vP2m">
+              <node concept="37vLTw" id="24lzbKWka1D" role="2Oq$k0">
+                <ref role="3cqZAo" node="24lzbKWk9ku" resolve="declaration" />
+              </node>
+              <node concept="3TrcHB" id="2oNrKyBcPph" role="2OqNvi">
+                <ref role="3TsBF5" to="tp4k:hyuzpDp" resolve="caption" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="2oNrKyBcHru" role="3cqZAp">
+          <node concept="3cpWsn" id="2oNrKyBcHrv" role="3cpWs9">
+            <property role="TrG5h" value="newCaption" />
+            <node concept="17QB3L" id="2oNrKyBcHrw" role="1tU5fm" />
+            <node concept="2OqwBi" id="24lzbKWk9mL" role="33vP2m">
+              <node concept="2OqwBi" id="24lzbKWk9mM" role="2Oq$k0">
+                <node concept="37vLTw" id="24lzbKWka5_" role="2Oq$k0">
+                  <ref role="3cqZAo" node="24lzbKWk9ku" resolve="declaration" />
+                </node>
+                <node concept="3CFZ6_" id="24lzbKWk9mN" role="2OqNvi">
+                  <node concept="3CFYIy" id="24lzbKWk9mO" role="3CFYIz">
+                    <ref role="3CFYIx" to="tegv:54z9_KDO4Av" resolve="GroupAnnotation" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2qgKlT" id="24lzbKWk9mP" role="2OqNvi">
+                <ref role="37wK5l" node="24lzbKWiSKe" resolve="generateGroupedCaption" />
+                <node concept="37vLTw" id="24lzbKWj6uP" role="37wK5m">
+                  <ref role="3cqZAo" node="2oNrKyBcLIz" resolve="caption" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="2oNrKyBcSDq" role="3cqZAp">
+          <node concept="37vLTI" id="2oNrKyBcW7G" role="3clFbG">
+            <node concept="37vLTw" id="2oNrKyBcW9G" role="37vLTx">
+              <ref role="3cqZAo" node="2oNrKyBcHrv" resolve="newCaption" />
+            </node>
+            <node concept="2OqwBi" id="2oNrKyBcSTH" role="37vLTJ">
+              <node concept="37vLTw" id="24lzbKWka9v" role="2Oq$k0">
+                <ref role="3cqZAo" node="24lzbKWk9ku" resolve="declaration" />
+              </node>
+              <node concept="3TrcHB" id="2oNrKyBcTK_" role="2OqNvi">
+                <ref role="3TsBF5" to="tp4k:hyuzpDp" resolve="caption" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="2oNrKyBcHsB" role="3cqZAp">
+          <node concept="2OqwBi" id="2oNrKyBcHsC" role="3clFbG">
+            <node concept="2OqwBi" id="2oNrKyBcHsD" role="2Oq$k0">
+              <node concept="37vLTw" id="24lzbKWkadn" role="2Oq$k0">
+                <ref role="3cqZAo" node="24lzbKWk9ku" resolve="declaration" />
+              </node>
+              <node concept="3CFZ6_" id="2oNrKyBcHsF" role="2OqNvi">
+                <node concept="3CFYIy" id="2oNrKyBcHsG" role="3CFYIz">
+                  <ref role="3CFYIx" to="tegv:54z9_KDO4Av" resolve="GroupAnnotation" />
+                </node>
+              </node>
+            </node>
+            <node concept="3YRAZt" id="2oNrKyBcHsH" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="3clFbF" id="24lzbKWkNJv" role="3cqZAp">
+          <node concept="37vLTw" id="24lzbKWkNJt" role="3clFbG">
+            <ref role="3cqZAo" node="24lzbKWk9ku" resolve="declaration" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="24lzbKWk9j3" role="1B3o_S" />
+      <node concept="3Tqbb2" id="24lzbKWkNCf" role="3clF45">
+        <ref role="ehGHo" to="tp4k:hwsE7KS" resolve="ActionDeclaration" />
+      </node>
+      <node concept="37vLTG" id="24lzbKWk9ku" role="3clF46">
+        <property role="TrG5h" value="declaration" />
+        <node concept="3Tqbb2" id="24lzbKWk9kt" role="1tU5fm">
+          <ref role="ehGHo" to="tp4k:hwsE7KS" resolve="ActionDeclaration" />
+        </node>
+      </node>
+    </node>
+    <node concept="3Tm1VV" id="24lzbKWhRGW" role="1B3o_S" />
   </node>
 </model>
 

--- a/code/intentionsmenu/com.mbeddr.mpsutil.intentions/languageModels/behavior.mps
+++ b/code/intentionsmenu/com.mbeddr.mpsutil.intentions/languageModels/behavior.mps
@@ -3,35 +3,85 @@
   <persistence version="9" />
   <languages>
     <use id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior" version="2" />
+    <use id="654422bf-e75f-44dc-936d-188890a746ce" name="de.slisson.mps.reflection" version="0" />
+    <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="14" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
+    <import index="cj4x" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor(MPS.Editor/)" />
+    <import index="qkt" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.actionSystem(MPS.IDEA/)" />
+    <import index="tp4s" ref="r:00000000-0000-4000-0000-011c89590360(jetbrains.mps.lang.plugin.behavior)" />
+    <import index="exr9" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor(MPS.Editor/)" />
+    <import index="7bx7" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.workbench.action(MPS.Platform/)" />
+    <import index="ih8q" ref="r:990d360b-3ac3-45fa-8ed3-0bbf017bba84(com.mbeddr.mpsutil.intentions.runtime)" />
+    <import index="tp4k" ref="r:00000000-0000-4000-0000-011c89590368(jetbrains.mps.lang.plugin.structure)" />
     <import index="tegv" ref="r:b91d2412-f094-4e55-8db6-3c782d7edc40(com.mbeddr.mpsutil.intentions.structure)" implicit="true" />
   </imports>
   <registry>
+    <language id="654422bf-e75f-44dc-936d-188890a746ce" name="de.slisson.mps.reflection">
+      <concept id="8473566765275063380" name="de.slisson.mps.reflection.structure.ReflectionFieldAccess" flags="ng" index="1PnCL0">
+        <reference id="1197029500499" name="fieldDeclaration" index="2Oxat5" />
+      </concept>
+    </language>
     <language id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior">
       <concept id="1225194240794" name="jetbrains.mps.lang.behavior.structure.ConceptBehavior" flags="ng" index="13h7C7">
         <reference id="1225194240799" name="concept" index="13h7C2" />
+        <child id="1225194240805" name="method" index="13h7CS" />
         <child id="1225194240801" name="constructor" index="13h7CW" />
       </concept>
       <concept id="1225194413805" name="jetbrains.mps.lang.behavior.structure.ConceptConstructorDeclaration" flags="in" index="13hLZK" />
+      <concept id="1225194472830" name="jetbrains.mps.lang.behavior.structure.ConceptMethodDeclaration" flags="ng" index="13i0hz" />
       <concept id="1225194691553" name="jetbrains.mps.lang.behavior.structure.ThisNodeExpression" flags="nn" index="13iPFW" />
     </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1224071154655" name="jetbrains.mps.baseLanguage.structure.AsExpression" flags="nn" index="0kSF2">
+        <child id="1224071154657" name="classifierType" index="0kSFW" />
+        <child id="1224071154656" name="expression" index="0kSFX" />
+      </concept>
       <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
         <child id="1068498886297" name="rValue" index="37vLTx" />
         <child id="1068498886295" name="lValue" index="37vLTJ" />
+      </concept>
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
+        <child id="1154032183016" name="body" index="2LFqv$" />
       </concept>
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
       </concept>
+      <concept id="3870108946630849399" name="jetbrains.mps.baseLanguage.structure.StaticFieldReferenceOperation" flags="ng" index="SiP3y" />
       <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
         <child id="1137022507850" name="body" index="2VODD2" />
       </concept>
+      <concept id="1070534934090" name="jetbrains.mps.baseLanguage.structure.CastExpression" flags="nn" index="10QFUN">
+        <child id="1070534934091" name="type" index="10QFUM" />
+        <child id="1070534934092" name="expression" index="10QFUP" />
+      </concept>
+      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
       <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
+      <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
+      <concept id="1225271283259" name="jetbrains.mps.baseLanguage.structure.NPEEqualsExpression" flags="nn" index="17R0WA" />
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123134" name="parameter" index="3clF46" />
+        <child id="1068580123135" name="body" index="3clF47" />
+      </concept>
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
+        <child id="1068580123160" name="condition" index="3clFbw" />
+        <child id="1068580123161" name="ifTrue" index="3clFbx" />
       </concept>
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
@@ -39,10 +89,72 @@
       <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
         <property id="1068580123138" name="value" index="3clFbU" />
       </concept>
+      <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6" />
+      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
+        <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
+      </concept>
+      <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+      </concept>
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+        <reference id="1107535924139" name="classifier" index="3uigEE" />
+      </concept>
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
+        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
+        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
+      </concept>
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
+        <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
+        <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
+      </concept>
+      <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
+      <concept id="2396822768958367367" name="jetbrains.mps.lang.smodel.structure.AbstractTypeCastExpression" flags="nn" index="$5XWr">
+        <child id="6733348108486823193" name="leftExpression" index="1m5AlR" />
+        <child id="3906496115198199033" name="conceptArgument" index="3oSUPX" />
+      </concept>
+      <concept id="1139613262185" name="jetbrains.mps.lang.smodel.structure.Node_GetParentOperation" flags="nn" index="1mfA1w" />
+      <concept id="1171999116870" name="jetbrains.mps.lang.smodel.structure.Node_IsNullOperation" flags="nn" index="3w_OXm" />
+      <concept id="1140137987495" name="jetbrains.mps.lang.smodel.structure.SNodeTypeCastExpression" flags="nn" index="1PxgMI">
+        <property id="1238684351431" name="asCast" index="1BlNFB" />
+      </concept>
+      <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
+        <reference id="1138405853777" name="concept" index="ehGHo" />
+      </concept>
       <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
         <reference id="1138056395725" name="property" index="3TsBF5" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+    <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="nn" index="25WWJ4">
+        <child id="540871147943773366" name="argument" index="25WWJ7" />
+      </concept>
+      <concept id="1226511727824" name="jetbrains.mps.baseLanguage.collections.structure.SetType" flags="in" index="2hMVRd">
+        <child id="1226511765987" name="elementType" index="2hN53Y" />
+      </concept>
+      <concept id="1153943597977" name="jetbrains.mps.baseLanguage.collections.structure.ForEachStatement" flags="nn" index="2Gpval">
+        <child id="1153944400369" name="variable" index="2Gsz3X" />
+        <child id="1153944424730" name="inputSequence" index="2GsD0m" />
+      </concept>
+      <concept id="1153944193378" name="jetbrains.mps.baseLanguage.collections.structure.ForEachVariable" flags="nr" index="2GrKxI" />
+      <concept id="1153944233411" name="jetbrains.mps.baseLanguage.collections.structure.ForEachVariableReference" flags="nn" index="2GrUjf">
+        <reference id="1153944258490" name="variable" index="2Gs0qQ" />
+      </concept>
+      <concept id="1167380149909" name="jetbrains.mps.baseLanguage.collections.structure.RemoveElementOperation" flags="nn" index="3dhRuq" />
+      <concept id="1197932370469" name="jetbrains.mps.baseLanguage.collections.structure.MapElement" flags="nn" index="3EllGN">
+        <child id="1197932505799" name="map" index="3ElQJh" />
+        <child id="1197932525128" name="key" index="3ElVtu" />
       </concept>
     </language>
   </registry>
@@ -64,6 +176,195 @@
           </node>
         </node>
       </node>
+    </node>
+  </node>
+  <node concept="13h7C7" id="$kD7tOMQMx">
+    <ref role="13h7C2" to="tegv:54z9_KDO4Av" resolve="GroupAnnotation" />
+    <node concept="13i0hz" id="$kD7tOMQXO" role="13h7CS">
+      <property role="TrG5h" value="update" />
+      <node concept="3Tm1VV" id="$kD7tOMQXP" role="1B3o_S" />
+      <node concept="3cqZAl" id="$kD7tOMQY8" role="3clF45" />
+      <node concept="3clFbS" id="$kD7tOMQXR" role="3clF47">
+        <node concept="3clFbF" id="$kD7tOMWZR" role="3cqZAp">
+          <node concept="37vLTI" id="$kD7tOMYVQ" role="3clFbG">
+            <node concept="37vLTw" id="$kD7tON0cV" role="37vLTx">
+              <ref role="3cqZAo" node="$kD7tOMWSG" resolve="newValue" />
+            </node>
+            <node concept="2OqwBi" id="$kD7tOMXk_" role="37vLTJ">
+              <node concept="13iPFW" id="$kD7tOMWZP" role="2Oq$k0" />
+              <node concept="3TrcHB" id="$kD7tOMXBB" role="2OqNvi">
+                <ref role="3TsBF5" to="tegv:54z9_KDO50a" resolve="label" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="7Sc8bwtQZHP" role="3cqZAp">
+          <node concept="3cpWsn" id="7Sc8bwtQZHS" role="3cpWs9">
+            <property role="TrG5h" value="actionDeclaration" />
+            <node concept="3Tqbb2" id="7Sc8bwtQZHN" role="1tU5fm">
+              <ref role="ehGHo" to="tp4k:hwsE7KS" resolve="ActionDeclaration" />
+            </node>
+            <node concept="1PxgMI" id="7Sc8bwtR0Yn" role="33vP2m">
+              <property role="1BlNFB" value="true" />
+              <node concept="chp4Y" id="7Sc8bwtR0Zi" role="3oSUPX">
+                <ref role="cht4Q" to="tp4k:hwsE7KS" resolve="ActionDeclaration" />
+              </node>
+              <node concept="2OqwBi" id="7Sc8bwtR0mp" role="1m5AlR">
+                <node concept="13iPFW" id="$kD7tOMSnW" role="2Oq$k0" />
+                <node concept="1mfA1w" id="7Sc8bwtR0AF" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="7Sc8bwtR15M" role="3cqZAp">
+          <node concept="3clFbS" id="7Sc8bwtR15O" role="3clFbx">
+            <node concept="3cpWs6" id="7Sc8bwtR1Yr" role="3cqZAp" />
+          </node>
+          <node concept="2OqwBi" id="7Sc8bwtR1s4" role="3clFbw">
+            <node concept="37vLTw" id="7Sc8bwtR1aL" role="2Oq$k0">
+              <ref role="3cqZAo" node="7Sc8bwtQZHS" resolve="actionDeclaration" />
+            </node>
+            <node concept="3w_OXm" id="7Sc8bwtR1QK" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="3cpWs8" id="7Sc8bwtP$z5" role="3cqZAp">
+          <node concept="3cpWsn" id="7Sc8bwtP$z6" role="3cpWs9">
+            <property role="TrG5h" value="editorComponent" />
+            <node concept="3uibUv" id="7Sc8bwtP$yz" role="1tU5fm">
+              <ref role="3uigEE" to="exr9:~EditorComponent" resolve="EditorComponent" />
+            </node>
+            <node concept="10QFUN" id="7Sc8bwtPV5Y" role="33vP2m">
+              <node concept="3uibUv" id="7Sc8bwtPV8w" role="10QFUM">
+                <ref role="3uigEE" to="exr9:~EditorComponent" resolve="EditorComponent" />
+              </node>
+              <node concept="2OqwBi" id="7Sc8bwtP$z7" role="10QFUP">
+                <node concept="37vLTw" id="$kD7tOMSPx" role="2Oq$k0">
+                  <ref role="3cqZAo" node="$kD7tOMR3H" resolve="context" />
+                </node>
+                <node concept="liA8E" id="7Sc8bwtP$z9" role="2OqNvi">
+                  <ref role="37wK5l" to="cj4x:~EditorContext.getEditorComponent()" resolve="getEditorComponent" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="7Sc8bwtQ_oN" role="3cqZAp">
+          <node concept="3cpWsn" id="7Sc8bwtQ_oO" role="3cpWs9">
+            <property role="TrG5h" value="producer" />
+            <node concept="3uibUv" id="7Sc8bwtQ$Wy" role="1tU5fm">
+              <ref role="3uigEE" to="ih8q:2jDew64JcPx" resolve="MyIntentionMenuProducer" />
+            </node>
+            <node concept="0kSF2" id="7Sc8bwtQ_oP" role="33vP2m">
+              <node concept="3uibUv" id="7Sc8bwtQ_oQ" role="0kSFW">
+                <ref role="3uigEE" to="ih8q:2jDew64JcPx" resolve="MyIntentionMenuProducer" />
+              </node>
+              <node concept="2OqwBi" id="7Sc8bwtQ_oR" role="0kSFX">
+                <node concept="2OqwBi" id="7Sc8bwtQ_oS" role="2Oq$k0">
+                  <node concept="37vLTw" id="7Sc8bwtQ_oT" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7Sc8bwtP$z6" resolve="editorComponent" />
+                  </node>
+                  <node concept="1PnCL0" id="7Sc8bwtQ_oU" role="2OqNvi">
+                    <ref role="2Oxat5" to="exr9:~EditorComponent.myIntentionsSupport" resolve="myIntentionsSupport" />
+                  </node>
+                </node>
+                <node concept="1PnCL0" id="7Sc8bwtQ_oV" role="2OqNvi">
+                  <ref role="2Oxat5" to="exr9:~IntentionsSupport.myMenuProducer" resolve="myMenuProducer" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="7Sc8bwtQBCD" role="3cqZAp">
+          <node concept="3cpWsn" id="7Sc8bwtQBCE" role="3cpWs9">
+            <property role="TrG5h" value="oldGroupEntries" />
+            <node concept="2hMVRd" id="7Sc8bwtQBrb" role="1tU5fm">
+              <node concept="3uibUv" id="7Sc8bwtQBre" role="2hN53Y">
+                <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
+              </node>
+            </node>
+            <node concept="3EllGN" id="7Sc8bwtQBCF" role="33vP2m">
+              <node concept="37vLTw" id="$kD7tOMSUJ" role="3ElVtu">
+                <ref role="3cqZAo" node="$kD7tOMSHu" resolve="oldValue" />
+              </node>
+              <node concept="2OqwBi" id="7Sc8bwtQBCH" role="3ElQJh">
+                <node concept="37vLTw" id="7Sc8bwtQBCI" role="2Oq$k0">
+                  <ref role="3cqZAo" node="7Sc8bwtQ_oO" resolve="producer" />
+                </node>
+                <node concept="SiP3y" id="7Sc8bwtQBCJ" role="2OqNvi">
+                  <ref role="3cqZAo" to="ih8q:5Rdndlpp80A" resolve="groupedActionsCache" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2Gpval" id="7Sc8bwtQTGT" role="3cqZAp">
+          <node concept="2GrKxI" id="7Sc8bwtQTGV" role="2Gsz3X">
+            <property role="TrG5h" value="entry" />
+          </node>
+          <node concept="37vLTw" id="7Sc8bwtQTNd" role="2GsD0m">
+            <ref role="3cqZAo" node="7Sc8bwtQBCE" resolve="oldGroupEntries" />
+          </node>
+          <node concept="3clFbS" id="7Sc8bwtQTGZ" role="2LFqv$">
+            <node concept="3clFbJ" id="7Sc8bwtQTOQ" role="3cqZAp">
+              <node concept="17R0WA" id="7Sc8bwtQYPw" role="3clFbw">
+                <node concept="2OqwBi" id="7Sc8bwtQX34" role="3uHU7B">
+                  <node concept="0kSF2" id="7Sc8bwtQWxE" role="2Oq$k0">
+                    <node concept="3uibUv" id="7Sc8bwtQWxG" role="0kSFW">
+                      <ref role="3uigEE" to="7bx7:~BaseAction" resolve="BaseAction" />
+                    </node>
+                    <node concept="2GrUjf" id="7Sc8bwtQTPk" role="0kSFX">
+                      <ref role="2Gs0qQ" node="7Sc8bwtQTGV" resolve="entry" />
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="7Sc8bwtQXNq" role="2OqNvi">
+                    <ref role="37wK5l" to="7bx7:~BaseAction.getActionId()" resolve="getActionId" />
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="7Sc8bwtR2iE" role="3uHU7w">
+                  <node concept="37vLTw" id="7Sc8bwtR1ZC" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7Sc8bwtQZHS" resolve="actionDeclaration" />
+                  </node>
+                  <node concept="2qgKlT" id="7Sc8bwtR2kj" role="2OqNvi">
+                    <ref role="37wK5l" to="tp4s:2JiSCAPXEb8" resolve="getActionId" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbS" id="7Sc8bwtQTOS" role="3clFbx">
+                <node concept="3clFbF" id="7Sc8bwtR2rE" role="3cqZAp">
+                  <node concept="2OqwBi" id="7Sc8bwtR3$0" role="3clFbG">
+                    <node concept="37vLTw" id="7Sc8bwtR2rD" role="2Oq$k0">
+                      <ref role="3cqZAo" node="7Sc8bwtQBCE" resolve="oldGroupEntries" />
+                    </node>
+                    <node concept="3dhRuq" id="7Sc8bwtR4E4" role="2OqNvi">
+                      <node concept="2GrUjf" id="7Sc8bwtR4GJ" role="25WWJ7">
+                        <ref role="2Gs0qQ" node="7Sc8bwtQTGV" resolve="entry" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3cpWs6" id="7Sc8bwtR4J1" role="3cqZAp" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="$kD7tOMR3H" role="3clF46">
+        <property role="TrG5h" value="context" />
+        <node concept="3uibUv" id="$kD7tOMR3G" role="1tU5fm">
+          <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="$kD7tOMSHu" role="3clF46">
+        <property role="TrG5h" value="oldValue" />
+        <node concept="17QB3L" id="$kD7tOMSOm" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="$kD7tOMWSG" role="3clF46">
+        <property role="TrG5h" value="newValue" />
+        <node concept="17QB3L" id="$kD7tOMWSI" role="1tU5fm" />
+      </node>
+    </node>
+    <node concept="13hLZK" id="$kD7tOMQMy" role="13h7CW">
+      <node concept="3clFbS" id="$kD7tOMQMz" role="2VODD2" />
     </node>
   </node>
 </model>

--- a/code/intentionsmenu/com.mbeddr.mpsutil.intentions/languageModels/behavior.mps
+++ b/code/intentionsmenu/com.mbeddr.mpsutil.intentions/languageModels/behavior.mps
@@ -16,10 +16,11 @@
     <import index="tp3j" ref="r:00000000-0000-4000-0000-011c89590353(jetbrains.mps.lang.intentions.structure)" />
     <import index="tegv" ref="r:b91d2412-f094-4e55-8db6-3c782d7edc40(com.mbeddr.mpsutil.intentions.structure)" />
     <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" />
-    <import index="3o3z" ref="39983771-4e9b-401b-a1a9-1da6c777c843/java:com.google.common.collect(MPS.ThirdParty/)" implicit="true" />
+    <import index="3o3z" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.google.common.collect(MPS.IDEA/)" implicit="true" />
   </imports>
   <registry>
     <language id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior">
+      <concept id="6496299201655527393" name="jetbrains.mps.lang.behavior.structure.LocalBehaviorMethodCall" flags="nn" index="BsUDl" />
       <concept id="1225194240794" name="jetbrains.mps.lang.behavior.structure.ConceptBehavior" flags="ng" index="13h7C7">
         <reference id="1225194240799" name="concept" index="13h7C2" />
         <child id="1225194240805" name="method" index="13h7CS" />
@@ -74,6 +75,8 @@
       <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
       <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
       <concept id="1225271283259" name="jetbrains.mps.baseLanguage.structure.NPEEqualsExpression" flags="nn" index="17R0WA" />
+      <concept id="1225271369338" name="jetbrains.mps.baseLanguage.structure.IsEmptyOperation" flags="nn" index="17RlXB" />
+      <concept id="1225271408483" name="jetbrains.mps.baseLanguage.structure.IsNotEmptyOperation" flags="nn" index="17RvpY" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
@@ -102,6 +105,9 @@
       </concept>
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
       <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
+      <concept id="1079359253375" name="jetbrains.mps.baseLanguage.structure.ParenthesizedExpression" flags="nn" index="1eOMI4">
+        <child id="1079359253376" name="expression" index="1eOMHV" />
+      </concept>
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
@@ -118,6 +124,11 @@
       </concept>
       <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="1163668896201" name="jetbrains.mps.baseLanguage.structure.TernaryOperatorExpression" flags="nn" index="3K4zz7">
+        <child id="1163668914799" name="condition" index="3K4Cdx" />
+        <child id="1163668922816" name="ifTrue" index="3K4E3e" />
+        <child id="1163668934364" name="ifFalse" index="3K4GZi" />
       </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
     </language>
@@ -440,15 +451,36 @@
             <node concept="37vLTw" id="38Yx6hD3$P_" role="3uHU7w">
               <ref role="3cqZAo" node="24lzbKWiXKS" resolve="caption" />
             </node>
-            <node concept="3cpWs3" id="24lzbKWiW4n" role="3uHU7B">
-              <node concept="2OqwBi" id="24lzbKWiU_c" role="3uHU7B">
-                <node concept="13iPFW" id="24lzbKWiUoy" role="2Oq$k0" />
-                <node concept="3TrcHB" id="24lzbKWiUNo" role="2OqNvi">
-                  <ref role="3TsBF5" to="tegv:54z9_KDO50a" resolve="label" />
-                </node>
-              </node>
+            <node concept="3cpWs3" id="5gDLJkKTf1j" role="3uHU7B">
               <node concept="Xl_RD" id="24lzbKWiW4q" role="3uHU7w">
-                <property role="Xl_RC" value=": " />
+                <property role="Xl_RC" value=" " />
+              </node>
+              <node concept="3cpWs3" id="24lzbKWiW4n" role="3uHU7B">
+                <node concept="1eOMI4" id="5gDLJkLgF1E" role="3uHU7B">
+                  <node concept="3K4zz7" id="5gDLJkLgF1A" role="1eOMHV">
+                    <node concept="2OqwBi" id="5gDLJkLgFcB" role="3K4E3e">
+                      <node concept="13iPFW" id="5gDLJkLgF2D" role="2Oq$k0" />
+                      <node concept="3TrcHB" id="5gDLJkLgFem" role="2OqNvi">
+                        <ref role="3TsBF5" to="tegv:54z9_KDO50a" resolve="label" />
+                      </node>
+                    </node>
+                    <node concept="Xl_RD" id="5gDLJkLgFfw" role="3K4GZi">
+                      <property role="Xl_RC" value="" />
+                    </node>
+                    <node concept="2OqwBi" id="5gDLJkLgCVT" role="3K4Cdx">
+                      <node concept="2OqwBi" id="24lzbKWiU_c" role="2Oq$k0">
+                        <node concept="13iPFW" id="24lzbKWiUoy" role="2Oq$k0" />
+                        <node concept="3TrcHB" id="24lzbKWiUNo" role="2OqNvi">
+                          <ref role="3TsBF5" to="tegv:54z9_KDO50a" resolve="label" />
+                        </node>
+                      </node>
+                      <node concept="17RvpY" id="5gDLJkLgD$1" role="2OqNvi" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="BsUDl" id="5gDLJkKTf2N" role="3uHU7w">
+                  <ref role="37wK5l" node="24lzbKWhznQ" resolve="getSeparator" />
+                </node>
               </node>
             </node>
           </node>
@@ -731,12 +763,28 @@
           <node concept="3cpWsn" id="2oNrKyBcLIz" role="3cpWs9">
             <property role="TrG5h" value="caption" />
             <node concept="17QB3L" id="2oNrKyBcLIu" role="1tU5fm" />
-            <node concept="2OqwBi" id="2oNrKyBcN8I" role="33vP2m">
-              <node concept="37vLTw" id="24lzbKWka1D" role="2Oq$k0">
-                <ref role="3cqZAo" node="24lzbKWk9ku" resolve="declaration" />
+            <node concept="3K4zz7" id="5gDLJkLeMnM" role="33vP2m">
+              <node concept="Xl_RD" id="5gDLJkLeMq1" role="3K4E3e">
+                <property role="Xl_RC" value="" />
               </node>
-              <node concept="3TrcHB" id="2oNrKyBcPph" role="2OqNvi">
-                <ref role="3TsBF5" to="tp4k:hyuzpDp" resolve="caption" />
+              <node concept="2OqwBi" id="5gDLJkLeJdu" role="3K4Cdx">
+                <node concept="2OqwBi" id="2oNrKyBcN8I" role="2Oq$k0">
+                  <node concept="37vLTw" id="24lzbKWka1D" role="2Oq$k0">
+                    <ref role="3cqZAo" node="24lzbKWk9ku" resolve="declaration" />
+                  </node>
+                  <node concept="3TrcHB" id="2oNrKyBcPph" role="2OqNvi">
+                    <ref role="3TsBF5" to="tp4k:hyuzpDp" resolve="caption" />
+                  </node>
+                </node>
+                <node concept="17RlXB" id="5gDLJkLeJQE" role="2OqNvi" />
+              </node>
+              <node concept="2OqwBi" id="5gDLJkLeMrW" role="3K4GZi">
+                <node concept="37vLTw" id="5gDLJkLeMrX" role="2Oq$k0">
+                  <ref role="3cqZAo" node="24lzbKWk9ku" resolve="declaration" />
+                </node>
+                <node concept="3TrcHB" id="5gDLJkLeMrY" role="2OqNvi">
+                  <ref role="3TsBF5" to="tp4k:hyuzpDp" resolve="caption" />
+                </node>
               </node>
             </node>
           </node>

--- a/code/intentionsmenu/com.mbeddr.mpsutil.intentions/languageModels/com.mbeddr.mpsutil.intentions.listeners.mps
+++ b/code/intentionsmenu/com.mbeddr.mpsutil.intentions/languageModels/com.mbeddr.mpsutil.intentions.listeners.mps
@@ -18,8 +18,10 @@
     <import index="qkt" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.actionSystem(MPS.IDEA/)" />
     <import index="7bx7" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.workbench.action(MPS.Platform/)" />
     <import index="alof" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.ide.project(MPS.Platform/)" />
+    <import index="3a50" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.ide(MPS.Platform/)" />
     <import index="tp4k" ref="r:00000000-0000-4000-0000-011c89590368(jetbrains.mps.lang.plugin.structure)" implicit="true" />
-    <import index="3o3z" ref="39983771-4e9b-401b-a1a9-1da6c777c843/java:com.google.common.collect(MPS.ThirdParty/)" implicit="true" />
+    <import index="wyuk" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.components(MPS.Core/)" implicit="true" />
+    <import index="3o3z" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.google.common.collect(MPS.IDEA/)" implicit="true" />
     <import index="tp4s" ref="r:00000000-0000-4000-0000-011c89590360(jetbrains.mps.lang.plugin.behavior)" implicit="true" />
   </imports>
   <registry>
@@ -28,7 +30,9 @@
         <child id="1224071154657" name="classifierType" index="0kSFW" />
         <child id="1224071154656" name="expression" index="0kSFX" />
       </concept>
+      <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
       <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
         <child id="1154032183016" name="body" index="2LFqv$" />
       </concept>
@@ -36,9 +40,13 @@
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
       </concept>
+      <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
+        <child id="1145553007750" name="creator" index="2ShVmc" />
+      </concept>
       <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
         <child id="1137022507850" name="body" index="2VODD2" />
       </concept>
+      <concept id="1081236700938" name="jetbrains.mps.baseLanguage.structure.StaticMethodDeclaration" flags="ig" index="2YIFZL" />
       <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
       </concept>
@@ -54,16 +62,24 @@
         <child id="1070534934091" name="type" index="10QFUM" />
         <child id="1070534934092" name="expression" index="10QFUP" />
       </concept>
+      <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu" />
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <child id="1068431790190" name="initializer" index="33vP2m" />
       </concept>
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
-      <concept id="1225271283259" name="jetbrains.mps.baseLanguage.structure.NPEEqualsExpression" flags="nn" index="17R0WA" />
+      <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
+      <concept id="1225271221393" name="jetbrains.mps.baseLanguage.structure.NPENotEqualsExpression" flags="nn" index="17QLQc" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
+      <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123134" name="parameter" index="3clF46" />
+        <child id="1068580123135" name="body" index="3clF47" />
+      </concept>
+      <concept id="1068580123152" name="jetbrains.mps.baseLanguage.structure.EqualsExpression" flags="nn" index="3clFbC" />
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
@@ -80,10 +96,17 @@
         <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
       </concept>
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1081516740877" name="jetbrains.mps.baseLanguage.structure.NotExpression" flags="nn" index="3fqX7Q">
+        <child id="1081516765348" name="expression" index="3fr31v" />
+      </concept>
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
+      <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
+        <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
+      </concept>
+      <concept id="7812454656619025412" name="jetbrains.mps.baseLanguage.structure.LocalMethodCall" flags="nn" index="1rXfSq" />
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
       </concept>
@@ -92,11 +115,26 @@
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
       <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
+        <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
       <concept id="1144226303539" name="jetbrains.mps.baseLanguage.structure.ForeachStatement" flags="nn" index="1DcWWT">
         <child id="1144226360166" name="iterable" index="1DdaDG" />
       </concept>
       <concept id="1144230876926" name="jetbrains.mps.baseLanguage.structure.AbstractForStatement" flags="nn" index="1DupvO">
         <child id="1144230900587" name="variable" index="1Duv9x" />
+      </concept>
+      <concept id="1082113931046" name="jetbrains.mps.baseLanguage.structure.ContinueStatement" flags="nn" index="3N13vt" />
+      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+      <concept id="1116615150612" name="jetbrains.mps.baseLanguage.structure.ClassifierClassExpression" flags="nn" index="3VsKOn">
+        <reference id="1116615189566" name="classifier" index="3VsUkX" />
+      </concept>
+    </language>
+    <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
+      <concept id="2524418899405758586" name="jetbrains.mps.baseLanguage.closures.structure.InferredClosureParameterDeclaration" flags="ig" index="gl6BB" />
+      <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
+        <child id="1199569906740" name="parameter" index="1bW2Oz" />
+        <child id="1199569916463" name="body" index="1bW5cS" />
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
@@ -129,12 +167,19 @@
       <concept id="6105788070834796500" name="com.mbeddr.mpsutil.modellisteners.structure.BeforeRootRemovedListener" flags="ig" index="3vkeCM" />
     </language>
     <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
+        <child id="1204796294226" name="closure" index="23t8la" />
+      </concept>
       <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="nn" index="25WWJ4">
         <child id="540871147943773366" name="argument" index="25WWJ7" />
       </concept>
       <concept id="1226511727824" name="jetbrains.mps.baseLanguage.collections.structure.SetType" flags="in" index="2hMVRd">
         <child id="1226511765987" name="elementType" index="2hN53Y" />
       </concept>
+      <concept id="1151688443754" name="jetbrains.mps.baseLanguage.collections.structure.ListType" flags="in" index="_YKpA">
+        <child id="1151688676805" name="elementType" index="_ZDj9" />
+      </concept>
+      <concept id="1151702311717" name="jetbrains.mps.baseLanguage.collections.structure.ToListOperation" flags="nn" index="ANE8D" />
       <concept id="1153943597977" name="jetbrains.mps.baseLanguage.collections.structure.ForEachStatement" flags="nn" index="2Gpval">
         <child id="1153944400369" name="variable" index="2Gsz3X" />
         <child id="1153944424730" name="inputSequence" index="2GsD0m" />
@@ -143,7 +188,13 @@
       <concept id="1153944233411" name="jetbrains.mps.baseLanguage.collections.structure.ForEachVariableReference" flags="nn" index="2GrUjf">
         <reference id="1153944258490" name="variable" index="2Gs0qQ" />
       </concept>
+      <concept id="1237721394592" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerCreator" flags="nn" index="HWqM0">
+        <child id="1237721435807" name="elementType" index="HW$YZ" />
+      </concept>
+      <concept id="1227008614712" name="jetbrains.mps.baseLanguage.collections.structure.LinkedListCreator" flags="nn" index="2Jqq0_" />
+      <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
       <concept id="1167380149909" name="jetbrains.mps.baseLanguage.collections.structure.RemoveElementOperation" flags="nn" index="3dhRuq" />
+      <concept id="1202128969694" name="jetbrains.mps.baseLanguage.collections.structure.SelectOperation" flags="nn" index="3$u5V9" />
     </language>
   </registry>
   <node concept="jA7cl" id="1_0AJInZoLD">
@@ -177,262 +228,414 @@
             <node concept="3w_OXm" id="1WeG0zuARD8" role="2OqNvi" />
           </node>
         </node>
-        <node concept="3clFbH" id="1WeG0zuARZx" role="3cqZAp" />
-        <node concept="2Gpval" id="1_0AJInZEh3" role="3cqZAp">
-          <node concept="2GrKxI" id="1_0AJInZEh5" role="2Gsz3X">
+        <node concept="3clFbH" id="5gDLJkKQnVJ" role="3cqZAp" />
+        <node concept="3cpWs8" id="5gDLJkKQql9" role="3cqZAp">
+          <node concept="3cpWsn" id="5gDLJkKQqla" role="3cpWs9">
+            <property role="TrG5h" value="projectManager" />
+            <node concept="3uibUv" id="5gDLJkKQpAE" role="1tU5fm">
+              <ref role="3uigEE" to="z1c3:~ProjectManager" resolve="ProjectManager" />
+            </node>
+            <node concept="2OqwBi" id="5gDLJkKQqlb" role="33vP2m">
+              <node concept="2OqwBi" id="5gDLJkKQqlc" role="2Oq$k0">
+                <node concept="2YIFZM" id="5gDLJkKQqld" role="2Oq$k0">
+                  <ref role="37wK5l" to="3a50:~MPSCoreComponents.getInstance()" resolve="getInstance" />
+                  <ref role="1Pybhc" to="3a50:~MPSCoreComponents" resolve="MPSCoreComponents" />
+                </node>
+                <node concept="liA8E" id="5gDLJkKQqle" role="2OqNvi">
+                  <ref role="37wK5l" to="3a50:~MPSCoreComponents.getPlatform()" resolve="getPlatform" />
+                </node>
+              </node>
+              <node concept="liA8E" id="5gDLJkKQqlf" role="2OqNvi">
+                <ref role="37wK5l" to="wyuk:~ComponentHost.findComponent(java.lang.Class)" resolve="findComponent" />
+                <node concept="3VsKOn" id="5gDLJkKQqlg" role="37wK5m">
+                  <ref role="3VsUkX" to="z1c3:~ProjectManager" resolve="ProjectManager" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="5gDLJkKQu8J" role="3cqZAp">
+          <node concept="3clFbS" id="5gDLJkKQu8L" role="3clFbx">
+            <node concept="3cpWs6" id="5gDLJkKQx6d" role="3cqZAp" />
+          </node>
+          <node concept="3clFbC" id="5gDLJkKQvSR" role="3clFbw">
+            <node concept="10Nm6u" id="5gDLJkKQwjn" role="3uHU7w" />
+            <node concept="37vLTw" id="5gDLJkKQv6y" role="3uHU7B">
+              <ref role="3cqZAo" node="5gDLJkKQqla" resolve="projectManager" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="5gDLJkKQtnd" role="3cqZAp" />
+        <node concept="1DcWWT" id="5gDLJkKRbwr" role="3cqZAp">
+          <node concept="3clFbS" id="5gDLJkKRbwt" role="2LFqv$">
+            <node concept="1DcWWT" id="5gDLJkKRfV8" role="3cqZAp">
+              <node concept="3clFbS" id="5gDLJkKRfVa" role="2LFqv$">
+                <node concept="3clFbJ" id="5gDLJkKRiIj" role="3cqZAp">
+                  <node concept="3clFbS" id="5gDLJkKRiIk" role="3clFbx">
+                    <node concept="3N13vt" id="5gDLJkKRpVP" role="3cqZAp" />
+                  </node>
+                  <node concept="3fqX7Q" id="5gDLJkKRiIm" role="3clFbw">
+                    <node concept="2ZW3vV" id="5gDLJkKRiIn" role="3fr31v">
+                      <node concept="3uibUv" id="5gDLJkKRiIo" role="2ZW6by">
+                        <ref role="3uigEE" to="exr9:~EditorComponent" resolve="EditorComponent" />
+                      </node>
+                      <node concept="37vLTw" id="5gDLJkKRkod" role="2ZW6bz">
+                        <ref role="3cqZAo" node="5gDLJkKRfVb" resolve="editorComponent" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbH" id="5gDLJkKRvbn" role="3cqZAp" />
+                <node concept="3cpWs8" id="1_0AJInZwkX" role="3cqZAp">
+                  <node concept="3cpWsn" id="1_0AJInZwkW" role="3cpWs9">
+                    <property role="TrG5h" value="ec" />
+                    <node concept="3uibUv" id="1_0AJInZwkY" role="1tU5fm">
+                      <ref role="3uigEE" to="exr9:~EditorComponent" resolve="EditorComponent" />
+                    </node>
+                    <node concept="10QFUN" id="1_0AJInZwkZ" role="33vP2m">
+                      <node concept="37vLTw" id="5gDLJkKREQ3" role="10QFUP">
+                        <ref role="3cqZAo" node="5gDLJkKRfVb" resolve="editorComponent" />
+                      </node>
+                      <node concept="3uibUv" id="1_0AJInZwl1" role="10QFUM">
+                        <ref role="3uigEE" to="exr9:~EditorComponent" resolve="EditorComponent" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3cpWs8" id="7Sc8bwtQ_oN" role="3cqZAp">
+                  <node concept="3cpWsn" id="7Sc8bwtQ_oO" role="3cpWs9">
+                    <property role="TrG5h" value="producer" />
+                    <node concept="3uibUv" id="7Sc8bwtQ$Wy" role="1tU5fm">
+                      <ref role="3uigEE" to="ih8q:2jDew64JcPx" resolve="ActionIntentionMenuProducer" />
+                    </node>
+                    <node concept="0kSF2" id="38Yx6hD7vAV" role="33vP2m">
+                      <node concept="3uibUv" id="38Yx6hD7vAY" role="0kSFW">
+                        <ref role="3uigEE" to="ih8q:2jDew64JcPx" resolve="ActionIntentionMenuProducer" />
+                      </node>
+                      <node concept="2YIFZM" id="38Yx6hD7iT$" role="0kSFX">
+                        <ref role="37wK5l" to="ih8q:38Yx6hD6zfT" resolve="getIntentionMenuProducer" />
+                        <ref role="1Pybhc" to="ih8q:4hHbxs9xqxD" resolve="MyIntentionsSupport" />
+                        <node concept="37vLTw" id="38Yx6hD7jvW" role="37wK5m">
+                          <ref role="3cqZAo" node="1_0AJInZwkW" resolve="ec" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3cpWs8" id="7Sc8bwtQBCD" role="3cqZAp">
+                  <node concept="3cpWsn" id="7Sc8bwtQBCE" role="3cpWs9">
+                    <property role="TrG5h" value="oldGroupEntries" />
+                    <node concept="2hMVRd" id="7Sc8bwtQBrb" role="1tU5fm">
+                      <node concept="3uibUv" id="7Sc8bwtQBre" role="2hN53Y">
+                        <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
+                      </node>
+                    </node>
+                    <node concept="2OqwBi" id="4rzEAhzorjp" role="33vP2m">
+                      <node concept="2OqwBi" id="7Sc8bwtQBCH" role="2Oq$k0">
+                        <node concept="37vLTw" id="7Sc8bwtQBCI" role="2Oq$k0">
+                          <ref role="3cqZAo" node="7Sc8bwtQ_oO" resolve="producer" />
+                        </node>
+                        <node concept="liA8E" id="6ob0HsMLT5w" role="2OqNvi">
+                          <ref role="37wK5l" to="ih8q:6ob0HsML7OT" resolve="getCache" />
+                        </node>
+                      </node>
+                      <node concept="liA8E" id="4rzEAhzos85" role="2OqNvi">
+                        <ref role="37wK5l" to="3o3z:~SetMultimap.get(java.lang.Object)" resolve="get" />
+                        <node concept="2OqwBi" id="4rzEAhzovE$" role="37wK5m">
+                          <node concept="37vLTw" id="4rzEAhzouDd" role="2Oq$k0">
+                            <ref role="3cqZAo" node="1WeG0zuAO7S" resolve="groupAnnotation" />
+                          </node>
+                          <node concept="3TrcHB" id="4rzEAhzowul" role="2OqNvi">
+                            <ref role="3TsBF5" to="tegv:54z9_KDO50a" resolve="label" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="2Gpval" id="7Sc8bwtQTGT" role="3cqZAp">
+                  <node concept="2GrKxI" id="7Sc8bwtQTGV" role="2Gsz3X">
+                    <property role="TrG5h" value="entry" />
+                  </node>
+                  <node concept="37vLTw" id="7Sc8bwtQTNd" role="2GsD0m">
+                    <ref role="3cqZAo" node="7Sc8bwtQBCE" resolve="oldGroupEntries" />
+                  </node>
+                  <node concept="3clFbS" id="7Sc8bwtQTGZ" role="2LFqv$">
+                    <node concept="3clFbJ" id="5gDLJkKRIdj" role="3cqZAp">
+                      <node concept="3clFbS" id="5gDLJkKRIdl" role="3clFbx">
+                        <node concept="3N13vt" id="5gDLJkKRNhu" role="3cqZAp" />
+                      </node>
+                      <node concept="17QLQc" id="5gDLJkKRLHk" role="3clFbw">
+                        <node concept="2OqwBi" id="5gDLJkKRJND" role="3uHU7B">
+                          <node concept="0kSF2" id="5gDLJkKRJNE" role="2Oq$k0">
+                            <node concept="3uibUv" id="5gDLJkKRJNF" role="0kSFW">
+                              <ref role="3uigEE" to="7bx7:~BaseAction" resolve="BaseAction" />
+                            </node>
+                            <node concept="2GrUjf" id="5gDLJkKRJNG" role="0kSFX">
+                              <ref role="2Gs0qQ" node="7Sc8bwtQTGV" resolve="entry" />
+                            </node>
+                          </node>
+                          <node concept="liA8E" id="5gDLJkKRJNH" role="2OqNvi">
+                            <ref role="37wK5l" to="7bx7:~BaseAction.getActionId()" resolve="getActionId" />
+                          </node>
+                        </node>
+                        <node concept="2OqwBi" id="5gDLJkKRJNI" role="3uHU7w">
+                          <node concept="j_vvf" id="5gDLJkKRJNJ" role="2Oq$k0" />
+                          <node concept="2qgKlT" id="5gDLJkKRJNK" role="2OqNvi">
+                            <ref role="37wK5l" to="tp4s:2JiSCAPXEb8" resolve="getActionId" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbH" id="5gDLJkKRNiU" role="3cqZAp" />
+                    <node concept="3clFbF" id="7Sc8bwtR2rE" role="3cqZAp">
+                      <node concept="2OqwBi" id="7Sc8bwtR3$0" role="3clFbG">
+                        <node concept="37vLTw" id="7Sc8bwtR2rD" role="2Oq$k0">
+                          <ref role="3cqZAo" node="7Sc8bwtQBCE" resolve="oldGroupEntries" />
+                        </node>
+                        <node concept="3dhRuq" id="7Sc8bwtR4E4" role="2OqNvi">
+                          <node concept="2GrUjf" id="7Sc8bwtR4GJ" role="25WWJ7">
+                            <ref role="2Gs0qQ" node="7Sc8bwtQTGV" resolve="entry" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3cpWsn" id="5gDLJkKRfVb" role="1Duv9x">
+                <property role="TrG5h" value="editorComponent" />
+                <node concept="3uibUv" id="5gDLJkKRfYM" role="1tU5fm">
+                  <ref role="3uigEE" to="cj4x:~EditorComponent" resolve="EditorComponent" />
+                </node>
+              </node>
+              <node concept="2YIFZM" id="5gDLJkKRg8v" role="1DdaDG">
+                <ref role="37wK5l" node="5gDLJkKQzn3" resolve="getOpenedEditorComponents" />
+                <ref role="1Pybhc" node="5gDLJkKPQ8A" resolve="EditorUtil" />
+                <node concept="37vLTw" id="5gDLJkKRgMn" role="37wK5m">
+                  <ref role="3cqZAo" node="5gDLJkKRbwu" resolve="project" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWsn" id="5gDLJkKRbwu" role="1Duv9x">
             <property role="TrG5h" value="project" />
-          </node>
-          <node concept="3clFbS" id="1_0AJInZEh9" role="2LFqv$">
-            <node concept="3cpWs8" id="1_0AJInZwkj" role="3cqZAp">
-              <node concept="3cpWsn" id="1_0AJInZwki" role="3cpWs9">
-                <property role="TrG5h" value="editors" />
-                <node concept="10Q1$e" id="1_0AJInZwkl" role="1tU5fm">
-                  <node concept="3uibUv" id="1_0AJInZwkk" role="10Q1$1">
-                    <ref role="3uigEE" to="iwsx:~FileEditor" resolve="FileEditor" />
-                  </node>
-                </node>
-                <node concept="2OqwBi" id="1_0AJInZyLs" role="33vP2m">
-                  <node concept="2YIFZM" id="1_0AJInZyCU" role="2Oq$k0">
-                    <ref role="1Pybhc" to="iwsx:~FileEditorManager" resolve="FileEditorManager" />
-                    <ref role="37wK5l" to="iwsx:~FileEditorManager.getInstance(com.intellij.openapi.project.Project)" resolve="getInstance" />
-                    <node concept="2YIFZM" id="1_0AJIo0818" role="37wK5m">
-                      <ref role="37wK5l" to="alof:~ProjectHelper.toIdeaProject(jetbrains.mps.project.Project)" resolve="toIdeaProject" />
-                      <ref role="1Pybhc" to="alof:~ProjectHelper" resolve="ProjectHelper" />
-                      <node concept="2GrUjf" id="1_0AJIo08hm" role="37wK5m">
-                        <ref role="2Gs0qQ" node="1_0AJInZEh5" resolve="project" />
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="liA8E" id="1_0AJInZyLt" role="2OqNvi">
-                    <ref role="37wK5l" to="iwsx:~FileEditorManager.getAllEditors()" resolve="getAllEditors" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="1DcWWT" id="1_0AJInZwkp" role="3cqZAp">
-              <node concept="37vLTw" id="1_0AJInZwlm" role="1DdaDG">
-                <ref role="3cqZAo" node="1_0AJInZwki" resolve="editors" />
-              </node>
-              <node concept="3cpWsn" id="1_0AJInZwlj" role="1Duv9x">
-                <property role="TrG5h" value="editor" />
-                <node concept="3uibUv" id="1_0AJInZwll" role="1tU5fm">
-                  <ref role="3uigEE" to="iwsx:~FileEditor" resolve="FileEditor" />
-                </node>
-              </node>
-              <node concept="3clFbS" id="1_0AJInZwkr" role="2LFqv$">
-                <node concept="3clFbJ" id="1_0AJInZwks" role="3cqZAp">
-                  <node concept="2ZW3vV" id="1_0AJInZwkv" role="3clFbw">
-                    <node concept="37vLTw" id="1_0AJInZwkt" role="2ZW6bz">
-                      <ref role="3cqZAo" node="1_0AJInZwlj" resolve="editor" />
-                    </node>
-                    <node concept="3uibUv" id="1_0AJInZwku" role="2ZW6by">
-                      <ref role="3uigEE" to="k3nr:~MPSFileNodeEditor" resolve="MPSFileNodeEditor" />
-                    </node>
-                  </node>
-                  <node concept="3clFbS" id="1_0AJInZwkx" role="3clFbx">
-                    <node concept="3cpWs8" id="1_0AJInZwkz" role="3cqZAp">
-                      <node concept="3cpWsn" id="1_0AJInZwky" role="3cpWs9">
-                        <property role="TrG5h" value="mpsEditor" />
-                        <node concept="3uibUv" id="1_0AJInZwk$" role="1tU5fm">
-                          <ref role="3uigEE" to="k3nr:~MPSFileNodeEditor" resolve="MPSFileNodeEditor" />
-                        </node>
-                        <node concept="10QFUN" id="1_0AJInZwk_" role="33vP2m">
-                          <node concept="37vLTw" id="1_0AJInZwkA" role="10QFUP">
-                            <ref role="3cqZAo" node="1_0AJInZwlj" resolve="editor" />
-                          </node>
-                          <node concept="3uibUv" id="1_0AJInZwkB" role="10QFUM">
-                            <ref role="3uigEE" to="k3nr:~MPSFileNodeEditor" resolve="MPSFileNodeEditor" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="3cpWs8" id="1_0AJInZwkD" role="3cqZAp">
-                      <node concept="3cpWsn" id="1_0AJInZwkC" role="3cpWs9">
-                        <property role="TrG5h" value="nodeEditor" />
-                        <node concept="3uibUv" id="1_0AJInZwkE" role="1tU5fm">
-                          <ref role="3uigEE" to="cj4x:~Editor" resolve="Editor" />
-                        </node>
-                        <node concept="2OqwBi" id="1_0AJInZyrS" role="33vP2m">
-                          <node concept="37vLTw" id="1_0AJInZwt4" role="2Oq$k0">
-                            <ref role="3cqZAo" node="1_0AJInZwky" resolve="mpsEditor" />
-                          </node>
-                          <node concept="liA8E" id="1_0AJInZyrT" role="2OqNvi">
-                            <ref role="37wK5l" to="k3nr:~MPSFileNodeEditor.getNodeEditor()" resolve="getNodeEditor" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="3clFbJ" id="1_0AJInZwkG" role="3cqZAp">
-                      <node concept="3y3z36" id="1_0AJInZwkH" role="3clFbw">
-                        <node concept="37vLTw" id="1_0AJInZwkI" role="3uHU7B">
-                          <ref role="3cqZAo" node="1_0AJInZwkC" resolve="nodeEditor" />
-                        </node>
-                        <node concept="10Nm6u" id="1_0AJInZwkJ" role="3uHU7w" />
-                      </node>
-                      <node concept="3clFbS" id="1_0AJInZwkL" role="3clFbx">
-                        <node concept="3cpWs8" id="1_0AJInZwkN" role="3cqZAp">
-                          <node concept="3cpWsn" id="1_0AJInZwkM" role="3cpWs9">
-                            <property role="TrG5h" value="editorComponent" />
-                            <node concept="3uibUv" id="1_0AJInZwkO" role="1tU5fm">
-                              <ref role="3uigEE" to="cj4x:~EditorComponent" resolve="EditorComponent" />
-                            </node>
-                            <node concept="2OqwBi" id="1_0AJInZG4i" role="33vP2m">
-                              <node concept="37vLTw" id="1_0AJInZwsY" role="2Oq$k0">
-                                <ref role="3cqZAo" node="1_0AJInZwkC" resolve="nodeEditor" />
-                              </node>
-                              <node concept="liA8E" id="1_0AJInZG4j" role="2OqNvi">
-                                <ref role="37wK5l" to="cj4x:~Editor.getCurrentEditorComponent()" resolve="getCurrentEditorComponent" />
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="3clFbJ" id="1_0AJInZwkQ" role="3cqZAp">
-                          <node concept="2ZW3vV" id="1_0AJInZwkT" role="3clFbw">
-                            <node concept="37vLTw" id="1_0AJInZwkR" role="2ZW6bz">
-                              <ref role="3cqZAo" node="1_0AJInZwkM" resolve="editorComponent" />
-                            </node>
-                            <node concept="3uibUv" id="1_0AJInZwkS" role="2ZW6by">
-                              <ref role="3uigEE" to="exr9:~EditorComponent" resolve="EditorComponent" />
-                            </node>
-                          </node>
-                          <node concept="3clFbS" id="1_0AJInZwkV" role="3clFbx">
-                            <node concept="3cpWs8" id="1_0AJInZwkX" role="3cqZAp">
-                              <node concept="3cpWsn" id="1_0AJInZwkW" role="3cpWs9">
-                                <property role="TrG5h" value="ec" />
-                                <node concept="3uibUv" id="1_0AJInZwkY" role="1tU5fm">
-                                  <ref role="3uigEE" to="exr9:~EditorComponent" resolve="EditorComponent" />
-                                </node>
-                                <node concept="10QFUN" id="1_0AJInZwkZ" role="33vP2m">
-                                  <node concept="37vLTw" id="1_0AJInZwl0" role="10QFUP">
-                                    <ref role="3cqZAo" node="1_0AJInZwkM" resolve="editorComponent" />
-                                  </node>
-                                  <node concept="3uibUv" id="1_0AJInZwl1" role="10QFUM">
-                                    <ref role="3uigEE" to="exr9:~EditorComponent" resolve="EditorComponent" />
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                            <node concept="3cpWs8" id="7Sc8bwtQ_oN" role="3cqZAp">
-                              <node concept="3cpWsn" id="7Sc8bwtQ_oO" role="3cpWs9">
-                                <property role="TrG5h" value="producer" />
-                                <node concept="3uibUv" id="7Sc8bwtQ$Wy" role="1tU5fm">
-                                  <ref role="3uigEE" to="ih8q:2jDew64JcPx" resolve="ActionIntentionMenuProducer" />
-                                </node>
-                                <node concept="0kSF2" id="38Yx6hD7vAV" role="33vP2m">
-                                  <node concept="3uibUv" id="38Yx6hD7vAY" role="0kSFW">
-                                    <ref role="3uigEE" to="ih8q:2jDew64JcPx" resolve="ActionIntentionMenuProducer" />
-                                  </node>
-                                  <node concept="2YIFZM" id="38Yx6hD7iT$" role="0kSFX">
-                                    <ref role="37wK5l" to="ih8q:38Yx6hD6zfT" resolve="getIntentionMenuProducer" />
-                                    <ref role="1Pybhc" to="ih8q:4hHbxs9xqxD" resolve="MyIntentionsSupport" />
-                                    <node concept="37vLTw" id="38Yx6hD7jvW" role="37wK5m">
-                                      <ref role="3cqZAo" node="1_0AJInZwkW" resolve="ec" />
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                            <node concept="3cpWs8" id="7Sc8bwtQBCD" role="3cqZAp">
-                              <node concept="3cpWsn" id="7Sc8bwtQBCE" role="3cpWs9">
-                                <property role="TrG5h" value="oldGroupEntries" />
-                                <node concept="2hMVRd" id="7Sc8bwtQBrb" role="1tU5fm">
-                                  <node concept="3uibUv" id="7Sc8bwtQBre" role="2hN53Y">
-                                    <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
-                                  </node>
-                                </node>
-                                <node concept="2OqwBi" id="4rzEAhzorjp" role="33vP2m">
-                                  <node concept="2OqwBi" id="7Sc8bwtQBCH" role="2Oq$k0">
-                                    <node concept="37vLTw" id="7Sc8bwtQBCI" role="2Oq$k0">
-                                      <ref role="3cqZAo" node="7Sc8bwtQ_oO" resolve="producer" />
-                                    </node>
-                                    <node concept="liA8E" id="6ob0HsMLT5w" role="2OqNvi">
-                                      <ref role="37wK5l" to="ih8q:6ob0HsML7OT" resolve="getCache" />
-                                    </node>
-                                  </node>
-                                  <node concept="liA8E" id="4rzEAhzos85" role="2OqNvi">
-                                    <ref role="37wK5l" to="3o3z:~SetMultimap.get(java.lang.Object)" resolve="get" />
-                                    <node concept="2OqwBi" id="4rzEAhzovE$" role="37wK5m">
-                                      <node concept="37vLTw" id="4rzEAhzouDd" role="2Oq$k0">
-                                        <ref role="3cqZAo" node="1WeG0zuAO7S" resolve="groupAnnotation" />
-                                      </node>
-                                      <node concept="3TrcHB" id="4rzEAhzowul" role="2OqNvi">
-                                        <ref role="3TsBF5" to="tegv:54z9_KDO50a" resolve="label" />
-                                      </node>
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                            <node concept="2Gpval" id="7Sc8bwtQTGT" role="3cqZAp">
-                              <node concept="2GrKxI" id="7Sc8bwtQTGV" role="2Gsz3X">
-                                <property role="TrG5h" value="entry" />
-                              </node>
-                              <node concept="37vLTw" id="7Sc8bwtQTNd" role="2GsD0m">
-                                <ref role="3cqZAo" node="7Sc8bwtQBCE" resolve="oldGroupEntries" />
-                              </node>
-                              <node concept="3clFbS" id="7Sc8bwtQTGZ" role="2LFqv$">
-                                <node concept="3clFbJ" id="7Sc8bwtQTOQ" role="3cqZAp">
-                                  <node concept="17R0WA" id="7Sc8bwtQYPw" role="3clFbw">
-                                    <node concept="2OqwBi" id="7Sc8bwtQX34" role="3uHU7B">
-                                      <node concept="0kSF2" id="7Sc8bwtQWxE" role="2Oq$k0">
-                                        <node concept="3uibUv" id="7Sc8bwtQWxG" role="0kSFW">
-                                          <ref role="3uigEE" to="7bx7:~BaseAction" resolve="BaseAction" />
-                                        </node>
-                                        <node concept="2GrUjf" id="7Sc8bwtQTPk" role="0kSFX">
-                                          <ref role="2Gs0qQ" node="7Sc8bwtQTGV" resolve="entry" />
-                                        </node>
-                                      </node>
-                                      <node concept="liA8E" id="7Sc8bwtQXNq" role="2OqNvi">
-                                        <ref role="37wK5l" to="7bx7:~BaseAction.getActionId()" resolve="getActionId" />
-                                      </node>
-                                    </node>
-                                    <node concept="2OqwBi" id="7Sc8bwtR2iE" role="3uHU7w">
-                                      <node concept="j_vvf" id="1_0AJIo0AYn" role="2Oq$k0" />
-                                      <node concept="2qgKlT" id="7Sc8bwtR2kj" role="2OqNvi">
-                                        <ref role="37wK5l" to="tp4s:2JiSCAPXEb8" resolve="getActionId" />
-                                      </node>
-                                    </node>
-                                  </node>
-                                  <node concept="3clFbS" id="7Sc8bwtQTOS" role="3clFbx">
-                                    <node concept="3clFbF" id="7Sc8bwtR2rE" role="3cqZAp">
-                                      <node concept="2OqwBi" id="7Sc8bwtR3$0" role="3clFbG">
-                                        <node concept="37vLTw" id="7Sc8bwtR2rD" role="2Oq$k0">
-                                          <ref role="3cqZAo" node="7Sc8bwtQBCE" resolve="oldGroupEntries" />
-                                        </node>
-                                        <node concept="3dhRuq" id="7Sc8bwtR4E4" role="2OqNvi">
-                                          <node concept="2GrUjf" id="7Sc8bwtR4GJ" role="25WWJ7">
-                                            <ref role="2Gs0qQ" node="7Sc8bwtQTGV" resolve="entry" />
-                                          </node>
-                                        </node>
-                                      </node>
-                                    </node>
-                                    <node concept="3cpWs6" id="7Sc8bwtR4J1" role="3cqZAp" />
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                            <node concept="3clFbH" id="1_0AJInZYq_" role="3cqZAp" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
+            <node concept="3uibUv" id="5gDLJkKRdz4" role="1tU5fm">
+              <ref role="3uigEE" to="z1c3:~Project" resolve="Project" />
             </node>
           </node>
-          <node concept="2OqwBi" id="1_0AJInZDrJ" role="2GsD0m">
-            <node concept="2YIFZM" id="1_0AJInZD3t" role="2Oq$k0">
-              <ref role="37wK5l" to="z1c3:~ProjectManager.getInstance()" resolve="getInstance" />
-              <ref role="1Pybhc" to="z1c3:~ProjectManager" resolve="ProjectManager" />
-            </node>
-            <node concept="liA8E" id="1_0AJInZDKY" role="2OqNvi">
+          <node concept="2OqwBi" id="5gDLJkKRctK" role="1DdaDG">
+            <node concept="liA8E" id="5gDLJkKRctL" role="2OqNvi">
               <ref role="37wK5l" to="z1c3:~ProjectManager.getOpenedProjects()" resolve="getOpenedProjects" />
+            </node>
+            <node concept="37vLTw" id="5gDLJkKRctM" role="2Oq$k0">
+              <ref role="3cqZAo" node="5gDLJkKQqla" resolve="projectManager" />
             </node>
           </node>
         </node>
       </node>
     </node>
+  </node>
+  <node concept="312cEu" id="5gDLJkKPQ8A">
+    <property role="TrG5h" value="EditorUtil" />
+    <node concept="2YIFZL" id="5gDLJkKPTPE" role="jymVt">
+      <property role="TrG5h" value="getOpenedEditors" />
+      <node concept="3clFbS" id="5gDLJkKPTPH" role="3clF47">
+        <node concept="3cpWs8" id="5gDLJkKPY_M" role="3cqZAp">
+          <node concept="3cpWsn" id="5gDLJkKPY_P" role="3cpWs9">
+            <property role="TrG5h" value="mpsEditors" />
+            <node concept="_YKpA" id="5gDLJkKPY_I" role="1tU5fm">
+              <node concept="3uibUv" id="5gDLJkKPYKf" role="_ZDj9">
+                <ref role="3uigEE" to="cj4x:~Editor" resolve="Editor" />
+              </node>
+            </node>
+            <node concept="2ShNRf" id="5gDLJkKPZjy" role="33vP2m">
+              <node concept="2Jqq0_" id="5gDLJkKPZCp" role="2ShVmc">
+                <node concept="3uibUv" id="5gDLJkKPZNs" role="HW$YZ">
+                  <ref role="3uigEE" to="cj4x:~Editor" resolve="Editor" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="5gDLJkKQ07c" role="3cqZAp" />
+        <node concept="3cpWs8" id="5gDLJkKPUrn" role="3cqZAp">
+          <node concept="3cpWsn" id="5gDLJkKPUro" role="3cpWs9">
+            <property role="TrG5h" value="editors" />
+            <node concept="10Q1$e" id="5gDLJkKPUrp" role="1tU5fm">
+              <node concept="3uibUv" id="5gDLJkKPUrq" role="10Q1$1">
+                <ref role="3uigEE" to="iwsx:~FileEditor" resolve="FileEditor" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="5gDLJkKPUrr" role="33vP2m">
+              <node concept="2YIFZM" id="5gDLJkKPUrs" role="2Oq$k0">
+                <ref role="1Pybhc" to="iwsx:~FileEditorManager" resolve="FileEditorManager" />
+                <ref role="37wK5l" to="iwsx:~FileEditorManager.getInstance(com.intellij.openapi.project.Project)" resolve="getInstance" />
+                <node concept="2YIFZM" id="5gDLJkKPUrt" role="37wK5m">
+                  <ref role="37wK5l" to="alof:~ProjectHelper.toIdeaProject(jetbrains.mps.project.Project)" resolve="toIdeaProject" />
+                  <ref role="1Pybhc" to="alof:~ProjectHelper" resolve="ProjectHelper" />
+                  <node concept="37vLTw" id="5gDLJkKPXoP" role="37wK5m">
+                    <ref role="3cqZAo" node="5gDLJkKPUal" resolve="project" />
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="5gDLJkKPUrv" role="2OqNvi">
+                <ref role="37wK5l" to="iwsx:~FileEditorManager.getAllEditors()" resolve="getAllEditors" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="5gDLJkKPXRL" role="3cqZAp" />
+        <node concept="1DcWWT" id="5gDLJkKPUrw" role="3cqZAp">
+          <node concept="37vLTw" id="5gDLJkKPUrx" role="1DdaDG">
+            <ref role="3cqZAo" node="5gDLJkKPUro" resolve="editors" />
+          </node>
+          <node concept="3cpWsn" id="5gDLJkKPUry" role="1Duv9x">
+            <property role="TrG5h" value="editor" />
+            <node concept="3uibUv" id="5gDLJkKPUrz" role="1tU5fm">
+              <ref role="3uigEE" to="iwsx:~FileEditor" resolve="FileEditor" />
+            </node>
+          </node>
+          <node concept="3clFbS" id="5gDLJkKPUr$" role="2LFqv$">
+            <node concept="3clFbJ" id="5gDLJkKPUr_" role="3cqZAp">
+              <node concept="2ZW3vV" id="5gDLJkKPUrA" role="3clFbw">
+                <node concept="37vLTw" id="5gDLJkKPUrB" role="2ZW6bz">
+                  <ref role="3cqZAo" node="5gDLJkKPUry" resolve="editor" />
+                </node>
+                <node concept="3uibUv" id="5gDLJkKPUrC" role="2ZW6by">
+                  <ref role="3uigEE" to="k3nr:~MPSFileNodeEditor" resolve="MPSFileNodeEditor" />
+                </node>
+              </node>
+              <node concept="3clFbS" id="5gDLJkKPUrD" role="3clFbx">
+                <node concept="3cpWs8" id="5gDLJkKPUrE" role="3cqZAp">
+                  <node concept="3cpWsn" id="5gDLJkKPUrF" role="3cpWs9">
+                    <property role="TrG5h" value="mpsEditor" />
+                    <node concept="3uibUv" id="5gDLJkKPUrG" role="1tU5fm">
+                      <ref role="3uigEE" to="k3nr:~MPSFileNodeEditor" resolve="MPSFileNodeEditor" />
+                    </node>
+                    <node concept="10QFUN" id="5gDLJkKPUrH" role="33vP2m">
+                      <node concept="37vLTw" id="5gDLJkKPUrI" role="10QFUP">
+                        <ref role="3cqZAo" node="5gDLJkKPUry" resolve="editor" />
+                      </node>
+                      <node concept="3uibUv" id="5gDLJkKPUrJ" role="10QFUM">
+                        <ref role="3uigEE" to="k3nr:~MPSFileNodeEditor" resolve="MPSFileNodeEditor" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3cpWs8" id="5gDLJkKPUrK" role="3cqZAp">
+                  <node concept="3cpWsn" id="5gDLJkKPUrL" role="3cpWs9">
+                    <property role="TrG5h" value="nodeEditor" />
+                    <node concept="3uibUv" id="5gDLJkKPUrM" role="1tU5fm">
+                      <ref role="3uigEE" to="cj4x:~Editor" resolve="Editor" />
+                    </node>
+                    <node concept="2OqwBi" id="5gDLJkKPUrN" role="33vP2m">
+                      <node concept="37vLTw" id="5gDLJkKPUrO" role="2Oq$k0">
+                        <ref role="3cqZAo" node="5gDLJkKPUrF" resolve="mpsEditor" />
+                      </node>
+                      <node concept="liA8E" id="5gDLJkKPUrP" role="2OqNvi">
+                        <ref role="37wK5l" to="k3nr:~MPSFileNodeEditor.getNodeEditor()" resolve="getNodeEditor" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbJ" id="5gDLJkKPUrQ" role="3cqZAp">
+                  <node concept="3y3z36" id="5gDLJkKPUrR" role="3clFbw">
+                    <node concept="37vLTw" id="5gDLJkKPUrS" role="3uHU7B">
+                      <ref role="3cqZAo" node="5gDLJkKPUrL" resolve="nodeEditor" />
+                    </node>
+                    <node concept="10Nm6u" id="5gDLJkKPUrT" role="3uHU7w" />
+                  </node>
+                  <node concept="3clFbS" id="5gDLJkKPUrU" role="3clFbx">
+                    <node concept="3clFbF" id="5gDLJkKQ1fH" role="3cqZAp">
+                      <node concept="2OqwBi" id="5gDLJkKQ2An" role="3clFbG">
+                        <node concept="37vLTw" id="5gDLJkKQ1fG" role="2Oq$k0">
+                          <ref role="3cqZAo" node="5gDLJkKPY_P" resolve="mpsEditors" />
+                        </node>
+                        <node concept="TSZUe" id="5gDLJkKQ3Bc" role="2OqNvi">
+                          <node concept="37vLTw" id="5gDLJkKQ3MX" role="25WWJ7">
+                            <ref role="3cqZAo" node="5gDLJkKPUrL" resolve="nodeEditor" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="5gDLJkKQ49w" role="3cqZAp">
+          <node concept="37vLTw" id="5gDLJkKQ49u" role="3clFbG">
+            <ref role="3cqZAo" node="5gDLJkKPY_P" resolve="mpsEditors" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="5gDLJkKPQb2" role="1B3o_S" />
+      <node concept="_YKpA" id="5gDLJkKPTyy" role="3clF45">
+        <node concept="3uibUv" id="5gDLJkKPTQH" role="_ZDj9">
+          <ref role="3uigEE" to="cj4x:~Editor" resolve="Editor" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="5gDLJkKPUal" role="3clF46">
+        <property role="TrG5h" value="project" />
+        <node concept="3uibUv" id="5gDLJkKPUak" role="1tU5fm">
+          <ref role="3uigEE" to="z1c3:~Project" resolve="Project" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="5gDLJkKQyxh" role="jymVt" />
+    <node concept="2YIFZL" id="5gDLJkKQzn3" role="jymVt">
+      <property role="TrG5h" value="getOpenedEditorComponents" />
+      <node concept="3clFbS" id="5gDLJkKQzn6" role="3clF47">
+        <node concept="3clFbF" id="5gDLJkKQ_uy" role="3cqZAp">
+          <node concept="2OqwBi" id="5gDLJkKQJtB" role="3clFbG">
+            <node concept="2OqwBi" id="5gDLJkKQBXA" role="2Oq$k0">
+              <node concept="1rXfSq" id="5gDLJkKQ_uw" role="2Oq$k0">
+                <ref role="37wK5l" node="5gDLJkKPTPE" resolve="getOpenedEditors" />
+                <node concept="37vLTw" id="5gDLJkKQA$0" role="37wK5m">
+                  <ref role="3cqZAo" node="5gDLJkKQz$y" resolve="project" />
+                </node>
+              </node>
+              <node concept="3$u5V9" id="5gDLJkKQDpP" role="2OqNvi">
+                <node concept="1bVj0M" id="5gDLJkKQDpR" role="23t8la">
+                  <node concept="3clFbS" id="5gDLJkKQDpS" role="1bW5cS">
+                    <node concept="3clFbF" id="5gDLJkKQKS5" role="3cqZAp">
+                      <node concept="2OqwBi" id="5gDLJkKQDCS" role="3clFbG">
+                        <node concept="37vLTw" id="5gDLJkKQEx8" role="2Oq$k0">
+                          <ref role="3cqZAo" node="5gDLJkKQDpT" resolve="it" />
+                        </node>
+                        <node concept="liA8E" id="5gDLJkKQDCU" role="2OqNvi">
+                          <ref role="37wK5l" to="cj4x:~Editor.getCurrentEditorComponent()" resolve="getCurrentEditorComponent" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="gl6BB" id="5gDLJkKQDpT" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="5gDLJkKQDpU" role="1tU5fm" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="ANE8D" id="5gDLJkKQKh$" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="5gDLJkKQyHg" role="1B3o_S" />
+      <node concept="_YKpA" id="5gDLJkKQyTV" role="3clF45">
+        <node concept="3uibUv" id="5gDLJkKQyW0" role="_ZDj9">
+          <ref role="3uigEE" to="cj4x:~EditorComponent" resolve="EditorComponent" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="5gDLJkKQz$y" role="3clF46">
+        <property role="TrG5h" value="project" />
+        <node concept="3uibUv" id="5gDLJkKQz$x" role="1tU5fm">
+          <ref role="3uigEE" to="z1c3:~Project" resolve="Project" />
+        </node>
+      </node>
+    </node>
+    <node concept="3Tm1VV" id="5gDLJkKPQ8B" role="1B3o_S" />
   </node>
 </model>
 

--- a/code/intentionsmenu/com.mbeddr.mpsutil.intentions/languageModels/com.mbeddr.mpsutil.intentions.listeners.mps
+++ b/code/intentionsmenu/com.mbeddr.mpsutil.intentions/languageModels/com.mbeddr.mpsutil.intentions.listeners.mps
@@ -19,14 +19,10 @@
     <import index="7bx7" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.workbench.action(MPS.Platform/)" />
     <import index="alof" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.ide.project(MPS.Platform/)" />
     <import index="tp4k" ref="r:00000000-0000-4000-0000-011c89590368(jetbrains.mps.lang.plugin.structure)" implicit="true" />
+    <import index="3o3z" ref="39983771-4e9b-401b-a1a9-1da6c777c843/java:com.google.common.collect(MPS.ThirdParty/)" implicit="true" />
     <import index="tp4s" ref="r:00000000-0000-4000-0000-011c89590360(jetbrains.mps.lang.plugin.behavior)" implicit="true" />
   </imports>
   <registry>
-    <language id="654422bf-e75f-44dc-936d-188890a746ce" name="de.slisson.mps.reflection">
-      <concept id="8473566765275063380" name="de.slisson.mps.reflection.structure.ReflectionFieldAccess" flags="ng" index="1PnCL0">
-        <reference id="1197029500499" name="fieldDeclaration" index="2Oxat5" />
-      </concept>
-    </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
       <concept id="1224071154655" name="jetbrains.mps.baseLanguage.structure.AsExpression" flags="nn" index="0kSF2">
         <child id="1224071154657" name="classifierType" index="0kSFW" />
@@ -40,7 +36,6 @@
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
       </concept>
-      <concept id="3870108946630849399" name="jetbrains.mps.baseLanguage.structure.StaticFieldReferenceOperation" flags="ng" index="SiP3y" />
       <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
         <child id="1137022507850" name="body" index="2VODD2" />
       </concept>
@@ -149,10 +144,6 @@
         <reference id="1153944258490" name="variable" index="2Gs0qQ" />
       </concept>
       <concept id="1167380149909" name="jetbrains.mps.baseLanguage.collections.structure.RemoveElementOperation" flags="nn" index="3dhRuq" />
-      <concept id="1197932370469" name="jetbrains.mps.baseLanguage.collections.structure.MapElement" flags="nn" index="3EllGN">
-        <child id="1197932505799" name="map" index="3ElQJh" />
-        <child id="1197932525128" name="key" index="3ElVtu" />
-      </concept>
     </language>
   </registry>
   <node concept="jA7cl" id="1_0AJInZoLD">
@@ -325,23 +316,17 @@
                               <node concept="3cpWsn" id="7Sc8bwtQ_oO" role="3cpWs9">
                                 <property role="TrG5h" value="producer" />
                                 <node concept="3uibUv" id="7Sc8bwtQ$Wy" role="1tU5fm">
-                                  <ref role="3uigEE" to="ih8q:2jDew64JcPx" resolve="MyIntentionMenuProducer" />
+                                  <ref role="3uigEE" to="ih8q:2jDew64JcPx" resolve="ActionIntentionMenuProducer" />
                                 </node>
-                                <node concept="0kSF2" id="7Sc8bwtQ_oP" role="33vP2m">
-                                  <node concept="3uibUv" id="7Sc8bwtQ_oQ" role="0kSFW">
-                                    <ref role="3uigEE" to="ih8q:2jDew64JcPx" resolve="MyIntentionMenuProducer" />
+                                <node concept="0kSF2" id="38Yx6hD7vAV" role="33vP2m">
+                                  <node concept="3uibUv" id="38Yx6hD7vAY" role="0kSFW">
+                                    <ref role="3uigEE" to="ih8q:2jDew64JcPx" resolve="ActionIntentionMenuProducer" />
                                   </node>
-                                  <node concept="2OqwBi" id="7Sc8bwtQ_oR" role="0kSFX">
-                                    <node concept="2OqwBi" id="7Sc8bwtQ_oS" role="2Oq$k0">
-                                      <node concept="37vLTw" id="7Sc8bwtQ_oT" role="2Oq$k0">
-                                        <ref role="3cqZAo" node="1_0AJInZwkW" resolve="ec" />
-                                      </node>
-                                      <node concept="1PnCL0" id="7Sc8bwtQ_oU" role="2OqNvi">
-                                        <ref role="2Oxat5" to="exr9:~EditorComponent.myIntentionsSupport" resolve="myIntentionsSupport" />
-                                      </node>
-                                    </node>
-                                    <node concept="1PnCL0" id="7Sc8bwtQ_oV" role="2OqNvi">
-                                      <ref role="2Oxat5" to="exr9:~IntentionsSupport.myMenuProducer" resolve="myMenuProducer" />
+                                  <node concept="2YIFZM" id="38Yx6hD7iT$" role="0kSFX">
+                                    <ref role="37wK5l" to="ih8q:38Yx6hD6zfT" resolve="getIntentionMenuProducer" />
+                                    <ref role="1Pybhc" to="ih8q:4hHbxs9xqxD" resolve="MyIntentionsSupport" />
+                                    <node concept="37vLTw" id="38Yx6hD7jvW" role="37wK5m">
+                                      <ref role="3cqZAo" node="1_0AJInZwkW" resolve="ec" />
                                     </node>
                                   </node>
                                 </node>
@@ -355,21 +340,24 @@
                                     <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
                                   </node>
                                 </node>
-                                <node concept="3EllGN" id="7Sc8bwtQBCF" role="33vP2m">
-                                  <node concept="2OqwBi" id="1_0AJIo090w" role="3ElVtu">
-                                    <node concept="37vLTw" id="1WeG0zuAWg2" role="2Oq$k0">
-                                      <ref role="3cqZAo" node="1WeG0zuAO7S" resolve="groupAnnotation" />
-                                    </node>
-                                    <node concept="3TrcHB" id="1_0AJIo09yW" role="2OqNvi">
-                                      <ref role="3TsBF5" to="tegv:54z9_KDO50a" resolve="label" />
-                                    </node>
-                                  </node>
-                                  <node concept="2OqwBi" id="7Sc8bwtQBCH" role="3ElQJh">
+                                <node concept="2OqwBi" id="4rzEAhzorjp" role="33vP2m">
+                                  <node concept="2OqwBi" id="7Sc8bwtQBCH" role="2Oq$k0">
                                     <node concept="37vLTw" id="7Sc8bwtQBCI" role="2Oq$k0">
                                       <ref role="3cqZAo" node="7Sc8bwtQ_oO" resolve="producer" />
                                     </node>
-                                    <node concept="SiP3y" id="7Sc8bwtQBCJ" role="2OqNvi">
-                                      <ref role="3cqZAo" to="ih8q:5Rdndlpp80A" resolve="groupedActionsCache" />
+                                    <node concept="liA8E" id="6ob0HsMLT5w" role="2OqNvi">
+                                      <ref role="37wK5l" to="ih8q:6ob0HsML7OT" resolve="getCache" />
+                                    </node>
+                                  </node>
+                                  <node concept="liA8E" id="4rzEAhzos85" role="2OqNvi">
+                                    <ref role="37wK5l" to="3o3z:~SetMultimap.get(java.lang.Object)" resolve="get" />
+                                    <node concept="2OqwBi" id="4rzEAhzovE$" role="37wK5m">
+                                      <node concept="37vLTw" id="4rzEAhzouDd" role="2Oq$k0">
+                                        <ref role="3cqZAo" node="1WeG0zuAO7S" resolve="groupAnnotation" />
+                                      </node>
+                                      <node concept="3TrcHB" id="4rzEAhzowul" role="2OqNvi">
+                                        <ref role="3TsBF5" to="tegv:54z9_KDO50a" resolve="label" />
+                                      </node>
                                     </node>
                                   </node>
                                 </node>

--- a/code/intentionsmenu/com.mbeddr.mpsutil.intentions/languageModels/com.mbeddr.mpsutil.intentions.listeners.mps
+++ b/code/intentionsmenu/com.mbeddr.mpsutil.intentions/languageModels/com.mbeddr.mpsutil.intentions.listeners.mps
@@ -1,0 +1,450 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:954058d8-dab1-4f34-881c-871bf5b70526(com.mbeddr.mpsutil.intentions.listeners)">
+  <persistence version="9" />
+  <languages>
+    <use id="309e0004-4976-4416-b947-ec02ae4ecef2" name="com.mbeddr.mpsutil.modellisteners" version="0" />
+    <use id="654422bf-e75f-44dc-936d-188890a746ce" name="de.slisson.mps.reflection" version="0" />
+    <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
+  </languages>
+  <imports>
+    <import index="exr9" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor(MPS.Editor/)" />
+    <import index="tegv" ref="r:b91d2412-f094-4e55-8db6-3c782d7edc40(com.mbeddr.mpsutil.intentions.structure)" />
+    <import index="k3nr" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.ide.editor(MPS.Editor/)" />
+    <import index="iwsx" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.fileEditor(MPS.IDEA/)" />
+    <import index="s9o5" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.editor(MPS.IDEA/)" />
+    <import index="z1c3" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.project(MPS.Core/)" />
+    <import index="cj4x" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor(MPS.Editor/)" />
+    <import index="ih8q" ref="r:990d360b-3ac3-45fa-8ed3-0bbf017bba84(com.mbeddr.mpsutil.intentions.runtime)" />
+    <import index="qkt" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.actionSystem(MPS.IDEA/)" />
+    <import index="7bx7" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.workbench.action(MPS.Platform/)" />
+    <import index="alof" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.ide.project(MPS.Platform/)" />
+    <import index="tp4k" ref="r:00000000-0000-4000-0000-011c89590368(jetbrains.mps.lang.plugin.structure)" implicit="true" />
+    <import index="tp4s" ref="r:00000000-0000-4000-0000-011c89590360(jetbrains.mps.lang.plugin.behavior)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="654422bf-e75f-44dc-936d-188890a746ce" name="de.slisson.mps.reflection">
+      <concept id="8473566765275063380" name="de.slisson.mps.reflection.structure.ReflectionFieldAccess" flags="ng" index="1PnCL0">
+        <reference id="1197029500499" name="fieldDeclaration" index="2Oxat5" />
+      </concept>
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1224071154655" name="jetbrains.mps.baseLanguage.structure.AsExpression" flags="nn" index="0kSF2">
+        <child id="1224071154657" name="classifierType" index="0kSFW" />
+        <child id="1224071154656" name="expression" index="0kSFX" />
+      </concept>
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
+        <child id="1154032183016" name="body" index="2LFqv$" />
+      </concept>
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="3870108946630849399" name="jetbrains.mps.baseLanguage.structure.StaticFieldReferenceOperation" flags="ng" index="SiP3y" />
+      <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
+        <child id="1137022507850" name="body" index="2VODD2" />
+      </concept>
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
+      </concept>
+      <concept id="1081256982272" name="jetbrains.mps.baseLanguage.structure.InstanceOfExpression" flags="nn" index="2ZW3vV">
+        <child id="1081256993305" name="classType" index="2ZW6by" />
+        <child id="1081256993304" name="leftExpression" index="2ZW6bz" />
+      </concept>
+      <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
+      <concept id="1070534760951" name="jetbrains.mps.baseLanguage.structure.ArrayType" flags="in" index="10Q1$e">
+        <child id="1070534760952" name="componentType" index="10Q1$1" />
+      </concept>
+      <concept id="1070534934090" name="jetbrains.mps.baseLanguage.structure.CastExpression" flags="nn" index="10QFUN">
+        <child id="1070534934091" name="type" index="10QFUM" />
+        <child id="1070534934092" name="expression" index="10QFUP" />
+      </concept>
+      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="1225271283259" name="jetbrains.mps.baseLanguage.structure.NPEEqualsExpression" flags="nn" index="17R0WA" />
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
+      <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
+        <child id="1068580123160" name="condition" index="3clFbw" />
+        <child id="1068580123161" name="ifTrue" index="3clFbx" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6" />
+      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
+        <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
+      </concept>
+      <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+        <reference id="1107535924139" name="classifier" index="3uigEE" />
+      </concept>
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
+        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
+        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
+      </concept>
+      <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
+      <concept id="1144226303539" name="jetbrains.mps.baseLanguage.structure.ForeachStatement" flags="nn" index="1DcWWT">
+        <child id="1144226360166" name="iterable" index="1DdaDG" />
+      </concept>
+      <concept id="1144230876926" name="jetbrains.mps.baseLanguage.structure.AbstractForStatement" flags="nn" index="1DupvO">
+        <child id="1144230900587" name="variable" index="1Duv9x" />
+      </concept>
+    </language>
+    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
+      <concept id="1171999116870" name="jetbrains.mps.lang.smodel.structure.Node_IsNullOperation" flags="nn" index="3w_OXm" />
+      <concept id="6407023681583036853" name="jetbrains.mps.lang.smodel.structure.NodeAttributeQualifier" flags="ng" index="3CFYIy">
+        <reference id="6407023681583036854" name="attributeConcept" index="3CFYIx" />
+      </concept>
+      <concept id="6407023681583031218" name="jetbrains.mps.lang.smodel.structure.AttributeAccess" flags="nn" index="3CFZ6_">
+        <child id="6407023681583036852" name="qualifier" index="3CFYIz" />
+      </concept>
+      <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
+        <reference id="1138405853777" name="concept" index="ehGHo" />
+      </concept>
+      <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
+        <reference id="1138056395725" name="property" index="3TsBF5" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+    <language id="309e0004-4976-4416-b947-ec02ae4ecef2" name="com.mbeddr.mpsutil.modellisteners">
+      <concept id="5818559022137760597" name="com.mbeddr.mpsutil.modellisteners.structure.Parameter_instance" flags="ng" index="j_vvf" />
+      <concept id="5818559022137597839" name="com.mbeddr.mpsutil.modellisteners.structure.ConceptModelListeners" flags="ng" index="jA7cl">
+        <reference id="1213093996982" name="concept" index="1M2myG" />
+        <child id="5818559022137986141" name="listeners" index="j$A37" />
+      </concept>
+      <concept id="6105788070834796500" name="com.mbeddr.mpsutil.modellisteners.structure.BeforeRootRemovedListener" flags="ig" index="3vkeCM" />
+    </language>
+    <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="nn" index="25WWJ4">
+        <child id="540871147943773366" name="argument" index="25WWJ7" />
+      </concept>
+      <concept id="1226511727824" name="jetbrains.mps.baseLanguage.collections.structure.SetType" flags="in" index="2hMVRd">
+        <child id="1226511765987" name="elementType" index="2hN53Y" />
+      </concept>
+      <concept id="1153943597977" name="jetbrains.mps.baseLanguage.collections.structure.ForEachStatement" flags="nn" index="2Gpval">
+        <child id="1153944400369" name="variable" index="2Gsz3X" />
+        <child id="1153944424730" name="inputSequence" index="2GsD0m" />
+      </concept>
+      <concept id="1153944193378" name="jetbrains.mps.baseLanguage.collections.structure.ForEachVariable" flags="nr" index="2GrKxI" />
+      <concept id="1153944233411" name="jetbrains.mps.baseLanguage.collections.structure.ForEachVariableReference" flags="nn" index="2GrUjf">
+        <reference id="1153944258490" name="variable" index="2Gs0qQ" />
+      </concept>
+      <concept id="1167380149909" name="jetbrains.mps.baseLanguage.collections.structure.RemoveElementOperation" flags="nn" index="3dhRuq" />
+      <concept id="1197932370469" name="jetbrains.mps.baseLanguage.collections.structure.MapElement" flags="nn" index="3EllGN">
+        <child id="1197932505799" name="map" index="3ElQJh" />
+        <child id="1197932525128" name="key" index="3ElVtu" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="jA7cl" id="1_0AJInZoLD">
+    <ref role="1M2myG" to="tp4k:hwsE7KS" resolve="ActionDeclaration" />
+    <node concept="3vkeCM" id="1WeG0zuACAi" role="j$A37">
+      <node concept="3clFbS" id="1WeG0zuACAk" role="2VODD2">
+        <node concept="3cpWs8" id="1WeG0zuAO7R" role="3cqZAp">
+          <node concept="3cpWsn" id="1WeG0zuAO7S" role="3cpWs9">
+            <property role="TrG5h" value="groupAnnotation" />
+            <node concept="3Tqbb2" id="1WeG0zuAO7$" role="1tU5fm">
+              <ref role="ehGHo" to="tegv:54z9_KDO4Av" resolve="GroupAnnotation" />
+            </node>
+            <node concept="2OqwBi" id="1WeG0zuAO7T" role="33vP2m">
+              <node concept="j_vvf" id="1WeG0zuAO7U" role="2Oq$k0" />
+              <node concept="3CFZ6_" id="1WeG0zuAO7V" role="2OqNvi">
+                <node concept="3CFYIy" id="1WeG0zuAO7W" role="3CFYIz">
+                  <ref role="3CFYIx" to="tegv:54z9_KDO4Av" resolve="GroupAnnotation" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="1WeG0zuAQ3O" role="3cqZAp">
+          <node concept="3clFbS" id="1WeG0zuAQ3Q" role="3clFbx">
+            <node concept="3cpWs6" id="1WeG0zuARZf" role="3cqZAp" />
+          </node>
+          <node concept="2OqwBi" id="1WeG0zuAR7l" role="3clFbw">
+            <node concept="37vLTw" id="1WeG0zuAQy3" role="2Oq$k0">
+              <ref role="3cqZAo" node="1WeG0zuAO7S" resolve="groupAnnotation" />
+            </node>
+            <node concept="3w_OXm" id="1WeG0zuARD8" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="1WeG0zuARZx" role="3cqZAp" />
+        <node concept="2Gpval" id="1_0AJInZEh3" role="3cqZAp">
+          <node concept="2GrKxI" id="1_0AJInZEh5" role="2Gsz3X">
+            <property role="TrG5h" value="project" />
+          </node>
+          <node concept="3clFbS" id="1_0AJInZEh9" role="2LFqv$">
+            <node concept="3cpWs8" id="1_0AJInZwkj" role="3cqZAp">
+              <node concept="3cpWsn" id="1_0AJInZwki" role="3cpWs9">
+                <property role="TrG5h" value="editors" />
+                <node concept="10Q1$e" id="1_0AJInZwkl" role="1tU5fm">
+                  <node concept="3uibUv" id="1_0AJInZwkk" role="10Q1$1">
+                    <ref role="3uigEE" to="iwsx:~FileEditor" resolve="FileEditor" />
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="1_0AJInZyLs" role="33vP2m">
+                  <node concept="2YIFZM" id="1_0AJInZyCU" role="2Oq$k0">
+                    <ref role="1Pybhc" to="iwsx:~FileEditorManager" resolve="FileEditorManager" />
+                    <ref role="37wK5l" to="iwsx:~FileEditorManager.getInstance(com.intellij.openapi.project.Project)" resolve="getInstance" />
+                    <node concept="2YIFZM" id="1_0AJIo0818" role="37wK5m">
+                      <ref role="37wK5l" to="alof:~ProjectHelper.toIdeaProject(jetbrains.mps.project.Project)" resolve="toIdeaProject" />
+                      <ref role="1Pybhc" to="alof:~ProjectHelper" resolve="ProjectHelper" />
+                      <node concept="2GrUjf" id="1_0AJIo08hm" role="37wK5m">
+                        <ref role="2Gs0qQ" node="1_0AJInZEh5" resolve="project" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="1_0AJInZyLt" role="2OqNvi">
+                    <ref role="37wK5l" to="iwsx:~FileEditorManager.getAllEditors()" resolve="getAllEditors" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="1DcWWT" id="1_0AJInZwkp" role="3cqZAp">
+              <node concept="37vLTw" id="1_0AJInZwlm" role="1DdaDG">
+                <ref role="3cqZAo" node="1_0AJInZwki" resolve="editors" />
+              </node>
+              <node concept="3cpWsn" id="1_0AJInZwlj" role="1Duv9x">
+                <property role="TrG5h" value="editor" />
+                <node concept="3uibUv" id="1_0AJInZwll" role="1tU5fm">
+                  <ref role="3uigEE" to="iwsx:~FileEditor" resolve="FileEditor" />
+                </node>
+              </node>
+              <node concept="3clFbS" id="1_0AJInZwkr" role="2LFqv$">
+                <node concept="3clFbJ" id="1_0AJInZwks" role="3cqZAp">
+                  <node concept="2ZW3vV" id="1_0AJInZwkv" role="3clFbw">
+                    <node concept="37vLTw" id="1_0AJInZwkt" role="2ZW6bz">
+                      <ref role="3cqZAo" node="1_0AJInZwlj" resolve="editor" />
+                    </node>
+                    <node concept="3uibUv" id="1_0AJInZwku" role="2ZW6by">
+                      <ref role="3uigEE" to="k3nr:~MPSFileNodeEditor" resolve="MPSFileNodeEditor" />
+                    </node>
+                  </node>
+                  <node concept="3clFbS" id="1_0AJInZwkx" role="3clFbx">
+                    <node concept="3cpWs8" id="1_0AJInZwkz" role="3cqZAp">
+                      <node concept="3cpWsn" id="1_0AJInZwky" role="3cpWs9">
+                        <property role="TrG5h" value="mpsEditor" />
+                        <node concept="3uibUv" id="1_0AJInZwk$" role="1tU5fm">
+                          <ref role="3uigEE" to="k3nr:~MPSFileNodeEditor" resolve="MPSFileNodeEditor" />
+                        </node>
+                        <node concept="10QFUN" id="1_0AJInZwk_" role="33vP2m">
+                          <node concept="37vLTw" id="1_0AJInZwkA" role="10QFUP">
+                            <ref role="3cqZAo" node="1_0AJInZwlj" resolve="editor" />
+                          </node>
+                          <node concept="3uibUv" id="1_0AJInZwkB" role="10QFUM">
+                            <ref role="3uigEE" to="k3nr:~MPSFileNodeEditor" resolve="MPSFileNodeEditor" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3cpWs8" id="1_0AJInZwkD" role="3cqZAp">
+                      <node concept="3cpWsn" id="1_0AJInZwkC" role="3cpWs9">
+                        <property role="TrG5h" value="nodeEditor" />
+                        <node concept="3uibUv" id="1_0AJInZwkE" role="1tU5fm">
+                          <ref role="3uigEE" to="cj4x:~Editor" resolve="Editor" />
+                        </node>
+                        <node concept="2OqwBi" id="1_0AJInZyrS" role="33vP2m">
+                          <node concept="37vLTw" id="1_0AJInZwt4" role="2Oq$k0">
+                            <ref role="3cqZAo" node="1_0AJInZwky" resolve="mpsEditor" />
+                          </node>
+                          <node concept="liA8E" id="1_0AJInZyrT" role="2OqNvi">
+                            <ref role="37wK5l" to="k3nr:~MPSFileNodeEditor.getNodeEditor()" resolve="getNodeEditor" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbJ" id="1_0AJInZwkG" role="3cqZAp">
+                      <node concept="3y3z36" id="1_0AJInZwkH" role="3clFbw">
+                        <node concept="37vLTw" id="1_0AJInZwkI" role="3uHU7B">
+                          <ref role="3cqZAo" node="1_0AJInZwkC" resolve="nodeEditor" />
+                        </node>
+                        <node concept="10Nm6u" id="1_0AJInZwkJ" role="3uHU7w" />
+                      </node>
+                      <node concept="3clFbS" id="1_0AJInZwkL" role="3clFbx">
+                        <node concept="3cpWs8" id="1_0AJInZwkN" role="3cqZAp">
+                          <node concept="3cpWsn" id="1_0AJInZwkM" role="3cpWs9">
+                            <property role="TrG5h" value="editorComponent" />
+                            <node concept="3uibUv" id="1_0AJInZwkO" role="1tU5fm">
+                              <ref role="3uigEE" to="cj4x:~EditorComponent" resolve="EditorComponent" />
+                            </node>
+                            <node concept="2OqwBi" id="1_0AJInZG4i" role="33vP2m">
+                              <node concept="37vLTw" id="1_0AJInZwsY" role="2Oq$k0">
+                                <ref role="3cqZAo" node="1_0AJInZwkC" resolve="nodeEditor" />
+                              </node>
+                              <node concept="liA8E" id="1_0AJInZG4j" role="2OqNvi">
+                                <ref role="37wK5l" to="cj4x:~Editor.getCurrentEditorComponent()" resolve="getCurrentEditorComponent" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3clFbJ" id="1_0AJInZwkQ" role="3cqZAp">
+                          <node concept="2ZW3vV" id="1_0AJInZwkT" role="3clFbw">
+                            <node concept="37vLTw" id="1_0AJInZwkR" role="2ZW6bz">
+                              <ref role="3cqZAo" node="1_0AJInZwkM" resolve="editorComponent" />
+                            </node>
+                            <node concept="3uibUv" id="1_0AJInZwkS" role="2ZW6by">
+                              <ref role="3uigEE" to="exr9:~EditorComponent" resolve="EditorComponent" />
+                            </node>
+                          </node>
+                          <node concept="3clFbS" id="1_0AJInZwkV" role="3clFbx">
+                            <node concept="3cpWs8" id="1_0AJInZwkX" role="3cqZAp">
+                              <node concept="3cpWsn" id="1_0AJInZwkW" role="3cpWs9">
+                                <property role="TrG5h" value="ec" />
+                                <node concept="3uibUv" id="1_0AJInZwkY" role="1tU5fm">
+                                  <ref role="3uigEE" to="exr9:~EditorComponent" resolve="EditorComponent" />
+                                </node>
+                                <node concept="10QFUN" id="1_0AJInZwkZ" role="33vP2m">
+                                  <node concept="37vLTw" id="1_0AJInZwl0" role="10QFUP">
+                                    <ref role="3cqZAo" node="1_0AJInZwkM" resolve="editorComponent" />
+                                  </node>
+                                  <node concept="3uibUv" id="1_0AJInZwl1" role="10QFUM">
+                                    <ref role="3uigEE" to="exr9:~EditorComponent" resolve="EditorComponent" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="3cpWs8" id="7Sc8bwtQ_oN" role="3cqZAp">
+                              <node concept="3cpWsn" id="7Sc8bwtQ_oO" role="3cpWs9">
+                                <property role="TrG5h" value="producer" />
+                                <node concept="3uibUv" id="7Sc8bwtQ$Wy" role="1tU5fm">
+                                  <ref role="3uigEE" to="ih8q:2jDew64JcPx" resolve="MyIntentionMenuProducer" />
+                                </node>
+                                <node concept="0kSF2" id="7Sc8bwtQ_oP" role="33vP2m">
+                                  <node concept="3uibUv" id="7Sc8bwtQ_oQ" role="0kSFW">
+                                    <ref role="3uigEE" to="ih8q:2jDew64JcPx" resolve="MyIntentionMenuProducer" />
+                                  </node>
+                                  <node concept="2OqwBi" id="7Sc8bwtQ_oR" role="0kSFX">
+                                    <node concept="2OqwBi" id="7Sc8bwtQ_oS" role="2Oq$k0">
+                                      <node concept="37vLTw" id="7Sc8bwtQ_oT" role="2Oq$k0">
+                                        <ref role="3cqZAo" node="1_0AJInZwkW" resolve="ec" />
+                                      </node>
+                                      <node concept="1PnCL0" id="7Sc8bwtQ_oU" role="2OqNvi">
+                                        <ref role="2Oxat5" to="exr9:~EditorComponent.myIntentionsSupport" resolve="myIntentionsSupport" />
+                                      </node>
+                                    </node>
+                                    <node concept="1PnCL0" id="7Sc8bwtQ_oV" role="2OqNvi">
+                                      <ref role="2Oxat5" to="exr9:~IntentionsSupport.myMenuProducer" resolve="myMenuProducer" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="3cpWs8" id="7Sc8bwtQBCD" role="3cqZAp">
+                              <node concept="3cpWsn" id="7Sc8bwtQBCE" role="3cpWs9">
+                                <property role="TrG5h" value="oldGroupEntries" />
+                                <node concept="2hMVRd" id="7Sc8bwtQBrb" role="1tU5fm">
+                                  <node concept="3uibUv" id="7Sc8bwtQBre" role="2hN53Y">
+                                    <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
+                                  </node>
+                                </node>
+                                <node concept="3EllGN" id="7Sc8bwtQBCF" role="33vP2m">
+                                  <node concept="2OqwBi" id="1_0AJIo090w" role="3ElVtu">
+                                    <node concept="37vLTw" id="1WeG0zuAWg2" role="2Oq$k0">
+                                      <ref role="3cqZAo" node="1WeG0zuAO7S" resolve="groupAnnotation" />
+                                    </node>
+                                    <node concept="3TrcHB" id="1_0AJIo09yW" role="2OqNvi">
+                                      <ref role="3TsBF5" to="tegv:54z9_KDO50a" resolve="label" />
+                                    </node>
+                                  </node>
+                                  <node concept="2OqwBi" id="7Sc8bwtQBCH" role="3ElQJh">
+                                    <node concept="37vLTw" id="7Sc8bwtQBCI" role="2Oq$k0">
+                                      <ref role="3cqZAo" node="7Sc8bwtQ_oO" resolve="producer" />
+                                    </node>
+                                    <node concept="SiP3y" id="7Sc8bwtQBCJ" role="2OqNvi">
+                                      <ref role="3cqZAo" to="ih8q:5Rdndlpp80A" resolve="groupedActionsCache" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="2Gpval" id="7Sc8bwtQTGT" role="3cqZAp">
+                              <node concept="2GrKxI" id="7Sc8bwtQTGV" role="2Gsz3X">
+                                <property role="TrG5h" value="entry" />
+                              </node>
+                              <node concept="37vLTw" id="7Sc8bwtQTNd" role="2GsD0m">
+                                <ref role="3cqZAo" node="7Sc8bwtQBCE" resolve="oldGroupEntries" />
+                              </node>
+                              <node concept="3clFbS" id="7Sc8bwtQTGZ" role="2LFqv$">
+                                <node concept="3clFbJ" id="7Sc8bwtQTOQ" role="3cqZAp">
+                                  <node concept="17R0WA" id="7Sc8bwtQYPw" role="3clFbw">
+                                    <node concept="2OqwBi" id="7Sc8bwtQX34" role="3uHU7B">
+                                      <node concept="0kSF2" id="7Sc8bwtQWxE" role="2Oq$k0">
+                                        <node concept="3uibUv" id="7Sc8bwtQWxG" role="0kSFW">
+                                          <ref role="3uigEE" to="7bx7:~BaseAction" resolve="BaseAction" />
+                                        </node>
+                                        <node concept="2GrUjf" id="7Sc8bwtQTPk" role="0kSFX">
+                                          <ref role="2Gs0qQ" node="7Sc8bwtQTGV" resolve="entry" />
+                                        </node>
+                                      </node>
+                                      <node concept="liA8E" id="7Sc8bwtQXNq" role="2OqNvi">
+                                        <ref role="37wK5l" to="7bx7:~BaseAction.getActionId()" resolve="getActionId" />
+                                      </node>
+                                    </node>
+                                    <node concept="2OqwBi" id="7Sc8bwtR2iE" role="3uHU7w">
+                                      <node concept="j_vvf" id="1_0AJIo0AYn" role="2Oq$k0" />
+                                      <node concept="2qgKlT" id="7Sc8bwtR2kj" role="2OqNvi">
+                                        <ref role="37wK5l" to="tp4s:2JiSCAPXEb8" resolve="getActionId" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                  <node concept="3clFbS" id="7Sc8bwtQTOS" role="3clFbx">
+                                    <node concept="3clFbF" id="7Sc8bwtR2rE" role="3cqZAp">
+                                      <node concept="2OqwBi" id="7Sc8bwtR3$0" role="3clFbG">
+                                        <node concept="37vLTw" id="7Sc8bwtR2rD" role="2Oq$k0">
+                                          <ref role="3cqZAo" node="7Sc8bwtQBCE" resolve="oldGroupEntries" />
+                                        </node>
+                                        <node concept="3dhRuq" id="7Sc8bwtR4E4" role="2OqNvi">
+                                          <node concept="2GrUjf" id="7Sc8bwtR4GJ" role="25WWJ7">
+                                            <ref role="2Gs0qQ" node="7Sc8bwtQTGV" resolve="entry" />
+                                          </node>
+                                        </node>
+                                      </node>
+                                    </node>
+                                    <node concept="3cpWs6" id="7Sc8bwtR4J1" role="3cqZAp" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="3clFbH" id="1_0AJInZYq_" role="3cqZAp" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="1_0AJInZDrJ" role="2GsD0m">
+            <node concept="2YIFZM" id="1_0AJInZD3t" role="2Oq$k0">
+              <ref role="37wK5l" to="z1c3:~ProjectManager.getInstance()" resolve="getInstance" />
+              <ref role="1Pybhc" to="z1c3:~ProjectManager" resolve="ProjectManager" />
+            </node>
+            <node concept="liA8E" id="1_0AJInZDKY" role="2OqNvi">
+              <ref role="37wK5l" to="z1c3:~ProjectManager.getOpenedProjects()" resolve="getOpenedProjects" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/code/intentionsmenu/com.mbeddr.mpsutil.intentions/languageModels/editor.mps
+++ b/code/intentionsmenu/com.mbeddr.mpsutil.intentions/languageModels/editor.mps
@@ -3,27 +3,34 @@
   <persistence version="9" />
   <languages>
     <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="14" />
+    <use id="654422bf-e75f-44dc-936d-188890a746ce" name="de.slisson.mps.reflection" version="0" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
+    <import index="cj4x" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor(MPS.Editor/)" />
+    <import index="exr9" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor(MPS.Editor/)" />
+    <import index="ih8q" ref="r:990d360b-3ac3-45fa-8ed3-0bbf017bba84(com.mbeddr.mpsutil.intentions.runtime)" />
+    <import index="qkt" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.actionSystem(MPS.IDEA/)" />
+    <import index="7bx7" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.workbench.action(MPS.Platform/)" />
     <import index="tegv" ref="r:b91d2412-f094-4e55-8db6-3c782d7edc40(com.mbeddr.mpsutil.intentions.structure)" implicit="true" />
-    <import index="tp3j" ref="r:00000000-0000-4000-0000-011c89590353(jetbrains.mps.lang.intentions.structure)" implicit="true" />
+    <import index="9j2l" ref="r:acd2b506-390d-4e84-8c47-cd8fb8c9e0c0(com.mbeddr.mpsutil.intentions.behavior)" implicit="true" />
   </imports>
   <registry>
     <language id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor">
       <concept id="1071666914219" name="jetbrains.mps.lang.editor.structure.ConceptEditorDeclaration" flags="ig" index="24kQdi" />
       <concept id="1106270549637" name="jetbrains.mps.lang.editor.structure.CellLayout_Horizontal" flags="nn" index="2iRfu4" />
       <concept id="1106270571710" name="jetbrains.mps.lang.editor.structure.CellLayout_Vertical" flags="nn" index="2iRkQZ" />
+      <concept id="1142886811589" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameter_node" flags="nn" index="pncrf" />
       <concept id="1080736578640" name="jetbrains.mps.lang.editor.structure.BaseEditorComponent" flags="ig" index="2wURMF">
         <child id="1080736633877" name="cellModel" index="2wV5jI" />
       </concept>
-      <concept id="1160493135005" name="jetbrains.mps.lang.editor.structure.CellMenuPart_PropertyValues_GetValues" flags="in" index="MLZmj" />
-      <concept id="1164824717996" name="jetbrains.mps.lang.editor.structure.CellMenuDescriptor" flags="ng" index="OXEIz">
-        <child id="1164824815888" name="cellMenuPart" index="OY2wv" />
+      <concept id="1216380990741" name="jetbrains.mps.lang.editor.structure.CellModel_TransactionalProperty" flags="sg" stub="8104358048506729358" index="PXfge">
+        <reference id="1216381219207" name="property" index="PY72s" />
+        <child id="1216381211800" name="handlerBlock" index="PY5m3" />
       </concept>
-      <concept id="1164833692343" name="jetbrains.mps.lang.editor.structure.CellMenuPart_PropertyValues" flags="ng" index="PvTIS">
-        <child id="1164833692344" name="valuesFunction" index="PvTIR" />
-      </concept>
+      <concept id="1216381054717" name="jetbrains.mps.lang.editor.structure.TransactionalPropertyHandler" flags="in" index="PXuZA" />
+      <concept id="1216381117100" name="jetbrains.mps.lang.editor.structure.TransactionPropertyHandler_oldValue" flags="nn" index="PXIeR" />
+      <concept id="1216381148013" name="jetbrains.mps.lang.editor.structure.TransactionPropertyHandler_newValue" flags="nn" index="PXPDQ" />
       <concept id="1149850725784" name="jetbrains.mps.lang.editor.structure.CellModel_AttributedNodeCell" flags="ng" index="2SsqMj" />
       <concept id="1186402211651" name="jetbrains.mps.lang.editor.structure.StyleSheet" flags="ng" index="V5hpn">
         <child id="1186402402630" name="styles" index="V601i" />
@@ -39,9 +46,6 @@
       <concept id="1139848536355" name="jetbrains.mps.lang.editor.structure.CellModel_WithRole" flags="ng" index="1$h60E">
         <reference id="1140103550593" name="relationDeclaration" index="1NtTu8" />
       </concept>
-      <concept id="1073389214265" name="jetbrains.mps.lang.editor.structure.EditorCellModel" flags="ng" index="3EYTF0">
-        <child id="1164826688380" name="menuDescriptor" index="P5bDN" />
-      </concept>
       <concept id="1073389446423" name="jetbrains.mps.lang.editor.structure.CellModel_Collection" flags="sn" stub="3013115976261988961" index="3EZMnI">
         <child id="1106270802874" name="cellLayout" index="2iSdaV" />
         <child id="1073389446424" name="childCellModel" index="3EZMnx" />
@@ -53,13 +57,12 @@
       <concept id="1219418625346" name="jetbrains.mps.lang.editor.structure.IStyleContainer" flags="ngI" index="3F0Thp">
         <child id="1219418656006" name="styleItem" index="3F10Kt" />
       </concept>
-      <concept id="1163613822479" name="jetbrains.mps.lang.editor.structure.CellMenuPart_Abstract_editedNode" flags="nn" index="3GMtW1" />
+      <concept id="1161622981231" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameter_editorContext" flags="nn" index="1Q80Hx" />
       <concept id="1166049232041" name="jetbrains.mps.lang.editor.structure.AbstractComponent" flags="ng" index="1XWOmA">
         <reference id="1166049300910" name="conceptDeclaration" index="1XX52x" />
       </concept>
     </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
-      <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
@@ -68,12 +71,6 @@
         <child id="1137022507850" name="body" index="2VODD2" />
       </concept>
       <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
-      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
-        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
-      </concept>
-      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
-        <child id="5680397130376446158" name="type" index="1tU5fm" />
-      </concept>
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
@@ -81,136 +78,40 @@
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
       <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT" />
-    </language>
-    <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
-      <concept id="2524418899405758586" name="jetbrains.mps.baseLanguage.closures.structure.InferredClosureParameterDeclaration" flags="ig" index="gl6BB" />
-      <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
-        <child id="1199569906740" name="parameter" index="1bW2Oz" />
-        <child id="1199569916463" name="body" index="1bW5cS" />
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
-      <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
-        <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
-      </concept>
-      <concept id="1143234257716" name="jetbrains.mps.lang.smodel.structure.Node_GetModelOperation" flags="nn" index="I4A8Y" />
-      <concept id="1171315804604" name="jetbrains.mps.lang.smodel.structure.Model_RootsOperation" flags="nn" index="2RRcyG">
-        <child id="6750920497477046361" name="conceptArgument" index="3MHsoP" />
-      </concept>
-      <concept id="1172008320231" name="jetbrains.mps.lang.smodel.structure.Node_IsNotNullOperation" flags="nn" index="3x8VRR" />
-      <concept id="6407023681583036853" name="jetbrains.mps.lang.smodel.structure.NodeAttributeQualifier" flags="ng" index="3CFYIy">
-        <reference id="6407023681583036854" name="attributeConcept" index="3CFYIx" />
-      </concept>
-      <concept id="6407023681583031218" name="jetbrains.mps.lang.smodel.structure.AttributeAccess" flags="nn" index="3CFZ6_">
-        <child id="6407023681583036852" name="qualifier" index="3CFYIz" />
-      </concept>
-      <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
-        <reference id="1138056395725" name="property" index="3TsBF5" />
-      </concept>
+      <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
     </language>
-    <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
-      <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
-        <child id="1204796294226" name="closure" index="23t8la" />
-      </concept>
-      <concept id="1151702311717" name="jetbrains.mps.baseLanguage.collections.structure.ToListOperation" flags="nn" index="ANE8D" />
-      <concept id="1202120902084" name="jetbrains.mps.baseLanguage.collections.structure.WhereOperation" flags="nn" index="3zZkjj" />
-      <concept id="1202128969694" name="jetbrains.mps.baseLanguage.collections.structure.SelectOperation" flags="nn" index="3$u5V9" />
-      <concept id="1178894719932" name="jetbrains.mps.baseLanguage.collections.structure.DistinctOperation" flags="nn" index="1VAtEI" />
-    </language>
   </registry>
   <node concept="24kQdi" id="54z9_KDO50z">
-    <ref role="1XX52x" to="tegv:54z9_KDO4Av" resolve="IntentionGroupAnnotation" />
+    <ref role="1XX52x" to="tegv:54z9_KDO4Av" resolve="GroupAnnotation" />
     <node concept="3EZMnI" id="54z9_KDO5SU" role="2wV5jI">
       <node concept="2iRkQZ" id="54z9_KDO5SV" role="2iSdaV" />
       <node concept="3EZMnI" id="54z9_KDO5SD" role="3EZMnx">
         <node concept="3F0ifn" id="54z9_KDO5SK" role="3EZMnx">
-          <property role="3F0ifm" value="intention group:" />
+          <property role="3F0ifm" value="group:" />
         </node>
-        <node concept="3F0A7n" id="54z9_KDO5SQ" role="3EZMnx">
-          <ref role="1NtTu8" to="tegv:54z9_KDO50a" resolve="label" />
-          <node concept="OXEIz" id="54z9_KDRbwY" role="P5bDN">
-            <node concept="PvTIS" id="54z9_KDRbx0" role="OY2wv">
-              <node concept="MLZmj" id="54z9_KDRbx1" role="PvTIR">
-                <node concept="3clFbS" id="54z9_KDRbx2" role="2VODD2">
-                  <node concept="3clFbF" id="54z9_KDRbIv" role="3cqZAp">
-                    <node concept="2OqwBi" id="54z9_KDRteZ" role="3clFbG">
-                      <node concept="2OqwBi" id="3TftwIKHnSK" role="2Oq$k0">
-                        <node concept="2OqwBi" id="54z9_KDRp$h" role="2Oq$k0">
-                          <node concept="2OqwBi" id="54z9_KDRdJN" role="2Oq$k0">
-                            <node concept="2OqwBi" id="54z9_KDRcsj" role="2Oq$k0">
-                              <node concept="2OqwBi" id="54z9_KDRbPE" role="2Oq$k0">
-                                <node concept="3GMtW1" id="54z9_KDRbIu" role="2Oq$k0" />
-                                <node concept="I4A8Y" id="54z9_KDRcb3" role="2OqNvi" />
-                              </node>
-                              <node concept="2RRcyG" id="54z9_KDRcEN" role="2OqNvi">
-                                <node concept="chp4Y" id="67K7yGVUU9_" role="3MHsoP">
-                                  <ref role="cht4Q" to="tp3j:2c3oNEsfcpP" resolve="BaseIntentionDeclaration" />
-                                </node>
-                              </node>
-                            </node>
-                            <node concept="3zZkjj" id="54z9_KDRng9" role="2OqNvi">
-                              <node concept="1bVj0M" id="54z9_KDRngb" role="23t8la">
-                                <node concept="3clFbS" id="54z9_KDRngc" role="1bW5cS">
-                                  <node concept="3clFbF" id="54z9_KDRnq7" role="3cqZAp">
-                                    <node concept="2OqwBi" id="54z9_KDRo_D" role="3clFbG">
-                                      <node concept="2OqwBi" id="54z9_KDRnB5" role="2Oq$k0">
-                                        <node concept="37vLTw" id="54z9_KDRnq6" role="2Oq$k0">
-                                          <ref role="3cqZAo" node="7Z$RfkF7IEN" resolve="it" />
-                                        </node>
-                                        <node concept="3CFZ6_" id="54z9_KDRo76" role="2OqNvi">
-                                          <node concept="3CFYIy" id="54z9_KDRoos" role="3CFYIz">
-                                            <ref role="3CFYIx" to="tegv:54z9_KDO4Av" resolve="IntentionGroupAnnotation" />
-                                          </node>
-                                        </node>
-                                      </node>
-                                      <node concept="3x8VRR" id="54z9_KDRpcs" role="2OqNvi" />
-                                    </node>
-                                  </node>
-                                </node>
-                                <node concept="gl6BB" id="7Z$RfkF7IEN" role="1bW2Oz">
-                                  <property role="TrG5h" value="it" />
-                                  <node concept="2jxLKc" id="7Z$RfkF7IEO" role="1tU5fm" />
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                          <node concept="3$u5V9" id="54z9_KDRqGc" role="2OqNvi">
-                            <node concept="1bVj0M" id="54z9_KDRqGe" role="23t8la">
-                              <node concept="3clFbS" id="54z9_KDRqGf" role="1bW5cS">
-                                <node concept="3clFbF" id="54z9_KDRqQY" role="3cqZAp">
-                                  <node concept="2OqwBi" id="54z9_KDRssN" role="3clFbG">
-                                    <node concept="2OqwBi" id="54z9_KDRr4Q" role="2Oq$k0">
-                                      <node concept="37vLTw" id="54z9_KDRqQX" role="2Oq$k0">
-                                        <ref role="3cqZAo" node="7Z$RfkF7IEP" resolve="it" />
-                                      </node>
-                                      <node concept="3CFZ6_" id="54z9_KDRrB2" role="2OqNvi">
-                                        <node concept="3CFYIy" id="54z9_KDRsdW" role="3CFYIz">
-                                          <ref role="3CFYIx" to="tegv:54z9_KDO4Av" resolve="IntentionGroupAnnotation" />
-                                        </node>
-                                      </node>
-                                    </node>
-                                    <node concept="3TrcHB" id="54z9_KDRsQX" role="2OqNvi">
-                                      <ref role="3TsBF5" to="tegv:54z9_KDO50a" resolve="label" />
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                              <node concept="gl6BB" id="7Z$RfkF7IEP" role="1bW2Oz">
-                                <property role="TrG5h" value="it" />
-                                <node concept="2jxLKc" id="7Z$RfkF7IEQ" role="1tU5fm" />
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="1VAtEI" id="3TftwIKHptq" role="2OqNvi" />
-                      </node>
-                      <node concept="ANE8D" id="54z9_KDRu6q" role="2OqNvi" />
-                    </node>
+        <node concept="PXfge" id="7Sc8bwtPvfD" role="3EZMnx">
+          <ref role="PY72s" to="tegv:54z9_KDO50a" resolve="label" />
+          <node concept="PXuZA" id="7Sc8bwtPvfF" role="PY5m3">
+            <node concept="3clFbS" id="7Sc8bwtPvfH" role="2VODD2">
+              <node concept="3clFbF" id="$kD7tOMT$T" role="3cqZAp">
+                <node concept="2OqwBi" id="$kD7tOMTWP" role="3clFbG">
+                  <node concept="pncrf" id="$kD7tOMT$S" role="2Oq$k0" />
+                  <node concept="2qgKlT" id="$kD7tOMWiN" role="2OqNvi">
+                    <ref role="37wK5l" to="9j2l:$kD7tOMQXO" resolve="update" />
+                    <node concept="1Q80Hx" id="$kD7tOMWn2" role="37wK5m" />
+                    <node concept="PXIeR" id="$kD7tOMWnL" role="37wK5m" />
+                    <node concept="PXPDQ" id="$kD7tON2ld" role="37wK5m" />
                   </node>
                 </node>
               </node>

--- a/code/intentionsmenu/com.mbeddr.mpsutil.intentions/languageModels/intentions.mps
+++ b/code/intentionsmenu/com.mbeddr.mpsutil.intentions/languageModels/intentions.mps
@@ -3,22 +3,23 @@
   <persistence version="9" />
   <languages>
     <use id="d7a92d38-f7db-40d0-8431-763b0c3c9f20" name="jetbrains.mps.lang.intentions" version="1" />
+    <use id="13744753-c81f-424a-9c1b-cf8943bf4e86" name="jetbrains.mps.lang.sharedConcepts" version="0" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
     <import index="tp3j" ref="r:00000000-0000-4000-0000-011c89590353(jetbrains.mps.lang.intentions.structure)" />
     <import index="tegv" ref="r:b91d2412-f094-4e55-8db6-3c782d7edc40(com.mbeddr.mpsutil.intentions.structure)" />
+    <import index="tp4k" ref="r:00000000-0000-4000-0000-011c89590368(jetbrains.mps.lang.plugin.structure)" implicit="true" />
+    <import index="9j2l" ref="r:acd2b506-390d-4e84-8c47-cd8fb8c9e0c0(com.mbeddr.mpsutil.intentions.behavior)" implicit="true" />
   </imports>
   <registry>
+    <language id="13744753-c81f-424a-9c1b-cf8943bf4e86" name="jetbrains.mps.lang.sharedConcepts">
+      <concept id="1194033889146" name="jetbrains.mps.lang.sharedConcepts.structure.ConceptFunctionParameter_editorContext" flags="nn" index="1XNTG" />
+    </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
       <concept id="1082485599095" name="jetbrains.mps.baseLanguage.structure.BlockStatement" flags="nn" index="9aQIb">
         <child id="1082485599096" name="statements" index="9aQI4" />
       </concept>
-      <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
-        <child id="1068498886297" name="rValue" index="37vLTx" />
-        <child id="1068498886295" name="lValue" index="37vLTJ" />
-      </concept>
-      <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
@@ -29,19 +30,7 @@
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
       </concept>
-      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
-        <child id="1068431790190" name="initializer" index="33vP2m" />
-      </concept>
-      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
-        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
-      </concept>
-      <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
-      <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
-      <concept id="1225271408483" name="jetbrains.mps.baseLanguage.structure.IsNotEmptyOperation" flags="nn" index="17RvpY" />
-      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
-        <child id="5680397130376446158" name="type" index="1tU5fm" />
-      </concept>
-      <concept id="1068580123152" name="jetbrains.mps.baseLanguage.structure.EqualsExpression" flags="nn" index="3clFbC" />
+      <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
@@ -56,24 +45,9 @@
       <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
         <property id="1068580123138" name="value" index="3clFbU" />
       </concept>
-      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
-        <property id="1068580320021" name="value" index="3cmrfH" />
-      </concept>
-      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
-        <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
-      </concept>
-      <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
-      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
-        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
-        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
-      </concept>
-      <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
-    </language>
-    <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
-      <concept id="2524418899405758586" name="jetbrains.mps.baseLanguage.closures.structure.InferredClosureParameterDeclaration" flags="ig" index="gl6BB" />
-      <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
-        <child id="1199569906740" name="parameter" index="1bW2Oz" />
-        <child id="1199569916463" name="body" index="1bW5cS" />
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
     </language>
     <language id="d7a92d38-f7db-40d0-8431-763b0c3c9f20" name="jetbrains.mps.lang.intentions">
@@ -105,27 +79,17 @@
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
-      <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
-        <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
-      </concept>
       <concept id="1140725362528" name="jetbrains.mps.lang.smodel.structure.Link_SetTargetOperation" flags="nn" index="2oxUTD">
         <child id="1140725362529" name="linkTarget" index="2oxUTC" />
       </concept>
+      <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
       <concept id="1138757581985" name="jetbrains.mps.lang.smodel.structure.Link_SetNewChildOperation" flags="nn" index="zfrQC" />
-      <concept id="1143234257716" name="jetbrains.mps.lang.smodel.structure.Node_GetModelOperation" flags="nn" index="I4A8Y" />
-      <concept id="1171315804604" name="jetbrains.mps.lang.smodel.structure.Model_RootsOperation" flags="nn" index="2RRcyG">
-        <child id="6750920497477046361" name="conceptArgument" index="3MHsoP" />
-      </concept>
       <concept id="1171999116870" name="jetbrains.mps.lang.smodel.structure.Node_IsNullOperation" flags="nn" index="3w_OXm" />
-      <concept id="1172008320231" name="jetbrains.mps.lang.smodel.structure.Node_IsNotNullOperation" flags="nn" index="3x8VRR" />
       <concept id="6407023681583036853" name="jetbrains.mps.lang.smodel.structure.NodeAttributeQualifier" flags="ng" index="3CFYIy">
         <reference id="6407023681583036854" name="attributeConcept" index="3CFYIx" />
       </concept>
       <concept id="6407023681583031218" name="jetbrains.mps.lang.smodel.structure.AttributeAccess" flags="nn" index="3CFZ6_">
         <child id="6407023681583036852" name="qualifier" index="3CFYIz" />
-      </concept>
-      <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
-        <reference id="1138405853777" name="concept" index="ehGHo" />
       </concept>
       <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
         <reference id="1138056395725" name="property" index="3TsBF5" />
@@ -137,176 +101,26 @@
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
     </language>
-    <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
-      <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
-        <child id="1204796294226" name="closure" index="23t8la" />
-      </concept>
-      <concept id="1151689724996" name="jetbrains.mps.baseLanguage.collections.structure.SequenceType" flags="in" index="A3Dl8">
-        <child id="1151689745422" name="elementType" index="A3Ik2" />
-      </concept>
-      <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
-      <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
-      <concept id="1202120902084" name="jetbrains.mps.baseLanguage.collections.structure.WhereOperation" flags="nn" index="3zZkjj" />
-      <concept id="1202128969694" name="jetbrains.mps.baseLanguage.collections.structure.SelectOperation" flags="nn" index="3$u5V9" />
-      <concept id="1178894719932" name="jetbrains.mps.baseLanguage.collections.structure.DistinctOperation" flags="nn" index="1VAtEI" />
-    </language>
   </registry>
   <node concept="2S6QgY" id="54z9_KDPbf$">
-    <property role="TrG5h" value="addGroupAnnotation" />
+    <property role="TrG5h" value="addGroupAnnotationToIntention" />
     <property role="2ZfUl0" value="true" />
     <ref role="2ZfgGC" to="tp3j:2c3oNEsfcpP" resolve="BaseIntentionDeclaration" />
     <node concept="2Sbjvc" id="54z9_KDPbf_" role="2ZfgGD">
       <node concept="3clFbS" id="54z9_KDPbfA" role="2VODD2">
         <node concept="3clFbJ" id="54z9_KDPcaj" role="3cqZAp">
           <node concept="3clFbS" id="54z9_KDPcak" role="3clFbx">
-            <node concept="3cpWs8" id="1rEu0HvmZ7y" role="3cqZAp">
-              <node concept="3cpWsn" id="1rEu0HvmZ7z" role="3cpWs9">
-                <property role="TrG5h" value="a" />
-                <node concept="3Tqbb2" id="1rEu0HvmZ7w" role="1tU5fm">
-                  <ref role="ehGHo" to="tegv:54z9_KDO4Av" resolve="IntentionGroupAnnotation" />
-                </node>
-                <node concept="2OqwBi" id="1rEu0HvmZ7$" role="33vP2m">
-                  <node concept="2OqwBi" id="1rEu0HvmZ7_" role="2Oq$k0">
-                    <node concept="2Sf5sV" id="1rEu0HvmZ7A" role="2Oq$k0" />
-                    <node concept="3CFZ6_" id="1rEu0HvmZ7B" role="2OqNvi">
-                      <node concept="3CFYIy" id="1rEu0HvmZ7C" role="3CFYIz">
-                        <ref role="3CFYIx" to="tegv:54z9_KDO4Av" resolve="IntentionGroupAnnotation" />
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="zfrQC" id="1rEu0HvmZ7D" role="2OqNvi" />
-                </node>
-              </node>
-            </node>
-            <node concept="3cpWs8" id="1rEu0Hvna9O" role="3cqZAp">
-              <node concept="3cpWsn" id="1rEu0Hvna9P" role="3cpWs9">
-                <property role="TrG5h" value="vals" />
-                <node concept="A3Dl8" id="1rEu0Hvna90" role="1tU5fm">
-                  <node concept="17QB3L" id="1rEu0Hvna93" role="A3Ik2" />
-                </node>
-                <node concept="2OqwBi" id="1rEu0Hvna9Q" role="33vP2m">
-                  <node concept="2OqwBi" id="1rEu0Hvna9R" role="2Oq$k0">
-                    <node concept="2OqwBi" id="1rEu0Hvna9S" role="2Oq$k0">
-                      <node concept="2OqwBi" id="1rEu0Hvna9T" role="2Oq$k0">
-                        <node concept="2OqwBi" id="1rEu0Hvna9U" role="2Oq$k0">
-                          <node concept="2Sf5sV" id="1rEu0Hvna9V" role="2Oq$k0" />
-                          <node concept="I4A8Y" id="1rEu0Hvna9W" role="2OqNvi" />
-                        </node>
-                        <node concept="2RRcyG" id="1rEu0Hvna9X" role="2OqNvi">
-                          <node concept="chp4Y" id="67K7yGVUU9A" role="3MHsoP">
-                            <ref role="cht4Q" to="tp3j:2c3oNEsfcpP" resolve="BaseIntentionDeclaration" />
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="3zZkjj" id="1rEu0Hvna9Y" role="2OqNvi">
-                        <node concept="1bVj0M" id="1rEu0Hvna9Z" role="23t8la">
-                          <node concept="3clFbS" id="1rEu0Hvnaa0" role="1bW5cS">
-                            <node concept="3clFbF" id="1rEu0Hvnaa1" role="3cqZAp">
-                              <node concept="1Wc70l" id="1rEu0HvnfhS" role="3clFbG">
-                                <node concept="2OqwBi" id="1rEu0HvngMq" role="3uHU7w">
-                                  <node concept="2OqwBi" id="1rEu0Hvng8i" role="2Oq$k0">
-                                    <node concept="2OqwBi" id="1rEu0HvnfxX" role="2Oq$k0">
-                                      <node concept="37vLTw" id="1rEu0HvnfpG" role="2Oq$k0">
-                                        <ref role="3cqZAo" node="7Z$RfkF7IER" resolve="it" />
-                                      </node>
-                                      <node concept="3CFZ6_" id="1rEu0HvnfQU" role="2OqNvi">
-                                        <node concept="3CFYIy" id="1rEu0HvnfXz" role="3CFYIz">
-                                          <ref role="3CFYIx" to="tegv:54z9_KDO4Av" resolve="IntentionGroupAnnotation" />
-                                        </node>
-                                      </node>
-                                    </node>
-                                    <node concept="3TrcHB" id="1rEu0HvngqI" role="2OqNvi">
-                                      <ref role="3TsBF5" to="tegv:54z9_KDO50a" resolve="label" />
-                                    </node>
-                                  </node>
-                                  <node concept="17RvpY" id="1rEu0HvnhM0" role="2OqNvi" />
-                                </node>
-                                <node concept="2OqwBi" id="1rEu0Hvnaa2" role="3uHU7B">
-                                  <node concept="2OqwBi" id="1rEu0Hvnaa3" role="2Oq$k0">
-                                    <node concept="37vLTw" id="1rEu0Hvnaa4" role="2Oq$k0">
-                                      <ref role="3cqZAo" node="7Z$RfkF7IER" resolve="it" />
-                                    </node>
-                                    <node concept="3CFZ6_" id="1rEu0Hvnaa5" role="2OqNvi">
-                                      <node concept="3CFYIy" id="1rEu0Hvnaa6" role="3CFYIz">
-                                        <ref role="3CFYIx" to="tegv:54z9_KDO4Av" resolve="IntentionGroupAnnotation" />
-                                      </node>
-                                    </node>
-                                  </node>
-                                  <node concept="3x8VRR" id="1rEu0Hvnaa7" role="2OqNvi" />
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                          <node concept="gl6BB" id="7Z$RfkF7IER" role="1bW2Oz">
-                            <property role="TrG5h" value="it" />
-                            <node concept="2jxLKc" id="7Z$RfkF7IES" role="1tU5fm" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="3$u5V9" id="1rEu0Hvnaaa" role="2OqNvi">
-                      <node concept="1bVj0M" id="1rEu0Hvnaab" role="23t8la">
-                        <node concept="3clFbS" id="1rEu0Hvnaac" role="1bW5cS">
-                          <node concept="3clFbF" id="1rEu0Hvnaad" role="3cqZAp">
-                            <node concept="2OqwBi" id="1rEu0Hvnaae" role="3clFbG">
-                              <node concept="2OqwBi" id="1rEu0Hvnaaf" role="2Oq$k0">
-                                <node concept="37vLTw" id="1rEu0Hvnaag" role="2Oq$k0">
-                                  <ref role="3cqZAo" node="7Z$RfkF7IET" resolve="it" />
-                                </node>
-                                <node concept="3CFZ6_" id="1rEu0Hvnaah" role="2OqNvi">
-                                  <node concept="3CFYIy" id="1rEu0Hvnaai" role="3CFYIz">
-                                    <ref role="3CFYIx" to="tegv:54z9_KDO4Av" resolve="IntentionGroupAnnotation" />
-                                  </node>
-                                </node>
-                              </node>
-                              <node concept="3TrcHB" id="1rEu0Hvnaaj" role="2OqNvi">
-                                <ref role="3TsBF5" to="tegv:54z9_KDO50a" resolve="label" />
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="gl6BB" id="7Z$RfkF7IET" role="1bW2Oz">
-                          <property role="TrG5h" value="it" />
-                          <node concept="2jxLKc" id="7Z$RfkF7IEU" role="1tU5fm" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="1VAtEI" id="1rEu0Hvnaam" role="2OqNvi" />
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbJ" id="1rEu0HvmYx2" role="3cqZAp">
-              <node concept="3clFbS" id="1rEu0HvmYx4" role="3clFbx">
-                <node concept="3clFbF" id="1rEu0HvmZjA" role="3cqZAp">
-                  <node concept="37vLTI" id="1rEu0HvmZKN" role="3clFbG">
-                    <node concept="2OqwBi" id="1rEu0HvnaYq" role="37vLTx">
-                      <node concept="37vLTw" id="1rEu0HvnaOM" role="2Oq$k0">
-                        <ref role="3cqZAo" node="1rEu0Hvna9P" resolve="vals" />
-                      </node>
-                      <node concept="1uHKPH" id="1rEu0Hvnbnc" role="2OqNvi" />
-                    </node>
-                    <node concept="2OqwBi" id="1rEu0HvmZls" role="37vLTJ">
-                      <node concept="37vLTw" id="1rEu0HvmZj$" role="2Oq$k0">
-                        <ref role="3cqZAo" node="1rEu0HvmZ7z" resolve="a" />
-                      </node>
-                      <node concept="3TrcHB" id="1rEu0HvmZwb" role="2OqNvi">
-                        <ref role="3TsBF5" to="tegv:54z9_KDO50a" resolve="label" />
-                      </node>
+            <node concept="3clFbF" id="$kD7tON8Bz" role="3cqZAp">
+              <node concept="2OqwBi" id="1rEu0HvmZ7$" role="3clFbG">
+                <node concept="2OqwBi" id="1rEu0HvmZ7_" role="2Oq$k0">
+                  <node concept="2Sf5sV" id="1rEu0HvmZ7A" role="2Oq$k0" />
+                  <node concept="3CFZ6_" id="1rEu0HvmZ7B" role="2OqNvi">
+                    <node concept="3CFYIy" id="1rEu0HvmZ7C" role="3CFYIz">
+                      <ref role="3CFYIx" to="tegv:54z9_KDO4Av" resolve="GroupAnnotation" />
                     </node>
                   </node>
                 </node>
-              </node>
-              <node concept="3clFbC" id="1rEu0Hvn4pI" role="3clFbw">
-                <node concept="3cmrfG" id="1rEu0Hvn4r0" role="3uHU7w">
-                  <property role="3cmrfH" value="1" />
-                </node>
-                <node concept="2OqwBi" id="1rEu0HvmYLC" role="3uHU7B">
-                  <node concept="37vLTw" id="1rEu0HvnaNP" role="2Oq$k0">
-                    <ref role="3cqZAo" node="1rEu0Hvna9P" resolve="vals" />
-                  </node>
-                  <node concept="34oBXx" id="1rEu0Hvn3Kz" role="2OqNvi" />
-                </node>
+                <node concept="zfrQC" id="1rEu0HvmZ7D" role="2OqNvi" />
               </node>
             </node>
           </node>
@@ -315,7 +129,7 @@
               <node concept="2Sf5sV" id="54z9_KDPcay" role="2Oq$k0" />
               <node concept="3CFZ6_" id="54z9_KDPcGz" role="2OqNvi">
                 <node concept="3CFYIy" id="54z9_KDPcHw" role="3CFYIz">
-                  <ref role="3CFYIx" to="tegv:54z9_KDO4Av" resolve="IntentionGroupAnnotation" />
+                  <ref role="3CFYIx" to="tegv:54z9_KDO4Av" resolve="GroupAnnotation" />
                 </node>
               </node>
             </node>
@@ -329,7 +143,7 @@
                     <node concept="2Sf5sV" id="54z9_KDPdFt" role="2Oq$k0" />
                     <node concept="3CFZ6_" id="54z9_KDPdWu" role="2OqNvi">
                       <node concept="3CFYIy" id="54z9_KDPdX7" role="3CFYIz">
-                        <ref role="3CFYIx" to="tegv:54z9_KDO4Av" resolve="IntentionGroupAnnotation" />
+                        <ref role="3CFYIx" to="tegv:54z9_KDO4Av" resolve="GroupAnnotation" />
                       </node>
                     </node>
                   </node>
@@ -423,6 +237,99 @@
         <node concept="3clFbF" id="frLjuvYWrO" role="3cqZAp">
           <node concept="Xl_RD" id="frLjuvYWrP" role="3clFbG">
             <property role="Xl_RC" value="Toggle Show Intention In Read-Only Cell Annotation" />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="2S6QgY" id="2oNrKyBdtmp">
+    <property role="TrG5h" value="addGroupAnnotationToAction" />
+    <property role="2ZfUl0" value="true" />
+    <ref role="2ZfgGC" to="tp4k:hwsE7KS" resolve="ActionDeclaration" />
+    <node concept="2Sbjvc" id="2oNrKyBdtmq" role="2ZfgGD">
+      <node concept="3clFbS" id="2oNrKyBdtmr" role="2VODD2">
+        <node concept="3clFbJ" id="2oNrKyBdtms" role="3cqZAp">
+          <node concept="3clFbS" id="2oNrKyBdtmt" role="3clFbx">
+            <node concept="3clFbF" id="$kD7tON8GU" role="3cqZAp">
+              <node concept="2OqwBi" id="2oNrKyBdtmx" role="3clFbG">
+                <node concept="2OqwBi" id="2oNrKyBdtmy" role="2Oq$k0">
+                  <node concept="2Sf5sV" id="2oNrKyBdtmz" role="2Oq$k0" />
+                  <node concept="3CFZ6_" id="2oNrKyBdtm$" role="2OqNvi">
+                    <node concept="3CFYIy" id="2oNrKyBdtm_" role="3CFYIz">
+                      <ref role="3CFYIx" to="tegv:54z9_KDO4Av" resolve="GroupAnnotation" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="zfrQC" id="2oNrKyBdtmA" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="2oNrKyBdtn_" role="3clFbw">
+            <node concept="2OqwBi" id="2oNrKyBdtnA" role="2Oq$k0">
+              <node concept="2Sf5sV" id="2oNrKyBdtnB" role="2Oq$k0" />
+              <node concept="3CFZ6_" id="2oNrKyBdtnC" role="2OqNvi">
+                <node concept="3CFYIy" id="2oNrKyBdtnD" role="3CFYIz">
+                  <ref role="3CFYIx" to="tegv:54z9_KDO4Av" resolve="GroupAnnotation" />
+                </node>
+              </node>
+            </node>
+            <node concept="3w_OXm" id="2oNrKyBdtnE" role="2OqNvi" />
+          </node>
+          <node concept="9aQIb" id="2oNrKyBdtnF" role="9aQIa">
+            <node concept="3clFbS" id="2oNrKyBdtnG" role="9aQI4">
+              <node concept="3clFbF" id="$kD7tONanW" role="3cqZAp">
+                <node concept="2OqwBi" id="$kD7tONb9D" role="3clFbG">
+                  <node concept="2OqwBi" id="$kD7tONaxn" role="2Oq$k0">
+                    <node concept="2Sf5sV" id="$kD7tONanV" role="2Oq$k0" />
+                    <node concept="3CFZ6_" id="$kD7tONayw" role="2OqNvi">
+                      <node concept="3CFYIy" id="$kD7tONaX7" role="3CFYIz">
+                        <ref role="3CFYIx" to="tegv:54z9_KDO4Av" resolve="GroupAnnotation" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2qgKlT" id="$kD7tONbrp" role="2OqNvi">
+                    <ref role="37wK5l" to="9j2l:$kD7tOMQXO" resolve="update" />
+                    <node concept="1XNTG" id="$kD7tONbvH" role="37wK5m" />
+                    <node concept="2OqwBi" id="$kD7tONdrS" role="37wK5m">
+                      <node concept="2OqwBi" id="$kD7tONcNG" role="2Oq$k0">
+                        <node concept="2Sf5sV" id="$kD7tONcxQ" role="2Oq$k0" />
+                        <node concept="3CFZ6_" id="$kD7tONdco" role="2OqNvi">
+                          <node concept="3CFYIy" id="$kD7tONdf3" role="3CFYIz">
+                            <ref role="3CFYIx" to="tegv:54z9_KDO4Av" resolve="GroupAnnotation" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3TrcHB" id="$kD7tONdI1" role="2OqNvi">
+                        <ref role="3TsBF5" to="tegv:54z9_KDO50a" resolve="label" />
+                      </node>
+                    </node>
+                    <node concept="10Nm6u" id="$kD7tONdK7" role="37wK5m" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbF" id="2oNrKyBdtnH" role="3cqZAp">
+                <node concept="2OqwBi" id="2oNrKyBdtnI" role="3clFbG">
+                  <node concept="2OqwBi" id="2oNrKyBdtnJ" role="2Oq$k0">
+                    <node concept="2Sf5sV" id="2oNrKyBdtnK" role="2Oq$k0" />
+                    <node concept="3CFZ6_" id="2oNrKyBdtnL" role="2OqNvi">
+                      <node concept="3CFYIy" id="2oNrKyBdtnM" role="3CFYIz">
+                        <ref role="3CFYIx" to="tegv:54z9_KDO4Av" resolve="GroupAnnotation" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3YRAZt" id="2oNrKyBdtnN" role="2OqNvi" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2S6ZIM" id="2oNrKyBdtnO" role="2ZfVej">
+      <node concept="3clFbS" id="2oNrKyBdtnP" role="2VODD2">
+        <node concept="3clFbF" id="2oNrKyBdtnQ" role="3cqZAp">
+          <node concept="Xl_RD" id="2oNrKyBdtnR" role="3clFbG">
+            <property role="Xl_RC" value="Toggle Group Annotation" />
           </node>
         </node>
       </node>

--- a/code/intentionsmenu/com.mbeddr.mpsutil.intentions/languageModels/structure.mps
+++ b/code/intentionsmenu/com.mbeddr.mpsutil.intentions/languageModels/structure.mps
@@ -6,6 +6,7 @@
     <devkit ref="78434eb8-b0e5-444b-850d-e7c4ad2da9ab(jetbrains.mps.devkit.aspect.structure)" />
   </languages>
   <imports>
+    <import index="tp4k" ref="r:00000000-0000-4000-0000-011c89590368(jetbrains.mps.lang.plugin.structure)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
     <import index="tp3j" ref="r:00000000-0000-4000-0000-011c89590353(jetbrains.mps.lang.intentions.structure)" implicit="true" />
   </imports>
@@ -40,13 +41,16 @@
     </language>
   </registry>
   <node concept="1TIwiD" id="54z9_KDO4Av">
-    <property role="TrG5h" value="IntentionGroupAnnotation" />
+    <property role="TrG5h" value="GroupAnnotation" />
     <property role="EcuMT" value="5846558918537398687" />
     <ref role="1TJDcQ" to="tpck:2ULFgo8_XDk" resolve="NodeAttribute" />
     <node concept="M6xJ_" id="54z9_KDO4JX" role="lGtFl">
       <property role="Hh88m" value="group" />
       <node concept="trNpa" id="54z9_KDOLSQ" role="EQaZv">
         <ref role="trN6q" to="tp3j:2c3oNEsfcpP" resolve="BaseIntentionDeclaration" />
+      </node>
+      <node concept="trNpa" id="2oNrKyBcF$K" role="EQaZv">
+        <ref role="trN6q" to="tp4k:hwsE7KS" resolve="ActionDeclaration" />
       </node>
     </node>
     <node concept="1TJgyi" id="54z9_KDO50a" role="1TKVEl">

--- a/code/intentionsmenu/com.mbeddr.mpsutil.intentions/languageModels/typesystem.mps
+++ b/code/intentionsmenu/com.mbeddr.mpsutil.intentions/languageModels/typesystem.mps
@@ -32,6 +32,7 @@
       <concept id="1207055528241" name="jetbrains.mps.lang.typesystem.structure.WarningStatement" flags="nn" index="a7r0C">
         <child id="1207055552304" name="warningText" index="a7wSD" />
       </concept>
+      <concept id="7992060018732187444" name="jetbrains.mps.lang.typesystem.structure.WarningStatementAnnotation" flags="ng" index="AMVWa" />
       <concept id="1195213580585" name="jetbrains.mps.lang.typesystem.structure.AbstractCheckingRule" flags="ig" index="18hYwZ">
         <child id="1195213635060" name="body" index="18ibNy" />
       </concept>
@@ -64,6 +65,9 @@
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
@@ -92,6 +96,9 @@
               <node concept="3TrEf2" id="6ob0HsMUWpK" role="2OqNvi">
                 <ref role="3Tt5mk" to="tp4k:hwtmbzj" resolve="updateBlock" />
               </node>
+            </node>
+            <node concept="AMVWa" id="5gDLJkKOttp" role="lGtFl">
+              <property role="TrG5h" value="groupAnnotationCondition" />
             </node>
           </node>
         </node>

--- a/code/intentionsmenu/com.mbeddr.mpsutil.intentions/languageModels/typesystem.mps
+++ b/code/intentionsmenu/com.mbeddr.mpsutil.intentions/languageModels/typesystem.mps
@@ -4,7 +4,107 @@
   <languages>
     <devkit ref="00000000-0000-4000-0000-1de82b3a4936(jetbrains.mps.devkit.aspect.typesystem)" />
   </languages>
-  <imports />
-  <registry />
+  <imports>
+    <import index="tp4k" ref="r:00000000-0000-4000-0000-011c89590368(jetbrains.mps.lang.plugin.structure)" implicit="true" />
+    <import index="tegv" ref="r:b91d2412-f094-4e55-8db6-3c782d7edc40(com.mbeddr.mpsutil.intentions.structure)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="5497648299878491908" name="jetbrains.mps.baseLanguage.structure.BaseVariableReference" flags="nn" index="1M0zk4">
+        <reference id="5497648299878491909" name="baseVariableDeclaration" index="1M0zk5" />
+      </concept>
+    </language>
+    <language id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem">
+      <concept id="1207055528241" name="jetbrains.mps.lang.typesystem.structure.WarningStatement" flags="nn" index="a7r0C">
+        <child id="1207055552304" name="warningText" index="a7wSD" />
+      </concept>
+      <concept id="1195213580585" name="jetbrains.mps.lang.typesystem.structure.AbstractCheckingRule" flags="ig" index="18hYwZ">
+        <child id="1195213635060" name="body" index="18ibNy" />
+      </concept>
+      <concept id="1195214364922" name="jetbrains.mps.lang.typesystem.structure.NonTypesystemRule" flags="ig" index="18kY7G" />
+      <concept id="3937244445246642777" name="jetbrains.mps.lang.typesystem.structure.AbstractReportStatement" flags="ng" index="1urrMJ">
+        <child id="3937244445246642781" name="nodeToReport" index="1urrMF" />
+      </concept>
+      <concept id="1174642788531" name="jetbrains.mps.lang.typesystem.structure.ConceptReference" flags="ig" index="1YaCAy">
+        <reference id="1174642800329" name="concept" index="1YaFvo" />
+      </concept>
+      <concept id="1174648085619" name="jetbrains.mps.lang.typesystem.structure.AbstractRule" flags="ng" index="1YuPPy">
+        <child id="1174648101952" name="applicableNode" index="1YuTPh" />
+      </concept>
+      <concept id="1174650418652" name="jetbrains.mps.lang.typesystem.structure.ApplicableNodeReference" flags="nn" index="1YBJjd">
+        <reference id="1174650432090" name="applicableNode" index="1YBMHb" />
+      </concept>
+    </language>
+    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1883223317721008708" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfStatement" flags="nn" index="Jncv_">
+        <reference id="1883223317721008712" name="nodeConcept" index="JncvD" />
+        <child id="1883223317721008709" name="body" index="Jncv$" />
+        <child id="1883223317721008711" name="variable" index="JncvA" />
+        <child id="1883223317721008710" name="nodeExpression" index="JncvB" />
+      </concept>
+      <concept id="1883223317721008713" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfVariable" flags="ng" index="JncvC" />
+      <concept id="1883223317721107059" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfVarReference" flags="nn" index="Jnkvi" />
+      <concept id="1139613262185" name="jetbrains.mps.lang.smodel.structure.Node_GetParentOperation" flags="nn" index="1mfA1w" />
+      <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="nn" index="3TrEf2">
+        <reference id="1138056516764" name="link" index="3Tt5mk" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="18kY7G" id="6ob0HsMUrAL">
+    <property role="TrG5h" value="check_GroupAnnotation" />
+    <node concept="3clFbS" id="6ob0HsMUrAM" role="18ibNy">
+      <node concept="Jncv_" id="6ob0HsMUsl2" role="3cqZAp">
+        <ref role="JncvD" to="tp4k:hwsE7KS" resolve="ActionDeclaration" />
+        <node concept="2OqwBi" id="6ob0HsMUslI" role="JncvB">
+          <node concept="1YBJjd" id="6ob0HsMUsli" role="2Oq$k0">
+            <ref role="1YBMHb" node="6ob0HsMUrAO" resolve="groupAnnotation" />
+          </node>
+          <node concept="1mfA1w" id="6ob0HsMUsmL" role="2OqNvi" />
+        </node>
+        <node concept="3clFbS" id="6ob0HsMUsl4" role="Jncv$">
+          <node concept="a7r0C" id="6ob0HsMUsnK" role="3cqZAp">
+            <node concept="Xl_RD" id="6ob0HsMUsnT" role="a7wSD">
+              <property role="Xl_RC" value="The applicable condition will be ignored when the group annotation is used" />
+            </node>
+            <node concept="2OqwBi" id="6ob0HsMUV8o" role="1urrMF">
+              <node concept="Jnkvi" id="6ob0HsMUsoB" role="2Oq$k0">
+                <ref role="1M0zk5" node="6ob0HsMUsl5" resolve="actionDeclaration" />
+              </node>
+              <node concept="3TrEf2" id="6ob0HsMUWpK" role="2OqNvi">
+                <ref role="3Tt5mk" to="tp4k:hwtmbzj" resolve="updateBlock" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="JncvC" id="6ob0HsMUsl5" role="JncvA">
+          <property role="TrG5h" value="actionDeclaration" />
+          <node concept="2jxLKc" id="6ob0HsMUsl6" role="1tU5fm" />
+        </node>
+      </node>
+    </node>
+    <node concept="1YaCAy" id="6ob0HsMUrAO" role="1YuTPh">
+      <property role="TrG5h" value="groupAnnotation" />
+      <ref role="1YaFvo" to="tegv:54z9_KDO4Av" resolve="GroupAnnotation" />
+    </node>
+  </node>
 </model>
 

--- a/code/languages/com.mbeddr.mpsutil.intentions.sandboxlang/com.mbeddr.mpsutil.intentions.sandboxlang.mpl
+++ b/code/languages/com.mbeddr.mpsutil.intentions.sandboxlang/com.mbeddr.mpsutil.intentions.sandboxlang.mpl
@@ -56,6 +56,7 @@
   </generators>
   <dependencies>
     <dependency reexport="false">b92f861d-0184-446d-b88b-6dcf0e070241(com.mbeddr.mpsutil.intentions)</dependency>
+    <dependency reexport="false">92d2ea16-5a42-4fdf-a676-c7604efe3504(de.slisson.mps.richtext)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:b92f861d-0184-446d-b88b-6dcf0e070241:com.mbeddr.mpsutil.intentions" version="0" />
@@ -98,9 +99,18 @@
     <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
     <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
     <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
+    <module reference="1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)" version="0" />
+    <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+    <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
     <module reference="b92f861d-0184-446d-b88b-6dcf0e070241(com.mbeddr.mpsutil.intentions)" version="0" />
     <module reference="4972ae94-72e7-499b-8766-0d6acffdb4f2(com.mbeddr.mpsutil.intentions.sandboxlang)" version="0" />
+    <module reference="848ef45d-e560-4e35-853c-f35a64cc135c(de.itemis.mps.editor.celllayout.runtime)" version="0" />
+    <module reference="24c96a96-b7a1-4f30-82da-0f8e279a2661(de.itemis.mps.editor.celllayout.styles)" version="0" />
+    <module reference="cce85e64-7b37-4ad5-b0e6-9d18324cdfb3(de.itemis.mps.selection.runtime)" version="0" />
+    <module reference="dc038ceb-b7ea-4fea-ac12-55f7400e97ba(de.slisson.mps.editor.multiline.runtime)" version="0" />
+    <module reference="f0fff802-6d26-4d2e-b89d-391357265626(de.slisson.mps.hacks.editor)" version="0" />
+    <module reference="92d2ea16-5a42-4fdf-a676-c7604efe3504(de.slisson.mps.richtext)" version="0" />
     <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
     <module reference="a9e4c532-c5f5-4bb7-99ef-42abb73bbb70(jetbrains.mps.lang.descriptor.aspects)" version="0" />
   </dependencyVersions>

--- a/code/languages/com.mbeddr.mpsutil.intentions.sandboxlang/models/com.mbeddr.mpsutil.intentions.sandboxlang.editor.mps
+++ b/code/languages/com.mbeddr.mpsutil.intentions.sandboxlang/models/com.mbeddr.mpsutil.intentions.sandboxlang.editor.mps
@@ -45,6 +45,7 @@
       <concept id="1219418625346" name="jetbrains.mps.lang.editor.structure.IStyleContainer" flags="ngI" index="3F0Thp">
         <child id="1219418656006" name="styleItem" index="3F10Kt" />
       </concept>
+      <concept id="1073389882823" name="jetbrains.mps.lang.editor.structure.CellModel_RefNode" flags="sg" stub="730538219795960754" index="3F1sOY" />
       <concept id="1073390211982" name="jetbrains.mps.lang.editor.structure.CellModel_RefNodeList" flags="sg" stub="2794558372793454595" index="3F2HdR" />
       <concept id="1166049232041" name="jetbrains.mps.lang.editor.structure.AbstractComponent" flags="ng" index="1XWOmA">
         <reference id="1166049300910" name="conceptDeclaration" index="1XX52x" />
@@ -67,8 +68,15 @@
   </registry>
   <node concept="24kQdi" id="197NvysMAmf">
     <ref role="1XX52x" to="iikq:197NvysM_3t" resolve="DemoNodeWithIntentions" />
-    <node concept="3F0A7n" id="TveEbQOnpu" role="2wV5jI">
-      <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
+    <node concept="3EZMnI" id="6ob0HsMV5FN" role="2wV5jI">
+      <node concept="2iRkQZ" id="6ob0HsMV5FO" role="2iSdaV" />
+      <node concept="3F0A7n" id="TveEbQOnpu" role="3EZMnx">
+        <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
+      </node>
+      <node concept="3F0ifn" id="6ob0HsMV5FP" role="3EZMnx" />
+      <node concept="3F1sOY" id="6ob0HsMV5FR" role="3EZMnx">
+        <ref role="1NtTu8" to="iikq:6ob0HsMV5FC" resolve="text" />
+      </node>
     </node>
   </node>
   <node concept="24kQdi" id="5qf1oe_GcsR">

--- a/code/languages/com.mbeddr.mpsutil.intentions.sandboxlang/models/com.mbeddr.mpsutil.intentions.sandboxlang.editor.mps
+++ b/code/languages/com.mbeddr.mpsutil.intentions.sandboxlang/models/com.mbeddr.mpsutil.intentions.sandboxlang.editor.mps
@@ -9,7 +9,6 @@
   <imports>
     <import index="zddv" ref="r:1b71c6d7-41ff-44a2-a61c-39c2a9779c34(com.mbeddr.mpsutil.intentions.editor)" />
     <import index="iikq" ref="r:7a511fd5-d829-4752-8daa-0ca5c0705ea8(com.mbeddr.mpsutil.intentions.sandboxlang.structure)" implicit="true" />
-    <import index="tpco" ref="r:00000000-0000-4000-0000-011c89590284(jetbrains.mps.lang.core.editor)" implicit="true" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
   </imports>
   <registry>
@@ -24,9 +23,6 @@
         <child id="1080736633877" name="cellModel" index="2wV5jI" />
       </concept>
       <concept id="795210086017940429" name="jetbrains.mps.lang.editor.structure.ReadOnlyStyleClassItem" flags="lg" index="xShMh" />
-      <concept id="1078939183254" name="jetbrains.mps.lang.editor.structure.CellModel_Component" flags="sg" stub="3162947552742194261" index="PMmxH">
-        <reference id="1078939183255" name="editorComponent" index="PMmxG" />
-      </concept>
       <concept id="1186414536763" name="jetbrains.mps.lang.editor.structure.BooleanStyleSheetItem" flags="ln" index="VOi$J">
         <property id="1186414551515" name="flag" index="VOm3f" />
       </concept>
@@ -71,8 +67,8 @@
   </registry>
   <node concept="24kQdi" id="197NvysMAmf">
     <ref role="1XX52x" to="iikq:197NvysM_3t" resolve="DemoNodeWithIntentions" />
-    <node concept="PMmxH" id="3pZvzolnXtY" role="2wV5jI">
-      <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
+    <node concept="3F0A7n" id="TveEbQOnpu" role="2wV5jI">
+      <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
     </node>
   </node>
   <node concept="24kQdi" id="5qf1oe_GcsR">

--- a/code/languages/com.mbeddr.mpsutil.intentions.sandboxlang/models/com.mbeddr.mpsutil.intentions.sandboxlang.intentions.mps
+++ b/code/languages/com.mbeddr.mpsutil.intentions.sandboxlang/models/com.mbeddr.mpsutil.intentions.sandboxlang.intentions.mps
@@ -46,7 +46,7 @@
       <concept id="278032644708909557" name="com.mbeddr.mpsutil.intentions.structure.ShowIntentionInReadyOnlyCell" flags="ng" index="2s3oj2">
         <property id="278032644708944807" name="flag" index="2s3gUg" />
       </concept>
-      <concept id="5846558918537398687" name="com.mbeddr.mpsutil.intentions.structure.IntentionGroupAnnotation" flags="ng" index="1SWQZ3">
+      <concept id="5846558918537398687" name="com.mbeddr.mpsutil.intentions.structure.GroupAnnotation" flags="ng" index="1SWQZ3">
         <property id="5846558918537400330" name="label" index="1SWRpm" />
       </concept>
     </language>
@@ -98,36 +98,18 @@
     <ref role="2ZfgGC" to="iikq:197NvysM_3t" resolve="DemoNodeWithIntentions" />
     <node concept="2S6ZIM" id="197NvysM_J4" role="2ZfVej">
       <node concept="3clFbS" id="197NvysM_J5" role="2VODD2">
-        <node concept="3SKdUt" id="5KWvuz1wniW" role="3cqZAp">
-          <node concept="1PaTwC" id="5KWvuz1wniX" role="1aUNEU">
-            <node concept="3oM_SD" id="5KWvuz1wnjM" role="1PaTwD">
-              <property role="3oM_SC" value="With" />
-            </node>
-            <node concept="3oM_SD" id="5KWvuz1wnjS" role="1PaTwD">
-              <property role="3oM_SC" value="whitespace" />
-            </node>
-            <node concept="3oM_SD" id="5KWvuz1wnk8" role="1PaTwD">
-              <property role="3oM_SC" value="to" />
-            </node>
-            <node concept="3oM_SD" id="5KWvuz1wnkf" role="1PaTwD">
-              <property role="3oM_SC" value="trim" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="197NvysM_La" role="3cqZAp">
-          <node concept="3cpWs3" id="197NvysM_Lc" role="3clFbG">
-            <node concept="Xl_RD" id="197NvysM_Ld" role="3uHU7w">
-              <property role="Xl_RC" value=" Demo Intention 1" />
-            </node>
-            <node concept="Xl_RD" id="197NvysM_Le" role="3uHU7B">
-              <property role="Xl_RC" value="Some Group:" />
-            </node>
+        <node concept="3clFbF" id="7b8v2ss9fi6" role="3cqZAp">
+          <node concept="Xl_RD" id="197NvysM_Ld" role="3clFbG">
+            <property role="Xl_RC" value=" Demo Intention 1" />
           </node>
         </node>
       </node>
     </node>
     <node concept="2Sbjvc" id="197NvysM_J6" role="2ZfgGD">
       <node concept="3clFbS" id="197NvysM_J7" role="2VODD2" />
+    </node>
+    <node concept="1SWQZ3" id="7b8v2ss1Adx" role="lGtFl">
+      <property role="1SWRpm" value="Some Group" />
     </node>
   </node>
   <node concept="2S6QgY" id="3pZvzolkwO8">

--- a/code/languages/com.mbeddr.mpsutil.intentions.sandboxlang/models/com.mbeddr.mpsutil.intentions.sandboxlang.structure.mps
+++ b/code/languages/com.mbeddr.mpsutil.intentions.sandboxlang/models/com.mbeddr.mpsutil.intentions.sandboxlang.structure.mps
@@ -44,6 +44,9 @@
     <property role="19KtqR" value="true" />
     <property role="34LRSv" value="DemoNodeWithIntentions" />
     <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+    <node concept="PrWs8" id="TveEbQOnps" role="PzmwI">
+      <ref role="PrY4T" to="tpck:h0TrEE$" resolve="INamedConcept" />
+    </node>
   </node>
   <node concept="1TIwiD" id="5qf1oe_GcsA">
     <property role="EcuMT" value="6237210071910106918" />

--- a/code/languages/com.mbeddr.mpsutil.intentions.sandboxlang/models/com.mbeddr.mpsutil.intentions.sandboxlang.structure.mps
+++ b/code/languages/com.mbeddr.mpsutil.intentions.sandboxlang/models/com.mbeddr.mpsutil.intentions.sandboxlang.structure.mps
@@ -6,6 +6,7 @@
     <devkit ref="78434eb8-b0e5-444b-850d-e7c4ad2da9ab(jetbrains.mps.devkit.aspect.structure)" />
   </languages>
   <imports>
+    <import index="87nw" ref="r:ca2ab6bb-f6e7-4c0f-a88c-b78b9b31fff3(de.slisson.mps.richtext.structure)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
   </imports>
   <registry>
@@ -44,6 +45,13 @@
     <property role="19KtqR" value="true" />
     <property role="34LRSv" value="DemoNodeWithIntentions" />
     <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+    <node concept="1TJgyj" id="6ob0HsMV5FC" role="1TKVEi">
+      <property role="IQ2ns" value="7352973939908041448" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="text" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <ref role="20lvS9" to="87nw:2dWzqxEB$Tx" resolve="Text" />
+    </node>
     <node concept="PrWs8" id="TveEbQOnps" role="PzmwI">
       <ref role="PrY4T" to="tpck:h0TrEE$" resolve="INamedConcept" />
     </node>

--- a/code/solutions/com.mbeddr.mpsutil.intentions.sandbox/models/com.mbeddr.mpsutil.intentions.sandbox.sandbox.mps
+++ b/code/solutions/com.mbeddr.mpsutil.intentions.sandbox/models/com.mbeddr.mpsutil.intentions.sandbox.sandbox.mps
@@ -21,7 +21,9 @@
       <concept id="6237210071910112531" name="com.mbeddr.mpsutil.intentions.sandboxlang.structure.ReadOnlyChildAllowed" flags="ng" index="3NfXyg" />
     </language>
   </registry>
-  <node concept="2ezpO_" id="197NvysMAlM" />
+  <node concept="2ezpO_" id="197NvysMAlM">
+    <property role="TrG5h" value="Demo Node With Intentions" />
+  </node>
   <node concept="3NfWa_" id="5qf1oe_Gzny">
     <property role="TrG5h" value="Root" />
     <node concept="3NfWaD" id="5qf1oe_Gznz" role="3NfWaF" />

--- a/code/solutions/com.mbeddr.mpsutil.intentions.sandbox/models/com.mbeddr.mpsutil.intentions.sandbox.sandbox.mps
+++ b/code/solutions/com.mbeddr.mpsutil.intentions.sandbox/models/com.mbeddr.mpsutil.intentions.sandbox.sandbox.mps
@@ -6,13 +6,23 @@
   </languages>
   <imports />
   <registry>
+    <language id="92d2ea16-5a42-4fdf-a676-c7604efe3504" name="de.slisson.mps.richtext">
+      <concept id="2557074442922380897" name="de.slisson.mps.richtext.structure.Text" flags="ng" index="19SGf9">
+        <child id="2557074442922392302" name="words" index="19SJt6" />
+      </concept>
+      <concept id="2557074442922438156" name="de.slisson.mps.richtext.structure.Word" flags="ng" index="19SUe$">
+        <property id="2557074442922438158" name="escapedValue" index="19SUeA" />
+      </concept>
+    </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
     </language>
     <language id="4972ae94-72e7-499b-8766-0d6acffdb4f2" name="com.mbeddr.mpsutil.intentions.sandboxlang">
-      <concept id="1317247883695247581" name="com.mbeddr.mpsutil.intentions.sandboxlang.structure.DemoNodeWithIntentions" flags="ng" index="2ezpO_" />
+      <concept id="1317247883695247581" name="com.mbeddr.mpsutil.intentions.sandboxlang.structure.DemoNodeWithIntentions" flags="ng" index="2ezpO_">
+        <child id="7352973939908041448" name="text" index="1kTPwZ" />
+      </concept>
       <concept id="6237210071910106919" name="com.mbeddr.mpsutil.intentions.sandboxlang.structure.ReadOnlyChild" flags="ng" index="3NfWa$" />
       <concept id="6237210071910106918" name="com.mbeddr.mpsutil.intentions.sandboxlang.structure.Root" flags="ng" index="3NfWa_">
         <child id="6237210071910106920" name="children" index="3NfWaF" />
@@ -23,6 +33,11 @@
   </registry>
   <node concept="2ezpO_" id="197NvysMAlM">
     <property role="TrG5h" value="Demo Node With Intentions" />
+    <node concept="19SGf9" id="6ob0HsMV969" role="1kTPwZ">
+      <node concept="19SUe$" id="6ob0HsMV96a" role="19SJt6">
+        <property role="19SUeA" value=" The following intentions should be visible in this test:&#10; - Dictionary&#10; - Groupless Intention 1&#10; -- MyGroup --&#10; - My Action&#10; -- Some Group --&#10; - Demo Intention 1&#10; - Demo Intention 2&#10; - Demo Intention 3" />
+      </node>
+    </node>
   </node>
   <node concept="3NfWa_" id="5qf1oe_Gzny">
     <property role="TrG5h" value="Root" />

--- a/code/solutions/com.mbeddr.mpsutil.intentions.tests/com.mbeddr.mpsutil.intentions.tests.msd
+++ b/code/solutions/com.mbeddr.mpsutil.intentions.tests/com.mbeddr.mpsutil.intentions.tests.msd
@@ -20,19 +20,22 @@
     <dependency reexport="false">34e84b8f-afa8-4364-abcd-a279fddddbe7(jetbrains.mps.editor.runtime)</dependency>
     <dependency reexport="false">3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)</dependency>
     <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
-    <dependency reexport="false">f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)</dependency>
+    <dependency reexport="false">b92f861d-0184-446d-b88b-6dcf0e070241(com.mbeddr.mpsutil.intentions)</dependency>
+    <dependency reexport="false">6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)</dependency>
   </dependencies>
   <languageVersions>
+    <language slang="l:f47b95d4-5e73-4c04-9204-18076950153b:com.mbeddr.mpsutil.compare" version="0" />
     <language slang="l:b92f861d-0184-446d-b88b-6dcf0e070241:com.mbeddr.mpsutil.intentions" version="0" />
     <language slang="l:4972ae94-72e7-499b-8766-0d6acffdb4f2:com.mbeddr.mpsutil.intentions.sandboxlang" version="0" />
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
     <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />
     <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
     <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="2" />
+    <language slang="l:c7d5b9dd-a05f-4be2-bc73-f2e16994cc67:jetbrains.mps.baseLanguage.lightweightdsl" version="1" />
     <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
     <language slang="l:f61473f9-130f-42f6-b98d-6c438812c2f6:jetbrains.mps.baseLanguage.unitTest" version="1" />
-    <language slang="l:63650c59-16c8-498a-99c8-005c7ee9515d:jetbrains.mps.lang.access" version="0" />
     <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
+    <language slang="l:d7a92d38-f7db-40d0-8431-763b0c3c9f20:jetbrains.mps.lang.intentions" version="1" />
     <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
     <language slang="l:28f9e497-3b42-4291-aeba-0a1039153ab1:jetbrains.mps.lang.plugin" version="6" />
     <language slang="l:ef7bf5ac-d06c-4342-b11d-e42104eb9343:jetbrains.mps.lang.plugin.standalone" version="0" />
@@ -48,16 +51,13 @@
     <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
+    <module reference="b92f861d-0184-446d-b88b-6dcf0e070241(com.mbeddr.mpsutil.intentions)" version="0" />
     <module reference="4bff7bbe-ce5f-432e-84bf-60809cb9987c(com.mbeddr.mpsutil.intentions.runtime)" version="0" />
     <module reference="4972ae94-72e7-499b-8766-0d6acffdb4f2(com.mbeddr.mpsutil.intentions.sandboxlang)" version="0" />
     <module reference="73a78daa-4204-43ee-8a0e-1b2b39741908(com.mbeddr.mpsutil.intentions.tests)" version="0" />
-    <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
-    <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
     <module reference="34e84b8f-afa8-4364-abcd-a279fddddbe7(jetbrains.mps.editor.runtime)" version="0" />
     <module reference="5b1f863d-65a0-41a6-a801-33896be24202(jetbrains.mps.ide.editor)" version="0" />
-    <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
     <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
-    <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
   </dependencyVersions>
 </solution>
 

--- a/code/solutions/com.mbeddr.mpsutil.intentions.tests/com.mbeddr.mpsutil.intentions.tests.msd
+++ b/code/solutions/com.mbeddr.mpsutil.intentions.tests/com.mbeddr.mpsutil.intentions.tests.msd
@@ -6,20 +6,37 @@
     </modelRoot>
   </models>
   <facets>
-    <facet compile="mps" classes="mps" ext="no" type="java">
+    <facet compile="mps" classes="mps" ext="yes" type="java">
       <classes generated="true" path="${module}/classes_gen" />
     </facet>
     <facet type="tests" />
   </facets>
   <dependencies>
     <dependency reexport="false">4972ae94-72e7-499b-8766-0d6acffdb4f2(com.mbeddr.mpsutil.intentions.sandboxlang)</dependency>
+    <dependency reexport="false">5b1f863d-65a0-41a6-a801-33896be24202(jetbrains.mps.ide.editor)</dependency>
+    <dependency reexport="false">4bff7bbe-ce5f-432e-84bf-60809cb9987c(com.mbeddr.mpsutil.intentions.runtime)</dependency>
+    <dependency reexport="false">498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)</dependency>
+    <dependency reexport="false">742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)</dependency>
+    <dependency reexport="false">34e84b8f-afa8-4364-abcd-a279fddddbe7(jetbrains.mps.editor.runtime)</dependency>
+    <dependency reexport="false">3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)</dependency>
+    <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
+    <dependency reexport="false">f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)</dependency>
   </dependencies>
   <languageVersions>
+    <language slang="l:b92f861d-0184-446d-b88b-6dcf0e070241:com.mbeddr.mpsutil.intentions" version="0" />
     <language slang="l:4972ae94-72e7-499b-8766-0d6acffdb4f2:com.mbeddr.mpsutil.intentions.sandboxlang" version="0" />
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
     <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />
+    <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
+    <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="2" />
+    <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
     <language slang="l:f61473f9-130f-42f6-b98d-6c438812c2f6:jetbrains.mps.baseLanguage.unitTest" version="1" />
+    <language slang="l:63650c59-16c8-498a-99c8-005c7ee9515d:jetbrains.mps.lang.access" version="0" />
     <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
+    <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
+    <language slang="l:28f9e497-3b42-4291-aeba-0a1039153ab1:jetbrains.mps.lang.plugin" version="6" />
+    <language slang="l:ef7bf5ac-d06c-4342-b11d-e42104eb9343:jetbrains.mps.lang.plugin.standalone" version="0" />
+    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
     <language slang="l:8585453e-6bfb-4d80-98de-b16074f1d86c:jetbrains.mps.lang.test" version="6" />
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
   </languageVersions>
@@ -27,10 +44,20 @@
     <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
     <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
     <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
+    <module reference="1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)" version="0" />
+    <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+    <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
+    <module reference="4bff7bbe-ce5f-432e-84bf-60809cb9987c(com.mbeddr.mpsutil.intentions.runtime)" version="0" />
     <module reference="4972ae94-72e7-499b-8766-0d6acffdb4f2(com.mbeddr.mpsutil.intentions.sandboxlang)" version="0" />
     <module reference="73a78daa-4204-43ee-8a0e-1b2b39741908(com.mbeddr.mpsutil.intentions.tests)" version="0" />
+    <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
+    <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
+    <module reference="34e84b8f-afa8-4364-abcd-a279fddddbe7(jetbrains.mps.editor.runtime)" version="0" />
+    <module reference="5b1f863d-65a0-41a6-a801-33896be24202(jetbrains.mps.ide.editor)" version="0" />
+    <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
     <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
+    <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
   </dependencyVersions>
 </solution>
 

--- a/code/solutions/com.mbeddr.mpsutil.intentions.tests/models/com.mbeddr.mpsutil.intentions.tests.plugin.mps
+++ b/code/solutions/com.mbeddr.mpsutil.intentions.tests/models/com.mbeddr.mpsutil.intentions.tests.plugin.mps
@@ -1,0 +1,217 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:561153e1-7e8c-4c8e-9afe-a4850f2fd430(com.mbeddr.mpsutil.intentions.tests.plugin)">
+  <persistence version="9" />
+  <languages>
+    <use id="28f9e497-3b42-4291-aeba-0a1039153ab1" name="jetbrains.mps.lang.plugin" version="6" />
+    <use id="ef7bf5ac-d06c-4342-b11d-e42104eb9343" name="jetbrains.mps.lang.plugin.standalone" version="0" />
+    <use id="760a0a8c-eabb-4521-8bfd-65db761a9ba3" name="jetbrains.mps.baseLanguage.logging" version="0" />
+    <use id="b92f861d-0184-446d-b88b-6dcf0e070241" name="com.mbeddr.mpsutil.intentions" version="0" />
+    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
+  </languages>
+  <imports>
+    <import index="ekwn" ref="r:9832fb5f-2578-4b58-8014-a5de79da988e(jetbrains.mps.ide.editor.actions)" />
+    <import index="qq03" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.ide.actions(MPS.Platform/)" />
+    <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" implicit="true" />
+    <import index="lui2" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.module(MPS.OpenAPI/)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="982eb8df-2c96-4bd7-9963-11712ea622e5" name="jetbrains.mps.lang.resources">
+      <concept id="2756621024541681841" name="jetbrains.mps.lang.resources.structure.Primitive" flags="ng" index="1irPi6">
+        <child id="1860120738943552529" name="fillColor" index="3PKjn_" />
+      </concept>
+      <concept id="2756621024541674821" name="jetbrains.mps.lang.resources.structure.TextIcon" flags="ng" index="1irR5M">
+        <property id="1358878980655415353" name="iconId" index="2$rrk2" />
+        <child id="2756621024541675110" name="layers" index="1irR9h" />
+      </concept>
+      <concept id="2756621024541675104" name="jetbrains.mps.lang.resources.structure.Circle" flags="ng" index="1irR9n" />
+      <concept id="1860120738943552477" name="jetbrains.mps.lang.resources.structure.ColorLiteral" flags="ng" index="3PKj8D">
+        <property id="1860120738943552481" name="val" index="3PKj8l" />
+      </concept>
+    </language>
+    <language id="28f9e497-3b42-4291-aeba-0a1039153ab1" name="jetbrains.mps.lang.plugin">
+      <concept id="1207145163717" name="jetbrains.mps.lang.plugin.structure.ElementListContents" flags="ng" index="ftmFs">
+        <child id="1207145201301" name="reference" index="ftvYc" />
+      </concept>
+      <concept id="1203071646776" name="jetbrains.mps.lang.plugin.structure.ActionDeclaration" flags="ng" index="sE7Ow">
+        <property id="1205250923097" name="caption" index="2uzpH1" />
+        <property id="4692598989365753297" name="updateInBackground" index="1rBW0U" />
+        <child id="1203083196627" name="updateBlock" index="tmbBb" />
+        <child id="1203083461638" name="executeFunction" index="tncku" />
+        <child id="1217413222820" name="parameter" index="1NuT2Z" />
+        <child id="8976425910813834639" name="icon" index="3Uehp1" />
+      </concept>
+      <concept id="1203083511112" name="jetbrains.mps.lang.plugin.structure.ExecuteBlock" flags="in" index="tnohg" />
+      <concept id="1203087890642" name="jetbrains.mps.lang.plugin.structure.ActionGroupDeclaration" flags="ng" index="tC5Ba">
+        <child id="1204991552650" name="modifier" index="2f5YQi" />
+        <child id="1207145245948" name="contents" index="ftER_" />
+      </concept>
+      <concept id="1203088046679" name="jetbrains.mps.lang.plugin.structure.ActionInstance" flags="ng" index="tCFHf">
+        <reference id="1203088061055" name="action" index="tCJdB" />
+      </concept>
+      <concept id="1203092361741" name="jetbrains.mps.lang.plugin.structure.ModificationStatement" flags="lg" index="tT9cl">
+        <reference id="1203092736097" name="modifiedGroup" index="tU$_T" />
+      </concept>
+      <concept id="1205681243813" name="jetbrains.mps.lang.plugin.structure.IsApplicableBlock" flags="in" index="2ScWuX" />
+      <concept id="5538333046911348654" name="jetbrains.mps.lang.plugin.structure.RequiredCondition" flags="ng" index="1oajcY" />
+      <concept id="1217252042208" name="jetbrains.mps.lang.plugin.structure.ActionDataParameterDeclaration" flags="ng" index="1DS2jV">
+        <reference id="1217252646389" name="key" index="1DUlNI" />
+      </concept>
+      <concept id="1217252428768" name="jetbrains.mps.lang.plugin.structure.ActionDataParameterReferenceOperation" flags="nn" index="1DTwFV" />
+      <concept id="1217413147516" name="jetbrains.mps.lang.plugin.structure.ActionParameter" flags="ngI" index="1NuADB">
+        <child id="5538333046911298738" name="condition" index="1oa70y" />
+      </concept>
+    </language>
+    <language id="ef7bf5ac-d06c-4342-b11d-e42104eb9343" name="jetbrains.mps.lang.plugin.standalone">
+      <concept id="7520713872864775836" name="jetbrains.mps.lang.plugin.standalone.structure.StandalonePluginDescriptor" flags="ng" index="2DaZZR" />
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
+        <child id="1137022507850" name="body" index="2VODD2" />
+      </concept>
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="1225271283259" name="jetbrains.mps.baseLanguage.structure.NPEEqualsExpression" flags="nn" index="17R0WA" />
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
+        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
+        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
+      </concept>
+    </language>
+    <language id="b92f861d-0184-446d-b88b-6dcf0e070241" name="com.mbeddr.mpsutil.intentions">
+      <concept id="5846558918537398687" name="com.mbeddr.mpsutil.intentions.structure.GroupAnnotation" flags="ng" index="1SWQZ3">
+        <property id="5846558918537400330" name="label" index="1SWRpm" />
+      </concept>
+    </language>
+    <language id="443f4c36-fcf5-4eb6-9500-8d06ed259e3e" name="jetbrains.mps.baseLanguage.classifiers">
+      <concept id="1205752633985" name="jetbrains.mps.baseLanguage.classifiers.structure.ThisClassifierExpression" flags="nn" index="2WthIp" />
+      <concept id="1205756064662" name="jetbrains.mps.baseLanguage.classifiers.structure.IMemberOperation" flags="ngI" index="2WEnae">
+        <reference id="1205756909548" name="member" index="2WH_rO" />
+      </concept>
+    </language>
+    <language id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi">
+      <concept id="361130699826193249" name="jetbrains.mps.lang.modelapi.structure.ModulePointer" flags="ng" index="1dCxOk">
+        <property id="1863527487546097500" name="moduleId" index="1XweGW" />
+        <property id="1863527487545993577" name="moduleName" index="1XxBO9" />
+      </concept>
+    </language>
+    <language id="760a0a8c-eabb-4521-8bfd-65db761a9ba3" name="jetbrains.mps.baseLanguage.logging">
+      <concept id="6332851714983831325" name="jetbrains.mps.baseLanguage.logging.structure.MsgStatement" flags="ng" index="2xdQw9">
+        <property id="6332851714983843871" name="severity" index="2xdLsb" />
+        <child id="5721587534047265374" name="message" index="9lYJi" />
+      </concept>
+    </language>
+    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1678062499342629858" name="jetbrains.mps.lang.smodel.structure.ModuleRefExpression" flags="ng" index="37shsh">
+        <child id="1678062499342629861" name="moduleId" index="37shsm" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="2DaZZR" id="3iqDEt57viZ" />
+  <node concept="tC5Ba" id="3iqDEt57vHA">
+    <property role="TrG5h" value="ActionsAsIntentionsGroup" />
+    <node concept="ftmFs" id="3iqDEt57vNS" role="ftER_">
+      <node concept="tCFHf" id="3iqDEt57vNU" role="ftvYc">
+        <ref role="tCJdB" node="3iqDEt57vKI" resolve="MyAction" />
+      </node>
+    </node>
+    <node concept="tT9cl" id="29wDeGIb4Uj" role="2f5YQi">
+      <ref role="tU$_T" to="ekwn:5YEoTZrFokU" resolve="ActionsAsIntentions" />
+    </node>
+  </node>
+  <node concept="sE7Ow" id="3iqDEt57vKI">
+    <property role="1rBW0U" value="true" />
+    <property role="TrG5h" value="MyAction" />
+    <property role="2uzpH1" value="My Action" />
+    <node concept="tnohg" id="3iqDEt57vKJ" role="tncku">
+      <node concept="3clFbS" id="3iqDEt57vKK" role="2VODD2">
+        <node concept="2xdQw9" id="3iqDEt5z$Ty" role="3cqZAp">
+          <property role="2xdLsb" value="gZ5fh_4/error" />
+          <node concept="Xl_RD" id="3iqDEt5z$T$" role="9lYJi">
+            <property role="Xl_RC" value="Hi" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1SWQZ3" id="2oNrKyBdO6X" role="lGtFl">
+      <property role="1SWRpm" value="MyGroup" />
+    </node>
+    <node concept="2ScWuX" id="4WKUOfJVR2k" role="tmbBb">
+      <node concept="3clFbS" id="4WKUOfJVR2l" role="2VODD2">
+        <node concept="3clFbF" id="4WKUOfJVTA_" role="3cqZAp">
+          <node concept="17R0WA" id="4WKUOfJVV1r" role="3clFbG">
+            <node concept="2OqwBi" id="4WKUOfJW10z" role="3uHU7B">
+              <node concept="2OqwBi" id="4WKUOfJVTAv" role="2Oq$k0">
+                <node concept="2WthIp" id="4WKUOfJVTAy" role="2Oq$k0" />
+                <node concept="1DTwFV" id="4WKUOfJW0V4" role="2OqNvi">
+                  <ref role="2WH_rO" node="4WKUOfJVSCA" resolve="model" />
+                </node>
+              </node>
+              <node concept="liA8E" id="4WKUOfJW1iw" role="2OqNvi">
+                <ref role="37wK5l" to="mhbf:~SModel.getModule()" resolve="getModule" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="4WKUOfJW50A" role="3uHU7w">
+              <node concept="37shsh" id="4WKUOfJW3EP" role="2Oq$k0">
+                <node concept="1dCxOk" id="4WKUOfJW4ws" role="37shsm">
+                  <property role="1XweGW" value="73a78daa-4204-43ee-8a0e-1b2b39741908" />
+                  <property role="1XxBO9" value="com.mbeddr.mpsutil.intentions.tests" />
+                </node>
+              </node>
+              <node concept="liA8E" id="4WKUOfJW6M$" role="2OqNvi">
+                <ref role="37wK5l" to="lui2:~SModuleReference.resolve(org.jetbrains.mps.openapi.module.SRepository)" resolve="resolve" />
+                <node concept="2OqwBi" id="4WKUOfJW8i9" role="37wK5m">
+                  <node concept="2OqwBi" id="4WKUOfJW6NY" role="2Oq$k0">
+                    <node concept="2WthIp" id="4WKUOfJW6O1" role="2Oq$k0" />
+                    <node concept="1DTwFV" id="4WKUOfJW6O3" role="2OqNvi">
+                      <ref role="2WH_rO" node="4WKUOfJVSCA" resolve="model" />
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="4WKUOfJW8CD" role="2OqNvi">
+                    <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1DS2jV" id="4WKUOfJVSCA" role="1NuT2Z">
+      <property role="TrG5h" value="model" />
+      <ref role="1DUlNI" to="qq03:~MPSCommonDataKeys.MODEL" resolve="MODEL" />
+      <node concept="1oajcY" id="4WKUOfJVSCB" role="1oa70y" />
+    </node>
+    <node concept="1irR5M" id="1_0AJInUXIC" role="3Uehp1">
+      <property role="2$rrk2" value="1" />
+      <node concept="1irR9n" id="1_0AJInUXYA" role="1irR9h">
+        <node concept="3PKj8D" id="1_0AJInUXYL" role="3PKjn_">
+          <property role="3PKj8l" value="00FFFF" />
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/code/solutions/com.mbeddr.mpsutil.intentions.tests/models/com.mbeddr.mpsutil.intentions.tests.tests@tests.mps
+++ b/code/solutions/com.mbeddr.mpsutil.intentions.tests/models/com.mbeddr.mpsutil.intentions.tests.tests@tests.mps
@@ -5,28 +5,25 @@
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="6" />
     <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
     <use id="4972ae94-72e7-499b-8766-0d6acffdb4f2" name="com.mbeddr.mpsutil.intentions.sandboxlang" version="0" />
-    <use id="63650c59-16c8-498a-99c8-005c7ee9515d" name="jetbrains.mps.lang.access" version="0" />
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
     <use id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections" version="2" />
-    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
+    <use id="d7a92d38-f7db-40d0-8431-763b0c3c9f20" name="jetbrains.mps.lang.intentions" version="1" />
+    <use id="b92f861d-0184-446d-b88b-6dcf0e070241" name="com.mbeddr.mpsutil.intentions" version="0" />
+    <use id="f47b95d4-5e73-4c04-9204-18076950153b" name="com.mbeddr.mpsutil.compare" version="0" />
   </languages>
   <imports>
     <import index="gw4x" ref="r:f1d822a2-1f43-4b14-8097-de7e855e6079(com.mbeddr.mpsutil.intentions.sandboxlang.intentions)" />
     <import index="ih8q" ref="r:990d360b-3ac3-45fa-8ed3-0bbf017bba84(com.mbeddr.mpsutil.intentions.runtime)" />
     <import index="qkt" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.actionSystem(MPS.IDEA/)" />
-    <import index="ddhc" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ide(MPS.IDEA/)" />
     <import index="7a0s" ref="r:2af017c2-293f-4ebb-99f3-81e353b3d6e6(jetbrains.mps.editor.runtime)" />
     <import index="lui2" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.module(MPS.OpenAPI/)" />
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
     <import index="mhfm" ref="3f233e7f-b8a6-46d2-a57f-795d56775243/java:org.jetbrains.annotations(Annotations/)" />
-    <import index="nddn" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.intentions(MPS.Editor/)" />
-    <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" />
-    <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" />
-    <import index="cj4x" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor(MPS.Editor/)" />
     <import index="exr9" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor(MPS.Editor/)" />
-    <import index="9w4s" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.util(MPS.IDEA/)" />
-    <import index="bd8o" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.application(MPS.IDEA/)" />
     <import index="7bx7" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.workbench.action(MPS.Platform/)" />
+    <import index="9j2l" ref="r:acd2b506-390d-4e84-8c47-cd8fb8c9e0c0(com.mbeddr.mpsutil.intentions.behavior)" />
+    <import index="3o3z" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.google.common.collect(MPS.IDEA/)" />
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
     <import index="z1c3" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.project(MPS.Core/)" implicit="true" />
   </imports>
@@ -52,15 +49,28 @@
       <concept id="1216913645126" name="jetbrains.mps.lang.test.structure.NodesTestCase" flags="lg" index="1lH9Xt">
         <property id="2616911529524314943" name="accessMode" index="3DII0k" />
         <child id="1216993439383" name="methods" index="1qtyYc" />
+        <child id="1217501822150" name="nodesToCheck" index="1SKRRt" />
         <child id="1217501895093" name="testMethods" index="1SL9yI" />
       </concept>
       <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
         <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
       </concept>
+      <concept id="1210673684636" name="jetbrains.mps.lang.test.structure.TestNodeAnnotation" flags="ng" index="3xLA65" />
+      <concept id="1210674524691" name="jetbrains.mps.lang.test.structure.TestNodeReference" flags="nn" index="3xONca">
+        <reference id="1210674534086" name="declaration" index="3xOPvv" />
+      </concept>
       <concept id="1225978065297" name="jetbrains.mps.lang.test.structure.SimpleNodeTest" flags="ng" index="1LZb2c" />
       <concept id="1225989773458" name="jetbrains.mps.lang.test.structure.InvokeIntentionStatement" flags="nn" index="1MFPAf">
         <reference id="1225989811227" name="intention" index="1MFYO6" />
       </concept>
+    </language>
+    <language id="28f9e497-3b42-4291-aeba-0a1039153ab1" name="jetbrains.mps.lang.plugin">
+      <concept id="1203071646776" name="jetbrains.mps.lang.plugin.structure.ActionDeclaration" flags="ng" index="sE7Ow">
+        <property id="1205250923097" name="caption" index="2uzpH1" />
+        <property id="4692598989365753297" name="updateInBackground" index="1rBW0U" />
+        <child id="1203083461638" name="executeFunction" index="tncku" />
+      </concept>
+      <concept id="1203083511112" name="jetbrains.mps.lang.plugin.structure.ExecuteBlock" flags="in" index="tnohg" />
     </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
       <concept id="1224071154655" name="jetbrains.mps.baseLanguage.structure.AsExpression" flags="nn" index="0kSF2">
@@ -69,10 +79,6 @@
       </concept>
       <concept id="1082485599095" name="jetbrains.mps.baseLanguage.structure.BlockStatement" flags="nn" index="9aQIb">
         <child id="1082485599096" name="statements" index="9aQI4" />
-      </concept>
-      <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
-        <child id="1068498886297" name="rValue" index="37vLTx" />
-        <child id="1068498886295" name="lValue" index="37vLTJ" />
       </concept>
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
       <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
@@ -96,7 +102,10 @@
       <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
         <child id="1145553007750" name="creator" index="2ShVmc" />
       </concept>
-      <concept id="3870108946630849399" name="jetbrains.mps.baseLanguage.structure.StaticFieldReferenceOperation" flags="ng" index="SiP3y" />
+      <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
+        <child id="1137022507850" name="body" index="2VODD2" />
+      </concept>
+      <concept id="1070475587102" name="jetbrains.mps.baseLanguage.structure.SuperConstructorInvocation" flags="nn" index="XkiVB" />
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
       </concept>
@@ -112,7 +121,9 @@
         <child id="1081256993304" name="leftExpression" index="2ZW6bz" />
       </concept>
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
-      <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu" />
+      <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu">
+        <child id="1165602531693" name="superclass" index="1zkMxy" />
+      </concept>
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <property id="1176718929932" name="isFinal" index="3TUv4t" />
         <child id="1068431790190" name="initializer" index="33vP2m" />
@@ -124,7 +135,6 @@
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
       <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
-      <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
       <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
       <concept id="1225271283259" name="jetbrains.mps.baseLanguage.structure.NPEEqualsExpression" flags="nn" index="17R0WA" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
@@ -152,6 +162,7 @@
       <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
         <property id="1068580123138" name="value" index="3clFbU" />
       </concept>
+      <concept id="1068580123140" name="jetbrains.mps.baseLanguage.structure.ConstructorDeclaration" flags="ig" index="3clFbW" />
       <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
         <property id="1068580320021" name="value" index="3cmrfH" />
       </concept>
@@ -168,6 +179,9 @@
         <child id="1206060619838" name="condition" index="3eO9$A" />
         <child id="1206060644605" name="statementList" index="3eOfB_" />
       </concept>
+      <concept id="1079359253375" name="jetbrains.mps.baseLanguage.structure.ParenthesizedExpression" flags="nn" index="1eOMI4">
+        <child id="1079359253376" name="expression" index="1eOMHV" />
+      </concept>
       <concept id="1154542696413" name="jetbrains.mps.baseLanguage.structure.ArrayCreatorWithInitializer" flags="nn" index="3g6Rrh">
         <child id="1154542793668" name="componentType" index="3g7fb8" />
         <child id="1154542803372" name="initValue" index="3g7hyw" />
@@ -176,9 +190,8 @@
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
-      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk">
-        <child id="1212687122400" name="typeParameter" index="1pMfVU" />
-      </concept>
+      <concept id="1073063089578" name="jetbrains.mps.baseLanguage.structure.SuperMethodCall" flags="nn" index="3nyPlj" />
+      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
       <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
         <property id="521412098689998745" name="nonStatic" index="2bfB8j" />
         <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
@@ -197,9 +210,25 @@
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+      <concept id="1146644641414" name="jetbrains.mps.baseLanguage.structure.ProtectedVisibility" flags="nn" index="3Tmbuc" />
       <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
       <concept id="1170345865475" name="jetbrains.mps.baseLanguage.structure.AnonymousClass" flags="ig" index="1Y3b0j">
         <reference id="1170346070688" name="classifier" index="1Y3XeK" />
+      </concept>
+    </language>
+    <language id="b92f861d-0184-446d-b88b-6dcf0e070241" name="com.mbeddr.mpsutil.intentions">
+      <concept id="5846558918537398687" name="com.mbeddr.mpsutil.intentions.structure.GroupAnnotation" flags="ng" index="1SWQZ3">
+        <property id="5846558918537400330" name="label" index="1SWRpm" />
+      </concept>
+    </language>
+    <language id="d7a92d38-f7db-40d0-8431-763b0c3c9f20" name="jetbrains.mps.lang.intentions">
+      <concept id="1192794744107" name="jetbrains.mps.lang.intentions.structure.IntentionDeclaration" flags="ig" index="2S6QgY" />
+      <concept id="1192794782375" name="jetbrains.mps.lang.intentions.structure.DescriptionBlock" flags="in" index="2S6ZIM" />
+      <concept id="1192795911897" name="jetbrains.mps.lang.intentions.structure.ExecuteBlock" flags="in" index="2Sbjvc" />
+      <concept id="2522969319638091381" name="jetbrains.mps.lang.intentions.structure.BaseIntentionDeclaration" flags="ig" index="2ZfUlf">
+        <reference id="2522969319638198290" name="forConcept" index="2ZfgGC" />
+        <child id="2522969319638198291" name="executeFunction" index="2ZfgGD" />
+        <child id="2522969319638093993" name="descriptionFunction" index="2ZfVej" />
       </concept>
     </language>
     <language id="443f4c36-fcf5-4eb6-9500-8d06ed259e3e" name="jetbrains.mps.baseLanguage.classifiers">
@@ -211,6 +240,9 @@
       <concept id="1205769149993" name="jetbrains.mps.baseLanguage.classifiers.structure.DefaultClassifierMethodCallOperation" flags="nn" index="2XshWL">
         <child id="1205770614681" name="actualArgument" index="2XxRq1" />
       </concept>
+    </language>
+    <language id="f47b95d4-5e73-4c04-9204-18076950153b" name="com.mbeddr.mpsutil.compare">
+      <concept id="756135271275943220" name="com.mbeddr.mpsutil.compare.structure.AssertNodeEquals" flags="ng" index="3GXo0L" />
     </language>
     <language id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest">
       <concept id="8427750732757990717" name="jetbrains.mps.baseLanguage.unitTest.structure.BinaryAssert" flags="nn" index="3tpDYu">
@@ -234,7 +266,6 @@
       </concept>
     </language>
     <language id="4972ae94-72e7-499b-8766-0d6acffdb4f2" name="com.mbeddr.mpsutil.intentions.sandboxlang">
-      <concept id="1317247883695247581" name="com.mbeddr.mpsutil.intentions.sandboxlang.structure.DemoNodeWithIntentions" flags="ng" index="2ezpO_" />
       <concept id="6237210071910106918" name="com.mbeddr.mpsutil.intentions.sandboxlang.structure.Root" flags="ng" index="3NfWa_">
         <child id="6237210071910106920" name="children" index="3NfWaF" />
       </concept>
@@ -247,7 +278,6 @@
       <concept id="1226511727824" name="jetbrains.mps.baseLanguage.collections.structure.SetType" flags="in" index="2hMVRd">
         <child id="1226511765987" name="elementType" index="2hN53Y" />
       </concept>
-      <concept id="1226516258405" name="jetbrains.mps.baseLanguage.collections.structure.HashSetCreator" flags="nn" index="2i4dXS" />
       <concept id="1151688443754" name="jetbrains.mps.baseLanguage.collections.structure.ListType" flags="in" index="_YKpA">
         <child id="1151688676805" name="elementType" index="_ZDj9" />
       </concept>
@@ -260,16 +290,8 @@
       <concept id="1153944233411" name="jetbrains.mps.baseLanguage.collections.structure.ForEachVariableReference" flags="nn" index="2GrUjf">
         <reference id="1153944258490" name="variable" index="2Gs0qQ" />
       </concept>
-      <concept id="1235573135402" name="jetbrains.mps.baseLanguage.collections.structure.SingletonSequenceCreator" flags="nn" index="2HTt$P">
-        <child id="1235573175711" name="elementType" index="2HTBi0" />
-        <child id="1235573187520" name="singletonValue" index="2HTEbv" />
-      </concept>
       <concept id="1237721394592" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerCreator" flags="nn" index="HWqM0">
         <child id="1237721435807" name="elementType" index="HW$YZ" />
-        <child id="1237731803878" name="copyFrom" index="I$8f6" />
-      </concept>
-      <concept id="1201306600024" name="jetbrains.mps.baseLanguage.collections.structure.ContainsKeyOperation" flags="nn" index="2Nt0df">
-        <child id="1201654602639" name="key" index="38cxEo" />
       </concept>
       <concept id="1160600644654" name="jetbrains.mps.baseLanguage.collections.structure.ListCreatorWithInit" flags="nn" index="Tc6Ow" />
       <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
@@ -277,15 +299,9 @@
       <concept id="1240217271293" name="jetbrains.mps.baseLanguage.collections.structure.LinkedHashSetCreator" flags="nn" index="32HrFt" />
       <concept id="1162934736510" name="jetbrains.mps.baseLanguage.collections.structure.GetElementOperation" flags="nn" index="34jXtK" />
       <concept id="1240325842691" name="jetbrains.mps.baseLanguage.collections.structure.AsSequenceOperation" flags="nn" index="39bAoz" />
-      <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
       <concept id="1225711141656" name="jetbrains.mps.baseLanguage.collections.structure.ListElementAccessExpression" flags="nn" index="1y4W85">
         <child id="1225711182005" name="list" index="1y566C" />
         <child id="1225711191269" name="index" index="1y58nS" />
-      </concept>
-      <concept id="1208542034276" name="jetbrains.mps.baseLanguage.collections.structure.MapClearOperation" flags="nn" index="1yHZxX" />
-      <concept id="1197932370469" name="jetbrains.mps.baseLanguage.collections.structure.MapElement" flags="nn" index="3EllGN">
-        <child id="1197932505799" name="map" index="3ElQJh" />
-        <child id="1197932525128" name="key" index="3ElVtu" />
       </concept>
     </language>
   </registry>
@@ -363,7 +379,7 @@
       <node concept="37vLTG" id="1NzaUygEoFs" role="3clF46">
         <property role="TrG5h" value="producer" />
         <node concept="3uibUv" id="1NzaUygEoFt" role="1tU5fm">
-          <ref role="3uigEE" to="ih8q:2jDew64JcPx" resolve="MyIntentionMenuProducer" />
+          <ref role="3uigEE" to="ih8q:2jDew64JcPx" resolve="ActionIntentionMenuProducer" />
         </node>
       </node>
       <node concept="37vLTG" id="1NzaUygEoFu" role="3clF46">
@@ -537,7 +553,7 @@
       <node concept="37vLTG" id="1NzaUygEqcy" role="3clF46">
         <property role="TrG5h" value="producer" />
         <node concept="3uibUv" id="1NzaUygEqcz" role="1tU5fm">
-          <ref role="3uigEE" to="ih8q:2jDew64JcPx" resolve="MyIntentionMenuProducer" />
+          <ref role="3uigEE" to="ih8q:2jDew64JcPx" resolve="ActionIntentionMenuProducer" />
         </node>
       </node>
       <node concept="37vLTG" id="1NzaUygEqc$" role="3clF46">
@@ -555,6 +571,87 @@
   <node concept="1lH9Xt" id="7b8v2ss1_wP">
     <property role="3DII0k" value="2hh8MJdVwqX/command" />
     <property role="TrG5h" value="GroupAnnotations" />
+    <node concept="1qefOq" id="24lzbKWiNzO" role="1SKRRt">
+      <node concept="2S6QgY" id="24lzbKWjFBL" role="1qenE9">
+        <property role="TrG5h" value="Intention" />
+        <ref role="2ZfgGC" to="tpck:gw2VY9q" resolve="BaseConcept" />
+        <node concept="2S6ZIM" id="24lzbKWjUdo" role="2ZfVej">
+          <node concept="3clFbS" id="24lzbKWjUdp" role="2VODD2">
+            <node concept="3clFbF" id="24lzbKWjUu8" role="3cqZAp">
+              <node concept="Xl_RD" id="24lzbKWjUu7" role="3clFbG">
+                <property role="Xl_RC" value="Intention" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2Sbjvc" id="24lzbKWjUty" role="2ZfgGD">
+          <node concept="3clFbS" id="24lzbKWjUtz" role="2VODD2" />
+        </node>
+        <node concept="3xLA65" id="38Yx6hD0u_f" role="lGtFl">
+          <property role="TrG5h" value="intention" />
+        </node>
+        <node concept="1SWQZ3" id="38Yx6hD0u_i" role="lGtFl">
+          <property role="1SWRpm" value="group" />
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="24lzbKWkloz" role="1SKRRt">
+      <node concept="2S6QgY" id="24lzbKWkq4P" role="1qenE9">
+        <property role="TrG5h" value="Intention" />
+        <ref role="2ZfgGC" to="tpck:gw2VY9q" resolve="BaseConcept" />
+        <node concept="2S6ZIM" id="24lzbKWkq4Q" role="2ZfVej">
+          <node concept="3clFbS" id="24lzbKWkq4R" role="2VODD2">
+            <node concept="3clFbF" id="38Yx6hD40GL" role="3cqZAp">
+              <node concept="3cpWs3" id="38Yx6hD3ix1" role="3clFbG">
+                <node concept="Xl_RD" id="38Yx6hD3ix2" role="3uHU7B">
+                  <property role="Xl_RC" value="group: " />
+                </node>
+                <node concept="1eOMI4" id="38Yx6hD3ix3" role="3uHU7w">
+                  <node concept="Xl_RD" id="38Yx6hD3ix4" role="1eOMHV">
+                    <property role="Xl_RC" value="Intention" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2Sbjvc" id="24lzbKWkq4U" role="2ZfgGD">
+          <node concept="3clFbS" id="24lzbKWkq4V" role="2VODD2" />
+        </node>
+        <node concept="3xLA65" id="24lzbKWkq60" role="lGtFl">
+          <property role="TrG5h" value="generatedIntention" />
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="24lzbKWjUuZ" role="1SKRRt">
+      <node concept="sE7Ow" id="24lzbKWk0Mi" role="1qenE9">
+        <property role="1rBW0U" value="true" />
+        <property role="TrG5h" value="Action" />
+        <property role="2uzpH1" value="Action" />
+        <node concept="tnohg" id="24lzbKWk7zD" role="tncku">
+          <node concept="3clFbS" id="24lzbKWk7zE" role="2VODD2" />
+        </node>
+        <node concept="3xLA65" id="38Yx6hD0LOx" role="lGtFl">
+          <property role="TrG5h" value="action" />
+        </node>
+        <node concept="1SWQZ3" id="38Yx6hD0LPG" role="lGtFl">
+          <property role="1SWRpm" value="group" />
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="24lzbKWkq63" role="1SKRRt">
+      <node concept="sE7Ow" id="24lzbKWkq64" role="1qenE9">
+        <property role="1rBW0U" value="true" />
+        <property role="TrG5h" value="Action" />
+        <property role="2uzpH1" value="group: Action" />
+        <node concept="tnohg" id="24lzbKWkq65" role="tncku">
+          <node concept="3clFbS" id="24lzbKWkq66" role="2VODD2" />
+        </node>
+        <node concept="3xLA65" id="24lzbKWkq67" role="lGtFl">
+          <property role="TrG5h" value="generatedAction" />
+        </node>
+      </node>
+    </node>
     <node concept="2XrIbr" id="7b8v2sshaES" role="1qtyYc">
       <property role="TrG5h" value="createAction" />
       <node concept="3uibUv" id="7b8v2sshaYd" role="3clF45">
@@ -712,6 +809,36 @@
         <node concept="17QB3L" id="7b8v2sshb2h" role="1tU5fm" />
       </node>
     </node>
+    <node concept="1LZb2c" id="24lzbKWiIOS" role="1SL9yI">
+      <property role="TrG5h" value="AnnotationStripping" />
+      <node concept="3cqZAl" id="24lzbKWiIOT" role="3clF45" />
+      <node concept="3clFbS" id="24lzbKWiIOX" role="3clF47">
+        <node concept="3GXo0L" id="24lzbKWkCJS" role="3cqZAp">
+          <node concept="3xONca" id="24lzbKWkHEC" role="3tpDZB">
+            <ref role="3xOPvv" node="24lzbKWkq60" resolve="generatedIntention" />
+          </node>
+          <node concept="2YIFZM" id="24lzbKWkMLE" role="3tpDZA">
+            <ref role="37wK5l" to="9j2l:24lzbKWhSQ3" resolve="updateIntention" />
+            <ref role="1Pybhc" to="9j2l:24lzbKWhRGV" resolve="DescriptionUpdater" />
+            <node concept="3xONca" id="38Yx6hD0E_F" role="37wK5m">
+              <ref role="3xOPvv" node="38Yx6hD0u_f" resolve="intention" />
+            </node>
+          </node>
+        </node>
+        <node concept="3GXo0L" id="24lzbKWl2YG" role="3cqZAp">
+          <node concept="3xONca" id="24lzbKWl2YH" role="3tpDZB">
+            <ref role="3xOPvv" node="24lzbKWkq67" resolve="generatedAction" />
+          </node>
+          <node concept="2YIFZM" id="24lzbKWleFG" role="3tpDZA">
+            <ref role="37wK5l" to="9j2l:24lzbKWk9jN" resolve="updateAction" />
+            <ref role="1Pybhc" to="9j2l:24lzbKWhRGV" resolve="DescriptionUpdater" />
+            <node concept="3xONca" id="38Yx6hD0MEk" role="37wK5m">
+              <ref role="3xOPvv" node="38Yx6hD0LOx" resolve="action" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
     <node concept="1LZb2c" id="7b8v2ss900p" role="1SL9yI">
       <property role="TrG5h" value="grouping" />
       <node concept="3cqZAl" id="7b8v2ss900q" role="3clF45" />
@@ -751,12 +878,12 @@
           <node concept="3cpWsn" id="7b8v2ss902Y" role="3cpWs9">
             <property role="TrG5h" value="producer" />
             <node concept="3uibUv" id="7b8v2ss902Z" role="1tU5fm">
-              <ref role="3uigEE" to="ih8q:2jDew64JcPx" resolve="MyIntentionMenuProducer" />
+              <ref role="3uigEE" node="6ob0HsMSh9f" resolve="TestActionIntentionMenuProducer" />
             </node>
             <node concept="2ShNRf" id="7b8v2ss903a" role="33vP2m">
               <node concept="1pGfFk" id="7b8v2ss94Rx" role="2ShVmc">
                 <property role="373rjd" value="true" />
-                <ref role="37wK5l" to="ih8q:2jDew64KaGG" resolve="MyIntentionMenuProducer" />
+                <ref role="37wK5l" node="6ob0HsMSnxV" resolve="TestActionIntentionMenuProducer" />
                 <node concept="37vLTw" id="7b8v2ss99TH" role="37wK5m">
                   <ref role="3cqZAo" node="7b8v2ss96Tq" resolve="component" />
                 </node>
@@ -784,25 +911,15 @@
           <node concept="3cpWsn" id="7b8v2ssbhSs" role="3cpWs9">
             <property role="TrG5h" value="groups" />
             <node concept="3uibUv" id="7b8v2ssbhSp" role="1tU5fm">
-              <ref role="3uigEE" to="33ny:~TreeMap" resolve="TreeMap" />
+              <ref role="3uigEE" to="3o3z:~Multimap" resolve="Multimap" />
               <node concept="17QB3L" id="7b8v2ssbia0" role="11_B2D" />
-              <node concept="_YKpA" id="7b8v2ssgUND" role="11_B2D">
-                <node concept="3uibUv" id="7b8v2ssgURd" role="_ZDj9">
-                  <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
-                </node>
+              <node concept="3uibUv" id="2H0U9nspwjs" role="11_B2D">
+                <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
               </node>
             </node>
-            <node concept="2ShNRf" id="7b8v2ssgYoP" role="33vP2m">
-              <node concept="1pGfFk" id="7b8v2ssgYBm" role="2ShVmc">
-                <property role="373rjd" value="true" />
-                <ref role="37wK5l" to="33ny:~TreeMap.&lt;init&gt;()" resolve="TreeMap" />
-                <node concept="17QB3L" id="7b8v2ssgYGo" role="1pMfVU" />
-                <node concept="_YKpA" id="7b8v2ssgZ2K" role="1pMfVU">
-                  <node concept="3uibUv" id="7b8v2ssgZeY" role="_ZDj9">
-                    <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
-                  </node>
-                </node>
-              </node>
+            <node concept="2YIFZM" id="4rzEAhztDk9" role="33vP2m">
+              <ref role="37wK5l" to="3o3z:~HashMultimap.create()" resolve="create" />
+              <ref role="1Pybhc" to="3o3z:~HashMultimap" resolve="HashMultimap" />
             </node>
           </node>
         </node>
@@ -812,7 +929,7 @@
               <ref role="3cqZAo" node="7b8v2ssbhSs" resolve="groups" />
             </node>
             <node concept="liA8E" id="7b8v2ssh6l1" role="2OqNvi">
-              <ref role="37wK5l" to="33ny:~TreeMap.put(java.lang.Object,java.lang.Object)" resolve="put" />
+              <ref role="37wK5l" to="3o3z:~Multimap.putAll(java.lang.Object,java.lang.Iterable)" resolve="putAll" />
               <node concept="Xl_RD" id="7b8v2ssh6EJ" role="37wK5m" />
               <node concept="2OqwBi" id="7b8v2sshjMX" role="37wK5m">
                 <node concept="2OqwBi" id="7b8v2sshid_" role="2Oq$k0">
@@ -866,7 +983,7 @@
               <ref role="3cqZAo" node="7b8v2ssbhSs" resolve="groups" />
             </node>
             <node concept="liA8E" id="7b8v2sshytb" role="2OqNvi">
-              <ref role="37wK5l" to="33ny:~TreeMap.put(java.lang.Object,java.lang.Object)" resolve="put" />
+              <ref role="37wK5l" to="3o3z:~Multimap.putAll(java.lang.Object,java.lang.Iterable)" resolve="putAll" />
               <node concept="Xl_RD" id="7b8v2sshytc" role="37wK5m">
                 <property role="Xl_RC" value="Z" />
               </node>
@@ -928,7 +1045,7 @@
               <ref role="3cqZAo" node="7b8v2ssbhSs" resolve="groups" />
             </node>
             <node concept="liA8E" id="7b8v2ssh_ll" role="2OqNvi">
-              <ref role="37wK5l" to="33ny:~TreeMap.put(java.lang.Object,java.lang.Object)" resolve="put" />
+              <ref role="37wK5l" to="3o3z:~Multimap.putAll(java.lang.Object,java.lang.Iterable)" resolve="putAll" />
               <node concept="Xl_RD" id="7b8v2sshCUE" role="37wK5m">
                 <property role="Xl_RC" value="X" />
               </node>
@@ -990,7 +1107,7 @@
               <ref role="3cqZAo" node="7b8v2ss902Y" resolve="producer" />
             </node>
             <node concept="liA8E" id="7b8v2ssbd24" role="2OqNvi">
-              <ref role="37wK5l" to="ih8q:4yZHsKxNkJT" resolve="populateMainMenu" />
+              <ref role="37wK5l" node="4yZHsKxNkJT" resolve="testPopulateMainMenu" />
               <node concept="37vLTw" id="7b8v2sshmP2" role="37wK5m">
                 <ref role="3cqZAo" node="7b8v2ssbdcP" resolve="mainGroup" />
               </node>
@@ -1362,12 +1479,12 @@
           <node concept="3cpWsn" id="7b8v2ssnHRZ" role="3cpWs9">
             <property role="TrG5h" value="producer" />
             <node concept="3uibUv" id="7b8v2ssnHS0" role="1tU5fm">
-              <ref role="3uigEE" to="ih8q:2jDew64JcPx" resolve="MyIntentionMenuProducer" />
+              <ref role="3uigEE" to="ih8q:2jDew64JcPx" resolve="ActionIntentionMenuProducer" />
             </node>
             <node concept="2ShNRf" id="7b8v2ssnHS1" role="33vP2m">
               <node concept="1pGfFk" id="7b8v2ssnHS2" role="2ShVmc">
                 <property role="373rjd" value="true" />
-                <ref role="37wK5l" to="ih8q:2jDew64KaGG" resolve="MyIntentionMenuProducer" />
+                <ref role="37wK5l" to="ih8q:2jDew64KaGG" resolve="ActionIntentionMenuProducer" />
                 <node concept="37vLTw" id="7b8v2ssnHS3" role="37wK5m">
                   <ref role="3cqZAo" node="7b8v2ssnHRT" resolve="component" />
                 </node>
@@ -1507,12 +1624,12 @@
           <node concept="3cpWsn" id="7b8v2sspUD1" role="3cpWs9">
             <property role="TrG5h" value="producer" />
             <node concept="3uibUv" id="7b8v2sspUD2" role="1tU5fm">
-              <ref role="3uigEE" to="ih8q:2jDew64JcPx" resolve="MyIntentionMenuProducer" />
+              <ref role="3uigEE" node="6ob0HsMSh9f" resolve="TestActionIntentionMenuProducer" />
             </node>
             <node concept="2ShNRf" id="7b8v2sspUD3" role="33vP2m">
               <node concept="1pGfFk" id="7b8v2sspUD4" role="2ShVmc">
                 <property role="373rjd" value="true" />
-                <ref role="37wK5l" to="ih8q:2jDew64KaGG" resolve="MyIntentionMenuProducer" />
+                <ref role="37wK5l" node="6ob0HsMSnxV" resolve="TestActionIntentionMenuProducer" />
                 <node concept="37vLTw" id="7b8v2sspUD5" role="37wK5m">
                   <ref role="3cqZAo" node="7b8v2sspUCV" resolve="component" />
                 </node>
@@ -1586,7 +1703,7 @@
               <ref role="3cqZAo" node="7b8v2sspUD1" resolve="producer" />
             </node>
             <node concept="liA8E" id="7b8v2sswvgq" role="2OqNvi">
-              <ref role="37wK5l" to="ih8q:lMPJvi802g" resolve="substituteAction" />
+              <ref role="37wK5l" node="lMPJvi802g" resolve="testSubstituteAction" />
               <node concept="37vLTw" id="7b8v2sswXsd" role="37wK5m">
                 <ref role="3cqZAo" node="7b8v2sswXkE" resolve="baseGroup" />
               </node>
@@ -1600,18 +1717,34 @@
           </node>
         </node>
         <node concept="3clFbH" id="7b8v2ssydXp" role="3cqZAp" />
-        <node concept="3vwNmj" id="7b8v2ssyei1" role="3cqZAp">
-          <node concept="2OqwBi" id="7b8v2ssygcu" role="3vwVQn">
-            <node concept="2OqwBi" id="7b8v2ssyf5N" role="2Oq$k0">
-              <node concept="37vLTw" id="7b8v2ssyeWx" role="2Oq$k0">
-                <ref role="3cqZAo" node="7b8v2sspUD1" resolve="producer" />
-              </node>
-              <node concept="SiP3y" id="7b8v2ssyfn6" role="2OqNvi">
-                <ref role="3cqZAo" to="ih8q:5Rdndlpp80A" resolve="groupedActionsCache" />
+        <node concept="3cpWs8" id="2H0U9nrXQwn" role="3cqZAp">
+          <node concept="3cpWsn" id="2H0U9nrXQwo" role="3cpWs9">
+            <property role="TrG5h" value="cache" />
+            <node concept="3uibUv" id="2H0U9nrXNe4" role="1tU5fm">
+              <ref role="3uigEE" to="3o3z:~SetMultimap" resolve="SetMultimap" />
+              <node concept="17QB3L" id="2H0U9nrXNe9" role="11_B2D" />
+              <node concept="3uibUv" id="2H0U9nrXNea" role="11_B2D">
+                <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
               </node>
             </node>
-            <node concept="2Nt0df" id="7b8v2ssyipY" role="2OqNvi">
-              <node concept="37vLTw" id="7b8v2ssyivw" role="38cxEo">
+            <node concept="2OqwBi" id="2H0U9nrXQwp" role="33vP2m">
+              <node concept="37vLTw" id="2H0U9nrXQwq" role="2Oq$k0">
+                <ref role="3cqZAo" node="7b8v2sspUD1" resolve="producer" />
+              </node>
+              <node concept="liA8E" id="2H0U9nrXQwr" role="2OqNvi">
+                <ref role="37wK5l" to="ih8q:6ob0HsML7OT" resolve="getCache" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vwNmj" id="7b8v2ssyei1" role="3cqZAp">
+          <node concept="2OqwBi" id="7b8v2ssygcu" role="3vwVQn">
+            <node concept="37vLTw" id="2H0U9nrXQws" role="2Oq$k0">
+              <ref role="3cqZAo" node="2H0U9nrXQwo" resolve="cache" />
+            </node>
+            <node concept="liA8E" id="2H0U9nrXXau" role="2OqNvi">
+              <ref role="37wK5l" to="3o3z:~Multimap.containsKey(java.lang.Object)" resolve="containsKey" />
+              <node concept="37vLTw" id="2H0U9nrXXrU" role="37wK5m">
                 <ref role="3cqZAo" node="7b8v2ssxtRZ" resolve="groupName" />
               </node>
             </node>
@@ -1626,24 +1759,29 @@
               <ref role="37wK5l" to="qkt:~AnAction.toString()" resolve="toString" />
             </node>
           </node>
-          <node concept="2OqwBi" id="7b8v2ssziMS" role="3tpDZA">
-            <node concept="2OqwBi" id="7b8v2ssyuHP" role="2Oq$k0">
-              <node concept="3EllGN" id="7b8v2ssyppn" role="2Oq$k0">
-                <node concept="37vLTw" id="7b8v2ssypz2" role="3ElVtu">
-                  <ref role="3cqZAo" node="7b8v2ssxtRZ" resolve="groupName" />
+          <node concept="2OqwBi" id="2H0U9nrYoRU" role="3tpDZA">
+            <node concept="2OqwBi" id="2H0U9nrYjWE" role="2Oq$k0">
+              <node concept="2OqwBi" id="2H0U9nrYg64" role="2Oq$k0">
+                <node concept="2OqwBi" id="2H0U9nrY8mg" role="2Oq$k0">
+                  <node concept="37vLTw" id="2H0U9nrY30F" role="2Oq$k0">
+                    <ref role="3cqZAo" node="2H0U9nrXQwo" resolve="cache" />
+                  </node>
+                  <node concept="liA8E" id="2H0U9nrY92O" role="2OqNvi">
+                    <ref role="37wK5l" to="3o3z:~SetMultimap.get(java.lang.Object)" resolve="get" />
+                    <node concept="37vLTw" id="2H0U9nrY9mm" role="37wK5m">
+                      <ref role="3cqZAo" node="7b8v2ssxtRZ" resolve="groupName" />
+                    </node>
+                  </node>
                 </node>
-                <node concept="2OqwBi" id="7b8v2ssyoij" role="3ElQJh">
-                  <node concept="37vLTw" id="7b8v2ssyls4" role="2Oq$k0">
-                    <ref role="3cqZAo" node="7b8v2sspUD1" resolve="producer" />
-                  </node>
-                  <node concept="SiP3y" id="7b8v2ssyo$x" role="2OqNvi">
-                    <ref role="3cqZAo" to="ih8q:5Rdndlpp80A" resolve="groupedActionsCache" />
-                  </node>
+                <node concept="liA8E" id="2H0U9nrYhAy" role="2OqNvi">
+                  <ref role="37wK5l" to="33ny:~Set.iterator()" resolve="iterator" />
                 </node>
               </node>
-              <node concept="1uHKPH" id="7b8v2ssyvSB" role="2OqNvi" />
+              <node concept="liA8E" id="2H0U9nrYo1O" role="2OqNvi">
+                <ref role="37wK5l" to="33ny:~Iterator.next()" resolve="next" />
+              </node>
             </node>
-            <node concept="liA8E" id="7b8v2sszj5_" role="2OqNvi">
+            <node concept="liA8E" id="2H0U9nrYpWp" role="2OqNvi">
               <ref role="37wK5l" to="qkt:~AnAction.toString()" resolve="toString" />
             </node>
           </node>
@@ -1758,12 +1896,12 @@
           <node concept="3cpWsn" id="7b8v2ss$Qo5" role="3cpWs9">
             <property role="TrG5h" value="producer" />
             <node concept="3uibUv" id="7b8v2ss$Qo6" role="1tU5fm">
-              <ref role="3uigEE" to="ih8q:2jDew64JcPx" resolve="MyIntentionMenuProducer" />
+              <ref role="3uigEE" to="ih8q:2jDew64JcPx" resolve="ActionIntentionMenuProducer" />
             </node>
             <node concept="2ShNRf" id="7b8v2ss$Qo7" role="33vP2m">
               <node concept="1pGfFk" id="7b8v2ss$Qo8" role="2ShVmc">
                 <property role="373rjd" value="true" />
-                <ref role="37wK5l" to="ih8q:2jDew64KaGG" resolve="MyIntentionMenuProducer" />
+                <ref role="37wK5l" to="ih8q:2jDew64KaGG" resolve="ActionIntentionMenuProducer" />
                 <node concept="37vLTw" id="7b8v2ss$Qo9" role="37wK5m">
                   <ref role="3cqZAo" node="7b8v2ss$QnZ" resolve="component" />
                 </node>
@@ -1848,25 +1986,15 @@
           <node concept="3cpWsn" id="7b8v2ss_Lg3" role="3cpWs9">
             <property role="TrG5h" value="expectedGroups" />
             <node concept="3uibUv" id="7b8v2ss_Lg4" role="1tU5fm">
-              <ref role="3uigEE" to="33ny:~TreeMap" resolve="TreeMap" />
+              <ref role="3uigEE" to="3o3z:~Multimap" resolve="Multimap" />
               <node concept="17QB3L" id="7b8v2ss_Lg5" role="11_B2D" />
-              <node concept="_YKpA" id="7b8v2ss_Lg6" role="11_B2D">
-                <node concept="3uibUv" id="7b8v2ss_Lg7" role="_ZDj9">
-                  <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
-                </node>
+              <node concept="3uibUv" id="2H0U9nsq_Y7" role="11_B2D">
+                <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
               </node>
             </node>
-            <node concept="2ShNRf" id="7b8v2ss_Lg8" role="33vP2m">
-              <node concept="1pGfFk" id="7b8v2ss_Lg9" role="2ShVmc">
-                <property role="373rjd" value="true" />
-                <ref role="37wK5l" to="33ny:~TreeMap.&lt;init&gt;()" resolve="TreeMap" />
-                <node concept="17QB3L" id="7b8v2ss_Lga" role="1pMfVU" />
-                <node concept="_YKpA" id="7b8v2ss_Lgb" role="1pMfVU">
-                  <node concept="3uibUv" id="7b8v2ss_Lgc" role="_ZDj9">
-                    <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
-                  </node>
-                </node>
-              </node>
+            <node concept="2YIFZM" id="2H0U9nsqmGJ" role="33vP2m">
+              <ref role="37wK5l" to="3o3z:~ArrayListMultimap.create()" resolve="create" />
+              <ref role="1Pybhc" to="3o3z:~ArrayListMultimap" resolve="ArrayListMultimap" />
             </node>
           </node>
         </node>
@@ -1876,27 +2004,17 @@
               <ref role="3cqZAo" node="7b8v2ss_Lg3" resolve="expectedGroups" />
             </node>
             <node concept="liA8E" id="7b8v2ss_UJ1" role="2OqNvi">
-              <ref role="37wK5l" to="33ny:~TreeMap.put(java.lang.Object,java.lang.Object)" resolve="put" />
+              <ref role="37wK5l" to="3o3z:~Multimap.put(java.lang.Object,java.lang.Object)" resolve="put" />
               <node concept="Xl_RD" id="7b8v2ss_Vtx" role="37wK5m" />
-              <node concept="2OqwBi" id="7b8v2ssAaPO" role="37wK5m">
-                <node concept="2ShNRf" id="7b8v2ssA3mf" role="2Oq$k0">
-                  <node concept="2HTt$P" id="7b8v2ssA42O" role="2ShVmc">
-                    <node concept="3uibUv" id="7b8v2ssA4Bu" role="2HTBi0">
-                      <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
-                    </node>
-                    <node concept="2OqwBi" id="7b8v2ssAUKa" role="2HTEbv">
-                      <node concept="37vLTw" id="7b8v2ssASWy" role="2Oq$k0">
-                        <ref role="3cqZAo" node="7b8v2ss_kzc" resolve="actions" />
-                      </node>
-                      <node concept="34jXtK" id="7b8v2ssAWBZ" role="2OqNvi">
-                        <node concept="3cmrfG" id="7b8v2ssAXcS" role="25WWJ7">
-                          <property role="3cmrfH" value="0" />
-                        </node>
-                      </node>
-                    </node>
+              <node concept="2OqwBi" id="7b8v2ssAUKa" role="37wK5m">
+                <node concept="37vLTw" id="7b8v2ssASWy" role="2Oq$k0">
+                  <ref role="3cqZAo" node="7b8v2ss_kzc" resolve="actions" />
+                </node>
+                <node concept="34jXtK" id="7b8v2ssAWBZ" role="2OqNvi">
+                  <node concept="3cmrfG" id="7b8v2ssAXcS" role="25WWJ7">
+                    <property role="3cmrfH" value="0" />
                   </node>
                 </node>
-                <node concept="ANE8D" id="7b8v2ssAcpn" role="2OqNvi" />
               </node>
             </node>
           </node>
@@ -1907,29 +2025,19 @@
               <ref role="3cqZAo" node="7b8v2ss_Lg3" resolve="expectedGroups" />
             </node>
             <node concept="liA8E" id="7b8v2ssAfxB" role="2OqNvi">
-              <ref role="37wK5l" to="33ny:~TreeMap.put(java.lang.Object,java.lang.Object)" resolve="put" />
+              <ref role="37wK5l" to="3o3z:~Multimap.put(java.lang.Object,java.lang.Object)" resolve="put" />
               <node concept="Xl_RD" id="7b8v2ssAfxC" role="37wK5m">
                 <property role="Xl_RC" value="X" />
               </node>
-              <node concept="2OqwBi" id="7b8v2ssAfxD" role="37wK5m">
-                <node concept="2ShNRf" id="7b8v2ssAfxE" role="2Oq$k0">
-                  <node concept="2HTt$P" id="7b8v2ssAfxF" role="2ShVmc">
-                    <node concept="3uibUv" id="7b8v2ssAfxG" role="2HTBi0">
-                      <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
-                    </node>
-                    <node concept="2OqwBi" id="7b8v2ssB1fJ" role="2HTEbv">
-                      <node concept="37vLTw" id="7b8v2ssB1fK" role="2Oq$k0">
-                        <ref role="3cqZAo" node="7b8v2ss_kzc" resolve="actions" />
-                      </node>
-                      <node concept="34jXtK" id="7b8v2ssB1fL" role="2OqNvi">
-                        <node concept="3cmrfG" id="7b8v2ssB1fM" role="25WWJ7">
-                          <property role="3cmrfH" value="1" />
-                        </node>
-                      </node>
-                    </node>
+              <node concept="2OqwBi" id="7b8v2ssB1fJ" role="37wK5m">
+                <node concept="37vLTw" id="7b8v2ssB1fK" role="2Oq$k0">
+                  <ref role="3cqZAo" node="7b8v2ss_kzc" resolve="actions" />
+                </node>
+                <node concept="34jXtK" id="7b8v2ssB1fL" role="2OqNvi">
+                  <node concept="3cmrfG" id="7b8v2ssB1fM" role="25WWJ7">
+                    <property role="3cmrfH" value="1" />
                   </node>
                 </node>
-                <node concept="ANE8D" id="7b8v2ssAfxM" role="2OqNvi" />
               </node>
             </node>
           </node>
@@ -1940,29 +2048,19 @@
               <ref role="3cqZAo" node="7b8v2ss_Lg3" resolve="expectedGroups" />
             </node>
             <node concept="liA8E" id="7b8v2ssAhZm" role="2OqNvi">
-              <ref role="37wK5l" to="33ny:~TreeMap.put(java.lang.Object,java.lang.Object)" resolve="put" />
+              <ref role="37wK5l" to="3o3z:~Multimap.put(java.lang.Object,java.lang.Object)" resolve="put" />
               <node concept="Xl_RD" id="7b8v2ssAhZn" role="37wK5m">
                 <property role="Xl_RC" value="Z" />
               </node>
-              <node concept="2OqwBi" id="7b8v2ssAhZo" role="37wK5m">
-                <node concept="2ShNRf" id="7b8v2ssAhZp" role="2Oq$k0">
-                  <node concept="2HTt$P" id="7b8v2ssAhZq" role="2ShVmc">
-                    <node concept="3uibUv" id="7b8v2ssAhZr" role="2HTBi0">
-                      <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
-                    </node>
-                    <node concept="2OqwBi" id="7b8v2ssB2G0" role="2HTEbv">
-                      <node concept="37vLTw" id="7b8v2ssB2G1" role="2Oq$k0">
-                        <ref role="3cqZAo" node="7b8v2ss_kzc" resolve="actions" />
-                      </node>
-                      <node concept="34jXtK" id="7b8v2ssB2G2" role="2OqNvi">
-                        <node concept="3cmrfG" id="7b8v2ssB2G3" role="25WWJ7">
-                          <property role="3cmrfH" value="2" />
-                        </node>
-                      </node>
-                    </node>
+              <node concept="2OqwBi" id="7b8v2ssB2G0" role="37wK5m">
+                <node concept="37vLTw" id="7b8v2ssB2G1" role="2Oq$k0">
+                  <ref role="3cqZAo" node="7b8v2ss_kzc" resolve="actions" />
+                </node>
+                <node concept="34jXtK" id="7b8v2ssB2G2" role="2OqNvi">
+                  <node concept="3cmrfG" id="7b8v2ssB2G3" role="25WWJ7">
+                    <property role="3cmrfH" value="2" />
                   </node>
                 </node>
-                <node concept="ANE8D" id="7b8v2ssAhZx" role="2OqNvi" />
               </node>
             </node>
           </node>
@@ -2030,12 +2128,12 @@
           <node concept="3cpWsn" id="7b8v2ssBd1i" role="3cpWs9">
             <property role="TrG5h" value="producer" />
             <node concept="3uibUv" id="7b8v2ssBd1j" role="1tU5fm">
-              <ref role="3uigEE" to="ih8q:2jDew64JcPx" resolve="MyIntentionMenuProducer" />
+              <ref role="3uigEE" to="ih8q:2jDew64JcPx" resolve="ActionIntentionMenuProducer" />
             </node>
             <node concept="2ShNRf" id="7b8v2ssBd1k" role="33vP2m">
               <node concept="1pGfFk" id="7b8v2ssBd1l" role="2ShVmc">
                 <property role="373rjd" value="true" />
-                <ref role="37wK5l" to="ih8q:2jDew64KaGG" resolve="MyIntentionMenuProducer" />
+                <ref role="37wK5l" to="ih8q:2jDew64KaGG" resolve="ActionIntentionMenuProducer" />
                 <node concept="37vLTw" id="7b8v2ssBd1m" role="37wK5m">
                   <ref role="3cqZAo" node="7b8v2ssBd1c" resolve="component" />
                 </node>
@@ -2061,47 +2159,48 @@
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="7b8v2ssDNu3" role="3cqZAp">
-          <node concept="2OqwBi" id="7b8v2ssDQcz" role="3clFbG">
-            <node concept="2OqwBi" id="7b8v2ssDNVc" role="2Oq$k0">
-              <node concept="37vLTw" id="7b8v2ssDNu1" role="2Oq$k0">
+        <node concept="3cpWs8" id="2H0U9nrXbgF" role="3cqZAp">
+          <node concept="3cpWsn" id="2H0U9nrXbgG" role="3cpWs9">
+            <property role="TrG5h" value="cache" />
+            <node concept="3uibUv" id="2H0U9nrX8li" role="1tU5fm">
+              <ref role="3uigEE" to="3o3z:~SetMultimap" resolve="SetMultimap" />
+              <node concept="17QB3L" id="2H0U9nrX8lo" role="11_B2D" />
+              <node concept="3uibUv" id="2H0U9nrX8ln" role="11_B2D">
+                <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="2H0U9nrXbgH" role="33vP2m">
+              <node concept="37vLTw" id="2H0U9nrXbgI" role="2Oq$k0">
                 <ref role="3cqZAo" node="7b8v2ssBd1i" resolve="producer" />
               </node>
-              <node concept="SiP3y" id="7b8v2ssDP7s" role="2OqNvi">
-                <ref role="3cqZAo" to="ih8q:5Rdndlpp80A" resolve="groupedActionsCache" />
+              <node concept="liA8E" id="2H0U9nrXbgJ" role="2OqNvi">
+                <ref role="37wK5l" to="ih8q:6ob0HsML7OT" resolve="getCache" />
               </node>
             </node>
-            <node concept="1yHZxX" id="7b8v2ssDS5L" role="2OqNvi" />
           </node>
         </node>
-        <node concept="3clFbF" id="7b8v2ssBl$J" role="3cqZAp">
-          <node concept="37vLTI" id="7b8v2ssBAKL" role="3clFbG">
-            <node concept="3EllGN" id="7b8v2ssBpfj" role="37vLTJ">
-              <node concept="Xl_RD" id="7b8v2ssB$yb" role="3ElVtu" />
-              <node concept="2OqwBi" id="7b8v2ssBlYb" role="3ElQJh">
-                <node concept="37vLTw" id="7b8v2ssBl$H" role="2Oq$k0">
-                  <ref role="3cqZAo" node="7b8v2ssBd1i" resolve="producer" />
-                </node>
-                <node concept="SiP3y" id="7b8v2ssBnJn" role="2OqNvi">
-                  <ref role="3cqZAo" to="ih8q:5Rdndlpp80A" resolve="groupedActionsCache" />
-                </node>
-              </node>
+        <node concept="3clFbF" id="7b8v2ssDNu3" role="3cqZAp">
+          <node concept="2OqwBi" id="7b8v2ssDQcz" role="3clFbG">
+            <node concept="37vLTw" id="2H0U9nrXbgK" role="2Oq$k0">
+              <ref role="3cqZAo" node="2H0U9nrXbgG" resolve="cache" />
             </node>
-            <node concept="2ShNRf" id="7b8v2ssBJu2" role="37vLTx">
-              <node concept="2i4dXS" id="7b8v2ssBKtU" role="2ShVmc">
-                <node concept="3uibUv" id="7b8v2ssBL7N" role="HW$YZ">
-                  <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
-                </node>
-                <node concept="2ShNRf" id="7b8v2ssBAKP" role="I$8f6">
-                  <node concept="2HTt$P" id="7b8v2ssBAKQ" role="2ShVmc">
-                    <node concept="3uibUv" id="7b8v2ssBAKR" role="2HTBi0">
-                      <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
-                    </node>
-                    <node concept="37vLTw" id="7b8v2ssBCTT" role="2HTEbv">
-                      <ref role="3cqZAo" node="7b8v2ssBsg4" resolve="existingAction" />
-                    </node>
-                  </node>
-                </node>
+            <node concept="liA8E" id="2H0U9nrX4R_" role="2OqNvi">
+              <ref role="37wK5l" to="3o3z:~Multimap.clear()" resolve="clear" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="2H0U9nrXsMY" role="3cqZAp">
+          <node concept="2OqwBi" id="2H0U9nrXuiJ" role="3clFbG">
+            <node concept="37vLTw" id="2H0U9nrXsMW" role="2Oq$k0">
+              <ref role="3cqZAo" node="2H0U9nrXbgG" resolve="cache" />
+            </node>
+            <node concept="liA8E" id="2H0U9nrXvvI" role="2OqNvi">
+              <ref role="37wK5l" to="3o3z:~Multimap.put(java.lang.Object,java.lang.Object)" resolve="put" />
+              <node concept="Xl_RD" id="2H0U9nrX$DJ" role="37wK5m">
+                <property role="Xl_RC" value="" />
+              </node>
+              <node concept="37vLTw" id="2H0U9nrXH6A" role="37wK5m">
+                <ref role="3cqZAo" node="7b8v2ssBsg4" resolve="existingAction" />
               </node>
             </node>
           </node>
@@ -2183,25 +2282,15 @@
           <node concept="3cpWsn" id="7b8v2ssBd1T" role="3cpWs9">
             <property role="TrG5h" value="expectedGroups" />
             <node concept="3uibUv" id="7b8v2ssBd1U" role="1tU5fm">
-              <ref role="3uigEE" to="33ny:~TreeMap" resolve="TreeMap" />
+              <ref role="3uigEE" to="3o3z:~Multimap" resolve="Multimap" />
               <node concept="17QB3L" id="7b8v2ssBd1V" role="11_B2D" />
-              <node concept="_YKpA" id="7b8v2ssBd1W" role="11_B2D">
-                <node concept="3uibUv" id="7b8v2ssBd1X" role="_ZDj9">
-                  <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
-                </node>
+              <node concept="3uibUv" id="2H0U9nsqLCC" role="11_B2D">
+                <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
               </node>
             </node>
-            <node concept="2ShNRf" id="7b8v2ssBd1Y" role="33vP2m">
-              <node concept="1pGfFk" id="7b8v2ssBd1Z" role="2ShVmc">
-                <property role="373rjd" value="true" />
-                <ref role="37wK5l" to="33ny:~TreeMap.&lt;init&gt;()" resolve="TreeMap" />
-                <node concept="17QB3L" id="7b8v2ssBd20" role="1pMfVU" />
-                <node concept="_YKpA" id="7b8v2ssBd21" role="1pMfVU">
-                  <node concept="3uibUv" id="7b8v2ssBd22" role="_ZDj9">
-                    <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
-                  </node>
-                </node>
-              </node>
+            <node concept="2YIFZM" id="2H0U9nsqQNz" role="33vP2m">
+              <ref role="37wK5l" to="3o3z:~ArrayListMultimap.create()" resolve="create" />
+              <ref role="1Pybhc" to="3o3z:~ArrayListMultimap" resolve="ArrayListMultimap" />
             </node>
           </node>
         </node>
@@ -2259,7 +2348,7 @@
               <ref role="3cqZAo" node="7b8v2ssBd1T" resolve="expectedGroups" />
             </node>
             <node concept="liA8E" id="7b8v2ssBd26" role="2OqNvi">
-              <ref role="37wK5l" to="33ny:~TreeMap.put(java.lang.Object,java.lang.Object)" resolve="put" />
+              <ref role="37wK5l" to="3o3z:~Multimap.putAll(java.lang.Object,java.lang.Iterable)" resolve="putAll" />
               <node concept="Xl_RD" id="7b8v2ssBd27" role="37wK5m" />
               <node concept="37vLTw" id="7b8v2ssCcf3" role="37wK5m">
                 <ref role="3cqZAo" node="7b8v2ssBU1_" resolve="firstActions" />
@@ -2273,29 +2362,19 @@
               <ref role="3cqZAo" node="7b8v2ssBd1T" resolve="expectedGroups" />
             </node>
             <node concept="liA8E" id="7b8v2ssBd2k" role="2OqNvi">
-              <ref role="37wK5l" to="33ny:~TreeMap.put(java.lang.Object,java.lang.Object)" resolve="put" />
+              <ref role="37wK5l" to="3o3z:~Multimap.put(java.lang.Object,java.lang.Object)" resolve="put" />
               <node concept="Xl_RD" id="7b8v2ssBd2l" role="37wK5m">
                 <property role="Xl_RC" value="X" />
               </node>
-              <node concept="2OqwBi" id="7b8v2ssBd2m" role="37wK5m">
-                <node concept="2ShNRf" id="7b8v2ssBd2n" role="2Oq$k0">
-                  <node concept="2HTt$P" id="7b8v2ssBd2o" role="2ShVmc">
-                    <node concept="3uibUv" id="7b8v2ssBd2p" role="2HTBi0">
-                      <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
-                    </node>
-                    <node concept="2OqwBi" id="7b8v2ssBd2q" role="2HTEbv">
-                      <node concept="37vLTw" id="7b8v2ssBd2r" role="2Oq$k0">
-                        <ref role="3cqZAo" node="7b8v2ssBd1u" resolve="actions" />
-                      </node>
-                      <node concept="34jXtK" id="7b8v2ssBd2s" role="2OqNvi">
-                        <node concept="3cmrfG" id="7b8v2ssBd2t" role="25WWJ7">
-                          <property role="3cmrfH" value="1" />
-                        </node>
-                      </node>
-                    </node>
+              <node concept="2OqwBi" id="7b8v2ssBd2q" role="37wK5m">
+                <node concept="37vLTw" id="7b8v2ssBd2r" role="2Oq$k0">
+                  <ref role="3cqZAo" node="7b8v2ssBd1u" resolve="actions" />
+                </node>
+                <node concept="34jXtK" id="7b8v2ssBd2s" role="2OqNvi">
+                  <node concept="3cmrfG" id="7b8v2ssBd2t" role="25WWJ7">
+                    <property role="3cmrfH" value="1" />
                   </node>
                 </node>
-                <node concept="ANE8D" id="7b8v2ssBd2u" role="2OqNvi" />
               </node>
             </node>
           </node>
@@ -2306,29 +2385,19 @@
               <ref role="3cqZAo" node="7b8v2ssBd1T" resolve="expectedGroups" />
             </node>
             <node concept="liA8E" id="7b8v2ssBd2y" role="2OqNvi">
-              <ref role="37wK5l" to="33ny:~TreeMap.put(java.lang.Object,java.lang.Object)" resolve="put" />
+              <ref role="37wK5l" to="3o3z:~Multimap.put(java.lang.Object,java.lang.Object)" resolve="put" />
               <node concept="Xl_RD" id="7b8v2ssBd2z" role="37wK5m">
                 <property role="Xl_RC" value="Z" />
               </node>
-              <node concept="2OqwBi" id="7b8v2ssBd2$" role="37wK5m">
-                <node concept="2ShNRf" id="7b8v2ssBd2_" role="2Oq$k0">
-                  <node concept="2HTt$P" id="7b8v2ssBd2A" role="2ShVmc">
-                    <node concept="3uibUv" id="7b8v2ssBd2B" role="2HTBi0">
-                      <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
-                    </node>
-                    <node concept="2OqwBi" id="7b8v2ssBd2C" role="2HTEbv">
-                      <node concept="37vLTw" id="7b8v2ssBd2D" role="2Oq$k0">
-                        <ref role="3cqZAo" node="7b8v2ssBd1u" resolve="actions" />
-                      </node>
-                      <node concept="34jXtK" id="7b8v2ssBd2E" role="2OqNvi">
-                        <node concept="3cmrfG" id="7b8v2ssBd2F" role="25WWJ7">
-                          <property role="3cmrfH" value="2" />
-                        </node>
-                      </node>
-                    </node>
+              <node concept="2OqwBi" id="7b8v2ssBd2C" role="37wK5m">
+                <node concept="37vLTw" id="7b8v2ssBd2D" role="2Oq$k0">
+                  <ref role="3cqZAo" node="7b8v2ssBd1u" resolve="actions" />
+                </node>
+                <node concept="34jXtK" id="7b8v2ssBd2E" role="2OqNvi">
+                  <node concept="3cmrfG" id="7b8v2ssBd2F" role="25WWJ7">
+                    <property role="3cmrfH" value="2" />
                   </node>
                 </node>
-                <node concept="ANE8D" id="7b8v2ssBd2G" role="2OqNvi" />
               </node>
             </node>
           </node>
@@ -2398,12 +2467,12 @@
           <node concept="3cpWsn" id="7b8v2ssLgb$" role="3cpWs9">
             <property role="TrG5h" value="producer" />
             <node concept="3uibUv" id="7b8v2ssLgb_" role="1tU5fm">
-              <ref role="3uigEE" to="ih8q:2jDew64JcPx" resolve="MyIntentionMenuProducer" />
+              <ref role="3uigEE" node="6ob0HsMSh9f" resolve="TestActionIntentionMenuProducer" />
             </node>
             <node concept="2ShNRf" id="7b8v2ssLgbA" role="33vP2m">
               <node concept="1pGfFk" id="7b8v2ssLgbB" role="2ShVmc">
                 <property role="373rjd" value="true" />
-                <ref role="37wK5l" to="ih8q:2jDew64KaGG" resolve="MyIntentionMenuProducer" />
+                <ref role="37wK5l" node="6ob0HsMSnxV" resolve="TestActionIntentionMenuProducer" />
                 <node concept="37vLTw" id="7b8v2ssLgbC" role="37wK5m">
                   <ref role="3cqZAo" node="7b8v2ssLgbu" resolve="component" />
                 </node>
@@ -2421,7 +2490,7 @@
               <ref role="3cqZAo" node="7b8v2ssLgb$" resolve="producer" />
             </node>
             <node concept="liA8E" id="7b8v2ssLKRd" role="2OqNvi">
-              <ref role="37wK5l" to="ih8q:7b8v2ssFpTf" resolve="trimGroupNameFromActionText" />
+              <ref role="37wK5l" node="7b8v2ssFpTf" resolve="testTrimGroupNameFromActionText" />
               <node concept="2OqwBi" id="7b8v2ssLz_U" role="37wK5m">
                 <node concept="2WthIp" id="7b8v2ssLz_X" role="2Oq$k0" />
                 <node concept="2XshWL" id="7b8v2ssLz_Z" role="2OqNvi">
@@ -2449,7 +2518,7 @@
               <ref role="3cqZAo" node="7b8v2ssLgb$" resolve="producer" />
             </node>
             <node concept="liA8E" id="7b8v2ssLQxJ" role="2OqNvi">
-              <ref role="37wK5l" to="ih8q:7b8v2ssFpTf" resolve="trimGroupNameFromActionText" />
+              <ref role="37wK5l" node="7b8v2ssFpTf" resolve="testTrimGroupNameFromActionText" />
               <node concept="2OqwBi" id="7b8v2ssLQxK" role="37wK5m">
                 <node concept="2WthIp" id="7b8v2ssLQxL" role="2Oq$k0" />
                 <node concept="2XshWL" id="7b8v2ssLQxM" role="2OqNvi">
@@ -2477,7 +2546,7 @@
               <ref role="3cqZAo" node="7b8v2ssLgb$" resolve="producer" />
             </node>
             <node concept="liA8E" id="7b8v2ssLVPe" role="2OqNvi">
-              <ref role="37wK5l" to="ih8q:7b8v2ssFpTf" resolve="trimGroupNameFromActionText" />
+              <ref role="37wK5l" node="7b8v2ssFpTf" resolve="testTrimGroupNameFromActionText" />
               <node concept="2OqwBi" id="7b8v2ssLVPf" role="37wK5m">
                 <node concept="2WthIp" id="7b8v2ssLVPg" role="2Oq$k0" />
                 <node concept="2XshWL" id="7b8v2ssLVPh" role="2OqNvi">
@@ -2500,7 +2569,7 @@
               <ref role="3cqZAo" node="7b8v2ssLgb$" resolve="producer" />
             </node>
             <node concept="liA8E" id="7b8v2ssON8d" role="2OqNvi">
-              <ref role="37wK5l" to="ih8q:7b8v2ssFpTf" resolve="trimGroupNameFromActionText" />
+              <ref role="37wK5l" node="7b8v2ssFpTf" resolve="testTrimGroupNameFromActionText" />
               <node concept="2OqwBi" id="7b8v2ssON8e" role="37wK5m">
                 <node concept="2WthIp" id="7b8v2ssON8f" role="2Oq$k0" />
                 <node concept="2XshWL" id="7b8v2ssON8g" role="2OqNvi">
@@ -2524,7 +2593,7 @@
               <ref role="3cqZAo" node="7b8v2ssLgb$" resolve="producer" />
             </node>
             <node concept="liA8E" id="7b8v2ssON8z" role="2OqNvi">
-              <ref role="37wK5l" to="ih8q:7b8v2ssFpTf" resolve="trimGroupNameFromActionText" />
+              <ref role="37wK5l" node="7b8v2ssFpTf" resolve="testTrimGroupNameFromActionText" />
               <node concept="2OqwBi" id="7b8v2ssON8$" role="37wK5m">
                 <node concept="2WthIp" id="7b8v2ssON8_" role="2Oq$k0" />
                 <node concept="2XshWL" id="7b8v2ssON8A" role="2OqNvi">
@@ -2548,7 +2617,7 @@
               <ref role="3cqZAo" node="7b8v2ssLgb$" resolve="producer" />
             </node>
             <node concept="liA8E" id="7b8v2ssON8I" role="2OqNvi">
-              <ref role="37wK5l" to="ih8q:7b8v2ssFpTf" resolve="trimGroupNameFromActionText" />
+              <ref role="37wK5l" node="7b8v2ssFpTf" resolve="testTrimGroupNameFromActionText" />
               <node concept="2OqwBi" id="7b8v2ssON8J" role="37wK5m">
                 <node concept="2WthIp" id="7b8v2ssON8K" role="2Oq$k0" />
                 <node concept="2XshWL" id="7b8v2ssON8L" role="2OqNvi">
@@ -2564,8 +2633,156 @@
       </node>
     </node>
   </node>
-  <node concept="2ezpO_" id="7b8v2ss95bK">
-    <property role="TrG5h" value="GroupTesting" />
+  <node concept="312cEu" id="6ob0HsMSh9f">
+    <property role="TrG5h" value="TestActionIntentionMenuProducer" />
+    <node concept="3Tm1VV" id="6ob0HsMSh9g" role="1B3o_S" />
+    <node concept="3uibUv" id="6ob0HsMSmXP" role="1zkMxy">
+      <ref role="3uigEE" to="ih8q:2jDew64JcPx" resolve="ActionIntentionMenuProducer" />
+    </node>
+    <node concept="3clFbW" id="6ob0HsMSnxV" role="jymVt">
+      <property role="TrG5h" value="IntentionMenuProducer" />
+      <node concept="3cqZAl" id="6ob0HsMSnxW" role="3clF45" />
+      <node concept="3Tm1VV" id="6ob0HsMSnxX" role="1B3o_S" />
+      <node concept="37vLTG" id="6ob0HsMSnxY" role="3clF46">
+        <property role="TrG5h" value="editor" />
+        <node concept="3uibUv" id="6ob0HsMSnxZ" role="1tU5fm">
+          <ref role="3uigEE" to="exr9:~EditorComponent" resolve="EditorComponent" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="6ob0HsMSnyg" role="3clF47">
+        <node concept="XkiVB" id="6ob0HsMSnyh" role="3cqZAp">
+          <ref role="37wK5l" to="ih8q:2jDew64KaGG" resolve="ActionIntentionMenuProducer" />
+          <node concept="37vLTw" id="6ob0HsMSnyi" role="37wK5m">
+            <ref role="3cqZAo" node="6ob0HsMSnxY" resolve="editor" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6ob0HsMSANV" role="jymVt" />
+    <node concept="3clFb_" id="4yZHsKxNkJT" role="jymVt">
+      <property role="TrG5h" value="testPopulateMainMenu" />
+      <node concept="37vLTG" id="4yZHsKxO40S" role="3clF46">
+        <property role="TrG5h" value="mainGroup" />
+        <node concept="3uibUv" id="4yZHsKxO40T" role="1tU5fm">
+          <ref role="3uigEE" to="qkt:~DefaultActionGroup" resolve="DefaultActionGroup" />
+        </node>
+        <node concept="2AHcQZ" id="7b8v2ss2sV3" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="2H0U9nsoJoB" role="3clF46">
+        <property role="TrG5h" value="groups" />
+        <node concept="3uibUv" id="2H0U9nsoJoC" role="1tU5fm">
+          <ref role="3uigEE" to="3o3z:~Multimap" resolve="Multimap" />
+          <node concept="17QB3L" id="2H0U9nsoJoD" role="11_B2D" />
+          <node concept="3uibUv" id="2H0U9nsbPo4" role="11_B2D">
+            <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
+          </node>
+        </node>
+        <node concept="2AHcQZ" id="2H0U9nsoJoE" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="4yZHsKxNkJW" role="3clF47">
+        <node concept="3clFbF" id="6ob0HsMSNes" role="3cqZAp">
+          <node concept="3nyPlj" id="6ob0HsMSNer" role="3clFbG">
+            <ref role="37wK5l" to="ih8q:4yZHsKxNkJT" resolve="populateMainMenu" />
+            <node concept="37vLTw" id="6ob0HsMSQse" role="37wK5m">
+              <ref role="3cqZAo" node="4yZHsKxO40S" resolve="mainGroup" />
+            </node>
+            <node concept="37vLTw" id="6ob0HsMSQBy" role="37wK5m">
+              <ref role="3cqZAo" node="2H0U9nsoJoB" resolve="groups" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="6ob0HsMSEeb" role="1B3o_S" />
+      <node concept="3cqZAl" id="4yZHsKxNeM_" role="3clF45" />
+    </node>
+    <node concept="2tJIrI" id="6ob0HsMTysx" role="jymVt" />
+    <node concept="3clFb_" id="lMPJvi802g" role="jymVt">
+      <property role="TrG5h" value="testSubstituteAction" />
+      <node concept="3clFbS" id="lMPJvi802j" role="3clF47">
+        <node concept="3clFbF" id="6ob0HsMT$PC" role="3cqZAp">
+          <node concept="3nyPlj" id="6ob0HsMT$PB" role="3clFbG">
+            <ref role="37wK5l" to="ih8q:lMPJvi802g" resolve="substituteAction" />
+            <node concept="37vLTw" id="6ob0HsMT_2M" role="37wK5m">
+              <ref role="3cqZAo" node="lMPJvi9cDl" resolve="mainGroup" />
+            </node>
+            <node concept="37vLTw" id="6ob0HsMT_fw" role="37wK5m">
+              <ref role="3cqZAo" node="lMPJvi8JyR" resolve="oldAction" />
+            </node>
+            <node concept="37vLTw" id="6ob0HsMT_sk" role="37wK5m">
+              <ref role="3cqZAo" node="lMPJviaN1m" resolve="groupName" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="6ob0HsMT$ty" role="1B3o_S" />
+      <node concept="3cqZAl" id="lMPJvi7Ziq" role="3clF45" />
+      <node concept="37vLTG" id="lMPJvi9cDl" role="3clF46">
+        <property role="TrG5h" value="mainGroup" />
+        <node concept="3uibUv" id="lMPJvi9ix4" role="1tU5fm">
+          <ref role="3uigEE" to="7bx7:~BaseGroup" resolve="BaseGroup" />
+        </node>
+        <node concept="2AHcQZ" id="7b8v2ss36sn" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="lMPJvi8JyR" role="3clF46">
+        <property role="TrG5h" value="oldAction" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3uibUv" id="lMPJvi8JyQ" role="1tU5fm">
+          <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
+        </node>
+        <node concept="2AHcQZ" id="7b8v2ss3iW0" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="lMPJviaN1m" role="3clF46">
+        <property role="TrG5h" value="groupName" />
+        <node concept="17QB3L" id="lMPJviaN1C" role="1tU5fm" />
+        <node concept="2AHcQZ" id="7b8v2ss3H7l" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6ob0HsMTKut" role="jymVt" />
+    <node concept="3clFb_" id="7b8v2ssFpTf" role="jymVt">
+      <property role="TrG5h" value="testTrimGroupNameFromActionText" />
+      <node concept="37vLTG" id="7b8v2ssFF26" role="3clF46">
+        <property role="TrG5h" value="action" />
+        <node concept="3uibUv" id="7b8v2ssFF27" role="1tU5fm">
+          <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
+        </node>
+        <node concept="2AHcQZ" id="7b8v2ssFF28" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="7b8v2ssFT5B" role="3clF46">
+        <property role="TrG5h" value="groupName" />
+        <node concept="17QB3L" id="7b8v2ssFT5C" role="1tU5fm" />
+        <node concept="2AHcQZ" id="7b8v2ssFT5D" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="7b8v2ssFpTi" role="3clF47">
+        <node concept="3clFbF" id="6ob0HsMTLcS" role="3cqZAp">
+          <node concept="1rXfSq" id="6ob0HsMTLcR" role="3clFbG">
+            <ref role="37wK5l" to="ih8q:7b8v2ssFpTf" resolve="trimGroupNameFromActionText" />
+            <node concept="37vLTw" id="6ob0HsMTLK$" role="37wK5m">
+              <ref role="3cqZAo" node="7b8v2ssFF26" resolve="action" />
+            </node>
+            <node concept="37vLTw" id="6ob0HsMTMp$" role="37wK5m">
+              <ref role="3cqZAo" node="7b8v2ssFT5B" resolve="groupName" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tmbuc" id="6ob0HsMOuMX" role="1B3o_S" />
+      <node concept="17QB3L" id="7b8v2ssEWNj" role="3clF45" />
+    </node>
+    <node concept="2tJIrI" id="6ob0HsMSANW" role="jymVt" />
   </node>
 </model>
 

--- a/code/solutions/com.mbeddr.mpsutil.intentions.tests/models/com.mbeddr.mpsutil.intentions.tests.tests@tests.mps
+++ b/code/solutions/com.mbeddr.mpsutil.intentions.tests/models/com.mbeddr.mpsutil.intentions.tests.tests@tests.mps
@@ -5,9 +5,30 @@
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="6" />
     <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
     <use id="4972ae94-72e7-499b-8766-0d6acffdb4f2" name="com.mbeddr.mpsutil.intentions.sandboxlang" version="0" />
+    <use id="63650c59-16c8-498a-99c8-005c7ee9515d" name="jetbrains.mps.lang.access" version="0" />
+    <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
+    <use id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections" version="2" />
+    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
   </languages>
   <imports>
     <import index="gw4x" ref="r:f1d822a2-1f43-4b14-8097-de7e855e6079(com.mbeddr.mpsutil.intentions.sandboxlang.intentions)" />
+    <import index="ih8q" ref="r:990d360b-3ac3-45fa-8ed3-0bbf017bba84(com.mbeddr.mpsutil.intentions.runtime)" />
+    <import index="qkt" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.actionSystem(MPS.IDEA/)" />
+    <import index="ddhc" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ide(MPS.IDEA/)" />
+    <import index="7a0s" ref="r:2af017c2-293f-4ebb-99f3-81e353b3d6e6(jetbrains.mps.editor.runtime)" />
+    <import index="lui2" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.module(MPS.OpenAPI/)" />
+    <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
+    <import index="mhfm" ref="3f233e7f-b8a6-46d2-a57f-795d56775243/java:org.jetbrains.annotations(Annotations/)" />
+    <import index="nddn" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.intentions(MPS.Editor/)" />
+    <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" />
+    <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" />
+    <import index="cj4x" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor(MPS.Editor/)" />
+    <import index="exr9" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor(MPS.Editor/)" />
+    <import index="9w4s" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.util(MPS.IDEA/)" />
+    <import index="bd8o" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.application(MPS.IDEA/)" />
+    <import index="7bx7" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.workbench.action(MPS.Platform/)" />
+    <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
+    <import index="z1c3" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.project(MPS.Core/)" implicit="true" />
   </imports>
   <registry>
     <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
@@ -27,16 +48,181 @@
       <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
         <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
       </concept>
+      <concept id="1225467090849" name="jetbrains.mps.lang.test.structure.ProjectExpression" flags="nn" index="1jxXqW" />
+      <concept id="1216913645126" name="jetbrains.mps.lang.test.structure.NodesTestCase" flags="lg" index="1lH9Xt">
+        <property id="2616911529524314943" name="accessMode" index="3DII0k" />
+        <child id="1216993439383" name="methods" index="1qtyYc" />
+        <child id="1217501895093" name="testMethods" index="1SL9yI" />
+      </concept>
       <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
         <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
       </concept>
+      <concept id="1225978065297" name="jetbrains.mps.lang.test.structure.SimpleNodeTest" flags="ng" index="1LZb2c" />
       <concept id="1225989773458" name="jetbrains.mps.lang.test.structure.InvokeIntentionStatement" flags="nn" index="1MFPAf">
         <reference id="1225989811227" name="intention" index="1MFYO6" />
       </concept>
     </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1224071154655" name="jetbrains.mps.baseLanguage.structure.AsExpression" flags="nn" index="0kSF2">
+        <child id="1224071154657" name="classifierType" index="0kSFW" />
+        <child id="1224071154656" name="expression" index="0kSFX" />
+      </concept>
+      <concept id="1082485599095" name="jetbrains.mps.baseLanguage.structure.BlockStatement" flags="nn" index="9aQIb">
+        <child id="1082485599096" name="statements" index="9aQI4" />
+      </concept>
+      <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
+        <child id="1068498886297" name="rValue" index="37vLTx" />
+        <child id="1068498886295" name="lValue" index="37vLTJ" />
+      </concept>
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
+      <concept id="1173175405605" name="jetbrains.mps.baseLanguage.structure.ArrayAccessExpression" flags="nn" index="AH0OO">
+        <child id="1173175577737" name="index" index="AHEQo" />
+        <child id="1173175590490" name="array" index="AHHXb" />
+      </concept>
+      <concept id="1188207840427" name="jetbrains.mps.baseLanguage.structure.AnnotationInstance" flags="nn" index="2AHcQZ">
+        <reference id="1188208074048" name="annotation" index="2AI5Lk" />
+      </concept>
+      <concept id="1188208481402" name="jetbrains.mps.baseLanguage.structure.HasAnnotation" flags="ngI" index="2AJDlI">
+        <child id="1188208488637" name="annotation" index="2AJF6D" />
+      </concept>
+      <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
+        <child id="1154032183016" name="body" index="2LFqv$" />
+      </concept>
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
+        <child id="1145553007750" name="creator" index="2ShVmc" />
+      </concept>
+      <concept id="3870108946630849399" name="jetbrains.mps.baseLanguage.structure.StaticFieldReferenceOperation" flags="ng" index="SiP3y" />
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="1182160077978" name="jetbrains.mps.baseLanguage.structure.AnonymousClassCreator" flags="nn" index="YeOm9">
+        <child id="1182160096073" name="cls" index="YeSDq" />
+      </concept>
+      <concept id="1081236700938" name="jetbrains.mps.baseLanguage.structure.StaticMethodDeclaration" flags="ig" index="2YIFZL" />
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
+      </concept>
+      <concept id="1081256982272" name="jetbrains.mps.baseLanguage.structure.InstanceOfExpression" flags="nn" index="2ZW3vV">
+        <child id="1081256993305" name="classType" index="2ZW6by" />
+        <child id="1081256993304" name="leftExpression" index="2ZW6bz" />
+      </concept>
+      <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
+      <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu" />
+      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <property id="1176718929932" name="isFinal" index="3TUv4t" />
+        <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ngI" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
+      </concept>
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
+      <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
+      <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
+      <concept id="1225271283259" name="jetbrains.mps.baseLanguage.structure.NPEEqualsExpression" flags="nn" index="17R0WA" />
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123134" name="parameter" index="3clF46" />
+        <child id="1068580123135" name="body" index="3clF47" />
+      </concept>
+      <concept id="1068580123165" name="jetbrains.mps.baseLanguage.structure.InstanceMethodDeclaration" flags="ig" index="3clFb_" />
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
+      <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
+        <child id="1082485599094" name="ifFalseStatement" index="9aQIa" />
+        <child id="1068580123160" name="condition" index="3clFbw" />
+        <child id="1068580123161" name="ifTrue" index="3clFbx" />
+        <child id="1206060520071" name="elsifClauses" index="3eNLev" />
+      </concept>
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
+        <property id="1068580123138" name="value" index="3clFbU" />
+      </concept>
+      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
+        <property id="1068580320021" name="value" index="3cmrfH" />
+      </concept>
+      <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
+      <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
+        <child id="1068581517676" name="expression" index="3cqZAk" />
+      </concept>
+      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
+        <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
+      </concept>
+      <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
+      <concept id="1206060495898" name="jetbrains.mps.baseLanguage.structure.ElsifClause" flags="ng" index="3eNFk2">
+        <child id="1206060619838" name="condition" index="3eO9$A" />
+        <child id="1206060644605" name="statementList" index="3eOfB_" />
+      </concept>
+      <concept id="1154542696413" name="jetbrains.mps.baseLanguage.structure.ArrayCreatorWithInitializer" flags="nn" index="3g6Rrh">
+        <child id="1154542793668" name="componentType" index="3g7fb8" />
+        <child id="1154542803372" name="initValue" index="3g7hyw" />
+      </concept>
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk">
+        <child id="1212687122400" name="typeParameter" index="1pMfVU" />
+      </concept>
+      <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
+        <property id="521412098689998745" name="nonStatic" index="2bfB8j" />
+        <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
+      </concept>
+      <concept id="7812454656619025412" name="jetbrains.mps.baseLanguage.structure.LocalMethodCall" flags="nn" index="1rXfSq" />
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+        <reference id="1107535924139" name="classifier" index="3uigEE" />
+        <child id="1109201940907" name="parameter" index="11_B2D" />
+      </concept>
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
+        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
+        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
+      </concept>
+      <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
+        <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+      <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
+      <concept id="1170345865475" name="jetbrains.mps.baseLanguage.structure.AnonymousClass" flags="ig" index="1Y3b0j">
+        <reference id="1170346070688" name="classifier" index="1Y3XeK" />
+      </concept>
+    </language>
+    <language id="443f4c36-fcf5-4eb6-9500-8d06ed259e3e" name="jetbrains.mps.baseLanguage.classifiers">
+      <concept id="1205752633985" name="jetbrains.mps.baseLanguage.classifiers.structure.ThisClassifierExpression" flags="nn" index="2WthIp" />
+      <concept id="1205756064662" name="jetbrains.mps.baseLanguage.classifiers.structure.IMemberOperation" flags="ngI" index="2WEnae">
+        <reference id="1205756909548" name="member" index="2WH_rO" />
+      </concept>
+      <concept id="1205769003971" name="jetbrains.mps.baseLanguage.classifiers.structure.DefaultClassifierMethodDeclaration" flags="ng" index="2XrIbr" />
+      <concept id="1205769149993" name="jetbrains.mps.baseLanguage.classifiers.structure.DefaultClassifierMethodCallOperation" flags="nn" index="2XshWL">
+        <child id="1205770614681" name="actualArgument" index="2XxRq1" />
+      </concept>
+    </language>
+    <language id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest">
+      <concept id="8427750732757990717" name="jetbrains.mps.baseLanguage.unitTest.structure.BinaryAssert" flags="nn" index="3tpDYu">
+        <child id="8427750732757990725" name="actual" index="3tpDZA" />
+        <child id="8427750732757990724" name="expected" index="3tpDZB" />
+      </concept>
+      <concept id="1171978097730" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertEquals" flags="nn" index="3vlDli" />
+      <concept id="1171981022339" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertTrue" flags="nn" index="3vwNmj">
+        <child id="1171981057159" name="condition" index="3vwVQn" />
+      </concept>
+      <concept id="1171983834376" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertFalse" flags="nn" index="3vFxKo">
+        <child id="1171983854940" name="condition" index="3vFALc" />
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
@@ -48,10 +234,59 @@
       </concept>
     </language>
     <language id="4972ae94-72e7-499b-8766-0d6acffdb4f2" name="com.mbeddr.mpsutil.intentions.sandboxlang">
+      <concept id="1317247883695247581" name="com.mbeddr.mpsutil.intentions.sandboxlang.structure.DemoNodeWithIntentions" flags="ng" index="2ezpO_" />
       <concept id="6237210071910106918" name="com.mbeddr.mpsutil.intentions.sandboxlang.structure.Root" flags="ng" index="3NfWa_">
         <child id="6237210071910106920" name="children" index="3NfWaF" />
       </concept>
       <concept id="6237210071910112531" name="com.mbeddr.mpsutil.intentions.sandboxlang.structure.ReadOnlyChildAllowed" flags="ng" index="3NfXyg" />
+    </language>
+    <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="nn" index="25WWJ4">
+        <child id="540871147943773366" name="argument" index="25WWJ7" />
+      </concept>
+      <concept id="1226511727824" name="jetbrains.mps.baseLanguage.collections.structure.SetType" flags="in" index="2hMVRd">
+        <child id="1226511765987" name="elementType" index="2hN53Y" />
+      </concept>
+      <concept id="1226516258405" name="jetbrains.mps.baseLanguage.collections.structure.HashSetCreator" flags="nn" index="2i4dXS" />
+      <concept id="1151688443754" name="jetbrains.mps.baseLanguage.collections.structure.ListType" flags="in" index="_YKpA">
+        <child id="1151688676805" name="elementType" index="_ZDj9" />
+      </concept>
+      <concept id="1151702311717" name="jetbrains.mps.baseLanguage.collections.structure.ToListOperation" flags="nn" index="ANE8D" />
+      <concept id="1153943597977" name="jetbrains.mps.baseLanguage.collections.structure.ForEachStatement" flags="nn" index="2Gpval">
+        <child id="1153944400369" name="variable" index="2Gsz3X" />
+        <child id="1153944424730" name="inputSequence" index="2GsD0m" />
+      </concept>
+      <concept id="1153944193378" name="jetbrains.mps.baseLanguage.collections.structure.ForEachVariable" flags="nr" index="2GrKxI" />
+      <concept id="1153944233411" name="jetbrains.mps.baseLanguage.collections.structure.ForEachVariableReference" flags="nn" index="2GrUjf">
+        <reference id="1153944258490" name="variable" index="2Gs0qQ" />
+      </concept>
+      <concept id="1235573135402" name="jetbrains.mps.baseLanguage.collections.structure.SingletonSequenceCreator" flags="nn" index="2HTt$P">
+        <child id="1235573175711" name="elementType" index="2HTBi0" />
+        <child id="1235573187520" name="singletonValue" index="2HTEbv" />
+      </concept>
+      <concept id="1237721394592" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerCreator" flags="nn" index="HWqM0">
+        <child id="1237721435807" name="elementType" index="HW$YZ" />
+        <child id="1237731803878" name="copyFrom" index="I$8f6" />
+      </concept>
+      <concept id="1201306600024" name="jetbrains.mps.baseLanguage.collections.structure.ContainsKeyOperation" flags="nn" index="2Nt0df">
+        <child id="1201654602639" name="key" index="38cxEo" />
+      </concept>
+      <concept id="1160600644654" name="jetbrains.mps.baseLanguage.collections.structure.ListCreatorWithInit" flags="nn" index="Tc6Ow" />
+      <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
+      <concept id="1160666733551" name="jetbrains.mps.baseLanguage.collections.structure.AddAllElementsOperation" flags="nn" index="X8dFx" />
+      <concept id="1240217271293" name="jetbrains.mps.baseLanguage.collections.structure.LinkedHashSetCreator" flags="nn" index="32HrFt" />
+      <concept id="1162934736510" name="jetbrains.mps.baseLanguage.collections.structure.GetElementOperation" flags="nn" index="34jXtK" />
+      <concept id="1240325842691" name="jetbrains.mps.baseLanguage.collections.structure.AsSequenceOperation" flags="nn" index="39bAoz" />
+      <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
+      <concept id="1225711141656" name="jetbrains.mps.baseLanguage.collections.structure.ListElementAccessExpression" flags="nn" index="1y4W85">
+        <child id="1225711182005" name="list" index="1y566C" />
+        <child id="1225711191269" name="index" index="1y58nS" />
+      </concept>
+      <concept id="1208542034276" name="jetbrains.mps.baseLanguage.collections.structure.MapClearOperation" flags="nn" index="1yHZxX" />
+      <concept id="1197932370469" name="jetbrains.mps.baseLanguage.collections.structure.MapElement" flags="nn" index="3EllGN">
+        <child id="1197932505799" name="map" index="3ElQJh" />
+        <child id="1197932525128" name="key" index="3ElVtu" />
+      </concept>
     </language>
   </registry>
   <node concept="LiM7Y" id="2$4DgwiMmuc">
@@ -85,6 +320,2252 @@
   </node>
   <node concept="2XOHcx" id="2$4DgwiMtiM">
     <property role="2XOHcw" value="${extensions.home}/code" />
+  </node>
+  <node concept="312cEu" id="1NzaUygE4Q4">
+    <property role="TrG5h" value="GroupTestHelper" />
+    <node concept="2YIFZL" id="1NzaUygEoFq" role="jymVt">
+      <property role="TrG5h" value="extractGroups" />
+      <node concept="3clFbS" id="1NzaUygEoFy" role="3clF47">
+        <node concept="3cpWs8" id="1NzaUygEoFz" role="3cqZAp">
+          <node concept="3cpWsn" id="1NzaUygEoF$" role="3cpWs9">
+            <property role="TrG5h" value="intentionsGroup" />
+            <node concept="3uibUv" id="1NzaUygEoF_" role="1tU5fm">
+              <ref role="3uigEE" to="qkt:~ActionGroup" resolve="ActionGroup" />
+            </node>
+            <node concept="2OqwBi" id="1NzaUygEoFA" role="33vP2m">
+              <node concept="37vLTw" id="1NzaUygEoFB" role="2Oq$k0">
+                <ref role="3cqZAo" node="1NzaUygEoFs" resolve="producer" />
+              </node>
+              <node concept="liA8E" id="1NzaUygEoFC" role="2OqNvi">
+                <ref role="37wK5l" to="ih8q:2jDew64HgSb" resolve="getIntentionsGroup" />
+                <node concept="37vLTw" id="1NzaUygEoFD" role="37wK5m">
+                  <ref role="3cqZAo" node="1NzaUygEoFu" resolve="context" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="1NzaUygEs7Y" role="3cqZAp">
+          <node concept="1rXfSq" id="1NzaUygEs7W" role="3clFbG">
+            <ref role="37wK5l" node="1NzaUygEqcw" resolve="extractGroup" />
+            <node concept="37vLTw" id="1NzaUygEsHB" role="37wK5m">
+              <ref role="3cqZAo" node="1NzaUygEoFs" resolve="producer" />
+            </node>
+            <node concept="37vLTw" id="1NzaUygEsMa" role="37wK5m">
+              <ref role="3cqZAo" node="1NzaUygEoF$" resolve="intentionsGroup" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2hMVRd" id="1NzaUygEoFw" role="3clF45">
+        <node concept="17QB3L" id="1NzaUygEoFx" role="2hN53Y" />
+      </node>
+      <node concept="37vLTG" id="1NzaUygEoFs" role="3clF46">
+        <property role="TrG5h" value="producer" />
+        <node concept="3uibUv" id="1NzaUygEoFt" role="1tU5fm">
+          <ref role="3uigEE" to="ih8q:2jDew64JcPx" resolve="MyIntentionMenuProducer" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="1NzaUygEoFu" role="3clF46">
+        <property role="TrG5h" value="context" />
+        <node concept="3uibUv" id="1NzaUygEoFv" role="1tU5fm">
+          <ref role="3uigEE" to="qkt:~DataContext" resolve="DataContext" />
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="1NzaUygEoFK" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="1NzaUygEaVS" role="jymVt" />
+    <node concept="2YIFZL" id="1NzaUygEqcw" role="jymVt">
+      <property role="TrG5h" value="extractGroup" />
+      <node concept="3clFbS" id="1NzaUygEqcC" role="3clF47">
+        <node concept="3cpWs8" id="1NzaUygEqcT" role="3cqZAp">
+          <node concept="3cpWsn" id="1NzaUygEqcU" role="3cpWs9">
+            <property role="TrG5h" value="groups" />
+            <node concept="2hMVRd" id="1NzaUygEqcV" role="1tU5fm">
+              <node concept="17QB3L" id="1NzaUygEqcW" role="2hN53Y" />
+            </node>
+            <node concept="2ShNRf" id="1NzaUygEqcX" role="33vP2m">
+              <node concept="32HrFt" id="1NzaUygEqcY" role="2ShVmc">
+                <node concept="17QB3L" id="1NzaUygEqcZ" role="HW$YZ" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="1NzaUygEqd0" role="3cqZAp" />
+        <node concept="3clFbJ" id="1NzaUygEqd1" role="3cqZAp">
+          <node concept="3clFbS" id="1NzaUygEqd2" role="3clFbx">
+            <node concept="3cpWs8" id="4CvP1bwpdar" role="3cqZAp">
+              <node concept="3cpWsn" id="4CvP1bwpdas" role="3cpWs9">
+                <property role="TrG5h" value="group" />
+                <node concept="17QB3L" id="4CvP1bwpdat" role="1tU5fm" />
+                <node concept="2OqwBi" id="4CvP1bwpdau" role="33vP2m">
+                  <node concept="37vLTw" id="4CvP1bwpdav" role="2Oq$k0">
+                    <ref role="3cqZAo" node="1NzaUygEqcy" resolve="producer" />
+                  </node>
+                  <node concept="liA8E" id="4CvP1bwpdaw" role="2OqNvi">
+                    <ref role="37wK5l" to="ih8q:3pwG8PSpGSr" resolve="getGroupName" />
+                    <node concept="37vLTw" id="4CvP1bwpdax" role="37wK5m">
+                      <ref role="3cqZAo" node="1NzaUygEqc$" resolve="action" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbJ" id="4CvP1bwprmJ" role="3cqZAp">
+              <node concept="3clFbS" id="4CvP1bwprmL" role="3clFbx">
+                <node concept="3clFbF" id="4CvP1bwpsWC" role="3cqZAp">
+                  <node concept="2OqwBi" id="4CvP1bwptZO" role="3clFbG">
+                    <node concept="37vLTw" id="4CvP1bwpsWA" role="2Oq$k0">
+                      <ref role="3cqZAo" node="1NzaUygEqcU" resolve="groups" />
+                    </node>
+                    <node concept="TSZUe" id="4CvP1bwpvmK" role="2OqNvi">
+                      <node concept="37vLTw" id="4CvP1bwpvzI" role="25WWJ7">
+                        <ref role="3cqZAo" node="4CvP1bwpdas" resolve="group" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3y3z36" id="4CvP1bwpsKF" role="3clFbw">
+                <node concept="10Nm6u" id="4CvP1bwpsLe" role="3uHU7w" />
+                <node concept="37vLTw" id="4CvP1bwpr_$" role="3uHU7B">
+                  <ref role="3cqZAo" node="4CvP1bwpdas" resolve="group" />
+                </node>
+              </node>
+            </node>
+            <node concept="2Gpval" id="1NzaUygEqd3" role="3cqZAp">
+              <node concept="2GrKxI" id="1NzaUygEqd4" role="2Gsz3X">
+                <property role="TrG5h" value="childAction" />
+              </node>
+              <node concept="3clFbS" id="1NzaUygEqd5" role="2LFqv$">
+                <node concept="3clFbF" id="1NzaUygEqd6" role="3cqZAp">
+                  <node concept="2OqwBi" id="1NzaUygEqd7" role="3clFbG">
+                    <node concept="37vLTw" id="1NzaUygEqd8" role="2Oq$k0">
+                      <ref role="3cqZAo" node="1NzaUygEqcU" resolve="groups" />
+                    </node>
+                    <node concept="X8dFx" id="1NzaUygEqd9" role="2OqNvi">
+                      <node concept="1rXfSq" id="1NzaUygEt_5" role="25WWJ7">
+                        <ref role="37wK5l" node="1NzaUygEqcw" resolve="extractGroup" />
+                        <node concept="37vLTw" id="1NzaUygEuil" role="37wK5m">
+                          <ref role="3cqZAo" node="1NzaUygEqcy" resolve="producer" />
+                        </node>
+                        <node concept="2GrUjf" id="1NzaUygEvyO" role="37wK5m">
+                          <ref role="2Gs0qQ" node="1NzaUygEqd4" resolve="childAction" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="2OqwBi" id="1NzaUygEqdf" role="2GsD0m">
+                <node concept="liA8E" id="1NzaUygEqdg" role="2OqNvi">
+                  <ref role="37wK5l" to="qkt:~ActionGroup.getChildren(com.intellij.openapi.actionSystem.AnActionEvent)" resolve="getChildren" />
+                  <node concept="10Nm6u" id="1NzaUygEqdh" role="37wK5m" />
+                </node>
+                <node concept="0kSF2" id="1NzaUygEqdi" role="2Oq$k0">
+                  <node concept="3uibUv" id="1NzaUygEqdj" role="0kSFW">
+                    <ref role="3uigEE" to="qkt:~ActionGroup" resolve="ActionGroup" />
+                  </node>
+                  <node concept="37vLTw" id="1NzaUygEqdk" role="0kSFX">
+                    <ref role="3cqZAo" node="1NzaUygEqc$" resolve="action" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2ZW3vV" id="1NzaUygEqdl" role="3clFbw">
+            <node concept="3uibUv" id="1NzaUygEqdm" role="2ZW6by">
+              <ref role="3uigEE" to="qkt:~ActionGroup" resolve="ActionGroup" />
+            </node>
+            <node concept="37vLTw" id="1NzaUygEqdn" role="2ZW6bz">
+              <ref role="3cqZAo" node="1NzaUygEqc$" resolve="action" />
+            </node>
+          </node>
+          <node concept="9aQIb" id="1NzaUygEqdo" role="9aQIa">
+            <node concept="3clFbS" id="1NzaUygEqdp" role="9aQI4">
+              <node concept="3cpWs8" id="1NzaUygEqdq" role="3cqZAp">
+                <node concept="3cpWsn" id="1NzaUygEqdr" role="3cpWs9">
+                  <property role="TrG5h" value="group" />
+                  <node concept="17QB3L" id="1NzaUygEqds" role="1tU5fm" />
+                  <node concept="2OqwBi" id="1NzaUygEqdt" role="33vP2m">
+                    <node concept="37vLTw" id="1NzaUygEqdu" role="2Oq$k0">
+                      <ref role="3cqZAo" node="1NzaUygEqcy" resolve="producer" />
+                    </node>
+                    <node concept="liA8E" id="1NzaUygEqdv" role="2OqNvi">
+                      <ref role="37wK5l" to="ih8q:3pwG8PSpGSr" resolve="getGroupName" />
+                      <node concept="37vLTw" id="1NzaUygEqdw" role="37wK5m">
+                        <ref role="3cqZAo" node="1NzaUygEqc$" resolve="action" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbJ" id="1NzaUygEqdC" role="3cqZAp">
+                <node concept="3clFbS" id="1NzaUygEqdD" role="3clFbx">
+                  <node concept="3clFbF" id="1NzaUygEqdE" role="3cqZAp">
+                    <node concept="2OqwBi" id="1NzaUygEqdF" role="3clFbG">
+                      <node concept="37vLTw" id="1NzaUygEqdG" role="2Oq$k0">
+                        <ref role="3cqZAo" node="1NzaUygEqcU" resolve="groups" />
+                      </node>
+                      <node concept="TSZUe" id="1NzaUygEqdH" role="2OqNvi">
+                        <node concept="37vLTw" id="1NzaUygEqdI" role="25WWJ7">
+                          <ref role="3cqZAo" node="1NzaUygEqdr" resolve="group" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3y3z36" id="1NzaUygEqdJ" role="3clFbw">
+                  <node concept="10Nm6u" id="1NzaUygEqdK" role="3uHU7w" />
+                  <node concept="37vLTw" id="1NzaUygEqdL" role="3uHU7B">
+                    <ref role="3cqZAo" node="1NzaUygEqdr" resolve="group" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="1NzaUygEqdM" role="3cqZAp">
+          <node concept="37vLTw" id="1NzaUygEqdN" role="3cqZAk">
+            <ref role="3cqZAo" node="1NzaUygEqcU" resolve="groups" />
+          </node>
+        </node>
+      </node>
+      <node concept="2hMVRd" id="1NzaUygEqcA" role="3clF45">
+        <node concept="17QB3L" id="1NzaUygEqcB" role="2hN53Y" />
+      </node>
+      <node concept="37vLTG" id="1NzaUygEqcy" role="3clF46">
+        <property role="TrG5h" value="producer" />
+        <node concept="3uibUv" id="1NzaUygEqcz" role="1tU5fm">
+          <ref role="3uigEE" to="ih8q:2jDew64JcPx" resolve="MyIntentionMenuProducer" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="1NzaUygEqc$" role="3clF46">
+        <property role="TrG5h" value="action" />
+        <node concept="3uibUv" id="1NzaUygEqc_" role="1tU5fm">
+          <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="1NzaUygEqdO" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="1NzaUygE91M" role="jymVt" />
+    <node concept="2tJIrI" id="1NzaUygE6KF" role="jymVt" />
+    <node concept="3Tm1VV" id="1NzaUygE4Q5" role="1B3o_S" />
+  </node>
+  <node concept="1lH9Xt" id="7b8v2ss1_wP">
+    <property role="3DII0k" value="2hh8MJdVwqX/command" />
+    <property role="TrG5h" value="GroupAnnotations" />
+    <node concept="2XrIbr" id="7b8v2sshaES" role="1qtyYc">
+      <property role="TrG5h" value="createAction" />
+      <node concept="3uibUv" id="7b8v2sshaYd" role="3clF45">
+        <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
+      </node>
+      <node concept="3clFbS" id="7b8v2sshaEU" role="3clF47">
+        <node concept="3cpWs8" id="7b8v2ssjEov" role="3cqZAp">
+          <node concept="3cpWsn" id="7b8v2ssjEow" role="3cpWs9">
+            <property role="TrG5h" value="action" />
+            <node concept="3uibUv" id="7b8v2ssjEou" role="1tU5fm">
+              <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
+            </node>
+            <node concept="2ShNRf" id="7b8v2ssjEox" role="33vP2m">
+              <node concept="YeOm9" id="7b8v2ssjEoy" role="2ShVmc">
+                <node concept="1Y3b0j" id="7b8v2ssjEoz" role="YeSDq">
+                  <property role="2bfB8j" value="true" />
+                  <property role="373rjd" value="true" />
+                  <ref role="1Y3XeK" to="qkt:~AnAction" resolve="AnAction" />
+                  <ref role="37wK5l" to="qkt:~AnAction.&lt;init&gt;(java.lang.String)" resolve="AnAction" />
+                  <node concept="3Tm1VV" id="7b8v2ssjEo$" role="1B3o_S" />
+                  <node concept="3clFb_" id="7b8v2ssjEo_" role="jymVt">
+                    <property role="TrG5h" value="actionPerformed" />
+                    <node concept="3Tm1VV" id="7b8v2ssjEoA" role="1B3o_S" />
+                    <node concept="3cqZAl" id="7b8v2ssjEoB" role="3clF45" />
+                    <node concept="37vLTG" id="7b8v2ssjEoC" role="3clF46">
+                      <property role="TrG5h" value="p1" />
+                      <node concept="3uibUv" id="7b8v2ssjEoD" role="1tU5fm">
+                        <ref role="3uigEE" to="qkt:~AnActionEvent" resolve="AnActionEvent" />
+                      </node>
+                      <node concept="2AHcQZ" id="7b8v2ssjEoE" role="2AJF6D">
+                        <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+                      </node>
+                    </node>
+                    <node concept="3clFbS" id="7b8v2ssjEoF" role="3clF47" />
+                    <node concept="2AHcQZ" id="7b8v2ssjEoG" role="2AJF6D">
+                      <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                    </node>
+                  </node>
+                  <node concept="2tJIrI" id="7b8v2sslWeV" role="jymVt" />
+                  <node concept="37vLTw" id="7b8v2ssjEoH" role="37wK5m">
+                    <ref role="3cqZAo" node="7b8v2sshb2i" resolve="name" />
+                  </node>
+                  <node concept="3clFb_" id="7b8v2sslY4c" role="jymVt">
+                    <property role="TrG5h" value="toString" />
+                    <node concept="3Tm1VV" id="7b8v2sslY4d" role="1B3o_S" />
+                    <node concept="2AHcQZ" id="7b8v2sslY4f" role="2AJF6D">
+                      <ref role="2AI5Lk" to="mhfm:~Nls" resolve="Nls" />
+                    </node>
+                    <node concept="3uibUv" id="7b8v2sslY4g" role="3clF45">
+                      <ref role="3uigEE" to="wyt6:~String" resolve="String" />
+                    </node>
+                    <node concept="3clFbS" id="7b8v2sslY4i" role="3clF47">
+                      <node concept="3clFbF" id="7b8v2ssm5rQ" role="3cqZAp">
+                        <node concept="37vLTw" id="7b8v2ssm5rN" role="3clFbG">
+                          <ref role="3cqZAo" node="7b8v2sshb2i" resolve="name" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2AHcQZ" id="7b8v2sslY4j" role="2AJF6D">
+                      <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="7b8v2ssokgn" role="3cqZAp">
+          <node concept="3clFbS" id="7b8v2ssokgp" role="3clFbx">
+            <node concept="3clFbF" id="7b8v2ssjH7s" role="3cqZAp">
+              <node concept="2OqwBi" id="7b8v2ssjJxy" role="3clFbG">
+                <node concept="2OqwBi" id="7b8v2ssjHWj" role="2Oq$k0">
+                  <node concept="37vLTw" id="7b8v2ssjH7q" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7b8v2ssjEow" resolve="action" />
+                  </node>
+                  <node concept="liA8E" id="7b8v2ssjJ4$" role="2OqNvi">
+                    <ref role="37wK5l" to="qkt:~AnAction.getTemplatePresentation()" resolve="getTemplatePresentation" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="7b8v2ssjKs_" role="2OqNvi">
+                  <ref role="37wK5l" to="qkt:~Presentation.setText(java.lang.String)" resolve="setText" />
+                  <node concept="3cpWs3" id="7b8v2ssjSqp" role="37wK5m">
+                    <node concept="37vLTw" id="7b8v2ssjTmT" role="3uHU7w">
+                      <ref role="3cqZAo" node="7b8v2sshb2i" resolve="name" />
+                    </node>
+                    <node concept="3cpWs3" id="7b8v2ssjPwb" role="3uHU7B">
+                      <node concept="37vLTw" id="7b8v2ssjNCr" role="3uHU7B">
+                        <ref role="3cqZAo" node="7b8v2ssj$52" resolve="group" />
+                      </node>
+                      <node concept="Xl_RD" id="7b8v2ssjPwe" role="3uHU7w">
+                        <property role="Xl_RC" value=":" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1Wc70l" id="7b8v2ssooKK" role="3clFbw">
+            <node concept="3y3z36" id="7b8v2ssosTd" role="3uHU7w">
+              <node concept="10Nm6u" id="7b8v2ssouNb" role="3uHU7w" />
+              <node concept="37vLTw" id="7b8v2ssoqr2" role="3uHU7B">
+                <ref role="3cqZAo" node="7b8v2sshb2i" resolve="name" />
+              </node>
+            </node>
+            <node concept="3y3z36" id="7b8v2sson_R" role="3uHU7B">
+              <node concept="37vLTw" id="7b8v2ssolrG" role="3uHU7B">
+                <ref role="3cqZAo" node="7b8v2ssj$52" resolve="group" />
+              </node>
+              <node concept="10Nm6u" id="7b8v2sson_U" role="3uHU7w" />
+            </node>
+          </node>
+          <node concept="3eNFk2" id="7b8v2ssozJ6" role="3eNLev">
+            <node concept="3y3z36" id="7b8v2ssoAPq" role="3eO9$A">
+              <node concept="10Nm6u" id="7b8v2ssoC0d" role="3uHU7w" />
+              <node concept="37vLTw" id="7b8v2sso$UR" role="3uHU7B">
+                <ref role="3cqZAo" node="7b8v2sshb2i" resolve="name" />
+              </node>
+            </node>
+            <node concept="3clFbS" id="7b8v2ssozJ8" role="3eOfB_">
+              <node concept="3clFbF" id="7b8v2ssoDaW" role="3cqZAp">
+                <node concept="2OqwBi" id="7b8v2ssoDaX" role="3clFbG">
+                  <node concept="2OqwBi" id="7b8v2ssoDaY" role="2Oq$k0">
+                    <node concept="37vLTw" id="7b8v2ssoDaZ" role="2Oq$k0">
+                      <ref role="3cqZAo" node="7b8v2ssjEow" resolve="action" />
+                    </node>
+                    <node concept="liA8E" id="7b8v2ssoDb0" role="2OqNvi">
+                      <ref role="37wK5l" to="qkt:~AnAction.getTemplatePresentation()" resolve="getTemplatePresentation" />
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="7b8v2ssoDb1" role="2OqNvi">
+                    <ref role="37wK5l" to="qkt:~Presentation.setText(java.lang.String)" resolve="setText" />
+                    <node concept="37vLTw" id="7b8v2ssoGI9" role="37wK5m">
+                      <ref role="3cqZAo" node="7b8v2sshb2i" resolve="name" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="7b8v2sshb40" role="3cqZAp">
+          <node concept="37vLTw" id="7b8v2ssjEoI" role="3cqZAk">
+            <ref role="3cqZAo" node="7b8v2ssjEow" resolve="action" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="7b8v2ssj$52" role="3clF46">
+        <property role="TrG5h" value="group" />
+        <node concept="17QB3L" id="7b8v2ssj_kx" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="7b8v2sshb2i" role="3clF46">
+        <property role="TrG5h" value="name" />
+        <property role="3TUv4t" value="true" />
+        <node concept="17QB3L" id="7b8v2sshb2h" role="1tU5fm" />
+      </node>
+    </node>
+    <node concept="1LZb2c" id="7b8v2ss900p" role="1SL9yI">
+      <property role="TrG5h" value="grouping" />
+      <node concept="3cqZAl" id="7b8v2ss900q" role="3clF45" />
+      <node concept="3clFbS" id="7b8v2ss900u" role="3clF47">
+        <node concept="3cpWs8" id="7b8v2ss9eec" role="3cqZAp">
+          <node concept="3cpWsn" id="7b8v2ss9eed" role="3cpWs9">
+            <property role="TrG5h" value="repository" />
+            <node concept="3uibUv" id="7b8v2ss9eck" role="1tU5fm">
+              <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
+            </node>
+            <node concept="2OqwBi" id="7b8v2ss9eee" role="33vP2m">
+              <node concept="1jxXqW" id="7b8v2ss9eef" role="2Oq$k0" />
+              <node concept="liA8E" id="7b8v2ss9eeg" role="2OqNvi">
+                <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="7b8v2ss96Tp" role="3cqZAp">
+          <node concept="3cpWsn" id="7b8v2ss96Tq" role="3cpWs9">
+            <property role="TrG5h" value="component" />
+            <node concept="3uibUv" id="7b8v2ss96Tr" role="1tU5fm">
+              <ref role="3uigEE" to="7a0s:6qGpHl7IHpK" resolve="HeadlessEditorComponent" />
+            </node>
+            <node concept="2ShNRf" id="7b8v2ss96Ue" role="33vP2m">
+              <node concept="1pGfFk" id="7b8v2ss976E" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="7a0s:2iNJDZP2RE6" resolve="HeadlessEditorComponent" />
+                <node concept="37vLTw" id="7b8v2ss9eei" role="37wK5m">
+                  <ref role="3cqZAo" node="7b8v2ss9eed" resolve="repository" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="7b8v2ss902X" role="3cqZAp">
+          <node concept="3cpWsn" id="7b8v2ss902Y" role="3cpWs9">
+            <property role="TrG5h" value="producer" />
+            <node concept="3uibUv" id="7b8v2ss902Z" role="1tU5fm">
+              <ref role="3uigEE" to="ih8q:2jDew64JcPx" resolve="MyIntentionMenuProducer" />
+            </node>
+            <node concept="2ShNRf" id="7b8v2ss903a" role="33vP2m">
+              <node concept="1pGfFk" id="7b8v2ss94Rx" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="ih8q:2jDew64KaGG" resolve="MyIntentionMenuProducer" />
+                <node concept="37vLTw" id="7b8v2ss99TH" role="37wK5m">
+                  <ref role="3cqZAo" node="7b8v2ss96Tq" resolve="component" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7b8v2ssbhh6" role="3cqZAp" />
+        <node concept="3cpWs8" id="7b8v2ssbdcO" role="3cqZAp">
+          <node concept="3cpWsn" id="7b8v2ssbdcP" role="3cpWs9">
+            <property role="TrG5h" value="mainGroup" />
+            <node concept="3uibUv" id="7b8v2ssbdcQ" role="1tU5fm">
+              <ref role="3uigEE" to="qkt:~DefaultActionGroup" resolve="DefaultActionGroup" />
+            </node>
+            <node concept="2ShNRf" id="7b8v2ssbdgI" role="33vP2m">
+              <node concept="1pGfFk" id="7b8v2ssbdso" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="qkt:~DefaultActionGroup.&lt;init&gt;()" resolve="DefaultActionGroup" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7b8v2ssbhFt" role="3cqZAp" />
+        <node concept="3cpWs8" id="7b8v2ssbhSr" role="3cqZAp">
+          <node concept="3cpWsn" id="7b8v2ssbhSs" role="3cpWs9">
+            <property role="TrG5h" value="groups" />
+            <node concept="3uibUv" id="7b8v2ssbhSp" role="1tU5fm">
+              <ref role="3uigEE" to="33ny:~TreeMap" resolve="TreeMap" />
+              <node concept="17QB3L" id="7b8v2ssbia0" role="11_B2D" />
+              <node concept="_YKpA" id="7b8v2ssgUND" role="11_B2D">
+                <node concept="3uibUv" id="7b8v2ssgURd" role="_ZDj9">
+                  <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
+                </node>
+              </node>
+            </node>
+            <node concept="2ShNRf" id="7b8v2ssgYoP" role="33vP2m">
+              <node concept="1pGfFk" id="7b8v2ssgYBm" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="33ny:~TreeMap.&lt;init&gt;()" resolve="TreeMap" />
+                <node concept="17QB3L" id="7b8v2ssgYGo" role="1pMfVU" />
+                <node concept="_YKpA" id="7b8v2ssgZ2K" role="1pMfVU">
+                  <node concept="3uibUv" id="7b8v2ssgZeY" role="_ZDj9">
+                    <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7b8v2ssgZqp" role="3cqZAp">
+          <node concept="2OqwBi" id="7b8v2ssh3LR" role="3clFbG">
+            <node concept="37vLTw" id="7b8v2ssgZqn" role="2Oq$k0">
+              <ref role="3cqZAo" node="7b8v2ssbhSs" resolve="groups" />
+            </node>
+            <node concept="liA8E" id="7b8v2ssh6l1" role="2OqNvi">
+              <ref role="37wK5l" to="33ny:~TreeMap.put(java.lang.Object,java.lang.Object)" resolve="put" />
+              <node concept="Xl_RD" id="7b8v2ssh6EJ" role="37wK5m" />
+              <node concept="2OqwBi" id="7b8v2sshjMX" role="37wK5m">
+                <node concept="2OqwBi" id="7b8v2sshid_" role="2Oq$k0">
+                  <node concept="2ShNRf" id="7b8v2sshgQ$" role="2Oq$k0">
+                    <node concept="3g6Rrh" id="7b8v2sshhS4" role="2ShVmc">
+                      <node concept="3uibUv" id="7b8v2sshgVD" role="3g7fb8">
+                        <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
+                      </node>
+                      <node concept="2OqwBi" id="7b8v2sshv1P" role="3g7hyw">
+                        <node concept="2WthIp" id="7b8v2sshv1S" role="2Oq$k0" />
+                        <node concept="2XshWL" id="7b8v2sshv1U" role="2OqNvi">
+                          <ref role="2WH_rO" node="7b8v2sshaES" resolve="createAction" />
+                          <node concept="Xl_RD" id="7b8v2ssjXiV" role="2XxRq1" />
+                          <node concept="Xl_RD" id="7b8v2sshvhB" role="2XxRq1">
+                            <property role="Xl_RC" value="C" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="2OqwBi" id="7b8v2sshwfH" role="3g7hyw">
+                        <node concept="2WthIp" id="7b8v2sshwfI" role="2Oq$k0" />
+                        <node concept="2XshWL" id="7b8v2sshwfJ" role="2OqNvi">
+                          <ref role="2WH_rO" node="7b8v2sshaES" resolve="createAction" />
+                          <node concept="Xl_RD" id="7b8v2ssk2Ww" role="2XxRq1" />
+                          <node concept="Xl_RD" id="7b8v2sshwfK" role="2XxRq1">
+                            <property role="Xl_RC" value="B" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="2OqwBi" id="7b8v2sshxQh" role="3g7hyw">
+                        <node concept="2WthIp" id="7b8v2sshxQi" role="2Oq$k0" />
+                        <node concept="2XshWL" id="7b8v2sshxQj" role="2OqNvi">
+                          <ref role="2WH_rO" node="7b8v2sshaES" resolve="createAction" />
+                          <node concept="Xl_RD" id="7b8v2ssk6LS" role="2XxRq1" />
+                          <node concept="Xl_RD" id="7b8v2sshxQk" role="2XxRq1">
+                            <property role="Xl_RC" value="A" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="39bAoz" id="7b8v2sshiHI" role="2OqNvi" />
+                </node>
+                <node concept="ANE8D" id="7b8v2sshl3t" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7b8v2sshyt8" role="3cqZAp">
+          <node concept="2OqwBi" id="7b8v2sshyt9" role="3clFbG">
+            <node concept="37vLTw" id="7b8v2sshyta" role="2Oq$k0">
+              <ref role="3cqZAo" node="7b8v2ssbhSs" resolve="groups" />
+            </node>
+            <node concept="liA8E" id="7b8v2sshytb" role="2OqNvi">
+              <ref role="37wK5l" to="33ny:~TreeMap.put(java.lang.Object,java.lang.Object)" resolve="put" />
+              <node concept="Xl_RD" id="7b8v2sshytc" role="37wK5m">
+                <property role="Xl_RC" value="Z" />
+              </node>
+              <node concept="2OqwBi" id="7b8v2sshytd" role="37wK5m">
+                <node concept="2OqwBi" id="7b8v2sshyte" role="2Oq$k0">
+                  <node concept="2ShNRf" id="7b8v2sshytf" role="2Oq$k0">
+                    <node concept="3g6Rrh" id="7b8v2sshytg" role="2ShVmc">
+                      <node concept="3uibUv" id="7b8v2sshyth" role="3g7fb8">
+                        <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
+                      </node>
+                      <node concept="2OqwBi" id="7b8v2sshyti" role="3g7hyw">
+                        <node concept="2WthIp" id="7b8v2sshytj" role="2Oq$k0" />
+                        <node concept="2XshWL" id="7b8v2sshytk" role="2OqNvi">
+                          <ref role="2WH_rO" node="7b8v2sshaES" resolve="createAction" />
+                          <node concept="Xl_RD" id="7b8v2ssk7pN" role="2XxRq1">
+                            <property role="Xl_RC" value="Z" />
+                          </node>
+                          <node concept="Xl_RD" id="7b8v2sshytl" role="2XxRq1">
+                            <property role="Xl_RC" value="C" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="2OqwBi" id="7b8v2sshytm" role="3g7hyw">
+                        <node concept="2WthIp" id="7b8v2sshytn" role="2Oq$k0" />
+                        <node concept="2XshWL" id="7b8v2sshyto" role="2OqNvi">
+                          <ref role="2WH_rO" node="7b8v2sshaES" resolve="createAction" />
+                          <node concept="Xl_RD" id="7b8v2ssk9hw" role="2XxRq1">
+                            <property role="Xl_RC" value="Z" />
+                          </node>
+                          <node concept="Xl_RD" id="7b8v2sshytp" role="2XxRq1">
+                            <property role="Xl_RC" value="B" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="2OqwBi" id="7b8v2sshytq" role="3g7hyw">
+                        <node concept="2WthIp" id="7b8v2sshytr" role="2Oq$k0" />
+                        <node concept="2XshWL" id="7b8v2sshyts" role="2OqNvi">
+                          <ref role="2WH_rO" node="7b8v2sshaES" resolve="createAction" />
+                          <node concept="Xl_RD" id="7b8v2sskh3q" role="2XxRq1">
+                            <property role="Xl_RC" value="Z" />
+                          </node>
+                          <node concept="Xl_RD" id="7b8v2sshytt" role="2XxRq1">
+                            <property role="Xl_RC" value="A" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="39bAoz" id="7b8v2sshytu" role="2OqNvi" />
+                </node>
+                <node concept="ANE8D" id="7b8v2sshytv" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7b8v2ssh_li" role="3cqZAp">
+          <node concept="2OqwBi" id="7b8v2ssh_lj" role="3clFbG">
+            <node concept="37vLTw" id="7b8v2ssh_lk" role="2Oq$k0">
+              <ref role="3cqZAo" node="7b8v2ssbhSs" resolve="groups" />
+            </node>
+            <node concept="liA8E" id="7b8v2ssh_ll" role="2OqNvi">
+              <ref role="37wK5l" to="33ny:~TreeMap.put(java.lang.Object,java.lang.Object)" resolve="put" />
+              <node concept="Xl_RD" id="7b8v2sshCUE" role="37wK5m">
+                <property role="Xl_RC" value="X" />
+              </node>
+              <node concept="2OqwBi" id="7b8v2ssh_ln" role="37wK5m">
+                <node concept="2OqwBi" id="7b8v2ssh_lo" role="2Oq$k0">
+                  <node concept="2ShNRf" id="7b8v2ssh_lp" role="2Oq$k0">
+                    <node concept="3g6Rrh" id="7b8v2ssh_lq" role="2ShVmc">
+                      <node concept="3uibUv" id="7b8v2ssh_lr" role="3g7fb8">
+                        <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
+                      </node>
+                      <node concept="2OqwBi" id="7b8v2ssh_ls" role="3g7hyw">
+                        <node concept="2WthIp" id="7b8v2ssh_lt" role="2Oq$k0" />
+                        <node concept="2XshWL" id="7b8v2ssh_lu" role="2OqNvi">
+                          <ref role="2WH_rO" node="7b8v2sshaES" resolve="createAction" />
+                          <node concept="Xl_RD" id="7b8v2sskiV0" role="2XxRq1">
+                            <property role="Xl_RC" value="X" />
+                          </node>
+                          <node concept="Xl_RD" id="7b8v2ssh_lv" role="2XxRq1">
+                            <property role="Xl_RC" value="C" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="2OqwBi" id="7b8v2ssh_lw" role="3g7hyw">
+                        <node concept="2WthIp" id="7b8v2ssh_lx" role="2Oq$k0" />
+                        <node concept="2XshWL" id="7b8v2ssh_ly" role="2OqNvi">
+                          <ref role="2WH_rO" node="7b8v2sshaES" resolve="createAction" />
+                          <node concept="Xl_RD" id="7b8v2sskkaO" role="2XxRq1">
+                            <property role="Xl_RC" value="X" />
+                          </node>
+                          <node concept="Xl_RD" id="7b8v2ssh_lz" role="2XxRq1">
+                            <property role="Xl_RC" value="B" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="2OqwBi" id="7b8v2ssh_l$" role="3g7hyw">
+                        <node concept="2WthIp" id="7b8v2ssh_l_" role="2Oq$k0" />
+                        <node concept="2XshWL" id="7b8v2ssh_lA" role="2OqNvi">
+                          <ref role="2WH_rO" node="7b8v2sshaES" resolve="createAction" />
+                          <node concept="Xl_RD" id="7b8v2sskm2x" role="2XxRq1">
+                            <property role="Xl_RC" value="X" />
+                          </node>
+                          <node concept="Xl_RD" id="7b8v2ssh_lB" role="2XxRq1">
+                            <property role="Xl_RC" value="A" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="39bAoz" id="7b8v2ssh_lC" role="2OqNvi" />
+                </node>
+                <node concept="ANE8D" id="7b8v2ssh_lD" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7b8v2ss99Yv" role="3cqZAp">
+          <node concept="2OqwBi" id="7b8v2ss9a6L" role="3clFbG">
+            <node concept="37vLTw" id="7b8v2ss99Yt" role="2Oq$k0">
+              <ref role="3cqZAo" node="7b8v2ss902Y" resolve="producer" />
+            </node>
+            <node concept="liA8E" id="7b8v2ssbd24" role="2OqNvi">
+              <ref role="37wK5l" to="ih8q:4yZHsKxNkJT" resolve="populateMainMenu" />
+              <node concept="37vLTw" id="7b8v2sshmP2" role="37wK5m">
+                <ref role="3cqZAo" node="7b8v2ssbdcP" resolve="mainGroup" />
+              </node>
+              <node concept="37vLTw" id="7b8v2sshnNL" role="37wK5m">
+                <ref role="3cqZAo" node="7b8v2ssbhSs" resolve="groups" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="7b8v2sshsDq" role="3cqZAp">
+          <node concept="3cpWsn" id="7b8v2sshsDr" role="3cpWs9">
+            <property role="TrG5h" value="children" />
+            <node concept="2OqwBi" id="7b8v2ssiE8D" role="33vP2m">
+              <node concept="2OqwBi" id="7b8v2ssizYs" role="2Oq$k0">
+                <node concept="2OqwBi" id="7b8v2sshsDs" role="2Oq$k0">
+                  <node concept="37vLTw" id="7b8v2sshsDt" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7b8v2ssbdcP" resolve="mainGroup" />
+                  </node>
+                  <node concept="liA8E" id="7b8v2sshsDu" role="2OqNvi">
+                    <ref role="37wK5l" to="qkt:~DefaultActionGroup.getChildActionsOrStubs()" resolve="getChildActionsOrStubs" />
+                  </node>
+                </node>
+                <node concept="39bAoz" id="7b8v2ssi$Nj" role="2OqNvi" />
+              </node>
+              <node concept="ANE8D" id="7b8v2ssiFI$" role="2OqNvi" />
+            </node>
+            <node concept="_YKpA" id="7b8v2ssiAK7" role="1tU5fm">
+              <node concept="3uibUv" id="7b8v2ssiCNQ" role="_ZDj9">
+                <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7b8v2ssnuKl" role="3cqZAp" />
+        <node concept="3cpWs8" id="7b8v2sshNMo" role="3cqZAp">
+          <node concept="3cpWsn" id="7b8v2sshNMp" role="3cpWs9">
+            <property role="TrG5h" value="expectedGroups" />
+            <node concept="2hMVRd" id="7b8v2sshNMq" role="1tU5fm">
+              <node concept="17QB3L" id="7b8v2sshNMr" role="2hN53Y" />
+            </node>
+            <node concept="2ShNRf" id="7b8v2sshNMs" role="33vP2m">
+              <node concept="32HrFt" id="7b8v2sshNMt" role="2ShVmc">
+                <node concept="17QB3L" id="7b8v2sshNMu" role="HW$YZ" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7b8v2sshYf5" role="3cqZAp">
+          <node concept="2OqwBi" id="7b8v2sshYf6" role="3clFbG">
+            <node concept="37vLTw" id="7b8v2sshYf7" role="2Oq$k0">
+              <ref role="3cqZAo" node="7b8v2sshNMp" resolve="expectedGroups" />
+            </node>
+            <node concept="TSZUe" id="7b8v2sshYf8" role="2OqNvi">
+              <node concept="Xl_RD" id="7b8v2sshYf9" role="25WWJ7" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7b8v2sshYfa" role="3cqZAp">
+          <node concept="2OqwBi" id="7b8v2sshYfb" role="3clFbG">
+            <node concept="37vLTw" id="7b8v2sshYfc" role="2Oq$k0">
+              <ref role="3cqZAo" node="7b8v2sshNMp" resolve="expectedGroups" />
+            </node>
+            <node concept="TSZUe" id="7b8v2sshYfd" role="2OqNvi">
+              <node concept="Xl_RD" id="7b8v2sshYfe" role="25WWJ7">
+                <property role="Xl_RC" value="X" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7b8v2sshYff" role="3cqZAp">
+          <node concept="2OqwBi" id="7b8v2sshYfg" role="3clFbG">
+            <node concept="37vLTw" id="7b8v2sshYfh" role="2Oq$k0">
+              <ref role="3cqZAo" node="7b8v2sshNMp" resolve="expectedGroups" />
+            </node>
+            <node concept="TSZUe" id="7b8v2sshYfi" role="2OqNvi">
+              <node concept="Xl_RD" id="7b8v2sshYfj" role="25WWJ7">
+                <property role="Xl_RC" value="Z" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7b8v2ssn9w4" role="3cqZAp" />
+        <node concept="3vlDli" id="7b8v2sshYfo" role="3cqZAp">
+          <node concept="2YIFZM" id="7b8v2ssi9DW" role="3tpDZA">
+            <ref role="37wK5l" node="1NzaUygEqcw" resolve="extractGroup" />
+            <ref role="1Pybhc" node="1NzaUygE4Q4" resolve="GroupTestHelper" />
+            <node concept="37vLTw" id="7b8v2ssi9DX" role="37wK5m">
+              <ref role="3cqZAo" node="7b8v2ss902Y" resolve="producer" />
+            </node>
+            <node concept="37vLTw" id="7b8v2ssi9DY" role="37wK5m">
+              <ref role="3cqZAo" node="7b8v2ssbdcP" resolve="mainGroup" />
+            </node>
+          </node>
+          <node concept="37vLTw" id="7b8v2sshYfs" role="3tpDZB">
+            <ref role="3cqZAo" node="7b8v2sshNMp" resolve="expectedGroups" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="7b8v2sskJXK" role="3cqZAp" />
+        <node concept="3vlDli" id="7b8v2sskL0A" role="3cqZAp">
+          <node concept="10Nm6u" id="7b8v2ssm_NO" role="3tpDZB" />
+          <node concept="2OqwBi" id="7b8v2ssmoJl" role="3tpDZA">
+            <node concept="0kSF2" id="7b8v2ssmni6" role="2Oq$k0">
+              <node concept="3uibUv" id="7b8v2ssmni8" role="0kSFW">
+                <ref role="3uigEE" to="qkt:~Separator" resolve="Separator" />
+              </node>
+              <node concept="1y4W85" id="7b8v2sskRsv" role="0kSFX">
+                <node concept="3cmrfG" id="7b8v2sskS3t" role="1y58nS">
+                  <property role="3cmrfH" value="0" />
+                </node>
+                <node concept="37vLTw" id="7b8v2sskM3o" role="1y566C">
+                  <ref role="3cqZAo" node="7b8v2sshsDr" resolve="children" />
+                </node>
+              </node>
+            </node>
+            <node concept="liA8E" id="7b8v2ssmq9N" role="2OqNvi">
+              <ref role="37wK5l" to="qkt:~Separator.getText()" resolve="getText" />
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="7b8v2ssmHyY" role="3cqZAp">
+          <node concept="Xl_RD" id="7b8v2ssmOxq" role="3tpDZB">
+            <property role="Xl_RC" value="A" />
+          </node>
+          <node concept="2OqwBi" id="7b8v2ssmLg5" role="3tpDZA">
+            <node concept="1y4W85" id="7b8v2ssmHz3" role="2Oq$k0">
+              <node concept="3cmrfG" id="7b8v2ssmHz4" role="1y58nS">
+                <property role="3cmrfH" value="1" />
+              </node>
+              <node concept="37vLTw" id="7b8v2ssmHz5" role="1y566C">
+                <ref role="3cqZAo" node="7b8v2sshsDr" resolve="children" />
+              </node>
+            </node>
+            <node concept="liA8E" id="7b8v2ssmM$l" role="2OqNvi">
+              <ref role="37wK5l" to="qkt:~AnAction.toString()" resolve="toString" />
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="7b8v2ssmR6s" role="3cqZAp">
+          <node concept="Xl_RD" id="7b8v2ssmR6t" role="3tpDZB">
+            <property role="Xl_RC" value="B" />
+          </node>
+          <node concept="2OqwBi" id="7b8v2ssmR6u" role="3tpDZA">
+            <node concept="1y4W85" id="7b8v2ssmR6v" role="2Oq$k0">
+              <node concept="3cmrfG" id="7b8v2ssmR6w" role="1y58nS">
+                <property role="3cmrfH" value="2" />
+              </node>
+              <node concept="37vLTw" id="7b8v2ssmR6x" role="1y566C">
+                <ref role="3cqZAo" node="7b8v2sshsDr" resolve="children" />
+              </node>
+            </node>
+            <node concept="liA8E" id="7b8v2ssmR6y" role="2OqNvi">
+              <ref role="37wK5l" to="qkt:~AnAction.toString()" resolve="toString" />
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="7b8v2ssmSnT" role="3cqZAp">
+          <node concept="Xl_RD" id="7b8v2ssmSnU" role="3tpDZB">
+            <property role="Xl_RC" value="C" />
+          </node>
+          <node concept="2OqwBi" id="7b8v2ssmSnV" role="3tpDZA">
+            <node concept="1y4W85" id="7b8v2ssmSnW" role="2Oq$k0">
+              <node concept="3cmrfG" id="7b8v2ssmSnX" role="1y58nS">
+                <property role="3cmrfH" value="3" />
+              </node>
+              <node concept="37vLTw" id="7b8v2ssmSnY" role="1y566C">
+                <ref role="3cqZAo" node="7b8v2sshsDr" resolve="children" />
+              </node>
+            </node>
+            <node concept="liA8E" id="7b8v2ssmSnZ" role="2OqNvi">
+              <ref role="37wK5l" to="qkt:~AnAction.toString()" resolve="toString" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7b8v2ssmUpn" role="3cqZAp" />
+        <node concept="3vlDli" id="7b8v2ssmUpp" role="3cqZAp">
+          <node concept="Xl_RD" id="7b8v2ssmYTF" role="3tpDZB">
+            <property role="Xl_RC" value="X" />
+          </node>
+          <node concept="2OqwBi" id="7b8v2ssmUpr" role="3tpDZA">
+            <node concept="0kSF2" id="7b8v2ssmUps" role="2Oq$k0">
+              <node concept="3uibUv" id="7b8v2ssmUpt" role="0kSFW">
+                <ref role="3uigEE" to="qkt:~Separator" resolve="Separator" />
+              </node>
+              <node concept="1y4W85" id="7b8v2ssmUpu" role="0kSFX">
+                <node concept="3cmrfG" id="7b8v2ssmUpv" role="1y58nS">
+                  <property role="3cmrfH" value="4" />
+                </node>
+                <node concept="37vLTw" id="7b8v2ssmUpw" role="1y566C">
+                  <ref role="3cqZAo" node="7b8v2sshsDr" resolve="children" />
+                </node>
+              </node>
+            </node>
+            <node concept="liA8E" id="7b8v2ssmUpx" role="2OqNvi">
+              <ref role="37wK5l" to="qkt:~Separator.getText()" resolve="getText" />
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="7b8v2ssmUpy" role="3cqZAp">
+          <node concept="Xl_RD" id="7b8v2ssmUpz" role="3tpDZB">
+            <property role="Xl_RC" value="A" />
+          </node>
+          <node concept="2OqwBi" id="7b8v2ssmUp$" role="3tpDZA">
+            <node concept="1y4W85" id="7b8v2ssmUp_" role="2Oq$k0">
+              <node concept="3cmrfG" id="7b8v2ssmUpA" role="1y58nS">
+                <property role="3cmrfH" value="5" />
+              </node>
+              <node concept="37vLTw" id="7b8v2ssmUpB" role="1y566C">
+                <ref role="3cqZAo" node="7b8v2sshsDr" resolve="children" />
+              </node>
+            </node>
+            <node concept="liA8E" id="7b8v2ssmUpC" role="2OqNvi">
+              <ref role="37wK5l" to="qkt:~AnAction.toString()" resolve="toString" />
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="7b8v2ssmUpD" role="3cqZAp">
+          <node concept="Xl_RD" id="7b8v2ssmUpE" role="3tpDZB">
+            <property role="Xl_RC" value="B" />
+          </node>
+          <node concept="2OqwBi" id="7b8v2ssmUpF" role="3tpDZA">
+            <node concept="1y4W85" id="7b8v2ssmUpG" role="2Oq$k0">
+              <node concept="3cmrfG" id="7b8v2ssmUpH" role="1y58nS">
+                <property role="3cmrfH" value="6" />
+              </node>
+              <node concept="37vLTw" id="7b8v2ssmUpI" role="1y566C">
+                <ref role="3cqZAo" node="7b8v2sshsDr" resolve="children" />
+              </node>
+            </node>
+            <node concept="liA8E" id="7b8v2ssmUpJ" role="2OqNvi">
+              <ref role="37wK5l" to="qkt:~AnAction.toString()" resolve="toString" />
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="7b8v2ssmUpK" role="3cqZAp">
+          <node concept="Xl_RD" id="7b8v2ssmUpL" role="3tpDZB">
+            <property role="Xl_RC" value="C" />
+          </node>
+          <node concept="2OqwBi" id="7b8v2ssmUpM" role="3tpDZA">
+            <node concept="1y4W85" id="7b8v2ssmUpN" role="2Oq$k0">
+              <node concept="3cmrfG" id="7b8v2ssmUpO" role="1y58nS">
+                <property role="3cmrfH" value="7" />
+              </node>
+              <node concept="37vLTw" id="7b8v2ssmUpP" role="1y566C">
+                <ref role="3cqZAo" node="7b8v2sshsDr" resolve="children" />
+              </node>
+            </node>
+            <node concept="liA8E" id="7b8v2ssmUpQ" role="2OqNvi">
+              <ref role="37wK5l" to="qkt:~AnAction.toString()" resolve="toString" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7b8v2ssmUpo" role="3cqZAp" />
+        <node concept="3vlDli" id="7b8v2ssn2dc" role="3cqZAp">
+          <node concept="Xl_RD" id="7b8v2ssn2dd" role="3tpDZB">
+            <property role="Xl_RC" value="Z" />
+          </node>
+          <node concept="2OqwBi" id="7b8v2ssn2de" role="3tpDZA">
+            <node concept="0kSF2" id="7b8v2ssn2df" role="2Oq$k0">
+              <node concept="3uibUv" id="7b8v2ssn2dg" role="0kSFW">
+                <ref role="3uigEE" to="qkt:~Separator" resolve="Separator" />
+              </node>
+              <node concept="1y4W85" id="7b8v2ssn2dh" role="0kSFX">
+                <node concept="3cmrfG" id="7b8v2ssn2di" role="1y58nS">
+                  <property role="3cmrfH" value="8" />
+                </node>
+                <node concept="37vLTw" id="7b8v2ssn2dj" role="1y566C">
+                  <ref role="3cqZAo" node="7b8v2sshsDr" resolve="children" />
+                </node>
+              </node>
+            </node>
+            <node concept="liA8E" id="7b8v2ssn2dk" role="2OqNvi">
+              <ref role="37wK5l" to="qkt:~Separator.getText()" resolve="getText" />
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="7b8v2ssn2dl" role="3cqZAp">
+          <node concept="Xl_RD" id="7b8v2ssn2dm" role="3tpDZB">
+            <property role="Xl_RC" value="A" />
+          </node>
+          <node concept="2OqwBi" id="7b8v2ssn2dn" role="3tpDZA">
+            <node concept="1y4W85" id="7b8v2ssn2do" role="2Oq$k0">
+              <node concept="3cmrfG" id="7b8v2ssn2dp" role="1y58nS">
+                <property role="3cmrfH" value="9" />
+              </node>
+              <node concept="37vLTw" id="7b8v2ssn2dq" role="1y566C">
+                <ref role="3cqZAo" node="7b8v2sshsDr" resolve="children" />
+              </node>
+            </node>
+            <node concept="liA8E" id="7b8v2ssn2dr" role="2OqNvi">
+              <ref role="37wK5l" to="qkt:~AnAction.toString()" resolve="toString" />
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="7b8v2ssn2ds" role="3cqZAp">
+          <node concept="Xl_RD" id="7b8v2ssn2dt" role="3tpDZB">
+            <property role="Xl_RC" value="B" />
+          </node>
+          <node concept="2OqwBi" id="7b8v2ssn2du" role="3tpDZA">
+            <node concept="1y4W85" id="7b8v2ssn2dv" role="2Oq$k0">
+              <node concept="3cmrfG" id="7b8v2ssn2dw" role="1y58nS">
+                <property role="3cmrfH" value="10" />
+              </node>
+              <node concept="37vLTw" id="7b8v2ssn2dx" role="1y566C">
+                <ref role="3cqZAo" node="7b8v2sshsDr" resolve="children" />
+              </node>
+            </node>
+            <node concept="liA8E" id="7b8v2ssn2dy" role="2OqNvi">
+              <ref role="37wK5l" to="qkt:~AnAction.toString()" resolve="toString" />
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="7b8v2ssn2dz" role="3cqZAp">
+          <node concept="Xl_RD" id="7b8v2ssn2d$" role="3tpDZB">
+            <property role="Xl_RC" value="C" />
+          </node>
+          <node concept="2OqwBi" id="7b8v2ssn2d_" role="3tpDZA">
+            <node concept="1y4W85" id="7b8v2ssn2dA" role="2Oq$k0">
+              <node concept="3cmrfG" id="7b8v2ssn2dB" role="1y58nS">
+                <property role="3cmrfH" value="11" />
+              </node>
+              <node concept="37vLTw" id="7b8v2ssn2dC" role="1y566C">
+                <ref role="3cqZAo" node="7b8v2sshsDr" resolve="children" />
+              </node>
+            </node>
+            <node concept="liA8E" id="7b8v2ssn2dD" role="2OqNvi">
+              <ref role="37wK5l" to="qkt:~AnAction.toString()" resolve="toString" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7b8v2ssn0r2" role="3cqZAp" />
+      </node>
+    </node>
+    <node concept="1LZb2c" id="7b8v2ssn_9v" role="1SL9yI">
+      <property role="TrG5h" value="getGroupName" />
+      <node concept="3cqZAl" id="7b8v2ssn_9w" role="3clF45" />
+      <node concept="3clFbS" id="7b8v2ssn_9$" role="3clF47">
+        <node concept="3cpWs8" id="7b8v2ssnHRM" role="3cqZAp">
+          <node concept="3cpWsn" id="7b8v2ssnHRN" role="3cpWs9">
+            <property role="TrG5h" value="repository" />
+            <node concept="3uibUv" id="7b8v2ssnHRO" role="1tU5fm">
+              <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
+            </node>
+            <node concept="2OqwBi" id="7b8v2ssnHRP" role="33vP2m">
+              <node concept="1jxXqW" id="7b8v2ssnHRQ" role="2Oq$k0" />
+              <node concept="liA8E" id="7b8v2ssnHRR" role="2OqNvi">
+                <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="7b8v2ssnHRS" role="3cqZAp">
+          <node concept="3cpWsn" id="7b8v2ssnHRT" role="3cpWs9">
+            <property role="TrG5h" value="component" />
+            <node concept="3uibUv" id="7b8v2ssnHRU" role="1tU5fm">
+              <ref role="3uigEE" to="7a0s:6qGpHl7IHpK" resolve="HeadlessEditorComponent" />
+            </node>
+            <node concept="2ShNRf" id="7b8v2ssnHRV" role="33vP2m">
+              <node concept="1pGfFk" id="7b8v2ssnHRW" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="7a0s:2iNJDZP2RE6" resolve="HeadlessEditorComponent" />
+                <node concept="37vLTw" id="7b8v2ssnHRX" role="37wK5m">
+                  <ref role="3cqZAo" node="7b8v2ssnHRN" resolve="repository" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="7b8v2ssnHRY" role="3cqZAp">
+          <node concept="3cpWsn" id="7b8v2ssnHRZ" role="3cpWs9">
+            <property role="TrG5h" value="producer" />
+            <node concept="3uibUv" id="7b8v2ssnHS0" role="1tU5fm">
+              <ref role="3uigEE" to="ih8q:2jDew64JcPx" resolve="MyIntentionMenuProducer" />
+            </node>
+            <node concept="2ShNRf" id="7b8v2ssnHS1" role="33vP2m">
+              <node concept="1pGfFk" id="7b8v2ssnHS2" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="ih8q:2jDew64KaGG" resolve="MyIntentionMenuProducer" />
+                <node concept="37vLTw" id="7b8v2ssnHS3" role="37wK5m">
+                  <ref role="3cqZAo" node="7b8v2ssnHRT" resolve="component" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="7b8v2ssnI54" role="3cqZAp">
+          <node concept="Xl_RD" id="7b8v2ssnJ4X" role="3tpDZB">
+            <property role="Xl_RC" value="Group" />
+          </node>
+          <node concept="2OqwBi" id="7b8v2ssnCMU" role="3tpDZA">
+            <node concept="37vLTw" id="7b8v2ssnCgI" role="2Oq$k0">
+              <ref role="3cqZAo" node="7b8v2ssnHRZ" resolve="producer" />
+            </node>
+            <node concept="liA8E" id="7b8v2ssnErN" role="2OqNvi">
+              <ref role="37wK5l" to="ih8q:3pwG8PSpGSr" resolve="getGroupName" />
+              <node concept="2OqwBi" id="7b8v2ssnIgE" role="37wK5m">
+                <node concept="2WthIp" id="7b8v2ssnIgH" role="2Oq$k0" />
+                <node concept="2XshWL" id="7b8v2ssnIgJ" role="2OqNvi">
+                  <ref role="2WH_rO" node="7b8v2sshaES" resolve="createAction" />
+                  <node concept="Xl_RD" id="7b8v2ssnIPA" role="2XxRq1">
+                    <property role="Xl_RC" value="Group" />
+                  </node>
+                  <node concept="Xl_RD" id="7b8v2ssnJ00" role="2XxRq1">
+                    <property role="Xl_RC" value="A" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="7b8v2ssnJay" role="3cqZAp">
+          <node concept="Xl_RD" id="7b8v2ssnJaz" role="3tpDZB" />
+          <node concept="2OqwBi" id="7b8v2ssnJa$" role="3tpDZA">
+            <node concept="37vLTw" id="7b8v2ssnJa_" role="2Oq$k0">
+              <ref role="3cqZAo" node="7b8v2ssnHRZ" resolve="producer" />
+            </node>
+            <node concept="liA8E" id="7b8v2ssnJaA" role="2OqNvi">
+              <ref role="37wK5l" to="ih8q:3pwG8PSpGSr" resolve="getGroupName" />
+              <node concept="2OqwBi" id="7b8v2ssnJaB" role="37wK5m">
+                <node concept="2WthIp" id="7b8v2ssnJaC" role="2Oq$k0" />
+                <node concept="2XshWL" id="7b8v2ssnJaD" role="2OqNvi">
+                  <ref role="2WH_rO" node="7b8v2sshaES" resolve="createAction" />
+                  <node concept="Xl_RD" id="7b8v2ssnJaE" role="2XxRq1" />
+                  <node concept="Xl_RD" id="7b8v2ssnJaF" role="2XxRq1">
+                    <property role="Xl_RC" value="A" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="7b8v2ssnJFD" role="3cqZAp">
+          <node concept="2OqwBi" id="7b8v2ssnJFF" role="3tpDZA">
+            <node concept="37vLTw" id="7b8v2ssnJFG" role="2Oq$k0">
+              <ref role="3cqZAo" node="7b8v2ssnHRZ" resolve="producer" />
+            </node>
+            <node concept="liA8E" id="7b8v2ssnJFH" role="2OqNvi">
+              <ref role="37wK5l" to="ih8q:3pwG8PSpGSr" resolve="getGroupName" />
+              <node concept="2OqwBi" id="7b8v2ssnJFI" role="37wK5m">
+                <node concept="2WthIp" id="7b8v2ssnJFJ" role="2Oq$k0" />
+                <node concept="2XshWL" id="7b8v2ssnJFK" role="2OqNvi">
+                  <ref role="2WH_rO" node="7b8v2sshaES" resolve="createAction" />
+                  <node concept="10Nm6u" id="7b8v2ssnKcV" role="2XxRq1" />
+                  <node concept="Xl_RD" id="7b8v2ssnJFM" role="2XxRq1">
+                    <property role="Xl_RC" value="A" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="Xl_RD" id="7b8v2ssoPng" role="3tpDZB">
+            <property role="Xl_RC" value="" />
+          </node>
+        </node>
+        <node concept="3vlDli" id="7b8v2ssnKsV" role="3cqZAp">
+          <node concept="Xl_RD" id="7b8v2sspo01" role="3tpDZB">
+            <property role="Xl_RC" value="" />
+          </node>
+          <node concept="2OqwBi" id="7b8v2ssnKsX" role="3tpDZA">
+            <node concept="37vLTw" id="7b8v2ssnKsY" role="2Oq$k0">
+              <ref role="3cqZAo" node="7b8v2ssnHRZ" resolve="producer" />
+            </node>
+            <node concept="liA8E" id="7b8v2ssnKsZ" role="2OqNvi">
+              <ref role="37wK5l" to="ih8q:3pwG8PSpGSr" resolve="getGroupName" />
+              <node concept="2OqwBi" id="7b8v2ssnKt0" role="37wK5m">
+                <node concept="2WthIp" id="7b8v2ssnKt1" role="2Oq$k0" />
+                <node concept="2XshWL" id="7b8v2ssnKt2" role="2OqNvi">
+                  <ref role="2WH_rO" node="7b8v2sshaES" resolve="createAction" />
+                  <node concept="10Nm6u" id="7b8v2ssnKt3" role="2XxRq1" />
+                  <node concept="10Nm6u" id="7b8v2ssnL1R" role="2XxRq1" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="7b8v2sspSG$" role="1SL9yI">
+      <property role="TrG5h" value="substituteAction" />
+      <node concept="3cqZAl" id="7b8v2sspSG_" role="3clF45" />
+      <node concept="3clFbS" id="7b8v2sspSGD" role="3clF47">
+        <node concept="3cpWs8" id="7b8v2sspUCO" role="3cqZAp">
+          <node concept="3cpWsn" id="7b8v2sspUCP" role="3cpWs9">
+            <property role="TrG5h" value="repository" />
+            <property role="3TUv4t" value="true" />
+            <node concept="3uibUv" id="7b8v2sspUCQ" role="1tU5fm">
+              <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
+            </node>
+            <node concept="2OqwBi" id="7b8v2sspUCR" role="33vP2m">
+              <node concept="1jxXqW" id="7b8v2sspUCS" role="2Oq$k0" />
+              <node concept="liA8E" id="7b8v2sspUCT" role="2OqNvi">
+                <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="7b8v2sspUCU" role="3cqZAp">
+          <node concept="3cpWsn" id="7b8v2sspUCV" role="3cpWs9">
+            <property role="TrG5h" value="component" />
+            <node concept="3uibUv" id="7b8v2sspUCW" role="1tU5fm">
+              <ref role="3uigEE" to="exr9:~EditorComponent" resolve="EditorComponent" />
+            </node>
+            <node concept="2ShNRf" id="7b8v2sspUCX" role="33vP2m">
+              <node concept="1pGfFk" id="7b8v2sspUCY" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="exr9:~NodeEditorComponent.&lt;init&gt;(org.jetbrains.mps.openapi.module.SRepository)" resolve="NodeEditorComponent" />
+                <node concept="37vLTw" id="7b8v2sspUCZ" role="37wK5m">
+                  <ref role="3cqZAo" node="7b8v2sspUCP" resolve="repository" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="7b8v2sspUD0" role="3cqZAp">
+          <node concept="3cpWsn" id="7b8v2sspUD1" role="3cpWs9">
+            <property role="TrG5h" value="producer" />
+            <node concept="3uibUv" id="7b8v2sspUD2" role="1tU5fm">
+              <ref role="3uigEE" to="ih8q:2jDew64JcPx" resolve="MyIntentionMenuProducer" />
+            </node>
+            <node concept="2ShNRf" id="7b8v2sspUD3" role="33vP2m">
+              <node concept="1pGfFk" id="7b8v2sspUD4" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="ih8q:2jDew64KaGG" resolve="MyIntentionMenuProducer" />
+                <node concept="37vLTw" id="7b8v2sspUD5" role="37wK5m">
+                  <ref role="3cqZAo" node="7b8v2sspUCV" resolve="component" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7b8v2sswXgJ" role="3cqZAp" />
+        <node concept="3cpWs8" id="7b8v2sswXkD" role="3cqZAp">
+          <node concept="3cpWsn" id="7b8v2sswXkE" role="3cpWs9">
+            <property role="TrG5h" value="baseGroup" />
+            <node concept="3uibUv" id="7b8v2sswXkF" role="1tU5fm">
+              <ref role="3uigEE" to="7bx7:~BaseGroup" resolve="BaseGroup" />
+            </node>
+            <node concept="2ShNRf" id="7b8v2sswXkG" role="33vP2m">
+              <node concept="1pGfFk" id="7b8v2sswXkH" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="7bx7:~BaseGroup.&lt;init&gt;(java.lang.String)" resolve="BaseGroup" />
+                <node concept="Xl_RD" id="7b8v2ssyeyJ" role="37wK5m">
+                  <property role="Xl_RC" value="BaseGroup" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="7b8v2ssxtRW" role="3cqZAp">
+          <node concept="3cpWsn" id="7b8v2ssxtRZ" role="3cpWs9">
+            <property role="TrG5h" value="groupName" />
+            <node concept="17QB3L" id="7b8v2ssxtRU" role="1tU5fm" />
+            <node concept="Xl_RD" id="7b8v2ssxuG5" role="33vP2m">
+              <property role="Xl_RC" value="group" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="7b8v2sswYmI" role="3cqZAp">
+          <node concept="3cpWsn" id="7b8v2sswYmJ" role="3cpWs9">
+            <property role="TrG5h" value="action" />
+            <node concept="3uibUv" id="7b8v2sswYmK" role="1tU5fm">
+              <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
+            </node>
+            <node concept="2OqwBi" id="7b8v2ssx1T0" role="33vP2m">
+              <node concept="2WthIp" id="7b8v2ssx1T3" role="2Oq$k0" />
+              <node concept="2XshWL" id="7b8v2ssx1T5" role="2OqNvi">
+                <ref role="2WH_rO" node="7b8v2sshaES" resolve="createAction" />
+                <node concept="37vLTw" id="7b8v2ssxvCK" role="2XxRq1">
+                  <ref role="3cqZAo" node="7b8v2ssxtRZ" resolve="groupName" />
+                </node>
+                <node concept="Xl_RD" id="7b8v2ssx2jR" role="2XxRq1">
+                  <property role="Xl_RC" value="Action" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7b8v2ssxI__" role="3cqZAp">
+          <node concept="2OqwBi" id="7b8v2ssxJvi" role="3clFbG">
+            <node concept="37vLTw" id="7b8v2ssxI_z" role="2Oq$k0">
+              <ref role="3cqZAo" node="7b8v2sswXkE" resolve="baseGroup" />
+            </node>
+            <node concept="liA8E" id="7b8v2ssxKr4" role="2OqNvi">
+              <ref role="37wK5l" to="qkt:~DefaultActionGroup.add(com.intellij.openapi.actionSystem.AnAction)" resolve="add" />
+              <node concept="37vLTw" id="7b8v2ssxK_t" role="37wK5m">
+                <ref role="3cqZAo" node="7b8v2sswYmJ" resolve="action" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7b8v2sswumJ" role="3cqZAp">
+          <node concept="2OqwBi" id="7b8v2sswuBq" role="3clFbG">
+            <node concept="37vLTw" id="7b8v2sswumH" role="2Oq$k0">
+              <ref role="3cqZAo" node="7b8v2sspUD1" resolve="producer" />
+            </node>
+            <node concept="liA8E" id="7b8v2sswvgq" role="2OqNvi">
+              <ref role="37wK5l" to="ih8q:lMPJvi802g" resolve="substituteAction" />
+              <node concept="37vLTw" id="7b8v2sswXsd" role="37wK5m">
+                <ref role="3cqZAo" node="7b8v2sswXkE" resolve="baseGroup" />
+              </node>
+              <node concept="37vLTw" id="7b8v2ssxqMX" role="37wK5m">
+                <ref role="3cqZAo" node="7b8v2sswYmJ" resolve="action" />
+              </node>
+              <node concept="37vLTw" id="7b8v2ssydTz" role="37wK5m">
+                <ref role="3cqZAo" node="7b8v2ssxtRZ" resolve="groupName" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7b8v2ssydXp" role="3cqZAp" />
+        <node concept="3vwNmj" id="7b8v2ssyei1" role="3cqZAp">
+          <node concept="2OqwBi" id="7b8v2ssygcu" role="3vwVQn">
+            <node concept="2OqwBi" id="7b8v2ssyf5N" role="2Oq$k0">
+              <node concept="37vLTw" id="7b8v2ssyeWx" role="2Oq$k0">
+                <ref role="3cqZAo" node="7b8v2sspUD1" resolve="producer" />
+              </node>
+              <node concept="SiP3y" id="7b8v2ssyfn6" role="2OqNvi">
+                <ref role="3cqZAo" to="ih8q:5Rdndlpp80A" resolve="groupedActionsCache" />
+              </node>
+            </node>
+            <node concept="2Nt0df" id="7b8v2ssyipY" role="2OqNvi">
+              <node concept="37vLTw" id="7b8v2ssyivw" role="38cxEo">
+                <ref role="3cqZAo" node="7b8v2ssxtRZ" resolve="groupName" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="7b8v2ssyiDw" role="3cqZAp">
+          <node concept="2OqwBi" id="7b8v2sszgoA" role="3tpDZB">
+            <node concept="37vLTw" id="7b8v2ssywKB" role="2Oq$k0">
+              <ref role="3cqZAo" node="7b8v2sswYmJ" resolve="action" />
+            </node>
+            <node concept="liA8E" id="7b8v2sszgWm" role="2OqNvi">
+              <ref role="37wK5l" to="qkt:~AnAction.toString()" resolve="toString" />
+            </node>
+          </node>
+          <node concept="2OqwBi" id="7b8v2ssziMS" role="3tpDZA">
+            <node concept="2OqwBi" id="7b8v2ssyuHP" role="2Oq$k0">
+              <node concept="3EllGN" id="7b8v2ssyppn" role="2Oq$k0">
+                <node concept="37vLTw" id="7b8v2ssypz2" role="3ElVtu">
+                  <ref role="3cqZAo" node="7b8v2ssxtRZ" resolve="groupName" />
+                </node>
+                <node concept="2OqwBi" id="7b8v2ssyoij" role="3ElQJh">
+                  <node concept="37vLTw" id="7b8v2ssyls4" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7b8v2sspUD1" resolve="producer" />
+                  </node>
+                  <node concept="SiP3y" id="7b8v2ssyo$x" role="2OqNvi">
+                    <ref role="3cqZAo" to="ih8q:5Rdndlpp80A" resolve="groupedActionsCache" />
+                  </node>
+                </node>
+              </node>
+              <node concept="1uHKPH" id="7b8v2ssyvSB" role="2OqNvi" />
+            </node>
+            <node concept="liA8E" id="7b8v2sszj5_" role="2OqNvi">
+              <ref role="37wK5l" to="qkt:~AnAction.toString()" resolve="toString" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7b8v2ssywZo" role="3cqZAp" />
+        <node concept="3vFxKo" id="7b8v2ssy_8S" role="3cqZAp">
+          <node concept="17R0WA" id="7b8v2ssy_HZ" role="3vFALc">
+            <node concept="2OqwBi" id="7b8v2ssyCIZ" role="3uHU7w">
+              <node concept="37vLTw" id="7b8v2ssy_Px" role="2Oq$k0">
+                <ref role="3cqZAo" node="7b8v2sswYmJ" resolve="action" />
+              </node>
+              <node concept="liA8E" id="7b8v2ssyCRt" role="2OqNvi">
+                <ref role="37wK5l" to="wyt6:~Object.hashCode()" resolve="hashCode" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="7b8v2ssyA$B" role="3uHU7B">
+              <node concept="AH0OO" id="7b8v2ssy_ii" role="2Oq$k0">
+                <node concept="3cmrfG" id="7b8v2ssy_ij" role="AHEQo">
+                  <property role="3cmrfH" value="0" />
+                </node>
+                <node concept="2OqwBi" id="7b8v2ssy_ik" role="AHHXb">
+                  <node concept="37vLTw" id="7b8v2ssy_il" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7b8v2sswXkE" resolve="baseGroup" />
+                  </node>
+                  <node concept="liA8E" id="7b8v2ssy_im" role="2OqNvi">
+                    <ref role="37wK5l" to="qkt:~DefaultActionGroup.getChildActionsOrStubs()" resolve="getChildActionsOrStubs" />
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="7b8v2ssyBbr" role="2OqNvi">
+                <ref role="37wK5l" to="wyt6:~Object.hashCode()" resolve="hashCode" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="7b8v2ssyA6r" role="3cqZAp">
+          <node concept="2OqwBi" id="7b8v2ss$oIO" role="3tpDZA">
+            <node concept="2OqwBi" id="7b8v2ss$7x2" role="2Oq$k0">
+              <node concept="37vLTw" id="7b8v2ssyDNK" role="2Oq$k0">
+                <ref role="3cqZAo" node="7b8v2sswYmJ" resolve="action" />
+              </node>
+              <node concept="liA8E" id="7b8v2ss$oBv" role="2OqNvi">
+                <ref role="37wK5l" to="qkt:~AnAction.getTemplatePresentation()" resolve="getTemplatePresentation" />
+              </node>
+            </node>
+            <node concept="liA8E" id="7b8v2ss$p01" role="2OqNvi">
+              <ref role="37wK5l" to="qkt:~Presentation.toString()" resolve="toString" />
+            </node>
+          </node>
+          <node concept="2OqwBi" id="7b8v2ss$nv6" role="3tpDZB">
+            <node concept="2OqwBi" id="7b8v2ss$dba" role="2Oq$k0">
+              <node concept="AH0OO" id="7b8v2ssyDFK" role="2Oq$k0">
+                <node concept="3cmrfG" id="7b8v2ssyDFL" role="AHEQo">
+                  <property role="3cmrfH" value="0" />
+                </node>
+                <node concept="2OqwBi" id="7b8v2ssyDFM" role="AHHXb">
+                  <node concept="37vLTw" id="7b8v2ssyDFN" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7b8v2sswXkE" resolve="baseGroup" />
+                  </node>
+                  <node concept="liA8E" id="7b8v2ssyDFO" role="2OqNvi">
+                    <ref role="37wK5l" to="qkt:~DefaultActionGroup.getChildActionsOrStubs()" resolve="getChildActionsOrStubs" />
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="7b8v2ss$nau" role="2OqNvi">
+                <ref role="37wK5l" to="qkt:~AnAction.getTemplatePresentation()" resolve="getTemplatePresentation" />
+              </node>
+            </node>
+            <node concept="liA8E" id="7b8v2ss$nZG" role="2OqNvi">
+              <ref role="37wK5l" to="qkt:~Presentation.toString()" resolve="toString" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="7b8v2ss$QnP" role="1SL9yI">
+      <property role="TrG5h" value="processActionGroupWithoutCache" />
+      <node concept="3cqZAl" id="7b8v2ss$QnQ" role="3clF45" />
+      <node concept="3clFbS" id="7b8v2ss$QnR" role="3clF47">
+        <node concept="3cpWs8" id="7b8v2ss$QnS" role="3cqZAp">
+          <node concept="3cpWsn" id="7b8v2ss$QnT" role="3cpWs9">
+            <property role="TrG5h" value="repository" />
+            <node concept="3uibUv" id="7b8v2ss$QnU" role="1tU5fm">
+              <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
+            </node>
+            <node concept="2OqwBi" id="7b8v2ss$QnV" role="33vP2m">
+              <node concept="1jxXqW" id="7b8v2ss$QnW" role="2Oq$k0" />
+              <node concept="liA8E" id="7b8v2ss$QnX" role="2OqNvi">
+                <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="7b8v2ss$QnY" role="3cqZAp">
+          <node concept="3cpWsn" id="7b8v2ss$QnZ" role="3cpWs9">
+            <property role="TrG5h" value="component" />
+            <node concept="3uibUv" id="7b8v2ss$Qo0" role="1tU5fm">
+              <ref role="3uigEE" to="7a0s:6qGpHl7IHpK" resolve="HeadlessEditorComponent" />
+            </node>
+            <node concept="2ShNRf" id="7b8v2ss$Qo1" role="33vP2m">
+              <node concept="1pGfFk" id="7b8v2ss$Qo2" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="7a0s:2iNJDZP2RE6" resolve="HeadlessEditorComponent" />
+                <node concept="37vLTw" id="7b8v2ss$Qo3" role="37wK5m">
+                  <ref role="3cqZAo" node="7b8v2ss$QnT" resolve="repository" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="7b8v2ss$Qo4" role="3cqZAp">
+          <node concept="3cpWsn" id="7b8v2ss$Qo5" role="3cpWs9">
+            <property role="TrG5h" value="producer" />
+            <node concept="3uibUv" id="7b8v2ss$Qo6" role="1tU5fm">
+              <ref role="3uigEE" to="ih8q:2jDew64JcPx" resolve="MyIntentionMenuProducer" />
+            </node>
+            <node concept="2ShNRf" id="7b8v2ss$Qo7" role="33vP2m">
+              <node concept="1pGfFk" id="7b8v2ss$Qo8" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="ih8q:2jDew64KaGG" resolve="MyIntentionMenuProducer" />
+                <node concept="37vLTw" id="7b8v2ss$Qo9" role="37wK5m">
+                  <ref role="3cqZAo" node="7b8v2ss$QnZ" resolve="component" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7b8v2ss$Qoa" role="3cqZAp" />
+        <node concept="3cpWs8" id="7b8v2ss$Qob" role="3cqZAp">
+          <node concept="3cpWsn" id="7b8v2ss$Qoc" role="3cpWs9">
+            <property role="TrG5h" value="mainGroup" />
+            <node concept="3uibUv" id="7b8v2ss$Qod" role="1tU5fm">
+              <ref role="3uigEE" to="qkt:~DefaultActionGroup" resolve="DefaultActionGroup" />
+            </node>
+            <node concept="2ShNRf" id="7b8v2ss$Qoe" role="33vP2m">
+              <node concept="1pGfFk" id="7b8v2ss$Qof" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="qkt:~DefaultActionGroup.&lt;init&gt;()" resolve="DefaultActionGroup" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="7b8v2ss_kzb" role="3cqZAp">
+          <node concept="3cpWsn" id="7b8v2ss_kzc" role="3cpWs9">
+            <property role="TrG5h" value="actions" />
+            <node concept="_YKpA" id="7b8v2ss_jI4" role="1tU5fm">
+              <node concept="3uibUv" id="7b8v2ss_jI7" role="_ZDj9">
+                <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="7b8v2ss_kzd" role="33vP2m">
+              <node concept="2OqwBi" id="7b8v2ss_kze" role="2Oq$k0">
+                <node concept="2ShNRf" id="7b8v2ss_kzf" role="2Oq$k0">
+                  <node concept="3g6Rrh" id="7b8v2ss_kzg" role="2ShVmc">
+                    <node concept="3uibUv" id="7b8v2ss_kzh" role="3g7fb8">
+                      <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
+                    </node>
+                    <node concept="2OqwBi" id="7b8v2ss_kzi" role="3g7hyw">
+                      <node concept="2WthIp" id="7b8v2ss_kzj" role="2Oq$k0" />
+                      <node concept="2XshWL" id="7b8v2ss_kzk" role="2OqNvi">
+                        <ref role="2WH_rO" node="7b8v2sshaES" resolve="createAction" />
+                        <node concept="Xl_RD" id="7b8v2ss_kzl" role="2XxRq1" />
+                        <node concept="Xl_RD" id="7b8v2ss_kzm" role="2XxRq1">
+                          <property role="Xl_RC" value="C" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2OqwBi" id="7b8v2ss_kzn" role="3g7hyw">
+                      <node concept="2WthIp" id="7b8v2ss_kzo" role="2Oq$k0" />
+                      <node concept="2XshWL" id="7b8v2ss_kzp" role="2OqNvi">
+                        <ref role="2WH_rO" node="7b8v2sshaES" resolve="createAction" />
+                        <node concept="Xl_RD" id="7b8v2ss_kzq" role="2XxRq1">
+                          <property role="Xl_RC" value="X" />
+                        </node>
+                        <node concept="Xl_RD" id="7b8v2ss_kzr" role="2XxRq1">
+                          <property role="Xl_RC" value="B" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2OqwBi" id="7b8v2ss_kzs" role="3g7hyw">
+                      <node concept="2WthIp" id="7b8v2ss_kzt" role="2Oq$k0" />
+                      <node concept="2XshWL" id="7b8v2ss_kzu" role="2OqNvi">
+                        <ref role="2WH_rO" node="7b8v2sshaES" resolve="createAction" />
+                        <node concept="Xl_RD" id="7b8v2ss_kzv" role="2XxRq1">
+                          <property role="Xl_RC" value="Z" />
+                        </node>
+                        <node concept="Xl_RD" id="7b8v2ss_kzw" role="2XxRq1">
+                          <property role="Xl_RC" value="A" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="39bAoz" id="7b8v2ss_kzx" role="2OqNvi" />
+              </node>
+              <node concept="ANE8D" id="7b8v2ss_kzy" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7b8v2ss_inC" role="3cqZAp" />
+        <node concept="3cpWs8" id="7b8v2ss_Lg2" role="3cqZAp">
+          <node concept="3cpWsn" id="7b8v2ss_Lg3" role="3cpWs9">
+            <property role="TrG5h" value="expectedGroups" />
+            <node concept="3uibUv" id="7b8v2ss_Lg4" role="1tU5fm">
+              <ref role="3uigEE" to="33ny:~TreeMap" resolve="TreeMap" />
+              <node concept="17QB3L" id="7b8v2ss_Lg5" role="11_B2D" />
+              <node concept="_YKpA" id="7b8v2ss_Lg6" role="11_B2D">
+                <node concept="3uibUv" id="7b8v2ss_Lg7" role="_ZDj9">
+                  <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
+                </node>
+              </node>
+            </node>
+            <node concept="2ShNRf" id="7b8v2ss_Lg8" role="33vP2m">
+              <node concept="1pGfFk" id="7b8v2ss_Lg9" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="33ny:~TreeMap.&lt;init&gt;()" resolve="TreeMap" />
+                <node concept="17QB3L" id="7b8v2ss_Lga" role="1pMfVU" />
+                <node concept="_YKpA" id="7b8v2ss_Lgb" role="1pMfVU">
+                  <node concept="3uibUv" id="7b8v2ss_Lgc" role="_ZDj9">
+                    <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7b8v2ss_LSy" role="3cqZAp">
+          <node concept="2OqwBi" id="7b8v2ss_OPg" role="3clFbG">
+            <node concept="37vLTw" id="7b8v2ss_LSw" role="2Oq$k0">
+              <ref role="3cqZAo" node="7b8v2ss_Lg3" resolve="expectedGroups" />
+            </node>
+            <node concept="liA8E" id="7b8v2ss_UJ1" role="2OqNvi">
+              <ref role="37wK5l" to="33ny:~TreeMap.put(java.lang.Object,java.lang.Object)" resolve="put" />
+              <node concept="Xl_RD" id="7b8v2ss_Vtx" role="37wK5m" />
+              <node concept="2OqwBi" id="7b8v2ssAaPO" role="37wK5m">
+                <node concept="2ShNRf" id="7b8v2ssA3mf" role="2Oq$k0">
+                  <node concept="2HTt$P" id="7b8v2ssA42O" role="2ShVmc">
+                    <node concept="3uibUv" id="7b8v2ssA4Bu" role="2HTBi0">
+                      <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
+                    </node>
+                    <node concept="2OqwBi" id="7b8v2ssAUKa" role="2HTEbv">
+                      <node concept="37vLTw" id="7b8v2ssASWy" role="2Oq$k0">
+                        <ref role="3cqZAo" node="7b8v2ss_kzc" resolve="actions" />
+                      </node>
+                      <node concept="34jXtK" id="7b8v2ssAWBZ" role="2OqNvi">
+                        <node concept="3cmrfG" id="7b8v2ssAXcS" role="25WWJ7">
+                          <property role="3cmrfH" value="0" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="ANE8D" id="7b8v2ssAcpn" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7b8v2ssAfx$" role="3cqZAp">
+          <node concept="2OqwBi" id="7b8v2ssAfx_" role="3clFbG">
+            <node concept="37vLTw" id="7b8v2ssAfxA" role="2Oq$k0">
+              <ref role="3cqZAo" node="7b8v2ss_Lg3" resolve="expectedGroups" />
+            </node>
+            <node concept="liA8E" id="7b8v2ssAfxB" role="2OqNvi">
+              <ref role="37wK5l" to="33ny:~TreeMap.put(java.lang.Object,java.lang.Object)" resolve="put" />
+              <node concept="Xl_RD" id="7b8v2ssAfxC" role="37wK5m">
+                <property role="Xl_RC" value="X" />
+              </node>
+              <node concept="2OqwBi" id="7b8v2ssAfxD" role="37wK5m">
+                <node concept="2ShNRf" id="7b8v2ssAfxE" role="2Oq$k0">
+                  <node concept="2HTt$P" id="7b8v2ssAfxF" role="2ShVmc">
+                    <node concept="3uibUv" id="7b8v2ssAfxG" role="2HTBi0">
+                      <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
+                    </node>
+                    <node concept="2OqwBi" id="7b8v2ssB1fJ" role="2HTEbv">
+                      <node concept="37vLTw" id="7b8v2ssB1fK" role="2Oq$k0">
+                        <ref role="3cqZAo" node="7b8v2ss_kzc" resolve="actions" />
+                      </node>
+                      <node concept="34jXtK" id="7b8v2ssB1fL" role="2OqNvi">
+                        <node concept="3cmrfG" id="7b8v2ssB1fM" role="25WWJ7">
+                          <property role="3cmrfH" value="1" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="ANE8D" id="7b8v2ssAfxM" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7b8v2ssAhZj" role="3cqZAp">
+          <node concept="2OqwBi" id="7b8v2ssAhZk" role="3clFbG">
+            <node concept="37vLTw" id="7b8v2ssAhZl" role="2Oq$k0">
+              <ref role="3cqZAo" node="7b8v2ss_Lg3" resolve="expectedGroups" />
+            </node>
+            <node concept="liA8E" id="7b8v2ssAhZm" role="2OqNvi">
+              <ref role="37wK5l" to="33ny:~TreeMap.put(java.lang.Object,java.lang.Object)" resolve="put" />
+              <node concept="Xl_RD" id="7b8v2ssAhZn" role="37wK5m">
+                <property role="Xl_RC" value="Z" />
+              </node>
+              <node concept="2OqwBi" id="7b8v2ssAhZo" role="37wK5m">
+                <node concept="2ShNRf" id="7b8v2ssAhZp" role="2Oq$k0">
+                  <node concept="2HTt$P" id="7b8v2ssAhZq" role="2ShVmc">
+                    <node concept="3uibUv" id="7b8v2ssAhZr" role="2HTBi0">
+                      <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
+                    </node>
+                    <node concept="2OqwBi" id="7b8v2ssB2G0" role="2HTEbv">
+                      <node concept="37vLTw" id="7b8v2ssB2G1" role="2Oq$k0">
+                        <ref role="3cqZAo" node="7b8v2ss_kzc" resolve="actions" />
+                      </node>
+                      <node concept="34jXtK" id="7b8v2ssB2G2" role="2OqNvi">
+                        <node concept="3cmrfG" id="7b8v2ssB2G3" role="25WWJ7">
+                          <property role="3cmrfH" value="2" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="ANE8D" id="7b8v2ssAhZx" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7b8v2ss_L9b" role="3cqZAp" />
+        <node concept="3vlDli" id="7b8v2ssAvv1" role="3cqZAp">
+          <node concept="37vLTw" id="7b8v2ssAxwI" role="3tpDZB">
+            <ref role="3cqZAo" node="7b8v2ss_Lg3" resolve="expectedGroups" />
+          </node>
+          <node concept="2OqwBi" id="7b8v2ss$QpI" role="3tpDZA">
+            <node concept="37vLTw" id="7b8v2ss$QpJ" role="2Oq$k0">
+              <ref role="3cqZAo" node="7b8v2ss$Qo5" resolve="producer" />
+            </node>
+            <node concept="liA8E" id="7b8v2ss$QpK" role="2OqNvi">
+              <ref role="37wK5l" to="ih8q:2A8KNgIs$a3" resolve="processActionGroup" />
+              <node concept="37vLTw" id="7b8v2ss$QpL" role="37wK5m">
+                <ref role="3cqZAo" node="7b8v2ss$Qoc" resolve="mainGroup" />
+              </node>
+              <node concept="10Nm6u" id="7b8v2ss_6f4" role="37wK5m" />
+              <node concept="37vLTw" id="7b8v2ss_n0s" role="37wK5m">
+                <ref role="3cqZAo" node="7b8v2ss_kzc" resolve="actions" />
+              </node>
+              <node concept="3clFbT" id="7b8v2ss_q2Z" role="37wK5m" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="7b8v2ssBd12" role="1SL9yI">
+      <property role="TrG5h" value="processActionGroupWithCache" />
+      <node concept="3cqZAl" id="7b8v2ssBd13" role="3clF45" />
+      <node concept="3clFbS" id="7b8v2ssBd14" role="3clF47">
+        <node concept="3cpWs8" id="7b8v2ssBd15" role="3cqZAp">
+          <node concept="3cpWsn" id="7b8v2ssBd16" role="3cpWs9">
+            <property role="TrG5h" value="repository" />
+            <node concept="3uibUv" id="7b8v2ssBd17" role="1tU5fm">
+              <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
+            </node>
+            <node concept="2OqwBi" id="7b8v2ssBd18" role="33vP2m">
+              <node concept="1jxXqW" id="7b8v2ssBd19" role="2Oq$k0" />
+              <node concept="liA8E" id="7b8v2ssBd1a" role="2OqNvi">
+                <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="7b8v2ssBd1b" role="3cqZAp">
+          <node concept="3cpWsn" id="7b8v2ssBd1c" role="3cpWs9">
+            <property role="TrG5h" value="component" />
+            <node concept="3uibUv" id="7b8v2ssBd1d" role="1tU5fm">
+              <ref role="3uigEE" to="7a0s:6qGpHl7IHpK" resolve="HeadlessEditorComponent" />
+            </node>
+            <node concept="2ShNRf" id="7b8v2ssBd1e" role="33vP2m">
+              <node concept="1pGfFk" id="7b8v2ssBd1f" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="7a0s:2iNJDZP2RE6" resolve="HeadlessEditorComponent" />
+                <node concept="37vLTw" id="7b8v2ssBd1g" role="37wK5m">
+                  <ref role="3cqZAo" node="7b8v2ssBd16" resolve="repository" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="7b8v2ssBd1h" role="3cqZAp">
+          <node concept="3cpWsn" id="7b8v2ssBd1i" role="3cpWs9">
+            <property role="TrG5h" value="producer" />
+            <node concept="3uibUv" id="7b8v2ssBd1j" role="1tU5fm">
+              <ref role="3uigEE" to="ih8q:2jDew64JcPx" resolve="MyIntentionMenuProducer" />
+            </node>
+            <node concept="2ShNRf" id="7b8v2ssBd1k" role="33vP2m">
+              <node concept="1pGfFk" id="7b8v2ssBd1l" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="ih8q:2jDew64KaGG" resolve="MyIntentionMenuProducer" />
+                <node concept="37vLTw" id="7b8v2ssBd1m" role="37wK5m">
+                  <ref role="3cqZAo" node="7b8v2ssBd1c" resolve="component" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="7b8v2ssBsg3" role="3cqZAp">
+          <node concept="3cpWsn" id="7b8v2ssBsg4" role="3cpWs9">
+            <property role="TrG5h" value="existingAction" />
+            <node concept="3uibUv" id="7b8v2ssBsg5" role="1tU5fm">
+              <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
+            </node>
+            <node concept="2OqwBi" id="7b8v2ssBvMS" role="33vP2m">
+              <node concept="2WthIp" id="7b8v2ssBvMV" role="2Oq$k0" />
+              <node concept="2XshWL" id="7b8v2ssBvMX" role="2OqNvi">
+                <ref role="2WH_rO" node="7b8v2sshaES" resolve="createAction" />
+                <node concept="Xl_RD" id="7b8v2ssBxrh" role="2XxRq1" />
+                <node concept="Xl_RD" id="7b8v2ssBziF" role="2XxRq1">
+                  <property role="Xl_RC" value="Existing" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7b8v2ssDNu3" role="3cqZAp">
+          <node concept="2OqwBi" id="7b8v2ssDQcz" role="3clFbG">
+            <node concept="2OqwBi" id="7b8v2ssDNVc" role="2Oq$k0">
+              <node concept="37vLTw" id="7b8v2ssDNu1" role="2Oq$k0">
+                <ref role="3cqZAo" node="7b8v2ssBd1i" resolve="producer" />
+              </node>
+              <node concept="SiP3y" id="7b8v2ssDP7s" role="2OqNvi">
+                <ref role="3cqZAo" to="ih8q:5Rdndlpp80A" resolve="groupedActionsCache" />
+              </node>
+            </node>
+            <node concept="1yHZxX" id="7b8v2ssDS5L" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="3clFbF" id="7b8v2ssBl$J" role="3cqZAp">
+          <node concept="37vLTI" id="7b8v2ssBAKL" role="3clFbG">
+            <node concept="3EllGN" id="7b8v2ssBpfj" role="37vLTJ">
+              <node concept="Xl_RD" id="7b8v2ssB$yb" role="3ElVtu" />
+              <node concept="2OqwBi" id="7b8v2ssBlYb" role="3ElQJh">
+                <node concept="37vLTw" id="7b8v2ssBl$H" role="2Oq$k0">
+                  <ref role="3cqZAo" node="7b8v2ssBd1i" resolve="producer" />
+                </node>
+                <node concept="SiP3y" id="7b8v2ssBnJn" role="2OqNvi">
+                  <ref role="3cqZAo" to="ih8q:5Rdndlpp80A" resolve="groupedActionsCache" />
+                </node>
+              </node>
+            </node>
+            <node concept="2ShNRf" id="7b8v2ssBJu2" role="37vLTx">
+              <node concept="2i4dXS" id="7b8v2ssBKtU" role="2ShVmc">
+                <node concept="3uibUv" id="7b8v2ssBL7N" role="HW$YZ">
+                  <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
+                </node>
+                <node concept="2ShNRf" id="7b8v2ssBAKP" role="I$8f6">
+                  <node concept="2HTt$P" id="7b8v2ssBAKQ" role="2ShVmc">
+                    <node concept="3uibUv" id="7b8v2ssBAKR" role="2HTBi0">
+                      <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
+                    </node>
+                    <node concept="37vLTw" id="7b8v2ssBCTT" role="2HTEbv">
+                      <ref role="3cqZAo" node="7b8v2ssBsg4" resolve="existingAction" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7b8v2ssBpXG" role="3cqZAp" />
+        <node concept="3cpWs8" id="7b8v2ssBd1o" role="3cqZAp">
+          <node concept="3cpWsn" id="7b8v2ssBd1p" role="3cpWs9">
+            <property role="TrG5h" value="mainGroup" />
+            <node concept="3uibUv" id="7b8v2ssBd1q" role="1tU5fm">
+              <ref role="3uigEE" to="qkt:~DefaultActionGroup" resolve="DefaultActionGroup" />
+            </node>
+            <node concept="2ShNRf" id="7b8v2ssBd1r" role="33vP2m">
+              <node concept="1pGfFk" id="7b8v2ssBd1s" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="qkt:~DefaultActionGroup.&lt;init&gt;()" resolve="DefaultActionGroup" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="7b8v2ssBd1t" role="3cqZAp">
+          <node concept="3cpWsn" id="7b8v2ssBd1u" role="3cpWs9">
+            <property role="TrG5h" value="actions" />
+            <node concept="_YKpA" id="7b8v2ssBd1v" role="1tU5fm">
+              <node concept="3uibUv" id="7b8v2ssBd1w" role="_ZDj9">
+                <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="7b8v2ssBd1x" role="33vP2m">
+              <node concept="2OqwBi" id="7b8v2ssBd1y" role="2Oq$k0">
+                <node concept="2ShNRf" id="7b8v2ssBd1z" role="2Oq$k0">
+                  <node concept="3g6Rrh" id="7b8v2ssBd1$" role="2ShVmc">
+                    <node concept="3uibUv" id="7b8v2ssBd1_" role="3g7fb8">
+                      <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
+                    </node>
+                    <node concept="2OqwBi" id="7b8v2ssBd1A" role="3g7hyw">
+                      <node concept="2WthIp" id="7b8v2ssBd1B" role="2Oq$k0" />
+                      <node concept="2XshWL" id="7b8v2ssBd1C" role="2OqNvi">
+                        <ref role="2WH_rO" node="7b8v2sshaES" resolve="createAction" />
+                        <node concept="Xl_RD" id="7b8v2ssBd1D" role="2XxRq1" />
+                        <node concept="Xl_RD" id="7b8v2ssBd1E" role="2XxRq1">
+                          <property role="Xl_RC" value="C" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2OqwBi" id="7b8v2ssBd1F" role="3g7hyw">
+                      <node concept="2WthIp" id="7b8v2ssBd1G" role="2Oq$k0" />
+                      <node concept="2XshWL" id="7b8v2ssBd1H" role="2OqNvi">
+                        <ref role="2WH_rO" node="7b8v2sshaES" resolve="createAction" />
+                        <node concept="Xl_RD" id="7b8v2ssBd1I" role="2XxRq1">
+                          <property role="Xl_RC" value="X" />
+                        </node>
+                        <node concept="Xl_RD" id="7b8v2ssBd1J" role="2XxRq1">
+                          <property role="Xl_RC" value="B" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2OqwBi" id="7b8v2ssBd1K" role="3g7hyw">
+                      <node concept="2WthIp" id="7b8v2ssBd1L" role="2Oq$k0" />
+                      <node concept="2XshWL" id="7b8v2ssBd1M" role="2OqNvi">
+                        <ref role="2WH_rO" node="7b8v2sshaES" resolve="createAction" />
+                        <node concept="Xl_RD" id="7b8v2ssBd1N" role="2XxRq1">
+                          <property role="Xl_RC" value="Z" />
+                        </node>
+                        <node concept="Xl_RD" id="7b8v2ssBd1O" role="2XxRq1">
+                          <property role="Xl_RC" value="A" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="39bAoz" id="7b8v2ssBd1P" role="2OqNvi" />
+              </node>
+              <node concept="ANE8D" id="7b8v2ssBd1Q" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7b8v2ssBd1R" role="3cqZAp" />
+        <node concept="3cpWs8" id="7b8v2ssBd1S" role="3cqZAp">
+          <node concept="3cpWsn" id="7b8v2ssBd1T" role="3cpWs9">
+            <property role="TrG5h" value="expectedGroups" />
+            <node concept="3uibUv" id="7b8v2ssBd1U" role="1tU5fm">
+              <ref role="3uigEE" to="33ny:~TreeMap" resolve="TreeMap" />
+              <node concept="17QB3L" id="7b8v2ssBd1V" role="11_B2D" />
+              <node concept="_YKpA" id="7b8v2ssBd1W" role="11_B2D">
+                <node concept="3uibUv" id="7b8v2ssBd1X" role="_ZDj9">
+                  <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
+                </node>
+              </node>
+            </node>
+            <node concept="2ShNRf" id="7b8v2ssBd1Y" role="33vP2m">
+              <node concept="1pGfFk" id="7b8v2ssBd1Z" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="33ny:~TreeMap.&lt;init&gt;()" resolve="TreeMap" />
+                <node concept="17QB3L" id="7b8v2ssBd20" role="1pMfVU" />
+                <node concept="_YKpA" id="7b8v2ssBd21" role="1pMfVU">
+                  <node concept="3uibUv" id="7b8v2ssBd22" role="_ZDj9">
+                    <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="7b8v2ssBU1y" role="3cqZAp">
+          <node concept="3cpWsn" id="7b8v2ssBU1_" role="3cpWs9">
+            <property role="TrG5h" value="firstActions" />
+            <node concept="_YKpA" id="7b8v2ssCiyh" role="1tU5fm">
+              <node concept="3uibUv" id="7b8v2ssCiyj" role="_ZDj9">
+                <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
+              </node>
+            </node>
+            <node concept="2ShNRf" id="7b8v2ssBYmr" role="33vP2m">
+              <node concept="Tc6Ow" id="7b8v2ssCjYD" role="2ShVmc">
+                <node concept="3uibUv" id="7b8v2ssCjYF" role="HW$YZ">
+                  <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7b8v2ssC2qy" role="3cqZAp">
+          <node concept="2OqwBi" id="7b8v2ssC4_N" role="3clFbG">
+            <node concept="37vLTw" id="7b8v2ssC2qw" role="2Oq$k0">
+              <ref role="3cqZAo" node="7b8v2ssBU1_" resolve="firstActions" />
+            </node>
+            <node concept="TSZUe" id="7b8v2ssC6vt" role="2OqNvi">
+              <node concept="2OqwBi" id="7b8v2ssBd2c" role="25WWJ7">
+                <node concept="37vLTw" id="7b8v2ssBd2d" role="2Oq$k0">
+                  <ref role="3cqZAo" node="7b8v2ssBd1u" resolve="actions" />
+                </node>
+                <node concept="34jXtK" id="7b8v2ssBd2e" role="2OqNvi">
+                  <node concept="3cmrfG" id="7b8v2ssBd2f" role="25WWJ7">
+                    <property role="3cmrfH" value="0" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7b8v2ssC7L2" role="3cqZAp">
+          <node concept="2OqwBi" id="7b8v2ssC7L3" role="3clFbG">
+            <node concept="37vLTw" id="7b8v2ssC7L4" role="2Oq$k0">
+              <ref role="3cqZAo" node="7b8v2ssBU1_" resolve="firstActions" />
+            </node>
+            <node concept="TSZUe" id="7b8v2ssC7L5" role="2OqNvi">
+              <node concept="37vLTw" id="7b8v2ssC9yE" role="25WWJ7">
+                <ref role="3cqZAo" node="7b8v2ssBsg4" resolve="existingAction" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7b8v2ssBd23" role="3cqZAp">
+          <node concept="2OqwBi" id="7b8v2ssBd24" role="3clFbG">
+            <node concept="37vLTw" id="7b8v2ssBd25" role="2Oq$k0">
+              <ref role="3cqZAo" node="7b8v2ssBd1T" resolve="expectedGroups" />
+            </node>
+            <node concept="liA8E" id="7b8v2ssBd26" role="2OqNvi">
+              <ref role="37wK5l" to="33ny:~TreeMap.put(java.lang.Object,java.lang.Object)" resolve="put" />
+              <node concept="Xl_RD" id="7b8v2ssBd27" role="37wK5m" />
+              <node concept="37vLTw" id="7b8v2ssCcf3" role="37wK5m">
+                <ref role="3cqZAo" node="7b8v2ssBU1_" resolve="firstActions" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7b8v2ssBd2h" role="3cqZAp">
+          <node concept="2OqwBi" id="7b8v2ssBd2i" role="3clFbG">
+            <node concept="37vLTw" id="7b8v2ssBd2j" role="2Oq$k0">
+              <ref role="3cqZAo" node="7b8v2ssBd1T" resolve="expectedGroups" />
+            </node>
+            <node concept="liA8E" id="7b8v2ssBd2k" role="2OqNvi">
+              <ref role="37wK5l" to="33ny:~TreeMap.put(java.lang.Object,java.lang.Object)" resolve="put" />
+              <node concept="Xl_RD" id="7b8v2ssBd2l" role="37wK5m">
+                <property role="Xl_RC" value="X" />
+              </node>
+              <node concept="2OqwBi" id="7b8v2ssBd2m" role="37wK5m">
+                <node concept="2ShNRf" id="7b8v2ssBd2n" role="2Oq$k0">
+                  <node concept="2HTt$P" id="7b8v2ssBd2o" role="2ShVmc">
+                    <node concept="3uibUv" id="7b8v2ssBd2p" role="2HTBi0">
+                      <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
+                    </node>
+                    <node concept="2OqwBi" id="7b8v2ssBd2q" role="2HTEbv">
+                      <node concept="37vLTw" id="7b8v2ssBd2r" role="2Oq$k0">
+                        <ref role="3cqZAo" node="7b8v2ssBd1u" resolve="actions" />
+                      </node>
+                      <node concept="34jXtK" id="7b8v2ssBd2s" role="2OqNvi">
+                        <node concept="3cmrfG" id="7b8v2ssBd2t" role="25WWJ7">
+                          <property role="3cmrfH" value="1" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="ANE8D" id="7b8v2ssBd2u" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7b8v2ssBd2v" role="3cqZAp">
+          <node concept="2OqwBi" id="7b8v2ssBd2w" role="3clFbG">
+            <node concept="37vLTw" id="7b8v2ssBd2x" role="2Oq$k0">
+              <ref role="3cqZAo" node="7b8v2ssBd1T" resolve="expectedGroups" />
+            </node>
+            <node concept="liA8E" id="7b8v2ssBd2y" role="2OqNvi">
+              <ref role="37wK5l" to="33ny:~TreeMap.put(java.lang.Object,java.lang.Object)" resolve="put" />
+              <node concept="Xl_RD" id="7b8v2ssBd2z" role="37wK5m">
+                <property role="Xl_RC" value="Z" />
+              </node>
+              <node concept="2OqwBi" id="7b8v2ssBd2$" role="37wK5m">
+                <node concept="2ShNRf" id="7b8v2ssBd2_" role="2Oq$k0">
+                  <node concept="2HTt$P" id="7b8v2ssBd2A" role="2ShVmc">
+                    <node concept="3uibUv" id="7b8v2ssBd2B" role="2HTBi0">
+                      <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
+                    </node>
+                    <node concept="2OqwBi" id="7b8v2ssBd2C" role="2HTEbv">
+                      <node concept="37vLTw" id="7b8v2ssBd2D" role="2Oq$k0">
+                        <ref role="3cqZAo" node="7b8v2ssBd1u" resolve="actions" />
+                      </node>
+                      <node concept="34jXtK" id="7b8v2ssBd2E" role="2OqNvi">
+                        <node concept="3cmrfG" id="7b8v2ssBd2F" role="25WWJ7">
+                          <property role="3cmrfH" value="2" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="ANE8D" id="7b8v2ssBd2G" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7b8v2ssBd2H" role="3cqZAp" />
+        <node concept="3vlDli" id="7b8v2ssBd2I" role="3cqZAp">
+          <node concept="37vLTw" id="7b8v2ssBd2J" role="3tpDZB">
+            <ref role="3cqZAo" node="7b8v2ssBd1T" resolve="expectedGroups" />
+          </node>
+          <node concept="2OqwBi" id="7b8v2ssBd2K" role="3tpDZA">
+            <node concept="37vLTw" id="7b8v2ssBd2L" role="2Oq$k0">
+              <ref role="3cqZAo" node="7b8v2ssBd1i" resolve="producer" />
+            </node>
+            <node concept="liA8E" id="7b8v2ssBd2M" role="2OqNvi">
+              <ref role="37wK5l" to="ih8q:2A8KNgIs$a3" resolve="processActionGroup" />
+              <node concept="37vLTw" id="7b8v2ssBd2N" role="37wK5m">
+                <ref role="3cqZAo" node="7b8v2ssBd1p" resolve="mainGroup" />
+              </node>
+              <node concept="10Nm6u" id="7b8v2ssBd2O" role="37wK5m" />
+              <node concept="37vLTw" id="7b8v2ssBd2P" role="37wK5m">
+                <ref role="3cqZAo" node="7b8v2ssBd1u" resolve="actions" />
+              </node>
+              <node concept="3clFbT" id="7b8v2ssBd2Q" role="37wK5m">
+                <property role="3clFbU" value="true" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="7b8v2ssLgbk" role="1SL9yI">
+      <property role="TrG5h" value="stripGroup" />
+      <node concept="3cqZAl" id="7b8v2ssLgbl" role="3clF45" />
+      <node concept="3clFbS" id="7b8v2ssLgbm" role="3clF47">
+        <node concept="3cpWs8" id="7b8v2ssLgbn" role="3cqZAp">
+          <node concept="3cpWsn" id="7b8v2ssLgbo" role="3cpWs9">
+            <property role="TrG5h" value="repository" />
+            <node concept="3uibUv" id="7b8v2ssLgbp" role="1tU5fm">
+              <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
+            </node>
+            <node concept="2OqwBi" id="7b8v2ssLgbq" role="33vP2m">
+              <node concept="1jxXqW" id="7b8v2ssLgbr" role="2Oq$k0" />
+              <node concept="liA8E" id="7b8v2ssLgbs" role="2OqNvi">
+                <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="7b8v2ssLgbt" role="3cqZAp">
+          <node concept="3cpWsn" id="7b8v2ssLgbu" role="3cpWs9">
+            <property role="TrG5h" value="component" />
+            <node concept="3uibUv" id="7b8v2ssLgbv" role="1tU5fm">
+              <ref role="3uigEE" to="7a0s:6qGpHl7IHpK" resolve="HeadlessEditorComponent" />
+            </node>
+            <node concept="2ShNRf" id="7b8v2ssLgbw" role="33vP2m">
+              <node concept="1pGfFk" id="7b8v2ssLgbx" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="7a0s:2iNJDZP2RE6" resolve="HeadlessEditorComponent" />
+                <node concept="37vLTw" id="7b8v2ssLgby" role="37wK5m">
+                  <ref role="3cqZAo" node="7b8v2ssLgbo" resolve="repository" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="7b8v2ssLgbz" role="3cqZAp">
+          <node concept="3cpWsn" id="7b8v2ssLgb$" role="3cpWs9">
+            <property role="TrG5h" value="producer" />
+            <node concept="3uibUv" id="7b8v2ssLgb_" role="1tU5fm">
+              <ref role="3uigEE" to="ih8q:2jDew64JcPx" resolve="MyIntentionMenuProducer" />
+            </node>
+            <node concept="2ShNRf" id="7b8v2ssLgbA" role="33vP2m">
+              <node concept="1pGfFk" id="7b8v2ssLgbB" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="ih8q:2jDew64KaGG" resolve="MyIntentionMenuProducer" />
+                <node concept="37vLTw" id="7b8v2ssLgbC" role="37wK5m">
+                  <ref role="3cqZAo" node="7b8v2ssLgbu" resolve="component" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7b8v2ssLzt1" role="3cqZAp" />
+        <node concept="3vlDli" id="7b8v2ssLzus" role="3cqZAp">
+          <node concept="Xl_RD" id="7b8v2ssLzxh" role="3tpDZB">
+            <property role="Xl_RC" value="A" />
+          </node>
+          <node concept="2OqwBi" id="7b8v2ssLKAB" role="3tpDZA">
+            <node concept="37vLTw" id="7b8v2ssLKuz" role="2Oq$k0">
+              <ref role="3cqZAo" node="7b8v2ssLgb$" resolve="producer" />
+            </node>
+            <node concept="liA8E" id="7b8v2ssLKRd" role="2OqNvi">
+              <ref role="37wK5l" to="ih8q:7b8v2ssFpTf" resolve="trimGroupNameFromActionText" />
+              <node concept="2OqwBi" id="7b8v2ssLz_U" role="37wK5m">
+                <node concept="2WthIp" id="7b8v2ssLz_X" role="2Oq$k0" />
+                <node concept="2XshWL" id="7b8v2ssLz_Z" role="2OqNvi">
+                  <ref role="2WH_rO" node="7b8v2sshaES" resolve="createAction" />
+                  <node concept="Xl_RD" id="7b8v2ssL$7_" role="2XxRq1">
+                    <property role="Xl_RC" value="group" />
+                  </node>
+                  <node concept="Xl_RD" id="7b8v2ssL$bC" role="2XxRq1">
+                    <property role="Xl_RC" value="A" />
+                  </node>
+                </node>
+              </node>
+              <node concept="Xl_RD" id="7b8v2ssLLq8" role="37wK5m">
+                <property role="Xl_RC" value="group" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="7b8v2ssLQxF" role="3cqZAp">
+          <node concept="Xl_RD" id="7b8v2ssLQxG" role="3tpDZB">
+            <property role="Xl_RC" value="A" />
+          </node>
+          <node concept="2OqwBi" id="7b8v2ssLQxH" role="3tpDZA">
+            <node concept="37vLTw" id="7b8v2ssLQxI" role="2Oq$k0">
+              <ref role="3cqZAo" node="7b8v2ssLgb$" resolve="producer" />
+            </node>
+            <node concept="liA8E" id="7b8v2ssLQxJ" role="2OqNvi">
+              <ref role="37wK5l" to="ih8q:7b8v2ssFpTf" resolve="trimGroupNameFromActionText" />
+              <node concept="2OqwBi" id="7b8v2ssLQxK" role="37wK5m">
+                <node concept="2WthIp" id="7b8v2ssLQxL" role="2Oq$k0" />
+                <node concept="2XshWL" id="7b8v2ssLQxM" role="2OqNvi">
+                  <ref role="2WH_rO" node="7b8v2sshaES" resolve="createAction" />
+                  <node concept="Xl_RD" id="7b8v2ssLQxN" role="2XxRq1">
+                    <property role="Xl_RC" value=" " />
+                  </node>
+                  <node concept="Xl_RD" id="7b8v2ssLQxO" role="2XxRq1">
+                    <property role="Xl_RC" value="A" />
+                  </node>
+                </node>
+              </node>
+              <node concept="Xl_RD" id="7b8v2ssLQxP" role="37wK5m">
+                <property role="Xl_RC" value=" " />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="7b8v2ssL$$g" role="3cqZAp">
+          <node concept="Xl_RD" id="7b8v2ssL$$h" role="3tpDZB">
+            <property role="Xl_RC" value="A" />
+          </node>
+          <node concept="2OqwBi" id="7b8v2ssLVPc" role="3tpDZA">
+            <node concept="37vLTw" id="7b8v2ssLVPd" role="2Oq$k0">
+              <ref role="3cqZAo" node="7b8v2ssLgb$" resolve="producer" />
+            </node>
+            <node concept="liA8E" id="7b8v2ssLVPe" role="2OqNvi">
+              <ref role="37wK5l" to="ih8q:7b8v2ssFpTf" resolve="trimGroupNameFromActionText" />
+              <node concept="2OqwBi" id="7b8v2ssLVPf" role="37wK5m">
+                <node concept="2WthIp" id="7b8v2ssLVPg" role="2Oq$k0" />
+                <node concept="2XshWL" id="7b8v2ssLVPh" role="2OqNvi">
+                  <ref role="2WH_rO" node="7b8v2sshaES" resolve="createAction" />
+                  <node concept="10Nm6u" id="7b8v2ssLWuJ" role="2XxRq1" />
+                  <node concept="Xl_RD" id="7b8v2ssLVPj" role="2XxRq1">
+                    <property role="Xl_RC" value="A" />
+                  </node>
+                </node>
+              </node>
+              <node concept="10Nm6u" id="7b8v2ssM4ZF" role="37wK5m" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7b8v2ssOObo" role="3cqZAp" />
+        <node concept="3vlDli" id="7b8v2ssON89" role="3cqZAp">
+          <node concept="Xl_RD" id="7b8v2ssON8a" role="3tpDZB" />
+          <node concept="2OqwBi" id="7b8v2ssON8b" role="3tpDZA">
+            <node concept="37vLTw" id="7b8v2ssON8c" role="2Oq$k0">
+              <ref role="3cqZAo" node="7b8v2ssLgb$" resolve="producer" />
+            </node>
+            <node concept="liA8E" id="7b8v2ssON8d" role="2OqNvi">
+              <ref role="37wK5l" to="ih8q:7b8v2ssFpTf" resolve="trimGroupNameFromActionText" />
+              <node concept="2OqwBi" id="7b8v2ssON8e" role="37wK5m">
+                <node concept="2WthIp" id="7b8v2ssON8f" role="2Oq$k0" />
+                <node concept="2XshWL" id="7b8v2ssON8g" role="2OqNvi">
+                  <ref role="2WH_rO" node="7b8v2sshaES" resolve="createAction" />
+                  <node concept="Xl_RD" id="7b8v2ssON8h" role="2XxRq1">
+                    <property role="Xl_RC" value="group" />
+                  </node>
+                  <node concept="Xl_RD" id="7b8v2ssON8i" role="2XxRq1" />
+                </node>
+              </node>
+              <node concept="Xl_RD" id="7b8v2ssON8j" role="37wK5m">
+                <property role="Xl_RC" value="group" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="7b8v2ssON8v" role="3cqZAp">
+          <node concept="Xl_RD" id="7b8v2ssON8w" role="3tpDZB" />
+          <node concept="2OqwBi" id="7b8v2ssON8x" role="3tpDZA">
+            <node concept="37vLTw" id="7b8v2ssON8y" role="2Oq$k0">
+              <ref role="3cqZAo" node="7b8v2ssLgb$" resolve="producer" />
+            </node>
+            <node concept="liA8E" id="7b8v2ssON8z" role="2OqNvi">
+              <ref role="37wK5l" to="ih8q:7b8v2ssFpTf" resolve="trimGroupNameFromActionText" />
+              <node concept="2OqwBi" id="7b8v2ssON8$" role="37wK5m">
+                <node concept="2WthIp" id="7b8v2ssON8_" role="2Oq$k0" />
+                <node concept="2XshWL" id="7b8v2ssON8A" role="2OqNvi">
+                  <ref role="2WH_rO" node="7b8v2sshaES" resolve="createAction" />
+                  <node concept="Xl_RD" id="7b8v2ssON8B" role="2XxRq1">
+                    <property role="Xl_RC" value=" " />
+                  </node>
+                  <node concept="Xl_RD" id="7b8v2ssON8C" role="2XxRq1" />
+                </node>
+              </node>
+              <node concept="Xl_RD" id="7b8v2ssON8D" role="37wK5m">
+                <property role="Xl_RC" value=" " />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="7b8v2ssON8E" role="3cqZAp">
+          <node concept="Xl_RD" id="7b8v2ssON8F" role="3tpDZB" />
+          <node concept="2OqwBi" id="7b8v2ssON8G" role="3tpDZA">
+            <node concept="37vLTw" id="7b8v2ssON8H" role="2Oq$k0">
+              <ref role="3cqZAo" node="7b8v2ssLgb$" resolve="producer" />
+            </node>
+            <node concept="liA8E" id="7b8v2ssON8I" role="2OqNvi">
+              <ref role="37wK5l" to="ih8q:7b8v2ssFpTf" resolve="trimGroupNameFromActionText" />
+              <node concept="2OqwBi" id="7b8v2ssON8J" role="37wK5m">
+                <node concept="2WthIp" id="7b8v2ssON8K" role="2Oq$k0" />
+                <node concept="2XshWL" id="7b8v2ssON8L" role="2OqNvi">
+                  <ref role="2WH_rO" node="7b8v2sshaES" resolve="createAction" />
+                  <node concept="10Nm6u" id="7b8v2ssON8M" role="2XxRq1" />
+                  <node concept="Xl_RD" id="7b8v2ssON8N" role="2XxRq1" />
+                </node>
+              </node>
+              <node concept="10Nm6u" id="7b8v2ssON8O" role="37wK5m" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="2ezpO_" id="7b8v2ss95bK">
+    <property role="TrG5h" value="GroupTesting" />
   </node>
 </model>
 

--- a/code/solutions/com.mbeddr.mpsutil.intentions.tests/models/com.mbeddr.mpsutil.intentions.tests.tests@tests.mps
+++ b/code/solutions/com.mbeddr.mpsutil.intentions.tests/models/com.mbeddr.mpsutil.intentions.tests.tests@tests.mps
@@ -10,6 +10,7 @@
     <use id="d7a92d38-f7db-40d0-8431-763b0c3c9f20" name="jetbrains.mps.lang.intentions" version="1" />
     <use id="b92f861d-0184-446d-b88b-6dcf0e070241" name="com.mbeddr.mpsutil.intentions" version="0" />
     <use id="f47b95d4-5e73-4c04-9204-18076950153b" name="com.mbeddr.mpsutil.compare" version="0" />
+    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
   </languages>
   <imports>
     <import index="gw4x" ref="r:f1d822a2-1f43-4b14-8097-de7e855e6079(com.mbeddr.mpsutil.intentions.sandboxlang.intentions)" />
@@ -23,12 +24,23 @@
     <import index="7bx7" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.workbench.action(MPS.Platform/)" />
     <import index="9j2l" ref="r:acd2b506-390d-4e84-8c47-cd8fb8c9e0c0(com.mbeddr.mpsutil.intentions.behavior)" />
     <import index="3o3z" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.google.common.collect(MPS.IDEA/)" />
+    <import index="rhn4" ref="r:3a311732-83fb-48d6-8930-f62568e9c8d1(com.mbeddr.mpsutil.intentions.typesystem)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
+    <import index="tegv" ref="r:b91d2412-f094-4e55-8db6-3c782d7edc40(com.mbeddr.mpsutil.intentions.structure)" implicit="true" />
     <import index="z1c3" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.project(MPS.Core/)" implicit="true" />
   </imports>
   <registry>
     <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="1215511704609" name="jetbrains.mps.lang.test.structure.NodeWarningCheckOperation" flags="ng" index="29bkU">
+        <child id="8489045168660938635" name="warningRef" index="3lydCh" />
+      </concept>
+      <concept id="1215603922101" name="jetbrains.mps.lang.test.structure.NodeOperationsContainer" flags="ng" index="7CXmI">
+        <child id="1215604436604" name="nodeOperations" index="7EUXB" />
+      </concept>
+      <concept id="7691029917083872157" name="jetbrains.mps.lang.test.structure.IRuleReference" flags="ngI" index="2u4UPC">
+        <reference id="8333855927540250453" name="declaration" index="39XzEq" />
+      </concept>
       <concept id="1229187653856" name="jetbrains.mps.lang.test.structure.EditorTestCase" flags="lg" index="LiM7Y">
         <property id="1883175908513350760" name="description" index="3YCmrE" />
         <child id="3143335925185262946" name="testNodeBefore" index="25YQCW" />
@@ -42,6 +54,7 @@
         <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
         <property id="1229432188737" name="isLastPosition" index="ZRATv" />
       </concept>
+      <concept id="4531408400486526326" name="jetbrains.mps.lang.test.structure.WarningStatementReference" flags="ng" index="2PQEqo" />
       <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
         <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
       </concept>
@@ -68,9 +81,11 @@
       <concept id="1203071646776" name="jetbrains.mps.lang.plugin.structure.ActionDeclaration" flags="ng" index="sE7Ow">
         <property id="1205250923097" name="caption" index="2uzpH1" />
         <property id="4692598989365753297" name="updateInBackground" index="1rBW0U" />
+        <child id="1203083196627" name="updateBlock" index="tmbBb" />
         <child id="1203083461638" name="executeFunction" index="tncku" />
       </concept>
       <concept id="1203083511112" name="jetbrains.mps.lang.plugin.structure.ExecuteBlock" flags="in" index="tnohg" />
+      <concept id="1205681243813" name="jetbrains.mps.lang.plugin.structure.IsApplicableBlock" flags="in" index="2ScWuX" />
     </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
       <concept id="1224071154655" name="jetbrains.mps.baseLanguage.structure.AsExpression" flags="nn" index="0kSF2">
@@ -255,6 +270,18 @@
       </concept>
       <concept id="1171983834376" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertFalse" flags="nn" index="3vFxKo">
         <child id="1171983854940" name="condition" index="3vFALc" />
+      </concept>
+      <concept id="1172073500303" name="jetbrains.mps.baseLanguage.unitTest.structure.Message" flags="ng" index="3_1$Yv">
+        <child id="1172073511101" name="message" index="3_1BAH" />
+      </concept>
+      <concept id="1172075514136" name="jetbrains.mps.baseLanguage.unitTest.structure.MessageHolder" flags="ngI" index="3_9gw8">
+        <child id="1172075534298" name="message" index="3_9lra" />
+      </concept>
+    </language>
+    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
+      <concept id="2644386474300074836" name="jetbrains.mps.lang.smodel.structure.ConceptIdRefExpression" flags="nn" index="35c_gC">
+        <reference id="2644386474300074837" name="conceptDeclaration" index="35c_gD" />
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
@@ -623,6 +650,104 @@
         </node>
       </node>
     </node>
+    <node concept="1qefOq" id="5gDLJkLfnEU" role="1SKRRt">
+      <node concept="2S6QgY" id="5gDLJkLfx$A" role="1qenE9">
+        <property role="TrG5h" value="Intention" />
+        <ref role="2ZfgGC" to="tpck:gw2VY9q" resolve="BaseConcept" />
+        <node concept="2S6ZIM" id="5gDLJkLfx$B" role="2ZfVej">
+          <node concept="3clFbS" id="5gDLJkLfx$C" role="2VODD2">
+            <node concept="3clFbF" id="5gDLJkLfx$D" role="3cqZAp">
+              <node concept="Xl_RD" id="5gDLJkLfx$E" role="3clFbG">
+                <property role="Xl_RC" value="Intention" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2Sbjvc" id="5gDLJkLfx$F" role="2ZfgGD">
+          <node concept="3clFbS" id="5gDLJkLfx$G" role="2VODD2" />
+        </node>
+        <node concept="3xLA65" id="5gDLJkLfx$H" role="lGtFl">
+          <property role="TrG5h" value="intentionNoGroup" />
+        </node>
+        <node concept="1SWQZ3" id="5gDLJkLfx$I" role="lGtFl" />
+      </node>
+    </node>
+    <node concept="1qefOq" id="5gDLJkLfx_J" role="1SKRRt">
+      <node concept="2S6QgY" id="5gDLJkLf$Ss" role="1qenE9">
+        <property role="TrG5h" value="Intention" />
+        <ref role="2ZfgGC" to="tpck:gw2VY9q" resolve="BaseConcept" />
+        <node concept="2S6ZIM" id="5gDLJkLf$St" role="2ZfVej">
+          <node concept="3clFbS" id="5gDLJkLf$Su" role="2VODD2">
+            <node concept="3clFbF" id="5gDLJkLf$Sv" role="3cqZAp">
+              <node concept="3cpWs3" id="5gDLJkLgWeY" role="3clFbG">
+                <node concept="Xl_RD" id="5gDLJkLgWeZ" role="3uHU7B">
+                  <property role="Xl_RC" value=": " />
+                </node>
+                <node concept="1eOMI4" id="5gDLJkLgWf0" role="3uHU7w">
+                  <node concept="Xl_RD" id="5gDLJkLgWf1" role="1eOMHV">
+                    <property role="Xl_RC" value="Intention" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2Sbjvc" id="5gDLJkLf$S$" role="2ZfgGD">
+          <node concept="3clFbS" id="5gDLJkLf$S_" role="2VODD2" />
+        </node>
+        <node concept="3xLA65" id="5gDLJkLf$SA" role="lGtFl">
+          <property role="TrG5h" value="generatedIntentionNoGroup" />
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="5gDLJkLaFkw" role="1SKRRt">
+      <node concept="2S6QgY" id="5gDLJkLaIAZ" role="1qenE9">
+        <property role="TrG5h" value="Intention" />
+        <ref role="2ZfgGC" to="tpck:gw2VY9q" resolve="BaseConcept" />
+        <node concept="2S6ZIM" id="5gDLJkLaIB0" role="2ZfVej">
+          <node concept="3clFbS" id="5gDLJkLaIB1" role="2VODD2">
+            <node concept="3clFbF" id="5gDLJkLaMP3" role="3cqZAp">
+              <node concept="10Nm6u" id="5gDLJkLaMP2" role="3clFbG" />
+            </node>
+          </node>
+        </node>
+        <node concept="2Sbjvc" id="5gDLJkLaIB4" role="2ZfgGD">
+          <node concept="3clFbS" id="5gDLJkLaIB5" role="2VODD2" />
+        </node>
+        <node concept="3xLA65" id="5gDLJkLaIB6" role="lGtFl">
+          <property role="TrG5h" value="intentionNoDescription" />
+        </node>
+        <node concept="1SWQZ3" id="5gDLJkLaIB7" role="lGtFl">
+          <property role="1SWRpm" value="group" />
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="5gDLJkLaMPH" role="1SKRRt">
+      <node concept="2S6QgY" id="5gDLJkLaRIY" role="1qenE9">
+        <property role="TrG5h" value="Intention" />
+        <ref role="2ZfgGC" to="tpck:gw2VY9q" resolve="BaseConcept" />
+        <node concept="2S6ZIM" id="5gDLJkLaRIZ" role="2ZfVej">
+          <node concept="3clFbS" id="5gDLJkLaRJ0" role="2VODD2">
+            <node concept="3clFbF" id="5gDLJkLaRJ1" role="3cqZAp">
+              <node concept="3cpWs3" id="5gDLJkLaRJ2" role="3clFbG">
+                <node concept="Xl_RD" id="5gDLJkLaRJ3" role="3uHU7B">
+                  <property role="Xl_RC" value="group: " />
+                </node>
+                <node concept="1eOMI4" id="5gDLJkLaRJ4" role="3uHU7w">
+                  <node concept="10Nm6u" id="5gDLJkLaS0_" role="1eOMHV" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2Sbjvc" id="5gDLJkLaRJ6" role="2ZfgGD">
+          <node concept="3clFbS" id="5gDLJkLaRJ7" role="2VODD2" />
+        </node>
+        <node concept="3xLA65" id="5gDLJkLaRJ8" role="lGtFl">
+          <property role="TrG5h" value="generatedIntentionNoDescription" />
+        </node>
+      </node>
+    </node>
     <node concept="1qefOq" id="24lzbKWjUuZ" role="1SKRRt">
       <node concept="sE7Ow" id="24lzbKWk0Mi" role="1qenE9">
         <property role="1rBW0U" value="true" />
@@ -633,6 +758,22 @@
         </node>
         <node concept="3xLA65" id="38Yx6hD0LOx" role="lGtFl">
           <property role="TrG5h" value="action" />
+        </node>
+        <node concept="2ScWuX" id="5gDLJkKOs_A" role="tmbBb">
+          <node concept="3clFbS" id="5gDLJkKOs_B" role="2VODD2">
+            <node concept="3clFbF" id="5gDLJkKOsS$" role="3cqZAp">
+              <node concept="3clFbT" id="5gDLJkKOsSz" role="3clFbG">
+                <property role="3clFbU" value="true" />
+              </node>
+            </node>
+          </node>
+          <node concept="7CXmI" id="5gDLJkKOt6R" role="lGtFl">
+            <node concept="29bkU" id="5gDLJkKOt6S" role="7EUXB">
+              <node concept="2PQEqo" id="5gDLJkKOuTA" role="3lydCh">
+                <ref role="39XzEq" to="rhn4:6ob0HsMUsnK" />
+              </node>
+            </node>
+          </node>
         </node>
         <node concept="1SWQZ3" id="38Yx6hD0LPG" role="lGtFl">
           <property role="1SWRpm" value="group" />
@@ -649,6 +790,120 @@
         </node>
         <node concept="3xLA65" id="24lzbKWkq67" role="lGtFl">
           <property role="TrG5h" value="generatedAction" />
+        </node>
+        <node concept="2ScWuX" id="5gDLJkLc4vm" role="tmbBb">
+          <node concept="3clFbS" id="5gDLJkLc4vn" role="2VODD2">
+            <node concept="3clFbF" id="5gDLJkLc4vo" role="3cqZAp">
+              <node concept="3clFbT" id="5gDLJkLc4vp" role="3clFbG">
+                <property role="3clFbU" value="true" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="5gDLJkLcDgo" role="1SKRRt">
+      <node concept="sE7Ow" id="5gDLJkLcGyZ" role="1qenE9">
+        <property role="1rBW0U" value="true" />
+        <property role="TrG5h" value="Action" />
+        <node concept="tnohg" id="5gDLJkLcGz0" role="tncku">
+          <node concept="3clFbS" id="5gDLJkLcGz1" role="2VODD2" />
+        </node>
+        <node concept="3xLA65" id="5gDLJkLcGz2" role="lGtFl">
+          <property role="TrG5h" value="actionEmptyCaption" />
+        </node>
+        <node concept="2ScWuX" id="5gDLJkLcGz4" role="tmbBb">
+          <node concept="3clFbS" id="5gDLJkLcGz5" role="2VODD2">
+            <node concept="3clFbF" id="5gDLJkLcGz6" role="3cqZAp">
+              <node concept="3clFbT" id="5gDLJkLcGz7" role="3clFbG">
+                <property role="3clFbU" value="true" />
+              </node>
+            </node>
+          </node>
+          <node concept="7CXmI" id="5gDLJkLcGz8" role="lGtFl">
+            <node concept="29bkU" id="5gDLJkLcGz9" role="7EUXB">
+              <node concept="2PQEqo" id="5gDLJkLcGza" role="3lydCh">
+                <ref role="39XzEq" to="rhn4:6ob0HsMUsnK" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SWQZ3" id="5gDLJkLcGz3" role="lGtFl">
+          <property role="1SWRpm" value="group" />
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="5gDLJkLcP3N" role="1SKRRt">
+      <node concept="sE7Ow" id="5gDLJkLcQqc" role="1qenE9">
+        <property role="1rBW0U" value="true" />
+        <property role="TrG5h" value="Action" />
+        <property role="2uzpH1" value="group: " />
+        <node concept="tnohg" id="5gDLJkLcQqd" role="tncku">
+          <node concept="3clFbS" id="5gDLJkLcQqe" role="2VODD2" />
+        </node>
+        <node concept="3xLA65" id="5gDLJkLcQqf" role="lGtFl">
+          <property role="TrG5h" value="generatedActionEmptyCaption" />
+        </node>
+        <node concept="2ScWuX" id="5gDLJkLcQqg" role="tmbBb">
+          <node concept="3clFbS" id="5gDLJkLcQqh" role="2VODD2">
+            <node concept="3clFbF" id="5gDLJkLcQqi" role="3cqZAp">
+              <node concept="3clFbT" id="5gDLJkLcQqj" role="3clFbG">
+                <property role="3clFbU" value="true" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="5gDLJkLjAvV" role="1SKRRt">
+      <node concept="sE7Ow" id="5gDLJkLjAvW" role="1qenE9">
+        <property role="1rBW0U" value="true" />
+        <property role="TrG5h" value="Action" />
+        <property role="2uzpH1" value="Action" />
+        <node concept="tnohg" id="5gDLJkLjAvX" role="tncku">
+          <node concept="3clFbS" id="5gDLJkLjAvY" role="2VODD2" />
+        </node>
+        <node concept="3xLA65" id="5gDLJkLjAvZ" role="lGtFl">
+          <property role="TrG5h" value="actionNoGroup" />
+        </node>
+        <node concept="2ScWuX" id="5gDLJkLjAw0" role="tmbBb">
+          <node concept="3clFbS" id="5gDLJkLjAw1" role="2VODD2">
+            <node concept="3clFbF" id="5gDLJkLjAw2" role="3cqZAp">
+              <node concept="3clFbT" id="5gDLJkLjAw3" role="3clFbG">
+                <property role="3clFbU" value="true" />
+              </node>
+            </node>
+          </node>
+          <node concept="7CXmI" id="5gDLJkLjAw4" role="lGtFl">
+            <node concept="29bkU" id="5gDLJkLjAw5" role="7EUXB">
+              <node concept="2PQEqo" id="5gDLJkLjAw6" role="3lydCh">
+                <ref role="39XzEq" to="rhn4:6ob0HsMUsnK" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SWQZ3" id="5gDLJkLjAw7" role="lGtFl" />
+      </node>
+    </node>
+    <node concept="1qefOq" id="5gDLJkLjRo2" role="1SKRRt">
+      <node concept="sE7Ow" id="5gDLJkLjWhA" role="1qenE9">
+        <property role="1rBW0U" value="true" />
+        <property role="TrG5h" value="Action" />
+        <property role="2uzpH1" value=": Action" />
+        <node concept="tnohg" id="5gDLJkLjWhB" role="tncku">
+          <node concept="3clFbS" id="5gDLJkLjWhC" role="2VODD2" />
+        </node>
+        <node concept="3xLA65" id="5gDLJkLjWhD" role="lGtFl">
+          <property role="TrG5h" value="generatedActionNoGroup" />
+        </node>
+        <node concept="2ScWuX" id="5gDLJkLjWhE" role="tmbBb">
+          <node concept="3clFbS" id="5gDLJkLjWhF" role="2VODD2">
+            <node concept="3clFbF" id="5gDLJkLjWhG" role="3cqZAp">
+              <node concept="3clFbT" id="5gDLJkLjWhH" role="3clFbG">
+                <property role="3clFbU" value="true" />
+              </node>
+            </node>
+          </node>
         </node>
       </node>
     </node>
@@ -741,8 +996,13 @@
                       <node concept="37vLTw" id="7b8v2ssjNCr" role="3uHU7B">
                         <ref role="3cqZAo" node="7b8v2ssj$52" resolve="group" />
                       </node>
-                      <node concept="Xl_RD" id="7b8v2ssjPwe" role="3uHU7w">
-                        <property role="Xl_RC" value=":" />
+                      <node concept="2OqwBi" id="5gDLJkL8RFe" role="3uHU7w">
+                        <node concept="35c_gC" id="5gDLJkL8Lw2" role="2Oq$k0">
+                          <ref role="35c_gD" to="tegv:54z9_KDO4Av" resolve="GroupAnnotation" />
+                        </node>
+                        <node concept="2qgKlT" id="5gDLJkL8UeT" role="2OqNvi">
+                          <ref role="37wK5l" to="9j2l:24lzbKWhznQ" resolve="getSeparator" />
+                        </node>
                       </node>
                     </node>
                   </node>
@@ -837,6 +1097,55 @@
             </node>
           </node>
         </node>
+        <node concept="3GXo0L" id="5gDLJkLf$UA" role="3cqZAp">
+          <node concept="3xONca" id="5gDLJkLf$UB" role="3tpDZB">
+            <ref role="3xOPvv" node="5gDLJkLf$SA" resolve="generatedIntentionNoGroup" />
+          </node>
+          <node concept="2YIFZM" id="5gDLJkLf$UC" role="3tpDZA">
+            <ref role="37wK5l" to="9j2l:24lzbKWhSQ3" resolve="updateIntention" />
+            <ref role="1Pybhc" to="9j2l:24lzbKWhRGV" resolve="DescriptionUpdater" />
+            <node concept="3xONca" id="5gDLJkLf$UD" role="37wK5m">
+              <ref role="3xOPvv" node="5gDLJkLfx$H" resolve="intentionNoGroup" />
+            </node>
+          </node>
+        </node>
+        <node concept="3GXo0L" id="5gDLJkLf$UE" role="3cqZAp">
+          <node concept="3xONca" id="5gDLJkLf$UF" role="3tpDZB">
+            <ref role="3xOPvv" node="5gDLJkLjWhD" resolve="generatedActionNoGroup" />
+          </node>
+          <node concept="2YIFZM" id="5gDLJkLf$UG" role="3tpDZA">
+            <ref role="37wK5l" to="9j2l:24lzbKWk9jN" resolve="updateAction" />
+            <ref role="1Pybhc" to="9j2l:24lzbKWhRGV" resolve="DescriptionUpdater" />
+            <node concept="3xONca" id="5gDLJkLf$UH" role="37wK5m">
+              <ref role="3xOPvv" node="5gDLJkLjAvZ" resolve="actionNoGroup" />
+            </node>
+          </node>
+        </node>
+        <node concept="3GXo0L" id="5gDLJkLaS5e" role="3cqZAp">
+          <node concept="3xONca" id="5gDLJkLaS5f" role="3tpDZB">
+            <ref role="3xOPvv" node="5gDLJkLaRJ8" resolve="generatedIntentionNoDescription" />
+          </node>
+          <node concept="2YIFZM" id="5gDLJkLaS5g" role="3tpDZA">
+            <ref role="37wK5l" to="9j2l:24lzbKWhSQ3" resolve="updateIntention" />
+            <ref role="1Pybhc" to="9j2l:24lzbKWhRGV" resolve="DescriptionUpdater" />
+            <node concept="3xONca" id="5gDLJkLaS5h" role="37wK5m">
+              <ref role="3xOPvv" node="5gDLJkLaIB6" resolve="intentionNoDescription" />
+            </node>
+          </node>
+        </node>
+        <node concept="3GXo0L" id="5gDLJkLcSn_" role="3cqZAp">
+          <node concept="3xONca" id="5gDLJkLcSnA" role="3tpDZB">
+            <ref role="3xOPvv" node="5gDLJkLcQqf" resolve="generatedActionEmptyCaption" />
+          </node>
+          <node concept="2YIFZM" id="5gDLJkLcSCy" role="3tpDZA">
+            <ref role="37wK5l" to="9j2l:24lzbKWk9jN" resolve="updateAction" />
+            <ref role="1Pybhc" to="9j2l:24lzbKWhRGV" resolve="DescriptionUpdater" />
+            <node concept="3xONca" id="5gDLJkLcSCz" role="37wK5m">
+              <ref role="3xOPvv" node="5gDLJkLcGz2" resolve="actionEmptyCaption" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="5gDLJkLaS1r" role="3cqZAp" />
       </node>
     </node>
     <node concept="1LZb2c" id="7b8v2ss900p" role="1SL9yI">
@@ -1516,6 +1825,11 @@
               </node>
             </node>
           </node>
+          <node concept="3_1$Yv" id="5gDLJkL943L" role="3_9lra">
+            <node concept="Xl_RD" id="5gDLJkL94bU" role="3_1BAH">
+              <property role="Xl_RC" value="[Group:A]" />
+            </node>
+          </node>
         </node>
         <node concept="3vlDli" id="7b8v2ssnJay" role="3cqZAp">
           <node concept="Xl_RD" id="7b8v2ssnJaz" role="3tpDZB" />
@@ -1535,6 +1849,11 @@
                   </node>
                 </node>
               </node>
+            </node>
+          </node>
+          <node concept="3_1$Yv" id="5gDLJkL9MNY" role="3_9lra">
+            <node concept="Xl_RD" id="5gDLJkL9Nap" role="3_1BAH">
+              <property role="Xl_RC" value="[:Name]" />
             </node>
           </node>
         </node>
@@ -1560,6 +1879,11 @@
           <node concept="Xl_RD" id="7b8v2ssoPng" role="3tpDZB">
             <property role="Xl_RC" value="" />
           </node>
+          <node concept="3_1$Yv" id="5gDLJkL9MWr" role="3_9lra">
+            <node concept="Xl_RD" id="5gDLJkL9N$d" role="3_1BAH">
+              <property role="Xl_RC" value="[A]" />
+            </node>
+          </node>
         </node>
         <node concept="3vlDli" id="7b8v2ssnKsV" role="3cqZAp">
           <node concept="Xl_RD" id="7b8v2sspo01" role="3tpDZB">
@@ -1579,6 +1903,67 @@
                   <node concept="10Nm6u" id="7b8v2ssnL1R" role="2XxRq1" />
                 </node>
               </node>
+            </node>
+          </node>
+          <node concept="3_1$Yv" id="5gDLJkL9N3q" role="3_9lra">
+            <node concept="Xl_RD" id="5gDLJkL9O5a" role="3_1BAH">
+              <property role="Xl_RC" value="[null]" />
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="5gDLJkLa3FF" role="3cqZAp">
+          <node concept="Xl_RD" id="5gDLJkLa3FG" role="3tpDZB">
+            <property role="Xl_RC" value="" />
+          </node>
+          <node concept="2OqwBi" id="5gDLJkLa3FH" role="3tpDZA">
+            <node concept="37vLTw" id="5gDLJkLa3FI" role="2Oq$k0">
+              <ref role="3cqZAo" node="7b8v2ssnHRZ" resolve="producer" />
+            </node>
+            <node concept="liA8E" id="5gDLJkLa3FJ" role="2OqNvi">
+              <ref role="37wK5l" to="ih8q:3pwG8PSpGSr" resolve="getGroupName" />
+              <node concept="2OqwBi" id="5gDLJkLa3FK" role="37wK5m">
+                <node concept="2WthIp" id="5gDLJkLa3FL" role="2Oq$k0" />
+                <node concept="2XshWL" id="5gDLJkLa3FM" role="2OqNvi">
+                  <ref role="2WH_rO" node="7b8v2sshaES" resolve="createAction" />
+                  <node concept="10Nm6u" id="5gDLJkLa3FN" role="2XxRq1" />
+                  <node concept="Xl_RD" id="5gDLJkLa4Ch" role="2XxRq1">
+                    <property role="Xl_RC" value=":A" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3_1$Yv" id="5gDLJkLa3FP" role="3_9lra">
+            <node concept="Xl_RD" id="5gDLJkLa3FQ" role="3_1BAH">
+              <property role="Xl_RC" value="[:A]" />
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="5gDLJkLaksk" role="3cqZAp">
+          <node concept="Xl_RD" id="5gDLJkLaksl" role="3tpDZB">
+            <property role="Xl_RC" value="" />
+          </node>
+          <node concept="2OqwBi" id="5gDLJkLaksm" role="3tpDZA">
+            <node concept="37vLTw" id="5gDLJkLaksn" role="2Oq$k0">
+              <ref role="3cqZAo" node="7b8v2ssnHRZ" resolve="producer" />
+            </node>
+            <node concept="liA8E" id="5gDLJkLakso" role="2OqNvi">
+              <ref role="37wK5l" to="ih8q:3pwG8PSpGSr" resolve="getGroupName" />
+              <node concept="2OqwBi" id="5gDLJkLaksp" role="37wK5m">
+                <node concept="2WthIp" id="5gDLJkLaksq" role="2Oq$k0" />
+                <node concept="2XshWL" id="5gDLJkLaksr" role="2OqNvi">
+                  <ref role="2WH_rO" node="7b8v2sshaES" resolve="createAction" />
+                  <node concept="10Nm6u" id="5gDLJkLakss" role="2XxRq1" />
+                  <node concept="Xl_RD" id="5gDLJkLakst" role="2XxRq1">
+                    <property role="Xl_RC" value="::A" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3_1$Yv" id="5gDLJkLaksu" role="3_9lra">
+            <node concept="Xl_RD" id="5gDLJkLaksv" role="3_1BAH">
+              <property role="Xl_RC" value="[::A]" />
             </node>
           </node>
         </node>

--- a/code/solutions/de.itemis.model.merge.test/models/de.itemis.model.merge.test.gen@tests.mps
+++ b/code/solutions/de.itemis.model.merge.test/models/de.itemis.model.merge.test.gen@tests.mps
@@ -155,7 +155,7 @@
         <property id="5900870464460619218" name="something" index="a8euY" />
       </concept>
       <concept id="9112015721041276140" name="de.itemis.model.merge.diamond.structure.Bottom" flags="ng" index="I1cVD" />
-      <concept id="9112015721041276139" name="de.itemis.model.merge.diamond.structure.Top" flags="ngI" index="I1cVI">
+      <concept id="9112015721041276139" name="de.itemis.model.merge.diamond.structure.Top" flags="ng" index="I1cVI">
         <property id="9112015721041703530" name="nada" index="I0P1J" />
         <property id="9112015721041276141" name="dummy" index="I1cVC" />
         <child id="1683059382312355250" name="optChild" index="1tLEw_" />

--- a/code/solutions/de.itemis.model.merge.test/models/de.itemis.model.merge.test.gen@tests.mps
+++ b/code/solutions/de.itemis.model.merge.test/models/de.itemis.model.merge.test.gen@tests.mps
@@ -155,7 +155,7 @@
         <property id="5900870464460619218" name="something" index="a8euY" />
       </concept>
       <concept id="9112015721041276140" name="de.itemis.model.merge.diamond.structure.Bottom" flags="ng" index="I1cVD" />
-      <concept id="9112015721041276139" name="de.itemis.model.merge.diamond.structure.Top" flags="ng" index="I1cVI">
+      <concept id="9112015721041276139" name="de.itemis.model.merge.diamond.structure.Top" flags="ngI" index="I1cVI">
         <property id="9112015721041703530" name="nada" index="I0P1J" />
         <property id="9112015721041276141" name="dummy" index="I1cVC" />
         <child id="1683059382312355250" name="optChild" index="1tLEw_" />

--- a/code/solutions/de.itemis.mps.extensions.changelog/models/de.itemis.mps.extensions.changelog.mps
+++ b/code/solutions/de.itemis.mps.extensions.changelog/models/de.itemis.mps.extensions.changelog.mps
@@ -386,6 +386,83 @@
             <property role="3oM_SC" value="inspector." />
           </node>
         </node>
+        <node concept="2DRihI" id="$kD7tOLc98" role="15bAlk">
+          <node concept="15Ami3" id="$kD7tOLccK" role="1PaTwD">
+            <node concept="37shsh" id="$kD7tOLccL" role="15Aodc">
+              <node concept="1dCxOk" id="$kD7tOLccQ" role="37shsm">
+                <property role="1XweGW" value="b92f861d-0184-446d-b88b-6dcf0e070241" />
+                <property role="1XxBO9" value="com.mbeddr.mpsutil.intentions" />
+              </node>
+            </node>
+          </node>
+          <node concept="3oM_SD" id="$kD7tOLccV" role="1PaTwD">
+            <property role="3oM_SC" value="Group" />
+          </node>
+          <node concept="3oM_SD" id="$kD7tOLcrS" role="1PaTwD">
+            <property role="3oM_SC" value="annotations" />
+          </node>
+          <node concept="3oM_SD" id="$kD7tOLccW" role="1PaTwD">
+            <property role="3oM_SC" value="can" />
+          </node>
+          <node concept="3oM_SD" id="$kD7tOLccX" role="1PaTwD">
+            <property role="3oM_SC" value="now" />
+          </node>
+          <node concept="3oM_SD" id="$kD7tOLcgC" role="1PaTwD">
+            <property role="3oM_SC" value="be" />
+          </node>
+          <node concept="3oM_SD" id="$kD7tOLcgD" role="1PaTwD">
+            <property role="3oM_SC" value="also" />
+          </node>
+          <node concept="3oM_SD" id="$kD7tOLcgE" role="1PaTwD">
+            <property role="3oM_SC" value="added" />
+          </node>
+          <node concept="3oM_SD" id="$kD7tOLcgF" role="1PaTwD">
+            <property role="3oM_SC" value="to" />
+          </node>
+          <node concept="3oM_SD" id="$kD7tOLcgG" role="1PaTwD">
+            <property role="3oM_SC" value="action" />
+          </node>
+          <node concept="3oM_SD" id="$kD7tOLckn" role="1PaTwD">
+            <property role="3oM_SC" value="declarations" />
+          </node>
+          <node concept="3oM_SD" id="$kD7tOLcko" role="1PaTwD">
+            <property role="3oM_SC" value="and" />
+          </node>
+          <node concept="3oM_SD" id="$kD7tOLckp" role="1PaTwD">
+            <property role="3oM_SC" value="are" />
+          </node>
+          <node concept="3oM_SD" id="$kD7tOLckq" role="1PaTwD">
+            <property role="3oM_SC" value="active" />
+          </node>
+          <node concept="3oM_SD" id="$kD7tOLckr" role="1PaTwD">
+            <property role="3oM_SC" value="when" />
+          </node>
+          <node concept="3oM_SD" id="$kD7tOLcks" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="$kD7tOLckt" role="1PaTwD">
+            <property role="3oM_SC" value="actions" />
+          </node>
+          <node concept="3oM_SD" id="$kD7tOLco8" role="1PaTwD">
+            <property role="3oM_SC" value="are" />
+          </node>
+          <node concept="3oM_SD" id="$kD7tOLco9" role="1PaTwD">
+            <property role="3oM_SC" value="added" />
+          </node>
+          <node concept="3oM_SD" id="$kD7tOLcoa" role="1PaTwD">
+            <property role="3oM_SC" value="to" />
+          </node>
+          <node concept="3oM_SD" id="$kD7tOLcob" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="$kD7tOLcoc" role="1PaTwD">
+            <property role="3oM_SC" value="ActionsAsIntentions" />
+            <property role="1X82VY" value="true" />
+          </node>
+          <node concept="3oM_SD" id="$kD7tOLcod" role="1PaTwD">
+            <property role="3oM_SC" value="group." />
+          </node>
+        </node>
       </node>
     </node>
     <node concept="15bmVD" id="7qYSchhSpfu" role="15bmVC">


### PR DESCRIPTION
Group annotations can now be also added to action declarations and are active when the actions are added to the *ActionsAsIntentions* group.

Known issues:
- The cache is not always invalidated. You have to restart MPS or Reload All Classes for the change to take effect.
- The is applicable block of actions is not evaluated. In the original implementation in MPS this also doesn't work.

<img width="643" alt="Scherm­afbeelding 2025-05-13 om 12 47 33" src="https://github.com/user-attachments/assets/fe8b5ef3-fbe3-4a59-b268-b96360ef37e7" />


<img width="238" alt="Scherm­afbeelding 2025-05-13 om 13 09 15" src="https://github.com/user-attachments/assets/eeb850ba-3014-481f-bc69-1f63886e5221" />