### PR TITLE
Drop migration info for old EnumDataTypeDeclaration

### DIFF
--- a/code/compare/languages/de.itemis.mps.compare.pattern/models/de.itemis.mps.compare.pattern.structure.mps
+++ b/code/compare/languages/de.itemis.mps.compare.pattern/models/de.itemis.mps.compare.pattern.structure.mps
@@ -15,14 +15,10 @@
       <concept id="3348158742936976480" name="jetbrains.mps.lang.structure.structure.EnumerationMemberDeclaration" flags="ng" index="25R33">
         <property id="1421157252384165432" name="memberId" index="3tVfz5" />
         <property id="672037151186491528" name="presentation" index="1L1pqM" />
-        <reference id="899069222106091871" name="oldMember" index="2wpffI" />
       </concept>
       <concept id="3348158742936976479" name="jetbrains.mps.lang.structure.structure.EnumerationDeclaration" flags="ng" index="25R3W">
         <reference id="1075010451642646892" name="defaultMember" index="1H5jkz" />
         <child id="3348158742936976577" name="members" index="25R1y" />
-      </concept>
-      <concept id="6491077959632463275" name="jetbrains.mps.lang.structure.structure.EnumPropertyMigrationInfo" flags="ng" index="3l_iC">
-        <child id="6491077959632463286" name="oldProperty" index="3l_iP" />
       </concept>
       <concept id="6054523464626862044" name="jetbrains.mps.lang.structure.structure.AttributeInfo_IsMultiple" flags="ng" index="tn0Fv">
         <property id="6054523464626875854" name="value" index="tnX3d" />
@@ -32,20 +28,6 @@
       </concept>
       <concept id="1082978164218" name="jetbrains.mps.lang.structure.structure.DataTypeDeclaration" flags="ng" index="AxPO6">
         <property id="7791109065626895363" name="datatypeId" index="3F6X1D" />
-      </concept>
-      <concept id="1082978164219" name="jetbrains.mps.lang.structure.structure.EnumerationDataTypeDeclaration_Old" flags="ng" index="AxPO7">
-        <property id="1197591154882" name="memberIdentifierPolicy" index="3lZH7k" />
-        <reference id="1083171729157" name="memberDataType" index="M4eZT" />
-        <child id="1083172003582" name="member" index="M5hS2" />
-      </concept>
-      <concept id="1588368162884797030" name="jetbrains.mps.lang.structure.structure.EnumMigrationInfo" flags="ng" index="2JgGob">
-        <property id="6491077959634662372" name="valueOpMigration" index="3scbB" />
-        <property id="6491077959634650670" name="nameOpMigration" index="3sfsH" />
-        <child id="6491077959632451996" name="oldEnum" index="3lCyv" />
-      </concept>
-      <concept id="1083171877298" name="jetbrains.mps.lang.structure.structure.EnumerationMemberDeclaration_Old" flags="ig" index="M4N5e">
-        <property id="1083923523172" name="externalValue" index="1uS6qo" />
-        <property id="1083923523171" name="internalValue" index="1uS6qv" />
       </concept>
       <concept id="2992811758677295509" name="jetbrains.mps.lang.structure.structure.AttributeInfo" flags="ng" index="M6xJ_">
         <property id="7588428831955550663" name="role" index="Hh88m" />
@@ -276,13 +258,6 @@
       <property role="TrG5h" value="kind" />
       <property role="IQ2nx" value="5058472606515323932" />
       <ref role="AX2Wp" node="17qUVvSZlZk" resolve="PatternBuilderListKind" />
-      <node concept="3l_iC" id="17qUVvSZm7B" role="lGtFl">
-        <node concept="1TJgyi" id="4oNjwzxoYgs" role="3l_iP">
-          <property role="TrG5h" value="kind" />
-          <property role="IQ2nx" value="5058472606515323932" />
-          <ref role="AX2Wp" node="4oNjwzxp3wx" resolve="PatternBuilderListKind" />
-        </node>
-      </node>
     </node>
     <node concept="PrWs8" id="53_zXRSPi6" role="PzmwI">
       <ref role="PrY4T" node="53_zXRSI6_" resolve="IPatternContext" />
@@ -379,36 +354,15 @@
     <property role="3GE5qa" value="pattern" />
     <property role="3F6X1D" value="5058472606515345441" />
     <ref role="1H5jkz" node="17qUVvSZlZm" resolve="_0" />
-    <node concept="2JgGob" id="17qUVvSZlZl" role="lGtFl">
-      <property role="3scbB" value="5CkWgdpp3fo/by_custom_methods" />
-      <property role="3sfsH" value="5CkWgdpp0p5/by_custom_methods" />
-      <node concept="AxPO7" id="4oNjwzxp3wx" role="3lCyv">
-        <property role="3GE5qa" value="pattern" />
-        <property role="TrG5h" value="PatternBuilderListKind" />
-        <property role="3lZH7k" value="hrlZj6Q/derive_from_internal_value" />
-        <property role="3F6X1D" value="5058472606515345441" />
-        <ref role="M4eZT" to="tpck:fKAOsGN" resolve="string" />
-        <node concept="M4N5e" id="4oNjwzxp3wy" role="M5hS2">
-          <property role="1uS6qo" value="EXACT_MEMBERS" />
-          <property role="1uS6qv" value="0" />
-        </node>
-        <node concept="M4N5e" id="4oNjwzxp3wz" role="M5hS2">
-          <property role="1uS6qv" value="1" />
-          <property role="1uS6qo" value="CONTAINS_MEMBERS" />
-        </node>
-      </node>
-    </node>
     <node concept="25R33" id="17qUVvSZlZm" role="25R1y">
       <property role="TrG5h" value="_0" />
       <property role="1L1pqM" value="EXACT_MEMBERS" />
       <property role="3tVfz5" value="5058472606515345442" />
-      <ref role="2wpffI" node="4oNjwzxp3wy" />
     </node>
     <node concept="25R33" id="17qUVvSZlZn" role="25R1y">
       <property role="TrG5h" value="_1" />
       <property role="1L1pqM" value="CONTAINS_MEMBERS" />
       <property role="3tVfz5" value="5058472606515345443" />
-      <ref role="2wpffI" node="4oNjwzxp3wz" />
     </node>
   </node>
 </model>

--- a/code/diagram/languages/de.itemis.mps.editor.diagram/languageModels/structure.mps
+++ b/code/diagram/languages/de.itemis.mps.editor.diagram/languageModels/structure.mps
@@ -22,14 +22,10 @@
       <concept id="3348158742936976480" name="jetbrains.mps.lang.structure.structure.EnumerationMemberDeclaration" flags="ng" index="25R33">
         <property id="1421157252384165432" name="memberId" index="3tVfz5" />
         <property id="672037151186491528" name="presentation" index="1L1pqM" />
-        <reference id="899069222106091871" name="oldMember" index="2wpffI" />
       </concept>
       <concept id="3348158742936976479" name="jetbrains.mps.lang.structure.structure.EnumerationDeclaration" flags="ng" index="25R3W">
         <reference id="1075010451642646892" name="defaultMember" index="1H5jkz" />
         <child id="3348158742936976577" name="members" index="25R1y" />
-      </concept>
-      <concept id="6491077959632463275" name="jetbrains.mps.lang.structure.structure.EnumPropertyMigrationInfo" flags="ng" index="3l_iC">
-        <child id="6491077959632463286" name="oldProperty" index="3l_iP" />
       </concept>
       <concept id="1224240836180" name="jetbrains.mps.lang.structure.structure.DeprecatedNodeAnnotation" flags="ig" index="asaX9">
         <property id="1225118933224" name="comment" index="YLQ7P" />
@@ -37,22 +33,8 @@
       <concept id="1082978164218" name="jetbrains.mps.lang.structure.structure.DataTypeDeclaration" flags="ng" index="AxPO6">
         <property id="7791109065626895363" name="datatypeId" index="3F6X1D" />
       </concept>
-      <concept id="1082978164219" name="jetbrains.mps.lang.structure.structure.EnumerationDataTypeDeclaration_Old" flags="ng" index="AxPO7">
-        <property id="1197591154882" name="memberIdentifierPolicy" index="3lZH7k" />
-        <reference id="1083171729157" name="memberDataType" index="M4eZT" />
-        <child id="1083172003582" name="member" index="M5hS2" />
-      </concept>
       <concept id="1082978499127" name="jetbrains.mps.lang.structure.structure.ConstrainedDataTypeDeclaration" flags="ng" index="Az7Fb">
         <property id="1083066089218" name="constraint" index="FLfZY" />
-      </concept>
-      <concept id="1588368162884797030" name="jetbrains.mps.lang.structure.structure.EnumMigrationInfo" flags="ng" index="2JgGob">
-        <property id="6491077959634662372" name="valueOpMigration" index="3scbB" />
-        <property id="6491077959634650670" name="nameOpMigration" index="3sfsH" />
-        <child id="6491077959632451996" name="oldEnum" index="3lCyv" />
-      </concept>
-      <concept id="1083171877298" name="jetbrains.mps.lang.structure.structure.EnumerationMemberDeclaration_Old" flags="ig" index="M4N5e">
-        <property id="1083923523172" name="externalValue" index="1uS6qo" />
-        <property id="1083923523171" name="internalValue" index="1uS6qv" />
       </concept>
       <concept id="1169125787135" name="jetbrains.mps.lang.structure.structure.AbstractConceptDeclaration" flags="ig" index="PkWjJ">
         <property id="6714410169261853888" name="conceptId" index="EcuMT" />
