### PR TITLE
Update actions/setup-gradle to v4.4.0

### DIFF
--- a/.github/workflows/vulnerability-scanning.yml
+++ b/.github/workflows/vulnerability-scanning.yml
@@ -13,7 +13,7 @@ jobs:
           distribution: temurin
           java-version: 17
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@06832c7b30a0129d7fb559bcc6e43d26f6374244 # v4
+        uses: gradle/actions/setup-gradle@8379f6a1328ee0e06e2bb424dadb7b159856a326 # v4.4.0
       - name: Call setup
         run: ./gradlew dependencies
       - name: Depcheck


### PR DESCRIPTION
Renovate seems to have trouble with it:

> Renovate failed to look up the following dependencies: Could not determine new digest for update (github-tags package gradle/actions).