### PR TITLE
mpsutil.grammarcells: Improve the default transformation text for optional cells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project are documented in this file.
 
 The format is *loosely* based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) .The project does *not* follow Semantic Versioning and the changes are documented in reverse chronological order, grouped by calendar month.
 
+## August 2025
+
+### Fixed
+
+- *com.mbeddr.mpsutil.grammarcells* The default transformation text for optional cells was improved.
+
 ## July 2025
 
 ### Fixed

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/generator/template/main@generator.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells/generator/template/main@generator.mps
@@ -3672,58 +3672,12 @@
                     <node concept="3cqGtN" id="2EPKBwviywN" role="2jZA2a">
                       <node concept="3cqJkl" id="2EPKBwviywO" role="3cqGtW">
                         <node concept="3clFbS" id="2EPKBwviywP" role="2VODD2">
-                          <node concept="3clFbF" id="2EPKBwviywQ" role="3cqZAp">
-                            <node concept="3cpWs3" id="2EPKBwviywR" role="3clFbG">
-                              <node concept="3cpWs3" id="2EPKBwviywS" role="3uHU7B">
-                                <node concept="3cpWs3" id="2EPKBwviywT" role="3uHU7B">
-                                  <node concept="2OqwBi" id="2EPKBwviywU" role="3uHU7w">
-                                    <node concept="2OqwBi" id="2EPKBwviywV" role="2Oq$k0">
-                                      <node concept="3yx0qK" id="2EPKBwviywW" role="2Oq$k0">
-                                        <ref role="3cqZAo" node="2EPKBwviyvH" resolve="link" />
-                                      </node>
-                                      <node concept="liA8E" id="2EPKBwviywX" role="2OqNvi">
-                                        <ref role="37wK5l" to="c17a:~SConceptFeature.getOwner()" resolve="getOwner" />
-                                      </node>
-                                    </node>
-                                    <node concept="liA8E" id="2EPKBwviywY" role="2OqNvi">
-                                      <ref role="37wK5l" to="c17a:~SAbstractConcept.getName()" resolve="getName" />
-                                    </node>
-                                  </node>
-                                  <node concept="3cpWs3" id="2EPKBwviywZ" role="3uHU7B">
-                                    <node concept="Xl_RD" id="2EPKBwviyx0" role="3uHU7w">
-                                      <property role="Xl_RC" value=" ---&gt; " />
-                                    </node>
-                                    <node concept="3cpWs3" id="2EPKBwviyx1" role="3uHU7B">
-                                      <node concept="Xl_RD" id="2EPKBwviyx2" role="3uHU7B">
-                                        <property role="Xl_RC" value="Optional: " />
-                                      </node>
-                                      <node concept="2OqwBi" id="2EPKBwviyx3" role="3uHU7w">
-                                        <node concept="2OqwBi" id="2EPKBwviyx4" role="2Oq$k0">
-                                          <node concept="3yx0qK" id="2EPKBwviyx5" role="2Oq$k0">
-                                            <ref role="3cqZAo" node="2EPKBwviyvH" resolve="link" />
-                                          </node>
-                                          <node concept="liA8E" id="2EPKBwviyx6" role="2OqNvi">
-                                            <ref role="37wK5l" to="c17a:~SAbstractLink.getTargetConcept()" resolve="getTargetConcept" />
-                                          </node>
-                                        </node>
-                                        <node concept="liA8E" id="2EPKBwviyx7" role="2OqNvi">
-                                          <ref role="37wK5l" to="c17a:~SAbstractConcept.getName()" resolve="getName" />
-                                        </node>
-                                      </node>
-                                    </node>
-                                  </node>
-                                </node>
-                                <node concept="Xl_RD" id="2EPKBwviyx8" role="3uHU7w">
-                                  <property role="Xl_RC" value="." />
-                                </node>
-                              </node>
-                              <node concept="2OqwBi" id="2EPKBwviyx9" role="3uHU7w">
-                                <node concept="3yx0qK" id="2EPKBwviyxa" role="2Oq$k0">
-                                  <ref role="3cqZAo" node="2EPKBwviyvH" resolve="link" />
-                                </node>
-                                <node concept="liA8E" id="2EPKBwviyxb" role="2OqNvi">
-                                  <ref role="37wK5l" to="c17a:~SNamedElement.getName()" resolve="getName" />
-                                </node>
+                          <node concept="3clFbF" id="iyWIxqrJMp" role="3cqZAp">
+                            <node concept="2YIFZM" id="iyWIxqrKk6" role="3clFbG">
+                              <ref role="37wK5l" to="czm:iyWIxqrATv" resolve="getDescriptionForContainmentLink" />
+                              <ref role="1Pybhc" to="czm:RbLMy696h3" resolve="GrammarCellsUtil" />
+                              <node concept="3yx0qK" id="iyWIxqrKPj" role="37wK5m">
+                                <ref role="3cqZAo" node="2EPKBwviyvH" resolve="link" />
                               </node>
                             </node>
                           </node>