@@ -708,13 +690,6 @@
       <property role="TrG5h" value="shape" />
       <property role="IQ2nx" value="7464726264117682321" />
       <ref role="AX2Wp" node="7WTFIQIcYq4" resolve="StandardShapes" />
-      <node concept="3l_iC" id="7WTFIQIcYvo" role="lGtFl">
-        <node concept="1TJgyi" id="6uo2fN6gQ2h" role="3l_iP">
-          <property role="TrG5h" value="shape" />
-          <property role="IQ2nx" value="7464726264117682321" />
-          <ref role="AX2Wp" node="6uo2fN6gPY$" resolve="StandardShapes" />
-        </node>
-      </node>
     </node>
   </node>
   <node concept="1TIwiD" id="6uo2fN6xziV">
@@ -953,13 +928,6 @@
       <property role="TrG5h" value="value" />
       <property role="IQ2nx" value="6987730699889504313" />
       <ref role="AX2Wp" node="7WTFIQIcYq9" resolve="LineStyleValues" />
-      <node concept="3l_iC" id="7WTFIQIcYvq" role="lGtFl">
-        <node concept="1TJgyi" id="63Tq0M90n0T" role="3l_iP">
-          <property role="TrG5h" value="value" />
-          <property role="IQ2nx" value="6987730699889504313" />
-          <ref role="AX2Wp" node="63Tq0M90n0O" resolve="LineStyleValues" />
-        </node>
-      </node>
     </node>
   </node>
   <node concept="1TIwiD" id="63Tq0M8Y_QV">
@@ -1601,13 +1569,6 @@
       <property role="TrG5h" value="direction" />
       <property role="IQ2nx" value="7623784619795245948" />
       <ref role="AX2Wp" node="7WTFIQIcYqd" resolve="Direction" />
-      <node concept="3l_iC" id="7WTFIQIcYvs" role="lGtFl">
-        <node concept="1TJgyi" id="6Bd7VwqYQHW" role="3l_iP">
-          <property role="TrG5h" value="direction" />
-          <property role="IQ2nx" value="7623784619795245948" />
-          <ref role="AX2Wp" node="6Bd7VwqYQAS" resolve="LayoutDirection" />
-        </node>
-      </node>
     </node>
     <node concept="1sEMCm" id="1FUCB8ocYka" role="bvy1s">
       <property role="1sEMCp" value="https://www.eclipse.org/elk/reference/algorithms/org-eclipse-elk-layered.html" />
@@ -2317,45 +2278,20 @@
     <property role="3GE5qa" value="shape" />
     <property role="3F6X1D" value="7464726264117682084" />
     <ref role="1H5jkz" node="7WTFIQIcYq6" resolve="RECTANGLE" />
-    <node concept="2JgGob" id="7WTFIQIcYq5" role="lGtFl">
-      <property role="3scbB" value="5CkWgdpp3eY/string_name" />
-      <property role="3sfsH" value="5CkWgdpp0p2/by_presentation" />
-      <node concept="AxPO7" id="6uo2fN6gPY$" role="3lCyv">
-        <property role="3GE5qa" value="shape" />
-        <property role="TrG5h" value="StandardShapes" />
-        <property role="3F6X1D" value="7464726264117682084" />
-        <ref role="M4eZT" to="tpck:fKAOsGN" resolve="string" />
-        <node concept="M4N5e" id="6uo2fN6gPY_" role="M5hS2">
-          <property role="1uS6qv" value="RECTANGLE" />
-          <property role="1uS6qo" value="rectangle" />
-        </node>
-        <node concept="M4N5e" id="6uo2fN6gQ6w" role="M5hS2">
-          <property role="1uS6qv" value="TRIANGLE" />
-          <property role="1uS6qo" value="triangle" />
-        </node>
-        <node concept="M4N5e" id="6uo2fN6gQ8h" role="M5hS2">
-          <property role="1uS6qv" value="ELLIPSE" />
-          <property role="1uS6qo" value="ellipse" />
-        </node>
-      </node>
-    </node>
     <node concept="25R33" id="7WTFIQIcYq6" role="25R1y">
       <property role="TrG5h" value="RECTANGLE" />
       <property role="1L1pqM" value="rectangle" />
       <property role="3tVfz5" value="7464726264117682085" />
-      <ref role="2wpffI" node="6uo2fN6gPY_" />
     </node>
     <node concept="25R33" id="7WTFIQIcYq7" role="25R1y">
       <property role="TrG5h" value="TRIANGLE" />
       <property role="1L1pqM" value="triangle" />
       <property role="3tVfz5" value="7464726264117682592" />
-      <ref role="2wpffI" node="6uo2fN6gQ6w" />
     </node>
     <node concept="25R33" id="7WTFIQIcYq8" role="25R1y">
       <property role="TrG5h" value="ELLIPSE" />
       <property role="1L1pqM" value="ellipse" />
       <property role="3tVfz5" value="7464726264117682705" />
-      <ref role="2wpffI" node="6uo2fN6gQ8h" />
     </node>
   </node>
   <node concept="25R3W" id="7WTFIQIcYqd">
@@ -2363,32 +2299,6 @@
     <property role="3GE5qa" value="layoutAlgorithm.config.layered" />
     <property role="3F6X1D" value="7623784619795245496" />
     <ref role="1H5jkz" node="2C8x_a2Qx7V" resolve="UNDEFINED" />
-    <node concept="2JgGob" id="7WTFIQIcYqe" role="lGtFl">
-      <property role="3scbB" value="5CkWgdpp3eY/string_name" />
-      <property role="3sfsH" value="5CkWgdpp0p1/by_name" />
-      <node concept="AxPO7" id="6Bd7VwqYQAS" role="3lCyv">
-        <property role="3GE5qa" value="layoutAlgorithm" />
-        <property role="TrG5h" value="LayoutDirection" />
-        <property role="3F6X1D" value="7623784619795245496" />
-        <ref role="M4eZT" to="tpck:fKAOsGN" resolve="string" />
-        <node concept="M4N5e" id="6Bd7VwqYQAT" role="M5hS2">
-          <property role="1uS6qo" value="RIGHT" />
-          <property role="1uS6qv" value="RIGHT" />
-        </node>
-        <node concept="M4N5e" id="6Bd7VwqYQBH" role="M5hS2">
-          <property role="1uS6qo" value="LEFT" />
-          <property role="1uS6qv" value="LEFT" />
-        </node>
-        <node concept="M4N5e" id="6Bd7VwqYQBO" role="M5hS2">
-          <property role="1uS6qo" value="UP" />
-          <property role="1uS6qv" value="UP" />
-        </node>
-        <node concept="M4N5e" id="6Bd7VwqYQBY" role="M5hS2">
-          <property role="1uS6qo" value="DOWN" />
-          <property role="1uS6qv" value="DOWN" />
-        </node>
-      </node>
-    </node>
     <node concept="25R33" id="2C8x_a2Qx7V" role="25R1y">
       <property role="3tVfz5" value="3028818438347428347" />
       <property role="TrG5h" value="UNDEFINED" />
@@ -2396,22 +2306,18 @@
     <node concept="25R33" id="7WTFIQIcYqf" role="25R1y">
       <property role="TrG5h" value="RIGHT" />
       <property role="3tVfz5" value="7623784619795245497" />
-      <ref role="2wpffI" node="6Bd7VwqYQAT" />
     </node>
     <node concept="25R33" id="7WTFIQIcYqg" role="25R1y">
       <property role="TrG5h" value="LEFT" />
       <property role="3tVfz5" value="7623784619795245549" />
-      <ref role="2wpffI" node="6Bd7VwqYQBH" />
     </node>
     <node concept="25R33" id="7WTFIQIcYqh" role="25R1y">
       <property role="TrG5h" value="UP" />
       <property role="3tVfz5" value="7623784619795245556" />
-      <ref role="2wpffI" node="6Bd7VwqYQBO" />
     </node>
     <node concept="25R33" id="7WTFIQIcYqi" role="25R1y">
       <property role="TrG5h" value="DOWN" />
       <property role="3tVfz5" value="7623784619795245566" />
-      <ref role="2wpffI" node="6Bd7VwqYQBY" />
     </node>
   </node>
   <node concept="25R3W" id="7WTFIQIcYq9">
@@ -2419,34 +2325,13 @@
     <property role="3GE5qa" value="style" />
     <property role="3F6X1D" value="6987730699889504308" />
     <ref role="1H5jkz" node="7WTFIQIcYqb" resolve="SOLID" />
-    <node concept="2JgGob" id="7WTFIQIcYqa" role="lGtFl">
-      <property role="3scbB" value="5CkWgdpp3eY/string_name" />
-      <property role="3sfsH" value="5CkWgdpp0p1/by_name" />
-      <node concept="AxPO7" id="63Tq0M90n0O" role="3lCyv">
-        <property role="3GE5qa" value="style" />
-        <property role="TrG5h" value="LineStyleValues" />
-        <property role="3lZH7k" value="hrlZj6Q/derive_from_internal_value" />
-        <property role="3F6X1D" value="6987730699889504308" />
-        <ref role="M4eZT" to="tpck:fKAOsGN" resolve="string" />
-        <node concept="M4N5e" id="63Tq0M90n0P" role="M5hS2">
-          <property role="1uS6qo" value="SOLID" />
-          <property role="1uS6qv" value="SOLID" />
-        </node>
-        <node concept="M4N5e" id="63Tq0M90n0Q" role="M5hS2">
-          <property role="1uS6qo" value="DASHED" />
-          <property role="1uS6qv" value="DASHED" />
-        </node>
-      </node>
-    </node>
     <node concept="25R33" id="7WTFIQIcYqb" role="25R1y">
       <property role="TrG5h" value="SOLID" />
       <property role="3tVfz5" value="6987730699889504309" />
