### PR TITLE
place table toolbar items in the new main toolbar of the new UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is *loosely* based on [Keep a Changelog](https://keepachangelog.com/e
 ### Fixed
 
 - *jetbrains.mps.lang.smodel.query* A NullPointerException was fixed in the query list typesystem checker.
+- Table Actions Toolbar items now appear in the new UI toolbar.
 
 ## June 2025
 

--- a/code/tables/languages/de.slisson.mps.tables/runtime/models/de/slisson/mps/tables/runtime/plugin.mps
+++ b/code/tables/languages/de.slisson.mps.tables/runtime/models/de/slisson/mps/tables/runtime/plugin.mps
@@ -23,9 +23,9 @@
     <import index="k3nr" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.ide.editor(MPS.Editor/)" />
     <import index="fnpx" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.notification(MPS.IDEA/)" />
     <import index="z2i8" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.icons(MPS.IDEA/)" />
+    <import index="qkt" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.actionSystem(MPS.IDEA/)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
     <import index="90d" ref="r:421d64ed-8024-497f-aeab-8bddeb389dd2(jetbrains.mps.lang.extension.methods)" implicit="true" />
-    <import index="tprs" ref="r:00000000-0000-4000-0000-011c895904a4(jetbrains.mps.ide.actions)" implicit="true" />
   </imports>
   <registry>
     <language id="982eb8df-2c96-4bd7-9963-11712ea622e5" name="jetbrains.mps.lang.resources">
@@ -38,6 +38,7 @@
     </language>
     <language id="28f9e497-3b42-4291-aeba-0a1039153ab1" name="jetbrains.mps.lang.plugin">
       <concept id="1204908117386" name="jetbrains.mps.lang.plugin.structure.Separator" flags="ng" index="2a7GMi" />
+      <concept id="1207145163717" name="jetbrains.mps.lang.plugin.structure.ElementListContents" flags="ng" index="ftmFs" />
       <concept id="1207145360364" name="jetbrains.mps.lang.plugin.structure.BuildGroupBlock" flags="in" index="fu6FP" />
       <concept id="1203071646776" name="jetbrains.mps.lang.plugin.structure.ActionDeclaration" flags="ng" index="sE7Ow">
         <property id="1205250923097" name="caption" index="2uzpH1" />
@@ -68,6 +69,9 @@
         <reference id="1217252646389" name="key" index="1DUlNI" />
       </concept>
       <concept id="1217252428768" name="jetbrains.mps.lang.plugin.structure.ActionDataParameterReferenceOperation" flags="nn" index="1DTwFV" />
+      <concept id="1204383956737" name="jetbrains.mps.lang.plugin.structure.InterfaceGroup" flags="ng" index="1ESbSp">
+        <child id="1206193920040" name="groupID" index="3mKD$K" />
+      </concept>
       <concept id="1217413147516" name="jetbrains.mps.lang.plugin.structure.ActionParameter" flags="ngI" index="1NuADB">
         <child id="5538333046911298738" name="condition" index="1oa70y" />
       </concept>
@@ -723,7 +727,7 @@
     <property role="3GE5qa" value="actions" />
     <property role="22ra45" value="true" />
     <node concept="tT9cl" id="7IUya7cdgY6" role="2f5YQi">
-      <ref role="tU$_T" to="tprs:WmrxDqdZv8" resolve="MPSToolBarRun" />
+      <ref role="tU$_T" node="1NwsJMVJ99k" resolve="MainToolbarCenter" />
     </node>
     <node concept="fu6FP" id="F5PM1gbEUw" role="ftER_">
       <node concept="3clFbS" id="F5PM1gbEUy" role="2VODD2">
@@ -1199,6 +1203,15 @@
         <ref role="1PxDUh" to="z2i8:~AllIcons$General" resolve="AllIcons.General" />
       </node>
     </node>
+  </node>
+  <node concept="1ESbSp" id="1NwsJMVJ99k">
+    <property role="3GE5qa" value="actions" />
+    <property role="TrG5h" value="MainToolbarCenter" />
+    <node concept="10M0yZ" id="1NwsJMVK74H" role="3mKD$K">
+      <ref role="3cqZAo" to="qkt:~IdeActions.GROUP_MAIN_TOOLBAR_CENTER" resolve="GROUP_MAIN_TOOLBAR_CENTER" />
+      <ref role="1PxDUh" to="qkt:~IdeActions" resolve="IdeActions" />
+    </node>
+    <node concept="ftmFs" id="1NwsJMVJ9zE" role="ftER_" />
   </node>
 </model>
 


### PR DESCRIPTION
Fixes #1505 

Changes in this PR can be seen in this screenshot:

<img width="1887" height="1168" alt="image" src="https://github.com/user-attachments/assets/01c1ff58-8054-4774-a0a5-5f12a40dd1e0" />

Unfortunately, MPS does not provide a bootstrap group for the new UI toolbar(s) and thus I added a custom one for the center.

I also searched the entire code but could not find any other actions which are placed in the toolbar. I will happily also move others if there are any.