@@ -4455,58 +4409,12 @@
                   <node concept="3cqGtN" id="2EPKBwvfcVy" role="2jZA2a">
                     <node concept="3cqJkl" id="2EPKBwvfcVz" role="3cqGtW">
                       <node concept="3clFbS" id="2EPKBwvfcV$" role="2VODD2">
-                        <node concept="3clFbF" id="2EPKBwvfcV_" role="3cqZAp">
-                          <node concept="3cpWs3" id="2EPKBwvfcVA" role="3clFbG">
-                            <node concept="3cpWs3" id="2EPKBwvfcVB" role="3uHU7B">
-                              <node concept="3cpWs3" id="2EPKBwvfcVC" role="3uHU7B">
-                                <node concept="2OqwBi" id="2EPKBwvfcVD" role="3uHU7w">
-                                  <node concept="2OqwBi" id="2EPKBwvfcVE" role="2Oq$k0">
-                                    <node concept="3yx0qK" id="2EPKBwvfUGA" role="2Oq$k0">
-                                      <ref role="3cqZAo" node="2EPKBwvfe11" resolve="link" />
-                                    </node>
-                                    <node concept="liA8E" id="2EPKBwvfcVG" role="2OqNvi">
-                                      <ref role="37wK5l" to="c17a:~SConceptFeature.getOwner()" resolve="getOwner" />
-                                    </node>
-                                  </node>
-                                  <node concept="liA8E" id="2EPKBwvfcVH" role="2OqNvi">
-                                    <ref role="37wK5l" to="c17a:~SAbstractConcept.getName()" resolve="getName" />
-                                  </node>
-                                </node>
-                                <node concept="3cpWs3" id="2EPKBwvfcVI" role="3uHU7B">
-                                  <node concept="Xl_RD" id="2EPKBwvfcVJ" role="3uHU7w">
-                                    <property role="Xl_RC" value=" ---&gt; " />
-                                  </node>
-                                  <node concept="3cpWs3" id="2EPKBwvfcVK" role="3uHU7B">
-                                    <node concept="Xl_RD" id="2EPKBwvfcVL" role="3uHU7B">
-                                      <property role="Xl_RC" value="Optional: " />
-                                    </node>
-                                    <node concept="2OqwBi" id="2EPKBwvfcVM" role="3uHU7w">
-                                      <node concept="2OqwBi" id="2EPKBwvfcVN" role="2Oq$k0">
-                                        <node concept="3yx0qK" id="2EPKBwvfU_5" role="2Oq$k0">
-                                          <ref role="3cqZAo" node="2EPKBwvfe11" resolve="link" />
-                                        </node>
-                                        <node concept="liA8E" id="2EPKBwvfcVP" role="2OqNvi">
-                                          <ref role="37wK5l" to="c17a:~SAbstractLink.getTargetConcept()" resolve="getTargetConcept" />
-                                        </node>
-                                      </node>
-                                      <node concept="liA8E" id="2EPKBwvfcVQ" role="2OqNvi">
-                                        <ref role="37wK5l" to="c17a:~SAbstractConcept.getName()" resolve="getName" />
-                                      </node>
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                              <node concept="Xl_RD" id="2EPKBwvfcVR" role="3uHU7w">
-                                <property role="Xl_RC" value="." />
-                              </node>
-                            </node>
-                            <node concept="2OqwBi" id="2EPKBwvfcVS" role="3uHU7w">
-                              <node concept="3yx0qK" id="2EPKBwvfUO7" role="2Oq$k0">
-                                <ref role="3cqZAo" node="2EPKBwvfe11" resolve="link" />
-                              </node>
-                              <node concept="liA8E" id="2EPKBwvfcVU" role="2OqNvi">
-                                <ref role="37wK5l" to="c17a:~SNamedElement.getName()" resolve="getName" />
-                              </node>
+                        <node concept="3clFbF" id="iyWIxqFxFE" role="3cqZAp">
+                          <node concept="2YIFZM" id="iyWIxqFxFG" role="3clFbG">
+                            <ref role="37wK5l" to="czm:iyWIxqrATv" resolve="getDescriptionForContainmentLink" />
+                            <ref role="1Pybhc" to="czm:RbLMy696h3" resolve="GrammarCellsUtil" />
+                            <node concept="3yx0qK" id="iyWIxqFxFH" role="37wK5m">
+                              <ref role="3cqZAo" node="2EPKBwvfe11" resolve="link" />
                             </node>
                           </node>
                         </node>