-      <ref role="2wpffI" node="63Tq0M90n0P" />
     </node>
     <node concept="25R33" id="7WTFIQIcYqc" role="25R1y">
       <property role="TrG5h" value="DASHED" />
       <property role="3tVfz5" value="6987730699889504310" />
-      <ref role="2wpffI" node="63Tq0M90n0Q" />
     </node>
   </node>
   <node concept="1TIwiD" id="3YGiJOY24vX">

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells.sandboxlang/models/com/mbeddr/mpsutil/grammarcells/sandboxlang/structure.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells.sandboxlang/models/com/mbeddr/mpsutil/grammarcells/sandboxlang/structure.mps
@@ -12,33 +12,16 @@
       <concept id="3348158742936976480" name="jetbrains.mps.lang.structure.structure.EnumerationMemberDeclaration" flags="ng" index="25R33">
         <property id="1421157252384165432" name="memberId" index="3tVfz5" />
         <property id="672037151186491528" name="presentation" index="1L1pqM" />
-        <reference id="899069222106091871" name="oldMember" index="2wpffI" />
       </concept>
       <concept id="3348158742936976479" name="jetbrains.mps.lang.structure.structure.EnumerationDeclaration" flags="ng" index="25R3W">
         <reference id="1075010451642646892" name="defaultMember" index="1H5jkz" />
         <child id="3348158742936976577" name="members" index="25R1y" />
       </concept>
-      <concept id="6491077959632463275" name="jetbrains.mps.lang.structure.structure.EnumPropertyMigrationInfo" flags="ng" index="3l_iC">
-        <child id="6491077959632463286" name="oldProperty" index="3l_iP" />
-      </concept>
       <concept id="1082978164218" name="jetbrains.mps.lang.structure.structure.DataTypeDeclaration" flags="ng" index="AxPO6">
         <property id="7791109065626895363" name="datatypeId" index="3F6X1D" />
       </concept>
-      <concept id="1082978164219" name="jetbrains.mps.lang.structure.structure.EnumerationDataTypeDeclaration_Old" flags="ng" index="AxPO7">
-        <reference id="1083171729157" name="memberDataType" index="M4eZT" />
-        <child id="1083172003582" name="member" index="M5hS2" />
-      </concept>
       <concept id="1082978499127" name="jetbrains.mps.lang.structure.structure.ConstrainedDataTypeDeclaration" flags="ng" index="Az7Fb">
         <property id="1083066089218" name="constraint" index="FLfZY" />
-      </concept>
-      <concept id="1588368162884797030" name="jetbrains.mps.lang.structure.structure.EnumMigrationInfo" flags="ng" index="2JgGob">
-        <property id="6491077959634662372" name="valueOpMigration" index="3scbB" />
-        <property id="6491077959634650670" name="nameOpMigration" index="3sfsH" />
-        <child id="6491077959632451996" name="oldEnum" index="3lCyv" />
-      </concept>
-      <concept id="1083171877298" name="jetbrains.mps.lang.structure.structure.EnumerationMemberDeclaration_Old" flags="ig" index="M4N5e">
-        <property id="1083923523172" name="externalValue" index="1uS6qo" />
-        <property id="1083923523171" name="internalValue" index="1uS6qv" />
       </concept>
       <concept id="1169125787135" name="jetbrains.mps.lang.structure.structure.AbstractConceptDeclaration" flags="ig" index="PkWjJ">
         <property id="6714410169261853888" name="conceptId" index="EcuMT" />
@@ -76,7 +59,6 @@
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
         <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
-        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
       </concept>
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
@@ -550,13 +532,6 @@
       <property role="TrG5h" value="enum1" />
       <property role="IQ2nx" value="8850773520007259153" />
       <ref role="AX2Wp" node="7WTFIQIcYqR" resolve="Enum1" />
-      <node concept="3l_iC" id="7WTFIQIcYvX" role="lGtFl">
-        <node concept="1TJgyi" id="7FkgTXZtQgh" role="3l_iP">
-          <property role="TrG5h" value="enum1" />
-          <property role="IQ2nx" value="8850773520007259153" />
-          <ref role="AX2Wp" node="7FkgTXZtQev" resolve="Enum1" />
-        </node>
-      </node>
     </node>
     <node concept="PrWs8" id="7FkgTXZtQeq" role="PzmwI">
       <ref role="PrY4T" node="6oKG1kMxn8A" resolve="IExpression" />
@@ -631,13 +606,6 @@
       <property role="TrG5h" value="unit" />
       <property role="IQ2nx" value="4330386229151410877" />
       <ref role="AX2Wp" node="7WTFIQIcYs2" resolve="Unit" />
-      <node concept="3l_iC" id="7WTFIQIcYvZ" role="lGtFl">
-        <node concept="1TJgyi" id="3KoBPk0O2EX" role="3l_iP">
-          <property role="TrG5h" value="unit" />
-          <property role="IQ2nx" value="4330386229151410877" />
-          <ref role="AX2Wp" node="3KoBPk0O2EF" resolve="Unit" />
-        </node>
-      </node>
     </node>
     <node concept="PrWs8" id="3KoBPk0O2EU" role="PzmwI">
       <ref role="PrY4T" node="6oKG1kMxn8A" resolve="IExpression" />
@@ -661,95 +629,42 @@
     <property role="TrG5h" value="Enum1" />
     <property role="3F6X1D" value="8850773520007259039" />
     <ref role="1H5jkz" node="7WTFIQIcYqT" resolve="a" />
-    <node concept="2JgGob" id="7WTFIQIcYqS" role="lGtFl">
-      <property role="3scbB" value="5CkWgdpp3fo/by_custom_methods" />
-      <property role="3sfsH" value="5CkWgdpp0p1/by_name" />
-      <node concept="AxPO7" id="7FkgTXZtQev" role="3lCyv">
-        <property role="TrG5h" value="Enum1" />
-        <property role="3F6X1D" value="8850773520007259039" />
-        <ref role="M4eZT" to="tpck:fKAOsGN" resolve="string" />
-        <node concept="M4N5e" id="7FkgTXZtQew" role="M5hS2">
-          <property role="1uS6qo" value="a" />
-          <property role="1uS6qv" value="100" />
-        </node>
-        <node concept="M4N5e" id="7FkgTXZtQeT" role="M5hS2">
-          <property role="1uS6qo" value="b" />
-          <property role="1uS6qv" value="101" />
-        </node>
-        <node concept="M4N5e" id="7FkgTXZtQf2" role="M5hS2">
-          <property role="1uS6qo" value="c" />
-          <property role="1uS6qv" value="102" />
-        </node>
-        <node concept="M4N5e" id="7FkgTXZtQff" role="M5hS2">
-          <property role="1uS6qo" value="d" />
-          <property role="1uS6qv" value="103" />
-        </node>
-      </node>
-    </node>
     <node concept="25R33" id="7WTFIQIcYqT" role="25R1y">
       <property role="TrG5h" value="a" />
       <property role="3tVfz5" value="8850773520007259040" />
       <property role="1L1pqM" value="A" />
-      <ref role="2wpffI" node="7FkgTXZtQew" />
     </node>
     <node concept="25R33" id="7WTFIQIcYqU" role="25R1y">
       <property role="TrG5h" value="b" />
       <property role="3tVfz5" value="8850773520007259065" />
       <property role="1L1pqM" value="B" />
-      <ref role="2wpffI" node="7FkgTXZtQeT" />
     </node>
     <node concept="25R33" id="7WTFIQIcYqV" role="25R1y">
       <property role="TrG5h" value="c" />
       <property role="3tVfz5" value="8850773520007259074" />
       <property role="1L1pqM" value="C" />
-      <ref role="2wpffI" node="7FkgTXZtQf2" />
     </node>
     <node concept="25R33" id="7WTFIQIcYqW" role="25R1y">
       <property role="TrG5h" value="d" />
       <property role="3tVfz5" value="8850773520007259087" />
       <property role="1L1pqM" value="D" />
-      <ref role="2wpffI" node="7FkgTXZtQff" />
     </node>
   </node>
   <node concept="25R3W" id="7WTFIQIcYs2">
     <property role="TrG5h" value="Unit" />
     <property role="3F6X1D" value="4330386229151410859" />
     <ref role="1H5jkz" node="7WTFIQIcYs4" resolve="m" />
-    <node concept="2JgGob" id="7WTFIQIcYs3" role="lGtFl">
-      <property role="3scbB" value="5CkWgdpp3eY/string_name" />
-      <property role="3sfsH" value="5CkWgdpp0p1/by_name" />
-      <node concept="AxPO7" id="3KoBPk0O2EF" role="3lCyv">
-        <property role="TrG5h" value="Unit" />
-        <property role="3F6X1D" value="4330386229151410859" />
-        <ref role="M4eZT" to="tpck:fKAOsGN" resolve="string" />
-        <node concept="M4N5e" id="3KoBPk0O2EG" role="M5hS2">
-          <property role="1uS6qo" value="m" />
-          <property role="1uS6qv" value="m" />
-        </node>
-        <node concept="M4N5e" id="3KoBPk0O2EH" role="M5hS2">
-          <property role="1uS6qo" value="s" />
-          <property role="1uS6qv" value="s" />
-        </node>
-        <node concept="M4N5e" id="3KoBPk0O2EM" role="M5hS2">
-          <property role="1uS6qo" value="kg" />
-          <property role="1uS6qv" value="kg" />
-        </node>
-      </node>
-    </node>
     <node concept="25R33" id="7WTFIQIcYs4" role="25R1y">
       <property role="TrG5h" value="m" />
       <property role="3tVfz5" value="4330386229151410860" />
