### PR TITLE
DeleteRowAction: made use of triggeredFromMPSAction flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is *loosely* based on [Keep a Changelog](https://keepachangelog.com/e
 - *com.mbeddr.mpsutil.blutil* Use `COPY_SRCL` in [IfInstanceOfElseIfClause](http://127.0.0.1:63320/node?ref=63e0e566-5131-447e-90e3-12ea330e1a00%2Fr%3Af5bd2ad9-cd54-4408-b815-07f9f306f074%28com.mbeddr.mpsutil.blutil%2Fcom.mbeddr.mpsutil.blutil.structure%29%2F8718469662507237778) to avoid build warnings
 - *com.mbeddr.mpsutil.intentions* Intentions are no longer duplicated every time the intentions menu is displayed
 - *com.mbeddr.mpsutil.intentions* The custom intentions menu now only displays applicable actions-as-intentions.
+- *de.slisson.mps.tables.runtime* Fixed bug where DeleteTableRow action would delete "next" row instead of "current" one
 
 ## May 2025
 

--- a/code/solutions/de.itemis.mps.extensions.changelog/models/de.itemis.mps.extensions.changelog.mps
+++ b/code/solutions/de.itemis.mps.extensions.changelog/models/de.itemis.mps.extensions.changelog.mps
@@ -463,6 +463,56 @@
             <property role="3oM_SC" value="actions-as-intentions." />
           </node>
         </node>
+        <node concept="2DRihI" id="2WnHFkAztf" role="15bAlk">
+          <property role="2RT3bR" value="0" />
+          <node concept="15Ami3" id="2u$v3Jv$kMG" role="1PaTwD">
+            <node concept="37shsh" id="2u$v3Jv$kMI" role="15Aodc">
+              <node concept="1dCxOk" id="2u$v3Jv$kTW" role="37shsm">
+                <property role="1XweGW" value="da21218f-a674-474d-8b4e-d59e33007003" />
+                <property role="1XxBO9" value="de.slisson.mps.tables.runtime" />
+              </node>
+            </node>
+          </node>
+          <node concept="3oM_SD" id="1uBh5lUymr2" role="1PaTwD">
+            <property role="3oM_SC" value="Fixed" />
+          </node>
+          <node concept="3oM_SD" id="1uBh5lUymr3" role="1PaTwD">
+            <property role="3oM_SC" value="bug" />
+          </node>
+          <node concept="3oM_SD" id="1uBh5lUymr4" role="1PaTwD">
+            <property role="3oM_SC" value="where" />
+          </node>
+          <node concept="3oM_SD" id="1uBh5lUymr6" role="1PaTwD">
+            <property role="3oM_SC" value="DeleteTableRow" />
+          </node>
+          <node concept="3oM_SD" id="1uBh5lUymr7" role="1PaTwD">
+            <property role="3oM_SC" value="action" />
+          </node>
+          <node concept="3oM_SD" id="1uBh5lUymr8" role="1PaTwD">
+            <property role="3oM_SC" value="would" />
+          </node>
+          <node concept="3oM_SD" id="1uBh5lUymrf" role="1PaTwD">
+            <property role="3oM_SC" value="delete" />
+          </node>
+          <node concept="3oM_SD" id="1uBh5lUymr9" role="1PaTwD">
+            <property role="3oM_SC" value="&quot;next&quot;" />
+          </node>
+          <node concept="3oM_SD" id="1uBh5lUymrg" role="1PaTwD">
+            <property role="3oM_SC" value="row" />
+          </node>
+          <node concept="3oM_SD" id="1uBh5lUymra" role="1PaTwD">
+            <property role="3oM_SC" value="instead" />
+          </node>
+          <node concept="3oM_SD" id="1uBh5lUymrb" role="1PaTwD">
+            <property role="3oM_SC" value="of" />
+          </node>
+          <node concept="3oM_SD" id="1uBh5lUymrc" role="1PaTwD">
+            <property role="3oM_SC" value="&quot;current&quot;" />
+          </node>
+          <node concept="3oM_SD" id="1uBh5lUymrh" role="1PaTwD">
+            <property role="3oM_SC" value="one" />
+          </node>
+        </node>
       </node>
     </node>
     <node concept="15bmVD" id="Ov8NH9d5KS" role="15bmVC">

--- a/code/tables/languages/de.slisson.mps.tables/runtime/models/de/slisson/mps/tables/runtime/plugin.mps
+++ b/code/tables/languages/de.slisson.mps.tables/runtime/models/de/slisson/mps/tables/runtime/plugin.mps
@@ -641,7 +641,9 @@
                   <ref role="Rm8GQ" to="hm5v:74LepNTVASM" resolve="DELETE" />
                   <ref role="1Px2BO" to="hm5v:74LepNTV$5n" resolve="TableActions.DeleteRowAction.DeleteType" />
                 </node>
-                <node concept="3clFbT" id="74LepNU8thk" role="37wK5m" />
+                <node concept="3clFbT" id="58VhZjv57JZ" role="37wK5m">
+                  <property role="3clFbU" value="true" />
+                </node>
               </node>
             </node>
             <node concept="liA8E" id="7IUya7cjmzY" role="2OqNvi">
@@ -688,7 +690,9 @@
                   <ref role="Rm8GQ" to="hm5v:74LepNTVASM" resolve="DELETE" />
                   <ref role="1Px2BO" to="hm5v:74LepNTV$5n" resolve="TableActions.DeleteRowAction.DeleteType" />
                 </node>
-                <node concept="3clFbT" id="74LepNU8t63" role="37wK5m" />
+                <node concept="3clFbT" id="74LepNU8t63" role="37wK5m">
+                  <property role="3clFbU" value="true" />
+                </node>
               </node>
             </node>
             <node concept="liA8E" id="7IUya7cja2q" role="2OqNvi">

--- a/code/tables/solutions/test.de.slisson.mps.tables/models/test/de/slisson/mps/tables@tests.mps
+++ b/code/tables/solutions/test.de.slisson.mps.tables/models/test/de/slisson/mps/tables@tests.mps
@@ -22,6 +22,7 @@
     <import index="y49u" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.util(MPS.OpenAPI/)" />
     <import index="dxuu" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:javax.swing(JDK/)" />
     <import index="3a50" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.ide(MPS.Platform/)" />
+    <import index="3bri" ref="r:c386283f-4bfc-42ea-a1b4-65abe196bd30(de.slisson.mps.tables.runtime.plugin)" />
   </imports>
   <registry>
     <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
@@ -240,6 +241,7 @@
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
         <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
       </concept>
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
@@ -2618,6 +2620,198 @@
           <ref role="3HSt7G" node="6eakByReRQs" />
           <node concept="3cmrfG" id="6eakByReRRq" role="3HSt7J">
             <property role="3cmrfH" value="5" />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="LiM7Y" id="2WnHFkwvOE">
+    <property role="TrG5h" value="TableAction_DeleteRow" />
+    <property role="3GE5qa" value="tableActions" />
+    <node concept="3clFbS" id="2WnHFkwvOF" role="LjaKd">
+      <node concept="2HxZob" id="2WnHFkwvPK" role="3cqZAp">
+        <node concept="1iFQzN" id="2WnHFkwvPL" role="3iKnsn">
+          <ref role="1iFR8X" to="3bri:7IUya7c4kr_" resolve="DeleteTableRow" />
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="2WnHFkwvPO" role="25YQCW">
+      <node concept="2r114T" id="2WnHFkwvPP" role="1qenE9">
+        <node concept="2r114E" id="2WnHFkwvPQ" role="2r1ock">
+          <property role="2r114l" value="R1" />
+          <node concept="1UFI08" id="2WnHFkwvPR" role="1UFgUr">
+            <node concept="1UFh5B" id="2WnHFkwvPS" role="1UFh5U">
+              <property role="1UFh5$" value="Abcd" />
+            </node>
+          </node>
+          <node concept="2r1o01" id="2WnHFkwvPT" role="2r1o1s">
+            <ref role="2r1o0d" node="2WnHFkwvPQ" />
+            <node concept="LIFWc" id="2WnHFkwU1B" role="lGtFl">
+              <property role="LIFWa" value="0" />
+              <property role="LIFWd" value="Collection_cvtybw_a" />
+            </node>
+          </node>
+        </node>
+        <node concept="2r114E" id="2WnHFkwxcu" role="2r1ock">
+          <property role="2r114l" value="R2" />
+          <node concept="1UFI08" id="2WnHFkwxcv" role="1UFgUr">
+            <node concept="1UFh5B" id="2WnHFkwxcw" role="1UFh5U">
+              <property role="1UFh5$" value="soHardToUse" />
+            </node>
+          </node>
+          <node concept="2r1o01" id="2WnHFkwxcx" role="2r1o1s">
+            <ref role="2r1o0d" node="2WnHFkwxcu" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="2WnHFkwvPV" role="25YQFr">
+      <node concept="2r114T" id="2WnHFkwRih" role="1qenE9">
+        <node concept="2r114E" id="2WnHFkwRin" role="2r1ock">
+          <property role="2r114l" value="R2" />
+          <node concept="1UFI08" id="2WnHFkwRio" role="1UFgUr">
+            <node concept="1UFh5B" id="2WnHFkwRip" role="1UFh5U">
+              <property role="1UFh5$" value="soHardToUse" />
+            </node>
+          </node>
+          <node concept="2r1o01" id="2WnHFkwRiq" role="2r1o1s">
+            <ref role="2r1o0d" node="2WnHFkwRin" />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="LiM7Y" id="2WnHFkwWPc">
+    <property role="TrG5h" value="TableAction_InsertRowAfter" />
+    <property role="3GE5qa" value="tableActions" />
+    <node concept="3clFbS" id="2WnHFkwWPd" role="LjaKd">
+      <node concept="2HxZob" id="2WnHFkwWPe" role="3cqZAp">
+        <node concept="1iFQzN" id="2WnHFkwWPf" role="3iKnsn">
+          <ref role="1iFR8X" to="3bri:7IUya7cjqn5" resolve="InsertTableRowAfter" />
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="2WnHFkwWPg" role="25YQCW">
+      <node concept="2r114T" id="2WnHFkwWPh" role="1qenE9">
+        <node concept="2r114E" id="2WnHFkwWPi" role="2r1ock">
+          <property role="2r114l" value="R1" />
+          <node concept="1UFI08" id="2WnHFkwWPj" role="1UFgUr">
+            <node concept="1UFh5B" id="2WnHFkwWPk" role="1UFh5U">
+              <property role="1UFh5$" value="Abcd" />
+            </node>
+          </node>
+          <node concept="2r1o01" id="2WnHFkwWPl" role="2r1o1s">
+            <ref role="2r1o0d" node="2WnHFkwWPi" />
+            <node concept="LIFWc" id="2WnHFkwWPm" role="lGtFl">
+              <property role="LIFWa" value="0" />
+              <property role="LIFWd" value="Collection_cvtybw_a" />
+            </node>
+          </node>
+        </node>
+        <node concept="2r114E" id="2WnHFkwWPn" role="2r1ock">
+          <property role="2r114l" value="R2" />
+          <node concept="1UFI08" id="2WnHFkwWPo" role="1UFgUr">
+            <node concept="1UFh5B" id="2WnHFkwWPp" role="1UFh5U">
+              <property role="1UFh5$" value="soHardToUse" />
+            </node>
+          </node>
+          <node concept="2r1o01" id="2WnHFkwWPq" role="2r1o1s">
+            <ref role="2r1o0d" node="2WnHFkwWPn" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="2WnHFkwWPr" role="25YQFr">
+      <node concept="2r114T" id="2WnHFkwWVi" role="1qenE9">
+        <node concept="2r114E" id="2WnHFkwWVj" role="2r1ock">
+          <property role="2r114l" value="R1" />
+          <node concept="1UFI08" id="2WnHFkwWVk" role="1UFgUr">
+            <node concept="1UFh5B" id="2WnHFkwWVl" role="1UFh5U">
+              <property role="1UFh5$" value="Abcd" />
+            </node>
+          </node>
+          <node concept="2r1o01" id="2WnHFkwWVm" role="2r1o1s">
+            <ref role="2r1o0d" node="2WnHFkwWVj" />
+          </node>
+        </node>
+        <node concept="2r114E" id="2WnHFkwWYf" role="2r1ock" />
+        <node concept="2r114E" id="2WnHFkwWVo" role="2r1ock">
+          <property role="2r114l" value="R2" />
+          <node concept="1UFI08" id="2WnHFkwWVp" role="1UFgUr">
+            <node concept="1UFh5B" id="2WnHFkwWVq" role="1UFh5U">
+              <property role="1UFh5$" value="soHardToUse" />
+            </node>
+          </node>
+          <node concept="2r1o01" id="2WnHFkwWVr" role="2r1o1s">
+            <ref role="2r1o0d" node="2WnHFkwWVo" />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="LiM7Y" id="2WnHFkwZiu">
+    <property role="TrG5h" value="TableAction_InsertRowBefore" />
+    <property role="3GE5qa" value="tableActions" />
+    <node concept="3clFbS" id="2WnHFkwZiv" role="LjaKd">
+      <node concept="2HxZob" id="2WnHFkwZiw" role="3cqZAp">
+        <node concept="1iFQzN" id="2WnHFkwZix" role="3iKnsn">
+          <ref role="1iFR8X" to="3bri:7IUya7cfBRk" resolve="InsertTableRowBefore" />
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="2WnHFkwZiy" role="25YQCW">
+      <node concept="2r114T" id="2WnHFkwZiz" role="1qenE9">
+        <node concept="2r114E" id="2WnHFkwZi$" role="2r1ock">
+          <property role="2r114l" value="R1" />
+          <node concept="1UFI08" id="2WnHFkwZi_" role="1UFgUr">
+            <node concept="1UFh5B" id="2WnHFkwZiA" role="1UFh5U">
+              <property role="1UFh5$" value="Abcd" />
+            </node>
+          </node>
+          <node concept="2r1o01" id="2WnHFkwZiB" role="2r1o1s">
+            <ref role="2r1o0d" node="2WnHFkwZi$" />
+            <node concept="LIFWc" id="2WnHFkwZiC" role="lGtFl">
+              <property role="LIFWa" value="0" />
+              <property role="LIFWd" value="Collection_cvtybw_a" />
+            </node>
+          </node>
+        </node>
+        <node concept="2r114E" id="2WnHFkwZiD" role="2r1ock">
+          <property role="2r114l" value="R2" />
+          <node concept="1UFI08" id="2WnHFkwZiE" role="1UFgUr">
+            <node concept="1UFh5B" id="2WnHFkwZiF" role="1UFh5U">
+              <property role="1UFh5$" value="soHardToUse" />
+            </node>
+          </node>
+          <node concept="2r1o01" id="2WnHFkwZiG" role="2r1o1s">
+            <ref role="2r1o0d" node="2WnHFkwZiD" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="2WnHFkwZiH" role="25YQFr">
+      <node concept="2r114T" id="2WnHFkwZiI" role="1qenE9">
+        <node concept="2r114E" id="2WnHFkwZiN" role="2r1ock" />
+        <node concept="2r114E" id="2WnHFkwZiJ" role="2r1ock">
+          <property role="2r114l" value="R1" />
+          <node concept="1UFI08" id="2WnHFkwZiK" role="1UFgUr">
+            <node concept="1UFh5B" id="2WnHFkwZiL" role="1UFh5U">
+              <property role="1UFh5$" value="Abcd" />
+            </node>
+          </node>
+          <node concept="2r1o01" id="2WnHFkwZiM" role="2r1o1s">
+            <ref role="2r1o0d" node="2WnHFkwZiJ" />
+          </node>
+        </node>
+        <node concept="2r114E" id="2WnHFkwZiO" role="2r1ock">
+          <property role="2r114l" value="R2" />
+          <node concept="1UFI08" id="2WnHFkwZiP" role="1UFgUr">
+            <node concept="1UFh5B" id="2WnHFkwZiQ" role="1UFh5U">
+              <property role="1UFh5$" value="soHardToUse" />
+            </node>
+          </node>
+          <node concept="2r1o01" id="2WnHFkwZiR" role="2r1o1s">
+            <ref role="2r1o0d" node="2WnHFkwZiO" />
           </node>
         </node>
       </node>


### PR DESCRIPTION
Fixes #1461

In addition I added some editor tests for [TableAction_DeleteRow](http://127.0.0.1:63320/node?ref=r%3A53747654-8f0d-48ae-96f3-1e68e62f0a2f%28test.de.slisson.mps.tables%40tests%29%2F53021589582773546), [TableAction_InsertRowBefore](http://127.0.0.1:63320/node?ref=r%3A53747654-8f0d-48ae-96f3-1e68e62f0a2f%28test.de.slisson.mps.tables%40tests%29%2F53021589582902430), [TableAction_InsertRowAfter](http://127.0.0.1:63320/node?ref=r%3A53747654-8f0d-48ae-96f3-1e68e62f0a2f%28test.de.slisson.mps.tables%40tests%29%2F53021589582892364)