@@ -6543,58 +6451,12 @@
                   <node concept="3cqGtN" id="2EPKBwvi6wt" role="2jZA2a">
                     <node concept="3cqJkl" id="2EPKBwvi6wu" role="3cqGtW">
                       <node concept="3clFbS" id="2EPKBwvi6wv" role="2VODD2">
-                        <node concept="3clFbF" id="2EPKBwvi6ww" role="3cqZAp">
-                          <node concept="3cpWs3" id="2EPKBwvi6wx" role="3clFbG">
-                            <node concept="3cpWs3" id="2EPKBwvi6wy" role="3uHU7B">
-                              <node concept="3cpWs3" id="2EPKBwvi6wz" role="3uHU7B">
-                                <node concept="2OqwBi" id="2EPKBwvi6w$" role="3uHU7w">
-                                  <node concept="2OqwBi" id="2EPKBwvi6w_" role="2Oq$k0">
-                                    <node concept="3yx0qK" id="2EPKBwvilie" role="2Oq$k0">
-                                      <ref role="3cqZAo" node="2EPKBwvigpL" resolve="link" />
-                                    </node>
-                                    <node concept="liA8E" id="2EPKBwvi6wB" role="2OqNvi">
-                                      <ref role="37wK5l" to="c17a:~SConceptFeature.getOwner()" resolve="getOwner" />
-                                    </node>
-                                  </node>
-                                  <node concept="liA8E" id="2EPKBwvi6wC" role="2OqNvi">
-                                    <ref role="37wK5l" to="c17a:~SAbstractConcept.getName()" resolve="getName" />
-                                  </node>
-                                </node>
-                                <node concept="3cpWs3" id="2EPKBwvi6wD" role="3uHU7B">
-                                  <node concept="Xl_RD" id="2EPKBwvi6wE" role="3uHU7w">
-                                    <property role="Xl_RC" value=" ---&gt; " />
-                                  </node>
-                                  <node concept="3cpWs3" id="2EPKBwvi6wF" role="3uHU7B">
-                                    <node concept="Xl_RD" id="2EPKBwvi6wG" role="3uHU7B">
-                                      <property role="Xl_RC" value="Optional: " />
-                                    </node>
-                                    <node concept="2OqwBi" id="2EPKBwvi6wH" role="3uHU7w">
-                                      <node concept="2OqwBi" id="2EPKBwvi6wI" role="2Oq$k0">
-                                        <node concept="3yx0qK" id="2EPKBwvilq7" role="2Oq$k0">
-                                          <ref role="3cqZAo" node="2EPKBwvigpL" resolve="link" />
-                                        </node>
-                                        <node concept="liA8E" id="2EPKBwvi6wK" role="2OqNvi">
-                                          <ref role="37wK5l" to="c17a:~SAbstractLink.getTargetConcept()" resolve="getTargetConcept" />
-                                        </node>
-                                      </node>
-                                      <node concept="liA8E" id="2EPKBwvi6wL" role="2OqNvi">
-                                        <ref role="37wK5l" to="c17a:~SAbstractConcept.getName()" resolve="getName" />
-                                      </node>
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                              <node concept="Xl_RD" id="2EPKBwvi6wM" role="3uHU7w">
-                                <property role="Xl_RC" value="." />
-                              </node>
-                            </node>
-                            <node concept="2OqwBi" id="2EPKBwvi6wN" role="3uHU7w">
-                              <node concept="3yx0qK" id="2EPKBwviltB" role="2Oq$k0">
-                                <ref role="3cqZAo" node="2EPKBwvigpL" resolve="link" />
-                              </node>
-                              <node concept="liA8E" id="2EPKBwvi6wP" role="2OqNvi">
-                                <ref role="37wK5l" to="c17a:~SNamedElement.getName()" resolve="getName" />
-                              </node>
+                        <node concept="3clFbF" id="iyWIxqFyJ6" role="3cqZAp">
+                          <node concept="2YIFZM" id="iyWIxqFyJ8" role="3clFbG">
+                            <ref role="37wK5l" to="czm:iyWIxqrATv" resolve="getDescriptionForContainmentLink" />
+                            <ref role="1Pybhc" to="czm:RbLMy696h3" resolve="GrammarCellsUtil" />
+                            <node concept="3yx0qK" id="iyWIxqFyJ9" role="37wK5m">
+                              <ref role="3cqZAo" node="2EPKBwvigpL" resolve="link" />
                             </node>
                           </node>
                         </node>