-      <ref role="2wpffI" node="3KoBPk0O2EG" />
     </node>
     <node concept="25R33" id="7WTFIQIcYs5" role="25R1y">
       <property role="TrG5h" value="s" />
       <property role="3tVfz5" value="4330386229151410861" />
-      <ref role="2wpffI" node="3KoBPk0O2EH" />
     </node>
     <node concept="25R33" id="7WTFIQIcYs6" role="25R1y">
       <property role="TrG5h" value="kg" />
       <property role="3tVfz5" value="4330386229151410866" />
-      <ref role="2wpffI" node="3KoBPk0O2EM" />
     </node>
   </node>
   <node concept="1TIwiD" id="6TEPcwQO0k7">

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/models/com/mbeddr/mpsutil/grammarcells/structure.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/models/com/mbeddr/mpsutil/grammarcells/structure.mps
@@ -15,9 +15,6 @@
   </imports>
   <registry>
     <language id="c72da2b9-7cce-4447-8389-f407dc1158b7" name="jetbrains.mps.lang.structure">
-      <concept id="6491077959632463275" name="jetbrains.mps.lang.structure.structure.EnumPropertyMigrationInfo" flags="ng" index="3l_iC">
-        <child id="6491077959632463286" name="oldProperty" index="3l_iP" />
-      </concept>
       <concept id="1224240836180" name="jetbrains.mps.lang.structure.structure.DeprecatedNodeAnnotation" flags="ig" index="asaX9">
         <property id="1225118933224" name="comment" index="YLQ7P" />
       </concept>
@@ -606,13 +603,6 @@
       <property role="TrG5h" value="side" />
       <property role="IQ2nx" value="7272510943425988883" />
       <ref role="AX2Wp" to="tpdg:3Ftr4R6BF3f" resolve="Side" />
-      <node concept="3l_iC" id="7WTFIQIcYwf" role="lGtFl">
-        <node concept="1TJgyi" id="6jH9yJK30$j" role="3l_iP">
-          <property role="TrG5h" value="side" />
-          <property role="IQ2nx" value="7272510943425988883" />
-          <ref role="AX2Wp" to="tpdg:3Ftr4R6BF3f" resolve="Side" />
-        </node>
-      </node>
     </node>
     <node concept="PrWs8" id="6jH9yJK30Bp" role="PzmwI">
       <ref role="PrY4T" node="3O7ZvCZLPYU" resolve="ICellWrapper" />

--- a/code/plaintextgen/languages/com.dslfoundry.plaintextgen/models/com/dslfoundry/plaintextgen/structure.mps
+++ b/code/plaintextgen/languages/com.dslfoundry.plaintextgen/models/com/dslfoundry/plaintextgen/structure.mps
@@ -13,34 +13,16 @@
       <concept id="3348158742936976480" name="jetbrains.mps.lang.structure.structure.EnumerationMemberDeclaration" flags="ng" index="25R33">
         <property id="1421157252384165432" name="memberId" index="3tVfz5" />
         <property id="672037151186491528" name="presentation" index="1L1pqM" />
-        <reference id="899069222106091871" name="oldMember" index="2wpffI" />
       </concept>
       <concept id="3348158742936976479" name="jetbrains.mps.lang.structure.structure.EnumerationDeclaration" flags="ng" index="25R3W">
         <reference id="1075010451642646892" name="defaultMember" index="1H5jkz" />
         <child id="3348158742936976577" name="members" index="25R1y" />
       </concept>
-      <concept id="6491077959632463275" name="jetbrains.mps.lang.structure.structure.EnumPropertyMigrationInfo" flags="ng" index="3l_iC">
-        <child id="6491077959632463286" name="oldProperty" index="3l_iP" />
-      </concept>
       <concept id="1082978164218" name="jetbrains.mps.lang.structure.structure.DataTypeDeclaration" flags="ng" index="AxPO6">
         <property id="7791109065626895363" name="datatypeId" index="3F6X1D" />
       </concept>
-      <concept id="1082978164219" name="jetbrains.mps.lang.structure.structure.EnumerationDataTypeDeclaration_Old" flags="ng" index="AxPO7">
-        <property id="1197591154882" name="memberIdentifierPolicy" index="3lZH7k" />
-        <reference id="1083171729157" name="memberDataType" index="M4eZT" />
-        <child id="1083172003582" name="member" index="M5hS2" />
-      </concept>
       <concept id="1082978499127" name="jetbrains.mps.lang.structure.structure.ConstrainedDataTypeDeclaration" flags="ng" index="Az7Fb">
         <property id="1083066089218" name="constraint" index="FLfZY" />
-      </concept>
-      <concept id="1588368162884797030" name="jetbrains.mps.lang.structure.structure.EnumMigrationInfo" flags="ng" index="2JgGob">
-        <property id="6491077959634662372" name="valueOpMigration" index="3scbB" />
-        <property id="6491077959634650670" name="nameOpMigration" index="3sfsH" />
-        <child id="6491077959632451996" name="oldEnum" index="3lCyv" />
-      </concept>
-      <concept id="1083171877298" name="jetbrains.mps.lang.structure.structure.EnumerationMemberDeclaration_Old" flags="ig" index="M4N5e">
-        <property id="1083923523172" name="externalValue" index="1uS6qo" />
-        <property id="1083923523171" name="internalValue" index="1uS6qv" />
       </concept>
       <concept id="1169125787135" name="jetbrains.mps.lang.structure.structure.AbstractConceptDeclaration" flags="ig" index="PkWjJ">
         <property id="6714410169261853888" name="conceptId" index="EcuMT" />
@@ -75,7 +57,6 @@
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
         <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
-        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
       </concept>
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
@@ -201,13 +182,6 @@
       <property role="TrG5h" value="lineEnding" />
       <property role="IQ2nx" value="8095834124169899852" />
       <ref role="AX2Wp" node="7WTFIQIcYt4" resolve="LineEnding" />
-      <node concept="3l_iC" id="7WTFIQIcYwq" role="lGtFl">
-        <node concept="1TJgyi" id="71qbzSbCuXc" role="3l_iP">
-          <property role="IQ2nx" value="8095834124169899852" />
-          <property role="TrG5h" value="lineEnding" />
-          <ref role="AX2Wp" node="71qbzSbCuX3" resolve="LineEnding" />
-        </node>
-      </node>
     </node>
   </node>
   <node concept="1TIwiD" id="4q7d2VGNiCW">
@@ -234,13 +208,6 @@
       <property role="TrG5h" value="align" />
       <property role="IQ2nx" value="7214912913997400475" />
       <ref role="AX2Wp" node="7WTFIQIcYsZ" resolve="TextAlignment" />
-      <node concept="3l_iC" id="7WTFIQIcYws" role="lGtFl">
-        <node concept="1TJgyi" id="6gwxh6GcoAr" role="3l_iP">
-          <property role="TrG5h" value="align" />
-          <property role="IQ2nx" value="7214912913997400475" />
-          <ref role="AX2Wp" node="2jBmyzyFesB" resolve="TextAlignment" />
-        </node>
-      </node>
     </node>
   </node>
   <node concept="PlHQZ" id="4GbnmmUbAAi">
@@ -266,41 +233,17 @@
       <property role="3tVfz5" value="5343426723084115562" />
       <property role="TrG5h" value="Native" />
     </node>
-    <node concept="2JgGob" id="7WTFIQIcYt5" role="lGtFl">
-      <property role="3scbB" value="5CkWgdpp3eY/string_name" />
-      <property role="3sfsH" value="5CkWgdpp0p1/by_name" />
-      <node concept="AxPO7" id="71qbzSbCuX3" role="3lCyv">
-        <property role="TrG5h" value="LineEnding" />
-        <property role="3F6X1D" value="8095834124169899843" />
-        <ref role="M4eZT" to="tpck:fKAOsGN" resolve="string" />
-        <node concept="M4N5e" id="71qbzSbCuX8" role="M5hS2">
-          <property role="1uS6qo" value="CRLF" />
-          <property role="1uS6qv" value="CRLF" />
-        </node>
-        <node concept="M4N5e" id="71qbzSbCuX4" role="M5hS2">
-          <property role="1uS6qv" value="CR" />
-          <property role="1uS6qo" value="CR" />
-        </node>
-        <node concept="M4N5e" id="71qbzSbCuX5" role="M5hS2">
-          <property role="1uS6qo" value="LF" />
-          <property role="1uS6qv" value="LF" />
-        </node>
-      </node>
-    </node>
     <node concept="25R33" id="7WTFIQIcYt6" role="25R1y">
       <property role="TrG5h" value="CRLF" />
       <property role="3tVfz5" value="8095834124169899848" />
-      <ref role="2wpffI" node="71qbzSbCuX8" />
     </node>
     <node concept="25R33" id="7WTFIQIcYt7" role="25R1y">
       <property role="TrG5h" value="CR" />
       <property role="3tVfz5" value="8095834124169899844" />
-      <ref role="2wpffI" node="71qbzSbCuX4" />
     </node>
     <node concept="25R33" id="7WTFIQIcYt8" role="25R1y">
       <property role="TrG5h" value="LF" />
       <property role="3tVfz5" value="8095834124169899845" />
