### PR TITLE
renovate: allow only -jre versions of Guava

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -14,5 +14,9 @@
       "matchPackageNames": ["org.eclipse*"],
       "groupName": "eclipse"
     },
+    {
+      "matchPackageNames": [ "com.google.guava:guava" ],
+      "allowedVersions": "/^.*-jre$/"
+    },
   ]
 }


### PR DESCRIPTION
Prevent from upgrading to -android, e.g. #1291.