@@ -7456,57 +7318,11 @@
                     <node concept="3cqJkl" id="2EPKBwv5o_s" role="3cqGtW">
                       <node concept="3clFbS" id="2EPKBwv5o_t" role="2VODD2">
                         <node concept="3clFbF" id="2EPKBwv5oEC" role="3cqZAp">
-                          <node concept="3cpWs3" id="2EPKBwv5s3O" role="3clFbG">
-                            <node concept="3cpWs3" id="2EPKBwv5rRh" role="3uHU7B">
-                              <node concept="3cpWs3" id="2EPKBwvcpyI" role="3uHU7B">
-                                <node concept="2OqwBi" id="2EPKBwv5r7u" role="3uHU7w">
-                                  <node concept="2OqwBi" id="2EPKBwv5qK_" role="2Oq$k0">
-                                    <node concept="3yx0qK" id="2EPKBwv5oEB" role="2Oq$k0">
-                                      <ref role="3cqZAo" node="2EPKBwv4H_$" resolve="link" />
-                                    </node>
-                                    <node concept="liA8E" id="2EPKBwv5qMI" role="2OqNvi">
-                                      <ref role="37wK5l" to="c17a:~SConceptFeature.getOwner()" resolve="getOwner" />
-                                    </node>
-                                  </node>
-                                  <node concept="liA8E" id="2EPKBwv5rvZ" role="2OqNvi">
-                                    <ref role="37wK5l" to="c17a:~SAbstractConcept.getName()" resolve="getName" />
-                                  </node>
-                                </node>
-                                <node concept="3cpWs3" id="2EPKBwvcpOz" role="3uHU7B">
-                                  <node concept="Xl_RD" id="2EPKBwvcpI1" role="3uHU7w">
-                                    <property role="Xl_RC" value=" ---&gt; " />
-                                  </node>
-                                  <node concept="3cpWs3" id="2EPKBwv5tRs" role="3uHU7B">
-                                    <node concept="Xl_RD" id="2EPKBwv5tUn" role="3uHU7B">
-                                      <property role="Xl_RC" value="Optional: " />
-                                    </node>
-                                    <node concept="2OqwBi" id="2EPKBwvcr6J" role="3uHU7w">
-                                      <node concept="2OqwBi" id="2EPKBwvcqgU" role="2Oq$k0">
-                                        <node concept="3yx0qK" id="2EPKBwvcpQq" role="2Oq$k0">
-                                          <ref role="3cqZAo" node="2EPKBwv4H_$" resolve="link" />
-                                        </node>
-                                        <node concept="liA8E" id="2EPKBwvcqO8" role="2OqNvi">
-                                          <ref role="37wK5l" to="c17a:~SAbstractLink.getTargetConcept()" resolve="getTargetConcept" />
-                                        </node>
-                                      </node>
-                                      <node concept="liA8E" id="2EPKBwvcrpd" role="2OqNvi">
-                                        <ref role="37wK5l" to="c17a:~SAbstractConcept.getName()" resolve="getName" />
-                                      </node>
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                              <node concept="Xl_RD" id="2EPKBwv5rRl" role="3uHU7w">
-                                <property role="Xl_RC" value="." />
-                              </node>
-                            </node>
-                            <node concept="2OqwBi" id="2EPKBwv5sye" role="3uHU7w">
-                              <node concept="3yx0qK" id="2EPKBwv5s49" role="2Oq$k0">
-                                <ref role="3cqZAo" node="2EPKBwv4H_$" resolve="link" />
-                              </node>
-                              <node concept="liA8E" id="2EPKBwv5t1F" role="2OqNvi">
-                                <ref role="37wK5l" to="c17a:~SNamedElement.getName()" resolve="getName" />
-                              </node>
+                          <node concept="2YIFZM" id="iyWIxqFzxG" role="3clFbG">
+                            <ref role="37wK5l" to="czm:iyWIxqrATv" resolve="getDescriptionForContainmentLink" />
+                            <ref role="1Pybhc" to="czm:RbLMy696h3" resolve="GrammarCellsUtil" />
+                            <node concept="3yx0qK" id="iyWIxqFzxH" role="37wK5m">
+                              <ref role="3cqZAo" node="2EPKBwv4H_$" resolve="link" />
                             </node>
                           </node>
                         </node>

