### PR TITLE
mpsutil.intentions: Fix an issue with intentions multiplying in the intentions menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is *loosely* based on [Keep a Changelog](https://keepachangelog.com/e
 
 - *com.mbeddr.mpsutil.compare* Fixed duplicated code generation for `assert node equals`
 - *com.mbeddr.mpsutil.blutil* Use `COPY_SRCL` in [IfInstanceOfElseIfClause](http://127.0.0.1:63320/node?ref=63e0e566-5131-447e-90e3-12ea330e1a00%2Fr%3Af5bd2ad9-cd54-4408-b815-07f9f306f074%28com.mbeddr.mpsutil.blutil%2Fcom.mbeddr.mpsutil.blutil.structure%29%2F8718469662507237778) to avoid build warnings
+- *com.mbeddr.mpsutil.intentions.runtime* An issue with multiplying intentions in the intentions menu was fixed when the default intention actions provider is unregisted through *IntentionActionsProvider.EP_NAME.*
 
 ## May 2025
 

--- a/code/intentionsmenu/com.mbeddr.mpsutil.intentions.runtime/models/com/mbeddr/mpsutil/intentions/runtime.mps
+++ b/code/intentionsmenu/com.mbeddr.mpsutil.intentions.runtime/models/com/mbeddr/mpsutil/intentions/runtime.mps
@@ -2659,157 +2659,80 @@
             </node>
           </node>
         </node>
-        <node concept="3clFbJ" id="3pwG8PSkQJZ" role="3cqZAp">
-          <node concept="2OqwBi" id="3pwG8PSkU2O" role="3clFbw">
-            <node concept="37vLTw" id="3pwG8PSkU2N" role="2Oq$k0">
-              <ref role="3cqZAo" node="3pwG8PSkQJB" resolve="intentionActions" />
+        <node concept="3clFbH" id="4tqcjem7lH0" role="3cqZAp" />
+        <node concept="3cpWs8" id="3pwG8PSkQKt" role="3cqZAp">
+          <node concept="3cpWsn" id="3pwG8PSkQKs" role="3cpWs9">
+            <property role="3TUv4t" value="false" />
+            <property role="TrG5h" value="intentionActionGroup" />
+            <node concept="3uibUv" id="3pwG8PSkQKu" role="1tU5fm">
+              <ref role="3uigEE" to="qkt:~DefaultActionGroup" resolve="DefaultActionGroup" />
             </node>
-            <node concept="liA8E" id="3pwG8PSkU2P" role="2OqNvi">
-              <ref role="37wK5l" to="33ny:~List.isEmpty()" resolve="isEmpty" />
-            </node>
-          </node>
-          <node concept="9aQIb" id="3pwG8PSkQKq" role="9aQIa">
-            <node concept="3clFbS" id="3pwG8PSkQKr" role="9aQI4">
-              <node concept="3cpWs8" id="3pwG8PSkQKt" role="3cqZAp">
-                <node concept="3cpWsn" id="3pwG8PSkQKs" role="3cpWs9">
-                  <property role="3TUv4t" value="false" />
-                  <property role="TrG5h" value="intentionActionGroup" />
-                  <node concept="3uibUv" id="3pwG8PSkQKu" role="1tU5fm">
-                    <ref role="3uigEE" to="qkt:~DefaultActionGroup" resolve="DefaultActionGroup" />
-                  </node>
-                  <node concept="1rXfSq" id="2xgTENkWs2P" role="33vP2m">
-                    <ref role="37wK5l" node="2xgTENkWs2J" resolve="createIntentionActionGroup" />
-                    <node concept="37vLTw" id="2xgTENkWs2M" role="37wK5m">
-                      <ref role="3cqZAo" node="3pwG8PSkQJm" resolve="node" />
-                    </node>
-                    <node concept="37vLTw" id="2xgTENkWs2N" role="37wK5m">
-                      <ref role="3cqZAo" node="3pwG8PSkQJk" resolve="intention" />
-                    </node>
-                    <node concept="37vLTw" id="2xgTENkWs2O" role="37wK5m">
-                      <ref role="3cqZAo" node="3pwG8PSkQJx" resolve="text" />
-                    </node>
-                  </node>
-                </node>
+            <node concept="1rXfSq" id="2xgTENkWs2P" role="33vP2m">
+              <ref role="37wK5l" node="2xgTENkWs2J" resolve="createIntentionActionGroup" />
+              <node concept="37vLTw" id="2xgTENkWs2M" role="37wK5m">
+                <ref role="3cqZAo" node="3pwG8PSkQJm" resolve="node" />
               </node>
-              <node concept="3clFbF" id="WznLMVAI9e" role="3cqZAp">
-                <node concept="2OqwBi" id="WznLMVB0IN" role="3clFbG">
-                  <node concept="2OqwBi" id="WznLMVAMUi" role="2Oq$k0">
-                    <node concept="37vLTw" id="WznLMVAI9c" role="2Oq$k0">
-                      <ref role="3cqZAo" node="3pwG8PSkQKs" resolve="intentionActionGroup" />
-                    </node>
-                    <node concept="liA8E" id="WznLMVAWzG" role="2OqNvi">
-                      <ref role="37wK5l" to="qkt:~AnAction.getTemplatePresentation()" resolve="getTemplatePresentation" />
-                    </node>
-                  </node>
-                  <node concept="liA8E" id="WznLMVB5do" role="2OqNvi">
-                    <ref role="37wK5l" to="qkt:~Presentation.setPerformGroup(boolean)" resolve="setPerformGroup" />
-                    <node concept="3clFbT" id="WznLMVB7UB" role="37wK5m">
-                      <property role="3clFbU" value="true" />
-                    </node>
-                  </node>
-                </node>
+              <node concept="37vLTw" id="2xgTENkWs2N" role="37wK5m">
+                <ref role="3cqZAo" node="3pwG8PSkQJk" resolve="intention" />
               </node>
-              <node concept="3clFbF" id="3pwG8PSkQKT" role="3cqZAp">
-                <node concept="2OqwBi" id="3pwG8PSkU2T" role="3clFbG">
-                  <node concept="37vLTw" id="3pwG8PSkU2S" role="2Oq$k0">
-                    <ref role="3cqZAo" node="3pwG8PSkQKs" resolve="intentionActionGroup" />
-                  </node>
-                  <node concept="liA8E" id="3pwG8PSkU2U" role="2OqNvi">
-                    <ref role="37wK5l" to="qkt:~DefaultActionGroup.addAll(java.util.Collection)" resolve="addAll" />
-                    <node concept="37vLTw" id="3pwG8PSkQKV" role="37wK5m">
-                      <ref role="3cqZAo" node="3pwG8PSkQJB" resolve="intentionActions" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3clFbF" id="3pwG8PSkQKW" role="3cqZAp">
-                <node concept="2OqwBi" id="3pwG8PSkQKX" role="3clFbG">
-                  <node concept="2OqwBi" id="3pwG8PSkU2Y" role="2Oq$k0">
-                    <node concept="37vLTw" id="3pwG8PSkU2X" role="2Oq$k0">
-                      <ref role="3cqZAo" node="3pwG8PSkQKs" resolve="intentionActionGroup" />
-                    </node>
-                    <node concept="liA8E" id="3pwG8PSkU2Z" role="2OqNvi">
-                      <ref role="37wK5l" to="qkt:~AnAction.getTemplatePresentation()" resolve="getTemplatePresentation" />
-                    </node>
-                  </node>
-                  <node concept="liA8E" id="3pwG8PSkQKZ" role="2OqNvi">
-                    <ref role="37wK5l" to="qkt:~Presentation.setIcon(javax.swing.Icon)" resolve="setIcon" />
-                    <node concept="37vLTw" id="3pwG8PSkQL0" role="37wK5m">
-                      <ref role="3cqZAo" node="3pwG8PSkQJp" resolve="icon" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3cpWs6" id="3pwG8PSkQL1" role="3cqZAp">
-                <node concept="37vLTw" id="3pwG8PSkQL2" role="3cqZAk">
-                  <ref role="3cqZAo" node="3pwG8PSkQKs" resolve="intentionActionGroup" />
-                </node>
+              <node concept="37vLTw" id="2xgTENkWs2O" role="37wK5m">
+                <ref role="3cqZAo" node="3pwG8PSkQJx" resolve="text" />
               </node>
             </node>
           </node>
-          <node concept="3clFbS" id="3pwG8PSkQK2" role="3clFbx">
-            <node concept="3cpWs6" id="3pwG8PSkQK3" role="3cqZAp">
-              <node concept="2ShNRf" id="3pwG8PSkQK4" role="3cqZAk">
-                <node concept="YeOm9" id="3pwG8PSkQK5" role="2ShVmc">
-                  <node concept="1Y3b0j" id="3pwG8PSkQK6" role="YeSDq">
-                    <property role="2bfB8j" value="true" />
-                    <property role="1sVAO0" value="false" />
-                    <property role="1EXbeo" value="false" />
-                    <ref role="1Y3XeK" to="7bx7:~BaseAction" resolve="BaseAction" />
-                    <ref role="37wK5l" to="7bx7:~BaseAction.&lt;init&gt;(java.lang.String,java.lang.String,javax.swing.Icon)" resolve="BaseAction" />
-                    <node concept="3Tm1VV" id="3pwG8PSkQK7" role="1B3o_S" />
-                    <node concept="3clFb_" id="3pwG8PSkQK8" role="jymVt">
-                      <property role="TrG5h" value="doExecute" />
-                      <property role="DiZV1" value="false" />
-                      <property role="od$2w" value="false" />
-                      <node concept="2AHcQZ" id="3pwG8PSkQK9" role="2AJF6D">
-                        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-                      </node>
-                      <node concept="37vLTG" id="3pwG8PSkQKa" role="3clF46">
-                        <property role="TrG5h" value="e" />
-                        <property role="3TUv4t" value="false" />
-                        <node concept="3uibUv" id="3pwG8PSkQKb" role="1tU5fm">
-                          <ref role="3uigEE" to="qkt:~AnActionEvent" resolve="AnActionEvent" />
-                        </node>
-                      </node>
-                      <node concept="37vLTG" id="3pwG8PSkQKc" role="3clF46">
-                        <property role="TrG5h" value="params" />
-                        <property role="3TUv4t" value="false" />
-                        <node concept="3uibUv" id="3pwG8PSkQKd" role="1tU5fm">
-                          <ref role="3uigEE" to="33ny:~Map" resolve="Map" />
-                          <node concept="17QB3L" id="4gYVSgE4zVR" role="11_B2D" />
-                          <node concept="3uibUv" id="3pwG8PSkQKf" role="11_B2D">
-                            <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="3clFbS" id="3pwG8PSkQKg" role="3clF47">
-                        <node concept="3clFbF" id="3pwG8PSkQKh" role="3cqZAp">
-                          <node concept="1rXfSq" id="3pwG8PSkQKi" role="3clFbG">
-                            <ref role="37wK5l" node="2jDew64RVuQ" resolve="executeIntention" />
-                            <node concept="37vLTw" id="3pwG8PSkQKj" role="37wK5m">
-                              <ref role="3cqZAo" node="3pwG8PSkQJk" resolve="intention" />
-                            </node>
-                            <node concept="37vLTw" id="3pwG8PSkQKk" role="37wK5m">
-                              <ref role="3cqZAo" node="3pwG8PSkQJm" resolve="node" />
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="3Tmbuc" id="3pwG8PSkQKl" role="1B3o_S" />
-                      <node concept="3cqZAl" id="3pwG8PSkQKm" role="3clF45" />
-                    </node>
-                    <node concept="37vLTw" id="3pwG8PSkQKn" role="37wK5m">
-                      <ref role="3cqZAo" node="3pwG8PSkQJx" resolve="text" />
-                    </node>
-                    <node concept="10Nm6u" id="3pwG8PSkQKo" role="37wK5m" />
-                    <node concept="37vLTw" id="3pwG8PSkQKp" role="37wK5m">
-                      <ref role="3cqZAo" node="3pwG8PSkQJp" resolve="icon" />
-                    </node>
-                  </node>
-                </node>
+        </node>
+        <node concept="3clFbF" id="WznLMVAI9e" role="3cqZAp">
+          <node concept="2OqwBi" id="WznLMVB0IN" role="3clFbG">
+            <node concept="2OqwBi" id="WznLMVAMUi" role="2Oq$k0">
+              <node concept="37vLTw" id="WznLMVAI9c" role="2Oq$k0">
+                <ref role="3cqZAo" node="3pwG8PSkQKs" resolve="intentionActionGroup" />
+              </node>
+              <node concept="liA8E" id="WznLMVAWzG" role="2OqNvi">
+                <ref role="37wK5l" to="qkt:~AnAction.getTemplatePresentation()" resolve="getTemplatePresentation" />
               </node>
             </node>
+            <node concept="liA8E" id="WznLMVB5do" role="2OqNvi">
+              <ref role="37wK5l" to="qkt:~Presentation.setPerformGroup(boolean)" resolve="setPerformGroup" />
+              <node concept="3clFbT" id="4tqcjem7KEJ" role="37wK5m">
+                <property role="3clFbU" value="true" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="3pwG8PSkQKT" role="3cqZAp">
+          <node concept="2OqwBi" id="3pwG8PSkU2T" role="3clFbG">
+            <node concept="37vLTw" id="3pwG8PSkU2S" role="2Oq$k0">
+              <ref role="3cqZAo" node="3pwG8PSkQKs" resolve="intentionActionGroup" />
+            </node>
+            <node concept="liA8E" id="3pwG8PSkU2U" role="2OqNvi">
+              <ref role="37wK5l" to="qkt:~DefaultActionGroup.addAll(java.util.Collection)" resolve="addAll" />
+              <node concept="37vLTw" id="3pwG8PSkQKV" role="37wK5m">
+                <ref role="3cqZAo" node="3pwG8PSkQJB" resolve="intentionActions" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="3pwG8PSkQKW" role="3cqZAp">
+          <node concept="2OqwBi" id="3pwG8PSkQKX" role="3clFbG">
+            <node concept="2OqwBi" id="3pwG8PSkU2Y" role="2Oq$k0">
+              <node concept="37vLTw" id="3pwG8PSkU2X" role="2Oq$k0">
+                <ref role="3cqZAo" node="3pwG8PSkQKs" resolve="intentionActionGroup" />
+              </node>
+              <node concept="liA8E" id="3pwG8PSkU2Z" role="2OqNvi">
+                <ref role="37wK5l" to="qkt:~AnAction.getTemplatePresentation()" resolve="getTemplatePresentation" />
+              </node>
+            </node>
+            <node concept="liA8E" id="3pwG8PSkQKZ" role="2OqNvi">
+              <ref role="37wK5l" to="qkt:~Presentation.setIcon(javax.swing.Icon)" resolve="setIcon" />
+              <node concept="37vLTw" id="3pwG8PSkQL0" role="37wK5m">
+                <ref role="3cqZAo" node="3pwG8PSkQJp" resolve="icon" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="3pwG8PSkQL1" role="3cqZAp">
+          <node concept="37vLTw" id="3pwG8PSkQL2" role="3cqZAk">
+            <ref role="3cqZAo" node="3pwG8PSkQKs" resolve="intentionActionGroup" />
           </node>
         </node>
       </node>

--- a/code/solutions/de.itemis.mps.extensions.changelog/models/de.itemis.mps.extensions.changelog.mps
+++ b/code/solutions/de.itemis.mps.extensions.changelog/models/de.itemis.mps.extensions.changelog.mps
@@ -306,6 +306,81 @@
             <property role="3oM_SC" value="warnings" />
           </node>
         </node>
+        <node concept="2DRihI" id="QO549dSiUY" role="15bAlk">
+          <property role="2RT3bR" value="0" />
+          <node concept="15Ami3" id="QO549dSiXt" role="1PaTwD">
+            <node concept="37shsh" id="QO549dSiXv" role="15Aodc">
+              <node concept="1dCxOk" id="QO549dSj4r" role="37shsm">
+                <property role="1XweGW" value="4bff7bbe-ce5f-432e-84bf-60809cb9987c" />
+                <property role="1XxBO9" value="com.mbeddr.mpsutil.intentions.runtime" />
+              </node>
+            </node>
+          </node>
+          <node concept="3oM_SD" id="QO549dSj6w" role="1PaTwD">
+            <property role="3oM_SC" value="An" />
+          </node>
+          <node concept="3oM_SD" id="QO549dSj8x" role="1PaTwD">
+            <property role="3oM_SC" value="issue" />
+          </node>
+          <node concept="3oM_SD" id="QO549dSjay" role="1PaTwD">
+            <property role="3oM_SC" value="with" />
+          </node>
+          <node concept="3oM_SD" id="QO549dSjaz" role="1PaTwD">
+            <property role="3oM_SC" value="multiplying" />
+          </node>
+          <node concept="3oM_SD" id="QO549dSjft" role="1PaTwD">
+            <property role="3oM_SC" value="intentions" />
+          </node>
+          <node concept="3oM_SD" id="QO549dSjkn" role="1PaTwD">
+            <property role="3oM_SC" value="in" />
+          </node>
+          <node concept="3oM_SD" id="QO549dSjmq" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="QO549dSjqk" role="1PaTwD">
+            <property role="3oM_SC" value="intentions" />
+          </node>
+          <node concept="3oM_SD" id="QO549dSjrl" role="1PaTwD">
+            <property role="3oM_SC" value="menu" />
+          </node>
+          <node concept="3oM_SD" id="QO549dSjrm" role="1PaTwD">
+            <property role="3oM_SC" value="was" />
+          </node>
+          <node concept="3oM_SD" id="QO549dSjsn" role="1PaTwD">
+            <property role="3oM_SC" value="fixed" />
+          </node>
+          <node concept="3oM_SD" id="QO549dSjso" role="1PaTwD">
+            <property role="3oM_SC" value="when" />
+          </node>
+          <node concept="3oM_SD" id="QO549dSjtp" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="QO549dSjtq" role="1PaTwD">
+            <property role="3oM_SC" value="default" />
+          </node>
+          <node concept="3oM_SD" id="QO549dSjur" role="1PaTwD">
+            <property role="3oM_SC" value="intention" />
+          </node>
+          <node concept="3oM_SD" id="QO549dSjws" role="1PaTwD">
+            <property role="3oM_SC" value="actions" />
+          </node>
+          <node concept="3oM_SD" id="QO549dSjxt" role="1PaTwD">
+            <property role="3oM_SC" value="provider" />
+          </node>
+          <node concept="3oM_SD" id="QO549dSjAn" role="1PaTwD">
+            <property role="3oM_SC" value="is" />
+          </node>
+          <node concept="3oM_SD" id="QO549dSjFh" role="1PaTwD">
+            <property role="3oM_SC" value="unregisted" />
+          </node>
+          <node concept="3oM_SD" id="QO549dSjKb" role="1PaTwD">
+            <property role="3oM_SC" value="through" />
+          </node>
+          <node concept="3oM_SD" id="QO549dSjLc" role="1PaTwD">
+            <property role="3oM_SC" value="IntentionActionsProvider.EP_NAME." />
+            <property role="1X82VY" value="true" />
+          </node>
+        </node>
       </node>
     </node>
     <node concept="15bmVD" id="Ov8NH9d5KS" role="15bmVC">


### PR DESCRIPTION
Do not populate the intention actions with a default action. It leads to intentions multiplying when the default intention action provider is deregistered through the extension point `IntentionActionsProvider.EP_Name`.

The issue and the fix can be testing with a new project plugin with the init block:
`IntentionActionsProvider.EP_NAME.getPoint().unregisterExtension(IntentionActionsProviderImpl.class);`