### PR TITLE
added efficient NodeHasher

### DIFF
--- a/code/.mps/.gitignore
+++ b/code/.mps/.gitignore
@@ -1,2 +1,5 @@
 workspace.xml
 product-workspace.xml
+
+inspectionProfiles/
+shelf/

--- a/code/.mps/modules.xml
+++ b/code/.mps/modules.xml
@@ -75,6 +75,8 @@
       <modulePath path="$PROJECT_DIR$/hacks/solutions/de.itemis.mps.nativelibs.loader/de.itemis.mps.nativelibs.loader.msd" folder="hacks" />
       <modulePath path="$PROJECT_DIR$/hacks/solutions/de.slisson.mps.hacks.editor/de.slisson.mps.hacks.editor.msd" folder="hacks" />
       <modulePath path="$PROJECT_DIR$/hacks/solutions/de.slisson.mps.reflection.runtime/de.slisson.mps.reflection.runtime.msd" folder="hacks" />
+      <modulePath path="$PROJECT_DIR$/hasher/solutions/nl.f1re.mpsutil.hasher.tests/nl.f1re.mpsutil.hasher.tests.msd" folder="hasher" />
+      <modulePath path="$PROJECT_DIR$/hasher/solutions/nl.f1re.mpsutil.hasher/nl.f1re.mpsutil.hasher.msd" folder="hasher" />
       <modulePath path="$PROJECT_DIR$/htmlcell/languages/de.itemis.mps.editor.htmlcell.demolang/de.itemis.mps.editor.htmlcell.demolang.mpl" folder="widgets" />
       <modulePath path="$PROJECT_DIR$/htmlcell/languages/de.itemis.mps.editor.htmlcell/de.itemis.mps.editor.htmlcell.mpl" folder="widgets" />
       <modulePath path="$PROJECT_DIR$/htmlcell/languages/de.itemis.mps.editor.htmlcell/sandbox/de.itemis.mps.editor.htmlcell.sandbox.msd" folder="widgets" />

--- a/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
+++ b/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
@@ -16863,6 +16863,9 @@
           <property role="3MwjfP" value="This plugin allows you to compare two nodes programmatically. The comparison can be configured and some features of nodes can be ignored." />
         </node>
       </node>
+      <node concept="m$_yC" id="3s41kb3BW1X" role="m$_yJ">
+        <ref role="m$_y1" node="2OJNL7ElZsF" resolve="de.q60.mps.collections.libs" />
+      </node>
     </node>
     <node concept="2G$12M" id="77YfcvOKyvQ" role="3989C9">
       <property role="TrG5h" value="de.itemis.mps.compare" />
@@ -17885,6 +17888,134 @@
         </node>
       </node>
     </node>
+    <node concept="m$_wf" id="3s41kb3HotE" role="3989C9">
+      <property role="m$_wk" value="nl.f1re.mpsutil.hasher" />
+      <node concept="3_J27D" id="3s41kb3HotL" role="m$_yQ">
+        <node concept="3Mxwew" id="3s41kb3HotM" role="3MwsjC">
+          <property role="3MwjfP" value="nl.f1re.mpsutil.hasher" />
+        </node>
+      </node>
+      <node concept="3_J27D" id="3s41kb3HotN" role="m_cZH">
+        <node concept="3Mxwew" id="3s41kb3HotO" role="3MwsjC">
+          <property role="3MwjfP" value="nl.f1re.mpsutil.hasher" />
+        </node>
+      </node>
+      <node concept="3_J27D" id="3s41kb3HotP" role="m$_w8">
+        <node concept="3Mxwey" id="3s41kb3HotQ" role="3MwsjC">
+          <ref role="3Mxwex" node="4MKCCgA1ncQ" resolve="versionNumber" />
+        </node>
+      </node>
+      <node concept="m$f5U" id="3s41kb3HotR" role="m$_yh">
+        <ref role="m$f5T" node="3s41kb3HmKw" resolve="nl.f1re.mpsutil.hasher" />
+      </node>
+      <node concept="2iUeEo" id="3s41kb3HotS" role="2iVFfd">
+        <property role="2iUeEt" value="F1RE B.V." />
+        <property role="2iUeEu" value="https://f1re.nl" />
+      </node>
+      <node concept="3_J27D" id="3s41kb3HotT" role="3s6cr7">
+        <node concept="3Mxwew" id="3s41kb3HotU" role="3MwsjC">
+          <property role="3MwjfP" value="This plugin allows you to efficiently calculate a hash of a subtree. The comparison can be configured and some features of nodes can be ignored." />
+        </node>
+      </node>
+      <node concept="m$_yC" id="3s41kb3HpDs" role="m$_yJ">
+        <ref role="m$_y1" to="ffeo:4k71ibbKLe8" resolve="jetbrains.mps.core" />
+      </node>
+      <node concept="m$_yC" id="3s41kb3HpLQ" role="m$_yJ">
+        <ref role="m$_y1" node="2OJNL7ElZsF" resolve="de.q60.mps.collections.libs" />
+      </node>
+    </node>
+    <node concept="2G$12M" id="3s41kb3HmKw" role="3989C9">
+      <property role="TrG5h" value="nl.f1re.mpsutil.hasher" />
+      <node concept="1E1JtA" id="3s41kb3BSJm" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="nl.f1re.mpsutil.hasher" />
+        <property role="3LESm3" value="078723b2-ab7f-48d1-b9bb-5f643b60d08e" />
+        <node concept="398BVA" id="3s41kb3BSRN" role="3LF7KH">
+          <ref role="398BVh" node="2fo8bJE$D4t" resolve="extensions.code" />
+          <node concept="2Ry0Ak" id="3s41kb3BTxO" role="iGT6I">
+            <property role="2Ry0Am" value="hasher" />
+            <node concept="2Ry0Ak" id="3s41kb3BTEg" role="2Ry0An">
+              <property role="2Ry0Am" value="solutions" />
+              <node concept="2Ry0Ak" id="3s41kb3BU3u" role="2Ry0An">
+                <property role="2Ry0Am" value="nl.f1re.mpsutil.hasher" />
+                <node concept="2Ry0Ak" id="3s41kb3HocQ" role="2Ry0An">
+                  <property role="2Ry0Am" value="nl.f1re.mpsutil.hasher.msd" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="3s41kb3BV2_" role="3bR37C">
+          <node concept="3bR9La" id="3s41kb3BV2A" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1H905DlDUSw" resolve="MPS.OpenAPI" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="3s41kb3BV2B" role="3bR37C">
+          <node concept="3bR9La" id="3s41kb3BV2C" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="3s41kb3BV2D" role="3bR37C">
+          <node concept="3bR9La" id="3s41kb3BV2E" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:7Kfy9QB6KXW" resolve="jetbrains.mps.lang.core" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="3s41kb3BV2F" role="3bR37C">
+          <node concept="3bR9La" id="3s41kb3BV2G" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1TaHNgiIbIQ" resolve="MPS.Core" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="3s41kb3BV2H" role="3bR37C">
+          <node concept="3bR9La" id="3s41kb3BV2I" role="1SiIV1">
+            <ref role="3bR37D" node="6fQhGuklQWU" resolve="de.q60.mps.collections.libs" />
+          </node>
+        </node>
+        <node concept="1BupzO" id="3s41kb3BV2U" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="3s41kb3Hr1T" role="1HemKq">
+            <node concept="398BVA" id="3s41kb3Hr1I" role="3LXTmr">
+              <ref role="398BVh" node="2fo8bJE$D4t" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="3s41kb3Hr1J" role="iGT6I">
+                <property role="2Ry0Am" value="hasher" />
+                <node concept="2Ry0Ak" id="3s41kb3Hr1K" role="2Ry0An">
+                  <property role="2Ry0Am" value="solutions" />
+                  <node concept="2Ry0Ak" id="3s41kb3Hr1L" role="2Ry0An">
+                    <property role="2Ry0Am" value="nl.f1re.mpsutil.hasher" />
+                    <node concept="2Ry0Ak" id="3s41kb3Hr1M" role="2Ry0An">
+                      <property role="2Ry0Am" value="models" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="3s41kb3Hr1U" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+        <node concept="3rtmxn" id="3s41kb3BVbm" role="3bR31x">
+          <node concept="3LXTmp" id="3s41kb3BVbn" role="3rtmxm">
+            <node concept="398BVA" id="3s41kb3BVbo" role="3LXTmr">
+              <ref role="398BVh" node="2fo8bJE$D4t" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="3s41kb3BVbp" role="iGT6I">
+                <property role="2Ry0Am" value="hasher" />
+                <node concept="2Ry0Ak" id="3s41kb3BVbq" role="2Ry0An">
+                  <property role="2Ry0Am" value="solutions" />
+                  <node concept="2Ry0Ak" id="3s41kb3BVbr" role="2Ry0An">
+                    <property role="2Ry0Am" value="nl.f1re.mpsutil.hasher" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="3s41kb3BVbt" role="3LXTna">
+              <property role="3qWCbO" value="icons/**" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
     <node concept="2_Ic$z" id="5KXebfcSw7" role="3989C9">
       <property role="2_Ic$$" value="true" />
       <property role="TZNOO" value="11" />
@@ -18545,6 +18676,10 @@
       <node concept="m$_wl" id="77YfcvONpu4" role="39821P">
         <ref role="m_rDy" node="77YfcvOMg42" resolve="de.itemis.mps.compare" />
         <node concept="pUk6x" id="77YfcvONvhs" role="pUk7w" />
+      </node>
+      <node concept="m$_wl" id="3s41kb3Hqb2" role="39821P">
+        <ref role="m_rDy" node="3s41kb3HotE" resolve="nl.f1re.mpsutil.hasher" />
+        <node concept="pUk6x" id="3s41kb3Hqb3" role="pUk7w" />
       </node>
     </node>
     <node concept="13uUGR" id="6aQMI6nH4L1" role="1l3spa">
@@ -25029,6 +25164,89 @@
         </node>
       </node>
     </node>
+    <node concept="2G$12M" id="3s41kb3Hrby" role="3989C9">
+      <property role="TrG5h" value="hasher" />
+      <node concept="1E1JtA" id="3s41kb3BVkF" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="nl.f1re.mpsutil.hasher.tests" />
+        <property role="3LESm3" value="35200322-041d-4e55-91d7-024e0b119604" />
+        <property role="aoJFB" value="eYcmk9QOlj/sources_and_tests" />
+        <node concept="398BVA" id="3s41kb3BVl8" role="3LF7KH">
+          <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+          <node concept="2Ry0Ak" id="3s41kb3BVmn" role="iGT6I">
+            <property role="2Ry0Am" value="hasher" />
+            <node concept="2Ry0Ak" id="3s41kb3BVmN" role="2Ry0An">
+              <property role="2Ry0Am" value="solutions" />
+              <node concept="2Ry0Ak" id="3s41kb3BVnC" role="2Ry0An">
+                <property role="2Ry0Am" value="nl.f1re.mpsutil.hasher.tests" />
+                <node concept="2Ry0Ak" id="3s41kb3BVot" role="2Ry0An">
+                  <property role="2Ry0Am" value="nl.f1re.mpsutil.hasher.tests.msd" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="3s41kb3BVND" role="3bR37C">
+          <node concept="3bR9La" id="3s41kb3BVNE" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="3s41kb3BVNF" role="3bR37C">
+          <node concept="3bR9La" id="3s41kb3BVNG" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="3s41kb3BVNH" role="3bR37C">
+          <node concept="3bR9La" id="3s41kb3BVNI" role="1SiIV1">
+            <ref role="3bR37D" node="3s41kb3BSJm" resolve="nl.f1re.mpsutil.hasher" />
+          </node>
+        </node>
+        <node concept="1BupzO" id="3s41kb3BVO0" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="3eie_C8LzN9" role="1HemKq">
+            <node concept="398BVA" id="3eie_C8LzMS" role="3LXTmr">
+              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="3eie_C8LzMT" role="iGT6I">
+                <property role="2Ry0Am" value="hasher" />
+                <node concept="2Ry0Ak" id="3eie_C8LzMU" role="2Ry0An">
+                  <property role="2Ry0Am" value="solutions" />
+                  <node concept="2Ry0Ak" id="3eie_C8LzMV" role="2Ry0An">
+                    <property role="2Ry0Am" value="nl.f1re.mpsutil.hasher.tests" />
+                    <node concept="2Ry0Ak" id="3eie_C8LzMW" role="2Ry0An">
+                      <property role="2Ry0Am" value="models" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="3eie_C8LzNa" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+        <node concept="3rtmxn" id="3s41kb3BVQB" role="3bR31x">
+          <node concept="3LXTmp" id="3s41kb3BVQC" role="3rtmxm">
+            <node concept="398BVA" id="3s41kb3BVQD" role="3LXTmr">
+              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="3s41kb3BVQE" role="iGT6I">
+                <property role="2Ry0Am" value="hasher" />
+                <node concept="2Ry0Ak" id="3s41kb3BVQF" role="2Ry0An">
+                  <property role="2Ry0Am" value="solutions" />
+                  <node concept="2Ry0Ak" id="3s41kb3BVQG" role="2Ry0An">
+                    <property role="2Ry0Am" value="nl.f1re.mpsutil.hasher.tests" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="3s41kb3BVQI" role="3LXTna">
+              <property role="3qWCbO" value="icons/**" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
     <node concept="2G$12M" id="4zIvKyxqSP7" role="3989C9">
       <property role="TrG5h" value="sandboxes" />
       <node concept="1E1JtD" id="4zIvKyxqTge" role="2G$12L">
@@ -25835,6 +26053,9 @@
       <node concept="L2wRC" id="inTShjy23t" role="39821P">
         <ref role="L2wRA" node="inTShjy1w6" resolve="de.itemis.mps.editor.math.tests" />
       </node>
+      <node concept="L2wRC" id="3s41kb3BVRV" role="39821P">
+        <ref role="L2wRA" node="3s41kb3BVkF" resolve="nl.f1re.mpsutil.hasher.tests" />
+      </node>
     </node>
     <node concept="2igEWh" id="H43MYuxQDj" role="1hWBAP">
       <property role="3UIfUI" value="2024" />
@@ -25930,6 +26151,9 @@
       </node>
       <node concept="22LTRM" id="2cqAxlkX47m" role="22LTRK">
         <ref role="22LTRN" node="2cqAxlknq_h" resolve="de.itemis.mps.comparator.diff.tests" />
+      </node>
+      <node concept="22LTRM" id="3s41kb3BVT9" role="22LTRK">
+        <ref role="22LTRN" node="3s41kb3BVkF" resolve="nl.f1re.mpsutil.hasher.tests" />
       </node>
     </node>
     <node concept="2igEWh" id="1OMGwhrtizD" role="1hWBAP">

--- a/code/compare/solutions/de.itemis.mps.comparator.diff.tests/models/de.itemis.mps.comparator.diff.tests.diffs@tests.mps
+++ b/code/compare/solutions/de.itemis.mps.comparator.diff.tests/models/de.itemis.mps.comparator.diff.tests.diffs@tests.mps
@@ -33,9 +33,9 @@
     <import index="87nw" ref="r:ca2ab6bb-f6e7-4c0f-a88c-b78b9b31fff3(de.slisson.mps.richtext.structure)" />
     <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" />
-    <import index="mqum" ref="r:ec874b45-e888-42e6-995a-a298cefdff55(de.itemis.mps.comparator.code)" />
+    <import index="mqum" ref="r:ec874b45-e888-42e6-995a-a298cefdff55(com.mbeddr.mpsutil.comparator.code)" />
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
-    <import index="cduv" ref="r:57a8e0f3-0113-45ee-931b-1dc409b3d2fe(de.itemis.mps.comparator.diff.tests.genplan)" />
+    <import index="cduv" ref="r:57a8e0f3-0113-45ee-931b-1dc409b3d2fe(com.mbeddr.mpsutil.comparator.diff.tests.genplan)" />
     <import index="tft2" ref="215c4c45-ba99-49f5-9ab7-4b6901a63cfd/java:jetbrains.mps.generator.impl.plan(MPS.Generator/)" />
     <import index="ao3" ref="7124e466-fc92-4803-a656-d7a6b7eb3910/java:jetbrains.mps.text(MPS.TextGen/)" />
     <import index="2o8p" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.diff.contents(MPS.IDEA/)" />
@@ -48,7 +48,7 @@
     <import index="7x5y" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.nio.charset(JDK/)" />
     <import index="lui2" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.module(MPS.OpenAPI/)" />
     <import index="18ew" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.util(MPS.Core/)" />
-    <import index="sotg" ref="r:f7b641c7-0327-4513-80ee-fa0921b93a79(de.itemis.mps.compare.typesystem)" />
+    <import index="sotg" ref="r:f7b641c7-0327-4513-80ee-fa0921b93a79(com.mbeddr.mpsutil.compare.typesystem)" />
     <import index="z1c4" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.project(MPS.Platform/)" />
     <import index="s9o5" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.editor(MPS.IDEA/)" />
     <import index="82uw" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util.function(JDK/)" />

--- a/code/hasher/solutions/nl.f1re.mpsutil.hasher.tests/models/nl.f1re.mpsutil.hasher.tests@tests.mps
+++ b/code/hasher/solutions/nl.f1re.mpsutil.hasher.tests/models/nl.f1re.mpsutil.hasher.tests@tests.mps
@@ -1,0 +1,5353 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:b8771590-5bb3-41cf-837c-5a3762dc6a04(nl.f1re.mpsutil.hasher.tests@tests)">
+  <persistence version="9" />
+  <languages>
+    <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="6" />
+    <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
+    <use id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation" version="5" />
+    <use id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections" version="2" />
+  </languages>
+  <imports>
+    <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" />
+    <import index="s53o" ref="r:d33052f8-d6ec-4c4e-a308-0c1006114272(nl.f1re.mpsutil.hasher)" />
+    <import index="w1kc" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel(MPS.Core/)" />
+    <import index="dush" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.persistence(MPS.OpenAPI/)" />
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
+    <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" implicit="true" />
+    <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
+    <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" implicit="true" />
+    <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
+        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
+      </concept>
+      <concept id="1216913645126" name="jetbrains.mps.lang.test.structure.NodesTestCase" flags="lg" index="1lH9Xt">
+        <property id="2616911529524314943" name="accessMode" index="3DII0k" />
+        <child id="1216993439383" name="methods" index="1qtyYc" />
+        <child id="1217501895093" name="testMethods" index="1SL9yI" />
+      </concept>
+      <concept id="1225978065297" name="jetbrains.mps.lang.test.structure.SimpleNodeTest" flags="ng" index="1LZb2c" />
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1219920932475" name="jetbrains.mps.baseLanguage.structure.VariableArityType" flags="in" index="8X2XB">
+        <child id="1219921048460" name="componentType" index="8Xvag" />
+      </concept>
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="1179360813171" name="jetbrains.mps.baseLanguage.structure.HexIntegerLiteral" flags="nn" index="2nou5x">
+        <property id="1179360856892" name="value" index="2noCCI" />
+      </concept>
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
+        <child id="1145553007750" name="creator" index="2ShVmc" />
+      </concept>
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
+      </concept>
+      <concept id="1070534934090" name="jetbrains.mps.baseLanguage.structure.CastExpression" flags="nn" index="10QFUN">
+        <child id="1070534934091" name="type" index="10QFUM" />
+        <child id="1070534934092" name="expression" index="10QFUP" />
+      </concept>
+      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ngI" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
+      </concept>
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
+      <concept id="1225271283259" name="jetbrains.mps.baseLanguage.structure.NPEEqualsExpression" flags="nn" index="17R0WA" />
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123134" name="parameter" index="3clF46" />
+        <child id="1068580123135" name="body" index="3clF47" />
+      </concept>
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
+        <property id="1068580123138" name="value" index="3clFbU" />
+      </concept>
+      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
+        <property id="1068580320021" name="value" index="3cmrfH" />
+      </concept>
+      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
+        <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
+      </concept>
+      <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+        <reference id="1107535924139" name="classifier" index="3uigEE" />
+      </concept>
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
+        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
+        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
+      </concept>
+    </language>
+    <language id="443f4c36-fcf5-4eb6-9500-8d06ed259e3e" name="jetbrains.mps.baseLanguage.classifiers">
+      <concept id="1205752633985" name="jetbrains.mps.baseLanguage.classifiers.structure.ThisClassifierExpression" flags="nn" index="2WthIp" />
+      <concept id="1205756064662" name="jetbrains.mps.baseLanguage.classifiers.structure.IMemberOperation" flags="ngI" index="2WEnae">
+        <reference id="1205756909548" name="member" index="2WH_rO" />
+      </concept>
+      <concept id="1205769003971" name="jetbrains.mps.baseLanguage.classifiers.structure.DefaultClassifierMethodDeclaration" flags="ng" index="2XrIbr" />
+      <concept id="1205769149993" name="jetbrains.mps.baseLanguage.classifiers.structure.DefaultClassifierMethodCallOperation" flags="nn" index="2XshWL">
+        <child id="1205770614681" name="actualArgument" index="2XxRq1" />
+      </concept>
+    </language>
+    <language id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation">
+      <concept id="5455284157994012186" name="jetbrains.mps.lang.quotation.structure.NodeBuilderInitLink" flags="ng" index="2pIpSj">
+        <reference id="5455284157994012188" name="link" index="2pIpSl" />
+        <child id="1595412875168045827" name="initValue" index="28nt2d" />
+      </concept>
+      <concept id="5455284157993911077" name="jetbrains.mps.lang.quotation.structure.NodeBuilderInitProperty" flags="ng" index="2pJxcG">
+        <reference id="5455284157993911078" name="property" index="2pJxcJ" />
+        <child id="1595412875168045201" name="initValue" index="28ntcv" />
+      </concept>
+      <concept id="5455284157993863837" name="jetbrains.mps.lang.quotation.structure.NodeBuilder" flags="nn" index="2pJPEk">
+        <child id="5455284157993863838" name="quotedNode" index="2pJPEn" />
+      </concept>
+      <concept id="5455284157993863840" name="jetbrains.mps.lang.quotation.structure.NodeBuilderNode" flags="nn" index="2pJPED">
+        <reference id="5455284157993910961" name="concept" index="2pJxaS" />
+        <child id="5455284157993911099" name="values" index="2pJxcM" />
+      </concept>
+      <concept id="6985522012210254362" name="jetbrains.mps.lang.quotation.structure.NodeBuilderPropertyExpression" flags="nn" index="WxPPo">
+        <child id="6985522012210254363" name="expression" index="WxPPp" />
+      </concept>
+      <concept id="8182547171709738802" name="jetbrains.mps.lang.quotation.structure.NodeBuilderList" flags="nn" index="36be1Y">
+        <child id="8182547171709738803" name="nodes" index="36be1Z" />
+      </concept>
+      <concept id="8182547171709752110" name="jetbrains.mps.lang.quotation.structure.NodeBuilderExpression" flags="nn" index="36biLy">
+        <child id="8182547171709752112" name="expression" index="36biLW" />
+      </concept>
+    </language>
+    <language id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest">
+      <concept id="8427750732757990717" name="jetbrains.mps.baseLanguage.unitTest.structure.BinaryAssert" flags="nn" index="3tpDYu">
+        <child id="8427750732757990725" name="actual" index="3tpDZA" />
+        <child id="8427750732757990724" name="expected" index="3tpDZB" />
+      </concept>
+      <concept id="1171978097730" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertEquals" flags="nn" index="3vlDli" />
+      <concept id="1171981022339" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertTrue" flags="nn" index="3vwNmj">
+        <child id="1171981057159" name="condition" index="3vwVQn" />
+      </concept>
+      <concept id="1171983834376" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertFalse" flags="nn" index="3vFxKo">
+        <child id="1171983854940" name="condition" index="3vFALc" />
+      </concept>
+    </language>
+    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1145404486709" name="jetbrains.mps.lang.smodel.structure.SemanticDowncastExpression" flags="nn" index="2JrnkZ">
+        <child id="1145404616321" name="leftExpression" index="2JrQYb" />
+      </concept>
+      <concept id="2644386474302386080" name="jetbrains.mps.lang.smodel.structure.PropertyIdRefExpression" flags="nn" index="355D3s">
+        <reference id="2644386474302386081" name="conceptDeclaration" index="355D3t" />
+        <reference id="2644386474302386082" name="propertyDeclaration" index="355D3u" />
+      </concept>
+      <concept id="2644386474301421077" name="jetbrains.mps.lang.smodel.structure.LinkIdRefExpression" flags="nn" index="359W_D">
+        <reference id="2644386474301421078" name="conceptDeclaration" index="359W_E" />
+        <reference id="2644386474301421079" name="linkDeclaration" index="359W_F" />
+      </concept>
+      <concept id="2644386474300074836" name="jetbrains.mps.lang.smodel.structure.ConceptIdRefExpression" flags="nn" index="35c_gC">
+        <reference id="2644386474300074837" name="conceptDeclaration" index="35c_gD" />
+      </concept>
+      <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
+        <reference id="1138405853777" name="concept" index="ehGHo" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+      <concept id="4222318806802425298" name="jetbrains.mps.lang.core.structure.SuppressErrorsAnnotation" flags="ng" index="15s5l7">
+        <property id="8575328350543493365" name="message" index="huDt6" />
+        <property id="2423417345669755629" name="filter" index="1eyWvh" />
+      </concept>
+    </language>
+    <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="1151702311717" name="jetbrains.mps.baseLanguage.collections.structure.ToListOperation" flags="nn" index="ANE8D" />
+      <concept id="1237721394592" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerCreator" flags="nn" index="HWqM0">
+        <child id="1237721435808" name="initValue" index="HW$Y0" />
+      </concept>
+      <concept id="1160600644654" name="jetbrains.mps.baseLanguage.collections.structure.ListCreatorWithInit" flags="nn" index="Tc6Ow" />
+      <concept id="1240325842691" name="jetbrains.mps.baseLanguage.collections.structure.AsSequenceOperation" flags="nn" index="39bAoz" />
+    </language>
+  </registry>
+  <node concept="1lH9Xt" id="3s41kb3swwN">
+    <property role="3DII0k" value="2hh8MJdVwqX/command" />
+    <property role="TrG5h" value="NodeHasherTests" />
+    <node concept="2XrIbr" id="3s41kb3w93N" role="1qtyYc">
+      <property role="TrG5h" value="create" />
+      <node concept="3uibUv" id="3s41kb3w95i" role="3clF45">
+        <ref role="3uigEE" to="s53o:36NsNggQrub" resolve="NodeHasher" />
+      </node>
+      <node concept="3clFbS" id="3s41kb3w93P" role="3clF47">
+        <node concept="3clFbF" id="3s41kb3w95V" role="3cqZAp">
+          <node concept="2OqwBi" id="3s41kb3xPV$" role="3clFbG">
+            <node concept="2ShNRf" id="3s41kb3w95T" role="2Oq$k0">
+              <node concept="1pGfFk" id="3s41kb3w9Ph" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="s53o:36NsNggQryX" resolve="NodeHasher" />
+                <node concept="2OqwBi" id="3s41kb3wb_F" role="37wK5m">
+                  <node concept="2OqwBi" id="3s41kb3w9Yj" role="2Oq$k0">
+                    <node concept="37vLTw" id="3s41kb3w9PD" role="2Oq$k0">
+                      <ref role="3cqZAo" node="3s41kb3w95z" resolve="nodes" />
+                    </node>
+                    <node concept="39bAoz" id="3s41kb3waR5" role="2OqNvi" />
+                  </node>
+                  <node concept="ANE8D" id="3s41kb3wckB" role="2OqNvi" />
+                </node>
+                <node concept="2nou5x" id="3s41kb3wco3" role="37wK5m">
+                  <property role="2noCCI" value="456" />
+                </node>
+              </node>
+            </node>
+            <node concept="liA8E" id="3s41kb3xQba" role="2OqNvi">
+              <ref role="37wK5l" to="s53o:36NsNggQrzG" resolve="setIncludeNodeIds" />
+              <node concept="3clFbT" id="3s41kb3xZNM" role="37wK5m" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="3s41kb3w95z" role="3clF46">
+        <property role="TrG5h" value="nodes" />
+        <node concept="8X2XB" id="3s41kb3w95C" role="1tU5fm">
+          <node concept="3Tqbb2" id="3s41kb3w95y" role="8Xvag" />
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="3s41kb3swwR" role="1SL9yI">
+      <property role="TrG5h" value="sameNode" />
+      <node concept="3cqZAl" id="3s41kb3swwS" role="3clF45" />
+      <node concept="3clFbS" id="3s41kb3swwW" role="3clF47">
+        <node concept="3cpWs8" id="3s41kb3swAx" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3swEt" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required link is not initialized `leftExpression'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/3741790230810467494]&quot;;" />
+            <property role="huDt6" value="Error: required link is not initialized `leftExpression'" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3swAy" role="3cpWs9">
+            <property role="TrG5h" value="a" />
+            <node concept="3Tqbb2" id="3s41kb3swxm" role="1tU5fm" />
+            <node concept="2ShNRf" id="3s41kb3sOV3" role="33vP2m">
+              <node concept="1pGfFk" id="3s41kb3sPgv" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="w1kc:~SNode.&lt;init&gt;(org.jetbrains.mps.openapi.language.SConcept,org.jetbrains.mps.openapi.model.SNodeId)" resolve="SNode" />
+                <node concept="35c_gC" id="3s41kb3sPkh" role="37wK5m">
+                  <ref role="35c_gD" to="tpee:fHWc73I" resolve="AndExpression" />
+                </node>
+                <node concept="2OqwBi" id="3s41kb3sR82" role="37wK5m">
+                  <node concept="2YIFZM" id="3s41kb3sR1V" role="2Oq$k0">
+                    <ref role="37wK5l" to="dush:~PersistenceFacade.getInstance()" resolve="getInstance" />
+                    <ref role="1Pybhc" to="dush:~PersistenceFacade" resolve="PersistenceFacade" />
+                  </node>
+                  <node concept="liA8E" id="3s41kb3sRgL" role="2OqNvi">
+                    <ref role="37wK5l" to="dush:~PersistenceFacade.createNodeId(java.lang.String)" resolve="createNodeId" />
+                    <node concept="Xl_RD" id="3s41kb3sRiW" role="37wK5m">
+                      <property role="Xl_RC" value="123" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="3s41kb3swED" role="3cqZAp" />
+        <node concept="3vwNmj" id="3s41kb3sxbg" role="3cqZAp">
+          <node concept="17R0WA" id="3s41kb3syI1" role="3vwVQn">
+            <node concept="2YIFZM" id="3s41kb3sxbX" role="3uHU7B">
+              <ref role="37wK5l" to="s53o:36NsNggQrzh" resolve="hash" />
+              <ref role="1Pybhc" to="s53o:36NsNggQrub" resolve="NodeHasher" />
+              <node concept="37vLTw" id="3s41kb3sxbY" role="37wK5m">
+                <ref role="3cqZAo" node="3s41kb3swAy" resolve="a" />
+              </node>
+            </node>
+            <node concept="2YIFZM" id="3s41kb3sz9K" role="3uHU7w">
+              <ref role="37wK5l" to="s53o:36NsNggQrzh" resolve="hash" />
+              <ref role="1Pybhc" to="s53o:36NsNggQrub" resolve="NodeHasher" />
+              <node concept="37vLTw" id="3s41kb3szJw" role="37wK5m">
+                <ref role="3cqZAo" node="3s41kb3swAy" resolve="a" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="3s41kb3xdQK" role="1SL9yI">
+      <property role="TrG5h" value="sameNode_differentSeed" />
+      <node concept="3cqZAl" id="3s41kb3xdQL" role="3clF45" />
+      <node concept="3clFbS" id="3s41kb3xdQM" role="3clF47">
+        <node concept="3cpWs8" id="3s41kb3xdQN" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3xdQO" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required link is not initialized `leftExpression'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/3741790230810467494]&quot;;" />
+            <property role="huDt6" value="Error: required link is not initialized `leftExpression'" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3xdQP" role="3cpWs9">
+            <property role="TrG5h" value="a" />
+            <node concept="3Tqbb2" id="3s41kb3xdQQ" role="1tU5fm" />
+            <node concept="2ShNRf" id="3s41kb3xdQR" role="33vP2m">
+              <node concept="1pGfFk" id="3s41kb3xdQS" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="w1kc:~SNode.&lt;init&gt;(org.jetbrains.mps.openapi.language.SConcept,org.jetbrains.mps.openapi.model.SNodeId)" resolve="SNode" />
+                <node concept="35c_gC" id="3s41kb3xdQT" role="37wK5m">
+                  <ref role="35c_gD" to="tpee:fHWc73I" resolve="AndExpression" />
+                </node>
+                <node concept="2OqwBi" id="3s41kb3xdQU" role="37wK5m">
+                  <node concept="2YIFZM" id="3s41kb3xdQV" role="2Oq$k0">
+                    <ref role="37wK5l" to="dush:~PersistenceFacade.getInstance()" resolve="getInstance" />
+                    <ref role="1Pybhc" to="dush:~PersistenceFacade" resolve="PersistenceFacade" />
+                  </node>
+                  <node concept="liA8E" id="3s41kb3xdQW" role="2OqNvi">
+                    <ref role="37wK5l" to="dush:~PersistenceFacade.createNodeId(java.lang.String)" resolve="createNodeId" />
+                    <node concept="Xl_RD" id="3s41kb3xdQX" role="37wK5m">
+                      <property role="Xl_RC" value="123" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="3s41kb3xdR9" role="3cqZAp" />
+        <node concept="3vFxKo" id="3s41kb3xix0" role="3cqZAp">
+          <node concept="17R0WA" id="3s41kb3xlFp" role="3vFALc">
+            <node concept="2OqwBi" id="3s41kb3xhZ1" role="3uHU7B">
+              <node concept="2ShNRf" id="3s41kb3xehD" role="2Oq$k0">
+                <node concept="1pGfFk" id="3s41kb3xffD" role="2ShVmc">
+                  <property role="373rjd" value="true" />
+                  <ref role="37wK5l" to="s53o:36NsNggQryX" resolve="NodeHasher" />
+                  <node concept="2ShNRf" id="3s41kb3xfiV" role="37wK5m">
+                    <node concept="Tc6Ow" id="3s41kb3xghv" role="2ShVmc">
+                      <node concept="37vLTw" id="3s41kb3xhHa" role="HW$Y0">
+                        <ref role="3cqZAo" node="3s41kb3xdQP" resolve="a" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3cmrfG" id="3s41kb3xhQA" role="37wK5m">
+                    <property role="3cmrfH" value="0" />
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3xilN" role="2OqNvi">
+                <ref role="37wK5l" to="s53o:36NsNggQr$I" resolve="hash" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="3s41kb3xm2Q" role="3uHU7w">
+              <node concept="2ShNRf" id="3s41kb3xm2R" role="2Oq$k0">
+                <node concept="1pGfFk" id="3s41kb3xm2S" role="2ShVmc">
+                  <property role="373rjd" value="true" />
+                  <ref role="37wK5l" to="s53o:36NsNggQryX" resolve="NodeHasher" />
+                  <node concept="2ShNRf" id="3s41kb3xm2T" role="37wK5m">
+                    <node concept="Tc6Ow" id="3s41kb3xm2U" role="2ShVmc">
+                      <node concept="37vLTw" id="3s41kb3xm2V" role="HW$Y0">
+                        <ref role="3cqZAo" node="3s41kb3xdQP" resolve="a" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3cmrfG" id="3s41kb3xm2W" role="37wK5m">
+                    <property role="3cmrfH" value="1" />
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3xm2X" role="2OqNvi">
+                <ref role="37wK5l" to="s53o:36NsNggQr$I" resolve="hash" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="3s41kb3xds0" role="1SL9yI">
+      <property role="TrG5h" value="equalNode" />
+      <node concept="3cqZAl" id="3s41kb3xds1" role="3clF45" />
+      <node concept="3clFbS" id="3s41kb3xds2" role="3clF47">
+        <node concept="3cpWs8" id="3s41kb3xds3" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3xds4" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required link is not initialized `leftExpression'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/3741790230810467494]&quot;;" />
+            <property role="huDt6" value="Error: required link is not initialized `leftExpression'" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3xds5" role="3cpWs9">
+            <property role="TrG5h" value="a" />
+            <node concept="3Tqbb2" id="3s41kb3xds6" role="1tU5fm" />
+            <node concept="2ShNRf" id="3s41kb3xds7" role="33vP2m">
+              <node concept="1pGfFk" id="3s41kb3xds8" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="w1kc:~SNode.&lt;init&gt;(org.jetbrains.mps.openapi.language.SConcept,org.jetbrains.mps.openapi.model.SNodeId)" resolve="SNode" />
+                <node concept="35c_gC" id="3s41kb3xds9" role="37wK5m">
+                  <ref role="35c_gD" to="tpee:fHWc73I" resolve="AndExpression" />
+                </node>
+                <node concept="2OqwBi" id="3s41kb3xdsa" role="37wK5m">
+                  <node concept="2YIFZM" id="3s41kb3xdsb" role="2Oq$k0">
+                    <ref role="37wK5l" to="dush:~PersistenceFacade.getInstance()" resolve="getInstance" />
+                    <ref role="1Pybhc" to="dush:~PersistenceFacade" resolve="PersistenceFacade" />
+                  </node>
+                  <node concept="liA8E" id="3s41kb3xdsc" role="2OqNvi">
+                    <ref role="37wK5l" to="dush:~PersistenceFacade.createNodeId(java.lang.String)" resolve="createNodeId" />
+                    <node concept="Xl_RD" id="3s41kb3xdsd" role="37wK5m">
+                      <property role="Xl_RC" value="123" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3s41kb3xdse" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3xdsf" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required link is not initialized `leftExpression'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/3741790230810467494]&quot;;" />
+            <property role="huDt6" value="Error: required link is not initialized `leftExpression'" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3xdsg" role="3cpWs9">
+            <property role="TrG5h" value="b" />
+            <node concept="3Tqbb2" id="3s41kb3xdsh" role="1tU5fm" />
+            <node concept="2ShNRf" id="3s41kb3xdsi" role="33vP2m">
+              <node concept="1pGfFk" id="3s41kb3xdsj" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="w1kc:~SNode.&lt;init&gt;(org.jetbrains.mps.openapi.language.SConcept,org.jetbrains.mps.openapi.model.SNodeId)" resolve="SNode" />
+                <node concept="35c_gC" id="3s41kb3xdsk" role="37wK5m">
+                  <ref role="35c_gD" to="tpee:fHWc73I" resolve="AndExpression" />
+                </node>
+                <node concept="2OqwBi" id="3s41kb3xdsl" role="37wK5m">
+                  <node concept="2YIFZM" id="3s41kb3xdsm" role="2Oq$k0">
+                    <ref role="37wK5l" to="dush:~PersistenceFacade.getInstance()" resolve="getInstance" />
+                    <ref role="1Pybhc" to="dush:~PersistenceFacade" resolve="PersistenceFacade" />
+                  </node>
+                  <node concept="liA8E" id="3s41kb3xdsn" role="2OqNvi">
+                    <ref role="37wK5l" to="dush:~PersistenceFacade.createNodeId(java.lang.String)" resolve="createNodeId" />
+                    <node concept="Xl_RD" id="3s41kb3xdso" role="37wK5m">
+                      <property role="Xl_RC" value="123" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="3s41kb3xdsp" role="3cqZAp" />
+        <node concept="3vwNmj" id="3s41kb3xdsq" role="3cqZAp">
+          <node concept="17R0WA" id="3s41kb3xdsr" role="3vwVQn">
+            <node concept="2YIFZM" id="3s41kb3xdss" role="3uHU7B">
+              <ref role="37wK5l" to="s53o:36NsNggQrzh" resolve="hash" />
+              <ref role="1Pybhc" to="s53o:36NsNggQrub" resolve="NodeHasher" />
+              <node concept="37vLTw" id="3s41kb3xdst" role="37wK5m">
+                <ref role="3cqZAo" node="3s41kb3xds5" resolve="a" />
+              </node>
+            </node>
+            <node concept="2YIFZM" id="3s41kb3xdsu" role="3uHU7w">
+              <ref role="37wK5l" to="s53o:36NsNggQrzh" resolve="hash" />
+              <ref role="1Pybhc" to="s53o:36NsNggQrub" resolve="NodeHasher" />
+              <node concept="37vLTw" id="3s41kb3xdsv" role="37wK5m">
+                <ref role="3cqZAo" node="3s41kb3xdsg" resolve="b" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="3s41kb3sRO3" role="1SL9yI">
+      <property role="TrG5h" value="differentConcept" />
+      <node concept="3cqZAl" id="3s41kb3sRO4" role="3clF45" />
+      <node concept="3clFbS" id="3s41kb3sRO5" role="3clF47">
+        <node concept="3cpWs8" id="3s41kb3sRO6" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3sRO7" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required link is not initialized `leftExpression'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/3741790230810467494]&quot;;" />
+            <property role="huDt6" value="Error: required link is not initialized `leftExpression'" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3sRO8" role="3cpWs9">
+            <property role="TrG5h" value="a" />
+            <node concept="3Tqbb2" id="3s41kb3sRO9" role="1tU5fm" />
+            <node concept="2ShNRf" id="3s41kb3sROa" role="33vP2m">
+              <node concept="1pGfFk" id="3s41kb3sROb" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="w1kc:~SNode.&lt;init&gt;(org.jetbrains.mps.openapi.language.SConcept,org.jetbrains.mps.openapi.model.SNodeId)" resolve="SNode" />
+                <node concept="35c_gC" id="3s41kb3sROc" role="37wK5m">
+                  <ref role="35c_gD" to="tpee:fHWc73I" resolve="AndExpression" />
+                </node>
+                <node concept="2OqwBi" id="3s41kb3sROd" role="37wK5m">
+                  <node concept="2YIFZM" id="3s41kb3sROe" role="2Oq$k0">
+                    <ref role="37wK5l" to="dush:~PersistenceFacade.getInstance()" resolve="getInstance" />
+                    <ref role="1Pybhc" to="dush:~PersistenceFacade" resolve="PersistenceFacade" />
+                  </node>
+                  <node concept="liA8E" id="3s41kb3sROf" role="2OqNvi">
+                    <ref role="37wK5l" to="dush:~PersistenceFacade.createNodeId(java.lang.String)" resolve="createNodeId" />
+                    <node concept="Xl_RD" id="3s41kb3sROg" role="37wK5m">
+                      <property role="Xl_RC" value="123" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3s41kb3sROh" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3sROi" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required link is not initialized `leftExpression'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/3741790230810467494]&quot;;" />
+            <property role="huDt6" value="Error: required link is not initialized `leftExpression'" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3sROj" role="3cpWs9">
+            <property role="TrG5h" value="b" />
+            <node concept="3Tqbb2" id="3s41kb3sROk" role="1tU5fm" />
+            <node concept="2ShNRf" id="3s41kb3sROl" role="33vP2m">
+              <node concept="1pGfFk" id="3s41kb3sROm" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="w1kc:~SNode.&lt;init&gt;(org.jetbrains.mps.openapi.language.SConcept,org.jetbrains.mps.openapi.model.SNodeId)" resolve="SNode" />
+                <node concept="35c_gC" id="3s41kb3sROn" role="37wK5m">
+                  <ref role="35c_gD" to="tpee:fI2lmyv" resolve="OrExpression" />
+                </node>
+                <node concept="2OqwBi" id="3s41kb3sROo" role="37wK5m">
+                  <node concept="2YIFZM" id="3s41kb3sROp" role="2Oq$k0">
+                    <ref role="37wK5l" to="dush:~PersistenceFacade.getInstance()" resolve="getInstance" />
+                    <ref role="1Pybhc" to="dush:~PersistenceFacade" resolve="PersistenceFacade" />
+                  </node>
+                  <node concept="liA8E" id="3s41kb3sROq" role="2OqNvi">
+                    <ref role="37wK5l" to="dush:~PersistenceFacade.createNodeId(java.lang.String)" resolve="createNodeId" />
+                    <node concept="Xl_RD" id="3s41kb3sROr" role="37wK5m">
+                      <property role="Xl_RC" value="123" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="3s41kb3sROs" role="3cqZAp" />
+        <node concept="3vFxKo" id="3s41kb3sS5f" role="3cqZAp">
+          <node concept="17R0WA" id="3s41kb3yyiZ" role="3vFALc">
+            <node concept="2OqwBi" id="3s41kb3yyj0" role="3uHU7B">
+              <node concept="2OqwBi" id="3s41kb3yyj1" role="2Oq$k0">
+                <node concept="2OqwBi" id="3s41kb3yyj2" role="2Oq$k0">
+                  <node concept="2WthIp" id="3s41kb3yyj3" role="2Oq$k0" />
+                  <node concept="2XshWL" id="3s41kb3yyj4" role="2OqNvi">
+                    <ref role="2WH_rO" node="3s41kb3w93N" resolve="create" />
+                    <node concept="37vLTw" id="3s41kb3yyj5" role="2XxRq1">
+                      <ref role="3cqZAo" node="3s41kb3sRO8" resolve="a" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="liA8E" id="3s41kb3yyj6" role="2OqNvi">
+                  <ref role="37wK5l" to="s53o:36NsNggQrzG" resolve="setIncludeNodeIds" />
+                  <node concept="3clFbT" id="3s41kb3yyBC" role="37wK5m">
+                    <property role="3clFbU" value="true" />
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3yyj8" role="2OqNvi">
+                <ref role="37wK5l" to="s53o:36NsNggQr$I" resolve="hash" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="3s41kb3yyj9" role="3uHU7w">
+              <node concept="2OqwBi" id="3s41kb3yyja" role="2Oq$k0">
+                <node concept="2OqwBi" id="3s41kb3yyjb" role="2Oq$k0">
+                  <node concept="2WthIp" id="3s41kb3yyjc" role="2Oq$k0" />
+                  <node concept="2XshWL" id="3s41kb3yyjd" role="2OqNvi">
+                    <ref role="2WH_rO" node="3s41kb3w93N" resolve="create" />
+                    <node concept="37vLTw" id="3s41kb3yyje" role="2XxRq1">
+                      <ref role="3cqZAo" node="3s41kb3sROj" resolve="b" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="liA8E" id="3s41kb3yyjf" role="2OqNvi">
+                  <ref role="37wK5l" to="s53o:36NsNggQrzG" resolve="setIncludeNodeIds" />
+                  <node concept="3clFbT" id="3s41kb3yyF0" role="37wK5m">
+                    <property role="3clFbU" value="true" />
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3yyjh" role="2OqNvi">
+                <ref role="37wK5l" to="s53o:36NsNggQr$I" resolve="hash" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="3s41kb3_X4E" role="1SL9yI">
+      <property role="TrG5h" value="differentId" />
+      <node concept="3cqZAl" id="3s41kb3_X4F" role="3clF45" />
+      <node concept="3clFbS" id="3s41kb3_X4G" role="3clF47">
+        <node concept="3cpWs8" id="3s41kb3_X4H" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3_X4I" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required link is not initialized `leftExpression'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/3741790230810467494]&quot;;" />
+            <property role="huDt6" value="Error: required link is not initialized `leftExpression'" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3_X4J" role="3cpWs9">
+            <property role="TrG5h" value="a" />
+            <node concept="3Tqbb2" id="3s41kb3_X4K" role="1tU5fm" />
+            <node concept="2ShNRf" id="3s41kb3_X4L" role="33vP2m">
+              <node concept="1pGfFk" id="3s41kb3_X4M" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="w1kc:~SNode.&lt;init&gt;(org.jetbrains.mps.openapi.language.SConcept,org.jetbrains.mps.openapi.model.SNodeId)" resolve="SNode" />
+                <node concept="35c_gC" id="3s41kb3_X4N" role="37wK5m">
+                  <ref role="35c_gD" to="tpee:fHWc73I" resolve="AndExpression" />
+                </node>
+                <node concept="2OqwBi" id="3s41kb3_X4O" role="37wK5m">
+                  <node concept="2YIFZM" id="3s41kb3_X4P" role="2Oq$k0">
+                    <ref role="37wK5l" to="dush:~PersistenceFacade.getInstance()" resolve="getInstance" />
+                    <ref role="1Pybhc" to="dush:~PersistenceFacade" resolve="PersistenceFacade" />
+                  </node>
+                  <node concept="liA8E" id="3s41kb3_X4Q" role="2OqNvi">
+                    <ref role="37wK5l" to="dush:~PersistenceFacade.createNodeId(java.lang.String)" resolve="createNodeId" />
+                    <node concept="Xl_RD" id="3s41kb3_X4R" role="37wK5m">
+                      <property role="Xl_RC" value="123" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3s41kb3_X4S" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3_X4T" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required link is not initialized `leftExpression'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/3741790230810467494]&quot;;" />
+            <property role="huDt6" value="Error: required link is not initialized `leftExpression'" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3_X4U" role="3cpWs9">
+            <property role="TrG5h" value="b" />
+            <node concept="3Tqbb2" id="3s41kb3_X4V" role="1tU5fm" />
+            <node concept="2ShNRf" id="3s41kb3_X4W" role="33vP2m">
+              <node concept="1pGfFk" id="3s41kb3_X4X" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="w1kc:~SNode.&lt;init&gt;(org.jetbrains.mps.openapi.language.SConcept,org.jetbrains.mps.openapi.model.SNodeId)" resolve="SNode" />
+                <node concept="35c_gC" id="3s41kb3_X4Y" role="37wK5m">
+                  <ref role="35c_gD" to="tpee:fHWc73I" resolve="AndExpression" />
+                </node>
+                <node concept="2OqwBi" id="3s41kb3_X4Z" role="37wK5m">
+                  <node concept="2YIFZM" id="3s41kb3_X50" role="2Oq$k0">
+                    <ref role="37wK5l" to="dush:~PersistenceFacade.getInstance()" resolve="getInstance" />
+                    <ref role="1Pybhc" to="dush:~PersistenceFacade" resolve="PersistenceFacade" />
+                  </node>
+                  <node concept="liA8E" id="3s41kb3_X51" role="2OqNvi">
+                    <ref role="37wK5l" to="dush:~PersistenceFacade.createNodeId(java.lang.String)" resolve="createNodeId" />
+                    <node concept="Xl_RD" id="3s41kb3_X52" role="37wK5m">
+                      <property role="Xl_RC" value="234" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="3s41kb3_X53" role="3cqZAp" />
+        <node concept="3vFxKo" id="3s41kb3_X54" role="3cqZAp">
+          <node concept="17R0WA" id="3s41kb3_X55" role="3vFALc">
+            <node concept="2OqwBi" id="3s41kb3_X56" role="3uHU7B">
+              <node concept="2OqwBi" id="3s41kb3_X57" role="2Oq$k0">
+                <node concept="2OqwBi" id="3s41kb3_X58" role="2Oq$k0">
+                  <node concept="2WthIp" id="3s41kb3_X59" role="2Oq$k0" />
+                  <node concept="2XshWL" id="3s41kb3_X5a" role="2OqNvi">
+                    <ref role="2WH_rO" node="3s41kb3w93N" resolve="create" />
+                    <node concept="37vLTw" id="3s41kb3_X5b" role="2XxRq1">
+                      <ref role="3cqZAo" node="3s41kb3_X4J" resolve="a" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="liA8E" id="3s41kb3_X5c" role="2OqNvi">
+                  <ref role="37wK5l" to="s53o:36NsNggQrzG" resolve="setIncludeNodeIds" />
+                  <node concept="3clFbT" id="3s41kb3_X5d" role="37wK5m">
+                    <property role="3clFbU" value="true" />
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3_X5e" role="2OqNvi">
+                <ref role="37wK5l" to="s53o:36NsNggQr$I" resolve="hash" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="3s41kb3_X5f" role="3uHU7w">
+              <node concept="2OqwBi" id="3s41kb3_X5g" role="2Oq$k0">
+                <node concept="2OqwBi" id="3s41kb3_X5h" role="2Oq$k0">
+                  <node concept="2WthIp" id="3s41kb3_X5i" role="2Oq$k0" />
+                  <node concept="2XshWL" id="3s41kb3_X5j" role="2OqNvi">
+                    <ref role="2WH_rO" node="3s41kb3w93N" resolve="create" />
+                    <node concept="37vLTw" id="3s41kb3_X5k" role="2XxRq1">
+                      <ref role="3cqZAo" node="3s41kb3_X4U" resolve="b" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="liA8E" id="3s41kb3_X5l" role="2OqNvi">
+                  <ref role="37wK5l" to="s53o:36NsNggQrzG" resolve="setIncludeNodeIds" />
+                  <node concept="3clFbT" id="3s41kb3_X5m" role="37wK5m">
+                    <property role="3clFbU" value="true" />
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3_X5n" role="2OqNvi">
+                <ref role="37wK5l" to="s53o:36NsNggQr$I" resolve="hash" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="3s41kb3w7Qj" role="1SL9yI">
+      <property role="TrG5h" value="differentId_ignored" />
+      <node concept="3cqZAl" id="3s41kb3w7Qk" role="3clF45" />
+      <node concept="3clFbS" id="3s41kb3w7Ql" role="3clF47">
+        <node concept="3cpWs8" id="3s41kb3w7Qm" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3w7Qn" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required link is not initialized `leftExpression'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/3741790230810467494]&quot;;" />
+            <property role="huDt6" value="Error: required link is not initialized `leftExpression'" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3w7Qo" role="3cpWs9">
+            <property role="TrG5h" value="a" />
+            <node concept="3Tqbb2" id="3s41kb3w7Qp" role="1tU5fm" />
+            <node concept="2ShNRf" id="3s41kb3w7Qq" role="33vP2m">
+              <node concept="1pGfFk" id="3s41kb3w7Qr" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="w1kc:~SNode.&lt;init&gt;(org.jetbrains.mps.openapi.language.SConcept,org.jetbrains.mps.openapi.model.SNodeId)" resolve="SNode" />
+                <node concept="35c_gC" id="3s41kb3w7Qs" role="37wK5m">
+                  <ref role="35c_gD" to="tpee:fHWc73I" resolve="AndExpression" />
+                </node>
+                <node concept="2OqwBi" id="3s41kb3w7Qt" role="37wK5m">
+                  <node concept="2YIFZM" id="3s41kb3w7Qu" role="2Oq$k0">
+                    <ref role="37wK5l" to="dush:~PersistenceFacade.getInstance()" resolve="getInstance" />
+                    <ref role="1Pybhc" to="dush:~PersistenceFacade" resolve="PersistenceFacade" />
+                  </node>
+                  <node concept="liA8E" id="3s41kb3w7Qv" role="2OqNvi">
+                    <ref role="37wK5l" to="dush:~PersistenceFacade.createNodeId(java.lang.String)" resolve="createNodeId" />
+                    <node concept="Xl_RD" id="3s41kb3w7Qw" role="37wK5m">
+                      <property role="Xl_RC" value="123" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3s41kb3w7Qx" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3w7Qy" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required link is not initialized `leftExpression'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/3741790230810467494]&quot;;" />
+            <property role="huDt6" value="Error: required link is not initialized `leftExpression'" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3w7Qz" role="3cpWs9">
+            <property role="TrG5h" value="b" />
+            <node concept="3Tqbb2" id="3s41kb3w7Q$" role="1tU5fm" />
+            <node concept="2ShNRf" id="3s41kb3w7Q_" role="33vP2m">
+              <node concept="1pGfFk" id="3s41kb3w7QA" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="w1kc:~SNode.&lt;init&gt;(org.jetbrains.mps.openapi.language.SConcept,org.jetbrains.mps.openapi.model.SNodeId)" resolve="SNode" />
+                <node concept="35c_gC" id="3s41kb3w7QB" role="37wK5m">
+                  <ref role="35c_gD" to="tpee:fHWc73I" resolve="AndExpression" />
+                </node>
+                <node concept="2OqwBi" id="3s41kb3w7QC" role="37wK5m">
+                  <node concept="2YIFZM" id="3s41kb3w7QD" role="2Oq$k0">
+                    <ref role="37wK5l" to="dush:~PersistenceFacade.getInstance()" resolve="getInstance" />
+                    <ref role="1Pybhc" to="dush:~PersistenceFacade" resolve="PersistenceFacade" />
+                  </node>
+                  <node concept="liA8E" id="3s41kb3w7QE" role="2OqNvi">
+                    <ref role="37wK5l" to="dush:~PersistenceFacade.createNodeId(java.lang.String)" resolve="createNodeId" />
+                    <node concept="Xl_RD" id="3s41kb3w7QF" role="37wK5m">
+                      <property role="Xl_RC" value="234" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="3s41kb3w7QG" role="3cqZAp" />
+        <node concept="3vwNmj" id="3s41kb3wVbi" role="3cqZAp">
+          <node concept="17R0WA" id="3s41kb3w7QI" role="3vwVQn">
+            <node concept="2OqwBi" id="3s41kb3weoG" role="3uHU7B">
+              <node concept="2OqwBi" id="3s41kb3wdaq" role="2Oq$k0">
+                <node concept="2OqwBi" id="3s41kb3wcya" role="2Oq$k0">
+                  <node concept="2WthIp" id="3s41kb3wcyd" role="2Oq$k0" />
+                  <node concept="2XshWL" id="3s41kb3wcyf" role="2OqNvi">
+                    <ref role="2WH_rO" node="3s41kb3w93N" resolve="create" />
+                    <node concept="37vLTw" id="3s41kb3wd3u" role="2XxRq1">
+                      <ref role="3cqZAo" node="3s41kb3w7Qo" resolve="a" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="liA8E" id="3s41kb3wdkz" role="2OqNvi">
+                  <ref role="37wK5l" to="s53o:36NsNggQrzG" resolve="setIncludeNodeIds" />
+                  <node concept="3clFbT" id="3s41kb3wdL8" role="37wK5m" />
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3wSNO" role="2OqNvi">
+                <ref role="37wK5l" to="s53o:36NsNggQr$I" resolve="hash" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="3s41kb3wUq0" role="3uHU7w">
+              <node concept="2OqwBi" id="3s41kb3wT_4" role="2Oq$k0">
+                <node concept="2OqwBi" id="3s41kb3wT0O" role="2Oq$k0">
+                  <node concept="2WthIp" id="3s41kb3wT0R" role="2Oq$k0" />
+                  <node concept="2XshWL" id="3s41kb3wT0T" role="2OqNvi">
+                    <ref role="2WH_rO" node="3s41kb3w93N" resolve="create" />
+                    <node concept="37vLTw" id="3s41kb3wTu6" role="2XxRq1">
+                      <ref role="3cqZAo" node="3s41kb3w7Qz" resolve="b" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="liA8E" id="3s41kb3wTU5" role="2OqNvi">
+                  <ref role="37wK5l" to="s53o:36NsNggQrzG" resolve="setIncludeNodeIds" />
+                  <node concept="3clFbT" id="3s41kb3wTXd" role="37wK5m" />
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3wUYi" role="2OqNvi">
+                <ref role="37wK5l" to="s53o:36NsNggQr$I" resolve="hash" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="3s41kb3xJdK" role="1SL9yI">
+      <property role="TrG5h" value="baseConcept_shortDescription" />
+      <node concept="3cqZAl" id="3s41kb3xJdL" role="3clF45" />
+      <node concept="3clFbS" id="3s41kb3xJdP" role="3clF47">
+        <node concept="3cpWs8" id="3s41kb3xJlu" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3xJok" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required link is not initialized `leftExpression'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/3741790230810467494]&quot;;" />
+            <property role="huDt6" value="Error: required link is not initialized `leftExpression'" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3xJlx" role="3cpWs9">
+            <property role="TrG5h" value="a" />
+            <node concept="3Tqbb2" id="3s41kb3xJlt" role="1tU5fm" />
+            <node concept="2pJPEk" id="3s41kb3xJlQ" role="33vP2m">
+              <node concept="2pJPED" id="3s41kb3xJlS" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:fHWc73I" resolve="AndExpression" />
+                <node concept="2pJxcG" id="3s41kb3xJnu" role="2pJxcM">
+                  <ref role="2pJxcJ" to="tpck:gOOYnlO" resolve="shortDescription" />
+                  <node concept="WxPPo" id="3s41kb3xJo3" role="28ntcv">
+                    <node concept="Xl_RD" id="3s41kb3xJo2" role="WxPPp">
+                      <property role="Xl_RC" value="a" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3s41kb3xJol" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3xJom" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required link is not initialized `leftExpression'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/3741790230810467494]&quot;;" />
+            <property role="huDt6" value="Error: required link is not initialized `leftExpression'" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3xJon" role="3cpWs9">
+            <property role="TrG5h" value="b" />
+            <node concept="3Tqbb2" id="3s41kb3xJoo" role="1tU5fm" />
+            <node concept="2pJPEk" id="3s41kb3xJop" role="33vP2m">
+              <node concept="2pJPED" id="3s41kb3xJoq" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:fHWc73I" resolve="AndExpression" />
+                <node concept="2pJxcG" id="3s41kb3xJor" role="2pJxcM">
+                  <ref role="2pJxcJ" to="tpck:gOOYnlO" resolve="shortDescription" />
+                  <node concept="WxPPo" id="3s41kb3xJos" role="28ntcv">
+                    <node concept="Xl_RD" id="3s41kb3xJot" role="WxPPp">
+                      <property role="Xl_RC" value="b" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="3s41kb3xJqi" role="3cqZAp" />
+        <node concept="3vFxKo" id="3s41kb3xJqq" role="3cqZAp">
+          <node concept="17R0WA" id="3s41kb3yy7r" role="3vFALc">
+            <node concept="2OqwBi" id="3s41kb3yy7s" role="3uHU7w">
+              <node concept="2OqwBi" id="3s41kb3yy7t" role="2Oq$k0">
+                <node concept="2OqwBi" id="3s41kb3yy7u" role="2Oq$k0">
+                  <node concept="2WthIp" id="3s41kb3yy7v" role="2Oq$k0" />
+                  <node concept="2XshWL" id="3s41kb3yy7w" role="2OqNvi">
+                    <ref role="2WH_rO" node="3s41kb3w93N" resolve="create" />
+                    <node concept="37vLTw" id="3s41kb3yy7x" role="2XxRq1">
+                      <ref role="3cqZAo" node="3s41kb3xJon" resolve="b" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="liA8E" id="3s41kb3yy7y" role="2OqNvi">
+                  <ref role="37wK5l" to="s53o:36NsNggQrzu" resolve="setIncludeBaseConceptProperties" />
+                  <node concept="3clFbT" id="3s41kb3yyhj" role="37wK5m">
+                    <property role="3clFbU" value="true" />
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3yy7$" role="2OqNvi">
+                <ref role="37wK5l" to="s53o:36NsNggQr$I" resolve="hash" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="3s41kb3yy7_" role="3uHU7B">
+              <node concept="2OqwBi" id="3s41kb3yy7A" role="2Oq$k0">
+                <node concept="2OqwBi" id="3s41kb3yy7B" role="2Oq$k0">
+                  <node concept="2WthIp" id="3s41kb3yy7C" role="2Oq$k0" />
+                  <node concept="2XshWL" id="3s41kb3yy7D" role="2OqNvi">
+                    <ref role="2WH_rO" node="3s41kb3w93N" resolve="create" />
+                    <node concept="37vLTw" id="3s41kb3yy7E" role="2XxRq1">
+                      <ref role="3cqZAo" node="3s41kb3xJlx" resolve="a" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="liA8E" id="3s41kb3yy7F" role="2OqNvi">
+                  <ref role="37wK5l" to="s53o:36NsNggQrzu" resolve="setIncludeBaseConceptProperties" />
+                  <node concept="3clFbT" id="3s41kb3yyfx" role="37wK5m">
+                    <property role="3clFbU" value="true" />
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3yy7H" role="2OqNvi">
+                <ref role="37wK5l" to="s53o:36NsNggQr$I" resolve="hash" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="3s41kb3xMf7" role="1SL9yI">
+      <property role="TrG5h" value="baseConcept_shortDescription_ignored" />
+      <node concept="3cqZAl" id="3s41kb3xMf8" role="3clF45" />
+      <node concept="3clFbS" id="3s41kb3xMf9" role="3clF47">
+        <node concept="3cpWs8" id="3s41kb3xMfa" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3xMfb" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required link is not initialized `leftExpression'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/3741790230810467494]&quot;;" />
+            <property role="huDt6" value="Error: required link is not initialized `leftExpression'" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3xMfc" role="3cpWs9">
+            <property role="TrG5h" value="a" />
+            <node concept="3Tqbb2" id="3s41kb3xMfd" role="1tU5fm" />
+            <node concept="2pJPEk" id="3s41kb3xMfe" role="33vP2m">
+              <node concept="2pJPED" id="3s41kb3xMff" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:fHWc73I" resolve="AndExpression" />
+                <node concept="2pJxcG" id="3s41kb3xMfg" role="2pJxcM">
+                  <ref role="2pJxcJ" to="tpck:gOOYnlO" resolve="shortDescription" />
+                  <node concept="WxPPo" id="3s41kb3xMfh" role="28ntcv">
+                    <node concept="Xl_RD" id="3s41kb3xMfi" role="WxPPp">
+                      <property role="Xl_RC" value="a" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3s41kb3xMfj" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3xMfk" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required link is not initialized `leftExpression'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/3741790230810467494]&quot;;" />
+            <property role="huDt6" value="Error: required link is not initialized `leftExpression'" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3xMfl" role="3cpWs9">
+            <property role="TrG5h" value="b" />
+            <node concept="3Tqbb2" id="3s41kb3xMfm" role="1tU5fm" />
+            <node concept="2pJPEk" id="3s41kb3xMfn" role="33vP2m">
+              <node concept="2pJPED" id="3s41kb3xMfo" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:fHWc73I" resolve="AndExpression" />
+                <node concept="2pJxcG" id="3s41kb3xMfp" role="2pJxcM">
+                  <ref role="2pJxcJ" to="tpck:gOOYnlO" resolve="shortDescription" />
+                  <node concept="WxPPo" id="3s41kb3xMfq" role="28ntcv">
+                    <node concept="Xl_RD" id="3s41kb3xMfr" role="WxPPp">
+                      <property role="Xl_RC" value="b" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="3s41kb3xMfs" role="3cqZAp" />
+        <node concept="3vwNmj" id="3s41kb3xNCN" role="3cqZAp">
+          <node concept="17R0WA" id="3s41kb3xMfu" role="3vwVQn">
+            <node concept="2OqwBi" id="3s41kb3xMfv" role="3uHU7w">
+              <node concept="2OqwBi" id="3s41kb3xMN1" role="2Oq$k0">
+                <node concept="2OqwBi" id="3s41kb3xMfw" role="2Oq$k0">
+                  <node concept="2WthIp" id="3s41kb3xMfx" role="2Oq$k0" />
+                  <node concept="2XshWL" id="3s41kb3xMfy" role="2OqNvi">
+                    <ref role="2WH_rO" node="3s41kb3w93N" resolve="create" />
+                    <node concept="37vLTw" id="3s41kb3xMfz" role="2XxRq1">
+                      <ref role="3cqZAo" node="3s41kb3xMfl" resolve="b" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="liA8E" id="3s41kb3xMZU" role="2OqNvi">
+                  <ref role="37wK5l" to="s53o:36NsNggQrzu" resolve="setIncludeBaseConceptProperties" />
+                  <node concept="3clFbT" id="3s41kb3xN1Q" role="37wK5m" />
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3xMf$" role="2OqNvi">
+                <ref role="37wK5l" to="s53o:36NsNggQr$I" resolve="hash" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="3s41kb3xMf_" role="3uHU7B">
+              <node concept="2OqwBi" id="3s41kb3xMuH" role="2Oq$k0">
+                <node concept="2OqwBi" id="3s41kb3xMfA" role="2Oq$k0">
+                  <node concept="2WthIp" id="3s41kb3xMfB" role="2Oq$k0" />
+                  <node concept="2XshWL" id="3s41kb3xMfC" role="2OqNvi">
+                    <ref role="2WH_rO" node="3s41kb3w93N" resolve="create" />
+                    <node concept="37vLTw" id="3s41kb3xMfD" role="2XxRq1">
+                      <ref role="3cqZAo" node="3s41kb3xMfc" resolve="a" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="liA8E" id="3s41kb3xMwV" role="2OqNvi">
+                  <ref role="37wK5l" to="s53o:36NsNggQrzu" resolve="setIncludeBaseConceptProperties" />
+                  <node concept="3clFbT" id="3s41kb3xN3G" role="37wK5m" />
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3xMfE" role="2OqNvi">
+                <ref role="37wK5l" to="s53o:36NsNggQr$I" resolve="hash" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="3s41kb3y1Wh" role="1SL9yI">
+      <property role="TrG5h" value="baseConcept_virtualPackage" />
+      <node concept="3cqZAl" id="3s41kb3y1Wi" role="3clF45" />
+      <node concept="3clFbS" id="3s41kb3y1Wj" role="3clF47">
+        <node concept="3cpWs8" id="3s41kb3y1Wk" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3y1Wl" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required link is not initialized `leftExpression'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/3741790230810467494]&quot;;" />
+            <property role="huDt6" value="Error: required link is not initialized `leftExpression'" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3y1Wm" role="3cpWs9">
+            <property role="TrG5h" value="a" />
+            <node concept="3Tqbb2" id="3s41kb3y1Wn" role="1tU5fm" />
+            <node concept="2pJPEk" id="3s41kb3y1Wo" role="33vP2m">
+              <node concept="2pJPED" id="3s41kb3y1Wp" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:fHWc73I" resolve="AndExpression" />
+                <node concept="2pJxcG" id="3s41kb3y1Wq" role="2pJxcM">
+                  <ref role="2pJxcJ" to="tpck:hnGE5uv" resolve="virtualPackage" />
+                  <node concept="WxPPo" id="3s41kb3y1Wr" role="28ntcv">
+                    <node concept="Xl_RD" id="3s41kb3y1Ws" role="WxPPp">
+                      <property role="Xl_RC" value="a" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3s41kb3y1Wt" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3y1Wu" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required link is not initialized `leftExpression'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/3741790230810467494]&quot;;" />
+            <property role="huDt6" value="Error: required link is not initialized `leftExpression'" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3y1Wv" role="3cpWs9">
+            <property role="TrG5h" value="b" />
+            <node concept="3Tqbb2" id="3s41kb3y1Ww" role="1tU5fm" />
+            <node concept="2pJPEk" id="3s41kb3y1Wx" role="33vP2m">
+              <node concept="2pJPED" id="3s41kb3y1Wy" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:fHWc73I" resolve="AndExpression" />
+                <node concept="2pJxcG" id="3s41kb3y1Wz" role="2pJxcM">
+                  <ref role="2pJxcJ" to="tpck:hnGE5uv" resolve="virtualPackage" />
+                  <node concept="WxPPo" id="3s41kb3y1W$" role="28ntcv">
+                    <node concept="Xl_RD" id="3s41kb3y1W_" role="WxPPp">
+                      <property role="Xl_RC" value="b" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="3s41kb3y1WA" role="3cqZAp" />
+        <node concept="3vFxKo" id="3s41kb3y1WB" role="3cqZAp">
+          <node concept="17R0WA" id="3s41kb3yxS$" role="3vFALc">
+            <node concept="2OqwBi" id="3s41kb3yxS_" role="3uHU7w">
+              <node concept="2OqwBi" id="3s41kb3yxSA" role="2Oq$k0">
+                <node concept="2OqwBi" id="3s41kb3yxSB" role="2Oq$k0">
+                  <node concept="2WthIp" id="3s41kb3yxSC" role="2Oq$k0" />
+                  <node concept="2XshWL" id="3s41kb3yxSD" role="2OqNvi">
+                    <ref role="2WH_rO" node="3s41kb3w93N" resolve="create" />
+                    <node concept="37vLTw" id="3s41kb3yxSE" role="2XxRq1">
+                      <ref role="3cqZAo" node="3s41kb3y1Wv" resolve="b" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="liA8E" id="3s41kb3yxSF" role="2OqNvi">
+                  <ref role="37wK5l" to="s53o:36NsNggQrzu" resolve="setIncludeBaseConceptProperties" />
+                  <node concept="3clFbT" id="3s41kb3yy5J" role="37wK5m">
+                    <property role="3clFbU" value="true" />
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3yxSH" role="2OqNvi">
+                <ref role="37wK5l" to="s53o:36NsNggQr$I" resolve="hash" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="3s41kb3yxSI" role="3uHU7B">
+              <node concept="2OqwBi" id="3s41kb3yxSJ" role="2Oq$k0">
+                <node concept="2OqwBi" id="3s41kb3yxSK" role="2Oq$k0">
+                  <node concept="2WthIp" id="3s41kb3yxSL" role="2Oq$k0" />
+                  <node concept="2XshWL" id="3s41kb3yxSM" role="2OqNvi">
+                    <ref role="2WH_rO" node="3s41kb3w93N" resolve="create" />
+                    <node concept="37vLTw" id="3s41kb3yxSN" role="2XxRq1">
+                      <ref role="3cqZAo" node="3s41kb3y1Wm" resolve="a" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="liA8E" id="3s41kb3yxSO" role="2OqNvi">
+                  <ref role="37wK5l" to="s53o:36NsNggQrzu" resolve="setIncludeBaseConceptProperties" />
+                  <node concept="3clFbT" id="3s41kb3yy3U" role="37wK5m">
+                    <property role="3clFbU" value="true" />
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3yxSQ" role="2OqNvi">
+                <ref role="37wK5l" to="s53o:36NsNggQr$I" resolve="hash" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="3s41kb3y1VB" role="1SL9yI">
+      <property role="TrG5h" value="baseConcept_virtualPackage_ignored" />
+      <node concept="3cqZAl" id="3s41kb3y1VC" role="3clF45" />
+      <node concept="3clFbS" id="3s41kb3y1VD" role="3clF47">
+        <node concept="3cpWs8" id="3s41kb3y1VE" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3y1VF" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required link is not initialized `leftExpression'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/3741790230810467494]&quot;;" />
+            <property role="huDt6" value="Error: required link is not initialized `leftExpression'" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3y1VG" role="3cpWs9">
+            <property role="TrG5h" value="a" />
+            <node concept="3Tqbb2" id="3s41kb3y1VH" role="1tU5fm" />
+            <node concept="2pJPEk" id="3s41kb3y1VI" role="33vP2m">
+              <node concept="2pJPED" id="3s41kb3y1VJ" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:fHWc73I" resolve="AndExpression" />
+                <node concept="2pJxcG" id="3s41kb3y1VK" role="2pJxcM">
+                  <ref role="2pJxcJ" to="tpck:hnGE5uv" resolve="virtualPackage" />
+                  <node concept="WxPPo" id="3s41kb3y1VL" role="28ntcv">
+                    <node concept="Xl_RD" id="3s41kb3y1VM" role="WxPPp">
+                      <property role="Xl_RC" value="a" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3s41kb3y1VN" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3y1VO" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required link is not initialized `leftExpression'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/3741790230810467494]&quot;;" />
+            <property role="huDt6" value="Error: required link is not initialized `leftExpression'" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3y1VP" role="3cpWs9">
+            <property role="TrG5h" value="b" />
+            <node concept="3Tqbb2" id="3s41kb3y1VQ" role="1tU5fm" />
+            <node concept="2pJPEk" id="3s41kb3y1VR" role="33vP2m">
+              <node concept="2pJPED" id="3s41kb3y1VS" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:fHWc73I" resolve="AndExpression" />
+                <node concept="2pJxcG" id="3s41kb3y1VT" role="2pJxcM">
+                  <ref role="2pJxcJ" to="tpck:hnGE5uv" resolve="virtualPackage" />
+                  <node concept="WxPPo" id="3s41kb3y1VU" role="28ntcv">
+                    <node concept="Xl_RD" id="3s41kb3y1VV" role="WxPPp">
+                      <property role="Xl_RC" value="b" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="3s41kb3y1VW" role="3cqZAp" />
+        <node concept="3vwNmj" id="3s41kb3y1VX" role="3cqZAp">
+          <node concept="17R0WA" id="3s41kb3y1VY" role="3vwVQn">
+            <node concept="2OqwBi" id="3s41kb3y1VZ" role="3uHU7w">
+              <node concept="2OqwBi" id="3s41kb3y1W0" role="2Oq$k0">
+                <node concept="2OqwBi" id="3s41kb3y1W1" role="2Oq$k0">
+                  <node concept="2WthIp" id="3s41kb3y1W2" role="2Oq$k0" />
+                  <node concept="2XshWL" id="3s41kb3y1W3" role="2OqNvi">
+                    <ref role="2WH_rO" node="3s41kb3w93N" resolve="create" />
+                    <node concept="37vLTw" id="3s41kb3y1W4" role="2XxRq1">
+                      <ref role="3cqZAo" node="3s41kb3y1VP" resolve="b" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="liA8E" id="3s41kb3y1W5" role="2OqNvi">
+                  <ref role="37wK5l" to="s53o:36NsNggQrzu" resolve="setIncludeBaseConceptProperties" />
+                  <node concept="3clFbT" id="3s41kb3y1W6" role="37wK5m" />
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3y1W7" role="2OqNvi">
+                <ref role="37wK5l" to="s53o:36NsNggQr$I" resolve="hash" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="3s41kb3y1W8" role="3uHU7B">
+              <node concept="2OqwBi" id="3s41kb3y1W9" role="2Oq$k0">
+                <node concept="2OqwBi" id="3s41kb3y1Wa" role="2Oq$k0">
+                  <node concept="2WthIp" id="3s41kb3y1Wb" role="2Oq$k0" />
+                  <node concept="2XshWL" id="3s41kb3y1Wc" role="2OqNvi">
+                    <ref role="2WH_rO" node="3s41kb3w93N" resolve="create" />
+                    <node concept="37vLTw" id="3s41kb3y1Wd" role="2XxRq1">
+                      <ref role="3cqZAo" node="3s41kb3y1VG" resolve="a" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="liA8E" id="3s41kb3y1We" role="2OqNvi">
+                  <ref role="37wK5l" to="s53o:36NsNggQrzu" resolve="setIncludeBaseConceptProperties" />
+                  <node concept="3clFbT" id="3s41kb3y1Wf" role="37wK5m" />
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3y1Wg" role="2OqNvi">
+                <ref role="37wK5l" to="s53o:36NsNggQr$I" resolve="hash" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="3s41kb3y6iO" role="1SL9yI">
+      <property role="TrG5h" value="baseConcept_smodelAttribute" />
+      <node concept="3cqZAl" id="3s41kb3y6iP" role="3clF45" />
+      <node concept="3clFbS" id="3s41kb3y6iQ" role="3clF47">
+        <node concept="3cpWs8" id="3s41kb3y6iR" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3y6iS" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required link is not initialized `leftExpression'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/3741790230810467494]&quot;;" />
+            <property role="huDt6" value="Error: required link is not initialized `leftExpression'" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3y6iT" role="3cpWs9">
+            <property role="TrG5h" value="a" />
+            <node concept="3Tqbb2" id="3s41kb3y6iU" role="1tU5fm" />
+            <node concept="2pJPEk" id="3s41kb3y6iV" role="33vP2m">
+              <node concept="2pJPED" id="3s41kb3y6iW" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:fHWc73I" resolve="AndExpression" />
+                <node concept="2pIpSj" id="3s41kb3y6TD" role="2pJxcM">
+                  <ref role="2pIpSl" to="tpck:4uZwTti3__2" resolve="smodelAttribute" />
+                  <node concept="36be1Y" id="3s41kb3y6YP" role="28nt2d">
+                    <node concept="2pJPED" id="3s41kb3y6ZO" role="36be1Z">
+                      <ref role="2pJxaS" to="tpck:3Rc6kd0K$RF" resolve="BaseCommentAttribute" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3s41kb3y6j0" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3y6j1" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required link is not initialized `leftExpression'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/3741790230810467494]&quot;;" />
+            <property role="huDt6" value="Error: required link is not initialized `leftExpression'" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3y6j2" role="3cpWs9">
+            <property role="TrG5h" value="b" />
+            <node concept="3Tqbb2" id="3s41kb3y6j3" role="1tU5fm" />
+            <node concept="2pJPEk" id="3s41kb3y6j4" role="33vP2m">
+              <node concept="2pJPED" id="3s41kb3y6j5" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:fHWc73I" resolve="AndExpression" />
+                <node concept="2pIpSj" id="3s41kb3y70P" role="2pJxcM">
+                  <ref role="2pIpSl" to="tpck:4uZwTti3__2" resolve="smodelAttribute" />
+                  <node concept="36be1Y" id="3s41kb3y70Q" role="28nt2d">
+                    <node concept="2pJPED" id="3s41kb3y70R" role="36be1Z">
+                      <ref role="2pJxaS" to="tpck:BpxLfMhSxq" resolve="ChildAttribute" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="3s41kb3y6j9" role="3cqZAp" />
+        <node concept="3vFxKo" id="3s41kb3y6ja" role="3cqZAp">
+          <node concept="17R0WA" id="3s41kb3yxH4" role="3vFALc">
+            <node concept="2OqwBi" id="3s41kb3yxH5" role="3uHU7w">
+              <node concept="2OqwBi" id="3s41kb3yxH6" role="2Oq$k0">
+                <node concept="2OqwBi" id="3s41kb3yxH7" role="2Oq$k0">
+                  <node concept="2WthIp" id="3s41kb3yxH8" role="2Oq$k0" />
+                  <node concept="2XshWL" id="3s41kb3yxH9" role="2OqNvi">
+                    <ref role="2WH_rO" node="3s41kb3w93N" resolve="create" />
+                    <node concept="37vLTw" id="3s41kb3yxHa" role="2XxRq1">
+                      <ref role="3cqZAo" node="3s41kb3y6j2" resolve="b" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="liA8E" id="3s41kb3yxHb" role="2OqNvi">
+                  <ref role="37wK5l" to="s53o:36NsNggQrz_" resolve="setIncludeAnnotations" />
+                  <node concept="3clFbT" id="3s41kb3yxQS" role="37wK5m">
+                    <property role="3clFbU" value="true" />
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3yxHd" role="2OqNvi">
+                <ref role="37wK5l" to="s53o:36NsNggQr$I" resolve="hash" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="3s41kb3yxHe" role="3uHU7B">
+              <node concept="2OqwBi" id="3s41kb3yxHf" role="2Oq$k0">
+                <node concept="2OqwBi" id="3s41kb3yxHg" role="2Oq$k0">
+                  <node concept="2WthIp" id="3s41kb3yxHh" role="2Oq$k0" />
+                  <node concept="2XshWL" id="3s41kb3yxHi" role="2OqNvi">
+                    <ref role="2WH_rO" node="3s41kb3w93N" resolve="create" />
+                    <node concept="37vLTw" id="3s41kb3yxHj" role="2XxRq1">
+                      <ref role="3cqZAo" node="3s41kb3y6iT" resolve="a" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="liA8E" id="3s41kb3yxHk" role="2OqNvi">
+                  <ref role="37wK5l" to="s53o:36NsNggQrz_" resolve="setIncludeAnnotations" />
+                  <node concept="3clFbT" id="3s41kb3yxP6" role="37wK5m">
+                    <property role="3clFbU" value="true" />
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3yxHm" role="2OqNvi">
+                <ref role="37wK5l" to="s53o:36NsNggQr$I" resolve="hash" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="3s41kb3y6ia" role="1SL9yI">
+      <property role="TrG5h" value="baseConcept_smodelAttribute_ignored" />
+      <node concept="3cqZAl" id="3s41kb3y6ib" role="3clF45" />
+      <node concept="3clFbS" id="3s41kb3y6ic" role="3clF47">
+        <node concept="3cpWs8" id="3s41kb3y74j" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3y74k" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required link is not initialized `leftExpression'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/3741790230810467494]&quot;;" />
+            <property role="huDt6" value="Error: required link is not initialized `leftExpression'" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3y74l" role="3cpWs9">
+            <property role="TrG5h" value="a" />
+            <node concept="3Tqbb2" id="3s41kb3y74m" role="1tU5fm" />
+            <node concept="2pJPEk" id="3s41kb3y74n" role="33vP2m">
+              <node concept="2pJPED" id="3s41kb3y74o" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:fHWc73I" resolve="AndExpression" />
+                <node concept="2pIpSj" id="3s41kb3y74p" role="2pJxcM">
+                  <ref role="2pIpSl" to="tpck:4uZwTti3__2" resolve="smodelAttribute" />
+                  <node concept="36be1Y" id="3s41kb3y74q" role="28nt2d">
+                    <node concept="2pJPED" id="3s41kb3y74r" role="36be1Z">
+                      <ref role="2pJxaS" to="tpck:3Rc6kd0K$RF" resolve="BaseCommentAttribute" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3s41kb3y74s" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3y74t" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required link is not initialized `leftExpression'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/3741790230810467494]&quot;;" />
+            <property role="huDt6" value="Error: required link is not initialized `leftExpression'" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3y74u" role="3cpWs9">
+            <property role="TrG5h" value="b" />
+            <node concept="3Tqbb2" id="3s41kb3y74v" role="1tU5fm" />
+            <node concept="2pJPEk" id="3s41kb3y74w" role="33vP2m">
+              <node concept="2pJPED" id="3s41kb3y74x" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:fHWc73I" resolve="AndExpression" />
+                <node concept="2pIpSj" id="3s41kb3y74y" role="2pJxcM">
+                  <ref role="2pIpSl" to="tpck:4uZwTti3__2" resolve="smodelAttribute" />
+                  <node concept="36be1Y" id="3s41kb3y74z" role="28nt2d">
+                    <node concept="2pJPED" id="3s41kb3y74$" role="36be1Z">
+                      <ref role="2pJxaS" to="tpck:BpxLfMhSxq" resolve="ChildAttribute" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="3s41kb3y6iv" role="3cqZAp" />
+        <node concept="3vwNmj" id="3s41kb3y6iw" role="3cqZAp">
+          <node concept="17R0WA" id="3s41kb3y6ix" role="3vwVQn">
+            <node concept="2OqwBi" id="3s41kb3y6iy" role="3uHU7w">
+              <node concept="2OqwBi" id="3s41kb3y6iz" role="2Oq$k0">
+                <node concept="2OqwBi" id="3s41kb3y6i$" role="2Oq$k0">
+                  <node concept="2WthIp" id="3s41kb3y6i_" role="2Oq$k0" />
+                  <node concept="2XshWL" id="3s41kb3y6iA" role="2OqNvi">
+                    <ref role="2WH_rO" node="3s41kb3w93N" resolve="create" />
+                    <node concept="37vLTw" id="3s41kb3y6iB" role="2XxRq1">
+                      <ref role="3cqZAo" node="3s41kb3y74u" resolve="b" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="liA8E" id="3s41kb3y6iC" role="2OqNvi">
+                  <ref role="37wK5l" to="s53o:36NsNggQrz_" resolve="setIncludeAnnotations" />
+                  <node concept="3clFbT" id="3s41kb3y6iD" role="37wK5m" />
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3y6iE" role="2OqNvi">
+                <ref role="37wK5l" to="s53o:36NsNggQr$I" resolve="hash" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="3s41kb3y6iF" role="3uHU7B">
+              <node concept="2OqwBi" id="3s41kb3y6iG" role="2Oq$k0">
+                <node concept="2OqwBi" id="3s41kb3y6iH" role="2Oq$k0">
+                  <node concept="2WthIp" id="3s41kb3y6iI" role="2Oq$k0" />
+                  <node concept="2XshWL" id="3s41kb3y6iJ" role="2OqNvi">
+                    <ref role="2WH_rO" node="3s41kb3w93N" resolve="create" />
+                    <node concept="37vLTw" id="3s41kb3y6iK" role="2XxRq1">
+                      <ref role="3cqZAo" node="3s41kb3y74l" resolve="a" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="liA8E" id="3s41kb3y6iL" role="2OqNvi">
+                  <ref role="37wK5l" to="s53o:36NsNggQrz_" resolve="setIncludeAnnotations" />
+                  <node concept="3clFbT" id="3s41kb3y6iM" role="37wK5m" />
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3y6iN" role="2OqNvi">
+                <ref role="37wK5l" to="s53o:36NsNggQr$I" resolve="hash" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="3s41kb3yh3y" role="1SL9yI">
+      <property role="TrG5h" value="normalizeBooleanProperties_false" />
+      <node concept="3cqZAl" id="3s41kb3yh3z" role="3clF45" />
+      <node concept="3clFbS" id="3s41kb3yh3$" role="3clF47">
+        <node concept="3cpWs8" id="3s41kb3yh3_" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3yh3A" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required link is not initialized `leftExpression'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/3741790230810467494]&quot;;" />
+            <property role="huDt6" value="Error: required link is not initialized `leftExpression'" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3yh3B" role="3cpWs9">
+            <property role="TrG5h" value="a" />
+            <node concept="3Tqbb2" id="3s41kb3yh3C" role="1tU5fm" />
+            <node concept="2pJPEk" id="3s41kb3yh3D" role="33vP2m">
+              <node concept="2pJPED" id="3s41kb3yh3E" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:fzclF8n" resolve="IfStatement" />
+                <node concept="2pJxcG" id="3s41kb3yiCq" role="2pJxcM">
+                  <ref role="2pJxcJ" to="tpee:3RZN444tIdK" resolve="forceOneLine" />
+                  <node concept="WxPPo" id="3s41kb3yiDG" role="28ntcv">
+                    <node concept="3clFbT" id="3s41kb3yiDF" role="WxPPp" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3s41kb3yh3I" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3yh3J" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required link is not initialized `leftExpression'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/3741790230810467494]&quot;;" />
+            <property role="huDt6" value="Error: required link is not initialized `leftExpression'" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3yh3K" role="3cpWs9">
+            <property role="TrG5h" value="b" />
+            <node concept="3Tqbb2" id="3s41kb3yh3L" role="1tU5fm" />
+            <node concept="2pJPEk" id="3s41kb3yh3M" role="33vP2m">
+              <node concept="2pJPED" id="3s41kb3yh3N" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:fzclF8n" resolve="IfStatement" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="3s41kb3yh3R" role="3cqZAp" />
+        <node concept="3vFxKo" id="3s41kb3yuLM" role="3cqZAp">
+          <node concept="17R0WA" id="3s41kb3yh3f" role="3vFALc">
+            <node concept="2OqwBi" id="3s41kb3yh3g" role="3uHU7w">
+              <node concept="2OqwBi" id="3s41kb3yh3h" role="2Oq$k0">
+                <node concept="2OqwBi" id="3s41kb3yh3i" role="2Oq$k0">
+                  <node concept="2WthIp" id="3s41kb3yh3j" role="2Oq$k0" />
+                  <node concept="2XshWL" id="3s41kb3yh3k" role="2OqNvi">
+                    <ref role="2WH_rO" node="3s41kb3w93N" resolve="create" />
+                    <node concept="37vLTw" id="3s41kb3yh3l" role="2XxRq1">
+                      <ref role="3cqZAo" node="3s41kb3yh3K" resolve="b" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="liA8E" id="3s41kb3yh3m" role="2OqNvi">
+                  <ref role="37wK5l" to="s53o:36NsNggQrzT" resolve="setNormalizeBooleanProperties" />
+                  <node concept="3clFbT" id="3s41kb3yh3n" role="37wK5m" />
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3yh3o" role="2OqNvi">
+                <ref role="37wK5l" to="s53o:36NsNggQr$I" resolve="hash" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="3s41kb3yh3p" role="3uHU7B">
+              <node concept="2OqwBi" id="3s41kb3yh3q" role="2Oq$k0">
+                <node concept="2OqwBi" id="3s41kb3yh3r" role="2Oq$k0">
+                  <node concept="2WthIp" id="3s41kb3yh3s" role="2Oq$k0" />
+                  <node concept="2XshWL" id="3s41kb3yh3t" role="2OqNvi">
+                    <ref role="2WH_rO" node="3s41kb3w93N" resolve="create" />
+                    <node concept="37vLTw" id="3s41kb3yh3u" role="2XxRq1">
+                      <ref role="3cqZAo" node="3s41kb3yh3B" resolve="a" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="liA8E" id="3s41kb3yh3v" role="2OqNvi">
+                  <ref role="37wK5l" to="s53o:36NsNggQrzT" resolve="setNormalizeBooleanProperties" />
+                  <node concept="3clFbT" id="3s41kb3yh3w" role="37wK5m" />
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3yh3x" role="2OqNvi">
+                <ref role="37wK5l" to="s53o:36NsNggQr$I" resolve="hash" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="3s41kb3y_vj" role="1SL9yI">
+      <property role="TrG5h" value="normalizeBooleanProperties_false_equal" />
+      <node concept="3cqZAl" id="3s41kb3y_vk" role="3clF45" />
+      <node concept="3clFbS" id="3s41kb3y_vl" role="3clF47">
+        <node concept="3cpWs8" id="3s41kb3y_vm" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3y_vn" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required link is not initialized `leftExpression'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/3741790230810467494]&quot;;" />
+            <property role="huDt6" value="Error: required link is not initialized `leftExpression'" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3y_vo" role="3cpWs9">
+            <property role="TrG5h" value="a" />
+            <node concept="3Tqbb2" id="3s41kb3y_vp" role="1tU5fm" />
+            <node concept="2pJPEk" id="3s41kb3y_vq" role="33vP2m">
+              <node concept="2pJPED" id="3s41kb3y_vr" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:fzclF8n" resolve="IfStatement" />
+                <node concept="2pJxcG" id="3s41kb3y_vs" role="2pJxcM">
+                  <ref role="2pJxcJ" to="tpee:3RZN444tIdK" resolve="forceOneLine" />
+                  <node concept="WxPPo" id="3s41kb3y_vt" role="28ntcv">
+                    <node concept="3clFbT" id="3s41kb3y_vu" role="WxPPp" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3s41kb3y_vv" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3y_vw" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required link is not initialized `leftExpression'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/3741790230810467494]&quot;;" />
+            <property role="huDt6" value="Error: required link is not initialized `leftExpression'" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3y_vx" role="3cpWs9">
+            <property role="TrG5h" value="b" />
+            <node concept="3Tqbb2" id="3s41kb3y_vy" role="1tU5fm" />
+            <node concept="2pJPEk" id="3s41kb3y_vz" role="33vP2m">
+              <node concept="2pJPED" id="3s41kb3y_v$" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:fzclF8n" resolve="IfStatement" />
+                <node concept="2pJxcG" id="3s41kb3yAig" role="2pJxcM">
+                  <ref role="2pJxcJ" to="tpee:3RZN444tIdK" resolve="forceOneLine" />
+                  <node concept="WxPPo" id="3s41kb3yAka" role="28ntcv">
+                    <node concept="3clFbT" id="3s41kb3yAk9" role="WxPPp" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="3s41kb3y_v_" role="3cqZAp" />
+        <node concept="3vwNmj" id="3s41kb3yAoE" role="3cqZAp">
+          <node concept="17R0WA" id="3s41kb3y_vB" role="3vwVQn">
+            <node concept="2OqwBi" id="3s41kb3y_vC" role="3uHU7w">
+              <node concept="2OqwBi" id="3s41kb3y_vD" role="2Oq$k0">
+                <node concept="2OqwBi" id="3s41kb3y_vE" role="2Oq$k0">
+                  <node concept="2WthIp" id="3s41kb3y_vF" role="2Oq$k0" />
+                  <node concept="2XshWL" id="3s41kb3y_vG" role="2OqNvi">
+                    <ref role="2WH_rO" node="3s41kb3w93N" resolve="create" />
+                    <node concept="37vLTw" id="3s41kb3y_vH" role="2XxRq1">
+                      <ref role="3cqZAo" node="3s41kb3y_vx" resolve="b" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="liA8E" id="3s41kb3y_vI" role="2OqNvi">
+                  <ref role="37wK5l" to="s53o:36NsNggQrzT" resolve="setNormalizeBooleanProperties" />
+                  <node concept="3clFbT" id="3s41kb3y_vJ" role="37wK5m" />
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3y_vK" role="2OqNvi">
+                <ref role="37wK5l" to="s53o:36NsNggQr$I" resolve="hash" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="3s41kb3y_vL" role="3uHU7B">
+              <node concept="2OqwBi" id="3s41kb3y_vM" role="2Oq$k0">
+                <node concept="2OqwBi" id="3s41kb3y_vN" role="2Oq$k0">
+                  <node concept="2WthIp" id="3s41kb3y_vO" role="2Oq$k0" />
+                  <node concept="2XshWL" id="3s41kb3y_vP" role="2OqNvi">
+                    <ref role="2WH_rO" node="3s41kb3w93N" resolve="create" />
+                    <node concept="37vLTw" id="3s41kb3y_vQ" role="2XxRq1">
+                      <ref role="3cqZAo" node="3s41kb3y_vo" resolve="a" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="liA8E" id="3s41kb3y_vR" role="2OqNvi">
+                  <ref role="37wK5l" to="s53o:36NsNggQrzT" resolve="setNormalizeBooleanProperties" />
+                  <node concept="3clFbT" id="3s41kb3y_vS" role="37wK5m" />
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3y_vT" role="2OqNvi">
+                <ref role="37wK5l" to="s53o:36NsNggQr$I" resolve="hash" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="3s41kb3yh2S" role="1SL9yI">
+      <property role="TrG5h" value="normalizeBooleanProperties_true" />
+      <node concept="3cqZAl" id="3s41kb3yh2T" role="3clF45" />
+      <node concept="3clFbS" id="3s41kb3yh2U" role="3clF47">
+        <node concept="3cpWs8" id="3s41kb3yiGM" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3yiGN" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required link is not initialized `leftExpression'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/3741790230810467494]&quot;;" />
+            <property role="huDt6" value="Error: required link is not initialized `leftExpression'" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3yiGO" role="3cpWs9">
+            <property role="TrG5h" value="a" />
+            <node concept="3Tqbb2" id="3s41kb3yiGP" role="1tU5fm" />
+            <node concept="2pJPEk" id="3s41kb3yiGQ" role="33vP2m">
+              <node concept="2pJPED" id="3s41kb3yiGR" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:fzclF8n" resolve="IfStatement" />
+                <node concept="2pJxcG" id="3s41kb3yiGS" role="2pJxcM">
+                  <ref role="2pJxcJ" to="tpee:3RZN444tIdK" resolve="forceOneLine" />
+                  <node concept="WxPPo" id="3s41kb3yiGT" role="28ntcv">
+                    <node concept="3clFbT" id="3s41kb3yiGU" role="WxPPp" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3s41kb3yiGV" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3yiGW" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required link is not initialized `leftExpression'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/3741790230810467494]&quot;;" />
+            <property role="huDt6" value="Error: required link is not initialized `leftExpression'" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3yiGX" role="3cpWs9">
+            <property role="TrG5h" value="b" />
+            <node concept="3Tqbb2" id="3s41kb3yiGY" role="1tU5fm" />
+            <node concept="2pJPEk" id="3s41kb3yiGZ" role="33vP2m">
+              <node concept="2pJPED" id="3s41kb3yiH0" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:fzclF8n" resolve="IfStatement" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="3s41kb3yh3d" role="3cqZAp" />
+        <node concept="3vwNmj" id="3s41kb3yqQx" role="3cqZAp">
+          <node concept="17R0WA" id="3s41kb3yqQy" role="3vwVQn">
+            <node concept="2OqwBi" id="3s41kb3yqQz" role="3uHU7w">
+              <node concept="2OqwBi" id="3s41kb3yqQ$" role="2Oq$k0">
+                <node concept="2OqwBi" id="3s41kb3yqQ_" role="2Oq$k0">
+                  <node concept="2WthIp" id="3s41kb3yqQA" role="2Oq$k0" />
+                  <node concept="2XshWL" id="3s41kb3yqQB" role="2OqNvi">
+                    <ref role="2WH_rO" node="3s41kb3w93N" resolve="create" />
+                    <node concept="37vLTw" id="3s41kb3yqQC" role="2XxRq1">
+                      <ref role="3cqZAo" node="3s41kb3yiGX" resolve="b" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="liA8E" id="3s41kb3yqQD" role="2OqNvi">
+                  <ref role="37wK5l" to="s53o:36NsNggQrzT" resolve="setNormalizeBooleanProperties" />
+                  <node concept="3clFbT" id="3s41kb3yrZU" role="37wK5m">
+                    <property role="3clFbU" value="true" />
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3yqQF" role="2OqNvi">
+                <ref role="37wK5l" to="s53o:36NsNggQr$I" resolve="hash" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="3s41kb3yqQG" role="3uHU7B">
+              <node concept="2OqwBi" id="3s41kb3yqQH" role="2Oq$k0">
+                <node concept="2OqwBi" id="3s41kb3yqQI" role="2Oq$k0">
+                  <node concept="2WthIp" id="3s41kb3yqQJ" role="2Oq$k0" />
+                  <node concept="2XshWL" id="3s41kb3yqQK" role="2OqNvi">
+                    <ref role="2WH_rO" node="3s41kb3w93N" resolve="create" />
+                    <node concept="37vLTw" id="3s41kb3yqQL" role="2XxRq1">
+                      <ref role="3cqZAo" node="3s41kb3yiGO" resolve="a" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="liA8E" id="3s41kb3yqQM" role="2OqNvi">
+                  <ref role="37wK5l" to="s53o:36NsNggQrzT" resolve="setNormalizeBooleanProperties" />
+                  <node concept="3clFbT" id="3s41kb3yrY8" role="37wK5m">
+                    <property role="3clFbU" value="true" />
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3yqQO" role="2OqNvi">
+                <ref role="37wK5l" to="s53o:36NsNggQr$I" resolve="hash" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="2XOHcx" id="5kFTseQQT1w">
+    <property role="2XOHcw" value="${extensions.home}/code" />
+  </node>
+  <node concept="1lH9Xt" id="3s41kb3A6jO">
+    <property role="3DII0k" value="2hh8MJdVwqX/command" />
+    <property role="TrG5h" value="NodeHasherTests_Properties" />
+    <node concept="2XrIbr" id="3s41kb3A6jP" role="1qtyYc">
+      <property role="TrG5h" value="create" />
+      <node concept="3uibUv" id="3s41kb3A6jQ" role="3clF45">
+        <ref role="3uigEE" to="s53o:36NsNggQrub" resolve="NodeHasher" />
+      </node>
+      <node concept="3clFbS" id="3s41kb3A6jR" role="3clF47">
+        <node concept="3clFbF" id="3s41kb3A6jS" role="3cqZAp">
+          <node concept="2OqwBi" id="3s41kb3A6jT" role="3clFbG">
+            <node concept="2ShNRf" id="3s41kb3A6jU" role="2Oq$k0">
+              <node concept="1pGfFk" id="3s41kb3A6jV" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="s53o:36NsNggQryX" resolve="NodeHasher" />
+                <node concept="2OqwBi" id="3s41kb3A6jW" role="37wK5m">
+                  <node concept="2OqwBi" id="3s41kb3A6jX" role="2Oq$k0">
+                    <node concept="37vLTw" id="3s41kb3A6jY" role="2Oq$k0">
+                      <ref role="3cqZAo" node="3s41kb3A6k4" resolve="nodes" />
+                    </node>
+                    <node concept="39bAoz" id="3s41kb3A6jZ" role="2OqNvi" />
+                  </node>
+                  <node concept="ANE8D" id="3s41kb3A6k0" role="2OqNvi" />
+                </node>
+                <node concept="2nou5x" id="3s41kb3A6k1" role="37wK5m">
+                  <property role="2noCCI" value="456" />
+                </node>
+              </node>
+            </node>
+            <node concept="liA8E" id="3s41kb3A6k2" role="2OqNvi">
+              <ref role="37wK5l" to="s53o:36NsNggQrzG" resolve="setIncludeNodeIds" />
+              <node concept="3clFbT" id="3s41kb3A6k3" role="37wK5m" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="3s41kb3A6k4" role="3clF46">
+        <property role="TrG5h" value="nodes" />
+        <node concept="8X2XB" id="3s41kb3A6k5" role="1tU5fm">
+          <node concept="3Tqbb2" id="3s41kb3A6k6" role="8Xvag" />
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="3s41kb3zVZN" role="1SL9yI">
+      <property role="TrG5h" value="different" />
+      <node concept="3cqZAl" id="3s41kb3zVZO" role="3clF45" />
+      <node concept="3clFbS" id="3s41kb3zVZP" role="3clF47">
+        <node concept="3cpWs8" id="3s41kb3zVZQ" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3zVZR" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required link is not initialized `leftExpression'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/3741790230810467494]&quot;;" />
+            <property role="huDt6" value="Error: required link is not initialized `leftExpression'" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3zVZS" role="3cpWs9">
+            <property role="TrG5h" value="a" />
+            <node concept="3Tqbb2" id="3s41kb3zVZT" role="1tU5fm" />
+            <node concept="2pJPEk" id="3s41kb3zVZU" role="33vP2m">
+              <node concept="2pJPED" id="3s41kb3zVZV" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:6LFqxSRBTg8" resolve="MethodDeclaration" />
+                <node concept="2pJxcG" id="3s41kb3zVZW" role="2pJxcM">
+                  <ref role="2pJxcJ" to="tpck:h0TrG11" resolve="name" />
+                  <node concept="WxPPo" id="3s41kb3zVZX" role="28ntcv">
+                    <node concept="Xl_RD" id="3s41kb3zVZY" role="WxPPp">
+                      <property role="Xl_RC" value="a" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3s41kb3zVZZ" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3zW00" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required link is not initialized `leftExpression'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/3741790230810467494]&quot;;" />
+            <property role="huDt6" value="Error: required link is not initialized `leftExpression'" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3zW01" role="3cpWs9">
+            <property role="TrG5h" value="b" />
+            <node concept="3Tqbb2" id="3s41kb3zW02" role="1tU5fm" />
+            <node concept="2pJPEk" id="3s41kb3zW03" role="33vP2m">
+              <node concept="2pJPED" id="3s41kb3zW04" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:6LFqxSRBTg8" resolve="MethodDeclaration" />
+                <node concept="2pJxcG" id="3s41kb3zW05" role="2pJxcM">
+                  <ref role="2pJxcJ" to="tpck:h0TrG11" resolve="name" />
+                  <node concept="WxPPo" id="3s41kb3zW06" role="28ntcv">
+                    <node concept="Xl_RD" id="3s41kb3zW07" role="WxPPp">
+                      <property role="Xl_RC" value="b" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="3s41kb3zW08" role="3cqZAp" />
+        <node concept="3vFxKo" id="3s41kb3zW09" role="3cqZAp">
+          <node concept="17R0WA" id="3s41kb3zW0a" role="3vFALc">
+            <node concept="2OqwBi" id="3s41kb3zW0b" role="3uHU7w">
+              <node concept="2OqwBi" id="3s41kb3zW0c" role="2Oq$k0">
+                <node concept="2WthIp" id="3s41kb3zW0d" role="2Oq$k0" />
+                <node concept="2XshWL" id="3s41kb3zW0e" role="2OqNvi">
+                  <ref role="2WH_rO" node="3s41kb3A6jP" resolve="create" />
+                  <node concept="37vLTw" id="3s41kb3zW0f" role="2XxRq1">
+                    <ref role="3cqZAo" node="3s41kb3zW01" resolve="b" />
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3zW0g" role="2OqNvi">
+                <ref role="37wK5l" to="s53o:36NsNggQr$I" resolve="hash" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="3s41kb3zW0h" role="3uHU7B">
+              <node concept="2OqwBi" id="3s41kb3zW0i" role="2Oq$k0">
+                <node concept="2WthIp" id="3s41kb3zW0j" role="2Oq$k0" />
+                <node concept="2XshWL" id="3s41kb3zW0k" role="2OqNvi">
+                  <ref role="2WH_rO" node="3s41kb3A6jP" resolve="create" />
+                  <node concept="37vLTw" id="3s41kb3zW0l" role="2XxRq1">
+                    <ref role="3cqZAo" node="3s41kb3zVZS" resolve="a" />
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3zW0m" role="2OqNvi">
+                <ref role="37wK5l" to="s53o:36NsNggQr$I" resolve="hash" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="3s41kb3A6tZ" role="1SL9yI">
+      <property role="TrG5h" value="different_ignored" />
+      <node concept="3cqZAl" id="3s41kb3A6u0" role="3clF45" />
+      <node concept="3clFbS" id="3s41kb3A6u1" role="3clF47">
+        <node concept="3cpWs8" id="3s41kb3A6u2" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3A6u3" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required link is not initialized `leftExpression'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/3741790230810467494]&quot;;" />
+            <property role="huDt6" value="Error: required link is not initialized `leftExpression'" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3A6u4" role="3cpWs9">
+            <property role="TrG5h" value="a" />
+            <node concept="3Tqbb2" id="3s41kb3A6u5" role="1tU5fm" />
+            <node concept="2pJPEk" id="3s41kb3A6u6" role="33vP2m">
+              <node concept="2pJPED" id="3s41kb3A6u7" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:6LFqxSRBTg8" resolve="MethodDeclaration" />
+                <node concept="2pJxcG" id="3s41kb3A6u8" role="2pJxcM">
+                  <ref role="2pJxcJ" to="tpck:h0TrG11" resolve="name" />
+                  <node concept="WxPPo" id="3s41kb3A6u9" role="28ntcv">
+                    <node concept="Xl_RD" id="3s41kb3A6ua" role="WxPPp">
+                      <property role="Xl_RC" value="a" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3s41kb3A6ub" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3A6uc" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required link is not initialized `leftExpression'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/3741790230810467494]&quot;;" />
+            <property role="huDt6" value="Error: required link is not initialized `leftExpression'" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3A6ud" role="3cpWs9">
+            <property role="TrG5h" value="b" />
+            <node concept="3Tqbb2" id="3s41kb3A6ue" role="1tU5fm" />
+            <node concept="2pJPEk" id="3s41kb3A6uf" role="33vP2m">
+              <node concept="2pJPED" id="3s41kb3A6ug" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:6LFqxSRBTg8" resolve="MethodDeclaration" />
+                <node concept="2pJxcG" id="3s41kb3A6uh" role="2pJxcM">
+                  <ref role="2pJxcJ" to="tpck:h0TrG11" resolve="name" />
+                  <node concept="WxPPo" id="3s41kb3A6ui" role="28ntcv">
+                    <node concept="Xl_RD" id="3s41kb3A6uj" role="WxPPp">
+                      <property role="Xl_RC" value="b" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="3s41kb3A6uk" role="3cqZAp" />
+        <node concept="3vwNmj" id="3s41kb3A6ul" role="3cqZAp">
+          <node concept="17R0WA" id="3s41kb3A6um" role="3vwVQn">
+            <node concept="2OqwBi" id="3s41kb3A6un" role="3uHU7w">
+              <node concept="2OqwBi" id="3s41kb3A6uo" role="2Oq$k0">
+                <node concept="2OqwBi" id="3s41kb3A6up" role="2Oq$k0">
+                  <node concept="2WthIp" id="3s41kb3A6uq" role="2Oq$k0" />
+                  <node concept="2XshWL" id="3s41kb3A6ur" role="2OqNvi">
+                    <ref role="2WH_rO" node="3s41kb3A6jP" resolve="create" />
+                    <node concept="37vLTw" id="3s41kb3A6us" role="2XxRq1">
+                      <ref role="3cqZAo" node="3s41kb3A6ud" resolve="b" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="liA8E" id="3s41kb3A6ut" role="2OqNvi">
+                  <ref role="37wK5l" to="s53o:36NsNggQr$6" resolve="ignore" />
+                  <node concept="355D3s" id="3s41kb3A6uu" role="37wK5m">
+                    <ref role="355D3t" to="tpck:h0TrEE$" resolve="INamedConcept" />
+                    <ref role="355D3u" to="tpck:h0TrG11" resolve="name" />
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3A6uv" role="2OqNvi">
+                <ref role="37wK5l" to="s53o:36NsNggQr$I" resolve="hash" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="3s41kb3A6uw" role="3uHU7B">
+              <node concept="2OqwBi" id="3s41kb3A6ux" role="2Oq$k0">
+                <node concept="2OqwBi" id="3s41kb3A6uy" role="2Oq$k0">
+                  <node concept="2WthIp" id="3s41kb3A6uz" role="2Oq$k0" />
+                  <node concept="2XshWL" id="3s41kb3A6u$" role="2OqNvi">
+                    <ref role="2WH_rO" node="3s41kb3A6jP" resolve="create" />
+                    <node concept="37vLTw" id="3s41kb3A6u_" role="2XxRq1">
+                      <ref role="3cqZAo" node="3s41kb3A6u4" resolve="a" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="liA8E" id="3s41kb3A6uA" role="2OqNvi">
+                  <ref role="37wK5l" to="s53o:36NsNggQr$6" resolve="ignore" />
+                  <node concept="355D3s" id="3s41kb3A6uB" role="37wK5m">
+                    <ref role="355D3t" to="tpck:h0TrEE$" resolve="INamedConcept" />
+                    <ref role="355D3u" to="tpck:h0TrG11" resolve="name" />
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3A6uC" role="2OqNvi">
+                <ref role="37wK5l" to="s53o:36NsNggQr$I" resolve="hash" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="3s41kb3A6uD" role="1SL9yI">
+      <property role="TrG5h" value="same" />
+      <node concept="3cqZAl" id="3s41kb3A6uE" role="3clF45" />
+      <node concept="3clFbS" id="3s41kb3A6uF" role="3clF47">
+        <node concept="3cpWs8" id="3s41kb3A6uG" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3A6uH" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required link is not initialized `leftExpression'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/3741790230810467494]&quot;;" />
+            <property role="huDt6" value="Error: required link is not initialized `leftExpression'" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3A6uI" role="3cpWs9">
+            <property role="TrG5h" value="a" />
+            <node concept="3Tqbb2" id="3s41kb3A6uJ" role="1tU5fm" />
+            <node concept="2pJPEk" id="3s41kb3A6uK" role="33vP2m">
+              <node concept="2pJPED" id="3s41kb3A6uL" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:6LFqxSRBTg8" resolve="MethodDeclaration" />
+                <node concept="2pJxcG" id="3s41kb3A6uM" role="2pJxcM">
+                  <ref role="2pJxcJ" to="tpck:h0TrG11" resolve="name" />
+                  <node concept="WxPPo" id="3s41kb3A6uN" role="28ntcv">
+                    <node concept="Xl_RD" id="3s41kb3A6uO" role="WxPPp">
+                      <property role="Xl_RC" value="x" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3s41kb3A6uP" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3A6uQ" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required link is not initialized `leftExpression'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/3741790230810467494]&quot;;" />
+            <property role="huDt6" value="Error: required link is not initialized `leftExpression'" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3A6uR" role="3cpWs9">
+            <property role="TrG5h" value="b" />
+            <node concept="3Tqbb2" id="3s41kb3A6uS" role="1tU5fm" />
+            <node concept="2pJPEk" id="3s41kb3A6uT" role="33vP2m">
+              <node concept="2pJPED" id="3s41kb3A6uU" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:6LFqxSRBTg8" resolve="MethodDeclaration" />
+                <node concept="2pJxcG" id="3s41kb3A6uV" role="2pJxcM">
+                  <ref role="2pJxcJ" to="tpck:h0TrG11" resolve="name" />
+                  <node concept="WxPPo" id="3s41kb3A6uW" role="28ntcv">
+                    <node concept="Xl_RD" id="3s41kb3A6uX" role="WxPPp">
+                      <property role="Xl_RC" value="x" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="3s41kb3A6uY" role="3cqZAp" />
+        <node concept="3vwNmj" id="3s41kb3A6uZ" role="3cqZAp">
+          <node concept="17R0WA" id="3s41kb3A6v0" role="3vwVQn">
+            <node concept="2OqwBi" id="3s41kb3A6v1" role="3uHU7w">
+              <node concept="2OqwBi" id="3s41kb3A6v2" role="2Oq$k0">
+                <node concept="2WthIp" id="3s41kb3A6v3" role="2Oq$k0" />
+                <node concept="2XshWL" id="3s41kb3A6v4" role="2OqNvi">
+                  <ref role="2WH_rO" node="3s41kb3A6jP" resolve="create" />
+                  <node concept="37vLTw" id="3s41kb3A6v5" role="2XxRq1">
+                    <ref role="3cqZAo" node="3s41kb3A6uR" resolve="b" />
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3A6v6" role="2OqNvi">
+                <ref role="37wK5l" to="s53o:36NsNggQr$I" resolve="hash" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="3s41kb3A6v7" role="3uHU7B">
+              <node concept="2OqwBi" id="3s41kb3A6v8" role="2Oq$k0">
+                <node concept="2WthIp" id="3s41kb3A6v9" role="2Oq$k0" />
+                <node concept="2XshWL" id="3s41kb3A6va" role="2OqNvi">
+                  <ref role="2WH_rO" node="3s41kb3A6jP" resolve="create" />
+                  <node concept="37vLTw" id="3s41kb3A6vb" role="2XxRq1">
+                    <ref role="3cqZAo" node="3s41kb3A6uI" resolve="a" />
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3A6vc" role="2OqNvi">
+                <ref role="37wK5l" to="s53o:36NsNggQr$I" resolve="hash" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="3s41kb3A6vd" role="1SL9yI">
+      <property role="TrG5h" value="same_ignored" />
+      <node concept="3cqZAl" id="3s41kb3A6ve" role="3clF45" />
+      <node concept="3clFbS" id="3s41kb3A6vf" role="3clF47">
+        <node concept="3cpWs8" id="3s41kb3A6vg" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3A6vh" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required link is not initialized `leftExpression'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/3741790230810467494]&quot;;" />
+            <property role="huDt6" value="Error: required link is not initialized `leftExpression'" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3A6vi" role="3cpWs9">
+            <property role="TrG5h" value="a" />
+            <node concept="3Tqbb2" id="3s41kb3A6vj" role="1tU5fm" />
+            <node concept="2pJPEk" id="3s41kb3A6vk" role="33vP2m">
+              <node concept="2pJPED" id="3s41kb3A6vl" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:6LFqxSRBTg8" resolve="MethodDeclaration" />
+                <node concept="2pJxcG" id="3s41kb3A6vm" role="2pJxcM">
+                  <ref role="2pJxcJ" to="tpck:h0TrG11" resolve="name" />
+                  <node concept="WxPPo" id="3s41kb3A6vn" role="28ntcv">
+                    <node concept="Xl_RD" id="3s41kb3A6vo" role="WxPPp">
+                      <property role="Xl_RC" value="x" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3s41kb3A6vp" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3A6vq" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required link is not initialized `leftExpression'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/3741790230810467494]&quot;;" />
+            <property role="huDt6" value="Error: required link is not initialized `leftExpression'" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3A6vr" role="3cpWs9">
+            <property role="TrG5h" value="b" />
+            <node concept="3Tqbb2" id="3s41kb3A6vs" role="1tU5fm" />
+            <node concept="2pJPEk" id="3s41kb3A6vt" role="33vP2m">
+              <node concept="2pJPED" id="3s41kb3A6vu" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:6LFqxSRBTg8" resolve="MethodDeclaration" />
+                <node concept="2pJxcG" id="3s41kb3A6vv" role="2pJxcM">
+                  <ref role="2pJxcJ" to="tpck:h0TrG11" resolve="name" />
+                  <node concept="WxPPo" id="3s41kb3A6vw" role="28ntcv">
+                    <node concept="Xl_RD" id="3s41kb3A6vx" role="WxPPp">
+                      <property role="Xl_RC" value="x" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="3s41kb3A6vy" role="3cqZAp" />
+        <node concept="3vwNmj" id="3s41kb3A6vz" role="3cqZAp">
+          <node concept="17R0WA" id="3s41kb3A6v$" role="3vwVQn">
+            <node concept="2OqwBi" id="3s41kb3A6v_" role="3uHU7w">
+              <node concept="2OqwBi" id="3s41kb3A6vA" role="2Oq$k0">
+                <node concept="2OqwBi" id="3s41kb3A6vB" role="2Oq$k0">
+                  <node concept="2WthIp" id="3s41kb3A6vC" role="2Oq$k0" />
+                  <node concept="2XshWL" id="3s41kb3A6vD" role="2OqNvi">
+                    <ref role="2WH_rO" node="3s41kb3A6jP" resolve="create" />
+                    <node concept="37vLTw" id="3s41kb3A6vE" role="2XxRq1">
+                      <ref role="3cqZAo" node="3s41kb3A6vr" resolve="b" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="liA8E" id="3s41kb3A6vF" role="2OqNvi">
+                  <ref role="37wK5l" to="s53o:36NsNggQr$6" resolve="ignore" />
+                  <node concept="355D3s" id="3s41kb3A6vG" role="37wK5m">
+                    <ref role="355D3t" to="tpck:h0TrEE$" resolve="INamedConcept" />
+                    <ref role="355D3u" to="tpck:h0TrG11" resolve="name" />
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3A6vH" role="2OqNvi">
+                <ref role="37wK5l" to="s53o:36NsNggQr$I" resolve="hash" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="3s41kb3A6vI" role="3uHU7B">
+              <node concept="2OqwBi" id="3s41kb3A6vJ" role="2Oq$k0">
+                <node concept="2OqwBi" id="3s41kb3A6vK" role="2Oq$k0">
+                  <node concept="2WthIp" id="3s41kb3A6vL" role="2Oq$k0" />
+                  <node concept="2XshWL" id="3s41kb3A6vM" role="2OqNvi">
+                    <ref role="2WH_rO" node="3s41kb3A6jP" resolve="create" />
+                    <node concept="37vLTw" id="3s41kb3A6vN" role="2XxRq1">
+                      <ref role="3cqZAo" node="3s41kb3A6vi" resolve="a" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="liA8E" id="3s41kb3A6vO" role="2OqNvi">
+                  <ref role="37wK5l" to="s53o:36NsNggQr$6" resolve="ignore" />
+                  <node concept="355D3s" id="3s41kb3A6vP" role="37wK5m">
+                    <ref role="355D3t" to="tpck:h0TrEE$" resolve="INamedConcept" />
+                    <ref role="355D3u" to="tpck:h0TrG11" resolve="name" />
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3A6vQ" role="2OqNvi">
+                <ref role="37wK5l" to="s53o:36NsNggQr$I" resolve="hash" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="3s41kb3A6vR" role="1SL9yI">
+      <property role="TrG5h" value="sameOrder" />
+      <node concept="3cqZAl" id="3s41kb3A6vS" role="3clF45" />
+      <node concept="3clFbS" id="3s41kb3A6vT" role="3clF47">
+        <node concept="3cpWs8" id="3s41kb3A6vU" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3A6vV" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required link is not initialized `leftExpression'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/3741790230810467494]&quot;;" />
+            <property role="huDt6" value="Error: required link is not initialized `leftExpression'" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3A6vW" role="3cpWs9">
+            <property role="TrG5h" value="a" />
+            <node concept="3Tqbb2" id="3s41kb3A6vX" role="1tU5fm" />
+            <node concept="2pJPEk" id="3s41kb3A6vY" role="33vP2m">
+              <node concept="2pJPED" id="3s41kb3A6vZ" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:6LFqxSRBTg8" resolve="MethodDeclaration" />
+                <node concept="2pJxcG" id="3s41kb3A6w0" role="2pJxcM">
+                  <ref role="2pJxcJ" to="tpck:h0TrG11" resolve="name" />
+                  <node concept="WxPPo" id="3s41kb3A6w1" role="28ntcv">
+                    <node concept="Xl_RD" id="3s41kb3A6w2" role="WxPPp">
+                      <property role="Xl_RC" value="x" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2pJxcG" id="3s41kb3A6w3" role="2pJxcM">
+                  <ref role="2pJxcJ" to="tpee:hcDiZZi" resolve="isFinal" />
+                  <node concept="WxPPo" id="3s41kb3A6w4" role="28ntcv">
+                    <node concept="3clFbT" id="3s41kb3A6w5" role="WxPPp">
+                      <property role="3clFbU" value="true" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3s41kb3A6w6" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3A6w7" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required link is not initialized `leftExpression'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/3741790230810467494]&quot;;" />
+            <property role="huDt6" value="Error: required link is not initialized `leftExpression'" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3A6w8" role="3cpWs9">
+            <property role="TrG5h" value="b" />
+            <node concept="3Tqbb2" id="3s41kb3A6w9" role="1tU5fm" />
+            <node concept="2pJPEk" id="3s41kb3A6wa" role="33vP2m">
+              <node concept="2pJPED" id="3s41kb3A6wb" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:6LFqxSRBTg8" resolve="MethodDeclaration" />
+                <node concept="2pJxcG" id="3s41kb3A6wc" role="2pJxcM">
+                  <ref role="2pJxcJ" to="tpck:h0TrG11" resolve="name" />
+                  <node concept="WxPPo" id="3s41kb3A6wd" role="28ntcv">
+                    <node concept="Xl_RD" id="3s41kb3A6we" role="WxPPp">
+                      <property role="Xl_RC" value="x" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2pJxcG" id="3s41kb3A6wf" role="2pJxcM">
+                  <ref role="2pJxcJ" to="tpee:hcDiZZi" resolve="isFinal" />
+                  <node concept="WxPPo" id="3s41kb3A6wg" role="28ntcv">
+                    <node concept="3clFbT" id="3s41kb3A6wh" role="WxPPp">
+                      <property role="3clFbU" value="true" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="3s41kb3A6wi" role="3cqZAp" />
+        <node concept="3vwNmj" id="3s41kb3A6wj" role="3cqZAp">
+          <node concept="17R0WA" id="3s41kb3A6wk" role="3vwVQn">
+            <node concept="2OqwBi" id="3s41kb3A6wl" role="3uHU7w">
+              <node concept="2OqwBi" id="3s41kb3A6wm" role="2Oq$k0">
+                <node concept="2WthIp" id="3s41kb3A6wn" role="2Oq$k0" />
+                <node concept="2XshWL" id="3s41kb3A6wo" role="2OqNvi">
+                  <ref role="2WH_rO" node="3s41kb3A6jP" resolve="create" />
+                  <node concept="37vLTw" id="3s41kb3A6wp" role="2XxRq1">
+                    <ref role="3cqZAo" node="3s41kb3A6w8" resolve="b" />
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3A6wq" role="2OqNvi">
+                <ref role="37wK5l" to="s53o:36NsNggQr$I" resolve="hash" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="3s41kb3A6wr" role="3uHU7B">
+              <node concept="2OqwBi" id="3s41kb3A6ws" role="2Oq$k0">
+                <node concept="2WthIp" id="3s41kb3A6wt" role="2Oq$k0" />
+                <node concept="2XshWL" id="3s41kb3A6wu" role="2OqNvi">
+                  <ref role="2WH_rO" node="3s41kb3A6jP" resolve="create" />
+                  <node concept="37vLTw" id="3s41kb3A6wv" role="2XxRq1">
+                    <ref role="3cqZAo" node="3s41kb3A6vW" resolve="a" />
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3A6ww" role="2OqNvi">
+                <ref role="37wK5l" to="s53o:36NsNggQr$I" resolve="hash" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="3s41kb3A6wx" role="1SL9yI">
+      <property role="TrG5h" value="differentOrder" />
+      <node concept="3cqZAl" id="3s41kb3A6wy" role="3clF45" />
+      <node concept="3clFbS" id="3s41kb3A6wz" role="3clF47">
+        <node concept="3cpWs8" id="3s41kb3A6w$" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3A6w_" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required link is not initialized `leftExpression'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/3741790230810467494]&quot;;" />
+            <property role="huDt6" value="Error: required link is not initialized `leftExpression'" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3A6wA" role="3cpWs9">
+            <property role="TrG5h" value="a" />
+            <node concept="3Tqbb2" id="3s41kb3A6wB" role="1tU5fm" />
+            <node concept="2pJPEk" id="3s41kb3A6wC" role="33vP2m">
+              <node concept="2pJPED" id="3s41kb3A6wD" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:6LFqxSRBTg8" resolve="MethodDeclaration" />
+                <node concept="2pJxcG" id="3s41kb3A6wE" role="2pJxcM">
+                  <ref role="2pJxcJ" to="tpck:h0TrG11" resolve="name" />
+                  <node concept="WxPPo" id="3s41kb3A6wF" role="28ntcv">
+                    <node concept="Xl_RD" id="3s41kb3A6wG" role="WxPPp">
+                      <property role="Xl_RC" value="x" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2pJxcG" id="3s41kb3A6wH" role="2pJxcM">
+                  <ref role="2pJxcJ" to="tpee:hcDiZZi" resolve="isFinal" />
+                  <node concept="WxPPo" id="3s41kb3A6wI" role="28ntcv">
+                    <node concept="3clFbT" id="3s41kb3A6wJ" role="WxPPp">
+                      <property role="3clFbU" value="true" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3s41kb3A6wK" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3A6wL" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required link is not initialized `leftExpression'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/3741790230810467494]&quot;;" />
+            <property role="huDt6" value="Error: required link is not initialized `leftExpression'" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3A6wM" role="3cpWs9">
+            <property role="TrG5h" value="b" />
+            <node concept="3Tqbb2" id="3s41kb3A6wN" role="1tU5fm" />
+            <node concept="2pJPEk" id="3s41kb3A6wO" role="33vP2m">
+              <node concept="2pJPED" id="3s41kb3A6wP" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:6LFqxSRBTg8" resolve="MethodDeclaration" />
+                <node concept="2pJxcG" id="3s41kb3A6wQ" role="2pJxcM">
+                  <ref role="2pJxcJ" to="tpee:hcDiZZi" resolve="isFinal" />
+                  <node concept="WxPPo" id="3s41kb3A6wR" role="28ntcv">
+                    <node concept="3clFbT" id="3s41kb3A6wS" role="WxPPp">
+                      <property role="3clFbU" value="true" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2pJxcG" id="3s41kb3A6wT" role="2pJxcM">
+                  <ref role="2pJxcJ" to="tpck:h0TrG11" resolve="name" />
+                  <node concept="WxPPo" id="3s41kb3A6wU" role="28ntcv">
+                    <node concept="Xl_RD" id="3s41kb3A6wV" role="WxPPp">
+                      <property role="Xl_RC" value="x" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="3s41kb3A6wW" role="3cqZAp" />
+        <node concept="3vlDli" id="3s41kb3A6wX" role="3cqZAp">
+          <node concept="2OqwBi" id="3s41kb3A6wY" role="3tpDZA">
+            <node concept="2OqwBi" id="3s41kb3A6wZ" role="2Oq$k0">
+              <node concept="2OqwBi" id="3s41kb3A6x0" role="2Oq$k0">
+                <node concept="2OqwBi" id="3s41kb3A6x1" role="2Oq$k0">
+                  <node concept="2JrnkZ" id="3s41kb3A6x2" role="2Oq$k0">
+                    <node concept="37vLTw" id="3s41kb3A6x3" role="2JrQYb">
+                      <ref role="3cqZAo" node="3s41kb3A6wA" resolve="a" />
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="3s41kb3A6x4" role="2OqNvi">
+                    <ref role="37wK5l" to="mhbf:~SNode.getProperties()" resolve="getProperties" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="3s41kb3A6x5" role="2OqNvi">
+                  <ref role="37wK5l" to="wyt6:~Iterable.iterator()" resolve="iterator" />
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3A6x6" role="2OqNvi">
+                <ref role="37wK5l" to="33ny:~Iterator.next()" resolve="next" />
+              </node>
+            </node>
+            <node concept="liA8E" id="3s41kb3A6x7" role="2OqNvi">
+              <ref role="37wK5l" to="c17a:~SProperty.getName()" resolve="getName" />
+            </node>
+          </node>
+          <node concept="Xl_RD" id="3s41kb3A6x8" role="3tpDZB">
+            <property role="Xl_RC" value="name" />
+          </node>
+        </node>
+        <node concept="3vlDli" id="3s41kb3A6x9" role="3cqZAp">
+          <node concept="2OqwBi" id="3s41kb3A6xa" role="3tpDZA">
+            <node concept="2OqwBi" id="3s41kb3A6xb" role="2Oq$k0">
+              <node concept="2OqwBi" id="3s41kb3A6xc" role="2Oq$k0">
+                <node concept="2OqwBi" id="3s41kb3A6xd" role="2Oq$k0">
+                  <node concept="2JrnkZ" id="3s41kb3A6xe" role="2Oq$k0">
+                    <node concept="37vLTw" id="3s41kb3A6xf" role="2JrQYb">
+                      <ref role="3cqZAo" node="3s41kb3A6wM" resolve="b" />
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="3s41kb3A6xg" role="2OqNvi">
+                    <ref role="37wK5l" to="mhbf:~SNode.getProperties()" resolve="getProperties" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="3s41kb3A6xh" role="2OqNvi">
+                  <ref role="37wK5l" to="wyt6:~Iterable.iterator()" resolve="iterator" />
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3A6xi" role="2OqNvi">
+                <ref role="37wK5l" to="33ny:~Iterator.next()" resolve="next" />
+              </node>
+            </node>
+            <node concept="liA8E" id="3s41kb3A6xj" role="2OqNvi">
+              <ref role="37wK5l" to="c17a:~SProperty.getName()" resolve="getName" />
+            </node>
+          </node>
+          <node concept="Xl_RD" id="3s41kb3A6xk" role="3tpDZB">
+            <property role="Xl_RC" value="isFinal" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="3s41kb3A6xl" role="3cqZAp" />
+        <node concept="3vwNmj" id="3s41kb3A6xm" role="3cqZAp">
+          <node concept="17R0WA" id="3s41kb3A6xn" role="3vwVQn">
+            <node concept="2OqwBi" id="3s41kb3A6xo" role="3uHU7w">
+              <node concept="2OqwBi" id="3s41kb3A6xp" role="2Oq$k0">
+                <node concept="2WthIp" id="3s41kb3A6xq" role="2Oq$k0" />
+                <node concept="2XshWL" id="3s41kb3A6xr" role="2OqNvi">
+                  <ref role="2WH_rO" node="3s41kb3A6jP" resolve="create" />
+                  <node concept="37vLTw" id="3s41kb3A6xs" role="2XxRq1">
+                    <ref role="3cqZAo" node="3s41kb3A6wM" resolve="b" />
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3A6xt" role="2OqNvi">
+                <ref role="37wK5l" to="s53o:36NsNggQr$I" resolve="hash" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="3s41kb3A6xu" role="3uHU7B">
+              <node concept="2OqwBi" id="3s41kb3A6xv" role="2Oq$k0">
+                <node concept="2WthIp" id="3s41kb3A6xw" role="2Oq$k0" />
+                <node concept="2XshWL" id="3s41kb3A6xx" role="2OqNvi">
+                  <ref role="2WH_rO" node="3s41kb3A6jP" resolve="create" />
+                  <node concept="37vLTw" id="3s41kb3A6xy" role="2XxRq1">
+                    <ref role="3cqZAo" node="3s41kb3A6wA" resolve="a" />
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3A6xz" role="2OqNvi">
+                <ref role="37wK5l" to="s53o:36NsNggQr$I" resolve="hash" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1lH9Xt" id="3s41kb3AaOB">
+    <property role="3DII0k" value="2hh8MJdVwqX/command" />
+    <property role="TrG5h" value="NodeHasherTests_References" />
+    <node concept="2XrIbr" id="3s41kb3AaOC" role="1qtyYc">
+      <property role="TrG5h" value="create" />
+      <node concept="3uibUv" id="3s41kb3AaOD" role="3clF45">
+        <ref role="3uigEE" to="s53o:36NsNggQrub" resolve="NodeHasher" />
+      </node>
+      <node concept="3clFbS" id="3s41kb3AaOE" role="3clF47">
+        <node concept="3clFbF" id="3s41kb3AaOF" role="3cqZAp">
+          <node concept="2OqwBi" id="3s41kb3AaOG" role="3clFbG">
+            <node concept="2ShNRf" id="3s41kb3AaOH" role="2Oq$k0">
+              <node concept="1pGfFk" id="3s41kb3AaOI" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="s53o:36NsNggQryX" resolve="NodeHasher" />
+                <node concept="2OqwBi" id="3s41kb3AaOJ" role="37wK5m">
+                  <node concept="2OqwBi" id="3s41kb3AaOK" role="2Oq$k0">
+                    <node concept="37vLTw" id="3s41kb3AaOL" role="2Oq$k0">
+                      <ref role="3cqZAo" node="3s41kb3AaOR" resolve="nodes" />
+                    </node>
+                    <node concept="39bAoz" id="3s41kb3AaOM" role="2OqNvi" />
+                  </node>
+                  <node concept="ANE8D" id="3s41kb3AaON" role="2OqNvi" />
+                </node>
+                <node concept="2nou5x" id="3s41kb3AaOO" role="37wK5m">
+                  <property role="2noCCI" value="456" />
+                </node>
+              </node>
+            </node>
+            <node concept="liA8E" id="3s41kb3AaOP" role="2OqNvi">
+              <ref role="37wK5l" to="s53o:36NsNggQrzG" resolve="setIncludeNodeIds" />
+              <node concept="3clFbT" id="3s41kb3AaOQ" role="37wK5m" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="3s41kb3AaOR" role="3clF46">
+        <property role="TrG5h" value="nodes" />
+        <node concept="8X2XB" id="3s41kb3AaOS" role="1tU5fm">
+          <node concept="3Tqbb2" id="3s41kb3AaOT" role="8Xvag" />
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="3s41kb3Ab3F" role="1SL9yI">
+      <property role="TrG5h" value="same_byName" />
+      <node concept="3cqZAl" id="3s41kb3Ab3G" role="3clF45" />
+      <node concept="3clFbS" id="3s41kb3Ab3H" role="3clF47">
+        <node concept="3cpWs8" id="3s41kb3Ab3I" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3Ab3J" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: type jetbrains.mps.smodel.SNode is not comparable with node&lt;ClassConcept&gt;&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c895902c5(jetbrains.mps.baseLanguage.typesystem)/6469607165247478858]&quot;;" />
+            <property role="huDt6" value="Error: type jetbrains.mps.smodel.SNode is not comparable with node&lt;ClassConcept&gt;" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3Ab3K" role="3cpWs9">
+            <property role="TrG5h" value="targetA" />
+            <node concept="3Tqbb2" id="3s41kb3Ab3L" role="1tU5fm">
+              <ref role="ehGHo" to="tpee:fz12cDA" resolve="ClassConcept" />
+            </node>
+            <node concept="10QFUN" id="3s41kb3Ab3M" role="33vP2m">
+              <node concept="2ShNRf" id="3s41kb3Ab3N" role="10QFUP">
+                <node concept="1pGfFk" id="3s41kb3Ab3O" role="2ShVmc">
+                  <property role="373rjd" value="true" />
+                  <ref role="37wK5l" to="w1kc:~SNode.&lt;init&gt;(org.jetbrains.mps.openapi.language.SConcept,org.jetbrains.mps.openapi.model.SNodeId)" resolve="SNode" />
+                  <node concept="35c_gC" id="3s41kb3Ab3P" role="37wK5m">
+                    <ref role="35c_gD" to="tpee:fz12cDA" resolve="ClassConcept" />
+                  </node>
+                  <node concept="2OqwBi" id="3s41kb3Ab3Q" role="37wK5m">
+                    <node concept="2YIFZM" id="3s41kb3Ab3R" role="2Oq$k0">
+                      <ref role="37wK5l" to="dush:~PersistenceFacade.getInstance()" resolve="getInstance" />
+                      <ref role="1Pybhc" to="dush:~PersistenceFacade" resolve="PersistenceFacade" />
+                    </node>
+                    <node concept="liA8E" id="3s41kb3Ab3S" role="2OqNvi">
+                      <ref role="37wK5l" to="dush:~PersistenceFacade.createNodeId(java.lang.String)" resolve="createNodeId" />
+                      <node concept="Xl_RD" id="3s41kb3Ab3T" role="37wK5m">
+                        <property role="Xl_RC" value="123" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3Tqbb2" id="3s41kb3Ab3U" role="10QFUM">
+                <ref role="ehGHo" to="tpee:fz12cDA" resolve="ClassConcept" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="3s41kb3Ab3V" role="3cqZAp">
+          <node concept="2OqwBi" id="3s41kb3Ab3W" role="3clFbG">
+            <node concept="2JrnkZ" id="3s41kb3Ab3X" role="2Oq$k0">
+              <node concept="37vLTw" id="3s41kb3Ab3Y" role="2JrQYb">
+                <ref role="3cqZAo" node="3s41kb3Ab3K" resolve="targetA" />
+              </node>
+            </node>
+            <node concept="liA8E" id="3s41kb3Ab3Z" role="2OqNvi">
+              <ref role="37wK5l" to="mhbf:~SNode.setProperty(org.jetbrains.mps.openapi.language.SProperty,java.lang.String)" resolve="setProperty" />
+              <node concept="355D3s" id="3s41kb3Ab40" role="37wK5m">
+                <ref role="355D3t" to="tpck:h0TrEE$" resolve="INamedConcept" />
+                <ref role="355D3u" to="tpck:h0TrG11" resolve="name" />
+              </node>
+              <node concept="Xl_RD" id="3s41kb3Ab41" role="37wK5m">
+                <property role="Xl_RC" value="targetX" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3s41kb3Ab42" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3Ab43" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: type jetbrains.mps.smodel.SNode is not comparable with node&lt;ClassConcept&gt;&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c895902c5(jetbrains.mps.baseLanguage.typesystem)/6469607165247478858]&quot;;" />
+            <property role="huDt6" value="Error: type jetbrains.mps.smodel.SNode is not comparable with node&lt;ClassConcept&gt;" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3Ab44" role="3cpWs9">
+            <property role="TrG5h" value="targetB" />
+            <node concept="3Tqbb2" id="3s41kb3Ab45" role="1tU5fm">
+              <ref role="ehGHo" to="tpee:fz12cDA" resolve="ClassConcept" />
+            </node>
+            <node concept="10QFUN" id="3s41kb3Ab46" role="33vP2m">
+              <node concept="2ShNRf" id="3s41kb3Ab47" role="10QFUP">
+                <node concept="1pGfFk" id="3s41kb3Ab48" role="2ShVmc">
+                  <property role="373rjd" value="true" />
+                  <ref role="37wK5l" to="w1kc:~SNode.&lt;init&gt;(org.jetbrains.mps.openapi.language.SConcept,org.jetbrains.mps.openapi.model.SNodeId)" resolve="SNode" />
+                  <node concept="35c_gC" id="3s41kb3Ab49" role="37wK5m">
+                    <ref role="35c_gD" to="tpee:fz12cDA" resolve="ClassConcept" />
+                  </node>
+                  <node concept="2OqwBi" id="3s41kb3Ab4a" role="37wK5m">
+                    <node concept="2YIFZM" id="3s41kb3Ab4b" role="2Oq$k0">
+                      <ref role="37wK5l" to="dush:~PersistenceFacade.getInstance()" resolve="getInstance" />
+                      <ref role="1Pybhc" to="dush:~PersistenceFacade" resolve="PersistenceFacade" />
+                    </node>
+                    <node concept="liA8E" id="3s41kb3Ab4c" role="2OqNvi">
+                      <ref role="37wK5l" to="dush:~PersistenceFacade.createNodeId(java.lang.String)" resolve="createNodeId" />
+                      <node concept="Xl_RD" id="3s41kb3Ab4d" role="37wK5m">
+                        <property role="Xl_RC" value="234" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3Tqbb2" id="3s41kb3Ab4e" role="10QFUM">
+                <ref role="ehGHo" to="tpee:fz12cDA" resolve="ClassConcept" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="3s41kb3Ab4f" role="3cqZAp">
+          <node concept="2OqwBi" id="3s41kb3Ab4g" role="3clFbG">
+            <node concept="2JrnkZ" id="3s41kb3Ab4h" role="2Oq$k0">
+              <node concept="37vLTw" id="3s41kb3Ab4i" role="2JrQYb">
+                <ref role="3cqZAo" node="3s41kb3Ab44" resolve="targetB" />
+              </node>
+            </node>
+            <node concept="liA8E" id="3s41kb3Ab4j" role="2OqNvi">
+              <ref role="37wK5l" to="mhbf:~SNode.setProperty(org.jetbrains.mps.openapi.language.SProperty,java.lang.String)" resolve="setProperty" />
+              <node concept="355D3s" id="3s41kb3Ab4k" role="37wK5m">
+                <ref role="355D3t" to="tpck:h0TrEE$" resolve="INamedConcept" />
+                <ref role="355D3u" to="tpck:h0TrG11" resolve="name" />
+              </node>
+              <node concept="Xl_RD" id="3s41kb3Ab4l" role="37wK5m">
+                <property role="Xl_RC" value="targetX" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3s41kb3Ab4m" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3Ab4n" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required reference is not initialized `constructorDeclaration'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/5721350981296887946]&quot;;" />
+            <property role="huDt6" value="Error: required reference is not initialized `constructorDeclaration'" />
+          </node>
+          <node concept="15s5l7" id="3s41kb3Ab4o" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required link is not initialized `leftExpression'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/3741790230810467494]&quot;;" />
+            <property role="huDt6" value="Error: required link is not initialized `leftExpression'" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3Ab4p" role="3cpWs9">
+            <property role="TrG5h" value="a" />
+            <node concept="3Tqbb2" id="3s41kb3Ab4q" role="1tU5fm" />
+            <node concept="2pJPEk" id="3s41kb3Ab4r" role="33vP2m">
+              <node concept="2pJPED" id="3s41kb3Ab4s" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:h1Y3b43" resolve="AnonymousClass" />
+                <node concept="2pIpSj" id="3s41kb3Ab4t" role="2pJxcM">
+                  <ref role="2pIpSl" to="tpee:h1Y3Xaw" resolve="classifier" />
+                  <node concept="36biLy" id="3s41kb3Ab4u" role="28nt2d">
+                    <node concept="37vLTw" id="3s41kb3Ab4v" role="36biLW">
+                      <ref role="3cqZAo" node="3s41kb3Ab3K" resolve="targetA" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3s41kb3Ab4w" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3Ab4x" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required reference is not initialized `constructorDeclaration'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/5721350981296887946]&quot;;" />
+            <property role="huDt6" value="Error: required reference is not initialized `constructorDeclaration'" />
+          </node>
+          <node concept="15s5l7" id="3s41kb3Ab4y" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required link is not initialized `leftExpression'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/3741790230810467494]&quot;;" />
+            <property role="huDt6" value="Error: required link is not initialized `leftExpression'" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3Ab4z" role="3cpWs9">
+            <property role="TrG5h" value="b" />
+            <node concept="3Tqbb2" id="3s41kb3Ab4$" role="1tU5fm" />
+            <node concept="2pJPEk" id="3s41kb3Ab4_" role="33vP2m">
+              <node concept="2pJPED" id="3s41kb3Ab4A" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:h1Y3b43" resolve="AnonymousClass" />
+                <node concept="2pIpSj" id="3s41kb3Ab4B" role="2pJxcM">
+                  <ref role="2pIpSl" to="tpee:h1Y3Xaw" resolve="classifier" />
+                  <node concept="36biLy" id="3s41kb3Ab4C" role="28nt2d">
+                    <node concept="37vLTw" id="3s41kb3Ab4D" role="36biLW">
+                      <ref role="3cqZAo" node="3s41kb3Ab44" resolve="targetB" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="3s41kb3Ab4E" role="3cqZAp" />
+        <node concept="3vwNmj" id="3s41kb3Ab4F" role="3cqZAp">
+          <node concept="17R0WA" id="3s41kb3Ab4G" role="3vwVQn">
+            <node concept="2OqwBi" id="3s41kb3Ab4H" role="3uHU7w">
+              <node concept="2OqwBi" id="3s41kb3Ab4I" role="2Oq$k0">
+                <node concept="2OqwBi" id="3s41kb3Ab4J" role="2Oq$k0">
+                  <node concept="2WthIp" id="3s41kb3Ab4K" role="2Oq$k0" />
+                  <node concept="2XshWL" id="3s41kb3Ab4L" role="2OqNvi">
+                    <ref role="2WH_rO" node="3s41kb3AaOC" resolve="create" />
+                    <node concept="37vLTw" id="3s41kb3Ab4M" role="2XxRq1">
+                      <ref role="3cqZAo" node="3s41kb3Ab4z" resolve="b" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="liA8E" id="3s41kb3Ab4N" role="2OqNvi">
+                  <ref role="37wK5l" to="s53o:36NsNggQrzG" resolve="setIncludeNodeIds" />
+                  <node concept="3clFbT" id="3s41kb3Ab4O" role="37wK5m" />
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3Ab4P" role="2OqNvi">
+                <ref role="37wK5l" to="s53o:36NsNggQr$I" resolve="hash" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="3s41kb3Ab4Q" role="3uHU7B">
+              <node concept="2OqwBi" id="3s41kb3Ab4R" role="2Oq$k0">
+                <node concept="2OqwBi" id="3s41kb3Ab4S" role="2Oq$k0">
+                  <node concept="2WthIp" id="3s41kb3Ab4T" role="2Oq$k0" />
+                  <node concept="2XshWL" id="3s41kb3Ab4U" role="2OqNvi">
+                    <ref role="2WH_rO" node="3s41kb3AaOC" resolve="create" />
+                    <node concept="37vLTw" id="3s41kb3Ab4V" role="2XxRq1">
+                      <ref role="3cqZAo" node="3s41kb3Ab4p" resolve="a" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="liA8E" id="3s41kb3Ab4W" role="2OqNvi">
+                  <ref role="37wK5l" to="s53o:36NsNggQrzG" resolve="setIncludeNodeIds" />
+                  <node concept="3clFbT" id="3s41kb3Ab4X" role="37wK5m" />
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3Ab4Y" role="2OqNvi">
+                <ref role="37wK5l" to="s53o:36NsNggQr$I" resolve="hash" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="3s41kb3Ab2n" role="1SL9yI">
+      <property role="TrG5h" value="different_byName" />
+      <node concept="3cqZAl" id="3s41kb3Ab2o" role="3clF45" />
+      <node concept="3clFbS" id="3s41kb3Ab2p" role="3clF47">
+        <node concept="3cpWs8" id="3s41kb3Ab2q" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3Ab2r" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: type jetbrains.mps.smodel.SNode is not comparable with node&lt;ClassConcept&gt;&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c895902c5(jetbrains.mps.baseLanguage.typesystem)/6469607165247478858]&quot;;" />
+            <property role="huDt6" value="Error: type jetbrains.mps.smodel.SNode is not comparable with node&lt;ClassConcept&gt;" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3Ab2s" role="3cpWs9">
+            <property role="TrG5h" value="targetA" />
+            <node concept="3Tqbb2" id="3s41kb3Ab2t" role="1tU5fm">
+              <ref role="ehGHo" to="tpee:fz12cDA" resolve="ClassConcept" />
+            </node>
+            <node concept="10QFUN" id="3s41kb3Ab2u" role="33vP2m">
+              <node concept="2ShNRf" id="3s41kb3Ab2v" role="10QFUP">
+                <node concept="1pGfFk" id="3s41kb3Ab2w" role="2ShVmc">
+                  <property role="373rjd" value="true" />
+                  <ref role="37wK5l" to="w1kc:~SNode.&lt;init&gt;(org.jetbrains.mps.openapi.language.SConcept,org.jetbrains.mps.openapi.model.SNodeId)" resolve="SNode" />
+                  <node concept="35c_gC" id="3s41kb3Ab2x" role="37wK5m">
+                    <ref role="35c_gD" to="tpee:fz12cDA" resolve="ClassConcept" />
+                  </node>
+                  <node concept="2OqwBi" id="3s41kb3Ab2y" role="37wK5m">
+                    <node concept="2YIFZM" id="3s41kb3Ab2z" role="2Oq$k0">
+                      <ref role="37wK5l" to="dush:~PersistenceFacade.getInstance()" resolve="getInstance" />
+                      <ref role="1Pybhc" to="dush:~PersistenceFacade" resolve="PersistenceFacade" />
+                    </node>
+                    <node concept="liA8E" id="3s41kb3Ab2$" role="2OqNvi">
+                      <ref role="37wK5l" to="dush:~PersistenceFacade.createNodeId(java.lang.String)" resolve="createNodeId" />
+                      <node concept="Xl_RD" id="3s41kb3Ab2_" role="37wK5m">
+                        <property role="Xl_RC" value="123" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3Tqbb2" id="3s41kb3Ab2A" role="10QFUM">
+                <ref role="ehGHo" to="tpee:fz12cDA" resolve="ClassConcept" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="3s41kb3Ab2B" role="3cqZAp">
+          <node concept="2OqwBi" id="3s41kb3Ab2C" role="3clFbG">
+            <node concept="2JrnkZ" id="3s41kb3Ab2D" role="2Oq$k0">
+              <node concept="37vLTw" id="3s41kb3Ab2E" role="2JrQYb">
+                <ref role="3cqZAo" node="3s41kb3Ab2s" resolve="targetA" />
+              </node>
+            </node>
+            <node concept="liA8E" id="3s41kb3Ab2F" role="2OqNvi">
+              <ref role="37wK5l" to="mhbf:~SNode.setProperty(org.jetbrains.mps.openapi.language.SProperty,java.lang.String)" resolve="setProperty" />
+              <node concept="355D3s" id="3s41kb3Ab2G" role="37wK5m">
+                <ref role="355D3t" to="tpck:h0TrEE$" resolve="INamedConcept" />
+                <ref role="355D3u" to="tpck:h0TrG11" resolve="name" />
+              </node>
+              <node concept="Xl_RD" id="3s41kb3Ab2H" role="37wK5m">
+                <property role="Xl_RC" value="targetA" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3s41kb3Ab2I" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3Ab2J" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: type jetbrains.mps.smodel.SNode is not comparable with node&lt;ClassConcept&gt;&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c895902c5(jetbrains.mps.baseLanguage.typesystem)/6469607165247478858]&quot;;" />
+            <property role="huDt6" value="Error: type jetbrains.mps.smodel.SNode is not comparable with node&lt;ClassConcept&gt;" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3Ab2K" role="3cpWs9">
+            <property role="TrG5h" value="targetB" />
+            <node concept="3Tqbb2" id="3s41kb3Ab2L" role="1tU5fm">
+              <ref role="ehGHo" to="tpee:fz12cDA" resolve="ClassConcept" />
+            </node>
+            <node concept="10QFUN" id="3s41kb3Ab2M" role="33vP2m">
+              <node concept="2ShNRf" id="3s41kb3Ab2N" role="10QFUP">
+                <node concept="1pGfFk" id="3s41kb3Ab2O" role="2ShVmc">
+                  <property role="373rjd" value="true" />
+                  <ref role="37wK5l" to="w1kc:~SNode.&lt;init&gt;(org.jetbrains.mps.openapi.language.SConcept,org.jetbrains.mps.openapi.model.SNodeId)" resolve="SNode" />
+                  <node concept="35c_gC" id="3s41kb3Ab2P" role="37wK5m">
+                    <ref role="35c_gD" to="tpee:fz12cDA" resolve="ClassConcept" />
+                  </node>
+                  <node concept="2OqwBi" id="3s41kb3Ab2Q" role="37wK5m">
+                    <node concept="2YIFZM" id="3s41kb3Ab2R" role="2Oq$k0">
+                      <ref role="37wK5l" to="dush:~PersistenceFacade.getInstance()" resolve="getInstance" />
+                      <ref role="1Pybhc" to="dush:~PersistenceFacade" resolve="PersistenceFacade" />
+                    </node>
+                    <node concept="liA8E" id="3s41kb3Ab2S" role="2OqNvi">
+                      <ref role="37wK5l" to="dush:~PersistenceFacade.createNodeId(java.lang.String)" resolve="createNodeId" />
+                      <node concept="Xl_RD" id="3s41kb3Ab2T" role="37wK5m">
+                        <property role="Xl_RC" value="123" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3Tqbb2" id="3s41kb3Ab2U" role="10QFUM">
+                <ref role="ehGHo" to="tpee:fz12cDA" resolve="ClassConcept" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="3s41kb3Ab2V" role="3cqZAp">
+          <node concept="2OqwBi" id="3s41kb3Ab2W" role="3clFbG">
+            <node concept="2JrnkZ" id="3s41kb3Ab2X" role="2Oq$k0">
+              <node concept="37vLTw" id="3s41kb3Ab2Y" role="2JrQYb">
+                <ref role="3cqZAo" node="3s41kb3Ab2K" resolve="targetB" />
+              </node>
+            </node>
+            <node concept="liA8E" id="3s41kb3Ab2Z" role="2OqNvi">
+              <ref role="37wK5l" to="mhbf:~SNode.setProperty(org.jetbrains.mps.openapi.language.SProperty,java.lang.String)" resolve="setProperty" />
+              <node concept="355D3s" id="3s41kb3Ab30" role="37wK5m">
+                <ref role="355D3t" to="tpck:h0TrEE$" resolve="INamedConcept" />
+                <ref role="355D3u" to="tpck:h0TrG11" resolve="name" />
+              </node>
+              <node concept="Xl_RD" id="3s41kb3Ab31" role="37wK5m">
+                <property role="Xl_RC" value="targetB" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3s41kb3Ab32" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3Ab33" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required reference is not initialized `constructorDeclaration'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/5721350981296887946]&quot;;" />
+            <property role="huDt6" value="Error: required reference is not initialized `constructorDeclaration'" />
+          </node>
+          <node concept="15s5l7" id="3s41kb3Ab34" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required link is not initialized `leftExpression'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/3741790230810467494]&quot;;" />
+            <property role="huDt6" value="Error: required link is not initialized `leftExpression'" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3Ab35" role="3cpWs9">
+            <property role="TrG5h" value="a" />
+            <node concept="3Tqbb2" id="3s41kb3Ab36" role="1tU5fm" />
+            <node concept="2pJPEk" id="3s41kb3Ab37" role="33vP2m">
+              <node concept="2pJPED" id="3s41kb3Ab38" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:h1Y3b43" resolve="AnonymousClass" />
+                <node concept="2pIpSj" id="3s41kb3Ab39" role="2pJxcM">
+                  <ref role="2pIpSl" to="tpee:h1Y3Xaw" resolve="classifier" />
+                  <node concept="36biLy" id="3s41kb3Ab3a" role="28nt2d">
+                    <node concept="37vLTw" id="3s41kb3Ab3b" role="36biLW">
+                      <ref role="3cqZAo" node="3s41kb3Ab2s" resolve="targetA" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3s41kb3Ab3c" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3Ab3d" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required reference is not initialized `constructorDeclaration'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/5721350981296887946]&quot;;" />
+            <property role="huDt6" value="Error: required reference is not initialized `constructorDeclaration'" />
+          </node>
+          <node concept="15s5l7" id="3s41kb3Ab3e" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required link is not initialized `leftExpression'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/3741790230810467494]&quot;;" />
+            <property role="huDt6" value="Error: required link is not initialized `leftExpression'" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3Ab3f" role="3cpWs9">
+            <property role="TrG5h" value="b" />
+            <node concept="3Tqbb2" id="3s41kb3Ab3g" role="1tU5fm" />
+            <node concept="2pJPEk" id="3s41kb3Ab3h" role="33vP2m">
+              <node concept="2pJPED" id="3s41kb3Ab3i" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:h1Y3b43" resolve="AnonymousClass" />
+                <node concept="2pIpSj" id="3s41kb3Ab3j" role="2pJxcM">
+                  <ref role="2pIpSl" to="tpee:h1Y3Xaw" resolve="classifier" />
+                  <node concept="36biLy" id="3s41kb3Ab3k" role="28nt2d">
+                    <node concept="37vLTw" id="3s41kb3Ab3l" role="36biLW">
+                      <ref role="3cqZAo" node="3s41kb3Ab2K" resolve="targetB" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="3s41kb3Ab3m" role="3cqZAp" />
+        <node concept="3vFxKo" id="3s41kb3Ab3n" role="3cqZAp">
+          <node concept="17R0WA" id="3s41kb3Ab3o" role="3vFALc">
+            <node concept="2OqwBi" id="3s41kb3Ab3p" role="3uHU7w">
+              <node concept="2OqwBi" id="3s41kb3Ab3q" role="2Oq$k0">
+                <node concept="2OqwBi" id="3s41kb3Ab3r" role="2Oq$k0">
+                  <node concept="2WthIp" id="3s41kb3Ab3s" role="2Oq$k0" />
+                  <node concept="2XshWL" id="3s41kb3Ab3t" role="2OqNvi">
+                    <ref role="2WH_rO" node="3s41kb3AaOC" resolve="create" />
+                    <node concept="37vLTw" id="3s41kb3Ab3u" role="2XxRq1">
+                      <ref role="3cqZAo" node="3s41kb3Ab3f" resolve="b" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="liA8E" id="3s41kb3Ab3v" role="2OqNvi">
+                  <ref role="37wK5l" to="s53o:36NsNggQrzG" resolve="setIncludeNodeIds" />
+                  <node concept="3clFbT" id="3s41kb3Ab3w" role="37wK5m" />
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3Ab3x" role="2OqNvi">
+                <ref role="37wK5l" to="s53o:36NsNggQr$I" resolve="hash" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="3s41kb3Ab3y" role="3uHU7B">
+              <node concept="2OqwBi" id="3s41kb3Ab3z" role="2Oq$k0">
+                <node concept="2OqwBi" id="3s41kb3Ab3$" role="2Oq$k0">
+                  <node concept="2WthIp" id="3s41kb3Ab3_" role="2Oq$k0" />
+                  <node concept="2XshWL" id="3s41kb3Ab3A" role="2OqNvi">
+                    <ref role="2WH_rO" node="3s41kb3AaOC" resolve="create" />
+                    <node concept="37vLTw" id="3s41kb3Ab3B" role="2XxRq1">
+                      <ref role="3cqZAo" node="3s41kb3Ab35" resolve="a" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="liA8E" id="3s41kb3Ab3C" role="2OqNvi">
+                  <ref role="37wK5l" to="s53o:36NsNggQrzG" resolve="setIncludeNodeIds" />
+                  <node concept="3clFbT" id="3s41kb3Ab3D" role="37wK5m" />
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3Ab3E" role="2OqNvi">
+                <ref role="37wK5l" to="s53o:36NsNggQr$I" resolve="hash" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="3s41kb3Ab4Z" role="1SL9yI">
+      <property role="TrG5h" value="different_byConcept" />
+      <node concept="3cqZAl" id="3s41kb3Ab50" role="3clF45" />
+      <node concept="3clFbS" id="3s41kb3Ab51" role="3clF47">
+        <node concept="3cpWs8" id="3s41kb3Ab52" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3Ab53" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: type jetbrains.mps.smodel.SNode is not comparable with node&lt;ClassConcept&gt;&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c895902c5(jetbrains.mps.baseLanguage.typesystem)/6469607165247478858]&quot;;" />
+            <property role="huDt6" value="Error: type jetbrains.mps.smodel.SNode is not comparable with node&lt;ClassConcept&gt;" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3Ab54" role="3cpWs9">
+            <property role="TrG5h" value="targetA" />
+            <node concept="3Tqbb2" id="3s41kb3Ab55" role="1tU5fm">
+              <ref role="ehGHo" to="tpee:fz12cDA" resolve="ClassConcept" />
+            </node>
+            <node concept="10QFUN" id="3s41kb3Ab56" role="33vP2m">
+              <node concept="2ShNRf" id="3s41kb3Ab57" role="10QFUP">
+                <node concept="1pGfFk" id="3s41kb3Ab58" role="2ShVmc">
+                  <property role="373rjd" value="true" />
+                  <ref role="37wK5l" to="w1kc:~SNode.&lt;init&gt;(org.jetbrains.mps.openapi.language.SConcept,org.jetbrains.mps.openapi.model.SNodeId)" resolve="SNode" />
+                  <node concept="35c_gC" id="3s41kb3Ab59" role="37wK5m">
+                    <ref role="35c_gD" to="tpee:fz12cDA" resolve="ClassConcept" />
+                  </node>
+                  <node concept="2OqwBi" id="3s41kb3Ab5a" role="37wK5m">
+                    <node concept="2YIFZM" id="3s41kb3Ab5b" role="2Oq$k0">
+                      <ref role="37wK5l" to="dush:~PersistenceFacade.getInstance()" resolve="getInstance" />
+                      <ref role="1Pybhc" to="dush:~PersistenceFacade" resolve="PersistenceFacade" />
+                    </node>
+                    <node concept="liA8E" id="3s41kb3Ab5c" role="2OqNvi">
+                      <ref role="37wK5l" to="dush:~PersistenceFacade.createNodeId(java.lang.String)" resolve="createNodeId" />
+                      <node concept="Xl_RD" id="3s41kb3Ab5d" role="37wK5m">
+                        <property role="Xl_RC" value="123" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3Tqbb2" id="3s41kb3Ab5e" role="10QFUM">
+                <ref role="ehGHo" to="tpee:fz12cDA" resolve="ClassConcept" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="3s41kb3Ab5f" role="3cqZAp">
+          <node concept="2OqwBi" id="3s41kb3Ab5g" role="3clFbG">
+            <node concept="2JrnkZ" id="3s41kb3Ab5h" role="2Oq$k0">
+              <node concept="37vLTw" id="3s41kb3Ab5i" role="2JrQYb">
+                <ref role="3cqZAo" node="3s41kb3Ab54" resolve="targetA" />
+              </node>
+            </node>
+            <node concept="liA8E" id="3s41kb3Ab5j" role="2OqNvi">
+              <ref role="37wK5l" to="mhbf:~SNode.setProperty(org.jetbrains.mps.openapi.language.SProperty,java.lang.String)" resolve="setProperty" />
+              <node concept="355D3s" id="3s41kb3Ab5k" role="37wK5m">
+                <ref role="355D3t" to="tpck:h0TrEE$" resolve="INamedConcept" />
+                <ref role="355D3u" to="tpck:h0TrG11" resolve="name" />
+              </node>
+              <node concept="Xl_RD" id="3s41kb3Ab5l" role="37wK5m">
+                <property role="Xl_RC" value="targetA" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3s41kb3Ab5m" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3Ab5n" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: type jetbrains.mps.smodel.SNode is not comparable with node&lt;ClassConcept&gt;&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c895902c5(jetbrains.mps.baseLanguage.typesystem)/6469607165247478858]&quot;;" />
+            <property role="huDt6" value="Error: type jetbrains.mps.smodel.SNode is not comparable with node&lt;ClassConcept&gt;" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3Ab5o" role="3cpWs9">
+            <property role="TrG5h" value="targetB" />
+            <node concept="3Tqbb2" id="3s41kb3Ab5p" role="1tU5fm">
+              <ref role="ehGHo" to="tpee:hiABswc" resolve="Annotation" />
+            </node>
+            <node concept="10QFUN" id="3s41kb3Ab5q" role="33vP2m">
+              <node concept="2ShNRf" id="3s41kb3Ab5r" role="10QFUP">
+                <node concept="1pGfFk" id="3s41kb3Ab5s" role="2ShVmc">
+                  <property role="373rjd" value="true" />
+                  <ref role="37wK5l" to="w1kc:~SNode.&lt;init&gt;(org.jetbrains.mps.openapi.language.SConcept,org.jetbrains.mps.openapi.model.SNodeId)" resolve="SNode" />
+                  <node concept="35c_gC" id="3s41kb3Ab5t" role="37wK5m">
+                    <ref role="35c_gD" to="tpee:hiABswc" resolve="Annotation" />
+                  </node>
+                  <node concept="2OqwBi" id="3s41kb3Ab5u" role="37wK5m">
+                    <node concept="2YIFZM" id="3s41kb3Ab5v" role="2Oq$k0">
+                      <ref role="37wK5l" to="dush:~PersistenceFacade.getInstance()" resolve="getInstance" />
+                      <ref role="1Pybhc" to="dush:~PersistenceFacade" resolve="PersistenceFacade" />
+                    </node>
+                    <node concept="liA8E" id="3s41kb3Ab5w" role="2OqNvi">
+                      <ref role="37wK5l" to="dush:~PersistenceFacade.createNodeId(java.lang.String)" resolve="createNodeId" />
+                      <node concept="Xl_RD" id="3s41kb3Ab5x" role="37wK5m">
+                        <property role="Xl_RC" value="123" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3Tqbb2" id="3s41kb3Ab5y" role="10QFUM">
+                <ref role="ehGHo" to="tpee:hiABswc" resolve="Annotation" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="3s41kb3Ab5z" role="3cqZAp">
+          <node concept="2OqwBi" id="3s41kb3Ab5$" role="3clFbG">
+            <node concept="2JrnkZ" id="3s41kb3Ab5_" role="2Oq$k0">
+              <node concept="37vLTw" id="3s41kb3Ab5A" role="2JrQYb">
+                <ref role="3cqZAo" node="3s41kb3Ab5o" resolve="targetB" />
+              </node>
+            </node>
+            <node concept="liA8E" id="3s41kb3Ab5B" role="2OqNvi">
+              <ref role="37wK5l" to="mhbf:~SNode.setProperty(org.jetbrains.mps.openapi.language.SProperty,java.lang.String)" resolve="setProperty" />
+              <node concept="355D3s" id="3s41kb3Ab5C" role="37wK5m">
+                <ref role="355D3t" to="tpck:h0TrEE$" resolve="INamedConcept" />
+                <ref role="355D3u" to="tpck:h0TrG11" resolve="name" />
+              </node>
+              <node concept="Xl_RD" id="3s41kb3Ab5D" role="37wK5m">
+                <property role="Xl_RC" value="targetB" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3s41kb3Ab5E" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3Ab5F" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required reference is not initialized `constructorDeclaration'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/5721350981296887946]&quot;;" />
+            <property role="huDt6" value="Error: required reference is not initialized `constructorDeclaration'" />
+          </node>
+          <node concept="15s5l7" id="3s41kb3Ab5G" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required link is not initialized `leftExpression'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/3741790230810467494]&quot;;" />
+            <property role="huDt6" value="Error: required link is not initialized `leftExpression'" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3Ab5H" role="3cpWs9">
+            <property role="TrG5h" value="a" />
+            <node concept="3Tqbb2" id="3s41kb3Ab5I" role="1tU5fm" />
+            <node concept="2pJPEk" id="3s41kb3Ab5J" role="33vP2m">
+              <node concept="2pJPED" id="3s41kb3Ab5K" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:h1Y3b43" resolve="AnonymousClass" />
+                <node concept="2pIpSj" id="3s41kb3Ab5L" role="2pJxcM">
+                  <ref role="2pIpSl" to="tpee:h1Y3Xaw" resolve="classifier" />
+                  <node concept="36biLy" id="3s41kb3Ab5M" role="28nt2d">
+                    <node concept="37vLTw" id="3s41kb3Ab5N" role="36biLW">
+                      <ref role="3cqZAo" node="3s41kb3Ab54" resolve="targetA" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3s41kb3Ab5O" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3Ab5P" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required reference is not initialized `constructorDeclaration'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/5721350981296887946]&quot;;" />
+            <property role="huDt6" value="Error: required reference is not initialized `constructorDeclaration'" />
+          </node>
+          <node concept="15s5l7" id="3s41kb3Ab5Q" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required link is not initialized `leftExpression'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/3741790230810467494]&quot;;" />
+            <property role="huDt6" value="Error: required link is not initialized `leftExpression'" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3Ab5R" role="3cpWs9">
+            <property role="TrG5h" value="b" />
+            <node concept="3Tqbb2" id="3s41kb3Ab5S" role="1tU5fm" />
+            <node concept="2pJPEk" id="3s41kb3Ab5T" role="33vP2m">
+              <node concept="2pJPED" id="3s41kb3Ab5U" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:h1Y3b43" resolve="AnonymousClass" />
+                <node concept="2pIpSj" id="3s41kb3Ab5V" role="2pJxcM">
+                  <ref role="2pIpSl" to="tpee:h1Y3Xaw" resolve="classifier" />
+                  <node concept="36biLy" id="3s41kb3Ab5W" role="28nt2d">
+                    <node concept="37vLTw" id="3s41kb3Ab5X" role="36biLW">
+                      <ref role="3cqZAo" node="3s41kb3Ab5o" resolve="targetB" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="3s41kb3Ab5Y" role="3cqZAp" />
+        <node concept="3vFxKo" id="3s41kb3Ab5Z" role="3cqZAp">
+          <node concept="17R0WA" id="3s41kb3Ab60" role="3vFALc">
+            <node concept="2OqwBi" id="3s41kb3Ab61" role="3uHU7w">
+              <node concept="2OqwBi" id="3s41kb3Ab62" role="2Oq$k0">
+                <node concept="2OqwBi" id="3s41kb3Ab63" role="2Oq$k0">
+                  <node concept="2WthIp" id="3s41kb3Ab64" role="2Oq$k0" />
+                  <node concept="2XshWL" id="3s41kb3Ab65" role="2OqNvi">
+                    <ref role="2WH_rO" node="3s41kb3AaOC" resolve="create" />
+                    <node concept="37vLTw" id="3s41kb3Ab66" role="2XxRq1">
+                      <ref role="3cqZAo" node="3s41kb3Ab5R" resolve="b" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="liA8E" id="3s41kb3Ab67" role="2OqNvi">
+                  <ref role="37wK5l" to="s53o:36NsNggQrzG" resolve="setIncludeNodeIds" />
+                  <node concept="3clFbT" id="3s41kb3Ab68" role="37wK5m" />
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3Ab69" role="2OqNvi">
+                <ref role="37wK5l" to="s53o:36NsNggQr$I" resolve="hash" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="3s41kb3Ab6a" role="3uHU7B">
+              <node concept="2OqwBi" id="3s41kb3Ab6b" role="2Oq$k0">
+                <node concept="2OqwBi" id="3s41kb3Ab6c" role="2Oq$k0">
+                  <node concept="2WthIp" id="3s41kb3Ab6d" role="2Oq$k0" />
+                  <node concept="2XshWL" id="3s41kb3Ab6e" role="2OqNvi">
+                    <ref role="2WH_rO" node="3s41kb3AaOC" resolve="create" />
+                    <node concept="37vLTw" id="3s41kb3Ab6f" role="2XxRq1">
+                      <ref role="3cqZAo" node="3s41kb3Ab5H" resolve="a" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="liA8E" id="3s41kb3Ab6g" role="2OqNvi">
+                  <ref role="37wK5l" to="s53o:36NsNggQrzG" resolve="setIncludeNodeIds" />
+                  <node concept="3clFbT" id="3s41kb3Ab6h" role="37wK5m" />
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3Ab6i" role="2OqNvi">
+                <ref role="37wK5l" to="s53o:36NsNggQr$I" resolve="hash" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="3s41kb3Ab6j" role="1SL9yI">
+      <property role="TrG5h" value="different_byId" />
+      <node concept="3cqZAl" id="3s41kb3Ab6k" role="3clF45" />
+      <node concept="3clFbS" id="3s41kb3Ab6l" role="3clF47">
+        <node concept="3cpWs8" id="3s41kb3Ab6m" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3Ab6n" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: type jetbrains.mps.smodel.SNode is not comparable with node&lt;ClassConcept&gt;&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c895902c5(jetbrains.mps.baseLanguage.typesystem)/6469607165247478858]&quot;;" />
+            <property role="huDt6" value="Error: type jetbrains.mps.smodel.SNode is not comparable with node&lt;ClassConcept&gt;" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3Ab6o" role="3cpWs9">
+            <property role="TrG5h" value="targetA" />
+            <node concept="3Tqbb2" id="3s41kb3Ab6p" role="1tU5fm">
+              <ref role="ehGHo" to="tpee:fz12cDA" resolve="ClassConcept" />
+            </node>
+            <node concept="10QFUN" id="3s41kb3Ab6q" role="33vP2m">
+              <node concept="2ShNRf" id="3s41kb3Ab6r" role="10QFUP">
+                <node concept="1pGfFk" id="3s41kb3Ab6s" role="2ShVmc">
+                  <property role="373rjd" value="true" />
+                  <ref role="37wK5l" to="w1kc:~SNode.&lt;init&gt;(org.jetbrains.mps.openapi.language.SConcept,org.jetbrains.mps.openapi.model.SNodeId)" resolve="SNode" />
+                  <node concept="35c_gC" id="3s41kb3Ab6t" role="37wK5m">
+                    <ref role="35c_gD" to="tpee:fz12cDA" resolve="ClassConcept" />
+                  </node>
+                  <node concept="2OqwBi" id="3s41kb3Ab6u" role="37wK5m">
+                    <node concept="2YIFZM" id="3s41kb3Ab6v" role="2Oq$k0">
+                      <ref role="37wK5l" to="dush:~PersistenceFacade.getInstance()" resolve="getInstance" />
+                      <ref role="1Pybhc" to="dush:~PersistenceFacade" resolve="PersistenceFacade" />
+                    </node>
+                    <node concept="liA8E" id="3s41kb3Ab6w" role="2OqNvi">
+                      <ref role="37wK5l" to="dush:~PersistenceFacade.createNodeId(java.lang.String)" resolve="createNodeId" />
+                      <node concept="Xl_RD" id="3s41kb3Ab6x" role="37wK5m">
+                        <property role="Xl_RC" value="123" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3Tqbb2" id="3s41kb3Ab6y" role="10QFUM">
+                <ref role="ehGHo" to="tpee:fz12cDA" resolve="ClassConcept" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="3s41kb3Ab6z" role="3cqZAp">
+          <node concept="2OqwBi" id="3s41kb3Ab6$" role="3clFbG">
+            <node concept="2JrnkZ" id="3s41kb3Ab6_" role="2Oq$k0">
+              <node concept="37vLTw" id="3s41kb3Ab6A" role="2JrQYb">
+                <ref role="3cqZAo" node="3s41kb3Ab6o" resolve="targetA" />
+              </node>
+            </node>
+            <node concept="liA8E" id="3s41kb3Ab6B" role="2OqNvi">
+              <ref role="37wK5l" to="mhbf:~SNode.setProperty(org.jetbrains.mps.openapi.language.SProperty,java.lang.String)" resolve="setProperty" />
+              <node concept="355D3s" id="3s41kb3Ab6C" role="37wK5m">
+                <ref role="355D3t" to="tpck:h0TrEE$" resolve="INamedConcept" />
+                <ref role="355D3u" to="tpck:h0TrG11" resolve="name" />
+              </node>
+              <node concept="Xl_RD" id="3s41kb3Ab6D" role="37wK5m">
+                <property role="Xl_RC" value="targetX" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3s41kb3Ab6E" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3Ab6F" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: type jetbrains.mps.smodel.SNode is not comparable with node&lt;ClassConcept&gt;&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c895902c5(jetbrains.mps.baseLanguage.typesystem)/6469607165247478858]&quot;;" />
+            <property role="huDt6" value="Error: type jetbrains.mps.smodel.SNode is not comparable with node&lt;ClassConcept&gt;" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3Ab6G" role="3cpWs9">
+            <property role="TrG5h" value="targetB" />
+            <node concept="3Tqbb2" id="3s41kb3Ab6H" role="1tU5fm">
+              <ref role="ehGHo" to="tpee:fz12cDA" resolve="ClassConcept" />
+            </node>
+            <node concept="10QFUN" id="3s41kb3Ab6I" role="33vP2m">
+              <node concept="2ShNRf" id="3s41kb3Ab6J" role="10QFUP">
+                <node concept="1pGfFk" id="3s41kb3Ab6K" role="2ShVmc">
+                  <property role="373rjd" value="true" />
+                  <ref role="37wK5l" to="w1kc:~SNode.&lt;init&gt;(org.jetbrains.mps.openapi.language.SConcept,org.jetbrains.mps.openapi.model.SNodeId)" resolve="SNode" />
+                  <node concept="35c_gC" id="3s41kb3Ab6L" role="37wK5m">
+                    <ref role="35c_gD" to="tpee:fz12cDA" resolve="ClassConcept" />
+                  </node>
+                  <node concept="2OqwBi" id="3s41kb3Ab6M" role="37wK5m">
+                    <node concept="2YIFZM" id="3s41kb3Ab6N" role="2Oq$k0">
+                      <ref role="37wK5l" to="dush:~PersistenceFacade.getInstance()" resolve="getInstance" />
+                      <ref role="1Pybhc" to="dush:~PersistenceFacade" resolve="PersistenceFacade" />
+                    </node>
+                    <node concept="liA8E" id="3s41kb3Ab6O" role="2OqNvi">
+                      <ref role="37wK5l" to="dush:~PersistenceFacade.createNodeId(java.lang.String)" resolve="createNodeId" />
+                      <node concept="Xl_RD" id="3s41kb3Ab6P" role="37wK5m">
+                        <property role="Xl_RC" value="234" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3Tqbb2" id="3s41kb3Ab6Q" role="10QFUM">
+                <ref role="ehGHo" to="tpee:fz12cDA" resolve="ClassConcept" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="3s41kb3Ab6R" role="3cqZAp">
+          <node concept="2OqwBi" id="3s41kb3Ab6S" role="3clFbG">
+            <node concept="2JrnkZ" id="3s41kb3Ab6T" role="2Oq$k0">
+              <node concept="37vLTw" id="3s41kb3Ab6U" role="2JrQYb">
+                <ref role="3cqZAo" node="3s41kb3Ab6G" resolve="targetB" />
+              </node>
+            </node>
+            <node concept="liA8E" id="3s41kb3Ab6V" role="2OqNvi">
+              <ref role="37wK5l" to="mhbf:~SNode.setProperty(org.jetbrains.mps.openapi.language.SProperty,java.lang.String)" resolve="setProperty" />
+              <node concept="355D3s" id="3s41kb3Ab6W" role="37wK5m">
+                <ref role="355D3t" to="tpck:h0TrEE$" resolve="INamedConcept" />
+                <ref role="355D3u" to="tpck:h0TrG11" resolve="name" />
+              </node>
+              <node concept="Xl_RD" id="3s41kb3Ab6X" role="37wK5m">
+                <property role="Xl_RC" value="targetX" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3s41kb3Ab6Y" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3Ab6Z" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required reference is not initialized `constructorDeclaration'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/5721350981296887946]&quot;;" />
+            <property role="huDt6" value="Error: required reference is not initialized `constructorDeclaration'" />
+          </node>
+          <node concept="15s5l7" id="3s41kb3Ab70" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required link is not initialized `leftExpression'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/3741790230810467494]&quot;;" />
+            <property role="huDt6" value="Error: required link is not initialized `leftExpression'" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3Ab71" role="3cpWs9">
+            <property role="TrG5h" value="a" />
+            <node concept="3Tqbb2" id="3s41kb3Ab72" role="1tU5fm" />
+            <node concept="2pJPEk" id="3s41kb3Ab73" role="33vP2m">
+              <node concept="2pJPED" id="3s41kb3Ab74" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:h1Y3b43" resolve="AnonymousClass" />
+                <node concept="2pIpSj" id="3s41kb3Ab75" role="2pJxcM">
+                  <ref role="2pIpSl" to="tpee:h1Y3Xaw" resolve="classifier" />
+                  <node concept="36biLy" id="3s41kb3Ab76" role="28nt2d">
+                    <node concept="37vLTw" id="3s41kb3Ab77" role="36biLW">
+                      <ref role="3cqZAo" node="3s41kb3Ab6o" resolve="targetA" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3s41kb3Ab78" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3Ab79" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required reference is not initialized `constructorDeclaration'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/5721350981296887946]&quot;;" />
+            <property role="huDt6" value="Error: required reference is not initialized `constructorDeclaration'" />
+          </node>
+          <node concept="15s5l7" id="3s41kb3Ab7a" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required link is not initialized `leftExpression'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/3741790230810467494]&quot;;" />
+            <property role="huDt6" value="Error: required link is not initialized `leftExpression'" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3Ab7b" role="3cpWs9">
+            <property role="TrG5h" value="b" />
+            <node concept="3Tqbb2" id="3s41kb3Ab7c" role="1tU5fm" />
+            <node concept="2pJPEk" id="3s41kb3Ab7d" role="33vP2m">
+              <node concept="2pJPED" id="3s41kb3Ab7e" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:h1Y3b43" resolve="AnonymousClass" />
+                <node concept="2pIpSj" id="3s41kb3Ab7f" role="2pJxcM">
+                  <ref role="2pIpSl" to="tpee:h1Y3Xaw" resolve="classifier" />
+                  <node concept="36biLy" id="3s41kb3Ab7g" role="28nt2d">
+                    <node concept="37vLTw" id="3s41kb3Ab7h" role="36biLW">
+                      <ref role="3cqZAo" node="3s41kb3Ab6G" resolve="targetB" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="3s41kb3Ab7i" role="3cqZAp" />
+        <node concept="3vFxKo" id="3s41kb3Ab7j" role="3cqZAp">
+          <node concept="17R0WA" id="3s41kb3Ab7k" role="3vFALc">
+            <node concept="2OqwBi" id="3s41kb3Ab7l" role="3uHU7w">
+              <node concept="2OqwBi" id="3s41kb3Ab7m" role="2Oq$k0">
+                <node concept="2OqwBi" id="3s41kb3Ab7n" role="2Oq$k0">
+                  <node concept="2WthIp" id="3s41kb3Ab7o" role="2Oq$k0" />
+                  <node concept="2XshWL" id="3s41kb3Ab7p" role="2OqNvi">
+                    <ref role="2WH_rO" node="3s41kb3AaOC" resolve="create" />
+                    <node concept="37vLTw" id="3s41kb3Ab7q" role="2XxRq1">
+                      <ref role="3cqZAo" node="3s41kb3Ab7b" resolve="b" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="liA8E" id="3s41kb3Ab7r" role="2OqNvi">
+                  <ref role="37wK5l" to="s53o:36NsNggQrzG" resolve="setIncludeNodeIds" />
+                  <node concept="3clFbT" id="3s41kb3Ab7s" role="37wK5m">
+                    <property role="3clFbU" value="true" />
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3Ab7t" role="2OqNvi">
+                <ref role="37wK5l" to="s53o:36NsNggQr$I" resolve="hash" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="3s41kb3Ab7u" role="3uHU7B">
+              <node concept="2OqwBi" id="3s41kb3Ab7v" role="2Oq$k0">
+                <node concept="2OqwBi" id="3s41kb3Ab7w" role="2Oq$k0">
+                  <node concept="2WthIp" id="3s41kb3Ab7x" role="2Oq$k0" />
+                  <node concept="2XshWL" id="3s41kb3Ab7y" role="2OqNvi">
+                    <ref role="2WH_rO" node="3s41kb3AaOC" resolve="create" />
+                    <node concept="37vLTw" id="3s41kb3Ab7z" role="2XxRq1">
+                      <ref role="3cqZAo" node="3s41kb3Ab71" resolve="a" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="liA8E" id="3s41kb3Ab7$" role="2OqNvi">
+                  <ref role="37wK5l" to="s53o:36NsNggQrzG" resolve="setIncludeNodeIds" />
+                  <node concept="3clFbT" id="3s41kb3Ab7_" role="37wK5m">
+                    <property role="3clFbU" value="true" />
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3Ab7A" role="2OqNvi">
+                <ref role="37wK5l" to="s53o:36NsNggQr$I" resolve="hash" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="3s41kb3Ab7B" role="1SL9yI">
+      <property role="TrG5h" value="different_byId_ignored" />
+      <node concept="3cqZAl" id="3s41kb3Ab7C" role="3clF45" />
+      <node concept="3clFbS" id="3s41kb3Ab7D" role="3clF47">
+        <node concept="3cpWs8" id="3s41kb3Ab7E" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3Ab7F" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: type jetbrains.mps.smodel.SNode is not comparable with node&lt;ClassConcept&gt;&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c895902c5(jetbrains.mps.baseLanguage.typesystem)/6469607165247478858]&quot;;" />
+            <property role="huDt6" value="Error: type jetbrains.mps.smodel.SNode is not comparable with node&lt;ClassConcept&gt;" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3Ab7G" role="3cpWs9">
+            <property role="TrG5h" value="targetA" />
+            <node concept="3Tqbb2" id="3s41kb3Ab7H" role="1tU5fm">
+              <ref role="ehGHo" to="tpee:fz12cDA" resolve="ClassConcept" />
+            </node>
+            <node concept="10QFUN" id="3s41kb3Ab7I" role="33vP2m">
+              <node concept="2ShNRf" id="3s41kb3Ab7J" role="10QFUP">
+                <node concept="1pGfFk" id="3s41kb3Ab7K" role="2ShVmc">
+                  <property role="373rjd" value="true" />
+                  <ref role="37wK5l" to="w1kc:~SNode.&lt;init&gt;(org.jetbrains.mps.openapi.language.SConcept,org.jetbrains.mps.openapi.model.SNodeId)" resolve="SNode" />
+                  <node concept="35c_gC" id="3s41kb3Ab7L" role="37wK5m">
+                    <ref role="35c_gD" to="tpee:fz12cDA" resolve="ClassConcept" />
+                  </node>
+                  <node concept="2OqwBi" id="3s41kb3Ab7M" role="37wK5m">
+                    <node concept="2YIFZM" id="3s41kb3Ab7N" role="2Oq$k0">
+                      <ref role="37wK5l" to="dush:~PersistenceFacade.getInstance()" resolve="getInstance" />
+                      <ref role="1Pybhc" to="dush:~PersistenceFacade" resolve="PersistenceFacade" />
+                    </node>
+                    <node concept="liA8E" id="3s41kb3Ab7O" role="2OqNvi">
+                      <ref role="37wK5l" to="dush:~PersistenceFacade.createNodeId(java.lang.String)" resolve="createNodeId" />
+                      <node concept="Xl_RD" id="3s41kb3Ab7P" role="37wK5m">
+                        <property role="Xl_RC" value="123" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3Tqbb2" id="3s41kb3Ab7Q" role="10QFUM">
+                <ref role="ehGHo" to="tpee:fz12cDA" resolve="ClassConcept" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="3s41kb3Ab7R" role="3cqZAp">
+          <node concept="2OqwBi" id="3s41kb3Ab7S" role="3clFbG">
+            <node concept="2JrnkZ" id="3s41kb3Ab7T" role="2Oq$k0">
+              <node concept="37vLTw" id="3s41kb3Ab7U" role="2JrQYb">
+                <ref role="3cqZAo" node="3s41kb3Ab7G" resolve="targetA" />
+              </node>
+            </node>
+            <node concept="liA8E" id="3s41kb3Ab7V" role="2OqNvi">
+              <ref role="37wK5l" to="mhbf:~SNode.setProperty(org.jetbrains.mps.openapi.language.SProperty,java.lang.String)" resolve="setProperty" />
+              <node concept="355D3s" id="3s41kb3Ab7W" role="37wK5m">
+                <ref role="355D3t" to="tpck:h0TrEE$" resolve="INamedConcept" />
+                <ref role="355D3u" to="tpck:h0TrG11" resolve="name" />
+              </node>
+              <node concept="Xl_RD" id="3s41kb3Ab7X" role="37wK5m">
+                <property role="Xl_RC" value="targetX" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3s41kb3Ab7Y" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3Ab7Z" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: type jetbrains.mps.smodel.SNode is not comparable with node&lt;ClassConcept&gt;&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c895902c5(jetbrains.mps.baseLanguage.typesystem)/6469607165247478858]&quot;;" />
+            <property role="huDt6" value="Error: type jetbrains.mps.smodel.SNode is not comparable with node&lt;ClassConcept&gt;" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3Ab80" role="3cpWs9">
+            <property role="TrG5h" value="targetB" />
+            <node concept="3Tqbb2" id="3s41kb3Ab81" role="1tU5fm">
+              <ref role="ehGHo" to="tpee:fz12cDA" resolve="ClassConcept" />
+            </node>
+            <node concept="10QFUN" id="3s41kb3Ab82" role="33vP2m">
+              <node concept="2ShNRf" id="3s41kb3Ab83" role="10QFUP">
+                <node concept="1pGfFk" id="3s41kb3Ab84" role="2ShVmc">
+                  <property role="373rjd" value="true" />
+                  <ref role="37wK5l" to="w1kc:~SNode.&lt;init&gt;(org.jetbrains.mps.openapi.language.SConcept,org.jetbrains.mps.openapi.model.SNodeId)" resolve="SNode" />
+                  <node concept="35c_gC" id="3s41kb3Ab85" role="37wK5m">
+                    <ref role="35c_gD" to="tpee:fz12cDA" resolve="ClassConcept" />
+                  </node>
+                  <node concept="2OqwBi" id="3s41kb3Ab86" role="37wK5m">
+                    <node concept="2YIFZM" id="3s41kb3Ab87" role="2Oq$k0">
+                      <ref role="37wK5l" to="dush:~PersistenceFacade.getInstance()" resolve="getInstance" />
+                      <ref role="1Pybhc" to="dush:~PersistenceFacade" resolve="PersistenceFacade" />
+                    </node>
+                    <node concept="liA8E" id="3s41kb3Ab88" role="2OqNvi">
+                      <ref role="37wK5l" to="dush:~PersistenceFacade.createNodeId(java.lang.String)" resolve="createNodeId" />
+                      <node concept="Xl_RD" id="3s41kb3Ab89" role="37wK5m">
+                        <property role="Xl_RC" value="234" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3Tqbb2" id="3s41kb3Ab8a" role="10QFUM">
+                <ref role="ehGHo" to="tpee:fz12cDA" resolve="ClassConcept" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="3s41kb3Ab8b" role="3cqZAp">
+          <node concept="2OqwBi" id="3s41kb3Ab8c" role="3clFbG">
+            <node concept="2JrnkZ" id="3s41kb3Ab8d" role="2Oq$k0">
+              <node concept="37vLTw" id="3s41kb3Ab8e" role="2JrQYb">
+                <ref role="3cqZAo" node="3s41kb3Ab80" resolve="targetB" />
+              </node>
+            </node>
+            <node concept="liA8E" id="3s41kb3Ab8f" role="2OqNvi">
+              <ref role="37wK5l" to="mhbf:~SNode.setProperty(org.jetbrains.mps.openapi.language.SProperty,java.lang.String)" resolve="setProperty" />
+              <node concept="355D3s" id="3s41kb3Ab8g" role="37wK5m">
+                <ref role="355D3t" to="tpck:h0TrEE$" resolve="INamedConcept" />
+                <ref role="355D3u" to="tpck:h0TrG11" resolve="name" />
+              </node>
+              <node concept="Xl_RD" id="3s41kb3Ab8h" role="37wK5m">
+                <property role="Xl_RC" value="targetX" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3s41kb3Ab8i" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3Ab8j" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required reference is not initialized `constructorDeclaration'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/5721350981296887946]&quot;;" />
+            <property role="huDt6" value="Error: required reference is not initialized `constructorDeclaration'" />
+          </node>
+          <node concept="15s5l7" id="3s41kb3Ab8k" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required link is not initialized `leftExpression'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/3741790230810467494]&quot;;" />
+            <property role="huDt6" value="Error: required link is not initialized `leftExpression'" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3Ab8l" role="3cpWs9">
+            <property role="TrG5h" value="a" />
+            <node concept="3Tqbb2" id="3s41kb3Ab8m" role="1tU5fm" />
+            <node concept="2pJPEk" id="3s41kb3Ab8n" role="33vP2m">
+              <node concept="2pJPED" id="3s41kb3Ab8o" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:h1Y3b43" resolve="AnonymousClass" />
+                <node concept="2pIpSj" id="3s41kb3Ab8p" role="2pJxcM">
+                  <ref role="2pIpSl" to="tpee:h1Y3Xaw" resolve="classifier" />
+                  <node concept="36biLy" id="3s41kb3Ab8q" role="28nt2d">
+                    <node concept="37vLTw" id="3s41kb3Ab8r" role="36biLW">
+                      <ref role="3cqZAo" node="3s41kb3Ab7G" resolve="targetA" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3s41kb3Ab8s" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3Ab8t" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required reference is not initialized `constructorDeclaration'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/5721350981296887946]&quot;;" />
+            <property role="huDt6" value="Error: required reference is not initialized `constructorDeclaration'" />
+          </node>
+          <node concept="15s5l7" id="3s41kb3Ab8u" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required link is not initialized `leftExpression'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/3741790230810467494]&quot;;" />
+            <property role="huDt6" value="Error: required link is not initialized `leftExpression'" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3Ab8v" role="3cpWs9">
+            <property role="TrG5h" value="b" />
+            <node concept="3Tqbb2" id="3s41kb3Ab8w" role="1tU5fm" />
+            <node concept="2pJPEk" id="3s41kb3Ab8x" role="33vP2m">
+              <node concept="2pJPED" id="3s41kb3Ab8y" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:h1Y3b43" resolve="AnonymousClass" />
+                <node concept="2pIpSj" id="3s41kb3Ab8z" role="2pJxcM">
+                  <ref role="2pIpSl" to="tpee:h1Y3Xaw" resolve="classifier" />
+                  <node concept="36biLy" id="3s41kb3Ab8$" role="28nt2d">
+                    <node concept="37vLTw" id="3s41kb3Ab8_" role="36biLW">
+                      <ref role="3cqZAo" node="3s41kb3Ab80" resolve="targetB" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="3s41kb3Ab8A" role="3cqZAp" />
+        <node concept="3vwNmj" id="3s41kb3Ab8B" role="3cqZAp">
+          <node concept="17R0WA" id="3s41kb3Ab8C" role="3vwVQn">
+            <node concept="2OqwBi" id="3s41kb3Ab8D" role="3uHU7w">
+              <node concept="2OqwBi" id="3s41kb3Ab8E" role="2Oq$k0">
+                <node concept="2OqwBi" id="3s41kb3Ab8F" role="2Oq$k0">
+                  <node concept="2WthIp" id="3s41kb3Ab8G" role="2Oq$k0" />
+                  <node concept="2XshWL" id="3s41kb3Ab8H" role="2OqNvi">
+                    <ref role="2WH_rO" node="3s41kb3AaOC" resolve="create" />
+                    <node concept="37vLTw" id="3s41kb3Ab8I" role="2XxRq1">
+                      <ref role="3cqZAo" node="3s41kb3Ab8v" resolve="b" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="liA8E" id="3s41kb3Ab8J" role="2OqNvi">
+                  <ref role="37wK5l" to="s53o:36NsNggQrzG" resolve="setIncludeNodeIds" />
+                  <node concept="3clFbT" id="3s41kb3Ab8K" role="37wK5m" />
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3Ab8L" role="2OqNvi">
+                <ref role="37wK5l" to="s53o:36NsNggQr$I" resolve="hash" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="3s41kb3Ab8M" role="3uHU7B">
+              <node concept="2OqwBi" id="3s41kb3Ab8N" role="2Oq$k0">
+                <node concept="2OqwBi" id="3s41kb3Ab8O" role="2Oq$k0">
+                  <node concept="2WthIp" id="3s41kb3Ab8P" role="2Oq$k0" />
+                  <node concept="2XshWL" id="3s41kb3Ab8Q" role="2OqNvi">
+                    <ref role="2WH_rO" node="3s41kb3AaOC" resolve="create" />
+                    <node concept="37vLTw" id="3s41kb3Ab8R" role="2XxRq1">
+                      <ref role="3cqZAo" node="3s41kb3Ab8l" resolve="a" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="liA8E" id="3s41kb3Ab8S" role="2OqNvi">
+                  <ref role="37wK5l" to="s53o:36NsNggQrzG" resolve="setIncludeNodeIds" />
+                  <node concept="3clFbT" id="3s41kb3Ab8T" role="37wK5m" />
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3Ab8U" role="2OqNvi">
+                <ref role="37wK5l" to="s53o:36NsNggQr$I" resolve="hash" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="3s41kb3Ab8V" role="1SL9yI">
+      <property role="TrG5h" value="different_ignored" />
+      <node concept="3cqZAl" id="3s41kb3Ab8W" role="3clF45" />
+      <node concept="3clFbS" id="3s41kb3Ab8X" role="3clF47">
+        <node concept="3cpWs8" id="3s41kb3Ab8Y" role="3cqZAp">
+          <node concept="3cpWsn" id="3s41kb3Ab8Z" role="3cpWs9">
+            <property role="TrG5h" value="targetA" />
+            <node concept="3Tqbb2" id="3s41kb3Ab90" role="1tU5fm">
+              <ref role="ehGHo" to="tpee:fz12cDA" resolve="ClassConcept" />
+            </node>
+            <node concept="2pJPEk" id="3s41kb3Ab91" role="33vP2m">
+              <node concept="2pJPED" id="3s41kb3Ab92" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:fz12cDA" resolve="ClassConcept" />
+                <node concept="2pJxcG" id="3s41kb3Ab93" role="2pJxcM">
+                  <ref role="2pJxcJ" to="tpck:h0TrG11" resolve="name" />
+                  <node concept="WxPPo" id="3s41kb3Ab94" role="28ntcv">
+                    <node concept="Xl_RD" id="3s41kb3Ab95" role="WxPPp">
+                      <property role="Xl_RC" value="targetA" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3s41kb3Ab96" role="3cqZAp">
+          <node concept="3cpWsn" id="3s41kb3Ab97" role="3cpWs9">
+            <property role="TrG5h" value="targetB" />
+            <node concept="3Tqbb2" id="3s41kb3Ab98" role="1tU5fm">
+              <ref role="ehGHo" to="tpee:hiABswc" resolve="Annotation" />
+            </node>
+            <node concept="2pJPEk" id="3s41kb3Ab99" role="33vP2m">
+              <node concept="2pJPED" id="3s41kb3Ab9a" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:hiABswc" resolve="Annotation" />
+                <node concept="2pJxcG" id="3s41kb3Ab9b" role="2pJxcM">
+                  <ref role="2pJxcJ" to="tpck:h0TrG11" resolve="name" />
+                  <node concept="WxPPo" id="3s41kb3Ab9c" role="28ntcv">
+                    <node concept="Xl_RD" id="3s41kb3Ab9d" role="WxPPp">
+                      <property role="Xl_RC" value="targetB" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3s41kb3Ab9e" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3Ab9f" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required reference is not initialized `constructorDeclaration'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/5721350981296887946]&quot;;" />
+            <property role="huDt6" value="Error: required reference is not initialized `constructorDeclaration'" />
+          </node>
+          <node concept="15s5l7" id="3s41kb3Ab9g" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required link is not initialized `leftExpression'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/3741790230810467494]&quot;;" />
+            <property role="huDt6" value="Error: required link is not initialized `leftExpression'" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3Ab9h" role="3cpWs9">
+            <property role="TrG5h" value="a" />
+            <node concept="3Tqbb2" id="3s41kb3Ab9i" role="1tU5fm" />
+            <node concept="2pJPEk" id="3s41kb3Ab9j" role="33vP2m">
+              <node concept="2pJPED" id="3s41kb3Ab9k" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:h1Y3b43" resolve="AnonymousClass" />
+                <node concept="2pIpSj" id="3s41kb3Ab9l" role="2pJxcM">
+                  <ref role="2pIpSl" to="tpee:h1Y3Xaw" resolve="classifier" />
+                  <node concept="36biLy" id="3s41kb3Ab9m" role="28nt2d">
+                    <node concept="37vLTw" id="3s41kb3Ab9n" role="36biLW">
+                      <ref role="3cqZAo" node="3s41kb3Ab8Z" resolve="targetA" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3s41kb3Ab9o" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3Ab9p" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required reference is not initialized `constructorDeclaration'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/5721350981296887946]&quot;;" />
+            <property role="huDt6" value="Error: required reference is not initialized `constructorDeclaration'" />
+          </node>
+          <node concept="15s5l7" id="3s41kb3Ab9q" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required link is not initialized `leftExpression'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/3741790230810467494]&quot;;" />
+            <property role="huDt6" value="Error: required link is not initialized `leftExpression'" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3Ab9r" role="3cpWs9">
+            <property role="TrG5h" value="b" />
+            <node concept="3Tqbb2" id="3s41kb3Ab9s" role="1tU5fm" />
+            <node concept="2pJPEk" id="3s41kb3Ab9t" role="33vP2m">
+              <node concept="2pJPED" id="3s41kb3Ab9u" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:h1Y3b43" resolve="AnonymousClass" />
+                <node concept="2pIpSj" id="3s41kb3Ab9v" role="2pJxcM">
+                  <ref role="2pIpSl" to="tpee:h1Y3Xaw" resolve="classifier" />
+                  <node concept="36biLy" id="3s41kb3Ab9w" role="28nt2d">
+                    <node concept="37vLTw" id="3s41kb3Ab9x" role="36biLW">
+                      <ref role="3cqZAo" node="3s41kb3Ab97" resolve="targetB" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="3s41kb3Ab9y" role="3cqZAp" />
+        <node concept="3vwNmj" id="3s41kb3Ab9z" role="3cqZAp">
+          <node concept="17R0WA" id="3s41kb3Ab9$" role="3vwVQn">
+            <node concept="2OqwBi" id="3s41kb3Ab9_" role="3uHU7w">
+              <node concept="2OqwBi" id="3s41kb3Ab9A" role="2Oq$k0">
+                <node concept="2OqwBi" id="3s41kb3Ab9B" role="2Oq$k0">
+                  <node concept="2WthIp" id="3s41kb3Ab9C" role="2Oq$k0" />
+                  <node concept="2XshWL" id="3s41kb3Ab9D" role="2OqNvi">
+                    <ref role="2WH_rO" node="3s41kb3AaOC" resolve="create" />
+                    <node concept="37vLTw" id="3s41kb3Ab9E" role="2XxRq1">
+                      <ref role="3cqZAo" node="3s41kb3Ab9r" resolve="b" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="liA8E" id="3s41kb3Ab9F" role="2OqNvi">
+                  <ref role="37wK5l" to="s53o:36NsNggQr$6" resolve="ignore" />
+                  <node concept="359W_D" id="3s41kb3Ab9G" role="37wK5m">
+                    <ref role="359W_E" to="tpee:h1Y3b43" resolve="AnonymousClass" />
+                    <ref role="359W_F" to="tpee:h1Y3Xaw" resolve="classifier" />
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3Ab9H" role="2OqNvi">
+                <ref role="37wK5l" to="s53o:36NsNggQr$I" resolve="hash" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="3s41kb3Ab9I" role="3uHU7B">
+              <node concept="2OqwBi" id="3s41kb3Ab9J" role="2Oq$k0">
+                <node concept="2OqwBi" id="3s41kb3Ab9K" role="2Oq$k0">
+                  <node concept="2WthIp" id="3s41kb3Ab9L" role="2Oq$k0" />
+                  <node concept="2XshWL" id="3s41kb3Ab9M" role="2OqNvi">
+                    <ref role="2WH_rO" node="3s41kb3AaOC" resolve="create" />
+                    <node concept="37vLTw" id="3s41kb3Ab9N" role="2XxRq1">
+                      <ref role="3cqZAo" node="3s41kb3Ab9h" resolve="a" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="liA8E" id="3s41kb3Ab9O" role="2OqNvi">
+                  <ref role="37wK5l" to="s53o:36NsNggQr$6" resolve="ignore" />
+                  <node concept="359W_D" id="3s41kb3Ab9P" role="37wK5m">
+                    <ref role="359W_E" to="tpee:h1Y3b43" resolve="AnonymousClass" />
+                    <ref role="359W_F" to="tpee:h1Y3Xaw" resolve="classifier" />
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3Ab9Q" role="2OqNvi">
+                <ref role="37wK5l" to="s53o:36NsNggQr$I" resolve="hash" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="3s41kb3Ab9R" role="1SL9yI">
+      <property role="TrG5h" value="same" />
+      <node concept="3cqZAl" id="3s41kb3Ab9S" role="3clF45" />
+      <node concept="3clFbS" id="3s41kb3Ab9T" role="3clF47">
+        <node concept="3cpWs8" id="3s41kb3Ab9U" role="3cqZAp">
+          <node concept="3cpWsn" id="3s41kb3Ab9V" role="3cpWs9">
+            <property role="TrG5h" value="target" />
+            <node concept="3Tqbb2" id="3s41kb3Ab9W" role="1tU5fm">
+              <ref role="ehGHo" to="tpee:fz12cDA" resolve="ClassConcept" />
+            </node>
+            <node concept="2pJPEk" id="3s41kb3Ab9X" role="33vP2m">
+              <node concept="2pJPED" id="3s41kb3Ab9Y" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:fz12cDA" resolve="ClassConcept" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3s41kb3Ab9Z" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3Aba0" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required reference is not initialized `constructorDeclaration'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/5721350981296887946]&quot;;" />
+            <property role="huDt6" value="Error: required reference is not initialized `constructorDeclaration'" />
+          </node>
+          <node concept="15s5l7" id="3s41kb3Aba1" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required link is not initialized `leftExpression'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/3741790230810467494]&quot;;" />
+            <property role="huDt6" value="Error: required link is not initialized `leftExpression'" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3Aba2" role="3cpWs9">
+            <property role="TrG5h" value="a" />
+            <node concept="3Tqbb2" id="3s41kb3Aba3" role="1tU5fm" />
+            <node concept="2pJPEk" id="3s41kb3Aba4" role="33vP2m">
+              <node concept="2pJPED" id="3s41kb3Aba5" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:h1Y3b43" resolve="AnonymousClass" />
+                <node concept="2pIpSj" id="3s41kb3Aba6" role="2pJxcM">
+                  <ref role="2pIpSl" to="tpee:h1Y3Xaw" resolve="classifier" />
+                  <node concept="36biLy" id="3s41kb3Aba7" role="28nt2d">
+                    <node concept="37vLTw" id="3s41kb3Aba8" role="36biLW">
+                      <ref role="3cqZAo" node="3s41kb3Ab9V" resolve="target" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3s41kb3Aba9" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3Abaa" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required reference is not initialized `constructorDeclaration'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/5721350981296887946]&quot;;" />
+            <property role="huDt6" value="Error: required reference is not initialized `constructorDeclaration'" />
+          </node>
+          <node concept="15s5l7" id="3s41kb3Abab" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required link is not initialized `leftExpression'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/3741790230810467494]&quot;;" />
+            <property role="huDt6" value="Error: required link is not initialized `leftExpression'" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3Abac" role="3cpWs9">
+            <property role="TrG5h" value="b" />
+            <node concept="3Tqbb2" id="3s41kb3Abad" role="1tU5fm" />
+            <node concept="2pJPEk" id="3s41kb3Abae" role="33vP2m">
+              <node concept="2pJPED" id="3s41kb3Abaf" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:h1Y3b43" resolve="AnonymousClass" />
+                <node concept="2pIpSj" id="3s41kb3Abag" role="2pJxcM">
+                  <ref role="2pIpSl" to="tpee:h1Y3Xaw" resolve="classifier" />
+                  <node concept="36biLy" id="3s41kb3Abah" role="28nt2d">
+                    <node concept="37vLTw" id="3s41kb3Abai" role="36biLW">
+                      <ref role="3cqZAo" node="3s41kb3Ab9V" resolve="target" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="3s41kb3Abaj" role="3cqZAp" />
+        <node concept="3vwNmj" id="3s41kb3Abak" role="3cqZAp">
+          <node concept="17R0WA" id="3s41kb3Abal" role="3vwVQn">
+            <node concept="2OqwBi" id="3s41kb3Abam" role="3uHU7w">
+              <node concept="2OqwBi" id="3s41kb3Aban" role="2Oq$k0">
+                <node concept="2WthIp" id="3s41kb3Abao" role="2Oq$k0" />
+                <node concept="2XshWL" id="3s41kb3Abap" role="2OqNvi">
+                  <ref role="2WH_rO" node="3s41kb3AaOC" resolve="create" />
+                  <node concept="37vLTw" id="3s41kb3Abaq" role="2XxRq1">
+                    <ref role="3cqZAo" node="3s41kb3Abac" resolve="b" />
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3Abar" role="2OqNvi">
+                <ref role="37wK5l" to="s53o:36NsNggQr$I" resolve="hash" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="3s41kb3Abas" role="3uHU7B">
+              <node concept="2OqwBi" id="3s41kb3Abat" role="2Oq$k0">
+                <node concept="2WthIp" id="3s41kb3Abau" role="2Oq$k0" />
+                <node concept="2XshWL" id="3s41kb3Abav" role="2OqNvi">
+                  <ref role="2WH_rO" node="3s41kb3AaOC" resolve="create" />
+                  <node concept="37vLTw" id="3s41kb3Abaw" role="2XxRq1">
+                    <ref role="3cqZAo" node="3s41kb3Aba2" resolve="a" />
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3Abax" role="2OqNvi">
+                <ref role="37wK5l" to="s53o:36NsNggQr$I" resolve="hash" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="3s41kb3Abay" role="1SL9yI">
+      <property role="TrG5h" value="same_ignored" />
+      <node concept="3cqZAl" id="3s41kb3Abaz" role="3clF45" />
+      <node concept="3clFbS" id="3s41kb3Aba$" role="3clF47">
+        <node concept="3cpWs8" id="3s41kb3Aba_" role="3cqZAp">
+          <node concept="3cpWsn" id="3s41kb3AbaA" role="3cpWs9">
+            <property role="TrG5h" value="target" />
+            <node concept="3Tqbb2" id="3s41kb3AbaB" role="1tU5fm">
+              <ref role="ehGHo" to="tpee:fz12cDA" resolve="ClassConcept" />
+            </node>
+            <node concept="2pJPEk" id="3s41kb3AbaC" role="33vP2m">
+              <node concept="2pJPED" id="3s41kb3AbaD" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:fz12cDA" resolve="ClassConcept" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3s41kb3AbaE" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3AbaF" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required reference is not initialized `constructorDeclaration'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/5721350981296887946]&quot;;" />
+            <property role="huDt6" value="Error: required reference is not initialized `constructorDeclaration'" />
+          </node>
+          <node concept="15s5l7" id="3s41kb3AbaG" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required link is not initialized `leftExpression'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/3741790230810467494]&quot;;" />
+            <property role="huDt6" value="Error: required link is not initialized `leftExpression'" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3AbaH" role="3cpWs9">
+            <property role="TrG5h" value="a" />
+            <node concept="3Tqbb2" id="3s41kb3AbaI" role="1tU5fm" />
+            <node concept="2pJPEk" id="3s41kb3AbaJ" role="33vP2m">
+              <node concept="2pJPED" id="3s41kb3AbaK" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:h1Y3b43" resolve="AnonymousClass" />
+                <node concept="2pIpSj" id="3s41kb3AbaL" role="2pJxcM">
+                  <ref role="2pIpSl" to="tpee:h1Y3Xaw" resolve="classifier" />
+                  <node concept="36biLy" id="3s41kb3AbaM" role="28nt2d">
+                    <node concept="37vLTw" id="3s41kb3AbaN" role="36biLW">
+                      <ref role="3cqZAo" node="3s41kb3AbaA" resolve="target" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3s41kb3AbaO" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3AbaP" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required reference is not initialized `constructorDeclaration'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/5721350981296887946]&quot;;" />
+            <property role="huDt6" value="Error: required reference is not initialized `constructorDeclaration'" />
+          </node>
+          <node concept="15s5l7" id="3s41kb3AbaQ" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required link is not initialized `leftExpression'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/3741790230810467494]&quot;;" />
+            <property role="huDt6" value="Error: required link is not initialized `leftExpression'" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3AbaR" role="3cpWs9">
+            <property role="TrG5h" value="b" />
+            <node concept="3Tqbb2" id="3s41kb3AbaS" role="1tU5fm" />
+            <node concept="2pJPEk" id="3s41kb3AbaT" role="33vP2m">
+              <node concept="2pJPED" id="3s41kb3AbaU" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:h1Y3b43" resolve="AnonymousClass" />
+                <node concept="2pIpSj" id="3s41kb3AbaV" role="2pJxcM">
+                  <ref role="2pIpSl" to="tpee:h1Y3Xaw" resolve="classifier" />
+                  <node concept="36biLy" id="3s41kb3AbaW" role="28nt2d">
+                    <node concept="37vLTw" id="3s41kb3AbaX" role="36biLW">
+                      <ref role="3cqZAo" node="3s41kb3AbaA" resolve="target" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="3s41kb3AbaY" role="3cqZAp" />
+        <node concept="3vwNmj" id="3s41kb3AbaZ" role="3cqZAp">
+          <node concept="17R0WA" id="3s41kb3Abb0" role="3vwVQn">
+            <node concept="2OqwBi" id="3s41kb3Abb1" role="3uHU7w">
+              <node concept="2OqwBi" id="3s41kb3Abb2" role="2Oq$k0">
+                <node concept="2OqwBi" id="3s41kb3Abb3" role="2Oq$k0">
+                  <node concept="2WthIp" id="3s41kb3Abb4" role="2Oq$k0" />
+                  <node concept="2XshWL" id="3s41kb3Abb5" role="2OqNvi">
+                    <ref role="2WH_rO" node="3s41kb3AaOC" resolve="create" />
+                    <node concept="37vLTw" id="3s41kb3Abb6" role="2XxRq1">
+                      <ref role="3cqZAo" node="3s41kb3AbaR" resolve="b" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="liA8E" id="3s41kb3Abb7" role="2OqNvi">
+                  <ref role="37wK5l" to="s53o:36NsNggQr$6" resolve="ignore" />
+                  <node concept="359W_D" id="3s41kb3Abb8" role="37wK5m">
+                    <ref role="359W_E" to="tpee:h1Y3b43" resolve="AnonymousClass" />
+                    <ref role="359W_F" to="tpee:h1Y3Xaw" resolve="classifier" />
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3Abb9" role="2OqNvi">
+                <ref role="37wK5l" to="s53o:36NsNggQr$I" resolve="hash" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="3s41kb3Abba" role="3uHU7B">
+              <node concept="2OqwBi" id="3s41kb3Abbb" role="2Oq$k0">
+                <node concept="2OqwBi" id="3s41kb3Abbc" role="2Oq$k0">
+                  <node concept="2WthIp" id="3s41kb3Abbd" role="2Oq$k0" />
+                  <node concept="2XshWL" id="3s41kb3Abbe" role="2OqNvi">
+                    <ref role="2WH_rO" node="3s41kb3AaOC" resolve="create" />
+                    <node concept="37vLTw" id="3s41kb3Abbf" role="2XxRq1">
+                      <ref role="3cqZAo" node="3s41kb3AbaH" resolve="a" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="liA8E" id="3s41kb3Abbg" role="2OqNvi">
+                  <ref role="37wK5l" to="s53o:36NsNggQr$6" resolve="ignore" />
+                  <node concept="359W_D" id="3s41kb3Abbh" role="37wK5m">
+                    <ref role="359W_E" to="tpee:h1Y3b43" resolve="AnonymousClass" />
+                    <ref role="359W_F" to="tpee:h1Y3Xaw" resolve="classifier" />
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3Abbi" role="2OqNvi">
+                <ref role="37wK5l" to="s53o:36NsNggQr$I" resolve="hash" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="3s41kb3Abbj" role="1SL9yI">
+      <property role="TrG5h" value="sameOrder" />
+      <node concept="3cqZAl" id="3s41kb3Abbk" role="3clF45" />
+      <node concept="3clFbS" id="3s41kb3Abbl" role="3clF47">
+        <node concept="3cpWs8" id="3s41kb3Abbm" role="3cqZAp">
+          <node concept="3cpWsn" id="3s41kb3Abbn" role="3cpWs9">
+            <property role="TrG5h" value="targetA" />
+            <node concept="3Tqbb2" id="3s41kb3Abbo" role="1tU5fm">
+              <ref role="ehGHo" to="tpee:fz12cDA" resolve="ClassConcept" />
+            </node>
+            <node concept="2pJPEk" id="3s41kb3Abbp" role="33vP2m">
+              <node concept="2pJPED" id="3s41kb3Abbq" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:fz12cDA" resolve="ClassConcept" />
+                <node concept="2pJxcG" id="3s41kb3Abbr" role="2pJxcM">
+                  <ref role="2pJxcJ" to="tpck:h0TrG11" resolve="name" />
+                  <node concept="WxPPo" id="3s41kb3Abbs" role="28ntcv">
+                    <node concept="Xl_RD" id="3s41kb3Abbt" role="WxPPp">
+                      <property role="Xl_RC" value="targetA" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3s41kb3Abbu" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3Abbv" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required link is not initialized `body'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/3741790230810467494]&quot;;" />
+            <property role="huDt6" value="Error: required link is not initialized `body'" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3Abbw" role="3cpWs9">
+            <property role="TrG5h" value="targetB" />
+            <node concept="3Tqbb2" id="3s41kb3Abbx" role="1tU5fm">
+              <ref role="ehGHo" to="tpee:fzclF84" resolve="ConstructorDeclaration" />
+            </node>
+            <node concept="2pJPEk" id="3s41kb3Abby" role="33vP2m">
+              <node concept="2pJPED" id="3s41kb3Abbz" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:fzclF84" resolve="ConstructorDeclaration" />
+                <node concept="2pJxcG" id="3s41kb3Abb$" role="2pJxcM">
+                  <ref role="2pJxcJ" to="tpck:h0TrG11" resolve="name" />
+                  <node concept="WxPPo" id="3s41kb3Abb_" role="28ntcv">
+                    <node concept="Xl_RD" id="3s41kb3AbbA" role="WxPPp">
+                      <property role="Xl_RC" value="targetB" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3s41kb3AbbB" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3AbbC" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required reference is not initialized `constructorDeclaration'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/5721350981296887946]&quot;;" />
+            <property role="huDt6" value="Error: required reference is not initialized `constructorDeclaration'" />
+          </node>
+          <node concept="15s5l7" id="3s41kb3AbbD" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required link is not initialized `leftExpression'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/3741790230810467494]&quot;;" />
+            <property role="huDt6" value="Error: required link is not initialized `leftExpression'" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3AbbE" role="3cpWs9">
+            <property role="TrG5h" value="a" />
+            <node concept="3Tqbb2" id="3s41kb3AbbF" role="1tU5fm" />
+            <node concept="2pJPEk" id="3s41kb3AbbG" role="33vP2m">
+              <node concept="2pJPED" id="3s41kb3AbbH" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:h1Y3b43" resolve="AnonymousClass" />
+                <node concept="2pIpSj" id="3s41kb3AbbI" role="2pJxcM">
+                  <ref role="2pIpSl" to="tpee:h1Y3Xaw" resolve="classifier" />
+                  <node concept="36biLy" id="3s41kb3AbbJ" role="28nt2d">
+                    <node concept="37vLTw" id="3s41kb3AbbK" role="36biLW">
+                      <ref role="3cqZAo" node="3s41kb3Abbn" resolve="targetA" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2pIpSj" id="3s41kb3AbbL" role="2pJxcM">
+                  <ref role="2pIpSl" to="tpee:2yoSzAaKW1s" resolve="constructorDeclaration" />
+                  <node concept="36biLy" id="3s41kb3AbbM" role="28nt2d">
+                    <node concept="37vLTw" id="3s41kb3AbbN" role="36biLW">
+                      <ref role="3cqZAo" node="3s41kb3Abbw" resolve="targetB" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3s41kb3AbbO" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3AbbP" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required reference is not initialized `constructorDeclaration'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/5721350981296887946]&quot;;" />
+            <property role="huDt6" value="Error: required reference is not initialized `constructorDeclaration'" />
+          </node>
+          <node concept="15s5l7" id="3s41kb3AbbQ" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required link is not initialized `leftExpression'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/3741790230810467494]&quot;;" />
+            <property role="huDt6" value="Error: required link is not initialized `leftExpression'" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3AbbR" role="3cpWs9">
+            <property role="TrG5h" value="b" />
+            <node concept="3Tqbb2" id="3s41kb3AbbS" role="1tU5fm" />
+            <node concept="2pJPEk" id="3s41kb3AbbT" role="33vP2m">
+              <node concept="2pJPED" id="3s41kb3AbbU" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:h1Y3b43" resolve="AnonymousClass" />
+                <node concept="2pIpSj" id="3s41kb3AbbV" role="2pJxcM">
+                  <ref role="2pIpSl" to="tpee:h1Y3Xaw" resolve="classifier" />
+                  <node concept="36biLy" id="3s41kb3AbbW" role="28nt2d">
+                    <node concept="37vLTw" id="3s41kb3AbbX" role="36biLW">
+                      <ref role="3cqZAo" node="3s41kb3Abbn" resolve="targetA" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2pIpSj" id="3s41kb3AbbY" role="2pJxcM">
+                  <ref role="2pIpSl" to="tpee:2yoSzAaKW1s" resolve="constructorDeclaration" />
+                  <node concept="36biLy" id="3s41kb3AbbZ" role="28nt2d">
+                    <node concept="37vLTw" id="3s41kb3Abc0" role="36biLW">
+                      <ref role="3cqZAo" node="3s41kb3Abbw" resolve="targetB" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="3s41kb3Abc1" role="3cqZAp" />
+        <node concept="3vwNmj" id="3s41kb3Abc2" role="3cqZAp">
+          <node concept="17R0WA" id="3s41kb3Abc3" role="3vwVQn">
+            <node concept="2OqwBi" id="3s41kb3Abc4" role="3uHU7w">
+              <node concept="2OqwBi" id="3s41kb3Abc5" role="2Oq$k0">
+                <node concept="2WthIp" id="3s41kb3Abc6" role="2Oq$k0" />
+                <node concept="2XshWL" id="3s41kb3Abc7" role="2OqNvi">
+                  <ref role="2WH_rO" node="3s41kb3AaOC" resolve="create" />
+                  <node concept="37vLTw" id="3s41kb3Abc8" role="2XxRq1">
+                    <ref role="3cqZAo" node="3s41kb3AbbR" resolve="b" />
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3Abc9" role="2OqNvi">
+                <ref role="37wK5l" to="s53o:36NsNggQr$I" resolve="hash" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="3s41kb3Abca" role="3uHU7B">
+              <node concept="2OqwBi" id="3s41kb3Abcb" role="2Oq$k0">
+                <node concept="2WthIp" id="3s41kb3Abcc" role="2Oq$k0" />
+                <node concept="2XshWL" id="3s41kb3Abcd" role="2OqNvi">
+                  <ref role="2WH_rO" node="3s41kb3AaOC" resolve="create" />
+                  <node concept="37vLTw" id="3s41kb3Abce" role="2XxRq1">
+                    <ref role="3cqZAo" node="3s41kb3AbbE" resolve="a" />
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3Abcf" role="2OqNvi">
+                <ref role="37wK5l" to="s53o:36NsNggQr$I" resolve="hash" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="3s41kb3Abcg" role="1SL9yI">
+      <property role="TrG5h" value="differentOrder" />
+      <node concept="3cqZAl" id="3s41kb3Abch" role="3clF45" />
+      <node concept="3clFbS" id="3s41kb3Abci" role="3clF47">
+        <node concept="3cpWs8" id="3s41kb3Abcj" role="3cqZAp">
+          <node concept="3cpWsn" id="3s41kb3Abck" role="3cpWs9">
+            <property role="TrG5h" value="targetA" />
+            <node concept="3Tqbb2" id="3s41kb3Abcl" role="1tU5fm">
+              <ref role="ehGHo" to="tpee:fz12cDA" resolve="ClassConcept" />
+            </node>
+            <node concept="2pJPEk" id="3s41kb3Abcm" role="33vP2m">
+              <node concept="2pJPED" id="3s41kb3Abcn" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:fz12cDA" resolve="ClassConcept" />
+                <node concept="2pJxcG" id="3s41kb3Abco" role="2pJxcM">
+                  <ref role="2pJxcJ" to="tpck:h0TrG11" resolve="name" />
+                  <node concept="WxPPo" id="3s41kb3Abcp" role="28ntcv">
+                    <node concept="Xl_RD" id="3s41kb3Abcq" role="WxPPp">
+                      <property role="Xl_RC" value="targetA" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3s41kb3Abcr" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3Abcs" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required link is not initialized `body'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/3741790230810467494]&quot;;" />
+            <property role="huDt6" value="Error: required link is not initialized `body'" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3Abct" role="3cpWs9">
+            <property role="TrG5h" value="targetB" />
+            <node concept="3Tqbb2" id="3s41kb3Abcu" role="1tU5fm">
+              <ref role="ehGHo" to="tpee:fzclF84" resolve="ConstructorDeclaration" />
+            </node>
+            <node concept="2pJPEk" id="3s41kb3Abcv" role="33vP2m">
+              <node concept="2pJPED" id="3s41kb3Abcw" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:fzclF84" resolve="ConstructorDeclaration" />
+                <node concept="2pJxcG" id="3s41kb3Abcx" role="2pJxcM">
+                  <ref role="2pJxcJ" to="tpck:h0TrG11" resolve="name" />
+                  <node concept="WxPPo" id="3s41kb3Abcy" role="28ntcv">
+                    <node concept="Xl_RD" id="3s41kb3Abcz" role="WxPPp">
+                      <property role="Xl_RC" value="targetB" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3s41kb3Abc$" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3Abc_" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required reference is not initialized `constructorDeclaration'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/5721350981296887946]&quot;;" />
+            <property role="huDt6" value="Error: required reference is not initialized `constructorDeclaration'" />
+          </node>
+          <node concept="15s5l7" id="3s41kb3AbcA" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required link is not initialized `leftExpression'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/3741790230810467494]&quot;;" />
+            <property role="huDt6" value="Error: required link is not initialized `leftExpression'" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3AbcB" role="3cpWs9">
+            <property role="TrG5h" value="a" />
+            <node concept="3Tqbb2" id="3s41kb3AbcC" role="1tU5fm" />
+            <node concept="2pJPEk" id="3s41kb3AbcD" role="33vP2m">
+              <node concept="2pJPED" id="3s41kb3AbcE" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:h1Y3b43" resolve="AnonymousClass" />
+                <node concept="2pIpSj" id="3s41kb3AbcF" role="2pJxcM">
+                  <ref role="2pIpSl" to="tpee:h1Y3Xaw" resolve="classifier" />
+                  <node concept="36biLy" id="3s41kb3AbcG" role="28nt2d">
+                    <node concept="37vLTw" id="3s41kb3AbcH" role="36biLW">
+                      <ref role="3cqZAo" node="3s41kb3Abck" resolve="targetA" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2pIpSj" id="3s41kb3AbcI" role="2pJxcM">
+                  <ref role="2pIpSl" to="tpee:2yoSzAaKW1s" resolve="constructorDeclaration" />
+                  <node concept="36biLy" id="3s41kb3AbcJ" role="28nt2d">
+                    <node concept="37vLTw" id="3s41kb3AbcK" role="36biLW">
+                      <ref role="3cqZAo" node="3s41kb3Abct" resolve="targetB" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3s41kb3AbcL" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3AbcM" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required reference is not initialized `constructorDeclaration'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/5721350981296887946]&quot;;" />
+            <property role="huDt6" value="Error: required reference is not initialized `constructorDeclaration'" />
+          </node>
+          <node concept="15s5l7" id="3s41kb3AbcN" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required link is not initialized `leftExpression'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/3741790230810467494]&quot;;" />
+            <property role="huDt6" value="Error: required link is not initialized `leftExpression'" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3AbcO" role="3cpWs9">
+            <property role="TrG5h" value="b" />
+            <node concept="3Tqbb2" id="3s41kb3AbcP" role="1tU5fm" />
+            <node concept="2pJPEk" id="3s41kb3AbcQ" role="33vP2m">
+              <node concept="2pJPED" id="3s41kb3AbcR" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:h1Y3b43" resolve="AnonymousClass" />
+                <node concept="2pIpSj" id="3s41kb3AbcS" role="2pJxcM">
+                  <ref role="2pIpSl" to="tpee:2yoSzAaKW1s" resolve="constructorDeclaration" />
+                  <node concept="36biLy" id="3s41kb3AbcT" role="28nt2d">
+                    <node concept="37vLTw" id="3s41kb3AbcU" role="36biLW">
+                      <ref role="3cqZAo" node="3s41kb3Abct" resolve="targetB" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2pIpSj" id="3s41kb3AbcV" role="2pJxcM">
+                  <ref role="2pIpSl" to="tpee:h1Y3Xaw" resolve="classifier" />
+                  <node concept="36biLy" id="3s41kb3AbcW" role="28nt2d">
+                    <node concept="37vLTw" id="3s41kb3AbcX" role="36biLW">
+                      <ref role="3cqZAo" node="3s41kb3Abck" resolve="targetA" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="3s41kb3AbcY" role="3cqZAp" />
+        <node concept="3vlDli" id="3s41kb3AbcZ" role="3cqZAp">
+          <node concept="2OqwBi" id="3s41kb3Abd0" role="3tpDZA">
+            <node concept="2OqwBi" id="3s41kb3Abd1" role="2Oq$k0">
+              <node concept="2OqwBi" id="3s41kb3Abd2" role="2Oq$k0">
+                <node concept="2OqwBi" id="3s41kb3Abd3" role="2Oq$k0">
+                  <node concept="2JrnkZ" id="3s41kb3Abd4" role="2Oq$k0">
+                    <node concept="37vLTw" id="3s41kb3Abd5" role="2JrQYb">
+                      <ref role="3cqZAo" node="3s41kb3AbcB" resolve="a" />
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="3s41kb3Abd6" role="2OqNvi">
+                    <ref role="37wK5l" to="mhbf:~SNode.getReferences()" resolve="getReferences" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="3s41kb3Abd7" role="2OqNvi">
+                  <ref role="37wK5l" to="wyt6:~Iterable.iterator()" resolve="iterator" />
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3Abd8" role="2OqNvi">
+                <ref role="37wK5l" to="33ny:~Iterator.next()" resolve="next" />
+              </node>
+            </node>
+            <node concept="liA8E" id="3s41kb3Abd9" role="2OqNvi">
+              <ref role="37wK5l" to="mhbf:~SReference.getTargetNode()" resolve="getTargetNode" />
+            </node>
+          </node>
+          <node concept="37vLTw" id="3s41kb3Abda" role="3tpDZB">
+            <ref role="3cqZAo" node="3s41kb3Abck" resolve="targetA" />
+          </node>
+        </node>
+        <node concept="3vlDli" id="3s41kb3Abdb" role="3cqZAp">
+          <node concept="37vLTw" id="3s41kb3Abdc" role="3tpDZB">
+            <ref role="3cqZAo" node="3s41kb3Abct" resolve="targetB" />
+          </node>
+          <node concept="2OqwBi" id="3s41kb3Abdd" role="3tpDZA">
+            <node concept="2OqwBi" id="3s41kb3Abde" role="2Oq$k0">
+              <node concept="2OqwBi" id="3s41kb3Abdf" role="2Oq$k0">
+                <node concept="2OqwBi" id="3s41kb3Abdg" role="2Oq$k0">
+                  <node concept="2JrnkZ" id="3s41kb3Abdh" role="2Oq$k0">
+                    <node concept="37vLTw" id="3s41kb3Abdi" role="2JrQYb">
+                      <ref role="3cqZAo" node="3s41kb3AbcO" resolve="b" />
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="3s41kb3Abdj" role="2OqNvi">
+                    <ref role="37wK5l" to="mhbf:~SNode.getReferences()" resolve="getReferences" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="3s41kb3Abdk" role="2OqNvi">
+                  <ref role="37wK5l" to="wyt6:~Iterable.iterator()" resolve="iterator" />
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3Abdl" role="2OqNvi">
+                <ref role="37wK5l" to="33ny:~Iterator.next()" resolve="next" />
+              </node>
+            </node>
+            <node concept="liA8E" id="3s41kb3Abdm" role="2OqNvi">
+              <ref role="37wK5l" to="mhbf:~SReference.getTargetNode()" resolve="getTargetNode" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="3s41kb3Abdn" role="3cqZAp" />
+        <node concept="3vwNmj" id="3s41kb3Abdo" role="3cqZAp">
+          <node concept="17R0WA" id="3s41kb3Abdp" role="3vwVQn">
+            <node concept="2OqwBi" id="3s41kb3Abdq" role="3uHU7w">
+              <node concept="2OqwBi" id="3s41kb3Abdr" role="2Oq$k0">
+                <node concept="2WthIp" id="3s41kb3Abds" role="2Oq$k0" />
+                <node concept="2XshWL" id="3s41kb3Abdt" role="2OqNvi">
+                  <ref role="2WH_rO" node="3s41kb3AaOC" resolve="create" />
+                  <node concept="37vLTw" id="3s41kb3Abdu" role="2XxRq1">
+                    <ref role="3cqZAo" node="3s41kb3AbcO" resolve="b" />
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3Abdv" role="2OqNvi">
+                <ref role="37wK5l" to="s53o:36NsNggQr$I" resolve="hash" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="3s41kb3Abdw" role="3uHU7B">
+              <node concept="2OqwBi" id="3s41kb3Abdx" role="2Oq$k0">
+                <node concept="2WthIp" id="3s41kb3Abdy" role="2Oq$k0" />
+                <node concept="2XshWL" id="3s41kb3Abdz" role="2OqNvi">
+                  <ref role="2WH_rO" node="3s41kb3AaOC" resolve="create" />
+                  <node concept="37vLTw" id="3s41kb3Abd$" role="2XxRq1">
+                    <ref role="3cqZAo" node="3s41kb3AbcB" resolve="a" />
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3Abd_" role="2OqNvi">
+                <ref role="37wK5l" to="s53o:36NsNggQr$I" resolve="hash" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1lH9Xt" id="3s41kb3BeDx">
+    <property role="3DII0k" value="2hh8MJdVwqX/command" />
+    <property role="TrG5h" value="NodeHasherTests_Containments" />
+    <node concept="2XrIbr" id="3s41kb3BeDy" role="1qtyYc">
+      <property role="TrG5h" value="create" />
+      <node concept="3uibUv" id="3s41kb3BeDz" role="3clF45">
+        <ref role="3uigEE" to="s53o:36NsNggQrub" resolve="NodeHasher" />
+      </node>
+      <node concept="3clFbS" id="3s41kb3BeD$" role="3clF47">
+        <node concept="3clFbF" id="3s41kb3BeD_" role="3cqZAp">
+          <node concept="2OqwBi" id="3s41kb3BeDA" role="3clFbG">
+            <node concept="2ShNRf" id="3s41kb3BeDB" role="2Oq$k0">
+              <node concept="1pGfFk" id="3s41kb3BeDC" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="s53o:36NsNggQryX" resolve="NodeHasher" />
+                <node concept="2OqwBi" id="3s41kb3BeDD" role="37wK5m">
+                  <node concept="2OqwBi" id="3s41kb3BeDE" role="2Oq$k0">
+                    <node concept="37vLTw" id="3s41kb3BeDF" role="2Oq$k0">
+                      <ref role="3cqZAo" node="3s41kb3BeDL" resolve="nodes" />
+                    </node>
+                    <node concept="39bAoz" id="3s41kb3BeDG" role="2OqNvi" />
+                  </node>
+                  <node concept="ANE8D" id="3s41kb3BeDH" role="2OqNvi" />
+                </node>
+                <node concept="2nou5x" id="3s41kb3BeDI" role="37wK5m">
+                  <property role="2noCCI" value="456" />
+                </node>
+              </node>
+            </node>
+            <node concept="liA8E" id="3s41kb3BeDJ" role="2OqNvi">
+              <ref role="37wK5l" to="s53o:36NsNggQrzG" resolve="setIncludeNodeIds" />
+              <node concept="3clFbT" id="3s41kb3BeDK" role="37wK5m" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="3s41kb3BeDL" role="3clF46">
+        <property role="TrG5h" value="nodes" />
+        <node concept="8X2XB" id="3s41kb3BeDM" role="1tU5fm">
+          <node concept="3Tqbb2" id="3s41kb3BeDN" role="8Xvag" />
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="3s41kb3BeF8" role="1SL9yI">
+      <property role="TrG5h" value="same" />
+      <node concept="3cqZAl" id="3s41kb3BeF9" role="3clF45" />
+      <node concept="3clFbS" id="3s41kb3BeFa" role="3clF47">
+        <node concept="3cpWs8" id="3s41kb3BeFN" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3BeFO" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required reference is not initialized `constructorDeclaration'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/5721350981296887946]&quot;;" />
+            <property role="huDt6" value="Error: required reference is not initialized `constructorDeclaration'" />
+          </node>
+          <node concept="15s5l7" id="3s41kb3BeFP" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required link is not initialized `leftExpression'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/3741790230810467494]&quot;;" />
+            <property role="huDt6" value="Error: required link is not initialized `leftExpression'" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3BeFQ" role="3cpWs9">
+            <property role="TrG5h" value="a" />
+            <node concept="3Tqbb2" id="3s41kb3BeFR" role="1tU5fm" />
+            <node concept="2pJPEk" id="3s41kb3BeFS" role="33vP2m">
+              <node concept="2pJPED" id="3s41kb3BeFT" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:fHWc73I" resolve="AndExpression" />
+                <node concept="2pIpSj" id="3s41kb3BeFU" role="2pJxcM">
+                  <ref role="2pIpSl" to="tpee:fJuHU4s" resolve="leftExpression" />
+                  <node concept="2pJPED" id="3s41kb3Bmrp" role="28nt2d">
+                    <ref role="2pJxaS" to="tpee:fzclF81" resolve="BooleanConstant" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3s41kb3BeFX" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3BeFY" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required reference is not initialized `constructorDeclaration'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/5721350981296887946]&quot;;" />
+            <property role="huDt6" value="Error: required reference is not initialized `constructorDeclaration'" />
+          </node>
+          <node concept="15s5l7" id="3s41kb3BeFZ" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required link is not initialized `leftExpression'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/3741790230810467494]&quot;;" />
+            <property role="huDt6" value="Error: required link is not initialized `leftExpression'" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3BeG0" role="3cpWs9">
+            <property role="TrG5h" value="b" />
+            <node concept="3Tqbb2" id="3s41kb3BeG1" role="1tU5fm" />
+            <node concept="2pJPEk" id="3s41kb3BeG2" role="33vP2m">
+              <node concept="2pJPED" id="3s41kb3Bmt2" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:fHWc73I" resolve="AndExpression" />
+                <node concept="2pIpSj" id="3s41kb3Bmt3" role="2pJxcM">
+                  <ref role="2pIpSl" to="tpee:fJuHU4s" resolve="leftExpression" />
+                  <node concept="2pJPED" id="3s41kb3Bmt4" role="28nt2d">
+                    <ref role="2pJxaS" to="tpee:fzclF81" resolve="BooleanConstant" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="3s41kb3BeG7" role="3cqZAp" />
+        <node concept="3vwNmj" id="3s41kb3BeG8" role="3cqZAp">
+          <node concept="17R0WA" id="3s41kb3BeG9" role="3vwVQn">
+            <node concept="2OqwBi" id="3s41kb3BeGa" role="3uHU7w">
+              <node concept="2OqwBi" id="3s41kb3BeGc" role="2Oq$k0">
+                <node concept="2WthIp" id="3s41kb3BeGd" role="2Oq$k0" />
+                <node concept="2XshWL" id="3s41kb3BeGe" role="2OqNvi">
+                  <ref role="2WH_rO" node="3s41kb3BeDy" resolve="create" />
+                  <node concept="37vLTw" id="3s41kb3BeGf" role="2XxRq1">
+                    <ref role="3cqZAo" node="3s41kb3BeG0" resolve="b" />
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3BeGi" role="2OqNvi">
+                <ref role="37wK5l" to="s53o:36NsNggQr$I" resolve="hash" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="3s41kb3BeGj" role="3uHU7B">
+              <node concept="2OqwBi" id="3s41kb3BeGl" role="2Oq$k0">
+                <node concept="2WthIp" id="3s41kb3BeGm" role="2Oq$k0" />
+                <node concept="2XshWL" id="3s41kb3BeGn" role="2OqNvi">
+                  <ref role="2WH_rO" node="3s41kb3BeDy" resolve="create" />
+                  <node concept="37vLTw" id="3s41kb3BeGo" role="2XxRq1">
+                    <ref role="3cqZAo" node="3s41kb3BeFQ" resolve="a" />
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3BeGr" role="2OqNvi">
+                <ref role="37wK5l" to="s53o:36NsNggQr$I" resolve="hash" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="3s41kb3BeDO" role="1SL9yI">
+      <property role="TrG5h" value="different_byValue" />
+      <node concept="3cqZAl" id="3s41kb3BeDP" role="3clF45" />
+      <node concept="3clFbS" id="3s41kb3BeDQ" role="3clF47">
+        <node concept="3cpWs8" id="3s41kb3BmZE" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3BmZF" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required reference is not initialized `constructorDeclaration'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/5721350981296887946]&quot;;" />
+            <property role="huDt6" value="Error: required reference is not initialized `constructorDeclaration'" />
+          </node>
+          <node concept="15s5l7" id="3s41kb3BmZG" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required link is not initialized `leftExpression'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/3741790230810467494]&quot;;" />
+            <property role="huDt6" value="Error: required link is not initialized `leftExpression'" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3BmZH" role="3cpWs9">
+            <property role="TrG5h" value="a" />
+            <node concept="3Tqbb2" id="3s41kb3BmZI" role="1tU5fm" />
+            <node concept="2pJPEk" id="3s41kb3BmZJ" role="33vP2m">
+              <node concept="2pJPED" id="3s41kb3BmZK" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:fHWc73I" resolve="AndExpression" />
+                <node concept="2pIpSj" id="3s41kb3BmZL" role="2pJxcM">
+                  <ref role="2pIpSl" to="tpee:fJuHU4s" resolve="leftExpression" />
+                  <node concept="2pJPED" id="3s41kb3BmZM" role="28nt2d">
+                    <ref role="2pJxaS" to="tpee:fzclF81" resolve="BooleanConstant" />
+                    <node concept="2pJxcG" id="3s41kb3Bn7e" role="2pJxcM">
+                      <ref role="2pJxcJ" to="tpee:fzclF82" resolve="value" />
+                      <node concept="WxPPo" id="3s41kb3Bn7h" role="28ntcv">
+                        <node concept="3clFbT" id="3s41kb3Bn7g" role="WxPPp">
+                          <property role="3clFbU" value="true" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3s41kb3BmZN" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3BmZO" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required reference is not initialized `constructorDeclaration'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/5721350981296887946]&quot;;" />
+            <property role="huDt6" value="Error: required reference is not initialized `constructorDeclaration'" />
+          </node>
+          <node concept="15s5l7" id="3s41kb3BmZP" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required link is not initialized `leftExpression'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/3741790230810467494]&quot;;" />
+            <property role="huDt6" value="Error: required link is not initialized `leftExpression'" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3BmZQ" role="3cpWs9">
+            <property role="TrG5h" value="b" />
+            <node concept="3Tqbb2" id="3s41kb3BmZR" role="1tU5fm" />
+            <node concept="2pJPEk" id="3s41kb3BmZS" role="33vP2m">
+              <node concept="2pJPED" id="3s41kb3BmZT" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:fHWc73I" resolve="AndExpression" />
+                <node concept="2pIpSj" id="3s41kb3BmZU" role="2pJxcM">
+                  <ref role="2pIpSl" to="tpee:fJuHU4s" resolve="leftExpression" />
+                  <node concept="2pJPED" id="3s41kb3BmZV" role="28nt2d">
+                    <ref role="2pJxaS" to="tpee:fzclF81" resolve="BooleanConstant" />
+                    <node concept="2pJxcG" id="3s41kb3Bnan" role="2pJxcM">
+                      <ref role="2pJxcJ" to="tpee:fzclF82" resolve="value" />
+                      <node concept="WxPPo" id="3s41kb3Bnc7" role="28ntcv">
+                        <node concept="3clFbT" id="3s41kb3Bnc6" role="WxPPp" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="3s41kb3BeEN" role="3cqZAp" />
+        <node concept="3vFxKo" id="3s41kb3BeEO" role="3cqZAp">
+          <node concept="17R0WA" id="3s41kb3BeEP" role="3vFALc">
+            <node concept="2OqwBi" id="3s41kb3BeEQ" role="3uHU7w">
+              <node concept="2OqwBi" id="3s41kb3BeES" role="2Oq$k0">
+                <node concept="2WthIp" id="3s41kb3BeET" role="2Oq$k0" />
+                <node concept="2XshWL" id="3s41kb3BeEU" role="2OqNvi">
+                  <ref role="2WH_rO" node="3s41kb3BeDy" resolve="create" />
+                  <node concept="37vLTw" id="3s41kb3BeEV" role="2XxRq1">
+                    <ref role="3cqZAo" node="3s41kb3BmZQ" resolve="b" />
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3BeEY" role="2OqNvi">
+                <ref role="37wK5l" to="s53o:36NsNggQr$I" resolve="hash" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="3s41kb3BeEZ" role="3uHU7B">
+              <node concept="2OqwBi" id="3s41kb3BeF1" role="2Oq$k0">
+                <node concept="2WthIp" id="3s41kb3BeF2" role="2Oq$k0" />
+                <node concept="2XshWL" id="3s41kb3BeF3" role="2OqNvi">
+                  <ref role="2WH_rO" node="3s41kb3BeDy" resolve="create" />
+                  <node concept="37vLTw" id="3s41kb3BeF4" role="2XxRq1">
+                    <ref role="3cqZAo" node="3s41kb3BmZH" resolve="a" />
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3BeF7" role="2OqNvi">
+                <ref role="37wK5l" to="s53o:36NsNggQr$I" resolve="hash" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="3s41kb3BeGs" role="1SL9yI">
+      <property role="TrG5h" value="different_byConcept" />
+      <node concept="3cqZAl" id="3s41kb3BeGt" role="3clF45" />
+      <node concept="3clFbS" id="3s41kb3BeGu" role="3clF47">
+        <node concept="3cpWs8" id="3s41kb3Bnjk" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3Bnjl" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required reference is not initialized `constructorDeclaration'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/5721350981296887946]&quot;;" />
+            <property role="huDt6" value="Error: required reference is not initialized `constructorDeclaration'" />
+          </node>
+          <node concept="15s5l7" id="3s41kb3Bnjm" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required link is not initialized `leftExpression'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/3741790230810467494]&quot;;" />
+            <property role="huDt6" value="Error: required link is not initialized `leftExpression'" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3Bnjn" role="3cpWs9">
+            <property role="TrG5h" value="a" />
+            <node concept="3Tqbb2" id="3s41kb3Bnjo" role="1tU5fm" />
+            <node concept="2pJPEk" id="3s41kb3Bnjp" role="33vP2m">
+              <node concept="2pJPED" id="3s41kb3Bnjq" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:fHWc73I" resolve="AndExpression" />
+                <node concept="2pIpSj" id="3s41kb3Bnjr" role="2pJxcM">
+                  <ref role="2pIpSl" to="tpee:fJuHU4s" resolve="leftExpression" />
+                  <node concept="2pJPED" id="3s41kb3Bnjs" role="28nt2d">
+                    <ref role="2pJxaS" to="tpee:fzclF81" resolve="BooleanConstant" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3s41kb3Bnjw" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3Bnjx" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required reference is not initialized `constructorDeclaration'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/5721350981296887946]&quot;;" />
+            <property role="huDt6" value="Error: required reference is not initialized `constructorDeclaration'" />
+          </node>
+          <node concept="15s5l7" id="3s41kb3Bnjy" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required link is not initialized `leftExpression'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/3741790230810467494]&quot;;" />
+            <property role="huDt6" value="Error: required link is not initialized `leftExpression'" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3Bnjz" role="3cpWs9">
+            <property role="TrG5h" value="b" />
+            <node concept="3Tqbb2" id="3s41kb3Bnj$" role="1tU5fm" />
+            <node concept="2pJPEk" id="3s41kb3Bnj_" role="33vP2m">
+              <node concept="2pJPED" id="3s41kb3BnjA" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:fHWc73I" resolve="AndExpression" />
+                <node concept="2pIpSj" id="3s41kb3BnjB" role="2pJxcM">
+                  <ref role="2pIpSl" to="tpee:fJuHU4s" resolve="leftExpression" />
+                  <node concept="2pJPED" id="3s41kb3BnjC" role="28nt2d">
+                    <ref role="2pJxaS" to="tpee:fzcpWvV" resolve="PlusExpression" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="3s41kb3BnjG" role="3cqZAp" />
+        <node concept="3vFxKo" id="3s41kb3BnjH" role="3cqZAp">
+          <node concept="17R0WA" id="3s41kb3BnjI" role="3vFALc">
+            <node concept="2OqwBi" id="3s41kb3BnjJ" role="3uHU7w">
+              <node concept="2OqwBi" id="3s41kb3BnjK" role="2Oq$k0">
+                <node concept="2WthIp" id="3s41kb3BnjL" role="2Oq$k0" />
+                <node concept="2XshWL" id="3s41kb3BnjM" role="2OqNvi">
+                  <ref role="2WH_rO" node="3s41kb3BeDy" resolve="create" />
+                  <node concept="37vLTw" id="3s41kb3BnjN" role="2XxRq1">
+                    <ref role="3cqZAo" node="3s41kb3Bnjz" resolve="b" />
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3BnjO" role="2OqNvi">
+                <ref role="37wK5l" to="s53o:36NsNggQr$I" resolve="hash" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="3s41kb3BnjP" role="3uHU7B">
+              <node concept="2OqwBi" id="3s41kb3BnjQ" role="2Oq$k0">
+                <node concept="2WthIp" id="3s41kb3BnjR" role="2Oq$k0" />
+                <node concept="2XshWL" id="3s41kb3BnjS" role="2OqNvi">
+                  <ref role="2WH_rO" node="3s41kb3BeDy" resolve="create" />
+                  <node concept="37vLTw" id="3s41kb3BnjT" role="2XxRq1">
+                    <ref role="3cqZAo" node="3s41kb3Bnjn" resolve="a" />
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3BnjU" role="2OqNvi">
+                <ref role="37wK5l" to="s53o:36NsNggQr$I" resolve="hash" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="3s41kb3BeHK" role="1SL9yI">
+      <property role="TrG5h" value="different_byContainment" />
+      <node concept="3cqZAl" id="3s41kb3BeHL" role="3clF45" />
+      <node concept="3clFbS" id="3s41kb3BeHM" role="3clF47">
+        <node concept="3cpWs8" id="3s41kb3Bnvm" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3Bnvn" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required reference is not initialized `constructorDeclaration'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/5721350981296887946]&quot;;" />
+            <property role="huDt6" value="Error: required reference is not initialized `constructorDeclaration'" />
+          </node>
+          <node concept="15s5l7" id="3s41kb3Bnvo" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required link is not initialized `leftExpression'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/3741790230810467494]&quot;;" />
+            <property role="huDt6" value="Error: required link is not initialized `leftExpression'" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3Bnvp" role="3cpWs9">
+            <property role="TrG5h" value="a" />
+            <node concept="3Tqbb2" id="3s41kb3Bnvq" role="1tU5fm" />
+            <node concept="2pJPEk" id="3s41kb3Bnvr" role="33vP2m">
+              <node concept="2pJPED" id="3s41kb3Bnvs" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:fHWc73I" resolve="AndExpression" />
+                <node concept="2pIpSj" id="3s41kb3Bnvt" role="2pJxcM">
+                  <ref role="2pIpSl" to="tpee:fJuHU4s" resolve="leftExpression" />
+                  <node concept="2pJPED" id="3s41kb3Bnvu" role="28nt2d">
+                    <ref role="2pJxaS" to="tpee:fzclF81" resolve="BooleanConstant" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3s41kb3Bnvv" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3Bnvw" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required reference is not initialized `constructorDeclaration'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/5721350981296887946]&quot;;" />
+            <property role="huDt6" value="Error: required reference is not initialized `constructorDeclaration'" />
+          </node>
+          <node concept="15s5l7" id="3s41kb3Bnvx" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required link is not initialized `leftExpression'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/3741790230810467494]&quot;;" />
+            <property role="huDt6" value="Error: required link is not initialized `leftExpression'" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3Bnvy" role="3cpWs9">
+            <property role="TrG5h" value="b" />
+            <node concept="3Tqbb2" id="3s41kb3Bnvz" role="1tU5fm" />
+            <node concept="2pJPEk" id="3s41kb3Bnv$" role="33vP2m">
+              <node concept="2pJPED" id="3s41kb3Bnv_" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:fHWc73I" resolve="AndExpression" />
+                <node concept="2pIpSj" id="3s41kb3BnvA" role="2pJxcM">
+                  <ref role="2pIpSl" to="tpee:fJuHU4r" resolve="rightExpression" />
+                  <node concept="2pJPED" id="3s41kb3BnvB" role="28nt2d">
+                    <ref role="2pJxaS" to="tpee:fzclF81" resolve="BooleanConstant" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="3s41kb3BeIJ" role="3cqZAp" />
+        <node concept="3vFxKo" id="3s41kb3BnDO" role="3cqZAp">
+          <node concept="17R0WA" id="3s41kb3BnDP" role="3vFALc">
+            <node concept="2OqwBi" id="3s41kb3BnDQ" role="3uHU7w">
+              <node concept="2OqwBi" id="3s41kb3BnDR" role="2Oq$k0">
+                <node concept="2WthIp" id="3s41kb3BnDS" role="2Oq$k0" />
+                <node concept="2XshWL" id="3s41kb3BnDT" role="2OqNvi">
+                  <ref role="2WH_rO" node="3s41kb3BeDy" resolve="create" />
+                  <node concept="37vLTw" id="3s41kb3BnDU" role="2XxRq1">
+                    <ref role="3cqZAo" node="3s41kb3Bnvy" resolve="b" />
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3BnDV" role="2OqNvi">
+                <ref role="37wK5l" to="s53o:36NsNggQr$I" resolve="hash" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="3s41kb3BnDW" role="3uHU7B">
+              <node concept="2OqwBi" id="3s41kb3BnDX" role="2Oq$k0">
+                <node concept="2WthIp" id="3s41kb3BnDY" role="2Oq$k0" />
+                <node concept="2XshWL" id="3s41kb3BnDZ" role="2OqNvi">
+                  <ref role="2WH_rO" node="3s41kb3BeDy" resolve="create" />
+                  <node concept="37vLTw" id="3s41kb3BnE0" role="2XxRq1">
+                    <ref role="3cqZAo" node="3s41kb3Bnvp" resolve="a" />
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3BnE1" role="2OqNvi">
+                <ref role="37wK5l" to="s53o:36NsNggQr$I" resolve="hash" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="3s41kb3BeKo" role="1SL9yI">
+      <property role="TrG5h" value="different_ignored" />
+      <node concept="3cqZAl" id="3s41kb3BeKp" role="3clF45" />
+      <node concept="3clFbS" id="3s41kb3BeKq" role="3clF47">
+        <node concept="3cpWs8" id="3s41kb3Bokb" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3Bokc" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required reference is not initialized `constructorDeclaration'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/5721350981296887946]&quot;;" />
+            <property role="huDt6" value="Error: required reference is not initialized `constructorDeclaration'" />
+          </node>
+          <node concept="15s5l7" id="3s41kb3Bokd" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required link is not initialized `leftExpression'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/3741790230810467494]&quot;;" />
+            <property role="huDt6" value="Error: required link is not initialized `leftExpression'" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3Boke" role="3cpWs9">
+            <property role="TrG5h" value="a" />
+            <node concept="3Tqbb2" id="3s41kb3Bokf" role="1tU5fm" />
+            <node concept="2pJPEk" id="3s41kb3Bokg" role="33vP2m">
+              <node concept="2pJPED" id="3s41kb3Bokh" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:fHWc73I" resolve="AndExpression" />
+                <node concept="2pIpSj" id="3s41kb3Boki" role="2pJxcM">
+                  <ref role="2pIpSl" to="tpee:fJuHU4s" resolve="leftExpression" />
+                  <node concept="2pJPED" id="3s41kb3Bokj" role="28nt2d">
+                    <ref role="2pJxaS" to="tpee:fzclF81" resolve="BooleanConstant" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3s41kb3Bokk" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3Bokl" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required reference is not initialized `constructorDeclaration'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/5721350981296887946]&quot;;" />
+            <property role="huDt6" value="Error: required reference is not initialized `constructorDeclaration'" />
+          </node>
+          <node concept="15s5l7" id="3s41kb3Bokm" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required link is not initialized `leftExpression'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/3741790230810467494]&quot;;" />
+            <property role="huDt6" value="Error: required link is not initialized `leftExpression'" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3Bokn" role="3cpWs9">
+            <property role="TrG5h" value="b" />
+            <node concept="3Tqbb2" id="3s41kb3Boko" role="1tU5fm" />
+            <node concept="2pJPEk" id="3s41kb3Bokp" role="33vP2m">
+              <node concept="2pJPED" id="3s41kb3Bokq" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:fHWc73I" resolve="AndExpression" />
+                <node concept="2pIpSj" id="3s41kb3Bokr" role="2pJxcM">
+                  <ref role="2pIpSl" to="tpee:fJuHU4s" resolve="leftExpression" />
+                  <node concept="2pJPED" id="3s41kb3Boks" role="28nt2d">
+                    <ref role="2pJxaS" to="tpee:fzcpWvV" resolve="PlusExpression" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="3s41kb3BeKZ" role="3cqZAp" />
+        <node concept="3vwNmj" id="3s41kb3BeL0" role="3cqZAp">
+          <node concept="17R0WA" id="3s41kb3BeL1" role="3vwVQn">
+            <node concept="2OqwBi" id="3s41kb3BeL2" role="3uHU7w">
+              <node concept="2OqwBi" id="3s41kb3BeL3" role="2Oq$k0">
+                <node concept="2OqwBi" id="3s41kb3BeL4" role="2Oq$k0">
+                  <node concept="2WthIp" id="3s41kb3BeL5" role="2Oq$k0" />
+                  <node concept="2XshWL" id="3s41kb3BeL6" role="2OqNvi">
+                    <ref role="2WH_rO" node="3s41kb3BeDy" resolve="create" />
+                    <node concept="37vLTw" id="3s41kb3BeL7" role="2XxRq1">
+                      <ref role="3cqZAo" node="3s41kb3Bokn" resolve="b" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="liA8E" id="3s41kb3BeL8" role="2OqNvi">
+                  <ref role="37wK5l" to="s53o:36NsNggQr$6" resolve="ignore" />
+                  <node concept="359W_D" id="3s41kb3BouQ" role="37wK5m">
+                    <ref role="359W_E" to="tpee:fHWc73I" resolve="AndExpression" />
+                    <ref role="359W_F" to="tpee:fJuHU4s" resolve="leftExpression" />
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3BeLa" role="2OqNvi">
+                <ref role="37wK5l" to="s53o:36NsNggQr$I" resolve="hash" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="3s41kb3BeLb" role="3uHU7B">
+              <node concept="2OqwBi" id="3s41kb3BeLc" role="2Oq$k0">
+                <node concept="2OqwBi" id="3s41kb3BeLd" role="2Oq$k0">
+                  <node concept="2WthIp" id="3s41kb3BeLe" role="2Oq$k0" />
+                  <node concept="2XshWL" id="3s41kb3BeLf" role="2OqNvi">
+                    <ref role="2WH_rO" node="3s41kb3BeDy" resolve="create" />
+                    <node concept="37vLTw" id="3s41kb3BeLg" role="2XxRq1">
+                      <ref role="3cqZAo" node="3s41kb3Boke" resolve="a" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="liA8E" id="3s41kb3BeLh" role="2OqNvi">
+                  <ref role="37wK5l" to="s53o:36NsNggQr$6" resolve="ignore" />
+                  <node concept="359W_D" id="3s41kb3BeLi" role="37wK5m">
+                    <ref role="359W_E" to="tpee:fHWc73I" resolve="AndExpression" />
+                    <ref role="359W_F" to="tpee:fJuHU4s" resolve="leftExpression" />
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3BeLj" role="2OqNvi">
+                <ref role="37wK5l" to="s53o:36NsNggQr$I" resolve="hash" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="3s41kb3BeLZ" role="1SL9yI">
+      <property role="TrG5h" value="same_ignored" />
+      <node concept="3cqZAl" id="3s41kb3BeM0" role="3clF45" />
+      <node concept="3clFbS" id="3s41kb3BeM1" role="3clF47">
+        <node concept="3cpWs8" id="3s41kb3BpEj" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3BpEk" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required reference is not initialized `constructorDeclaration'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/5721350981296887946]&quot;;" />
+            <property role="huDt6" value="Error: required reference is not initialized `constructorDeclaration'" />
+          </node>
+          <node concept="15s5l7" id="3s41kb3BpEl" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required link is not initialized `leftExpression'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/3741790230810467494]&quot;;" />
+            <property role="huDt6" value="Error: required link is not initialized `leftExpression'" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3BpEm" role="3cpWs9">
+            <property role="TrG5h" value="a" />
+            <node concept="3Tqbb2" id="3s41kb3BpEn" role="1tU5fm" />
+            <node concept="2pJPEk" id="3s41kb3BpEo" role="33vP2m">
+              <node concept="2pJPED" id="3s41kb3BpEp" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:fHWc73I" resolve="AndExpression" />
+                <node concept="2pIpSj" id="3s41kb3BpEq" role="2pJxcM">
+                  <ref role="2pIpSl" to="tpee:fJuHU4s" resolve="leftExpression" />
+                  <node concept="2pJPED" id="3s41kb3BpEr" role="28nt2d">
+                    <ref role="2pJxaS" to="tpee:fzclF81" resolve="BooleanConstant" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3s41kb3BpEs" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3BpEt" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required reference is not initialized `constructorDeclaration'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/5721350981296887946]&quot;;" />
+            <property role="huDt6" value="Error: required reference is not initialized `constructorDeclaration'" />
+          </node>
+          <node concept="15s5l7" id="3s41kb3BpEu" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required link is not initialized `leftExpression'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/3741790230810467494]&quot;;" />
+            <property role="huDt6" value="Error: required link is not initialized `leftExpression'" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3BpEv" role="3cpWs9">
+            <property role="TrG5h" value="b" />
+            <node concept="3Tqbb2" id="3s41kb3BpEw" role="1tU5fm" />
+            <node concept="2pJPEk" id="3s41kb3BpEx" role="33vP2m">
+              <node concept="2pJPED" id="3s41kb3BpEy" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:fHWc73I" resolve="AndExpression" />
+                <node concept="2pIpSj" id="3s41kb3BpEz" role="2pJxcM">
+                  <ref role="2pIpSl" to="tpee:fJuHU4s" resolve="leftExpression" />
+                  <node concept="2pJPED" id="3s41kb3BpE$" role="28nt2d">
+                    <ref role="2pJxaS" to="tpee:fzclF81" resolve="BooleanConstant" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="3s41kb3BeMr" role="3cqZAp" />
+        <node concept="3vwNmj" id="3s41kb3BeMs" role="3cqZAp">
+          <node concept="17R0WA" id="3s41kb3BeMt" role="3vwVQn">
+            <node concept="2OqwBi" id="3s41kb3BeMu" role="3uHU7w">
+              <node concept="2OqwBi" id="3s41kb3BeMv" role="2Oq$k0">
+                <node concept="2OqwBi" id="3s41kb3BeMw" role="2Oq$k0">
+                  <node concept="2WthIp" id="3s41kb3BeMx" role="2Oq$k0" />
+                  <node concept="2XshWL" id="3s41kb3BeMy" role="2OqNvi">
+                    <ref role="2WH_rO" node="3s41kb3BeDy" resolve="create" />
+                    <node concept="37vLTw" id="3s41kb3BeMz" role="2XxRq1">
+                      <ref role="3cqZAo" node="3s41kb3BpEv" resolve="b" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="liA8E" id="3s41kb3BeM$" role="2OqNvi">
+                  <ref role="37wK5l" to="s53o:36NsNggQr$6" resolve="ignore" />
+                  <node concept="359W_D" id="3s41kb3BpNE" role="37wK5m">
+                    <ref role="359W_E" to="tpee:fHWc73I" resolve="AndExpression" />
+                    <ref role="359W_F" to="tpee:fJuHU4s" resolve="leftExpression" />
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3BeMA" role="2OqNvi">
+                <ref role="37wK5l" to="s53o:36NsNggQr$I" resolve="hash" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="3s41kb3BeMB" role="3uHU7B">
+              <node concept="2OqwBi" id="3s41kb3BeMC" role="2Oq$k0">
+                <node concept="2OqwBi" id="3s41kb3BeMD" role="2Oq$k0">
+                  <node concept="2WthIp" id="3s41kb3BeME" role="2Oq$k0" />
+                  <node concept="2XshWL" id="3s41kb3BeMF" role="2OqNvi">
+                    <ref role="2WH_rO" node="3s41kb3BeDy" resolve="create" />
+                    <node concept="37vLTw" id="3s41kb3BeMG" role="2XxRq1">
+                      <ref role="3cqZAo" node="3s41kb3BpEm" resolve="a" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="liA8E" id="3s41kb3BeMH" role="2OqNvi">
+                  <ref role="37wK5l" to="s53o:36NsNggQr$6" resolve="ignore" />
+                  <node concept="359W_D" id="3s41kb3BpKw" role="37wK5m">
+                    <ref role="359W_E" to="tpee:fHWc73I" resolve="AndExpression" />
+                    <ref role="359W_F" to="tpee:fJuHU4s" resolve="leftExpression" />
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3BeMJ" role="2OqNvi">
+                <ref role="37wK5l" to="s53o:36NsNggQr$I" resolve="hash" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="3s41kb3BeMK" role="1SL9yI">
+      <property role="TrG5h" value="differentContainments_sameOrder" />
+      <node concept="3cqZAl" id="3s41kb3BeML" role="3clF45" />
+      <node concept="3clFbS" id="3s41kb3BeMM" role="3clF47">
+        <node concept="3cpWs8" id="3s41kb3BqlO" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3BqlP" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required reference is not initialized `constructorDeclaration'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/5721350981296887946]&quot;;" />
+            <property role="huDt6" value="Error: required reference is not initialized `constructorDeclaration'" />
+          </node>
+          <node concept="15s5l7" id="3s41kb3BqlQ" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required link is not initialized `leftExpression'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/3741790230810467494]&quot;;" />
+            <property role="huDt6" value="Error: required link is not initialized `leftExpression'" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3BqlR" role="3cpWs9">
+            <property role="TrG5h" value="a" />
+            <node concept="3Tqbb2" id="3s41kb3BqlS" role="1tU5fm" />
+            <node concept="2pJPEk" id="3s41kb3BqlT" role="33vP2m">
+              <node concept="2pJPED" id="3s41kb3BqlU" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:fHWc73I" resolve="AndExpression" />
+                <node concept="2pIpSj" id="3s41kb3BqlV" role="2pJxcM">
+                  <ref role="2pIpSl" to="tpee:fJuHU4s" resolve="leftExpression" />
+                  <node concept="2pJPED" id="3s41kb3BqlW" role="28nt2d">
+                    <ref role="2pJxaS" to="tpee:fzclF81" resolve="BooleanConstant" />
+                  </node>
+                </node>
+                <node concept="2pIpSj" id="3s41kb3BqoE" role="2pJxcM">
+                  <ref role="2pIpSl" to="tpee:fJuHU4r" resolve="rightExpression" />
+                  <node concept="2pJPED" id="3s41kb3BqpJ" role="28nt2d">
+                    <ref role="2pJxaS" to="tpee:fzcpWvV" resolve="PlusExpression" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3s41kb3BqlX" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3BqlY" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required reference is not initialized `constructorDeclaration'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/5721350981296887946]&quot;;" />
+            <property role="huDt6" value="Error: required reference is not initialized `constructorDeclaration'" />
+          </node>
+          <node concept="15s5l7" id="3s41kb3BqlZ" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required link is not initialized `leftExpression'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/3741790230810467494]&quot;;" />
+            <property role="huDt6" value="Error: required link is not initialized `leftExpression'" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3Bqm0" role="3cpWs9">
+            <property role="TrG5h" value="b" />
+            <node concept="3Tqbb2" id="3s41kb3Bqm1" role="1tU5fm" />
+            <node concept="2pJPEk" id="3s41kb3Bqm2" role="33vP2m">
+              <node concept="2pJPED" id="3s41kb3Bqm3" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:fHWc73I" resolve="AndExpression" />
+                <node concept="2pIpSj" id="3s41kb3BqqD" role="2pJxcM">
+                  <ref role="2pIpSl" to="tpee:fJuHU4s" resolve="leftExpression" />
+                  <node concept="2pJPED" id="3s41kb3BqqE" role="28nt2d">
+                    <ref role="2pJxaS" to="tpee:fzclF81" resolve="BooleanConstant" />
+                  </node>
+                </node>
+                <node concept="2pIpSj" id="3s41kb3BqqF" role="2pJxcM">
+                  <ref role="2pIpSl" to="tpee:fJuHU4r" resolve="rightExpression" />
+                  <node concept="2pJPED" id="3s41kb3BqqG" role="28nt2d">
+                    <ref role="2pJxaS" to="tpee:fzcpWvV" resolve="PlusExpression" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="3s41kb3BeNu" role="3cqZAp" />
+        <node concept="3vwNmj" id="3s41kb3BeNv" role="3cqZAp">
+          <node concept="17R0WA" id="3s41kb3BeNw" role="3vwVQn">
+            <node concept="2OqwBi" id="3s41kb3BeNx" role="3uHU7w">
+              <node concept="2OqwBi" id="3s41kb3BeNy" role="2Oq$k0">
+                <node concept="2WthIp" id="3s41kb3BeNz" role="2Oq$k0" />
+                <node concept="2XshWL" id="3s41kb3BeN$" role="2OqNvi">
+                  <ref role="2WH_rO" node="3s41kb3BeDy" resolve="create" />
+                  <node concept="37vLTw" id="3s41kb3BeN_" role="2XxRq1">
+                    <ref role="3cqZAo" node="3s41kb3Bqm0" resolve="b" />
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3BeNA" role="2OqNvi">
+                <ref role="37wK5l" to="s53o:36NsNggQr$I" resolve="hash" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="3s41kb3BeNB" role="3uHU7B">
+              <node concept="2OqwBi" id="3s41kb3BeNC" role="2Oq$k0">
+                <node concept="2WthIp" id="3s41kb3BeND" role="2Oq$k0" />
+                <node concept="2XshWL" id="3s41kb3BeNE" role="2OqNvi">
+                  <ref role="2WH_rO" node="3s41kb3BeDy" resolve="create" />
+                  <node concept="37vLTw" id="3s41kb3BeNF" role="2XxRq1">
+                    <ref role="3cqZAo" node="3s41kb3BqlR" resolve="a" />
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3BeNG" role="2OqNvi">
+                <ref role="37wK5l" to="s53o:36NsNggQr$I" resolve="hash" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="3s41kb3BeNH" role="1SL9yI">
+      <property role="TrG5h" value="differentContainments_differentOrder" />
+      <node concept="3cqZAl" id="3s41kb3BeNI" role="3clF45" />
+      <node concept="3clFbS" id="3s41kb3BeNJ" role="3clF47">
+        <node concept="3cpWs8" id="3s41kb3BqP2" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3BqP3" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required reference is not initialized `constructorDeclaration'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/5721350981296887946]&quot;;" />
+            <property role="huDt6" value="Error: required reference is not initialized `constructorDeclaration'" />
+          </node>
+          <node concept="15s5l7" id="3s41kb3BqP4" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required link is not initialized `leftExpression'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/3741790230810467494]&quot;;" />
+            <property role="huDt6" value="Error: required link is not initialized `leftExpression'" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3BqP5" role="3cpWs9">
+            <property role="TrG5h" value="a" />
+            <node concept="3Tqbb2" id="3s41kb3BqP6" role="1tU5fm" />
+            <node concept="2pJPEk" id="3s41kb3BqP7" role="33vP2m">
+              <node concept="2pJPED" id="3s41kb3BqP8" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:fHWc73I" resolve="AndExpression" />
+                <node concept="2pIpSj" id="3s41kb3BqP9" role="2pJxcM">
+                  <ref role="2pIpSl" to="tpee:fJuHU4s" resolve="leftExpression" />
+                  <node concept="2pJPED" id="3s41kb3BqPa" role="28nt2d">
+                    <ref role="2pJxaS" to="tpee:fzclF81" resolve="BooleanConstant" />
+                  </node>
+                </node>
+                <node concept="2pIpSj" id="3s41kb3BqPb" role="2pJxcM">
+                  <ref role="2pIpSl" to="tpee:fJuHU4r" resolve="rightExpression" />
+                  <node concept="2pJPED" id="3s41kb3BqPc" role="28nt2d">
+                    <ref role="2pJxaS" to="tpee:fzcpWvV" resolve="PlusExpression" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3s41kb3BqPd" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3BqPe" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required reference is not initialized `constructorDeclaration'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/5721350981296887946]&quot;;" />
+            <property role="huDt6" value="Error: required reference is not initialized `constructorDeclaration'" />
+          </node>
+          <node concept="15s5l7" id="3s41kb3BqPf" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required link is not initialized `leftExpression'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/3741790230810467494]&quot;;" />
+            <property role="huDt6" value="Error: required link is not initialized `leftExpression'" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3BqPg" role="3cpWs9">
+            <property role="TrG5h" value="b" />
+            <node concept="3Tqbb2" id="3s41kb3BqPh" role="1tU5fm" />
+            <node concept="2pJPEk" id="3s41kb3BqPi" role="33vP2m">
+              <node concept="2pJPED" id="3s41kb3BqPj" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:fHWc73I" resolve="AndExpression" />
+                <node concept="2pIpSj" id="3s41kb3BqPm" role="2pJxcM">
+                  <ref role="2pIpSl" to="tpee:fJuHU4r" resolve="rightExpression" />
+                  <node concept="2pJPED" id="3s41kb3BqPn" role="28nt2d">
+                    <ref role="2pJxaS" to="tpee:fzcpWvV" resolve="PlusExpression" />
+                  </node>
+                </node>
+                <node concept="2pIpSj" id="3s41kb3BqPk" role="2pJxcM">
+                  <ref role="2pIpSl" to="tpee:fJuHU4s" resolve="leftExpression" />
+                  <node concept="2pJPED" id="3s41kb3BqPl" role="28nt2d">
+                    <ref role="2pJxaS" to="tpee:fzclF81" resolve="BooleanConstant" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="3s41kb3BeOr" role="3cqZAp" />
+        <node concept="3vlDli" id="3s41kb3BeOs" role="3cqZAp">
+          <node concept="2OqwBi" id="3s41kb3BeOt" role="3tpDZA">
+            <node concept="2OqwBi" id="3s41kb3BeOu" role="2Oq$k0">
+              <node concept="2OqwBi" id="3s41kb3BeOv" role="2Oq$k0">
+                <node concept="2OqwBi" id="3s41kb3BeOw" role="2Oq$k0">
+                  <node concept="2JrnkZ" id="3s41kb3BeOx" role="2Oq$k0">
+                    <node concept="37vLTw" id="3s41kb3BeOy" role="2JrQYb">
+                      <ref role="3cqZAo" node="3s41kb3BqP5" resolve="a" />
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="3s41kb3BeOz" role="2OqNvi">
+                    <ref role="37wK5l" to="mhbf:~SNode.getChildren()" resolve="getChildren" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="3s41kb3BeO$" role="2OqNvi">
+                  <ref role="37wK5l" to="wyt6:~Iterable.iterator()" resolve="iterator" />
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3BeO_" role="2OqNvi">
+                <ref role="37wK5l" to="33ny:~Iterator.next()" resolve="next" />
+              </node>
+            </node>
+            <node concept="liA8E" id="3s41kb3BeOA" role="2OqNvi">
+              <ref role="37wK5l" to="mhbf:~SNode.getConcept()" resolve="getConcept" />
+            </node>
+          </node>
+          <node concept="35c_gC" id="3s41kb3Bs3E" role="3tpDZB">
+            <ref role="35c_gD" to="tpee:fzclF81" resolve="BooleanConstant" />
+          </node>
+        </node>
+        <node concept="3vlDli" id="3s41kb3BeOC" role="3cqZAp">
+          <node concept="35c_gC" id="3s41kb3Bt21" role="3tpDZB">
+            <ref role="35c_gD" to="tpee:fzcpWvV" resolve="PlusExpression" />
+          </node>
+          <node concept="2OqwBi" id="3s41kb3BsFC" role="3tpDZA">
+            <node concept="2OqwBi" id="3s41kb3BsFD" role="2Oq$k0">
+              <node concept="2OqwBi" id="3s41kb3BsFE" role="2Oq$k0">
+                <node concept="2OqwBi" id="3s41kb3BsFF" role="2Oq$k0">
+                  <node concept="2JrnkZ" id="3s41kb3BsFG" role="2Oq$k0">
+                    <node concept="37vLTw" id="3s41kb3BsFH" role="2JrQYb">
+                      <ref role="3cqZAo" node="3s41kb3BqPg" resolve="b" />
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="3s41kb3BsFI" role="2OqNvi">
+                    <ref role="37wK5l" to="mhbf:~SNode.getChildren()" resolve="getChildren" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="3s41kb3BsFJ" role="2OqNvi">
+                  <ref role="37wK5l" to="wyt6:~Iterable.iterator()" resolve="iterator" />
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3BsFK" role="2OqNvi">
+                <ref role="37wK5l" to="33ny:~Iterator.next()" resolve="next" />
+              </node>
+            </node>
+            <node concept="liA8E" id="3s41kb3BsFL" role="2OqNvi">
+              <ref role="37wK5l" to="mhbf:~SNode.getConcept()" resolve="getConcept" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="3s41kb3BeOO" role="3cqZAp" />
+        <node concept="3vwNmj" id="3s41kb3BeOP" role="3cqZAp">
+          <node concept="17R0WA" id="3s41kb3BeOQ" role="3vwVQn">
+            <node concept="2OqwBi" id="3s41kb3BeOR" role="3uHU7w">
+              <node concept="2OqwBi" id="3s41kb3BeOS" role="2Oq$k0">
+                <node concept="2WthIp" id="3s41kb3BeOT" role="2Oq$k0" />
+                <node concept="2XshWL" id="3s41kb3BeOU" role="2OqNvi">
+                  <ref role="2WH_rO" node="3s41kb3BeDy" resolve="create" />
+                  <node concept="37vLTw" id="3s41kb3BeOV" role="2XxRq1">
+                    <ref role="3cqZAo" node="3s41kb3BqPg" resolve="b" />
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3BeOW" role="2OqNvi">
+                <ref role="37wK5l" to="s53o:36NsNggQr$I" resolve="hash" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="3s41kb3BeOX" role="3uHU7B">
+              <node concept="2OqwBi" id="3s41kb3BeOY" role="2Oq$k0">
+                <node concept="2WthIp" id="3s41kb3BeOZ" role="2Oq$k0" />
+                <node concept="2XshWL" id="3s41kb3BeP0" role="2OqNvi">
+                  <ref role="2WH_rO" node="3s41kb3BeDy" resolve="create" />
+                  <node concept="37vLTw" id="3s41kb3BeP1" role="2XxRq1">
+                    <ref role="3cqZAo" node="3s41kb3BqP5" resolve="a" />
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3BeP2" role="2OqNvi">
+                <ref role="37wK5l" to="s53o:36NsNggQr$I" resolve="hash" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="3s41kb3BAC4" role="1SL9yI">
+      <property role="TrG5h" value="sameContainment_sameOrder" />
+      <node concept="3cqZAl" id="3s41kb3BAC5" role="3clF45" />
+      <node concept="3clFbS" id="3s41kb3BAC6" role="3clF47">
+        <node concept="3cpWs8" id="3s41kb3BAC7" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3BAC8" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required reference is not initialized `constructorDeclaration'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/5721350981296887946]&quot;;" />
+            <property role="huDt6" value="Error: required reference is not initialized `constructorDeclaration'" />
+          </node>
+          <node concept="15s5l7" id="3s41kb3BAC9" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required link is not initialized `leftExpression'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/3741790230810467494]&quot;;" />
+            <property role="huDt6" value="Error: required link is not initialized `leftExpression'" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3BACa" role="3cpWs9">
+            <property role="TrG5h" value="a" />
+            <node concept="3Tqbb2" id="3s41kb3BACb" role="1tU5fm" />
+            <node concept="2pJPEk" id="3s41kb3BACc" role="33vP2m">
+              <node concept="2pJPED" id="3s41kb3BACd" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:fzclF80" resolve="StatementList" />
+                <node concept="2pIpSj" id="3s41kb3BACe" role="2pJxcM">
+                  <ref role="2pIpSl" to="tpee:fzcqZ_x" resolve="statement" />
+                  <node concept="36be1Y" id="3s41kb3BC9U" role="28nt2d">
+                    <node concept="2pJPED" id="3s41kb3BCaT" role="36be1Z">
+                      <ref role="2pJxaS" to="tpee:fzclF8n" resolve="IfStatement" />
+                    </node>
+                    <node concept="2pJPED" id="3s41kb3BCeZ" role="36be1Z">
+                      <ref role="2pJxaS" to="tpee:fE$JKWJ" resolve="WhileStatement" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3s41kb3BACi" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3BACj" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required reference is not initialized `constructorDeclaration'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/5721350981296887946]&quot;;" />
+            <property role="huDt6" value="Error: required reference is not initialized `constructorDeclaration'" />
+          </node>
+          <node concept="15s5l7" id="3s41kb3BACk" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required link is not initialized `leftExpression'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/3741790230810467494]&quot;;" />
+            <property role="huDt6" value="Error: required link is not initialized `leftExpression'" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3BACl" role="3cpWs9">
+            <property role="TrG5h" value="b" />
+            <node concept="3Tqbb2" id="3s41kb3BACm" role="1tU5fm" />
+            <node concept="2pJPEk" id="3s41kb3BACn" role="33vP2m">
+              <node concept="2pJPED" id="3s41kb3BCh6" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:fzclF80" resolve="StatementList" />
+                <node concept="2pIpSj" id="3s41kb3BCh7" role="2pJxcM">
+                  <ref role="2pIpSl" to="tpee:fzcqZ_x" resolve="statement" />
+                  <node concept="36be1Y" id="3s41kb3BCh8" role="28nt2d">
+                    <node concept="2pJPED" id="3s41kb3BCh9" role="36be1Z">
+                      <ref role="2pJxaS" to="tpee:fzclF8n" resolve="IfStatement" />
+                    </node>
+                    <node concept="2pJPED" id="3s41kb3BCha" role="36be1Z">
+                      <ref role="2pJxaS" to="tpee:fE$JKWJ" resolve="WhileStatement" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="3s41kb3BACt" role="3cqZAp" />
+        <node concept="3vwNmj" id="3s41kb3BACu" role="3cqZAp">
+          <node concept="17R0WA" id="3s41kb3BACv" role="3vwVQn">
+            <node concept="2OqwBi" id="3s41kb3BACw" role="3uHU7w">
+              <node concept="2OqwBi" id="3s41kb3BACx" role="2Oq$k0">
+                <node concept="2WthIp" id="3s41kb3BACy" role="2Oq$k0" />
+                <node concept="2XshWL" id="3s41kb3BACz" role="2OqNvi">
+                  <ref role="2WH_rO" node="3s41kb3BeDy" resolve="create" />
+                  <node concept="37vLTw" id="3s41kb3BAC$" role="2XxRq1">
+                    <ref role="3cqZAo" node="3s41kb3BACl" resolve="b" />
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3BAC_" role="2OqNvi">
+                <ref role="37wK5l" to="s53o:36NsNggQr$I" resolve="hash" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="3s41kb3BACA" role="3uHU7B">
+              <node concept="2OqwBi" id="3s41kb3BACB" role="2Oq$k0">
+                <node concept="2WthIp" id="3s41kb3BACC" role="2Oq$k0" />
+                <node concept="2XshWL" id="3s41kb3BACD" role="2OqNvi">
+                  <ref role="2WH_rO" node="3s41kb3BeDy" resolve="create" />
+                  <node concept="37vLTw" id="3s41kb3BACE" role="2XxRq1">
+                    <ref role="3cqZAo" node="3s41kb3BACa" resolve="a" />
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3BACF" role="2OqNvi">
+                <ref role="37wK5l" to="s53o:36NsNggQr$I" resolve="hash" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="3s41kb3BAB3" role="1SL9yI">
+      <property role="TrG5h" value="sameContainment_differentOrder" />
+      <node concept="3cqZAl" id="3s41kb3BAB4" role="3clF45" />
+      <node concept="3clFbS" id="3s41kb3BAB5" role="3clF47">
+        <node concept="3cpWs8" id="3s41kb3BCin" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3BCio" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required reference is not initialized `constructorDeclaration'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/5721350981296887946]&quot;;" />
+            <property role="huDt6" value="Error: required reference is not initialized `constructorDeclaration'" />
+          </node>
+          <node concept="15s5l7" id="3s41kb3BCip" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required link is not initialized `leftExpression'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/3741790230810467494]&quot;;" />
+            <property role="huDt6" value="Error: required link is not initialized `leftExpression'" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3BCiq" role="3cpWs9">
+            <property role="TrG5h" value="a" />
+            <node concept="3Tqbb2" id="3s41kb3BCir" role="1tU5fm" />
+            <node concept="2pJPEk" id="3s41kb3BCis" role="33vP2m">
+              <node concept="2pJPED" id="3s41kb3BCit" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:fzclF80" resolve="StatementList" />
+                <node concept="2pIpSj" id="3s41kb3BCiu" role="2pJxcM">
+                  <ref role="2pIpSl" to="tpee:fzcqZ_x" resolve="statement" />
+                  <node concept="36be1Y" id="3s41kb3BCiv" role="28nt2d">
+                    <node concept="2pJPED" id="3s41kb3BCiw" role="36be1Z">
+                      <ref role="2pJxaS" to="tpee:fzclF8n" resolve="IfStatement" />
+                    </node>
+                    <node concept="2pJPED" id="3s41kb3BCix" role="36be1Z">
+                      <ref role="2pJxaS" to="tpee:fE$JKWJ" resolve="WhileStatement" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3s41kb3BCiy" role="3cqZAp">
+          <node concept="15s5l7" id="3s41kb3BCiz" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required reference is not initialized `constructorDeclaration'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/5721350981296887946]&quot;;" />
+            <property role="huDt6" value="Error: required reference is not initialized `constructorDeclaration'" />
+          </node>
+          <node concept="15s5l7" id="3s41kb3BCi$" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: required link is not initialized `leftExpression'&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c8959034a(jetbrains.mps.lang.quotation.typesystem)/3741790230810467494]&quot;;" />
+            <property role="huDt6" value="Error: required link is not initialized `leftExpression'" />
+          </node>
+          <node concept="3cpWsn" id="3s41kb3BCi_" role="3cpWs9">
+            <property role="TrG5h" value="b" />
+            <node concept="3Tqbb2" id="3s41kb3BCiA" role="1tU5fm" />
+            <node concept="2pJPEk" id="3s41kb3BCiB" role="33vP2m">
+              <node concept="2pJPED" id="3s41kb3BCiC" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:fzclF80" resolve="StatementList" />
+                <node concept="2pIpSj" id="3s41kb3BCiD" role="2pJxcM">
+                  <ref role="2pIpSl" to="tpee:fzcqZ_x" resolve="statement" />
+                  <node concept="36be1Y" id="3s41kb3BCiE" role="28nt2d">
+                    <node concept="2pJPED" id="3s41kb3BCiG" role="36be1Z">
+                      <ref role="2pJxaS" to="tpee:fE$JKWJ" resolve="WhileStatement" />
+                    </node>
+                    <node concept="2pJPED" id="3s41kb3BCiF" role="36be1Z">
+                      <ref role="2pJxaS" to="tpee:fzclF8n" resolve="IfStatement" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="3s41kb3BCiH" role="3cqZAp" />
+        <node concept="3vFxKo" id="3s41kb3BCsV" role="3cqZAp">
+          <node concept="17R0WA" id="3s41kb3BCiJ" role="3vFALc">
+            <node concept="2OqwBi" id="3s41kb3BCiK" role="3uHU7w">
+              <node concept="2OqwBi" id="3s41kb3BCiL" role="2Oq$k0">
+                <node concept="2WthIp" id="3s41kb3BCiM" role="2Oq$k0" />
+                <node concept="2XshWL" id="3s41kb3BCiN" role="2OqNvi">
+                  <ref role="2WH_rO" node="3s41kb3BeDy" resolve="create" />
+                  <node concept="37vLTw" id="3s41kb3BCiO" role="2XxRq1">
+                    <ref role="3cqZAo" node="3s41kb3BCi_" resolve="b" />
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3BCiP" role="2OqNvi">
+                <ref role="37wK5l" to="s53o:36NsNggQr$I" resolve="hash" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="3s41kb3BCiQ" role="3uHU7B">
+              <node concept="2OqwBi" id="3s41kb3BCiR" role="2Oq$k0">
+                <node concept="2WthIp" id="3s41kb3BCiS" role="2Oq$k0" />
+                <node concept="2XshWL" id="3s41kb3BCiT" role="2OqNvi">
+                  <ref role="2WH_rO" node="3s41kb3BeDy" resolve="create" />
+                  <node concept="37vLTw" id="3s41kb3BCiU" role="2XxRq1">
+                    <ref role="3cqZAo" node="3s41kb3BCiq" resolve="a" />
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3BCiV" role="2OqNvi">
+                <ref role="37wK5l" to="s53o:36NsNggQr$I" resolve="hash" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/code/hasher/solutions/nl.f1re.mpsutil.hasher.tests/nl.f1re.mpsutil.hasher.tests.msd
+++ b/code/hasher/solutions/nl.f1re.mpsutil.hasher.tests/nl.f1re.mpsutil.hasher.tests.msd
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<solution name="nl.f1re.mpsutil.hasher.tests" uuid="35200322-041d-4e55-91d7-024e0b119604" moduleVersion="0">
+  <models>
+    <modelRoot type="default" contentPath="${module}">
+      <sourceRoot location="models" />
+    </modelRoot>
+  </models>
+  <facets>
+    <facet compile="mps" classes="mps" ext="no" type="java">
+      <classes generated="true" path="${module}/classes_gen" />
+    </facet>
+    <facet type="tests" />
+  </facets>
+  <dependencies>
+    <dependency reexport="false">f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)</dependency>
+    <dependency reexport="false">078723b2-ab7f-48d1-b9bb-5f643b60d08e(nl.f1re.mpsutil.hasher)</dependency>
+    <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
+  </dependencies>
+  <languageVersions>
+    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
+    <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />
+    <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
+    <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="2" />
+    <language slang="l:f61473f9-130f-42f6-b98d-6c438812c2f6:jetbrains.mps.baseLanguage.unitTest" version="1" />
+    <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
+    <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
+    <language slang="l:8585453e-6bfb-4d80-98de-b16074f1d86c:jetbrains.mps.lang.test" version="6" />
+    <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
+  </languageVersions>
+  <dependencyVersions>
+    <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
+    <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
+    <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
+    <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+    <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
+    <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
+    <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
+    <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
+    <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
+    <module reference="078723b2-ab7f-48d1-b9bb-5f643b60d08e(nl.f1re.mpsutil.hasher)" version="0" />
+    <module reference="35200322-041d-4e55-91d7-024e0b119604(nl.f1re.mpsutil.hasher.tests)" version="0" />
+  </dependencyVersions>
+</solution>
+

--- a/code/hasher/solutions/nl.f1re.mpsutil.hasher/models/nl.f1re.mpsutil.hasher.mps
+++ b/code/hasher/solutions/nl.f1re.mpsutil.hasher/models/nl.f1re.mpsutil.hasher.mps
@@ -1,0 +1,3128 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:d33052f8-d6ec-4c4e-a308-0c1006114272(nl.f1re.mpsutil.hasher)">
+  <persistence version="9" />
+  <languages>
+    <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
+    <use id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc" version="2" />
+    <use id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections" version="2" />
+    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
+  </languages>
+  <imports>
+    <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" />
+    <import index="kscp" ref="ecfb9949-7433-4db5-85de-0f84d172e4ce/java:com.google.common.hash(de.q60.mps.collections.libs/)" />
+    <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" />
+    <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" />
+    <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
+    <import index="xx25" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel.adapter.structure.types(MPS.Core/)" />
+    <import index="7x5y" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.nio.charset(JDK/)" />
+    <import index="vxxo" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel.adapter.structure.concept(MPS.Core/)" />
+    <import index="ze1i" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel.runtime(MPS.Core/)" />
+    <import index="e8bb" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel.adapter.ids(MPS.Core/)" />
+    <import index="pwx" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel.adapter.structure.property(MPS.Core/)" />
+    <import index="rzjr" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel.adapter.structure.ref(MPS.Core/)" />
+    <import index="wb4m" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel.adapter.structure.link(MPS.Core/)" />
+    <import index="mcvo" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel.adapter.structure.language(MPS.Core/)" />
+    <import index="w1kc" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel(MPS.Core/)" />
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" />
+  </imports>
+  <registry>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1219920932475" name="jetbrains.mps.baseLanguage.structure.VariableArityType" flags="in" index="8X2XB">
+        <child id="1219921048460" name="componentType" index="8Xvag" />
+      </concept>
+      <concept id="1082485599095" name="jetbrains.mps.baseLanguage.structure.BlockStatement" flags="nn" index="9aQIb">
+        <child id="1082485599096" name="statements" index="9aQI4" />
+      </concept>
+      <concept id="7485977462274819189" name="jetbrains.mps.baseLanguage.structure.FormatOperation" flags="ng" index="2cAKMz">
+        <child id="7485977462274819664" name="arguments" index="2cAKU6" />
+      </concept>
+      <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
+        <child id="1068498886297" name="rValue" index="37vLTx" />
+        <child id="1068498886295" name="lValue" index="37vLTJ" />
+      </concept>
+      <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="1179360813171" name="jetbrains.mps.baseLanguage.structure.HexIntegerLiteral" flags="nn" index="2nou5x">
+        <property id="1179360856892" name="value" index="2noCCI" />
+      </concept>
+      <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
+      <concept id="1188207840427" name="jetbrains.mps.baseLanguage.structure.AnnotationInstance" flags="nn" index="2AHcQZ">
+        <reference id="1188208074048" name="annotation" index="2AI5Lk" />
+      </concept>
+      <concept id="1188208481402" name="jetbrains.mps.baseLanguage.structure.HasAnnotation" flags="ngI" index="2AJDlI">
+        <child id="1188208488637" name="annotation" index="2AJF6D" />
+      </concept>
+      <concept id="2820489544401957797" name="jetbrains.mps.baseLanguage.structure.DefaultClassCreator" flags="nn" index="HV5vD">
+        <reference id="2820489544401957798" name="classifier" index="HV5vE" />
+      </concept>
+      <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
+        <child id="1154032183016" name="body" index="2LFqv$" />
+      </concept>
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <property id="2523873803623706117" name="isMultiline" index="hSjvv" />
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1197029447546" name="jetbrains.mps.baseLanguage.structure.FieldReferenceOperation" flags="nn" index="2OwXpG">
+        <reference id="1197029500499" name="fieldDeclaration" index="2Oxat5" />
+      </concept>
+      <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
+        <child id="1145553007750" name="creator" index="2ShVmc" />
+      </concept>
+      <concept id="1070462154015" name="jetbrains.mps.baseLanguage.structure.StaticFieldDeclaration" flags="ig" index="Wx3nA" />
+      <concept id="1070475354124" name="jetbrains.mps.baseLanguage.structure.ThisExpression" flags="nn" index="Xjq3P" />
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="1081236700938" name="jetbrains.mps.baseLanguage.structure.StaticMethodDeclaration" flags="ig" index="2YIFZL" />
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
+      </concept>
+      <concept id="1164991038168" name="jetbrains.mps.baseLanguage.structure.ThrowStatement" flags="nn" index="YS8fn">
+        <child id="1164991057263" name="throwable" index="YScLw" />
+      </concept>
+      <concept id="1081256982272" name="jetbrains.mps.baseLanguage.structure.InstanceOfExpression" flags="nn" index="2ZW3vV">
+        <child id="1081256993305" name="classType" index="2ZW6by" />
+        <child id="1081256993304" name="leftExpression" index="2ZW6bz" />
+      </concept>
+      <concept id="1070533707846" name="jetbrains.mps.baseLanguage.structure.StaticFieldReference" flags="nn" index="10M0yZ">
+        <reference id="1144433057691" name="classifier" index="1PxDUh" />
+      </concept>
+      <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
+      <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
+      <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
+      <concept id="1070534934090" name="jetbrains.mps.baseLanguage.structure.CastExpression" flags="nn" index="10QFUN">
+        <child id="1070534934091" name="type" index="10QFUM" />
+        <child id="1070534934092" name="expression" index="10QFUP" />
+      </concept>
+      <concept id="1068390468200" name="jetbrains.mps.baseLanguage.structure.FieldDeclaration" flags="ig" index="312cEg" />
+      <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu">
+        <property id="1075300953594" name="abstractClass" index="1sVAO0" />
+        <child id="1095933932569" name="implementedInterface" index="EKbjA" />
+        <child id="1165602531693" name="superclass" index="1zkMxy" />
+      </concept>
+      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <property id="1176718929932" name="isFinal" index="3TUv4t" />
+        <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ngI" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
+      </concept>
+      <concept id="1109279763828" name="jetbrains.mps.baseLanguage.structure.TypeVariableDeclaration" flags="ng" index="16euLQ">
+        <child id="1214996921760" name="bound" index="3ztrMU" />
+      </concept>
+      <concept id="1109279851642" name="jetbrains.mps.baseLanguage.structure.GenericDeclaration" flags="ng" index="16eOlS">
+        <child id="1109279881614" name="typeVariableDeclaration" index="16eVyc" />
+      </concept>
+      <concept id="1109283449304" name="jetbrains.mps.baseLanguage.structure.TypeVariableReference" flags="in" index="16syzq">
+        <reference id="1109283546497" name="typeVariableDeclaration" index="16sUi3" />
+      </concept>
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
+      <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
+      <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
+      <concept id="1225271283259" name="jetbrains.mps.baseLanguage.structure.NPEEqualsExpression" flags="nn" index="17R0WA" />
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123134" name="parameter" index="3clF46" />
+        <child id="1068580123135" name="body" index="3clF47" />
+      </concept>
+      <concept id="1068580123165" name="jetbrains.mps.baseLanguage.structure.InstanceMethodDeclaration" flags="ig" index="3clFb_" />
+      <concept id="1068580123152" name="jetbrains.mps.baseLanguage.structure.EqualsExpression" flags="nn" index="3clFbC" />
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
+      <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
+        <child id="1082485599094" name="ifFalseStatement" index="9aQIa" />
+        <child id="1068580123160" name="condition" index="3clFbw" />
+        <child id="1068580123161" name="ifTrue" index="3clFbx" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
+        <property id="1068580123138" name="value" index="3clFbU" />
+      </concept>
+      <concept id="1068580123140" name="jetbrains.mps.baseLanguage.structure.ConstructorDeclaration" flags="ig" index="3clFbW" />
+      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
+        <property id="1068580320021" name="value" index="3cmrfH" />
+      </concept>
+      <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
+      <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
+        <child id="1068581517676" name="expression" index="3cqZAk" />
+      </concept>
+      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
+        <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
+      </concept>
+      <concept id="1068581242867" name="jetbrains.mps.baseLanguage.structure.LongType" flags="in" index="3cpWsb" />
+      <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
+      <concept id="1079359253375" name="jetbrains.mps.baseLanguage.structure.ParenthesizedExpression" flags="nn" index="1eOMI4">
+        <child id="1079359253376" name="expression" index="1eOMHV" />
+      </concept>
+      <concept id="1081516740877" name="jetbrains.mps.baseLanguage.structure.NotExpression" flags="nn" index="3fqX7Q">
+        <child id="1081516765348" name="expression" index="3fr31v" />
+      </concept>
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+        <child id="4972241301747169160" name="typeArgument" index="3PaCim" />
+      </concept>
+      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
+      <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
+        <property id="521412098689998745" name="nonStatic" index="2bfB8j" />
+        <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
+      </concept>
+      <concept id="7812454656619025412" name="jetbrains.mps.baseLanguage.structure.LocalMethodCall" flags="nn" index="1rXfSq" />
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+        <reference id="1107535924139" name="classifier" index="3uigEE" />
+        <child id="1109201940907" name="parameter" index="11_B2D" />
+      </concept>
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
+        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
+        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
+      </concept>
+      <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
+        <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="1163668896201" name="jetbrains.mps.baseLanguage.structure.TernaryOperatorExpression" flags="nn" index="3K4zz7">
+        <child id="1163668914799" name="condition" index="3K4Cdx" />
+        <child id="1163668922816" name="ifTrue" index="3K4E3e" />
+        <child id="1163668934364" name="ifFalse" index="3K4GZi" />
+      </concept>
+      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+      <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
+      <concept id="1146644641414" name="jetbrains.mps.baseLanguage.structure.ProtectedVisibility" flags="nn" index="3Tmbuc" />
+      <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
+    </language>
+    <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
+      <concept id="2524418899405758586" name="jetbrains.mps.baseLanguage.closures.structure.InferredClosureParameterDeclaration" flags="ig" index="gl6BB" />
+      <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
+        <child id="1199569906740" name="parameter" index="1bW2Oz" />
+        <child id="1199569916463" name="body" index="1bW5cS" />
+      </concept>
+    </language>
+    <language id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc">
+      <concept id="2546654756694997551" name="jetbrains.mps.baseLanguage.javadoc.structure.LinkInlineDocTag" flags="ng" index="92FcH">
+        <child id="2546654756694997556" name="reference" index="92FcQ" />
+        <child id="3106559687488913694" name="line" index="2XjZqd" />
+      </concept>
+      <concept id="6832197706140518104" name="jetbrains.mps.baseLanguage.javadoc.structure.DocMethodParameterReference" flags="ng" index="zr_55" />
+      <concept id="6832197706140518103" name="jetbrains.mps.baseLanguage.javadoc.structure.BaseParameterReference" flags="ng" index="zr_5a">
+        <reference id="6832197706140518108" name="param" index="zr_51" />
+      </concept>
+      <concept id="5349172909345501395" name="jetbrains.mps.baseLanguage.javadoc.structure.BaseDocComment" flags="ng" index="P$AiS">
+        <child id="8465538089690331502" name="body" index="TZ5H$" />
+        <child id="5383422241790532083" name="tags" index="3nqlJM" />
+      </concept>
+      <concept id="5349172909345532724" name="jetbrains.mps.baseLanguage.javadoc.structure.MethodDocComment" flags="ng" index="P$JXv" />
+      <concept id="8465538089690881930" name="jetbrains.mps.baseLanguage.javadoc.structure.ParameterBlockDocTag" flags="ng" index="TUZQ0">
+        <property id="8465538089690881934" name="text" index="TUZQ4" />
+        <child id="6832197706140518123" name="parameter" index="zr_5Q" />
+      </concept>
+      <concept id="8465538089690331500" name="jetbrains.mps.baseLanguage.javadoc.structure.CommentLine" flags="ng" index="TZ5HA">
+        <child id="8970989240999019149" name="part" index="1dT_Ay" />
+      </concept>
+      <concept id="2217234381367530195" name="jetbrains.mps.baseLanguage.javadoc.structure.MethodDocReference" flags="ng" index="VXe0Z">
+        <reference id="2217234381367530196" name="methodDeclaration" index="VXe0S" />
+      </concept>
+      <concept id="8970989240999019145" name="jetbrains.mps.baseLanguage.javadoc.structure.InlineTagCommentLinePart" flags="ng" index="1dT_AA">
+        <child id="6962838954693749192" name="tag" index="qph3F" />
+      </concept>
+      <concept id="8970989240999019143" name="jetbrains.mps.baseLanguage.javadoc.structure.TextCommentLinePart" flags="ng" index="1dT_AC">
+        <property id="8970989240999019144" name="text" index="1dT_AB" />
+      </concept>
+      <concept id="2068944020170241612" name="jetbrains.mps.baseLanguage.javadoc.structure.ClassifierDocComment" flags="ng" index="3UR2Jj" />
+    </language>
+    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="2644386474302386080" name="jetbrains.mps.lang.smodel.structure.PropertyIdRefExpression" flags="nn" index="355D3s">
+        <reference id="2644386474302386081" name="conceptDeclaration" index="355D3t" />
+        <reference id="2644386474302386082" name="propertyDeclaration" index="355D3u" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+      <concept id="4222318806802425298" name="jetbrains.mps.lang.core.structure.SuppressErrorsAnnotation" flags="ng" index="15s5l7">
+        <property id="8575328350543493365" name="message" index="huDt6" />
+        <property id="2423417345669755629" name="filter" index="1eyWvh" />
+      </concept>
+    </language>
+    <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
+        <child id="1204796294226" name="closure" index="23t8la" />
+      </concept>
+      <concept id="1176906603202" name="jetbrains.mps.baseLanguage.collections.structure.BinaryOperation" flags="nn" index="56pJg">
+        <child id="1176906787974" name="rightExpression" index="576Qk" />
+      </concept>
+      <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="nn" index="25WWJ4">
+        <child id="540871147943773366" name="argument" index="25WWJ7" />
+      </concept>
+      <concept id="1176923520476" name="jetbrains.mps.baseLanguage.collections.structure.ExcludeOperation" flags="nn" index="66VNe" />
+      <concept id="1226511727824" name="jetbrains.mps.baseLanguage.collections.structure.SetType" flags="in" index="2hMVRd">
+        <child id="1226511765987" name="elementType" index="2hN53Y" />
+      </concept>
+      <concept id="1151688443754" name="jetbrains.mps.baseLanguage.collections.structure.ListType" flags="in" index="_YKpA">
+        <child id="1151688676805" name="elementType" index="_ZDj9" />
+      </concept>
+      <concept id="1151689724996" name="jetbrains.mps.baseLanguage.collections.structure.SequenceType" flags="in" index="A3Dl8">
+        <child id="1151689745422" name="elementType" index="A3Ik2" />
+      </concept>
+      <concept id="1151702311717" name="jetbrains.mps.baseLanguage.collections.structure.ToListOperation" flags="nn" index="ANE8D" />
+      <concept id="1209727891789" name="jetbrains.mps.baseLanguage.collections.structure.ComparatorSortOperation" flags="nn" index="2DpFxk">
+        <child id="1209727996925" name="ascending" index="2Dq5b$" />
+      </concept>
+      <concept id="1153943597977" name="jetbrains.mps.baseLanguage.collections.structure.ForEachStatement" flags="nn" index="2Gpval">
+        <child id="1153944400369" name="variable" index="2Gsz3X" />
+        <child id="1153944424730" name="inputSequence" index="2GsD0m" />
+      </concept>
+      <concept id="1153944193378" name="jetbrains.mps.baseLanguage.collections.structure.ForEachVariable" flags="nr" index="2GrKxI" />
+      <concept id="1153944233411" name="jetbrains.mps.baseLanguage.collections.structure.ForEachVariableReference" flags="nn" index="2GrUjf">
+        <reference id="1153944258490" name="variable" index="2Gs0qQ" />
+      </concept>
+      <concept id="1237721394592" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerCreator" flags="nn" index="HWqM0">
+        <child id="1237721435807" name="elementType" index="HW$YZ" />
+      </concept>
+      <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
+      <concept id="1240217271293" name="jetbrains.mps.baseLanguage.collections.structure.LinkedHashSetCreator" flags="nn" index="32HrFt" />
+      <concept id="1240325842691" name="jetbrains.mps.baseLanguage.collections.structure.AsSequenceOperation" flags="nn" index="39bAoz" />
+      <concept id="1167380149909" name="jetbrains.mps.baseLanguage.collections.structure.RemoveElementOperation" flags="nn" index="3dhRuq" />
+      <concept id="1178286324487" name="jetbrains.mps.baseLanguage.collections.structure.SortDirection" flags="nn" index="1nlBCl" />
+      <concept id="1202120902084" name="jetbrains.mps.baseLanguage.collections.structure.WhereOperation" flags="nn" index="3zZkjj" />
+      <concept id="1172254888721" name="jetbrains.mps.baseLanguage.collections.structure.ContainsOperation" flags="nn" index="3JPx81" />
+      <concept id="1180964022718" name="jetbrains.mps.baseLanguage.collections.structure.ConcatOperation" flags="nn" index="3QWeyG" />
+      <concept id="1178894719932" name="jetbrains.mps.baseLanguage.collections.structure.DistinctOperation" flags="nn" index="1VAtEI" />
+    </language>
+  </registry>
+  <node concept="312cEu" id="36NsNggQrub">
+    <property role="TrG5h" value="NodeHasher" />
+    <property role="2bfB8j" value="true" />
+    <node concept="3Tm1VV" id="36NsNggQruc" role="1B3o_S" />
+    <node concept="3UR2Jj" id="36NsNggQrEP" role="lGtFl">
+      <node concept="TZ5HA" id="36NsNggQrER" role="TZ5H$">
+        <node concept="1dT_AC" id="36NsNggQrES" role="1dT_Ay">
+          <property role="1dT_AB" value="Hashes all passed nodes by their concept, property+value, (deep) containments+node, and references+target. " />
+        </node>
+      </node>
+      <node concept="TZ5HA" id="36NsNggQrET" role="TZ5H$">
+        <node concept="1dT_AC" id="36NsNggQrEU" role="1dT_Ay">
+          <property role="1dT_AB" value=" " />
+        </node>
+      </node>
+      <node concept="TZ5HA" id="36NsNggQrEV" role="TZ5H$">
+        <node concept="1dT_AC" id="36NsNggQrEW" role="1dT_Ay">
+          <property role="1dT_AB" value="Can ignore {" />
+        </node>
+        <node concept="1dT_AA" id="3s41kb3nWK8" role="1dT_Ay">
+          <node concept="92FcH" id="3s41kb3nWKa" role="qph3F">
+            <node concept="TZ5HA" id="3s41kb3nWKc" role="2XjZqd">
+              <node concept="1dT_AC" id="3s41kb3nY5K" role="1dT_Ay">
+                <property role="1dT_AB" value="node ids" />
+              </node>
+            </node>
+            <node concept="VXe0Z" id="3s41kb3nXqx" role="92FcQ">
+              <ref role="VXe0S" node="36NsNggQrzG" resolve="setIncludeNodeIds" />
+            </node>
+          </node>
+        </node>
+        <node concept="1dT_AC" id="3s41kb3nWK7" role="1dT_Ay">
+          <property role="1dT_AB" value="," />
+        </node>
+      </node>
+      <node concept="TZ5HA" id="3s41kb3o3aO" role="TZ5H$">
+        <node concept="1dT_AC" id="3s41kb3o3aP" role="1dT_Ay">
+          <property role="1dT_AB" value="" />
+        </node>
+        <node concept="1dT_AA" id="3s41kb3nY5M" role="1dT_Ay">
+          <node concept="92FcH" id="3s41kb3nY5O" role="qph3F">
+            <node concept="TZ5HA" id="3s41kb3nY5Q" role="2XjZqd">
+              <node concept="1dT_AC" id="3s41kb3nYL9" role="1dT_Ay">
+                <property role="1dT_AB" value="BaseConcept properties" />
+              </node>
+            </node>
+            <node concept="VXe0Z" id="3s41kb3nY5U" role="92FcQ">
+              <ref role="VXe0S" node="36NsNggQrzu" resolve="setIncludeBaseConceptProperties" />
+            </node>
+          </node>
+        </node>
+        <node concept="1dT_AC" id="3s41kb3nY5L" role="1dT_Ay">
+          <property role="1dT_AB" value="," />
+        </node>
+      </node>
+      <node concept="TZ5HA" id="3s41kb3o79o" role="TZ5H$">
+        <node concept="1dT_AC" id="3s41kb3o79p" role="1dT_Ay">
+          <property role="1dT_AB" value="" />
+        </node>
+        <node concept="1dT_AA" id="3s41kb3nYLb" role="1dT_Ay">
+          <node concept="92FcH" id="3s41kb3nYLd" role="qph3F">
+            <node concept="TZ5HA" id="3s41kb3nYLf" role="2XjZqd">
+              <node concept="1dT_AC" id="3s41kb3nZ67" role="1dT_Ay">
+                <property role="1dT_AB" value="annotations/node attributes" />
+              </node>
+            </node>
+            <node concept="VXe0Z" id="3s41kb3nYLj" role="92FcQ">
+              <ref role="VXe0S" node="36NsNggQrz_" resolve="setIncludeAnnotations" />
+            </node>
+          </node>
+        </node>
+        <node concept="1dT_AC" id="3s41kb3nYLa" role="1dT_Ay">
+          <property role="1dT_AB" value="," />
+        </node>
+      </node>
+      <node concept="TZ5HA" id="3s41kb3o9FH" role="TZ5H$">
+        <node concept="1dT_AC" id="3s41kb3o9FI" role="1dT_Ay">
+          <property role="1dT_AB" value="and " />
+        </node>
+        <node concept="1dT_AA" id="3s41kb3nZ69" role="1dT_Ay">
+          <node concept="92FcH" id="3s41kb3nZ6b" role="qph3F">
+            <node concept="TZ5HA" id="3s41kb3nZ6d" role="2XjZqd">
+              <node concept="1dT_AC" id="3s41kb3nZLw" role="1dT_Ay">
+                <property role="1dT_AB" value="arbitrary features" />
+              </node>
+            </node>
+            <node concept="VXe0Z" id="3s41kb3nZ6h" role="92FcQ">
+              <ref role="VXe0S" node="36NsNggQr$6" resolve="ignore" />
+            </node>
+          </node>
+        </node>
+        <node concept="1dT_AC" id="3s41kb3nZ68" role="1dT_Ay">
+          <property role="1dT_AB" value="." />
+        </node>
+      </node>
+      <node concept="TZ5HA" id="36NsNggQrEX" role="TZ5H$">
+        <node concept="1dT_AC" id="36NsNggQrEY" role="1dT_Ay">
+          <property role="1dT_AB" value="By default, everything is included. " />
+        </node>
+      </node>
+      <node concept="TZ5HA" id="36NsNggQrEZ" role="TZ5H$">
+        <node concept="1dT_AC" id="36NsNggQrF0" role="1dT_Ay">
+          <property role="1dT_AB" value=" " />
+        </node>
+      </node>
+      <node concept="TZ5HA" id="36NsNggQrF1" role="TZ5H$">
+        <node concept="1dT_AC" id="36NsNggQrF2" role="1dT_Ay">
+          <property role="1dT_AB" value="If we consider node ids, we compare reference targets by node id;" />
+        </node>
+      </node>
+      <node concept="TZ5HA" id="3s41kb3ocNT" role="TZ5H$">
+        <node concept="1dT_AC" id="3s41kb3ocNU" role="1dT_Ay">
+          <property role="1dT_AB" value="otherwise by the target node's " />
+        </node>
+        <node concept="1dT_AA" id="3s41kb3oeN6" role="1dT_Ay">
+          <node concept="92FcH" id="3s41kb3oeN8" role="qph3F">
+            <node concept="TZ5HA" id="3s41kb3oeNa" role="2XjZqd" />
+            <node concept="VXe0Z" id="3s41kb3oeNe" role="92FcQ">
+              <ref role="VXe0S" to="w1kc:~SNode.getPresentation()" resolve="getPresentation" />
+            </node>
+          </node>
+        </node>
+        <node concept="1dT_AC" id="3s41kb3oeN5" role="1dT_Ay">
+          <property role="1dT_AB" value="." />
+        </node>
+      </node>
+    </node>
+    <node concept="Wx3nA" id="36NsNggQrxK" role="jymVt">
+      <property role="TrG5h" value="UNSET_PROPERTY_VALUE" />
+      <property role="3TUv4t" value="true" />
+      <node concept="17QB3L" id="36NsNggQBaj" role="1tU5fm" />
+      <node concept="Xl_RD" id="36NsNggQrxM" role="33vP2m">
+        <property role="Xl_RC" value="false" />
+      </node>
+      <node concept="3Tm6S6" id="36NsNggQrxN" role="1B3o_S" />
+    </node>
+    <node concept="Wx3nA" id="3s41kb3rQYk" role="jymVt">
+      <property role="3TUv4t" value="true" />
+      <property role="TrG5h" value="SHORT_DESCRIPTION" />
+      <node concept="15s5l7" id="3s41kb3s2k7" role="lGtFl">
+        <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Warning: shortDescription is deprecated since build 3.5 (This property should not be used. Override ISmartReferent#getDescriptionText(context) to customize description text )&quot;;FLAVOUR_RULE_ID=&quot;[r:cec599e3-51d2-48a7-af31-989e3cbd593c(jetbrains.mps.lang.core.typesystem)/1225207423729]&quot;;" />
+        <property role="huDt6" value="Warning: shortDescription is deprecated since build 3.5 (This property should not be used. Override ISmartReferent#getDescriptionText(context) to customize description text )" />
+      </node>
+      <node concept="3Tm6S6" id="3s41kb3rQYh" role="1B3o_S" />
+      <node concept="3uibUv" id="3s41kb3rQYi" role="1tU5fm">
+        <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
+      </node>
+      <node concept="355D3s" id="3s41kb3rQYj" role="33vP2m">
+        <ref role="355D3t" to="tpck:gw2VY9q" resolve="BaseConcept" />
+        <ref role="355D3u" to="tpck:gOOYnlO" resolve="shortDescription" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="3s41kb3rZ$Q" role="jymVt" />
+    <node concept="312cEg" id="36NsNggQrxO" role="jymVt">
+      <property role="TrG5h" value="nodes" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="36NsNggQrxR" role="1B3o_S" />
+      <node concept="_YKpA" id="36NsNggSdHp" role="1tU5fm">
+        <node concept="3uibUv" id="36NsNggSdHq" role="_ZDj9">
+          <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
+        </node>
+      </node>
+    </node>
+    <node concept="312cEg" id="36NsNggQrxS" role="jymVt">
+      <property role="TrG5h" value="hasher" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3uibUv" id="36NsNggQrxU" role="1tU5fm">
+        <ref role="3uigEE" to="kscp:~Hasher" resolve="Hasher" />
+      </node>
+      <node concept="3Tm6S6" id="36NsNggQrxV" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="3s41kb3ojoJ" role="jymVt" />
+    <node concept="312cEg" id="36NsNggQrxW" role="jymVt">
+      <property role="TrG5h" value="ignoredProperties" />
+      <property role="3TUv4t" value="true" />
+      <node concept="2hMVRd" id="36NsNggRCh0" role="1tU5fm">
+        <node concept="3uibUv" id="36NsNggRCh2" role="2hN53Y">
+          <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="36NsNggQry0" role="1B3o_S" />
+      <node concept="2ShNRf" id="3s41kb37zvs" role="33vP2m">
+        <node concept="32HrFt" id="3s41kb37zvh" role="2ShVmc">
+          <node concept="3uibUv" id="3s41kb37zvi" role="HW$YZ">
+            <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="312cEg" id="36NsNggQry1" role="jymVt">
+      <property role="TrG5h" value="ignoredContainments" />
+      <property role="3TUv4t" value="true" />
+      <node concept="2hMVRd" id="36NsNggRERP" role="1tU5fm">
+        <node concept="3uibUv" id="36NsNggQry4" role="2hN53Y">
+          <ref role="3uigEE" to="c17a:~SContainmentLink" resolve="SContainmentLink" />
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="36NsNggQry5" role="1B3o_S" />
+      <node concept="2ShNRf" id="3s41kb37AaH" role="33vP2m">
+        <node concept="32HrFt" id="3s41kb37Aay" role="2ShVmc">
+          <node concept="3uibUv" id="3s41kb37Aaz" role="HW$YZ">
+            <ref role="3uigEE" to="c17a:~SContainmentLink" resolve="SContainmentLink" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="312cEg" id="36NsNggQry6" role="jymVt">
+      <property role="TrG5h" value="ignoredReferences" />
+      <property role="3TUv4t" value="true" />
+      <node concept="2hMVRd" id="36NsNggRGZh" role="1tU5fm">
+        <node concept="3uibUv" id="36NsNggQry9" role="2hN53Y">
+          <ref role="3uigEE" to="c17a:~SReferenceLink" resolve="SReferenceLink" />
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="36NsNggQrya" role="1B3o_S" />
+      <node concept="2ShNRf" id="3s41kb37CS5" role="33vP2m">
+        <node concept="32HrFt" id="3s41kb37CRU" role="2ShVmc">
+          <node concept="3uibUv" id="3s41kb37CRV" role="HW$YZ">
+            <ref role="3uigEE" to="c17a:~SReferenceLink" resolve="SReferenceLink" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="312cEg" id="36NsNggQryb" role="jymVt">
+      <property role="TrG5h" value="includeNodeIds" />
+      <node concept="10P_77" id="36NsNggQryd" role="1tU5fm" />
+      <node concept="3clFbT" id="36NsNggQrye" role="33vP2m">
+        <property role="3clFbU" value="true" />
+      </node>
+      <node concept="3Tm6S6" id="36NsNggQryf" role="1B3o_S" />
+    </node>
+    <node concept="312cEg" id="36NsNggQryg" role="jymVt">
+      <property role="TrG5h" value="normalizeBooleanProperties" />
+      <node concept="10P_77" id="36NsNggQryi" role="1tU5fm" />
+      <node concept="3clFbT" id="36NsNggQryj" role="33vP2m">
+        <property role="3clFbU" value="true" />
+      </node>
+      <node concept="3Tm6S6" id="36NsNggQryk" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="3s41kb3om0G" role="jymVt" />
+    <node concept="3clFbW" id="36NsNggQryX" role="jymVt">
+      <node concept="3cqZAl" id="36NsNggQryY" role="3clF45" />
+      <node concept="37vLTG" id="36NsNggQryZ" role="3clF46">
+        <property role="TrG5h" value="nodes" />
+        <node concept="_YKpA" id="36NsNggRPzW" role="1tU5fm">
+          <node concept="3uibUv" id="36NsNggRSvk" role="_ZDj9">
+            <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="36NsNggQrz1" role="3clF46">
+        <property role="TrG5h" value="seed" />
+        <node concept="10Oyi0" id="36NsNggQrz2" role="1tU5fm" />
+      </node>
+      <node concept="3clFbS" id="36NsNggQrz3" role="3clF47">
+        <node concept="3clFbF" id="36NsNggQrz4" role="3cqZAp">
+          <node concept="37vLTI" id="36NsNggQrz5" role="3clFbG">
+            <node concept="2OqwBi" id="36NsNggQrz6" role="37vLTJ">
+              <node concept="Xjq3P" id="36NsNggQrz7" role="2Oq$k0" />
+              <node concept="2OwXpG" id="36NsNggQrz8" role="2OqNvi">
+                <ref role="2Oxat5" node="36NsNggQrxO" resolve="nodes" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="36NsNggQrz9" role="37vLTx">
+              <ref role="3cqZAo" node="36NsNggQryZ" resolve="nodes" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="36NsNggQrza" role="3cqZAp">
+          <node concept="37vLTI" id="36NsNggQrzb" role="3clFbG">
+            <node concept="37vLTw" id="36NsNggQrzc" role="37vLTJ">
+              <ref role="3cqZAo" node="36NsNggQrxS" resolve="hasher" />
+            </node>
+            <node concept="2OqwBi" id="3s41kb3v4In" role="37vLTx">
+              <node concept="2YIFZM" id="3s41kb38op3" role="2Oq$k0">
+                <ref role="37wK5l" to="kscp:~Hashing.murmur3_32(int)" resolve="murmur3_32" />
+                <ref role="1Pybhc" to="kscp:~Hashing" resolve="Hashing" />
+                <node concept="37vLTw" id="3s41kb3xwmQ" role="37wK5m">
+                  <ref role="3cqZAo" node="36NsNggQrz1" resolve="seed" />
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3v5Lf" role="2OqNvi">
+                <ref role="37wK5l" to="kscp:~HashFunction.newHasher()" resolve="newHasher" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="36NsNggQrzf" role="1B3o_S" />
+      <node concept="P$JXv" id="36NsNggQrzg" role="lGtFl">
+        <node concept="TZ5HA" id="36NsNggQrF3" role="TZ5H$">
+          <node concept="1dT_AC" id="36NsNggQrF4" role="1dT_Ay">
+            <property role="1dT_AB" value="Hashes all nodes. " />
+          </node>
+        </node>
+        <node concept="TUZQ0" id="3s41kb3oq3z" role="3nqlJM">
+          <property role="TUZQ4" value="Nodes to hash. The order of nodes, and (in)direct children of the same containment, matters." />
+          <node concept="zr_55" id="3s41kb3oqrH" role="zr_5Q">
+            <ref role="zr_51" node="36NsNggQryZ" resolve="nodes" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="3s41kb3or$e" role="jymVt" />
+    <node concept="2YIFZL" id="36NsNggQrzh" role="jymVt">
+      <property role="TrG5h" value="hash" />
+      <node concept="37vLTG" id="36NsNggQrzi" role="3clF46">
+        <property role="TrG5h" value="nodes" />
+        <node concept="8X2XB" id="36NsNggQrzk" role="1tU5fm">
+          <node concept="3uibUv" id="36NsNggQrzj" role="8Xvag">
+            <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbS" id="36NsNggQrzl" role="3clF47">
+        <node concept="3clFbF" id="36NsNggQrzm" role="3cqZAp">
+          <node concept="2OqwBi" id="36NsNggQM8i" role="3clFbG">
+            <node concept="2ShNRf" id="36NsNggQJJv" role="2Oq$k0">
+              <node concept="1pGfFk" id="36NsNggQJMB" role="2ShVmc">
+                <ref role="37wK5l" node="36NsNggQryX" resolve="NodeHasher" />
+                <node concept="2OqwBi" id="36NsNggQJMC" role="37wK5m">
+                  <node concept="2OqwBi" id="36NsNggQJMD" role="2Oq$k0">
+                    <node concept="37vLTw" id="36NsNggQJME" role="2Oq$k0">
+                      <ref role="3cqZAo" node="36NsNggQrzi" resolve="nodes" />
+                    </node>
+                    <node concept="39bAoz" id="36NsNggRM0A" role="2OqNvi" />
+                  </node>
+                  <node concept="ANE8D" id="36NsNggRMX3" role="2OqNvi" />
+                </node>
+                <node concept="2nou5x" id="36NsNggQJOO" role="37wK5m">
+                  <property role="2noCCI" value="21375341" />
+                </node>
+              </node>
+            </node>
+            <node concept="liA8E" id="36NsNggQM8j" role="2OqNvi">
+              <ref role="37wK5l" node="36NsNggQr$I" resolve="hash" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="36NsNggQrzr" role="1B3o_S" />
+      <node concept="10Oyi0" id="36NsNggQrzs" role="3clF45" />
+      <node concept="P$JXv" id="36NsNggQrzt" role="lGtFl">
+        <node concept="TZ5HA" id="36NsNggQrF9" role="TZ5H$">
+          <node concept="1dT_AC" id="36NsNggQrFa" role="1dT_Ay">
+            <property role="1dT_AB" value="Convenience factory to hash nodes with default seed, including node ids and all features. " />
+          </node>
+        </node>
+        <node concept="TUZQ0" id="3s41kb3ovm0" role="3nqlJM">
+          <property role="TUZQ4" value="Nodes to hash. The order of nodes, and (in)direct children of the same containment, matters." />
+          <node concept="zr_55" id="3s41kb3ow31" role="zr_5Q">
+            <ref role="zr_51" node="36NsNggQrzi" resolve="nodes" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="3s41kb3oxrz" role="jymVt" />
+    <node concept="3clFb_" id="36NsNggQrzu" role="jymVt">
+      <property role="TrG5h" value="setIncludeBaseConceptProperties" />
+      <node concept="37vLTG" id="36NsNggQrzv" role="3clF46">
+        <property role="TrG5h" value="includeBaseConceptProperties" />
+        <node concept="10P_77" id="36NsNggQrzw" role="1tU5fm" />
+      </node>
+      <node concept="3clFbS" id="36NsNggQrzx" role="3clF47">
+        <node concept="3clFbJ" id="3s41kb3o_Ga" role="3cqZAp">
+          <node concept="37vLTw" id="3s41kb3oDsx" role="3clFbw">
+            <ref role="3cqZAo" node="36NsNggQrzv" resolve="includeBaseConceptProperties" />
+          </node>
+          <node concept="3clFbS" id="3s41kb3o_Gc" role="3clFbx">
+            <node concept="3clFbF" id="3s41kb3oFsN" role="3cqZAp">
+              <node concept="2OqwBi" id="3s41kb3oIaO" role="3clFbG">
+                <node concept="37vLTw" id="3s41kb3oFsM" role="2Oq$k0">
+                  <ref role="3cqZAo" node="36NsNggQrxW" resolve="ignoredProperties" />
+                </node>
+                <node concept="3dhRuq" id="3s41kb3oLeL" role="2OqNvi">
+                  <node concept="37vLTw" id="3s41kb3rQYn" role="25WWJ7">
+                    <ref role="3cqZAo" node="3s41kb3rQYk" resolve="SHORT_DESCRIPTION" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="3s41kb3rahl" role="3cqZAp">
+              <node concept="2OqwBi" id="3s41kb3rahm" role="3clFbG">
+                <node concept="37vLTw" id="3s41kb3rahn" role="2Oq$k0">
+                  <ref role="3cqZAo" node="36NsNggQrxW" resolve="ignoredProperties" />
+                </node>
+                <node concept="3dhRuq" id="3s41kb3raho" role="2OqNvi">
+                  <node concept="10M0yZ" id="3s41kb3rahp" role="25WWJ7">
+                    <ref role="3cqZAo" to="w1kc:~SNodeUtil.property_BaseConcept_virtualPackage" resolve="property_BaseConcept_virtualPackage" />
+                    <ref role="1PxDUh" to="w1kc:~SNodeUtil" resolve="SNodeUtil" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="9aQIb" id="3s41kb3pOQ5" role="9aQIa">
+            <node concept="3clFbS" id="3s41kb3pOQ6" role="9aQI4">
+              <node concept="3clFbF" id="3s41kb3pS0y" role="3cqZAp">
+                <node concept="2OqwBi" id="3s41kb3pWJY" role="3clFbG">
+                  <node concept="37vLTw" id="3s41kb3pS0x" role="2Oq$k0">
+                    <ref role="3cqZAo" node="36NsNggQrxW" resolve="ignoredProperties" />
+                  </node>
+                  <node concept="TSZUe" id="3s41kb3q0t7" role="2OqNvi">
+                    <node concept="37vLTw" id="3s41kb3s8vJ" role="25WWJ7">
+                      <ref role="3cqZAo" node="3s41kb3rQYk" resolve="SHORT_DESCRIPTION" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbF" id="3s41kb3rx93" role="3cqZAp">
+                <node concept="2OqwBi" id="3s41kb3rx94" role="3clFbG">
+                  <node concept="37vLTw" id="3s41kb3rx95" role="2Oq$k0">
+                    <ref role="3cqZAo" node="36NsNggQrxW" resolve="ignoredProperties" />
+                  </node>
+                  <node concept="TSZUe" id="3s41kb3rx96" role="2OqNvi">
+                    <node concept="10M0yZ" id="3s41kb3rx97" role="25WWJ7">
+                      <ref role="3cqZAo" to="w1kc:~SNodeUtil.property_BaseConcept_virtualPackage" resolve="property_BaseConcept_virtualPackage" />
+                      <ref role="1PxDUh" to="w1kc:~SNodeUtil" resolve="SNodeUtil" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="3s41kb3wzfK" role="3cqZAp">
+          <node concept="Xjq3P" id="3s41kb3w_oR" role="3cqZAk" />
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="36NsNggQrzy" role="1B3o_S" />
+      <node concept="3uibUv" id="3s41kb3wsVM" role="3clF45">
+        <ref role="3uigEE" node="36NsNggQrub" resolve="NodeHasher" />
+      </node>
+      <node concept="P$JXv" id="36NsNggQrz$" role="lGtFl">
+        <node concept="TZ5HA" id="36NsNggQrFf" role="TZ5H$">
+          <node concept="1dT_AC" id="36NsNggQrFg" role="1dT_Ay">
+            <property role="1dT_AB" value="Whether we consider &lt;tt&gt;BaseConcept.shortDescription&lt;/tt&gt; and &lt;tt&gt;BaseConcept.virtualPackage&lt;/tt&gt; properties while hashing. " />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="3s41kb3qBOj" role="jymVt" />
+    <node concept="3clFb_" id="36NsNggQrz_" role="jymVt">
+      <property role="TrG5h" value="setIncludeAnnotations" />
+      <node concept="37vLTG" id="36NsNggQrzA" role="3clF46">
+        <property role="TrG5h" value="includeAnnotations" />
+        <node concept="10P_77" id="36NsNggQrzB" role="1tU5fm" />
+      </node>
+      <node concept="3clFbS" id="36NsNggQrzC" role="3clF47">
+        <node concept="3clFbJ" id="3s41kb3q4mG" role="3cqZAp">
+          <node concept="37vLTw" id="3s41kb3q64X" role="3clFbw">
+            <ref role="3cqZAo" node="36NsNggQrzA" resolve="includeAnnotations" />
+          </node>
+          <node concept="3clFbS" id="3s41kb3q4mI" role="3clFbx">
+            <node concept="3clFbF" id="3s41kb3qa8d" role="3cqZAp">
+              <node concept="2OqwBi" id="3s41kb3qcSU" role="3clFbG">
+                <node concept="37vLTw" id="3s41kb3qa8c" role="2Oq$k0">
+                  <ref role="3cqZAo" node="36NsNggQry1" resolve="ignoredContainments" />
+                </node>
+                <node concept="3dhRuq" id="3s41kb3qgFU" role="2OqNvi">
+                  <node concept="10M0yZ" id="3s41kb3qmNW" role="25WWJ7">
+                    <ref role="3cqZAo" to="w1kc:~SNodeUtil.link_BaseConcept_smodelAttribute" resolve="link_BaseConcept_smodelAttribute" />
+                    <ref role="1PxDUh" to="w1kc:~SNodeUtil" resolve="SNodeUtil" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="9aQIb" id="3s41kb3qoSp" role="9aQIa">
+            <node concept="3clFbS" id="3s41kb3qoSq" role="9aQI4">
+              <node concept="3clFbF" id="3s41kb3qqWB" role="3cqZAp">
+                <node concept="2OqwBi" id="3s41kb3qtI7" role="3clFbG">
+                  <node concept="37vLTw" id="3s41kb3qqWA" role="2Oq$k0">
+                    <ref role="3cqZAo" node="36NsNggQry1" resolve="ignoredContainments" />
+                  </node>
+                  <node concept="TSZUe" id="3s41kb3qxIk" role="2OqNvi">
+                    <node concept="10M0yZ" id="3s41kb3q$L2" role="25WWJ7">
+                      <ref role="3cqZAo" to="w1kc:~SNodeUtil.link_BaseConcept_smodelAttribute" resolve="link_BaseConcept_smodelAttribute" />
+                      <ref role="1PxDUh" to="w1kc:~SNodeUtil" resolve="SNodeUtil" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="3s41kb3wDCn" role="3cqZAp">
+          <node concept="Xjq3P" id="3s41kb3wDCo" role="3cqZAk" />
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="36NsNggQrzD" role="1B3o_S" />
+      <node concept="3uibUv" id="3s41kb3wBwC" role="3clF45">
+        <ref role="3uigEE" node="36NsNggQrub" resolve="NodeHasher" />
+      </node>
+      <node concept="P$JXv" id="36NsNggQrzF" role="lGtFl">
+        <node concept="TZ5HA" id="36NsNggQrFh" role="TZ5H$">
+          <node concept="1dT_AC" id="36NsNggQrFi" role="1dT_Ay">
+            <property role="1dT_AB" value="Whether we consider &lt;tt&gt;BaseConcept.smodelAttribute&lt;/tt&gt; containment while hashing. " />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="3s41kb3qFHT" role="jymVt" />
+    <node concept="3clFb_" id="36NsNggQrzG" role="jymVt">
+      <property role="TrG5h" value="setIncludeNodeIds" />
+      <node concept="37vLTG" id="36NsNggQrzH" role="3clF46">
+        <property role="TrG5h" value="includeNodeIds" />
+        <node concept="10P_77" id="36NsNggQrzI" role="1tU5fm" />
+      </node>
+      <node concept="3clFbS" id="36NsNggQrzJ" role="3clF47">
+        <node concept="3clFbF" id="36NsNggQrzK" role="3cqZAp">
+          <node concept="37vLTI" id="36NsNggQrzL" role="3clFbG">
+            <node concept="2OqwBi" id="36NsNggQrzM" role="37vLTJ">
+              <node concept="Xjq3P" id="36NsNggQrzN" role="2Oq$k0" />
+              <node concept="2OwXpG" id="36NsNggQrzO" role="2OqNvi">
+                <ref role="2Oxat5" node="36NsNggQryb" resolve="includeNodeIds" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="36NsNggQrzP" role="37vLTx">
+              <ref role="3cqZAo" node="36NsNggQrzH" resolve="includeNodeIds" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="3s41kb3wFKh" role="3cqZAp">
+          <node concept="Xjq3P" id="3s41kb3wFKi" role="3cqZAk" />
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="36NsNggQrzQ" role="1B3o_S" />
+      <node concept="3uibUv" id="3s41kb3wlpc" role="3clF45">
+        <ref role="3uigEE" node="36NsNggQrub" resolve="NodeHasher" />
+      </node>
+      <node concept="P$JXv" id="36NsNggQrzS" role="lGtFl">
+        <node concept="TZ5HA" id="36NsNggQrFj" role="TZ5H$">
+          <node concept="1dT_AC" id="36NsNggQrFk" role="1dT_Ay">
+            <property role="1dT_AB" value="Whether we consider node ids while hashing. " />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="3s41kb3qJd1" role="jymVt" />
+    <node concept="3clFb_" id="36NsNggQrzT" role="jymVt">
+      <property role="TrG5h" value="setNormalizeBooleanProperties" />
+      <node concept="37vLTG" id="36NsNggQrzU" role="3clF46">
+        <property role="TrG5h" value="normalizeBooleanProperties" />
+        <node concept="10P_77" id="36NsNggQrzV" role="1tU5fm" />
+      </node>
+      <node concept="3clFbS" id="36NsNggQrzW" role="3clF47">
+        <node concept="3clFbF" id="36NsNggQrzX" role="3cqZAp">
+          <node concept="37vLTI" id="36NsNggQrzY" role="3clFbG">
+            <node concept="2OqwBi" id="36NsNggQrzZ" role="37vLTJ">
+              <node concept="Xjq3P" id="36NsNggQr$0" role="2Oq$k0" />
+              <node concept="2OwXpG" id="36NsNggQr$1" role="2OqNvi">
+                <ref role="2Oxat5" node="36NsNggQryg" resolve="normalizeBooleanProperties" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="36NsNggQr$2" role="37vLTx">
+              <ref role="3cqZAo" node="36NsNggQrzU" resolve="normalizeBooleanProperties" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="3s41kb3wMeU" role="3cqZAp">
+          <node concept="Xjq3P" id="3s41kb3wMeV" role="3cqZAk" />
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="36NsNggQr$3" role="1B3o_S" />
+      <node concept="3uibUv" id="3s41kb3wHSp" role="3clF45">
+        <ref role="3uigEE" node="36NsNggQrub" resolve="NodeHasher" />
+      </node>
+      <node concept="P$JXv" id="36NsNggQr$5" role="lGtFl">
+        <node concept="TZ5HA" id="36NsNggQrFl" role="TZ5H$">
+          <node concept="1dT_AC" id="36NsNggQrFm" role="1dT_Ay">
+            <property role="1dT_AB" value="Whether we enforce boolean properties with value &quot;false&quot; to be present. " />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="3s41kb3qLT3" role="jymVt" />
+    <node concept="3clFb_" id="36NsNggQr$6" role="jymVt">
+      <property role="TrG5h" value="ignore" />
+      <node concept="37vLTG" id="36NsNggQr$7" role="3clF46">
+        <property role="TrG5h" value="feature" />
+        <node concept="3uibUv" id="36NsNggQr$8" role="1tU5fm">
+          <ref role="3uigEE" to="c17a:~SConceptFeature" resolve="SConceptFeature" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="36NsNggQr$9" role="3clF47">
+        <node concept="3clFbJ" id="36NsNggQr$a" role="3cqZAp">
+          <node concept="2ZW3vV" id="36NsNggQr$d" role="3clFbw">
+            <node concept="37vLTw" id="36NsNggQr$b" role="2ZW6bz">
+              <ref role="3cqZAo" node="36NsNggQr$7" resolve="feature" />
+            </node>
+            <node concept="3uibUv" id="36NsNggQr$c" role="2ZW6by">
+              <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
+            </node>
+          </node>
+          <node concept="3clFbJ" id="36NsNggQr$l" role="9aQIa">
+            <node concept="2ZW3vV" id="36NsNggQr$o" role="3clFbw">
+              <node concept="37vLTw" id="36NsNggQr$m" role="2ZW6bz">
+                <ref role="3cqZAo" node="36NsNggQr$7" resolve="feature" />
+              </node>
+              <node concept="3uibUv" id="36NsNggQr$n" role="2ZW6by">
+                <ref role="3uigEE" to="c17a:~SContainmentLink" resolve="SContainmentLink" />
+              </node>
+            </node>
+            <node concept="3clFbJ" id="36NsNggQr$w" role="9aQIa">
+              <node concept="2ZW3vV" id="36NsNggQr$z" role="3clFbw">
+                <node concept="37vLTw" id="36NsNggQr$x" role="2ZW6bz">
+                  <ref role="3cqZAo" node="36NsNggQr$7" resolve="feature" />
+                </node>
+                <node concept="3uibUv" id="36NsNggQr$y" role="2ZW6by">
+                  <ref role="3uigEE" to="c17a:~SReferenceLink" resolve="SReferenceLink" />
+                </node>
+              </node>
+              <node concept="3clFbS" id="36NsNggQr$_" role="3clFbx">
+                <node concept="3clFbF" id="36NsNggQr$A" role="3cqZAp">
+                  <node concept="2OqwBi" id="3s41kb38Sja" role="3clFbG">
+                    <node concept="37vLTw" id="3s41kb38QuM" role="2Oq$k0">
+                      <ref role="3cqZAo" node="36NsNggQry6" resolve="ignoredReferences" />
+                    </node>
+                    <node concept="TSZUe" id="3s41kb38U7g" role="2OqNvi">
+                      <node concept="10QFUN" id="36NsNggQKF_" role="25WWJ7">
+                        <node concept="37vLTw" id="36NsNggQKFA" role="10QFUP">
+                          <ref role="3cqZAo" node="36NsNggQr$7" resolve="feature" />
+                        </node>
+                        <node concept="3uibUv" id="36NsNggQKFB" role="10QFUM">
+                          <ref role="3uigEE" to="c17a:~SReferenceLink" resolve="SReferenceLink" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbS" id="36NsNggQr$q" role="3clFbx">
+              <node concept="3clFbF" id="36NsNggQr$r" role="3cqZAp">
+                <node concept="2OqwBi" id="3s41kb38JqO" role="3clFbG">
+                  <node concept="37vLTw" id="3s41kb38GQI" role="2Oq$k0">
+                    <ref role="3cqZAo" node="36NsNggQry1" resolve="ignoredContainments" />
+                  </node>
+                  <node concept="TSZUe" id="3s41kb38M3Y" role="2OqNvi">
+                    <node concept="10QFUN" id="36NsNggQI9w" role="25WWJ7">
+                      <node concept="37vLTw" id="36NsNggQI9x" role="10QFUP">
+                        <ref role="3cqZAo" node="36NsNggQr$7" resolve="feature" />
+                      </node>
+                      <node concept="3uibUv" id="36NsNggQI9y" role="10QFUM">
+                        <ref role="3uigEE" to="c17a:~SContainmentLink" resolve="SContainmentLink" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbS" id="36NsNggQr$f" role="3clFbx">
+            <node concept="3clFbF" id="36NsNggQr$g" role="3cqZAp">
+              <node concept="2OqwBi" id="3s41kb38$Z2" role="3clFbG">
+                <node concept="37vLTw" id="3s41kb38zna" role="2Oq$k0">
+                  <ref role="3cqZAo" node="36NsNggQrxW" resolve="ignoredProperties" />
+                </node>
+                <node concept="TSZUe" id="3s41kb38Dfd" role="2OqNvi">
+                  <node concept="10QFUN" id="36NsNggQHS6" role="25WWJ7">
+                    <node concept="37vLTw" id="36NsNggQHS7" role="10QFUP">
+                      <ref role="3cqZAo" node="36NsNggQr$7" resolve="feature" />
+                    </node>
+                    <node concept="3uibUv" id="36NsNggQHS8" role="10QFUM">
+                      <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="3s41kb3wQvH" role="3cqZAp">
+          <node concept="Xjq3P" id="3s41kb3wQvI" role="3cqZAk" />
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="36NsNggQr$F" role="1B3o_S" />
+      <node concept="3uibUv" id="3s41kb3wOnd" role="3clF45">
+        <ref role="3uigEE" node="36NsNggQrub" resolve="NodeHasher" />
+      </node>
+      <node concept="P$JXv" id="36NsNggQr$H" role="lGtFl">
+        <node concept="TZ5HA" id="36NsNggQrFn" role="TZ5H$">
+          <node concept="1dT_AC" id="36NsNggQrFo" role="1dT_Ay">
+            <property role="1dT_AB" value="Excludes given feature from hashing " />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="3s41kb3qQBf" role="jymVt" />
+    <node concept="3clFb_" id="36NsNggQr$I" role="jymVt">
+      <property role="TrG5h" value="hash" />
+      <node concept="3clFbS" id="36NsNggQr$J" role="3clF47">
+        <node concept="2Gpval" id="3s41kb38Xif" role="3cqZAp">
+          <node concept="2GrKxI" id="3s41kb38Xih" role="2Gsz3X">
+            <property role="TrG5h" value="node" />
+          </node>
+          <node concept="37vLTw" id="3s41kb392hv" role="2GsD0m">
+            <ref role="3cqZAo" node="36NsNggQrxO" resolve="nodes" />
+          </node>
+          <node concept="3clFbS" id="3s41kb38Xil" role="2LFqv$">
+            <node concept="3clFbF" id="36NsNggQr$S" role="3cqZAp">
+              <node concept="1rXfSq" id="36NsNggQr$T" role="3clFbG">
+                <ref role="37wK5l" node="36NsNggQr_1" resolve="hashNode" />
+                <node concept="2GrUjf" id="3s41kb39cVT" role="37wK5m">
+                  <ref role="2Gs0qQ" node="3s41kb38Xih" resolve="node" />
+                </node>
+                <node concept="3clFbT" id="36NsNggQr$V" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="36NsNggQr$W" role="3cqZAp">
+          <node concept="2OqwBi" id="3s41kb3vpga" role="3clFbG">
+            <node concept="2OqwBi" id="3s41kb398zf" role="2Oq$k0">
+              <node concept="37vLTw" id="3s41kb3971L" role="2Oq$k0">
+                <ref role="3cqZAo" node="36NsNggQrxS" resolve="hasher" />
+              </node>
+              <node concept="liA8E" id="3s41kb399CL" role="2OqNvi">
+                <ref role="37wK5l" to="kscp:~Hasher.hash()" resolve="hash" />
+              </node>
+            </node>
+            <node concept="liA8E" id="3s41kb3vvy6" role="2OqNvi">
+              <ref role="37wK5l" to="kscp:~HashCode.asInt()" resolve="asInt" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="36NsNggQr$Y" role="1B3o_S" />
+      <node concept="10Oyi0" id="36NsNggQr$Z" role="3clF45" />
+      <node concept="P$JXv" id="36NsNggQr_0" role="lGtFl">
+        <node concept="TZ5HA" id="36NsNggQrFp" role="TZ5H$">
+          <node concept="1dT_AC" id="36NsNggQrFq" role="1dT_Ay">
+            <property role="1dT_AB" value="Returns the calculated hash of all nodes and their descendants with all configured includes/ignores. " />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="36NsNggQrFr" role="TZ5H$">
+          <node concept="1dT_AC" id="36NsNggQrFs" role="1dT_Ay">
+            <property role="1dT_AB" value=" " />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="36NsNggQrFt" role="TZ5H$">
+          <node concept="1dT_AC" id="36NsNggQrFu" role="1dT_Ay">
+            <property role="1dT_AB" value="@return The calculated hash. " />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="3s41kb3qTka" role="jymVt" />
+    <node concept="2tJIrI" id="3s41kb3qW2E" role="jymVt" />
+    <node concept="3clFb_" id="36NsNggQr_1" role="jymVt">
+      <property role="TrG5h" value="hashNode" />
+      <node concept="37vLTG" id="36NsNggQr_2" role="3clF46">
+        <property role="TrG5h" value="node" />
+        <node concept="3uibUv" id="36NsNggQr_3" role="1tU5fm">
+          <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="36NsNggQr_4" role="3clF46">
+        <property role="TrG5h" value="includeContainment" />
+        <node concept="10P_77" id="36NsNggQr_5" role="1tU5fm" />
+      </node>
+      <node concept="3clFbS" id="36NsNggQr_6" role="3clF47">
+        <node concept="3clFbF" id="36NsNggQr_7" role="3cqZAp">
+          <node concept="1rXfSq" id="36NsNggQr_8" role="3clFbG">
+            <ref role="37wK5l" node="36NsNggQrBq" resolve="put" />
+            <node concept="2OqwBi" id="36NsNggS34P" role="37wK5m">
+              <node concept="37vLTw" id="36NsNggQI15" role="2Oq$k0">
+                <ref role="3cqZAo" node="36NsNggQr_2" resolve="node" />
+              </node>
+              <node concept="liA8E" id="36NsNggS34Q" role="2OqNvi">
+                <ref role="37wK5l" to="mhbf:~SNode.getConcept()" resolve="getConcept" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="3s41kb3eyVa" role="3cqZAp" />
+        <node concept="3clFbJ" id="36NsNggQr_a" role="3cqZAp">
+          <node concept="37vLTw" id="36NsNggQr_b" role="3clFbw">
+            <ref role="3cqZAo" node="36NsNggQryb" resolve="includeNodeIds" />
+          </node>
+          <node concept="3clFbS" id="36NsNggQr_d" role="3clFbx">
+            <node concept="3clFbF" id="36NsNggQr_e" role="3cqZAp">
+              <node concept="1rXfSq" id="36NsNggQr_f" role="3clFbG">
+                <ref role="37wK5l" node="36NsNggQrEt" resolve="put" />
+                <node concept="2OqwBi" id="36NsNggRVUw" role="37wK5m">
+                  <node concept="37vLTw" id="36NsNggQIkk" role="2Oq$k0">
+                    <ref role="3cqZAo" node="36NsNggQr_2" resolve="node" />
+                  </node>
+                  <node concept="liA8E" id="36NsNggRVUx" role="2OqNvi">
+                    <ref role="37wK5l" to="mhbf:~SNode.getNodeId()" resolve="getNodeId" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="3s41kb3c66F" role="3cqZAp" />
+        <node concept="3clFbJ" id="36NsNggQr_h" role="3cqZAp">
+          <node concept="37vLTw" id="36NsNggQr_i" role="3clFbw">
+            <ref role="3cqZAo" node="36NsNggQr_4" resolve="includeContainment" />
+          </node>
+          <node concept="3clFbS" id="36NsNggQr_k" role="3clFbx">
+            <node concept="3clFbF" id="36NsNggQr_l" role="3cqZAp">
+              <node concept="1rXfSq" id="36NsNggQr_m" role="3clFbG">
+                <ref role="37wK5l" node="36NsNggQrD3" resolve="put" />
+                <node concept="2OqwBi" id="36NsNggS1wR" role="37wK5m">
+                  <node concept="37vLTw" id="36NsNggQIgr" role="2Oq$k0">
+                    <ref role="3cqZAo" node="36NsNggQr_2" resolve="node" />
+                  </node>
+                  <node concept="liA8E" id="36NsNggS1wS" role="2OqNvi">
+                    <ref role="37wK5l" to="mhbf:~SNode.getContainmentLink()" resolve="getContainmentLink" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="3s41kb3c95Q" role="3cqZAp" />
+        <node concept="2Gpval" id="3s41kb39fLk" role="3cqZAp">
+          <node concept="2GrKxI" id="3s41kb39fLm" role="2Gsz3X">
+            <property role="TrG5h" value="prop" />
+          </node>
+          <node concept="2OqwBi" id="3s41kb39yah" role="2GsD0m">
+            <node concept="2OqwBi" id="3s41kb39orQ" role="2Oq$k0">
+              <node concept="1rXfSq" id="3s41kb39kq$" role="2Oq$k0">
+                <ref role="37wK5l" node="36NsNggQr_z" resolve="collectConceptProperties" />
+                <node concept="37vLTw" id="3s41kb39nm4" role="37wK5m">
+                  <ref role="3cqZAo" node="36NsNggQr_2" resolve="node" />
+                </node>
+              </node>
+              <node concept="66VNe" id="3s41kb39uV_" role="2OqNvi">
+                <node concept="37vLTw" id="3s41kb39wQ1" role="576Qk">
+                  <ref role="3cqZAo" node="36NsNggQrxW" resolve="ignoredProperties" />
+                </node>
+              </node>
+            </node>
+            <node concept="2DpFxk" id="3s41kb39_q7" role="2OqNvi">
+              <node concept="1nlBCl" id="3s41kb39_q9" role="2Dq5b$">
+                <property role="3clFbU" value="true" />
+              </node>
+              <node concept="2ShNRf" id="3s41kb39Cr3" role="23t8la">
+                <node concept="HV5vD" id="3s41kb39EgT" role="2ShVmc">
+                  <property role="373rjd" value="true" />
+                  <ref role="HV5vE" node="36NsNggQrvp" resolve="NodeHasher.PropertyComparator" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbS" id="3s41kb39fLq" role="2LFqv$">
+            <node concept="3clFbF" id="3s41kb39FoH" role="3cqZAp">
+              <node concept="1rXfSq" id="3s41kb39FoG" role="3clFbG">
+                <ref role="37wK5l" node="36NsNggQr_E" resolve="hashProperty" />
+                <node concept="37vLTw" id="3s41kb39Hrl" role="37wK5m">
+                  <ref role="3cqZAo" node="36NsNggQr_2" resolve="node" />
+                </node>
+                <node concept="2GrUjf" id="3s41kb39Kdl" role="37wK5m">
+                  <ref role="2Gs0qQ" node="3s41kb39fLm" resolve="prop" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="3s41kb3caPC" role="3cqZAp" />
+        <node concept="2Gpval" id="3s41kb3ccAr" role="3cqZAp">
+          <node concept="2GrKxI" id="3s41kb3ccAt" role="2Gsz3X">
+            <property role="TrG5h" value="ref" />
+          </node>
+          <node concept="2OqwBi" id="3s41kb3cU46" role="2GsD0m">
+            <node concept="2OqwBi" id="3s41kb3cwcg" role="2Oq$k0">
+              <node concept="1eOMI4" id="3s41kb3cq4q" role="2Oq$k0">
+                <node concept="10QFUN" id="3s41kb3cq4p" role="1eOMHV">
+                  <node concept="2OqwBi" id="3s41kb3cq4m" role="10QFUP">
+                    <node concept="37vLTw" id="3s41kb3cq4n" role="2Oq$k0">
+                      <ref role="3cqZAo" node="36NsNggQr_2" resolve="node" />
+                    </node>
+                    <node concept="liA8E" id="3s41kb3cq4o" role="2OqNvi">
+                      <ref role="37wK5l" to="mhbf:~SNode.getReferences()" resolve="getReferences" />
+                    </node>
+                  </node>
+                  <node concept="A3Dl8" id="3s41kb3csh8" role="10QFUM">
+                    <node concept="3uibUv" id="3s41kb3cu5A" role="A3Ik2">
+                      <ref role="3uigEE" to="mhbf:~SReference" resolve="SReference" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3zZkjj" id="3s41kb3cyWY" role="2OqNvi">
+                <node concept="1bVj0M" id="3s41kb3cyX0" role="23t8la">
+                  <node concept="3clFbS" id="3s41kb3cyX1" role="1bW5cS">
+                    <node concept="3clFbF" id="3s41kb3c_71" role="3cqZAp">
+                      <node concept="3fqX7Q" id="3s41kb3c_6Z" role="3clFbG">
+                        <node concept="2OqwBi" id="3s41kb3cF4_" role="3fr31v">
+                          <node concept="37vLTw" id="3s41kb3cC2D" role="2Oq$k0">
+                            <ref role="3cqZAo" node="36NsNggQry6" resolve="ignoredReferences" />
+                          </node>
+                          <node concept="3JPx81" id="3s41kb3cI7i" role="2OqNvi">
+                            <node concept="2OqwBi" id="3s41kb3cMJQ" role="25WWJ7">
+                              <node concept="37vLTw" id="3s41kb3cKiI" role="2Oq$k0">
+                                <ref role="3cqZAo" node="3s41kb3cyX2" resolve="it" />
+                              </node>
+                              <node concept="liA8E" id="3s41kb3cQO8" role="2OqNvi">
+                                <ref role="37wK5l" to="mhbf:~SReference.getLink()" resolve="getLink" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="gl6BB" id="3s41kb3cyX2" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="3s41kb3cyX3" role="1tU5fm" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="2DpFxk" id="3s41kb3cX3n" role="2OqNvi">
+              <node concept="1nlBCl" id="3s41kb3cX3p" role="2Dq5b$">
+                <property role="3clFbU" value="true" />
+              </node>
+              <node concept="2ShNRf" id="3s41kb3cYXF" role="23t8la">
+                <node concept="HV5vD" id="3s41kb3d30v" role="2ShVmc">
+                  <property role="373rjd" value="true" />
+                  <ref role="HV5vE" node="36NsNggQrw6" resolve="NodeHasher.ReferenceComparator" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbS" id="3s41kb3ccAx" role="2LFqv$">
+            <node concept="3clFbF" id="3s41kb3d4U_" role="3cqZAp">
+              <node concept="1rXfSq" id="3s41kb3d4U$" role="3clFbG">
+                <ref role="37wK5l" node="36NsNggQrA7" resolve="hashReference" />
+                <node concept="2GrUjf" id="3s41kb3d6JT" role="37wK5m">
+                  <ref role="2Gs0qQ" node="3s41kb3ccAt" resolve="ref" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="3s41kb3d8Ac" role="3cqZAp" />
+        <node concept="2Gpval" id="3s41kb3daXs" role="3cqZAp">
+          <node concept="2GrKxI" id="3s41kb3daXu" role="2Gsz3X">
+            <property role="TrG5h" value="child" />
+          </node>
+          <node concept="2OqwBi" id="3s41kb3ebjG" role="2GsD0m">
+            <node concept="2OqwBi" id="3s41kb3d$fv" role="2Oq$k0">
+              <node concept="1eOMI4" id="3s41kb3dsJ4" role="2Oq$k0">
+                <node concept="10QFUN" id="3s41kb3dsJ3" role="1eOMHV">
+                  <node concept="2OqwBi" id="3s41kb3dsJ0" role="10QFUP">
+                    <node concept="37vLTw" id="3s41kb3dsJ1" role="2Oq$k0">
+                      <ref role="3cqZAo" node="36NsNggQr_2" resolve="node" />
+                    </node>
+                    <node concept="liA8E" id="3s41kb3dsJ2" role="2OqNvi">
+                      <ref role="37wK5l" to="mhbf:~SNode.getChildren()" resolve="getChildren" />
+                    </node>
+                  </node>
+                  <node concept="A3Dl8" id="3s41kb3du$Z" role="10QFUM">
+                    <node concept="3uibUv" id="3s41kb3dwv_" role="A3Ik2">
+                      <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3zZkjj" id="3s41kb3dBaT" role="2OqNvi">
+                <node concept="1bVj0M" id="3s41kb3dBaV" role="23t8la">
+                  <node concept="3clFbS" id="3s41kb3dBaW" role="1bW5cS">
+                    <node concept="3clFbF" id="3s41kb3dOos" role="3cqZAp">
+                      <node concept="3fqX7Q" id="3s41kb3dOoq" role="3clFbG">
+                        <node concept="2OqwBi" id="3s41kb3dTqB" role="3fr31v">
+                          <node concept="37vLTw" id="3s41kb3dQX1" role="2Oq$k0">
+                            <ref role="3cqZAo" node="36NsNggQry1" resolve="ignoredContainments" />
+                          </node>
+                          <node concept="3JPx81" id="3s41kb3e0mJ" role="2OqNvi">
+                            <node concept="2OqwBi" id="3s41kb3e6ba" role="25WWJ7">
+                              <node concept="37vLTw" id="3s41kb3e3x3" role="2Oq$k0">
+                                <ref role="3cqZAo" node="3s41kb3dBaX" resolve="it" />
+                              </node>
+                              <node concept="liA8E" id="3s41kb3e8Xr" role="2OqNvi">
+                                <ref role="37wK5l" to="mhbf:~SNode.getContainmentLink()" resolve="getContainmentLink" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="gl6BB" id="3s41kb3dBaX" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="3s41kb3dBaY" role="1tU5fm" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="2DpFxk" id="3s41kb3efXm" role="2OqNvi">
+              <node concept="1nlBCl" id="3s41kb3efXo" role="2Dq5b$">
+                <property role="3clFbU" value="true" />
+              </node>
+              <node concept="2ShNRf" id="3s41kb3ehXY" role="23t8la">
+                <node concept="HV5vD" id="3s41kb3ekt9" role="2ShVmc">
+                  <property role="373rjd" value="true" />
+                  <ref role="HV5vE" node="36NsNggQrwV" resolve="NodeHasher.ContainmentComparator" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbS" id="3s41kb3daXy" role="2LFqv$">
+            <node concept="3clFbF" id="3s41kb3emt9" role="3cqZAp">
+              <node concept="1rXfSq" id="3s41kb3emt8" role="3clFbG">
+                <ref role="37wK5l" node="36NsNggQr_1" resolve="hashNode" />
+                <node concept="2GrUjf" id="3s41kb3eq2H" role="37wK5m">
+                  <ref role="2Gs0qQ" node="3s41kb3daXu" resolve="child" />
+                </node>
+                <node concept="3clFbT" id="3s41kb3eu$H" role="37wK5m">
+                  <property role="3clFbU" value="true" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="36NsNggQr_r" role="1B3o_S" />
+      <node concept="3cqZAl" id="36NsNggQr_s" role="3clF45" />
+    </node>
+    <node concept="2tJIrI" id="3s41kb3ewwT" role="jymVt" />
+    <node concept="3clFb_" id="36NsNggQr_z" role="jymVt">
+      <property role="TrG5h" value="collectConceptProperties" />
+      <node concept="37vLTG" id="36NsNggQr_$" role="3clF46">
+        <property role="TrG5h" value="node" />
+        <node concept="3uibUv" id="36NsNggQr__" role="1tU5fm">
+          <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="36NsNggQr_A" role="3clF47">
+        <node concept="3clFbF" id="3s41kb39OLH" role="3cqZAp">
+          <node concept="2OqwBi" id="3s41kb3aABA" role="3clFbG">
+            <property role="hSjvv" value="true" />
+            <node concept="2OqwBi" id="3s41kb39XHl" role="2Oq$k0">
+              <property role="hSjvv" value="true" />
+              <node concept="1eOMI4" id="3s41kb39Ug7" role="2Oq$k0">
+                <node concept="10QFUN" id="3s41kb39Ug6" role="1eOMHV">
+                  <node concept="2OqwBi" id="3s41kb39Ug3" role="10QFUP">
+                    <node concept="37vLTw" id="3s41kb39Ug4" role="2Oq$k0">
+                      <ref role="3cqZAo" node="36NsNggQr_$" resolve="node" />
+                    </node>
+                    <node concept="liA8E" id="3s41kb39Ug5" role="2OqNvi">
+                      <ref role="37wK5l" to="mhbf:~SNode.getProperties()" resolve="getProperties" />
+                    </node>
+                  </node>
+                  <node concept="A3Dl8" id="3s41kb39UYS" role="10QFUM">
+                    <node concept="3uibUv" id="3s41kb39WfC" role="A3Ik2">
+                      <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3QWeyG" id="3s41kb3a0Kt" role="2OqNvi">
+                <node concept="3K4zz7" id="3s41kb3a79o" role="576Qk">
+                  <node concept="2OqwBi" id="3s41kb3bnyX" role="3K4E3e">
+                    <node concept="1eOMI4" id="3s41kb3aieK" role="2Oq$k0">
+                      <node concept="10QFUN" id="3s41kb3aieJ" role="1eOMHV">
+                        <node concept="2OqwBi" id="3s41kb3aieE" role="10QFUP">
+                          <node concept="2OqwBi" id="3s41kb3aieF" role="2Oq$k0">
+                            <node concept="37vLTw" id="3s41kb3aieG" role="2Oq$k0">
+                              <ref role="3cqZAo" node="36NsNggQr_$" resolve="node" />
+                            </node>
+                            <node concept="liA8E" id="3s41kb3aieH" role="2OqNvi">
+                              <ref role="37wK5l" to="mhbf:~SNode.getConcept()" resolve="getConcept" />
+                            </node>
+                          </node>
+                          <node concept="liA8E" id="3s41kb3aieI" role="2OqNvi">
+                            <ref role="37wK5l" to="c17a:~SAbstractConcept.getProperties()" resolve="getProperties" />
+                          </node>
+                        </node>
+                        <node concept="A3Dl8" id="3s41kb3ajnX" role="10QFUM">
+                          <node concept="3uibUv" id="3s41kb3ale_" role="A3Ik2">
+                            <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3zZkjj" id="3s41kb3bpRJ" role="2OqNvi">
+                      <node concept="1bVj0M" id="3s41kb3aRYK" role="23t8la">
+                        <node concept="3clFbS" id="3s41kb3aRYL" role="1bW5cS">
+                          <node concept="3clFbF" id="3s41kb3aV5j" role="3cqZAp">
+                            <node concept="17R0WA" id="3s41kb3b7cV" role="3clFbG">
+                              <node concept="10M0yZ" id="3s41kb3bgS_" role="3uHU7w">
+                                <ref role="3cqZAo" to="xx25:~SPrimitiveTypes.BOOLEAN" resolve="BOOLEAN" />
+                                <ref role="1PxDUh" to="xx25:~SPrimitiveTypes" resolve="SPrimitiveTypes" />
+                              </node>
+                              <node concept="2OqwBi" id="3s41kb3aXAP" role="3uHU7B">
+                                <node concept="37vLTw" id="3s41kb3aV5i" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="3s41kb3aRYM" resolve="it" />
+                                </node>
+                                <node concept="liA8E" id="3s41kb3b4MV" role="2OqNvi">
+                                  <ref role="37wK5l" to="c17a:~SProperty.getType()" resolve="getType" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="gl6BB" id="3s41kb3aRYM" role="1bW2Oz">
+                          <property role="TrG5h" value="it" />
+                          <node concept="2jxLKc" id="3s41kb3aRYN" role="1tU5fm" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2YIFZM" id="3s41kb3ar70" role="3K4GZi">
+                    <ref role="37wK5l" to="33ny:~Collections.emptyList()" resolve="emptyList" />
+                    <ref role="1Pybhc" to="33ny:~Collections" resolve="Collections" />
+                    <node concept="3uibUv" id="3s41kb3azhF" role="3PaCim">
+                      <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="3s41kb3a3$U" role="3K4Cdx">
+                    <node concept="Xjq3P" id="3s41kb3a1SE" role="2Oq$k0" />
+                    <node concept="2OwXpG" id="3s41kb3a4LC" role="2OqNvi">
+                      <ref role="2Oxat5" node="36NsNggQryg" resolve="normalizeBooleanProperties" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="1VAtEI" id="3s41kb3aJin" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="36NsNggQr_B" role="1B3o_S" />
+      <node concept="A3Dl8" id="3s41kb39srZ" role="3clF45">
+        <node concept="3uibUv" id="3s41kb39ss1" role="A3Ik2">
+          <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="3s41kb3eABQ" role="jymVt" />
+    <node concept="3clFb_" id="36NsNggQr_E" role="jymVt">
+      <property role="TrG5h" value="hashProperty" />
+      <node concept="37vLTG" id="36NsNggQr_F" role="3clF46">
+        <property role="TrG5h" value="node" />
+        <node concept="3uibUv" id="36NsNggQr_G" role="1tU5fm">
+          <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="36NsNggQr_H" role="3clF46">
+        <property role="TrG5h" value="property" />
+        <node concept="3uibUv" id="36NsNggQr_I" role="1tU5fm">
+          <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="36NsNggQr_J" role="3clF47">
+        <node concept="3clFbF" id="36NsNggQr_K" role="3cqZAp">
+          <node concept="1rXfSq" id="36NsNggQr_L" role="3clFbG">
+            <ref role="37wK5l" node="36NsNggQrC5" resolve="put" />
+            <node concept="37vLTw" id="36NsNggQr_M" role="37wK5m">
+              <ref role="3cqZAo" node="36NsNggQr_H" resolve="property" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="36NsNggQr_O" role="3cqZAp">
+          <node concept="3cpWsn" id="36NsNggQr_N" role="3cpWs9">
+            <property role="TrG5h" value="value" />
+            <node concept="17QB3L" id="36NsNggQA9z" role="1tU5fm" />
+            <node concept="2OqwBi" id="36NsNggRVrE" role="33vP2m">
+              <node concept="37vLTw" id="36NsNggQKFo" role="2Oq$k0">
+                <ref role="3cqZAo" node="36NsNggQr_F" resolve="node" />
+              </node>
+              <node concept="liA8E" id="36NsNggRVrF" role="2OqNvi">
+                <ref role="37wK5l" to="mhbf:~SNode.getProperty(org.jetbrains.mps.openapi.language.SProperty)" resolve="getProperty" />
+                <node concept="37vLTw" id="36NsNggRVrG" role="37wK5m">
+                  <ref role="3cqZAo" node="36NsNggQr_H" resolve="property" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="36NsNggQr_S" role="3cqZAp">
+          <node concept="3clFbC" id="36NsNggQr_T" role="3clFbw">
+            <node concept="37vLTw" id="36NsNggQr_U" role="3uHU7B">
+              <ref role="3cqZAo" node="36NsNggQr_N" resolve="value" />
+            </node>
+            <node concept="10Nm6u" id="36NsNggQr_V" role="3uHU7w" />
+          </node>
+          <node concept="3clFbS" id="36NsNggQr_X" role="3clFbx">
+            <node concept="3clFbF" id="36NsNggQr_Y" role="3cqZAp">
+              <node concept="37vLTI" id="36NsNggQr_Z" role="3clFbG">
+                <node concept="37vLTw" id="36NsNggQrA0" role="37vLTJ">
+                  <ref role="3cqZAo" node="36NsNggQr_N" resolve="value" />
+                </node>
+                <node concept="37vLTw" id="36NsNggQrA1" role="37vLTx">
+                  <ref role="3cqZAo" node="36NsNggQrxK" resolve="UNSET_PROPERTY_VALUE" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="3s41kb3ggQm" role="3cqZAp">
+          <node concept="1rXfSq" id="3s41kb3ggQk" role="3clFbG">
+            <ref role="37wK5l" node="3s41kb3fJGx" resolve="put" />
+            <node concept="37vLTw" id="3s41kb3giSC" role="37wK5m">
+              <ref role="3cqZAo" node="36NsNggQr_N" resolve="value" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="36NsNggQrA5" role="1B3o_S" />
+      <node concept="3cqZAl" id="36NsNggQrA6" role="3clF45" />
+    </node>
+    <node concept="2tJIrI" id="3s41kb3eDi8" role="jymVt" />
+    <node concept="3clFb_" id="36NsNggQrA7" role="jymVt">
+      <property role="TrG5h" value="hashReference" />
+      <node concept="37vLTG" id="36NsNggQrA8" role="3clF46">
+        <property role="TrG5h" value="ref" />
+        <node concept="3uibUv" id="36NsNggQrA9" role="1tU5fm">
+          <ref role="3uigEE" to="mhbf:~SReference" resolve="SReference" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="36NsNggQrAa" role="3clF47">
+        <node concept="3clFbF" id="36NsNggQrAb" role="3cqZAp">
+          <node concept="1rXfSq" id="36NsNggQrAc" role="3clFbG">
+            <ref role="37wK5l" node="36NsNggQrC$" resolve="put" />
+            <node concept="2OqwBi" id="36NsNggRYpC" role="37wK5m">
+              <node concept="37vLTw" id="36NsNggQI5K" role="2Oq$k0">
+                <ref role="3cqZAo" node="36NsNggQrA8" resolve="ref" />
+              </node>
+              <node concept="liA8E" id="36NsNggRYpD" role="2OqNvi">
+                <ref role="37wK5l" to="mhbf:~SReference.getLink()" resolve="getLink" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="36NsNggQrAe" role="3cqZAp">
+          <node concept="1Wc70l" id="36NsNggQrAf" role="3clFbw">
+            <node concept="37vLTw" id="36NsNggQrAg" role="3uHU7B">
+              <ref role="3cqZAo" node="36NsNggQryb" resolve="includeNodeIds" />
+            </node>
+            <node concept="3y3z36" id="36NsNggQrAh" role="3uHU7w">
+              <node concept="2OqwBi" id="36NsNggRXqE" role="3uHU7B">
+                <node concept="37vLTw" id="36NsNggQJRH" role="2Oq$k0">
+                  <ref role="3cqZAo" node="36NsNggQrA8" resolve="ref" />
+                </node>
+                <node concept="liA8E" id="36NsNggRXqF" role="2OqNvi">
+                  <ref role="37wK5l" to="mhbf:~SReference.getTargetNodeId()" resolve="getTargetNodeId" />
+                </node>
+              </node>
+              <node concept="10Nm6u" id="36NsNggQrAj" role="3uHU7w" />
+            </node>
+          </node>
+          <node concept="3clFbJ" id="36NsNggQrAp" role="9aQIa">
+            <node concept="3y3z36" id="36NsNggQrAq" role="3clFbw">
+              <node concept="2OqwBi" id="36NsNggRZUI" role="3uHU7B">
+                <node concept="37vLTw" id="36NsNggQHOI" role="2Oq$k0">
+                  <ref role="3cqZAo" node="36NsNggQrA8" resolve="ref" />
+                </node>
+                <node concept="liA8E" id="36NsNggRZUJ" role="2OqNvi">
+                  <ref role="37wK5l" to="mhbf:~SReference.getTargetNode()" resolve="getTargetNode" />
+                </node>
+              </node>
+              <node concept="10Nm6u" id="36NsNggQrAs" role="3uHU7w" />
+            </node>
+            <node concept="9aQIb" id="36NsNggQrAz" role="9aQIa">
+              <node concept="3clFbS" id="36NsNggQrA$" role="9aQI4">
+                <node concept="3clFbF" id="3s41kb3gQyJ" role="3cqZAp">
+                  <node concept="1rXfSq" id="3s41kb3gQyH" role="3clFbG">
+                    <ref role="37wK5l" node="3s41kb3fJGx" resolve="put" />
+                    <node concept="2OqwBi" id="36NsNggSb0H" role="37wK5m">
+                      <node concept="2OqwBi" id="36NsNggRWG2" role="2Oq$k0">
+                        <node concept="37vLTw" id="36NsNggQLBH" role="2Oq$k0">
+                          <ref role="3cqZAo" node="36NsNggQrA8" resolve="ref" />
+                        </node>
+                        <node concept="liA8E" id="36NsNggRWG3" role="2OqNvi">
+                          <ref role="37wK5l" to="mhbf:~SReference.describeTarget()" resolve="describeTarget" />
+                        </node>
+                      </node>
+                      <node concept="liA8E" id="36NsNggSb0I" role="2OqNvi">
+                        <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbS" id="36NsNggQrAu" role="3clFbx">
+              <node concept="3clFbF" id="3s41kb3gxM1" role="3cqZAp">
+                <node concept="1rXfSq" id="3s41kb3gxLZ" role="3clFbG">
+                  <ref role="37wK5l" node="3s41kb3fJGx" resolve="put" />
+                  <node concept="2OqwBi" id="36NsNggSauG" role="37wK5m">
+                    <node concept="2OqwBi" id="36NsNggRXU1" role="2Oq$k0">
+                      <node concept="37vLTw" id="36NsNggQIk4" role="2Oq$k0">
+                        <ref role="3cqZAo" node="36NsNggQrA8" resolve="ref" />
+                      </node>
+                      <node concept="liA8E" id="36NsNggRXU2" role="2OqNvi">
+                        <ref role="37wK5l" to="mhbf:~SReference.getTargetNode()" resolve="getTargetNode" />
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="36NsNggSauH" role="2OqNvi">
+                      <ref role="37wK5l" to="mhbf:~SNode.getPresentation()" resolve="getPresentation" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbS" id="36NsNggQrAl" role="3clFbx">
+            <node concept="3clFbF" id="36NsNggQrAm" role="3cqZAp">
+              <node concept="1rXfSq" id="36NsNggQrAn" role="3clFbG">
+                <ref role="37wK5l" node="36NsNggQrEt" resolve="put" />
+                <node concept="2OqwBi" id="36NsNggS0rr" role="37wK5m">
+                  <node concept="37vLTw" id="36NsNggQHW5" role="2Oq$k0">
+                    <ref role="3cqZAo" node="36NsNggQrA8" resolve="ref" />
+                  </node>
+                  <node concept="liA8E" id="36NsNggS0rs" role="2OqNvi">
+                    <ref role="37wK5l" to="mhbf:~SReference.getTargetNodeId()" resolve="getTargetNodeId" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="36NsNggQrAD" role="1B3o_S" />
+      <node concept="3cqZAl" id="36NsNggQrAE" role="3clF45" />
+    </node>
+    <node concept="2tJIrI" id="3s41kb3zbtu" role="jymVt" />
+    <node concept="3clFb_" id="36NsNggQrAF" role="jymVt">
+      <property role="TrG5h" value="put" />
+      <node concept="37vLTG" id="36NsNggQrAG" role="3clF46">
+        <property role="TrG5h" value="concept" />
+        <node concept="3uibUv" id="36NsNggQrAH" role="1tU5fm">
+          <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="36NsNggQrAI" role="3clF47">
+        <node concept="3clFbJ" id="36NsNggQrAJ" role="3cqZAp">
+          <node concept="2ZW3vV" id="36NsNggQrAM" role="3clFbw">
+            <node concept="37vLTw" id="36NsNggQrAK" role="2ZW6bz">
+              <ref role="3cqZAo" node="36NsNggQrAG" resolve="concept" />
+            </node>
+            <node concept="3uibUv" id="36NsNggQrAL" role="2ZW6by">
+              <ref role="3uigEE" to="c17a:~SConcept" resolve="SConcept" />
+            </node>
+          </node>
+          <node concept="3clFbJ" id="36NsNggQrAU" role="9aQIa">
+            <node concept="2ZW3vV" id="36NsNggQrAX" role="3clFbw">
+              <node concept="37vLTw" id="36NsNggQrAV" role="2ZW6bz">
+                <ref role="3cqZAo" node="36NsNggQrAG" resolve="concept" />
+              </node>
+              <node concept="3uibUv" id="36NsNggQrAW" role="2ZW6by">
+                <ref role="3uigEE" to="vxxo:~SAbstractConceptAdapter" resolve="SAbstractConceptAdapter" />
+              </node>
+            </node>
+            <node concept="3clFbS" id="36NsNggQrAZ" role="3clFbx">
+              <node concept="3cpWs8" id="36NsNggQrB1" role="3cqZAp">
+                <node concept="3cpWsn" id="36NsNggQrB0" role="3cpWs9">
+                  <property role="TrG5h" value="descriptor" />
+                  <node concept="3uibUv" id="36NsNggQrB2" role="1tU5fm">
+                    <ref role="3uigEE" to="ze1i:~ConceptDescriptor" resolve="ConceptDescriptor" />
+                  </node>
+                  <node concept="2OqwBi" id="3s41kb3eM9p" role="33vP2m">
+                    <node concept="1eOMI4" id="36NsNggQrB7" role="2Oq$k0">
+                      <node concept="10QFUN" id="36NsNggQrB4" role="1eOMHV">
+                        <node concept="37vLTw" id="36NsNggQrB5" role="10QFUP">
+                          <ref role="3cqZAo" node="36NsNggQrAG" resolve="concept" />
+                        </node>
+                        <node concept="3uibUv" id="36NsNggQrB6" role="10QFUM">
+                          <ref role="3uigEE" to="vxxo:~SAbstractConceptAdapter" resolve="SAbstractConceptAdapter" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="3s41kb3eM9q" role="2OqNvi">
+                      <ref role="37wK5l" to="vxxo:~SAbstractConceptAdapter.getConceptDescriptor()" resolve="getConceptDescriptor" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbJ" id="36NsNggQrB8" role="3cqZAp">
+                <node concept="3y3z36" id="36NsNggQrB9" role="3clFbw">
+                  <node concept="37vLTw" id="36NsNggQrBa" role="3uHU7B">
+                    <ref role="3cqZAo" node="36NsNggQrB0" resolve="descriptor" />
+                  </node>
+                  <node concept="10Nm6u" id="36NsNggQrBb" role="3uHU7w" />
+                </node>
+                <node concept="3clFbS" id="36NsNggQrBd" role="3clFbx">
+                  <node concept="3clFbF" id="36NsNggQrBe" role="3cqZAp">
+                    <node concept="1rXfSq" id="36NsNggQrBf" role="3clFbG">
+                      <ref role="37wK5l" node="36NsNggQrBT" resolve="put" />
+                      <node concept="2OqwBi" id="3s41kb3eXDE" role="37wK5m">
+                        <node concept="37vLTw" id="36NsNggQIby" role="2Oq$k0">
+                          <ref role="3cqZAo" node="36NsNggQrB0" resolve="descriptor" />
+                        </node>
+                        <node concept="liA8E" id="3s41kb3eXDF" role="2OqNvi">
+                          <ref role="37wK5l" to="ze1i:~ConceptDescriptor.getId()" resolve="getId" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3cpWs6" id="36NsNggQrBh" role="3cqZAp" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbS" id="36NsNggQrAO" role="3clFbx">
+            <node concept="3clFbF" id="36NsNggQrAP" role="3cqZAp">
+              <node concept="1rXfSq" id="36NsNggQrAQ" role="3clFbG">
+                <ref role="37wK5l" node="36NsNggQrBq" resolve="put" />
+                <node concept="10QFUN" id="36NsNggQrAR" role="37wK5m">
+                  <node concept="37vLTw" id="36NsNggQrAS" role="10QFUP">
+                    <ref role="3cqZAo" node="36NsNggQrAG" resolve="concept" />
+                  </node>
+                  <node concept="3uibUv" id="36NsNggQrAT" role="10QFUM">
+                    <ref role="3uigEE" to="c17a:~SConcept" resolve="SConcept" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="2N1SaI_aXLJ" role="3cqZAp" />
+        <node concept="YS8fn" id="2N1SaI_8zpS" role="3cqZAp">
+          <node concept="2ShNRf" id="2N1SaI_8_BM" role="YScLw">
+            <node concept="1pGfFk" id="2N1SaI_8HlG" role="2ShVmc">
+              <property role="373rjd" value="true" />
+              <ref role="37wK5l" to="wyt6:~IllegalStateException.&lt;init&gt;(java.lang.String)" resolve="IllegalStateException" />
+              <node concept="2OqwBi" id="2N1SaI_afOr" role="37wK5m">
+                <node concept="Xl_RD" id="2N1SaI_9PFZ" role="2Oq$k0">
+                  <property role="Xl_RC" value="Cannot hash concept %s: %s" />
+                </node>
+                <node concept="2cAKMz" id="2N1SaI_ajls" role="2OqNvi">
+                  <node concept="2OqwBi" id="2N1SaI_ao47" role="2cAKU6">
+                    <node concept="37vLTw" id="2N1SaI_alyL" role="2Oq$k0">
+                      <ref role="3cqZAo" node="36NsNggQrAG" resolve="concept" />
+                    </node>
+                    <node concept="liA8E" id="2N1SaI_aqY8" role="2OqNvi">
+                      <ref role="37wK5l" to="wyt6:~Object.getClass()" resolve="getClass" />
+                    </node>
+                  </node>
+                  <node concept="37vLTw" id="2N1SaI_ayIT" role="2cAKU6">
+                    <ref role="3cqZAo" node="36NsNggQrAG" resolve="concept" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="36NsNggQrBo" role="1B3o_S" />
+      <node concept="3cqZAl" id="36NsNggQrBp" role="3clF45" />
+    </node>
+    <node concept="2tJIrI" id="3s41kb3zfH6" role="jymVt" />
+    <node concept="3clFb_" id="36NsNggQrBq" role="jymVt">
+      <property role="TrG5h" value="put" />
+      <node concept="37vLTG" id="36NsNggQrBr" role="3clF46">
+        <property role="TrG5h" value="concept" />
+        <node concept="3uibUv" id="36NsNggQrBs" role="1tU5fm">
+          <ref role="3uigEE" to="c17a:~SConcept" resolve="SConcept" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="36NsNggQrBt" role="3clF47">
+        <node concept="3clFbJ" id="36NsNggQrBu" role="3cqZAp">
+          <node concept="2ZW3vV" id="36NsNggQrBx" role="3clFbw">
+            <node concept="37vLTw" id="36NsNggQrBv" role="2ZW6bz">
+              <ref role="3cqZAo" node="36NsNggQrBr" resolve="concept" />
+            </node>
+            <node concept="3uibUv" id="36NsNggQrBw" role="2ZW6by">
+              <ref role="3uigEE" to="vxxo:~SConceptAdapterById" resolve="SConceptAdapterById" />
+            </node>
+          </node>
+          <node concept="3clFbS" id="36NsNggQrBz" role="3clFbx">
+            <node concept="3cpWs8" id="36NsNggQrB_" role="3cqZAp">
+              <node concept="3cpWsn" id="36NsNggQrB$" role="3cpWs9">
+                <property role="TrG5h" value="id" />
+                <node concept="3uibUv" id="36NsNggQrBA" role="1tU5fm">
+                  <ref role="3uigEE" to="e8bb:~SConceptId" resolve="SConceptId" />
+                </node>
+                <node concept="2OqwBi" id="3s41kb3eNQJ" role="33vP2m">
+                  <node concept="1eOMI4" id="36NsNggQrBF" role="2Oq$k0">
+                    <node concept="10QFUN" id="36NsNggQrBC" role="1eOMHV">
+                      <node concept="37vLTw" id="36NsNggQrBD" role="10QFUP">
+                        <ref role="3cqZAo" node="36NsNggQrBr" resolve="concept" />
+                      </node>
+                      <node concept="3uibUv" id="36NsNggQrBE" role="10QFUM">
+                        <ref role="3uigEE" to="vxxo:~SConceptAdapterById" resolve="SConceptAdapterById" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="3s41kb3eNQK" role="2OqNvi">
+                    <ref role="37wK5l" to="vxxo:~SConceptAdapterById.getId()" resolve="getId" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="36NsNggQrBG" role="3cqZAp">
+              <node concept="1rXfSq" id="36NsNggQrBH" role="3clFbG">
+                <ref role="37wK5l" node="36NsNggQrBT" resolve="put" />
+                <node concept="37vLTw" id="36NsNggQrBI" role="37wK5m">
+                  <ref role="3cqZAo" node="36NsNggQrB$" resolve="id" />
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs6" id="2N1SaI_b2mv" role="3cqZAp" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="2N1SaI_b6Cp" role="3cqZAp" />
+        <node concept="YS8fn" id="2N1SaI_bbEi" role="3cqZAp">
+          <node concept="2ShNRf" id="2N1SaI_bbEj" role="YScLw">
+            <node concept="1pGfFk" id="2N1SaI_bbEk" role="2ShVmc">
+              <property role="373rjd" value="true" />
+              <ref role="37wK5l" to="wyt6:~IllegalStateException.&lt;init&gt;(java.lang.String)" resolve="IllegalStateException" />
+              <node concept="2OqwBi" id="2N1SaI_bbEl" role="37wK5m">
+                <node concept="Xl_RD" id="2N1SaI_bbEm" role="2Oq$k0">
+                  <property role="Xl_RC" value="Cannot hash concept %s: %s" />
+                </node>
+                <node concept="2cAKMz" id="2N1SaI_bbEn" role="2OqNvi">
+                  <node concept="2OqwBi" id="2N1SaI_bbEo" role="2cAKU6">
+                    <node concept="37vLTw" id="2N1SaI_bbEp" role="2Oq$k0">
+                      <ref role="3cqZAo" node="36NsNggQrBr" resolve="concept" />
+                    </node>
+                    <node concept="liA8E" id="2N1SaI_bbEq" role="2OqNvi">
+                      <ref role="37wK5l" to="wyt6:~Object.getClass()" resolve="getClass" />
+                    </node>
+                  </node>
+                  <node concept="37vLTw" id="2N1SaI_bbEr" role="2cAKU6">
+                    <ref role="3cqZAo" node="36NsNggQrBr" resolve="concept" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="36NsNggQrBR" role="1B3o_S" />
+      <node concept="3cqZAl" id="36NsNggQrBS" role="3clF45" />
+    </node>
+    <node concept="2tJIrI" id="3s41kb3ziGz" role="jymVt" />
+    <node concept="3clFb_" id="36NsNggQrBT" role="jymVt">
+      <property role="TrG5h" value="put" />
+      <node concept="37vLTG" id="36NsNggQrBU" role="3clF46">
+        <property role="TrG5h" value="conceptId" />
+        <node concept="3uibUv" id="36NsNggQrBV" role="1tU5fm">
+          <ref role="3uigEE" to="e8bb:~SConceptId" resolve="SConceptId" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="36NsNggQrBW" role="3clF47">
+        <node concept="3clFbF" id="36NsNggQrBX" role="3cqZAp">
+          <node concept="1rXfSq" id="36NsNggQrBY" role="3clFbG">
+            <ref role="37wK5l" node="36NsNggQrEh" resolve="put" />
+            <node concept="2OqwBi" id="3s41kb3fp_p" role="37wK5m">
+              <node concept="37vLTw" id="36NsNggQJW5" role="2Oq$k0">
+                <ref role="3cqZAo" node="36NsNggQrBU" resolve="conceptId" />
+              </node>
+              <node concept="liA8E" id="3s41kb3fp_q" role="2OqNvi">
+                <ref role="37wK5l" to="e8bb:~SConceptId.getLanguageId()" resolve="getLanguageId" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="3s41kb3n9wA" role="3cqZAp">
+          <node concept="1rXfSq" id="3s41kb3n9wB" role="3clFbG">
+            <ref role="37wK5l" node="3s41kb3mhVz" resolve="put" />
+            <node concept="2OqwBi" id="3s41kb3ffqa" role="37wK5m">
+              <node concept="37vLTw" id="36NsNggQLBb" role="2Oq$k0">
+                <ref role="3cqZAo" node="36NsNggQrBU" resolve="conceptId" />
+              </node>
+              <node concept="liA8E" id="3s41kb3ffqb" role="2OqNvi">
+                <ref role="37wK5l" to="e8bb:~SConceptId.getIdValue()" resolve="getIdValue" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="36NsNggQrC3" role="1B3o_S" />
+      <node concept="3cqZAl" id="36NsNggQrC4" role="3clF45" />
+    </node>
+    <node concept="2tJIrI" id="3s41kb3zlt4" role="jymVt" />
+    <node concept="3clFb_" id="36NsNggQrC5" role="jymVt">
+      <property role="TrG5h" value="put" />
+      <node concept="37vLTG" id="36NsNggQrC6" role="3clF46">
+        <property role="TrG5h" value="property" />
+        <node concept="3uibUv" id="36NsNggQrC7" role="1tU5fm">
+          <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="36NsNggQrC8" role="3clF47">
+        <node concept="3clFbJ" id="36NsNggQrC9" role="3cqZAp">
+          <node concept="2ZW3vV" id="36NsNggQrCc" role="3clFbw">
+            <node concept="37vLTw" id="36NsNggQrCa" role="2ZW6bz">
+              <ref role="3cqZAo" node="36NsNggQrC6" resolve="property" />
+            </node>
+            <node concept="3uibUv" id="36NsNggQrCb" role="2ZW6by">
+              <ref role="3uigEE" to="pwx:~SPropertyAdapter" resolve="SPropertyAdapter" />
+            </node>
+          </node>
+          <node concept="3clFbS" id="36NsNggQrCe" role="3clFbx">
+            <node concept="3cpWs8" id="2N1SaI_dRQd" role="3cqZAp">
+              <node concept="3cpWsn" id="2N1SaI_dRQe" role="3cpWs9">
+                <property role="TrG5h" value="id" />
+                <node concept="3uibUv" id="2N1SaI_dRQf" role="1tU5fm">
+                  <ref role="3uigEE" to="e8bb:~SPropertyId" resolve="SPropertyId" />
+                </node>
+                <node concept="2OqwBi" id="2N1SaI_dRQg" role="33vP2m">
+                  <node concept="1eOMI4" id="2N1SaI_dRQh" role="2Oq$k0">
+                    <node concept="10QFUN" id="2N1SaI_dRQi" role="1eOMHV">
+                      <node concept="37vLTw" id="2N1SaI_dRQj" role="10QFUP">
+                        <ref role="3cqZAo" node="36NsNggQrC6" resolve="property" />
+                      </node>
+                      <node concept="3uibUv" id="2N1SaI_dRQk" role="10QFUM">
+                        <ref role="3uigEE" to="pwx:~SPropertyAdapter" resolve="SPropertyAdapter" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="2N1SaI_dRQl" role="2OqNvi">
+                    <ref role="37wK5l" to="pwx:~SPropertyAdapter.getId()" resolve="getId" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="2N1SaI_dRQa" role="3cqZAp">
+              <node concept="1rXfSq" id="2N1SaI_dRQb" role="3clFbG">
+                <ref role="37wK5l" node="36NsNggQrDD" resolve="put" />
+                <node concept="37vLTw" id="2N1SaI_dRQc" role="37wK5m">
+                  <ref role="3cqZAo" node="2N1SaI_dRQe" resolve="id" />
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs6" id="2N1SaI_eJ_o" role="3cqZAp" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="2N1SaI_bnGE" role="3cqZAp" />
+        <node concept="YS8fn" id="2N1SaI_blzq" role="3cqZAp">
+          <node concept="2ShNRf" id="2N1SaI_blzr" role="YScLw">
+            <node concept="1pGfFk" id="2N1SaI_blzs" role="2ShVmc">
+              <property role="373rjd" value="true" />
+              <ref role="37wK5l" to="wyt6:~IllegalStateException.&lt;init&gt;(java.lang.String)" resolve="IllegalStateException" />
+              <node concept="2OqwBi" id="2N1SaI_blzt" role="37wK5m">
+                <node concept="Xl_RD" id="2N1SaI_blzu" role="2Oq$k0">
+                  <property role="Xl_RC" value="Cannot hash property %s: %s" />
+                </node>
+                <node concept="2cAKMz" id="2N1SaI_blzv" role="2OqNvi">
+                  <node concept="2OqwBi" id="2N1SaI_blzw" role="2cAKU6">
+                    <node concept="37vLTw" id="2N1SaI_blzx" role="2Oq$k0">
+                      <ref role="3cqZAo" node="36NsNggQrC6" resolve="property" />
+                    </node>
+                    <node concept="liA8E" id="2N1SaI_blzy" role="2OqNvi">
+                      <ref role="37wK5l" to="wyt6:~Object.getClass()" resolve="getClass" />
+                    </node>
+                  </node>
+                  <node concept="37vLTw" id="2N1SaI_blzz" role="2cAKU6">
+                    <ref role="3cqZAo" node="36NsNggQrC6" resolve="property" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="36NsNggQrCy" role="1B3o_S" />
+      <node concept="3cqZAl" id="36NsNggQrCz" role="3clF45" />
+    </node>
+    <node concept="2tJIrI" id="3s41kb3zogI" role="jymVt" />
+    <node concept="3clFb_" id="36NsNggQrC$" role="jymVt">
+      <property role="TrG5h" value="put" />
+      <node concept="37vLTG" id="36NsNggQrC_" role="3clF46">
+        <property role="TrG5h" value="ref" />
+        <node concept="3uibUv" id="36NsNggQrCA" role="1tU5fm">
+          <ref role="3uigEE" to="c17a:~SReferenceLink" resolve="SReferenceLink" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="36NsNggQrCB" role="3clF47">
+        <node concept="3clFbJ" id="36NsNggQrCC" role="3cqZAp">
+          <node concept="2ZW3vV" id="36NsNggQrCF" role="3clFbw">
+            <node concept="37vLTw" id="36NsNggQrCD" role="2ZW6bz">
+              <ref role="3cqZAo" node="36NsNggQrC_" resolve="ref" />
+            </node>
+            <node concept="3uibUv" id="36NsNggQrCE" role="2ZW6by">
+              <ref role="3uigEE" to="rzjr:~SReferenceLinkAdapter" resolve="SReferenceLinkAdapter" />
+            </node>
+          </node>
+          <node concept="3clFbS" id="36NsNggQrCH" role="3clFbx">
+            <node concept="3cpWs8" id="36NsNggQrCJ" role="3cqZAp">
+              <node concept="3cpWsn" id="36NsNggQrCI" role="3cpWs9">
+                <property role="TrG5h" value="id" />
+                <node concept="3uibUv" id="36NsNggQrCK" role="1tU5fm">
+                  <ref role="3uigEE" to="e8bb:~SReferenceLinkId" resolve="SReferenceLinkId" />
+                </node>
+                <node concept="2OqwBi" id="3s41kb3iU4X" role="33vP2m">
+                  <node concept="1eOMI4" id="36NsNggQrCP" role="2Oq$k0">
+                    <node concept="10QFUN" id="36NsNggQrCM" role="1eOMHV">
+                      <node concept="37vLTw" id="36NsNggQrCN" role="10QFUP">
+                        <ref role="3cqZAo" node="36NsNggQrC_" resolve="ref" />
+                      </node>
+                      <node concept="3uibUv" id="36NsNggQrCO" role="10QFUM">
+                        <ref role="3uigEE" to="rzjr:~SReferenceLinkAdapter" resolve="SReferenceLinkAdapter" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="3s41kb3iU4Y" role="2OqNvi">
+                    <ref role="37wK5l" to="rzjr:~SReferenceLinkAdapter.getId()" resolve="getId" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="36NsNggQrCQ" role="3cqZAp">
+              <node concept="1rXfSq" id="36NsNggQrCR" role="3clFbG">
+                <ref role="37wK5l" node="36NsNggQrDD" resolve="put" />
+                <node concept="37vLTw" id="36NsNggQrCS" role="37wK5m">
+                  <ref role="3cqZAo" node="36NsNggQrCI" resolve="id" />
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs6" id="2N1SaI_fBxw" role="3cqZAp" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="2N1SaI_bRWa" role="3cqZAp" />
+        <node concept="YS8fn" id="2N1SaI_bUTs" role="3cqZAp">
+          <node concept="2ShNRf" id="2N1SaI_bUTt" role="YScLw">
+            <node concept="1pGfFk" id="2N1SaI_bUTu" role="2ShVmc">
+              <property role="373rjd" value="true" />
+              <ref role="37wK5l" to="wyt6:~IllegalStateException.&lt;init&gt;(java.lang.String)" resolve="IllegalStateException" />
+              <node concept="2OqwBi" id="2N1SaI_bUTv" role="37wK5m">
+                <node concept="Xl_RD" id="2N1SaI_bUTw" role="2Oq$k0">
+                  <property role="Xl_RC" value="Cannot hash reference %s: %s" />
+                </node>
+                <node concept="2cAKMz" id="2N1SaI_bUTx" role="2OqNvi">
+                  <node concept="2OqwBi" id="2N1SaI_bUTy" role="2cAKU6">
+                    <node concept="37vLTw" id="2N1SaI_bUTz" role="2Oq$k0">
+                      <ref role="3cqZAo" node="36NsNggQrC_" resolve="ref" />
+                    </node>
+                    <node concept="liA8E" id="2N1SaI_bUT$" role="2OqNvi">
+                      <ref role="37wK5l" to="wyt6:~Object.getClass()" resolve="getClass" />
+                    </node>
+                  </node>
+                  <node concept="37vLTw" id="2N1SaI_bUT_" role="2cAKU6">
+                    <ref role="3cqZAo" node="36NsNggQrC_" resolve="ref" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="36NsNggQrD1" role="1B3o_S" />
+      <node concept="3cqZAl" id="36NsNggQrD2" role="3clF45" />
+    </node>
+    <node concept="2tJIrI" id="3s41kb3zsSC" role="jymVt" />
+    <node concept="3clFb_" id="36NsNggQrD3" role="jymVt">
+      <property role="TrG5h" value="put" />
+      <node concept="37vLTG" id="36NsNggQrD4" role="3clF46">
+        <property role="TrG5h" value="containment" />
+        <node concept="3uibUv" id="36NsNggQrD5" role="1tU5fm">
+          <ref role="3uigEE" to="c17a:~SContainmentLink" resolve="SContainmentLink" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="36NsNggQrD6" role="3clF47">
+        <node concept="3clFbJ" id="36NsNggQrD7" role="3cqZAp">
+          <node concept="3clFbC" id="36NsNggQrD8" role="3clFbw">
+            <node concept="37vLTw" id="36NsNggQrD9" role="3uHU7B">
+              <ref role="3cqZAo" node="36NsNggQrD4" resolve="containment" />
+            </node>
+            <node concept="10Nm6u" id="36NsNggQrDa" role="3uHU7w" />
+          </node>
+          <node concept="3clFbS" id="36NsNggQrDc" role="3clFbx">
+            <node concept="3cpWs6" id="36NsNggQrDd" role="3cqZAp" />
+          </node>
+        </node>
+        <node concept="3clFbJ" id="36NsNggQrDe" role="3cqZAp">
+          <node concept="2ZW3vV" id="36NsNggQrDh" role="3clFbw">
+            <node concept="37vLTw" id="36NsNggQrDf" role="2ZW6bz">
+              <ref role="3cqZAo" node="36NsNggQrD4" resolve="containment" />
+            </node>
+            <node concept="3uibUv" id="36NsNggQrDg" role="2ZW6by">
+              <ref role="3uigEE" to="wb4m:~SContainmentLinkAdapter" resolve="SContainmentLinkAdapter" />
+            </node>
+          </node>
+          <node concept="3clFbS" id="36NsNggQrDj" role="3clFbx">
+            <node concept="3cpWs8" id="36NsNggQrDl" role="3cqZAp">
+              <node concept="3cpWsn" id="36NsNggQrDk" role="3cpWs9">
+                <property role="TrG5h" value="id" />
+                <node concept="3uibUv" id="36NsNggQrDm" role="1tU5fm">
+                  <ref role="3uigEE" to="e8bb:~SContainmentLinkId" resolve="SContainmentLinkId" />
+                </node>
+                <node concept="2OqwBi" id="3s41kb3jlFs" role="33vP2m">
+                  <node concept="1eOMI4" id="36NsNggQrDr" role="2Oq$k0">
+                    <node concept="10QFUN" id="36NsNggQrDo" role="1eOMHV">
+                      <node concept="37vLTw" id="36NsNggQrDp" role="10QFUP">
+                        <ref role="3cqZAo" node="36NsNggQrD4" resolve="containment" />
+                      </node>
+                      <node concept="3uibUv" id="36NsNggQrDq" role="10QFUM">
+                        <ref role="3uigEE" to="wb4m:~SContainmentLinkAdapter" resolve="SContainmentLinkAdapter" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="3s41kb3jlFt" role="2OqNvi">
+                    <ref role="37wK5l" to="wb4m:~SContainmentLinkAdapter.getId()" resolve="getId" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="36NsNggQrDs" role="3cqZAp">
+              <node concept="1rXfSq" id="36NsNggQrDt" role="3clFbG">
+                <ref role="37wK5l" node="36NsNggQrDD" resolve="put" />
+                <node concept="37vLTw" id="36NsNggQrDu" role="37wK5m">
+                  <ref role="3cqZAo" node="36NsNggQrDk" resolve="id" />
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs6" id="2N1SaI_fJaO" role="3cqZAp" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="2N1SaI_cdnt" role="3cqZAp" />
+        <node concept="YS8fn" id="2N1SaI_ceCr" role="3cqZAp">
+          <node concept="2ShNRf" id="2N1SaI_ceCs" role="YScLw">
+            <node concept="1pGfFk" id="2N1SaI_ceCt" role="2ShVmc">
+              <property role="373rjd" value="true" />
+              <ref role="37wK5l" to="wyt6:~IllegalStateException.&lt;init&gt;(java.lang.String)" resolve="IllegalStateException" />
+              <node concept="2OqwBi" id="2N1SaI_ceCu" role="37wK5m">
+                <node concept="Xl_RD" id="2N1SaI_ceCv" role="2Oq$k0">
+                  <property role="Xl_RC" value="Cannot hash containment %s: %s" />
+                </node>
+                <node concept="2cAKMz" id="2N1SaI_ceCw" role="2OqNvi">
+                  <node concept="2OqwBi" id="2N1SaI_ceCx" role="2cAKU6">
+                    <node concept="37vLTw" id="2N1SaI_ceCy" role="2Oq$k0">
+                      <ref role="3cqZAo" node="36NsNggQrD4" resolve="containment" />
+                    </node>
+                    <node concept="liA8E" id="2N1SaI_ceCz" role="2OqNvi">
+                      <ref role="37wK5l" to="wyt6:~Object.getClass()" resolve="getClass" />
+                    </node>
+                  </node>
+                  <node concept="37vLTw" id="2N1SaI_ceC$" role="2cAKU6">
+                    <ref role="3cqZAo" node="36NsNggQrD4" resolve="containment" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="36NsNggQrDB" role="1B3o_S" />
+      <node concept="3cqZAl" id="36NsNggQrDC" role="3clF45" />
+    </node>
+    <node concept="2tJIrI" id="3s41kb3zvE$" role="jymVt" />
+    <node concept="3clFb_" id="36NsNggQrDD" role="jymVt">
+      <property role="TrG5h" value="put" />
+      <node concept="37vLTG" id="36NsNggQrDE" role="3clF46">
+        <property role="TrG5h" value="featureId" />
+        <node concept="3uibUv" id="36NsNggQrDF" role="1tU5fm">
+          <ref role="3uigEE" to="e8bb:~SConceptFeatureId" resolve="SConceptFeatureId" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="36NsNggQrDG" role="3clF47">
+        <node concept="3clFbF" id="36NsNggQrDH" role="3cqZAp">
+          <node concept="1rXfSq" id="36NsNggQrDI" role="3clFbG">
+            <ref role="37wK5l" node="36NsNggQrBT" resolve="put" />
+            <node concept="2OqwBi" id="3s41kb3fn4g" role="37wK5m">
+              <node concept="37vLTw" id="36NsNggQKC4" role="2Oq$k0">
+                <ref role="3cqZAo" node="36NsNggQrDE" resolve="featureId" />
+              </node>
+              <node concept="liA8E" id="3s41kb3fn4h" role="2OqNvi">
+                <ref role="37wK5l" to="e8bb:~SConceptFeatureId.getConceptId()" resolve="getConceptId" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="3s41kb3mSEh" role="3cqZAp">
+          <node concept="1rXfSq" id="3s41kb3mSEi" role="3clFbG">
+            <ref role="37wK5l" node="3s41kb3mhVz" resolve="put" />
+            <node concept="2OqwBi" id="3s41kb3fjkQ" role="37wK5m">
+              <node concept="37vLTw" id="36NsNggQI5o" role="2Oq$k0">
+                <ref role="3cqZAo" node="36NsNggQrDE" resolve="featureId" />
+              </node>
+              <node concept="liA8E" id="3s41kb3fjkR" role="2OqNvi">
+                <ref role="37wK5l" to="e8bb:~SConceptFeatureId.getIdValue()" resolve="getIdValue" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="36NsNggQrDN" role="1B3o_S" />
+      <node concept="3cqZAl" id="36NsNggQrDO" role="3clF45" />
+    </node>
+    <node concept="2tJIrI" id="3s41kb3zyrS" role="jymVt" />
+    <node concept="3clFb_" id="36NsNggQrDP" role="jymVt">
+      <property role="TrG5h" value="put" />
+      <node concept="37vLTG" id="36NsNggQrDQ" role="3clF46">
+        <property role="TrG5h" value="language" />
+        <node concept="3uibUv" id="36NsNggQrDR" role="1tU5fm">
+          <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="36NsNggQrDS" role="3clF47">
+        <node concept="3clFbJ" id="36NsNggQrDT" role="3cqZAp">
+          <node concept="2ZW3vV" id="36NsNggQrDW" role="3clFbw">
+            <node concept="37vLTw" id="36NsNggQrDU" role="2ZW6bz">
+              <ref role="3cqZAo" node="36NsNggQrDQ" resolve="language" />
+            </node>
+            <node concept="3uibUv" id="36NsNggQrDV" role="2ZW6by">
+              <ref role="3uigEE" to="mcvo:~SLanguageAdapterById" resolve="SLanguageAdapterById" />
+            </node>
+          </node>
+          <node concept="3clFbS" id="36NsNggQrDY" role="3clFbx">
+            <node concept="3cpWs8" id="36NsNggQrE0" role="3cqZAp">
+              <node concept="3cpWsn" id="36NsNggQrDZ" role="3cpWs9">
+                <property role="TrG5h" value="id" />
+                <node concept="3uibUv" id="36NsNggQrE1" role="1tU5fm">
+                  <ref role="3uigEE" to="e8bb:~SLanguageId" resolve="SLanguageId" />
+                </node>
+                <node concept="2OqwBi" id="3s41kb3kjHE" role="33vP2m">
+                  <node concept="1eOMI4" id="36NsNggQrE6" role="2Oq$k0">
+                    <node concept="10QFUN" id="36NsNggQrE3" role="1eOMHV">
+                      <node concept="37vLTw" id="36NsNggQrE4" role="10QFUP">
+                        <ref role="3cqZAo" node="36NsNggQrDQ" resolve="language" />
+                      </node>
+                      <node concept="3uibUv" id="36NsNggQrE5" role="10QFUM">
+                        <ref role="3uigEE" to="mcvo:~SLanguageAdapterById" resolve="SLanguageAdapterById" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="3s41kb3kjHF" role="2OqNvi">
+                    <ref role="37wK5l" to="mcvo:~SLanguageAdapterById.getId()" resolve="getId" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="36NsNggQrE7" role="3cqZAp">
+              <node concept="1rXfSq" id="36NsNggQrE8" role="3clFbG">
+                <ref role="37wK5l" node="36NsNggQrEh" resolve="put" />
+                <node concept="37vLTw" id="36NsNggQrE9" role="37wK5m">
+                  <ref role="3cqZAo" node="36NsNggQrDZ" resolve="id" />
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs6" id="2N1SaI_fNko" role="3cqZAp" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="2N1SaI_cGNg" role="3cqZAp" />
+        <node concept="YS8fn" id="2N1SaI_cEsJ" role="3cqZAp">
+          <node concept="2ShNRf" id="2N1SaI_cEsK" role="YScLw">
+            <node concept="1pGfFk" id="2N1SaI_cEsL" role="2ShVmc">
+              <property role="373rjd" value="true" />
+              <ref role="37wK5l" to="wyt6:~IllegalStateException.&lt;init&gt;(java.lang.String)" resolve="IllegalStateException" />
+              <node concept="2OqwBi" id="2N1SaI_cEsM" role="37wK5m">
+                <node concept="Xl_RD" id="2N1SaI_cEsN" role="2Oq$k0">
+                  <property role="Xl_RC" value="Cannot hash language %s: %s" />
+                </node>
+                <node concept="2cAKMz" id="2N1SaI_cEsO" role="2OqNvi">
+                  <node concept="2OqwBi" id="2N1SaI_cEsP" role="2cAKU6">
+                    <node concept="37vLTw" id="2N1SaI_cEsQ" role="2Oq$k0">
+                      <ref role="3cqZAo" node="36NsNggQrDQ" resolve="language" />
+                    </node>
+                    <node concept="liA8E" id="2N1SaI_cEsR" role="2OqNvi">
+                      <ref role="37wK5l" to="wyt6:~Object.getClass()" resolve="getClass" />
+                    </node>
+                  </node>
+                  <node concept="37vLTw" id="2N1SaI_cEsS" role="2cAKU6">
+                    <ref role="3cqZAo" node="36NsNggQrDQ" resolve="language" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="36NsNggQrEf" role="1B3o_S" />
+      <node concept="3cqZAl" id="36NsNggQrEg" role="3clF45" />
+    </node>
+    <node concept="2tJIrI" id="3s41kb3zBkZ" role="jymVt" />
+    <node concept="3clFb_" id="36NsNggQrEh" role="jymVt">
+      <property role="TrG5h" value="put" />
+      <node concept="37vLTG" id="36NsNggQrEi" role="3clF46">
+        <property role="TrG5h" value="languageId" />
+        <node concept="3uibUv" id="36NsNggQrEj" role="1tU5fm">
+          <ref role="3uigEE" to="e8bb:~SLanguageId" resolve="SLanguageId" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="36NsNggQrEk" role="3clF47">
+        <node concept="3clFbF" id="3s41kb3mBnn" role="3cqZAp">
+          <node concept="1rXfSq" id="3s41kb3mBnl" role="3clFbG">
+            <ref role="37wK5l" node="3s41kb3mhVz" resolve="put" />
+            <node concept="2OqwBi" id="3s41kb3f80a" role="37wK5m">
+              <node concept="37vLTw" id="36NsNggQI5w" role="2Oq$k0">
+                <ref role="3cqZAo" node="36NsNggQrEi" resolve="languageId" />
+              </node>
+              <node concept="liA8E" id="3s41kb3f80b" role="2OqNvi">
+                <ref role="37wK5l" to="e8bb:~SLanguageId.getHighBits()" resolve="getHighBits" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="3s41kb3mOFe" role="3cqZAp">
+          <node concept="1rXfSq" id="3s41kb3mOFc" role="3clFbG">
+            <ref role="37wK5l" node="3s41kb3mhVz" resolve="put" />
+            <node concept="2OqwBi" id="3s41kb3faC_" role="37wK5m">
+              <node concept="37vLTw" id="36NsNggQIfG" role="2Oq$k0">
+                <ref role="3cqZAo" node="36NsNggQrEi" resolve="languageId" />
+              </node>
+              <node concept="liA8E" id="3s41kb3faCA" role="2OqNvi">
+                <ref role="37wK5l" to="e8bb:~SLanguageId.getLowBits()" resolve="getLowBits" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="36NsNggQrEr" role="1B3o_S" />
+      <node concept="3cqZAl" id="36NsNggQrEs" role="3clF45" />
+    </node>
+    <node concept="2tJIrI" id="3s41kb3zE7m" role="jymVt" />
+    <node concept="3clFb_" id="36NsNggQrEt" role="jymVt">
+      <property role="TrG5h" value="put" />
+      <node concept="37vLTG" id="36NsNggQrEu" role="3clF46">
+        <property role="TrG5h" value="nodeId" />
+        <node concept="3uibUv" id="36NsNggQrEv" role="1tU5fm">
+          <ref role="3uigEE" to="mhbf:~SNodeId" resolve="SNodeId" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="36NsNggQrEw" role="3clF47">
+        <node concept="3clFbJ" id="36NsNggQrEx" role="3cqZAp">
+          <node concept="2ZW3vV" id="36NsNggQrE$" role="3clFbw">
+            <node concept="37vLTw" id="36NsNggQrEy" role="2ZW6bz">
+              <ref role="3cqZAo" node="36NsNggQrEu" resolve="nodeId" />
+            </node>
+            <node concept="3uibUv" id="36NsNggQrEz" role="2ZW6by">
+              <ref role="3uigEE" to="w1kc:~SNodeId$Regular" resolve="SNodeId.Regular" />
+            </node>
+          </node>
+          <node concept="9aQIb" id="36NsNggQrEI" role="9aQIa">
+            <node concept="3clFbS" id="36NsNggQrEJ" role="9aQI4">
+              <node concept="3clFbF" id="3s41kb3lYm0" role="3cqZAp">
+                <node concept="1rXfSq" id="3s41kb3lYlY" role="3clFbG">
+                  <ref role="37wK5l" node="3s41kb3fJGx" resolve="put" />
+                  <node concept="2OqwBi" id="36NsNggS21V" role="37wK5m">
+                    <node concept="37vLTw" id="36NsNggQJW0" role="2Oq$k0">
+                      <ref role="3cqZAo" node="36NsNggQrEu" resolve="nodeId" />
+                    </node>
+                    <node concept="liA8E" id="36NsNggS21W" role="2OqNvi">
+                      <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbS" id="36NsNggQrEA" role="3clFbx">
+            <node concept="3clFbF" id="3s41kb3mQDP" role="3cqZAp">
+              <node concept="1rXfSq" id="3s41kb3mQDQ" role="3clFbG">
+                <ref role="37wK5l" node="3s41kb3mhVz" resolve="put" />
+                <node concept="2OqwBi" id="3s41kb3lG0l" role="37wK5m">
+                  <node concept="1eOMI4" id="36NsNggQI9E" role="2Oq$k0">
+                    <node concept="10QFUN" id="36NsNggQI9F" role="1eOMHV">
+                      <node concept="37vLTw" id="36NsNggQI9G" role="10QFUP">
+                        <ref role="3cqZAo" node="36NsNggQrEu" resolve="nodeId" />
+                      </node>
+                      <node concept="3uibUv" id="36NsNggQI9H" role="10QFUM">
+                        <ref role="3uigEE" to="w1kc:~SNodeId$Regular" resolve="SNodeId.Regular" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="3s41kb3lG0m" role="2OqNvi">
+                    <ref role="37wK5l" to="w1kc:~SNodeId$Regular.getId()" resolve="getId" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="36NsNggQrEN" role="1B3o_S" />
+      <node concept="3cqZAl" id="36NsNggQrEO" role="3clF45" />
+    </node>
+    <node concept="2tJIrI" id="3s41kb3fymT" role="jymVt" />
+    <node concept="3clFb_" id="3s41kb3fJGx" role="jymVt">
+      <property role="TrG5h" value="put" />
+      <node concept="3clFbS" id="3s41kb3fJG$" role="3clF47">
+        <node concept="3clFbF" id="3s41kb3fRgG" role="3cqZAp">
+          <node concept="2OqwBi" id="3s41kb3fU5H" role="3clFbG">
+            <node concept="37vLTw" id="3s41kb3fRgF" role="2Oq$k0">
+              <ref role="3cqZAo" node="36NsNggQrxS" resolve="hasher" />
+            </node>
+            <node concept="liA8E" id="3s41kb3fWzO" role="2OqNvi">
+              <ref role="37wK5l" to="kscp:~Hasher.putString(java.lang.CharSequence,java.nio.charset.Charset)" resolve="putString" />
+              <node concept="37vLTw" id="3s41kb3fYAe" role="37wK5m">
+                <ref role="3cqZAo" node="3s41kb3fMhw" resolve="str" />
+              </node>
+              <node concept="10M0yZ" id="3s41kb3g930" role="37wK5m">
+                <ref role="3cqZAo" to="7x5y:~StandardCharsets.UTF_8" resolve="UTF_8" />
+                <ref role="1PxDUh" to="7x5y:~StandardCharsets" resolve="StandardCharsets" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="3s41kb3fDrj" role="1B3o_S" />
+      <node concept="3cqZAl" id="3s41kb3fHw$" role="3clF45" />
+      <node concept="37vLTG" id="3s41kb3fMhw" role="3clF46">
+        <property role="TrG5h" value="str" />
+        <node concept="3uibUv" id="3s41kb3gb55" role="1tU5fm">
+          <ref role="3uigEE" to="wyt6:~CharSequence" resolve="CharSequence" />
+        </node>
+      </node>
+    </node>
+    <node concept="3clFb_" id="3s41kb3mhVz" role="jymVt">
+      <property role="TrG5h" value="put" />
+      <node concept="3clFbS" id="3s41kb3mhVA" role="3clF47">
+        <node concept="3clFbF" id="3s41kb3moPk" role="3cqZAp">
+          <node concept="2OqwBi" id="3s41kb3mr9C" role="3clFbG">
+            <node concept="37vLTw" id="3s41kb3moPj" role="2Oq$k0">
+              <ref role="3cqZAo" node="36NsNggQrxS" resolve="hasher" />
+            </node>
+            <node concept="liA8E" id="3s41kb3mtz4" role="2OqNvi">
+              <ref role="37wK5l" to="kscp:~Hasher.putLong(long)" resolve="putLong" />
+              <node concept="37vLTw" id="3s41kb3mwBK" role="37wK5m">
+                <ref role="3cqZAo" node="3s41kb3mkww" resolve="l" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="3s41kb3mcni" role="1B3o_S" />
+      <node concept="3cqZAl" id="3s41kb3meGN" role="3clF45" />
+      <node concept="37vLTG" id="3s41kb3mkww" role="3clF46">
+        <property role="TrG5h" value="l" />
+        <node concept="3cpWsb" id="3s41kb3mkwv" role="1tU5fm" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="3s41kb3n_PP" role="jymVt" />
+    <node concept="312cEu" id="36NsNggQrud" role="jymVt">
+      <property role="TrG5h" value="FeatureComparator" />
+      <property role="1sVAO0" value="true" />
+      <node concept="3Tm6S6" id="36NsNggQrue" role="1B3o_S" />
+      <node concept="16euLQ" id="36NsNggQruf" role="16eVyc">
+        <property role="TrG5h" value="T" />
+        <node concept="3uibUv" id="36NsNggQrug" role="3ztrMU">
+          <ref role="3uigEE" to="e8bb:~SConceptFeatureId" resolve="SConceptFeatureId" />
+        </node>
+      </node>
+      <node concept="3UR2Jj" id="36NsNggQrvo" role="lGtFl">
+        <node concept="TZ5HA" id="36NsNggQrFv" role="TZ5H$">
+          <node concept="1dT_AC" id="36NsNggQrFw" role="1dT_Ay">
+            <property role="1dT_AB" value="We need to normalize the order of features (&lt;i&gt;not&lt;/i&gt; feature values), " />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="36NsNggQrFx" role="TZ5H$">
+          <node concept="1dT_AC" id="36NsNggQrFy" role="1dT_Ay">
+            <property role="1dT_AB" value="as the order depends on insertion order but doesn't carry meaning. " />
+          </node>
+        </node>
+      </node>
+      <node concept="3clFb_" id="36NsNggQruh" role="jymVt">
+        <property role="TrG5h" value="compareFeature" />
+        <node concept="37vLTG" id="36NsNggQrui" role="3clF46">
+          <property role="TrG5h" value="a" />
+          <node concept="16syzq" id="36NsNggQruj" role="1tU5fm">
+            <ref role="16sUi3" node="36NsNggQruf" resolve="T" />
+          </node>
+        </node>
+        <node concept="37vLTG" id="36NsNggQruk" role="3clF46">
+          <property role="TrG5h" value="b" />
+          <node concept="16syzq" id="36NsNggQrul" role="1tU5fm">
+            <ref role="16sUi3" node="36NsNggQruf" resolve="T" />
+          </node>
+        </node>
+        <node concept="3clFbS" id="36NsNggQrum" role="3clF47">
+          <node concept="3cpWs8" id="36NsNggQruo" role="3cqZAp">
+            <node concept="3cpWsn" id="36NsNggQrun" role="3cpWs9">
+              <property role="TrG5h" value="idCompare" />
+              <node concept="10Oyi0" id="36NsNggQrup" role="1tU5fm" />
+              <node concept="2YIFZM" id="36NsNggQHOT" role="33vP2m">
+                <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
+                <ref role="37wK5l" to="wyt6:~Long.compare(long,long)" resolve="compare" />
+                <node concept="2OqwBi" id="3s41kb3f5H8" role="37wK5m">
+                  <node concept="37vLTw" id="36NsNggQHOV" role="2Oq$k0">
+                    <ref role="3cqZAo" node="36NsNggQrui" resolve="a" />
+                  </node>
+                  <node concept="liA8E" id="3s41kb3f5H9" role="2OqNvi">
+                    <ref role="37wK5l" to="e8bb:~SConceptFeatureId.getIdValue()" resolve="getIdValue" />
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="3s41kb3foko" role="37wK5m">
+                  <node concept="37vLTw" id="36NsNggQLC4" role="2Oq$k0">
+                    <ref role="3cqZAo" node="36NsNggQruk" resolve="b" />
+                  </node>
+                  <node concept="liA8E" id="3s41kb3fokp" role="2OqNvi">
+                    <ref role="37wK5l" to="e8bb:~SConceptFeatureId.getIdValue()" resolve="getIdValue" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbJ" id="36NsNggQrut" role="3cqZAp">
+            <node concept="3y3z36" id="36NsNggQruu" role="3clFbw">
+              <node concept="37vLTw" id="36NsNggQruv" role="3uHU7B">
+                <ref role="3cqZAo" node="36NsNggQrun" resolve="idCompare" />
+              </node>
+              <node concept="3cmrfG" id="36NsNggQruw" role="3uHU7w">
+                <property role="3cmrfH" value="0" />
+              </node>
+            </node>
+            <node concept="3clFbS" id="36NsNggQruy" role="3clFbx">
+              <node concept="3cpWs6" id="36NsNggQruz" role="3cqZAp">
+                <node concept="37vLTw" id="36NsNggQru$" role="3cqZAk">
+                  <ref role="3cqZAo" node="36NsNggQrun" resolve="idCompare" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="36NsNggQruA" role="3cqZAp">
+            <node concept="3cpWsn" id="36NsNggQru_" role="3cpWs9">
+              <property role="TrG5h" value="aConcept" />
+              <node concept="3uibUv" id="36NsNggQruB" role="1tU5fm">
+                <ref role="3uigEE" to="e8bb:~SConceptId" resolve="SConceptId" />
+              </node>
+              <node concept="2OqwBi" id="3s41kb3fbRl" role="33vP2m">
+                <node concept="37vLTw" id="36NsNggQJYG" role="2Oq$k0">
+                  <ref role="3cqZAo" node="36NsNggQrui" resolve="a" />
+                </node>
+                <node concept="liA8E" id="3s41kb3fbRm" role="2OqNvi">
+                  <ref role="37wK5l" to="e8bb:~SConceptFeatureId.getConceptId()" resolve="getConceptId" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="36NsNggQruE" role="3cqZAp">
+            <node concept="3cpWsn" id="36NsNggQruD" role="3cpWs9">
+              <property role="TrG5h" value="bConcept" />
+              <node concept="3uibUv" id="36NsNggQruF" role="1tU5fm">
+                <ref role="3uigEE" to="e8bb:~SConceptId" resolve="SConceptId" />
+              </node>
+              <node concept="2OqwBi" id="3s41kb3flOh" role="33vP2m">
+                <node concept="37vLTw" id="36NsNggQIed" role="2Oq$k0">
+                  <ref role="3cqZAo" node="36NsNggQruk" resolve="b" />
+                </node>
+                <node concept="liA8E" id="3s41kb3flOi" role="2OqNvi">
+                  <ref role="37wK5l" to="e8bb:~SConceptFeatureId.getConceptId()" resolve="getConceptId" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="36NsNggQruI" role="3cqZAp">
+            <node concept="3cpWsn" id="36NsNggQruH" role="3cpWs9">
+              <property role="TrG5h" value="conceptCompare" />
+              <node concept="10Oyi0" id="36NsNggQruJ" role="1tU5fm" />
+              <node concept="2YIFZM" id="36NsNggQIa1" role="33vP2m">
+                <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
+                <ref role="37wK5l" to="wyt6:~Long.compare(long,long)" resolve="compare" />
+                <node concept="2OqwBi" id="3s41kb3fse9" role="37wK5m">
+                  <node concept="37vLTw" id="36NsNggQIa3" role="2Oq$k0">
+                    <ref role="3cqZAo" node="36NsNggQru_" resolve="aConcept" />
+                  </node>
+                  <node concept="liA8E" id="3s41kb3fsea" role="2OqNvi">
+                    <ref role="37wK5l" to="e8bb:~SConceptId.getIdValue()" resolve="getIdValue" />
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="3s41kb3fd6e" role="37wK5m">
+                  <node concept="37vLTw" id="36NsNggQIa5" role="2Oq$k0">
+                    <ref role="3cqZAo" node="36NsNggQruD" resolve="bConcept" />
+                  </node>
+                  <node concept="liA8E" id="3s41kb3fd6f" role="2OqNvi">
+                    <ref role="37wK5l" to="e8bb:~SConceptId.getIdValue()" resolve="getIdValue" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbJ" id="36NsNggQruN" role="3cqZAp">
+            <node concept="3y3z36" id="36NsNggQruO" role="3clFbw">
+              <node concept="37vLTw" id="36NsNggQruP" role="3uHU7B">
+                <ref role="3cqZAo" node="36NsNggQruH" resolve="conceptCompare" />
+              </node>
+              <node concept="3cmrfG" id="36NsNggQruQ" role="3uHU7w">
+                <property role="3cmrfH" value="0" />
+              </node>
+            </node>
+            <node concept="3clFbS" id="36NsNggQruS" role="3clFbx">
+              <node concept="3cpWs6" id="36NsNggQruT" role="3cqZAp">
+                <node concept="37vLTw" id="36NsNggQruU" role="3cqZAk">
+                  <ref role="3cqZAo" node="36NsNggQruH" resolve="conceptCompare" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="36NsNggQruW" role="3cqZAp">
+            <node concept="3cpWsn" id="36NsNggQruV" role="3cpWs9">
+              <property role="TrG5h" value="aLanguage" />
+              <node concept="3uibUv" id="36NsNggQruX" role="1tU5fm">
+                <ref role="3uigEE" to="e8bb:~SLanguageId" resolve="SLanguageId" />
+              </node>
+              <node concept="2OqwBi" id="3s41kb3fspD" role="33vP2m">
+                <node concept="37vLTw" id="36NsNggQI5G" role="2Oq$k0">
+                  <ref role="3cqZAo" node="36NsNggQru_" resolve="aConcept" />
+                </node>
+                <node concept="liA8E" id="3s41kb3fspE" role="2OqNvi">
+                  <ref role="37wK5l" to="e8bb:~SConceptId.getLanguageId()" resolve="getLanguageId" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="36NsNggQrv0" role="3cqZAp">
+            <node concept="3cpWsn" id="36NsNggQruZ" role="3cpWs9">
+              <property role="TrG5h" value="bLanguage" />
+              <node concept="3uibUv" id="36NsNggQrv1" role="1tU5fm">
+                <ref role="3uigEE" to="e8bb:~SLanguageId" resolve="SLanguageId" />
+              </node>
+              <node concept="2OqwBi" id="3s41kb3fgP1" role="33vP2m">
+                <node concept="37vLTw" id="36NsNggQIg0" role="2Oq$k0">
+                  <ref role="3cqZAo" node="36NsNggQruD" resolve="bConcept" />
+                </node>
+                <node concept="liA8E" id="3s41kb3fgP2" role="2OqNvi">
+                  <ref role="37wK5l" to="e8bb:~SConceptId.getLanguageId()" resolve="getLanguageId" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs6" id="36NsNggQrv3" role="3cqZAp">
+            <node concept="2OqwBi" id="3s41kb3fv4U" role="3cqZAk">
+              <node concept="2OqwBi" id="3s41kb3f9q5" role="2Oq$k0">
+                <node concept="37vLTw" id="36NsNggQIkg" role="2Oq$k0">
+                  <ref role="3cqZAo" node="36NsNggQruV" resolve="aLanguage" />
+                </node>
+                <node concept="liA8E" id="3s41kb3f9q6" role="2OqNvi">
+                  <ref role="37wK5l" to="e8bb:~SLanguageId.getIdValue()" resolve="getIdValue" />
+                </node>
+              </node>
+              <node concept="liA8E" id="3s41kb3fv4V" role="2OqNvi">
+                <ref role="37wK5l" to="33ny:~UUID.compareTo(java.util.UUID)" resolve="compareTo" />
+                <node concept="2OqwBi" id="3s41kb3fv4W" role="37wK5m">
+                  <node concept="37vLTw" id="3s41kb3fv4X" role="2Oq$k0">
+                    <ref role="3cqZAo" node="36NsNggQruZ" resolve="bLanguage" />
+                  </node>
+                  <node concept="liA8E" id="3s41kb3fv4Y" role="2OqNvi">
+                    <ref role="37wK5l" to="e8bb:~SLanguageId.getIdValue()" resolve="getIdValue" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3Tmbuc" id="36NsNggQrv7" role="1B3o_S" />
+        <node concept="10Oyi0" id="36NsNggQrv8" role="3clF45" />
+      </node>
+      <node concept="2tJIrI" id="3s41kb3nOZw" role="jymVt" />
+      <node concept="3clFb_" id="36NsNggQrv9" role="jymVt">
+        <property role="TrG5h" value="name" />
+        <node concept="37vLTG" id="36NsNggQrva" role="3clF46">
+          <property role="TrG5h" value="a" />
+          <node concept="3uibUv" id="36NsNggQrvb" role="1tU5fm">
+            <ref role="3uigEE" to="c17a:~SConceptFeature" resolve="SConceptFeature" />
+          </node>
+        </node>
+        <node concept="3clFbS" id="36NsNggQrvc" role="3clF47">
+          <node concept="3cpWs6" id="36NsNggQrvd" role="3cqZAp">
+            <node concept="3cpWs3" id="36NsNggQrve" role="3cqZAk">
+              <node concept="3cpWs3" id="36NsNggQrvf" role="3uHU7B">
+                <node concept="2OqwBi" id="36NsNggR_Ku" role="3uHU7B">
+                  <node concept="2OqwBi" id="36NsNggR$yk" role="2Oq$k0">
+                    <node concept="2OqwBi" id="36NsNggRxIJ" role="2Oq$k0">
+                      <node concept="37vLTw" id="36NsNggQIbn" role="2Oq$k0">
+                        <ref role="3cqZAo" node="36NsNggQrva" resolve="a" />
+                      </node>
+                      <node concept="liA8E" id="36NsNggRxIK" role="2OqNvi">
+                        <ref role="37wK5l" to="c17a:~SConceptFeature.getOwner()" resolve="getOwner" />
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="36NsNggR$yl" role="2OqNvi">
+                      <ref role="37wK5l" to="c17a:~SAbstractConcept.getLanguage()" resolve="getLanguage" />
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="36NsNggR_Kv" role="2OqNvi">
+                    <ref role="37wK5l" to="c17a:~SLanguage.getQualifiedName()" resolve="getQualifiedName" />
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="36NsNggRzL8" role="3uHU7w">
+                  <node concept="2OqwBi" id="36NsNggRrXI" role="2Oq$k0">
+                    <node concept="37vLTw" id="36NsNggQHS0" role="2Oq$k0">
+                      <ref role="3cqZAo" node="36NsNggQrva" resolve="a" />
+                    </node>
+                    <node concept="liA8E" id="36NsNggRrXJ" role="2OqNvi">
+                      <ref role="37wK5l" to="c17a:~SConceptFeature.getOwner()" resolve="getOwner" />
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="36NsNggRzL9" role="2OqNvi">
+                    <ref role="37wK5l" to="c17a:~SAbstractConcept.getName()" resolve="getName" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2OqwBi" id="36NsNggRvay" role="3uHU7w">
+                <node concept="37vLTw" id="36NsNggQHPl" role="2Oq$k0">
+                  <ref role="3cqZAo" node="36NsNggQrva" resolve="a" />
+                </node>
+                <node concept="liA8E" id="36NsNggRvaz" role="2OqNvi">
+                  <ref role="37wK5l" to="c17a:~SNamedElement.getName()" resolve="getName" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3Tmbuc" id="36NsNggQrvm" role="1B3o_S" />
+        <node concept="17QB3L" id="36NsNggQBFU" role="3clF45" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="3s41kb3nDRA" role="jymVt" />
+    <node concept="312cEu" id="36NsNggQrvp" role="jymVt">
+      <property role="TrG5h" value="PropertyComparator" />
+      <node concept="3Tm6S6" id="36NsNggQrvq" role="1B3o_S" />
+      <node concept="3uibUv" id="36NsNggQrvr" role="1zkMxy">
+        <ref role="3uigEE" node="36NsNggQrud" resolve="NodeHasher.FeatureComparator" />
+        <node concept="3uibUv" id="36NsNggQrvs" role="11_B2D">
+          <ref role="3uigEE" to="e8bb:~SPropertyId" resolve="SPropertyId" />
+        </node>
+      </node>
+      <node concept="3uibUv" id="36NsNggQrvt" role="EKbjA">
+        <ref role="3uigEE" to="33ny:~Comparator" resolve="Comparator" />
+        <node concept="3uibUv" id="36NsNggQrvu" role="11_B2D">
+          <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
+        </node>
+      </node>
+      <node concept="3clFb_" id="36NsNggQrvv" role="jymVt">
+        <property role="TrG5h" value="compare" />
+        <node concept="2AHcQZ" id="36NsNggQrvw" role="2AJF6D">
+          <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+        </node>
+        <node concept="37vLTG" id="36NsNggQrvx" role="3clF46">
+          <property role="TrG5h" value="a" />
+          <node concept="3uibUv" id="36NsNggQrvy" role="1tU5fm">
+            <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
+          </node>
+        </node>
+        <node concept="37vLTG" id="36NsNggQrvz" role="3clF46">
+          <property role="TrG5h" value="b" />
+          <node concept="3uibUv" id="36NsNggQrv$" role="1tU5fm">
+            <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
+          </node>
+        </node>
+        <node concept="3clFbS" id="36NsNggQrv_" role="3clF47">
+          <node concept="3clFbJ" id="36NsNggQrvA" role="3cqZAp">
+            <node concept="1Wc70l" id="36NsNggQrvB" role="3clFbw">
+              <node concept="2ZW3vV" id="36NsNggQrvE" role="3uHU7B">
+                <node concept="37vLTw" id="36NsNggQrvC" role="2ZW6bz">
+                  <ref role="3cqZAo" node="36NsNggQrvx" resolve="a" />
+                </node>
+                <node concept="3uibUv" id="36NsNggQrvD" role="2ZW6by">
+                  <ref role="3uigEE" to="pwx:~SPropertyAdapter" resolve="SPropertyAdapter" />
+                </node>
+              </node>
+              <node concept="2ZW3vV" id="36NsNggQrvH" role="3uHU7w">
+                <node concept="37vLTw" id="36NsNggQrvF" role="2ZW6bz">
+                  <ref role="3cqZAo" node="36NsNggQrvz" resolve="b" />
+                </node>
+                <node concept="3uibUv" id="36NsNggQrvG" role="2ZW6by">
+                  <ref role="3uigEE" to="pwx:~SPropertyAdapter" resolve="SPropertyAdapter" />
+                </node>
+              </node>
+            </node>
+            <node concept="9aQIb" id="36NsNggQrvW" role="9aQIa">
+              <node concept="3clFbS" id="36NsNggQrvX" role="9aQI4">
+                <node concept="3cpWs6" id="36NsNggQrvY" role="3cqZAp">
+                  <node concept="2OqwBi" id="36NsNggQKxD" role="3cqZAk">
+                    <node concept="1rXfSq" id="36NsNggQrw0" role="2Oq$k0">
+                      <ref role="37wK5l" node="36NsNggQrv9" resolve="name" />
+                      <node concept="37vLTw" id="36NsNggQrw1" role="37wK5m">
+                        <ref role="3cqZAo" node="36NsNggQrvx" resolve="a" />
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="36NsNggQKxE" role="2OqNvi">
+                      <ref role="37wK5l" to="wyt6:~String.compareTo(java.lang.String)" resolve="compareTo" />
+                      <node concept="1rXfSq" id="36NsNggQKxF" role="37wK5m">
+                        <ref role="37wK5l" node="36NsNggQrv9" resolve="name" />
+                        <node concept="37vLTw" id="36NsNggQKxG" role="37wK5m">
+                          <ref role="3cqZAo" node="36NsNggQrvz" resolve="b" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbS" id="36NsNggQrvJ" role="3clFbx">
+              <node concept="3cpWs6" id="36NsNggQrvK" role="3cqZAp">
+                <node concept="1rXfSq" id="36NsNggQrvL" role="3cqZAk">
+                  <ref role="37wK5l" node="36NsNggQruh" resolve="compareFeature" />
+                  <node concept="2OqwBi" id="3s41kb3nvDX" role="37wK5m">
+                    <node concept="1eOMI4" id="36NsNggQrvQ" role="2Oq$k0">
+                      <node concept="10QFUN" id="36NsNggQrvN" role="1eOMHV">
+                        <node concept="37vLTw" id="36NsNggQrvO" role="10QFUP">
+                          <ref role="3cqZAo" node="36NsNggQrvx" resolve="a" />
+                        </node>
+                        <node concept="3uibUv" id="36NsNggQrvP" role="10QFUM">
+                          <ref role="3uigEE" to="pwx:~SPropertyAdapter" resolve="SPropertyAdapter" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="3s41kb3nvDY" role="2OqNvi">
+                      <ref role="37wK5l" to="pwx:~SPropertyAdapter.getId()" resolve="getId" />
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="3s41kb3nwQk" role="37wK5m">
+                    <node concept="1eOMI4" id="36NsNggQrvV" role="2Oq$k0">
+                      <node concept="10QFUN" id="36NsNggQrvS" role="1eOMHV">
+                        <node concept="37vLTw" id="36NsNggQrvT" role="10QFUP">
+                          <ref role="3cqZAo" node="36NsNggQrvz" resolve="b" />
+                        </node>
+                        <node concept="3uibUv" id="36NsNggQrvU" role="10QFUM">
+                          <ref role="3uigEE" to="pwx:~SPropertyAdapter" resolve="SPropertyAdapter" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="3s41kb3nwQl" role="2OqNvi">
+                      <ref role="37wK5l" to="pwx:~SPropertyAdapter.getId()" resolve="getId" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3Tm1VV" id="36NsNggQrw4" role="1B3o_S" />
+        <node concept="10Oyi0" id="36NsNggQrw5" role="3clF45" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="3s41kb3nGvz" role="jymVt" />
+    <node concept="312cEu" id="36NsNggQrw6" role="jymVt">
+      <property role="TrG5h" value="ReferenceComparator" />
+      <node concept="3Tm6S6" id="36NsNggQrw7" role="1B3o_S" />
+      <node concept="3uibUv" id="36NsNggQrw8" role="1zkMxy">
+        <ref role="3uigEE" node="36NsNggQrud" resolve="NodeHasher.FeatureComparator" />
+        <node concept="3uibUv" id="36NsNggQrw9" role="11_B2D">
+          <ref role="3uigEE" to="e8bb:~SReferenceLinkId" resolve="SReferenceLinkId" />
+        </node>
+      </node>
+      <node concept="3uibUv" id="36NsNggQrwa" role="EKbjA">
+        <ref role="3uigEE" to="33ny:~Comparator" resolve="Comparator" />
+        <node concept="3uibUv" id="36NsNggQrwb" role="11_B2D">
+          <ref role="3uigEE" to="mhbf:~SReference" resolve="SReference" />
+        </node>
+      </node>
+      <node concept="3clFb_" id="36NsNggQrwc" role="jymVt">
+        <property role="TrG5h" value="compare" />
+        <node concept="2AHcQZ" id="36NsNggQrwd" role="2AJF6D">
+          <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+        </node>
+        <node concept="37vLTG" id="36NsNggQrwe" role="3clF46">
+          <property role="TrG5h" value="aRef" />
+          <node concept="3uibUv" id="36NsNggQrwf" role="1tU5fm">
+            <ref role="3uigEE" to="mhbf:~SReference" resolve="SReference" />
+          </node>
+        </node>
+        <node concept="37vLTG" id="36NsNggQrwg" role="3clF46">
+          <property role="TrG5h" value="bRef" />
+          <node concept="3uibUv" id="36NsNggQrwh" role="1tU5fm">
+            <ref role="3uigEE" to="mhbf:~SReference" resolve="SReference" />
+          </node>
+        </node>
+        <node concept="3clFbS" id="36NsNggQrwi" role="3clF47">
+          <node concept="3cpWs8" id="36NsNggQrwk" role="3cqZAp">
+            <node concept="3cpWsn" id="36NsNggQrwj" role="3cpWs9">
+              <property role="TrG5h" value="a" />
+              <node concept="3uibUv" id="36NsNggQrwl" role="1tU5fm">
+                <ref role="3uigEE" to="c17a:~SReferenceLink" resolve="SReferenceLink" />
+              </node>
+              <node concept="2OqwBi" id="36NsNggRYTn" role="33vP2m">
+                <node concept="37vLTw" id="36NsNggQIf_" role="2Oq$k0">
+                  <ref role="3cqZAo" node="36NsNggQrwe" resolve="aRef" />
+                </node>
+                <node concept="liA8E" id="36NsNggRYTo" role="2OqNvi">
+                  <ref role="37wK5l" to="mhbf:~SReference.getLink()" resolve="getLink" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="36NsNggQrwo" role="3cqZAp">
+            <node concept="3cpWsn" id="36NsNggQrwn" role="3cpWs9">
+              <property role="TrG5h" value="b" />
+              <node concept="3uibUv" id="36NsNggQrwp" role="1tU5fm">
+                <ref role="3uigEE" to="c17a:~SReferenceLink" resolve="SReferenceLink" />
+              </node>
+              <node concept="2OqwBi" id="36NsNggS2zh" role="33vP2m">
+                <node concept="37vLTw" id="36NsNggQJJl" role="2Oq$k0">
+                  <ref role="3cqZAo" node="36NsNggQrwg" resolve="bRef" />
+                </node>
+                <node concept="liA8E" id="36NsNggS2zi" role="2OqNvi">
+                  <ref role="37wK5l" to="mhbf:~SReference.getLink()" resolve="getLink" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbJ" id="36NsNggQrwr" role="3cqZAp">
+            <node concept="1Wc70l" id="36NsNggQrws" role="3clFbw">
+              <node concept="2ZW3vV" id="36NsNggQrwv" role="3uHU7B">
+                <node concept="37vLTw" id="36NsNggQrwt" role="2ZW6bz">
+                  <ref role="3cqZAo" node="36NsNggQrwj" resolve="a" />
+                </node>
+                <node concept="3uibUv" id="36NsNggQrwu" role="2ZW6by">
+                  <ref role="3uigEE" to="rzjr:~SReferenceLinkAdapter" resolve="SReferenceLinkAdapter" />
+                </node>
+              </node>
+              <node concept="2ZW3vV" id="36NsNggQrwy" role="3uHU7w">
+                <node concept="37vLTw" id="36NsNggQrww" role="2ZW6bz">
+                  <ref role="3cqZAo" node="36NsNggQrwn" resolve="b" />
+                </node>
+                <node concept="3uibUv" id="36NsNggQrwx" role="2ZW6by">
+                  <ref role="3uigEE" to="rzjr:~SReferenceLinkAdapter" resolve="SReferenceLinkAdapter" />
+                </node>
+              </node>
+            </node>
+            <node concept="9aQIb" id="36NsNggQrwL" role="9aQIa">
+              <node concept="3clFbS" id="36NsNggQrwM" role="9aQI4">
+                <node concept="3cpWs6" id="36NsNggQrwN" role="3cqZAp">
+                  <node concept="2OqwBi" id="36NsNggQIYN" role="3cqZAk">
+                    <node concept="1rXfSq" id="36NsNggQrwP" role="2Oq$k0">
+                      <ref role="37wK5l" node="36NsNggQrv9" resolve="name" />
+                      <node concept="37vLTw" id="36NsNggQrwQ" role="37wK5m">
+                        <ref role="3cqZAo" node="36NsNggQrwj" resolve="a" />
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="36NsNggQIYO" role="2OqNvi">
+                      <ref role="37wK5l" to="wyt6:~String.compareTo(java.lang.String)" resolve="compareTo" />
+                      <node concept="1rXfSq" id="36NsNggQIYP" role="37wK5m">
+                        <ref role="37wK5l" node="36NsNggQrv9" resolve="name" />
+                        <node concept="37vLTw" id="36NsNggQIYQ" role="37wK5m">
+                          <ref role="3cqZAo" node="36NsNggQrwn" resolve="b" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbS" id="36NsNggQrw$" role="3clFbx">
+              <node concept="3cpWs6" id="36NsNggQrw_" role="3cqZAp">
+                <node concept="1rXfSq" id="36NsNggQrwA" role="3cqZAk">
+                  <ref role="37wK5l" node="36NsNggQruh" resolve="compareFeature" />
+                  <node concept="2OqwBi" id="3s41kb3nzfZ" role="37wK5m">
+                    <node concept="1eOMI4" id="36NsNggQrwF" role="2Oq$k0">
+                      <node concept="10QFUN" id="36NsNggQrwC" role="1eOMHV">
+                        <node concept="37vLTw" id="36NsNggQrwD" role="10QFUP">
+                          <ref role="3cqZAo" node="36NsNggQrwj" resolve="a" />
+                        </node>
+                        <node concept="3uibUv" id="36NsNggQrwE" role="10QFUM">
+                          <ref role="3uigEE" to="rzjr:~SReferenceLinkAdapter" resolve="SReferenceLinkAdapter" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="3s41kb3nzg0" role="2OqNvi">
+                      <ref role="37wK5l" to="rzjr:~SReferenceLinkAdapter.getId()" resolve="getId" />
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="3s41kb3nsf2" role="37wK5m">
+                    <node concept="1eOMI4" id="36NsNggQrwK" role="2Oq$k0">
+                      <node concept="10QFUN" id="36NsNggQrwH" role="1eOMHV">
+                        <node concept="37vLTw" id="36NsNggQrwI" role="10QFUP">
+                          <ref role="3cqZAo" node="36NsNggQrwn" resolve="b" />
+                        </node>
+                        <node concept="3uibUv" id="36NsNggQrwJ" role="10QFUM">
+                          <ref role="3uigEE" to="rzjr:~SReferenceLinkAdapter" resolve="SReferenceLinkAdapter" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="3s41kb3nsf3" role="2OqNvi">
+                      <ref role="37wK5l" to="rzjr:~SReferenceLinkAdapter.getId()" resolve="getId" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3Tm1VV" id="36NsNggQrwT" role="1B3o_S" />
+        <node concept="10Oyi0" id="36NsNggQrwU" role="3clF45" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="3s41kb3nLj_" role="jymVt" />
+    <node concept="312cEu" id="36NsNggQrwV" role="jymVt">
+      <property role="TrG5h" value="ContainmentComparator" />
+      <node concept="3Tm6S6" id="36NsNggQrwW" role="1B3o_S" />
+      <node concept="3uibUv" id="36NsNggQrwX" role="1zkMxy">
+        <ref role="3uigEE" node="36NsNggQrud" resolve="NodeHasher.FeatureComparator" />
+        <node concept="3uibUv" id="36NsNggQrwY" role="11_B2D">
+          <ref role="3uigEE" to="e8bb:~SContainmentLinkId" resolve="SContainmentLinkId" />
+        </node>
+      </node>
+      <node concept="3uibUv" id="36NsNggQrwZ" role="EKbjA">
+        <ref role="3uigEE" to="33ny:~Comparator" resolve="Comparator" />
+        <node concept="3uibUv" id="36NsNggQrx0" role="11_B2D">
+          <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
+        </node>
+      </node>
+      <node concept="3clFb_" id="36NsNggQrx1" role="jymVt">
+        <property role="TrG5h" value="compare" />
+        <node concept="2AHcQZ" id="36NsNggQrx2" role="2AJF6D">
+          <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+        </node>
+        <node concept="37vLTG" id="36NsNggQrx3" role="3clF46">
+          <property role="TrG5h" value="aChild" />
+          <node concept="3uibUv" id="36NsNggQrx4" role="1tU5fm">
+            <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
+          </node>
+        </node>
+        <node concept="37vLTG" id="36NsNggQrx5" role="3clF46">
+          <property role="TrG5h" value="bChild" />
+          <node concept="3uibUv" id="36NsNggQrx6" role="1tU5fm">
+            <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
+          </node>
+        </node>
+        <node concept="3clFbS" id="36NsNggQrx7" role="3clF47">
+          <node concept="3cpWs8" id="36NsNggQrx9" role="3cqZAp">
+            <node concept="3cpWsn" id="36NsNggQrx8" role="3cpWs9">
+              <property role="TrG5h" value="a" />
+              <node concept="3uibUv" id="36NsNggQrxa" role="1tU5fm">
+                <ref role="3uigEE" to="c17a:~SContainmentLink" resolve="SContainmentLink" />
+              </node>
+              <node concept="2OqwBi" id="36NsNggRZpp" role="33vP2m">
+                <node concept="37vLTw" id="36NsNggQIft" role="2Oq$k0">
+                  <ref role="3cqZAo" node="36NsNggQrx3" resolve="aChild" />
+                </node>
+                <node concept="liA8E" id="36NsNggRZpq" role="2OqNvi">
+                  <ref role="37wK5l" to="mhbf:~SNode.getContainmentLink()" resolve="getContainmentLink" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="36NsNggQrxd" role="3cqZAp">
+            <node concept="3cpWsn" id="36NsNggQrxc" role="3cpWs9">
+              <property role="TrG5h" value="b" />
+              <node concept="3uibUv" id="36NsNggQrxe" role="1tU5fm">
+                <ref role="3uigEE" to="c17a:~SContainmentLink" resolve="SContainmentLink" />
+              </node>
+              <node concept="2OqwBi" id="36NsNggRUXF" role="33vP2m">
+                <node concept="37vLTw" id="36NsNggQIg8" role="2Oq$k0">
+                  <ref role="3cqZAo" node="36NsNggQrx5" resolve="bChild" />
+                </node>
+                <node concept="liA8E" id="36NsNggRUXG" role="2OqNvi">
+                  <ref role="37wK5l" to="mhbf:~SNode.getContainmentLink()" resolve="getContainmentLink" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbJ" id="36NsNggQrxg" role="3cqZAp">
+            <node concept="1Wc70l" id="36NsNggQrxh" role="3clFbw">
+              <node concept="2ZW3vV" id="36NsNggQrxk" role="3uHU7B">
+                <node concept="37vLTw" id="36NsNggQrxi" role="2ZW6bz">
+                  <ref role="3cqZAo" node="36NsNggQrx8" resolve="a" />
+                </node>
+                <node concept="3uibUv" id="36NsNggQrxj" role="2ZW6by">
+                  <ref role="3uigEE" to="wb4m:~SContainmentLinkAdapter" resolve="SContainmentLinkAdapter" />
+                </node>
+              </node>
+              <node concept="2ZW3vV" id="36NsNggQrxn" role="3uHU7w">
+                <node concept="37vLTw" id="36NsNggQrxl" role="2ZW6bz">
+                  <ref role="3cqZAo" node="36NsNggQrxc" resolve="b" />
+                </node>
+                <node concept="3uibUv" id="36NsNggQrxm" role="2ZW6by">
+                  <ref role="3uigEE" to="wb4m:~SContainmentLinkAdapter" resolve="SContainmentLinkAdapter" />
+                </node>
+              </node>
+            </node>
+            <node concept="9aQIb" id="36NsNggQrxA" role="9aQIa">
+              <node concept="3clFbS" id="36NsNggQrxB" role="9aQI4">
+                <node concept="3cpWs6" id="36NsNggQrxC" role="3cqZAp">
+                  <node concept="2OqwBi" id="36NsNggQJDD" role="3cqZAk">
+                    <node concept="1rXfSq" id="36NsNggQrxE" role="2Oq$k0">
+                      <ref role="37wK5l" node="36NsNggQrv9" resolve="name" />
+                      <node concept="37vLTw" id="36NsNggQrxF" role="37wK5m">
+                        <ref role="3cqZAo" node="36NsNggQrx8" resolve="a" />
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="36NsNggQJDE" role="2OqNvi">
+                      <ref role="37wK5l" to="wyt6:~String.compareTo(java.lang.String)" resolve="compareTo" />
+                      <node concept="1rXfSq" id="36NsNggQJDF" role="37wK5m">
+                        <ref role="37wK5l" node="36NsNggQrv9" resolve="name" />
+                        <node concept="37vLTw" id="36NsNggQJDG" role="37wK5m">
+                          <ref role="3cqZAo" node="36NsNggQrxc" resolve="b" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbS" id="36NsNggQrxp" role="3clFbx">
+              <node concept="3cpWs6" id="36NsNggQrxq" role="3cqZAp">
+                <node concept="1rXfSq" id="36NsNggQrxr" role="3cqZAk">
+                  <ref role="37wK5l" node="36NsNggQruh" resolve="compareFeature" />
+                  <node concept="2OqwBi" id="3s41kb3ny34" role="37wK5m">
+                    <node concept="1eOMI4" id="36NsNggQrxw" role="2Oq$k0">
+                      <node concept="10QFUN" id="36NsNggQrxt" role="1eOMHV">
+                        <node concept="37vLTw" id="36NsNggQrxu" role="10QFUP">
+                          <ref role="3cqZAo" node="36NsNggQrx8" resolve="a" />
+                        </node>
+                        <node concept="3uibUv" id="36NsNggQrxv" role="10QFUM">
+                          <ref role="3uigEE" to="wb4m:~SContainmentLinkAdapter" resolve="SContainmentLinkAdapter" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="3s41kb3ny35" role="2OqNvi">
+                      <ref role="37wK5l" to="wb4m:~SContainmentLinkAdapter.getId()" resolve="getId" />
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="3s41kb3nutW" role="37wK5m">
+                    <node concept="1eOMI4" id="36NsNggQrx_" role="2Oq$k0">
+                      <node concept="10QFUN" id="36NsNggQrxy" role="1eOMHV">
+                        <node concept="37vLTw" id="36NsNggQrxz" role="10QFUP">
+                          <ref role="3cqZAo" node="36NsNggQrxc" resolve="b" />
+                        </node>
+                        <node concept="3uibUv" id="36NsNggQrx$" role="10QFUM">
+                          <ref role="3uigEE" to="wb4m:~SContainmentLinkAdapter" resolve="SContainmentLinkAdapter" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="3s41kb3nutX" role="2OqNvi">
+                      <ref role="37wK5l" to="wb4m:~SContainmentLinkAdapter.getId()" resolve="getId" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3Tm1VV" id="36NsNggQrxI" role="1B3o_S" />
+        <node concept="10Oyi0" id="36NsNggQrxJ" role="3clF45" />
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/code/hasher/solutions/nl.f1re.mpsutil.hasher/nl.f1re.mpsutil.hasher.msd
+++ b/code/hasher/solutions/nl.f1re.mpsutil.hasher/nl.f1re.mpsutil.hasher.msd
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<solution name="nl.f1re.mpsutil.hasher" uuid="078723b2-ab7f-48d1-b9bb-5f643b60d08e" moduleVersion="0">
+  <models>
+    <modelRoot type="default" contentPath="${module}">
+      <sourceRoot location="models" />
+    </modelRoot>
+  </models>
+  <facets>
+    <facet compile="mps" classes="mps" ext="no" type="java">
+      <classes generated="true" path="${module}/classes_gen" />
+    </facet>
+  </facets>
+  <dependencies>
+    <dependency reexport="false">ecfb9949-7433-4db5-85de-0f84d172e4ce(de.q60.mps.collections.libs)</dependency>
+    <dependency reexport="false">8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)</dependency>
+    <dependency reexport="false">6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)</dependency>
+    <dependency reexport="false">ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)</dependency>
+    <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
+  </dependencies>
+  <languageVersions>
+    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
+    <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
+    <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="2" />
+    <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
+    <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
+    <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
+    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
+    <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
+  </languageVersions>
+  <dependencyVersions>
+    <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
+    <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
+    <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
+    <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+    <module reference="ecfb9949-7433-4db5-85de-0f84d172e4ce(de.q60.mps.collections.libs)" version="0" />
+    <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
+    <module reference="078723b2-ab7f-48d1-b9bb-5f643b60d08e(nl.f1re.mpsutil.hasher)" version="0" />
+  </dependencyVersions>
+</solution>
+

--- a/code/solutions/de.itemis.mps.extensions.changelog/models/de.itemis.mps.extensions.changelog.mps
+++ b/code/solutions/de.itemis.mps.extensions.changelog/models/de.itemis.mps.extensions.changelog.mps
@@ -424,6 +424,35 @@
             <property role="3oM_SC" value="components." />
           </node>
         </node>
+        <node concept="2DRihI" id="3s41kb3Q2x$" role="15bAlk">
+          <property role="2RT3bR" value="0" />
+          <node concept="15Ami3" id="3s41kb3Q2y3" role="1PaTwD">
+            <node concept="37shsh" id="3s41kb3Q2y5" role="15Aodc">
+              <node concept="1dCxOk" id="3s41kb3Q2yb" role="37shsm">
+                <property role="1XweGW" value="078723b2-ab7f-48d1-b9bb-5f643b60d08e" />
+                <property role="1XxBO9" value="nl.f1re.mpsutil.hasher" />
+              </node>
+            </node>
+          </node>
+          <node concept="3oM_SD" id="3s41kb3Q2y2" role="1PaTwD">
+            <property role="3oM_SC" value="Added" />
+          </node>
+          <node concept="3oM_SD" id="3s41kb3Q2yj" role="1PaTwD">
+            <property role="3oM_SC" value="efficient," />
+          </node>
+          <node concept="3oM_SD" id="3s41kb3Q2yq" role="1PaTwD">
+            <property role="3oM_SC" value="configurable" />
+          </node>
+          <node concept="3oM_SD" id="3s41kb3Q2yk" role="1PaTwD">
+            <property role="3oM_SC" value="hashing" />
+          </node>
+          <node concept="3oM_SD" id="3s41kb3Q2yl" role="1PaTwD">
+            <property role="3oM_SC" value="of" />
+          </node>
+          <node concept="3oM_SD" id="3s41kb3Q2yr" role="1PaTwD">
+            <property role="3oM_SC" value="subtrees." />
+          </node>
+        </node>
       </node>
       <node concept="15bAme" id="iyWIxrRh41" role="15bAlL">
         <node concept="2DRihI" id="iyWIxrRh42" role="15bAlk">


### PR DESCRIPTION
implements #1531 

I put it into the `compare` plugin, as comparing and hashing nodes are quite similar (cf. Java `Object.equals()` and `Object.hashCode()`). This introduces a new dependency to `de.q60.mps.collections.libs`.

I used namespace `nl.f1re.mpsutil.hasher`.

Both of this can be adjusted.