--- a/code/grammarcells/solutions/com.mbeddr.mpsutil.grammarcells.runtime/models/com/mbeddr/mpsutil/grammarcells/runtime.mps
+++ b/code/grammarcells/solutions/com.mbeddr.mpsutil.grammarcells.runtime/models/com/mbeddr/mpsutil/grammarcells/runtime.mps
@@ -852,7 +852,7 @@
       <node concept="17QB3L" id="2EPKBwuUoIR" role="1tU5fm" />
       <node concept="3Tm1VV" id="2EPKBwuUw$Q" role="1B3o_S" />
       <node concept="Xl_RD" id="2EPKBwuUuY0" role="33vP2m">
-        <property role="Xl_RC" value="𐂂𐂅𐃍" />
+        <property role="Xl_RC" value="☆" />
       </node>
     </node>
     <node concept="2tJIrI" id="2EPKBwuUlQf" role="jymVt" />
@@ -4521,6 +4521,143 @@
       </node>
       <node concept="10P_77" id="4ntVsBGj3ru" role="3clF45" />
       <node concept="3Tm1VV" id="4ntVsBGiW3C" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="iyWIxqritn" role="jymVt" />
+    <node concept="2YIFZL" id="iyWIxqrATv" role="jymVt">
+      <property role="TrG5h" value="getDescriptionForContainmentLink" />
+      <node concept="3clFbS" id="iyWIxqrATy" role="3clF47">
+        <node concept="3cpWs8" id="iyWIxqu2aW" role="3cqZAp">
+          <node concept="3cpWsn" id="iyWIxqu2aX" role="3cpWs9">
+            <property role="TrG5h" value="builder" />
+            <node concept="3uibUv" id="iyWIxqu2aY" role="1tU5fm">
+              <ref role="3uigEE" to="wyt6:~StringBuilder" resolve="StringBuilder" />
+            </node>
+            <node concept="2ShNRf" id="iyWIxqu2aZ" role="33vP2m">
+              <node concept="1pGfFk" id="iyWIxqu2b0" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="wyt6:~StringBuilder.&lt;init&gt;()" resolve="StringBuilder" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="iyWIxqu2b1" role="3cqZAp">
+          <node concept="3cpWsn" id="iyWIxqu2b2" role="3cpWs9">
+            <property role="TrG5h" value="targetConcept" />
+            <node concept="3uibUv" id="iyWIxqu2b3" role="1tU5fm">
+              <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
+            </node>
+            <node concept="2OqwBi" id="iyWIxqu2b4" role="33vP2m">
+              <node concept="37vLTw" id="iyWIxqu2b5" role="2Oq$k0">
+                <ref role="3cqZAo" node="iyWIxqrFAo" resolve="link" />
+              </node>
+              <node concept="liA8E" id="iyWIxqu2b6" role="2OqNvi">
+                <ref role="37wK5l" to="c17a:~SAbstractLink.getTargetConcept()" resolve="getTargetConcept" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="iyWIxqu2b7" role="3cqZAp">
+          <node concept="2OqwBi" id="iyWIxqu2b8" role="3clFbG">
+            <node concept="37vLTw" id="iyWIxqu2b9" role="2Oq$k0">
+              <ref role="3cqZAo" node="iyWIxqu2aX" resolve="builder" />
+            </node>
+            <node concept="liA8E" id="iyWIxqu2ba" role="2OqNvi">
+              <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
+              <node concept="3K4zz7" id="iyWIxqu2bb" role="37wK5m">
+                <node concept="2OqwBi" id="iyWIxqu2bc" role="3K4E3e">
+                  <node concept="37vLTw" id="iyWIxqu2bd" role="2Oq$k0">
+                    <ref role="3cqZAo" node="iyWIxqu2b2" resolve="targetConcept" />
+                  </node>
+                  <node concept="liA8E" id="iyWIxqu2be" role="2OqNvi">
+                    <ref role="37wK5l" to="c17a:~SAbstractConcept.getConceptAlias()" resolve="getConceptAlias" />
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="iyWIxqu2bf" role="3K4GZi">
+                  <node concept="37vLTw" id="iyWIxqu2bg" role="2Oq$k0">
+                    <ref role="3cqZAo" node="iyWIxqu2b2" resolve="targetConcept" />
+                  </node>
+                  <node concept="liA8E" id="iyWIxqu2bh" role="2OqNvi">
+                    <ref role="37wK5l" to="c17a:~SAbstractConcept.getName()" resolve="getName" />
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="iyWIxqu2bi" role="3K4Cdx">
+                  <node concept="2OqwBi" id="iyWIxqu2bj" role="2Oq$k0">
+                    <node concept="37vLTw" id="iyWIxqu2bk" role="2Oq$k0">
+                      <ref role="3cqZAo" node="iyWIxqu2b2" resolve="targetConcept" />
+                    </node>
+                    <node concept="liA8E" id="iyWIxqu2bl" role="2OqNvi">
+                      <ref role="37wK5l" to="c17a:~SAbstractConcept.getConceptAlias()" resolve="getConceptAlias" />
+                    </node>
+                  </node>
+                  <node concept="17RvpY" id="iyWIxqu2bm" role="2OqNvi" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="iyWIxqu2bn" role="3cqZAp">
+          <node concept="2OqwBi" id="iyWIxqu2bo" role="3clFbG">
+            <node concept="37vLTw" id="iyWIxqu2bp" role="2Oq$k0">
+              <ref role="3cqZAo" node="iyWIxqu2aX" resolve="builder" />
+            </node>
+            <node concept="liA8E" id="iyWIxqu2bq" role="2OqNvi">
+              <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
+              <node concept="Xl_RD" id="iyWIxqu2br" role="37wK5m">
+                <property role="Xl_RC" value=" (" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="iyWIxqu2bs" role="3cqZAp">
+          <node concept="2OqwBi" id="iyWIxqu2bt" role="3clFbG">
+            <node concept="37vLTw" id="iyWIxqu2bu" role="2Oq$k0">
+              <ref role="3cqZAo" node="iyWIxqu2aX" resolve="builder" />
+            </node>
+            <node concept="liA8E" id="iyWIxqu2bv" role="2OqNvi">
+              <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
+              <node concept="2OqwBi" id="iyWIxqu2bw" role="37wK5m">
+                <node concept="37vLTw" id="iyWIxqu2bx" role="2Oq$k0">
+                  <ref role="3cqZAo" node="iyWIxqrFAo" resolve="link" />
+                </node>
+                <node concept="liA8E" id="iyWIxqu2by" role="2OqNvi">
+                  <ref role="37wK5l" to="c17a:~SNamedElement.getName()" resolve="getName" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="iyWIxqu2bz" role="3cqZAp">
+          <node concept="2OqwBi" id="iyWIxqu2b$" role="3clFbG">
+            <node concept="37vLTw" id="iyWIxqu2b_" role="2Oq$k0">
+              <ref role="3cqZAo" node="iyWIxqu2aX" resolve="builder" />
+            </node>
+            <node concept="liA8E" id="iyWIxqu2bA" role="2OqNvi">
+              <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
+              <node concept="Xl_RD" id="iyWIxqu2bB" role="37wK5m">
+                <property role="Xl_RC" value=") – optional" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="iyWIxqufMj" role="3cqZAp">
+          <node concept="2OqwBi" id="iyWIxquhe3" role="3clFbG">
+            <node concept="37vLTw" id="iyWIxqufMh" role="2Oq$k0">
+              <ref role="3cqZAo" node="iyWIxqu2aX" resolve="builder" />
+            </node>
+            <node concept="liA8E" id="iyWIxqukh7" role="2OqNvi">
+              <ref role="37wK5l" to="wyt6:~StringBuilder.toString()" resolve="toString" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="iyWIxqrqOP" role="1B3o_S" />
+      <node concept="17QB3L" id="iyWIxqrvWJ" role="3clF45" />
+      <node concept="37vLTG" id="iyWIxqrFAo" role="3clF46">
+        <property role="TrG5h" value="link" />
+        <node concept="3uibUv" id="iyWIxqrFAn" role="1tU5fm">
+          <ref role="3uigEE" to="c17a:~SContainmentLink" resolve="SContainmentLink" />
+        </node>
+      </node>
     </node>
     <node concept="3Tm1VV" id="RbLMy696h4" role="1B3o_S" />
   </node>