-      <ref role="2wpffI" node="71qbzSbCuX5" />
     </node>
   </node>
   <node concept="25R3W" id="7WTFIQIcYsZ">
@@ -308,46 +251,20 @@
     <property role="3GE5qa" value="vertical" />
     <property role="3F6X1D" value="2659193236633741095" />
     <ref role="1H5jkz" node="7WTFIQIcYt1" resolve="left" />
-    <node concept="2JgGob" id="7WTFIQIcYt0" role="lGtFl">
-      <property role="3scbB" value="5CkWgdpp3eY/string_name" />
-      <property role="3sfsH" value="5CkWgdpp0p1/by_name" />
-      <node concept="AxPO7" id="2jBmyzyFesB" role="3lCyv">
-        <property role="3GE5qa" value="vertical" />
-        <property role="TrG5h" value="TextAlignment" />
-        <property role="3lZH7k" value="hrlZj6Q/derive_from_internal_value" />
-        <property role="3F6X1D" value="2659193236633741095" />
-        <ref role="M4eZT" to="tpck:fKAOsGN" resolve="string" />
-        <node concept="M4N5e" id="2jBmyzyFesC" role="M5hS2">
-          <property role="1uS6qv" value="left" />
-          <property role="1uS6qo" value="◧" />
-        </node>
-        <node concept="M4N5e" id="2jBmyzyFesD" role="M5hS2">
-          <property role="1uS6qv" value="center" />
-          <property role="1uS6qo" value="◫" />
-        </node>
-        <node concept="M4N5e" id="2jBmyzyFesG" role="M5hS2">
-          <property role="1uS6qo" value="◨" />
-          <property role="1uS6qv" value="right" />
-        </node>
-      </node>
-    </node>
     <node concept="25R33" id="7WTFIQIcYt1" role="25R1y">
       <property role="TrG5h" value="left" />
       <property role="1L1pqM" value="◧" />
       <property role="3tVfz5" value="2659193236633741096" />
-      <ref role="2wpffI" node="2jBmyzyFesC" />
     </node>
     <node concept="25R33" id="7WTFIQIcYt2" role="25R1y">
       <property role="TrG5h" value="center" />
       <property role="1L1pqM" value="◫" />
       <property role="3tVfz5" value="2659193236633741097" />
-      <ref role="2wpffI" node="2jBmyzyFesD" />
     </node>
     <node concept="25R33" id="7WTFIQIcYt3" role="25R1y">
       <property role="TrG5h" value="right" />
       <property role="1L1pqM" value="◨" />
       <property role="3tVfz5" value="2659193236633741100" />
-      <ref role="2wpffI" node="2jBmyzyFesG" />
     </node>
   </node>
 </model>

--- a/code/structurecheck/languages/de.itemis.mps.structurecheck/languageModels/structure.mps
+++ b/code/structurecheck/languages/de.itemis.mps.structurecheck/languageModels/structure.mps
@@ -13,30 +13,13 @@
     <language id="c72da2b9-7cce-4447-8389-f407dc1158b7" name="jetbrains.mps.lang.structure">
       <concept id="3348158742936976480" name="jetbrains.mps.lang.structure.structure.EnumerationMemberDeclaration" flags="ng" index="25R33">
         <property id="1421157252384165432" name="memberId" index="3tVfz5" />
-        <reference id="899069222106091871" name="oldMember" index="2wpffI" />
       </concept>
       <concept id="3348158742936976479" name="jetbrains.mps.lang.structure.structure.EnumerationDeclaration" flags="ng" index="25R3W">
         <reference id="1075010451642646892" name="defaultMember" index="1H5jkz" />
         <child id="3348158742936976577" name="members" index="25R1y" />
       </concept>
-      <concept id="6491077959632463275" name="jetbrains.mps.lang.structure.structure.EnumPropertyMigrationInfo" flags="ng" index="3l_iC">
-        <child id="6491077959632463286" name="oldProperty" index="3l_iP" />
-      </concept>
       <concept id="1082978164218" name="jetbrains.mps.lang.structure.structure.DataTypeDeclaration" flags="ng" index="AxPO6">
         <property id="7791109065626895363" name="datatypeId" index="3F6X1D" />
-      </concept>
-      <concept id="1082978164219" name="jetbrains.mps.lang.structure.structure.EnumerationDataTypeDeclaration_Old" flags="ng" index="AxPO7">
-        <reference id="1083171729157" name="memberDataType" index="M4eZT" />
-        <child id="1083172003582" name="member" index="M5hS2" />
-      </concept>
-      <concept id="1588368162884797030" name="jetbrains.mps.lang.structure.structure.EnumMigrationInfo" flags="ng" index="2JgGob">
-        <property id="6491077959634662372" name="valueOpMigration" index="3scbB" />
-        <property id="6491077959634650670" name="nameOpMigration" index="3sfsH" />
-        <child id="6491077959632451996" name="oldEnum" index="3lCyv" />
-      </concept>
-      <concept id="1083171877298" name="jetbrains.mps.lang.structure.structure.EnumerationMemberDeclaration_Old" flags="ig" index="M4N5e">
-        <property id="1083923523172" name="externalValue" index="1uS6qo" />
-        <property id="1083923523171" name="internalValue" index="1uS6qv" />
       </concept>
       <concept id="1169125787135" name="jetbrains.mps.lang.structure.structure.AbstractConceptDeclaration" flags="ig" index="PkWjJ">
         <property id="6714410169261853888" name="conceptId" index="EcuMT" />
@@ -66,9 +49,6 @@
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
-      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
-        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
-      </concept>
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
@@ -157,13 +137,6 @@
       <property role="TrG5h" value="rule" />
       <property role="IQ2nx" value="380240910834182503" />
       <ref role="AX2Wp" node="7WTFIQIcYtx" resolve="SequenceCheckerType" />
-      <node concept="3l_iC" id="7WTFIQIcYwF" role="lGtFl">
-        <node concept="1TJgyi" id="l6SLw3lU_B" role="3l_iP">
-          <property role="TrG5h" value="rule" />
-          <property role="IQ2nx" value="380240910834182503" />
-          <ref role="AX2Wp" node="l6SLw3lU$a" resolve="SequenceCheckerType" />
-        </node>
-      </node>
     </node>
     <node concept="1TJgyj" id="l6SLw3lTYF" role="1TKVEi">
       <property role="20lmBu" value="fLJjDmT/aggregation" />
@@ -254,50 +227,21 @@
     <property role="TrG5h" value="SequenceCheckerType" />
     <property role="3F6X1D" value="380240910834182410" />
     <ref role="1H5jkz" node="7WTFIQIcYtz" resolve="exactly" />
-    <node concept="2JgGob" id="7WTFIQIcYty" role="lGtFl">
-      <property role="3scbB" value="5CkWgdpp3eY/string_name" />
-      <property role="3sfsH" value="5CkWgdpp0p1/by_name" />
-      <node concept="AxPO7" id="l6SLw3lU$a" role="3lCyv">
-        <property role="TrG5h" value="SequenceCheckerType" />
-        <property role="3F6X1D" value="380240910834182410" />
-        <ref role="M4eZT" to="tpck:fKAOsGN" resolve="string" />
-        <node concept="M4N5e" id="l6SLw3lU$b" role="M5hS2">
-          <property role="1uS6qo" value="exactly" />
-          <property role="1uS6qv" value="exactly" />
-        </node>
-        <node concept="M4N5e" id="l6SLw3lU$s" role="M5hS2">
-          <property role="1uS6qo" value="allOrMore" />
-          <property role="1uS6qv" value="allOrMore" />
-        </node>
-        <node concept="M4N5e" id="l6SLw3lU$M" role="M5hS2">
-          <property role="1uS6qo" value="allOrLess" />
-          <property role="1uS6qv" value="allOrLess" />
-        </node>
-        <node concept="M4N5e" id="l6SLw3lU_b" role="M5hS2">
-          <property role="1uS6qo" value="noneOfThese" />
-          <property role="1uS6qv" value="noneOfThese" />
-        </node>
-      </node>
-    </node>
     <node concept="25R33" id="7WTFIQIcYtz" role="25R1y">
       <property role="TrG5h" value="exactly" />
       <property role="3tVfz5" value="380240910834182411" />
-      <ref role="2wpffI" node="l6SLw3lU$b" />
     </node>
     <node concept="25R33" id="7WTFIQIcYt$" role="25R1y">
       <property role="TrG5h" value="allOrMore" />
       <property role="3tVfz5" value="380240910834182428" />
-      <ref role="2wpffI" node="l6SLw3lU$s" />
     </node>
     <node concept="25R33" id="7WTFIQIcYt_" role="25R1y">
       <property role="TrG5h" value="allOrLess" />
       <property role="3tVfz5" value="380240910834182450" />
-      <ref role="2wpffI" node="l6SLw3lU$M" />
     </node>
     <node concept="25R33" id="7WTFIQIcYtA" role="25R1y">
       <property role="TrG5h" value="noneOfThese" />
       <property role="3tVfz5" value="380240910834182475" />
-      <ref role="2wpffI" node="l6SLw3lU_b" />
     </node>
   </node>
   <node concept="1TIwiD" id="uffbfdOXGY">

