### PR TITLE
test: increase heap size to fix OutOfMemoryError

### DIFF
--- a/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
+++ b/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
@@ -25220,6 +25220,9 @@
         <ref role="22LTRN" node="77YfcvOTUs4" resolve="test.com.mbeddr.mpsutil.compare" />
       </node>
     </node>
+    <node concept="2igEWh" id="1OMGwhrtizD" role="1hWBAP">
+      <property role="3UIfUI" value="1024" />
+    </node>
   </node>
 </model>
 


### PR DESCRIPTION
The heap dump produced by the JVM shows no suspicious objects, it seems that the increased memory requirements are simply due to the project growth. More classes have to be loaded from the jars, more text (source code) is being generated and kept in memory.