--- a/code/solutions/de.itemis.mps.extensions.changelog/models/de.itemis.mps.extensions.changelog.mps
+++ b/code/solutions/de.itemis.mps.extensions.changelog/models/de.itemis.mps.extensions.changelog.mps
@@ -234,6 +234,51 @@
         </node>
       </node>
     </node>
+    <node concept="15bmVD" id="iyWIxrRh43" role="15bmVC">
+      <node concept="15ShDW" id="iyWIxrRh40" role="15bq2Y">
+        <property role="15ShDY" value="Po4Z58IgAR/August" />
+        <property role="15ShDw" value="2025" />
+      </node>
+      <node concept="15bAme" id="iyWIxrRh41" role="15bAlL">
+        <node concept="2DRihI" id="iyWIxrRh42" role="15bAlk">
+          <node concept="15Ami3" id="iyWIxrRh44" role="1PaTwD">
+            <node concept="37shsh" id="iyWIxrRh45" role="15Aodc">
+              <node concept="1dCxOk" id="iyWIxrRh4a" role="37shsm">
+                <property role="1XweGW" value="9d69e719-78c8-4286-90db-fb19c107d049" />
+                <property role="1XxBO9" value="com.mbeddr.mpsutil.grammarcells" />
+              </node>
+            </node>
+          </node>
+          <node concept="3oM_SD" id="iyWIxrRh4f" role="1PaTwD">
+            <property role="3oM_SC" value="The" />
+          </node>
+          <node concept="3oM_SD" id="iyWIxrRh4g" role="1PaTwD">
+            <property role="3oM_SC" value="default" />
+          </node>
+          <node concept="3oM_SD" id="iyWIxrRh4h" role="1PaTwD">
+            <property role="3oM_SC" value="transformation" />
+          </node>
+          <node concept="3oM_SD" id="iyWIxrRh4i" role="1PaTwD">
+            <property role="3oM_SC" value="text" />
+          </node>
+          <node concept="3oM_SD" id="iyWIxrRh4j" role="1PaTwD">
+            <property role="3oM_SC" value="for" />
+          </node>
+          <node concept="3oM_SD" id="iyWIxrRh4k" role="1PaTwD">
+            <property role="3oM_SC" value="optional" />
+          </node>
+          <node concept="3oM_SD" id="iyWIxrRh4l" role="1PaTwD">
+            <property role="3oM_SC" value="cells" />
+          </node>
+          <node concept="3oM_SD" id="iyWIxrRh4m" role="1PaTwD">
+            <property role="3oM_SC" value="was" />
+          </node>
+          <node concept="3oM_SD" id="iyWIxrRh4n" role="1PaTwD">
+            <property role="3oM_SC" value="improved." />
+          </node>
+        </node>
+      </node>
+    </node>
     <node concept="15bmVD" id="7TVB4chcCo0" role="15bmVC">
       <node concept="15ShDW" id="7TVB4chcCnX" role="15bq2Y">
         <property role="15ShDY" value="Po4Z58IgAJ/July" />


### PR DESCRIPTION
The old one used Unicode characters that can't be displayed on Windows and Linux and was not user-friendly.