--- a/code/tables/languages/de.slisson.mps.tables/languageModels/structure.mps
+++ b/code/tables/languages/de.slisson.mps.tables/languageModels/structure.mps
@@ -16,33 +16,14 @@
       <concept id="3348158742936976480" name="jetbrains.mps.lang.structure.structure.EnumerationMemberDeclaration" flags="ng" index="25R33">
         <property id="1421157252384165432" name="memberId" index="3tVfz5" />
         <property id="672037151186491528" name="presentation" index="1L1pqM" />
-        <reference id="899069222106091871" name="oldMember" index="2wpffI" />
       </concept>
       <concept id="3348158742936976479" name="jetbrains.mps.lang.structure.structure.EnumerationDeclaration" flags="ng" index="25R3W">
         <reference id="1075010451642646892" name="defaultMember" index="1H5jkz" />
         <child id="3348158742936976577" name="members" index="25R1y" />
       </concept>
-      <concept id="6491077959632463275" name="jetbrains.mps.lang.structure.structure.EnumPropertyMigrationInfo" flags="ng" index="3l_iC">
-        <child id="6491077959632463286" name="oldProperty" index="3l_iP" />
-      </concept>
       <concept id="1224240836180" name="jetbrains.mps.lang.structure.structure.DeprecatedNodeAnnotation" flags="ig" index="asaX9" />
       <concept id="1082978164218" name="jetbrains.mps.lang.structure.structure.DataTypeDeclaration" flags="ng" index="AxPO6">
         <property id="7791109065626895363" name="datatypeId" index="3F6X1D" />
-      </concept>
-      <concept id="1082978164219" name="jetbrains.mps.lang.structure.structure.EnumerationDataTypeDeclaration_Old" flags="ng" index="AxPO7">
-        <property id="1197591154882" name="memberIdentifierPolicy" index="3lZH7k" />
-        <reference id="1083171729157" name="memberDataType" index="M4eZT" />
-        <reference id="1083241965437" name="defaultMember" index="Qgau1" />
-        <child id="1083172003582" name="member" index="M5hS2" />
-      </concept>
-      <concept id="1588368162884797030" name="jetbrains.mps.lang.structure.structure.EnumMigrationInfo" flags="ng" index="2JgGob">
-        <property id="6491077959634662372" name="valueOpMigration" index="3scbB" />
-        <property id="6491077959634650670" name="nameOpMigration" index="3sfsH" />
-        <child id="6491077959632451996" name="oldEnum" index="3lCyv" />
-      </concept>
-      <concept id="1083171877298" name="jetbrains.mps.lang.structure.structure.EnumerationMemberDeclaration_Old" flags="ig" index="M4N5e">
-        <property id="1083923523172" name="externalValue" index="1uS6qo" />
-        <property id="1083923523171" name="internalValue" index="1uS6qv" />
       </concept>
       <concept id="1169125787135" name="jetbrains.mps.lang.structure.structure.AbstractConceptDeclaration" flags="ig" index="PkWjJ">
         <property id="6714410169261853888" name="conceptId" index="EcuMT" />
@@ -574,13 +555,6 @@
       <property role="TrG5h" value="displayType" />
       <property role="IQ2nx" value="3785936898452719116" />
       <ref role="AX2Wp" node="7WTFIQIcYtQ" resolve="ListDisplayType" />
-      <node concept="3l_iC" id="7WTFIQIcYwO" role="lGtFl">
-        <node concept="1TJgyi" id="3iamoNAkooc" role="3l_iP">
-          <property role="TrG5h" value="displayType" />
-          <property role="IQ2nx" value="3785936898452719116" />
-          <ref role="AX2Wp" node="3iamoNAkolt" resolve="ListDisplayType" />
-        </node>
-      </node>
     </node>
   </node>
   <node concept="1TIwiD" id="1dAqnm8x0Tk">
@@ -1102,13 +1076,6 @@
       <property role="TrG5h" value="alignment" />
       <property role="IQ2nx" value="4384308856523593885" />
       <ref role="AX2Wp" node="7WTFIQIcYu1" resolve="HorizontalAlignment" />
-      <node concept="3l_iC" id="7WTFIQIcYwS" role="lGtFl">
-        <node concept="1TJgyi" id="3NocqOaG1yt" role="3l_iP">
-          <property role="TrG5h" value="alignment" />
-          <property role="IQ2nx" value="4384308856523593885" />
-          <ref role="AX2Wp" node="3NocqOaFOpf" resolve="HorizontalAlignment" />
-        </node>
-      </node>
     </node>
   </node>
   <node concept="1TIwiD" id="1gyFNfOBoc6">
@@ -1166,13 +1133,6 @@
       <property role="TrG5h" value="alignment" />
       <property role="IQ2nx" value="4384308856523581138" />
       <ref role="AX2Wp" node="7WTFIQIcYtW" resolve="VerticalAlignment" />
-      <node concept="3l_iC" id="7WTFIQIcYwU" role="lGtFl">
-        <node concept="1TJgyi" id="3NocqOaFYri" role="3l_iP">
-          <property role="TrG5h" value="alignment" />
-          <property role="IQ2nx" value="4384308856523581138" />
-          <ref role="AX2Wp" node="3NocqOaFOcL" resolve="VerticalAlignment" />
-        </node>
-      </node>
     </node>
   </node>
   <node concept="1TIwiD" id="7C0FR5_exlh">
@@ -1294,56 +1254,25 @@
     <property role="3GE5qa" value="CellQuery" />
     <property role="3F6X1D" value="3785936898452718941" />
     <ref role="1H5jkz" node="7WTFIQIcYtS" resolve="vlist" />
-    <node concept="2JgGob" id="7WTFIQIcYtR" role="lGtFl">
-      <property role="3scbB" value="5CkWgdpp3eY/string_name" />
-      <property role="3sfsH" value="5CkWgdpp0p1/by_name" />
-      <node concept="AxPO7" id="3iamoNAkolt" role="3lCyv">
-        <property role="3GE5qa" value="CellQuery" />
-        <property role="TrG5h" value="ListDisplayType" />
-        <property role="3lZH7k" value="hrlZj6Q/derive_from_internal_value" />
-        <property role="3F6X1D" value="3785936898452718941" />
-        <ref role="M4eZT" to="tpck:fKAOsGN" resolve="string" />
-        <node concept="M4N5e" id="3iamoNAkond" role="M5hS2">
-          <property role="1uS6qo" value="vertical list" />
-          <property role="1uS6qv" value="vlist" />
-        </node>
-        <node concept="M4N5e" id="3iamoNAkonh" role="M5hS2">
-          <property role="1uS6qo" value="horizontal list" />
-          <property role="1uS6qv" value="hlist" />
-        </node>
-        <node concept="M4N5e" id="3iamoNAkolu" role="M5hS2">
-          <property role="1uS6qo" value="vertical cells" />
-          <property role="1uS6qv" value="vcells" />
-        </node>
-        <node concept="M4N5e" id="3iamoNAkona" role="M5hS2">
-          <property role="1uS6qo" value="horizontal cells" />
-          <property role="1uS6qv" value="hcells" />
-        </node>
-      </node>
-    </node>
     <node concept="25R33" id="7WTFIQIcYtS" role="25R1y">
       <property role="TrG5h" value="vlist" />
       <property role="1L1pqM" value="vertical list" />
       <property role="3tVfz5" value="3785936898452719053" />
-      <ref role="2wpffI" node="3iamoNAkond" />
     </node>
     <node concept="25R33" id="7WTFIQIcYtT" role="25R1y">
       <property role="TrG5h" value="hlist" />
       <property role="1L1pqM" value="horizontal list" />
       <property role="3tVfz5" value="3785936898452719057" />
-      <ref role="2wpffI" node="3iamoNAkonh" />
     </node>
     <node concept="25R33" id="7WTFIQIcYtU" role="25R1y">
       <property role="TrG5h" value="vcells" />
       <property role="1L1pqM" value="vertical cells" />
       <property role="3tVfz5" value="3785936898452718942" />
-      <ref role="2wpffI" node="3iamoNAkolu" />
     </node>
     <node concept="25R33" id="7WTFIQIcYtV" role="25R1y">
       <property role="TrG5h" value="hcells" />
       <property role="1L1pqM" value="horizontal cells" />
       <property role="3tVfz5" value="3785936898452719050" />
-      <ref role="2wpffI" node="3iamoNAkona" />
     </node>
   </node>
   <node concept="25R3W" id="7WTFIQIcYtW">
@@ -1351,43 +1280,17 @@
     <property role="3GE5qa" value="Style" />
     <property role="3F6X1D" value="4384308856523539249" />
     <ref role="1H5jkz" node="7WTFIQIcYtY" resolve="TOP" />
-    <node concept="2JgGob" id="7WTFIQIcYtX" role="lGtFl">
-      <property role="3scbB" value="5CkWgdpp3eY/string_name" />
-      <property role="3sfsH" value="5CkWgdpp0p1/by_name" />
-      <node concept="AxPO7" id="3NocqOaFOcL" role="3lCyv">
-        <property role="3GE5qa" value="Style" />
-        <property role="TrG5h" value="VerticalAlignment" />
-        <property role="3F6X1D" value="4384308856523539249" />
-        <ref role="M4eZT" to="tpck:fKAOsGN" resolve="string" />
-        <ref role="Qgau1" node="3NocqOaFOgn" />
-        <node concept="M4N5e" id="3NocqOaFOgn" role="M5hS2">
-          <property role="1uS6qo" value="TOP" />
-          <property role="1uS6qv" value="TOP" />
-        </node>
-        <node concept="M4N5e" id="3NocqOaFOoQ" role="M5hS2">
-          <property role="1uS6qo" value="BOTTOM" />
-          <property role="1uS6qv" value="BOTTOM" />
-        </node>
-        <node concept="M4N5e" id="3NocqOaFOoT" role="M5hS2">
-          <property role="1uS6qo" value="CENTER" />
-          <property role="1uS6qv" value="CENTER" />
-        </node>
-      </node>
-    </node>
     <node concept="25R33" id="7WTFIQIcYtY" role="25R1y">
       <property role="TrG5h" value="TOP" />
       <property role="3tVfz5" value="4384308856523539479" />
-      <ref role="2wpffI" node="3NocqOaFOgn" />
     </node>
     <node concept="25R33" id="7WTFIQIcYtZ" role="25R1y">
       <property role="TrG5h" value="BOTTOM" />
       <property role="3tVfz5" value="4384308856523540022" />
-      <ref role="2wpffI" node="3NocqOaFOoQ" />
     </node>
     <node concept="25R33" id="7WTFIQIcYu0" role="25R1y">
       <property role="TrG5h" value="CENTER" />
       <property role="3tVfz5" value="4384308856523540025" />
-      <ref role="2wpffI" node="3NocqOaFOoT" />
     </node>
   </node>
   <node concept="25R3W" id="7WTFIQIcYu1">
@@ -1395,43 +1298,17 @@
     <property role="3GE5qa" value="Style" />
     <property role="3F6X1D" value="4384308856523540047" />
     <ref role="1H5jkz" node="7WTFIQIcYu3" resolve="LEFT" />
-    <node concept="2JgGob" id="7WTFIQIcYu2" role="lGtFl">
-      <property role="3scbB" value="5CkWgdpp3eY/string_name" />
-      <property role="3sfsH" value="5CkWgdpp0p1/by_name" />
-      <node concept="AxPO7" id="3NocqOaFOpf" role="3lCyv">
-        <property role="3GE5qa" value="Style" />
-        <property role="TrG5h" value="HorizontalAlignment" />
-        <property role="3F6X1D" value="4384308856523540047" />
-        <ref role="M4eZT" to="tpck:fKAOsGN" resolve="string" />
-        <ref role="Qgau1" node="3NocqOaFOpg" />
-        <node concept="M4N5e" id="3NocqOaFOpg" role="M5hS2">
-          <property role="1uS6qo" value="LEFT" />
-          <property role="1uS6qv" value="LEFT" />
-        </node>
-        <node concept="M4N5e" id="3NocqOaFOph" role="M5hS2">
-          <property role="1uS6qo" value="RIGHT" />
-          <property role="1uS6qv" value="RIGHT" />
-        </node>
-        <node concept="M4N5e" id="3NocqOaFOpk" role="M5hS2">
-          <property role="1uS6qo" value="CENTER" />
-          <property role="1uS6qv" value="CENTER" />
-        </node>
-      </node>
-    </node>
     <node concept="25R33" id="7WTFIQIcYu3" role="25R1y">
       <property role="TrG5h" value="LEFT" />
       <property role="3tVfz5" value="4384308856523540048" />
-      <ref role="2wpffI" node="3NocqOaFOpg" />
     </node>
     <node concept="25R33" id="7WTFIQIcYu4" role="25R1y">
       <property role="TrG5h" value="RIGHT" />
       <property role="3tVfz5" value="4384308856523540049" />
-      <ref role="2wpffI" node="3NocqOaFOph" />
     </node>
     <node concept="25R33" id="7WTFIQIcYu5" role="25R1y">
       <property role="TrG5h" value="CENTER" />
       <property role="3tVfz5" value="4384308856523540052" />
-      <ref role="2wpffI" node="3NocqOaFOpk" />
     </node>
   </node>
 </model>

--- a/code/treenotation/com.mbeddr.mpsutil.treenotation/generator/template/main@generator.mps
+++ b/code/treenotation/com.mbeddr.mpsutil.treenotation/generator/template/main@generator.mps
@@ -28,13 +28,9 @@
     <import index="i8bi" ref="r:c3548bac-30eb-4a2a-937c-0111d5697309(jetbrains.mps.lang.smodel.generator.smodelAdapter)" />
     <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" />
-    <import index="zce0" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.smodel.action(MPS.Editor/)" />
-    <import index="sn11" ref="r:836426ab-a6f4-4fa3-9a9c-34c02ed6ab5d(jetbrains.mps.ide.icons)" />
-    <import index="dxuu" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:javax.swing(JDK/)" />
     <import index="tpce" ref="r:00000000-0000-4000-0000-011c89590292(jetbrains.mps.lang.structure.structure)" />
-    <import index="ykok" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel.constraints(MPS.Core/)" />
     <import index="pdwk" ref="8e98f4e2-decf-4e97-bf80-9109e8b759ee/java:jetbrains.mps.core.aspects.constraints.rules.kinds(jetbrains.mps.lang.constraints.rules.runtime/)" />
-    <import index="ykol" ref="8e98f4e2-decf-4e97-bf80-9109e8b759ee/java:jetbrains.mps.smodel.constraints(jetbrains.mps.lang.constraints.rules.runtime/)" />
+    <import index="ykok" ref="8e98f4e2-decf-4e97-bf80-9109e8b759ee/java:jetbrains.mps.smodel.constraints(jetbrains.mps.lang.constraints.rules.runtime/)" />
     <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" implicit="true" />
     <import index="wvyf" ref="r:5a252772-b920-4950-9982-f2f3538e3e16(com.mbeddr.mpsutil.treenotation.behavior)" implicit="true" />
     <import index="tpcn" ref="r:00000000-0000-4000-0000-011c8959028b(jetbrains.mps.lang.structure.behavior)" implicit="true" />
@@ -862,8 +858,8 @@
                                 <node concept="3clFbF" id="7fqbBL2xDNb" role="3cqZAp">
                                   <node concept="2OqwBi" id="7fqbBL2xDNc" role="3clFbG">
                                     <node concept="2YIFZM" id="7fqbBL2xDNd" role="2Oq$k0">
-                                      <ref role="37wK5l" to="ykol:~ConstraintsCanBeFacade.checkCanBeChild(jetbrains.mps.core.aspects.constraints.rules.kinds.ContainmentContext)" resolve="checkCanBeChild" />
-                                      <ref role="1Pybhc" to="ykol:~ConstraintsCanBeFacade" resolve="ConstraintsCanBeFacade" />
+                                      <ref role="37wK5l" to="ykok:~ConstraintsCanBeFacade.checkCanBeChild(jetbrains.mps.core.aspects.constraints.rules.kinds.ContainmentContext)" resolve="checkCanBeChild" />
+                                      <ref role="1Pybhc" to="ykok:~ConstraintsCanBeFacade" resolve="ConstraintsCanBeFacade" />
                                       <node concept="2OqwBi" id="7fqbBL2xDNe" role="37wK5m">
                                         <node concept="2OqwBi" id="7fqbBL2xDNf" role="2Oq$k0">
                                           <node concept="2OqwBi" id="7fqbBL2xDNg" role="2Oq$k0">

--- a/code/widgets/languages/de.itemis.mps.editor.dropdown.demolang/languageModels/structure.mps
+++ b/code/widgets/languages/de.itemis.mps.editor.dropdown.demolang/languageModels/structure.mps
@@ -13,30 +13,13 @@
     <language id="c72da2b9-7cce-4447-8389-f407dc1158b7" name="jetbrains.mps.lang.structure">
       <concept id="3348158742936976480" name="jetbrains.mps.lang.structure.structure.EnumerationMemberDeclaration" flags="ng" index="25R33">
         <property id="1421157252384165432" name="memberId" index="3tVfz5" />
-        <reference id="899069222106091871" name="oldMember" index="2wpffI" />
       </concept>
       <concept id="3348158742936976479" name="jetbrains.mps.lang.structure.structure.EnumerationDeclaration" flags="ng" index="25R3W">
         <reference id="1075010451642646892" name="defaultMember" index="1H5jkz" />
         <child id="3348158742936976577" name="members" index="25R1y" />
       </concept>
-      <concept id="6491077959632463275" name="jetbrains.mps.lang.structure.structure.EnumPropertyMigrationInfo" flags="ng" index="3l_iC">
-        <child id="6491077959632463286" name="oldProperty" index="3l_iP" />
-      </concept>
       <concept id="1082978164218" name="jetbrains.mps.lang.structure.structure.DataTypeDeclaration" flags="ng" index="AxPO6">
         <property id="7791109065626895363" name="datatypeId" index="3F6X1D" />
-      </concept>
-      <concept id="1082978164219" name="jetbrains.mps.lang.structure.structure.EnumerationDataTypeDeclaration_Old" flags="ng" index="AxPO7">
-        <reference id="1083171729157" name="memberDataType" index="M4eZT" />
-        <child id="1083172003582" name="member" index="M5hS2" />
-      </concept>
-      <concept id="1588368162884797030" name="jetbrains.mps.lang.structure.structure.EnumMigrationInfo" flags="ng" index="2JgGob">
-        <property id="6491077959634662372" name="valueOpMigration" index="3scbB" />
-        <property id="6491077959634650670" name="nameOpMigration" index="3sfsH" />
-        <child id="6491077959632451996" name="oldEnum" index="3lCyv" />
-      </concept>
-      <concept id="1083171877298" name="jetbrains.mps.lang.structure.structure.EnumerationMemberDeclaration_Old" flags="ig" index="M4N5e">
-        <property id="1083923523172" name="externalValue" index="1uS6qo" />
-        <property id="1083923523171" name="internalValue" index="1uS6qv" />
       </concept>
       <concept id="1169125787135" name="jetbrains.mps.lang.structure.structure.AbstractConceptDeclaration" flags="ig" index="PkWjJ">
         <property id="6714410169261853888" name="conceptId" index="EcuMT" />
@@ -59,9 +42,6 @@
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
-      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
-        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
-      </concept>
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
@@ -82,54 +62,23 @@
       <property role="TrG5h" value="value" />
       <property role="IQ2nx" value="4141535073102651192" />
       <ref role="AX2Wp" node="7WTFIQIcYuH" resolve="Values" />
-      <node concept="3l_iC" id="7WTFIQIcYxk" role="lGtFl">
-        <node concept="1TJgyi" id="3_TG3j96HWS" role="3l_iP">
-          <property role="TrG5h" value="value" />
-          <property role="IQ2nx" value="4141535073102651192" />
-          <ref role="AX2Wp" node="3_TG3j96fsf" resolve="Values" />
-        </node>
-      </node>
     </node>
   </node>
   <node concept="25R3W" id="7WTFIQIcYuH">
     <property role="TrG5h" value="Values" />
     <property role="3F6X1D" value="4141535073102526223" />
     <ref role="1H5jkz" node="7WTFIQIcYuJ" resolve="Value1" />
-    <node concept="2JgGob" id="7WTFIQIcYuI" role="lGtFl">
-      <property role="3scbB" value="5CkWgdpp3eY/string_name" />
-      <property role="3sfsH" value="5CkWgdpp0p1/by_name" />
-      <node concept="AxPO7" id="3_TG3j96fsf" role="3lCyv">
-        <property role="TrG5h" value="Values" />
-        <property role="3F6X1D" value="4141535073102526223" />
-        <ref role="M4eZT" to="tpck:fKAOsGN" resolve="string" />
-        <node concept="M4N5e" id="3_TG3j96fsg" role="M5hS2">
-          <property role="1uS6qo" value="Value1" />
-          <property role="1uS6qv" value="Value1" />
-        </node>
-        <node concept="M4N5e" id="3_TG3j96fsh" role="M5hS2">
-          <property role="1uS6qo" value="Value2" />
-          <property role="1uS6qv" value="Value2" />
-        </node>
-        <node concept="M4N5e" id="3_TG3j96fso" role="M5hS2">
-          <property role="1uS6qo" value="Value3" />
-          <property role="1uS6qv" value="Value3" />
-        </node>
-      </node>
-    </node>
     <node concept="25R33" id="7WTFIQIcYuJ" role="25R1y">
       <property role="TrG5h" value="Value1" />
       <property role="3tVfz5" value="4141535073102526224" />
-      <ref role="2wpffI" node="3_TG3j96fsg" />
     </node>
     <node concept="25R33" id="7WTFIQIcYuK" role="25R1y">
       <property role="TrG5h" value="Value2" />
       <property role="3tVfz5" value="4141535073102526225" />
-      <ref role="2wpffI" node="3_TG3j96fsh" />
     </node>
     <node concept="25R33" id="7WTFIQIcYuL" role="25R1y">
       <property role="TrG5h" value="Value3" />
       <property role="3tVfz5" value="4141535073102526232" />
-      <ref role="2wpffI" node="3_TG3j96fso" />
     </node>
   </node>
 </model>

--- a/code/widgets/languages/de.itemis.mps.editor.enumeration.demolang/models/structure.mps
+++ b/code/widgets/languages/de.itemis.mps.editor.enumeration.demolang/models/structure.mps
@@ -12,31 +12,13 @@
     <language id="c72da2b9-7cce-4447-8389-f407dc1158b7" name="jetbrains.mps.lang.structure">
       <concept id="3348158742936976480" name="jetbrains.mps.lang.structure.structure.EnumerationMemberDeclaration" flags="ng" index="25R33">
         <property id="1421157252384165432" name="memberId" index="3tVfz5" />
-        <reference id="899069222106091871" name="oldMember" index="2wpffI" />
       </concept>
       <concept id="3348158742936976479" name="jetbrains.mps.lang.structure.structure.EnumerationDeclaration" flags="ng" index="25R3W">
         <reference id="1075010451642646892" name="defaultMember" index="1H5jkz" />
         <child id="3348158742936976577" name="members" index="25R1y" />
       </concept>
-      <concept id="6491077959632463275" name="jetbrains.mps.lang.structure.structure.EnumPropertyMigrationInfo" flags="ng" index="3l_iC">
-        <child id="6491077959632463286" name="oldProperty" index="3l_iP" />
-      </concept>
       <concept id="1082978164218" name="jetbrains.mps.lang.structure.structure.DataTypeDeclaration" flags="ng" index="AxPO6">
         <property id="7791109065626895363" name="datatypeId" index="3F6X1D" />
-      </concept>
-      <concept id="1082978164219" name="jetbrains.mps.lang.structure.structure.EnumerationDataTypeDeclaration_Old" flags="ng" index="AxPO7">
-        <property id="1197591154882" name="memberIdentifierPolicy" index="3lZH7k" />
-        <reference id="1083171729157" name="memberDataType" index="M4eZT" />
-        <child id="1083172003582" name="member" index="M5hS2" />
-      </concept>
-      <concept id="1588368162884797030" name="jetbrains.mps.lang.structure.structure.EnumMigrationInfo" flags="ng" index="2JgGob">
-        <property id="6491077959634662372" name="valueOpMigration" index="3scbB" />
-        <property id="6491077959634650670" name="nameOpMigration" index="3sfsH" />
-        <child id="6491077959632451996" name="oldEnum" index="3lCyv" />
-      </concept>
-      <concept id="1083171877298" name="jetbrains.mps.lang.structure.structure.EnumerationMemberDeclaration_Old" flags="ig" index="M4N5e">
-        <property id="1083923523172" name="externalValue" index="1uS6qo" />
-        <property id="1083923523171" name="internalValue" index="1uS6qv" />
       </concept>
       <concept id="1169125787135" name="jetbrains.mps.lang.structure.structure.AbstractConceptDeclaration" flags="ig" index="PkWjJ">
         <property id="6714410169261853888" name="conceptId" index="EcuMT" />
@@ -52,9 +34,6 @@
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
-      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
-        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
-      </concept>
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
@@ -69,13 +48,6 @@
       <property role="TrG5h" value="test1" />
       <property role="IQ2nx" value="2135528801629920491" />
       <ref role="AX2Wp" node="7WTFIQIcYuY" resolve="TestEnum" />
-      <node concept="3l_iC" id="7WTFIQIcYxs" role="lGtFl">
-        <node concept="1TJgyi" id="1QyV25GL5NF" role="3l_iP">
-          <property role="IQ2nx" value="2135528801629920491" />
-          <property role="TrG5h" value="test1" />
-          <ref role="AX2Wp" node="1QyV25GL5N$" resolve="TestEnum" />
-        </node>
-      </node>
     </node>
     <node concept="1TJgyi" id="1lcLMGyEfGg" role="1TKVEl">
       <property role="IQ2nx" value="1534820561105517328" />
@@ -87,42 +59,17 @@
     <property role="TrG5h" value="TestEnum" />
     <property role="3F6X1D" value="2135528801629920484" />
     <ref role="1H5jkz" node="7WTFIQIcYv0" resolve="a" />
-    <node concept="2JgGob" id="7WTFIQIcYuZ" role="lGtFl">
-      <property role="3scbB" value="5CkWgdpp3eY/string_name" />
-      <property role="3sfsH" value="5CkWgdpp0p1/by_name" />
-      <node concept="AxPO7" id="1QyV25GL5N$" role="3lCyv">
-        <property role="TrG5h" value="TestEnum" />
-        <property role="3lZH7k" value="hrlZj6Q/derive_from_internal_value" />
-        <property role="3F6X1D" value="2135528801629920484" />
-        <ref role="M4eZT" to="tpck:fKAOsGN" resolve="string" />
-        <node concept="M4N5e" id="1QyV25GL5N_" role="M5hS2">
-          <property role="1uS6qo" value="a" />
-          <property role="1uS6qv" value="a" />
-        </node>
-        <node concept="M4N5e" id="1QyV25GL5NA" role="M5hS2">
-          <property role="1uS6qo" value="b" />
-          <property role="1uS6qv" value="b" />
-        </node>
-        <node concept="M4N5e" id="1vp0nsAbecS" role="M5hS2">
-          <property role="1uS6qo" value="c" />
-          <property role="1uS6qv" value="c" />
-        </node>
-      </node>
-    </node>
     <node concept="25R33" id="7WTFIQIcYv0" role="25R1y">
       <property role="TrG5h" value="a" />
       <property role="3tVfz5" value="2135528801629920485" />
-      <ref role="2wpffI" node="1QyV25GL5N_" />
     </node>
     <node concept="25R33" id="7WTFIQIcYv1" role="25R1y">
       <property role="TrG5h" value="b" />
       <property role="3tVfz5" value="2135528801629920486" />
-      <ref role="2wpffI" node="1QyV25GL5NA" />
     </node>
     <node concept="25R33" id="7WTFIQIcYv2" role="25R1y">
       <property role="TrG5h" value="c" />
       <property role="3tVfz5" value="1718406344071766840" />
-      <ref role="2wpffI" node="1vp0nsAbecS" />
     </node>
   </node>
 </model>


### PR DESCRIPTION
Instances of EnumerationDataTypeDeclaration_Old were necessary for enum migration back in 2019, it is safe to assume all usages have been migrated now.